### PR TITLE
fix(dashboard): restore reverse-proxy WS access and action-status polling in --insecure mode

### DIFF
--- a/hermes_cli/dashboard_auth/public_paths.py
+++ b/hermes_cli/dashboard_auth/public_paths.py
@@ -46,4 +46,8 @@ PUBLIC_API_PATHS: frozenset[str] = frozenset({
     # Read-only theme + plugin manifests for the dashboard skin engine.
     "/api/dashboard/themes",
     "/api/dashboard/plugins",
+    # Read-only per-action log poller used by the post-update progress modal.
+    # The operator already has filesystem access to ~/.hermes/logs/<action>.log;
+    # this endpoint just streams it over the dashboard WS RPC without auth.
+    "/api/actions/{name}/status",
 })

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3379,10 +3379,6 @@ _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
 def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     """Check if the WebSocket client IP is acceptable.
 
-    Loopback mode: only loopback clients allowed — the legacy
-    ``?token=<_SESSION_TOKEN>`` path is the only auth we have, so we
-    don't want LAN hosts guessing tokens.
-
     Gated mode: any peer is allowed — uvicorn's ``proxy_headers=True``
     (enabled when the OAuth gate is active so cookies can pick up
     ``X-Forwarded-Proto``) rewrites ``ws.client.host`` to the
@@ -3390,11 +3386,24 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     OAuth gate + single-use ``?ticket=`` is the auth at that point; the
     Host/Origin guard in :func:`_ws_host_origin_is_allowed` is what
     blocks DNS-rebinding here, not the peer IP.
+
+    Loopback / ``--insecure`` mode: the legacy ``?token=<_SESSION_TOKEN>``
+    query parameter is the auth. In ``--insecure`` mode the operator has
+    chosen to terminate auth at the proxy layer (SSO, mTLS, basic auth,
+    etc.) and the WS arrives from the proxy's IP, not 127.0.0.1. The IP
+    check is dropped so the same ``?token=`` check used on every other
+    HTTP endpoint is the sole auth gate for WS in this mode.
     """
     if getattr(app.state, "auth_required", False):
         return True
     client_host = ws.client.host if ws.client else ""
     if not client_host:
+        return True
+    # In --insecure/loopback mode, rely on the ?token= check in _ws_auth_ok
+    # rather than IP-restricting the WS. Reverse proxies terminate auth at
+    # the proxy layer and forward with the proxy IP as the client host.
+    allow_public = getattr(app.state, "allow_public", False)
+    if allow_public:
         return True
     return client_host in _LOOPBACK_HOSTS
 


### PR DESCRIPTION
Fix two regressions that landed in v0.14.0 which together render the dashboard unusable when fronted by a reverse proxy in `--insecure` mode.

## Changes

### 1. Restore `/api/actions/{name}/status` polling in `--insecure` mode

The SPA polls this endpoint every ~2 seconds to drive the post-update progress modal. In v0.14.0 it started returning 401 through reverse proxies because the endpoint was not covered by the session-token middleware interceptor — `POST /api/hermes/update` (the kickoff) carried the header correctly, but the status poller did not.

Fix: add `/api/actions/{name}/status` to `PUBLIC_API_PATHS` in `hermes_cli/dashboard_auth/public_paths.py`. The response is read-only and only exposes `~/.hermes/logs/<action>.log`, which the operator already has shell access to.

### 2. Restore WebSocket access from reverse-proxy IPs in `--insecure` mode

In `--insecure` mode `_ws_client_is_allowed()` was locking all WS endpoints (`/api/ws`, `/api/events`, `/api/pty`) to loopback IPs only. The operator chose `--insecure` precisely because they're terminating auth at the proxy layer (SSO, mTLS, basic auth, etc.), and the WS arrives from the proxy's IP, not `127.0.0.1`. The existing `?token=` constant-time check in `_ws_auth_ok` is the same protection used on every authed HTTP endpoint, which is not similarly IP-restricted.

Fix: in `_ws_client_is_allowed()`, respect the `allow_public` flag (`--insecure` mode) and skip the IP check when it is set, relying on the `?token=` check as the sole auth gate for WS in that mode.

Both changes are minimal and targeted — no architecture changes, no new dependencies.

Closes #34227