### PR TITLE
docs(kanban): clarify dispatcher fallback semantics

### DIFF
--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -507,7 +507,7 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `auto_decompose` | `true` | Dispatcher auto-runs the decomposer every tick. |
 | `auto_decompose_per_tick` | `3` | Cap on decompositions per dispatcher tick. Excess defers to the next tick. |
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
-| `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
+| `default_assignee` | `""` | When set, the dispatcher assigns otherwise-unassigned `ready` tasks to this profile; when empty, it keeps skipping them. Separately, decomposer-created work with a missing or unknown profile uses this setting when valid, then falls back to the active default profile. |
 | `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. |
 
 And the two auxiliary LLM slots:
@@ -688,6 +688,7 @@ All commands are also available as a slash command in the interactive CLI and in
 ```yaml
 kanban:
   max_in_progress: 2
+  max_in_progress_per_profile: 1
   auto_promote_children: false
   default_workdir: ~/work/active-project
 ```

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
@@ -406,7 +406,7 @@ hermes dashboard        # 导航栏中出现 "Kanban" 标签页，位于 "Skills
 | `auto_decompose` | `true` | 调度器每 tick 自动运行分解器。 |
 | `auto_decompose_per_tick` | `3` | 每个调度器 tick 的分解上限。超出部分推迟到下一个 tick。 |
 | `orchestrator_profile` | `""` | 拥有分解权的配置文件。空 = 回退到活动默认配置文件。 |
-| `default_assignee` | `""` | LLM 选择未知配置文件时子任务的落地位置。空 = 回退到活动默认配置文件。 |
+| `default_assignee` | `""` | 设置后，调度器会将其他无指派的 `ready` 任务分配给此 profile；留空则继续跳过这些任务。另外，对于分解器创建且未指定或选择了未知 profile 的任务，会在此设置有效时优先使用它，否则回退到活动默认 profile。 |
 | `auto_subscribe_on_create` | `true` | 当 worker 在具有持久投递通道的会话（消息网关或 TUI）内调用 `kanban_create` 时，原始会话会自动订阅新任务的完成/阻塞事件。调度器仍负责驱动投递 —— 此设置只决定调用者的聊天/密钥是否出现在通知订阅表中。设为 `false` 则要求对每个任务显式调用 `kanban_notify-subscribe`。 |
 
 以及两个辅助 LLM 槽：


### PR DESCRIPTION
## Summary

- add `max_in_progress_per_profile` to the existing concurrency YAML example without duplicating the table row already on `main`
- clarify in both English and zh-Hans that the dispatcher only assigns unassigned `ready` tasks when `default_assignee` is configured
- distinguish that behavior from decomposer-created work, which falls back to the active default profile when the configured value is empty or invalid

## Validation

- verified the gateway watcher maps an empty value to no dispatcher fallback
- verified `dispatch_once` skips unassigned work unless a configured profile resolves
- verified the decomposer separately resolves missing/unknown assignees to the configured profile and then the active default
- confirmed no overlapping open docs PR or target-file relocation
- `git diff --check`

Docs-only change; dispatcher behavior is unchanged. This is the targeted salvage requested in the maintainer review.