### PR TITLE
test(tui_gateway): stop reloading server module in fixture teardown

### DIFF
--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -44,11 +44,17 @@ def server(hermes_home):
     ):
         mod = importlib.import_module("tui_gateway.server")
         yield mod
+        # Reset module-level session state without re-importing. importlib.reload
+        # would re-register the module's atexit hooks (ThreadPoolExecutor
+        # shutdown, _shutdown_sessions); the duplicates race the stderr
+        # buffer at interpreter shutdown and surface as Fatal Python error:
+        # _enter_buffered_busy. Clearing the per-session dicts gives the
+        # next test a clean slate; _methods is NOT cleared because it's
+        # populated at module import time and re-registration only happens
+        # via reload (which we don't do).
         mod._sessions.clear()
         mod._pending.clear()
         mod._answers.clear()
-        mod._methods.clear()
-        importlib.reload(mod)
 
 
 @pytest.fixture()

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -30,11 +30,17 @@ def server():
         import importlib
         mod = importlib.import_module("tui_gateway.server")
         yield mod
+        # Reset module-level session state without re-importing. importlib.reload
+        # would re-register the module's atexit hooks (ThreadPoolExecutor
+        # shutdown, _shutdown_sessions); the duplicates race the stderr
+        # buffer at interpreter shutdown and surface as Fatal Python error:
+        # _enter_buffered_busy. Clearing the per-session dicts gives the
+        # next test a clean slate; _methods is NOT cleared because it's
+        # populated at module import time and re-registration only happens
+        # via reload (which we don't do).
         mod._sessions.clear()
         mod._pending.clear()
         mod._answers.clear()
-        mod._methods.clear()
-        importlib.reload(mod)
 
 
 @pytest.fixture()

--- a/tests/tui_gateway/test_review_summary_callback.py
+++ b/tests/tui_gateway/test_review_summary_callback.py
@@ -34,11 +34,17 @@ def server():
 
         mod = importlib.import_module("tui_gateway.server")
         yield mod
+        # Reset module-level session state without re-importing. importlib.reload
+        # would re-register the module's atexit hooks (ThreadPoolExecutor
+        # shutdown, _shutdown_sessions); the duplicates race the stderr
+        # buffer at interpreter shutdown and surface as Fatal Python error:
+        # _enter_buffered_busy. Clearing the per-session dicts gives the
+        # next test a clean slate; _methods is NOT cleared because it's
+        # populated at module import time and re-registration only happens
+        # via reload (which we don't do).
         mod._sessions.clear()
         mod._pending.clear()
         mod._answers.clear()
-        mod._methods.clear()
-        importlib.reload(mod)
 
 
 def test_init_session_attaches_background_review_callback(server, monkeypatch):


### PR DESCRIPTION
Stops three tui_gateway test fixtures from reloading `tui_gateway.server` in teardown. The reloads were re-registering the module's atexit hooks on every test, accumulating duplicates across the session, and racing the stderr buffer at interpreter shutdown — which surfaces as a CI flake where "all tests pass" but the slice exits non-zero.

## The flake

Affected slices fail with:

```
204 files, 3572 tests passed, 0 failed (100% complete) in 80.2s
─────────────────────────────────────────────────────────────────
Fatal Python error: _enter_buffered_busy: could not acquire lock for
  <_io.BufferedWriter name='<stderr>'> at interpreter shutdown,
  possibly due to daemon threads
##[error] Process completed with exit code 1
```

Surfaced today on PR #34193 test slice 1 — same shape was hitting the docker integration tests earlier in the day too. The exit-code-non-zero turns the slice red even though every test reported PASS.

## Root cause

`tui_gateway/server.py` registers two atexit hooks at module load time:

```python
# line 170
_pool = concurrent.futures.ThreadPoolExecutor(...)
atexit.register(lambda: _pool.shutdown(wait=False, cancel_futures=True))

# line 336
atexit.register(_shutdown_sessions)
```

Three test fixtures called `importlib.reload(mod)` at teardown to reset per-test session state. Each reload re-runs the module-level code, including the atexit registrations. After N tests using the fixture, the atexit registry has N+1 copies of each hook. At pytest interpreter shutdown all N+1 try to fire in parallel and race for the stderr buffer flush.

## Fix

Drop `importlib.reload(mod)` from the three fixtures. Per-test reset is handled by clearing the mutable session dicts (`_sessions`, `_pending`, `_answers`). `_methods` is also no longer cleared — it's populated at module import time and would only repopulate via reload, so clearing it without the reload broke `session.resume` / `command.dispatch` / `slash.exec` method registration across tests.

```diff
 yield mod
 mod._sessions.clear()
 mod._pending.clear()
 mod._answers.clear()
-mod._methods.clear()
-importlib.reload(mod)
```

| File | Before | After |
|---|---|---|
| `tests/tui_gateway/test_review_summary_callback.py` | reloaded on teardown | dict-clear only |
| `tests/tui_gateway/test_goal_command.py` | reloaded on teardown | dict-clear only |
| `tests/tui_gateway/test_protocol.py` | reloaded on teardown | dict-clear only |

The second reload in `test_protocol.py` at line 211 (reload of `tui_gateway.transport` for the `HERMES_TUI_GATEWAY_NO_FLUSH` env-var test) is preserved — `transport.py` has no atexit hooks or threads, so reload is safe there.

## Validation

- `tests/tui_gateway/` full directory: **84/84 pass**, exit code 0, no Fatal Python error at interpreter shutdown.
- Targeted re-runs of the specific tests that used to leak (`test_session_resume_returns_hydrated_messages`, `test_slash_exec_*`, `test_command_dispatch_*`): all pass in order-shuffled session.

## Origin

This PR is a side-fix from triaging an unrelated CI failure on PR #34193 — the kanban checkpoint reminder feature. The atexit-duplicate issue is independent of any kanban work; it's a test-infrastructure bug that benefits every PR. Splitting it into its own PR so it lands cleanly regardless of whether #34193 ships.

## Infographic

![tui-gateway-test-reload-flake](https://v3b.fal.media/files/b/0a9c1705/_eqBDmKQaqc3wRTOP19n7_VUL4Q1ED.png)
