### PR TITLE
fix(kanban): confirm corruption before backoff

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5432,9 +5432,10 @@ class GatewayRunner:
         # Avoid hot-looping corrupt-looking board DBs, but do not suppress
         # same-fingerprint retries forever: transient WAL/open races can
         # surface as "database disk image is malformed" for one tick.
-        CORRUPT_BOARD_RETRY_AFTER_SECONDS = 300
+        CORRUPT_BOARD_MIN_RETRY_AFTER_SECONDS = 30.0
+        CORRUPT_BOARD_MAX_RETRY_AFTER_SECONDS = 900.0
         disabled_corrupt_boards: dict[
-            str, tuple[tuple[str, int | None, int | None], float]
+            str, tuple[tuple[str, int | None, int | None], float, float]
         ] = {}
 
         def _board_db_fingerprint(slug: str) -> tuple[str, int | None, int | None]:
@@ -5461,6 +5462,78 @@ class GatewayRunner:
                 or "database disk image is malformed" in msg
             )
 
+        def _quick_check_confirms_corruption(
+            slug: str,
+            fingerprint: tuple[str, int | None, int | None],
+            original_exc: Exception,
+        ) -> bool:
+            """Confirm a corrupt-looking board error with read-only quick_check."""
+            path = _kb.kanban_db_path(slug)
+            quick_check_conn = None
+            try:
+                uri = path.expanduser().resolve().as_uri() + "?mode=ro"
+                quick_check_conn = sqlite3.connect(uri, uri=True, timeout=1.0)
+                row = quick_check_conn.execute("PRAGMA quick_check").fetchone()
+            except sqlite3.DatabaseError as quick_check_exc:
+                if _is_corrupt_board_db_error(quick_check_exc):
+                    return True
+                logger.warning(
+                    "kanban dispatcher: board %s database %s looked corrupt (%s), "
+                    "but read-only PRAGMA quick_check failed without confirming "
+                    "corruption (%s); treating as transient",
+                    slug,
+                    fingerprint[0],
+                    original_exc,
+                    quick_check_exc,
+                )
+                return False
+            except Exception as quick_check_exc:
+                logger.warning(
+                    "kanban dispatcher: board %s database %s looked corrupt (%s), "
+                    "but read-only PRAGMA quick_check could not confirm corruption "
+                    "(%s); treating as transient",
+                    slug,
+                    fingerprint[0],
+                    original_exc,
+                    quick_check_exc,
+                )
+                return False
+            finally:
+                if quick_check_conn is not None:
+                    try:
+                        quick_check_conn.close()
+                    except Exception:
+                        pass
+
+            result = "" if not row else str(row[0]).strip().lower()
+            if result == "ok":
+                logger.warning(
+                    "kanban dispatcher: board %s database %s looked corrupt (%s), "
+                    "but read-only PRAGMA quick_check returned ok; treating as transient",
+                    slug,
+                    fingerprint[0],
+                    original_exc,
+                )
+                return False
+            return True
+
+        def _disable_confirmed_corrupt_board(
+            slug: str,
+            fingerprint: tuple[str, int | None, int | None],
+            retry_after: float,
+        ) -> None:
+            disabled_corrupt_boards[slug] = (fingerprint, time.monotonic(), retry_after)
+            logger.error(
+                "kanban dispatcher: board %s database %s is not a valid SQLite "
+                "database after read-only PRAGMA quick_check; pausing dispatch "
+                "for this board for %.0fs or until the file changes/the gateway "
+                "restarts. Move or restore the file, then run `hermes kanban init` "
+                "if you need a fresh board.",
+                slug,
+                fingerprint[0],
+                retry_after,
+            )
+
         def _tick_once_for_board(slug: str) -> "Optional[object]":
             """Run one dispatch_once for a specific board.
 
@@ -5472,21 +5545,23 @@ class GatewayRunner:
             """
             conn = None
             fingerprint = _board_db_fingerprint(slug)
+            retry_after = CORRUPT_BOARD_MIN_RETRY_AFTER_SECONDS
             disabled_entry = disabled_corrupt_boards.get(slug)
             if disabled_entry is not None:
-                disabled_fingerprint, disabled_at = disabled_entry
+                disabled_fingerprint, disabled_at, disabled_retry_after = disabled_entry
                 age = time.monotonic() - disabled_at
-                if (
-                    disabled_fingerprint == fingerprint
-                    and age < CORRUPT_BOARD_RETRY_AFTER_SECONDS
-                ):
+                if disabled_fingerprint == fingerprint and age < disabled_retry_after:
                     return None
                 if disabled_fingerprint == fingerprint:
                     logger.info(
                         "kanban dispatcher: board %s database fingerprint unchanged "
-                        "after %.0fs quarantine; retrying dispatch",
+                        "after %.0fs backoff; retrying dispatch",
                         slug,
                         age,
+                    )
+                    retry_after = min(
+                        disabled_retry_after * 2.0,
+                        CORRUPT_BOARD_MAX_RETRY_AFTER_SECONDS,
                     )
                 else:
                     logger.info(
@@ -5502,7 +5577,7 @@ class GatewayRunner:
                 # re-ran the migration on a second connection, racing
                 # the first. See the matching comment in
                 # `_kanban_notifier_watcher` and issue #21378.
-                return _kb.dispatch_once(
+                result = _kb.dispatch_once(
                     conn,
                     board=slug,
                     max_spawn=max_spawn,
@@ -5510,33 +5585,19 @@ class GatewayRunner:
                     failure_limit=failure_limit,
                     stale_timeout_seconds=stale_timeout_seconds,
                 )
+                disabled_corrupt_boards.pop(slug, None)
+                return result
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):
-                    disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())
-                    logger.error(
-                        "kanban dispatcher: board %s database %s is not a valid "
-                        "SQLite database; pausing dispatch for this board until "
-                        "the file changes, the gateway restarts, or the "
-                        "quarantine timer expires. Move or restore the file, "
-                        "then run `hermes kanban init` if you need a fresh board.",
-                        slug,
-                        fingerprint[0],
-                    )
+                    if _quick_check_confirms_corruption(slug, fingerprint, exc):
+                        _disable_confirmed_corrupt_board(slug, fingerprint, retry_after)
                     return None
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None
             except Exception as exc:
                 if _is_corrupt_board_db_error(exc):
-                    disabled_corrupt_boards[slug] = (fingerprint, time.monotonic())
-                    logger.error(
-                        "kanban dispatcher: board %s database %s is not a valid "
-                        "SQLite database; pausing dispatch for this board until "
-                        "the file changes, the gateway restarts, or the "
-                        "quarantine timer expires. Move or restore the file, "
-                        "then run `hermes kanban init` if you need a fresh board.",
-                        slug,
-                        fingerprint[0],
-                    )
+                    if _quick_check_confirms_corruption(slug, fingerprint, exc):
+                        _disable_confirmed_corrupt_board(slug, fingerprint, retry_after)
                     return None
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)
                 return None

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3708,10 +3708,10 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     assert calls["connect"] == 5
 
 
-def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
+def test_gateway_dispatcher_retries_corrupt_board_after_backoff(
     monkeypatch, tmp_path, caplog
 ):
-    """A corrupt-looking board is retried after the quarantine TTL expires."""
+    """A confirmed corrupt-looking board is retried after backoff expires."""
     import asyncio
     import inspect
     import logging
@@ -3749,14 +3749,14 @@ def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
     monkeypatch.setattr(_kb, "kanban_db_path", lambda board=None: corrupt_db)
 
     real_monotonic = time.monotonic
-    time_values = iter([1000.0, 1001.0, 1301.0, 1301.0])
+    time_values = iter([1000.0, 1001.0, 1031.0, 1031.0])
 
     def _monotonic_for_gateway_dispatcher():
         caller = inspect.currentframe().f_back  # type: ignore[union-attr]
         code = caller.f_code if caller is not None else None
         filename = code.co_filename if code is not None else ""
         if filename.endswith("gateway/run.py"):
-            return next(time_values, 1301.0)
+            return next(time_values, 1031.0)
         return real_monotonic()
 
     monkeypatch.setattr("gateway.run.time.monotonic", _monotonic_for_gateway_dispatcher)
@@ -3793,6 +3793,186 @@ def test_gateway_dispatcher_retries_corrupt_board_after_quarantine(
     assert sum("not a valid SQLite database" in msg for msg in messages) == 2
     assert any("database fingerprint unchanged" in msg for msg in messages)
     assert calls["tick"] == 3
+
+
+def test_gateway_dispatcher_does_not_disable_when_quick_check_passes(
+    monkeypatch, tmp_path, caplog
+):
+    """A transient open error is not latched when read-only quick_check is ok."""
+    import asyncio
+    import logging
+    import sqlite3
+
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    import hermes_cli.kanban_db as _kb
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    db_path = tmp_path / "kanban.db"
+    db_path.write_text("not used by quick_check fake", encoding="utf-8")
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [{"slug": _kb.DEFAULT_BOARD}],
+    )
+    monkeypatch.setattr(
+        _kb,
+        "read_board_metadata",
+        lambda slug: {"slug": slug},
+    )
+    monkeypatch.setattr(_kb, "kanban_db_path", lambda board=None: db_path)
+
+    calls = {"connect": 0, "tick": 0, "quick_check": 0}
+
+    def _connect(*args, **kwargs):
+        calls["connect"] += 1
+        raise sqlite3.DatabaseError("database disk image is malformed")
+
+    class _QuickCheckOkConn:
+        def execute(self, sql):
+            assert sql == "PRAGMA quick_check"
+            calls["quick_check"] += 1
+            return self
+
+        def fetchone(self):
+            return ("ok",)
+
+        def close(self):
+            pass
+
+    def _sqlite_connect(*args, **kwargs):
+        return _QuickCheckOkConn()
+
+    async def _to_thread(fn, *args, **kwargs):
+        result = fn(*args, **kwargs)
+        if getattr(fn, "__name__", "") == "_tick_once":
+            calls["tick"] += 1
+            if calls["tick"] >= 2:
+                runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr(_kb, "connect", _connect)
+    monkeypatch.setattr("gateway.run.sqlite3.connect", _sqlite_connect)
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep)
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(
+                runner._kanban_dispatcher_watcher(),
+                timeout=3.0,
+            )
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("PRAGMA quick_check returned ok" in msg for msg in messages)
+    assert not any("not a valid SQLite database" in msg for msg in messages)
+    assert calls["tick"] == 2
+    assert calls["quick_check"] >= 2
+
+
+def test_gateway_dispatcher_corrupt_board_exponential_backoff(
+    monkeypatch, tmp_path, caplog
+):
+    """Repeated confirmed corruption doubles retry backoff for same fingerprint."""
+    import asyncio
+    import inspect
+    import logging
+    import sqlite3
+
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    import hermes_cli.kanban_db as _kb
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    corrupt_db = tmp_path / "kanban.db"
+    corrupt_db.write_text("not sqlite", encoding="utf-8")
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [{"slug": _kb.DEFAULT_BOARD}],
+    )
+    monkeypatch.setattr(
+        _kb,
+        "read_board_metadata",
+        lambda slug: {"slug": slug},
+    )
+    monkeypatch.setattr(_kb, "kanban_db_path", lambda board=None: corrupt_db)
+
+    real_monotonic = time.monotonic
+    time_values = iter([1000.0, 1029.0, 1030.0, 1030.0, 1089.0, 1090.0, 1090.0])
+
+    def _monotonic_for_gateway_dispatcher():
+        caller = inspect.currentframe().f_back  # type: ignore[union-attr]
+        code = caller.f_code if caller is not None else None
+        filename = code.co_filename if code is not None else ""
+        if filename.endswith("gateway/run.py"):
+            return next(time_values, 1090.0)
+        return real_monotonic()
+
+    calls = {"tick": 0}
+
+    def _connect(*args, **kwargs):
+        raise sqlite3.DatabaseError("file is not a database")
+
+    async def _to_thread(fn, *args, **kwargs):
+        result = fn(*args, **kwargs)
+        if getattr(fn, "__name__", "") == "_tick_once":
+            calls["tick"] += 1
+            if calls["tick"] >= 5:
+                runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr("gateway.run.time.monotonic", _monotonic_for_gateway_dispatcher)
+    monkeypatch.setattr(_kb, "connect", _connect)
+    monkeypatch.setattr("gateway.run.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.run.asyncio.sleep", _sleep)
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(
+                runner._kanban_dispatcher_watcher(),
+                timeout=3.0,
+            )
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert sum("not a valid SQLite database" in msg for msg in messages) == 3
+    assert any("for this board for 30s" in msg for msg in messages)
+    assert any("for this board for 60s" in msg for msg in messages)
+    assert any("for this board for 120s" in msg for msg in messages)
+    assert sum("database fingerprint unchanged" in msg for msg in messages) == 2
+    assert calls["tick"] == 5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds read-only `PRAGMA quick_check` confirmation before the gateway dispatcher backs off a corrupt-looking kanban board.
- Replaces the flat corrupt-board retry window with same-fingerprint exponential backoff.

Refs #33486.

## Why
- Issue #33486 tracks salvaging the deferred PR #32857 commit 5 on top of c94ad8981.
- Current main retries corrupt boards after a flat 5-minute quarantine, but still latches every matching open error without distinguishing transient EIO/open races from confirmed SQLite corruption.

## Changes
- `gateway/run.py`: runs a read-only quick_check probe for corrupt-looking board errors, treats `ok` as transient, and records confirmed corruption with 30s → 900s capped exponential backoff while preserving fingerprint-change retry.
- `tests/hermes_cli/test_kanban_core_functionality.py`: updates the existing retry test for the new backoff window and adds coverage for quick_check-ok transient handling plus same-fingerprint exponential backoff.

## Validation
- `python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -k 'gateway_dispatcher_disables_corrupt_board_without_traceback or gateway_dispatcher_retries_corrupt_board_after_backoff or gateway_dispatcher_does_not_disable_when_quick_check_passes or gateway_dispatcher_corrupt_board_exponential_backoff' -o 'addopts=' -q`\n- `python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -o 'addopts=' -q`\n- `python -m py_compile gateway/run.py tests/hermes_cli/test_kanban_core_functionality.py`\n- `python -m ruff check gateway/run.py tests/hermes_cli/test_kanban_core_functionality.py`\n\n## Scope\n- In scope: gateway dispatcher corrupt-board confirmation and retry/backoff behavior.\n- Out of scope: broader kanban DB recovery flows, worker spawning, and unrelated PR #32857 salvage commits.\n\nCredit: @steveonjava for the original quick_check/backoff design in PR #32857 commit 5, and @donovan-yohan for the current fingerprint-change retry foundation in c94ad8981.