### PR TITLE
fix: parse openai-codex slash model switches

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1521,6 +1521,16 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
     provider from the input or *current_provider* if none was specified.
     """
     stripped = raw.strip()
+
+    # Provider-qualified input normally uses ``provider:model``.  A common
+    # human mistake is ``openai-codex/gpt-5.5`` because OpenRouter-style model
+    # slugs also use slashes.  Treat only the Codex OAuth provider this way:
+    # broad ``provider/model`` parsing would break legitimate aggregator slugs
+    # such as ``anthropic/claude-sonnet-4.5`` on OpenRouter.
+    codex_prefix = "openai-codex/"
+    if stripped.lower().startswith(codex_prefix) and len(stripped) > len(codex_prefix):
+        return ("openai-codex", stripped[len(codex_prefix):].strip())
+
     colon = stripped.find(":")
     if colon > 0:
         provider_part = stripped[:colon].strip().lower()

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -75,6 +75,23 @@ class TestParseModelInput:
         assert provider == "openrouter"
         assert model == "gpt-5.4"
 
+    def test_openai_codex_slash_provider_model_switches_provider(self):
+        """Human-friendly openai-codex/model should not stay on the current provider."""
+        provider, model = parse_model_input("openai-codex/gpt-5.5", "claude-api-proxy")
+        assert provider == "openai-codex"
+        assert model == "gpt-5.5"
+
+    def test_openai_codex_empty_slash_keeps_current_provider(self):
+        provider, model = parse_model_input("openai-codex/", "claude-api-proxy")
+        assert provider == "claude-api-proxy"
+        assert model == "openai-codex/"
+
+    def test_anthropic_slash_slug_still_keeps_current_provider(self):
+        """Do not globally treat provider/model as provider syntax; OpenRouter needs slugs."""
+        provider, model = parse_model_input("anthropic/claude-sonnet-4.5", "openrouter")
+        assert provider == "openrouter"
+        assert model == "anthropic/claude-sonnet-4.5"
+
     def test_nous_provider_switch(self):
         provider, model = parse_model_input("nous:hermes-3", "openrouter")
         assert provider == "nous"


### PR DESCRIPTION
Slash model switches of the form `openai-codex/gpt-5.5` were not parsed correctly in model validation. This adds handling so codex-style provider/model slash switches resolve properly. Includes regression tests in test_model_validation.py.