### PR TITLE
docs: fix ./hermes launch instructions in Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Quick start for contributors — clone and go with `setup-hermes.sh`:
 git clone https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
 ./setup-hermes.sh     # installs uv, creates venv, installs .[all], symlinks ~/.local/bin/hermes
-./hermes              # auto-detects the venv, no need to `source` first
+hermes                # use the symlinked command — or: source venv/bin/activate && ./hermes
 ```
 
 Manual path (equivalent to the above):


### PR DESCRIPTION
## What does this PR do?

The Contributing quick-start in README.md states that `./hermes` auto-detects the venv and can be run without `source`-ing first. This is incorrect — the script uses `#!/usr/bin/env python3`, which resolves to the system Python rather than the project venv, causing a `ModuleNotFoundError` on a fresh clone.

The correct entry point for contributors is the symlinked `hermes` command (created by `setup-hermes.sh`), which points at `venv/bin/hermes` and uses the venv Python via its shebang. This PR corrects the snippet to reflect that.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `README.md`: replace `./hermes  # auto-detects the venv, no need to source first` with `hermes  # use the symlinked command — or: source venv/bin/activate && ./hermes`

## How to Test

1. Clone the repo and run `./setup-hermes.sh`
2. Without activating the venv, run `./hermes` — observe the `ModuleNotFoundError` (reproduces the bug the old docs implied didn't exist)
3. Run `hermes` (the symlinked command) — works correctly
4. Run `source venv/bin/activate && ./hermes` — works correctly

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — or N/A (docs-only change)
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

**Before (fails without venv activated):**
```
$ ./hermes
Traceback (most recent call last):
  ...
ModuleNotFoundError: No module named 'yaml'
```

**After (use symlink or activate first):**
```
$ hermes --help        # symlink — always works
$ source venv/bin/activate && ./hermes --help   # explicit venv
```