### PR TITLE
fix(mcp): fail fast when sdk is missing

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -173,11 +173,16 @@ def _probe_single_server(
     Raises on connection failure.
     """
     from tools.mcp_tool import (
+        _MCP_AVAILABLE,
         _ensure_mcp_loop,
+        _missing_mcp_sdk_message,
         _run_on_mcp_loop,
         _connect_server,
         _stop_mcp_loop,
     )
+
+    if not _MCP_AVAILABLE:
+        raise ImportError(_missing_mcp_sdk_message(name))
 
     _ensure_mcp_loop()
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -442,6 +442,20 @@ class TestMcpTest:
         assert "Connected" in out
         assert "Tools discovered: 2" in out
 
+    def test_test_missing_mcp_sdk_shows_pipx_hint(self, tmp_path, capsys):
+        _seed_config(tmp_path, {
+            "demo": {"command": "python3", "args": ["-c", "print(1)"]},
+        })
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        with patch("tools.mcp_tool._MCP_AVAILABLE", False):
+            cmd_mcp_test(_make_args(name="demo"))
+
+        out = capsys.readouterr().out
+        assert "Connection failed" in out
+        assert "pipx inject hermes-agent mcp" in out
+        assert "hermes-agent[mcp]" in out
+
 
 # ---------------------------------------------------------------------------
 # Tests: env var interpolation
@@ -599,4 +613,3 @@ class TestMcpLogin:
         cmd_mcp_login(_make_args(name="srv"))
         out = capsys.readouterr().out
         assert "no URL" in out or "not an OAuth" in out
-

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -253,6 +253,20 @@ _MCP_MESSAGE_HANDLER_SUPPORTED = _check_message_handler_support()
 if _MCP_AVAILABLE and not _MCP_MESSAGE_HANDLER_SUPPORTED:
     logger.debug("MCP SDK does not support message_handler -- dynamic tool discovery disabled")
 
+
+def _missing_mcp_sdk_message(server_name: str | None = None) -> str:
+    """Return a consistent install hint when the optional MCP SDK is absent."""
+    target = f"MCP server '{server_name}'" if server_name else "MCP support"
+    return (
+        f"{target} requires the 'mcp' Python SDK, but it is not installed. "
+        "If you installed Hermes with pipx, run:\n"
+        "  pipx inject hermes-agent mcp\n"
+        "Otherwise install with:\n"
+        "  pip install 'hermes-agent[mcp]'\n"
+        "or (full install):\n"
+        "  pip install 'hermes-agent[all]'"
+    )
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -1340,13 +1354,7 @@ class MCPServerTask:
     async def _run_stdio(self, config: dict):
         """Run the server using stdio transport."""
         if not _MCP_AVAILABLE:
-            raise ImportError(
-                f"MCP server '{self.name}' requires the 'mcp' Python SDK, but "
-                "it is not installed. Install with:\n"
-                "  pip install 'hermes-agent[mcp]'\n"
-                "or (full install):\n"
-                "  pip install 'hermes-agent[all]'"
-            )
+            raise ImportError(_missing_mcp_sdk_message(self.name))
 
         command = config.get("command")
         args = config.get("args", [])


### PR DESCRIPTION
## Summary
- fail fast in `hermes mcp add/test/configure/login` when the optional `mcp` SDK is not installed instead of entering connection retries
- reuse one shared missing-SDK message so the CLI and stdio transport both tell pipx users to run `pipx inject hermes-agent mcp`
- add a CLI regression test covering `hermes mcp test` with the SDK absent

Closes #34220.

## Verification
- `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_mcp_config.py -k 'TestMcpTest or test_test_missing_mcp_sdk_shows_pipx_hint'`
- `uv run --frozen pytest -q -o addopts='' tests/tools/test_mcp_tool.py -k stdio_unavailable_raises_importerror_not_nameerror`
- `uv run --frozen ruff check hermes_cli/mcp_config.py tools/mcp_tool.py tests/hermes_cli/test_mcp_config.py`
- `git diff --check`
