### PR TITLE
fix(tui): move mtime check and file read inside _cfg_lock

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -660,16 +660,15 @@ def _load_cfg() -> dict:
         import yaml
 
         p = _hermes_home / "config.yaml"
-        mtime = p.stat().st_mtime if p.exists() else None
         with _cfg_lock:
+            mtime = p.stat().st_mtime if p.exists() else None
             if _cfg_cache is not None and _cfg_mtime == mtime and _cfg_path == p:
                 return copy.deepcopy(_cfg_cache)
-        if p.exists():
-            with open(p, encoding="utf-8") as f:
-                data = yaml.safe_load(f) or {}
-        else:
-            data = {}
-        with _cfg_lock:
+            if p.exists():
+                with open(p, encoding="utf-8") as f:
+                    data = yaml.safe_load(f) or {}
+            else:
+                data = {}
             _cfg_cache = copy.deepcopy(data)
             _cfg_mtime = mtime
             _cfg_path = p


### PR DESCRIPTION
## Problem

`_load_cfg()` reads the file mtime (line 666) and reads the file contents (lines 670-672) **outside** the `_cfg_lock`. This creates a TOCTOU (time-of-check-time-of-use) race condition:

1. Two concurrent threads can both observe a cache miss, both read the file, and both race to update `_cfg_cache`.
2. If `_save_cfg` writes the YAML file from another thread concurrently, one thread may read a partially-written file, cache garbage, and serve it to all subsequent callers until the mtime changes.

## Fix

Move the mtime check, file read, and cache update inside a single `_cfg_lock` scope. This eliminates the race window where concurrent threads can read stale or partially-written config.

## Before vs After

| Scenario | Before | After |
|---|---|---|
| Two threads hit cache miss simultaneously | Both read file, both update cache (race) | One reads and updates, other hits cache |
| File being written by _save_cfg | Thread may read partial YAML | Thread waits for lock, reads complete file |

## Risk
Minimal — the lock is held slightly longer (including the file I/O), but config reads are infrequent and the file is small (~2KB typical). The `copy.deepcopy` on the return path ensures no shared mutable state.