### PR TITLE
perf(cli): open /model picker without live-discovery stalls

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7629,7 +7629,14 @@ class HermesCLI:
             try:
                 if ctx is None:
                     raise RuntimeError("inventory context unavailable")
-                providers = build_models_payload(ctx, max_models=50)["providers"]
+                # Opening the normal picker should be instant: use configured/static
+                # model lists and skip synchronous provider /models probes. The
+                # explicit `/model --refresh` path keeps live discovery enabled.
+                providers = build_models_payload(
+                    ctx,
+                    max_models=50,
+                    allow_live_discovery=force_refresh,
+                )["providers"]
             except Exception:
                 providers = []
 

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -115,6 +115,7 @@ def build_models_payload(
     picker_hints: bool = False,
     canonical_order: bool = False,
     max_models: int = 50,
+    allow_live_discovery: bool = True,
 ) -> dict:
     """Build the ``{providers, model, provider}`` shape every consumer
     needs from a single substrate call.
@@ -128,6 +129,9 @@ def build_models_payload(
     - ``canonical_order``: reorder canonical-slug rows to
       ``CANONICAL_PROVIDERS`` declaration order; truly-custom rows go
       last (TUI display order).
+    - ``allow_live_discovery``: permit provider-specific /models probes
+      when the substrate builds each row's model list. Disable this for
+      latency-sensitive pickers that can use configured/static/cached data.
     """
     from hermes_cli.model_switch import list_authenticated_providers
 
@@ -138,6 +142,7 @@ def build_models_payload(
         user_providers=ctx.user_providers,
         custom_providers=ctx.custom_providers,
         max_models=max_models,
+        allow_live_discovery=allow_live_discovery,
     )
 
     if include_unconfigured:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1058,6 +1058,7 @@ def list_authenticated_providers(
     custom_providers: list | None = None,
     max_models: int = 8,
     current_model: str = "",
+    allow_live_discovery: bool = True,
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
 
@@ -1075,6 +1076,8 @@ def list_authenticated_providers(
       - source: str — "built-in", "models.dev", "user-config"
 
     Only includes providers that have API keys set or are user-defined endpoints.
+    ``allow_live_discovery=False`` keeps the picker on configured/static data
+    instead of synchronous provider /models probes.
     """
     import os
     from agent.models_dev import (
@@ -1164,7 +1167,7 @@ def list_authenticated_providers(
         except Exception:
             return False
 
-    data = fetch_models_dev()
+    data = fetch_models_dev() if allow_live_discovery else {}
 
     # Build curated model lists keyed by hermes provider ID
     curated: dict[str, list[str]] = dict(_PROVIDER_MODELS)
@@ -1174,18 +1177,27 @@ def list_authenticated_providers(
     # newly added Portal models surface in the /model picker without
     # requiring a Hermes release. Falls back to the in-repo
     # _PROVIDER_MODELS["nous"] snapshot when the manifest is unreachable.
-    curated["nous"] = get_curated_nous_model_ids()
+    # Latency-sensitive callers can disable live discovery to stay entirely
+    # on the in-repo snapshot.
+    curated["nous"] = (
+        get_curated_nous_model_ids()
+        if allow_live_discovery
+        else list(_PROVIDER_MODELS.get("nous", []))
+    )
     # Ollama Cloud uses dynamic discovery (no static curated list)
     if "ollama-cloud" not in curated:
-        from hermes_cli.models import fetch_ollama_cloud_models
-        curated["ollama-cloud"] = fetch_ollama_cloud_models()
+        if allow_live_discovery:
+            from hermes_cli.models import fetch_ollama_cloud_models
+            curated["ollama-cloud"] = fetch_ollama_cloud_models()
+        else:
+            curated["ollama-cloud"] = []
     # LM Studio has no static catalog — probe its native /api/v1/models
     # endpoint live so the picker reflects whatever the user has loaded.
     # Base URL precedence: LM_BASE_URL env var > active config's base_url
     # (when current provider is lmstudio) > 127.0.0.1 default.
     # On auth rejection or unreachable server, fall back to the caller-supplied
     # current model so the picker still shows something when offline / mis-keyed.
-    if "lmstudio" not in curated and (
+    if allow_live_discovery and "lmstudio" not in curated and (
         os.environ.get("LM_API_KEY") or os.environ.get("LM_BASE_URL") or current_provider.strip().lower() == "lmstudio"
     ):
         from hermes_cli.models import fetch_lmstudio_models
@@ -1250,11 +1262,12 @@ def list_authenticated_providers(
         # Unified pathway: route through cached_provider_model_ids() so the
         # /model picker sees the SAME list `hermes model` would build, with
         # disk caching to keep the picker open snappy. Falls back to the
-        # curated static list when the live fetcher returns nothing.
-        model_ids = cached_provider_model_ids(hermes_id)
+        # curated static list when the live fetcher returns nothing. Fast
+        # picker callers disable live discovery and use the curated list only.
+        model_ids = cached_provider_model_ids(hermes_id) if allow_live_discovery else []
         if not model_ids:
             model_ids = curated.get(hermes_id, [])
-            if hermes_id in _MODELS_DEV_PREFERRED:
+            if allow_live_discovery and hermes_id in _MODELS_DEV_PREFERRED:
                 model_ids = _merge_with_models_dev(hermes_id, model_ids)
         total = len(model_ids)
         top = model_ids[:max_models]
@@ -1325,7 +1338,7 @@ def list_authenticated_providers(
         # This catches credentials that exist in external stores (e.g.
         # Codex CLI ~/.codex/auth.json) which _seed_from_singletons()
         # imports on demand but aren't in the raw auth.json yet.
-        if not has_creds:
+        if allow_live_discovery and not has_creds:
             try:
                 from agent.credential_pool import load_pool
                 pool = load_pool(hermes_slug)
@@ -1340,7 +1353,7 @@ def list_authenticated_providers(
         # But the /model picker is discovery-oriented — we WANT to show
         # providers the user can switch to, even if they aren't currently
         # configured.
-        if not has_creds and hermes_slug == "anthropic":
+        if allow_live_discovery and not has_creds and hermes_slug == "anthropic":
             try:
                 from agent.anthropic_adapter import (
                     read_claude_code_credentials,
@@ -1364,23 +1377,32 @@ def list_authenticated_providers(
             # catalog. ``cached_provider_model_ids()`` falls back to the
             # curated list when the live endpoint is unreachable, so this
             # is safe for unauthenticated and offline cases too.
-            model_ids = cached_provider_model_ids(hermes_slug)
+            model_ids = (
+                cached_provider_model_ids(hermes_slug)
+                if allow_live_discovery
+                else []
+            )
+            if not model_ids:
+                model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
         # For aws_sdk providers (bedrock), use live discovery so the list
         # reflects the active region (eu.*, ap.*) not the static us.* list.
         elif overlay.auth_type == "aws_sdk":
-            try:
-                _ids = cached_provider_model_ids(hermes_slug)
-                model_ids = _ids if _ids else (curated.get(hermes_slug, []) or curated.get(pid, []))
-            except Exception:
+            if allow_live_discovery:
+                try:
+                    _ids = cached_provider_model_ids(hermes_slug)
+                    model_ids = _ids if _ids else (curated.get(hermes_slug, []) or curated.get(pid, []))
+                except Exception:
+                    model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
+            else:
                 model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
         else:
             # Unified pathway — see Section 1 rationale. Fall back to the
             # curated dict (with models.dev merge for preferred providers)
             # when the live fetcher comes up empty.
-            model_ids = cached_provider_model_ids(hermes_slug)
+            model_ids = cached_provider_model_ids(hermes_slug) if allow_live_discovery else []
             if not model_ids:
                 model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
-                if hermes_slug in _MODELS_DEV_PREFERRED:
+                if allow_live_discovery and hermes_slug in _MODELS_DEV_PREFERRED:
                     model_ids = _merge_with_models_dev(hermes_slug, model_ids)
         total = len(model_ids)
         top = model_ids[:max_models]
@@ -1426,7 +1448,7 @@ def list_authenticated_providers(
                     _cp_has_creds = True
             except Exception:
                 pass
-        if not _cp_has_creds:
+        if allow_live_discovery and not _cp_has_creds:
             try:
                 from agent.credential_pool import load_pool
                 _cp_pool = load_pool(_cp.slug)
@@ -1447,14 +1469,17 @@ def list_authenticated_providers(
         # For bedrock, use live discovery so the list reflects the active
         # region (eu.*, us.*, ap.*) instead of the hardcoded us.* static list.
         if _cp_config and getattr(_cp_config, "auth_type", "") == "aws_sdk":
-            try:
-                _ids = cached_provider_model_ids(_cp.slug)
-                _cp_model_ids = _ids if _ids else curated.get(_cp.slug, [])
-            except Exception:
+            if allow_live_discovery:
+                try:
+                    _ids = cached_provider_model_ids(_cp.slug)
+                    _cp_model_ids = _ids if _ids else curated.get(_cp.slug, [])
+                except Exception:
+                    _cp_model_ids = curated.get(_cp.slug, [])
+            else:
                 _cp_model_ids = curated.get(_cp.slug, [])
         else:
             # Unified pathway — same as sections 1 and 2.
-            _cp_model_ids = cached_provider_model_ids(_cp.slug)
+            _cp_model_ids = cached_provider_model_ids(_cp.slug) if allow_live_discovery else []
             if not _cp_model_ids:
                 _cp_model_ids = curated.get(_cp.slug, [])
         _cp_total = len(_cp_model_ids)
@@ -1540,7 +1565,7 @@ def list_authenticated_providers(
             discover = ep_cfg.get("discover_models", True)
             if isinstance(discover, str):
                 discover = discover.lower() not in {"false", "no", "0"}
-            if api_url and api_key and discover:
+            if allow_live_discovery and api_url and api_key and discover:
                 try:
                     from hermes_cli.models import fetch_api_models
                     live_models = fetch_api_models(api_key, api_url)
@@ -1720,7 +1745,7 @@ def list_authenticated_providers(
             # - Without an api_key AND no explicit models, fall through to
             #   live discovery so bare-endpoint custom providers (local
             #   llama.cpp / Ollama servers) still appear populated.
-            should_probe = bool(api_url) and (bool(api_key) or not grp["models"])
+            should_probe = allow_live_discovery and bool(api_url) and (bool(api_key) or not grp["models"])
             if should_probe:
                 try:
                     from hermes_cli.models import fetch_api_models

--- a/tests/cli/test_model_picker_speed.py
+++ b/tests/cli/test_model_picker_speed.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import patch
+
+from cli import HermesCLI
+from hermes_cli.inventory import ConfigContext
+
+
+def _ctx() -> ConfigContext:
+    return ConfigContext(
+        current_provider="slow-provider",
+        current_model="configured-model",
+        current_base_url="https://slow.example/v1",
+        user_providers={
+            "slow-provider": {
+                "name": "Slow Provider",
+                "base_url": "https://slow.example/v1",
+                "api_key": "test-key",
+                "models": {"configured-model": {}},
+            }
+        },
+        custom_providers=[],
+    )
+
+
+def _make_cli(opened: dict[str, Any]) -> HermesCLI:
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.provider = "slow-provider"
+    cli.model = "configured-model"
+    cli.base_url = "https://slow.example/v1"
+
+    def _open_model_picker(
+        providers,
+        current_model,
+        current_provider,
+        user_provs=None,
+        custom_provs=None,
+    ):
+        opened["providers"] = providers
+        opened["current_model"] = current_model
+        opened["current_provider"] = current_provider
+        opened["user_provs"] = user_provs
+        opened["custom_provs"] = custom_provs
+
+    cli._open_model_picker = _open_model_picker
+    return cli
+
+
+def _empty_pool():
+    class EmptyPool:
+        def has_credentials(self) -> bool:
+            return False
+
+    return EmptyPool()
+
+
+def test_no_arg_model_picker_uses_configured_models_without_live_probe():
+    """Opening `/model` should not block on live custom-provider /models probes."""
+    opened: dict[str, Any] = {}
+    cli = _make_cli(opened)
+
+    with patch.dict(os.environ, {}, clear=True), \
+         patch("hermes_cli.inventory.load_picker_context", return_value=_ctx()), \
+         patch("agent.models_dev.fetch_models_dev", return_value={}), \
+         patch("agent.credential_pool.load_pool") as load_pool, \
+         patch("hermes_cli.models.get_curated_nous_model_ids", return_value=[]), \
+         patch("hermes_cli.models.fetch_api_models", return_value=["live-only-model"]) as live_fetch:
+        cli._handle_model_switch("/model")
+
+    live_fetch.assert_not_called()
+    load_pool.assert_not_called()
+    providers = opened["providers"]
+    assert providers[0]["slug"] == "slow-provider"
+    assert providers[0]["models"] == ["configured-model"]
+
+
+def test_model_refresh_keeps_live_probe_path():
+    """`/model --refresh` remains the explicit slow/live catalog path."""
+    opened: dict[str, Any] = {}
+    cli = _make_cli(opened)
+
+    with patch.dict(os.environ, {}, clear=True), \
+         patch("hermes_cli.inventory.load_picker_context", return_value=_ctx()), \
+         patch("agent.models_dev.fetch_models_dev", return_value={}), \
+         patch("agent.credential_pool.load_pool", return_value=_empty_pool()), \
+         patch("hermes_cli.models.clear_provider_models_cache") as clear_cache, \
+         patch("hermes_cli.models.get_curated_nous_model_ids", return_value=[]), \
+         patch("hermes_cli.models.fetch_api_models", return_value=["live-only-model"]) as live_fetch:
+        cli._handle_model_switch("/model --refresh")
+
+    clear_cache.assert_called_once_with()
+    live_fetch.assert_called_once_with("test-key", "https://slow.example/v1")
+    providers = opened["providers"]
+    assert providers[0]["models"] == ["live-only-model"]


### PR DESCRIPTION
## What does this PR do?

Optimizes the interactive CLI `/model` picker open path by keeping the default no-arg picker on configured/static model lists instead of doing synchronous live discovery while the modal is opening.

Why this is the smallest safe change:
- Normal `/model` now passes `allow_live_discovery=False` into the existing inventory substrate.
- Existing default behavior remains unchanged for other inventory callers because the new flag defaults to `True`.
- Explicit `/model --refresh` still clears the cache and uses live discovery, so users retain the slow/fresh catalog path when they ask for it.

Benchmark from a deterministic custom-provider probe fixture:

| Path | Elapsed | live `/models` calls | Models shown |
| --- | ---: | ---: | --- |
| Before/default live discovery | 7771.4 ms | 1 | `live-only-model` |
| After normal `/model` open | 5.8 ms | 0 | `configured-model` |

Raw benchmark lines:

```text
TIMING: BASELINE /model live_discovery=True elapsed_ms=7771.4 fetch_api_models_calls=1 models=['live-only-model']
TIMING: AFTER /model live_discovery=False elapsed_ms=5.8 fetch_api_models_calls=0 models=['configured-model']
```

## Related Issue

Related to the `/model` live-discovery tradeoff discussed in #23609. This PR does not close it; it preserves explicit refresh/live discovery while making the default picker open path fast.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: default no-arg `/model` uses fast/static inventory; `/model --refresh` keeps live discovery.
- `hermes_cli/inventory.py`: exposes an `allow_live_discovery` option on the shared model payload builder.
- `hermes_cli/model_switch.py`: gates provider `/models`, models.dev, credential-pool, and external credential discovery behind that option.
- `tests/cli/test_model_picker_speed.py`: covers both the fast default path and explicit refresh path.

## How to Test

1. Run the focused regression suite:
   ```bash
   scripts/run_tests.sh tests/cli/test_model_picker_speed.py tests/hermes_cli/test_inventory.py tests/hermes_cli/test_models_dev_preferred_merge.py tests/hermes_cli/test_opencode_go_in_model_list.py
   ```
2. Open Hermes and run `/model`; the picker should open without waiting on custom provider live `/models` probes.
3. Run `/model --refresh`; live model discovery should still run for users who explicitly ask for fresh catalogs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/cli/test_model_picker_speed.py tests/hermes_cli/test_inventory.py tests/hermes_cli/test_models_dev_preferred_merge.py tests/hermes_cli/test_opencode_go_in_model_list.py
=== Summary: 4 files, 33 tests passed, 0 failed (100% complete) in 5.6s (32 workers) ===
```
