### PR TITLE
fix(tui): cap verbose tool detail payloads

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -73,6 +73,11 @@ def test_tui_verbose_tool_details_fail_closed_when_redaction_fails(monkeypatch):
     assert server._tool_result_text("token=secret") == ""
 
 
+def test_tui_verbose_tool_default_caps_stay_small_for_ink_heap():
+    assert server._TUI_VERBOSE_TEXT_MAX_CHARS == 4_096
+    assert server._TUI_VERBOSE_TEXT_MAX_LINES == 80
+
+
 def test_tui_verbose_tool_details_are_capped_before_emit(monkeypatch):
     monkeypatch.setattr(server, "_TUI_VERBOSE_TEXT_MAX_CHARS", 12)
     monkeypatch.setattr(server, "_TUI_VERBOSE_TEXT_MAX_LINES", 2)
@@ -82,6 +87,35 @@ def test_tui_verbose_tool_details_are_capped_before_emit(monkeypatch):
     assert capped.startswith("[showing verbose tail; omitted ")
     assert capped.endswith("three\nfour")
     assert "one" not in capped
+
+
+def test_tui_verbose_tool_complete_caps_large_result_payloads(monkeypatch):
+    redact_module = types.ModuleType("agent.redact")
+    monkeypatch.setitem(sys.modules, "agent.redact", redact_module)
+    setattr(redact_module, "redact_sensitive_text", lambda text, **_kwargs: str(text))
+
+    helpers_module = types.ModuleType("agent.tool_dispatch_helpers")
+    giant = ("snapshot node\n" * 200) + ("x" * 5_000)
+    monkeypatch.setitem(sys.modules, "agent.tool_dispatch_helpers", helpers_module)
+    setattr(helpers_module, "_multimodal_text_summary", lambda _result: giant)
+
+    events: list[tuple[str, str, dict]] = []
+    monkeypatch.setattr(
+        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+    )
+    monkeypatch.setitem(
+        server._sessions,
+        "verbose-cap-test",
+        {"tool_progress_mode": "verbose", "tool_started_at": {}},
+    )
+
+    server._on_tool_complete("verbose-cap-test", "tool-1", "browser_snapshot", {}, "ignored")
+
+    event_type, sid, payload = events[0]
+    assert event_type == "tool.complete"
+    assert sid == "verbose-cap-test"
+    assert payload["result_text"].startswith("[showing verbose tail; omitted ")
+    assert len(payload["result_text"]) <= server._TUI_VERBOSE_TEXT_MAX_CHARS + 128
 
 
 def test_tui_verbose_tool_events_omit_details_when_redaction_fails(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1501,8 +1501,11 @@ def _tool_ctx(name: str, args: dict) -> str:
         return ""
 
 
-_TUI_VERBOSE_TEXT_MAX_CHARS = 16_000
-_TUI_VERBOSE_TEXT_MAX_LINES = 240
+# TUI tool details live inside Ink/React state and transcript snapshots.
+# Keep them much smaller than general live-render tails so repeated large
+# browser/session_search payloads do not balloon the Node heap.
+_TUI_VERBOSE_TEXT_MAX_CHARS = 4_096
+_TUI_VERBOSE_TEXT_MAX_LINES = 80
 
 
 def _cap_tui_verbose_text(text: str) -> str:


### PR DESCRIPTION
## Summary
- lower the TUI-only verbose tool detail cap from 16k chars / 240 lines to 4096 chars / 80 lines
- keep the cap scoped to `tui_gateway` so CLI behavior stays unchanged
- add a regression test that exercises a large `browser_snapshot` result payload and asserts it is capped before emit

## Why
Repeated browser snapshot and other large tool results were being retained inside Ink transcript/tool trail state. The TUI already bounded item counts, but each verbose tool row could still hold a very large payload, which let repeated browser-heavy turns grow the Node heap until the UI exited.

## Validation
- `uv run --frozen pytest -q -o addopts= tests/test_tui_gateway_server.py -k 'tui_verbose_tool'`
- `uv run --frozen ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`
- `git diff --check`