### PR TITLE
fix(gateway): handle launchctl error 125/5 on macOS 26

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2798,8 +2798,37 @@ def get_launchd_label() -> str:
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 
+_launchd_domain_cache: str | None = None
+
 def _launchd_domain() -> str:
-    return f"gui/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
+    """Return the launchd domain (e.g. ``gui/<uid>``).
+
+    On some macOS setups (e.g. SSH-only sessions, screen-sharing without a
+    login window) ``gui/<uid>`` is unavailable — launchctl returns exit code
+    125 or 5.  When that happens we probe once and fall back to
+    ``user/<uid>`` for the rest of the process lifetime.
+    """
+    global _launchd_domain_cache
+    if _launchd_domain_cache is not None:
+        return _launchd_domain_cache
+    uid = os.getuid()
+    gui_domain = f"gui/{uid}"
+    try:
+        subprocess.run(
+            ["launchctl", "print", f"{gui_domain}/"],
+            capture_output=True,
+            timeout=5,
+            check=True,
+        )
+        _launchd_domain_cache = gui_domain
+    except subprocess.CalledProcessError as exc:
+        if exc.returncode in {125, 5}:
+            _launchd_domain_cache = f"user/{uid}"
+        else:
+            _launchd_domain_cache = gui_domain
+    except Exception:
+        _launchd_domain_cache = gui_domain
+    return _launchd_domain_cache
 
 
 def generate_launchd_plist() -> str:
@@ -2975,7 +3004,7 @@ def launchd_start():
     try:
         subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
     except subprocess.CalledProcessError as e:
-        if e.returncode not in {3, 113}:
+        if e.returncode not in {3, 113, 125, 5}:
             raise
         print("↻ launchd job was unloaded; reloading service definition")
         subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
@@ -2999,7 +3028,7 @@ def launchd_stop():
     try:
         subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)
     except subprocess.CalledProcessError as e:
-        if e.returncode in {3, 113}:
+        if e.returncode in {3, 113, 125, 5}:
             pass  # Already unloaded — nothing to stop.
         else:
             raise
@@ -3071,7 +3100,7 @@ def launchd_restart():
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
     except subprocess.CalledProcessError as e:
-        if e.returncode not in {3, 113}:
+        if e.returncode not in {3, 113, 125, 5}:
             raise
         # Job not loaded — bootstrap and start fresh
         print("↻ launchd job was unloaded; reloading")


### PR DESCRIPTION
Fixes #23387

## Problem
On macOS 26.4.1, `launchctl kickstart gui/<uid>/...` returns error 125 and `launchctl bootstrap gui/<uid> ...` returns error 5. The existing error handlers in launchd_start/stop/restart only handled codes 3 and 113, so error 125/5 crashed `hermes gateway start/stop/restart` with a cryptic traceback on all macOS 26 systems.

## Changes
- Added return codes 125 and 5 to the handled set in all three launchd management functions
- Added `_launchd_domain()` fallback: if `gui/<uid>` fails with 125/5, probe once and fall back to `user/<uid>` for the rest of the process lifetime
- Cached the resolved domain in `_launchd_domain_cache` to avoid repeated probes