### PR TITLE
Draft: Add optional LiteParse PDF extraction

### DIFF
--- a/skills/productivity/ocr-and-documents/SKILL.md
+++ b/skills/productivity/ocr-and-documents/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ocr-and-documents
-description: "Extract text from PDFs/scans (pymupdf, marker-pdf)."
-version: 2.3.0
+description: "Extract text from PDFs and scanned documents."
+version: 2.4.0
 author: Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
@@ -32,27 +32,57 @@ Only use local extraction when: the file is local, web_extract fails, or you nee
 
 ## Step 2: Choose Local Extractor
 
-| Feature | pymupdf (~25MB) | marker-pdf (~3-5GB) |
-|---------|-----------------|---------------------|
-| **Text-based PDF** | ✅ | ✅ |
-| **Scanned PDF (OCR)** | ❌ | ✅ (90+ languages) |
-| **Tables** | ✅ (basic) | ✅ (high accuracy) |
-| **Equations / LaTeX** | ❌ | ✅ |
-| **Code blocks** | ❌ | ✅ |
-| **Forms** | ❌ | ✅ |
-| **Headers/footers removal** | ❌ | ✅ |
-| **Reading order detection** | ❌ | ✅ |
-| **Images extraction** | ✅ (embedded) | ✅ (with context) |
-| **Images → text (OCR)** | ❌ | ✅ |
-| **EPUB** | ✅ | ✅ |
-| **Markdown output** | ✅ (via pymupdf4llm) | ✅ (native, higher quality) |
-| **Install size** | ~25MB | ~3-5GB (PyTorch + models) |
-| **Speed** | Instant | ~1-14s/page (CPU), ~0.2s/page (GPU) |
+| Feature | LiteParse (`lit`, optional) | pymupdf (~25MB) | marker-pdf (~3-5GB) |
+|---------|-----------------------------|-----------------|---------------------|
+| **Text-based PDF** | ✅ fast, spatial JSON/text | ✅ | ✅ |
+| **Scanned PDF (OCR)** | Optional OCR; tessdata may be required | ❌ | ✅ (90+ languages) |
+| **Tables** | ✅ layout/bbox metadata | ✅ (basic) | ✅ (high accuracy) |
+| **Equations / LaTeX** | ❌ | ❌ | ✅ |
+| **Code blocks** | ❌ | ❌ | ✅ |
+| **Forms** | ❌ | ❌ | ✅ |
+| **Headers/footers removal** | ❌ | ❌ | ✅ |
+| **Reading order detection** | Basic spatial ordering | ❌ | ✅ |
+| **Images extraction** | Page screenshots | ✅ (embedded) | ✅ (with context) |
+| **Images → text (OCR)** | Optional OCR; depends on OCR data/server | ❌ | ✅ |
+| **EPUB** | Via conversion only | ✅ | ✅ |
+| **Markdown output** | ❌ (text/JSON only) | ✅ (via pymupdf4llm) | ✅ (native, higher quality) |
+| **Install size** | Small optional CLI/package | ~25MB | ~3-5GB (PyTorch + models) |
+| **Speed** | Fast local PDFium path | Instant | ~1-14s/page (CPU), ~0.2s/page (GPU) |
 
-**Decision**: Use pymupdf unless you need OCR, equations, forms, or complex layout analysis.
+**Decision**: For local text-based PDFs, try LiteParse first if `lit` is already installed. Use pymupdf when LiteParse is unavailable, when you need PDF edits such as split/merge/search, or when you need markdown. Use marker-pdf for OCR-heavy scans, equations, forms, or complex layout analysis.
 
 If the user needs marker capabilities but the system lacks ~5GB free disk:
 > "This document needs OCR/advanced extraction (marker-pdf), which requires ~5GB for PyTorch and models. Your system has [X]GB free. Options: free up space, provide a URL so I can use web_extract, or I can try pymupdf which works for text-based PDFs but not scanned documents or equations."
+
+---
+
+## LiteParse (optional fast text path)
+
+LiteParse is an optional local parser. Do not require it for existing PDF extraction: the helper script falls back to pymupdf for plain text when `lit` is missing. It is read-only; keep using pymupdf/nano-pdf for PDF creation, splitting, merging, search, and edits.
+
+```bash
+# Optional install path; do not install unless the user wants this backend.
+pip install liteparse
+```
+
+**Via helper script**:
+```bash
+python scripts/extract_liteparse.py --check
+python scripts/extract_liteparse.py document.pdf              # Text, no OCR, falls back to pymupdf
+python scripts/extract_liteparse.py document.pdf --json       # Structured JSON with boxes/font metadata
+python scripts/extract_liteparse.py document.pdf --pages 1-5  # LiteParse uses 1-based page selectors
+python scripts/extract_liteparse.py document.pdf --output out.txt
+python scripts/extract_liteparse.py document.pdf --screenshots screenshots/
+```
+
+**Direct CLI**:
+```bash
+lit parse document.pdf --format text --no-ocr
+lit parse document.pdf --format json -o output.json --no-ocr
+lit screenshot document.pdf -o screenshots/
+```
+
+Use `--ocr` only when OCR is explicitly needed and the local LiteParse install has usable Tesseract data or an OCR server configured. This skill does not install OCR data.
 
 ---
 
@@ -164,9 +194,10 @@ No extra dependencies needed — pymupdf covers split, merge, search, and text e
 ## Notes
 
 - `web_extract` is always first choice for URLs
+- LiteParse is optional and fast for local text-based PDFs; use it only when `lit` is already available or the user asks to install it
 - pymupdf is the safe default — instant, no models, works everywhere
 - marker-pdf is for OCR, scanned docs, equations, complex layouts — install only when needed
-- Both helper scripts accept `--help` for full usage
+- Helper scripts accept `--help` for full usage
 - marker-pdf downloads ~2.5GB of models to `~/.cache/huggingface/` on first use
 - For Word docs: `pip install python-docx` (better than OCR — parses actual structure)
 - For PowerPoint: see the `powerpoint` skill (uses python-pptx)

--- a/skills/productivity/ocr-and-documents/scripts/extract_liteparse.py
+++ b/skills/productivity/ocr-and-documents/scripts/extract_liteparse.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Extract text from PDFs with LiteParse when the ``lit`` CLI is installed.
+
+LiteParse is optional. This helper uses ``lit parse`` for fast local PDF text
+extraction, and falls back to the existing pymupdf helper for plain text when
+``lit`` is unavailable.
+
+Usage:
+    python extract_liteparse.py document.pdf
+    python extract_liteparse.py document.pdf --json
+    python extract_liteparse.py document.pdf --pages 1-5,10
+    python extract_liteparse.py document.pdf --output output.txt
+    python extract_liteparse.py document.pdf --screenshots screenshots/
+    python extract_liteparse.py --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from shutil import which
+
+
+def find_liteparse_cli() -> str | None:
+    """Return the installed LiteParse CLI path, if available."""
+    return which("lit")
+
+
+def build_parse_command(
+    lit_path: str,
+    pdf_path: str,
+    *,
+    output_format: str = "text",
+    target_pages: str | None = None,
+    output: str | None = None,
+    ocr: bool = False,
+    ocr_language: str | None = None,
+    tessdata_path: str | None = None,
+    max_pages: int | None = None,
+    dpi: int | None = None,
+    password: str | None = None,
+) -> list[str]:
+    """Build a ``lit parse`` command without executing it."""
+    cmd = [
+        lit_path,
+        "parse",
+        pdf_path,
+        "--format",
+        output_format,
+        "--quiet",
+    ]
+
+    if not ocr:
+        cmd.append("--no-ocr")
+    if target_pages:
+        cmd.extend(["--target-pages", target_pages])
+    if output:
+        cmd.extend(["-o", output])
+    if ocr_language:
+        cmd.extend(["--ocr-language", ocr_language])
+    if tessdata_path:
+        cmd.extend(["--tessdata-path", tessdata_path])
+    if max_pages is not None:
+        cmd.extend(["--max-pages", str(max_pages)])
+    if dpi is not None:
+        cmd.extend(["--dpi", str(dpi)])
+    if password:
+        cmd.extend(["--password", password])
+
+    return cmd
+
+
+def build_screenshot_command(
+    lit_path: str,
+    pdf_path: str,
+    output_dir: str,
+    *,
+    target_pages: str | None = None,
+    dpi: int | None = None,
+    password: str | None = None,
+) -> list[str]:
+    """Build a ``lit screenshot`` command without executing it."""
+    cmd = [lit_path, "screenshot", pdf_path, "-o", output_dir, "--quiet"]
+    if target_pages:
+        cmd.extend(["--target-pages", target_pages])
+    if dpi is not None:
+        cmd.extend(["--dpi", str(dpi)])
+    if password:
+        cmd.extend(["--password", password])
+    return cmd
+
+
+def _one_based_pages_to_zero_based(page_spec: str) -> str:
+    """Translate LiteParse's 1-based page selectors for extract_pymupdf.py."""
+    translated: list[str] = []
+    for part in page_spec.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        if "-" in token:
+            start, end = token.split("-", 1)
+            translated.append(f"{_page_to_zero_based(start)}-{_page_to_zero_based(end)}")
+        else:
+            translated.append(_page_to_zero_based(token))
+    return ",".join(translated)
+
+
+def _page_to_zero_based(value: str) -> str:
+    page = int(value)
+    return str(page - 1 if page > 0 else page)
+
+
+def run_pymupdf_fallback(pdf_path: str, *, target_pages: str | None, output: str | None) -> int:
+    """Run the existing pymupdf helper for plain-text fallback."""
+    fallback_script = Path(__file__).with_name("extract_pymupdf.py")
+    cmd = [sys.executable, str(fallback_script), pdf_path]
+    if target_pages:
+        cmd.extend(["--pages", _one_based_pages_to_zero_based(target_pages)])
+
+    print(
+        "LiteParse CLI 'lit' was not found; falling back to extract_pymupdf.py.",
+        file=sys.stderr,
+    )
+    if output:
+        result = subprocess.run(cmd, text=True, capture_output=True, check=False)
+        if result.stdout:
+            Path(output).write_text(result.stdout, encoding="utf-8")
+        if result.stderr:
+            print(result.stderr, file=sys.stderr, end="")
+        return result.returncode
+
+    return subprocess.run(cmd, check=False).returncode
+
+
+def run(args: argparse.Namespace) -> int:
+    lit_path = find_liteparse_cli()
+
+    if args.check:
+        if lit_path:
+            print(f"LiteParse CLI available: {lit_path}")
+            return 0
+        print("LiteParse CLI not found. Install optional package 'liteparse' to enable it.")
+        return 1
+
+    if not args.pdf:
+        print(__doc__)
+        return 2
+
+    if lit_path:
+        if args.screenshots:
+            Path(args.screenshots).mkdir(parents=True, exist_ok=True)
+            cmd = build_screenshot_command(
+                lit_path,
+                args.pdf,
+                args.screenshots,
+                target_pages=args.pages,
+                dpi=args.dpi,
+                password=args.password,
+            )
+        else:
+            cmd = build_parse_command(
+                lit_path,
+                args.pdf,
+                output_format="json" if args.json else "text",
+                target_pages=args.pages,
+                output=args.output,
+                ocr=args.ocr,
+                ocr_language=args.ocr_language,
+                tessdata_path=args.tessdata_path,
+                max_pages=args.max_pages,
+                dpi=args.dpi,
+                password=args.password,
+            )
+        return subprocess.run(cmd, check=False).returncode
+
+    if args.screenshots:
+        print(
+            "LiteParse CLI 'lit' is required for screenshot generation; no fallback was run.",
+            file=sys.stderr,
+        )
+        return 127
+    if args.json:
+        print(
+            "LiteParse CLI 'lit' is required for structured JSON output; no fallback was run.",
+            file=sys.stderr,
+        )
+        return 127
+
+    return run_pymupdf_fallback(args.pdf, target_pages=args.pages, output=args.output)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Extract PDF text with optional LiteParse fast path.")
+    parser.add_argument("pdf", nargs="?", help="PDF path to parse.")
+    parser.add_argument("--check", action="store_true", help="Check whether the LiteParse 'lit' CLI is available.")
+    parser.add_argument("--json", action="store_true", help="Return LiteParse structured JSON instead of text.")
+    parser.add_argument("--pages", help='1-based LiteParse page selector, e.g. "1-5,10,15-20".')
+    parser.add_argument("--output", "-o", help="Write parse output to this file.")
+    parser.add_argument("--screenshots", metavar="DIR", help="Generate page screenshots into DIR using LiteParse.")
+    parser.add_argument("--ocr", action="store_true", help="Enable LiteParse OCR. Default is disabled for speed.")
+    parser.add_argument("--ocr-language", help="Tesseract OCR language code, e.g. eng or fra.")
+    parser.add_argument("--tessdata-path", help="Directory containing Tesseract .traineddata files.")
+    parser.add_argument("--max-pages", type=int, help="Maximum pages to parse.")
+    parser.add_argument("--dpi", type=int, help="Rendering DPI for OCR or screenshots.")
+    parser.add_argument("--password", help="Password for encrypted PDFs.")
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    sys.exit(run(parse_args(sys.argv[1:])))

--- a/skills/productivity/ocr-and-documents/scripts/extract_pymupdf.py
+++ b/skills/productivity/ocr-and-documents/scripts/extract_pymupdf.py
@@ -12,6 +12,21 @@ Usage:
 import sys
 import json
 
+
+def parse_pages(page_spec: str) -> list[int]:
+    pages = []
+    for part in page_spec.split(","):
+        token = part.strip()
+        if not token:
+            continue
+        if "-" in token:
+            start, end = token.split("-", 1)
+            pages.extend(range(int(start), int(end) + 1))
+        else:
+            pages.append(int(token))
+    return pages
+
+
 def extract_text(path, pages=None):
     import pymupdf
     doc = pymupdf.open(path)
@@ -77,12 +92,7 @@ if __name__ == "__main__":
 
     if "--pages" in args:
         idx = args.index("--pages")
-        p = args[idx + 1]
-        if "-" in p:
-            start, end = p.split("-")
-            pages = list(range(int(start), int(end) + 1))
-        else:
-            pages = [int(p)]
+        pages = parse_pages(args[idx + 1])
 
     if "--metadata" in args:
         show_metadata(path)

--- a/tests/skills/test_ocr_documents_liteparse_skill.py
+++ b/tests/skills/test_ocr_documents_liteparse_skill.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "skills" / "productivity" / "ocr-and-documents" / "scripts" / "extract_liteparse.py"
+PYMUPDF_SCRIPT = SCRIPT.with_name("extract_pymupdf.py")
+
+
+@pytest.fixture()
+def liteparse_module():
+    spec = importlib.util.spec_from_file_location("extract_liteparse", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def pymupdf_module():
+    spec = importlib.util.spec_from_file_location("extract_pymupdf", PYMUPDF_SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_parse_command_defaults_to_fast_text_path(liteparse_module):
+    cmd = liteparse_module.build_parse_command(
+        "/usr/local/bin/lit",
+        "document.pdf",
+        output_format="json",
+        target_pages="1-5,10",
+        output="output.json",
+    )
+
+    assert cmd == [
+        "/usr/local/bin/lit",
+        "parse",
+        "document.pdf",
+        "--format",
+        "json",
+        "--quiet",
+        "--no-ocr",
+        "--target-pages",
+        "1-5,10",
+        "-o",
+        "output.json",
+    ]
+
+
+def test_check_reports_missing_liteparse_as_optional(liteparse_module, monkeypatch, capsys):
+    monkeypatch.setattr(liteparse_module, "which", lambda name: None)
+
+    result = liteparse_module.run(liteparse_module.parse_args(["--check"]))
+
+    assert result == 1
+    assert "LiteParse CLI not found" in capsys.readouterr().out
+
+
+def test_missing_liteparse_falls_back_to_pymupdf_for_text(liteparse_module, monkeypatch, capsys):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(liteparse_module, "subprocess", subprocess)
+    monkeypatch.setattr(liteparse_module.subprocess, "run", fake_run)
+
+    result = liteparse_module.run_pymupdf_fallback(
+        "document.pdf",
+        target_pages="1-5,10",
+        output=None,
+    )
+
+    assert result == 0
+    assert calls == [
+        (
+            [
+                sys.executable,
+                str(SCRIPT.with_name("extract_pymupdf.py")),
+                "document.pdf",
+                "--pages",
+                "0-4,9",
+            ],
+            {"check": False},
+        )
+    ]
+    assert "falling back to extract_pymupdf.py" in capsys.readouterr().err
+
+
+def test_missing_liteparse_json_does_not_fake_structured_output(liteparse_module, monkeypatch, capsys):
+    monkeypatch.setattr(liteparse_module, "find_liteparse_cli", lambda: None)
+    monkeypatch.setattr(
+        liteparse_module,
+        "run_pymupdf_fallback",
+        lambda *args, **kwargs: pytest.fail("JSON fallback should not run"),
+    )
+
+    result = liteparse_module.run(liteparse_module.parse_args(["document.pdf", "--json"]))
+
+    assert result == 127
+    assert "required for structured JSON output" in capsys.readouterr().err
+
+
+def test_pymupdf_page_parser_accepts_fallback_page_lists(pymupdf_module):
+    assert pymupdf_module.parse_pages("0-4,9,11-12") == [0, 1, 2, 3, 4, 9, 11, 12]


### PR DESCRIPTION
## Summary
- Add an optional `extract_liteparse.py` helper for the `ocr-and-documents` skill.
- Use `lit parse` for fast text/JSON extraction and `lit screenshot` for page screenshots when LiteParse is installed.
- Keep LiteParse optional: plain-text extraction falls back to the existing pymupdf helper when `lit` is unavailable; JSON/screenshots fail clearly instead of faking structured output.
- Document LiteParse selection guidance and page selector behavior.

Refs JoinedAI/feedback#14

## Test Plan
- [x] `scripts/run_tests.sh tests/skills/test_ocr_documents_liteparse_skill.py tests/website/test_generate_skill_docs.py`
- [x] `git diff --check`
- [x] Verified LiteParse README documents `lit parse`, `--format`, `--target-pages`, `--no-ocr`, `lit screenshot`, and `--quiet`.

## Notes
- I could not run a live LiteParse extraction because `lit` is not installed in this worktree environment.
