### PR TITLE
fix(opencode-go): don't send 'thinking' and 'reasoning_effort' together for Kimi K2

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -41,17 +41,18 @@ class OpenCodeGoProfile(ProviderProfile):
         top_level: dict[str, Any] = {}
 
         if _is_kimi_k2_model(model):
-            # Kimi K2 on OpenCode Go uses Moonshot's native wire shape:
-            # extra_body.thinking (binary toggle) + top-level reasoning_effort
-            # (low|medium|high). Mirrors the KimiProfile (api.moonshot.ai/v1).
+            # Kimi K2 on OpenCode Go is Fireworks-backed and rejects requests
+            # that carry both 'thinking' and 'reasoning_effort' ("cannot specify
+            # both 'thinking' and 'reasoning_effort'"). Emit exactly one:
+            # reasoning_effort alone when thinking is on, the binary
+            # thinking:disabled toggle when it is off.
             if not isinstance(reasoning_config, dict):
                 # No config → leave server defaults alone.
                 return extra_body, top_level
 
             enabled = reasoning_config.get("enabled") is not False
-            extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
-
             if not enabled:
+                extra_body["thinking"] = {"type": "disabled"}
                 return extra_body, top_level
 
             effort = (reasoning_config.get("effort") or "").strip().lower()

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -19,9 +19,11 @@ def opencode_go_profile():
 class TestOpenCodeGoKimiReasoning:
     """Kimi K2 on OpenCode Go (Fireworks-backed) emits exactly one reasoning control.
 
-    The upstream rejects requests carrying both 'thinking' and 'reasoning_effort',
-    so the profile sends reasoning_effort alone when thinking is on and the binary
-    thinking:disabled toggle when it is off.
+    The upstream rejects requests carrying both 'thinking' and 'reasoning_effort'.
+    The profile therefore sends reasoning_effort alone when thinking is on with a
+    recognized effort, the binary thinking:disabled toggle when thinking is off,
+    and nothing (server default) when thinking is on but no recognized effort is
+    given.
     """
 
     def test_high_effort_emits_effort_only(self, opencode_go_profile):
@@ -31,6 +33,8 @@ class TestOpenCodeGoKimiReasoning:
         )
         assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
+        # The whole point of this profile: never emit both controls at once.
+        assert not ("thinking" in extra_body and "reasoning_effort" in top_level)
 
     def test_disabled_emits_thinking_disabled_without_effort(self, opencode_go_profile):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
@@ -167,9 +171,9 @@ class TestOpenCodeGoFullKwargsIntegration:
             base_url="https://opencode.ai/zen/go/v1",
         )
         # Fireworks-backed Kimi rejects 'thinking' + 'reasoning_effort' together,
-        # so only reasoning_effort is emitted and no extra_body.thinking is set.
+        # so only reasoning_effort is emitted and no extra_body is set at all.
         assert kwargs["reasoning_effort"] == "high"
-        assert "thinking" not in kwargs.get("extra_body", {})
+        assert kwargs.get("extra_body", {}) == {}
 
     def test_deepseek_thinking_reaches_extra_body_and_top_level(
         self, opencode_go_profile

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -17,14 +17,19 @@ def opencode_go_profile():
 
 
 class TestOpenCodeGoKimiReasoning:
-    """Kimi K2 models use Moonshot's thinking + reasoning_effort shape on OpenCode Go."""
+    """Kimi K2 on OpenCode Go (Fireworks-backed) emits exactly one reasoning control.
 
-    def test_high_effort_emits_thinking_and_effort(self, opencode_go_profile):
+    The upstream rejects requests carrying both 'thinking' and 'reasoning_effort',
+    so the profile sends reasoning_effort alone when thinking is on and the binary
+    thinking:disabled toggle when it is off.
+    """
+
+    def test_high_effort_emits_effort_only(self, opencode_go_profile):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "high"},
             model="kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
 
     def test_disabled_emits_thinking_disabled_without_effort(self, opencode_go_profile):
@@ -35,13 +40,14 @@ class TestOpenCodeGoKimiReasoning:
         assert extra_body == {"thinking": {"type": "disabled"}}
         assert top_level == {}
 
-    def test_minimal_effort_enables_thinking_without_effort(self, opencode_go_profile):
-        # "minimal" is not a Moonshot-supported value — drop it, keep thinking on.
+    def test_minimal_effort_falls_back_to_server_default(self, opencode_go_profile):
+        # "minimal" is not a supported value — drop it. With thinking on but no
+        # effort, emit neither key so the server applies its own default.
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "minimal"},
             model="kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {}
 
     @pytest.mark.parametrize(
@@ -56,7 +62,7 @@ class TestOpenCodeGoKimiReasoning:
             reasoning_config={"enabled": True, "effort": effort},
             model="moonshotai/kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
 
     def test_low_and_medium_pass_through(self, opencode_go_profile):
@@ -65,7 +71,7 @@ class TestOpenCodeGoKimiReasoning:
                 reasoning_config={"enabled": True, "effort": effort},
                 model="kimi-k2.5",
             )
-            assert extra_body == {"thinking": {"type": "enabled"}}
+            assert extra_body == {}
             assert top_level == {"reasoning_effort": effort}
 
     def test_no_config_preserves_server_default(self, opencode_go_profile):
@@ -149,7 +155,7 @@ class TestOpenCodeGoModelGating:
 class TestOpenCodeGoFullKwargsIntegration:
     """End-to-end transport kwargs include the profile-provided controls."""
 
-    def test_kimi_reasoning_reaches_extra_body_and_top_level(self, opencode_go_profile):
+    def test_kimi_reasoning_reaches_top_level_only(self, opencode_go_profile):
         from agent.transports.chat_completions import ChatCompletionsTransport
 
         kwargs = ChatCompletionsTransport().build_kwargs(
@@ -160,8 +166,10 @@ class TestOpenCodeGoFullKwargsIntegration:
             reasoning_config={"enabled": True, "effort": "high"},
             base_url="https://opencode.ai/zen/go/v1",
         )
-        assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
+        # Fireworks-backed Kimi rejects 'thinking' + 'reasoning_effort' together,
+        # so only reasoning_effort is emitted and no extra_body.thinking is set.
         assert kwargs["reasoning_effort"] == "high"
+        assert "thinking" not in kwargs.get("extra_body", {})
 
     def test_deepseek_thinking_reaches_extra_body_and_top_level(
         self, opencode_go_profile


### PR DESCRIPTION
Every reasoning-enabled call through `opencode-go/kimi-k2.*` currently fails with HTTP 400. OpenCode Go has moved Kimi K2 onto a **Fireworks-backed** endpoint (responses now report `model: accounts/fireworks/models/kimi-k2p6`) that rejects any request carrying **both** `thinking` and `reasoning_effort`. `OpenCodeGoProfile` was written to mirror Moonshot's native wire shape and always emits both for kimi-k2, so the gateway and every cron job on this model/provider combo error out on each turn:

```
HTTP 400 invalid_request_error
"Error from provider: cannot specify both 'thinking' and 'reasoning_effort'"
```

## What changed

- `plugins/model-providers/opencode-zen/__init__.py` (+6/-5): in the kimi-k2 branch of `OpenCodeGoProfile.build_api_kwargs_extras`, emit exactly one reasoning control instead of both — `reasoning_effort` alone when thinking is on (it already carries the low/medium/high granularity), and the binary `thinking: {type: disabled}` toggle when it is off.
- `tests/plugins/model_providers/test_opencode_go_profile.py` (+22/-10): update the Kimi assertions to the single-control invariant, add an explicit "never both keys at once" guard, and tighten the integration test to pin `extra_body == {}`.

## Behavior

|                                   | Before                                          | After                                 |
|-----------------------------------|-------------------------------------------------|---------------------------------------|
| kimi-k2, thinking on + effort     | `thinking: enabled` **and** `reasoning_effort`  | `reasoning_effort` only               |
| kimi-k2, thinking off             | `thinking: disabled`                            | `thinking: disabled` (**unchanged**)  |
| kimi-k2, thinking on, no effort   | `thinking: enabled`                             | neither key (server default)          |
| `reasoning_config` None / non-dict| nothing                                         | nothing (**unchanged**)               |
| deepseek-v4 branch                | `thinking` + `reasoning_effort`                 | **unchanged** (see Scope)             |
| glm / qwen / minimax / etc.       | nothing                                         | nothing (**unchanged**)               |

## Validation

`scripts/run_tests.sh tests/plugins/model_providers/test_opencode_go_profile.py` — 21/21 passing (assertions updated for the single-control behavior; no net new tests).

Wire-level confirmation against the live endpoint (`https://opencode.ai/zen/go/v1/chat/completions`, model `kimi-k2.6`):

| request shape                          | result   |
|----------------------------------------|----------|
| `thinking` + `reasoning_effort`        | HTTP 400 |
| `reasoning_effort` only                | HTTP 200 |
| `thinking` only                        | HTTP 200 |

End-to-end: a Kimi-K2 gateway/cron job that previously 400'd on every turn now completes after this change.

## Scope

The `deepseek-v4` branch in the same profile follows the identical "emit both" pattern and would hit the same rejection if OpenCode Go routes DeepSeek the same way. I scoped this PR to Kimi K2 because that's what I could verify against the live endpoint — flagging it so maintainers can decide whether DeepSeek needs the same treatment rather than changing it speculatively.