### PR TITLE
feat: refine TUI action feed and stabilize tmux composer

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1521,6 +1521,8 @@ def _launch_tui(
     env.setdefault("HERMES_PYTHON", sys.executable)
     env.setdefault("HERMES_CWD", os.getcwd())
     env.setdefault("NODE_ENV", "development" if tui_dev else "production")
+    if env.get("TMUX") and "HERMES_TUI_INLINE" not in env:
+        env["HERMES_TUI_INLINE"] = "1"
 
     wt_info = None
     if worktree:

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -842,6 +842,50 @@ def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
     assert env["NODE_ENV"] == "production"
 
 
+def test_launch_tui_defaults_inline_mode_inside_tmux(monkeypatch, main_mod):
+    captured = {}
+
+    monkeypatch.setenv("TMUX", "/tmp/tmux-501/default,123,0")
+    monkeypatch.delenv("HERMES_TUI_INLINE", raising=False)
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["node", "dist/entry.js"], Path(".")),
+    )
+    monkeypatch.setattr(
+        main_mod.subprocess,
+        "call",
+        lambda argv, cwd=None, env=None: captured.update({"env": env}) or 1,
+    )
+
+    with pytest.raises(SystemExit):
+        main_mod._launch_tui()
+
+    assert captured["env"]["HERMES_TUI_INLINE"] == "1"
+
+
+def test_launch_tui_respects_explicit_inline_override_inside_tmux(monkeypatch, main_mod):
+    captured = {}
+
+    monkeypatch.setenv("TMUX", "/tmp/tmux-501/default,123,0")
+    monkeypatch.setenv("HERMES_TUI_INLINE", "0")
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["node", "dist/entry.js"], Path(".")),
+    )
+    monkeypatch.setattr(
+        main_mod.subprocess,
+        "call",
+        lambda argv, cwd=None, env=None: captured.update({"env": env}) or 1,
+    )
+
+    with pytest.raises(SystemExit):
+        main_mod._launch_tui()
+
+    assert captured["env"]["HERMES_TUI_INLINE"] == "0"
+
+
 def test_launch_tui_exit_code_42_relaunches_update(monkeypatch, main_mod):
     from unittest.mock import patch
 

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -20,7 +20,7 @@ import reconciler from '../reconciler.js'
 import { finishSelection, hasSelection, type SelectionState, startSelection } from '../selection.js'
 import { getTerminalFocused, setTerminalFocused } from '../terminal-focus-state.js'
 import { TerminalQuerier, xtversion } from '../terminal-querier.js'
-import { isXtermJs, setXtversionName, supportsExtendedKeys } from '../terminal.js'
+import { isXtermJs, setXtversionName, shouldEnableKittyKeyboard, shouldEnableModifyOtherKeys } from '../terminal.js'
 import {
   DISABLE_KITTY_KEYBOARD,
   DISABLE_MODIFY_OTHER_KEYS,
@@ -282,12 +282,15 @@ export default class App extends PureComponent<Props, State> {
         this.props.stdout.write(EFE)
 
         // Enable extended key reporting so ctrl+shift+<letter> is
-        // distinguishable from ctrl+<letter>. We write both the kitty stack
-        // push (CSI >1u) and xterm modifyOtherKeys level 2 (CSI >4;2m) —
-        // terminals honor whichever they implement (tmux only accepts the
-        // latter).
-        if (supportsExtendedKeys()) {
+        // distinguishable from ctrl+<letter>. Direct terminals use the Kitty
+        // stack push (CSI >1u); tmux panes use only tmux-native
+        // modifyOtherKeys so the outer terminal does not switch Ctrl+B away
+        // from the byte tmux needs for its prefix.
+        if (shouldEnableKittyKeyboard()) {
           this.props.stdout.write(ENABLE_KITTY_KEYBOARD)
+        }
+
+        if (shouldEnableModifyOtherKeys()) {
           this.props.stdout.write(ENABLE_MODIFY_OTHER_KEYS)
         }
 

--- a/ui-tui/packages/hermes-ink/src/ink/global.d.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/global.d.ts
@@ -1,1 +1,9 @@
-export {}
+declare module 'signal-exit' {
+  export type ExitHandler = (code: number | null, signal: NodeJS.Signals | null) => void
+
+  export interface Options {
+    alwaysLast?: boolean
+  }
+
+  export function onExit(handler: ExitHandler, options?: Options): () => void
+}

--- a/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 import Text from './components/Text.js'
 import Ink from './ink.js'
-import { CURSOR_HOME, ERASE_SCREEN } from './termio/csi.js'
+import { CURSOR_HOME, ERASE_SCREEN, ERASE_SCROLLBACK } from './termio/csi.js'
 
 class FakeTty extends EventEmitter {
   chunks: string[] = []
@@ -21,30 +21,132 @@ class FakeTty extends EventEmitter {
 
 const tick = () => new Promise<void>(resolve => queueMicrotask(resolve))
 
+function createInk(stdout = new FakeTty()) {
+  const stdin = new FakeTty()
+  const stderr = new FakeTty()
+  const ink = new Ink({
+    exitOnCtrlC: false,
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+  return { ink, stdout }
+}
+
+async function withEnv(updates: Record<string, string | undefined>, fn: () => Promise<void>): Promise<void> {
+  const original = new Map<string, string | undefined>()
+
+  for (const key of Object.keys(updates)) {
+    original.set(key, process.env[key])
+    const value = updates[key]
+
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+
+  try {
+    await fn()
+  } finally {
+    for (const [key, value] of original) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+}
+
 describe('Ink resize healing', () => {
   it('heals same-dimension alt-screen resize events with an erase before repaint', async () => {
-    const stdout = new FakeTty()
-    const stdin = new FakeTty()
-    const stderr = new FakeTty()
-    const ink = new Ink({
-      exitOnCtrlC: false,
-      patchConsole: false,
-      stderr: stderr as unknown as NodeJS.WriteStream,
-      stdin: stdin as unknown as NodeJS.ReadStream,
-      stdout: stdout as unknown as NodeJS.WriteStream
+    const { ink, stdout } = createInk()
+
+    try {
+      ink.setAltScreenActive(true)
+      ink.render(React.createElement(Text, null, 'hello'))
+      ink.onRender()
+      stdout.chunks = []
+
+      stdout.emit('resize')
+      ink.onRender()
+      await tick()
+
+      expect(stdout.chunks.join('')).toContain(ERASE_SCREEN + CURSOR_HOME)
+    } finally {
+      ink.unmount()
+    }
+  })
+
+  it('heals same-dimension tmux inline resize events with a visible-screen erase and full repaint', async () => {
+    await withEnv({ HERMES_TUI_MAIN_SCREEN_RESIZE_REPAINT: undefined, TMUX: '/tmp/tmux-501/default,1,0' }, async () => {
+      const { ink, stdout } = createInk()
+
+      try {
+        ink.render(React.createElement(Text, null, 'hello'))
+        ink.onRender()
+        stdout.chunks = []
+
+        stdout.emit('resize')
+        ink.onRender()
+        await tick()
+
+        const output = stdout.chunks.join('')
+        expect(output).toContain(ERASE_SCREEN + CURSOR_HOME)
+        expect(output).toContain('hello')
+        expect(output).not.toContain(ERASE_SCROLLBACK)
+      } finally {
+        ink.unmount()
+      }
     })
+  })
 
-    ink.setAltScreenActive(true)
-    ink.render(React.createElement(Text, null, 'hello'))
-    ink.onRender()
-    stdout.chunks = []
+  it('heals dimension-changing tmux inline resize events without clearing scrollback', async () => {
+    await withEnv({ HERMES_TUI_MAIN_SCREEN_RESIZE_REPAINT: undefined, TMUX: '/tmp/tmux-501/default,1,0' }, async () => {
+      const { ink, stdout } = createInk()
 
-    stdout.emit('resize')
-    ink.onRender()
-    await tick()
+      try {
+        ink.render(React.createElement(Text, null, 'hello'))
+        ink.onRender()
+        stdout.chunks = []
+        stdout.columns = 30
+        stdout.rows = 8
 
-    expect(stdout.chunks.join('')).toContain(ERASE_SCREEN + CURSOR_HOME)
+        stdout.emit('resize')
+        ink.onRender()
+        await tick()
 
-    ink.unmount()
+        const output = stdout.chunks.join('')
+        expect(output).toContain(ERASE_SCREEN + CURSOR_HOME)
+        expect(output).toContain('hello')
+        expect(output).not.toContain(ERASE_SCROLLBACK)
+      } finally {
+        ink.unmount()
+      }
+    })
+  })
+
+  it('ignores same-dimension main-screen resize events outside tmux', async () => {
+    await withEnv({ HERMES_TUI_MAIN_SCREEN_RESIZE_REPAINT: undefined, TMUX: undefined }, async () => {
+      const { ink, stdout } = createInk()
+
+      try {
+        ink.render(React.createElement(Text, null, 'hello'))
+        ink.onRender()
+        stdout.chunks = []
+
+        stdout.emit('resize')
+        ink.onRender()
+        await tick()
+
+        expect(stdout.chunks.join('')).toBe('')
+      } finally {
+        ink.unmount()
+      }
+    })
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -77,7 +77,8 @@ import {
 } from './selection.js'
 import {
   needsAltScreenResizeScrollbackClear,
-  supportsExtendedKeys,
+  shouldEnableKittyKeyboard,
+  shouldEnableModifyOtherKeys,
   SYNC_OUTPUT_SUPPORTED,
   type Terminal,
   writeDiffToTerminal
@@ -676,7 +677,8 @@ export default class Ink {
     // without the pop we'd accumulate depth on each editor round-trip).
     this.options.stdout.write(
       '\x1b[?1004h' +
-        (supportsExtendedKeys() ? DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD + ENABLE_MODIFY_OTHER_KEYS : '')
+        (shouldEnableKittyKeyboard() ? DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD : '') +
+        (shouldEnableModifyOtherKeys() ? ENABLE_MODIFY_OTHER_KEYS : '')
     )
   }
   onRender() {
@@ -1344,8 +1346,12 @@ export default class Ink {
     // allowlisted terminals at raw-mode entry; a terminal reset clears them).
     // Pop-before-push keeps Kitty stack depth at 1 instead of accumulating
     // on each call.
-    if (supportsExtendedKeys()) {
-      this.options.stdout.write(DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD + ENABLE_MODIFY_OTHER_KEYS)
+    if (shouldEnableKittyKeyboard()) {
+      this.options.stdout.write(DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD)
+    }
+
+    if (shouldEnableModifyOtherKeys()) {
+      this.options.stdout.write(ENABLE_MODIFY_OTHER_KEYS)
     }
 
     if (!this.altScreenActive) {

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -137,6 +137,20 @@ const DEEP_ERASE_THEN_HOME_PATCH = Object.freeze({
   content: ERASE_SCREEN + ERASE_SCROLLBACK + CURSOR_HOME
 })
 
+function shouldHealMainScreenResize(): boolean {
+  const override = process.env['HERMES_TUI_MAIN_SCREEN_RESIZE_REPAINT']
+
+  if (override === '0' || override === 'false') {
+    return false
+  }
+
+  if (override === '1' || override === 'true') {
+    return true
+  }
+
+  return !!process.env['TMUX']
+}
+
 // Cached per-Ink-instance, invalidated on resize. frame.cursor.y for
 // alt-screen is always terminalRows - 1 (renderer.ts).
 function makeAltScreenParkPatch(terminalRows: number) {
@@ -280,11 +294,11 @@ export default class Ink {
   // one full-render frame; steady-state frames after clear it and regain
   // the blit + narrow-damage fast path.
   private prevFrameContaminated = false
-  // Set by handleResize: prepend ERASE_SCREEN to the next onRender's patches
-  // INSIDE the BSU/ESU block so clear+paint is atomic. Writing ERASE_SCREEN
-  // synchronously in handleResize would leave the screen blank for the ~80ms
-  // render() takes; deferring into the atomic block means old content stays
-  // visible until the new frame is fully ready.
+  // Set by resize/self-heal paths: prepend ERASE_SCREEN to the next
+  // onRender's patches instead of clearing synchronously. In alt screen this
+  // lands inside the BSU/ESU block when supported; in tmux inline/main-screen
+  // mode it still keeps the visible clear adjacent to the full repaint and
+  // preserves scrollback (CSI 2J, not 3J).
   private needsEraseBeforePaint = false
   // Native cursor positioning: a component (via useDeclaredCursor) declares
   // where the terminal cursor should be parked after each frame. Terminal
@@ -490,13 +504,15 @@ export default class Ink {
     const cols = this.options.stdout.columns || 80
     const rows = this.options.stdout.rows || 24
     const dimsChanged = cols !== this.terminalColumns || rows !== this.terminalRows
+    const canAltScreenResizeHeal = this.altScreenActive && !this.isPaused && this.options.stdout.isTTY
+    const canMainScreenResizeHeal = !this.altScreenActive && !this.isPaused && this.options.stdout.isTTY && shouldHealMainScreenResize()
 
     // Terminals often emit 2+ resize events for one user action
     // (window settling). Same-dimension events are usually no-ops,
-    // but in alt-screen mode a same-dimension resize can signal a
-    // terminal host reflow or buffer restore that leaves stale glyphs
+    // but in full-screen or tmux inline modes a same-dimension resize can
+    // signal a terminal host reflow or buffer restore that leaves stale glyphs
     // on the physical screen — treat it as a repaint signal.
-    if (!dimsChanged && !(this.altScreenActive && !this.isPaused && this.options.stdout.isTTY)) {
+    if (!dimsChanged && !canAltScreenResizeHeal && !canMainScreenResizeHeal) {
       return
     }
 
@@ -530,8 +546,19 @@ export default class Ink {
     // by handleResume (SIGCONT) and the sleep-wake detector; resize itself
     // doesn't exit alt-screen. Do NOT write ERASE_SCREEN: render() below
     // can take ~80ms; erasing first leaves the screen blank that whole time.
-    if (this.altScreenActive && !this.isPaused && this.options.stdout.isTTY) {
+    if (canAltScreenResizeHeal) {
       this.prepareAltScreenResizeRepaint()
+    } else if (canMainScreenResizeHeal) {
+      // tmux inline/main-screen mode preserves scrollback, but terminal
+      // clients (notably mobile/remote clients such as Termius) can keep
+      // stale cells after detach/reattach, window-size changes, or switching
+      // between tmux windows with different dimensions. tmux's logical buffer
+      // can be clean while the client display is dirty. Treat resize events as
+      // a repaint signal here too: clear only the visible screen and force a
+      // full frame diff from a blank previous frame.
+      this.repaint()
+      this.prevFrameContaminated = true
+      this.needsEraseBeforePaint = true
     }
 
     // Already queued: later events in this burst updated dims/alt-screen
@@ -948,6 +975,7 @@ export default class Ink {
     const optimizeMs = performance.now() - tOptimize
     const hasDiff = optimized.length > 0
     const needsAltScreenErase = this.altScreenActive && this.needsEraseBeforePaint
+    const needsMainScreenErase = !this.altScreenActive && this.needsEraseBeforePaint
 
     if (this.altScreenActive && (hasDiff || needsAltScreenErase)) {
       // Prepend CSI H to anchor the physical cursor to (0,0) so
@@ -977,6 +1005,11 @@ export default class Ink {
       }
 
       optimized.push(this.altScreenParkPatch)
+    }
+
+    if (needsMainScreenErase) {
+      this.needsEraseBeforePaint = false
+      optimized.unshift(ERASE_THEN_HOME_PATCH)
     }
 
     // Native cursor positioning: park the terminal cursor at the declared
@@ -1191,15 +1224,15 @@ export default class Ink {
    */
   repaint(): void {
     this.frontFrame = emptyFrame(
-      this.frontFrame.viewport.height,
-      this.frontFrame.viewport.width,
+      this.terminalRows,
+      this.terminalColumns,
       this.stylePool,
       this.charPool,
       this.hyperlinkPool
     )
     this.backFrame = emptyFrame(
-      this.backFrame.viewport.height,
-      this.backFrame.viewport.width,
+      this.terminalRows,
+      this.terminalColumns,
       this.stylePool,
       this.charPool,
       this.hyperlinkPool

--- a/ui-tui/packages/hermes-ink/src/ink/terminal.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { needsAltScreenResizeScrollbackClear } from './terminal.js'
+import { needsAltScreenResizeScrollbackClear, shouldEnableKittyKeyboard, shouldEnableModifyOtherKeys } from './terminal.js'
 
 describe('terminal resize quirks', () => {
   it('uses a deeper alt-screen resize clear for Apple Terminal', () => {
@@ -11,5 +11,23 @@ describe('terminal resize quirks', () => {
   it('keeps the normal resize repaint path for modern terminals', () => {
     expect(needsAltScreenResizeScrollbackClear({ TERM_PROGRAM: 'vscode' })).toBe(false)
     expect(needsAltScreenResizeScrollbackClear({ TERM_PROGRAM: 'iTerm.app' })).toBe(false)
+  })
+})
+
+describe('extended keyboard modes', () => {
+  it('does not push Kitty keyboard mode through tmux to the outer terminal', () => {
+    expect(shouldEnableKittyKeyboard({ TMUX: '/tmp/tmux-501/default,123,0' }, 'iTerm.app')).toBe(false)
+  })
+
+  it('does not push modifyOtherKeys from inside tmux because it can break the prefix byte path', () => {
+    expect(shouldEnableModifyOtherKeys('iTerm.app', { TMUX: '/tmp/tmux-501/default,123,0' })).toBe(false)
+  })
+
+  it('enables modifyOtherKeys directly in allowlisted non-tmux terminals', () => {
+    expect(shouldEnableModifyOtherKeys('iTerm.app', {})).toBe(true)
+  })
+
+  it('enables Kitty keyboard mode directly in allowlisted non-tmux terminals', () => {
+    expect(shouldEnableKittyKeyboard({}, 'iTerm.app')).toBe(true)
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/terminal.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/terminal.ts
@@ -177,15 +177,40 @@ export function needsAltScreenResizeScrollbackClear(env: NodeJS.ProcessEnv = pro
 // disambiguation. We previously enabled unconditionally (#23350), assuming
 // terminals silently ignore unknown CSI — but some terminals honor the enable
 // and emit codepoints our input parser doesn't handle (notably over SSH and
-// in xterm.js-based terminals like VS Code). tmux is allowlisted because it
-// accepts modifyOtherKeys and doesn't forward the kitty sequence to the outer
-// terminal.
+// in xterm.js-based terminals like VS Code). tmux is kept in the capability
+// allowlist for explicit probes/tests, but the actual enable helpers below do
+// not push extended-key modes from inside tmux by default because that can
+// break the tmux prefix path in the outer terminal.
 const EXTENDED_KEYS_TERMINALS = ['iTerm.app', 'kitty', 'WezTerm', 'ghostty', 'tmux', 'windows-terminal', 'vscode']
 
 /** True if this terminal correctly handles extended key reporting
  *  (Kitty keyboard protocol + xterm modifyOtherKeys). */
-export function supportsExtendedKeys(): boolean {
-  return EXTENDED_KEYS_TERMINALS.includes(env.terminal ?? '')
+export function supportsExtendedKeys(terminal: string | null = env.terminal): boolean {
+  return EXTENDED_KEYS_TERMINALS.includes(terminal ?? '')
+}
+
+/**
+ * Kitty keyboard mode must not be pushed from inside tmux. Some outer
+ * terminals (notably iTerm2) honor CSI >1u even when it is emitted by an app
+ * running in a tmux pane; then Ctrl+B reaches tmux as a CSI-u sequence
+ * rather than the C-b prefix byte, so the user's tmux prefix stops working. Tmux has
+ * its own extended-key negotiation, but requesting either Kitty or
+ * modifyOtherKeys from a pane can still make outer terminals report Ctrl+B in
+ * a form tmux does not treat as the prefix. Keep app-initiated extended-key
+ * modes for direct terminal sessions only unless a user explicitly opts in.
+ */
+export function shouldEnableKittyKeyboard(
+  processEnv: NodeJS.ProcessEnv = process.env,
+  terminal: string | null = env.terminal
+): boolean {
+  return supportsExtendedKeys(terminal) && !processEnv.TMUX
+}
+
+export function shouldEnableModifyOtherKeys(
+  terminal: string | null = env.terminal,
+  processEnv: NodeJS.ProcessEnv = process.env
+): boolean {
+  return supportsExtendedKeys(terminal) && !processEnv.TMUX
 }
 
 /** True if the terminal scrolls the viewport when it receives cursor-up

--- a/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
+++ b/ui-tui/packages/hermes-ink/src/utils/execFileNoThrow.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process'
+import { spawn, type ChildProcess, type StdioOptions } from 'child_process'
 type ExecFileOptions = {
   input?: string
   timeout?: number
@@ -32,11 +32,11 @@ export function execFileNoThrow(
     // doesn't inherit those pipe FDs — prevents handle leaks that can
     // keep the parent process alive. No output data is collected in
     // this mode; both stdout and stderr will be empty strings.
-    const stdioConfig = options.resolveOnExit
-      ? ['pipe', 'ignore', 'ignore'] as const
-      : 'pipe' as const
+    const stdioConfig: StdioOptions = options.resolveOnExit
+      ? ['pipe', 'ignore', 'ignore']
+      : 'pipe'
 
-    const child = spawn(file, args, {
+    const child: ChildProcess = spawn(file, args, {
       cwd: options.useCwd ? process.cwd() : undefined,
       env: options.env,
       stdio: stdioConfig

--- a/ui-tui/src/__tests__/actionFeed.test.ts
+++ b/ui-tui/src/__tests__/actionFeed.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { actionStatusGlyph, foldActionDetail, parseActionCall } from '../lib/actionFeed.js'
+
+describe('actionFeed formatter', () => {
+  it.each([
+    ['Read File("/tmp/project/src/app.ts")', 'Read …/src/app.ts'],
+    ['Search Files("statusbar")', 'Searched "statusbar"'],
+    ['Terminal("pytest tests/foo.py -q")', 'Ran "pytest tests/foo.py -q"'],
+    ['Patch("ui-tui/src/components/appChrome.tsx")', 'Edited …/components/appChrome.tsx'],
+    ['Write File("docs/plan.md")', 'Wrote docs/plan.md'],
+    ['Todo', 'Updated todos'],
+    ['Delegate Task("review implementation")', 'Delegated "review implementation"']
+  ])('formats %s as %s', (input, expected) => {
+    expect(parseActionCall(input).title).toBe(expected)
+  })
+
+  it('ignores duration suffixes when parsing the action subject', () => {
+    expect(parseActionCall('Terminal("npm test") (1.2s)').title).toBe('Ran "npm test"')
+  })
+
+  it('folds long multiline detail bodies', () => {
+    const folded = foldActionDetail(['Result:', 'line 1', 'line 2', 'line 3', 'line 4', 'line 5'].join('\n'), 3)
+
+    expect(folded.preview).toBe(['Result:', 'line 1', 'line 2'].join('\n'))
+    expect(folded.hiddenLines).toBe(3)
+  })
+
+  it('returns stable status glyphs', () => {
+    expect(actionStatusGlyph('running')).toBe('●')
+    expect(actionStatusGlyph('success')).toBe('✓')
+    expect(actionStatusGlyph('error')).toBe('✗')
+  })
+})

--- a/ui-tui/src/__tests__/actionFeed.test.ts
+++ b/ui-tui/src/__tests__/actionFeed.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { actionStatusGlyph, foldActionDetail, parseActionCall } from '../lib/actionFeed.js'
+import { actionStatusGlyph, foldActionDetail, parseActionCall, selectVisibleActionFeedItems } from '../lib/actionFeed.js'
 
 describe('actionFeed formatter', () => {
   it.each([
@@ -30,5 +30,29 @@ describe('actionFeed formatter', () => {
     expect(actionStatusGlyph('running')).toBe('●')
     expect(actionStatusGlyph('success')).toBe('✓')
     expect(actionStatusGlyph('error')).toBe('✗')
+  })
+
+  it('limits visible actions to important and recent items', () => {
+    const actions = [
+      { label: 'Read File("a")', status: 'success' as const },
+      { label: 'Search Files("b")', status: 'success' as const },
+      { label: 'Read File("c")', status: 'success' as const },
+      { label: 'Patch("src/app.ts")', status: 'success' as const },
+      { label: 'Search Files("d")', status: 'success' as const },
+      { label: 'Todo', status: 'success' as const },
+      { label: 'Read File("e")', status: 'success' as const },
+      { label: 'Terminal("npm test")', status: 'running' as const }
+    ]
+
+    const selected = selectVisibleActionFeedItems(actions)
+
+    expect(selected.hidden).toBe(3)
+    expect(selected.items.map(item => item.label)).toEqual([
+      'Patch("src/app.ts")',
+      'Search Files("d")',
+      'Todo',
+      'Read File("e")',
+      'Terminal("npm test")'
+    ])
   })
 })

--- a/ui-tui/src/__tests__/actionFeed.test.ts
+++ b/ui-tui/src/__tests__/actionFeed.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { actionStatusGlyph, foldActionDetail, parseActionCall, selectVisibleActionFeedItems } from '../lib/actionFeed.js'
+import {
+  actionStatusGlyph,
+  foldActionDetail,
+  parseActionCall,
+  selectVisibleActionFeedItems,
+  summarizeHiddenActionFeedItems
+} from '../lib/actionFeed.js'
 
 describe('actionFeed formatter', () => {
   it.each([
@@ -32,7 +38,7 @@ describe('actionFeed formatter', () => {
     expect(actionStatusGlyph('error')).toBe('✗')
   })
 
-  it('limits visible actions to important and recent items', () => {
+  it('limits visible actions to a few meaningful rows', () => {
     const actions = [
       { label: 'Read File("a")', status: 'success' as const },
       { label: 'Search Files("b")', status: 'success' as const },
@@ -46,13 +52,40 @@ describe('actionFeed formatter', () => {
 
     const selected = selectVisibleActionFeedItems(actions)
 
-    expect(selected.hidden).toBe(3)
+    expect(selected.hidden).toBe(5)
+    expect(summarizeHiddenActionFeedItems(selected.hiddenItems)).toBe('Read×3 · Searched×2')
     expect(selected.items.map(item => item.label)).toEqual([
       'Patch("src/app.ts")',
-      'Search Files("d")',
       'Todo',
-      'Read File("e")',
       'Terminal("npm test")'
     ])
+  })
+
+  it('falls back to one recent low-value row when no major actions exist', () => {
+    const actions = [
+      { label: 'Read File("a")', status: 'success' as const },
+      { label: 'Search Files("b")', status: 'success' as const },
+      { label: 'Read File("c")', status: 'success' as const },
+      { label: 'Search Files("d")', status: 'success' as const }
+    ]
+
+    const selected = selectVisibleActionFeedItems(actions)
+
+    expect(selected.hidden).toBe(3)
+    expect(selected.items.map(item => item.label)).toEqual(['Search Files("d")'])
+  })
+
+  it('summarizes hidden actions with a compact width budget', () => {
+    const summary = summarizeHiddenActionFeedItems(
+      [
+        { label: 'Very Long Custom Tool Name That Would Wrap("alpha")', status: 'success' as const },
+        { label: 'Another Extremely Long Hidden Tool Name("beta")', status: 'success' as const },
+        { label: 'Yet Another Hidden Tool Name("gamma")', status: 'success' as const }
+      ],
+      3,
+      28
+    )
+
+    expect(summary.length).toBeLessThanOrEqual(28)
   })
 })

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -89,7 +89,7 @@ describe('StatusRule compact footer', () => {
     const text = textContent(element)
 
     expect(text).toContain('gpt 5.5 xhigh')
-    expect(text).toContain('Context 74.9k/272k 28%')
+    expect(text).toContain('Context 74.9k/272k 28% [███░░░░░░░]')
     expect(text).not.toContain('Ctrl+C interrupt')
     expect(text).not.toContain('voice')
     expect(text).not.toContain('sessions')

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -3,8 +3,11 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { StatusRule } from '../components/appChrome.js'
 import { DEFAULT_THEME } from '../theme.js'
+import type { Usage } from '../types.js'
 
 type ReactNodeLike = React.ReactNode
+
+const emptyUsage: Usage = { calls: 0, input: 0, output: 0, total: 0 }
 
 const textContent = (node: ReactNodeLike): string => {
   if (node === null || node === undefined || typeof node === 'boolean') {
@@ -71,7 +74,7 @@ describe('StatusRule session count click target', () => {
       statusColor: DEFAULT_THEME.color.ok,
       t: DEFAULT_THEME,
       turnStartedAt: null,
-      usage: { total: 0 },
+      usage: emptyUsage,
       voiceLabel: ''
     })
 
@@ -80,5 +83,28 @@ describe('StatusRule session count click target', () => {
     expect(clickableSessionCount).not.toBeNull()
     clickableSessionCount!.props.onClick({ stopImmediatePropagation: vi.fn() })
     expect(openSwitcher).toHaveBeenCalledOnce()
+  })
+})
+
+describe('StatusRule status hints', () => {
+  it('shows a compact interrupt hint while the agent is busy', () => {
+    const element = StatusRule({
+      bgCount: 0,
+      busy: true,
+      cols: 120,
+      cwdLabel: '',
+      liveSessionCount: 0,
+      model: 'openai/gpt-5.5',
+      sessionStartedAt: null,
+      showCost: false,
+      status: 'running',
+      statusColor: DEFAULT_THEME.color.warn,
+      t: DEFAULT_THEME,
+      turnStartedAt: null,
+      usage: emptyUsage,
+      voiceLabel: ''
+    })
+
+    expect(textContent(element)).toContain('Ctrl+C interrupt')
   })
 })

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -57,54 +57,46 @@ const findClickableWithText = (node: ReactNodeLike, needle: string): React.React
   return findClickableWithText(node.props.children, needle)
 }
 
-describe('StatusRule session count click target', () => {
-  it('makes the live session count itself clickable', () => {
+describe('StatusRule compact footer', () => {
+  it('keeps the footer to model, context, and session time only', () => {
     const openSwitcher = vi.fn()
     const element = StatusRule({
-      bgCount: 0,
-      busy: false,
-      cols: 100,
-      cwdLabel: '~/repo',
-      liveSessionCount: 1,
-      model: 'kimi-k2.6',
-      onSessionCountClick: openSwitcher,
-      sessionStartedAt: null,
-      showCost: false,
-      status: 'ready',
-      statusColor: DEFAULT_THEME.color.ok,
-      t: DEFAULT_THEME,
-      turnStartedAt: null,
-      usage: emptyUsage,
-      voiceLabel: ''
-    })
-
-    const clickableSessionCount = findClickableWithText(element, '1 session')
-
-    expect(clickableSessionCount).not.toBeNull()
-    clickableSessionCount!.props.onClick({ stopImmediatePropagation: vi.fn() })
-    expect(openSwitcher).toHaveBeenCalledOnce()
-  })
-})
-
-describe('StatusRule status hints', () => {
-  it('shows a compact interrupt hint while the agent is busy', () => {
-    const element = StatusRule({
-      bgCount: 0,
+      bgCount: 7,
       busy: true,
       cols: 120,
-      cwdLabel: '',
-      liveSessionCount: 0,
+      cwdLabel: '~/repo',
+      liveSessionCount: 2,
       model: 'openai/gpt-5.5',
-      sessionStartedAt: null,
-      showCost: false,
+      modelReasoningEffort: 'xhigh',
+      onSessionCountClick: openSwitcher,
+      sessionStartedAt: Date.now(),
+      showCost: true,
       status: 'running',
       statusColor: DEFAULT_THEME.color.warn,
       t: DEFAULT_THEME,
-      turnStartedAt: null,
-      usage: emptyUsage,
-      voiceLabel: ''
+      turnStartedAt: Date.now(),
+      usage: {
+        ...emptyUsage,
+        context_max: 272000,
+        context_percent: 28,
+        context_used: 74900,
+        cost_usd: 1.23,
+        compressions: 3
+      },
+      voiceLabel: 'voice on'
     })
 
-    expect(textContent(element)).toContain('Ctrl+C interrupt')
+    const text = textContent(element)
+
+    expect(text).toContain('gpt 5.5 xhigh')
+    expect(text).toContain('Context 74.9k/272k 28%')
+    expect(text).not.toContain('Ctrl+C interrupt')
+    expect(text).not.toContain('voice')
+    expect(text).not.toContain('sessions')
+    expect(text).not.toContain('bg')
+    expect(text).not.toContain('cmp')
+    expect(text).not.toContain('$')
+    expect(findClickableWithText(element, '2 sessions')).toBeNull()
+    expect(openSwitcher).not.toHaveBeenCalled()
   })
 })

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -57,6 +57,24 @@ const findClickableWithText = (node: ReactNodeLike, needle: string): React.React
   return findClickableWithText(node.props.children, needle)
 }
 
+const findElementsWithExactText = (node: ReactNodeLike, exact: string): React.ReactElement<Record<string, any>>[] => {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return []
+  }
+
+  if (Array.isArray(node)) {
+    return node.flatMap(child => findElementsWithExactText(child, exact))
+  }
+
+  if (!React.isValidElement(node)) {
+    return []
+  }
+
+  const here = node.props.children === exact ? [node] : []
+
+  return [...here, ...findElementsWithExactText(node.props.children, exact)]
+}
+
 describe('StatusRule compact footer', () => {
   it('keeps the footer to model, context, and session time only', () => {
     const openSwitcher = vi.fn()
@@ -90,6 +108,9 @@ describe('StatusRule compact footer', () => {
 
     expect(text).toContain('gpt 5.5 xhigh')
     expect(text).toContain('Context 74.9k/272k 28% [███░░░░░░░]')
+    const contextSeparators = findElementsWithExactText(element, ' │ ')
+    expect(contextSeparators.length).toBeGreaterThanOrEqual(2)
+    expect(contextSeparators.every(node => node.props.color === DEFAULT_THEME.color.muted)).toBe(true)
     expect(text).not.toContain('Ctrl+C interrupt')
     expect(text).not.toContain('voice')
     expect(text).not.toContain('sessions')

--- a/ui-tui/src/__tests__/appOverlaysCompletion.test.ts
+++ b/ui-tui/src/__tests__/appOverlaysCompletion.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { completionRowStyle } from '../components/appOverlays.js'
+import { completionOverlayMode, completionRowStyle } from '../components/appOverlays.js'
 import { DEFAULT_THEME } from '../theme.js'
+
+describe('completionOverlayMode', () => {
+  it('renders slash completions in normal layout flow instead of absolute-overlapping the composer', () => {
+    expect(completionOverlayMode()).toBe('flow')
+  })
+})
 
 describe('completionRowStyle', () => {
   it('keeps inactive slash completions free of row and meta backgrounds', () => {

--- a/ui-tui/src/__tests__/appOverlaysCompletion.test.ts
+++ b/ui-tui/src/__tests__/appOverlaysCompletion.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { completionRowStyle } from '../components/appOverlays.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+describe('completionRowStyle', () => {
+  it('keeps inactive slash completions free of row and meta backgrounds', () => {
+    const style = completionRowStyle(false, DEFAULT_THEME)
+
+    expect(style.rowBackground).toBeUndefined()
+    expect(style.commandColor).toBe(DEFAULT_THEME.color.label)
+    expect(style.metaColor).toBe(DEFAULT_THEME.color.muted)
+  })
+
+  it('uses a dark status background and brighter text only for the active row', () => {
+    const style = completionRowStyle(true, DEFAULT_THEME)
+
+    expect(style.rowBackground).toBe(DEFAULT_THEME.color.statusBg)
+    expect(style.commandColor).toBe(DEFAULT_THEME.color.primary)
+    expect(style.metaColor).toBe(DEFAULT_THEME.color.text)
+  })
+})

--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -95,6 +95,19 @@ describe('INLINE_RE emphasis', () => {
   })
 })
 
+describe('code fence rendering', () => {
+  it('renders the fence language as a separate label, not command text', () => {
+    const lines = renderPlain(
+      React.createElement(Box, null, React.createElement(Md, { t: DEFAULT_THEME, text: '```bash\npython3 dev.py\n```' }))
+    )
+
+    const normalized = lines.map(line => line.replace(/\s+/g, ' ').trim())
+
+    expect(normalized.some(line => line.includes('bash code block'))).toBe(true)
+    expect(lines.some(line => line.trim() === 'python3 dev.py')).toBe(true)
+  })
+})
+
 describe('stripInlineMarkup', () => {
   it('strips word-boundary emphasis only', () => {
     expect(stripInlineMarkup('say _hi_ there')).toBe('say hi there')

--- a/ui-tui/src/__tests__/messageLine.test.ts
+++ b/ui-tui/src/__tests__/messageLine.test.ts
@@ -1,19 +1,23 @@
 import { describe, expect, it } from 'vitest'
 
-import { shouldShowResponseSeparator } from '../components/messageLine.js'
+import { splitAssistantLogPrefix } from '../lib/assistantLogPrefix.js'
 
-describe('shouldShowResponseSeparator', () => {
-  it('separates assistant response text from visible details', () => {
-    expect(shouldShowResponseSeparator({ role: 'assistant', text: 'final', thinking: 'plan' }, true)).toBe(true)
+describe('splitAssistantLogPrefix', () => {
+  it('extracts prepared progress prefixes for emphasized rendering', () => {
+    expect(splitAssistantLogPrefix('**진행상황:**\n파일 확인 중입니다.')).toEqual({
+      body: '파일 확인 중입니다.',
+      prefix: '진행상황'
+    })
   })
 
-  it('does not add a response separator without details or body text', () => {
-    expect(shouldShowResponseSeparator({ role: 'assistant', text: 'final' }, false)).toBe(false)
-    expect(shouldShowResponseSeparator({ role: 'assistant', text: '   ', thinking: 'plan' }, true)).toBe(false)
+  it('extracts same-line prepared progress prefixes', () => {
+    expect(splitAssistantLogPrefix('검증: 테스트를 다시 실행합니다.')).toEqual({
+      body: '테스트를 다시 실행합니다.',
+      prefix: '검증'
+    })
   })
 
-  it('does not add response separators to non-assistant transcript rows', () => {
-    expect(shouldShowResponseSeparator({ role: 'user', text: 'prompt' }, true)).toBe(false)
-    expect(shouldShowResponseSeparator({ role: 'system', text: 'note' }, true)).toBe(false)
+  it('leaves ordinary assistant prose untouched', () => {
+    expect(splitAssistantLogPrefix('일반 답변입니다.')).toBeNull()
   })
 })

--- a/ui-tui/src/__tests__/prompt.test.ts
+++ b/ui-tui/src/__tests__/prompt.test.ts
@@ -18,14 +18,14 @@ describe('composerPromptText', () => {
   })
 
   it('uses a Termux-safe ASCII prompt marker in normal mode', () => {
-    expect(composerPromptText('❯', 'coder', false, true, 50)).toBe('>')
+    expect(composerPromptText('❯', 'coder', false, true, 50)).toBe(':')
   })
 
   it('keeps profile prefix suppressed on narrow Termux widths', () => {
-    expect(composerPromptText('❯', 'upstr', false, true, 72)).toBe('>')
+    expect(composerPromptText('❯', 'upstr', false, true, 72)).toBe(':')
   })
 
   it('allows profile prefix on very wide Termux panes', () => {
-    expect(composerPromptText('❯', 'upstr', false, true, 120)).toBe('upstr >')
+    expect(composerPromptText('❯', 'upstr', false, true, 120)).toBe('upstr :')
   })
 })

--- a/ui-tui/src/__tests__/termuxComposerLayout.test.ts
+++ b/ui-tui/src/__tests__/termuxComposerLayout.test.ts
@@ -5,15 +5,15 @@ import { composerPromptText } from '../lib/prompt.js'
 
 describe('Termux composer prompt + width guards', () => {
   it('uses a single-cell ASCII prompt marker in Termux mode', () => {
-    expect(composerPromptText('❯', 'coder', false, true, 50)).toBe('>')
+    expect(composerPromptText('❯', 'coder', false, true, 50)).toBe(':')
   })
 
   it('suppresses profile prefixes on narrow Termux panes', () => {
-    expect(composerPromptText('❯', 'upstr', false, true, 72)).toBe('>')
+    expect(composerPromptText('❯', 'upstr', false, true, 72)).toBe(':')
   })
 
   it('keeps profile context on very wide Termux panes', () => {
-    expect(composerPromptText('❯', 'upstr', false, true, 120)).toBe('upstr >')
+    expect(composerPromptText('❯', 'upstr', false, true, 120)).toBe('upstr :')
   })
 
   it('reserves fewer columns for gutter on narrow Termux widths', () => {

--- a/ui-tui/src/__tests__/textInputFastEcho.test.ts
+++ b/ui-tui/src/__tests__/textInputFastEcho.test.ts
@@ -212,6 +212,19 @@ describe('supportsFastEchoTerminal', () => {
     expect(supportsFastEchoTerminal({ TERM_PROGRAM: 'Apple_Terminal' } as NodeJS.ProcessEnv)).toBe(false)
   })
 
+  it('disables fast-echo by default inside tmux to avoid cursor/IME drift below the composer', () => {
+    expect(supportsFastEchoTerminal({ TMUX: '/tmp/tmux-501/default,123,0' } as NodeJS.ProcessEnv)).toBe(false)
+  })
+
+  it('allows explicit tmux fast-echo opt-in for debugging only', () => {
+    expect(
+      supportsFastEchoTerminal({
+        HERMES_TUI_FAST_ECHO: '1',
+        TMUX: '/tmp/tmux-501/default,123,0'
+      } as NodeJS.ProcessEnv)
+    ).toBe(true)
+  })
+
   it('disables fast-echo by default in Termux mode', () => {
     expect(
       supportsFastEchoTerminal({ TERMUX_VERSION: '0.118.0', PREFIX: '/data/data/com.termux/files/usr' } as NodeJS.ProcessEnv)

--- a/ui-tui/src/__tests__/textInputFastEcho.test.ts
+++ b/ui-tui/src/__tests__/textInputFastEcho.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { canFastAppendShape, canFastBackspaceShape, supportsFastEchoTerminal } from '../components/textInput.js'
+import {
+  canFastAppendShape,
+  canFastBackspaceShape,
+  containsHangulImeCommit,
+  normalizeImeTerminatorOrder,
+  shouldDeferImeTerminator,
+  supportsFastEchoTerminal
+} from '../components/textInput.js'
 
 // The fast-echo path bypasses Ink and writes characters directly to stdout
 // for the common case of typing plain English at the end of the line. These
@@ -16,6 +23,33 @@ import { canFastAppendShape, canFastBackspaceShape, supportsFastEchoTerminal } f
 //   - #5221  TUI input box renders incorrectly for CJK / East-Asian wide
 //   - #7443  CLI TUI renders and deletes Chinese characters incorrectly
 //   - #17602 / #17603  Chinese text scattering / ghosting
+
+describe('IME terminator ordering', () => {
+  it('moves leading punctuation after a following Hangul commit', () => {
+    expect(normalizeImeTerminatorOrder('.돼')).toBe('돼.')
+    expect(normalizeImeTerminatorOrder('!돼')).toBe('돼!')
+    expect(normalizeImeTerminatorOrder('?돼')).toBe('돼?')
+  })
+
+  it('does not rewrite ordinary ASCII chunks, spaces, or already-correct Korean text', () => {
+    expect(normalizeImeTerminatorOrder('.done')).toBe('.done')
+    expect(normalizeImeTerminatorOrder(' 돼')).toBe(' 돼')
+    expect(normalizeImeTerminatorOrder('돼.')).toBe('돼.')
+  })
+
+  it('identifies short ASCII IME terminators for brief deferral', () => {
+    expect(shouldDeferImeTerminator('.')).toBe(true)
+    expect(shouldDeferImeTerminator('!')).toBe(true)
+    expect(shouldDeferImeTerminator(' ')).toBe(true)
+    expect(shouldDeferImeTerminator('a')).toBe(false)
+    expect(shouldDeferImeTerminator('....')).toBe(false)
+  })
+
+  it('recognizes Hangul commit text', () => {
+    expect(containsHangulImeCommit('돼')).toBe(true)
+    expect(containsHangulImeCommit('abc')).toBe(false)
+  })
+})
 
 describe('canFastAppendShape', () => {
   const COLS = 40

--- a/ui-tui/src/__tests__/textInputWrap.test.ts
+++ b/ui-tui/src/__tests__/textInputWrap.test.ts
@@ -2,7 +2,13 @@ import { wrapAnsi } from '@hermes/ink'
 import { describe, expect, it } from 'vitest'
 
 import { offsetFromPosition } from '../components/textInput.js'
-import { composerPromptWidth, cursorLayout, inputVisualHeight, stableComposerColumns } from '../lib/inputMetrics.js'
+import {
+  composerInputSurfaceHeight,
+  composerPromptWidth,
+  cursorLayout,
+  inputVisualHeight,
+  stableComposerColumns
+} from '../lib/inputMetrics.js'
 
 // Helper: compute the "end of text" position that wrap-ansi would render
 // the input to. This is what Ink's <Text wrap="wrap"> uses, so cursorLayout
@@ -98,6 +104,11 @@ describe('input metrics helpers', () => {
     expect(inputVisualHeight('one\ntwo', 40)).toBe(2)
     // Multi-line wrap case sanity
     expect(inputVisualHeight('hello world', 8)).toBe(2)
+  })
+
+  it('keeps the composer background surface at least three rows tall', () => {
+    expect(composerInputSurfaceHeight(inputVisualHeight('', 80))).toBe(3)
+    expect(composerInputSurfaceHeight(inputVisualHeight('one\ntwo\nthree\nfour', 80))).toBe(4)
   })
 
   it('counts the prompt gap as its own cell', () => {

--- a/ui-tui/src/__tests__/textInputWrap.test.ts
+++ b/ui-tui/src/__tests__/textInputWrap.test.ts
@@ -106,8 +106,8 @@ describe('input metrics helpers', () => {
     expect(inputVisualHeight('hello world', 8)).toBe(2)
   })
 
-  it('keeps the composer background surface at least three rows tall', () => {
-    expect(composerInputSurfaceHeight(inputVisualHeight('', 80))).toBe(3)
+  it('keeps the compact composer background surface at one row for empty input', () => {
+    expect(composerInputSurfaceHeight(inputVisualHeight('', 80))).toBe(1)
     expect(composerInputSurfaceHeight(inputVisualHeight('one\ntwo\nthree\nfour', 80))).toBe(4)
   })
 

--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -44,7 +44,7 @@ describe('DEFAULT_THEME', () => {
     const { DEFAULT_THEME } = await importThemeWithCleanEnv()
 
     expect(DEFAULT_THEME.brand.name).toBe('Hermes Agent')
-    expect(DEFAULT_THEME.brand.prompt).toBe('>')
+    expect(DEFAULT_THEME.brand.prompt).toBe(':')
     expect(DEFAULT_THEME.brand.tool).toBe('┊')
   })
 

--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -44,7 +44,7 @@ describe('DEFAULT_THEME', () => {
     const { DEFAULT_THEME } = await importThemeWithCleanEnv()
 
     expect(DEFAULT_THEME.brand.name).toBe('Hermes Agent')
-    expect(DEFAULT_THEME.brand.prompt).toBe('❯')
+    expect(DEFAULT_THEME.brand.prompt).toBe('>')
     expect(DEFAULT_THEME.brand.tool).toBe('┊')
   })
 

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -48,14 +48,14 @@ describe('applyDisplay', () => {
     expect(s.streaming).toBe(false)
   })
 
-  it('coerces legacy true + "on" alias to top', () => {
+  it('coerces legacy true + "on" alias to bottom', () => {
     const setBell = vi.fn()
 
     applyDisplay({ config: { display: { tui_statusbar: true as unknown as 'on' } } }, setBell)
-    expect($uiState.get().statusBar).toBe('top')
+    expect($uiState.get().statusBar).toBe('bottom')
 
     applyDisplay({ config: { display: { tui_statusbar: 'on' } } }, setBell)
-    expect($uiState.get().statusBar).toBe('top')
+    expect($uiState.get().statusBar).toBe('bottom')
   })
 
   it('applies v1 parity defaults when display fields are missing', () => {
@@ -68,7 +68,7 @@ describe('applyDisplay', () => {
     expect(s.inlineDiffs).toBe(true)
     expect(s.showCost).toBe(false)
     expect(s.showReasoning).toBe(false)
-    expect(s.statusBar).toBe('top')
+    expect(s.statusBar).toBe('bottom')
     expect(s.streaming).toBe(true)
     expect(s.sections).toEqual({})
   })
@@ -163,34 +163,34 @@ describe('applyDisplay', () => {
     expect($uiState.get().statusBar).toBe('bottom')
 
     applyDisplay({ config: { display: { tui_statusbar: 'top' } } }, setBell)
-    expect($uiState.get().statusBar).toBe('top')
+    expect($uiState.get().statusBar).toBe('bottom')
   })
 })
 
 describe('normalizeStatusBar', () => {
-  it('maps legacy bool + on alias to top/off', () => {
-    expect(normalizeStatusBar(true)).toBe('top')
+  it('maps legacy bool + on alias to bottom/off', () => {
+    expect(normalizeStatusBar(true)).toBe('bottom')
     expect(normalizeStatusBar(false)).toBe('off')
-    expect(normalizeStatusBar('on')).toBe('top')
+    expect(normalizeStatusBar('on')).toBe('bottom')
   })
 
-  it('passes through the canonical enum', () => {
+  it('keeps supported enum values but coerces top to bottom', () => {
     expect(normalizeStatusBar('off')).toBe('off')
-    expect(normalizeStatusBar('top')).toBe('top')
+    expect(normalizeStatusBar('top')).toBe('bottom')
     expect(normalizeStatusBar('bottom')).toBe('bottom')
   })
 
-  it('defaults missing/unknown values to top', () => {
-    expect(normalizeStatusBar(undefined)).toBe('top')
-    expect(normalizeStatusBar(null)).toBe('top')
-    expect(normalizeStatusBar('sideways')).toBe('top')
-    expect(normalizeStatusBar(42)).toBe('top')
+  it('defaults missing/unknown values to bottom', () => {
+    expect(normalizeStatusBar(undefined)).toBe('bottom')
+    expect(normalizeStatusBar(null)).toBe('bottom')
+    expect(normalizeStatusBar('sideways')).toBe('bottom')
+    expect(normalizeStatusBar(42)).toBe('bottom')
   })
 
   it('trims whitespace and folds case', () => {
     expect(normalizeStatusBar(' Bottom ')).toBe('bottom')
-    expect(normalizeStatusBar('TOP')).toBe('top')
-    expect(normalizeStatusBar('  on  ')).toBe('top')
+    expect(normalizeStatusBar('TOP')).toBe('bottom')
+    expect(normalizeStatusBar('  on  ')).toBe('bottom')
     expect(normalizeStatusBar('OFF')).toBe('off')
   })
 })

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { applyVoiceRecordResponse, shouldFallThroughForScroll } from '../app/useInputHandlers.js'
+import { applyCompletionReplacement, applyVoiceRecordResponse, shouldFallThroughForScroll } from '../app/useInputHandlers.js'
 
 const baseKey = {
   downArrow: false,
@@ -39,6 +39,28 @@ describe('shouldFallThroughForScroll — keep transcript scrolling alive during 
 
   it('does NOT fall through for unrelated state (no scroll keys held)', () => {
     expect(shouldFallThroughForScroll(baseKey)).toBe(false)
+  })
+})
+
+describe('applyCompletionReplacement', () => {
+  it('inserts only the completion text field, never display/meta prompt text', () => {
+    expect(
+      applyCompletionReplacement('/', 1, {
+        display: '/help',
+        meta: 'Show help and commands',
+        text: '/help'
+      })
+    ).toBe('/help')
+  })
+
+  it('preserves the existing leading slash when replacing a slash-command prefix', () => {
+    expect(
+      applyCompletionReplacement('/he', 1, {
+        display: '/help',
+        meta: 'Show help and commands',
+        text: '/help'
+      })
+    ).toBe('/help')
   })
 })
 

--- a/ui-tui/src/__tests__/virtualHeights.test.ts
+++ b/ui-tui/src/__tests__/virtualHeights.test.ts
@@ -18,10 +18,10 @@ describe('virtual height estimates', () => {
   })
 
   it('uses compound user prompt width when estimating user message wrapping', () => {
-    const msg: Msg = { role: 'user', text: 'x'.repeat(21) }
+    const msg: Msg = { role: 'user', text: 'x'.repeat(23) }
 
-    expect(estimatedMsgHeight(msg, 26, { compact: false, details: false, userPrompt: '❯' })).toBe(3)
-    expect(estimatedMsgHeight(msg, 26, { compact: false, details: false, userPrompt: 'Ψ >' })).toBe(4)
+    expect(estimatedMsgHeight(msg, 30, { compact: false, details: false, userPrompt: '❯' })).toBe(3)
+    expect(estimatedMsgHeight(msg, 30, { compact: false, details: false, userPrompt: 'Ψ >' })).toBe(4)
   })
 
   it('includes detail sections when visible', () => {
@@ -32,15 +32,15 @@ describe('virtual height estimates', () => {
     )
   })
 
-  it('accounts for the response separator when assistant details are visible', () => {
+  it('accounts for attached action-feed details when assistant details are visible', () => {
     const msg: Msg = { role: 'assistant', text: 'ok', thinking: 'plan' }
 
     expect(estimatedMsgHeight(msg, 80, { compact: false, details: true })).toBe(
-      estimatedMsgHeight(msg, 80, { compact: false, details: false }) + 3
+      estimatedMsgHeight(msg, 80, { compact: false, details: false }) + 2
     )
   })
 
-  it('does not account for a response separator without visible details', () => {
+  it('does not account for attached details without visible details', () => {
     const msg: Msg = { role: 'assistant', text: 'ok' }
 
     expect(estimatedMsgHeight(msg, 80, { compact: false, details: true })).toBe(
@@ -69,6 +69,23 @@ describe('virtual height estimates', () => {
         toolsVisible: false
       })
     ).toBe(estimatedMsgHeight(toolsOnly, 80, { compact: false, details: false }))
+  })
+
+  it('accounts for assistant log prefix rows', () => {
+    const plain: Msg = { role: 'assistant', text: '파일 확인 중입니다.' }
+    const prefixed: Msg = { role: 'assistant', text: '진행상황: 파일 확인 중입니다.' }
+
+    expect(estimatedMsgHeight(prefixed, 80, { compact: false, details: false })).toBe(
+      estimatedMsgHeight(plain, 80, { compact: false, details: false }) + 1
+    )
+  })
+
+  it('reserves the action-feed bottom gap for visible trail rows', () => {
+    const trail: Msg = { kind: 'trail', role: 'system', text: '', tools: ['Terminal("npm test")'] }
+
+    expect(estimatedMsgHeight(trail, 80, { compact: false, details: true })).toBe(
+      estimatedMsgHeight(trail, 80, { compact: false, details: true, toolsVisible: false }) + 2
+    )
   })
 
   it('reserves two extra rows for the inter-turn separator on non-first user messages', () => {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -340,7 +340,10 @@ export interface AppLayoutComposerProps {
 }
 
 export interface AppLayoutProgressProps {
+  busy: boolean
   showProgressArea: boolean
+  statusColor: string
+  turnStartedAt: null | number
 }
 
 export interface AppLayoutStatusProps {

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -520,23 +520,25 @@ export const coreCommands: SlashCommand[] = [
 
   {
     aliases: ['sb'],
-    help: 'status bar position (on|off|top|bottom)',
+    help: 'status bar position (on|off|bottom)',
     name: 'statusbar',
     run: (arg, ctx) => {
       const mode = arg.trim().toLowerCase()
-      const toggle: StatusBarMode = ctx.ui.statusBar === 'off' ? 'top' : 'off'
+      const toggle: StatusBarMode = ctx.ui.statusBar === 'off' ? 'bottom' : 'off'
 
       const next: null | StatusBarMode =
         !mode || mode === 'toggle'
           ? toggle
-          : mode === 'on' || mode === 'top'
-            ? 'top'
-            : mode === 'off' || mode === 'bottom'
-              ? mode
-              : null
+          : mode === 'on'
+            ? 'bottom'
+            : mode === 'top'
+              ? 'bottom'
+              : mode === 'off' || mode === 'bottom'
+                ? mode
+                : null
 
       if (!next) {
-        return ctx.transcript.sys('usage: /statusbar [on|off|top|bottom|toggle]')
+        return ctx.transcript.sys('usage: /statusbar [on|off|bottom|toggle]')
       }
 
       patchUiState({ statusBar: next })

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -324,7 +324,7 @@ class TurnController {
     const todos = parseTodos(value)
 
     if (todos !== null) {
-      patchTurnState({ todos })
+      patchTurnState({ todoCollapsed: false, todos })
     }
   }
 

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -25,7 +25,7 @@ const buildUiState = (): UiState => ({
   showReasoning: false,
   sid: null,
   status: 'summoning hermes…',
-  statusBar: 'top',
+  statusBar: 'bottom',
   streaming: true,
   theme: DEFAULT_THEME,
   usage: ZERO

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -28,12 +28,12 @@ import { patchUiState } from './uiStore.js'
 const STATUSBAR_ALIAS: Record<string, StatusBarMode> = {
   bottom: 'bottom',
   off: 'off',
-  on: 'top',
-  top: 'top'
+  on: 'bottom',
+  top: 'bottom'
 }
 
 export const normalizeStatusBar = (raw: unknown): StatusBarMode =>
-  raw === false ? 'off' : typeof raw === 'string' ? (STATUSBAR_ALIAS[raw.trim().toLowerCase()] ?? 'top') : 'top'
+  raw === false ? 'off' : typeof raw === 'string' ? (STATUSBAR_ALIAS[raw.trim().toLowerCase()] ?? 'bottom') : 'bottom'
 
 const BUSY_MODES = new Set<BusyInputMode>(['interrupt', 'queue', 'steer'])
 

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -15,7 +15,7 @@ import { computePrecisionWheelStep, initPrecisionWheel } from '../lib/precisionW
 import { computeWheelStep, initWheelAccelForHost } from '../lib/wheelAccel.js'
 
 import { getInputSelection } from './inputSelectionStore.js'
-import type { InputHandlerContext, InputHandlerResult } from './interfaces.js'
+import type { CompletionItem, InputHandlerContext, InputHandlerResult } from './interfaces.js'
 import { $isBlocked, $overlayState, patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
 import { patchTurnState } from './turnStore.js'
@@ -77,6 +77,17 @@ export function applyVoiceRecordResponse(
   } else {
     voice.setProcessing(false)
   }
+}
+
+export function applyCompletionReplacement(
+  input: string,
+  compReplace: number,
+  row: Pick<CompletionItem, 'text'>
+): string {
+  const replaceUntil = Math.max(0, Math.min(compReplace, input.length))
+  const text = input.startsWith('/') && row.text.startsWith('/') && replaceUntil > 0 ? row.text.slice(1) : row.text
+
+  return input.slice(0, replaceUntil) + text
 }
 
 export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
@@ -551,12 +562,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       const row = cState.completions[cState.compIdx]
 
       if (row?.text) {
-        const text =
-          cState.input.startsWith('/') && row.text.startsWith('/') && cState.compReplace > 0
-            ? row.text.slice(1)
-            : row.text
-
-        cActions.setInput(cState.input.slice(0, cState.compReplace) + text)
+        cActions.setInput(applyCompletionReplacement(cState.input, cState.compReplace, row))
       }
 
       return

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -997,7 +997,15 @@ export function useMainApp(gw: GatewayClient) {
   // Pass current progress through unfrozen — streaming update throttling
   // handles interaction load; progress must stay truthful so panels don't
   // randomly disappear when the live tail scrolls offscreen.
-  const appProgress = useMemo(() => ({ showProgressArea }), [showProgressArea])
+  const appProgress = useMemo(
+    () => ({
+      busy: ui.busy,
+      showProgressArea,
+      statusColor: statusColorOf(ui.status, ui.theme.color),
+      turnStartedAt: ui.sid ? turnStartedAt : null
+    }),
+    [showProgressArea, turnStartedAt, ui.busy, ui.sid, ui.status, ui.theme.color]
+  )
 
   const cwd = ui.info?.cwd || process.env.HERMES_CWD || process.cwd()
   const gitBranch = useGitBranch(cwd)

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -322,6 +322,7 @@ export function StatusRule({
   const bar = usage.context_max ? ctxBar(pct) : ''
   const { leftWidth, rightWidth, separatorWidth } = statusRuleWidths(cols, cwdLabel)
   const sessionCountText = liveSessionCount > 0 ? statusSessionCountLabel(liveSessionCount) : ''
+  const busyHint = busy ? 'Ctrl+C interrupt' : ''
   const handleSessionCountClick = (event: { stopImmediatePropagation?: () => void }) => {
     event.stopImmediatePropagation?.()
     onSessionCountClick?.()
@@ -399,6 +400,12 @@ export function StatusRule({
           <Text color={t.color.muted} wrap="truncate-end">
             {' │ '}
             {bgCount} bg
+          </Text>
+        ) : null}
+        {busyHint ? (
+          <Text color={t.color.warn} wrap="truncate-end">
+            {' │ '}
+            {busyHint}
           </Text>
         ) : null}
         {showCost && typeof usage.cost_usd === 'number' ? (

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -30,6 +30,13 @@ function ctxBarColor(pct: number | undefined, t: Theme) {
   return t.color.statusGood
 }
 
+function ctxBar(pct: number | undefined, w = 10) {
+  const p = Math.max(0, Math.min(100, pct ?? 0))
+  const filled = Math.round((p / 100) * w)
+
+  return '█'.repeat(filled) + '░'.repeat(w - filled)
+}
+
 export function statusRuleWidths(cols: number, cwdLabel: string) {
   const width = Math.max(1, Math.floor(cols || 1))
   const desiredSeparatorWidth = width >= 24 ? 3 : 1
@@ -123,6 +130,7 @@ export function StatusRule({
     : usage.total > 0
       ? `${fmtK(usage.total)} tok`
       : ''
+  const bar = usage.context_max ? ctxBar(pct) : ''
 
   return (
     <Box height={1}>
@@ -134,16 +142,26 @@ export function StatusRule({
           {modelLabel(model, modelReasoningEffort, modelFast)}
         </Text>
         {ctxLabel ? (
-          <Text color={contextColor} wrap="truncate-end">
-            {' │ '}
-            Context {ctxLabel}
-          </Text>
+          <>
+            <Text color={contextColor} wrap="truncate-end">
+              {' │ '}
+              Context {ctxLabel}
+            </Text>
+            {bar ? (
+              <Text color={contextColor} wrap="truncate-end">
+                {' '}
+                [{bar}]
+              </Text>
+            ) : null}
+          </>
         ) : null}
         {sessionStartedAt ? (
-          <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
-            <SessionDuration startedAt={sessionStartedAt} />
-          </Text>
+          <>
+            <Text color={ctxLabel ? contextColor : t.color.muted}> │ </Text>
+            <Text color={t.color.muted} wrap="truncate-end">
+              <SessionDuration startedAt={sessionStartedAt} />
+            </Text>
+          </>
         ) : null}
       </Box>
     </Box>

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -9,6 +9,7 @@ import type { Theme } from '../theme.js'
 import type { Msg, Usage } from '../types.js'
 
 const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
+const STATUS_SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
 
 function ctxBarColor(pct: number | undefined, t: Theme) {
   if (pct == null) {
@@ -88,6 +89,28 @@ const shortModelLabel = (model: string) =>
 const modelLabel = (model: string, effort?: string, fast?: boolean) =>
   [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
 
+function StatusBusyIndicator({ busy, t }: { busy: boolean; t: Theme }) {
+  const [frame, setFrame] = useState(0)
+
+  useEffect(() => {
+    if (!busy) {
+      setFrame(0)
+
+      return
+    }
+
+    const id = setInterval(() => setFrame(value => (value + 1) % STATUS_SPINNER_FRAMES.length), 120)
+
+    return () => clearInterval(id)
+  }, [busy])
+
+  if (!busy) {
+    return null
+  }
+
+  return <Text color={t.color.accent}>{STATUS_SPINNER_FRAMES[frame]} </Text>
+}
+
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   const [active, setActive] = useState(false)
   const [color, setColor] = useState(t.color.accent)
@@ -114,6 +137,7 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
 }
 
 export function StatusRule({
+  busy,
   cols,
   model,
   modelFast,
@@ -138,13 +162,16 @@ export function StatusRule({
         <Text color={t.color.border} wrap="truncate-end">
           {'─ '}
         </Text>
+        <StatusBusyIndicator busy={busy} t={t} />
         <Text color={t.color.muted} wrap="truncate-end">
           {modelLabel(model, modelReasoningEffort, modelFast)}
         </Text>
         {ctxLabel ? (
           <>
-            <Text color={contextColor} wrap="truncate-end">
+            <Text color={t.color.muted} wrap="truncate-end">
               {' │ '}
+            </Text>
+            <Text color={contextColor} wrap="truncate-end">
               Context {ctxLabel}
             </Text>
             {bar ? (
@@ -157,7 +184,7 @@ export function StatusRule({
         ) : null}
         {sessionStartedAt ? (
           <>
-            <Text color={ctxLabel ? contextColor : t.color.muted}> │ </Text>
+            <Text color={t.color.muted}> │ </Text>
             <Text color={t.color.muted} wrap="truncate-end">
               <SessionDuration startedAt={sessionStartedAt} />
             </Text>

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -1,6 +1,7 @@
 import { Box, type ScrollBoxHandle, stringWidth, Text } from '@hermes/ink'
 import { type ReactNode, type RefObject, useEffect, useRef, useState } from 'react'
 
+import { VERBS } from '../content/verbs.js'
 import { fmtDuration } from '../domain/messages.js'
 import { stickyPromptFromViewport } from '../domain/viewport.js'
 import { fmtK } from '../lib/text.js'
@@ -10,6 +11,9 @@ import type { Msg, Usage } from '../types.js'
 
 const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
 const STATUS_SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+
+export const VERB_PAD_LEN = Math.max(...VERBS.map(verb => verb.length)) + 1
+export const padVerb = (verb: string) => `${verb}…`.padEnd(VERB_PAD_LEN)
 
 function ctxBarColor(pct: number | undefined, t: Theme) {
   if (pct == null) {

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -1,127 +1,14 @@
 import { Box, type ScrollBoxHandle, stringWidth, Text } from '@hermes/ink'
-import { useStore } from '@nanostores/react'
-import { type ReactNode, type RefObject, useEffect, useMemo, useRef, useState } from 'react'
-import unicodeSpinners from 'unicode-animations'
+import { type ReactNode, type RefObject, useEffect, useRef, useState } from 'react'
 
-import { $delegationState } from '../app/delegationStore.js'
-import type { IndicatorStyle } from '../app/interfaces.js'
-import { useTurnSelector } from '../app/turnStore.js'
-import { $uiState } from '../app/uiStore.js'
-import { FACES } from '../content/faces.js'
-import { VERBS } from '../content/verbs.js'
 import { fmtDuration } from '../domain/messages.js'
 import { stickyPromptFromViewport } from '../domain/viewport.js'
-import { buildSubagentTree, treeTotals, widthByDepth } from '../lib/subagentTree.js'
 import { fmtK } from '../lib/text.js'
 import { useScrollbarSnapshot, useViewportSnapshot } from '../lib/viewportStore.js'
 import type { Theme } from '../theme.js'
 import type { Msg, Usage } from '../types.js'
 
-const FACE_TICK_MS = 2500
 const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
-
-// Keep verb segment width stable so status-bar content to the right doesn't
-// jitter when the ticker rotates between short/long verbs.
-export const VERB_PAD_LEN = VERBS.reduce((max, v) => Math.max(max, v.length), 0) + 1 // + ellipsis
-export const padVerb = (verb: string) => `${verb}…`.padEnd(VERB_PAD_LEN, ' ')
-
-// Compact alternates for the `emoji` and `ascii` indicator styles.
-// Each entry is a fixed-width (display-width) glyph.
-const EMOJI_FRAMES = ['⚕ ', '🌀', '🤔', '✨', '🍵', '🔮']
-const ASCII_FRAMES = ['|', '/', '-', '\\']
-
-// Faster tick for spinner-style indicators — they read as motion only
-// at frame rates closer to their authored interval.
-const SPINNER_TICK_MS = 100
-
-interface IndicatorRender {
-  frame: string
-  intervalMs: number
-  // When false, FaceTicker hides the rotating verb and just shows the
-  // glyph + duration.  Lets `unicode` stay minimal while the other
-  // styles keep the verb-rotation flavour users associate with the
-  // running… status.
-  showVerb: boolean
-}
-
-const renderIndicator = (style: IndicatorStyle, tick: number): IndicatorRender => {
-  if (style === 'kaomoji') {
-    return { frame: FACES[tick % FACES.length] ?? '', intervalMs: FACE_TICK_MS, showVerb: true }
-  }
-
-  if (style === 'emoji') {
-    return {
-      frame: EMOJI_FRAMES[tick % EMOJI_FRAMES.length] ?? '⚕ ',
-      intervalMs: SPINNER_TICK_MS * 6,
-      showVerb: true
-    }
-  }
-
-  if (style === 'ascii') {
-    return {
-      frame: ASCII_FRAMES[tick % ASCII_FRAMES.length] ?? '|',
-      intervalMs: SPINNER_TICK_MS,
-      showVerb: true
-    }
-  }
-
-  // 'unicode' — braille spinner (fixed 1-col).  Authored interval is
-  // ~80ms; honour it but bound below at a safe minimum so React
-  // re-renders stay reasonable.  This style is for users who want
-  // the cleanest possible status, so no verb rotation either.
-  const spinner = unicodeSpinners.braille
-  const frame = spinner.frames[tick % spinner.frames.length] ?? '⠋'
-
-  return { frame, intervalMs: Math.max(SPINNER_TICK_MS, spinner.interval), showVerb: false }
-}
-
-function FaceTicker({ color, startedAt }: { color: string; startedAt?: null | number }) {
-  const ui = useStore($uiState)
-  const style = ui.indicatorStyle
-  const [tick, setTick] = useState(() => Math.floor(Math.random() * 1000))
-  const [verbTick, setVerbTick] = useState(() => Math.floor(Math.random() * VERBS.length))
-  const [now, setNow] = useState(() => Date.now())
-
-  // Pre-compute cadence + verb-visibility for the active style so an
-  // `/indicator` switch re-arms the interval (and skips the verb timer
-  // for verb-less styles like `unicode`) without leaving the previous
-  // timer dangling.
-  const { intervalMs, showVerb } = renderIndicator(style, 0)
-
-  useEffect(() => {
-    const glyph = setInterval(() => setTick(n => n + 1), intervalMs)
-    const clock = setInterval(() => setNow(Date.now()), 1000)
-    // Verb timer is gated on `showVerb` — `unicode` style hides the verb
-    // entirely, so cycling `verbTick` would be an avoidable re-render.
-    const verb = showVerb ? setInterval(() => setVerbTick(n => n + 1), FACE_TICK_MS) : null
-
-    return () => {
-      clearInterval(glyph)
-      clearInterval(clock)
-
-      if (verb !== null) {
-        clearInterval(verb)
-      }
-    }
-  }, [intervalMs, showVerb])
-
-  const { frame } = renderIndicator(style, tick)
-  const verb = VERBS[verbTick % VERBS.length] ?? ''
-  const verbSegment = showVerb ? ` ${padVerb(verb)}` : ''
-  // Leading space keeps a gap between the frame and the duration when the
-  // verb segment is hidden (e.g. `unicode` spinner style).  When the verb
-  // IS shown, its trailing padding already provides the gap, so the extra
-  // space is harmless.
-  const durationSegment = startedAt ? ` · ${fmtDuration(now - startedAt)}` : ''
-
-  return (
-    <Text color={color}>
-      {frame}
-      {verbSegment}
-      {durationSegment}
-    </Text>
-  )
-}
 
 function ctxBarColor(pct: number | undefined, t: Theme) {
   if (pct == null) {
@@ -143,17 +30,6 @@ function ctxBarColor(pct: number | undefined, t: Theme) {
   return t.color.statusGood
 }
 
-function statusSessionCountLabel(count: number) {
-  return `${count} ${count === 1 ? 'session' : 'sessions'}`
-}
-
-function ctxBar(pct: number | undefined, w = 10) {
-  const p = Math.max(0, Math.min(100, pct ?? 0))
-  const filled = Math.round((p / 100) * w)
-
-  return '█'.repeat(filled) + '░'.repeat(w - filled)
-}
-
 export function statusRuleWidths(cols: number, cwdLabel: string) {
   const width = Math.max(1, Math.floor(cols || 1))
   const desiredSeparatorWidth = width >= 24 ? 3 : 1
@@ -169,67 +45,6 @@ export function statusRuleWidths(cols: number, cwdLabel: string) {
   const leftWidth = Math.max(1, width - separatorWidth - rightWidth)
 
   return { leftWidth, rightWidth, separatorWidth }
-}
-
-function SpawnHud({ t }: { t: Theme }) {
-  // Tight HUD that only appears when the session is actually fanning out.
-  // Colour escalates to warn/error as depth or concurrency approaches the cap.
-  const delegation = useStore($delegationState)
-  const subagents = useTurnSelector(state => state.subagents)
-
-  const tree = useMemo(() => buildSubagentTree(subagents), [subagents])
-  const totals = useMemo(() => treeTotals(tree), [tree])
-
-  if (!totals.descendantCount && !delegation.paused) {
-    return null
-  }
-
-  const maxDepth = delegation.maxSpawnDepth
-  const maxConc = delegation.maxConcurrentChildren
-  const depth = Math.max(0, totals.maxDepthFromHere)
-  const active = totals.activeCount
-
-  // `max_concurrent_children` is a per-parent cap, not a global one.
-  // `activeCount` sums every running agent across the tree and would
-  // over-warn for multi-orchestrator runs.  The widest level of the tree
-  // is a closer proxy to "most concurrent spawns that could be hitting a
-  // single parent's slot budget".
-  const widestLevel = widthByDepth(tree).reduce((a, b) => Math.max(a, b), 0)
-  const depthRatio = maxDepth ? depth / maxDepth : 0
-  const concRatio = maxConc ? widestLevel / maxConc : 0
-  const ratio = Math.max(depthRatio, concRatio)
-
-  const color = delegation.paused || ratio >= 1 ? t.color.error : ratio >= 0.66 ? t.color.warn : t.color.muted
-
-  const pieces: string[] = []
-
-  if (delegation.paused) {
-    pieces.push('⏸ paused')
-  }
-
-  if (totals.descendantCount > 0) {
-    const depthLabel = maxDepth ? `${depth}/${maxDepth}` : `${depth}`
-    pieces.push(`d${depthLabel}`)
-
-    if (active > 0) {
-      // Label pairs the widest-level count (drives concRatio above) with
-      // the total active count for context.  `W/cap` triggers the warn,
-      // `+N` is everything else currently running across the tree.
-      const extra = Math.max(0, active - widestLevel)
-      const widthLabel = maxConc ? `${widestLevel}/${maxConc}` : `${widestLevel}`
-      const suffix = extra > 0 ? `+${extra}` : ''
-      pieces.push(`⚡${widthLabel}${suffix}`)
-    }
-  }
-
-  const atCap = depthRatio >= 1 || concRatio >= 1
-
-  return (
-    <Text color={color}>
-      {atCap ? ' │ ⚠ ' : ' │ '}
-      {pieces.join(' ')}
-    </Text>
-  )
 }
 
 function SessionDuration({ startedAt }: { startedAt: number }) {
@@ -292,79 +107,36 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
 }
 
 export function StatusRule({
-  cwdLabel,
   cols,
-  busy,
-  status,
-  statusColor,
   model,
   modelFast,
   modelReasoningEffort,
   usage,
-  bgCount,
-  liveSessionCount,
   sessionStartedAt,
-  showCost,
-  turnStartedAt,
-  voiceLabel,
-  onSessionCountClick,
   t
 }: StatusRuleProps) {
   const pct = usage.context_percent
-  const barColor = ctxBarColor(pct, t)
+  const contextColor = ctxBarColor(pct, t)
 
   const ctxLabel = usage.context_max
-    ? `${fmtK(usage.context_used ?? 0)}/${fmtK(usage.context_max)}`
+    ? `${fmtK(usage.context_used ?? 0)}/${fmtK(usage.context_max)}${pct != null ? ` ${pct}%` : ''}`
     : usage.total > 0
       ? `${fmtK(usage.total)} tok`
       : ''
 
-  const bar = usage.context_max ? ctxBar(pct) : ''
-  const { leftWidth, rightWidth, separatorWidth } = statusRuleWidths(cols, cwdLabel)
-  const sessionCountText = liveSessionCount > 0 ? statusSessionCountLabel(liveSessionCount) : ''
-  const busyHint = busy ? 'Ctrl+C interrupt' : ''
-  const handleSessionCountClick = (event: { stopImmediatePropagation?: () => void }) => {
-    event.stopImmediatePropagation?.()
-    onSessionCountClick?.()
-  }
-
-  const sessionCountNode = sessionCountText ? (
-    onSessionCountClick ? (
-      <Box flexShrink={0} onClick={handleSessionCountClick}>
-        <Text color={t.color.accent}> │ {sessionCountText}</Text>
-      </Box>
-    ) : (
-      <Text color={t.color.muted}> │ {sessionCountText}</Text>
-    )
-  ) : null
-
   return (
     <Box height={1}>
-      <Box flexDirection="row" flexShrink={1} overflow="hidden" width={leftWidth}>
+      <Box flexDirection="row" flexShrink={1} overflow="hidden" width={Math.max(1, cols)}>
         <Text color={t.color.border} wrap="truncate-end">
           {'─ '}
         </Text>
-        {busy ? (
-          <FaceTicker color={statusColor} startedAt={turnStartedAt} />
-        ) : (
-          <Text color={statusColor} wrap="truncate-end">
-            {status}
-          </Text>
-        )}
         <Text color={t.color.muted} wrap="truncate-end">
-          {' │ '}
           {modelLabel(model, modelReasoningEffort, modelFast)}
         </Text>
         {ctxLabel ? (
-          <Text color={t.color.muted} wrap="truncate-end">
+          <Text color={contextColor} wrap="truncate-end">
             {' │ '}
-            {ctxLabel}
-          </Text>
-        ) : null}
-        {bar ? (
-          <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
-            <Text color={barColor}>[{bar}]</Text> <Text color={barColor}>{pct != null ? `${pct}%` : ''}</Text>
+            Context {ctxLabel}
           </Text>
         ) : null}
         {sessionStartedAt ? (
@@ -373,59 +145,7 @@ export function StatusRule({
             <SessionDuration startedAt={sessionStartedAt} />
           </Text>
         ) : null}
-        {typeof usage.compressions === 'number' && usage.compressions > 0 ? (
-          <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
-            <Text
-              color={usage.compressions >= 10 ? t.color.error : usage.compressions >= 5 ? t.color.warn : t.color.muted}
-            >
-              cmp {usage.compressions}
-            </Text>
-          </Text>
-        ) : null}
-        <SpawnHud t={t} />
-        {voiceLabel ? (
-          <Text
-            color={
-              voiceLabel.startsWith('●') ? t.color.error : voiceLabel.startsWith('◉') ? t.color.warn : t.color.muted
-            }
-            wrap="truncate-end"
-          >
-            {' │ '}
-            {voiceLabel}
-          </Text>
-        ) : null}
-        {sessionCountNode}
-        {bgCount > 0 ? (
-          <Text color={t.color.muted} wrap="truncate-end">
-            {' │ '}
-            {bgCount} bg
-          </Text>
-        ) : null}
-        {busyHint ? (
-          <Text color={t.color.warn} wrap="truncate-end">
-            {' │ '}
-            {busyHint}
-          </Text>
-        ) : null}
-        {showCost && typeof usage.cost_usd === 'number' ? (
-          <Text color={t.color.muted} wrap="truncate-end">
-            {' │ $'}
-            {usage.cost_usd.toFixed(4)}
-          </Text>
-        ) : null}
       </Box>
-
-      {rightWidth > 0 ? (
-        <>
-          <Text color={t.color.border}>{separatorWidth >= 3 ? ' ─ ' : ' '}</Text>
-          <Box flexShrink={0} width={rightWidth}>
-            <Text color={t.color.label} wrap="truncate-end">
-              {cwdLabel}
-            </Text>
-          </Box>
-        </>
-      ) : null}
     </Box>
   )
 }

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -20,7 +20,7 @@ import { composerPromptText } from '../lib/prompt.js'
 
 import { AgentsOverlay } from './agentsOverlay.js'
 import { GoodVibesHeart, StatusRule, StickyPromptTracker, TranscriptScrollbar } from './appChrome.js'
-import { FloatingOverlays, PromptZone } from './appOverlays.js'
+import { CompletionOverlay, FloatingOverlays, PromptZone } from './appOverlays.js'
 import { Banner, Panel, SessionPanel } from './branding.js'
 import { FpsOverlay } from './fpsOverlay.js'
 import { HelpHint } from './helpHint.js'
@@ -235,17 +235,16 @@ const ComposerPane = memo(function ComposerPane({
 
       <Box flexDirection="column" marginTop={ui.statusBar === 'top' ? 0 : 1} position="relative">
         <FloatingOverlays
-          cols={composer.cols}
-          compIdx={composer.compIdx}
-          completions={composer.completions}
-          onActiveSessionSelect={actions.activateLiveSession}
           onActiveSessionClose={actions.closeLiveSession}
+          onActiveSessionSelect={actions.activateLiveSession}
           onModelSelect={actions.onModelSelect}
           onNewLiveSession={actions.newLiveSession}
           onNewPromptSession={actions.newPromptSession}
           onPickerSelect={actions.resumeById}
           pagerPageSize={composer.pagerPageSize}
         />
+
+        <CompletionOverlay cols={composer.cols} compIdx={composer.compIdx} completions={composer.completions} />
 
         {composer.input === '?' && !composer.inputBuf.length && <HelpHint t={ui.theme} />}
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -25,7 +25,7 @@ import { FpsOverlay } from './fpsOverlay.js'
 import { HelpHint } from './helpHint.js'
 import { MessageLine } from './messageLine.js'
 import { QueuedMessages } from './queuedMessages.js'
-import { LiveTodoPanel, StreamingAssistant } from './streamingAssistant.js'
+import { StreamingAssistant } from './streamingAssistant.js'
 import { TextInput, type TextInputMouseApi } from './textInput.js'
 
 const PromptPrefix = memo(function PromptPrefix({
@@ -60,21 +60,6 @@ const TranscriptPane = memo(function TranscriptPane({
   transcript
 }: Pick<AppLayoutProps, 'actions' | 'composer' | 'progress' | 'transcript'>) {
   const ui = useStore($uiState)
-
-  // LiveTodoPanel rides as a child of the latest user-message row so it
-  // visually belongs to the prompt and follows it during scroll. -1 when
-  // empty → row.index === -1 is always false → no render.
-  const lastUserIdx = useMemo(() => {
-    const items = transcript.historyItems
-
-    for (let i = items.length - 1; i >= 0; i--) {
-      if (items[i].role === 'user') {
-        return i
-      }
-    }
-
-    return -1
-  }, [transcript.historyItems])
 
   // Index of the first user-role message; every later user message gets a
   // small dash above it so multi-turn transcripts visually segment by
@@ -130,7 +115,6 @@ const TranscriptPane = memo(function TranscriptPane({
                 />
               )}
 
-              {row.index === lastUserIdx && <LiveTodoPanel />}
             </Box>
           ))}
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -10,6 +10,7 @@ import { INLINE_MODE, SHOW_FPS, TERMUX_TUI_MODE } from '../config/env.js'
 import { PLACEHOLDER } from '../content/placeholders.js'
 import {
   COMPOSER_PROMPT_GAP_WIDTH,
+  composerInputSurfaceHeight,
   composerPromptWidth,
   inputVisualHeight,
   stableComposerColumns
@@ -158,6 +159,7 @@ const ComposerPane = memo(function ComposerPane({
   const promptBlank = ' '.repeat(promptWidth)
   const inputColumns = stableComposerColumns(composer.cols, promptWidth, TERMUX_TUI_MODE)
   const inputHeight = inputVisualHeight(composer.input, inputColumns)
+  const inputSurfaceHeight = composerInputSurfaceHeight(inputHeight)
   const inputMouseRef = useRef<null | TextInputMouseApi>(null)
 
   const captureInputDrag = (e: GutterMouseEvent) => {
@@ -250,7 +252,7 @@ const ComposerPane = memo(function ComposerPane({
         {!isBlocked && (
           <>
             {composer.inputBuf.map((line, i) => (
-              <Box key={i}>
+              <Box backgroundColor={ui.theme.color.completionBg} key={i} width={Math.max(1, composer.cols - 2)}>
                 <Box width={promptWidth}>
                   {i === 0 ? (
                     <PromptPrefix color={ui.theme.color.muted} promptText={promptText} width={promptWidth} />
@@ -264,6 +266,8 @@ const ComposerPane = memo(function ComposerPane({
             ))}
 
             <Box
+              backgroundColor={ui.theme.color.completionBg}
+              height={inputSurfaceHeight}
               onMouseDown={captureInputDrag}
               onMouseDrag={dragFromPromptRow}
               onMouseUp={endInputDrag}
@@ -289,6 +293,7 @@ const ComposerPane = memo(function ComposerPane({
                   onPaste={composer.handleTextPaste}
                   onSubmit={composer.submit}
                   placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'Ctrl+C to interrupt…' : ''}
+                  placeholderColor={ui.theme.color.muted}
                   value={composer.input}
                   voiceRecordKey={composer.voiceRecordKey}
                 />

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -18,6 +18,8 @@ import { SkillsHub } from './skillsHub.js'
 
 const COMPLETION_WINDOW = 16
 
+export const completionOverlayMode = () => 'flow' as const
+
 export function completionRowStyle(active: boolean, theme: Theme) {
   return {
     commandColor: active ? theme.color.primary : theme.color.label,
@@ -25,6 +27,61 @@ export function completionRowStyle(active: boolean, theme: Theme) {
     metaColor: active ? theme.color.text : theme.color.muted,
     rowBackground: active ? theme.color.statusBg : undefined
   }
+}
+
+export function CompletionOverlay({
+  cols,
+  compIdx,
+  completions
+}: Pick<AppOverlaysProps, 'cols' | 'compIdx' | 'completions'>) {
+  const theme = useStore($uiTheme)
+
+  if (!completions.length) {
+    return null
+  }
+
+  // Fixed viewport centered on compIdx — previously the slice end was
+  // compIdx + 8 so the dropdown grew from 8 rows to 16 as the user scrolled
+  // down, bouncing the height on every keystroke.
+  const viewportSize = Math.min(COMPLETION_WINDOW, completions.length)
+  const start = Math.max(0, Math.min(compIdx - Math.floor(COMPLETION_WINDOW / 2), completions.length - viewportSize))
+
+  return (
+    <FloatBox color={theme.color.primary}>
+      <Box flexDirection="column" width={Math.max(28, cols - 6)}>
+        {completions.slice(start, start + viewportSize).map((item, i) => {
+          const active = start + i === compIdx
+          const style = completionRowStyle(active, theme)
+
+          return (
+            <Box
+              backgroundColor={style.rowBackground}
+              flexDirection="row"
+              key={`${start + i}:${item.text}:${item.display}:${item.meta ?? ''}`}
+              width="100%"
+            >
+              {/* flexShrink=0 — when meta overflows the row, Ink/Yoga
+                  otherwise shaves the last char off the display column
+                  (e.g. /goal renders as /goa). */}
+              <Box flexShrink={0}>
+                <Text color={style.markerColor}>{active ? ' ❯ ' : '   '}</Text>
+                <Text bold={active} color={style.commandColor}>
+                  {' '}
+                  {item.display}
+                </Text>
+              </Box>
+              {item.meta ? (
+                <Text color={style.metaColor} dimColor={!active}>
+                  {' '}
+                  {item.meta}
+                </Text>
+              ) : null}
+            </Box>
+          )
+        })}
+      </Box>
+    </FloatBox>
+  )
 }
 
 export function PromptZone({
@@ -103,9 +160,6 @@ export function PromptZone({
 }
 
 export function FloatingOverlays({
-  cols,
-  compIdx,
-  completions,
   onActiveSessionSelect,
   onActiveSessionClose,
   onModelSelect,
@@ -115,9 +169,6 @@ export function FloatingOverlays({
   pagerPageSize
 }: Pick<
   AppOverlaysProps,
-  | 'cols'
-  | 'compIdx'
-  | 'completions'
   | 'onActiveSessionSelect'
   | 'onActiveSessionClose'
   | 'onModelSelect'
@@ -131,24 +182,11 @@ export function FloatingOverlays({
   const sid = useStore($uiSessionId)
   const theme = useStore($uiTheme)
 
-  const hasAny =
-    overlay.modelPicker ||
-    overlay.pager ||
-    overlay.picker ||
-    overlay.sessions ||
-    overlay.skillsHub ||
-    completions.length
+  const hasAny = overlay.modelPicker || overlay.pager || overlay.picker || overlay.sessions || overlay.skillsHub
 
   if (!hasAny) {
     return null
   }
-
-  // Fixed viewport centered on compIdx — previously the slice end was
-  // compIdx + 8 so the dropdown grew from 8 rows to 16 as the user scrolled
-  // down, bouncing the height on every keystroke.
-  const viewportSize = Math.min(COMPLETION_WINDOW, completions.length)
-
-  const start = Math.max(0, Math.min(compIdx - Math.floor(COMPLETION_WINDOW / 2), completions.length - viewportSize))
 
   return (
     <Box alignItems="flex-start" bottom="100%" flexDirection="column" left={0} position="absolute" right={0}>
@@ -222,42 +260,6 @@ export function FloatingOverlays({
         </FloatBox>
       )}
 
-      {!!completions.length && (
-        <FloatBox color={theme.color.primary}>
-          <Box flexDirection="column" width={Math.max(28, cols - 6)}>
-            {completions.slice(start, start + viewportSize).map((item, i) => {
-              const active = start + i === compIdx
-              const style = completionRowStyle(active, theme)
-
-              return (
-                <Box
-                  backgroundColor={style.rowBackground}
-                  flexDirection="row"
-                  key={`${start + i}:${item.text}:${item.display}:${item.meta ?? ''}`}
-                  width="100%"
-                >
-                  {/* flexShrink=0 — when meta overflows the row, Ink/Yoga
-                      otherwise shaves the last char off the display column
-                      (e.g. /goal renders as /goa). */}
-                  <Box flexShrink={0}>
-                    <Text color={style.markerColor}>{active ? ' ❯ ' : '   '}</Text>
-                    <Text bold={active} color={style.commandColor}>
-                      {' '}
-                      {item.display}
-                    </Text>
-                  </Box>
-                  {item.meta ? (
-                    <Text color={style.metaColor} dimColor={!active}>
-                      {' '}
-                      {item.meta}
-                    </Text>
-                  ) : null}
-                </Box>
-              )
-            })}
-          </Box>
-        </FloatBox>
-      )}
     </Box>
   )
 }

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -5,6 +5,7 @@ import { useGateway } from '../app/gatewayContext.js'
 import type { AppOverlaysProps } from '../app/interfaces.js'
 import { $overlayState, patchOverlayState } from '../app/overlayStore.js'
 import { $uiSessionId, $uiTheme } from '../app/uiStore.js'
+import type { Theme } from '../theme.js'
 
 import { ActiveSessionSwitcher } from './activeSessionSwitcher.js'
 import { FloatBox } from './appChrome.js'
@@ -16,6 +17,15 @@ import { SessionPicker } from './sessionPicker.js'
 import { SkillsHub } from './skillsHub.js'
 
 const COMPLETION_WINDOW = 16
+
+export function completionRowStyle(active: boolean, theme: Theme) {
+  return {
+    commandColor: active ? theme.color.primary : theme.color.label,
+    markerColor: active ? theme.color.primary : theme.color.muted,
+    metaColor: active ? theme.color.text : theme.color.muted,
+    rowBackground: active ? theme.color.statusBg : undefined
+  }
+}
 
 export function PromptZone({
   cols,
@@ -217,10 +227,11 @@ export function FloatingOverlays({
           <Box flexDirection="column" width={Math.max(28, cols - 6)}>
             {completions.slice(start, start + viewportSize).map((item, i) => {
               const active = start + i === compIdx
+              const style = completionRowStyle(active, theme)
 
               return (
                 <Box
-                  backgroundColor={active ? theme.color.completionCurrentBg : theme.color.completionBg}
+                  backgroundColor={style.rowBackground}
                   flexDirection="row"
                   key={`${start + i}:${item.text}:${item.display}:${item.meta ?? ''}`}
                   width="100%"
@@ -229,16 +240,14 @@ export function FloatingOverlays({
                       otherwise shaves the last char off the display column
                       (e.g. /goal renders as /goa). */}
                   <Box flexShrink={0}>
-                    <Text bold color={theme.color.label}>
+                    <Text color={style.markerColor}>{active ? ' ❯ ' : '   '}</Text>
+                    <Text bold={active} color={style.commandColor}>
                       {' '}
                       {item.display}
                     </Text>
                   </Box>
                   {item.meta ? (
-                    <Text
-                      backgroundColor={active ? theme.color.completionMetaCurrentBg : theme.color.completionMetaBg}
-                      color={theme.color.muted}
-                    >
+                    <Text color={style.metaColor} dimColor={!active}>
                       {' '}
                       {item.meta}
                     </Text>

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -752,7 +752,18 @@ function MdImpl({ cols, compact, t, text }: MdProps) {
 
         nodes.push(
           <Box flexDirection="column" key={key} paddingLeft={2}>
-            {lang && !isDiff && <Text color={t.color.muted}>{'─ ' + lang}</Text>}
+            {lang && !isDiff && (
+              <Box>
+                <Text color={t.color.muted}>┌─ </Text>
+                <Text bold inverse color={t.color.text}>
+                  {' '}
+                  {lang}{' '}
+                </Text>
+                <Text color={t.color.muted} dim>
+                  {' code block'}
+                </Text>
+              </Box>
+            )}
 
             {block.map((l, j) => {
               if (highlighted) {

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -7,6 +7,7 @@ import { sectionMode } from '../domain/details.js'
 import { userDisplay } from '../domain/messages.js'
 import { ROLE } from '../domain/roles.js'
 import { transcriptBodyWidth, transcriptGutterWidth } from '../lib/inputMetrics.js'
+import { splitAssistantLogPrefix } from '../lib/assistantLogPrefix.js'
 import {
   boundedLiveRenderText,
   compactPreview,
@@ -66,7 +67,7 @@ export const MessageLine = memo(function MessageLine({
 
   if (msg.kind === 'trail' && (msg.tools?.length || tools.length || thinking)) {
     return thinkingMode !== 'hidden' || toolsMode !== 'hidden' || activityMode !== 'hidden' ? (
-      <Box flexDirection="column">
+      <Box flexDirection="column" marginBottom={1}>
         <ToolTrail
           commandOverride={detailsModeCommandOverride}
           detailsMode={detailsMode}
@@ -109,8 +110,6 @@ export const MessageLine = memo(function MessageLine({
   const showDetails =
     (toolsMode !== 'hidden' && Boolean(msg.tools?.length)) || (thinkingMode !== 'hidden' && Boolean(thinking))
 
-  const showResponseSeparator = shouldShowResponseSeparator(msg, showDetails)
-
   const content = (() => {
     if (msg.kind === 'slash') {
       return <Text color={t.color.muted}>{msg.text}</Text>
@@ -143,6 +142,26 @@ export const MessageLine = memo(function MessageLine({
 
     if (msg.role === 'assistant') {
       const bodyWidth = transcriptBodyWidth(cols, msg.role, t.brand.prompt, TERMUX_TUI_MODE)
+      const logPrefix = splitAssistantLogPrefix(msg.text)
+
+      if (logPrefix) {
+        const bodyText = isStreaming ? boundedLiveRenderText(logPrefix.body) : logPrefix.body
+
+        return (
+          <Box flexDirection="column">
+            <Text bold color={t.color.label}>
+              {logPrefix.prefix}:
+            </Text>
+            {bodyText ? (
+              isStreaming ? (
+                <StreamingMd cols={bodyWidth} compact={compact} t={t} text={bodyText} />
+              ) : (
+                <Md cols={bodyWidth} compact={compact} t={t} text={bodyText} />
+              )
+            ) : null}
+          </Box>
+        )
+      }
 
       return isStreaming ? (
         // Incremental markdown: split at the last stable block boundary so
@@ -181,11 +200,21 @@ export const MessageLine = memo(function MessageLine({
   return (
     <Box
       flexDirection="column"
-      marginBottom={msg.role === 'user' || isDiffSegment ? 1 : 0}
+      marginBottom={msg.role === 'user' || isDiffSegment || showDetails ? 1 : 0}
       marginTop={msg.role === 'user' || msg.kind === 'slash' || isDiffSegment ? 1 : 0}
     >
+      <Box backgroundColor={userBackground} paddingX={msg.role === 'user' ? 1 : 0}>
+        <NoSelect flexShrink={0} fromLeftEdge width={gutterWidth}>
+          <Text bold={msg.role === 'user'} color={prefix}>
+            {glyph}{' '}
+          </Text>
+        </NoSelect>
+
+        <Box width={transcriptBodyWidth(cols, msg.role, t.brand.prompt, TERMUX_TUI_MODE)}>{content}</Box>
+      </Box>
+
       {showDetails && (
-        <Box flexDirection="column" marginBottom={1}>
+        <Box flexDirection="column">
           <ToolTrail
             commandOverride={detailsModeCommandOverride}
             detailsMode={detailsMode}
@@ -198,33 +227,9 @@ export const MessageLine = memo(function MessageLine({
           />
         </Box>
       )}
-
-      {showResponseSeparator && (
-        <Box marginBottom={1}>
-          <NoSelect flexShrink={0} fromLeftEdge width={gutterWidth}>
-            <Text color={t.color.border}>└─ </Text>
-          </NoSelect>
-          <Text color={t.color.muted} dim>
-            Response
-          </Text>
-        </Box>
-      )}
-
-      <Box backgroundColor={userBackground} paddingX={msg.role === 'user' ? 1 : 0}>
-        <NoSelect flexShrink={0} fromLeftEdge width={gutterWidth}>
-          <Text bold={msg.role === 'user'} color={prefix}>
-            {glyph}{' '}
-          </Text>
-        </NoSelect>
-
-        <Box width={transcriptBodyWidth(cols, msg.role, t.brand.prompt, TERMUX_TUI_MODE)}>{content}</Box>
-      </Box>
     </Box>
   )
 })
-
-export const shouldShowResponseSeparator = (msg: Msg, showDetails: boolean): boolean =>
-  msg.role === 'assistant' && showDetails && /\S/.test(msg.text)
 
 interface MessageLineProps {
   cols: number

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -176,6 +176,8 @@ export const MessageLine = memo(function MessageLine({
   // against the prose around it.
   const isDiffSegment = msg.kind === 'diff'
 
+  const userBackground = msg.role === 'user' ? t.color.completionBg : undefined
+
   return (
     <Box
       flexDirection="column"
@@ -208,7 +210,7 @@ export const MessageLine = memo(function MessageLine({
         </Box>
       )}
 
-      <Box>
+      <Box backgroundColor={userBackground} paddingX={msg.role === 'user' ? 1 : 0}>
         <NoSelect flexShrink={0} fromLeftEdge width={gutterWidth}>
           <Text bold={msg.role === 'user'} color={prefix}>
             {glyph}{' '}

--- a/ui-tui/src/components/streamingAssistant.tsx
+++ b/ui-tui/src/components/streamingAssistant.tsx
@@ -15,6 +15,15 @@ import { TodoPanel } from './todoPanel.js'
 const groupedSegments = (segments: Msg[]): Msg[] =>
   segments.reduce<Msg[]>((acc, msg) => appendToolShelfMessage(acc, msg), [])
 
+const WORKING_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+const WORKING_BAR_WIDTH = 14
+
+const workingBar = (tick: number, width = WORKING_BAR_WIDTH) => {
+  const head = tick % width
+
+  return `[${Array.from({ length: width }, (_, index) => (index === head ? '◆' : index < head ? '━' : '─')).join('')}]`
+}
+
 const InlineProgress = memo(function InlineProgress({ progress }: { progress: AppLayoutProgressProps }) {
   const [now, setNow] = useState(() => Date.now())
 
@@ -24,7 +33,7 @@ const InlineProgress = memo(function InlineProgress({ progress }: { progress: Ap
     }
 
     setNow(Date.now())
-    const id = setInterval(() => setNow(Date.now()), 1000)
+    const id = setInterval(() => setNow(Date.now()), 250)
 
     return () => clearInterval(id)
   }, [progress.busy, progress.turnStartedAt])
@@ -33,11 +42,16 @@ const InlineProgress = memo(function InlineProgress({ progress }: { progress: Ap
     return null
   }
 
-  const elapsed = progress.turnStartedAt ? fmtDuration(now - progress.turnStartedAt) : '…'
+  const elapsedMs = progress.turnStartedAt ? now - progress.turnStartedAt : 0
+  const elapsed = progress.turnStartedAt ? fmtDuration(elapsedMs) : '…'
+  const tick = Math.floor(elapsedMs / 250)
 
   return (
     <Box marginBottom={1} marginTop={1}>
-      <Text color={progress.statusColor}>• Working ({elapsed} · Ctrl+C to interrupt)</Text>
+      <Text color={progress.statusColor}>
+        {WORKING_FRAMES[tick % WORKING_FRAMES.length]} Working {elapsed} {workingBar(tick)}
+        <Text dim> Ctrl+C to interrupt</Text>
+      </Text>
     </Box>
   )
 })
@@ -63,8 +77,6 @@ export const StreamingAssistant = memo(function StreamingAssistant({
 
   return (
     <>
-      <InlineProgress progress={progress} />
-
       {groupedSegments(streamSegments).map((msg, i) => (
         <MessageLine
           cols={cols}
@@ -119,6 +131,9 @@ export const StreamingAssistant = memo(function StreamingAssistant({
           t={ui.theme}
         />
       )}
+
+      <LiveTodoPanel />
+      <InlineProgress progress={progress} />
     </>
   )
 })

--- a/ui-tui/src/components/streamingAssistant.tsx
+++ b/ui-tui/src/components/streamingAssistant.tsx
@@ -1,9 +1,11 @@
 import { useStore } from '@nanostores/react'
-import { memo } from 'react'
+import { Box, Text } from '@hermes/ink'
+import { memo, useEffect, useState } from 'react'
 
 import type { AppLayoutProgressProps } from '../app/interfaces.js'
 import { toggleTodoCollapsed, useTurnSelector } from '../app/turnStore.js'
 import { $uiState } from '../app/uiStore.js'
+import { fmtDuration } from '../domain/messages.js'
 import { appendToolShelfMessage } from '../lib/liveProgress.js'
 import type { DetailsMode, Msg, SectionVisibility } from '../types.js'
 
@@ -12,6 +14,33 @@ import { TodoPanel } from './todoPanel.js'
 
 const groupedSegments = (segments: Msg[]): Msg[] =>
   segments.reduce<Msg[]>((acc, msg) => appendToolShelfMessage(acc, msg), [])
+
+const InlineProgress = memo(function InlineProgress({ progress }: { progress: AppLayoutProgressProps }) {
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    if (!progress.busy) {
+      return
+    }
+
+    setNow(Date.now())
+    const id = setInterval(() => setNow(Date.now()), 1000)
+
+    return () => clearInterval(id)
+  }, [progress.busy, progress.turnStartedAt])
+
+  if (!progress.busy) {
+    return null
+  }
+
+  const elapsed = progress.turnStartedAt ? fmtDuration(now - progress.turnStartedAt) : '…'
+
+  return (
+    <Box marginBottom={1} marginTop={1}>
+      <Text color={progress.statusColor}>• Working ({elapsed} · Ctrl+C to interrupt)</Text>
+    </Box>
+  )
+})
 
 export const StreamingAssistant = memo(function StreamingAssistant({
   cols,
@@ -28,12 +57,14 @@ export const StreamingAssistant = memo(function StreamingAssistant({
   const activeTools = useTurnSelector(state => state.tools)
   const showStreamingArea = Boolean(streaming)
 
-  if (!progress.showProgressArea && !showStreamingArea && !activeTools.length) {
+  if (!progress.busy && !progress.showProgressArea && !showStreamingArea && !activeTools.length) {
     return null
   }
 
   return (
     <>
+      <InlineProgress progress={progress} />
+
       {groupedSegments(streamSegments).map((msg, i) => (
         <MessageLine
           cols={cols}

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -36,6 +36,10 @@ const PRINTABLE = /^[ -~\u00a0-\uffff]+$/
 const BRACKET_PASTE = new RegExp(`${ESC}?\\[20[01]~`, 'g')
 const FRAME_BATCH_MS = 16
 const MULTI_CLICK_MS = 500
+const IME_TERMINATOR_HOLD_MS = 40
+const IME_TERMINATOR_RE = /^[ .,!?:;]+$/
+const LEADING_IME_TERMINATOR_RE = /^([.,!?:;]+)([\u1100-\u11ff\u3130-\u318f\ua960-\ua97f\uac00-\ud7af\ud7b0-\ud7ff]+)$/
+const HANGUL_IME_COMMIT_RE = /[\u1100-\u11ff\u3130-\u318f\ua960-\ua97f\uac00-\ud7af\ud7b0-\ud7ff]/
 
 const invert = (s: string) => INV + s + INV_OFF
 const dim = (s: string) => DIM + s + DIM_OFF
@@ -121,6 +125,21 @@ export function applyPrintableInsert(
 }
 
 export const shouldRouteMultiCharInputAsPaste = (text: string): boolean => text.includes('\n')
+
+export const containsHangulImeCommit = (text: string): boolean => HANGUL_IME_COMMIT_RE.test(text)
+
+export const shouldDeferImeTerminator = (text: string): boolean =>
+  text.length > 0 && text.length <= 3 && IME_TERMINATOR_RE.test(text)
+
+export const normalizeImeTerminatorOrder = (text: string): string => {
+  const match = LEADING_IME_TERMINATOR_RE.exec(text)
+
+  if (!match) {
+    return text
+  }
+
+  return `${match[2]}${match[1]}`
+}
 
 function prevPos(s: string, p: number) {
   const pos = snapPos(s, p)
@@ -436,6 +455,7 @@ export function TextInput({
   const editVersionRef = useRef(0)
   const parentChangeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pendingParentValue = useRef<string | null>(null)
+  const pendingImeTerminator = useRef<null | { text: string; timer: ReturnType<typeof setTimeout> | null }>(null)
   const localRenderTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lineWidthRef = useRef(stringWidth(value.includes('\n') ? value.slice(value.lastIndexOf('\n') + 1) : value))
   const mouseAnchorRef = useRef<null | number>(null)
@@ -571,6 +591,10 @@ export function TextInput({
 
       if (parentChangeTimer.current) {
         clearTimeout(parentChangeTimer.current)
+      }
+
+      if (pendingImeTerminator.current?.timer) {
+        clearTimeout(pendingImeTerminator.current.timer)
       }
 
       if (localRenderTimer.current) {
@@ -731,6 +755,7 @@ export function TextInput({
     }
 
     flushParentChange()
+    flushPendingImeTerminator()
   }
 
   const scheduleKeyBurstCommit = (next: string, nextCur: number) => {
@@ -744,6 +769,51 @@ export function TextInput({
       keyBurstTimer.current = null
       flushParentChange()
     }, FRAME_BATCH_MS)
+  }
+
+  const takePendingImeTerminator = () => {
+    const pending = pendingImeTerminator.current
+
+    if (!pending) {
+      return ''
+    }
+
+    if (pending.timer) {
+      clearTimeout(pending.timer)
+    }
+
+    pendingImeTerminator.current = null
+
+    return pending.text
+  }
+
+  const flushPendingImeTerminator = () => {
+    const text = takePendingImeTerminator()
+
+    if (!text) {
+      return false
+    }
+
+    const c = curRef.current
+    const v = vRef.current
+    commit(v.slice(0, c) + text + v.slice(c), c + text.length)
+
+    return true
+  }
+
+  const deferImeTerminator = (text: string) => {
+    const existing = pendingImeTerminator.current
+
+    if (existing?.timer) {
+      clearTimeout(existing.timer)
+    }
+
+    const nextText = `${existing?.text ?? ''}${text}`
+    const timer = setTimeout(() => {
+      flushPendingImeTerminator()
+    }, IME_TERMINATOR_HOLD_MS)
+
+    pendingImeTerminator.current = { text: nextText, timer }
   }
 
   const clearSel = () => {
@@ -961,12 +1031,15 @@ export function TextInput({
       const actionDeleteToStart = (mod && inp === 'u') || isMacActionFallback(k, inp, 'u')
       const actionKillToEnd = (mod && inp === 'k') || isMacActionFallback(k, inp, 'k')
       const actionDeleteWord = (mod && inp === 'w') || isMacActionFallback(k, inp, 'w')
-      const range = selRange()
+      let range = selRange()
       const delFwd = k.delete || fwdDel.current
       const isPrintableInput = (event.keypress.isPasted || inp.length > 0) && PRINTABLE.test(inp.replace(BRACKET_PASTE, ''))
 
       if (!isPrintableInput) {
         flushKeyBurst()
+        c = curRef.current
+        v = vRef.current
+        range = selRange()
       }
 
       if (mod && inp === 'z') {
@@ -1082,7 +1155,11 @@ export function TextInput({
         }
       } else if (event.keypress.isPasted || inp.length > 0) {
         const bracketed = event.keypress.isPasted || inp.includes('[200~')
-        const text = inp.replace(BRACKET_PASTE, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+        let text = inp.replace(BRACKET_PASTE, '').replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+
+        if (!event.keypress.isPasted) {
+          text = normalizeImeTerminatorOrder(text)
+        }
 
         if (bracketed && emitPaste({ bracketed: true, cursor: c, text, value: v })) {
           return
@@ -1092,8 +1169,33 @@ export function TextInput({
           return
         }
 
+        if (!event.keypress.isPasted && pendingImeTerminator.current && containsHangulImeCommit(text) && !text.includes('\n')) {
+          const suffix = takePendingImeTerminator()
+          const inserted = applyPrintableInsert(v, c, `${text}${suffix}`, range)
+
+          if (!inserted) {
+            return
+          }
+
+          commit(inserted.value, inserted.cursor)
+
+          return
+        }
+
+        if (!event.keypress.isPasted && pendingImeTerminator.current) {
+          flushPendingImeTerminator()
+          c = curRef.current
+          v = vRef.current
+        }
+
         if (text === '\n') {
           return commit(ins(v, c, '\n'), c + 1)
+        }
+
+        if (!event.keypress.isPasted && !range && shouldDeferImeTerminator(text)) {
+          deferImeTerminator(text)
+
+          return
         }
 
         if (text.length > 1 || text.includes('\n')) {
@@ -1115,7 +1217,12 @@ export function TextInput({
 
           v = inserted.value
           c = inserted.cursor
-          scheduleKeyBurstCommit(v, c)
+
+          if (containsHangulImeCommit(text)) {
+            commit(v, c)
+          } else {
+            scheduleKeyBurstCommit(v, c)
+          }
 
           return
         }

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -29,8 +29,6 @@ const { Box, Text, useStdin, useInput, useStdout, stringWidth, useCursorAdvance,
 const ESC = '\x1b'
 const INV = `${ESC}[7m`
 const INV_OFF = `${ESC}[27m`
-const DIM = `${ESC}[2m`
-const DIM_OFF = `${ESC}[22m`
 const FWD_DEL_RE = new RegExp(`${ESC}\\[3(?:[~$^]|;)`)
 const PRINTABLE = /^[ -~\u00a0-\uffff]+$/
 const BRACKET_PASTE = new RegExp(`${ESC}?\\[20[01]~`, 'g')
@@ -42,7 +40,6 @@ const LEADING_IME_TERMINATOR_RE = /^([.,!?:;]+)([\u1100-\u11ff\u3130-\u318f\ua96
 const HANGUL_IME_COMMIT_RE = /[\u1100-\u11ff\u3130-\u318f\ua960-\ua97f\uac00-\ud7af\ud7b0-\ud7ff]/
 
 const invert = (s: string) => INV + s + INV_OFF
-const dim = (s: string) => DIM + s + DIM_OFF
 
 let _seg: Intl.Segmenter | null = null
 const seg = () => (_seg ??= new Intl.Segmenter(undefined, { granularity: 'grapheme' }))
@@ -438,6 +435,7 @@ export function TextInput({
   mouseApiRef,
   voiceRecordKey = DEFAULT_VOICE_RECORD_KEY,
   placeholder = '',
+  placeholderColor,
   focus = true
 }: TextInputProps) {
   const [cur, setCur] = useState(value.length)
@@ -519,17 +517,15 @@ export function TextInput({
 
   const nativeCursor = focus && termFocus && !selected && !!stdout?.isTTY
 
-  // Placeholder text is just a hint, not a selection — render it dim
-  // without inverse styling. In a TTY the hardware cursor parks at column
-  // 0 and visually marks the input start. Non-TTY surfaces still need the
-  // synthetic inverse first-char to draw a cursor at all.
+  // Placeholder text is just a hint, not a selection. Render it as normal
+  // Ink text instead of embedding ANSI dim/reset sequences in the content;
+  // raw SGR resets can visually punch through the composer's background box
+  // in some terminals. In a TTY the hardware cursor parks at column 0 and
+  // visually marks the input start. Non-TTY surfaces still need a synthetic
+  // inverse first-char to draw a cursor at all.
   const rendered = useMemo(() => {
     if (!focus) {
-      return display || dim(placeholder)
-    }
-
-    if (!display && placeholder) {
-      return nativeCursor ? dim(placeholder) : invert(placeholder[0] ?? ' ') + dim(placeholder.slice(1))
+      return display
     }
 
     if (selected) {
@@ -537,7 +533,9 @@ export function TextInput({
     }
 
     return nativeCursor ? display || ' ' : renderWithCursor(display, cur)
-  }, [cur, display, focus, nativeCursor, placeholder, selected])
+  }, [cur, display, focus, nativeCursor, selected])
+
+  const showPlaceholder = !display && !!placeholder
 
   useEffect(() => {
     if (self.current) {
@@ -1333,7 +1331,22 @@ export function TextInput({
       ref={boxRef}
       width={columns}
     >
-      <Text wrap="wrap">{rendered}</Text>
+      {showPlaceholder ? (
+        <Text wrap="wrap">
+          {focus && !nativeCursor ? (
+            <>
+              <Text color={placeholderColor} inverse>
+                {placeholder[0] ?? ' '}
+              </Text>
+              <Text color={placeholderColor}>{placeholder.slice(1)}</Text>
+            </>
+          ) : (
+            <Text color={placeholderColor}>{placeholder}</Text>
+          )}
+        </Text>
+      ) : (
+        <Text wrap="wrap">{rendered}</Text>
+      )}
     </Box>
   )
 }
@@ -1364,6 +1377,7 @@ interface TextInputProps {
   ) => { cursor: number; value: string } | Promise<{ cursor: number; value: string } | null> | null
   onSubmit?: (v: string) => void
   placeholder?: string
+  placeholderColor?: string
   value: string
   voiceRecordKey?: ParsedVoiceRecordKey
 }

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -40,6 +40,22 @@ const LEADING_IME_TERMINATOR_RE = /^([.,!?:;]+)([\u1100-\u11ff\u3130-\u318f\ua96
 const HANGUL_IME_COMMIT_RE = /[\u1100-\u11ff\u3130-\u318f\ua960-\ua97f\uac00-\ud7af\ud7b0-\ud7ff]/
 
 const invert = (s: string) => INV + s + INV_OFF
+const truthy = (value?: string) => /^(?:1|true|yes|on)$/i.test((value ?? '').trim())
+const falsy = (value?: string) => /^(?:0|false|no|off)$/i.test((value ?? '').trim())
+
+function parseFastEchoOverride(env: NodeJS.ProcessEnv): boolean | null {
+  const raw = env.HERMES_TUI_FAST_ECHO
+
+  if (truthy(raw)) {
+    return true
+  }
+
+  if (falsy(raw)) {
+    return false
+  }
+
+  return null
+}
 
 let _seg: Intl.Segmenter | null = null
 const seg = () => (_seg ??= new Intl.Segmenter(undefined, { granularity: 'grapheme' }))
@@ -344,9 +360,23 @@ export function canFastBackspaceShape(current: string, cursor: number, columns?:
 }
 
 export function supportsFastEchoTerminal(env: NodeJS.ProcessEnv = process.env): boolean {
+  const explicitOverride = parseFastEchoOverride(env)
+
+  if (explicitOverride !== null) {
+    return explicitOverride
+  }
+
   // Terminal.app still shows paint/cursor artifacts under the fast-echo
   // bypass path. Fall back to the normal Ink render path there.
   if ((env.TERM_PROGRAM ?? '').trim() === 'Apple_Terminal') {
+    return false
+  }
+
+  // tmux adds its own cursor/IME/alternate-buffer state layer. The direct
+  // stdout fast-echo path can race React layout there, which is exactly how
+  // typed text ends up visually below the composer instead of inside it. Keep
+  // tmux on the normal Ink render path unless explicitly opted in.
+  if (env.TMUX) {
     return false
   }
 

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -9,6 +9,7 @@ import {
   foldActionDetail,
   parseActionCall,
   selectVisibleActionFeedItems,
+  summarizeHiddenActionFeedItems,
   type ActionStatus
 } from '../lib/actionFeed.js'
 import {
@@ -254,15 +255,18 @@ function Chevron({
   tone?: 'dim' | 'error' | 'warn'
 }) {
   const color = tone === 'error' ? t.color.error : tone === 'warn' ? t.color.warn : t.color.muted
+  const emphasizedTitle = title === 'Action feed'
 
   return (
     <Box onClick={(e: any) => onClick(!!e?.shiftKey || !!e?.ctrlKey)}>
       <Text color={color} dim={tone === 'dim'}>
         <Text color={t.color.accent}>{open ? '▾ ' : '▸ '}</Text>
-        {title}
+        <Text bold={emphasizedTitle} color={emphasizedTitle ? t.color.label : color}>
+          {title}
+        </Text>
         {typeof count === 'number' ? ` (${count})` : ''}
         {suffix ? (
-          <Text color={t.color.statusFg} dim>
+          <Text color={t.color.statusFg} dim wrap="truncate-end">
             {'  '}
             {suffix}
           </Text>
@@ -908,7 +912,7 @@ export const ToolTrail = memo(function ToolTrail({
 
   // ── Derived ────────────────────────────────────────────────────
 
-  const { hidden: hiddenActionCount, items: visibleGroups } = selectVisibleActionFeedItems(groups)
+  const { hidden: hiddenActionCount, hiddenItems: hiddenActionGroups, items: visibleGroups } = selectVisibleActionFeedItems(groups)
   const hasTools = visibleGroups.length > 0
   const hasSubagents = subagents.length > 0
   const hasMeta = meta.length > 0
@@ -929,7 +933,11 @@ export const ToolTrail = memo(function ToolTrail({
   const visibleDelegateGroups = visibleGroups.filter(g => g.label.startsWith('Delegate Task'))
   const inlineDelegateKey =
     hasSubagents && allDelegateGroups.length === 1 && visibleDelegateGroups.length === 1 ? visibleDelegateGroups[0]!.key : null
-  const actionFeedSuffix = [hiddenActionCount > 0 ? `+${hiddenActionCount} hidden` : null, toolTokensLabel]
+  const hiddenActionSummary = summarizeHiddenActionFeedItems(hiddenActionGroups)
+  const actionFeedSuffix = [
+    hiddenActionCount > 0 ? `+${hiddenActionCount} hidden${hiddenActionSummary ? `: ${hiddenActionSummary}` : ''}` : null,
+    toolTokensLabel
+  ]
     .filter(Boolean)
     .join('  ')
 

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -4,7 +4,13 @@ import spinners, { type BrailleSpinnerName } from 'unicode-animations'
 
 import { THINKING_COT_MAX } from '../config/limits.js'
 import { sectionMode } from '../domain/details.js'
-import { actionStatusGlyph, foldActionDetail, parseActionCall, type ActionStatus } from '../lib/actionFeed.js'
+import {
+  actionStatusGlyph,
+  foldActionDetail,
+  parseActionCall,
+  selectVisibleActionFeedItems,
+  type ActionStatus
+} from '../lib/actionFeed.js'
 import {
   buildSubagentTree,
   fmtCost,
@@ -902,7 +908,8 @@ export const ToolTrail = memo(function ToolTrail({
 
   // ── Derived ────────────────────────────────────────────────────
 
-  const hasTools = groups.length > 0
+  const { hidden: hiddenActionCount, items: visibleGroups } = selectVisibleActionFeedItems(groups)
+  const hasTools = visibleGroups.length > 0
   const hasSubagents = subagents.length > 0
   const hasMeta = meta.length > 0
   const hasThinking = !!cot || reasoningActive || reasoningStreaming
@@ -918,8 +925,13 @@ export const ToolTrail = memo(function ToolTrail({
   const toolTokensLabel = toolTokens !== undefined && toolTokens > 0 ? `~${fmtK(toolTokens)} tokens` : undefined
 
   const totalTokensLabel = tokenCount > 0 && toolTokenCount > 0 ? `~${fmtK(totalTokenCount)} total` : null
-  const delegateGroups = groups.filter(g => g.label.startsWith('Delegate Task'))
-  const inlineDelegateKey = hasSubagents && delegateGroups.length === 1 ? delegateGroups[0]!.key : null
+  const allDelegateGroups = groups.filter(g => g.label.startsWith('Delegate Task'))
+  const visibleDelegateGroups = visibleGroups.filter(g => g.label.startsWith('Delegate Task'))
+  const inlineDelegateKey =
+    hasSubagents && allDelegateGroups.length === 1 && visibleDelegateGroups.length === 1 ? visibleDelegateGroups[0]!.key : null
+  const actionFeedSuffix = [hiddenActionCount > 0 ? `+${hiddenActionCount} hidden` : null, toolTokensLabel]
+    .filter(Boolean)
+    .join('  ')
 
   const toolLabel = (group: Group) => {
     const { duration, label } = splitToolDuration(String(group.content))
@@ -1078,7 +1090,7 @@ export const ToolTrail = memo(function ToolTrail({
     panels.push({
       header: (
         <Chevron
-          count={groups.length}
+          count={visibleGroups.length}
           onClick={shift => {
             if (shift) {
               expandAll()
@@ -1087,7 +1099,7 @@ export const ToolTrail = memo(function ToolTrail({
             }
           }}
           open={openTools}
-          suffix={toolTokensLabel}
+          suffix={actionFeedSuffix || undefined}
           t={t}
           title="Action feed"
         />
@@ -1096,8 +1108,8 @@ export const ToolTrail = memo(function ToolTrail({
       open: openTools,
       render: rails => (
         <Box flexDirection="column">
-          {groups.map((group, index) => {
-            const branch: TreeBranch = index === groups.length - 1 ? 'last' : 'mid'
+          {visibleGroups.map((group, index) => {
+            const branch: TreeBranch = index === visibleGroups.length - 1 ? 'last' : 'mid'
             const childRails = nextTreeRails(rails, branch)
             const hasInlineSubagents = inlineDelegateKey === group.key
 

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -4,6 +4,7 @@ import spinners, { type BrailleSpinnerName } from 'unicode-animations'
 
 import { THINKING_COT_MAX } from '../config/limits.js'
 import { sectionMode } from '../domain/details.js'
+import { actionStatusGlyph, foldActionDetail, parseActionCall, type ActionStatus } from '../lib/actionFeed.js'
 import {
   buildSubagentTree,
   fmtCost,
@@ -684,6 +685,7 @@ interface Group {
   details: DetailRow[]
   key: string
   label: string
+  status: ActionStatus
 }
 
 export const ToolTrail = memo(function ToolTrail({
@@ -790,24 +792,37 @@ export const ToolTrail = memo(function ToolTrail({
   const groups: Group[] = []
   const meta: DetailRow[] = []
   const pushDetail = (row: DetailRow) => (groups.at(-1)?.details ?? meta).push(row)
+  const foldedDetail = (detail: string, tone: ActionStatus) => {
+    const folded = foldActionDetail(detail)
+    const hidden = folded.hiddenLines > 0 ? `\n… +${folded.hiddenLines} lines hidden` : ''
+
+    return {
+      color: tone === 'error' ? t.color.error : t.color.muted,
+      content: `${folded.preview}${hidden}`,
+      dimColor: tone !== 'error'
+    }
+  }
 
   for (const [i, line] of trail.entries()) {
     const parsed = parseToolTrailResultLine(line)
 
     if (parsed) {
+      const status: ActionStatus = parsed.mark === '✗' ? 'error' : 'success'
+      const { duration, label: callWithoutDuration } = splitToolDuration(parsed.call)
+      const action = parseActionCall(callWithoutDuration)
+
       groups.push({
-        color: parsed.mark === '✗' ? t.color.error : t.color.text,
-        content: parsed.call,
+        color: status === 'error' ? t.color.error : t.color.text,
+        content: `${action.title}${duration}`,
         details: [],
         key: `tr-${i}`,
-        label: parsed.call
+        label: parsed.call,
+        status
       })
 
       if (parsed.detail) {
         pushDetail({
-          color: parsed.mark === '✗' ? t.color.error : t.color.muted,
-          content: parsed.detail,
-          dimColor: parsed.mark !== '✗',
+          ...foldedDetail(parsed.detail, status),
           key: `tr-${i}-d`
         })
       }
@@ -823,7 +838,8 @@ export const ToolTrail = memo(function ToolTrail({
         content: label,
         details: [{ color: t.color.muted, content: 'drafting...', dimColor: true, key: `tr-${i}-d` }],
         key: `tr-${i}`,
-        label
+        label,
+        status: 'running'
       })
 
       continue
@@ -851,16 +867,19 @@ export const ToolTrail = memo(function ToolTrail({
 
   for (const tool of tools) {
     const label = formatToolCall(tool.name, tool.context || '')
+    const action = parseActionCall(label)
+    const args = tool.verboseArgs ? foldActionDetail(`Args:\n${boundedLiveRenderText(tool.verboseArgs)}`) : null
 
     groups.push({
       color: t.color.text,
       key: tool.id,
       label,
-      details: tool.verboseArgs
+      status: 'running',
+      details: args
         ? [
             {
               color: t.color.muted,
-              content: `Args:\n${boundedLiveRenderText(tool.verboseArgs)}`,
+              content: `${args.preview}${args.hiddenLines > 0 ? `\n… +${args.hiddenLines} lines hidden` : ''}`,
               dimColor: true,
               key: `${tool.id}-args`
             }
@@ -868,7 +887,7 @@ export const ToolTrail = memo(function ToolTrail({
         : [],
       content: (
         <>
-          <Spinner color={t.color.accent} variant="tool" /> {label}
+          {action.title}
           {tool.startedAt ? ` (${fmtElapsed(now - tool.startedAt)})` : ''}
         </>
       )
@@ -915,6 +934,14 @@ export const ToolTrail = memo(function ToolTrail({
     ) : (
       group.content
     )
+  }
+
+  const actionGlyph = (group: Group) => {
+    if (group.status === 'running') {
+      return <Spinner color={t.color.accent} variant="tool" />
+    }
+
+    return <Text color={group.status === 'error' ? t.color.error : t.color.accent}>{actionStatusGlyph(group.status)}</Text>
   }
 
   // ── Backstop: floating alerts when every panel is hidden ─────────
@@ -1062,7 +1089,7 @@ export const ToolTrail = memo(function ToolTrail({
           open={openTools}
           suffix={toolTokensLabel}
           t={t}
-          title="Tool calls"
+          title="Action feed"
         />
       ),
       key: 'tools',
@@ -1081,7 +1108,7 @@ export const ToolTrail = memo(function ToolTrail({
                   color={group.color}
                   content={
                     <>
-                      <Text color={t.color.accent}>● </Text>
+                      {actionGlyph(group)} {' '}
                       {toolLabel(group)}
                     </>
                   }

--- a/ui-tui/src/config/env.ts
+++ b/ui-tui/src/config/env.ts
@@ -1,4 +1,5 @@
 import type { MouseTrackingMode } from '@hermes/ink'
+
 import { isTermuxTuiMode } from '../lib/termux.js'
 
 const truthy = (v?: string) => /^(?:1|true|yes|on)$/i.test((v ?? '').trim())
@@ -49,15 +50,20 @@ export const MOUSE_TRACKING: MouseTrackingMode = resolvedBootMouseEnabled ? 'all
 
 export const NO_CONFIRM_DESTRUCTIVE = truthy(process.env.HERMES_TUI_NO_CONFIRM)
 
-const inlineOverride = parseToggle(process.env.HERMES_TUI_INLINE)
-
 // Skip AlternateScreen — TUI renders into the primary buffer so the host
 // terminal's native scrollback captures whatever scrolls off the top.
 //
-// On Termux we default this on: users often background/foreground the app,
-// and primary-buffer rendering makes long-thread review and copy/paste much
-// less fragile. Override explicitly with HERMES_TUI_INLINE=0/1.
-export const INLINE_MODE = inlineOverride ?? TERMUX_TUI_MODE
+// On Termux and tmux we default this on: users often rely on the host/tmux
+// scrollback and copy-mode (`Ctrl-b [`). AlternateScreen makes tmux report
+// `alternate_on=1` and keeps pane history at 0, so copy-mode opens but cannot
+// scroll the Hermes transcript. Override explicitly with HERMES_TUI_INLINE=0/1.
+export const isInlineModeEnabled = (env: NodeJS.ProcessEnv = process.env): boolean => {
+  const override = parseToggle(env.HERMES_TUI_INLINE)
+
+  return override ?? (isTermuxTuiMode(env) || !!env.TMUX)
+}
+
+export const INLINE_MODE = isInlineModeEnabled()
 
 // Live FPS counter overlay, fed by ink's onFrame (real render rate, not a
 // synthetic timer).

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -5,7 +5,7 @@ import './lib/forceTruecolor.js'
 
 import type { FrameEvent } from '@hermes/ink'
 
-import { TERMUX_TUI_MODE } from './config/env.js'
+import { INLINE_MODE } from './config/env.js'
 import { GatewayClient } from './gatewayClient.js'
 import { setupGracefulExit } from './lib/gracefulExit.js'
 import { formatBytes, type HeapDumpResult, performHeapDump } from './lib/memory.js'
@@ -22,10 +22,10 @@ if (!process.stdin.isTTY) {
 // terminal tab can still have mouse/focus/paste modes enabled.
 resetTerminalModes()
 
-// Desktop terminals benefit from a clean startup slate because the TUI usually
-// runs in AlternateScreen. On Termux we keep prior output intact so users can
-// review/copy earlier assistant replies after reopening the app.
-if (TERMUX_TUI_MODE) {
+// AlternateScreen sessions benefit from a clean startup slate. Inline sessions
+// (Termux/tmux/HERMES_TUI_INLINE=1) intentionally keep primary-buffer
+// scrollback so native/tmux copy-mode can review earlier output.
+if (INLINE_MODE) {
   process.stdout.write('\n')
 } else {
   process.stdout.write('\x1b[2J\x1b[H\x1b[3J')

--- a/ui-tui/src/lib/actionFeed.ts
+++ b/ui-tui/src/lib/actionFeed.ts
@@ -2,6 +2,8 @@ import { compactPreview } from './text.js'
 
 export type ActionStatus = 'error' | 'running' | 'success'
 
+export const ACTION_FEED_VISIBLE_LIMIT = 5
+
 export interface ParsedActionCall {
   action: string
   subject: string
@@ -110,4 +112,45 @@ export const foldActionDetail = (detail: string, maxLines = 4, maxChars = 420): 
 
   const hiddenLines = Math.max(0, lines.length - visible.length)
   return { hiddenLines, preview: visible.join('\n') }
+}
+
+export interface ActionFeedItemLike {
+  label: string
+  status: ActionStatus
+}
+
+const IMPORTANT_ACTION_LABEL_RE = /^(?:Browser (?:Click|Navigate|Type)|Delegate Task|Execute Code|Patch|Terminal|Todo|Write File)/
+
+export const isImportantActionLabel = (label: string): boolean => IMPORTANT_ACTION_LABEL_RE.test(label)
+
+export const selectVisibleActionFeedItems = <T extends ActionFeedItemLike>(
+  items: readonly T[],
+  limit = ACTION_FEED_VISIBLE_LIMIT
+): { hidden: number; items: T[] } => {
+  if (items.length <= limit) {
+    return { hidden: 0, items: [...items] }
+  }
+
+  const keep = new Set<number>()
+
+  items.forEach((item, index) => {
+    if (item.status !== 'success' || isImportantActionLabel(item.label)) {
+      keep.add(index)
+    }
+  })
+
+  for (let index = Math.max(0, items.length - 2); index < items.length; index += 1) {
+    keep.add(index)
+  }
+
+  for (let index = items.length - 1; keep.size < Math.min(limit, items.length) && index >= 0; index -= 1) {
+    keep.add(index)
+  }
+
+  const selected = [...keep].sort((a, b) => a - b).slice(-limit)
+
+  return {
+    hidden: Math.max(0, items.length - selected.length),
+    items: selected.map(index => items[index]!)
+  }
 }

--- a/ui-tui/src/lib/actionFeed.ts
+++ b/ui-tui/src/lib/actionFeed.ts
@@ -2,7 +2,7 @@ import { compactPreview } from './text.js'
 
 export type ActionStatus = 'error' | 'running' | 'success'
 
-export const ACTION_FEED_VISIBLE_LIMIT = 5
+export const ACTION_FEED_VISIBLE_LIMIT = 3
 
 export interface ParsedActionCall {
   action: string
@@ -36,7 +36,7 @@ const tailPath = (value: string) => {
   return parts.length > 2 ? `…/${parts.slice(-2).join('/')}` : cleaned
 }
 
-const quoted = (value: string) => (value ? `"${compactPreview(cleanSubject(value), 56)}"` : '')
+const quoted = (value: string) => (value ? `"${compactPreview(cleanSubject(value), 72)}"` : '')
 
 const ACTIONS: Record<string, (subject: string) => ParsedActionCall> = {
   'Browser Back': () => ({ action: 'Went back', subject: '', title: 'Went back' }),
@@ -119,38 +119,83 @@ export interface ActionFeedItemLike {
   status: ActionStatus
 }
 
+export interface ActionFeedSelection<T extends ActionFeedItemLike> {
+  hidden: number
+  hiddenItems: T[]
+  items: T[]
+}
+
 const IMPORTANT_ACTION_LABEL_RE = /^(?:Browser (?:Click|Navigate|Type)|Delegate Task|Execute Code|Patch|Terminal|Todo|Write File)/
 
 export const isImportantActionLabel = (label: string): boolean => IMPORTANT_ACTION_LABEL_RE.test(label)
 
+const actionPriority = <T extends ActionFeedItemLike>(item: T, index: number): number => {
+  if (item.status === 'running') {
+    return 1_000 + index
+  }
+
+  if (item.status === 'error') {
+    return 900 + index
+  }
+
+  if (isImportantActionLabel(item.label)) {
+    return 600 + index
+  }
+
+  // Successful Read/Search calls are useful context, but too noisy as primary
+  // feed rows. Keep them available for the hidden summary unless there is
+  // nothing more meaningful to show.
+  return 0
+}
+
+export const summarizeHiddenActionFeedItems = <T extends ActionFeedItemLike>(
+  items: readonly T[],
+  maxKinds = 3,
+  maxChars = 48
+): string => {
+  if (!items.length) {
+    return ''
+  }
+
+  const counts = new Map<string, number>()
+
+  for (const item of items) {
+    const label = parseActionCall(item.label).action || 'Tool'
+    counts.set(label, (counts.get(label) ?? 0) + 1)
+  }
+
+  const entries = [...counts.entries()].sort((a, b) => b[1] - a[1])
+  const visible = entries.slice(0, maxKinds).map(([label, count]) => `${label}${count > 1 ? `×${count}` : ''}`)
+  const rest = entries.slice(maxKinds).reduce((sum, [, count]) => sum + count, 0)
+  const summary = [...visible, rest > 0 ? `+${rest}` : ''].filter(Boolean).join(' · ')
+
+  return compactPreview(summary, maxChars)
+}
+
 export const selectVisibleActionFeedItems = <T extends ActionFeedItemLike>(
   items: readonly T[],
   limit = ACTION_FEED_VISIBLE_LIMIT
-): { hidden: number; items: T[] } => {
-  if (items.length <= limit) {
-    return { hidden: 0, items: [...items] }
+): ActionFeedSelection<T> => {
+  const visibleLimit = Math.max(1, limit)
+
+  if (items.length <= visibleLimit) {
+    return { hidden: 0, hiddenItems: [], items: [...items] }
   }
 
-  const keep = new Set<number>()
+  const ranked = items
+    .map((item, index) => ({ index, priority: actionPriority(item, index) }))
+    .filter(({ priority }) => priority > 0)
+    .sort((a, b) => b.priority - a.priority)
 
-  items.forEach((item, index) => {
-    if (item.status !== 'success' || isImportantActionLabel(item.label)) {
-      keep.add(index)
-    }
-  })
-
-  for (let index = Math.max(0, items.length - 2); index < items.length; index += 1) {
-    keep.add(index)
-  }
-
-  for (let index = items.length - 1; keep.size < Math.min(limit, items.length) && index >= 0; index -= 1) {
-    keep.add(index)
-  }
-
-  const selected = [...keep].sort((a, b) => a - b).slice(-limit)
+  const selected = (ranked.length ? ranked.slice(0, visibleLimit).map(entry => entry.index) : [items.length - 1]).sort(
+    (a, b) => a - b
+  )
+  const selectedSet = new Set(selected)
+  const hiddenItems = items.filter((_, index) => !selectedSet.has(index))
 
   return {
     hidden: Math.max(0, items.length - selected.length),
+    hiddenItems,
     items: selected.map(index => items[index]!)
   }
 }

--- a/ui-tui/src/lib/actionFeed.ts
+++ b/ui-tui/src/lib/actionFeed.ts
@@ -1,0 +1,113 @@
+import { compactPreview } from './text.js'
+
+export type ActionStatus = 'error' | 'running' | 'success'
+
+export interface ParsedActionCall {
+  action: string
+  subject: string
+  title: string
+}
+
+export interface FoldedActionDetail {
+  hiddenLines: number
+  preview: string
+}
+
+const CALL_RE = /^(.*?)(?:\("([\s\S]*)"\))?$/
+const DURATION_RE = / \(\d+(?:\.\d)?s\)$/
+
+const cleanSubject = (value = '') =>
+  value
+    .replace(/^['"]|['"]$/g, '')
+    .replace(/\\n/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+const tailPath = (value: string) => {
+  const cleaned = cleanSubject(value)
+
+  if (!cleaned) {
+    return ''
+  }
+
+  const parts = cleaned.split('/').filter(Boolean)
+  return parts.length > 2 ? `…/${parts.slice(-2).join('/')}` : cleaned
+}
+
+const quoted = (value: string) => (value ? `"${compactPreview(cleanSubject(value), 56)}"` : '')
+
+const ACTIONS: Record<string, (subject: string) => ParsedActionCall> = {
+  'Browser Back': () => ({ action: 'Went back', subject: '', title: 'Went back' }),
+  'Browser Click': subject => ({ action: 'Clicked', subject: quoted(subject), title: ['Clicked', quoted(subject)].filter(Boolean).join(' ') }),
+  'Browser Console': subject => ({ action: 'Inspected console', subject: quoted(subject), title: ['Inspected console', quoted(subject)].filter(Boolean).join(' ') }),
+  'Browser Navigate': subject => ({ action: 'Opened', subject: quoted(subject), title: ['Opened', quoted(subject)].filter(Boolean).join(' ') }),
+  'Browser Press': subject => ({ action: 'Pressed key', subject: quoted(subject), title: ['Pressed key', quoted(subject)].filter(Boolean).join(' ') }),
+  'Browser Scroll': subject => ({ action: 'Scrolled', subject: quoted(subject), title: ['Scrolled', quoted(subject)].filter(Boolean).join(' ') }),
+  'Browser Snapshot': () => ({ action: 'Read page snapshot', subject: '', title: 'Read page snapshot' }),
+  'Browser Type': subject => ({ action: 'Typed', subject: quoted(subject), title: ['Typed', quoted(subject)].filter(Boolean).join(' ') }),
+  'Delegate Task': subject => ({ action: 'Delegated', subject: quoted(subject), title: ['Delegated', quoted(subject)].filter(Boolean).join(' ') }),
+  'Execute Code': subject => ({ action: 'Ran Python', subject: quoted(subject), title: ['Ran Python', quoted(subject)].filter(Boolean).join(' ') }),
+  Patch: subject => ({ action: 'Edited', subject: tailPath(subject), title: ['Edited', tailPath(subject)].filter(Boolean).join(' ') }),
+  'Read File': subject => ({ action: 'Read', subject: tailPath(subject), title: ['Read', tailPath(subject)].filter(Boolean).join(' ') }),
+  'Search Files': subject => ({ action: 'Searched', subject: quoted(subject), title: ['Searched', quoted(subject)].filter(Boolean).join(' ') }),
+  Terminal: subject => ({ action: 'Ran', subject: quoted(subject), title: ['Ran', quoted(subject)].filter(Boolean).join(' ') }),
+  Todo: () => ({ action: 'Updated todos', subject: '', title: 'Updated todos' }),
+  'Write File': subject => ({ action: 'Wrote', subject: tailPath(subject), title: ['Wrote', tailPath(subject)].filter(Boolean).join(' ') })
+}
+
+export const parseActionCall = (call: string): ParsedActionCall => {
+  const body = String(call || '').replace(DURATION_RE, '').trim()
+  const match = body.match(CALL_RE)
+  const rawName = (match?.[1] ?? body).trim()
+  const subject = match?.[2] ?? ''
+  const formatter = ACTIONS[rawName]
+
+  if (formatter) {
+    return formatter(subject)
+  }
+
+  const fallbackSubject = quoted(subject)
+  return {
+    action: rawName || 'Tool',
+    subject: fallbackSubject,
+    title: [rawName || 'Tool', fallbackSubject].filter(Boolean).join(' ')
+  }
+}
+
+export const actionStatusGlyph = (status: ActionStatus) => {
+  if (status === 'running') {
+    return '●'
+  }
+
+  return status === 'error' ? '✗' : '✓'
+}
+
+export const foldActionDetail = (detail: string, maxLines = 4, maxChars = 420): FoldedActionDetail => {
+  const raw = String(detail || '').trim()
+
+  if (!raw) {
+    return { hiddenLines: 0, preview: '' }
+  }
+
+  const lines = raw.split('\n')
+  const visible: string[] = []
+  let used = 0
+
+  for (const line of lines) {
+    const next = visible.length ? used + 1 + line.length : used + line.length
+
+    if (visible.length >= maxLines || next > maxChars) {
+      break
+    }
+
+    visible.push(line)
+    used = next
+  }
+
+  if (!visible.length) {
+    visible.push(compactPreview(lines[0] ?? raw, maxChars))
+  }
+
+  const hiddenLines = Math.max(0, lines.length - visible.length)
+  return { hiddenLines, preview: visible.join('\n') }
+}

--- a/ui-tui/src/lib/assistantLogPrefix.ts
+++ b/ui-tui/src/lib/assistantLogPrefix.ts
@@ -1,0 +1,41 @@
+const ASSISTANT_LOG_PREFIXES = [
+  '진행상황',
+  '완료',
+  '결과',
+  '확인',
+  '검증',
+  '테스트',
+  '주의',
+  '경고',
+  '참고',
+  '다음',
+  '계획',
+  '요약',
+  '문제',
+  '해결',
+  'PLAN',
+  'VERIFY'
+]
+
+const ASSISTANT_LOG_PREFIX_RE = new RegExp(
+  `^\\s*(?:\\*\\*)?(${ASSISTANT_LOG_PREFIXES.join('|')})(?:\\*\\*)?\\s*[:：](?:\\*\\*)?\\s*([\\s\\S]*)$`,
+  'i'
+)
+
+export interface AssistantLogPrefix {
+  body: string
+  prefix: string
+}
+
+export const splitAssistantLogPrefix = (text: string): null | AssistantLogPrefix => {
+  const match = ASSISTANT_LOG_PREFIX_RE.exec(text)
+
+  if (!match) {
+    return null
+  }
+
+  return {
+    body: (match[2] ?? '').replace(/^\s*\n/, '').trimStart(),
+    prefix: match[1] ?? ''
+  }
+}

--- a/ui-tui/src/lib/inputMetrics.ts
+++ b/ui-tui/src/lib/inputMetrics.ts
@@ -3,6 +3,7 @@ import { stringWidth, wrapAnsi } from '@hermes/ink'
 import type { Role } from '../types.js'
 
 export const COMPOSER_PROMPT_GAP_WIDTH = 1
+export const COMPOSER_INPUT_SURFACE_MIN_HEIGHT = 3
 
 let _seg: Intl.Segmenter | null = null
 const seg = () => (_seg ??= new Intl.Segmenter(undefined, { granularity: 'grapheme' }))
@@ -168,6 +169,10 @@ export function offsetFromPosition(value: string, row: number, col: number, cols
 
 export function inputVisualHeight(value: string, columns: number) {
   return cursorLayout(value, value.length, columns).line + 1
+}
+
+export function composerInputSurfaceHeight(inputHeight: number) {
+  return Math.max(COMPOSER_INPUT_SURFACE_MIN_HEIGHT, inputHeight)
 }
 
 export function composerPromptWidth(promptText: string) {

--- a/ui-tui/src/lib/inputMetrics.ts
+++ b/ui-tui/src/lib/inputMetrics.ts
@@ -3,7 +3,7 @@ import { stringWidth, wrapAnsi } from '@hermes/ink'
 import type { Role } from '../types.js'
 
 export const COMPOSER_PROMPT_GAP_WIDTH = 1
-export const COMPOSER_INPUT_SURFACE_MIN_HEIGHT = 3
+export const COMPOSER_INPUT_SURFACE_MIN_HEIGHT = 1
 
 let _seg: Intl.Segmenter | null = null
 const seg = () => (_seg ??= new Intl.Segmenter(undefined, { granularity: 'grapheme' }))

--- a/ui-tui/src/lib/prompt.ts
+++ b/ui-tui/src/lib/prompt.ts
@@ -1,4 +1,4 @@
-const TERMUX_SAFE_PROMPT = '>'
+const TERMUX_SAFE_PROMPT = ':'
 
 export function composerPromptText(
   prompt: string,

--- a/ui-tui/src/lib/virtualHeights.ts
+++ b/ui-tui/src/lib/virtualHeights.ts
@@ -1,6 +1,7 @@
 import { TERMUX_TUI_MODE } from '../config/env.js'
 import type { Msg } from '../types.js'
 
+import { splitAssistantLogPrefix } from './assistantLogPrefix.js'
 import { transcriptBodyWidth } from './inputMetrics.js'
 
 const hashText = (text: string) => {
@@ -102,8 +103,9 @@ export const estimatedMsgHeight = (
   }
 
   const bodyWidth = transcriptBodyWidth(cols, msg.role, userPrompt, TERMUX_TUI_MODE)
-  const text = msg.text
-  let h = wrappedLines(text || ' ', bodyWidth)
+  const logPrefix = msg.role === 'assistant' ? splitAssistantLogPrefix(msg.text) : null
+  const text = logPrefix ? logPrefix.body : msg.text
+  let h = logPrefix ? 1 + (text ? wrappedLines(text, bodyWidth) : 0) : wrappedLines(text || ' ', bodyWidth)
 
   if (!compact && msg.role === 'assistant') {
     // Paragraph gaps add up to 6 extra rows of breathing room. Slice
@@ -122,10 +124,17 @@ export const estimatedMsgHeight = (
     if (hasVisibleDetails) {
       h += (hasVisibleTools ? (msg.tools?.length ?? 0) : 0) + (hasVisibleThinking ? wrappedLines(msg.thinking ?? '', bodyWidth) : 0)
 
-      if (msg.role === 'assistant' && /\S/.test(msg.text)) {
-        h += 2
+      if (msg.role === 'assistant') {
+        // Assistant details now render directly under the natural-language
+        // message as one visual module. There is no separate "Response" label,
+        // but the outer message still reserves a bottom gap after the feed.
+        h += 1
       }
     }
+  }
+
+  if (msg.kind === 'trail' && details && ((toolsVisible && msg.tools?.length) || (thinkingVisible && /\S/.test(msg.thinking ?? '')))) {
+    h += 1
   }
 
   if (msg.role === 'user' || msg.kind === 'diff') {

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -239,7 +239,7 @@ function normalizeAnsiForeground(color: string): string {
 const BRAND: ThemeBrand = {
   name: 'Hermes Agent',
   icon: '⚕',
-  prompt: '>',
+  prompt: ':',
   welcome: 'Type your message or /help for commands.',
   goodbye: 'Goodbye! ⚕',
   tool: '┊',

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -239,7 +239,7 @@ function normalizeAnsiForeground(color: string): string {
 const BRAND: ThemeBrand = {
   name: 'Hermes Agent',
   icon: '⚕',
-  prompt: '❯',
+  prompt: '>',
   welcome: 'Type your message or /help for commands.',
   goodbye: 'Goodbye! ⚕',
   tool: '┊',


### PR DESCRIPTION
## Summary

- Add a Codex-style TUI action feed/chrome refresh with folded tool details and clearer status/composer behavior.
- Stabilize tmux launches by defaulting to inline mode, avoiding alternate-screen scrollback loss, and disabling extended keyboard modes inside tmux.
- Prevent tmux composer cursor drift by disabling fast-echo by default in tmux, while keeping `HERMES_TUI_FAST_ECHO=1` as an explicit debug opt-in.
- Render slash completion in normal layout flow instead of a floating overlay that can smear over the composer.
- Add regression coverage for action feed formatting, composer layout, slash completion insertion, tmux terminal behavior, fast-echo gating, and launcher inline defaults.

## Verification

- [x] `git diff --check origin/main...HEAD`
- [x] `env -u SSH_CLIENT -u SSH_TTY -u SSH_CONNECTION PYTHON=/Users/kyuetaekoh/.hermes/hermes-agent/venv/bin/python npm --prefix ui-tui run type-check`
- [x] `env -u SSH_CLIENT -u SSH_TTY -u SSH_CONNECTION PYTHON=/Users/kyuetaekoh/.hermes/hermes-agent/venv/bin/python npm --prefix ui-tui test -- --run` — 86 files passed, 911 tests passed, 1 skipped
- [x] `/Users/kyuetaekoh/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_tui_resume_flow.py` — 43 passed
- [x] `env -u SSH_CLIENT -u SSH_TTY -u SSH_CONNECTION PYTHON=/Users/kyuetaekoh/.hermes/hermes-agent/venv/bin/python npm --prefix ui-tui run build`

## Notes

- `HERMES_TUI_INLINE=0` still allows explicit override of the tmux inline default.
- `HERMES_TUI_FAST_ECHO=1` intentionally remains as a tmux debug backdoor, but the default is off in tmux to protect cursor/layout correctness.
