### PR TITLE
fix(mcp): fail fast with actionable error when mcp SDK missing (#34220)

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -264,12 +264,32 @@ def _probe_single_server(
         raise ValueError("; ".join(issues))
 
     from tools.mcp_tool import (
+        _MCP_AVAILABLE,
         _ensure_mcp_loop,
         _run_on_mcp_loop,
         _connect_server,
         _stop_mcp_loop_if_idle,
         _parse_boolish,
     )
+
+    # Fail fast with an actionable error message before kicking off the
+    # event loop + connect_server retry path. Without this, the internal
+    # ``_run_stdio`` / ``_run_http`` ImportError gets buried under the
+    # per-attempt retry-backoff loop and the outer 15s tool-call timeout,
+    # surfacing only as ``TimeoutError: MCP call timed out after 15.0s``
+    # to the user — which is what #34220 reported as the headline
+    # ``NameError: name 'StdioServerParameters' is not defined``-shaped
+    # opaque failure. (#34220)
+    if not _MCP_AVAILABLE:
+        raise ImportError(
+            "The 'mcp' Python SDK is required for 'hermes mcp' commands but "
+            "is not installed. Install with:\n"
+            "  pip install 'hermes-agent[mcp]'\n"
+            "or, for pipx installs:\n"
+            "  pipx inject hermes-agent mcp\n"
+            "or, for the full install:\n"
+            "  pip install 'hermes-agent[all]'"
+        )
 
     config = _resolve_mcp_server_config(config)
     if connect_timeout is None:

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -1011,3 +1011,30 @@ class TestMcpReauth:
         cmd_mcp_reauth(_make_args(name="ghost", all=False))
         out = capsys.readouterr().out
         assert "not found" in out
+
+class TestProbeSingleServerMcpMissing:
+    """#34220: fail fast when mcp SDK missing."""
+
+    def test_probe_raises_importerror_fast_when_mcp_missing(self, monkeypatch):
+        from hermes_cli import mcp_config
+        import tools.mcp_tool as mcp_tool
+        monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", False, raising=False)
+        with pytest.raises(ImportError) as exc_info:
+            mcp_config._probe_single_server(
+                "ghost-server",
+                {"command": "echo", "args": ["hi"]},
+                connect_timeout=5,
+            )
+        msg = str(exc_info.value)
+        assert "mcp" in msg.lower()
+        assert "hermes-agent[mcp]" in msg
+
+    def test_probe_actionable_error_mentions_pipx_inject(self, monkeypatch):
+        from hermes_cli import mcp_config
+        import tools.mcp_tool as mcp_tool
+        monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", False, raising=False)
+        with pytest.raises(ImportError) as exc_info:
+            mcp_config._probe_single_server(
+                "ghost-server", {"command": "echo"}, connect_timeout=5
+            )
+        assert "pipx inject" in str(exc_info.value)


### PR DESCRIPTION
Fixes #34220.

## Problem

When the `mcp` Python SDK is not installed in the venv (common after pipx installs, where `mcp` is not in `Requires-Dist` so it's not auto-installed), `hermes mcp test` and `hermes mcp add` both surface opaque errors instead of the actionable install hint:

- **v0.14.0:** `NameError: name 'StdioServerParameters' is not defined`
- **v0.15.x:** `TimeoutError: MCP call timed out after 15.0s`

## Root cause

`_probe_single_server` kicks off the event loop and the `_connect_server` retry path before any check on `_MCP_AVAILABLE`. The inner `_run_stdio` / `_run_http` checks do exist (and raise a clean `ImportError` with the install hint), but their error gets buried under:
1. The 3-attempt retry-backoff loop in `MCPServerTask.run`
2. The outer 15s tool-call timeout in `_run_on_mcp_loop`

By the time the user sees an error, the actionable message has been mangled into a `TimeoutError`.

## Fix

Add an explicit `_MCP_AVAILABLE` fast-path check at the top of `_probe_single_server`. Synchronous `ImportError`, zero retries, zero timeout, actionable install hint covering all install shapes:

```python
if not _MCP_AVAILABLE:
    raise ImportError(
        "The 'mcp' Python SDK is required for 'hermes mcp' commands but "
        "is not installed. Install with:\n"
        "  pip install 'hermes-agent[mcp]'\n"
        "or, for pipx installs:\n"
        "  pipx inject hermes-agent mcp\n"
        "or, for the full install:\n"
        "  pip install 'hermes-agent[all]'"
    )
```

## Verification

With `mcp` uninstalled, before vs after:

| | Before | After |
|---|---|---|
| Error type | `TimeoutError` | `ImportError` |
| Time to error | 15+ seconds | 0.000s |
| Message | `MCP call timed out after 15.0s` | The actionable install hint above |
| Retries before failure | 3 with exponential backoff | 0 |

## Tests

Adds `TestProbeSingleServerMcpMissing` in `test_mcp_config.py`:
- `test_probe_raises_importerror_fast_when_mcp_missing` — verifies the fast-path raises `ImportError` synchronously and the hint mentions `hermes-agent[mcp]`
- `test_probe_actionable_error_mentions_pipx_inject` — verifies the hint covers the pipx install shape (the reporter's environment)

```
$ pytest tests/hermes_cli/test_mcp_config.py
34 passed in 0.66s
```

All existing tests still pass; 2 new regression tests cover the missing-SDK fast path.

Co-authored-by: Cursor <cursoragent@cursor.com>