### PR TITLE
fix(hindsight): use aretain_batch in hindsight_retain tool for proper document tracking

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1521,14 +1521,33 @@ class HindsightMemoryProvider(MemoryProvider):
                 return tool_error("Missing required parameter: content")
             context = args.get("context")
             try:
-                retain_kwargs = self._build_retain_kwargs(
+                item = self._build_retain_kwargs(
                     content,
                     context=context,
                     tags=args.get("tags"),
                 )
-                logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
-                             self._bank_id, len(content), context)
-                self._run_hindsight_operation(lambda client: client.aretain(**retain_kwargs))
+                # bank_id and retain_async are top-level aretain_batch params,
+                # not per-item fields — strip them from the item dict.
+                item.pop("bank_id", None)
+                item.pop("retain_async", None)
+
+                # Resolve document_id and update_mode based on API capability
+                document_id, update_mode = self._resolve_retain_target(self._document_id)
+                if update_mode is not None:
+                    item["update_mode"] = update_mode
+
+                logger.debug(
+                    "Tool hindsight_retain: bank=%s, doc=%s, mode=%s, async=%s, content_len=%d",
+                    self._bank_id, document_id, update_mode, self._retain_async, len(content),
+                )
+                self._run_hindsight_operation(
+                    lambda client: client.aretain_batch(
+                        bank_id=self._bank_id,
+                        items=[item],
+                        document_id=document_id,
+                        retain_async=self._retain_async,
+                    )
+                )
                 logger.debug("Tool hindsight_retain: success")
                 return json.dumps({"result": "Memory stored successfully."})
             except Exception as e:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -466,16 +466,20 @@ class TestToolHandlers:
             "hindsight_retain", {"content": "user likes dark mode"}
         ))
         assert result["result"] == "Memory stored successfully."
-        provider._client.aretain.assert_called_once()
-        call_kwargs = provider._client.aretain.call_args.kwargs
+        provider._client.aretain_batch.assert_called_once()
+        call_kwargs = provider._client.aretain_batch.call_args.kwargs
         assert call_kwargs["bank_id"] == "test-bank"
-        assert call_kwargs["content"] == "user likes dark mode"
+        assert call_kwargs["document_id"] is not None
+        assert call_kwargs["retain_async"] is True
+        assert len(call_kwargs["items"]) == 1
+        assert call_kwargs["items"][0]["content"] == "user likes dark mode"
 
     def test_retain_with_tags(self, provider_with_config):
         p = provider_with_config(retain_tags=["pref", "ui"])
         p.handle_tool_call("hindsight_retain", {"content": "likes dark mode"})
-        call_kwargs = p._client.aretain.call_args.kwargs
-        assert call_kwargs["tags"] == ["pref", "ui"]
+        call_kwargs = p._client.aretain_batch.call_args.kwargs
+        item = call_kwargs["items"][0]
+        assert item["tags"] == ["pref", "ui"]
 
     def test_retain_merges_per_call_tags_with_config_tags(self, provider_with_config):
         p = provider_with_config(retain_tags=["pref", "ui"])
@@ -483,13 +487,15 @@ class TestToolHandlers:
             "hindsight_retain",
             {"content": "likes dark mode", "tags": ["client:x", "ui"]},
         )
-        call_kwargs = p._client.aretain.call_args.kwargs
-        assert call_kwargs["tags"] == ["pref", "ui", "client:x"]
+        call_kwargs = p._client.aretain_batch.call_args.kwargs
+        item = call_kwargs["items"][0]
+        assert item["tags"] == ["pref", "ui", "client:x"]
 
     def test_retain_without_tags(self, provider):
         provider.handle_tool_call("hindsight_retain", {"content": "hello"})
-        call_kwargs = provider._client.aretain.call_args.kwargs
-        assert "tags" not in call_kwargs
+        call_kwargs = provider._client.aretain_batch.call_args.kwargs
+        item = call_kwargs["items"][0]
+        assert "tags" not in item
 
     def test_retain_missing_content(self, provider):
         result = json.loads(provider.handle_tool_call(
@@ -555,7 +561,7 @@ class TestToolHandlers:
         assert "error" in result
 
     def test_retain_error_handling(self, provider):
-        provider._client.aretain.side_effect = RuntimeError("connection failed")
+        provider._client.aretain_batch.side_effect = RuntimeError("connection failed")
         result = json.loads(provider.handle_tool_call(
             "hindsight_retain", {"content": "test"}
         ))


### PR DESCRIPTION
## Summary

The `hindsight_retain` tool handler was calling `client.aretain()` (singular), which stores content without a `document_id`. This orphaned observations — they were written to the `memory_units` table but never picked up by the consolidation engine, which requires document-scoped memories.

## Root Cause

`sync_turn` (auto-retain on turn end) correctly uses `aretain_batch()` with `document_id`, but the `hindsight_retain` tool handler used the simpler `aretain()` path.

| Path | Method | document_id | Triggers consolidation |
|------|--------|:-----------:|:---------------------:|
| `sync_turn` (auto-retain) | `aretain_batch(items=[...], document_id=...)` | ✅ | ✅ |
| `hindsight_retain` tool (before) | `aretain(content=...)` | ❌ | ❌ |
| `hindsight_retain` tool (after) | `aretain_batch(items=[...], document_id=...)` | ✅ | ✅ |

## Changes

- **`plugins/memory/hindsight/__init__.py`**: Changed `hindsight_retain` tool handler to use `aretain_batch` instead of `aretain`, passing the session `document_id` resolved via `_resolve_retain_target()` (same logic `sync_turn` uses) and `retain_async=True`.
- **`tests/plugins/memory/test_hindsight_provider.py`**: Updated retain tool tests to assert against `aretain_batch.call_args.kwargs` and inspect the `items[0]` dict for per-item fields (`content`, `tags`).

## Testing

All 100 tests in `tests/plugins/memory/test_hindsight_provider.py` pass.
