### PR TITLE
feat: restore telegram command browser workflow on v0.15

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2543,6 +2543,7 @@ def run_conversation(
                     error_type,
                     agent._client_log_context(),
                     _error_summary,
+                    exc_info=True,
                 )
 
                 _provider = getattr(agent, "provider", "unknown")
@@ -3168,7 +3169,7 @@ def run_conversation(
                             f"{agent.log_prefix}        hermes fallback add   (interactive picker — same as `hermes model`)",
                             force=True,
                         )
-                    logger.error(f"{agent.log_prefix}Non-retryable client error: {api_error}")
+                    logger.error(f"{agent.log_prefix}Non-retryable client error: {api_error}", exc_info=True)
                     # Skip session persistence when the error is likely
                     # context-overflow related (status 400 + large session).
                     # Persisting the failed user message would make the

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -478,6 +478,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # Clarify button state: clarify_id → session_key (for the clarify tool's
         # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
         self._clarify_state: Dict[str, str] = {}
+        # Interactive command browser state: message_id -> page/entries metadata.
+        self._command_browser_state: Dict[int, dict] = {}
         # Notification mode for message sends.
         # "important" — only final responses, approvals, and slash confirmations
         #               trigger notifications; tool progress, streaming, status
@@ -2780,6 +2782,136 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_clarify failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    def _render_command_browser_page(
+        self,
+        entries: list[dict],
+        *,
+        page: int,
+        page_size: int,
+        title: str,
+    ) -> tuple[str, Any]:
+        total = len(entries)
+        total_pages = max(1, (total + page_size - 1) // page_size)
+        page = max(1, min(page, total_pages))
+        start = (page - 1) * page_size
+        end = min(start + page_size, total)
+        page_entries = entries[start:end]
+
+        lines = [
+            f"📚 <b>{_html.escape(title)}</b>",
+            "",
+            f"Page {page}/{total_pages} • tap a button to run the command",
+            "",
+        ]
+        for idx, entry in enumerate(page_entries, start=start):
+            command_text = str(entry.get("command_text", "")).strip() or "/?"
+            description = str(entry.get("description", "")).strip()
+            lines.append(
+                f"{idx + 1}. <code>{_html.escape(command_text)}</code>"
+                + (f" — {_html.escape(description)}" if description else "")
+            )
+
+        rows = []
+        for idx, entry in enumerate(page_entries, start=start):
+            label = str(entry.get("button_text") or entry.get("command_text") or f"cmd {idx + 1}").strip()
+            if len(label) > 28:
+                label = label[:25] + "..."
+            rows.append([
+                InlineKeyboardButton(label, callback_data=f"gc:r:{idx}")
+            ])
+
+        nav = []
+        if page > 1:
+            nav.append(InlineKeyboardButton("◀ Prev", callback_data=f"gc:p:{page - 1}"))
+        nav.append(InlineKeyboardButton(f"{page}/{total_pages}", callback_data="gc:nop"))
+        if page < total_pages:
+            nav.append(InlineKeyboardButton("Next ▶", callback_data=f"gc:p:{page + 1}"))
+        rows.append(nav)
+        return "\n".join(lines), InlineKeyboardMarkup(rows)
+
+    def _build_callback_command_event(
+        self,
+        query,
+        command_text: str,
+        *,
+        update_id: Optional[int] = None,
+    ) -> MessageEvent:
+        chat = getattr(query.message, "chat", None)
+        user = getattr(query, "from_user", None)
+        chat_type_raw = str(getattr(chat, "type", "")).split(".")[-1].lower()
+        chat_type = "dm"
+        if chat_type_raw in {"group", "supergroup"}:
+            chat_type = "group"
+        elif chat_type_raw == "channel":
+            chat_type = "channel"
+        thread_id = getattr(query.message, "message_thread_id", None)
+        source = self.build_source(
+            chat_id=str(getattr(chat, "id", getattr(query.message, "chat_id", ""))),
+            chat_name=getattr(chat, "title", None) or getattr(chat, "full_name", None),
+            chat_type=chat_type,
+            user_id=str(getattr(user, "id", "") or getattr(chat, "id", "")),
+            user_name=getattr(user, "full_name", None) or getattr(user, "first_name", None),
+            thread_id=str(thread_id) if thread_id is not None else None,
+            message_id=str(getattr(query.message, "message_id", "")),
+        )
+        return MessageEvent(
+            text=command_text,
+            message_type=MessageType.COMMAND,
+            source=source,
+            raw_message=getattr(query, "message", None),
+            message_id=str(getattr(query.message, "message_id", "")),
+            platform_update_id=update_id,
+            timestamp=getattr(query.message, "date", None),
+        )
+
+    async def send_command_browser(
+        self,
+        chat_id: str,
+        entries: list[dict],
+        *,
+        page: int = 1,
+        page_size: int = 8,
+        title: str = "Command Browser",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            text, keyboard = self._render_command_browser_page(
+                entries,
+                page=page,
+                page_size=page_size,
+                title=title,
+            )
+            thread_id = self._metadata_thread_id(metadata)
+            reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
+            msg = await self._send_message_with_thread_fallback(
+                chat_id=int(chat_id),
+                text=text,
+                parse_mode=ParseMode.HTML,
+                reply_markup=keyboard,
+                reply_to_message_id=reply_to_id,
+                **self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                    reply_to_mode=self._reply_to_mode,
+                ),
+                **self._link_preview_kwargs(),
+            )
+            self._command_browser_state[int(msg.message_id)] = {
+                "entries": list(entries),
+                "page": page,
+                "page_size": page_size,
+                "title": title,
+            }
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_command_browser failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
     async def send_model_picker(
         self,
         chat_id: str,
@@ -3106,6 +3238,97 @@ class TelegramAdapter(BasePlatformAdapter):
         query_chat_type = getattr(query_chat, "type", None)
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
+
+        # --- Command browser callbacks (gc:verb:arg) ---
+        if data.startswith("gc:"):
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to use command buttons.")
+                return
+
+            state = self._command_browser_state.get(int(getattr(query_message, "message_id", 0) or 0))
+            if not state:
+                await query.answer(text="This command panel has expired. Use /commands again.")
+                return
+
+            parts = data.split(":", 2)
+            action = parts[1] if len(parts) > 1 else ""
+            if action == "nop":
+                await query.answer()
+                return
+            if action == "p":
+                try:
+                    page = int(parts[2])
+                except (IndexError, ValueError):
+                    await query.answer(text="Invalid page.")
+                    return
+                text, keyboard = self._render_command_browser_page(
+                    state.get("entries", []),
+                    page=page,
+                    page_size=int(state.get("page_size", 8) or 8),
+                    title=str(state.get("title", "Command Browser")),
+                )
+                state["page"] = page
+                await query.edit_message_text(
+                    text=text,
+                    parse_mode=ParseMode.HTML,
+                    reply_markup=keyboard,
+                )
+                await query.answer()
+                return
+            if action == "r":
+                try:
+                    index = int(parts[2])
+                except (IndexError, ValueError):
+                    await query.answer(text="Invalid command.")
+                    return
+                entries = state.get("entries", [])
+                if index < 0 or index >= len(entries):
+                    await query.answer(text="Command not found.")
+                    return
+                command_text = str(entries[index].get("command_text", "")).strip()
+                if not command_text:
+                    await query.answer(text="Command not available.")
+                    return
+                await query.answer(text=f"Running {command_text}")
+                try:
+                    await query.edit_message_text(
+                        text=f"▶️ <b>Running</b> <code>{_html.escape(command_text)}</code>",
+                        parse_mode=ParseMode.HTML,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+                response = None
+                if self._message_handler:
+                    event = self._build_callback_command_event(
+                        query,
+                        command_text,
+                        update_id=getattr(update, "update_id", None),
+                    )
+                    response = await self._message_handler(event)
+                    text_response, _eph_ttl = self._unwrap_ephemeral(response)
+                    if text_response and query_message is not None:
+                        metadata = (
+                            {"thread_id": str(query_thread_id)}
+                            if query_thread_id is not None
+                            else None
+                        )
+                        await self.send(
+                            chat_id=str(query_chat_id),
+                            content=text_response,
+                            reply_to=str(getattr(query_message, "message_id", "")),
+                            metadata=metadata,
+                        )
+                return
+            await query.answer(text="Unknown command action.")
+            return
 
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mm:", "mb", "mx", "mg:")):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7334,6 +7334,10 @@ class GatewayRunner:
             if _cmd_def_inner and _cmd_def_inner.name in _DEDICATED_HANDLERS:
                 if _cmd_def_inner.name == "help":
                     return await self._handle_help_command(event)
+                if _cmd_def_inner.name == "menu":
+                    return await self._handle_menu_command(event)
+                if _cmd_def_inner.name == "inbox":
+                    return await self._handle_inbox_command(event)
                 if _cmd_def_inner.name == "commands":
                     return await self._handle_commands_command(event)
                 if _cmd_def_inner.name == "profile":
@@ -7588,6 +7592,12 @@ class GatewayRunner:
         if canonical == "start":
             logger.info("Ignoring /start platform ping for session %s", _quick_key)
             return ""
+
+        if canonical == "menu":
+            return await self._handle_menu_command(event)
+
+        if canonical == "inbox":
+            return await self._handle_inbox_command(event)
 
         if canonical == "commands":
             return await self._handle_commands_command(event)
@@ -10218,8 +10228,8 @@ class GatewayRunner:
             getattr(getattr(event, "source", None), "platform", None),
         )
 
-    async def _handle_commands_command(self, event: MessageEvent) -> str:
-        from hermes_cli.commands import gateway_help_lines
+    async def _handle_commands_command(self, event: MessageEvent) -> Optional[str]:
+        from hermes_cli.commands import gateway_help_lines, _sanitize_telegram_name
 
         raw_args = event.get_command_args().strip()
         if raw_args:
@@ -10232,6 +10242,26 @@ class GatewayRunner:
 
         # Build combined entry list: built-in commands + skill commands
         entries = list(gateway_help_lines())
+        browser_entries: list[dict[str, str]] = []
+        for line in entries:
+            if not line.startswith("`/"):
+                continue
+            try:
+                command_block, description = line.split("` -- ", 1)
+            except ValueError:
+                continue
+            command_block = command_block.strip("`")
+            command_name = command_block.split()[0]
+            browser_entries.append(
+                {
+                    "command_text": _telegramize_command_mentions(
+                        command_name,
+                        getattr(getattr(event, "source", None), "platform", None),
+                    ),
+                    "button_text": _sanitize_telegram_name(command_name.lstrip("/")) or command_name.lstrip("/"),
+                    "description": description,
+                }
+            )
         try:
             from agent.skill_commands import get_skill_commands
             skill_cmds = get_skill_commands()
@@ -10241,6 +10271,16 @@ class GatewayRunner:
                 for cmd in sorted(skill_cmds):
                     desc = skill_cmds[cmd].get("description", "").strip() or t("gateway.commands.default_desc")
                     entries.append(f"`{cmd}` — {desc}")
+                    browser_entries.append(
+                        {
+                            "command_text": _telegramize_command_mentions(
+                                cmd,
+                                getattr(getattr(event, "source", None), "platform", None),
+                            ),
+                            "button_text": _sanitize_telegram_name(cmd.lstrip("/")) or cmd.lstrip("/"),
+                            "description": desc,
+                        }
+                    )
         except Exception:
             pass
 
@@ -10248,6 +10288,25 @@ class GatewayRunner:
             return t("gateway.commands.none")
 
         from gateway.config import Platform
+        if event.source.platform == Platform.TELEGRAM:
+            adapter_map = getattr(self, "adapters", {}) or {}
+            adapter = adapter_map.get(Platform.TELEGRAM)
+            if adapter is not None and hasattr(adapter, "send_command_browser"):
+                metadata = self._thread_metadata_for_source(
+                    event.source,
+                    self._reply_anchor_for_event(event),
+                )
+                browser_result = await adapter.send_command_browser(
+                    chat_id=event.source.chat_id,
+                    entries=browser_entries,
+                    page=requested_page,
+                    page_size=8,
+                    title="Command Browser",
+                    metadata=metadata,
+                )
+                if getattr(browser_result, "success", False):
+                    return None
+
         page_size = 15 if event.source.platform == Platform.TELEGRAM else 20
         total_pages = max(1, (len(entries) + page_size - 1) // page_size)
         page = max(1, min(requested_page, total_pages))
@@ -10272,6 +10331,246 @@ class GatewayRunner:
             "\n".join(lines),
             getattr(getattr(event, "source", None), "platform", None),
         )
+
+    def _ronii_root(self) -> Path:
+        return Path.home() / ".hermes" / "profiles" / "ronii"
+
+    def _ronii_runner_path(self) -> Path:
+        return self._ronii_root() / "scripts" / "ronii_runner.py"
+
+    def _load_ronii_recent_inbox_items(self, limit: int = 6) -> list[dict[str, Any]]:
+        db_path = self._ronii_root() / "db" / "ronii.db"
+        if not db_path.exists():
+            return []
+        with sqlite3.connect(db_path) as con:
+            rows = con.execute(
+                "SELECT id, entity_uid, title, state, canonical_url, attributes_json "
+                "FROM entities WHERE type='inbox_item' ORDER BY updated_at DESC, id DESC LIMIT ?",
+                (max(1, int(limit)),),
+            ).fetchall()
+        items: list[dict[str, Any]] = []
+        for row in rows:
+            attrs = {}
+            try:
+                attrs = json.loads(row[5] or "{}")
+            except Exception:
+                attrs = {}
+            items.append(
+                {
+                    "id": row[0],
+                    "entity_uid": row[1],
+                    "title": row[2] or row[1] or f"Inbox {row[0]}",
+                    "state": row[3] or "-",
+                    "url": row[4] or "",
+                    "classification": attrs.get("classification", "unknown"),
+                    "status": attrs.get("status", row[3] or "unknown"),
+                }
+            )
+        return items
+
+    def _run_ronii_runner_command(self, command: str, *args: str) -> str:
+        import subprocess
+
+        runner_path = self._ronii_runner_path()
+        if not runner_path.exists():
+            return "Ronii inbox runner is not configured on this host."
+
+        proc = subprocess.run(
+            [sys.executable, str(runner_path), command, *[str(a) for a in args if str(a).strip()]],
+            capture_output=True,
+            text=True,
+            timeout=45,
+        )
+        output = (proc.stdout or "").strip()
+        error = (proc.stderr or "").strip()
+        if proc.returncode != 0:
+            return error or output or f"Ronii runner failed: exit {proc.returncode}"
+        return output or "(no output)"
+
+    def _build_menu_payload(self, section: str) -> tuple[str, list[dict[str, str]]]:
+        if section == "main":
+            return (
+                "Quick Menu",
+                [
+                    {"command_text": "/status", "button_text": "상태", "description": "현재 세션 상태 확인"},
+                    {"command_text": "/model", "button_text": "모델", "description": "모델/프로바이더 선택"},
+                    {"command_text": "/menu inbox", "button_text": "인박스", "description": "Ronii 인박스 메뉴"},
+                    {"command_text": "/menu session", "button_text": "세션", "description": "세션 관련 빠른 명령"},
+                    {"command_text": "/menu ops", "button_text": "운영", "description": "재시작/업데이트 등 운영 명령"},
+                    {"command_text": "/menu help", "button_text": "도움", "description": "도움말과 전체 명령 브라우저"},
+                ],
+            )
+        if section == "session":
+            return (
+                "Quick Menu • Session",
+                [
+                    {"command_text": "/profile", "button_text": "프로필", "description": "현재 프로필 정보"},
+                    {"command_text": "/usage", "button_text": "사용량", "description": "현재 세션 사용량 확인"},
+                    {"command_text": "/help", "button_text": "도움말", "description": "핵심 명령 요약"},
+                    {"command_text": "/menu main", "button_text": "메인으로", "description": "메인 메뉴로 돌아가기"},
+                ],
+            )
+        if section == "ops":
+            return (
+                "Quick Menu • Ops",
+                [
+                    {"command_text": "/status", "button_text": "상태", "description": "현재 세션 상태 확인"},
+                    {"command_text": "/restart", "button_text": "재시작", "description": "게이트웨이 재시작"},
+                    {"command_text": "/update", "button_text": "업데이트", "description": "Hermes 업데이트"},
+                    {"command_text": "/menu main", "button_text": "메인으로", "description": "메인 메뉴로 돌아가기"},
+                ],
+            )
+        if section == "help":
+            return (
+                "Quick Menu • Help",
+                [
+                    {"command_text": "/help", "button_text": "도움말", "description": "주요 명령 요약"},
+                    {"command_text": "/commands", "button_text": "전체명령", "description": "전체 명령 브라우저 열기"},
+                    {"command_text": "/status", "button_text": "상태", "description": "현재 세션 상태 확인"},
+                    {"command_text": "/menu main", "button_text": "메인으로", "description": "메인 메뉴로 돌아가기"},
+                ],
+            )
+        if section == "inbox":
+            return (
+                "Quick Menu • Inbox",
+                [
+                    {"command_text": "/inbox recent", "button_text": "최근 항목", "description": "최근 inbox 항목 목록"},
+                    {"command_text": "/inbox domain list", "button_text": "도메인 규칙", "description": "현재 domain rule 목록"},
+                    {"command_text": "/inbox help", "button_text": "사용법", "description": "view/dig/reanalyze 사용법"},
+                    {"command_text": "/menu main", "button_text": "메인으로", "description": "메인 메뉴로 돌아가기"},
+                ],
+            )
+        raise ValueError(f"unknown menu section: {section}")
+
+    async def _send_quick_menu(self, event: MessageEvent, title: str, entries: list[dict[str, str]]) -> Optional[str]:
+        from hermes_cli.commands import _sanitize_telegram_name
+        from gateway.config import Platform
+
+        if event.source.platform == Platform.TELEGRAM:
+            adapter_map = getattr(self, "adapters", {}) or {}
+            adapter = adapter_map.get(Platform.TELEGRAM)
+            if adapter is not None and hasattr(adapter, "send_command_browser"):
+                metadata = self._thread_metadata_for_source(
+                    event.source,
+                    self._reply_anchor_for_event(event),
+                )
+                browser_entries = []
+                for entry in entries:
+                    command_text = _telegramize_command_mentions(
+                        entry["command_text"],
+                        getattr(getattr(event, "source", None), "platform", None),
+                    )
+                    browser_entries.append(
+                        {
+                            "command_text": command_text,
+                            "button_text": entry.get("button_text") or _sanitize_telegram_name(command_text.lstrip("/")) or command_text.lstrip("/"),
+                            "description": entry.get("description", ""),
+                        }
+                    )
+                browser_result = await adapter.send_command_browser(
+                    chat_id=event.source.chat_id,
+                    entries=browser_entries,
+                    page=1,
+                    page_size=max(4, len(browser_entries)),
+                    title=title,
+                    metadata=metadata,
+                )
+                if getattr(browser_result, "success", False):
+                    return None
+
+        lines = [f"**{title}**", ""]
+        for entry in entries:
+            lines.append(f"`{entry['command_text']}` — {entry['description']}")
+        return _telegramize_command_mentions(
+            "\n".join(lines),
+            getattr(getattr(event, "source", None), "platform", None),
+        )
+
+    async def _handle_menu_command(self, event: MessageEvent) -> Optional[str]:
+        raw_args = (event.get_command_args() or "").strip().lower()
+        section = raw_args or "main"
+        if section not in {"main", "session", "ops", "help", "inbox"}:
+            return "Usage: /menu [main|session|ops|help|inbox]"
+        title, entries = self._build_menu_payload(section)
+        return await self._send_quick_menu(event, title, entries)
+
+    async def _handle_inbox_command(self, event: MessageEvent) -> Optional[str]:
+        raw_args = (event.get_command_args() or "").strip()
+        if not raw_args:
+            return await self._send_quick_menu(event, *self._build_menu_payload("inbox"))
+
+        parts = raw_args.split()
+        action = parts[0].lower()
+        rest = parts[1:]
+
+        if action == "help":
+            lines = [
+                "**Ronii Inbox**",
+                "",
+                "`/inbox recent` — 최근 항목 버튼 메뉴",
+                "`/inbox actions <id>` — 항목별 액션 메뉴",
+                "`/inbox view <id>` — 5프레임 요약 보기",
+                "`/inbox dig <id>` — Notion handoff 생성",
+                "`/inbox reanalyze <id>` — 강제 재분석",
+                "`/inbox domain list` — 도메인 규칙 보기",
+            ]
+            return _telegramize_command_mentions(
+                "\n".join(lines),
+                getattr(getattr(event, "source", None), "platform", None),
+            )
+
+        if action == "recent":
+            items = self._load_ronii_recent_inbox_items(limit=6)
+            if not items:
+                return "Ronii inbox recent items not found."
+            entries = []
+            for item in items:
+                title = str(item.get("title") or item.get("entity_uid") or f"Inbox {item.get('id')}")
+                short = title[:18] + "…" if len(title) > 18 else title
+                entries.append(
+                    {
+                        "command_text": f"/inbox actions {item['id']}",
+                        "button_text": f"#{item['id']} {short}"[:28],
+                        "description": f"{item.get('classification', '-')}/{item.get('status', '-')}",
+                    }
+                )
+            entries.append({"command_text": "/menu inbox", "button_text": "뒤로", "description": "인박스 메뉴로 돌아가기"})
+            return await self._send_quick_menu(event, "Quick Menu • Inbox Recent", entries)
+
+        if action == "actions":
+            if not rest:
+                return "Usage: /inbox actions <id>"
+            identifier = rest[0]
+            entries = [
+                {"command_text": f"/inbox view {identifier}", "button_text": "view", "description": "5프레임 요약 보기"},
+                {"command_text": f"/inbox dig {identifier}", "button_text": "dig", "description": "Notion handoff 생성"},
+                {"command_text": f"/inbox reanalyze {identifier}", "button_text": "reanalyze", "description": "강제 재분석"},
+                {"command_text": "/inbox recent", "button_text": "목록", "description": "최근 항목으로 돌아가기"},
+            ]
+            return await self._send_quick_menu(event, f"Inbox Actions • {identifier}", entries)
+
+        if action in {"view", "dig", "reanalyze"}:
+            if not rest:
+                return f"Usage: /inbox {action} <id>"
+            runner_command = {
+                "view": "inbox_view",
+                "dig": "inbox_dig",
+                "reanalyze": "inbox_reanalyze",
+            }[action]
+            return _telegramize_command_mentions(
+                self._run_ronii_runner_command(runner_command, rest[0]),
+                getattr(getattr(event, "source", None), "platform", None),
+            )
+
+        if action == "domain":
+            subaction = rest[0].lower() if rest else "list"
+            domain_args = [subaction, *rest[1:]]
+            return _telegramize_command_mentions(
+                self._run_ronii_runner_command("inbox_domain", *domain_args),
+                getattr(getattr(event, "source", None), "platform", None),
+            )
+
+        return "Usage: /inbox <help|recent|actions|view|dig|reanalyze|domain> [args]"
 
     async def _handle_model_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /model command — switch model for this session.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -196,6 +196,11 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Tools & Skills", cli_only=True),
 
     # Info
+    CommandDef("menu", "Open a compact quick-action menu for common gateway commands", "Info",
+               gateway_only=True, args_hint="[main|session|ops|help|inbox]"),
+    CommandDef("inbox", "Operate Ronii inbox items and review queues", "Info",
+               gateway_only=True, args_hint="<help|recent|actions|view|dig|reanalyze|domain> [args]",
+               subcommands=("help", "recent", "actions", "view", "dig", "reanalyze", "domain")),
     CommandDef("commands", "Browse all commands and skills (paginated)", "Info",
                gateway_only=True, args_hint="[page]"),
     CommandDef("help", "Show available commands", "Info"),
@@ -340,6 +345,8 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "commands",
         "deny",
         "help",
+        "inbox",
+        "menu",
         "new",
         "profile",
         "queue",

--- a/tests/gateway/test_gateway_command_help.py
+++ b/tests/gateway/test_gateway_command_help.py
@@ -1,5 +1,8 @@
 """Gateway command help rendering tests."""
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from gateway.config import Platform
@@ -86,3 +89,167 @@ async def test_help_keeps_non_telegram_slash_command_mentions_unchanged(monkeypa
     )
 
     assert "`/Linear`" in result
+
+
+@pytest.mark.asyncio
+async def test_commands_telegram_uses_interactive_browser_when_supported(monkeypatch):
+    """Telegram /commands should use the adapter's interactive browser when available."""
+    monkeypatch.setattr(
+        "agent.skill_commands.get_skill_commands",
+        lambda: {"/Linear": {"description": "Open Linear"}},
+    )
+
+    runner = _make_runner()
+    adapter = MagicMock()
+    adapter.send_command_browser = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="42")
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._thread_metadata_for_source = MagicMock(return_value=None)
+    runner._reply_anchor_for_event = MagicMock(return_value=None)
+
+    result = await runner._handle_commands_command(
+        _make_event("/commands", Platform.TELEGRAM)
+    )
+
+    assert result is None
+    adapter.send_command_browser.assert_awaited_once()
+    kwargs = adapter.send_command_browser.await_args.kwargs
+    entries = kwargs["entries"]
+    assert any(entry["command_text"] == "/help" for entry in entries)
+    assert any(entry["command_text"] == "/linear" for entry in entries)
+
+
+@pytest.mark.asyncio
+async def test_menu_telegram_uses_interactive_browser_when_supported():
+    """Telegram /menu should use the adapter's interactive browser with curated entries."""
+    runner = _make_runner()
+    adapter = MagicMock()
+    adapter.send_command_browser = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="84")
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._thread_metadata_for_source = MagicMock(return_value=None)
+    runner._reply_anchor_for_event = MagicMock(return_value=None)
+
+    result = await runner._handle_menu_command(
+        _make_event("/menu", Platform.TELEGRAM)
+    )
+
+    assert result is None
+    adapter.send_command_browser.assert_awaited_once()
+    kwargs = adapter.send_command_browser.await_args.kwargs
+    assert kwargs["title"] == "Quick Menu"
+    entries = kwargs["entries"]
+    assert [entry["command_text"] for entry in entries] == [
+        "/status",
+        "/model",
+        "/menu inbox",
+        "/menu session",
+        "/menu ops",
+        "/menu help",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_menu_inbox_telegram_uses_interactive_browser_when_supported():
+    """Telegram /menu inbox should open the curated Ronii inbox submenu."""
+    runner = _make_runner()
+    adapter = MagicMock()
+    adapter.send_command_browser = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="85")
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._thread_metadata_for_source = MagicMock(return_value=None)
+    runner._reply_anchor_for_event = MagicMock(return_value=None)
+
+    result = await runner._handle_menu_command(
+        _make_event("/menu inbox", Platform.TELEGRAM)
+    )
+
+    assert result is None
+    kwargs = adapter.send_command_browser.await_args.kwargs
+    assert kwargs["title"] == "Quick Menu • Inbox"
+    assert [entry["command_text"] for entry in kwargs["entries"]] == [
+        "/inbox recent",
+        "/inbox domain list",
+        "/inbox help",
+        "/menu main",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_inbox_recent_telegram_renders_recent_item_buttons():
+    """Telegram /inbox recent should render recent-item action buttons."""
+    runner = _make_runner()
+    adapter = MagicMock()
+    adapter.send_command_browser = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="86")
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._thread_metadata_for_source = MagicMock(return_value=None)
+    runner._reply_anchor_for_event = MagicMock(return_value=None)
+    runner._load_ronii_recent_inbox_items = MagicMock(
+        return_value=[
+            {"id": 17, "title": "A very important inbox item", "classification": "link_only", "status": "done"},
+            {"id": 18, "title": "Second item", "classification": "dlq", "status": "failed"},
+        ]
+    )
+
+    result = await runner._handle_inbox_command(
+        _make_event("/inbox recent", Platform.TELEGRAM)
+    )
+
+    assert result is None
+    kwargs = adapter.send_command_browser.await_args.kwargs
+    assert kwargs["title"] == "Quick Menu • Inbox Recent"
+    assert [entry["command_text"] for entry in kwargs["entries"]] == [
+        "/inbox actions 17",
+        "/inbox actions 18",
+        "/menu inbox",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_inbox_actions_text_menu_contains_item_commands():
+    """Non-Telegram /inbox actions should expose view/dig/reanalyze commands."""
+    runner = _make_runner()
+
+    result = await runner._handle_inbox_command(
+        _make_event("/inbox actions 17", Platform.DISCORD)
+    )
+
+    assert result is not None
+    assert "**Inbox Actions • 17**" in result
+    assert "`/inbox view 17`" in result
+    assert "`/inbox dig 17`" in result
+    assert "`/inbox reanalyze 17`" in result
+
+
+@pytest.mark.asyncio
+async def test_inbox_view_routes_to_ronii_runner():
+    """/inbox view delegates to the Ronii runner wrapper."""
+    runner = _make_runner()
+    runner._run_ronii_runner_command = MagicMock(return_value="VIEW OUTPUT")
+
+    result = await runner._handle_inbox_command(
+        _make_event("/inbox view 17", Platform.DISCORD)
+    )
+
+    runner._run_ronii_runner_command.assert_called_once_with("inbox_view", "17")
+    assert result == "VIEW OUTPUT"
+
+
+@pytest.mark.asyncio
+async def test_menu_text_fallback_renders_compact_sections():
+    """Non-Telegram /menu falls back to a compact text menu."""
+    runner = _make_runner()
+
+    result = await runner._handle_menu_command(
+        _make_event("/menu ops", Platform.DISCORD)
+    )
+
+    assert result is not None
+    assert "**Quick Menu • Ops**" in result
+    assert "`/restart`" in result
+    assert "`/menu main`" in result

--- a/tests/gateway/test_telegram_command_browser.py
+++ b/tests/gateway/test_telegram_command_browser.py
@@ -1,0 +1,160 @@
+"""Tests for Telegram interactive command browser buttons."""
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Minimal Telegram mock so TelegramAdapter can be imported
+# ---------------------------------------------------------------------------
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from gateway.platforms.telegram import TelegramAdapter
+
+
+def _make_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+class TestTelegramCommandBrowser:
+    @pytest.mark.asyncio
+    async def test_send_command_browser_renders_buttons_and_stores_state(self):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=200))
+
+        result = await adapter.send_command_browser(
+            chat_id="12345",
+            entries=[
+                {"command_text": "/status", "button_text": "status", "description": "Show status"},
+                {"command_text": "/model", "button_text": "model", "description": "Switch model"},
+            ],
+            page=1,
+            page_size=1,
+            title="Command Browser",
+        )
+
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert kwargs["chat_id"] == 12345
+        assert kwargs["reply_markup"] is not None
+        assert "Command Browser" in kwargs["text"]
+        assert 200 in adapter._command_browser_state
+        state = adapter._command_browser_state[200]
+        assert state["page"] == 1
+        assert len(state["entries"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_command_browser_page_navigation_edits_same_message(self):
+        adapter = _make_adapter()
+        adapter._command_browser_state[42] = {
+            "entries": [
+                {"command_text": "/status", "button_text": "status", "description": "Show status"},
+                {"command_text": "/model", "button_text": "model", "description": "Switch model"},
+            ],
+            "page": 1,
+            "page_size": 1,
+            "title": "Command Browser",
+        }
+
+        query = AsyncMock()
+        query.data = "gc:p:2"
+        query.message = MagicMock()
+        query.message.message_id = 42
+        query.message.chat_id = 12345
+        query.message.chat = MagicMock()
+        query.message.chat.type = "private"
+        query.message.message_thread_id = None
+        query.from_user = MagicMock()
+        query.from_user.id = "777"
+        query.from_user.first_name = "Tester"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, MagicMock())
+
+        edit_kwargs = query.edit_message_text.call_args[1]
+        assert "/model" in edit_kwargs["text"]
+        assert adapter._command_browser_state[42]["page"] == 2
+        query.answer.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_command_browser_run_dispatches_selected_command(self):
+        adapter = _make_adapter()
+        adapter._command_browser_state[42] = {
+            "entries": [
+                {"command_text": "/status", "button_text": "status", "description": "Show status"},
+            ],
+            "page": 1,
+            "page_size": 10,
+            "title": "Command Browser",
+        }
+        adapter._message_handler = AsyncMock(return_value="Current status")
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="9"))
+
+        query = AsyncMock()
+        query.data = "gc:r:0"
+        query.message = MagicMock()
+        query.message.message_id = 42
+        query.message.chat_id = 12345
+        query.message.chat = MagicMock()
+        query.message.chat.id = 12345
+        query.message.chat.type = "private"
+        query.message.chat.title = None
+        query.message.chat.full_name = "Tester Chat"
+        query.message.message_thread_id = None
+        query.message.date = None
+        query.message.from_user = None
+        query.from_user = MagicMock()
+        query.from_user.id = "777"
+        query.from_user.full_name = "Tester"
+        query.from_user.first_name = "Tester"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        update.update_id = 123
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            await adapter._handle_callback_query(update, MagicMock())
+
+        await_args = adapter._message_handler.await_args
+        assert await_args is not None
+        dispatched_event = await_args.args[0]
+        assert dispatched_event.text == "/status"
+        adapter.send.assert_awaited_once()
+        query.edit_message_text.assert_awaited()


### PR DESCRIPTION
## Summary
- update Hermes Agent to v0.15.1
- restore Telegram command browser, /menu, and /inbox workflow
- keep the upstream v0.15.1 Codex runtime implementation instead of reapplying the old local patch

## Validation
- pytest tests/gateway/test_gateway_command_help.py tests/gateway/test_telegram_command_browser.py
- python -m py_compile agent/conversation_loop.py gateway/platforms/telegram.py gateway/run.py hermes_cli/commands.py tests/gateway/test_gateway_command_help.py tests/gateway/test_telegram_command_browser.py

## Notes
- conversation loop logging improvements were merged with upstream content-policy handling
- gateway /start support from upstream was preserved while restoring /menu and /inbox routing