### PR TITLE
feat(cli): add CJK/UTF-8 support for session browse search

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -838,8 +838,35 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
                         scroll_offset = 0
                 elif key == ord("q") and not search_text:
                     return
+                elif key >= 128:
+                    # UTF-8 multi-byte sequence (CJK, etc.)
+                    # First byte determines sequence length
+                    byte_seq = bytes([key])
+                    if 0xC0 <= key <= 0xDF:
+                        seq_len = 2
+                    elif 0xE0 <= key <= 0xEF:
+                        seq_len = 3
+                    elif 0xF0 <= key <= 0xF7:
+                        seq_len = 4
+                    else:
+                        seq_len = 3  # fallback for CJK
+                    
+                    while len(byte_seq) < seq_len:
+                        next_key = stdscr.getch()
+                        if next_key == -1:
+                            break
+                        byte_seq += bytes([next_key])
+                    
+                    try:
+                        char = byte_seq.decode('utf-8')
+                        search_text += char
+                        filtered = [s for s in sessions if _match(s, search_text)]
+                        cursor = 0
+                        scroll_offset = 0
+                    except UnicodeDecodeError:
+                        pass
                 elif 32 <= key <= 126:
-                    # Printable character → add to search filter
+                    # Printable ASCII character → add to search filter
                     search_text += chr(key)
                     filtered = [s for s in sessions if _match(s, search_text)]
                     cursor = 0
@@ -13544,7 +13571,8 @@ Examples:
             source = getattr(args, "source", None)
             _browse_exclude = None if source else ["tool"]
             sessions = db.list_sessions_rich(
-                source=source, exclude_sources=_browse_exclude, limit=limit
+                source=source, exclude_sources=_browse_exclude, limit=limit,
+                order_by_last_active=True
             )
             db.close()
             if not sessions:


### PR DESCRIPTION
## Summary

This PR adds UTF-8 multi-byte character support for the curses-based session browser picker, enabling Chinese/Japanese/Korean (CJK) text input for live search filtering.

## Changes

### UTF-8 Input Handling
- Added handling for UTF-8 multi-byte sequences in the curses key input loop
- Previous code only processed ASCII range (32-126), ignoring CJK characters
- CJK characters (E0-EF range) are now properly decoded by accumulating 3 bytes and converting to Unicode

### UX Improvement
- Changed `sessions browse` default sort to `order_by_last_active=True`
- Users now see most recently active sessions first instead of creation time order

## Technical Details

UTF-8 byte sequence detection:
- 0xC0-0xDF: 2-byte sequences (extended Latin, Cyrillic)
- 0xE0-0xEF: 3-byte sequences (CJK - Chinese, Japanese, Korean)
- 0xF0-0xF7: 4-byte sequences (emoji, rare CJK)

The code accumulates bytes until a complete UTF-8 character is formed, then decodes and adds to search string.

## Testing

Tested with Chinese input in `hermes sessions browse`:
- Chinese characters now correctly filter sessions
- Backspace correctly removes one Unicode character (Python strings are Unicode-aware)
- No crashes or input handling issues

## Motivation

The session browser is a frequently-used feature for navigating conversation history. CJK users (large user base in China, Japan, Korea) were unable to search by Chinese keywords, making it difficult to find relevant sessions.