### PR TITLE
fix(skills-page): restore per-source pills and category sidebar (stale useMemo deps)

### DIFF
--- a/website/src/pages/skills/index.tsx
+++ b/website/src/pages/skills/index.tsx
@@ -500,7 +500,7 @@ export default function SkillsDashboard() {
   const sources = useMemo(() => {
     const set = new Set(allSkillsLocal.map((s) => s.source));
     return SOURCE_ORDER.filter((s) => s === "all" || set.has(s));
-  }, []);
+  }, [allSkillsLocal]);
 
   const categoryEntries = useMemo(() => {
     const pool =
@@ -523,7 +523,7 @@ export default function SkillsDashboard() {
     return Array.from(map.entries())
       .sort((a, b) => b[1].count - a[1].count)
       .map(([key, { label, count }]) => ({ key, label, count }));
-  }, [sourceFilter]);
+  }, [sourceFilter, allSkillsLocal]);
 
   const filtered = useMemo(() => {
     const q = debouncedSearch.toLowerCase().trim();


### PR DESCRIPTION
## Summary

Regression from PR #33809 (lazy-fetch refactor). The live skills page renders only the "All 87,639" source button — no per-source pills (ClawHub, skills.sh, LobeHub, etc.) — and the Category sidebar shows only "All Skills 87,639" with no breakdown. Filtering is unusable.

Root cause: two `useMemo` blocks that compute their results from `allSkillsLocal` were missing it from their deps arrays. They ran once at mount when `allSkillsLocal` was still `[]`, and never recomputed when the fetch resolved.

## Changes

`website/src/pages/skills/index.tsx`:

```diff
   const sources = useMemo(() => {
     const set = new Set(allSkillsLocal.map((s) => s.source));
     return SOURCE_ORDER.filter((s) => s === "all" || set.has(s));
-  }, []);
+  }, [allSkillsLocal]);
```

```diff
     return Array.from(map.entries())
       .sort((a, b) => b[1].count - a[1].count)
       .map(([key, { label, count }]) => ({ key, label, count }));
-  }, [sourceFilter]);
+  }, [sourceFilter, allSkillsLocal]);
```

## Validation

Local `npm run build` green on both `en` and `zh-Hans` locales.

## Infographic

![source-pills-restored](https://v3b.fal.media/files/b/0a9c1596/3QItf9rv4OpdfT-1U0npp_VMJL60rh.png)
