### PR TITLE
fix(cron): skip delivery fallback during shutdown

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -336,13 +336,13 @@ def load_jobs() -> List[Dict[str, Any]]:
         return []
     
     try:
-        with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+        with open(JOBS_FILE, 'r', encoding='utf-8-sig') as f:
             data = json.load(f)
             return data.get("jobs", [])
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         try:
-            with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+            with open(JOBS_FILE, 'r', encoding='utf-8-sig') as f:
                 data = json.loads(f.read(), strict=False)
                 jobs = data.get("jobs", [])
                 if jobs:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -400,6 +400,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         return msg
 
     delivery_errors = []
+    shutdown_skips = []
 
     for target in targets:
         platform_name = target["platform"]
@@ -457,7 +458,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         if _is_interpreter_shutdown_message(err):
                             msg = f"delivery to {platform_name}:{chat_id} skipped during interpreter shutdown"
                             logger.warning("Job '%s': %s", job["id"], msg)
-                            delivery_errors.append(msg)
+                            shutdown_skips.append(msg)
                             continue
                         logger.warning(
                             "Job '%s': live adapter send to %s:%s failed (%s), falling back to standalone",
@@ -476,7 +477,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if _is_interpreter_shutdown_runtime_error(e):
                     msg = f"delivery to {platform_name}:{chat_id} skipped during interpreter shutdown"
                     logger.warning("Job '%s': %s", job["id"], msg)
-                    delivery_errors.append(msg)
+                    shutdown_skips.append(msg)
                     continue
                 logger.warning(
                     "Job '%s': live adapter delivery to %s:%s failed (%s), falling back to standalone",
@@ -515,7 +516,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 if _is_interpreter_shutdown_message(err):
                     msg = f"delivery to {platform_name}:{chat_id} skipped during interpreter shutdown"
                     logger.warning("Job '%s': %s", job["id"], msg)
-                    delivery_errors.append(msg)
+                    shutdown_skips.append(msg)
                     continue
                 msg = f"delivery error: {err}"
                 logger.error("Job '%s': %s", job["id"], msg)
@@ -525,6 +526,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     if delivery_errors:
         return "; ".join(delivery_errors)
+    if shutdown_skips:
+        logger.info(
+            "Job '%s': suppressing shutdown delivery skip as non-actionable: %s",
+            job["id"],
+            "; ".join(shutdown_skips),
+        )
     return None
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -41,6 +41,23 @@ from hermes_time import now as _hermes_now
 logger = logging.getLogger(__name__)
 
 
+def _is_interpreter_shutdown_message(value: object) -> bool:
+    """Return True when a value describes Python finalization shutdown."""
+    return "cannot schedule new futures after interpreter shutdown" in str(value).lower()
+
+
+def _is_interpreter_shutdown_runtime_error(exc: BaseException) -> bool:
+    """Return True for executor failures caused by Python finalization.
+
+    During process shutdown, ThreadPoolExecutor.submit can raise
+    RuntimeError: cannot schedule new futures after interpreter shutdown.
+    Cron may still be finishing a due job (and saving/delivery bookkeeping)
+    during gateway/daemon teardown; treat that case as a shutdown-mode signal
+    rather than a job failure whenever we can still finish work synchronously.
+    """
+    return isinstance(exc, RuntimeError) and _is_interpreter_shutdown_message(exc)
+
+
 def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     """Resolve the toolset list for a cron job.
 
@@ -117,9 +134,17 @@ SILENT_MARKER = "[SILENT]"
 # Resolve Hermes home directory (respects HERMES_HOME override)
 _hermes_home = get_hermes_home()
 
-# File-based lock prevents concurrent ticks from gateway + daemon + systemd timer
+# File-based lock prevents concurrent ticks from gateway + daemon + systemd timer.
+# Keep the legacy globals for tests/callers that patch them, while letting
+# _hermes_home monkeypatches dynamically move the lock away from a live gateway.
 _LOCK_DIR = _hermes_home / "cron"
 _LOCK_FILE = _LOCK_DIR / ".tick.lock"
+
+
+def _get_tick_lock_file() -> Path:
+    if _LOCK_FILE != _LOCK_DIR / ".tick.lock":
+        return _LOCK_FILE
+    return get_hermes_home() / "cron" / ".tick.lock"
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
@@ -414,10 +439,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
                 if text_to_send:
-                    future = asyncio.run_coroutine_threadsafe(
-                        runtime_adapter.send(chat_id, text_to_send, metadata=send_metadata),
-                        loop,
-                    )
+                    text_coro = runtime_adapter.send(chat_id, text_to_send, metadata=send_metadata)
+                    try:
+                        future = asyncio.run_coroutine_threadsafe(text_coro, loop)
+                    except RuntimeError:
+                        close = getattr(text_coro, "close", None)
+                        if close is not None:
+                            close()
+                        raise
                     try:
                         send_result = future.result(timeout=60)
                     except TimeoutError:
@@ -425,6 +454,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         raise
                     if send_result and not getattr(send_result, "success", True):
                         err = getattr(send_result, "error", "unknown")
+                        if _is_interpreter_shutdown_message(err):
+                            msg = f"delivery to {platform_name}:{chat_id} skipped during interpreter shutdown"
+                            logger.warning("Job '%s': %s", job["id"], msg)
+                            delivery_errors.append(msg)
+                            continue
                         logger.warning(
                             "Job '%s': live adapter send to %s:%s failed (%s), falling back to standalone",
                             job["id"], platform_name, chat_id, err,
@@ -439,6 +473,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     delivered = True
             except Exception as e:
+                if _is_interpreter_shutdown_runtime_error(e):
+                    msg = f"delivery to {platform_name}:{chat_id} skipped during interpreter shutdown"
+                    logger.warning("Job '%s': %s", job["id"], msg)
+                    delivery_errors.append(msg)
+                    continue
                 logger.warning(
                     "Job '%s': live adapter delivery to %s:%s failed (%s), falling back to standalone",
                     job["id"], platform_name, chat_id, e,
@@ -695,6 +734,20 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 if not output_files:
                     continue  # silent skip — no output yet
                 latest_output = output_files[0].read_text(encoding="utf-8").strip()
+                # Do not feed recursive infrastructure failures back into the
+                # next run. A failed hourly commander output includes the full
+                # prior prompt/context, so context_from can otherwise amplify
+                # the same scheduler traceback forever and crowd out useful
+                # work context.
+                failed_output = "(FAILED)" in latest_output[:300]
+                shutdown_failure = "cannot schedule new futures after interpreter shutdown" in latest_output.lower()
+                script_interrupt = "KeyboardInterrupt" in latest_output and "hourly_commander_context.py" in latest_output
+                if failed_output and (shutdown_failure or script_interrupt):
+                    logger.warning(
+                        "context_from: skipping failed infrastructure output for job %r",
+                        source_job_id,
+                    )
+                    continue
                 # Truncate to 8K characters to avoid prompt bloat
                 _MAX_CONTEXT_CHARS = 8000
                 if len(latest_output) > _MAX_CONTEXT_CHARS:
@@ -770,6 +823,13 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     if prompt:
         parts.extend(["", f"The user has provided the following instruction alongside the skill invocation: {prompt}"])
     return "\n".join(parts)
+
+
+def _cron_memory_enabled(enabled_toolsets) -> bool:
+    """Return True when a cron job explicitly enables memory-capable tools."""
+    if not enabled_toolsets:
+        return False
+    return any(str(toolset).lower() in {"memory", "all"} for toolset in enabled_toolsets)
 
 
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
@@ -991,6 +1051,19 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             except Exception as e:
                 logger.debug("Job '%s': failed to load credential pool for %s: %s", job_id, runtime_provider, e)
 
+        _cron_enabled_toolsets = _resolve_cron_enabled_toolsets(job, _cfg)
+        # Cron used to force skip_memory=not _cron_memory_enabled(enabled_toolsets), which made the memory tool
+        # appear in jobs that enabled the memory toolset but fail at runtime
+        # with "Memory is not available."  Only skip memory for cron jobs that
+        # did not opt into the memory toolset.  Writes remain explicit tool
+        # calls; enabling the toolset means the job intentionally requested
+        # durable memory access.
+        _cron_memory_requested = (
+            _cron_enabled_toolsets is None
+            or "all" in _cron_enabled_toolsets
+            or "memory" in _cron_enabled_toolsets
+        )
+
         agent = AIAgent(
             model=model,
             api_key=runtime.get("api_key"),
@@ -1008,14 +1081,14 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             providers_ignored=pr.get("ignore"),
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
-            enabled_toolsets=_resolve_cron_enabled_toolsets(job, _cfg),
+            enabled_toolsets=_cron_enabled_toolsets,
             disabled_toolsets=["cronjob", "messaging", "clarify"],
             quiet_mode=True,
             # When a workdir is configured, inject AGENTS.md / CLAUDE.md /
             # .cursorrules from that directory; otherwise preserve the old
             # behaviour (don't inject SOUL.md/AGENTS.md from the scheduler cwd).
             skip_context_files=not bool(_job_workdir),
-            skip_memory=True,  # Cron system prompts would corrupt user representations
+            skip_memory=not _cron_memory_requested,
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,
@@ -1037,12 +1110,25 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # env passthrough registrations) when the cron run hops into the worker
         # thread used for inactivity timeout monitoring.
         _cron_context = contextvars.copy_context()
-        _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
+        _cron_future = None
         _inactivity_timeout = False
         try:
+            try:
+                _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
+            except RuntimeError as submit_exc:
+                if not _is_interpreter_shutdown_runtime_error(submit_exc):
+                    raise
+                logger.warning(
+                    "Job '%s': cron worker pool is shutting down; running synchronously",
+                    job_name,
+                )
+                _cron_pool.shutdown(wait=False, cancel_futures=True)
+                result = _cron_context.run(agent.run_conversation, prompt)
+                _cron_inactivity_limit = None
             if _cron_inactivity_limit is None:
                 # Unlimited — just wait for the result.
-                result = _cron_future.result()
+                if _cron_future is not None:
+                    result = _cron_future.result()
             else:
                 result = None
                 while True:
@@ -1207,12 +1293,13 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
     Returns:
         Number of jobs executed (0 if another tick is already running)
     """
-    _LOCK_DIR.mkdir(parents=True, exist_ok=True)
+    lock_file = _get_tick_lock_file()
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
 
     # Cross-platform file locking: fcntl on Unix, msvcrt on Windows
     lock_fd = None
     try:
-        lock_fd = open(_LOCK_FILE, "w")
+        lock_fd = open(lock_file, "w")
         if fcntl:
             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         elif msvcrt:
@@ -1268,7 +1355,16 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         def _process_job(job: dict) -> bool:
             """Run one due job end-to-end: execute, save, deliver, mark."""
             try:
-                success, output, final_response, error = run_job(job)
+                run_result = run_job(job)
+                if (
+                    not isinstance(run_result, tuple)
+                    or len(run_result) != 4
+                ):
+                    raise RuntimeError(
+                        "run_job returned invalid result "
+                        f"{type(run_result).__name__}: {run_result!r}"
+                    )
+                success, output, final_response, error = run_result
 
                 output_file = save_job_output(job["id"], output)
                 if verbose:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -511,11 +511,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 continue
 
             if result and result.get("error"):
-                msg = f"delivery error: {result['error']}"
+                err = result["error"]
+                if _is_interpreter_shutdown_message(err):
+                    msg = f"delivery to {platform_name}:{chat_id} skipped during interpreter shutdown"
+                    logger.warning("Job '%s': %s", job["id"], msg)
+                    delivery_errors.append(msg)
+                    continue
+                msg = f"delivery error: {err}"
                 logger.error("Job '%s': %s", job["id"], msg)
                 delivery_errors.append(msg)
                 continue
-
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
 
     if delivery_errors:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -34,6 +34,7 @@ _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
 _GATEWAY_LOCK_FILENAME = "gateway.lock"
 _gateway_lock_handle = None
+_gateway_lock_path = None
 
 
 def _get_pid_path() -> Path:
@@ -214,7 +215,10 @@ def _read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:
     if not pid_path.exists():
         return None
 
-    raw = pid_path.read_text().strip()
+    try:
+        raw = pid_path.read_text().strip()
+    except OSError:
+        return None
     if not raw:
         return None
 
@@ -312,11 +316,13 @@ def acquire_gateway_runtime_lock() -> bool:
     Unlike the PID file, the lock is owned by the live process itself. If the
     process dies abruptly, the OS releases the lock automatically.
     """
-    global _gateway_lock_handle
-    if _gateway_lock_handle is not None:
-        return True
-
+    global _gateway_lock_handle, _gateway_lock_path
     path = _get_gateway_lock_path()
+    if _gateway_lock_handle is not None:
+        if _gateway_lock_path == path:
+            return True
+        release_gateway_runtime_lock()
+
     path.parent.mkdir(parents=True, exist_ok=True)
     handle = open(path, "a+", encoding="utf-8")
     if not _try_acquire_file_lock(handle):
@@ -324,16 +330,19 @@ def acquire_gateway_runtime_lock() -> bool:
         return False
     _write_gateway_lock_record(handle)
     _gateway_lock_handle = handle
+    _gateway_lock_path = path
     return True
 
 
 def release_gateway_runtime_lock() -> None:
     """Release the gateway runtime lock when owned by this process."""
-    global _gateway_lock_handle
+    global _gateway_lock_handle, _gateway_lock_path
     handle = _gateway_lock_handle
     if handle is None:
+        _gateway_lock_path = None
         return
     _gateway_lock_handle = None
+    _gateway_lock_path = None
     _release_file_lock(handle)
     try:
         handle.close()
@@ -343,9 +352,9 @@ def release_gateway_runtime_lock() -> None:
 
 def is_gateway_runtime_lock_active(lock_path: Optional[Path] = None) -> bool:
     """Return True when some process currently owns the gateway runtime lock."""
-    global _gateway_lock_handle
+    global _gateway_lock_handle, _gateway_lock_path
     resolved_lock_path = lock_path or _get_gateway_lock_path()
-    if _gateway_lock_handle is not None and resolved_lock_path == _get_gateway_lock_path():
+    if _gateway_lock_handle is not None and resolved_lock_path == _gateway_lock_path:
         return True
 
     if not resolved_lock_path.exists():
@@ -501,8 +510,12 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         if not stale:
             try:
                 os.kill(existing_pid, 0)
-            except (ProcessLookupError, PermissionError, OSError):
-                # Windows raises OSError with WinError 87 for invalid pid check
+            except (ProcessLookupError, PermissionError, OSError, SystemError):
+                # Windows normally raises OSError with WinError 87 for invalid
+                # pid checks, but some native Windows/Python builds surface the
+                # same failure as ``SystemError: <class 'OSError'> returned a
+                # result with an exception set``. Treat both as stale locks so
+                # gateway startup is not blocked by a dead scoped lock record.
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
@@ -758,6 +771,8 @@ def get_running_pid(
 
     primary_record = _read_pid_record(resolved_pid_path)
     fallback_record = _read_gateway_lock_record(resolved_lock_path)
+    if fallback_record is None and _gateway_lock_handle is not None and _gateway_lock_path == resolved_lock_path:
+        fallback_record = _build_pid_record()
 
     for record in (primary_record, fallback_record):
         pid = _pid_from_record(record)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -421,13 +421,13 @@ class TestDeliverResultWrapping:
         voice_call = adapter.send_voice.call_args
         assert voice_call[1]["audio_path"] == "/tmp/cron-voice.mp3"
 
-    def test_live_adapter_shutdown_runtime_error_returns_delivery_error(self):
-        """If the gateway loop is finalizing, do not fall back into standalone delivery.
+    def test_live_adapter_shutdown_runtime_error_is_suppressed(self):
+        """If the gateway loop is finalizing, suppress non-actionable delivery noise.
 
         Regression: run_coroutine_threadsafe can raise
         "cannot schedule new futures after interpreter shutdown" during gateway
-        teardown, which previously led to noisy delivery failures and leaked the
-        created coroutine.
+        teardown. This should not fall back into standalone delivery, leak the
+        created coroutine, or persist as the job's last_error.
         """
         from gateway.config import Platform
 
@@ -457,7 +457,7 @@ class TestDeliverResultWrapping:
                 loop=loop,
             )
 
-        assert "skipped during interpreter shutdown" in result
+        assert result is None
         send_mock.assert_not_called()
 
     def test_live_adapter_routes_image_to_send_image_file(self):
@@ -1947,10 +1947,10 @@ class TestDeliverResultTimeoutCancelsFuture:
                 loop=loop,
             )
 
-        assert "skipped during interpreter shutdown" in result
+        assert result is None
         standalone_send.assert_not_awaited()
 
-    def test_standalone_shutdown_error_is_reported_without_generic_failure(self):
+    def test_standalone_shutdown_error_is_suppressed_as_non_actionable_skip(self):
         """Standalone Telegram delivery can surface Python finalization as a SendResult error."""
         from gateway.config import Platform
         from cron.scheduler import _deliver_result
@@ -1975,8 +1975,7 @@ class TestDeliverResultTimeoutCancelsFuture:
              patch("tools.send_message_tool._send_to_platform", new=standalone_send):
             result = _deliver_result(job, "Hello world", adapters={}, loop=None)
 
-        assert "skipped during interpreter shutdown" in result
-        assert "delivery error:" not in result
+        assert result is None
         standalone_send.assert_awaited_once()
 
 class TestSendMediaTimeoutCancelsFuture:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1950,6 +1950,34 @@ class TestDeliverResultTimeoutCancelsFuture:
         assert "skipped during interpreter shutdown" in result
         standalone_send.assert_not_awaited()
 
+    def test_standalone_shutdown_error_is_reported_without_generic_failure(self):
+        """Standalone Telegram delivery can surface Python finalization as a SendResult error."""
+        from gateway.config import Platform
+        from cron.scheduler import _deliver_result
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        job = {
+            "id": "standalone-shutdown-delivery-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+
+        standalone_send = AsyncMock(return_value={
+            "error": "Telegram send failed: Unknown error in HTTP implementation: RuntimeError('cannot schedule new futures after interpreter shutdown')"
+        })
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            result = _deliver_result(job, "Hello world", adapters={}, loop=None)
+
+        assert "skipped during interpreter shutdown" in result
+        assert "delivery error:" not in result
+        standalone_send.assert_awaited_once()
 
 class TestSendMediaTimeoutCancelsFuture:
     """Same orphan-coroutine guarantee for _send_media_via_adapter's

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -421,6 +421,45 @@ class TestDeliverResultWrapping:
         voice_call = adapter.send_voice.call_args
         assert voice_call[1]["audio_path"] == "/tmp/cron-voice.mp3"
 
+    def test_live_adapter_shutdown_runtime_error_returns_delivery_error(self):
+        """If the gateway loop is finalizing, do not fall back into standalone delivery.
+
+        Regression: run_coroutine_threadsafe can raise
+        "cannot schedule new futures after interpreter shutdown" during gateway
+        teardown, which previously led to noisy delivery failures and leaked the
+        created coroutine.
+        """
+        from gateway.config import Platform
+
+        adapter = AsyncMock()
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        job = {
+            "id": "shutdown-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "1234"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=RuntimeError("cannot schedule new futures after interpreter shutdown")), \
+             patch("tools.send_message_tool._send_to_platform") as send_mock:
+            result = _deliver_result(
+                job,
+                "shutdown delivery",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert "skipped during interpreter shutdown" in result
+        send_mock.assert_not_called()
+
     def test_live_adapter_routes_image_to_send_image_file(self):
         """Image MEDIA files should be routed to send_image_file, not send_voice."""
         from gateway.config import Platform
@@ -782,6 +821,51 @@ class TestRunJobSessionPersistence:
 
         kwargs = mock_agent_cls.call_args.kwargs
         assert kwargs["enabled_toolsets"] == ["web", "terminal", "file"]
+
+    def test_run_job_allows_memory_when_memory_toolset_enabled(self, tmp_path):
+        """Cron jobs that opt into the memory toolset should get a memory store.
+
+        Regression: run_job previously passed skip_memory=True unconditionally,
+        so the memory tool was visible but failed at runtime with "Memory is not
+        available" for jobs that explicitly enabled memory.
+        """
+        job = {
+            "id": "memory-job",
+            "name": "test",
+            "prompt": "hello",
+            "enabled_toolsets": ["terminal", "memory", "skills"],
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["enabled_toolsets"] == ["terminal", "memory", "skills"]
+        assert kwargs["skip_memory"] is False
+
+    def test_run_job_skips_memory_when_memory_toolset_not_enabled(self, tmp_path):
+        """Cron jobs without memory keep the old no-memory behavior."""
+        job = {
+            "id": "no-memory-job",
+            "name": "test",
+            "prompt": "hello",
+            "enabled_toolsets": ["terminal", "skills"],
+        }
+        fake_db, patches = self._make_run_job_patches(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["enabled_toolsets"] == ["terminal", "skills"]
+        assert kwargs["skip_memory"] is True
 
     def test_run_job_enabled_toolsets_resolves_from_platform_config_when_not_set(self, tmp_path):
         """When a job has no explicit enabled_toolsets, the scheduler now
@@ -1816,6 +1900,55 @@ class TestDeliverResultTimeoutCancelsFuture:
         # 2. The standalone fallback delivered — no double send, no silent drop
         assert result is None, f"expected successful delivery, got error: {result!r}"
         standalone_send.assert_awaited_once()
+
+
+    def test_live_adapter_shutdown_error_does_not_fallback_to_standalone(self):
+        """Interpreter shutdown errors surfaced as adapter SendResult failures
+        must not fall through to standalone delivery, which can leak a coroutine
+        and record a noisy Telegram delivery failure during gateway teardown.
+        """
+        from concurrent.futures import Future
+        from gateway.config import Platform
+        from cron.scheduler import _deliver_result
+
+        adapter = AsyncMock()
+        send_result = MagicMock(success=False)
+        send_result.error = "Unknown error in HTTP implementation: RuntimeError('cannot schedule new futures after interpreter shutdown')"
+        adapter.send.return_value = send_result
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        completed_future = Future()
+        completed_future.set_result(send_result)
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return completed_future
+
+        job = {
+            "id": "shutdown-delivery-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg),              patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}),              patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro),              patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            result = _deliver_result(
+                job,
+                "Hello world",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert "skipped during interpreter shutdown" in result
+        standalone_send.assert_not_awaited()
 
 
 class TestSendMediaTimeoutCancelsFuture:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -389,6 +389,28 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
         assert payload["metadata"]["platform"] == "telegram"
 
+    def test_acquire_scoped_lock_treats_windows_systemerror_pid_probe_as_stale(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+        }))
+
+        def fake_kill(pid, sig):
+            raise SystemError("<class 'OSError'> returned a result with an exception set")
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+
     def test_acquire_scoped_lock_recovers_empty_lock_file(self, tmp_path, monkeypatch):
         """Empty lock file (0 bytes) left by a crashed process should be treated as stale."""
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))


### PR DESCRIPTION
Fixes a recurring cron/gateway delivery failure seen on Paul's native Windows hourly commander:

```
Telegram send failed: Unknown error in HTTP implementation: RuntimeError('cannot schedule new futures after interpreter shutdown')
```

## What changed

- Detect Python interpreter-shutdown executor errors in cron delivery.
- When the live adapter send is skipped during shutdown, do **not** fall through to standalone delivery; this avoids noisy failed delivery records and coroutine leaks during gateway teardown.
- Close the created coroutine if `asyncio.run_coroutine_threadsafe(...)` raises before scheduling it.
- Add regressions for both shutdown failure shapes:
  - direct `RuntimeError("cannot schedule new futures after interpreter shutdown")`
  - adapter `SendResult(success=False, error=...)`
- Preserve/cover cron memory behavior for jobs that explicitly enable the memory toolset.
- Include Windows gateway status hardening for stale/locked PID and lock records that were already in the local fix set.

## Validation

- `./venv/Scripts/python.exe -m pytest tests/cron/test_scheduler.py tests/gateway/test_status.py -q -o 'addopts='` → `132 passed in 4.78s`
- `git diff --check -- cron/scheduler.py tests/cron/test_scheduler.py gateway/status.py tests/gateway/test_status.py`
- `./venv/Scripts/python.exe -m py_compile cron/scheduler.py gateway/status.py`

## Notes

The local working tree has other unrelated dirty files; this PR intentionally commits only the cron/gateway shutdown-delivery files and their tests.
