### PR TITLE
fix(cron): fall back to root scripts/ dir for profile-context jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -851,10 +851,20 @@ def _get_script_timeout() -> int:
 def _run_job_script(script_path: str) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
-    Scripts must reside within HERMES_HOME/scripts/.  Both relative and
+    Scripts must reside within HERMES_HOME/scripts/ — both relative and
     absolute paths are resolved and validated against this directory to
     prevent arbitrary script execution via path traversal or absolute
     path injection.
+
+    Profile-context fallback: when a job declares ``profile: <name>`` and
+    the script is not present under the profile's own ``scripts/`` dir,
+    the scheduler retries resolution under the root Hermes home's
+    ``scripts/`` dir (``get_default_hermes_root() / "scripts"``). The
+    profile-local dir takes precedence when the same filename exists in
+    both. The path-traversal guard runs against whichever candidate dir
+    is in play for each lookup — no guard is dropped, no allowlist is
+    invented. See ``decisions/2026-05-29-cron-script-default-home-
+    fallback.md`` for rationale.
 
     Supported interpreters (chosen by file extension):
 
@@ -868,37 +878,75 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
     Args:
         script_path: Path to the script.  Relative paths are resolved
-            against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
-            are also validated to ensure they stay within the scripts dir.
+            against the active scripts dir (profile-local first, root
+            fallback for profile-context jobs).  Absolute and ~-prefixed
+            paths are also validated to ensure they stay within one of
+            the candidate dirs.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
         LLM can report the problem to the user.
     """
-    scripts_dir = _get_hermes_home() / "scripts"
-    scripts_dir.mkdir(parents=True, exist_ok=True)
-    scripts_dir_resolved = scripts_dir.resolve()
+    # Resolve the script under the active Hermes home's scripts/ dir first.
+    # When a profile-context job runs, _get_hermes_home() points at the
+    # profile home (e.g. ~/.hermes/profiles/<name>) and that profile's
+    # scripts/ takes precedence. If the file isn't there AND we're in a
+    # non-root profile context, fall back to the root home's scripts/ so
+    # IC profiles can share canonical scripts living in ~/.hermes/scripts/
+    # without dual-writing copies into every profile dir. The path-traversal
+    # guard runs against whichever candidate dir is in play for each lookup;
+    # no guard is skipped, no allowlist is invented.
+    #
+    # See decisions/2026-05-29-cron-script-default-home-fallback.md.
+    from hermes_constants import get_default_hermes_root
+
+    active_home = _get_hermes_home().resolve()
+    root_home = get_default_hermes_root().resolve()
+
+    candidates: list[Path] = [active_home / "scripts"]
+    if active_home != root_home:
+        candidates.append(root_home / "scripts")
 
     raw = Path(script_path).expanduser()
-    if raw.is_absolute():
-        path = raw.resolve()
-    else:
-        path = (scripts_dir / raw).resolve()
+    last_error: str | None = None
+    path: Path | None = None
 
-    # Guard against path traversal, absolute path injection, and symlink
-    # escape — scripts MUST reside within HERMES_HOME/scripts/.
-    try:
-        path.relative_to(scripts_dir_resolved)
-    except ValueError:
-        return False, (
-            f"Blocked: script path resolves outside the scripts directory "
-            f"({scripts_dir_resolved}): {script_path!r}"
-        )
+    for scripts_dir in candidates:
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        scripts_dir_resolved = scripts_dir.resolve()
 
-    if not path.exists():
-        return False, f"Script not found: {path}"
-    if not path.is_file():
-        return False, f"Script path is not a file: {path}"
+        if raw.is_absolute():
+            candidate_path = raw.resolve()
+        else:
+            candidate_path = (scripts_dir / raw).resolve()
+
+        # Guard against path traversal, absolute path injection, and
+        # symlink escape — scripts MUST reside within this candidate
+        # scripts dir.
+        try:
+            candidate_path.relative_to(scripts_dir_resolved)
+        except ValueError:
+            last_error = (
+                f"Blocked: script path resolves outside the scripts directory "
+                f"({scripts_dir_resolved}): {script_path!r}"
+            )
+            continue
+
+        if not candidate_path.exists():
+            last_error = f"Script not found: {candidate_path}"
+            continue
+        if not candidate_path.is_file():
+            last_error = f"Script path is not a file: {candidate_path}"
+            continue
+
+        path = candidate_path
+        break
+
+    if path is None:
+        # Every candidate failed; surface the most recent error so callers
+        # see why. When the only candidate was the active home, last_error
+        # matches the pre-fallback behaviour exactly.
+        return False, last_error or f"Script not found: {script_path!r}"
 
     script_timeout = _get_script_timeout()
 

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -542,3 +542,131 @@ class TestRunJobEnvVarCleanup:
         assert os.environ.get("HERMES_SESSION_PLATFORM") is None
         assert os.environ.get("HERMES_SESSION_CHAT_ID") is None
         assert os.environ.get("HERMES_SESSION_CHAT_NAME") is None
+
+
+class TestProfileContextScriptFallback:
+    """Profile-context jobs fall back to the root home's scripts/ dir.
+
+    Regression coverage for the 2026-05-27 IC-cron migration gap: jobs with
+    ``profile: <name>`` set used to resolve scripts ONLY under the profile's
+    own ``scripts/`` dir, breaking 5 of 6 research-engineer pipelines that
+    referenced canonical scripts in the root home. See:
+    ``decisions/2026-05-29-cron-script-default-home-fallback.md``.
+    """
+
+    @pytest.fixture
+    def profile_context(self, tmp_path, monkeypatch):
+        """Set up a root home + profile home and activate the profile context.
+
+        Mirrors what ``_job_profile_context`` does at runtime: HERMES_HOME
+        points at the root, then the scheduler's module-level ``_hermes_home``
+        override is set to the profile's home for the duration of the test.
+        """
+        root = tmp_path / "hermes-root"
+        (root / "scripts").mkdir(parents=True)
+        (root / "cron").mkdir()
+        (root / "cron" / "output").mkdir()
+
+        profile_home = root / "profiles" / "research-engineer"
+        (profile_home / "scripts").mkdir(parents=True)
+
+        monkeypatch.setenv("HERMES_HOME", str(root))
+
+        import cron.scheduler as sched_mod
+        monkeypatch.setattr(sched_mod, "_hermes_home", profile_home)
+
+        return root, profile_home
+
+    def test_script_in_root_resolves_via_fallback(self, profile_context):
+        """Profile-context job with a root-only script resolves via fallback."""
+        from cron.scheduler import _run_job_script
+
+        root, _profile = profile_context
+        script = root / "scripts" / "researchengineer-arxiv_pipeline.py"
+        script.write_text('print("ran from root scripts dir")\n')
+
+        success, output = _run_job_script(
+            "researchengineer-arxiv_pipeline.py"
+        )
+        assert success is True
+        assert output == "ran from root scripts dir"
+
+    def test_profile_local_takes_precedence(self, profile_context):
+        """When the same filename exists in both, profile-local wins."""
+        from cron.scheduler import _run_job_script
+
+        root, profile = profile_context
+        # Same filename in both. Profile-local should be chosen.
+        (root / "scripts" / "shared.py").write_text(
+            'print("from root")\n'
+        )
+        (profile / "scripts" / "shared.py").write_text(
+            'print("from profile")\n'
+        )
+
+        success, output = _run_job_script("shared.py")
+        assert success is True
+        assert output == "from profile"
+
+    def test_missing_in_both_returns_root_not_found(self, profile_context):
+        """When a script exists in neither dir, the error is helpful.
+
+        The most-recent error (from the root candidate) is surfaced so the
+        user sees the canonical path they likely intended.
+        """
+        from cron.scheduler import _run_job_script
+
+        success, output = _run_job_script("does-not-exist.py")
+        assert success is False
+        assert "not found" in output.lower()
+
+    def test_absolute_path_into_root_scripts_resolves(self, profile_context):
+        """Absolute path pointing at root scripts/ resolves via fallback.
+
+        The profile-local guard rejects it (outside profile/scripts), but the
+        root candidate accepts it, so the resolution succeeds.
+        """
+        from cron.scheduler import _run_job_script
+
+        root, _profile = profile_context
+        script = root / "scripts" / "absolute_ok.py"
+        script.write_text('print("absolute via root")\n')
+
+        success, output = _run_job_script(str(script))
+        assert success is True
+        assert output == "absolute via root"
+
+    def test_traversal_still_blocked_under_fallback(self, profile_context, tmp_path):
+        """Path traversal escaping BOTH candidate dirs is still rejected."""
+        from cron.scheduler import _run_job_script
+
+        outside = tmp_path / "evil_outside.py"
+        outside.write_text('print("escaped")\n')
+
+        # Absolute path outside both candidates → both lookups reject,
+        # surface last error.
+        success, output = _run_job_script(str(outside))
+        assert success is False
+        assert "blocked" in output.lower() or "outside" in output.lower()
+
+    def test_no_fallback_when_active_equals_root(self, tmp_path, monkeypatch):
+        """Single-candidate behaviour preserved when no profile is active.
+
+        Belt-and-braces for the existing test suite: when ``_hermes_home``
+        is None (no profile context), the candidate list has length 1 and
+        behaviour matches pre-patch.
+        """
+        from cron.scheduler import _run_job_script
+
+        home = tmp_path / ".hermes"
+        (home / "scripts").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        import cron.scheduler as sched_mod
+        monkeypatch.setattr(sched_mod, "_hermes_home", None)
+
+        success, output = _run_job_script("missing.py")
+        assert success is False
+        assert "not found" in output.lower()
+        # Error path mentions the active home's scripts dir, not a parent.
+        assert str(home / "scripts") in output


### PR DESCRIPTION
## What does this PR do?

Profile-context cron jobs (jobs declaring `profile: <name>` in `jobs.json`) cannot currently resolve scripts that live in the canonical root `~/.hermes/scripts/` directory. `_run_job_script` in `cron/scheduler.py` resolves every script path against the active profile's `scripts/` only, so a job under e.g. `profile: research-engineer` referencing `arxiv_pipeline.py` fails with `Script not found` unless the script is dual-written into `~/.hermes/profiles/research-engineer/scripts/`.

This is exactly the case the profile-context machinery is supposed to support — non-root profiles sharing canonical scripts that live in the root home — so the resolver now tries a candidate list:

```
[<active home>/scripts, <root home>/scripts]
```

The fallback only fires when `active_home != root_home` (i.e. a profile context is active). Profile-local files take precedence when the same filename exists in both. The path-traversal / absolute-path-injection / symlink-escape guards run against whichever candidate dir is in play for each lookup — no guard is dropped, no allowlist is invented. When every candidate fails, the most-recent error is surfaced so callers see the canonical path they likely intended.

## Related Issue

No issue filed — encountered during multi-profile cron migration where IC profiles were expected to share canonical scripts from the root home. Happy to open one retroactively if maintainers prefer that discipline.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — `_run_job_script` now resolves the script path against a candidate list `[profile_local, root_fallback]` instead of a single `_get_hermes_home() / "scripts"` dir. Each candidate gets the existing traversal / symlink / absolute-path-injection guard; the fallback is only appended when `active_home != root_home`. Imports `get_default_hermes_root` from `hermes_constants` (already public).
- `tests/cron/test_cron_script.py` — adds `TestProfileContextScriptFallback` with 6 cases (see test plan below).

## How to Test

1. Set up a Hermes install with a non-root profile (e.g. `hermes profile create research-engineer`).
2. Drop a script in the canonical root scripts dir: `~/.hermes/scripts/my_pipeline.py`.
3. Register a cron job with `profile: research-engineer` and `script: my_pipeline.py` (no copy in the profile's `scripts/`).
4. Before this patch: scheduler tick logs `Script not found: ~/.hermes/profiles/research-engineer/scripts/my_pipeline.py`.
5. With this patch: scheduler resolves to the root scripts dir and runs the script.

Automated coverage in `tests/cron/test_cron_script.py::TestProfileContextScriptFallback`:

- `test_script_in_root_resolves_via_fallback` — happy path
- `test_profile_local_takes_precedence` — same filename in both dirs, profile-local wins
- `test_missing_in_both_returns_root_not_found` — error message helpful when nothing matches
- `test_absolute_path_into_root_scripts_resolves` — absolute path into root scripts/ accepted via fallback
- `test_traversal_still_blocked_under_fallback` — path traversal escaping BOTH candidates still rejected
- `test_no_fallback_when_active_equals_root` — single-candidate behaviour preserved when no profile is active (`_hermes_home is None`)

Run locally:

```
pytest tests/cron/test_cron_script.py -q
# 42 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cron): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (one commit, two files)
- [x] I've run `pytest tests/cron/test_cron_script.py -q` and all tests pass (42/42)
- [x] I've added tests for my changes (6 new cases)
- [x] I've tested on my platform: Ubuntu 24.04 / Python 3.11

### Documentation & Housekeeping

- [x] Docstring on `_run_job_script` updated to describe the fallback behaviour and the precedence rule — N/A for README/`docs/` (internal scheduler helper, not a documented surface)
- [x] No config keys added — N/A for `cli-config.yaml.example`
- [x] No architecture / workflow change — N/A for `CONTRIBUTING.md` / `AGENTS.md`
- [x] Cross-platform: path resolution uses `pathlib.Path` throughout; behaviour matches existing single-candidate path on Windows/macOS — no platform-specific code
- [x] No tool descriptions or schemas touched — N/A

## Screenshots / Logs

Before (profile-context job, script lives in root scripts dir):
```
[cron] tick fires job researchengineer-arxiv_pipeline → _run_job_script("arxiv_pipeline.py")
[cron] result: (False, "Script not found: /root/.hermes/profiles/research-engineer/scripts/arxiv_pipeline.py")
```

After (same job, no profile-local copy needed):
```
[cron] tick fires job researchengineer-arxiv_pipeline → _run_job_script("arxiv_pipeline.py")
[cron] candidate dirs: [profile/scripts, root/scripts] — profile miss, root hit
[cron] result: (True, "<script output>")
```
