### PR TITLE
fix(anthropic): catch JSONDecodeError in credential write

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1072,7 +1072,7 @@ def _write_claude_code_credentials(
             except OSError:
                 pass
             raise
-    except (OSError, IOError) as e:
+    except (OSError, IOError, json.JSONDecodeError) as e:
         logger.debug("Failed to write refreshed credentials: %s", e)
 
 


### PR DESCRIPTION
## Problem

`_write_claude_code_credentials()` reads `~/.claude/.credentials.json` with `json.loads()` inside a `try` block that only catches `(OSError, IOError)`. If the credentials file is corrupted (invalid JSON), `json.JSONDecodeError` (a `ValueError` subclass) escapes this handler and propagates to the caller `_refresh_oauth_token`, which logs a generic "Failed to refresh" message instead of the specific credential-corruption issue.

## Fix

Add `json.JSONDecodeError` to the except clause so corrupted credential files are handled gracefully with a debug log message, matching the error handling pattern used elsewhere in the codebase.

## Risk
Minimal — only adds an exception handler for a case that previously crashed with an unhandled traceback.