### PR TITLE
fix(delegation): allow explicit code_execution + honor explicit toolsets

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -158,8 +158,16 @@ class TestChildSystemPrompt(unittest.TestCase):
 
 class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):
+        # delegation/clarify/memory remain blocked by default; code_execution
+        # is now allowed (it pairs naturally with `terminal`, which subagents
+        # already inherit — blocking only `code_execution` was asymmetric).
         result = _strip_blocked_tools(["terminal", "file", "delegation", "clarify", "memory", "code_execution"])
-        self.assertEqual(sorted(result), ["file", "terminal"])
+        self.assertEqual(sorted(result), ["code_execution", "file", "terminal"])
+
+    def test_code_execution_no_longer_blocked(self):
+        """Regression: code_execution must survive the default block strip."""
+        result = _strip_blocked_tools(["code_execution"])
+        self.assertEqual(result, ["code_execution"])
 
     def test_preserves_allowed_toolsets(self):
         result = _strip_blocked_tools(["terminal", "file", "web", "browser"])
@@ -1058,8 +1066,9 @@ class TestSubagentCostRollup(unittest.TestCase):
 
 class TestBlockedTools(unittest.TestCase):
     def test_blocked_tools_constant(self):
-        for tool in ["delegate_task", "clarify", "memory", "send_message", "execute_code"]:
+        for tool in ["delegate_task", "clarify", "memory", "send_message"]:
             self.assertIn(tool, DELEGATE_BLOCKED_TOOLS)
+        self.assertNotIn("execute_code", DELEGATE_BLOCKED_TOOLS)
 
     def test_constants(self):
         from tools.delegate_tool import (

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -169,6 +169,59 @@ class TestStripBlockedTools(unittest.TestCase):
         result = _strip_blocked_tools(["code_execution"])
         self.assertEqual(result, ["code_execution"])
 
+    def test_explicit_request_cannot_obtain_delegation(self):
+        """Explicit toolsets must NOT bypass the recursion gate.
+
+        Caught by @liuhao1024 on #34294: removing the strip from the
+        explicit-request branch unblocked delegation/clarify/memory as well
+        as code_execution. `delegation` is granted by ROLE (the orchestrator
+        re-add), not by request -- granting it per-request lets a subagent
+        spawn subagents recursively.
+        """
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = [
+            "terminal", "file", "web",
+            "delegation", "clarify", "memory", "code_execution",
+        ]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="explicitly ask for everything",
+                context=None,
+                toolsets=[
+                    "terminal", "delegation", "clarify",
+                    "memory", "code_execution",
+                ],
+                model=None,
+                max_iterations=5,
+                parent_agent=parent,
+                task_count=1,
+            )
+            kwargs = MockAgent.call_args.kwargs
+
+        child = kwargs.get("enabled_toolsets") or kwargs.get("toolsets") or []
+        # This PR's stated goal: explicit code_execution is honored.
+        self.assertIn("code_execution", child)
+        self.assertIn("terminal", child)
+        # The safety gate holds regardless of what the caller asked for.
+        for blocked in ("delegation", "clarify", "memory"):
+            self.assertNotIn(
+                blocked, child,
+                f"{blocked} must not be grantable by explicit request",
+            )
+
+    def test_strip_keeps_code_execution_but_drops_safety_toolsets(self):
+        """The strip set change is scoped to code_execution only."""
+        result = _strip_blocked_tools(
+            ["terminal", "file", "delegation", "clarify",
+             "memory", "code_execution"]
+        )
+        self.assertEqual(
+            sorted(result), ["code_execution", "file", "terminal"]
+        )
+
     def test_preserves_allowed_toolsets(self):
         result = _strip_blocked_tools(["terminal", "file", "web", "browser"])
         self.assertEqual(sorted(result), ["browser", "file", "terminal", "web"])

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -48,7 +48,6 @@ DELEGATE_BLOCKED_TOOLS = frozenset(
         "clarify",  # no user interaction
         "memory",  # no writes to shared MEMORY.md
         "send_message",  # no cross-platform side effects
-        "execute_code",  # children should reason step-by-step, not write scripts
         "cronjob",  # no scheduling more work in the parent's name
     ]
 )
@@ -764,16 +763,22 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
 
 
 def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
-    """Remove toolsets that contain only blocked tools.
+    """Remove toolsets that are blocked from default subagent inheritance.
 
-    The strip set is derived from DELEGATE_BLOCKED_TOOLS plus the explicit
-    composite/scenario toolsets (delegation, code_execution) that have no
-    one-to-one tool. This keeps the blocklist and the strip set in lockstep
-    so new blocked tools can't silently leak through as toolset names.
+    Applied only when toolsets are *inherited* from the parent or fall back
+    to DEFAULT_TOOLSETS — *explicit* caller requests at the
+    ``delegate_task()`` call site bypass this strip (see the explicit-
+    request branch around line ~945).  Rationale: silent deletion of
+    explicitly requested toolsets is a footgun; user intent wins.
+
+    ``code_execution`` is intentionally NOT in this set: subagents already
+    receive ``terminal`` (a strictly larger capability), so blocking
+    ``execute_code`` is asymmetric and prevents legitimate use cases like
+    "compute SHA256 + sum of primes" from working at all.
     """
     # Composite toolsets that should never pass through to children, even
     # though their individual tools aren't all in DELEGATE_BLOCKED_TOOLS.
-    _COMPOSITE_BLOCKED_TOOLSETS = frozenset({"delegation", "code_execution"})
+    _COMPOSITE_BLOCKED_TOOLSETS = frozenset({"delegation"})
     blocked_toolset_names = {
         name
         for name, defn in TOOLSETS.items()
@@ -1128,7 +1133,9 @@ def _build_child_agent(
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
             )
-        child_toolsets = _strip_blocked_tools(child_toolsets)
+        # Explicit caller requests bypass the default block list (memory,
+        # clarify, delegation): user intent wins over implicit safety
+        # defaults.  See _strip_blocked_tools() docstring for rationale.
     elif parent_agent and parent_enabled is not None:
         child_toolsets = _strip_blocked_tools(parent_enabled)
     elif parent_toolsets:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -763,18 +763,21 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
 
 
 def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
-    """Remove toolsets that are blocked from default subagent inheritance.
+    """Remove toolsets that must never reach a subagent.
 
-    Applied only when toolsets are *inherited* from the parent or fall back
-    to DEFAULT_TOOLSETS — *explicit* caller requests at the
-    ``delegate_task()`` call site bypass this strip (see the explicit-
-    request branch around line ~945).  Rationale: silent deletion of
-    explicitly requested toolsets is a footgun; user intent wins.
+    Applied on EVERY path — inherited from the parent, fallen back to
+    DEFAULT_TOOLSETS, *and* explicitly requested at the ``delegate_task()``
+    call site. ``delegation`` is granted by ROLE (the orchestrator re-add in
+    ``_build_child_agent``), never by request: allowing a caller to request it
+    would let a subagent spawn subagents recursively, defeating the gate.
+    ``clarify`` and ``memory`` are likewise parent-only surfaces.
 
     ``code_execution`` is intentionally NOT in this set: subagents already
     receive ``terminal`` (a strictly larger capability), so blocking
     ``execute_code`` is asymmetric and prevents legitimate use cases like
-    "compute SHA256 + sum of primes" from working at all.
+    "compute SHA256 + sum of primes" from working at all. Removing it from
+    the strip set is what lets an explicit request obtain it, without
+    unblocking the three safety-critical toolsets alongside it.
     """
     # Composite toolsets that should never pass through to children, even
     # though their individual tools aren't all in DELEGATE_BLOCKED_TOOLS.
@@ -1133,9 +1136,15 @@ def _build_child_agent(
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
             )
-        # Explicit caller requests bypass the default block list (memory,
-        # clarify, delegation): user intent wins over implicit safety
-        # defaults.  See _strip_blocked_tools() docstring for rationale.
+        # Explicit caller requests still lose the safety-critical toolsets.
+        # `code_execution` is no longer in the strip set (see
+        # _strip_blocked_tools), so an explicit request now gets it — which is
+        # this PR's stated goal. `delegation`/`clarify`/`memory` must NOT ride
+        # along: `delegation` in particular is gated by ROLE, not by request
+        # (see the orchestrator re-add below), and granting it per-request lets
+        # a subagent spawn subagents that spawn subagents. Caught by
+        # @liuhao1024 on #34294.
+        child_toolsets = _strip_blocked_tools(child_toolsets)
     elif parent_agent and parent_enabled is not None:
         child_toolsets = _strip_blocked_tools(parent_enabled)
     elif parent_toolsets:


### PR DESCRIPTION
Delegated tasks stripped `code_execution` and did not honor explicitly-requested toolsets. `_strip_blocked_tools` now keeps `code_execution` when explicitly requested and explicit toolsets are honored. Includes test_delegate.py coverage.