### PR TITLE
fix(memory/holographic): OR-fallback for multi-token FTS5 queries

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -18,6 +18,11 @@ try:
 except ImportError:
     import holographic as hrr  # type: ignore[no-redef]
 
+try:
+    from .store import _build_or_fallback, _is_explicit_fts5_query
+except ImportError:
+    from store import _build_or_fallback, _is_explicit_fts5_query  # type: ignore[no-redef]
+
 
 class FactRetriever:
     """Multi-strategy fact retrieval with trust-weighted scoring."""
@@ -522,6 +527,18 @@ class FactRetriever:
         except Exception:
             # FTS5 MATCH can fail on malformed queries — fall back to empty
             return []
+
+        # FTS5 simple tokenizer treats whitespace as AND and does no CJK
+        # segmentation, so multi-token Chinese queries from natural language
+        # almost always miss. Retry as OR when AND found nothing.
+        if not rows and not _is_explicit_fts5_query(query):
+            or_query = _build_or_fallback(query)
+            if or_query:
+                params[0] = or_query
+                try:
+                    rows = conn.execute(sql, params).fetchall()
+                except Exception:
+                    return []
 
         if not rows:
             return []

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -95,6 +95,23 @@ def _clamp_trust(value: float) -> float:
     return max(_TRUST_MIN, min(_TRUST_MAX, value))
 
 
+def _is_explicit_fts5_query(query: str) -> bool:
+    """Detect when the caller already wrote FTS5 syntax so we leave it alone."""
+    if any(c in query for c in '"*()'):
+        return True
+    upper_tokens = query.upper().split()
+    return any(kw in upper_tokens for kw in ("OR", "AND", "NOT", "NEAR"))
+
+
+def _build_or_fallback(query: str) -> str:
+    """Rewrite a whitespace-separated query as phrase-quoted OR'd tokens."""
+    tokens = [t.replace('"', '').strip() for t in query.split()]
+    tokens = [t for t in tokens if t]
+    if len(tokens) < 2:
+        return ""
+    return " OR ".join(f'"{t}"' for t in tokens)
+
+
 class MemoryStore:
     """SQLite-backed fact store with entity resolution and trust scoring."""
 
@@ -227,6 +244,16 @@ class MemoryStore:
 
             rows = self._conn.execute(sql, params).fetchall()
             results = [self._row_to_dict(r) for r in rows]
+
+            # FTS5 simple tokenizer treats whitespace as AND and does no CJK
+            # segmentation, so multi-token Chinese queries from natural
+            # language almost always miss. Retry as OR when AND found nothing.
+            if not results and not _is_explicit_fts5_query(query):
+                or_query = _build_or_fallback(query)
+                if or_query:
+                    params[0] = or_query
+                    rows = self._conn.execute(sql, params).fetchall()
+                    results = [self._row_to_dict(r) for r in rows]
 
             if results:
                 ids = [r["fact_id"] for r in results]

--- a/tests/plugins/memory/test_holographic_or_fallback.py
+++ b/tests/plugins/memory/test_holographic_or_fallback.py
@@ -1,0 +1,150 @@
+"""Regression tests for the FTS5 OR-fallback in the holographic memory plugin.
+
+The bug: SQLite FTS5 with the default ``simple`` tokenizer treats whitespace
+between tokens as logical AND, and does no CJK word segmentation. Multi-token
+Chinese queries from agent natural language therefore almost always missed,
+even when the data contained every key token, because compound CJK tokens
+in the stored content did not match the agent's individual word boundaries.
+
+These tests pin the OR-fallback behavior at both layers the tool can reach:
+``MemoryStore.search_facts`` (direct caller) and ``FactRetriever._fts_candidates``
+(the path used by the agent-facing ``fact_store(action='search')`` tool).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from plugins.memory.holographic.store import (
+    MemoryStore,
+    _build_or_fallback,
+    _is_explicit_fts5_query,
+)
+from plugins.memory.holographic.retrieval import FactRetriever
+
+
+# ---------------------------------------------------------------------------
+# Pure-function helpers
+# ---------------------------------------------------------------------------
+
+
+def test_or_fallback_quotes_each_token() -> None:
+    out = _build_or_fallback("Kerpen 仓库 DPD")
+    assert out == '"Kerpen" OR "仓库" OR "DPD"'
+
+
+def test_or_fallback_skips_single_token() -> None:
+    assert _build_or_fallback("DPD") == ""
+    assert _build_or_fallback("  仓库  ") == ""
+
+
+def test_or_fallback_strips_embedded_quotes() -> None:
+    # Embedded double-quotes would break the OR construction; strip them.
+    assert _build_or_fallback('foo "bar" baz') == '"foo" OR "bar" OR "baz"'
+
+
+@pytest.mark.parametrize(
+    "query, expected",
+    [
+        ("Kerpen DPD", False),
+        ('"Kerpen"', True),
+        ("Kerpen OR DPD", True),
+        ("Kerpen AND DPD", True),
+        ("Kerpen*", True),
+        ("(Kerpen)", True),
+        ("Kerpen NOT DPD", True),
+        ("Kerpen NEAR DPD", True),
+        ("中文 普通 查询", False),
+    ],
+)
+def test_explicit_fts5_detection(query: str, expected: bool) -> None:
+    assert _is_explicit_fts5_query(query) is expected
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the store
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def store(tmp_path) -> MemoryStore:
+    s = MemoryStore(db_path=str(tmp_path / "test.db"))
+    # Content modeled on a real-world contact note. The compound CJK token
+    # "仓库的发货对接和提货事情" is what the simple tokenizer keeps as a
+    # single token — a bare query of "仓库" cannot match it under AND.
+    s.add_fact(
+        "联系人 > +49 172 2363399：意大利裔德国人，DPD 快递公司的客户经理，"
+        "足球教练；正在帮安排 Kerpen 仓库的发货对接和提货事情。",
+        category="contact",
+    )
+    s.add_fact(
+        "Davide Venturiello 是 DPD 客户经理/足球教练，email Davide.Venturiello@dpd.de。",
+        category="contact",
+    )
+    s.add_fact(
+        "Aachen 的奔驰 GLE 车灯由 Abdullah (AutoFabrik Aachen) 修理。",
+        category="contact",
+    )
+    return s
+
+
+def test_store_search_multi_token_cjk_query_hits(store: MemoryStore) -> None:
+    # Pre-patch: this returned [] because '仓库' and '客户经理' don't exist
+    # as standalone tokens (FTS5 simple tokenizer doesn't segment CJK), so
+    # the AND-conjunctive MATCH failed even though 'DPD', 'Kerpen', and
+    # '2363399' are individually present.
+    results = store.search_facts(
+        "Kerpen 仓库 DPD 客户经理 足球教练 2363399",
+        min_trust=0.0,
+        limit=5,
+    )
+    assert results, "OR-fallback should rescue this multi-token CJK query"
+    contents = " ".join(r["content"] for r in results)
+    assert "DPD" in contents
+
+
+def test_store_search_explicit_fts5_query_is_left_alone(store: MemoryStore) -> None:
+    # Explicit OR — should pass through without re-rewriting.
+    results = store.search_facts('"DPD" OR "GLE"', min_trust=0.0, limit=5)
+    assert results
+    contents = " ".join(r["content"] for r in results)
+    assert "DPD" in contents and "GLE" in contents
+
+
+def test_store_search_unmatched_or_returns_empty(store: MemoryStore) -> None:
+    # When none of the tokens exist, OR-fallback should still return nothing.
+    results = store.search_facts(
+        "完全不存在的内容 xyzzy nonexistenttoken",
+        min_trust=0.0,
+        limit=5,
+    )
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the retriever (the path the agent tool uses)
+# ---------------------------------------------------------------------------
+
+
+def test_retriever_search_multi_token_cjk_query_hits(store: MemoryStore) -> None:
+    # Pre-patch: FactRetriever.search delegated stage-1 to _fts_candidates,
+    # which used raw MATCH ?. With no candidates from stage 1, stage 2/3
+    # never ran and the agent-facing tool returned `{"count": 0}` even when
+    # the answer was clearly in the store.
+    retriever = FactRetriever(store)
+    results = retriever.search(
+        "Kerpen 仓库 DPD 联系人 Davide Venturiello",
+        min_trust=0.0,
+        limit=5,
+    )
+    assert results, "Retriever should surface DPD/Davide rows for this query"
+    contents = " ".join(r["content"] for r in results)
+    assert "DPD" in contents or "Davide" in contents
+
+
+def test_retriever_single_token_still_works(store: MemoryStore) -> None:
+    # Single token never triggers the OR-fallback (build returns ""), so
+    # this also pins that the patch does not regress simple queries.
+    retriever = FactRetriever(store)
+    results = retriever.search("DPD", min_trust=0.0, limit=5)
+    assert results


### PR DESCRIPTION
## Summary

The holographic memory plugin's `fact_store(action='search')` tool silently returns `{"results": [], "count": 0}` on most multi-word natural-language Chinese queries from the agent, even when the data contains every key token. End-to-end reproduction in a self-chat WhatsApp recall test: a query containing the exact phone number `2363399` yielded 0 rows from `fact_store` despite the contact being stored verbatim in `memory_store.db`.

## Root cause

Two-part interaction in SQLite FTS5 with the default `simple` tokenizer:

1. **FTS5 treats whitespace between tokens as logical AND.** Multi-term queries require *every* token to match a token in the indexed content.
2. **The `simple` tokenizer does no CJK segmentation**, so stored content keeps long compound runs as single tokens (e.g. `仓库的发货对接和提货事情` is one indexed token). A bare query of `仓库` cannot match it; a multi-token query containing `仓库` therefore fails conjunctively even when the other tokens — `DPD`, `Kerpen`, `2363399` — *do* match individually.

Manual SQL repro on a populated store:

| query                                              | hits |
|----------------------------------------------------|------|
| `MATCH '2363399'`                                  | ✓ #341 |
| `MATCH 'DPD'`                                      | ✓ #341 |
| `MATCH 'Kerpen'`                                   | ✓ #341 |
| `MATCH '仓库'`                                     | 0 |
| `MATCH 'Kerpen 仓库 DPD 客户经理 2363399'` (AND)   | 0 |
| `MATCH '"Kerpen" OR "仓库" OR "DPD" OR ...'`       | ✓ #341 |

## Fix

When `MATCH` returns nothing for a non-FTS5-syntactic query, retry the same `MATCH` with the query rewritten as phrase-quoted OR'd tokens. `fts.rank` ordering, `trust_score` floor, and category filter are all preserved across the retry.

The OR-fallback is applied at both layers that hit FTS5 so the fix doesn't matter which entry point the caller used:

- `MemoryStore.search_facts` — direct caller into the store
- `FactRetriever._fts_candidates` — stage 1 of the hybrid pipeline used by `FactRetriever.search`, which is the path the agent-facing `fact_store(action='search')` tool actually goes through

Explicit FTS5 syntax in the caller's query (`"phrase"`, `OR`/`AND`/`NOT`/`NEAR`, `*`, `()`) is detected via `_is_explicit_fts5_query` and passed through unchanged so callers who already know what they want still get strict matching. Single-token queries skip the rewrite entirely (no behavior change).

## Test plan

- [x] **17 new unit tests** in `tests/plugins/memory/test_holographic_or_fallback.py`:
  - Helper-level: token quoting, single-token skip, embedded-quote stripping, explicit-FTS5 detection (parameterized over 9 query shapes)
  - End-to-end through `MemoryStore.search_facts`: multi-token CJK hits, explicit FTS5 passthrough, unmatched-tokens returns empty
  - End-to-end through `FactRetriever.search`: multi-token CJK hits, single-token regression check
- [x] **258 existing sibling tests** in `tests/agent/test_memory_provider.py` and `tests/plugins/memory/` continue to pass — no regressions
- [x] **Manual end-to-end** against a populated 347-fact `memory_store.db`: the failing query `"Kerpen 仓库 DPD 联系人 Davide Venturiello"` returns 5 ranked candidates including the expected contact rows (#341, #348, #349). Agent's `fact_store(action='search')` tool went from `(0.00s, 27 chars)` returning `{"results": [], "count": 0}` to `(0.46s, 4226 chars)` returning the correct facts.

## Notes

- The deeper fix would be switching the FTS5 tokenizer to `unicode61` with `tokenchars` or a trigram virtual table. That's a schema migration and a behavioral change for every existing install; this OR-fallback is the surgical fix that ships value today without touching the index.
- Solo compound-CJK queries (e.g. just `仓库`) still return 0 — that's a tokenizer-level limitation the OR-fallback can't address. This patch fixes the *much more common* case where the agent generates a multi-token query mixing alphanumerics and Chinese terms.