### PR TITLE
fix(gateway): surface dropped MEDIA paths in send_message result

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2810,11 +2810,29 @@ class BasePlatformAdapter(ABC):
         return validate_media_delivery_path(path, session_key=session_key)
 
     @staticmethod
+    def partition_media_delivery_paths(
+        media_files, session_key: str = "",
+    ) -> Tuple[List[Tuple[str, bool]], List[Tuple[str, bool]]]:
+        """Split MEDIA paths into accepted and rejected delivery paths."""
+        safe_media: List[Tuple[str, bool]] = []
+        dropped_media: List[Tuple[str, bool]] = []
+        for media_path, is_voice in media_files or []:
+            safe_path = _validated_delivery_path(
+                media_path, session_key, "MEDIA directive path"
+            )
+            if safe_path:
+                safe_media.append((safe_path, bool(is_voice)))
+            else:
+                dropped_media.append((str(media_path), bool(is_voice)))
+        return safe_media, dropped_media
+
+    @staticmethod
     def filter_media_delivery_paths(media_files, session_key: str = "") -> List[Tuple[str, bool]]:
         """Drop unsafe MEDIA paths and normalize accepted paths."""
-        return [
-            (safe_path, bool(is_voice)) for media_path, is_voice in media_files or []
-            if (safe_path := _validated_delivery_path(media_path, session_key, "MEDIA directive path"))]
+        safe_media, _dropped_media = BasePlatformAdapter.partition_media_delivery_paths(
+            media_files, session_key=session_key
+        )
+        return safe_media
 
     @staticmethod
     def filter_local_delivery_paths(file_paths, session_key: str = "") -> List[str]:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4336,16 +4336,32 @@ class BasePlatformAdapter(ABC):
         return validate_media_delivery_path(path)
 
     @staticmethod
-    def filter_media_delivery_paths(media_files) -> List[Tuple[str, bool]]:
-        """Drop unsafe MEDIA paths and normalize accepted paths."""
+    def partition_media_delivery_paths(
+        media_files,
+    ) -> Tuple[List[Tuple[str, bool]], List[Tuple[str, bool]]]:
+        """Split MEDIA paths into (safe, dropped) based on the delivery allowlist.
+
+        Same gate as :func:`validate_media_delivery_path`; the dropped list
+        preserves the caller's original ``(path, is_voice)`` pairs so the
+        caller can surface a user-facing warning instead of letting the
+        send silently succeed with text only (issue #32644).
+        """
         safe_media: List[Tuple[str, bool]] = []
+        dropped_media: List[Tuple[str, bool]] = []
         for media_path, is_voice in media_files or []:
             raw = str(media_path)
             safe_path = validate_media_delivery_path(raw)
             if safe_path:
                 safe_media.append((safe_path, bool(is_voice)))
             else:
+                dropped_media.append((str(media_path), bool(is_voice)))
                 logger.warning("Skipping unsafe MEDIA directive path: %s", _log_safe_path(raw))
+        return safe_media, dropped_media
+
+    @staticmethod
+    def filter_media_delivery_paths(media_files) -> List[Tuple[str, bool]]:
+        """Drop unsafe MEDIA paths and normalize accepted paths."""
+        safe_media, _dropped = BasePlatformAdapter.partition_media_delivery_paths(media_files)
         return safe_media
 
     @staticmethod

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -32,7 +32,7 @@ def test_media_delivery_denies_encrypted_bitwarden_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(base, "_HERMES_ROOT", hermes_home)
     path = hermes_home / "cache" / "bws_cache.enc.json"
     path.parent.mkdir()
-    path.write_text("encrypted-secret-cache")
+    path.write_text("encrypted-secret-cache", encoding="utf-8")
 
     assert path in base._media_delivery_denied_paths()
     assert base.validate_media_delivery_path(str(path)) is None
@@ -516,6 +516,27 @@ class TestMediaDeliveryPathValidation:
 
         assert filtered == [(str(safe.resolve()), True)]
 
+    def test_partition_returns_dropped_paths_so_caller_can_warn(self, tmp_path, monkeypatch):
+        """``partition_media_delivery_paths`` is the silent-drop fix: the
+        caller needs both the safe and the dropped list so a text-only send
+        does not silently report success on a stripped attachment
+        (issue #32644).
+        """
+        root = tmp_path / "media-cache"
+        safe = root / "speech.ogg"
+        unsafe = tmp_path / "outside.ogg"
+        safe.parent.mkdir(parents=True)
+        safe.write_bytes(b"OggS")
+        unsafe.write_bytes(b"OggS")
+        self._patch_roots(monkeypatch, root)
+
+        safe_list, dropped_list = BasePlatformAdapter.partition_media_delivery_paths([
+            (str(unsafe), False),
+            (str(safe), True),
+        ])
+
+        assert safe_list == [(str(safe.resolve()), True)]
+        assert dropped_list == [(str(unsafe), False)]
 
     def test_allows_stale_kanban_attachment_but_not_neighboring_workspace(
         self, tmp_path, monkeypatch,
@@ -595,7 +616,7 @@ class TestMediaDeliveryDefaultMode:
         self._patch_roots(monkeypatch)
 
         notes = tmp_path / "notes.md"
-        notes.write_text("# Old notes\n")
+        notes.write_text("# Old notes\n", encoding="utf-8")
         old_mtime = time.time() - 7200  # 2 hours ago — far outside any window
         os.utime(notes, (old_mtime, old_mtime))
 
@@ -621,7 +642,7 @@ class TestMediaDeliveryDefaultMode:
         hermes_dir = fake_home / ".hermes"
         (hermes_dir / "mcp-tokens").mkdir(parents=True)
         secret = hermes_dir / rel
-        secret.write_text('{"access_token": "live-bearer-abc123"}')
+        secret.write_text('{"access_token": "live-bearer-abc123"}', encoding="utf-8")
         monkeypatch.setenv("HOME", str(fake_home))
         monkeypatch.setattr(
             "gateway.platforms.base._HERMES_HOME",
@@ -648,7 +669,9 @@ class TestMediaDeliveryDefaultMode:
         hermes_dir = fake_home / ".hermes"
         hermes_dir.mkdir(parents=True)
         token = hermes_dir / "google_token.json"
-        token.write_text('{"access_token": "***", "refresh_token": "***"}')
+        token.write_text(
+            '{"access_token": "***", "refresh_token": "***"}', encoding="utf-8"
+        )
         monkeypatch.setenv("HOME", str(fake_home))
         monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
         monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -33,7 +33,7 @@ def test_media_delivery_denies_encrypted_bitwarden_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(base, "_HERMES_ROOT", hermes_home)
     path = hermes_home / "cache" / "bws_cache.enc.json"
     path.parent.mkdir()
-    path.write_text("encrypted-secret-cache")
+    path.write_text("encrypted-secret-cache", encoding="utf-8")
 
     assert path in base._media_delivery_denied_paths()
     assert base.validate_media_delivery_path(str(path)) is None
@@ -517,6 +517,27 @@ class TestMediaDeliveryPathValidation:
 
         assert filtered == [(str(safe.resolve()), True)]
 
+    def test_partition_returns_dropped_paths_so_caller_can_warn(self, tmp_path, monkeypatch):
+        """``partition_media_delivery_paths`` is the silent-drop fix: the
+        caller needs both the safe and the dropped list so a text-only send
+        does not silently report success on a stripped attachment
+        (issue #32644).
+        """
+        root = tmp_path / "media-cache"
+        safe = root / "speech.ogg"
+        unsafe = tmp_path / "outside.ogg"
+        safe.parent.mkdir(parents=True)
+        safe.write_bytes(b"OggS")
+        unsafe.write_bytes(b"OggS")
+        self._patch_roots(monkeypatch, root)
+
+        safe_list, dropped_list = BasePlatformAdapter.partition_media_delivery_paths([
+            (str(unsafe), False),
+            (str(safe), True),
+        ])
+
+        assert safe_list == [(str(safe.resolve()), True)]
+        assert dropped_list == [(str(unsafe), False)]
 
     def test_allows_stale_kanban_attachment_but_not_neighboring_workspace(
         self, tmp_path, monkeypatch,
@@ -596,7 +617,7 @@ class TestMediaDeliveryDefaultMode:
         self._patch_roots(monkeypatch)
 
         notes = tmp_path / "notes.md"
-        notes.write_text("# Old notes\n")
+        notes.write_text("# Old notes\n", encoding="utf-8")
         old_mtime = time.time() - 7200  # 2 hours ago — far outside any window
         os.utime(notes, (old_mtime, old_mtime))
 
@@ -622,7 +643,7 @@ class TestMediaDeliveryDefaultMode:
         hermes_dir = fake_home / ".hermes"
         (hermes_dir / "mcp-tokens").mkdir(parents=True)
         secret = hermes_dir / rel
-        secret.write_text('{"access_token": "live-bearer-abc123"}')
+        secret.write_text('{"access_token": "live-bearer-abc123"}', encoding="utf-8")
         monkeypatch.setenv("HOME", str(fake_home))
         monkeypatch.setattr(
             "gateway.platforms.base._HERMES_HOME",
@@ -649,7 +670,9 @@ class TestMediaDeliveryDefaultMode:
         hermes_dir = fake_home / ".hermes"
         hermes_dir.mkdir(parents=True)
         token = hermes_dir / "google_token.json"
-        token.write_text('{"access_token": "***", "refresh_token": "***"}')
+        token.write_text(
+            '{"access_token": "***", "refresh_token": "***"}', encoding="utf-8"
+        )
         monkeypatch.setenv("HOME", str(fake_home))
         monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
         monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
@@ -903,7 +926,7 @@ class TestDockerContainerMediaPathTranslation:
         home = sandbox / "docker" / "default" / "home"
         secret = home / ".hermes"
         secret.mkdir(parents=True)
-        (secret / "auth.json").write_text('{"token": "SECRET"}')
+        (secret / "auth.json").write_text('{"token": "SECRET"}', encoding="utf-8")
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
@@ -1399,7 +1422,7 @@ class TestDockerProfileSandboxMediaTranslation:
         home = self._sandbox_dir() / "home"
         home.mkdir(parents=True, exist_ok=True)
         produced = home / "note.txt"
-        produced.write_text("hi")
+        produced.write_text("hi", encoding="utf-8")
 
         assert BasePlatformAdapter.validate_media_delivery_path(
             "/root/note.txt", session_key=self.SESSION_KEY
@@ -1413,7 +1436,7 @@ class TestDockerProfileSandboxMediaTranslation:
         for task in ("default", f"session:{self.SESSION_KEY}"):
             secrets = self._sandbox_dir(task) / "home" / ".hermes"
             secrets.mkdir(parents=True, exist_ok=True)
-            (secrets / "auth.json").write_text("{}")
+            (secrets / "auth.json").write_text("{}", encoding="utf-8")
 
         assert (
             BasePlatformAdapter.validate_media_delivery_path(

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -345,7 +345,18 @@ class TestSendMessageTool:
                 )
             )
 
+        # Text sent, but the result must flag that the MEDIA attachment was
+        # dropped so CLI/MCP callers do not read "success" as "media
+        # delivered" (issue #32644).
         assert result["success"] is True
+        assert result["media_dropped"] == [str(secret)]
+        assert result["warnings"] == [
+            "1 MEDIA attachment(s) were dropped because the path is outside the gateway's "
+            "allowed delivery roots; only text was delivered. Move the file under a "
+            "Hermes-managed cache or add its directory to gateway.media_delivery_allow_dirs. "
+            "Alternatively, when gateway.strict is enabled, set gateway.trust_recent_files to true "
+            "to allow recently produced files."
+        ]
         send_mock.assert_awaited_once_with(
             Platform.TELEGRAM,
             telegram_cfg,
@@ -355,6 +366,34 @@ class TestSendMessageTool:
             media_files=[],
             force_document=False,
         )
+
+    def test_media_dropped_warning_not_added_when_send_errors(self, tmp_path, monkeypatch):
+        """An upstream send failure must not be masked by the media-dropped
+        warning; ``media_dropped`` is only attached to a successful result.
+        """
+        monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "1")
+        monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "0")
+        config, _telegram_cfg = _make_config()
+        secret = tmp_path / "secret.pdf"
+        secret.write_bytes(b"%PDF secret")
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"error": "boom"})):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": f"hello\nMEDIA:{secret}",
+                    }
+                )
+            )
+
+        assert "error" in result
+        assert "media_dropped" not in result
+        assert "warnings" not in result
 
     def test_top_level_send_failure_redacts_query_token(self):
         config, _telegram_cfg = _make_config()
@@ -870,7 +909,7 @@ class TestSendTelegramThreadIdMapping:
 
         # Create a test file
         test_file = tmp_path / "doc.txt"
-        test_file.write_text("test content")
+        test_file.write_text("test content", encoding="utf-8")
 
         asyncio.run(
             _send_telegram(

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -339,7 +339,18 @@ class TestSendMessageTool:
                 )
             )
 
+        # Text sent, but the result must flag that the MEDIA attachment was
+        # dropped so CLI/MCP callers do not read "success" as "media
+        # delivered" (issue #32644).
         assert result["success"] is True
+        assert result["media_dropped"] == [str(secret)]
+        assert result["warnings"] == [
+            "1 MEDIA attachment(s) were dropped because the path is outside the gateway's "
+            "allowed delivery roots; only text was delivered. Move the file under a "
+            "Hermes-managed cache or add its directory to gateway.media_delivery_allow_dirs. "
+            "Alternatively, when gateway.strict is enabled, set gateway.trust_recent_files to true "
+            "to allow recently produced files."
+        ]
         send_mock.assert_awaited_once_with(
             Platform.TELEGRAM,
             telegram_cfg,
@@ -349,6 +360,34 @@ class TestSendMessageTool:
             media_files=[],
             force_document=False,
         )
+
+    def test_media_dropped_warning_not_added_when_send_errors(self, tmp_path, monkeypatch):
+        """An upstream send failure must not be masked by the media-dropped
+        warning; ``media_dropped`` is only attached to a successful result.
+        """
+        monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "1")
+        monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "0")
+        config, _telegram_cfg = _make_config()
+        secret = tmp_path / "secret.pdf"
+        secret.write_bytes(b"%PDF secret")
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"error": "boom"})):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": f"hello\nMEDIA:{secret}",
+                    }
+                )
+            )
+
+        assert "error" in result
+        assert "media_dropped" not in result
+        assert "warnings" not in result
 
     def test_top_level_send_failure_redacts_query_token(self):
         config, _telegram_cfg = _make_config()
@@ -829,7 +868,7 @@ class TestSendTelegramThreadIdMapping:
 
         # Create a test file
         test_file = tmp_path / "doc.txt"
-        test_file.write_text("test content")
+        test_file.write_text("test content", encoding="utf-8")
 
         asyncio.run(
             _send_telegram(

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -440,7 +440,7 @@ def _handle_send(args):
     force_document_attachments = "[[as_document]]" in message
 
     media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    media_files, dropped_media = BasePlatformAdapter.partition_media_delivery_paths(media_files)
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 
     used_home_channel = False
@@ -500,6 +500,22 @@ def _handle_send(args):
         )
         if used_home_channel and isinstance(result, dict) and result.get("success"):
             result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
+
+        # Surface MEDIA paths that the delivery allowlist dropped so CLI/MCP
+        # callers can react instead of treating a text-only send as a fully
+        # successful attachment send (issue #32644).
+        if dropped_media and isinstance(result, dict) and result.get("success"):
+            warnings = list(result.get("warnings", []))
+            dropped_paths = [path for path, _is_voice in dropped_media]
+            warnings.append(
+                f"{len(dropped_paths)} MEDIA attachment(s) were dropped because the path is outside "
+                "the gateway's allowed delivery roots; only text was delivered. Move the file under a "
+                "Hermes-managed cache or add its directory to gateway.media_delivery_allow_dirs. "
+                "Alternatively, when gateway.strict is enabled, set gateway.trust_recent_files to true "
+                "to allow recently produced files."
+            )
+            result["warnings"] = warnings
+            result["media_dropped"] = dropped_paths
 
         # Mirror the sent message into the target's gateway session
         if isinstance(result, dict) and result.get("success") and mirror_text:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -120,7 +120,7 @@ def _handle_send(args):
     # Capture [[as_document]] before extract_media strips it (images keep original bytes via send_document).
     force_document_attachments = "[[as_document]]" in message
     media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    media_files, dropped_media = BasePlatformAdapter.partition_media_delivery_paths(media_files)
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
     used_home_channel = not chat_id
     if used_home_channel:
@@ -146,6 +146,17 @@ def _handle_send(args):
         if isinstance(result, dict) and result.get("success"):
             if used_home_channel:
                 result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
+            if dropped_media:
+                dropped_paths = [path for path, _is_voice in dropped_media]
+                warning = (
+                    f"{len(dropped_paths)} MEDIA attachment(s) were dropped because the path is outside "
+                    "the gateway's allowed delivery roots; only text was delivered. Move the file under a "
+                    "Hermes-managed cache or add its directory to gateway.media_delivery_allow_dirs. "
+                    "Alternatively, when gateway.strict is enabled, set gateway.trust_recent_files to true "
+                    "to allow recently produced files."
+                )
+                result["warnings"] = [*result.get("warnings", []), warning]
+                result["media_dropped"] = dropped_paths
             if mirror_text and _mirror_sent_message(platform_name, chat_id, mirror_text, thread_id):
                 result["mirrored"] = True
         if isinstance(result, dict) and "error" in result:


### PR DESCRIPTION
## What does this PR do?

The `send_message` tool extracted `MEDIA:` directives, ran them through `filter_media_delivery_paths` (which silently drops paths outside the delivery allowlist), and then sent the remaining text. A successful text send was returned to the model as `{"success": true}` with no signal that the attachment had been stripped, so the agent reported "media sent" while the user only saw plain text — the exact failure reported in #32644.

This PR adds `partition_media_delivery_paths` on `BasePlatformAdapter` returning `(safe, dropped)`. `filter_media_delivery_paths` keeps its old return shape by delegating to the partition (no behavior change for existing callers). `send_message_tool._handle_send` switches to the partition and, on a successful send, attaches a `"MEDIA attachment(s) were dropped"` warning plus a `media_dropped: [...]` field listing the rejected paths, so the agent can correct the path or expand `HERMES_MEDIA_ALLOW_DIRS` instead of treating text-only delivery as a fully successful attachment send.

Scope is intentionally narrow: this addresses acceptance criteria 1, 2, and the `send_message` half of 4 from the issue. The gateway post-stream delivery path in `gateway/run.py::_deliver_post_stream_media` also calls `filter_media_delivery_paths` and silently drops paths after text has already streamed; turning that into a user-visible follow-up message is a separate UX decision and is deferred to a follow-up PR. The operator-facing `sendVoice`/`sendAudio` smoke-test command (AC 3) is likewise deferred.

## Related Issue

Refs #32644

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`: add `BasePlatformAdapter.partition_media_delivery_paths(media_files) -> (safe, dropped)`. Refactor `filter_media_delivery_paths` to delegate to it so existing callers keep their old return shape and per-path warning log.
- `tools/send_message_tool.py`: in `_handle_send`, use the partition helper and, on a successful send, attach a user-facing `warnings` entry plus a `media_dropped: [<paths>]` field so the model/operator sees that the attachment was filtered out. The warning is only added when the underlying send succeeded — error results are not mutated.
- `tests/gateway/test_platform_base.py`: add `test_partition_returns_dropped_paths_so_caller_can_warn` covering the new `(safe, dropped)` return shape under the strict allowlist.
- `tests/tools/test_send_message_tool.py`: the existing `test_media_tag_outside_allowed_roots_is_not_sent` now asserts that `result["media_dropped"]` and the warning are populated (it previously codified the silent-success bug). Add `test_media_dropped_warning_not_added_when_send_errors` so an upstream send failure isn't masked by the new warning.

## How to Test

1. `pytest tests/gateway/test_platform_base.py::TestMediaDeliveryPathValidation tests/tools/test_send_message_tool.py -q` — 134 tests, all green locally.
2. End-to-end repro from #32644: with `HERMES_MEDIA_DELIVERY_STRICT=1` and `HERMES_MEDIA_TRUST_RECENT_FILES=0`, call `send_message_tool({"action": "send", "target": "telegram:<chat>", "message": "[[audio_as_voice]]\nMEDIA:/tmp/outside-allowlist.ogg"})`. The returned JSON now contains `"media_dropped": ["/tmp/outside-allowlist.ogg"]` plus a `warnings` entry naming the dropped attachment, instead of a bare `{"success": true}`.
3. Negative coverage: when `_send_to_platform` returns `{"error": "..."}`, the test confirms `media_dropped` is not attached — so a real send failure isn't masked.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_send_message_tool.py tests/gateway/test_platform_base.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / darwin-arm64 (Python 3.11). No Windows footguns introduced — `scripts/check-windows-footguns.py` clean on the four touched files.

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, new method's docstring covers the behavior change and existing callers see no API change.
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config keys.
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — change is pure Python list/tuple manipulation, no signals/subprocess/path-mode involved.
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A, the `send_message` schema is unchanged; the result dict gains an optional `media_dropped` field on success which is additive.

## Addressing maintainer feedback

@alt-glitch noted (PR triage comment) that this competes with #32880, #32054, and #31864 — all targeting #32644 (silent MEDIA attachment drop):

- **#32880** — send_message-only; the most focused of the four.
- **#32054** — broader; also touches `run.py` and `scheduler.py`.
- **#31864** — restructures the `filter_*` return type across 13 call sites.

This PR sits between them: it adds `partition_media_delivery_paths` on `BasePlatformAdapter` and surfaces dropped paths in the `send_message` result, while keeping `filter_media_delivery_paths`' existing return shape (no change at its other call sites). Scope is intentionally limited to the four files above; the gateway post-stream path and the smoke-test command remain deferred (`Refs #32644`, not `Closes`). Happy to defer to whichever of the competing PRs the maintainers prefer — flagging the overlap here so the duplication is visible.

<!-- autocontrib:worker-id=issue-new-d909e7f5 kind=pr-open -->
