### PR TITLE
fix(kanban): checkpoint reminder before worker exits with text response (closes #27178)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -710,6 +710,16 @@ def run_conversation(
     compression_attempts = 0
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
 
+    # Kanban-worker checkpoint reminder: track whether the worker has already
+    # been nudged once this turn to call kanban_complete/kanban_block. If a
+    # text-response exit fires without the agent having called either tool,
+    # we inject ONE synthetic user message reminding the agent to checkpoint
+    # and continue the loop for one more iteration (#27178). The flag caps
+    # the nudge at one — if the agent ignores the reminder on the followup
+    # turn, we let the natural exit fire and the dispatcher's existing
+    # protocol_violation path handles it.
+    _kanban_checkpoint_reminder_sent = False
+
     # Per-turn file-mutation verifier state.  Keyed by resolved path;
     # each failed ``write_file`` / ``patch`` call records the error
     # preview.  Later successful writes to the same path remove the
@@ -4234,6 +4244,81 @@ def run_conversation(
                 messages.append(final_msg)
                 
                 _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
+
+                # Kanban-worker checkpoint nudge (#27178): if a dispatcher-
+                # spawned worker is about to exit naturally without having
+                # called kanban_complete/kanban_block, the dispatcher will
+                # flag it as a protocol_violation and immediately trip the
+                # failure breaker — even when the agent actually did
+                # substantive work but just forgot to checkpoint. Give the
+                # agent ONE more turn with an injected reminder before
+                # letting the worker exit; if it still doesn't checkpoint
+                # the existing protocol_violation path catches it.
+                #
+                # Scoped to dispatcher-spawned workers (HERMES_KANBAN_TASK
+                # env var); normal chat sessions never see this.
+                _kanban_task_env = os.environ.get("HERMES_KANBAN_TASK")
+                if (
+                    _kanban_task_env
+                    and not _kanban_checkpoint_reminder_sent
+                ):
+                    _called_kanban_terminal = False
+                    for _m in messages:
+                        if not (isinstance(_m, dict) and _m.get("role") == "assistant"):
+                            continue
+                        for _tc in (_m.get("tool_calls") or []):
+                            if not isinstance(_tc, dict):
+                                continue
+                            _fn = (_tc.get("function") or {}).get("name", "")
+                            if _fn in ("kanban_complete", "kanban_block"):
+                                _called_kanban_terminal = True
+                                break
+                        if _called_kanban_terminal:
+                            break
+                    if not _called_kanban_terminal:
+                        # Append a synthetic user-role reminder. This is the
+                        # only safe role at this position: the last message
+                        # is the assistant's text response (just appended
+                        # above), so the next message must be user or tool.
+                        # There's no pending tool_call to answer, so user
+                        # is correct and preserves role alternation.
+                        _reminder_text = (
+                            f"You ended your turn without calling "
+                            f"`kanban_complete` or `kanban_block` for task "
+                            f"`{_kanban_task_env}`. Every kanban worker run "
+                            f"MUST end with one of these tool calls so the "
+                            f"dispatcher knows the task outcome.\n\n"
+                            f"If your work is finished, call "
+                            f"`kanban_complete(task_id=\"{_kanban_task_env}\", "
+                            f"summary=\"...\", result=\"...\")`.\n\n"
+                            f"If you cannot finish without more input "
+                            f"(missing permissions, ambiguous requirements, "
+                            f"a dependency on a human decision), call "
+                            f"`kanban_block(task_id=\"{_kanban_task_env}\", "
+                            f"reason=\"...\")`.\n\n"
+                            f"Please make that call now."
+                        )
+                        messages.append({
+                            "role": "user",
+                            "content": _reminder_text,
+                            "_kanban_checkpoint_reminder": True,
+                        })
+                        _kanban_checkpoint_reminder_sent = True
+                        logger.info(
+                            "kanban worker: injected checkpoint reminder "
+                            "for task %s after text_response exit (turn %d)",
+                            _kanban_task_env, api_call_count,
+                        )
+                        if not agent.quiet_mode:
+                            agent._safe_print(
+                                "↺ kanban worker: prompting agent to "
+                                "checkpoint before exit"
+                            )
+                        # Re-enter the loop for one more iteration. Don't
+                        # print the "Conversation completed" banner; the
+                        # turn isn't done.
+                        continue
+
                 if not agent.quiet_mode:
                     agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
                 break

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1296,6 +1296,8 @@ AUTHOR_MAP = {
     "mail@sadiksaifi.dev": "sadiksaifi",
     "231588442+vynxevainglory-ai@users.noreply.github.com": "vynxevainglory-ai",  # PR #29233 salvage (kanban scrollbar + body overflow)
     "vynxevainglory@gmail.com": "vynxevainglory-ai",
+    "2693665+Jonnybooyy@users.noreply.github.com": "Jonnybooyy",  # #27178 (kanban checkpoint reminder co-author)
+    "jonlopez101@gmail.com": "Jonnybooyy",
     # batch salvage (May 2026 LHF run, group 8)
     "266824395+AceWattGit@users.noreply.github.com": "AceWattGit",  # PR #28159 salvage (_pool_may_recover NameError)
     "57024493+YuanHanzhong@users.noreply.github.com": "YuanHanzhong",  # PR #28032 salvage (x.com status link-like)

--- a/tests/run_agent/test_kanban_checkpoint_reminder.py
+++ b/tests/run_agent/test_kanban_checkpoint_reminder.py
@@ -1,0 +1,164 @@
+"""Regression tests for #27178 — kanban worker checkpoint reminder.
+
+When a dispatcher-spawned kanban worker exits with a text response
+(finish_reason=stop) without having called kanban_complete or
+kanban_block, the dispatcher flags it as protocol_violation and
+immediately trips the failure breaker. Many of these cases are the
+agent having done substantive work but forgetting to checkpoint
+(reporter @Jonnybooyy's "Concern 3" repro shape in #27178).
+
+The fix injects ONE synthetic user-role reminder before the worker
+exits, giving the agent a chance to call kanban_complete/block on
+a final turn. Capped at one nudge per turn so a non-compliant agent
+falls through to the existing protocol_violation path.
+
+These tests are intentionally light: the main contract is exercised
+via a source-level invariant check (catches refactors that drop the
+nudge) plus a message-list unit test that exercises the
+detection logic directly. A full end-to-end run_conversation test
+would require mocking the LLM client, which is heavyweight and
+covered by the broader run_agent test suite.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+
+def test_conversation_loop_has_kanban_checkpoint_reminder():
+    """Source-level invariant: agent/conversation_loop.py must contain
+    the kanban-worker checkpoint nudge block. Catches refactors that
+    drop the env-gated reminder injection.
+    """
+    cl_path = (
+        pathlib.Path(__file__).resolve().parent.parent.parent
+        / "agent" / "conversation_loop.py"
+    )
+    src = cl_path.read_text()
+    # The nudge must be env-gated on HERMES_KANBAN_TASK so normal chat
+    # sessions never see it.
+    assert "HERMES_KANBAN_TASK" in src, (
+        "conversation_loop.py must reference HERMES_KANBAN_TASK to gate "
+        "the kanban-worker checkpoint nudge — see #27178"
+    )
+    # The reminder block must check for prior kanban_complete or
+    # kanban_block calls before injecting (idempotency / don't nudge
+    # tasks that already checkpointed).
+    assert "kanban_complete" in src and "kanban_block" in src, (
+        "conversation_loop.py must check for kanban_complete / "
+        "kanban_block in messages before injecting reminder"
+    )
+    # The cap-at-one-nudge flag is what prevents reminder loops.
+    assert "_kanban_checkpoint_reminder_sent" in src, (
+        "conversation_loop.py must track _kanban_checkpoint_reminder_sent "
+        "to cap the nudge at one per turn — see #27178"
+    )
+
+
+def test_kanban_terminal_call_detection_logic():
+    """Verify the message-scan logic correctly identifies whether a
+    worker has already called kanban_complete or kanban_block.
+
+    This mirrors the inline scan in conversation_loop.py. If the scan
+    pattern there changes, this test should be updated to match.
+    """
+    # Case 1: messages with a kanban_complete tool call → detected
+    msgs_with_complete = [
+        {"role": "system", "content": "..."},
+        {"role": "user", "content": "do the task"},
+        {"role": "assistant", "content": "ok", "tool_calls": [
+            {"id": "c1", "type": "function",
+             "function": {"name": "kanban_complete",
+                          "arguments": '{"task_id": "t_x"}'}}
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "name": "kanban_complete",
+         "content": "ok"},
+        {"role": "assistant", "content": "done"},
+    ]
+    assert _scan_for_kanban_terminal(msgs_with_complete) is True
+
+    # Case 2: messages with kanban_block → detected
+    msgs_with_block = [
+        {"role": "user", "content": "do it"},
+        {"role": "assistant", "tool_calls": [
+            {"id": "b1", "type": "function",
+             "function": {"name": "kanban_block",
+                          "arguments": '{"task_id": "t_x", "reason": "need input"}'}}
+        ]},
+        {"role": "tool", "tool_call_id": "b1", "name": "kanban_block",
+         "content": "ok"},
+        {"role": "assistant", "content": "blocked"},
+    ]
+    assert _scan_for_kanban_terminal(msgs_with_block) is True
+
+    # Case 3: only non-terminal kanban tool calls (kanban_show, heartbeat,
+    # comment) — not detected. These are NOT terminal.
+    msgs_non_terminal_only = [
+        {"role": "user", "content": "do it"},
+        {"role": "assistant", "tool_calls": [
+            {"id": "s1", "type": "function",
+             "function": {"name": "kanban_show", "arguments": "{}"}}
+        ]},
+        {"role": "tool", "tool_call_id": "s1", "content": "..."},
+        {"role": "assistant", "tool_calls": [
+            {"id": "h1", "type": "function",
+             "function": {"name": "kanban_heartbeat",
+                          "arguments": '{"task_id": "t_x"}'}}
+        ]},
+        {"role": "tool", "tool_call_id": "h1", "content": "ok"},
+        {"role": "assistant", "content": "I'm done writing the file"},
+    ]
+    assert _scan_for_kanban_terminal(msgs_non_terminal_only) is False
+
+    # Case 4: mixed — kanban_show + kanban_complete → detected
+    msgs_mixed = [
+        {"role": "user", "content": "do it"},
+        {"role": "assistant", "tool_calls": [
+            {"id": "s1", "type": "function",
+             "function": {"name": "kanban_show", "arguments": "{}"}}
+        ]},
+        {"role": "tool", "tool_call_id": "s1", "content": "..."},
+        {"role": "assistant", "tool_calls": [
+            {"id": "c1", "type": "function",
+             "function": {"name": "kanban_complete",
+                          "arguments": '{"task_id": "t_x"}'}}
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "content": "ok"},
+        {"role": "assistant", "content": "complete"},
+    ]
+    assert _scan_for_kanban_terminal(msgs_mixed) is True
+
+    # Case 5: empty / no tool calls → not detected
+    msgs_empty = [
+        {"role": "user", "content": "do it"},
+        {"role": "assistant", "content": "I think it's done"},
+    ]
+    assert _scan_for_kanban_terminal(msgs_empty) is False
+
+    # Case 6: tool call with None arguments dict shouldn't crash
+    msgs_malformed = [
+        {"role": "assistant", "tool_calls": [None, "garbage",
+                                             {"function": None}]},
+        {"role": "assistant", "content": "done"},
+    ]
+    assert _scan_for_kanban_terminal(msgs_malformed) is False
+
+
+def _scan_for_kanban_terminal(messages: list) -> bool:
+    """Reimplementation of the message-scan logic in conversation_loop.py.
+
+    Kept here as a test-side copy because the production scan is inlined
+    inside run_conversation and not easily importable. If the production
+    scan changes (e.g. adds more terminal tool names), update this too.
+    """
+    for m in messages:
+        if not (isinstance(m, dict) and m.get("role") == "assistant"):
+            continue
+        for tc in (m.get("tool_calls") or []):
+            if not isinstance(tc, dict):
+                continue
+            fn = (tc.get("function") or {}).get("name", "")
+            if fn in ("kanban_complete", "kanban_block"):
+                return True
+    return False


### PR DESCRIPTION
Fixes #27178 — kanban workers that finish with a text response (`finish_reason=stop`) without calling `kanban_complete` / `kanban_block` are flagged as `protocol_violation` by the dispatcher, even when the agent did substantive work and just forgot to checkpoint.

## The bug

Reporter @Jonnybooyy's repro shape: agent worked through 28 tool turns / 29 API calls over ~3 minutes (`search_files`, `read_file`, `terminal`, recovery from one tool error), then ended with:

```
Turn ended: reason=text_response(finish_reason=stop)
  model=gpt-5.3-codex api_calls=29/60 budget=29/60 tool_turns=28
  last_msg_role=assistant response_len=668
```

The agent never called `kanban_complete` or `kanban_block`. From the agent's perspective the turn ended normally. From the dispatcher's perspective: the task is still `running` in the DB, the worker exited rc=0, so this trips `_classify_worker_exit() == "clean_exit"` → `protocol_violation` → `failure_limit=1` (immediate breaker trip) → task → `blocked`. The agent's 28 turns of work were thrown away.

This is the canonical "agent forgot to checkpoint" pattern. It is NOT the model being broken; it's the prompt-following gap between a kanban worker's job (always end with a terminal tool call) and a normal chat session's job (it's fine to just stop).

## The fix

When the worker is about to exit naturally via text response, give the agent ONE more turn with a synthetic user-role reminder:

```
You ended your turn without calling `kanban_complete` or `kanban_block`
for task `t_a1b2c3d4`. Every kanban worker run MUST end with one of
these tool calls so the dispatcher knows the task outcome.

If your work is finished:
  kanban_complete(task_id="t_a1b2c3d4", summary="...", result="...")

If you cannot finish without more input:
  kanban_block(task_id="t_a1b2c3d4", reason="...")

Please make that call now.
```

The injection is structurally identical to the existing `_handle_max_iterations` pattern (`chat_completion_helpers.py:1289`) which already appends a synthetic user message when iteration budget is exhausted. Same role-alternation properties, same "after final assistant response" position.

## Invariants preserved

| Property | Check |
|---|---|
| Normal chat sessions unaffected | Env-gated on `HERMES_KANBAN_TASK` — only set by the kanban dispatcher when spawning workers |
| No mid-loop synthetic injection | Reminder fires AFTER the assistant's final text response is appended, BEFORE the loop's `break`. Same position as user typing a follow-up message in interactive chat |
| Role alternation correctness | Sequence is `assistant (text response) → user (reminder) → assistant (next turn)`. Standard forward-flow alternation |
| No reminder loop | `_kanban_checkpoint_reminder_sent` flag scoped to one turn caps at exactly 1 nudge. If the agent ignores the reminder, the natural exit fires again, the flag prevents re-injection, and the existing protocol_violation path handles it |
| Idempotent on already-checkpointed tasks | Pre-injection scan checks for any prior `kanban_complete` / `kanban_block` tool call in messages; if found, no reminder |
| AGENTS.md "no synthetic user mid-loop" rule | That rule specifically prohibits injection BETWEEN tool_call and tool_result. This injection is at the post-final-assistant-response position which the precedent (`_handle_max_iterations`) already uses |

## Reporter's other suggestions (deferred)

The bug report contained 4 suggested fixes. This PR implements #1 (checkpoint reminder on `finish_reason=stop`). The others are worth separate consideration:

- **#2** ("Differentiate the dispatcher error message" — split protocol_violation into clean_exit_no_checkpoint vs true_crash vs model_auth_error): legitimate triage improvement, separate PR. Not blocking the agent-side fix here.
- **#3** ("Render the checkpoint requirement at every turn"): would help with by-turn-28-it's-out-of-the-recency-window forgetting. Conflicts with prompt-caching invariants (every-turn-append breaks the cache). The single-reminder approach in this PR is a less invasive alternative that gets most of the benefit.
- **#4** ("Don't auto-block on the first checkpoint-omission failure"): with this PR, the agent gets a checkpoint nudge BEFORE the dispatcher ever sees the clean exit. If the agent ignores the nudge, the existing `failure_limit=1` behavior still applies. That trip is now informative (agent ignored 2 chances) rather than punitive (one strike on first miss).

## Validation

- `tests/run_agent/test_kanban_checkpoint_reminder.py` — 2 new tests:
  - **Source-level invariant** catching refactors that drop the env-gated nudge
  - **Message-scan detection logic** across 6 message-shape scenarios (kanban_complete alone, kanban_block alone, non-terminal kanban_show/heartbeat only, mixed kanban_show + kanban_complete, empty, malformed tool_calls)
- `tests/run_agent/` full suite + kanban + signal-handler suites: **1947/1947 pass** (one order-dependent flake in `test_provider_parity.py` confirmed unrelated — passes in isolation, same flake exists on `origin/main`).

## Credit

- **@Jonnybooyy** — root-cause diagnosis (three repro shapes across three runs, all surfacing as the same `protocol_violation` string, which made root-cause diagnosis significantly slower than necessary). Proposed fix #1 ("Inject a checkpoint reminder on `finish_reason=stop` without prior checkpoint") was the design that shipped. `Co-authored-by:` trailer on the commit; AUTHOR_MAP entry added.
- **@cardtest15-coder, @alt-glitch** — triage cross-references that helped scope this as distinct from the existing `protocol_violation` cluster.

## Infographic

![kanban-checkpoint-reminder](https://v3b.fal.media/files/b/0a9c1573/-uZwYGpY3yq4KTNH87_mR_DI0UPbMk.png)
