### PR TITLE
fix(mcp): scope oauth callback ports per provider

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -206,6 +206,95 @@ class TestBuildOAuthAuth:
         assert provider is not None
         assert provider.context.client_metadata.scope == "read write admin"
 
+    def test_per_provider_redirect_handler_keeps_its_own_port(self, monkeypatch, capsys):
+        pytest.importorskip("mcp")
+        import tools.mcp_oauth as mod
+
+        captured = []
+
+        class _FakeProvider:
+            def __init__(self, **kwargs):
+                captured.append(kwargs)
+
+        with patch.object(mod, "_OAUTH_AVAILABLE", True), \
+             patch.object(mod, "OAuthClientProvider", _FakeProvider), \
+             patch.object(mod, "_is_interactive", return_value=True), \
+             patch.object(mod, "_maybe_preregister_client"), \
+             patch.object(mod, "HermesTokenStorage") as mock_storage_cls:
+            mock_storage_cls.return_value = MagicMock(has_cached_tokens=lambda: True)
+            build_oauth_auth("first", "https://example.com/mcp", {"redirect_port": 51001})
+            build_oauth_auth("second", "https://example.com/mcp", {"redirect_port": 51002})
+
+        monkeypatch.setenv("SSH_CLIENT", "1.2.3.4 1234 22")
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.setattr(mod, "_can_open_browser", lambda: False)
+        mod._oauth_port = 59999
+
+        asyncio.run(captured[0]["redirect_handler"]("https://example.com/auth"))
+        first_err = capsys.readouterr().err
+        assert "51001" in first_err
+        assert "59999" not in first_err
+
+        asyncio.run(captured[1]["redirect_handler"]("https://example.com/auth"))
+        second_err = capsys.readouterr().err
+        assert "51002" in second_err
+        assert "59999" not in second_err
+
+    def test_per_provider_callback_handler_keeps_its_own_port(self, monkeypatch):
+        pytest.importorskip("mcp")
+        import tools.mcp_oauth as mod
+
+        captured = []
+
+        class _FakeProvider:
+            def __init__(self, **kwargs):
+                captured.append(kwargs)
+
+        class _FakeHTTPServer:
+            calls = []
+
+            def __init__(self, addr, handler_cls):
+                self.__class__.calls.append(addr)
+
+            def handle_request(self):
+                return None
+
+            def server_close(self):
+                return None
+
+        class _FakeThread:
+            def __init__(self, target, daemon, args=()):
+                self.target = target
+                self.daemon = daemon
+                self.args = args
+
+            def start(self):
+                return None
+
+        def _ready_result():
+            return object(), {"auth_code": "code", "state": "state", "error": None}
+
+        with patch.object(mod, "_OAUTH_AVAILABLE", True), \
+             patch.object(mod, "OAuthClientProvider", _FakeProvider), \
+             patch.object(mod, "_is_interactive", return_value=True), \
+             patch.object(mod, "_maybe_preregister_client"), \
+             patch.object(mod, "HermesTokenStorage") as mock_storage_cls:
+            mock_storage_cls.return_value = MagicMock(has_cached_tokens=lambda: True)
+            build_oauth_auth("first", "https://example.com/mcp", {"redirect_port": 51101})
+            build_oauth_auth("second", "https://example.com/mcp", {"redirect_port": 51102})
+
+        monkeypatch.setattr(mod, "HTTPServer", _FakeHTTPServer)
+        monkeypatch.setattr(mod.threading, "Thread", _FakeThread)
+        monkeypatch.setattr(mod, "_make_callback_handler", _ready_result)
+        mod._oauth_port = 59999
+
+        first = asyncio.run(captured[0]["callback_handler"]())
+        second = asyncio.run(captured[1]["callback_handler"]())
+
+        assert _FakeHTTPServer.calls == [("127.0.0.1", 51101), ("127.0.0.1", 51102)]
+        assert first == ("code", "state")
+        assert second == ("code", "state")
+
 
 # ---------------------------------------------------------------------------
 # Utility functions

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -397,55 +397,64 @@ def _make_callback_handler() -> tuple[type, dict]:
 # ---------------------------------------------------------------------------
 
 
+def _make_redirect_handler(port: int | None):
+    """Return a redirect handler bound to a single OAuth flow's callback port."""
+
+    async def _handler(authorization_url: str) -> None:
+        msg = (
+            f"\n  MCP OAuth: authorization required.\n"
+            f"  Open this URL in your browser:\n\n"
+            f"    {authorization_url}\n"
+        )
+        print(msg, file=sys.stderr)
+
+        # On a remote SSH session the OAuth provider redirects to
+        # http://127.0.0.1:<port>/callback, which reaches the callback server on
+        # the *remote* machine — not the user's local machine where the browser
+        # opened. Two ways out: paste the redirect URL back (default fallback,
+        # offered by _wait_for_callback on interactive TTYs), or set up an SSH
+        # port forward so the redirect tunnels through.
+        if port and (os.getenv("SSH_CLIENT") or os.getenv("SSH_TTY")):
+            print(
+                f"  Remote session detected. After you authorize, the provider redirects to\n"
+                f"    http://127.0.0.1:{port}/callback\n"
+                f"  which only the listener on THIS machine can receive. Two options:\n"
+                f"\n"
+                f"    1. Easiest — when your browser shows a connection error after\n"
+                f"       authorizing, copy the full URL from the address bar and paste\n"
+                f"       it at the prompt below. The pasted ``code=...&state=...`` is\n"
+                f"       enough to complete the flow.\n"
+                f"\n"
+                f"    2. Or forward the port first in a separate terminal:\n"
+                f"         ssh -N -L {port}:127.0.0.1:{port} <user>@<this-host>\n"
+                f"       then open the URL above and let it redirect normally.\n"
+                f"\n"
+                f"  See: https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh\n",
+                file=sys.stderr,
+            )
+
+        if _can_open_browser():
+            try:
+                opened = webbrowser.open(authorization_url)
+                if opened:
+                    print("  (Browser opened automatically.)\n", file=sys.stderr)
+                else:
+                    print("  (Could not open browser — please open the URL manually.)\n", file=sys.stderr)
+            except Exception:
+                print("  (Could not open browser — please open the URL manually.)\n", file=sys.stderr)
+        else:
+            print("  (Headless environment detected — open the URL manually.)\n", file=sys.stderr)
+
+    return _handler
+
+
 async def _redirect_handler(authorization_url: str) -> None:
     """Show the authorization URL to the user.
 
     Opens the browser automatically when possible; always prints the URL
     as a fallback for headless/SSH/gateway environments.
     """
-    msg = (
-        f"\n  MCP OAuth: authorization required.\n"
-        f"  Open this URL in your browser:\n\n"
-        f"    {authorization_url}\n"
-    )
-    print(msg, file=sys.stderr)
-
-    # On a remote SSH session the OAuth provider redirects to
-    # http://127.0.0.1:<port>/callback, which reaches the callback server on
-    # the *remote* machine — not the user's local machine where the browser
-    # opened.  Two ways out: paste the redirect URL back (default fallback,
-    # offered by _wait_for_callback on interactive TTYs), or set up an SSH
-    # port forward so the redirect tunnels through.
-    if _oauth_port and (os.getenv("SSH_CLIENT") or os.getenv("SSH_TTY")):
-        print(
-            f"  Remote session detected. After you authorize, the provider redirects to\n"
-            f"    http://127.0.0.1:{_oauth_port}/callback\n"
-            f"  which only the listener on THIS machine can receive. Two options:\n"
-            f"\n"
-            f"    1. Easiest — when your browser shows a connection error after\n"
-            f"       authorizing, copy the full URL from the address bar and paste\n"
-            f"       it at the prompt below. The pasted ``code=...&state=...`` is\n"
-            f"       enough to complete the flow.\n"
-            f"\n"
-            f"    2. Or forward the port first in a separate terminal:\n"
-            f"         ssh -N -L {_oauth_port}:127.0.0.1:{_oauth_port} <user>@<this-host>\n"
-            f"       then open the URL above and let it redirect normally.\n"
-            f"\n"
-            f"  See: https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh\n",
-            file=sys.stderr,
-        )
-
-    if _can_open_browser():
-        try:
-            opened = webbrowser.open(authorization_url)
-            if opened:
-                print("  (Browser opened automatically.)\n", file=sys.stderr)
-            else:
-                print("  (Could not open browser — please open the URL manually.)\n", file=sys.stderr)
-        except Exception:
-            print("  (Could not open browser — please open the URL manually.)\n", file=sys.stderr)
-    else:
-        print("  (Headless environment detected — open the URL manually.)\n", file=sys.stderr)
+    await _make_redirect_handler(_oauth_port)(authorization_url)
 
 
 async def _wait_for_callback() -> tuple[str, str | None]:
@@ -474,66 +483,71 @@ async def _wait_for_callback() -> tuple[str, str | None]:
             "before _wait_for_oauth_callback"
         )
 
-    # The callback server is already running (started in build_oauth_auth).
-    # We just need to poll for the result.
-    handler_cls, result = _make_callback_handler()
+    return await _make_callback_waiter(_oauth_port)()
 
-    # Start a temporary server on the known port
-    try:
-        server = HTTPServer(("127.0.0.1", _oauth_port), handler_cls)
-    except OSError:
-        # Port already in use — the server from build_oauth_auth is running.
-        # Fall back to polling the server started by build_oauth_auth.
-        raise OAuthNonInteractiveError(
-            "OAuth callback timed out — could not bind callback port. "
-            "Complete the authorization in a browser first, then retry."
-        )
 
-    server_thread = threading.Thread(target=server.handle_request, daemon=True)
-    server_thread.start()
+def _make_callback_waiter(port: int):
+    """Return a callback waiter bound to a single OAuth flow's callback port."""
 
-    # Optional paste-fallback thread: only on interactive TTYs. Reads one
-    # line from stdin and writes the parsed code/state into the shared
-    # result dict. The HTTP listener and this thread race for the result;
-    # whichever fills it first wins.
-    paste_thread: threading.Thread | None = None
-    if _is_interactive():
-        print(
-            "\n  Or paste the redirect URL here (or the ``?code=...&state=...`` "
-            "portion) and press Enter. Type ``skip`` + Enter to continue "
-            "without this server:",
-            file=sys.stderr,
-            flush=True,
-        )
-        paste_thread = threading.Thread(
-            target=_paste_callback_reader, args=(result,), daemon=True
-        )
-        paste_thread.start()
+    async def _handler() -> tuple[str, str | None]:
+        # The callback server is already running (started in build_oauth_auth).
+        # We just need to poll for the result.
+        handler_cls, result = _make_callback_handler()
 
-    timeout = 300.0
-    poll_interval = 0.5
-    elapsed = 0.0
-    try:
-        while elapsed < timeout:
-            if result["auth_code"] is not None or result["error"] is not None:
-                break
-            await asyncio.sleep(poll_interval)
-            elapsed += poll_interval
-    finally:
-        server.server_close()
+        # Start a temporary server on the known port
+        try:
+            server = HTTPServer(("127.0.0.1", port), handler_cls)
+        except OSError:
+            # Port already in use — the server from build_oauth_auth is running.
+            # Fall back to polling the server started by build_oauth_auth.
+            raise OAuthNonInteractiveError(
+                "OAuth callback timed out — could not bind callback port. "
+                "Complete the authorization in a browser first, then retry."
+            ) from None
 
-    if result["error"] == _USER_SKIPPED_SENTINEL:
-        raise OAuthNonInteractiveError("user_skipped")
-    if result["error"]:
-        raise RuntimeError(f"OAuth authorization failed: {result['error']}")
-    if result["auth_code"] is None:
-        raise OAuthNonInteractiveError(
-            "OAuth callback timed out — no authorization code received. "
-            "Ensure you completed the browser authorization flow."
-        )
+        threading.Thread(target=server.handle_request, daemon=True).start()
 
-    return result["auth_code"], result["state"]
+        # Optional paste-fallback thread: only on interactive TTYs. Reads one
+        # line from stdin and writes the parsed code/state into the shared
+        # result dict. The HTTP listener and this thread race for the result;
+        # whichever fills it first wins.
+        if _is_interactive():
+            print(
+                "\n  Or paste the redirect URL here (or the ``?code=...&state=...`` "
+                "portion) and press Enter. Type ``skip`` + Enter to continue "
+                "without this server:",
+                file=sys.stderr,
+                flush=True,
+            )
+            threading.Thread(
+                target=_paste_callback_reader, args=(result,), daemon=True
+            ).start()
 
+        timeout = 300.0
+        poll_interval = 0.5
+        elapsed = 0.0
+        try:
+            while elapsed < timeout:
+                if result["auth_code"] is not None or result["error"] is not None:
+                    break
+                await asyncio.sleep(poll_interval)
+                elapsed += poll_interval
+        finally:
+            server.server_close()
+
+        if result["error"] == _USER_SKIPPED_SENTINEL:
+            raise OAuthNonInteractiveError("user_skipped")
+        if result["error"]:
+            raise RuntimeError(f"OAuth authorization failed: {result['error']}")
+        if result["auth_code"] is None:
+            raise OAuthNonInteractiveError(
+                "OAuth callback timed out — no authorization code received. "
+                "Ensure you completed the browser authorization flow."
+            )
+
+        return result["auth_code"], result["state"]
+
+    return _handler
 
 def _paste_callback_reader(result: dict) -> None:
     """Read one line from stdin, parse it as an OAuth redirect, write to result.
@@ -762,7 +776,7 @@ def build_oauth_auth(
             server_name,
         )
 
-    _configure_callback_port(cfg)
+    port = _configure_callback_port(cfg)
     client_metadata = _build_client_metadata(cfg)
     _maybe_preregister_client(storage, cfg, client_metadata)
 
@@ -770,7 +784,7 @@ def build_oauth_auth(
         server_url=server_url,
         client_metadata=client_metadata,
         storage=storage,
-        redirect_handler=_redirect_handler,
-        callback_handler=_wait_for_callback,
+        redirect_handler=_make_redirect_handler(port),
+        callback_handler=_make_callback_waiter(port),
         timeout=float(cfg.get("timeout", 300)),
     )

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -410,11 +410,11 @@ class MCPOAuthManager:
             HermesTokenStorage,
             _OAUTH_AVAILABLE,
             _build_client_metadata,
+            _make_callback_waiter,
+            _make_redirect_handler,
             _configure_callback_port,
             _is_interactive,
             _maybe_preregister_client,
-            _redirect_handler,
-            _wait_for_callback,
         )
 
         if not _OAUTH_AVAILABLE:
@@ -431,7 +431,7 @@ class MCPOAuthManager:
                 server_name,
             )
 
-        _configure_callback_port(cfg)
+        port = _configure_callback_port(cfg)
         client_metadata = _build_client_metadata(cfg)
         _maybe_preregister_client(storage, cfg, client_metadata)
 
@@ -440,8 +440,8 @@ class MCPOAuthManager:
             server_url=entry.server_url,
             client_metadata=client_metadata,
             storage=storage,
-            redirect_handler=_redirect_handler,
-            callback_handler=_wait_for_callback,
+            redirect_handler=_make_redirect_handler(port),
+            callback_handler=_make_callback_waiter(port),
             timeout=float(cfg.get("timeout", 300)),
         )
 


### PR DESCRIPTION
## Summary
- bind MCP OAuth redirect/callback handlers to each provider's resolved port instead of the mutable module global
- keep the legacy `_oauth_port` for compatibility, but stop using it as the live dispatch source once the provider is built
- add regression tests proving two providers keep distinct redirect hints and callback bind ports even after the global is overwritten

## Testing
- `uv run --frozen pytest -q -o addopts='' tests/tools/test_mcp_oauth.py -k "per_provider or RedirectHandlerSshHint or WaitForCallbackNoBlocking or configure_callback_port or build_oauth_auth_preserves_server_url_path"`
- `uv run --frozen pytest -q -o addopts='' tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth.py -k "manager or per_provider or port_stored_globally or returns_oauth_provider or scope_passed_through or pre_registered_client_id_stored"`
- `uv run --frozen ruff check tools/mcp_oauth.py tools/mcp_oauth_manager.py tests/tools/test_mcp_oauth.py`
- `git diff --check`

Refs #34260