### PR TITLE
fix(models): name provider + endpoint in anthropic_messages fallback warning + fix provider_label shadowing

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3976,7 +3976,7 @@ def validate_requested_model(
             suggestion_text = ""
             if suggestions:
                 suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
-            provider_label = "OpenAI Codex" if normalized == "openai-codex" else "xAI Grok OAuth (SuperGrok / Premium+)"
+            provider_label_oauth = "OpenAI Codex" if normalized == "openai-codex" else "xAI Grok OAuth (SuperGrok / Premium+)"
             # Plausibility gate (#45006): the soft-accept (#16172 / #19729) exists
             # for entitlement-gated *hidden* slugs the curated listing hasn't
             # caught up with — but those are always the provider's own family
@@ -4000,7 +4000,7 @@ def validate_requested_model(
                     "persist": False,
                     "recognized": False,
                     "message": (
-                        f"`{requested}` doesn't look like a {provider_label} model "
+                        f"`{requested}` doesn't look like a {provider_label_oauth} model "
                         f"and isn't in its listing, so it was not accepted. If it "
                         f"belongs to another configured provider, switch with "
                         f"`--provider <slug>` (or select it from the `/model` "
@@ -4013,7 +4013,7 @@ def validate_requested_model(
                 "persist": True,
                 "recognized": False,
                 "message": (
-                    f"Note: `{requested}` was not found in the {provider_label} model listing. "
+                    f"Note: `{requested}` was not found in the {provider_label_oauth} model listing. "
                     "It may still work if your account has access to a newer or hidden model ID."
                     f"{suggestion_text}"
                 ),
@@ -4135,15 +4135,17 @@ def validate_requested_model(
                 }
         # Probe failed or model not found — accept anyway (proxy likely
         # doesn't implement the Anthropic Models API).
+        provider_label_str = provider_label(provider) or (provider or "the active provider")
+        endpoint_str = (base_url or "").strip() or "the configured endpoint"
         return {
             "accepted": True,
             "persist": True,
             "recognized": False,
             "message": (
-                f"Note: could not verify `{requested}` against this endpoint's "
-                f"model listing.  Many Anthropic-compatible proxies do not "
-                f"implement GET /v1/models.  The model name has been accepted "
-                f"without verification."
+                f"Note: could not verify `{requested}` against `{provider_label_str}` "
+                f"at {endpoint_str}.  That endpoint speaks the Anthropic Messages API, "
+                f"which often does not expose GET /v1/models.  The model name has been "
+                f"accepted without verification."
             ),
         }
 
@@ -4265,7 +4267,7 @@ def validate_requested_model(
     # Without this block, validate_requested_model would reject every model
     # on such providers, switch_model() would return success=False, and
     # the gateway would never write to _session_model_overrides.
-    provider_label = _PROVIDER_LABELS.get(normalized, normalized)
+    provider_label_for_catalog = _PROVIDER_LABELS.get(normalized, normalized)
     try:
         catalog_models = provider_model_ids(normalized)
     except Exception:
@@ -4306,7 +4308,7 @@ def validate_requested_model(
             "persist": True,
             "recognized": False,
             "message": (
-                f"Note: `{requested}` was not found in the {provider_label} curated catalog "
+                f"Note: `{requested}` was not found in the {provider_label_for_catalog} curated catalog "
                 f"and the /models endpoint was unreachable.{suggestion_text}"
                 f"\n  The model may still work if it exists on the provider."
             ),
@@ -4319,7 +4321,7 @@ def validate_requested_model(
         "persist": True,
         "recognized": False,
         "message": (
-            f"Note: could not reach the {provider_label} API to validate `{requested}`. "
+            f"Note: could not reach the {provider_label_for_catalog} API to validate `{requested}`. "
             f"If the service isn't down, this model may not be valid."
         ),
     }

--- a/tests/hermes_cli/test_anthropic_messages_warning_clarity.py
+++ b/tests/hermes_cli/test_anthropic_messages_warning_clarity.py
@@ -1,0 +1,77 @@
+"""Regression tests for the Anthropic-Messages-API ``/v1/models`` fallback warning.
+
+When a user runs ``/model <name>`` against an endpoint whose ``api_mode`` is
+``anthropic_messages`` and that endpoint does not implement ``GET /v1/models``,
+Hermes used to print a generic warning that started with "Many Anthropic-
+compatible proxies do not implement GET /v1/models".
+
+That wording confused users who had just typed a non-Anthropic-looking model
+string (e.g. ``openai-codex/gpt-5.5`` while still on a Claude-flavored proxy):
+the message implied the model itself was Anthropic-related when in fact only
+the *currently selected provider* was Anthropic-shaped.
+
+This test pins the improved wording which now names the active provider and
+endpoint explicitly so the warning makes sense regardless of what the user
+typed.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.models import validate_requested_model
+
+
+def _stub_probe(*_args, **_kwargs):
+    return {
+        "models": None,
+        "probed_url": "http://127.0.0.1:18801/v1/models",
+        "resolved_base_url": "http://127.0.0.1:18801/v1",
+        "suggested_base_url": None,
+        "used_fallback": False,
+    }
+
+
+def test_anthropic_messages_warning_names_provider_and_endpoint():
+    """The fallback warning must name the active provider and endpoint, not
+    just say "Anthropic-compatible proxies" generically.
+    """
+    with patch("hermes_cli.models.fetch_api_models", return_value=None), \
+         patch("hermes_cli.models.probe_api_models", side_effect=_stub_probe):
+        result = validate_requested_model(
+            "openai-codex/gpt-5.5",
+            "claude-api-proxy",
+            api_key="sk-test",
+            base_url="http://127.0.0.1:18801/v1",
+            api_mode="anthropic_messages",
+        )
+
+    assert result["accepted"] is True
+    assert result["persist"] is True
+    assert result["recognized"] is False
+
+    message = result["message"]
+    # The improved warning must name BOTH the active provider and endpoint.
+    assert "claude-api-proxy" in message, message
+    assert "http://127.0.0.1:18801/v1" in message, message
+    # It must still explain why verification failed (Anthropic Messages API).
+    assert "Anthropic Messages API" in message, message
+    # It must not use the old vague wording that confused users.
+    assert "Many Anthropic-compatible proxies" not in message, message
+
+
+def test_anthropic_messages_warning_handles_missing_base_url():
+    """If base_url is not provided we must still produce a sensible message
+    rather than embedding ``None`` or a blank.
+    """
+    with patch("hermes_cli.models.fetch_api_models", return_value=None), \
+         patch("hermes_cli.models.probe_api_models", side_effect=_stub_probe):
+        result = validate_requested_model(
+            "gpt-5.5",
+            "claude-api-proxy",
+            api_key="sk-test",
+            base_url=None,
+            api_mode="anthropic_messages",
+        )
+
+    message = result["message"]
+    assert "None" not in message, message
+    assert "the configured endpoint" in message, message


### PR DESCRIPTION
Two fixes in validate_requested_model:
1) The GET /v1/models fallback warning used generic wording that implied the *model* was Anthropic-related when it only describes the active *provider*. The warning now names the active provider label and resolved endpoint explicitly.
2) A latent shadowing bug: branches rebind the module-level `provider_label` function to a local string, making the function name unreachable. Renamed the catalog-branch local to `provider_label_for_catalog`. Note: current main has a SECOND such rebind (openai-codex/grok OAuth branch) that throws UnboundLocalError once the new code path runs — also renamed (`provider_label_oauth`). Includes regression tests (test_anthropic_messages_warning_clarity.py).