### PR TITLE
fix(update): clean web/node_modules before dashboard rebuild (#34312)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6658,13 +6658,17 @@ def _run_npm_install_deterministic(
     )
 
 
-def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
+def _build_web_ui(web_dir: Path, *, fatal: bool = False, clean_install: bool = False) -> bool:
     """Build the web UI frontend if npm is available.
 
     Args:
         web_dir: Path to the ``web/`` source directory.
         fatal: If True, print error guidance and return False on failure
                instead of a soft warning (used by ``hermes web``).
+        clean_install: If True, remove ``web/node_modules`` before reinstalling.
+            ``hermes update`` overlays new source over an existing checkout; a
+            clean reinstall avoids leaving ``web/node_modules`` in a mixed old
+            + new state after dependency version bumps (#34312).
 
     Returns True if the build succeeded or was skipped (no package.json).
     """
@@ -6708,6 +6712,15 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
             text = blob.decode("utf-8", errors="replace").rstrip() if isinstance(blob, bytes) else blob.rstrip()
             if text:
                 _say(text)
+
+    if clean_install:
+        node_modules = web_dir / "node_modules"
+        if node_modules.exists():
+            _say("→ Refreshing web/node_modules from a clean slate...")
+            try:
+                shutil.rmtree(node_modules)
+            except OSError as exc:
+                _say(f"  ⚠ Failed to remove {node_modules}: {exc}")
 
     r1 = _run_npm_install_deterministic(npm, web_dir, extra_args=("--silent",))
     if r1.returncode != 0:
@@ -7234,7 +7247,7 @@ def _update_via_zip(args):
     # optional — a failure here only affects ``hermes dashboard``. Make
     # that visible so users don't panic and reboot mid-build (#33788).
     print("→ Core update complete. Building dashboard (optional)...")
-    _build_web_ui(PROJECT_ROOT / "web")
+    _build_web_ui(PROJECT_ROOT / "web", clean_install=True)
 
     # Sync skills
     try:
@@ -9312,7 +9325,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # optional from a CLI perspective. Telegraphing this avoids the
         # "stuck at webui-build → reboot → broken install" trap (#33788).
         print("→ Core update complete. Building dashboard (optional)...")
-        _build_web_ui(PROJECT_ROOT / "web")
+        _build_web_ui(PROJECT_ROOT / "web", clean_install=True)
 
         print()
         print("✓ Code updated!")

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -150,6 +150,7 @@ class TestCmdUpdateBranchFallback:
         import subprocess as _subprocess
         build_ok = _subprocess.CompletedProcess([], 0, stdout="", stderr="")
         with patch.object(hm, "_is_termux_env", return_value=False), \
+             patch.object(hm.shutil, "rmtree") as mock_rmtree, \
              patch.object(hm, "_run_with_idle_timeout", return_value=build_ok) as mock_idle:
             cmd_update(mock_args)
 
@@ -193,6 +194,8 @@ class TestCmdUpdateBranchFallback:
         idle_args, idle_kwargs = mock_idle.call_args
         assert idle_args[0] == ["/usr/bin/npm", "run", "build"]
         assert idle_kwargs["cwd"] == PROJECT_ROOT / "web"
+        if (PROJECT_ROOT / "web" / "node_modules").exists():
+            mock_rmtree.assert_called_once_with(PROJECT_ROOT / "web" / "node_modules")
 
         # Regression for #18840: repo root + ui-tui installs must stream
         # output (capture_output=False) so postinstall progress is visible

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -163,6 +163,23 @@ class TestBuildWebUISkipsWhenFresh:
         assert args[0] == ["/usr/bin/npm", "run", "build"]
         assert kwargs["cwd"] == web_dir
 
+    def test_clean_install_removes_existing_node_modules_before_npm_ci(self, tmp_path):
+        web_dir, _ = _make_web_dir(tmp_path)
+        node_modules = web_dir / "node_modules"
+        node_modules.mkdir()
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+
+        install_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        build_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main.shutil.rmtree") as mock_rmtree, \
+             patch("hermes_cli.main.subprocess.run", return_value=install_cp), \
+             patch("hermes_cli.main._run_with_idle_timeout", return_value=build_cp):
+            result = _build_web_ui(web_dir, clean_install=True)
+
+        assert result is True
+        mock_rmtree.assert_called_once_with(node_modules)
+
 
 class TestBuildWebUIRetryAndStaleFallback:
     """Coverage for the retry + stale-dist fallback added in #23824 / issue #23817."""


### PR DESCRIPTION
## Summary
- remove `web/node_modules` before the post-update dashboard rebuild path
- keep the clean reinstall scoped to `hermes update` so normal `hermes web` launches stay unchanged
- add regression coverage for the clean-install path and update command flow

## Testing
- uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_cmd_update.py -k 'refreshes_repo_and_tui_node_dependencies'
- uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_web_ui_build.py -k 'clean_install_removes_existing_node_modules_before_npm_ci or runs_npm_when_dist_missing or web_build_uses_idle_timeout_helper'
- uv run --frozen ruff check hermes_cli/main.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_web_ui_build.py
- git diff --check

## Attribution
- latest `origin/main` rebased to `c834624f7de8136b0010f0771ee7a89dc5e92942` before push
- no shared baseline red observed on the newest 3 company PRs
