### PR TITLE
fix(discord): read bot token from Hermes env

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -212,20 +212,32 @@ that requires raw IDs).  Discord is excluded because mentions use ``<@user_id>``
 and the LLM needs the real ID to tag users."""
 
 
+def _discord_token_available() -> bool:
+    """Return True when the Discord bot token is available to tool checks."""
+    if (os.environ.get("DISCORD_BOT_TOKEN") or "").strip():
+        return True
+    try:
+        from hermes_cli.config import get_env_value
+
+        return bool((get_env_value("DISCORD_BOT_TOKEN") or "").strip())
+    except Exception:
+        return False
+
+
 def _discord_tools_loaded() -> bool:
     """True iff the agent will actually have Discord tools this session.
 
     Two conditions must hold:
       1. The `discord` or `discord_admin` toolset is enabled for the
          Discord platform via `hermes tools` (opt-in, default OFF).
-      2. `DISCORD_BOT_TOKEN` is set — the tool's `check_fn` gates on it
-         at registry time, so the toolset being enabled in config is not
-         enough if the token isn't configured.
+      2. `DISCORD_BOT_TOKEN` is configured in process env or Hermes .env —
+         the tool's `check_fn` gates on it, so the toolset being enabled
+         in config is not enough if the token isn't configured.
 
     Returns False (safe default — keeps the stale-API disclaimer) on any
     error so a bad config can't silently promise tools the agent lacks.
     """
-    if not (os.environ.get("DISCORD_BOT_TOKEN") or "").strip():
+    if not _discord_token_available():
         return False
     try:
         from hermes_cli.config import load_config

--- a/tests/tools/test_discord_tool_env.py
+++ b/tests/tools/test_discord_tool_env.py
@@ -1,0 +1,36 @@
+"""Discord tool token resolution tests."""
+
+from hermes_cli.config import get_config_path, get_env_path, invalidate_env_cache
+
+
+def _write_discord_env(token: str = "discord-file-token") -> None:
+    get_env_path().write_text(f"DISCORD_BOT_TOKEN={token}\n", encoding="utf-8")
+    invalidate_env_cache()
+
+
+def test_discord_tool_check_reads_hermes_env(monkeypatch):
+    """The Discord REST tool should honor tokens stored in Hermes .env."""
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    _write_discord_env()
+
+    from tools.discord_tool import _get_bot_token, check_discord_tool_requirements
+
+    assert _get_bot_token() == "discord-file-token"
+    assert check_discord_tool_requirements() is True
+
+
+def test_discord_session_context_detects_hermes_env_token(monkeypatch):
+    """Discord gateway context should not hide tools when token lives in .env."""
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    _write_discord_env()
+    get_config_path().write_text(
+        "platform_toolsets:\n"
+        "  discord:\n"
+        "  - discord\n",
+        encoding="utf-8",
+    )
+
+    from gateway.session import _discord_token_available, _discord_tools_loaded
+
+    assert _discord_token_available() is True
+    assert _discord_tools_loaded() is True

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -51,8 +51,17 @@ _FLAG_GATEWAY_MESSAGE_CONTENT_LIMITED = 1 << 19
 # ---------------------------------------------------------------------------
 
 def _get_bot_token() -> Optional[str]:
-    """Resolve the Discord bot token from environment."""
-    return os.getenv("DISCORD_BOT_TOKEN", "").strip() or None
+    """Resolve the Discord bot token from process env or Hermes .env."""
+    token = os.getenv("DISCORD_BOT_TOKEN", "").strip()
+    if token:
+        return token
+    try:
+        from hermes_cli.config import get_env_value
+
+        token = (get_env_value("DISCORD_BOT_TOKEN") or "").strip()
+        return token or None
+    except Exception:
+        return None
 
 
 def _discord_request(


### PR DESCRIPTION
## What does this PR do?

Fixes Discord REST tool visibility when `DISCORD_BOT_TOKEN` is configured in Hermes' `.env` file but not exported into the process environment.

The Discord gateway setup writes the token to Hermes `.env`, but the Discord tool requirement checks and gateway session context were only looking at `os.environ`. That meant users could have a correctly configured Discord gateway while `discord` / `discord_admin` tools were silently filtered out of the agent schema.

This PR makes the Discord token resolution path check process env first, then fall back to Hermes `.env` via `get_env_value()`.

## Related Issue

Fixes #30565

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/discord_tool.py`
  - Resolve `DISCORD_BOT_TOKEN` from process env first, then Hermes `.env`.
- `gateway/session.py`
  - Add a shared Discord token availability helper for gateway context checks.
  - Keep the safe fallback behavior if config/env lookup fails.
- `tests/tools/test_discord_tool_env.py`
  - Cover Discord tool requirement checks when the token exists only in Hermes `.env`.
  - Cover gateway/session Discord tool visibility when the token exists only in Hermes `.env`.

## How to Test

1. Put `DISCORD_BOT_TOKEN` in Hermes `.env`.
2. Ensure it is not exported into the shell/process environment.
3. Enable the Discord toolset for a Discord gateway session.
4. Start the gateway and verify the Discord tools are available instead of silently hidden.

Local validation run:

```bash
python -m pytest tests/tools/test_discord_tool_env.py tests/tools/test_discord_tool.py -q -o 'addopts='
# 92 passed, 1 warning
```

I searched for existing PRs/issues related to `DISCORD_BOT_TOKEN`, `discord_tool`, and hidden Discord tools. I found #30565 but no open equivalent PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Python 3.14.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. Regression coverage is in `tests/tools/test_discord_tool_env.py`.
