### PR TITLE
docs(skills): clarify repair-official restore prompt

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1082,7 +1082,11 @@ def do_repair_official(name: str, restore: bool = False,
     c = console or _console
     if restore and not skip_confirm:
         c.print(f"\n[bold]Restore official optional skill '{name}' from repo source?[/]")
-        c.print("[dim]Existing matching active copies will be moved to a restore backup before copying the official source.[/]")
+        c.print(
+            "[dim]Any existing copies at the canonical path or elsewhere "
+            "that do not match the official source will be moved to a "
+            "backup directory under ~/.hermes/skills/.restore-backups/.[/]"
+        )
         try:
             answer = input("Confirm [y/N]: ").strip().lower()
         except (EOFError, KeyboardInterrupt):

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,7 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import do_check, do_install, do_list, do_repair_official, do_update, handle_skills_slash
 
 
 class _DummyLockFile:
@@ -144,6 +144,28 @@ def test_do_list_filter_hub(three_source_env):
     assert "hub-skill" in output
     assert "builtin-skill" not in output
     assert "local-skill" not in output
+
+
+def test_repair_official_restore_prompt_names_canonical_and_noncanonical_backups(monkeypatch):
+    import tools.skills_sync as skills_sync
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    monkeypatch.setattr("builtins.input", lambda _prompt: "n")
+    monkeypatch.setattr(
+        skills_sync,
+        "restore_official_optional_skill",
+        lambda *_args, **_kwargs: pytest.fail("cancelled prompt should not repair"),
+    )
+
+    do_repair_official("trl-fine-tuning", restore=True, console=console)
+    output = sink.getvalue()
+
+    assert "canonical path or elsewhere" in output
+    assert "do not match" in output
+    assert "official source" in output
+    assert "~/.hermes/skills/.restore-backups/" in output
 
 
 def test_do_list_filter_builtin(three_source_env):


### PR DESCRIPTION
## Summary
- Clarifies the `hermes skills repair-official --restore` confirmation prompt so users know non-matching canonical-path and elsewhere copies can be moved to restore backups.
- Refs #33463 (W4).

## Why
- #33463 notes the old wording only mentioned "matching active copies," but the restore path can also back up a hand-edited canonical destination when it differs from the official optional-skill source.

## Changes
- `hermes_cli/skills_hub.py`: rewords the restore confirmation warning to name canonical-path and elsewhere copies, the official-source comparison, and the restore-backups directory.
- `tests/hermes_cli/test_skills_hub.py`: covers the warning text before cancellation.

## Validation
- `python -m pytest tests/hermes_cli/test_skills_hub.py::test_repair_official_restore_prompt_names_canonical_and_noncanonical_backups -o 'addopts=' -q`
- `python -m pytest tests/hermes_cli/test_skills_hub.py -o 'addopts=' -q`

## Scope
- In scope: confirmation wording for `repair-official --restore`.
- Out of scope: the other independent #33463 follow-ups (install-path depth caps, collision detection, atomic lock writes, and no-op result wording).
