### PR TITLE
fix(discord): sanitize Codex sender names

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -105,6 +105,33 @@ def _clean_discord_id(entry: str) -> str:
     return entry.strip()
 
 
+def _sanitize_context_sender_name(
+    display_name: Any,
+    *,
+    fallback_name: Any = None,
+    fallback: str = "user",
+    is_bot: bool = False,
+) -> str:
+    """Return a Codex-safe sender label for Discord context prefixes.
+
+    OpenAI's Responses API validates ``name`` fields against
+    ``^[a-zA-Z0-9_-]+$``. Shared-session sender prefixes such as
+    ``[Sis 💜]`` can be promoted into structured participant names later in
+    the pipeline, so Discord display names must be normalized before they
+    reach agent context.
+    """
+    for raw in (display_name, fallback_name):
+        if raw is None:
+            continue
+        cleaned = re.sub(r"[^A-Za-z0-9_-]+", "_", str(raw)).strip("_")
+        if cleaned:
+            label = cleaned[:64]
+            if is_bot and not label.endswith("_bot"):
+                label = f"{label[:60]}_bot"
+            return label
+    return "bot" if is_bot and fallback == "user" else fallback
+
+
 def check_discord_requirements() -> bool:
     """Check if Discord dependencies are available.
 
@@ -3492,7 +3519,10 @@ class DiscordAdapter(BasePlatformAdapter):
             chat_name=chat_name,
             chat_type=chat_type,
             user_id=str(interaction.user.id),
-            user_name=interaction.user.display_name,
+            user_name=_sanitize_context_sender_name(
+                getattr(interaction.user, "display_name", None),
+                fallback_name=getattr(interaction.user, "name", None),
+            ),
             thread_id=thread_id,
             chat_topic=chat_topic,
         )
@@ -3574,7 +3604,10 @@ class DiscordAdapter(BasePlatformAdapter):
             chat_name=chat_name,
             chat_type="thread",
             user_id=str(interaction.user.id),
-            user_name=interaction.user.display_name,
+            user_name=_sanitize_context_sender_name(
+                getattr(interaction.user, "display_name", None),
+                fallback_name=getattr(interaction.user, "name", None),
+            ),
             thread_id=thread_id,
             chat_topic=chat_topic,
         )
@@ -3825,9 +3858,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not content:
                     continue
 
-                name = msg.author.display_name
-                if getattr(msg.author, "bot", False):
-                    name = f"{name} [bot]"
+                name = _sanitize_context_sender_name(
+                    getattr(msg.author, "display_name", None),
+                    fallback_name=getattr(msg.author, "name", None),
+                    is_bot=getattr(msg.author, "bot", False),
+                )
                 collected.append(f"[{name}] {content}")
 
             if not collected:
@@ -4661,7 +4696,11 @@ class DiscordAdapter(BasePlatformAdapter):
             chat_name=chat_name,
             chat_type=chat_type,
             user_id=str(message.author.id),
-            user_name=message.author.display_name,
+            user_name=_sanitize_context_sender_name(
+                getattr(message.author, "display_name", None),
+                fallback_name=getattr(message.author, "name", None),
+                is_bot=getattr(message.author, "bot", False),
+            ),
             thread_id=thread_id,
             chat_topic=chat_topic,
             is_bot=getattr(message.author, "bot", False),

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -213,6 +213,21 @@ async def test_discord_free_response_in_server_channels(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_discord_event_source_user_name_is_sanitized_for_agent_context(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    message = make_message(channel=FakeTextChannel(channel_id=123), content="hello from channel")
+    message.author.display_name = "Sis 💜"
+    message.author.name = "sis"
+
+    await adapter._handle_message(message)
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.user_name == "Sis"
+
+
+@pytest.mark.asyncio
 async def test_discord_free_response_in_threads(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
@@ -661,8 +676,33 @@ async def test_fetch_channel_context_stops_at_self_message_and_reverses_to_chron
 
     assert result == (
         "[Recent channel messages]\n"
-        "[Gemini [bot]] latest bot note\n"
+        "[Gemini_bot] latest bot note\n"
         "[Alice] latest human note"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_sanitizes_non_ascii_sender_names(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    other_bot = SimpleNamespace(id=55, display_name="Ghost 👻", name="ghost", bot=True)
+    human = SimpleNamespace(id=56, display_name="Sis 💜", name="sis", bot=False)
+
+    channel = FakeHistoryChannel(
+        [
+            make_history_message(author=human, content="latest human note", msg_id=3),
+            make_history_message(author=other_bot, content="latest bot note", msg_id=2),
+        ],
+        channel_id=123,
+    )
+
+    result = await adapter._fetch_channel_context(channel, before=make_message(channel=channel, content="trigger"))
+
+    assert result == (
+        "[Recent channel messages]\n"
+        "[Ghost_bot] latest bot note\n"
+        "[Sis] latest human note"
     )
 
 
@@ -757,7 +797,7 @@ async def test_fetch_channel_context_cache_uses_latest_window_when_after_set(ada
 
     result = await adapter._fetch_channel_context(channel, before=trigger)
 
-    assert "[Codex [bot]] final analysis" in result
+    assert "[Codex_bot] final analysis" in result
     assert "[Alice] latest follow-up" in result
     assert "old tool trace 1" not in result
     assert "old tool trace 2" not in result
@@ -925,5 +965,4 @@ async def test_discord_auto_thread_skips_backfill(adapter, monkeypatch):
 
     adapter._auto_create_thread.assert_awaited_once()
     adapter._fetch_channel_context.assert_not_awaited()
-
 


### PR DESCRIPTION
## Summary
- sanitize Discord sender labels before they enter shared-session agent context
- normalize history backfill bot labels to Codex-safe names as well
- add regression coverage for event source names and channel-context backfill

Fixes #34113

## Proof
- `uv run --frozen pytest -q -o addopts= tests/gateway/test_discord_free_response.py -k 'sanitized_for_agent_context or sanitizes_non_ascii_sender_names or fetch_channel_context_stops_at_self_message_and_reverses_to_chronological_order or fetch_channel_context_cache_uses_latest_window_when_after_set'`\n- `uv run --frozen ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_free_response.py`\n- `git diff --check`