### PR TITLE
fix(pricing): detect per-million pricing units to fix 1M× custom-endpoint overestimate (#34256)

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1128,6 +1128,32 @@ def _openrouter_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
     )
 
 
+# Above this threshold (in dollars), a pricing field cannot plausibly be a
+# per-token rate — it would imply >$1,000 per million tokens, which no real
+# model charges. Many provider catalogs (notably Crof, see #34256) expose
+# ``cost.input`` / ``cost.output`` already in per-million dollars (e.g.
+# 0.04 = $0.04/M). Without this guard we'd multiply by 1,000,000 and report
+# nonsensical session costs ($555 for a 13k-token cron run).
+#
+# 0.001 corresponds to $1,000/M tokens. Real frontier models in 2026 top out
+# around $75/M (Anthropic Opus 4 input) and even Grok-4-fast is ~$10/M input,
+# so any value at or above 0.001 is unambiguously per-million units.
+_PER_MILLION_HEURISTIC_THRESHOLD = Decimal("0.001")
+
+
+def _pricing_field_looks_per_million(*values: Optional[Decimal]) -> bool:
+    """Heuristic: return True when at least one pricing value is too large
+    to be a per-token rate, indicating the source already publishes
+    per-million-token rates (Crof-style metadata).
+
+    See #34256 for the failure mode this prevents.
+    """
+    for v in values:
+        if v is not None and v >= _PER_MILLION_HEURISTIC_THRESHOLD:
+            return True
+    return False
+
+
 def _pricing_entry_from_metadata(
     metadata: Dict[str, Dict[str, Any]],
     model_id: str,
@@ -1154,16 +1180,27 @@ def _pricing_entry_from_metadata(
     if prompt is None and completion is None and request is None:
         return None
 
-    def _per_token_to_per_million(value: Optional[Decimal]) -> Optional[Decimal]:
-        if value is None:
-            return None
-        return value * _ONE_MILLION
+    # Detect whether the source publishes per-million-token rates (Crof,
+    # etc.) or per-token rates (OpenRouter, official OpenAI/Anthropic docs)
+    # via a value-range heuristic. See #34256.
+    already_per_million = _pricing_field_looks_per_million(prompt, completion, cache_read, cache_write)
+
+    if already_per_million:
+        def _passthrough(value: Optional[Decimal]) -> Optional[Decimal]:
+            return value
+        convert = _passthrough
+    else:
+        def _per_token_to_per_million(value: Optional[Decimal]) -> Optional[Decimal]:
+            if value is None:
+                return None
+            return value * _ONE_MILLION
+        convert = _per_token_to_per_million
 
     return PricingEntry(
-        input_cost_per_million=_per_token_to_per_million(prompt),
-        output_cost_per_million=_per_token_to_per_million(completion),
-        cache_read_cost_per_million=_per_token_to_per_million(cache_read),
-        cache_write_cost_per_million=_per_token_to_per_million(cache_write),
+        input_cost_per_million=convert(prompt),
+        output_cost_per_million=convert(completion),
+        cache_read_cost_per_million=convert(cache_read),
+        cache_write_cost_per_million=convert(cache_write),
         request_cost=request,
         source="provider_models_api",
         source_url=source_url,


### PR DESCRIPTION
Fixes #34256.

## Problem

Hermes recorded **$555.17** as the estimated cost for a 13,233-token Crof custom-endpoint session. The math:
```
12998 * 0.04 + 235 * 0.15 = 555.17   ← treating per-million rates as per-token
(12998 * 0.04 + 235 * 0.15) / 1,000,000 = $0.00055517   ← correct
```

## Root cause

`agent/usage_pricing.py:_pricing_entry_from_metadata` unconditionally multiplies pricing fields by 1,000,000 to convert dollars-per-token → dollars-per-million.

- OpenRouter: `pricing.prompt = "0.000005"` is **per-token** ($5/M) → multiply ✅
- Crof catalog: `cost.input = 0.04` is already **per-million** ($0.04/M) → DON'T multiply ❌

The `alias_map` in `agent/model_metadata.py` collapses `input` → `prompt` and `output` → `completion` from both sources into the same field, losing the unit information.

## Fix

Add a value-range heuristic. Any pricing field >= $0.001 (= $1,000/M-tokens) is unambiguously per-million — no real model charges that much per token. Frontier 2026 prices top out around:

| Model | Input | Output |
|---|---|---|
| Anthropic Opus 4 | $15/M | $75/M |
| Anthropic Opus 4.8 | $5/M | $25/M |
| OpenAI GPT-5.5 | ~$10/M | ~$30/M |
| Grok-4-fast | ~$10/M | ~$30/M |

So any per-token field >= 0.001 ($1,000/M) would be 13×+ the most expensive real model — physically impossible. When the heuristic detects per-million scale, the multiplication is skipped.

```python
_PER_MILLION_HEURISTIC_THRESHOLD = Decimal("0.001")  # = $1000/M tokens

def _pricing_field_looks_per_million(*values):
    return any(v is not None and v >= _PER_MILLION_HEURISTIC_THRESHOLD for v in values)
```

If ANY of prompt/completion/cache_read/cache_write trips the threshold, all are treated as per-million (they always ship together in the same unit). Otherwise per-token semantics apply as before.

## Why value-range heuristic vs provider-specific switch

Catalogs that ship per-million rates aren't limited to Crof — many provider-side `/v1/models` endpoints do this. Hard-coding per-provider unit conventions doesn't scale. The two unit conventions live in non-overlapping orders of magnitude, so the heuristic is unambiguous.

## Tests

4 new tests in `tests/agent/test_usage_pricing.py`:

| Test | Verifies |
|---|---|
| `test_crof_custom_endpoint_per_million_rates_are_not_re_multiplied` | Crof catalog passes through unchanged |
| `test_crof_per_million_pricing_produces_correct_cost` | End-to-end: 13k-token session costs sub-penny, not $555 |
| `test_openrouter_per_token_pricing_still_works` | Dominant OpenRouter path unchanged |
| `test_per_million_heuristic_unit_function` | Unit test of the helper across edge cases |

```
$ pytest tests/agent/test_usage_pricing.py
15 passed in 1.67s
```

All 15 tests pass (4 new + 11 existing — including the OpenRouter and earlier custom-endpoint regression tests).

Credit to **@jazzyalex** for the surgical root-cause analysis with the exact math that pinned the bug.

Co-authored-by: Cursor <cursoragent@cursor.com>