### PR TITLE
fix(send_message): validate telegram media paths

### DIFF
--- a/tests/tools/test_send_message_tool_media_safety.py
+++ b/tests/tools/test_send_message_tool_media_safety.py
@@ -1,0 +1,60 @@
+import asyncio
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from tools.send_message_tool import _send_telegram
+
+
+def _install_fake_telegram(monkeypatch, bot):
+    telegram_mod = types.ModuleType("telegram")
+
+    class FakeBot:
+        def __init__(self, token, **_kwargs):
+            self._bot = bot
+
+        def __getattr__(self, name):
+            return getattr(self._bot, name)
+
+    telegram_mod.Bot = FakeBot
+
+    constants_mod = types.ModuleType("telegram.constants")
+    constants_mod.ParseMode = SimpleNamespace(HTML="HTML", MARKDOWN_V2="MarkdownV2")
+
+    monkeypatch.setitem(sys.modules, "telegram", telegram_mod)
+    monkeypatch.setitem(sys.modules, "telegram.constants", constants_mod)
+
+
+def test_send_telegram_skips_unsafe_media_path(monkeypatch, tmp_path):
+    test_file = tmp_path / "doc.txt"
+    test_file.write_text("secret")
+
+    bot = MagicMock()
+    bot.send_message = AsyncMock()
+    bot.send_photo = AsyncMock()
+    bot.send_video = AsyncMock()
+    bot.send_voice = AsyncMock()
+    bot.send_audio = AsyncMock()
+    bot.send_document = AsyncMock()
+    _install_fake_telegram(monkeypatch, bot)
+    monkeypatch.setattr(
+        "gateway.platforms.base.BasePlatformAdapter.validate_media_delivery_path",
+        lambda _path: None,
+    )
+
+    result = asyncio.run(
+        _send_telegram(
+            "token",
+            "12345",
+            "",
+            media_files=[(str(test_file), False)],
+        )
+    )
+
+    assert "error" in result
+    assert "No deliverable text or media remained" in result["error"]
+    assert result["warnings"] == [
+        f"Skipping unsafe media path outside allowed roots: {test_file}"
+    ]
+    bot.send_document.assert_not_awaited()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -949,10 +949,17 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 logger.warning(warning)
                 warnings.append(warning)
                 continue
+            from gateway.platforms.base import BasePlatformAdapter
+            safe_media_path = BasePlatformAdapter.validate_media_delivery_path(media_path)
+            if safe_media_path is None:
+                warning = f"Skipping unsafe media path outside allowed roots: {media_path}"
+                logger.warning(warning)
+                warnings.append(warning)
+                continue
 
-            ext = os.path.splitext(media_path)[1].lower()
+            ext = os.path.splitext(safe_media_path)[1].lower()
             try:
-                with open(media_path, "rb") as f:
+                with open(safe_media_path, "rb") as f:
                     media_kwargs = dict(thread_kwargs)
                     try:
                         if ext in _IMAGE_EXTS and not force_document:
@@ -1009,7 +1016,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                         else:
                             raise
             except Exception as e:
-                warning = _sanitize_error_text(f"Failed to send media {media_path}: {e}")
+                warning = _sanitize_error_text(f"Failed to send media {safe_media_path}: {e}")
                 logger.error(warning)
                 warnings.append(warning)
 


### PR DESCRIPTION
## What does this PR do?

Adds a standalone Telegram-side media path validation check to `send_message` so files outside `MEDIA_DELIVERY_SAFE_ROOTS` are skipped before they can be opened and uploaded.

## Why does it change?

`send_message` already filters `MEDIA:` tags on the main tool path, but `_send_telegram()` could still be called with raw `media_files` and only checked `os.path.exists()`. That left a gap where standalone Telegram sends could bypass `validate_media_delivery_path()` and upload files outside the gateway allowlist.

## Root cause

The gateway response delivery path validates media paths again at send time, but `tools/send_message_tool.py::_send_telegram()` did not. The standalone helper therefore trusted pre-filtered inputs and lacked a final safe-root check.

## User impact

- Unsafe Telegram media paths are now skipped with a warning instead of being uploaded.
- Safe paths continue to work, and canonical validated paths are what get opened.

## How was this tested?

- `uv run --frozen pytest -q -o addopts='' tests/tools/test_send_message_tool_media_safety.py`
- `uv run --frozen ruff check tools/send_message_tool.py tests/tools/test_send_message_tool_media_safety.py`
- `git diff --check`
