### PR TITLE
fix(tui): restore context token estimate on session resume/branch

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2473,6 +2473,18 @@ def _(rid, params: dict) -> dict:
             agent = _make_agent(sid, target, session_id=target)
         finally:
             _clear_session_context(tokens)
+        # Restore context token tracking from loaded history so the status
+        # bar shows an accurate estimate immediately on resume instead of
+        # waiting for the first API call to populate last_prompt_tokens.
+        try:
+            from agent.model_metadata import estimate_messages_tokens_rough
+
+            est = estimate_messages_tokens_rough(history)
+            comp = getattr(agent, "context_compressor", None)
+            if comp and est > 0:
+                comp.last_prompt_tokens = est
+        except Exception:
+            pass
         _init_session(sid, target, agent, history, cols=int(params.get("cols", 80)))
     except Exception as e:
         return _err(rid, 5000, f"resume failed: {e}")
@@ -3044,6 +3056,18 @@ def _(rid, params: dict) -> dict:
             agent = _make_agent(new_sid, new_key, session_id=new_key)
         finally:
             _clear_session_context(tokens)
+        # Restore context token tracking from branched history so the status
+        # bar shows an accurate estimate immediately instead of waiting for
+        # the first API call to populate last_prompt_tokens.
+        try:
+            from agent.model_metadata import estimate_messages_tokens_rough
+
+            est = estimate_messages_tokens_rough(history)
+            comp = getattr(agent, "context_compressor", None)
+            if comp and est > 0:
+                comp.last_prompt_tokens = est
+        except Exception:
+            pass
         _init_session(
             new_sid, new_key, agent, list(history), cols=session.get("cols", 80)
         )


### PR DESCRIPTION
The status bar showed 0 context tokens when a session was resumed until the first API call populated last_prompt_tokens. Now we estimate from the loaded conversation history using estimate_messages_tokens_rough() and restore it to the compressor before emitting session.info.

Covers both session.resume and session.branch handlers.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

