### PR TITLE
Draft: Queue busy messages by default

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -423,7 +423,7 @@ def load_cli_config() -> Dict[str, Any]:
             "resume_skip_tool_only": True,
             "show_reasoning": False,
             "streaming": True,
-            "busy_input_mode": "interrupt",
+            "busy_input_mode": "queue",
             "persistent_output": True,
             "persistent_output_max_lines": 200,
 
@@ -2934,16 +2934,18 @@ class HermesCLI:
             enabled=CLI_CONFIG["display"].get("persistent_output", True),
             max_lines=CLI_CONFIG["display"].get("persistent_output_max_lines", 200),
         )
-        # busy_input_mode: "interrupt" (Enter interrupts current run),
-        # "queue" (Enter queues for next turn), or "steer" (Enter injects
-        # mid-run via /steer, arriving after the next tool call).
-        _bim = str(CLI_CONFIG["display"].get("busy_input_mode", "interrupt")).strip().lower()
+        # busy_input_mode: "queue" (Enter queues for next turn),
+        # "steer" (Enter injects after the next tool call), or
+        # "interrupt" (Enter interrupts the current run).
+        _bim = str(CLI_CONFIG["display"].get("busy_input_mode", "queue")).strip().lower()
         if _bim == "queue":
             self.busy_input_mode = "queue"
         elif _bim == "steer":
             self.busy_input_mode = "steer"
-        else:
+        elif _bim == "interrupt":
             self.busy_input_mode = "interrupt"
+        else:
+            self.busy_input_mode = "queue"
 
         # self.verbose ONLY controls global DEBUG logging (root logger level).
         # display.tool_progress="verbose" controls tool-call rendering (full args,
@@ -9780,7 +9782,7 @@ class HermesCLI:
             /busy status        Show current busy input mode
             /busy queue         Queue input for the next turn instead of interrupting
             /busy steer         Inject Enter mid-run via /steer (after next tool call)
-            /busy interrupt     Interrupt the current run on Enter (default)
+            /busy interrupt     Interrupt the current run on Enter
         """
         parts = cmd.strip().split(maxsplit=1)
         if len(parts) < 2 or parts[1].strip().lower() == "status":
@@ -12187,7 +12189,7 @@ class HermesCLI:
 
             # Re-queue the interrupt message (and any that arrived while we were
             # processing the first) as the next prompt for process_loop.
-            # Only reached when busy_input_mode == "interrupt" (the default).
+            # Only reached when busy_input_mode == "interrupt".
             # In "queue" mode Enter routes directly to _pending_input so this
             # block is never hit.
             if pending_message and hasattr(self, '_pending_input'):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1669,8 +1669,8 @@ class GatewayRunner:
     # Class-level defaults so partial construction in tests doesn't
     # blow up on attribute access.
     _running_agents_ts: Dict[str, float] = {}
-    _busy_input_mode: str = "interrupt"
-    _busy_text_mode: str = "interrupt"
+    _busy_input_mode: str = "queue"
+    _busy_text_mode: str = "queue"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     _exit_code: Optional[int] = None
     _draining: bool = False
@@ -2946,7 +2946,9 @@ class GatewayRunner:
             return "queue"
         if mode == "steer":
             return "steer"
-        return "interrupt"
+        if mode == "interrupt":
+            return "interrupt"
+        return "queue"
 
     @staticmethod
     def _load_busy_text_mode() -> str:
@@ -3145,14 +3147,8 @@ class GatewayRunner:
         running_agent = self._running_agents.get(session_key)
 
         effective_mode = self._busy_input_mode
-        busy_text_mode = getattr(self, "_busy_text_mode", "queue")
-        if (
-            event.message_type == MessageType.TEXT
-            and busy_text_mode == "queue"
-            and effective_mode != "steer"
-        ):
-            return False
-
+        if effective_mode not in {"queue", "steer", "interrupt"}:
+            effective_mode = "queue"
         # Steer mode: inject mid-run via running_agent.steer() instead of
         # queueing + interrupting.  If the agent isn't running yet
         # (sentinel) or lacks steer(), or the payload is empty, fall back
@@ -3231,6 +3227,8 @@ class GatewayRunner:
         # to avoid spamming the user when they send multiple messages quickly
         _BUSY_ACK_COOLDOWN = 30
         now = time.time()
+        if not hasattr(self, "_busy_ack_ts") or self._busy_ack_ts is None:
+            self._busy_ack_ts = {}
         last_ack = self._busy_ack_ts.get(session_key, 0)
         if now - last_ack < _BUSY_ACK_COOLDOWN:
             return True  # interrupt sent (if not queue), ack already delivered recently
@@ -7016,12 +7014,9 @@ class GatewayRunner:
             _slash_confirm_mod.clear_if_stale(_quick_key)
 
         # PRIORITY handling when an agent is already running for this session.
-        # Default behavior is to interrupt immediately so user text/stop messages
-        # are handled with minimal latency.
-        #
-        # Special case: Telegram/photo bursts often arrive as multiple near-
-        # simultaneous updates. Do NOT interrupt for photo-only follow-ups here;
-        # let the adapter-level batching/queueing logic absorb them.
+        # Default behavior is to queue normal follow-up messages for the next
+        # turn and acknowledge them immediately. Explicit /stop, /queue, and
+        # /steer keep their dedicated control-plane semantics.
 
         # Staleness eviction: detect leaked locks from hung/crashed handlers.
         # With inactivity-based timeout, active tasks can run for hours, so
@@ -7309,109 +7304,8 @@ class GatewayRunner:
                     f"mid-turn. Wait for the current response or `/stop` first."
                 )
 
-            if event.message_type == MessageType.PHOTO:
-                logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
-                adapter = self.adapters.get(source.platform)
-                if adapter:
-                    merge_pending_message_event(adapter._pending_messages, _quick_key, event)
+            if await self._handle_active_session_busy_message(event, _quick_key):
                 return None
-
-            _telegram_followup_grace = float(
-                os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
-            )
-            _started_at = self._running_agents_ts.get(_quick_key, 0)
-            if (
-                source.platform == Platform.TELEGRAM
-                and event.message_type == MessageType.TEXT
-                and _telegram_followup_grace > 0
-                and _started_at
-                and (time.time() - _started_at) <= _telegram_followup_grace
-            ):
-                logger.debug(
-                    "Telegram follow-up arrived %.2fs after run start for %s — queueing without interrupt",
-                    time.time() - _started_at,
-                    _quick_key,
-                )
-                adapter = self.adapters.get(source.platform)
-                if adapter:
-                    merge_pending_message_event(
-                        adapter._pending_messages,
-                        _quick_key,
-                        event,
-                        merge_text=True,
-                    )
-                return None
-
-            running_agent = self._running_agents.get(_quick_key)
-            if running_agent is _AGENT_PENDING_SENTINEL:
-                # Agent is being set up but not ready yet.
-                if event.get_command() == "stop":
-                    # Force-clean the sentinel so the session is unlocked.
-                    self._release_running_agent_state(_quick_key)
-                    logger.info("HARD STOP (pending) for session %s — sentinel cleared", _quick_key)
-                    return EphemeralReply("⚡ Force-stopped. The agent was still starting — session unlocked.")
-                # Queue the message so it will be picked up after the
-                # agent starts.
-                adapter = self.adapters.get(source.platform)
-                if adapter:
-                    merge_pending_message_event(
-                        adapter._pending_messages,
-                        _quick_key,
-                        event,
-                        merge_text=True,
-                    )
-                return None
-            if self._draining:
-                if self._queue_during_drain_enabled():
-                    self._queue_or_replace_pending_event(_quick_key, event)
-                return (
-                    f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
-                    if self._queue_during_drain_enabled()
-                    else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
-                )
-            if self._busy_input_mode == "queue":
-                logger.debug("PRIORITY queue follow-up for session %s", _quick_key)
-                self._queue_or_replace_pending_event(_quick_key, event)
-                return None
-            if self._busy_input_mode == "steer":
-                # Steer mode: inject text into the running agent mid-run via
-                # agent.steer().  Falls back to queue semantics if the payload
-                # is empty, the agent lacks steer(), or steer() rejects.
-                steer_text = (event.text or "").strip()
-                steered = False
-                if steer_text and hasattr(running_agent, "steer"):
-                    try:
-                        steered = bool(running_agent.steer(steer_text))
-                    except Exception as exc:
-                        logger.warning("PRIORITY steer failed for session %s: %s", _quick_key, exc)
-                        steered = False
-                if steered:
-                    logger.debug("PRIORITY steer for session %s", _quick_key)
-                    return None
-                logger.debug("PRIORITY steer-fallback-to-queue for session %s", _quick_key)
-                self._queue_or_replace_pending_event(_quick_key, event)
-                return None
-            # #30170 — Subagent protection (PRIORITY path). Same rationale
-            # as ``_handle_active_session_busy_message``: an interrupt
-            # cascades through ``_active_children`` and aborts in-flight
-            # delegate_task work. Demote to queue semantics when the
-            # parent is currently driving subagents so a conversational
-            # follow-up doesn't destroy minutes of subagent progress.
-            # /stop reaches its dedicated handler above, so the operator
-            # still has a clean escape hatch.
-            if self._agent_has_active_subagents(running_agent):
-                logger.info(
-                    "PRIORITY interrupt demoted to queue for session %s "
-                    "because the running agent has active subagents (#30170)",
-                    _quick_key,
-                )
-                self._queue_or_replace_pending_event(_quick_key, event)
-                return None
-            logger.debug("PRIORITY interrupt for session %s", _quick_key)
-            running_agent.interrupt(event.text)
-            # NOTE: self._pending_messages was write-only (never consumed).
-            # The actual interrupt message is delivered via adapter._pending_messages
-            # which is read by _run_agent. Removed to prevent unbounded growth.
             return None
 
         # Check for commands

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1151,7 +1151,7 @@ DEFAULT_CONFIG = {
         # when an exchange was tool-heavy. Set False to restore the legacy
         # behavior of showing tool-call summaries inline.
         "resume_skip_tool_only": True,
-        "busy_input_mode": "interrupt",  # interrupt | queue | steer
+        "busy_input_mode": "queue",  # queue | steer | interrupt
         # When true, `hermes --tui` auto-resumes the most recent human-
         # facing session on launch instead of forging a fresh one.
         # Mirrors `hermes -c` muscle memory.  Default off so existing

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -117,17 +117,17 @@ class TestFallbackChainInit:
 
 
 class TestBusyInputMode:
-    def test_default_busy_input_mode_is_interrupt(self):
+    def test_default_busy_input_mode_is_queue(self):
         cli = _make_cli()
-        assert cli.busy_input_mode == "interrupt"
+        assert cli.busy_input_mode == "queue"
 
     def test_busy_input_mode_queue_is_honored(self):
         cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})
         assert cli.busy_input_mode == "queue"
 
-    def test_unknown_busy_input_mode_falls_back_to_interrupt(self):
+    def test_unknown_busy_input_mode_falls_back_to_queue(self):
         cli = _make_cli(config_overrides={"display": {"busy_input_mode": "bogus"}})
-        assert cli.busy_input_mode == "interrupt"
+        assert cli.busy_input_mode == "queue"
 
     def test_queue_command_works_while_busy(self):
         """When agent is running, /queue should still put the prompt in _pending_input."""
@@ -164,8 +164,8 @@ class TestBusyInputMode:
         assert cli._interrupt_queue.empty()
 
     def test_interrupt_mode_routes_busy_enter_to_interrupt(self):
-        """In interrupt mode (default), Enter while busy goes to _interrupt_queue."""
-        cli = _make_cli()
+        """In explicit interrupt mode, Enter while busy goes to _interrupt_queue."""
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "interrupt"}})
         cli._agent_running = True
         text = "redirect"
         if cli.busy_input_mode == "queue":

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -122,6 +122,31 @@ class TestBusySessionAck:
         running_agent.interrupt.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_handle_message_priority_path_sends_queue_ack(self):
+        """The runner-level active-agent guard should visibly ack queued text."""
+        from gateway.run import GatewayRunner
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        event = _make_event(text="queue this while busy")
+        sk = build_session_key(event.source)
+
+        running_agent = MagicMock()
+        runner._running_agents[sk] = running_agent
+        runner.adapters[event.source.platform] = adapter
+
+        result = await GatewayRunner._handle_message(runner, event)
+
+        assert result is None
+        assert adapter._pending_messages[sk] is event
+        running_agent.interrupt.assert_not_called()
+        adapter._send_with_retry.assert_called_once()
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Queued for the next turn" in content
+
+    @pytest.mark.asyncio
     async def test_sends_ack_when_agent_running(self):
         """First message during busy session should get a status ack."""
         runner, sentinel = _make_runner()
@@ -190,10 +215,10 @@ class TestBusySessionAck:
         assert "Interrupting" not in content
 
     @pytest.mark.asyncio
-    async def test_busy_text_mode_queue_delegates_to_adapter_handle_message(self):
-        """busy_text_mode=queue lets the adapter debounce text silently."""
+    async def test_busy_text_mode_queue_acknowledges_and_queues(self):
+        """Queue-mode busy text now gets an immediate visible ack."""
         runner, sentinel = _make_runner()
-        runner._busy_input_mode = "interrupt"
+        runner._busy_input_mode = "queue"
         runner._busy_text_mode = "queue"
         adapter = _make_adapter()
 
@@ -209,11 +234,13 @@ class TestBusySessionAck:
         result1 = await runner._handle_active_session_busy_message(first, sk)
         result2 = await runner._handle_active_session_busy_message(second, sk)
 
-        assert result1 is False
-        assert result2 is False
-        assert sk not in adapter._pending_messages
+        assert result1 is True
+        assert result2 is True
+        assert adapter._pending_messages[sk].text == "part one\npart two"
         agent.interrupt.assert_not_called()
-        adapter._send_with_retry.assert_not_called()
+        adapter._send_with_retry.assert_called_once()
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "Queued for the next turn" in content
 
     @pytest.mark.asyncio
     async def test_steer_mode_calls_agent_steer_no_interrupt_no_queue(self):

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -93,7 +93,7 @@ def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, mon
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_INPUT_MODE", raising=False)
 
-    assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "queue"
 
     (tmp_path / "config.yaml").write_text(
         "display:\n  busy_input_mode: queue\n", encoding="utf-8"
@@ -111,9 +111,9 @@ def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, mon
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "steer")
     assert gateway_run.GatewayRunner._load_busy_input_mode() == "steer"
 
-    # Unknown values fall through to the safe default
+    # Unknown values fall through to the safe queueing default
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "bogus")
-    assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "queue"
 
 
 def test_load_busy_text_mode_defaults_to_queue_and_allows_interrupt(tmp_path, monkeypatch):

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -243,7 +243,7 @@ Where the terminal cannot distinguish them, `Alt+Enter` and `Ctrl+J` continue to
 
 You can interrupt the agent at any point:
 
-- **Type a new message + Enter** while the agent is working — it interrupts and processes your new instructions
+- **Set `display.busy_input_mode: interrupt` and type a new message + Enter** while the agent is working — it interrupts and processes your new instructions
 - **`Ctrl+C`** — interrupt the current operation (press twice within 2s to force exit)
 - In-progress terminal commands are killed immediately (SIGTERM, then SIGKILL after 1s)
 - Multiple messages typed during interrupt are combined into one prompt
@@ -254,17 +254,17 @@ The `display.busy_input_mode` config key controls what happens when you press En
 
 | Mode | Behavior |
 |------|----------|
-| `"interrupt"` (default) | Your message interrupts the current operation and is processed immediately |
-| `"queue"` | Your message is silently queued and sent as the next turn after the agent finishes |
+| `"queue"` (default) | Your message is queued and sent as the next turn after the agent finishes |
+| `"interrupt"` | Your message interrupts the current operation and is processed immediately |
 | `"steer"` | Your message is injected into the current run via `/steer`, arriving at the agent after the next tool call — no interrupt, no new turn |
 
 ```yaml
 # ~/.hermes/config.yaml
 display:
-  busy_input_mode: "steer"   # or "queue" or "interrupt" (default)
+  busy_input_mode: "steer"   # or "queue" (default) or "interrupt"
 ```
 
-`"queue"` mode is useful when you want to prepare follow-up messages without accidentally canceling in-flight work. `"steer"` mode is useful when you want to redirect the agent mid-task without interrupting — e.g. "actually, also check the tests" while it's still editing code. Unknown values fall back to `"interrupt"`.
+`"queue"` mode is useful when you want to prepare follow-up messages without accidentally canceling in-flight work. `"steer"` mode is useful when you want to redirect the agent mid-task without interrupting — e.g. "actually, also check the tests" while it's still editing code. Unknown values fall back to `"queue"`.
 
 `"steer"` has two automatic fallbacks: if the agent hasn't started yet, or if images are attached, the message falls back to `"queue"` behavior so nothing is lost.
 
@@ -278,7 +278,7 @@ You can also change it inside the CLI:
 ```
 
 :::tip First-touch hint
-The very first time you press Enter while Hermes is working, Hermes prints a one-line reminder explaining the `/busy` knob (`"(tip) Your message interrupted the current run…"`). It only fires once per install — a flag in `config.yaml` under `onboarding.seen.busy_input_prompt` latches it. Delete that key to see the tip again.
+The very first time you press Enter while Hermes is working, Hermes prints a one-line reminder explaining the `/busy` knob. It only fires once per install — a flag in `config.yaml` under `onboarding.seen.busy_input_prompt` latches it. Delete that key to see the tip again.
 :::
 
 ### Suspending to Background

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -265,7 +265,7 @@ Use `/whoami` from any platform to see the active scope, your tier (admin / user
 
 ## Interrupting the Agent
 
-Send any message while the agent is working to interrupt it. Key behaviors:
+Set `display.busy_input_mode: interrupt` if you want messages sent while the agent is working to interrupt it. Key behaviors:
 
 - **In-progress terminal commands are killed immediately** (SIGTERM, then SIGKILL after 1s)
 - **Tool calls are cancelled** — only the currently-executing one runs, the rest are skipped
@@ -274,14 +274,15 @@ Send any message while the agent is working to interrupt it. Key behaviors:
 
 ### Queue vs interrupt vs steer (busy-input mode)
 
-By default, messaging a busy agent interrupts it. Two other modes are available:
+By default, messaging a busy agent queues the follow-up for the next turn and sends a visible acknowledgment. Other modes are available:
 
 - `queue` — follow-up messages wait and run as the next turn after the current task finishes.
+- `interrupt` — follow-up messages interrupt the current run and are processed immediately.
 - `steer` — follow-up messages are injected into the current run via `/steer`, arriving at the agent after the next tool call. No interrupt, no new turn. Falls back to `queue` behavior if the agent hasn't started yet.
 
 ```yaml
 display:
-  busy_input_mode: steer   # or queue, or interrupt (default)
+  busy_input_mode: steer   # or queue (default), or interrupt
   busy_ack_enabled: true   # set to false to suppress the ⚡/⏳/⏩ chat reply entirely
 ```
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/cli.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/cli.md
@@ -239,7 +239,7 @@ personalities:
 
 你可以在任意时刻中断 agent：
 
-- **输入新消息 + Enter**，在 agent 工作时——中断并处理你的新指令
+- **设置 `display.busy_input_mode: interrupt` 后输入新消息 + Enter**，在 agent 工作时——中断并处理你的新指令
 - **`Ctrl+C`**——中断当前操作（2 秒内双击强制退出）
 - 正在进行的终端命令会立即被终止（SIGTERM，1 秒后 SIGKILL）
 - 中断期间输入的多条消息会合并为一条 prompt
@@ -250,17 +250,17 @@ personalities:
 
 | 模式 | 行为 |
 |------|----------|
-| `"interrupt"`（默认） | 你的消息中断当前操作并立即处理 |
-| `"queue"` | 你的消息被静默排队，在 agent 完成后作为下一轮发送 |
+| `"queue"`（默认） | 你的消息被排队，在 agent 完成后作为下一轮发送 |
+| `"interrupt"` | 你的消息中断当前操作并立即处理 |
 | `"steer"` | 你的消息通过 `/steer` 注入当前运行，在下一次工具调用后到达 agent——不中断，不开启新轮次 |
 
 ```yaml
 # ~/.hermes/config.yaml
 display:
-  busy_input_mode: "steer"   # 或 "queue" 或 "interrupt"（默认）
+  busy_input_mode: "steer"   # 或 "queue"（默认）或 "interrupt"
 ```
 
-`"queue"` 模式适合在不意外取消进行中工作的情况下准备后续消息。`"steer"` 模式适合在不中断的情况下在任务执行中途重定向 agent——例如在它还在编辑代码时说"顺便也检查一下测试"。未知值会回退到 `"interrupt"`。
+`"queue"` 模式适合在不意外取消进行中工作的情况下准备后续消息。`"steer"` 模式适合在不中断的情况下在任务执行中途重定向 agent——例如在它还在编辑代码时说"顺便也检查一下测试"。未知值会回退到 `"queue"`。
 
 `"steer"` 有两个自动回退：如果 agent 尚未启动，或附有图片，消息会回退到 `"queue"` 行为，确保内容不丢失。
 
@@ -274,7 +274,7 @@ display:
 ```
 
 :::tip 首次提示
-第一次在 Hermes 工作时按下 Enter，Hermes 会打印一行提示，说明 `/busy` 选项（`"(tip) Your message interrupted the current run…"`）。每次安装只触发一次——`config.yaml` 中 `onboarding.seen.busy_input_prompt` 下的标志会锁定它。删除该键可再次看到提示。
+第一次在 Hermes 工作时按下 Enter，Hermes 会打印一行提示，说明 `/busy` 选项。每次安装只触发一次——`config.yaml` 中 `onboarding.seen.busy_input_prompt` 下的标志会锁定它。删除该键可再次看到提示。
 :::
 
 ### 挂起到后台

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/index.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/index.md
@@ -261,7 +261,7 @@ gateway:
 
 ## 中断 Agent
 
-在 agent 工作时发送任意消息即可中断它。关键行为：
+如果你希望在 agent 工作时发送的消息中断当前运行，请设置 `display.busy_input_mode: interrupt`。关键行为：
 
 - **正在执行的终端命令立即终止**（SIGTERM，1 秒后 SIGKILL）
 - **工具调用被取消** — 仅当前正在执行的工具调用会运行，其余跳过
@@ -270,14 +270,15 @@ gateway:
 
 ### 队列 vs 中断 vs 引导（繁忙输入模式）
 
-默认情况下，向繁忙的 agent 发送消息会中断它。另有两种模式可用：
+默认情况下，向繁忙的 agent 发送消息会排队到下一轮，并立即发送可见确认。也可以使用其他模式：
 
 - `queue` — 后续消息等待，在当前任务完成后作为下一轮运行。
+- `interrupt` — 后续消息中断当前运行并立即处理。
 - `steer` — 后续消息通过 `/steer` 注入当前运行，在下一次工具调用后到达 agent。不中断，不开新轮次。如果 agent 尚未开始，则回退为 `queue` 行为。
 
 ```yaml
 display:
-  busy_input_mode: steer   # 或 queue，或 interrupt（默认）
+  busy_input_mode: steer   # 或 queue（默认），或 interrupt
   busy_ack_enabled: true   # 设为 false 可完全抑制 ⚡/⏳/⏩ 聊天回复
 ```
 


### PR DESCRIPTION
## Summary
- Change default busy follow-up behavior from interrupting to queueing for the next turn.
- Preserve explicit `/steer`, `busy_input_mode: steer`, `/stop`, `/new`, `/reset`, and explicit `busy_input_mode: interrupt` control paths.
- Route the runner-level active-agent path through the shared busy handler so queued messages get the visible queued ack consistently.
- Update CLI/config defaults, tests, and English/Chinese docs.

Refs JoinedAI/feedback#16

## Test Plan
- [x] `scripts/run_tests.sh tests/gateway/test_queue_consumption.py tests/gateway/test_pending_drain_race.py tests/gateway/test_pending_drain_no_recursion.py tests/gateway/test_session_race_guard.py tests/gateway/test_interrupt_key_match.py tests/gateway/test_busy_session_ack.py tests/gateway/test_steer_command.py tests/gateway/test_restart_drain.py tests/gateway/test_telegram_photo_interrupts.py tests/gateway/test_busy_session_auth_bypass.py tests/gateway/test_subagent_protection_30170.py tests/gateway/test_active_session_text_merge.py tests/gateway/test_command_bypass_active_session.py tests/gateway/test_status_command.py tests/gateway/test_config_env_bridge_authority.py tests/cli/test_cli_init.py tests/cli/test_busy_input_mode_command.py tests/agent/test_onboarding.py`
- [x] `git diff --check`

## Compatibility
Existing configs that explicitly set `display.busy_input_mode: interrupt` keep interrupt behavior. Generated/default configs now use queue.
