### PR TITLE
fix: source shell init for background terminal jobs

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -433,6 +433,32 @@ class TestPruning:
 # =========================================================================
 
 class TestSpawnEnvSanitization:
+    def test_spawn_local_sources_terminal_shell_init_files(self, registry, tmp_path):
+        """Background jobs must see the same shell-init PATH additions as foreground terminal calls.
+
+        Foreground LocalEnvironment captures ~/.profile/~/.bashrc into a session snapshot before
+        executing commands. Local background jobs bypass that snapshot and spawn directly through
+        ProcessRegistry, so they must explicitly source the same init files; otherwise tools added
+        by user shell startup (gh, npm, dotnet shims, etc.) are missing only in background mode.
+        """
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        tool = bin_dir / "hermes-bg-path-tool"
+        tool.write_text("#!/usr/bin/env bash\nprintf 'BACKGROUND_PATH_OK\\n'\n", encoding="utf-8")
+        tool.chmod(0o755)
+
+        init_file = tmp_path / "shell-init.sh"
+        init_file.write_text(f'export PATH="{bin_dir}:$PATH"\n', encoding="utf-8")
+
+        with patch("tools.process_registry._resolve_shell_init_files", return_value=[str(init_file)]), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_local("hermes-bg-path-tool", cwd=str(tmp_path))
+            result = registry.wait(session.id, timeout=5)
+
+        assert result["status"] == "exited"
+        assert result["exit_code"] == 0
+        assert "BACKGROUND_PATH_OK" in result["output"]
+
     def test_spawn_local_strips_blocked_vars_from_background_env(self, registry):
         captured = {}
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -41,7 +41,13 @@ import time
 import uuid
 
 _IS_WINDOWS = platform.system() == "Windows"
-from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
+from tools.environments.local import (
+    _find_shell,
+    _prepend_shell_init,
+    _resolve_safe_cwd,
+    _resolve_shell_init_files,
+    _sanitize_subprocess_env,
+)
 from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -497,6 +503,24 @@ class ProcessRegistry:
             except (OSError, ProcessLookupError, PermissionError):
                 pass
 
+    @staticmethod
+    def _background_shell_command(command: str) -> str:
+        """Return the shell script used for local background processes.
+
+        Foreground local terminal calls create a login-shell snapshot after
+        sourcing the configured terminal shell-init files (defaulting to the
+        user's profile/bashrc files). Background jobs bypass LocalEnvironment's
+        snapshot and spawn directly through ProcessRegistry, so source the same
+        files here before running the requested command. This keeps PATH
+        additions for CLIs installed by the user's shell startup available in
+        both foreground and background terminal modes.
+        """
+        cmd = f"set +m; {command}"
+        init_files = _resolve_shell_init_files()
+        if init_files:
+            cmd = _prepend_shell_init(cmd, init_files)
+        return cmd
+
     # ----- Spawn -----
 
     @staticmethod
@@ -550,8 +574,9 @@ class ProcessRegistry:
                 user_shell = _find_shell()
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
                 pty_env["PYTHONUNBUFFERED"] = "1"
+                pty_command = self._background_shell_command(command)
                 pty_proc = _PtyProcessCls.spawn(
-                    [user_shell, "-lic", f"set +m; {command}"],
+                    [user_shell, "-lic", pty_command],
                     cwd=session.cwd,
                     env=pty_env,
                     dimensions=(30, 120),
@@ -591,10 +616,11 @@ class ProcessRegistry:
         # stdout is a pipe, hiding output from process(action="poll")).
         bg_env = _sanitize_subprocess_env(os.environ, env_vars)
         bg_env["PYTHONUNBUFFERED"] = "1"
+        bg_command = self._background_shell_command(command)
         _popen_kwargs = {"creationflags": windows_hide_flags()} if _IS_WINDOWS else {}
 
         proc = subprocess.Popen(
-            [user_shell, "-lic", f"set +m; {command}"],
+            [user_shell, "-lic", bg_command],
             text=True,
             cwd=session.cwd,
             env=bg_env,


### PR DESCRIPTION
## Summary
- Source the same terminal shell-init files for local background jobs that foreground terminal calls use for their session snapshot
- Apply the behavior to both pipe and PTY background process paths
- Add a regression test covering PATH additions from shell init files

## Tests
- `/opt/data/home/hermes-agent/venv/bin/python -m pytest tests/tools/test_process_registry.py::TestSpawnEnvSanitization::test_spawn_local_sources_terminal_shell_init_files -q`
- `/opt/data/home/hermes-agent/venv/bin/python -m pytest tests/tools/test_process_registry.py tests/tools/test_local_env_blocklist.py -q`

Note: the second command passes with pre-existing thread warnings in `test_local_env_blocklist.py` caused by mocked stdout fileno behavior.