### PR TITLE
fix(agent): fall through to env var when OpenRouter credential pool exhausted

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1493,13 +1493,16 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
-        if not or_key:
-            _mark_provider_unhealthy("openrouter", ttl=60)
-            return None, None
-        base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
-        logger.debug("Auxiliary client: OpenRouter via pool")
-        return OpenAI(api_key=or_key, base_url=base_url,
-                       default_headers=build_or_headers()), model or _OPENROUTER_MODEL
+        if or_key:
+            base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
+            logger.debug("Auxiliary client: OpenRouter via pool")
+            return OpenAI(api_key=or_key, base_url=base_url,
+                           default_headers=build_or_headers()), model or _OPENROUTER_MODEL
+        # Pool exists but no usable entry — fall through to env var below.
+        # Pool exhaustion may be from a model-specific 429 (e.g. one provider
+        # rate-limiting one model), not a key-level issue.  Falling through
+        # lets the env var — which is the same key the pool was seeded from —
+        # take over when the pool can't provide a working entry.
 
     or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
     if not or_key:


### PR DESCRIPTION
What changed

In _try_openrouter() (agent/auxiliary_client.py), when the credential pool has an entry but no usable key — because it was marked exhausted from a model-specific 429 — fall through to the OPENROUTER_API_KEY environment variable instead of returning None.

Why

The credential pool exhaustion is overly broad. When one model on one upstream provider returns 429 (e.g., ibm-granite rate-limited by W&B), the entire API key is marked exhausted for up to an hour. This blocks ALL OpenRouter auxiliary access — even for completely unrelated models that work fine. The env var holds the same key the pool was seeded from; the bug is that the pool gate short-circuits before the env var fallback path is reached.

The vision auxiliary slot is the canary. Its auto-detection chain (OpenRouter → Nous) has no api-key provider fallback. When the pool blocks OpenRouter, vision is dead with no recovery path — even though the key is valid.

How to verify

1. Have an OpenRouter credential pool entry marked as rate-limited (429)
2. Run hermes — the vision slot previously failed with "No LLM provider configured for task=vision provider=openrouter"
3. After this fix: vision succeeds via the env var fallback
4. All other OpenRouter auxiliary slots (compression, session_search, skills_hub, etc.) also recover

Tests

scripts/run_tests.sh tests/agent/

134 files, 3591 passed, 0 failed — including test_auxiliary_client.py at 182 passed.

Platforms tested

- Rocky Linux 9.7, Python 3.11