### PR TITLE
fix(hindsight): use atomic write for config.json

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -633,7 +633,24 @@ class HindsightMemoryProvider(MemoryProvider):
             except Exception:
                 pass
         existing.update(values)
-        config_path.write_text(json.dumps(existing, indent=2))
+        import tempfile
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(config_path.parent),
+            prefix=f".{config_path.stem}_",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(json.dumps(existing, indent=2))
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, config_path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     def post_setup(self, hermes_home: str, config: dict) -> None:
         """Custom setup wizard — installs only the deps needed for the selected mode."""


### PR DESCRIPTION
## Problem

`HindsightMemoryPlugin.save_config()` uses `Path.write_text()` which truncates the file then writes new content. If the process is killed mid-write (SIGKILL, OOM, power loss), the config file is left empty or truncated — losing all Hindsight configuration.

## Fix

Use `tempfile.mkstemp` + `fsync` + `os.replace` for atomic writes, matching the pattern used throughout the codebase:
- `tools/skill_usage.py` (lines 343-356)
- `utils.py:atomic_json_write()` (lines 85-136)

The write now:
1. Creates a temp file in the same directory
2. Writes and fsyncs to disk
3. Atomically replaces the target file
4. Cleans up temp file on any exception

## Risk
Minimal — zero behavioral change on success path. Only adds crash-safety for the config write operation. Only fires during the interactive setup wizard, not during normal runtime.