### PR TITLE
fix(cli): show reasoning without streaming

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4020,9 +4020,13 @@ class HermesCLI:
 
     def _current_reasoning_callback(self):
         """Return the active reasoning display callback for the current mode."""
-        if self.show_reasoning and self.streaming_enabled:
-            return self._stream_reasoning_delta
-        if self.verbose and not self.show_reasoning:
+        if self.show_reasoning:
+            return (
+                self._stream_reasoning_delta
+                if self.streaming_enabled
+                else self._on_reasoning
+            )
+        if self.verbose:
             return self._on_reasoning
         return None
 
@@ -4031,6 +4035,8 @@ class HermesCLI:
         preview_text = reasoning_text.strip()
         if not preview_text:
             return
+        if getattr(self, "show_reasoning", False):
+            self._reasoning_shown_this_turn = True
 
         try:
             term_width = shutil.get_terminal_size().columns

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -305,13 +305,15 @@ class TestReasoningCallback(unittest.TestCase):
 
 
 class TestReasoningPreviewBuffering(unittest.TestCase):
-    def _make_cli(self):
+    def _make_cli(self, *, show_reasoning=False):
         from cli import HermesCLI
 
         cli = HermesCLI.__new__(HermesCLI)
         cli.verbose = True
+        cli.show_reasoning = show_reasoning
         cli._spinner_text = ""
         cli._reasoning_preview_buf = ""
+        cli._reasoning_shown_this_turn = False
         cli._invalidate = lambda *args, **kwargs: None
         return cli
 
@@ -373,6 +375,15 @@ class TestReasoningPreviewBuffering(unittest.TestCase):
         cli._flush_reasoning_preview(force=False)
         self.assertEqual(cli._reasoning_preview_buf, "a" * 30)
 
+    @patch("cli._cprint")
+    def test_show_reasoning_preview_marks_turn_as_displayed(self, mock_cprint):
+        cli = self._make_cli(show_reasoning=True)
+
+        cli._emit_reasoning_preview("working through the answer")
+
+        self.assertTrue(cli._reasoning_shown_this_turn)
+        self.assertEqual(mock_cprint.call_count, 1)
+
 
 class TestReasoningDisplayModeSelection(unittest.TestCase):
     def _make_cli(self, *, show_reasoning=False, streaming_enabled=False, verbose=False):
@@ -386,10 +397,12 @@ class TestReasoningDisplayModeSelection(unittest.TestCase):
         cli._on_reasoning = lambda text: ("preview", text)
         return cli
 
-    def test_show_reasoning_non_streaming_uses_final_box_only(self):
+    def test_show_reasoning_non_streaming_uses_preview_callback(self):
         cli = self._make_cli(show_reasoning=True, streaming_enabled=False, verbose=False)
 
-        self.assertIsNone(cli._current_reasoning_callback())
+        callback = cli._current_reasoning_callback()
+        self.assertIsNotNone(callback)
+        self.assertEqual(callback("x"), ("preview", "x"))
 
     def test_show_reasoning_streaming_uses_live_reasoning_box(self):
         cli = self._make_cli(show_reasoning=True, streaming_enabled=True, verbose=False)


### PR DESCRIPTION
## Summary
- make CLI `show_reasoning` work even when `streaming: false` by routing non-streaming reasoning through the preview callback
- mark previewed reasoning as already shown so the final response path does not render a duplicate reasoning box
- update CLI regression tests for non-streaming reasoning display selection and preview de-duplication

Closes #34209.

## Verification
- `uv run --frozen pytest -q -o addopts='' tests/cli/test_reasoning_command.py -k 'ReasoningPreviewBuffering or ReasoningDisplayModeSelection'`
- `uv run --frozen ruff check cli.py tests/cli/test_reasoning_command.py`
- `git diff --check`
