### PR TITLE
fix(cli): honor MCP probe connect timeout

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -214,7 +214,7 @@ def _resolve_mcp_server_config(config: dict) -> dict:
 
 
 def _probe_single_server(
-    name: str, config: dict, connect_timeout: float = 30
+    name: str, config: dict, connect_timeout: Optional[float] = None
 ) -> List[Tuple[str, str]]:
     """Temporarily connect to one MCP server, list its tools, disconnect.
 
@@ -233,9 +233,14 @@ def _probe_single_server(
     )
 
     config = _resolve_mcp_server_config(config)
+    if connect_timeout is None:
+        raw_timeout = config.get("connect_timeout", 30)
+        try:
+            connect_timeout = max(1.0, float(raw_timeout))
+        except (TypeError, ValueError):
+            connect_timeout = 30.0
 
     _ensure_mcp_loop()
-
     tools_found: List[Tuple[str, str]] = []
 
     async def _probe():

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -445,6 +445,44 @@ class TestMcpTest:
         assert "Connected" in out
         assert "Tools discovered: 2" in out
 
+    def test_probe_uses_configured_connect_timeout(self, monkeypatch):
+        """OAuth-capable probes must not hard-code a short 30s timeout."""
+        import asyncio
+        from hermes_cli import mcp_config
+        import tools.mcp_tool as mcp_tool
+
+        captured = {}
+
+        class FakeServer:
+            _tools = []
+
+            async def shutdown(self):
+                captured["shutdown"] = True
+
+        async def fake_connect(name, config):
+            return FakeServer()
+
+        def fake_run_on_mcp_loop(coro, timeout):
+            captured["outer_timeout"] = timeout
+            return asyncio.run(coro)
+
+        async def fake_wait_for(awaitable, timeout):
+            captured["inner_timeout"] = timeout
+            return await awaitable
+
+        monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", lambda: None)
+        monkeypatch.setattr(mcp_tool, "_stop_mcp_loop", lambda: None)
+        monkeypatch.setattr(mcp_tool, "_connect_server", fake_connect)
+        monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", fake_run_on_mcp_loop)
+        monkeypatch.setattr(mcp_config.asyncio, "wait_for", fake_wait_for)
+
+        assert mcp_config._probe_single_server(
+            "supabase", {"connect_timeout": 300}
+        ) == []
+        assert captured["inner_timeout"] == 300.0
+        assert captured["outer_timeout"] == 310.0
+        assert captured["shutdown"] is True
+
 
 # ---------------------------------------------------------------------------
 # Tests: env var interpolation


### PR DESCRIPTION
## What does this PR do?

Fixes MCP server probing so per-server `connect_timeout` values are honored during `hermes mcp test`, `hermes mcp login`, and add/login probe flows.

Before this change, `_probe_single_server()` had a hard-coded 30 second default and callers usually passed no override. That meant a config like:

```yaml
mcp_servers:
  supabase:
    url: https://mcp.supabase.com/mcp
    auth: oauth
    connect_timeout: 300
```

still failed around 40 seconds total because the inner connect used 30 seconds and the outer loop used `30 + 10`.

This PR reads `connect_timeout` from the server config when no explicit override is supplied, clamps/parses it safely, and uses the same value for the inner connection and outer loop budget.

## Related Issue

Fixes #24097

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/mcp_config.py`
  - Let `_probe_single_server()` accept `connect_timeout=None`.
  - Read `config["connect_timeout"]` when no explicit timeout is supplied.
  - Coerce invalid values back to the existing 30 second default and clamp valid values to at least 1 second.
  - Apply the resolved timeout to both `asyncio.wait_for()` and `_run_on_mcp_loop()`.
- `tests/hermes_cli/test_mcp_config.py`
  - Add regression coverage proving a configured `connect_timeout: 300` reaches the inner probe timeout and the outer loop budget.

## How to Test

1. Configure an OAuth MCP server with `connect_timeout: 300`.
2. Run `hermes mcp login <server>` or `hermes mcp test <server>`.
3. Confirm the probe uses the configured timeout instead of failing at the old 40 second total ceiling.

Local validation run:

```bash
python -m pytest tests/hermes_cli/test_mcp_config.py -q -o 'addopts='
# 33 passed
```

I searched existing PRs for MCP probe timeout / `connect_timeout`. Open PRs #34245 and #34223 touch the same function for missing MCP SDK fast-fail behavior, but they do not address the ignored configured timeout.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Python 3.14.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. Regression coverage is in `tests/hermes_cli/test_mcp_config.py`.
