### PR TITLE
fix(cli): dedupe Bitwarden BWS_ACCESS_TOKEN warning across subprocesses

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -38,6 +38,17 @@ _SECRET_SOURCES: dict[str, str] = {}
 # config re-parse, and the ASCII sanitization sweep still ran every time.
 _APPLIED_HOMES: set[str] = set()
 
+# Cross-process dedup for the BSM status line.  ``hermes`` startup spawns
+# child Python processes (gateway, TUI server, ACP adapter, ...) that each
+# call ``load_hermes_dotenv()`` at import time — _APPLIED_HOMES above is
+# module-level state and does not survive a subprocess boundary, so without
+# this marker users see the same "BWS_ACCESS_TOKEN is not set" warning 2-3x
+# per startup (#32715).  We set this env var when we first print the line;
+# subprocesses inherit os.environ and skip the print.  The work (config
+# read, fetch attempt, env injection) still runs in each subprocess — only
+# the duplicated stderr noise is suppressed.
+_BWS_STATUS_PRINTED_ENV = "_HERMES_BWS_STATUS_PRINTED"
+
 
 def get_secret_source(env_var: str) -> str | None:
     """Return the label of the secret source that supplied ``env_var``, if any.
@@ -63,6 +74,10 @@ def reset_secret_source_cache() -> None:
     that want to refresh after a config change.
     """
     _APPLIED_HOMES.clear()
+    # Also drop the cross-process print marker so the next call can emit the
+    # status line again (tests rely on this, and a long-running process that
+    # explicitly resets state probably wants the next attempt to be visible).
+    os.environ.pop(_BWS_STATUS_PRINTED_ENV, None)
 
 
 def format_secret_source_suffix(env_var: str) -> str:
@@ -136,7 +151,7 @@ def _sanitize_loaded_credentials() -> None:
             "  This usually means the key was copy-pasted from a PDF, "
             "rich-text editor, or web page that substituted lookalike\n"
             "  Unicode glyphs for ASCII letters. If authentication fails "
-            "(e.g. \"API key not valid\"), re-copy the key from the\n"
+            '(e.g. "API key not valid"), re-copy the key from the\n'
             "  provider's dashboard and run `hermes setup` (or edit the "
             ".env file in a plain-text editor).",
             file=sys.stderr,
@@ -190,6 +205,7 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
         sanitized = _sanitize_env_lines(stripped)
         if sanitized != original:
             import tempfile
+
             fd, tmp = tempfile.mkstemp(
                 dir=str(path.parent), suffix=".tmp", prefix=".env_"
             )
@@ -305,6 +321,16 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         # came from BSM rather than .env.
         for name in result.applied:
             _SECRET_SOURCES[name] = "bitwarden"
+
+    # Cross-process print dedup: subprocesses inherit os.environ and skip
+    # re-emitting the same status line.  Mark *before* printing so that even
+    # if multiple sibling subprocesses race past the check, only the first
+    # one wins — and tests can pre-set the marker to assert the suppression.
+    if os.environ.get(_BWS_STATUS_PRINTED_ENV):
+        return
+    os.environ[_BWS_STATUS_PRINTED_ENV] = "1"
+
+    if result.applied:
         print(
             f"  Bitwarden Secrets Manager: applied {len(result.applied)} "
             f"secret{'s' if len(result.applied) != 1 else ''} "

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -7,6 +7,7 @@ don't see an unexplained "credentials ✓" line when their .env is empty.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -57,10 +58,7 @@ def test_format_secret_source_suffix_generic_label_for_future_sources():
     # Future-proofing: a new secret source (e.g. "vault") should still
     # produce a sensible label without needing to edit every call site.
     env_loader._SECRET_SOURCES["OPENAI_API_KEY"] = "vault"
-    assert (
-        env_loader.format_secret_source_suffix("OPENAI_API_KEY")
-        == " (from vault)"
-    )
+    assert env_loader.format_secret_source_suffix("OPENAI_API_KEY") == " (from vault)"
 
 
 def test_apply_external_secret_sources_records_bitwarden_origin(tmp_path, monkeypatch):
@@ -110,15 +108,107 @@ def test_apply_external_secret_sources_noop_when_disabled(tmp_path, monkeypatch)
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     config_path = tmp_path / "config.yaml"
     config_path.write_text(
-        "secrets:\n"
-        "  bitwarden:\n"
-        "    enabled: false\n",
+        "secrets:\n  bitwarden:\n    enabled: false\n",
         encoding="utf-8",
     )
 
     env_loader._apply_external_secret_sources(tmp_path)
 
     assert env_loader.get_secret_source("ANTHROPIC_API_KEY") is None
+
+
+def test_apply_external_secret_sources_dedupes_across_subprocesses(
+    tmp_path, monkeypatch, capsys
+):
+    """``hermes`` startup spawns child Python processes (gateway, TUI, ACP
+    adapter) that each call ``load_hermes_dotenv()`` at import time.  The
+    in-process ``_APPLIED_HOMES`` guard doesn't survive a subprocess
+    boundary, so without the cross-process marker users saw the
+    "BWS_ACCESS_TOKEN is not set" warning 2-3x per startup (#32715).
+    A pre-set marker in ``os.environ`` (as a child would inherit from its
+    parent) must suppress the status line entirely.
+    """
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: test-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n",
+        encoding="utf-8",
+    )
+
+    from agent.secret_sources.bitwarden import FetchResult
+
+    def _fake_apply(**_kwargs):
+        # Mirror the real "BWS_ACCESS_TOKEN unset" failure mode the issue
+        # reports — that's the noise we're deduping.
+        return FetchResult(
+            error=(
+                "secrets.bitwarden.enabled is true but BWS_ACCESS_TOKEN is "
+                "not set.  Run `hermes secrets bitwarden setup`."
+            )
+        )
+
+    import agent.secret_sources.bitwarden as bw_module
+
+    monkeypatch.setattr(bw_module, "apply_bitwarden_secrets", _fake_apply)
+
+    # Simulate a child process: parent already printed the warning and set
+    # the marker; the inherited environ carries it across the fork/spawn.
+    monkeypatch.setenv(env_loader._BWS_STATUS_PRINTED_ENV, "1")
+
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    captured = capsys.readouterr()
+    assert "Bitwarden Secrets Manager" not in captured.err, (
+        "Cross-process dedup is broken: the status line printed even "
+        "though the parent process had already set "
+        f"{env_loader._BWS_STATUS_PRINTED_ENV}=1.  Stderr was: {captured.err!r}"
+    )
+
+
+def test_apply_external_secret_sources_prints_warning_once_then_sets_marker(
+    tmp_path, monkeypatch, capsys
+):
+    """First subprocess to hit the BWS_ACCESS_TOKEN-unset path must print
+    the warning *and* set the marker so its siblings stay quiet.
+    """
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: test-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n",
+        encoding="utf-8",
+    )
+
+    from agent.secret_sources.bitwarden import FetchResult
+
+    err_text = (
+        "secrets.bitwarden.enabled is true but BWS_ACCESS_TOKEN is "
+        "not set.  Run `hermes secrets bitwarden setup`."
+    )
+
+    def _fake_apply(**_kwargs):
+        return FetchResult(error=err_text)
+
+    import agent.secret_sources.bitwarden as bw_module
+
+    monkeypatch.setattr(bw_module, "apply_bitwarden_secrets", _fake_apply)
+
+    monkeypatch.delenv(env_loader._BWS_STATUS_PRINTED_ENV, raising=False)
+
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    captured = capsys.readouterr()
+    assert err_text in captured.err
+    assert os.environ.get(env_loader._BWS_STATUS_PRINTED_ENV) == "1"
 
 
 def test_apply_external_secret_sources_dedupes_within_process(tmp_path, monkeypatch):
@@ -153,6 +243,7 @@ def test_apply_external_secret_sources_dedupes_within_process(tmp_path, monkeypa
         )
 
     import agent.secret_sources.bitwarden as bw_module
+
     monkeypatch.setattr(bw_module, "apply_bitwarden_secrets", _fake_apply)
 
     # Five calls in a row, simulating module-import-time invocations from


### PR DESCRIPTION
## What does this PR do?

Dedupes the Bitwarden Secrets Manager status line across the child Python processes spawned during `hermes` startup, so a user with `secrets.bitwarden.enabled: true` but no `BWS_ACCESS_TOKEN` no longer sees the same warning 2–3 times before the interactive session starts.

The in-process `_APPLIED_HOMES` guard (added in #32271 the day before this issue was filed) already collapses within-process repeats. That guard is module state, so it doesn't survive a subprocess boundary — and the spawned helpers (gateway, TUI server, ACP adapter, ...) each import their entrypoint module which calls `load_hermes_dotenv()` at import time, so each one re-emitted the warning. This PR adds a cross-process marker via `os.environ` so siblings inherit it and stay quiet.

Functional behavior in each subprocess is unchanged: the config read, the (cached) fetch attempt, the credential injection into `os.environ`, the ASCII sanitization pass, and the source-tracking dict update all still run. Only the duplicated stderr noise is suppressed.

## Related Issue

Fixes #32715

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/env_loader.py`: introduced `_BWS_STATUS_PRINTED_ENV = "_HERMES_BWS_STATUS_PRINTED"`; gated the three `print("  Bitwarden Secrets Manager: ...")` call sites on its absence; set it before printing (so a sibling race only lets the first one through); extended `reset_secret_source_cache()` to pop the marker so tests and explicit refresh callers can re-emit.
- `tests/test_env_loader_secret_sources.py`: added `test_apply_external_secret_sources_dedupes_across_subprocesses` (pre-set marker + `enabled: true` config → no stderr) and `test_apply_external_secret_sources_prints_warning_once_then_sets_marker` (marker absent → warning printed and marker set to `"1"`).

## How to Test

1. Reproduce the bug on `main`: in a fresh `HERMES_HOME`, write `~/.hermes/config.yaml` with `secrets:\n  bitwarden:\n    enabled: true\n    project_id: foo\n`, ensure `BWS_ACCESS_TOKEN` is unset, run `hermes`, and confirm the `secrets.bitwarden.enabled is true but BWS_ACCESS_TOKEN is not set...` line appears 2–3 times on stderr before the prompt.
2. Apply this branch and repeat step 1 — the line should appear exactly once.
3. Run the targeted suites locally: `$VIRTUAL_ENV/bin/pytest tests/test_env_loader_secret_sources.py tests/test_bitwarden_secrets.py tests/hermes_cli/test_env_loader.py -q --timeout=60`. The new tests in `test_env_loader_secret_sources.py` directly exercise the cross-process and first-emit behaviors via `monkeypatch.setenv(env_loader._BWS_STATUS_PRINTED_ENV, "1")`.
4. Confirm credential injection still works: run `test_apply_external_secret_sources_records_bitwarden_origin` (unchanged); it stubs a successful BSM fetch and asserts `get_secret_source("ANTHROPIC_API_KEY") == "bitwarden"` still holds, verifying that the gated print sites did not also gate the sanitization / source-tracking work.
5. Sanity: `$VIRTUAL_ENV/bin/ruff check hermes_cli/env_loader.py tests/test_env_loader_secret_sources.py` and `ruff format --check` both clean; `scripts/check-windows-footguns.py` clean for the two files.

## What platforms tested on

- macOS on darwin-arm64 (local) — full targeted pytest run, ruff lint/format, Windows footgun checker all clean. The change is plain `os.environ` reads/writes with no platform-specific surface, so behavior is identical on Linux, macOS, native Windows, and WSL2; the inheritance semantics (`os.environ` propagates across `subprocess.Popen` on every supported platform) are what the fix relies on.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran the env-loader / bitwarden / secret-source slice — 57 passed, 2 skipped)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS arm64 (local)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (no user-visible config or behavior added; the marker env var is internal, leading underscore)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `os.environ` propagation is the same on every supported platform; `scripts/check-windows-footguns.py` clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

<!-- autocontrib:worker-id=issue-new-0b3e946d kind=pr-open -->