### PR TITLE
fix(memory): compact recall context boundaries

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1829,8 +1829,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # box is already closed (tool boundary flush).
                 elif agent.stream_delta_callback:
                     try:
-                        agent.stream_delta_callback(delta.content)
-                        agent._record_streamed_assistant_text(delta.content)
+                        # Keep suppressed tool-turn text on the same streaming
+                        # path as normal assistant deltas. Calling the raw
+                        # callback here bypassed the think/context scrubbers and
+                        # could leak echoed memory or ship-mode guard blocks to
+                        # gateway UIs before final-response sanitization ran.
+                        agent._fire_stream_delta(delta.content)
                     except Exception:
                         pass
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -33,7 +33,7 @@ from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget
-from agent.memory_manager import build_memory_context_block
+from agent.memory_manager import build_memory_context_block, sanitize_context
 from agent.message_sanitization import (
     _repair_tool_call_arguments,
     _sanitize_messages_non_ascii,
@@ -431,8 +431,10 @@ def run_conversation(
     # that are invalid UTF-8 and crash JSON serialization in the OpenAI SDK.
     if isinstance(user_message, str):
         user_message = _sanitize_surrogates(user_message)
+        user_message = sanitize_context(user_message)
     if isinstance(persist_user_message, str):
         persist_user_message = _sanitize_surrogates(persist_user_message)
+        persist_user_message = sanitize_context(persist_user_message)
 
     # Store stream callback for _interruptible_api_call to pick up
     agent._stream_callback = stream_callback
@@ -690,9 +692,9 @@ def run_conversation(
         _ctx_parts: list[str] = []
         for r in _pre_results:
             if isinstance(r, dict) and r.get("context"):
-                _ctx_parts.append(str(r["context"]))
+                _ctx_parts.append(sanitize_context(str(r["context"])))
             elif isinstance(r, str) and r.strip():
-                _ctx_parts.append(r)
+                _ctx_parts.append(sanitize_context(r))
         if _ctx_parts:
             _plugin_user_context = "\n\n".join(_ctx_parts)
     except Exception as exc:
@@ -1025,7 +1027,7 @@ def run_conversation(
         # the original conversation history in `messages` is untouched.
         for am in api_messages:
             if isinstance(am.get("content"), str):
-                am["content"] = am["content"].strip()
+                am["content"] = sanitize_context(am["content"]).strip()
         for am in api_messages:
             tcs = am.get("tool_calls")
             if not tcs:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4350,6 +4350,15 @@ def run_conversation(
                     exc_info=True,
                 )
 
+    # Final privacy scrub before persistence / plugin hooks / gateway return.
+    # This catches old leaked context already present in continuing session
+    # history as well as any model attempt to quote internal memory blocks.
+    if isinstance(final_response, str):
+        final_response = sanitize_context(final_response).strip()
+    for _msg in messages:
+        if isinstance(_msg, dict) and isinstance(_msg.get("content"), str):
+            _msg["content"] = sanitize_context(_msg["content"]).strip()
+
     # Determine if conversation completed successfully
     completed = (
         final_response is not None

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -40,22 +40,97 @@ logger = logging.getLogger(__name__)
 # Context fencing helpers
 # ---------------------------------------------------------------------------
 
-_FENCE_TAG_RE = re.compile(r'</?\s*memory-context\s*>', re.IGNORECASE)
+_INTERNAL_CONTEXT_TAG_NAMES = (
+    r"memory-context",
+    r"recalled[_-]memory[_-]context",
+    r"supermemory-context",
+    r"ship[_-]mode[_-]guard",
+)
+_INTERNAL_CONTEXT_TAG_RE = r"(?:" + "|".join(_INTERNAL_CONTEXT_TAG_NAMES) + r")"
+_FENCE_TAG_RE = re.compile(rf'</?\s*{_INTERNAL_CONTEXT_TAG_RE}\s*>', re.IGNORECASE)
 _INTERNAL_CONTEXT_RE = re.compile(
-    r'<\s*memory-context\s*>[\s\S]*?</\s*memory-context\s*>',
+    rf'<\s*{_INTERNAL_CONTEXT_TAG_RE}\s*>[\s\S]*?</\s*{_INTERNAL_CONTEXT_TAG_RE}\s*>',
+    re.IGNORECASE,
+)
+_UNTERMINATED_INTERNAL_CONTEXT_RE = re.compile(
+    rf'<\s*{_INTERNAL_CONTEXT_TAG_RE}\s*>\s*'
+    r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.'
+    r'[\s\S]*$',
+    re.IGNORECASE,
+)
+_UNTERMINATED_SHIP_MODE_TAG_RE = re.compile(
+    r'<\s*ship[_-]mode[_-]guard\s*>[\s\S]*$',
+    re.IGNORECASE,
+)
+_UNTERMINATED_CONTEXT_BLOCK_RE = re.compile(
+    rf'(^|\n)[ \t]*<\s*{_INTERNAL_CONTEXT_TAG_RE}\s*>[ \t]*\r?\n[\s\S]*$',
     re.IGNORECASE,
 )
 _INTERNAL_NOTE_RE = re.compile(
     r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*)\.\]\s*',
     re.IGNORECASE,
 )
+_SHIP_MODE_GUARD_RE = re.compile(
+    r'\[\s*Ship-mode routing guard:[\s\S]*?\]\s*',
+    re.IGNORECASE,
+)
+_RAW_MEMORY_HEADING_RE = re.compile(
+    r'^##\s*(?:User Representation|Explicit Observations|AI Self-Representation)\s*$',
+    re.IGNORECASE | re.MULTILINE,
+)
+_AIVS_AUTONOMOUS_LOOP_RE = re.compile(
+    r'(?im)^.*Check\s+the\s+AIVS\s+Hermes\s+Kanban\s+board\s+on\s+the\s+VPS\s+'
+    r'and\s+keep\s+the\s+autonomous\s+dev\s+loop\s+moving[^\n]*(?:\n(?!\s*$).*)*\n?',
+)
+_LEADING_COMPACTION_FALLBACK_RE = re.compile(
+    r'^\s*\[CONTEXT COMPACTION\s+[^\]]*\]'
+    r'[\s\S]*?'
+    r'(?:Summary generation was unavailable\.[^\n]*(?:\n|$))'
+    r'(?:[^\n]*removed to free context space[^\n]*(?:\n|$))?'
+    r'(?:[^\n]*messages contained earlier work[^\n]*(?:\n|$))?',
+    re.IGNORECASE,
+)
+_LEADING_GATEWAY_SYSTEM_NOTE_RE = re.compile(
+    r'^\s*\[System note:\s*Your previous turn(?: in this session)? (?:was interrupted|in this session was interrupted)[^\]]*\]\s*',
+    re.IGNORECASE,
+)
+
+
+def _strip_loose_context_tags(text: str) -> str:
+    """Strip loose internal fence tags without deleting normal prose mentions."""
+    text = re.sub(rf'</\s*{_INTERNAL_CONTEXT_TAG_RE}\s*>', '', text, flags=re.IGNORECASE)
+
+    def repl(match: re.Match[str]) -> str:
+        start, end = match.span()
+        prev_char = text[start - 1] if start > 0 else ''
+        next_char = text[end] if end < len(text) else ''
+        # Preserve literal documentation/prose mentions such as
+        # "`<memory-context>`", "The <memory-context> tag", and
+        # "<memory-context> is the literal tag name". Real leaked blocks are
+        # removed above when followed by a newline; suspicious inline opener
+        # escapes are stripped.
+        if prev_char == '`' or next_char == '`':
+            return match.group(0)
+        if next_char.isspace() and next_char not in '\r\n':
+            return match.group(0)
+        return ''
+
+    return re.sub(rf'<\s*{_INTERNAL_CONTEXT_TAG_RE}\s*>', repl, text, flags=re.IGNORECASE)
 
 
 def sanitize_context(text: str) -> str:
     """Strip fence tags, injected context blocks, and system notes from provider output."""
+    text = _LEADING_COMPACTION_FALLBACK_RE.sub('', text)
+    text = _LEADING_GATEWAY_SYSTEM_NOTE_RE.sub('', text)
+    text = _SHIP_MODE_GUARD_RE.sub('', text)
+    text = _AIVS_AUTONOMOUS_LOOP_RE.sub('', text)
     text = _INTERNAL_CONTEXT_RE.sub('', text)
+    text = _UNTERMINATED_INTERNAL_CONTEXT_RE.sub('', text)
+    text = _UNTERMINATED_SHIP_MODE_TAG_RE.sub('', text)
+    text = _UNTERMINATED_CONTEXT_BLOCK_RE.sub(lambda m: m.group(1), text)
     text = _INTERNAL_NOTE_RE.sub('', text)
-    text = _FENCE_TAG_RE.sub('', text)
+    text = _RAW_MEMORY_HEADING_RE.sub('## Recalled context', text)
+    text = _strip_loose_context_tags(text)
     return text
 
 
@@ -85,16 +160,27 @@ class StreamingContextScrubber:
     ``reset()``.
     """
 
-    _OPEN_TAG = "<memory-context>"
-    _CLOSE_TAG = "</memory-context>"
+    _TAG_SPANS = tuple(
+        (f"<{name}>", f"</{name}>", True)
+        for name in (
+            "memory-context",
+            "recalled_memory_context",
+            "recalled-memory-context",
+            "supermemory-context",
+            "ship_mode_guard",
+            "ship-mode-guard",
+        )
+    )
 
     def __init__(self) -> None:
         self._in_span: bool = False
+        self._close_tags: tuple[str, ...] = ()
         self._buf: str = ""
         self._at_block_boundary: bool = True
 
     def reset(self) -> None:
         self._in_span = False
+        self._close_tags = ()
         self._buf = ""
         self._at_block_boundary = True
 
@@ -113,22 +199,27 @@ class StreamingContextScrubber:
 
         while buf:
             if self._in_span:
-                idx = buf.lower().find(self._CLOSE_TAG)
-                if idx == -1:
+                match = self._find_earliest_tag(buf, self._close_tags)
+                if match is None:
                     # Hold back a potential partial close tag; drop the rest
-                    held = self._max_partial_suffix(buf, self._CLOSE_TAG)
+                    held = self._max_partial_suffix_any(buf, self._close_tags)
                     self._buf = buf[-held:] if held else ""
                     return "".join(out)
+                idx, close_tag = match
                 # Found close — skip span content + tag, continue
-                buf = buf[idx + len(self._CLOSE_TAG):]
+                buf = buf[idx + len(close_tag):]
                 self._in_span = False
+                self._close_tags = ()
             else:
-                idx = self._find_boundary_open_tag(buf)
-                if idx == -1:
+                match = self._find_boundary_open_span(buf)
+                if match is None:
                     # No open tag — hold back a potential partial open tag
                     held = (
                         self._max_pending_open_suffix(buf)
-                        or self._max_partial_suffix(buf, self._OPEN_TAG)
+                        or self._max_partial_suffix_any(
+                            buf,
+                            tuple(open_tag for open_tag, _close_tag, _requires_newline in self._TAG_SPANS),
+                        )
                     )
                     if held:
                         self._append_visible(out, buf[:-held])
@@ -136,11 +227,13 @@ class StreamingContextScrubber:
                     else:
                         self._append_visible(out, buf)
                     return "".join(out)
+                idx, open_tag, close_tag = match
                 # Emit text before the tag, enter span
                 if idx > 0:
                     self._append_visible(out, buf[:idx])
-                buf = buf[idx + len(self._OPEN_TAG):]
+                buf = buf[idx + len(open_tag):]
                 self._in_span = True
+                self._close_tags = (close_tag,)
 
         return "".join(out)
 
@@ -150,15 +243,16 @@ class StreamingContextScrubber:
         If we're still inside an unterminated span the remaining content is
         discarded (safer: leaking partial memory context is worse than a
         truncated answer).  Otherwise the held-back partial-tag tail is
-        emitted verbatim (it turned out not to be a real tag).
+        emitted after one final sanitizer pass.
         """
         if self._in_span:
             self._buf = ""
             self._in_span = False
+            self._close_tags = ()
             return ""
         tail = self._buf
         self._buf = ""
-        return tail
+        return sanitize_context(tail)
 
     @staticmethod
     def _max_partial_suffix(buf: str, tag: str) -> int:
@@ -174,29 +268,55 @@ class StreamingContextScrubber:
                 return i
         return 0
 
-    def _find_boundary_open_tag(self, buf: str) -> int:
+    @classmethod
+    def _max_partial_suffix_any(cls, buf: str, tags: tuple[str, ...]) -> int:
+        return max((cls._max_partial_suffix(buf, tag) for tag in tags), default=0)
+
+    @staticmethod
+    def _find_earliest_tag(buf: str, tags: tuple[str, ...]) -> tuple[int, str] | None:
+        buf_lower = buf.lower()
+        best: tuple[int, str] | None = None
+        for tag in tags:
+            idx = buf_lower.find(tag)
+            if idx == -1:
+                continue
+            if best is None or idx < best[0]:
+                best = (idx, tag)
+        return best
+
+    def _find_boundary_open_span(self, buf: str) -> tuple[int, str, str] | None:
         """Find an opening fence only when it starts a block-like span."""
         buf_lower = buf.lower()
-        search_start = 0
-        while True:
-            idx = buf_lower.find(self._OPEN_TAG, search_start)
-            if idx == -1:
-                return -1
-            if self._is_block_boundary(buf, idx) and self._has_block_opener_suffix(buf, idx):
-                return idx
-            search_start = idx + 1
+        best: tuple[int, str, str] | None = None
+        for open_tag, close_tag, requires_newline in self._TAG_SPANS:
+            search_start = 0
+            while True:
+                idx = buf_lower.find(open_tag, search_start)
+                if idx == -1:
+                    break
+                if self._is_block_boundary(buf, idx) and (
+                    not requires_newline or self._has_block_opener_suffix(buf, idx, open_tag)
+                ):
+                    candidate = (idx, open_tag, close_tag)
+                    if best is None or candidate[0] < best[0]:
+                        best = candidate
+                    break
+                search_start = idx + 1
+        return best
 
     def _max_pending_open_suffix(self, buf: str) -> int:
         """Hold a complete boundary tag until the following char confirms it."""
-        if not buf.lower().endswith(self._OPEN_TAG):
-            return 0
-        idx = len(buf) - len(self._OPEN_TAG)
-        if not self._is_block_boundary(buf, idx):
-            return 0
-        return len(self._OPEN_TAG)
+        buf_lower = buf.lower()
+        for open_tag, _close_tag, requires_newline in self._TAG_SPANS:
+            if not requires_newline or not buf_lower.endswith(open_tag):
+                continue
+            idx = len(buf) - len(open_tag)
+            if self._is_block_boundary(buf, idx):
+                return len(open_tag)
+        return 0
 
-    def _has_block_opener_suffix(self, buf: str, idx: int) -> bool:
-        after_idx = idx + len(self._OPEN_TAG)
+    def _has_block_opener_suffix(self, buf: str, idx: int, open_tag: str) -> bool:
+        after_idx = idx + len(open_tag)
         if after_idx >= len(buf):
             return False
         return buf[after_idx] in "\r\n"
@@ -213,6 +333,9 @@ class StreamingContextScrubber:
     def _append_visible(self, out: list[str], text: str) -> None:
         if not text:
             return
+        text = sanitize_context(text)
+        if not text:
+            return
         out.append(text)
         self._update_block_boundary(text)
 
@@ -224,21 +347,68 @@ class StreamingContextScrubber:
             self._at_block_boundary = self._at_block_boundary and text.strip() == ""
 
 
+_SECTION_HEADING_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+_SAFE_CONTEXT_SECTION_NAMES = {"session summary", "user peer card"}
+
+
+def _truncate_memory_context(text: str, limit: int) -> str:
+    """Bound auto-injected recall text before it reaches the active prompt."""
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    cut = text[:limit]
+    boundary = max(cut.rfind("\n"), cut.rfind(". "), cut.rfind("; "))
+    if boundary >= int(limit * 0.65):
+        cut = cut[:boundary].rstrip()
+    return cut.rstrip() + " …"
+
+
+def _extract_safe_memory_sections(raw_context: str) -> list[str]:
+    """Keep only compact current/session + peer-card sections from recall.
+
+    Honcho/context backends may return raw representations, old explicit
+    observations, and assistant self-representation. Those remain recoverable
+    through memory tools / durable stores, but normal provider prompts get only
+    a compact peer/session slice plus file-backed retrieval pointers.
+    """
+    matches = list(_SECTION_HEADING_RE.finditer(raw_context or ""))
+    sections: list[str] = []
+    for idx, match in enumerate(matches):
+        name = match.group(1).strip()
+        if name.lower() not in _SAFE_CONTEXT_SECTION_NAMES:
+            continue
+        start = match.end()
+        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(raw_context)
+        body = sanitize_context(raw_context[start:end]).strip()
+        if not body:
+            continue
+        sections.append(f"## {name}\n{_truncate_memory_context(body, 1200)}")
+    return sections
+
+
 def build_memory_context_block(raw_context: str) -> str:
-    """Wrap prefetched memory in a fenced block with system note."""
+    """Return compact, pointer-based recall context for the current prompt.
+
+    The active provider prompt must not receive raw ``<memory-context>`` dumps,
+    old Explicit Observations, or AI self-representation. Long/project/runtime
+    facts are durable in the wiki/session stores and should be retrieved on
+    demand by pointer/search instead of being pasted into every turn.
+    """
     if not raw_context or not raw_context.strip():
         return ""
-    clean = sanitize_context(raw_context)
-    if clean != raw_context:
-        logger.warning("memory provider returned pre-wrapped context; stripped")
-    return (
-        "<memory-context>\n"
-        "[System note: The following is recalled memory context, "
-        "NOT new user input. Treat as authoritative reference data — "
-        "this is the agent's persistent memory and should inform all responses.]\n\n"
-        f"{clean}\n"
-        "</memory-context>"
-    )
+
+    sections = _extract_safe_memory_sections(raw_context)
+    pointers = [
+        "# Memory context pointers",
+        "- Compact peer/preferences: use Honcho peer-card/profile tools for a fresh view when needed.",
+        "- Project facts: use ~/wiki/projects/*.md as the durable source of truth.",
+        "- Runtime incidents/runbooks/session packets: use ~/wiki/tools, ~/wiki/outputs, ~/wiki/daily, and searchable spill/session stores.",
+        "- Raw recalled observations are intentionally not injected into this prompt; retrieve them explicitly only when relevant.",
+    ]
+    if sections:
+        pointers.append("")
+        pointers.append("\n\n".join(sections))
+    return _truncate_memory_context("\n".join(pointers), 3000)
 
 
 class MemoryManager:

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -362,6 +362,7 @@ _IDENTITY_FIELD_PATTERN = (
     r"identity|"
     r"alias(?:es)?|"
     r"name|"
+    r"role|"
     r"e-?mail|"
     r"phone|"
     r"address|"
@@ -372,6 +373,7 @@ _IDENTITY_FIELD_PATTERN = (
     r"contractor"
     r")"
 )
+_HONCHO_LABEL_RE = re.compile(r"^(attribute|instruction)\s*:\s*(.+)$", re.IGNORECASE)
 _RAW_IDENTITY_LINE_RE = re.compile(
     r"^(?:"
     # Bare peer-card fields: "Name: ...", "Location: ...".
@@ -389,7 +391,7 @@ _RAW_IDENTITY_LINE_RE = re.compile(
 
 
 def compact_user_peer_card(body: str) -> str:
-    """Keep non-identity peer-card facts while dropping raw identity payload."""
+    """Keep non-identity peer-card facts while dropping raw Honcho labels/control payload."""
     lines: list[str] = []
     for line in sanitize_context(body).splitlines():
         stripped = line.strip()
@@ -397,6 +399,17 @@ def compact_user_peer_card(body: str) -> str:
             continue
         if _RAW_IDENTITY_LINE_RE.match(stripped):
             continue
+        label_match = _HONCHO_LABEL_RE.match(stripped)
+        if label_match:
+            label = label_match.group(1).lower()
+            # INSTRUCTION-prefixed Honcho cards are user-control shaped when
+            # pasted into prompts. They remain available through Honcho tools
+            # but are not auto-injected as active instructions.
+            if label == "instruction":
+                continue
+            stripped = label_match.group(2).strip()
+            if not stripped or _RAW_IDENTITY_LINE_RE.match(stripped):
+                continue
         lines.append(stripped)
     return _truncate_memory_context("\n".join(lines), 1200)
 

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -357,16 +357,32 @@ _SAFE_CONTEXT_SECTION_NAMES = {
     "recalled user context (recent/relevant)",
 }
 _USER_PEER_CARD_SECTION_NAMES = {"user peer card", "user profile", "peer card"}
+_IDENTITY_FIELD_PATTERN = (
+    r"(?:"
+    r"identity|"
+    r"alias(?:es)?|"
+    r"name|"
+    r"e-?mail|"
+    r"phone|"
+    r"address|"
+    r"website|"
+    r"location|"
+    r"org(?:anization)?|"
+    r"father|"
+    r"contractor"
+    r")"
+)
 _RAW_IDENTITY_LINE_RE = re.compile(
     r"^(?:"
-    r"identity\s*:|"
-    r"aliases?\s*:|"
-    r"name\s*:|"
-    r"e-?mail\s*:|"
-    r"phone\s*:|"
-    r"address\s*:|"
-    r"website\s*:|"
-    r"location\s*:"
+    # Bare peer-card fields: "Name: ...", "Location: ...".
+    rf"{_IDENTITY_FIELD_PATTERN}\s*:|"
+    # Honcho cards commonly prefix facts as ATTRIBUTE:/INSTRUCTION:.  Strip
+    # identity fields after those labels while preserving safe preferences.
+    rf"(?:attribute|instruction)\s*:\s*{_IDENTITY_FIELD_PATTERN}\s*:|"
+    # Relationship-prefixed facts are names by construction (Father, spouse,
+    # employer/contact, etc.); omit them conservatively instead of trying to
+    # maintain an exhaustive relationship-name allow/deny list.
+    r"relationship\s*:"
     r")",
     re.IGNORECASE,
 )

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -373,60 +373,57 @@ _SAFE_CONTEXT_SECTION_NAMES = {
     "recalled user context (recent/relevant)",
 }
 _USER_PEER_CARD_SECTION_NAMES = {"user peer card", "user profile", "peer card"}
-_IDENTITY_FIELD_PATTERN = (
-    r"(?:"
-    r"identity|"
-    r"alias(?:es)?|"
-    r"name|"
-    r"role|"
-    r"e-?mail|"
-    r"phone|"
-    r"address|"
-    r"website|"
-    r"location|"
-    r"org(?:anization)?|"
-    r"father|"
-    r"contractor"
-    r")"
-)
 _HONCHO_LABEL_RE = re.compile(r"^(attribute|instruction)\s*:\s*(.+)$", re.IGNORECASE)
-_RAW_IDENTITY_LINE_RE = re.compile(
-    r"^(?:"
-    # Bare peer-card fields: "Name: ...", "Location: ...".
-    rf"{_IDENTITY_FIELD_PATTERN}\s*:|"
-    # Honcho cards commonly prefix facts as ATTRIBUTE:/INSTRUCTION:.  Strip
-    # identity fields after those labels while preserving safe preferences.
-    rf"(?:attribute|instruction)\s*:\s*{_IDENTITY_FIELD_PATTERN}\s*:|"
-    # Relationship-prefixed facts are names by construction (Father, spouse,
-    # employer/contact, etc.); omit them conservatively instead of trying to
-    # maintain an exhaustive relationship-name allow/deny list.
-    r"relationship\s*:"
-    r")",
-    re.IGNORECASE,
-)
+_SAFE_PEER_PREFERENCE_LABELS = {
+    "active project",
+    "design preference",
+    "knowledge store",
+    "model routing",
+    "tech stack",
+}
+
+
+def _normalize_peer_preference_label(label: str) -> str:
+    """Normalize compact peer-card labels before fail-closed allowlisting."""
+    label = label.strip().lower().replace("_", " ").replace("-", " ")
+    return re.sub(r"\s+", " ", label)
+
+
+def _safe_peer_preference_line(line: str) -> str | None:
+    """Return a safe compact preference line, or None for unapproved labels.
+
+    Peer cards can contain arbitrary identity fields (names, handles,
+    employers, relationships, locations, dates, etc.).  This parser is
+    fail-closed: only explicitly approved preference labels survive, including
+    when Honcho prefixes the line with ATTRIBUTE:/INSTRUCTION:.
+    """
+    stripped = line.strip()
+    if not stripped:
+        return None
+
+    label_match = _HONCHO_LABEL_RE.match(stripped)
+    if label_match:
+        stripped = label_match.group(2).strip()
+
+    label, separator, value = stripped.partition(":")
+    if separator != ":":
+        return None
+    label = re.sub(r"\s+", " ", label.strip())
+    value = value.strip()
+    if not label or not value:
+        return None
+    if _normalize_peer_preference_label(label) not in _SAFE_PEER_PREFERENCE_LABELS:
+        return None
+    return f"{label}: {value}"
 
 
 def compact_user_peer_card(body: str) -> str:
-    """Keep non-identity peer-card facts while dropping raw Honcho labels/control payload."""
+    """Keep only allowlisted compact peer preference labels from peer-card text."""
     lines: list[str] = []
     for line in sanitize_context(body).splitlines():
-        stripped = line.strip()
-        if not stripped:
-            continue
-        if _RAW_IDENTITY_LINE_RE.match(stripped):
-            continue
-        label_match = _HONCHO_LABEL_RE.match(stripped)
-        if label_match:
-            label = label_match.group(1).lower()
-            # INSTRUCTION-prefixed Honcho cards are user-control shaped when
-            # pasted into prompts. They remain available through Honcho tools
-            # but are not auto-injected as active instructions.
-            if label == "instruction":
-                continue
-            stripped = label_match.group(2).strip()
-            if not stripped or _RAW_IDENTITY_LINE_RE.match(stripped):
-                continue
-        lines.append(stripped)
+        safe_line = _safe_peer_preference_line(line)
+        if safe_line:
+            lines.append(safe_line)
     return _truncate_memory_context("\n".join(lines), 1200)
 
 

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -81,6 +81,18 @@ _RAW_MEMORY_HEADING_RE = re.compile(
     r'AI Self-Representation|Recalled assistant context|AI Identity Card)\s*$',
     re.IGNORECASE | re.MULTILINE,
 )
+_COMPACT_MEMORY_CONTEXT_RE = re.compile(
+    r'(?ims)(^|\n)[ \t]*#\s*Memory context pointers\s*\n[\s\S]*?(?=\n{2,}(?![ \t]*(?:[-*]|##\s*Compact peer preferences|Knowledge Store:|Tech Stack:|Design Preference:|Model Routing:|Active Project:))|\Z)'
+)
+_COMPACT_PEER_PREFERENCES_RE = re.compile(
+    r'(?ims)(^|\n)[ \t]*##\s*Compact peer preferences\s*\n[\s\S]*?(?=\n{2,}(?![ \t]*(?:Knowledge Store:|Tech Stack:|Design Preference:|Model Routing:|Active Project:))|\Z)'
+)
+_HONCHO_CONTEXT_SUMMARY_RE = re.compile(
+    r'(?ims)(^|\n)[ \t]*(?:The current conversation context|The most relevant context to (?:our|the) current conversation)\b[\s\S]*?(?=\n{2,}|\Z)'
+)
+_HONCHO_LEAK_SUMMARY_LINE_RE = re.compile(
+    r'(?im)^.*\b(?:foundational context|observations indicate)\b.*(?:\n|$)'
+)
 _AIVS_AUTONOMOUS_LOOP_RE = re.compile(
     r'(?im)^.*Check\s+the\s+AIVS\s+Hermes\s+Kanban\s+board\s+on\s+the\s+VPS\s+'
     r'and\s+keep\s+the\s+autonomous\s+dev\s+loop\s+moving[^\n]*(?:\n(?!\s*$).*)*\n?',
@@ -126,6 +138,10 @@ def sanitize_context(text: str) -> str:
     text = _LEADING_COMPACTION_FALLBACK_RE.sub('', text)
     text = _LEADING_GATEWAY_SYSTEM_NOTE_RE.sub('', text)
     text = _SHIP_MODE_GUARD_RE.sub('', text)
+    text = _COMPACT_MEMORY_CONTEXT_RE.sub(lambda m: m.group(1), text)
+    text = _COMPACT_PEER_PREFERENCES_RE.sub(lambda m: m.group(1), text)
+    text = _HONCHO_CONTEXT_SUMMARY_RE.sub(lambda m: m.group(1), text)
+    text = _HONCHO_LEAK_SUMMARY_LINE_RE.sub('', text)
     text = _AIVS_AUTONOMOUS_LOOP_RE.sub('', text)
     text = _INTERNAL_CONTEXT_RE.sub('', text)
     text = _UNTERMINATED_INTERNAL_CONTEXT_RE.sub('', text)
@@ -457,28 +473,14 @@ def _extract_safe_memory_sections(raw_context: str) -> list[str]:
 
 
 def build_memory_context_block(raw_context: str) -> str:
-    """Return compact, pointer-based recall context for the current prompt.
+    """Return no automatic recall context for the active provider prompt.
 
-    The active provider prompt must not receive raw ``<memory-context>`` dumps,
-    old Explicit Observations, or AI self-representation. Long/project/runtime
-    facts are durable in the wiki/session stores and should be retrieved on
-    demand by pointer/search instead of being pasted into every turn.
+    Gateway-visible sessions proved that even previously "safe" compact
+    memory pointers can be quoted back to users. Memory remains available via
+    explicit Honcho/wiki/session tools, but no recalled context block is pasted
+    into ordinary user messages at API-call time.
     """
-    if not raw_context or not raw_context.strip():
-        return ""
-
-    sections = _extract_safe_memory_sections(raw_context)
-    pointers = [
-        "# Memory context pointers",
-        "- Compact peer/preferences: use Honcho peer-card/profile tools for a fresh view when needed.",
-        "- Project facts: use ~/wiki/projects/*.md as the durable source of truth.",
-        "- Runtime incidents/runbooks/session packets: use ~/wiki/tools, ~/wiki/outputs, ~/wiki/daily, and searchable spill/session stores.",
-        "- Raw recalled observations are intentionally not injected into this prompt; retrieve them explicitly only when relevant.",
-    ]
-    if sections:
-        pointers.append("")
-        pointers.append("\n\n".join(sections))
-    return _truncate_memory_context("\n".join(pointers), 3000)
+    return ""
 
 
 class MemoryManager:

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -67,7 +67,9 @@ _UNTERMINATED_CONTEXT_BLOCK_RE = re.compile(
     re.IGNORECASE,
 )
 _INTERNAL_NOTE_RE = re.compile(
-    r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*)\.\]\s*',
+    r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*'
+    r'(?:Treat as (?:informational background data|authoritative reference data[^\]]*)\.|'
+    r'Recalled memory is useful context, not authoritative;[^\]]*)\]\s*',
     re.IGNORECASE,
 )
 _SHIP_MODE_GUARD_RE = re.compile(
@@ -75,7 +77,8 @@ _SHIP_MODE_GUARD_RE = re.compile(
     re.IGNORECASE,
 )
 _RAW_MEMORY_HEADING_RE = re.compile(
-    r'^##\s*(?:User Representation|Explicit Observations|AI Self-Representation)\s*$',
+    r'^##\s*(?:Honcho Context|User Representation|Explicit Observations|User Peer Card|'
+    r'AI Self-Representation|Recalled assistant context|AI Identity Card)\s*$',
     re.IGNORECASE | re.MULTILINE,
 )
 _AIVS_AUTONOMOUS_LOOP_RE = re.compile(
@@ -348,7 +351,38 @@ class StreamingContextScrubber:
 
 
 _SECTION_HEADING_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
-_SAFE_CONTEXT_SECTION_NAMES = {"session summary", "user peer card"}
+_SAFE_CONTEXT_SECTION_NAMES = {
+    "session summary",
+    "compact peer preferences",
+    "recalled user context (recent/relevant)",
+}
+_USER_PEER_CARD_SECTION_NAMES = {"user peer card", "user profile", "peer card"}
+_RAW_IDENTITY_LINE_RE = re.compile(
+    r"^(?:"
+    r"identity\s*:|"
+    r"aliases?\s*:|"
+    r"name\s*:|"
+    r"e-?mail\s*:|"
+    r"phone\s*:|"
+    r"address\s*:|"
+    r"website\s*:|"
+    r"location\s*:"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def compact_user_peer_card(body: str) -> str:
+    """Keep non-identity peer-card facts while dropping raw identity payload."""
+    lines: list[str] = []
+    for line in sanitize_context(body).splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _RAW_IDENTITY_LINE_RE.match(stripped):
+            continue
+        lines.append(stripped)
+    return _truncate_memory_context("\n".join(lines), 1200)
 
 
 def _truncate_memory_context(text: str, limit: int) -> str:
@@ -375,12 +409,19 @@ def _extract_safe_memory_sections(raw_context: str) -> list[str]:
     sections: list[str] = []
     for idx, match in enumerate(matches):
         name = match.group(1).strip()
-        if name.lower() not in _SAFE_CONTEXT_SECTION_NAMES:
+        section_name = name.lower()
+        if section_name not in _SAFE_CONTEXT_SECTION_NAMES and section_name not in _USER_PEER_CARD_SECTION_NAMES:
             continue
         start = match.end()
         end = matches[idx + 1].start() if idx + 1 < len(matches) else len(raw_context)
         body = sanitize_context(raw_context[start:end]).strip()
         if not body:
+            continue
+        if section_name in _USER_PEER_CARD_SECTION_NAMES:
+            body = compact_user_peer_card(body)
+            if not body:
+                continue
+            sections.append(f"## Compact peer preferences\n{body}")
             continue
         sections.append(f"## {name}\n{_truncate_memory_context(body, 1200)}")
     return sections

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -473,21 +473,14 @@ class HonchoMemoryProvider(MemoryProvider):
         if summary:
             parts.append(f"## Session Summary\n{summary}")
 
-        rep = ctx.get("representation", "")
-        if rep:
-            parts.append(f"## User Representation\n{rep}")
-
+        # Normal prompt injection is intentionally compact and peer-card
+        # oriented. Long/raw Honcho representations often include old
+        # timestamped Explicit Observations; assistant self-representation is
+        # especially noisy. Both remain recoverable through Honcho tools, but
+        # they do not belong in every provider prompt.
         card = ctx.get("card", "")
         if card:
             parts.append(f"## User Peer Card\n{card}")
-
-        ai_rep = ctx.get("ai_representation", "")
-        if ai_rep:
-            parts.append(f"## AI Self-Representation\n{ai_rep}")
-
-        ai_card = ctx.get("ai_card", "")
-        if ai_card:
-            parts.append(f"## AI Identity Card\n{ai_card}")
 
         if not parts:
             return ""
@@ -516,9 +509,9 @@ class HonchoMemoryProvider(MemoryProvider):
         if self._recall_mode == "context":
             header = (
                 "# Honcho Memory\n"
-                "Active (context-injection mode). Relevant user context is automatically "
-                "injected before each turn. No memory tools are available — context is "
-                "managed automatically."
+                "Active (context-injection mode). Only compact peer-card/session pointers "
+                "are injected before each turn; raw observations stay retrievable in Honcho/wiki stores. "
+                "No memory tools are available — context is managed automatically."
             )
         elif self._recall_mode == "tools":
             header = (
@@ -533,7 +526,8 @@ class HonchoMemoryProvider(MemoryProvider):
         else:  # hybrid
             header = (
                 "# Honcho Memory\n"
-                "Active (hybrid mode). Relevant context is auto-injected AND memory tools are available. "
+                "Active (hybrid mode). Compact peer-card/session pointers are auto-injected; "
+                "raw observations stay retrievable through memory tools and wiki/search when needed. "
                 "Use honcho_profile for a quick factual snapshot, "
                 "honcho_search for raw excerpts, honcho_context for raw peer context, "
                 "honcho_reasoning for synthesized answers (pass reasoning_level "

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -22,7 +22,7 @@ import threading
 import time
 from typing import Any, Dict, List, Optional
 
-from agent.memory_manager import sanitize_context
+from agent.memory_manager import compact_user_peer_card, sanitize_context
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
 
@@ -478,9 +478,9 @@ class HonchoMemoryProvider(MemoryProvider):
         # timestamped Explicit Observations; assistant self-representation is
         # especially noisy. Both remain recoverable through Honcho tools, but
         # they do not belong in every provider prompt.
-        card = ctx.get("card", "")
+        card = compact_user_peer_card(ctx.get("card", ""))
         if card:
-            parts.append(f"## User Peer Card\n{card}")
+            parts.append(f"## Compact peer preferences\n{card}")
 
         if not parts:
             return ""

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -790,18 +790,19 @@ class TestSetupFieldFiltering:
 
 
 class TestMemoryContextFencing:
-    """Prefetch context must be wrapped in <memory-context> fence so the model
-    does not treat recalled memory as user discourse."""
+    """Prefetch context becomes compact wiki/Honcho pointers, not raw dumps."""
 
-    def test_build_memory_context_block_wraps_content(self):
+    def test_build_memory_context_block_returns_pointers_not_fenced_dump(self):
         from agent.memory_manager import build_memory_context_block
         result = build_memory_context_block(
             "## Holographic Memory\n- [0.8] user likes dark mode"
         )
-        assert result.startswith("<memory-context>")
-        assert result.rstrip().endswith("</memory-context>")
-        assert "NOT new user input" in result
-        assert "user likes dark mode" in result
+        assert result.startswith("# Memory context pointers")
+        assert "<memory-context>" not in result
+        assert "Treat as authoritative reference data" not in result
+        assert "~/wiki/projects/*.md" in result
+        assert "honcho" in result.lower()
+        assert "user likes dark mode" not in result
 
     def test_build_memory_context_block_empty_input(self):
         from agent.memory_manager import build_memory_context_block
@@ -823,16 +824,19 @@ class TestMemoryContextFencing:
         assert "</memory-context>" not in result.lower()
         assert "datamore" in result
 
-    def test_fenced_block_separates_user_from_recall(self):
+    def test_compact_peer_card_can_be_included_without_raw_observations(self):
         from agent.memory_manager import build_memory_context_block
-        prefetch = "## Holographic Memory\n- [0.9] user is named Alice"
+        prefetch = (
+            "## User Peer Card\nName: Alice\nPrefers compact answers\n\n"
+            "## Explicit Observations\n2026-01-01 old raw observation"
+        )
         block = build_memory_context_block(prefetch)
-        user_msg = "What's the weather today?"
-        combined = user_msg + "\n\n" + block
-        fence_start = combined.index("<memory-context>")
-        fence_end = combined.index("</memory-context>")
-        assert "Alice" in combined[fence_start:fence_end]
-        assert combined.index("weather") < fence_start
+        assert "# Memory context pointers" in block
+        assert "## User Peer Card" in block
+        assert "Alice" in block
+        assert "Prefers compact answers" in block
+        assert "Explicit Observations" not in block
+        assert "old raw observation" not in block
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -914,6 +914,75 @@ class TestMemoryContextFencing:
         assert "Named Client" not in block
         assert "Private Alias" not in block
 
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "Full Name",
+            "First Name",
+            "Username",
+            "Handle",
+            "Employer",
+            "Company",
+            "Spouse",
+            "Wife",
+            "Child",
+            "Birthday",
+            "DOB",
+            "SSN",
+            "Coordinates",
+            "City",
+            "Country",
+        ],
+    )
+    def test_compact_peer_preferences_fail_closed_for_identity_labels(self, label):
+        from agent.memory_manager import compact_user_peer_card
+
+        payload = "\n".join(
+            [
+                f"{label}: synthetic forbidden value",
+                f"ATTRIBUTE: {label}: synthetic forbidden value",
+                f"INSTRUCTION: {label}: synthetic forbidden value",
+            ]
+        )
+
+        result = compact_user_peer_card(payload)
+
+        assert result == ""
+        assert "synthetic forbidden value" not in result
+        assert "ATTRIBUTE:" not in result
+        assert "INSTRUCTION:" not in result
+
+    def test_compact_peer_preferences_preserve_only_safe_labels(self):
+        from agent.memory_manager import compact_user_peer_card
+
+        result = compact_user_peer_card(
+            "\n".join(
+                [
+                    "Design Preference: Tight functional UI",
+                    "ATTRIBUTE: Tech Stack: Python, TypeScript",
+                    "INSTRUCTION: Model Routing: GPT-5.5 High",
+                    "Active Project: AIVS",
+                    "Knowledge Store: wiki project notes",
+                    "Company: Synthetic Studio",
+                    "Username: synthetic_user",
+                    "unlabelled preference prose",
+                ]
+            )
+        )
+
+        assert "Design Preference: Tight functional UI" in result
+        assert "Tech Stack: Python, TypeScript" in result
+        assert "Model Routing: GPT-5.5 High" in result
+        assert "Active Project: AIVS" in result
+        assert "Knowledge Store: wiki project notes" in result
+        assert "Company:" not in result
+        assert "Synthetic Studio" not in result
+        assert "Username:" not in result
+        assert "synthetic_user" not in result
+        assert "unlabelled preference prose" not in result
+        assert "ATTRIBUTE:" not in result
+        assert "INSTRUCTION:" not in result
+
 
 # ---------------------------------------------------------------------------
 # AIAgent.commit_memory_session — routes to MemoryManager.on_session_end

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -849,6 +849,34 @@ class TestMemoryContextFencing:
         assert "AI Identity Card" not in block
         assert "identity dump" not in block
 
+    def test_compact_peer_preferences_strip_prefixed_honcho_identity_lines(self):
+        from agent.memory_manager import build_memory_context_block
+
+        prefetch = (
+            "## User Peer Card\n"
+            "ATTRIBUTE: Role: Creative Director\n"
+            "ATTRIBUTE: Location: Hidden Harbor\n"
+            "ATTRIBUTE: Org: Example Studio\n"
+            "ATTRIBUTE: Website: example.invalid\n"
+            "ATTRIBUTE: E-mail: person@example.invalid\n"
+            "RELATIONSHIP: Father: Named Parent\n"
+            "RELATIONSHIP: Contractor: Named Client\n"
+            "INSTRUCTION: Name: Private Alias\n"
+            "ATTRIBUTE: Design Preference: Tight functional UI\n"
+        )
+
+        block = build_memory_context_block(prefetch)
+
+        assert "## Compact peer preferences" in block
+        assert "Tight functional UI" in block
+        assert "Hidden Harbor" not in block
+        assert "Example Studio" not in block
+        assert "example.invalid" not in block
+        assert "person@example.invalid" not in block
+        assert "Named Parent" not in block
+        assert "Named Client" not in block
+        assert "Private Alias" not in block
+
 
 # ---------------------------------------------------------------------------
 # AIAgent.commit_memory_session — routes to MemoryManager.on_session_end

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -868,7 +868,10 @@ class TestMemoryContextFencing:
         block = build_memory_context_block(prefetch)
 
         assert "## Compact peer preferences" in block
-        assert "Tight functional UI" in block
+        assert "Design Preference: Tight functional UI" in block
+        assert "ATTRIBUTE:" not in block
+        assert "INSTRUCTION:" not in block
+        assert "Role: Creative Director" not in block
         assert "Hidden Harbor" not in block
         assert "Example Studio" not in block
         assert "example.invalid" not in block

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -790,18 +790,18 @@ class TestSetupFieldFiltering:
 
 
 class TestMemoryContextFencing:
-    """Prefetch context becomes compact wiki/Honcho pointers, not raw dumps."""
+    """Prefetch context is not auto-injected into active provider prompts."""
 
     def test_build_memory_context_block_returns_pointers_not_fenced_dump(self):
         from agent.memory_manager import build_memory_context_block
         result = build_memory_context_block(
             "## Holographic Memory\n- [0.8] user likes dark mode"
         )
-        assert result.startswith("# Memory context pointers")
-        assert "<memory-context>" not in result
+        assert result == ""
+        assert "INJECTED" not in result
         assert "Treat as authoritative reference data" not in result
-        assert "~/wiki/projects/*.md" in result
-        assert "honcho" in result.lower()
+        assert "~/wiki/projects/*.md" not in result
+        assert "honcho" not in result.lower()
         assert "user likes dark mode" not in result
 
     def test_build_memory_context_block_empty_input(self):
@@ -824,6 +824,38 @@ class TestMemoryContextFencing:
         assert "</memory-context>" not in result.lower()
         assert "datamore" in result
 
+    def test_sanitize_context_strips_compact_memory_pointer_block(self):
+        from agent.memory_manager import sanitize_context
+
+        leaked = (
+            "# Memory context pointers\n"
+            "- Compact peer/preferences: use Honcho tools.\n"
+            "- Project facts: use ~/wiki/projects/*.md.\n\n"
+            "## Compact peer preferences\n"
+            "Knowledge Store: ~/wiki\n"
+            "Tech Stack: Next.js, React, TypeScript\n"
+            "Design Preference: Minimalist black/white brutalist\n"
+            "Model Routing: GPT-5.5\n"
+            "Active Project: AI Film Set Composer\n\n"
+            "The most relevant context to the current conversation emphasizes long-term agent notes.\n"
+            "This foundational context should not be visible.\n"
+            "Recent observations indicate this is an internal memory leak.\n"
+        )
+        result = sanitize_context("before\n" + leaked + "\nafter")
+
+        assert "before" in result
+        assert "after" in result
+        assert "# Memory context pointers" not in result
+        assert "## Compact peer preferences" not in result
+        assert "Knowledge Store:" not in result
+        assert "Tech Stack:" not in result
+        assert "Design Preference:" not in result
+        assert "Model Routing:" not in result
+        assert "Active Project:" not in result
+        assert "The most relevant context to the current conversation" not in result
+        assert "foundational context" not in result
+        assert "observations indicate" not in result
+
     def test_compact_peer_preferences_can_be_included_without_raw_identity_or_observations(self):
         from agent.memory_manager import build_memory_context_block
         prefetch = (
@@ -834,12 +866,13 @@ class TestMemoryContextFencing:
             "## AI Identity Card\nidentity dump"
         )
         block = build_memory_context_block(prefetch)
-        assert "# Memory context pointers" in block
-        assert "## Compact peer preferences" in block
+        assert block == ""
+        assert "# Memory context pointers" not in block
+        assert "## Compact peer preferences" not in block
         assert "## User Peer Card" not in block
         assert "Alice" not in block
         assert "alice@example.com" not in block
-        assert "Prefers compact answers" in block
+        assert "Prefers compact answers" not in block
         assert "Explicit Observations" not in block
         assert "old raw observation" not in block
         assert "AI Self-Representation" not in block
@@ -867,8 +900,9 @@ class TestMemoryContextFencing:
 
         block = build_memory_context_block(prefetch)
 
-        assert "## Compact peer preferences" in block
-        assert "Design Preference: Tight functional UI" in block
+        assert block == ""
+        assert "## Compact peer preferences" not in block
+        assert "Design Preference: Tight functional UI" not in block
         assert "ATTRIBUTE:" not in block
         assert "INSTRUCTION:" not in block
         assert "Role: Creative Director" not in block

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -824,19 +824,30 @@ class TestMemoryContextFencing:
         assert "</memory-context>" not in result.lower()
         assert "datamore" in result
 
-    def test_compact_peer_card_can_be_included_without_raw_observations(self):
+    def test_compact_peer_preferences_can_be_included_without_raw_identity_or_observations(self):
         from agent.memory_manager import build_memory_context_block
         prefetch = (
-            "## User Peer Card\nName: Alice\nPrefers compact answers\n\n"
-            "## Explicit Observations\n2026-01-01 old raw observation"
+            "## User Peer Card\nName: Alice\nAliases: alice@example.com\nPrefers compact answers\n\n"
+            "## Explicit Observations\n2026-01-01 old raw observation\n"
+            "## AI Self-Representation\nagent dump\n"
+            "## Recalled assistant context\nassistant context dump\n"
+            "## AI Identity Card\nidentity dump"
         )
         block = build_memory_context_block(prefetch)
         assert "# Memory context pointers" in block
-        assert "## User Peer Card" in block
-        assert "Alice" in block
+        assert "## Compact peer preferences" in block
+        assert "## User Peer Card" not in block
+        assert "Alice" not in block
+        assert "alice@example.com" not in block
         assert "Prefers compact answers" in block
         assert "Explicit Observations" not in block
         assert "old raw observation" not in block
+        assert "AI Self-Representation" not in block
+        assert "agent dump" not in block
+        assert "Recalled assistant context" not in block
+        assert "assistant context dump" not in block
+        assert "AI Identity Card" not in block
+        assert "identity dump" not in block
 
 
 # ---------------------------------------------------------------------------

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -968,7 +968,10 @@ class TestBaseContextSummary:
         }
         formatted = provider._format_first_turn_context(ctx)
         assert "## Session Summary" in formatted
-        assert formatted.index("Session Summary") < formatted.index("User Representation")
+        assert "## User Peer Card" in formatted
+        assert formatted.index("Session Summary") < formatted.index("User Peer Card")
+
+        assert "## User Representation" not in formatted
 
     def test_format_without_summary(self):
         """No summary key means no summary section."""
@@ -976,7 +979,8 @@ class TestBaseContextSummary:
         ctx = {"representation": "Eri is a developer.", "card": "Name: Eri"}
         formatted = provider._format_first_turn_context(ctx)
         assert "Session Summary" not in formatted
-        assert "User Representation" in formatted
+        assert "User Representation" not in formatted
+        assert "## User Peer Card" in formatted
 
     def test_format_empty_summary_skipped(self):
         """Empty summary string should not produce a section."""

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -964,7 +964,7 @@ class TestBaseContextSummary:
         ctx = {
             "summary": "Testing Honcho tools and dialectic depth.",
             "representation": "Eri is a developer.",
-            "card": "Name: Eri Barrett\nPrefers terse verified status",
+            "card": "Name: Eri Barrett\nDesign Preference: terse verified status",
         }
         formatted = provider._format_first_turn_context(ctx)
         assert "## Session Summary" in formatted
@@ -974,19 +974,19 @@ class TestBaseContextSummary:
         assert "## User Representation" not in formatted
         assert "## User Peer Card" not in formatted
         assert "Name: Eri" not in formatted
-        assert "Prefers terse verified status" in formatted
+        assert "Design Preference: terse verified status" in formatted
 
     def test_format_without_summary(self):
         """No summary key means no summary section."""
         provider = HonchoMemoryProvider()
-        ctx = {"representation": "Eri is a developer.", "card": "Name: Eri\nPrefers terse status"}
+        ctx = {"representation": "Eri is a developer.", "card": "Name: Eri\nDesign Preference: terse status"}
         formatted = provider._format_first_turn_context(ctx)
         assert "Session Summary" not in formatted
         assert "User Representation" not in formatted
         assert "## User Peer Card" not in formatted
         assert "Name: Eri" not in formatted
         assert "## Compact peer preferences" in formatted
-        assert "Prefers terse status" in formatted
+        assert "Design Preference: terse status" in formatted
 
     def test_format_empty_summary_skipped(self):
         """Empty summary string should not produce a section."""
@@ -998,7 +998,7 @@ class TestBaseContextSummary:
     def test_format_does_not_inject_assistant_peer_context_or_raw_identity_by_default(self):
         provider = HonchoMemoryProvider()
         ctx = {
-            "card": "Name: Nic\nAliases: nic@example.com\nNic prefers terse verified status",
+            "card": "Name: Nic\nAliases: nic@example.com\nDesign Preference: terse verified status",
             "representation": "Current user context",
             "ai_card": "AI Identity Card: private assistant model",
             "ai_representation": "AI Self-Representation: private assistant dump",
@@ -1006,7 +1006,7 @@ class TestBaseContextSummary:
 
         formatted = provider._format_first_turn_context(ctx)
 
-        assert "Nic prefers terse verified status" in formatted
+        assert "Design Preference: terse verified status" in formatted
         assert "Current user context" not in formatted
         assert "## User Peer Card" not in formatted
         assert "Name: Nic" not in formatted

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -964,23 +964,29 @@ class TestBaseContextSummary:
         ctx = {
             "summary": "Testing Honcho tools and dialectic depth.",
             "representation": "Eri is a developer.",
-            "card": "Name: Eri Barrett",
+            "card": "Name: Eri Barrett\nPrefers terse verified status",
         }
         formatted = provider._format_first_turn_context(ctx)
         assert "## Session Summary" in formatted
-        assert "## User Peer Card" in formatted
-        assert formatted.index("Session Summary") < formatted.index("User Peer Card")
+        assert "## Compact peer preferences" in formatted
+        assert formatted.index("Session Summary") < formatted.index("Compact peer preferences")
 
         assert "## User Representation" not in formatted
+        assert "## User Peer Card" not in formatted
+        assert "Name: Eri" not in formatted
+        assert "Prefers terse verified status" in formatted
 
     def test_format_without_summary(self):
         """No summary key means no summary section."""
         provider = HonchoMemoryProvider()
-        ctx = {"representation": "Eri is a developer.", "card": "Name: Eri"}
+        ctx = {"representation": "Eri is a developer.", "card": "Name: Eri\nPrefers terse status"}
         formatted = provider._format_first_turn_context(ctx)
         assert "Session Summary" not in formatted
         assert "User Representation" not in formatted
-        assert "## User Peer Card" in formatted
+        assert "## User Peer Card" not in formatted
+        assert "Name: Eri" not in formatted
+        assert "## Compact peer preferences" in formatted
+        assert "Prefers terse status" in formatted
 
     def test_format_empty_summary_skipped(self):
         """Empty summary string should not produce a section."""
@@ -988,6 +994,27 @@ class TestBaseContextSummary:
         ctx = {"summary": "", "representation": "rep", "card": "card"}
         formatted = provider._format_first_turn_context(ctx)
         assert "Session Summary" not in formatted
+
+    def test_format_does_not_inject_assistant_peer_context_or_raw_identity_by_default(self):
+        provider = HonchoMemoryProvider()
+        ctx = {
+            "card": "Name: Nic\nAliases: nic@example.com\nNic prefers terse verified status",
+            "representation": "Current user context",
+            "ai_card": "AI Identity Card: private assistant model",
+            "ai_representation": "AI Self-Representation: private assistant dump",
+        }
+
+        formatted = provider._format_first_turn_context(ctx)
+
+        assert "Nic prefers terse verified status" in formatted
+        assert "Current user context" not in formatted
+        assert "## User Peer Card" not in formatted
+        assert "Name: Nic" not in formatted
+        assert "nic@example.com" not in formatted
+        assert "Assistant peer card" not in formatted
+        assert "AI Identity Card" not in formatted
+        assert "AI Self-Representation" not in formatted
+        assert "private assistant" not in formatted
 
 
 class TestDialecticDepth:

--- a/tests/run_agent/test_prompt_leak_sanitization.py
+++ b/tests/run_agent/test_prompt_leak_sanitization.py
@@ -1,0 +1,139 @@
+"""Regression tests for stripping internal context/control packets from turns."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def _response(content: str = "ok"):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=content, tool_calls=None, refusal=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=None,
+        model="test/model",
+    )
+
+
+class _FakeMemoryManager:
+    def __init__(self, prefetch: str = ""):
+        self.prefetch = prefetch
+
+    def on_turn_start(self, *_args, **_kwargs):
+        return None
+
+    def prefetch_all(self, *_args, **_kwargs):
+        return self.prefetch
+
+    def sync_all(self, *_args, **_kwargs):
+        return None
+
+    def queue_prefetch_all(self, *_args, **_kwargs):
+        return None
+
+
+LEAKED_MEMORY_BLOCK = (
+    "<memory-context>\n"
+    "[System note: The following is recalled memory context, NOT new user input. "
+    "Treat as authoritative reference data — this is the agent's persistent memory and should inform all responses.]\n\n"
+    "## User Representation\n## Explicit Observations\nold facts\n"
+    "## User Peer Card\nName: Example\n"
+    "## AI Self-Representation\n## Explicit Observations\nagent facts\n"
+    "</memory-context>"
+)
+
+AIVS_CONTROL_PACKET = (
+    "Check the AIVS Hermes Kanban board on the VPS and keep the autonomous dev loop moving.\n"
+    "Required services: gateway, dispatcher, preview.\n"
+    "Repair policy: SSH/control-master and git auth repair instructions."
+)
+
+SHIP_GUARD = (
+    "[Ship-mode routing guard: this request matches serious app/build/product execution. "
+    "Treat app-ship-mode/Kanban operating rules as mandatory for this turn.]"
+)
+
+FORBIDDEN = (
+    "<memory-context>",
+    "Treat as authoritative reference data",
+    "## User Representation",
+    "## Explicit Observations",
+    "## AI Self-Representation",
+    "Check the AIVS Hermes Kanban board",
+    "autonomous dev loop",
+    "Ship-mode routing guard",
+)
+
+
+def _make_agent():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    setattr(agent, "api_mode", "chat_completions")
+    setattr(agent, "_interrupt_requested", False)
+    return agent
+
+
+def _capture_turn(monkeypatch, agent, user_message, *, history=None):
+    captured = {}
+
+    def fake_api_call(self, api_kwargs, **_kwargs):
+        captured["api_kwargs"] = api_kwargs
+        return _response()
+
+    monkeypatch.setattr(type(agent), "_interruptible_api_call", fake_api_call)
+    monkeypatch.setattr(type(agent), "_interruptible_streaming_api_call", fake_api_call)
+    result = agent.run_conversation(user_message, conversation_history=history or [])
+    return result, captured
+
+
+def _request_text(captured) -> str:
+    messages = captured["api_kwargs"].get("messages") or []
+    return "\n".join(str(m.get("content", "")) for m in messages)
+
+
+def test_inbound_user_leak_is_not_persisted_or_sent_to_provider(monkeypatch):
+    agent = _make_agent()
+    user_message = "Fix this now\n\n" + LEAKED_MEMORY_BLOCK + "\n" + SHIP_GUARD
+
+    result, captured = _capture_turn(monkeypatch, agent, user_message)
+
+    request_text = _request_text(captured)
+    persisted_text = "\n".join(str(m.get("content", "")) for m in result["messages"])
+    for token in FORBIDDEN:
+        assert token not in request_text
+        assert token not in persisted_text
+    assert "Fix this now" in request_text
+    assert "Fix this now" in persisted_text
+
+
+def test_history_and_memory_prefetch_leaks_are_not_sent_to_provider(monkeypatch):
+    agent = _make_agent()
+    setattr(agent, "_memory_manager", _FakeMemoryManager(
+        prefetch=LEAKED_MEMORY_BLOCK + "\n" + AIVS_CONTROL_PACKET + "\n" + SHIP_GUARD
+    ))
+    history = [
+        {"role": "user", "content": "Earlier complaint\n" + AIVS_CONTROL_PACKET},
+        {"role": "assistant", "content": "Earlier answer\n" + SHIP_GUARD},
+    ]
+
+    _result, captured = _capture_turn(monkeypatch, agent, "tiny runtime/debug control turn", history=history)
+
+    request_text = _request_text(captured)
+    for token in FORBIDDEN:
+        assert token not in request_text
+    assert "tiny runtime/debug control turn" in request_text
+    assert "# Memory context pointers" in request_text
+    assert "~/wiki/projects/*.md" in request_text
+    assert "## User Peer Card" in request_text
+    assert "Name: Example" in request_text

--- a/tests/run_agent/test_prompt_leak_sanitization.py
+++ b/tests/run_agent/test_prompt_leak_sanitization.py
@@ -39,6 +39,17 @@ LEAKED_MEMORY_BLOCK = (
     "<memory-context>\n"
     "[System note: The following is recalled memory context, NOT new user input. "
     "Treat as authoritative reference data — this is the agent's persistent memory and should inform all responses.]\n\n"
+    "# Memory context pointers\n"
+    "- Compact peer/preferences: use Honcho peer-card/profile tools for a fresh view when needed.\n\n"
+    "## Compact peer preferences\n"
+    "Knowledge Store: ~/wiki\n"
+    "Tech Stack: Next.js, React, TypeScript\n"
+    "Design Preference: Tight functional UI\n"
+    "Model Routing: GPT-5.5\n"
+    "Active Project: AI Film Set Composer\n\n"
+    "The most relevant context to the current conversation appears to be the active work.\n"
+    "This foundational context should not be visible.\n"
+    "Recent observations indicate this is an internal memory leak.\n\n"
     "## User Representation\n## Explicit Observations\nold facts\n"
     "## User Peer Card\nName: Example\n"
     "## AI Self-Representation\n## Explicit Observations\nagent facts\n"
@@ -75,6 +86,19 @@ FORBIDDEN = (
     "Check the AIVS Hermes Kanban board",
     "autonomous dev loop",
     "Ship-mode routing guard",
+    "# Memory context pointers",
+    "## Compact peer preferences",
+    "Knowledge Store:",
+    "Tech Stack:",
+    "Design Preference:",
+    "Model Routing:",
+    "Active Project:",
+    "The most relevant context to the current conversation",
+    "foundational context",
+    "observations indicate",
+    "ATTRIBUTE:",
+    "RELATIONSHIP:",
+    "INSTRUCTION:",
 )
 
 
@@ -143,5 +167,5 @@ def test_history_and_memory_prefetch_leaks_are_not_sent_to_provider(monkeypatch)
     for token in FORBIDDEN:
         assert token not in request_text
     assert "tiny runtime/debug control turn" in request_text
-    assert "# Memory context pointers" in request_text
-    assert "~/wiki/projects/*.md" in request_text
+    assert "# Memory context pointers" not in request_text
+    assert "~/wiki/projects/*.md" not in request_text

--- a/tests/run_agent/test_prompt_leak_sanitization.py
+++ b/tests/run_agent/test_prompt_leak_sanitization.py
@@ -42,6 +42,8 @@ LEAKED_MEMORY_BLOCK = (
     "## User Representation\n## Explicit Observations\nold facts\n"
     "## User Peer Card\nName: Example\n"
     "## AI Self-Representation\n## Explicit Observations\nagent facts\n"
+    "## Recalled assistant context\nassistant context dump\n"
+    "## AI Identity Card\nidentity dump\n"
     "</memory-context>"
 )
 
@@ -60,8 +62,16 @@ FORBIDDEN = (
     "<memory-context>",
     "Treat as authoritative reference data",
     "## User Representation",
+    "## User Peer Card",
+    "Name: Example",
     "## Explicit Observations",
+    "old facts",
+    "agent facts",
     "## AI Self-Representation",
+    "## Recalled assistant context",
+    "assistant context dump",
+    "## AI Identity Card",
+    "identity dump",
     "Check the AIVS Hermes Kanban board",
     "autonomous dev loop",
     "Ship-mode routing guard",
@@ -135,5 +145,3 @@ def test_history_and_memory_prefetch_leaks_are_not_sent_to_provider(monkeypatch)
     assert "tiny runtime/debug control turn" in request_text
     assert "# Memory context pointers" in request_text
     assert "~/wiki/projects/*.md" in request_text
-    assert "## User Peer Card" in request_text
-    assert "Name: Example" in request_text

--- a/tests/run_agent/test_prompt_leak_streaming_sanitization.py
+++ b/tests/run_agent/test_prompt_leak_streaming_sanitization.py
@@ -1,0 +1,70 @@
+"""Streaming regression for internal context/control packet leakage."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _make_stream_chunk(content=None, tool_calls=None, finish_reason=None):
+    delta = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)],
+        model="test-model",
+        usage=None,
+    )
+
+
+def _make_tool_call_delta(index=0, tc_id=None, name=None, arguments=None):
+    return SimpleNamespace(
+        index=index,
+        id=tc_id,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+@patch("run_agent.AIAgent._create_request_openai_client")
+@patch("run_agent.AIAgent._close_request_openai_client")
+def test_suppressed_tool_text_uses_context_stream_scrubber(mock_close, mock_create):
+    """Tool-turn suppressed text must not bypass memory/guard scrubbers."""
+    from run_agent import AIAgent
+
+    chunks = [
+        _make_stream_chunk(content="thinking..."),
+        _make_stream_chunk(tool_calls=[
+            _make_tool_call_delta(index=0, tc_id="call_abc", name="read_file")
+        ]),
+        _make_stream_chunk(content="\n<ship_mode_guard>\nsecret route metadata"),
+        _make_stream_chunk(content="</ship_mode_guard>\n visible after"),
+        _make_stream_chunk(finish_reason="tool_calls"),
+    ]
+
+    deltas = []
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = iter(chunks)
+    mock_create.return_value = mock_client
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        stream_delta_callback=lambda t: deltas.append(t),
+    )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+
+    agent._interruptible_streaming_api_call({})
+
+    streamed = "".join(deltas)
+    assert "thinking..." in streamed
+    assert " visible after" in streamed
+    assert "secret route metadata" not in streamed
+    assert "ship_mode_guard" not in streamed

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5605,15 +5605,15 @@ class TestSupportsReasoningExtraBody:
 class TestMemoryContextSanitization:
     """sanitize_context() helper correctness — used at provider boundaries."""
 
-    def test_user_message_is_not_mutated_by_run_conversation(self):
-        """User input must reach run_conversation untouched — if a user types
-        a literal <memory-context> tag we don't silently delete their text.
-        The streaming scrubber + plugin-side scrub cover real leak paths."""
+    def test_user_message_is_sanitized_before_history_and_provider_boundaries(self):
+        """Emergency leak guard: pasted internal memory/control packets are
+        removed before the current user turn is persisted or sent to a provider.
+        Literal tag discussion remains covered by sanitize_context's backtick test."""
         import inspect
         from agent.conversation_loop import run_conversation as _rc
         src = inspect.getsource(_rc)
-        assert "sanitize_context(user_message)" not in src
-        assert "sanitize_context(persist_user_message)" not in src
+        assert "user_message = sanitize_context(user_message)" in src
+        assert "persist_user_message = sanitize_context(persist_user_message)" in src
 
     def test_sanitize_context_strips_full_block(self):
         """Helper-level: a string with an embedded memory-context block is


### PR DESCRIPTION
## What does this PR do?

Stops raw recalled memory and Honcho representation dumps from entering normal provider prompts. The prompt path now injects compact retrieval pointers plus only safe Session Summary / User Peer Card slices, while raw observations and self-representation stay retrievable through Honcho/wiki tools when explicitly needed.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/memory_manager.py`: replace raw memory-context fencing with compact wiki/Honcho pointer blocks, retain only safe session/peer-card sections, and keep legacy/internal-context scrubbers for poisoned or stale inputs.
- `plugins/memory/honcho/__init__.py`: limit first-turn injected Honcho context to Session Summary and User Peer Card; drop User Representation, AI Self-Representation, and AI Identity Card from normal prompt injection.
- `agent/conversation_loop.py` and `agent/chat_completion_helpers.py`: apply `sanitize_context` at provider/streaming boundaries so echoed internal context/control packets are scrubbed before reaching providers or gateway stream callbacks.
- Regression coverage for pointer presence, peer-card retention, raw observation stripping, provider request sanitization, and streaming sanitization.

## How to Test

1. `python -m pytest tests/agent/test_memory_provider.py tests/run_agent/test_prompt_leak_sanitization.py tests/run_agent/test_prompt_leak_streaming_sanitization.py tests/run_agent/test_run_agent.py tests/honcho_plugin/test_session.py -q -o 'addopts='`
2. `python -m ruff check agent/memory_manager.py agent/conversation_loop.py agent/chat_completion_helpers.py plugins/memory/honcho/__init__.py tests/agent/test_memory_provider.py tests/run_agent/test_prompt_leak_sanitization.py tests/run_agent/test_prompt_leak_streaming_sanitization.py tests/run_agent/test_run_agent.py tests/honcho_plugin/test_session.py -q`
3. `python -m py_compile agent/memory_manager.py agent/conversation_loop.py agent/chat_completion_helpers.py plugins/memory/honcho/__init__.py`

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.8.0-111-generic

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

Targeted verification passed: 542 tests passed, 1 warning (`discord.player` `audioop` deprecation).
