### PR TITLE
fix(fast): gate overrides by provider runtime

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1624,6 +1624,7 @@ def init_agent(
         "base_url": agent.base_url,
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
+        "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
         "client_kwargs": dict(agent._client_kwargs),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -919,6 +919,7 @@ def restore_primary_runtime(agent) -> bool:
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
+        agent.request_overrides = dict(rt.get("request_overrides") or {})
         agent._client_kwargs = dict(rt["client_kwargs"])
         agent._use_prompt_caching = rt["use_prompt_caching"]
         # Default to native layout when the restored snapshot predates the
@@ -1563,6 +1564,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "base_url": agent.base_url,
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
+        "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
         "client_kwargs": dict(agent._client_kwargs),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1155,6 +1155,10 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True
+        # Request overrides are specific to the primary runtime selected for
+        # the current turn. Do not leak OpenAI service_tier or Anthropic speed
+        # parameters into Copilot, DeepSeek, or other fallback providers.
+        agent.request_overrides = {}
 
         # Clear the credential pool when the fallback provider doesn't match
         # the pool's provider.  The pool was seeded for the primary provider;

--- a/cli.py
+++ b/cli.py
@@ -4760,7 +4760,7 @@ class HermesCLI:
         Processing / Anthropic fast mode, attach `request_overrides` so the
         API call is marked accordingly.
         """
-        from hermes_cli.models import resolve_fast_mode_overrides
+        from hermes_cli.models import resolve_fast_mode_overrides_for_runtime
 
         runtime = {
             "api_key": self.api_key,
@@ -4790,7 +4790,12 @@ class HermesCLI:
             return route
 
         try:
-            overrides = resolve_fast_mode_overrides(route["model"])
+            overrides = resolve_fast_mode_overrides_for_runtime(
+                route["model"],
+                provider=runtime["provider"],
+                api_mode=runtime["api_mode"],
+                base_url=runtime["base_url"],
+            )
         except Exception:
             overrides = None
         route["request_overrides"] = overrides

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2445,7 +2445,7 @@ class GatewayRunner:
         mode, attach `request_overrides` so the API call is marked
         accordingly.
         """
-        from hermes_cli.models import resolve_fast_mode_overrides
+        from hermes_cli.models import resolve_fast_mode_overrides_for_runtime
 
         runtime = {
             "api_key": runtime_kwargs.get("api_key"),
@@ -2475,7 +2475,12 @@ class GatewayRunner:
             return route
 
         try:
-            overrides = resolve_fast_mode_overrides(route["model"])
+            overrides = resolve_fast_mode_overrides_for_runtime(
+                route["model"],
+                provider=runtime["provider"],
+                api_mode=runtime["api_mode"],
+                base_url=runtime["base_url"],
+            )
         except Exception:
             overrides = None
         route["request_overrides"] = overrides or {}
@@ -16878,6 +16883,8 @@ class GatewayRunner:
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
+            if isinstance(getattr(agent, "_primary_runtime", None), dict):
+                agent._primary_runtime["request_overrides"] = dict(agent.request_overrides)
 
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -14,6 +14,7 @@ import urllib.error
 import time
 from difflib import get_close_matches
 from pathlib import Path
+from urllib.parse import urlparse
 from typing import Any, NamedTuple, Optional
 
 from hermes_cli import __version__ as _HERMES_VERSION
@@ -1786,11 +1787,11 @@ def provider_label(provider: Optional[str]) -> str:
 # See https://openai.com/api-priority-processing/ for the canonical list.
 #
 # Pattern-based matching — any OpenAI flagship model (gpt-*, o1*, o3*, o4*)
-# is assumed to support Priority Processing. service_tier=priority is silently
-# ignored by non-OpenAI endpoints (OpenRouter/Copilot/opencode-zen proxies
-# strip the field), so false positives are harmless. Codex-series models
-# (gpt-5-codex, gpt-5.3-codex, etc.) are excluded — they don't expose the
-# service_tier parameter through the Codex Responses API.
+# is assumed to support Priority Processing on OpenAI-compatible primary
+# runtimes. Provider-aware call sites must still avoid injecting
+# service_tier into third-party endpoints such as Copilot/DeepSeek fallbacks.
+# Codex-series models (gpt-5-codex, gpt-5.3-codex, etc.) are excluded — they
+# don't expose the service_tier parameter through the Codex Responses API.
 _OPENAI_FAST_MODE_PREFIXES: tuple[str, ...] = (
     "gpt-",
     "o1",
@@ -1867,6 +1868,57 @@ def resolve_fast_mode_overrides(model_id: Optional[str]) -> dict[str, Any] | Non
     if _is_anthropic_fast_model(model_id):
         return {"speed": "fast"}
     return {"service_tier": "priority"}
+
+
+def _hostname_for_fast_mode(base_url: Optional[str]) -> str:
+    raw = str(base_url or "").strip()
+    if not raw:
+        return ""
+    try:
+        return (urlparse(raw).hostname or "").strip().lower()
+    except Exception:
+        return ""
+
+
+def _is_direct_openai_fast_runtime(provider: Optional[str], base_url: Optional[str]) -> bool:
+    normalized = normalize_provider(provider) if provider else ""
+    if normalized == "openai-codex":
+        return True
+    if normalized != "openai":
+        return False
+    host = _hostname_for_fast_mode(base_url)
+    return not host or host == "api.openai.com"
+
+
+def _is_direct_anthropic_fast_runtime(provider: Optional[str], base_url: Optional[str]) -> bool:
+    normalized = normalize_provider(provider) if provider else ""
+    if normalized != "anthropic":
+        return False
+    host = _hostname_for_fast_mode(base_url)
+    return not host or host == "api.anthropic.com"
+
+
+def resolve_fast_mode_overrides_for_runtime(
+    model_id: Optional[str],
+    *,
+    provider: Optional[str] = None,
+    api_mode: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> dict[str, Any] | None:
+    """Return fast-mode request overrides for a concrete provider runtime."""
+    del api_mode  # Reserved for future endpoint-specific gates.
+
+    if _is_anthropic_fast_model(model_id):
+        if _is_direct_anthropic_fast_runtime(provider, base_url):
+            return {"speed": "fast"}
+        return None
+
+    if _is_openai_fast_model(model_id):
+        if _is_direct_openai_fast_runtime(provider, base_url):
+            return {"service_tier": "priority"}
+        return None
+
+    return None
 
 
 def _resolve_copilot_catalog_api_key() -> str:

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -223,6 +223,28 @@ class TestFastModeRouting(unittest.TestCase):
         stub = SimpleNamespace(
             model="gpt-5.4",
             api_key="primary-key",
+            base_url="https://api.openai.com/v1",
+            provider="openai",
+            api_mode="chat_completions",
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=None,
+            service_tier="priority",
+        )
+
+        route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
+
+        # Provider should NOT have changed
+        assert route["runtime"]["provider"] == "openai"
+        assert route["runtime"]["api_mode"] == "chat_completions"
+        # But request_overrides should be set
+        assert route["request_overrides"] == {"service_tier": "priority"}
+
+    def test_turn_route_skips_fast_overrides_for_openrouter_runtime(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="gpt-5.4",
+            api_key="primary-key",
             base_url="https://openrouter.ai/api/v1",
             provider="openrouter",
             api_mode="chat_completions",
@@ -234,10 +256,45 @@ class TestFastModeRouting(unittest.TestCase):
 
         route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
 
-        # Provider should NOT have changed
         assert route["runtime"]["provider"] == "openrouter"
-        assert route["runtime"]["api_mode"] == "chat_completions"
-        # But request_overrides should be set
+        assert route["request_overrides"] is None
+
+    def test_turn_route_skips_fast_overrides_for_copilot_runtime(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="gpt-5.4",
+            api_key="primary-key",
+            base_url="https://api.githubcopilot.com",
+            provider="copilot",
+            api_mode="chat_completions",
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=None,
+            service_tier="priority",
+        )
+
+        route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
+
+        assert route["runtime"]["provider"] == "copilot"
+        assert route["request_overrides"] is None
+
+    def test_turn_route_allows_priority_processing_for_openai_codex_runtime(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="gpt-5.5",
+            api_key="primary-key",
+            base_url="https://chatgpt.com/backend-api/codex",
+            provider="openai-codex",
+            api_mode="codex_responses",
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=None,
+            service_tier="priority",
+        )
+
+        route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
+
+        assert route["runtime"]["provider"] == "openai-codex"
         assert route["request_overrides"] == {"service_tier": "priority"}
 
     def test_turn_route_keeps_primary_runtime_when_model_has_no_fast_backend(self):

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -88,6 +88,26 @@ def test_turn_route_injects_priority_processing_without_changing_runtime():
     runner._service_tier = "priority"
     runtime_kwargs = {
         "api_key": "***",
+        "base_url": "https://api.openai.com/v1",
+        "provider": "openai",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(runner, "hi", "gpt-5.4", runtime_kwargs)
+
+    assert route["runtime"]["provider"] == "openai"
+    assert route["runtime"]["api_mode"] == "chat_completions"
+    assert route["request_overrides"] == {"service_tier": "priority"}
+
+
+def test_turn_route_skips_priority_processing_for_openrouter_runtime():
+    runner = _make_runner()
+    runner._service_tier = "priority"
+    runtime_kwargs = {
+        "api_key": "***",
         "base_url": "https://openrouter.ai/api/v1",
         "provider": "openrouter",
         "api_mode": "chat_completions",
@@ -99,7 +119,44 @@ def test_turn_route_injects_priority_processing_without_changing_runtime():
     route = gateway_run.GatewayRunner._resolve_turn_agent_config(runner, "hi", "gpt-5.4", runtime_kwargs)
 
     assert route["runtime"]["provider"] == "openrouter"
-    assert route["runtime"]["api_mode"] == "chat_completions"
+    assert route["request_overrides"] == {}
+
+
+def test_turn_route_skips_priority_processing_for_copilot_runtime():
+    runner = _make_runner()
+    runner._service_tier = "priority"
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://api.githubcopilot.com",
+        "provider": "copilot",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(runner, "hi", "gpt-5.4", runtime_kwargs)
+
+    assert route["runtime"]["provider"] == "copilot"
+    assert route["request_overrides"] == {}
+
+
+def test_turn_route_allows_priority_processing_for_openai_codex_runtime():
+    runner = _make_runner()
+    runner._service_tier = "priority"
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "provider": "openai-codex",
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(runner, "hi", "gpt-5.5", runtime_kwargs)
+
+    assert route["runtime"]["provider"] == "openai-codex"
     assert route["request_overrides"] == {"service_tier": "priority"}
 
 
@@ -162,9 +219,9 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
         gateway_run,
         "_resolve_runtime_agent_kwargs",
         lambda: {
-            "provider": "openrouter",
+            "provider": "openai",
             "api_mode": "chat_completions",
-            "base_url": "https://openrouter.ai/api/v1",
+            "base_url": "https://api.openai.com/v1",
             "api_key": "***",
         },
     )

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -32,7 +32,12 @@ def _make_tool_defs(*names: str) -> list:
     ]
 
 
-def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm.example.com/v1"):
+def _make_agent(
+    fallback_model=None,
+    provider="custom",
+    base_url="https://my-llm.example.com/v1",
+    request_overrides=None,
+):
     """Create a minimal AIAgent with optional fallback config."""
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
@@ -46,6 +51,7 @@ def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
+            request_overrides=request_overrides,
             fallback_model=fallback_model,
         )
         agent.client = MagicMock()
@@ -74,7 +80,13 @@ class TestPrimaryRuntimeSnapshot:
         assert rt["base_url"] == "https://my-llm.example.com/v1"
         assert rt["api_mode"] == agent.api_mode
         assert "client_kwargs" in rt
+        assert "request_overrides" in rt
         assert "compressor_context_length" in rt
+
+    def test_snapshot_includes_request_overrides(self):
+        agent = _make_agent(request_overrides={"service_tier": "priority"})
+
+        assert agent._primary_runtime["request_overrides"] == {"service_tier": "priority"}
 
     def test_snapshot_includes_compressor_state(self):
         agent = _make_agent()
@@ -167,6 +179,24 @@ class TestRestorePrimaryRuntime:
         assert agent._fallback_activated is False
         assert agent.model == original_model
         assert agent.provider == original_provider
+
+    def test_restores_primary_request_overrides(self):
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+            request_overrides={"service_tier": "priority"},
+        )
+
+        mock_client = _mock_resolve()
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            agent._try_activate_fallback()
+
+        assert agent.request_overrides == {}
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        assert agent.request_overrides == {"service_tier": "priority"}
 
     def test_resets_fallback_index(self):
         """After restore, the full fallback chain should be available again."""

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -103,6 +103,21 @@ class TestFallbackChainAdvancement:
             assert agent.model == "gpt-4o"
             assert agent._fallback_activated is True
 
+    def test_fallback_clears_primary_request_overrides(self):
+        fbs = [{"provider": "copilot", "model": "gpt-5.4"}]
+        agent = _make_agent(fallback_model=fbs)
+        agent.request_overrides = {"service_tier": "priority"}
+        agent._primary_runtime["request_overrides"] = {"service_tier": "priority"}
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(base_url="https://api.githubcopilot.com"), "gpt-5.4"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.provider == "copilot"
+        assert agent.request_overrides == {}
+
     def test_second_fallback_works(self):
         fbs = [
             {"provider": "openai", "model": "gpt-4o"},


### PR DESCRIPTION
## Summary
- keep model-level fast-mode availability separate from runtime request kwargs
- gate `service_tier` / `speed` overrides by the concrete provider and base URL selected for the turn
- clear primary `request_overrides` during fallback and restore them when returning to the primary runtime

## Why
`/fast` currently resolves overrides from the model name alone. For `gpt-*` models this can inject OpenAI `service_tier` into non-OpenAI runtimes such as OpenRouter, Copilot, or fallback providers. Those providers may reject or mishandle OpenAI-only kwargs even when the model name looks OpenAI-compatible.

## Tests
- `python -m pytest tests/cli/test_fast_command.py tests/gateway/test_fast_command.py tests/run_agent/test_primary_runtime_restore.py tests/run_agent/test_provider_fallback.py -q`
