### PR TITLE
fix(aux): keep xai oauth auxiliary on chat completions

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1832,11 +1832,12 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
 
 
 def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
-    """Build a CodexAuxiliaryClient for an xAI Grok OAuth-authenticated session.
+    """Build a native OpenAI-wire client for an xAI Grok OAuth session.
 
-    xAI's ``/v1/responses`` endpoint speaks the OpenAI Responses API, so we
-    wrap a plain ``OpenAI`` client in ``CodexAuxiliaryClient`` to translate
-    ``chat.completions.create()`` calls into ``responses.stream()`` requests.
+    Auxiliary tasks still call ``chat.completions.create()`` directly.  xAI
+    OAuth access tokens are only accepted on that chat-completions surface, so
+    this path must return a plain ``OpenAI`` client instead of routing through
+    ``CodexAuxiliaryClient`` and ``/v1/responses``.
 
     The caller must pass an explicit model — pinning a default for Grok
     would silently rot when xAI's allowlist drifts.  Returns ``(None, None)``
@@ -1852,9 +1853,8 @@ def _build_xai_oauth_aux_client(model: str) -> Tuple[Optional[Any], Optional[str
     if resolved is None:
         return None, None
     api_key, base_url = resolved
-    logger.debug("Auxiliary client: xAI OAuth (%s via Responses API)", model)
-    real_client = OpenAI(api_key=api_key, base_url=base_url)
-    return CodexAuxiliaryClient(real_client, model), model
+    logger.debug("Auxiliary client: xAI OAuth (%s via Chat Completions API)", model)
+    return OpenAI(api_key=api_key, base_url=base_url), model
 
 
 def _build_codex_client(model: str) -> Tuple[Optional[Any], Optional[str]]:
@@ -3319,7 +3319,7 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
-    # ── xAI Grok OAuth (loopback PKCE → Responses API) ───────────────
+    # ── xAI Grok OAuth (loopback PKCE → Chat Completions API) ────────
     # Without this branch, an xai-oauth main provider falls through to the
     # generic ``oauth_external`` arm below and returns ``(None, None)``,
     # silently re-routing every auxiliary task (compression, web extract,

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -1893,7 +1893,7 @@ def test_pool_manual_entry_does_not_sync_back_to_singleton(tmp_path, monkeypatch
 # ---------------------------------------------------------------------------
 
 
-def test_auxiliary_client_routes_xai_oauth_through_responses_api(tmp_path, monkeypatch):
+def test_auxiliary_client_routes_xai_oauth_through_chat_completions_api(tmp_path, monkeypatch):
     """Without explicit xai-oauth handling in ``resolve_provider_client``, an
     xai-oauth main provider falls through to the generic ``oauth_external``
     arm and returns ``(None, None)`` — silently re-routing every auxiliary
@@ -1904,7 +1904,7 @@ def test_auxiliary_client_routes_xai_oauth_through_responses_api(tmp_path, monke
     their xAI subscription.
 
     Pin the routing contract: ``resolve_provider_client("xai-oauth", model)``
-    must return a non-None client wrapping the xAI Responses API."""
+    must return a non-None client on xAI's native chat-completions surface."""
     from agent.auxiliary_client import (
         CodexAuxiliaryClient,
         resolve_provider_client,
@@ -1919,14 +1919,14 @@ def test_auxiliary_client_routes_xai_oauth_through_responses_api(tmp_path, monke
 
     client, model = resolve_provider_client("xai-oauth", model="grok-4")
     assert client is not None, (
-        "xai-oauth must route to a Responses-API client; falling through to "
+        "xai-oauth must route to a native xAI client; falling through to "
         "the generic oauth_external branch silently swaps providers for "
         "every auxiliary task."
     )
-    assert isinstance(client, CodexAuxiliaryClient)
+    assert not isinstance(client, CodexAuxiliaryClient)
     assert model == "grok-4"
-    # The wrapper preserves base_url + api_key so async wrappers and cache
-    # eviction can introspect them.  Pin both to the live xAI runtime.
+    # Preserve base_url + api_key so async wrappers and cache eviction can
+    # introspect them. Pin both to the live xAI runtime.
     assert str(client.base_url).rstrip("/") == DEFAULT_XAI_OAUTH_BASE_URL
     assert client.api_key == fresh
 


### PR DESCRIPTION
Fixes #34171.

## Summary
- keep xAI OAuth auxiliary clients on native chat completions instead of wrapping them in the Responses adapter
- preserve the existing explicit-model and unauthenticated fallthrough behavior
- update the xAI OAuth routing regression test to pin the chat-completions contract

## Testing
- uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_auth_xai_oauth_provider.py -k "auxiliary_client_routes_xai_oauth_through_chat_completions_api or auxiliary_client_xai_oauth_returns_none_when_unauthenticated or auxiliary_client_xai_oauth_requires_explicit_model"
- uv run --frozen ruff check agent/auxiliary_client.py tests/hermes_cli/test_auth_xai_oauth_provider.py
- git diff --check