### PR TITLE
feat(caching): add per-provider cache_ttl override (#34080 item 1)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -483,6 +483,16 @@ def init_agent(
 
         _pc_cfg = _load_pc_cfg().get("prompt_caching", {}) or {}
         _ttl = _pc_cfg.get("cache_ttl", "5m")
+        # Per-provider override: prompt_caching.provider_overrides.<provider>.cache_ttl
+        # takes precedence over the global cache_ttl. Allows operators to set
+        # longer TTLs for specific providers (e.g. DeepSeek 1h vs Anthropic 5m).
+        _overrides = _pc_cfg.get("provider_overrides", {}) or {}
+        if isinstance(_overrides, dict) and agent.provider and agent.provider in _overrides:
+            _prov = _overrides[agent.provider]
+            if isinstance(_prov, dict):
+                _prov_ttl = _prov.get("cache_ttl")
+                if _prov_ttl in {"5m", "1h"}:
+                    _ttl = _prov_ttl
         if _ttl in {"5m", "1h"}:
             agent._cache_ttl = _ttl
     except Exception:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -948,8 +948,13 @@ DEFAULT_CONFIG = {
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
     # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
+    # provider_overrides: per-provider cache_ttl overrides. Each key is a
+    #   provider name (e.g. "anthropic", "openrouter"), each value is a
+    #   dict with an optional "cache_ttl" key. Provider entries override
+    #   the global cache_ttl for sessions using that provider.
     "prompt_caching": {
         "cache_ttl": "5m",
+        "provider_overrides": {},
     },
 
     # OpenRouter-specific settings.

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -857,6 +857,93 @@ class TestInit:
             )
             assert a._cache_ttl == "1h"
 
+    def test_prompt_caching_provider_override_wins(self):
+        """provider_overrides.<provider>.cache_ttl takes precedence over global."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "prompt_caching": {
+                        "cache_ttl": "5m",
+                        "provider_overrides": {
+                            "commandcode": {"cache_ttl": "1h"},
+                        },
+                    }
+                },
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                model="deepseek/deepseek-v4-pro",
+                provider="commandcode",
+                base_url="https://api.commandcode.ai/provider/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a._cache_ttl == "1h"
+
+    def test_prompt_caching_provider_no_override_falls_back(self):
+        """Provider without override falls back to global cache_ttl."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "prompt_caching": {
+                        "cache_ttl": "5m",
+                        "provider_overrides": {
+                            "otherprovider": {"cache_ttl": "1h"},
+                        },
+                    }
+                },
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                model="anthropic/claude-sonnet-4-20250514",
+                provider="anthropic",
+                base_url="https://api.anthropic.com",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a._cache_ttl == "5m"
+
+    def test_prompt_caching_invalid_provider_ttl_ignored(self):
+        """Invalid provider cache_ttl values are ignored, falls back to global."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={
+                    "prompt_caching": {
+                        "cache_ttl": "5m",
+                        "provider_overrides": {
+                            "commandcode": {"cache_ttl": "2h"},
+                        },
+                    }
+                },
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                model="deepseek/deepseek-v4-pro",
+                provider="commandcode",
+                base_url="https://api.commandcode.ai/provider/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a._cache_ttl == "5m"
+
     def test_model_max_tokens_from_config(self):
         """model.max_tokens config populates the chat-completions request cap."""
         with (


### PR DESCRIPTION
## Summary

- Adds `prompt_caching.provider_overrides` — per-provider cache_ttl configuration
- Agent init resolves provider-level `cache_ttl` after global, enabling provider-specific TTLs
- Only valid Anthropic tiers (`"5m"`, `"1h"`) are accepted; invalid values silently fall through to global default

## Motivation

Addresses item 1 of #34080 — per-provider configurable `cache_ttl`.

Different providers have different caching economics:
- **DeepSeek**: cache is dirt cheap but the default 5m TTL invalidates cache across conversation pauses, generating huge cache_read token counts (~84% of session tokens). A 1h TTL eliminates re-caching after brief pauses.
- **Anthropic native**: 1h writes cost 2× vs 1.25× for 5m. Short-session profiles want 5m; long-running sessions want 1h.
- **Custom endpoints** proxying Anthropic-compatible APIs may support either tier.

Without provider-level overrides, the global `cache_ttl` is a one-size-fits-all knob.

Closes #34080 (item 1 only)

## Changes

- Add `provider_overrides` dict (default `{}`) to `prompt_caching` config defaults
- Extend cache_ttl resolution in `agent/agent_init.py` to check `provider_overrides.<provider>.cache_ttl` after global TTL
- Add 3 new tests: override wins, no-override fallback, invalid override ignored

## Test Plan

- [x] Unit tests pass (`pytest tests/run_agent/test_run_agent.py::TestInit -k "cache_ttl"`)
- [x] Global cache_ttl still works unchanged
- [x] Provider override takes precedence when matching provider
- [x] Unknown providers fall back to global
- [x] Invalid TTL values ("2h") are silently ignored

Config example:
```yaml
prompt_caching:
  cache_ttl: "5m"
  provider_overrides:
    commandcode:
      cache_ttl: "1h"
    deepseek:
      cache_ttl: "1h"
```

## Notes for Reviewers

- Minimal change — 10 lines of logic in `agent_init.py`, default config entry, 3 tests
- Per-provider override structure matches the existing `custom_providers` and `provider_overrides` patterns already used elsewhere in the codebase
- Only `"cache_ttl"` is supported as an override key today; the dict structure leaves room for future per-provider prompt-caching options without a config migration
