### PR TITLE
fix(cli): detect profile-scoped dashboard processes

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -62,6 +62,7 @@ except ModuleNotFoundError:
     pass
 
 import os
+import shlex
 import sys
 
 
@@ -6781,11 +6782,71 @@ def _find_stale_dashboard_pids() -> list[int]:
 
     Returns an empty list on any scan error (missing ps/wmic, timeout, etc.).
     """
-    patterns = [
-        "hermes dashboard",
-        "hermes_cli.main dashboard",
-        "hermes_cli/main.py dashboard",
-    ]
+    def _is_dashboard_command(command: str) -> bool:
+        """Return True for real Hermes dashboard invocations.
+
+        Match argv shape instead of greedy substrings so profile-scoped
+        dashboards like ``hermes -p lspchan dashboard`` are detected while
+        unrelated chat/bash processes merely mentioning "dashboard" are not.
+        """
+        try:
+            argv = shlex.split(command)
+        except ValueError:
+            argv = command.split()
+        if not argv:
+            return False
+
+        value_flags = {
+            "-z",
+            "--oneshot",
+            "--prompt",
+            "-m",
+            "--model",
+            "--provider",
+            "-t",
+            "--toolsets",
+            "--resume",
+            "-r",
+            "--continue",
+            "-c",
+            "--skills",
+            "-s",
+            "--profile",
+            "-p",
+        }
+
+        def _first_cli_command(start: int) -> str | None:
+            i = start
+            while i < len(argv):
+                arg = argv[i]
+                if arg == "--":
+                    return argv[i + 1] if i + 1 < len(argv) else None
+                if arg.startswith("--") and "=" in arg:
+                    i += 1
+                    continue
+                if arg in value_flags:
+                    i += 2
+                    continue
+                if arg.startswith("-"):
+                    i += 1
+                    continue
+                return arg
+            return None
+
+        exe = os.path.basename(argv[0])
+        if exe == "hermes":
+            return _first_cli_command(1) == "dashboard"
+
+        if exe.startswith("python") and len(argv) >= 3:
+            if argv[1] == "-m" and argv[2] == "hermes_cli.main":
+                return _first_cli_command(3) == "dashboard"
+            script = argv[1].replace("\\", "/")
+            if script.endswith("hermes_cli/main.py"):
+                return _first_cli_command(2) == "dashboard"
+            if os.path.basename(script) == "hermes":
+                return _first_cli_command(2) == "dashboard"
+        return False
+
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
 
@@ -6815,10 +6876,7 @@ def _find_stale_dashboard_pids() -> list[int]:
                     current_cmd = line[len("CommandLine=") :]
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
-                    if (
-                        any(p in current_cmd for p in patterns)
-                        and int(pid_str) != self_pid
-                    ):
+                    if _is_dashboard_command(current_cmd) and int(pid_str) != self_pid:
                         try:
                             dashboard_pids.append(int(pid_str))
                         except ValueError:
@@ -6849,7 +6907,7 @@ def _find_stale_dashboard_pids() -> list[int]:
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if _is_dashboard_command(command) and pid != self_pid:
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -112,10 +112,22 @@ class TestFindStaleDashboardPids:
                     _ps_line(12345, "python3 -m hermes_cli.main dashboard --port 9119"),
                     _ps_line(12346, "hermes dashboard --port 9120 --no-open"),
                     _ps_line(12347, "python /home/x/hermes_cli/main.py dashboard"),
+                    _ps_line(12348, "/home/u/.hermes/hermes-agent/venv/bin/hermes -p lspchan dashboard --port 19120"),
+                    _ps_line(12349, "/home/u/.hermes/hermes-agent/venv/bin/hermes --profile upchan-bot dashboard --port 19121"),
+                    _ps_line(12350, "python3 /home/u/.hermes/hermes-agent/venv/bin/hermes -p lspchan dashboard --port 19120"),
+                    _ps_line(12351, "python3 /home/u/.hermes/hermes-agent/venv/bin/hermes --profile upchan-bot dashboard --port 19121"),
                 ]) + "\n",
                 stderr="",
             )
-            assert sorted(_find_stale_dashboard_pids()) == [12345, 12346, 12347]
+            assert sorted(_find_stale_dashboard_pids()) == [
+                12345,
+                12346,
+                12347,
+                12348,
+                12349,
+                12350,
+                12351,
+            ]
 
     def test_self_pid_excluded(self):
         with patch("subprocess.run") as mock_run:
@@ -151,6 +163,11 @@ class TestFindStaleDashboardPids:
                     _ps_line(12345, "python3 -m hermes_cli.main dashboard --port 9119"),
                     _ps_line(22222, "python3 -m hermes_cli.main chat -q 'rewrite my dashboard'"),
                     _ps_line(33333, "node /opt/grafana/dashboard-server.js"),
+                    _ps_line(44444, "bash -c 'echo hermes -p lspchan dashboard'"),
+                    _ps_line(55555, "hermes chat -q dashboard"),
+                    _ps_line(66666, "python3 /home/u/.hermes/hermes-agent/venv/bin/hermes chat -q dashboard"),
+                    _ps_line(77777, "hermes --oneshot dashboard"),
+                    _ps_line(88888, "python3 -m hermes_cli.main --oneshot dashboard"),
                 ]) + "\n",
                 stderr="",
             )


### PR DESCRIPTION
## Summary
- Detect profile-scoped dashboard processes such as `hermes -p <profile> dashboard` and `hermes --profile <profile> dashboard` during stale dashboard cleanup
- Handle console-script launch shapes like `python .../bin/hermes -p <profile> dashboard`
- Tighten matching around the first real CLI command so `chat -q dashboard`, one-shot prompts, and shell strings are not killed accidentally

## Context
#16872 was closed by #17832, which added stale dashboard cleanup after `hermes update`. This is a follow-up for a detection gap left by that fix: the cleanup matched plain `hermes dashboard` but missed standard profile-scoped dashboard invocations used by multi-profile users.

This is not specific to systemd or Tailscale/Tailserve; those setups only made the stale process easier to notice. The affected command shape is documented/standard for profile-scoped dashboard usage.

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_update_stale_dashboard.py`
- `python -m pytest tests/hermes_cli/test_update_stale_dashboard.py -q -o 'addopts='`
- `python scripts/check-windows-footguns.py hermes_cli/main.py tests/hermes_cli/test_update_stale_dashboard.py`
- `git diff --check origin/main...HEAD`
- `python -m compileall -q hermes_cli/main.py tests/hermes_cli/test_update_stale_dashboard.py`

## Platforms tested
- Linux 6.17.0-1011-oracle

## Notes
- Existing unrelated issue #24150 covers macOS phantom/stale PID reporting and appears separate from this profile-argument detection gap.
- Existing unrelated issue #23457 covers Docker gateway state path/profile mismatch and is also separate.
