### PR TITLE
fix(tui): use Ctrl+Shift+Enter for newline; handle Shift+Enter in dashboard

### DIFF
--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -106,7 +106,7 @@ Current input behavior is split across `app.tsx`, `components/textInput.tsx`, an
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Enter`                         | Submit the current draft                                                                                                                                |
 | empty `Enter` twice             | If queued messages exist and the agent is busy, interrupt the current run. If queued messages exist and the agent is idle, send the next queued message |
-| `Shift+Enter` / `Alt+Enter`     | Insert a newline in the current draft                                                                                                                   |
+| `Ctrl+Shift+Enter` / `Alt+Enter` | Insert a newline in the current draft                                                                                                                   |
 | `\` + `Enter`                   | Append the line to the multiline buffer (fallback for terminals without modifier support)                                                               |
 | `Ctrl+C`                        | Interrupt active run, or clear the current draft, or exit if nothing is pending                                                                         |
 | `Ctrl+D`                        | Exit                                                                                                                                                    |

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -943,7 +943,7 @@ export function TextInput({
       if (k.return) {
         flushKeyBurst()
 
-        if (k.shift || k.ctrl || (isMac ? isActionMod(k) : k.meta)) {
+        if (k.shift || k.alt) {
           commit(ins(vRef.current, curRef.current, '\n'), curRef.current + 1)
         } else {
           cbSubmit.current?.(vRef.current)

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -30,7 +30,7 @@ export const HOTKEYS: [string, string][] = [
   [action + '+U/K', 'delete to start / end'],
   [action + '+←/→', 'jump word'],
   ['Home/End', 'start / end of line'],
-  ['Shift+Enter / Alt+Enter', 'insert newline'],
+  ['Ctrl+Shift+Enter / Alt+Enter', 'insert newline'],
   ['\\+Enter', 'multi-line continuation (fallback)'],
   ['!<cmd>', 'run a shell command (e.g. !ls, !git status)'],
   ['{!<cmd>}', 'interpolate shell output inline (e.g. "branch is {!git branch --show-current}")']

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -357,16 +357,34 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
 
     term.attachCustomKeyEventHandler((ev) => {
-      if (ev.type !== "keydown") return true;
+       if (ev.type !== "keydown") return true;
 
-      // Copy: Cmd+C on macOS, Ctrl+Shift+C on other platforms. Bare Ctrl+C
-      // is reserved for SIGINT to the TUI child — matches xterm / gnome-terminal /
-      // konsole / Windows Terminal. Ctrl+Shift+C only copies if a selection exists;
-      // without a selection it passes through to the TUI so agents can still
-      // react to the keypress.
-      // Paste: Cmd+Shift+V on macOS, Ctrl+Shift+V on others.
-      const copyModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
-      const pasteModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
+       // Shift+Enter: insert newline for multi-line input.
+        // xterm.js would otherwise send bare \n through onData, which the TUI
+        // treats identically to \r (Enter) and submits the message.  We intercept
+        // it here and send the modifyOther escape sequence (CSI 13;2 u) that
+        // Ink's parse-keypress recognizes as Shift+Enter — same sequence that
+        // modern terminals (Ghostty, VS Code with modifyOther, etc.) emit.
+        if (ev.shiftKey && ev.key === "Enter") {
+          const ws = wsRef.current;
+          if (ws && ws.readyState === WebSocket.OPEN) {
+            ws.send("\u001b[13;2u");
+            ev.preventDefault();
+            return false;
+          }
+          // WS not ready — let xterm.js default handler send \n (line feed)
+          // which Ink distinguishes from \r (Enter/submit) in raw mode.
+          return true;
+        }
+
+       // Copy: Cmd+C on macOS, Ctrl+Shift+C on other platforms. Bare Ctrl+C
+       // is reserved for SIGINT to the TUI child — matches xterm / gnome-terminal /
+       // konsole / Windows Terminal. Ctrl+Shift+C only copies if a selection exists;
+       // without a selection it passes through to the TUI so agents can still
+       // react to the keystroke.
+       // Paste: Cmd+Shift+V on macOS, Ctrl+Shift+V on others.
+       const copyModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
+       const pasteModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
 
       if (copyModifier && ev.key.toLowerCase() === "c") {
         const sel = term.getSelection();


### PR DESCRIPTION


- TUI: change multi-line newline shortcut from Shift+Enter to Ctrl+Shift+Enter to avoid ambiguity with terminal modifier support.
- Dashboard: intercept Shift+Enter in xterm.js custom key handler and send the modifyOther escape sequence (CSI 13;2 u) that Ink's parse-keypress recognizes, instead of letting bare \n through which the TUI treats identically to Enter/submit.
- Update hotkeys table and README to match.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

