### PR TITLE
fix(cli): keep context meter live without usage

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -860,6 +860,25 @@ def run_conversation(
             api_messages, tools=agent.tools or None
         )
 
+        # Keep the live TUI context meter meaningful even when a provider does
+        # not return usage.  The exact provider usage below will overwrite this
+        # after successful responses.  This is intentionally NOT applied to
+        # session token/cost counters; it is only a request-size estimate for
+        # context occupancy.  The Codex Responses SDK recovery path can return
+        # a synthesized response with usage=None after response.completed has
+        # output=null, which otherwise leaves the status bar stuck at 0/N.
+        _compressor = getattr(agent, "context_compressor", None)
+        if _compressor is not None:
+            try:
+                _estimated_prompt_tokens = max(0, int(approx_request_tokens or 0))
+                _current_prompt_tokens = max(
+                    0, int(getattr(_compressor, "last_prompt_tokens", 0) or 0)
+                )
+                if _estimated_prompt_tokens > _current_prompt_tokens:
+                    _compressor.last_prompt_tokens = _estimated_prompt_tokens
+            except Exception:
+                pass
+
         _runtime_context_error = _ollama_context_limit_error(
             agent, approx_request_tokens
         )

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -702,6 +702,34 @@ def test_run_conversation_codex_plain_text(monkeypatch):
     assert result["messages"][-1]["content"] == "OK"
 
 
+def test_run_conversation_codex_without_usage_keeps_context_meter(monkeypatch):
+    """Recovered Codex streams can lack usage; keep TUI context estimated."""
+    agent = _build_agent(monkeypatch)
+
+    def _response_without_usage(api_kwargs):
+        return SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    content=[SimpleNamespace(type="output_text", text="OK")],
+                )
+            ],
+            status="completed",
+            model="gpt-5-codex",
+        )
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _response_without_usage)
+
+    result = agent.run_conversation("Say OK")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "OK"
+    compressor = getattr(agent, "context_compressor")
+    assert compressor.last_prompt_tokens > 0
+    assert agent.session_prompt_tokens == 0
+    assert agent.session_total_tokens == 0
+
+
 def test_run_conversation_codex_empty_output_with_output_text(monkeypatch):
     """Regression: empty response.output + valid output_text should succeed,
     not trigger retry/fallback. The validation stage must defer to


### PR DESCRIPTION
## What does this PR do?

Keeps the classic CLI/TUI context meter meaningful when a provider returns a successful response without usage metadata.

Hermes already estimates the outgoing request size before making the provider call. This PR stores that estimate on `context_compressor.last_prompt_tokens` before the API request so the status bar can show current context occupancy even if the provider response later has `usage=None`.

Real provider usage still wins when present, and this estimate is intentionally not added to session token/cost counters.

## Related Issue

No linked issue. This fixes a local dogfood regression where OpenAI Codex Responses recovery could return a synthesized successful response without usage, leaving the CLI context meter stuck at `0/<ctx>` after successful turns.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_loop.py`
  - Writes the rough request-token estimate to `context_compressor.last_prompt_tokens` before provider invocation.
  - Leaves session token/cost counters unchanged when provider usage is absent.
- `tests/run_agent/test_run_agent_codex_responses.py`
  - Adds a Codex no-usage regression covering a successful response with no usage metadata.
  - Asserts the context meter estimate updates while session token counters remain zero.

## How to Test

1. Use a provider path that can return a successful response with `usage=None`.
2. Send a successful prompt.
3. Confirm the CLI context meter no longer remains at `0/<ctx>` solely because usage metadata is missing.

Local validation run:

```bash
python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='
# 69 passed, 1 warning
```

I searched existing PRs/issues for `context meter`, `last_prompt_tokens`, `usage=None`, and Codex Responses recovery. Open PR #34096 touches context-meter concepts for Cursor provider work, and draft PR #26051 touches broader context/compression behavior, but neither fixes this no-usage Codex response path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Python 3.14.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. Regression coverage is in `tests/run_agent/test_run_agent_codex_responses.py`.
