### PR TITLE
fix(gateway): map pool-only Codex 429 cooldown to rate-limit, not missing creds

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3796,6 +3796,21 @@ def resolve_codex_runtime_credentials(
                 "last_refresh": None,
                 "auth_mode": "chatgpt",
             }
+        # Singleton missing AND no usable pool token. If every token-bearing
+        # pool entry is currently in a 429 quota-cooldown, this is a transient
+        # rate-limit — not a missing credential — and the operator-facing
+        # error must say so. Otherwise prompting `hermes auth` is misleading
+        # (re-auth cannot lift a usage cap) and panics the operator (#32790).
+        cooldown_remaining = _pool_codex_rate_limit_remaining()
+        if cooldown_remaining is not None:
+            raise AuthError(
+                "Codex provider quota exhausted (429); every stored credential "
+                f"is in cooldown. Retry after {_format_cooldown_wait(cooldown_remaining)}. "
+                "Credentials are still valid.",
+                provider="openai-codex",
+                code=CODEX_RATE_LIMITED_CODE,
+                relogin_required=False,
+            ) from read_error
         if read_error is not None:
             raise read_error
         raise AuthError(
@@ -3880,6 +3895,61 @@ def _pool_codex_access_token() -> str:
     except Exception:
         logger.debug("Codex pool fallback lookup failed", exc_info=True)
     return ""
+
+
+def _pool_codex_rate_limit_remaining() -> Optional[float]:
+    """Return seconds remaining on the longest 429 cooldown across token-bearing
+    ``openai-codex`` pool entries, or ``None`` when no such entry is currently
+    in a 429 cooldown.
+
+    Used by ``resolve_codex_runtime_credentials`` to distinguish "credentials
+    are missing" from "credentials exist but every entry is in upstream-quota
+    cooldown" — only the latter should surface as a transient rate-limit
+    notice instead of a misleading "run hermes auth" prompt (#32790). 401/403
+    cooldowns are intentionally not counted: those represent real credential
+    failures where re-auth is the correct remediation.
+    """
+    try:
+        with _auth_store_lock():
+            auth_store = _load_auth_store()
+        pool = auth_store.get("credential_pool")
+        if not isinstance(pool, dict):
+            return None
+        entries = pool.get("openai-codex")
+        if not isinstance(entries, list):
+            return None
+        now = time.time()
+        longest: Optional[float] = None
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            token = entry.get("access_token")
+            if not isinstance(token, str) or not token.strip():
+                continue
+            if entry.get("last_error_code") != 429:
+                continue
+            reset_at = entry.get("last_error_reset_at")
+            if not isinstance(reset_at, (int, float)) or reset_at <= now:
+                continue
+            remaining = float(reset_at - now)
+            if longest is None or remaining > longest:
+                longest = remaining
+        return longest
+    except Exception:
+        logger.debug("Codex pool rate-limit lookup failed", exc_info=True)
+        return None
+
+
+def _format_cooldown_wait(seconds: float) -> str:
+    """Format a remaining-cooldown duration into a short ``HhMm`` / ``MmSs`` / ``Ss`` string."""
+    total = max(0, int(seconds))
+    minutes, secs = divmod(total, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"
 
 
 # =============================================================================

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -22,7 +22,9 @@ from hermes_cli.auth import (
 )
 
 
-def _setup_hermes_auth(hermes_home: Path, *, access_token: str = "access", refresh_token: str = "refresh"):
+def _setup_hermes_auth(
+    hermes_home: Path, *, access_token: str = "access", refresh_token: str = "refresh"
+):
     """Write Codex tokens into the Hermes auth store."""
     hermes_home.mkdir(parents=True, exist_ok=True)
     auth_store = {
@@ -46,7 +48,12 @@ def _setup_hermes_auth(hermes_home: Path, *, access_token: str = "access", refre
 
 def _jwt_with_exp(exp_epoch: int) -> str:
     payload = {"exp": exp_epoch}
-    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=").decode("utf-8")
+    encoded = (
+        base64
+        .urlsafe_b64encode(json.dumps(payload).encode("utf-8"))
+        .rstrip(b"=")
+        .decode("utf-8")
+    )
     return f"h.{encoded}.s"
 
 
@@ -84,10 +91,14 @@ def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkey
     assert exc.value.relogin_required is True
 
 
-def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, monkeypatch):
+def test_resolve_codex_runtime_credentials_refreshes_expiring_token(
+    tmp_path, monkeypatch
+):
     hermes_home = tmp_path / "hermes"
     expiring_token = _jwt_with_exp(int(time.time()) - 10)
-    _setup_hermes_auth(hermes_home, access_token=expiring_token, refresh_token="refresh-old")
+    _setup_hermes_auth(
+        hermes_home, access_token=expiring_token, refresh_token="refresh-old"
+    )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     called = {"count": 0}
@@ -106,7 +117,9 @@ def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, mo
 
 def test_resolve_codex_runtime_credentials_force_refresh(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
-    _setup_hermes_auth(hermes_home, access_token="access-current", refresh_token="refresh-old")
+    _setup_hermes_auth(
+        hermes_home, access_token="access-current", refresh_token="refresh-old"
+    )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     called = {"count": 0}
@@ -117,13 +130,17 @@ def test_resolve_codex_runtime_credentials_force_refresh(tmp_path, monkeypatch):
 
     monkeypatch.setattr("hermes_cli.auth._refresh_codex_auth_tokens", _fake_refresh)
 
-    resolved = resolve_codex_runtime_credentials(force_refresh=True, refresh_if_expiring=False)
+    resolved = resolve_codex_runtime_credentials(
+        force_refresh=True, refresh_if_expiring=False
+    )
 
     assert called["count"] == 1
     assert resolved["api_key"] == "access-forced"
 
 
-def test_resolve_codex_runtime_credentials_falls_back_to_pool_when_singleton_empty(tmp_path, monkeypatch):
+def test_resolve_codex_runtime_credentials_falls_back_to_pool_when_singleton_empty(
+    tmp_path, monkeypatch
+):
     """Regression for #32992 — chat path returns 401 when singleton is empty but pool has creds.
 
     The chat path historically went through ``resolve_codex_runtime_credentials`` which
@@ -161,7 +178,9 @@ def test_resolve_codex_runtime_credentials_falls_back_to_pool_when_singleton_emp
     assert resolved["base_url"]  # default codex backend URL
 
 
-def test_resolve_codex_runtime_credentials_pool_fallback_skips_exhausted(tmp_path, monkeypatch):
+def test_resolve_codex_runtime_credentials_pool_fallback_skips_exhausted(
+    tmp_path, monkeypatch
+):
     """The pool fallback skips entries currently in an exhaustion cooldown window."""
     import time as _time
 
@@ -194,7 +213,9 @@ def test_resolve_codex_runtime_credentials_pool_fallback_skips_exhausted(tmp_pat
     assert resolved["source"] == "credential_pool"
 
 
-def test_resolve_codex_runtime_credentials_pool_fallback_no_usable_entry(tmp_path, monkeypatch):
+def test_resolve_codex_runtime_credentials_pool_fallback_no_usable_entry(
+    tmp_path, monkeypatch
+):
     """When both singleton and pool are empty/unusable, the original AuthError propagates."""
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)
@@ -213,6 +234,96 @@ def test_resolve_codex_runtime_credentials_pool_fallback_no_usable_entry(tmp_pat
     with pytest.raises(AuthError) as exc:
         resolve_codex_runtime_credentials()
     assert exc.value.code == "codex_auth_missing"
+
+
+def test_resolve_codex_runtime_credentials_pool_all_rate_limited(tmp_path, monkeypatch):
+    """Singleton missing + every pool entry in 429 cooldown → rate-limit error.
+
+    Regression for #32790: a user whose tokens live only in the pool (e.g. set
+    up via ``hermes auth add openai-codex``) gets a misleading "No Codex
+    credentials stored. Run `hermes auth`" when all pool entries are in
+    upstream-quota cooldown, even though credentials are valid and only the
+    cap has been hit. The classification must be CODEX_RATE_LIMITED_CODE so
+    the gateway surfaces a "retry later" notice instead of an auth-failure
+    panic.
+    """
+    import time as _time
+
+    from hermes_cli.auth import CODEX_RATE_LIMITED_CODE, is_rate_limited_auth_error
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    future_reset = _time.time() + 3 * 3600 + 15 * 60  # 3h 15m cooldown remaining
+    auth_store = {
+        "version": 1,
+        "providers": {},  # singleton missing — pool-only setup
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "source": "device_code",
+                    "access_token": "rate-limited-token",
+                    "last_status": "exhausted",
+                    "last_error_code": 429,
+                    "last_error_reason": "usage_limit_reached",
+                    "last_error_reset_at": future_reset,
+                },
+            ],
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc:
+        resolve_codex_runtime_credentials()
+    err = exc.value
+    assert err.code == CODEX_RATE_LIMITED_CODE
+    assert err.relogin_required is False
+    assert is_rate_limited_auth_error(err) is True
+    # User-facing message must reflect quota cap, not missing credentials.
+    rendered = str(err)
+    assert "No Codex credentials stored" not in rendered
+    assert "quota" in rendered.lower()
+    assert "Credentials are still valid" in rendered
+    # Cooldown should be reported in a human-friendly h/m form, not raw seconds.
+    assert "3h" in rendered
+
+
+def test_resolve_codex_runtime_credentials_pool_401_remains_auth_error(
+    tmp_path, monkeypatch
+):
+    """401-cooldowns (real auth failures) must not be reclassified as rate-limits.
+
+    Re-auth IS the right remediation for 401, so we keep the existing
+    ``codex_auth_missing`` propagation rather than silencing it as a quota cap.
+    """
+    import time as _time
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    future_reset = _time.time() + 600
+    auth_store = {
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "source": "device_code",
+                    "access_token": "revoked-token",
+                    "last_status": "exhausted",
+                    "last_error_code": 401,
+                    "last_error_reason": "token_invalidated",
+                    "last_error_reset_at": future_reset,
+                },
+            ],
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc:
+        resolve_codex_runtime_credentials()
+    assert exc.value.code == "codex_auth_missing"
+    assert exc.value.relogin_required is True
 
 
 def test_resolve_provider_explicit_codex_does_not_fallback(monkeypatch):
@@ -244,42 +355,46 @@ def test_save_codex_tokens_syncs_credential_pool(tmp_path, monkeypatch):
     """
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)
-    (hermes_home / "auth.json").write_text(json.dumps({
-        "version": 1,
-        "providers": {
-            "openai-codex": {
-                "tokens": {"access_token": "old-at", "refresh_token": "old-rt"},
-                "last_refresh": "2026-01-01T00:00:00Z",
-                "auth_mode": "chatgpt",
+    (hermes_home / "auth.json").write_text(
+        json.dumps({
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {"access_token": "old-at", "refresh_token": "old-rt"},
+                    "last_refresh": "2026-01-01T00:00:00Z",
+                    "auth_mode": "chatgpt",
+                },
             },
-        },
-        "credential_pool": {
-            "openai-codex": [
-                {
-                    "id": "abc123",
-                    "source": "device_code",
-                    "auth_type": "oauth",
-                    "access_token": "old-at",
-                    "refresh_token": "old-rt",
-                    "last_status": "exhausted",
-                    "last_error_code": 401,
-                    "last_error_reason": "token_invalidated",
-                    "last_error_reset_at": 9999999999,
-                },
-                {
-                    "id": "manual1",
-                    "source": "manual:codex",
-                    "auth_type": "oauth",
-                    "access_token": "manual-at",
-                    "refresh_token": "manual-rt",
-                },
-            ],
-        },
-    }))
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "abc123",
+                        "source": "device_code",
+                        "auth_type": "oauth",
+                        "access_token": "old-at",
+                        "refresh_token": "old-rt",
+                        "last_status": "exhausted",
+                        "last_error_code": 401,
+                        "last_error_reason": "token_invalidated",
+                        "last_error_reset_at": 9999999999,
+                    },
+                    {
+                        "id": "manual1",
+                        "source": "manual:codex",
+                        "auth_type": "oauth",
+                        "access_token": "manual-at",
+                        "refresh_token": "manual-rt",
+                    },
+                ],
+            },
+        })
+    )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
-    _save_codex_tokens({"access_token": "new-at", "refresh_token": "new-rt"},
-                       last_refresh="2026-05-27T00:00:00Z")
+    _save_codex_tokens(
+        {"access_token": "new-at", "refresh_token": "new-rt"},
+        last_refresh="2026-05-27T00:00:00Z",
+    )
 
     auth = json.loads((hermes_home / "auth.json").read_text())
     pool = auth["credential_pool"]["openai-codex"]
@@ -322,61 +437,65 @@ def test_save_codex_tokens_syncs_manual_device_code_entries(tmp_path, monkeypatc
     """
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)
-    (hermes_home / "auth.json").write_text(json.dumps({
-        "version": 1,
-        "providers": {
-            "openai-codex": {
-                "tokens": {"access_token": "old-at", "refresh_token": "old-rt"},
-                "last_refresh": "2026-01-01T00:00:00Z",
-                "auth_mode": "chatgpt",
+    (hermes_home / "auth.json").write_text(
+        json.dumps({
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {"access_token": "old-at", "refresh_token": "old-rt"},
+                    "last_refresh": "2026-01-01T00:00:00Z",
+                    "auth_mode": "chatgpt",
+                },
             },
-        },
-        "credential_pool": {
-            "openai-codex": [
-                {
-                    "id": "seeded",
-                    "source": "device_code",
-                    "auth_type": "oauth",
-                    "access_token": "old-at",
-                    "refresh_token": "old-rt",
-                },
-                # Legacy alias from the #33000 workaround era — its tokens
-                # match the singleton, so it is a true alias and SHOULD be
-                # refreshed (preserves #33538 behavior).
-                {
-                    "id": "legacy-alias",
-                    "source": "manual:device_code",
-                    "auth_type": "oauth",
-                    "access_token": "old-at",
-                    "refresh_token": "old-rt",
-                    "last_status": "exhausted",
-                    "last_error_code": 401,
-                    "last_error_reason": "token_invalidated",
-                },
-                # Independent account from `hermes auth add openai-codex` —
-                # its tokens are distinct from the singleton.  Must NOT be
-                # overwritten by a re-auth that targeted a different account
-                # (#39236).
-                {
-                    "id": "independent",
-                    "source": "manual:device_code",
-                    "auth_type": "oauth",
-                    "access_token": "independent-at",
-                    "refresh_token": "independent-rt",
-                },
-                {
-                    "id": "api-key",
-                    "source": "manual:api_key",
-                    "auth_type": "api_key",
-                    "access_token": "user-api-key",
-                },
-            ],
-        },
-    }))
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "seeded",
+                        "source": "device_code",
+                        "auth_type": "oauth",
+                        "access_token": "old-at",
+                        "refresh_token": "old-rt",
+                    },
+                    # Legacy alias from the #33000 workaround era — its tokens
+                    # match the singleton, so it is a true alias and SHOULD be
+                    # refreshed (preserves #33538 behavior).
+                    {
+                        "id": "legacy-alias",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "access_token": "old-at",
+                        "refresh_token": "old-rt",
+                        "last_status": "exhausted",
+                        "last_error_code": 401,
+                        "last_error_reason": "token_invalidated",
+                    },
+                    # Independent account from `hermes auth add openai-codex` —
+                    # its tokens are distinct from the singleton.  Must NOT be
+                    # overwritten by a re-auth that targeted a different account
+                    # (#39236).
+                    {
+                        "id": "independent",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "access_token": "independent-at",
+                        "refresh_token": "independent-rt",
+                    },
+                    {
+                        "id": "api-key",
+                        "source": "manual:api_key",
+                        "auth_type": "api_key",
+                        "access_token": "user-api-key",
+                    },
+                ],
+            },
+        })
+    )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
-    _save_codex_tokens({"access_token": "fresh-at", "refresh_token": "fresh-rt"},
-                       last_refresh="2026-05-28T00:00:00Z")
+    _save_codex_tokens(
+        {"access_token": "fresh-at", "refresh_token": "fresh-rt"},
+        last_refresh="2026-05-28T00:00:00Z",
+    )
 
     auth = json.loads((hermes_home / "auth.json").read_text())
     pool = auth["credential_pool"]["openai-codex"]
@@ -406,7 +525,9 @@ def test_save_codex_tokens_syncs_manual_device_code_entries(tmp_path, monkeypatc
     assert "refresh_token" not in api_key or api_key.get("refresh_token") is None
 
 
-def test_save_codex_tokens_does_not_overwrite_independent_manual_entries(tmp_path, monkeypatch):
+def test_save_codex_tokens_does_not_overwrite_independent_manual_entries(
+    tmp_path, monkeypatch
+):
     """Re-auth must NOT overwrite ``manual:device_code`` entries that hold
     independent token material (different OpenAI/ChatGPT accounts).
 
@@ -425,52 +546,54 @@ def test_save_codex_tokens_does_not_overwrite_independent_manual_entries(tmp_pat
     """
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)
-    (hermes_home / "auth.json").write_text(json.dumps({
-        "version": 1,
-        "providers": {
-            "openai-codex": {
-                # Old singleton tokens — represent "account A" which the user
-                # logged in with via setup originally.
-                "tokens": {"access_token": "acctA-at", "refresh_token": "acctA-rt"},
-                "last_refresh": "2026-01-01T00:00:00Z",
-                "auth_mode": "chatgpt",
-                "label": "account-A",
-            },
-        },
-        "credential_pool": {
-            "openai-codex": [
-                # The seeded singleton mirror of account A.
-                {
-                    "id": "seeded",
+    (hermes_home / "auth.json").write_text(
+        json.dumps({
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    # Old singleton tokens — represent "account A" which the user
+                    # logged in with via setup originally.
+                    "tokens": {"access_token": "acctA-at", "refresh_token": "acctA-rt"},
+                    "last_refresh": "2026-01-01T00:00:00Z",
+                    "auth_mode": "chatgpt",
                     "label": "account-A",
-                    "source": "device_code",
-                    "auth_type": "oauth",
-                    "access_token": "acctA-at",
-                    "refresh_token": "acctA-rt",
                 },
-                # Two INDEPENDENT manual entries added later via
-                # ``hermes auth add openai-codex`` (account B and account C).
-                # Each has its OWN distinct token material, unrelated to the
-                # singleton.
-                {
-                    "id": "acctB",
-                    "label": "account-B",
-                    "source": "manual:device_code",
-                    "auth_type": "oauth",
-                    "access_token": "acctB-at",
-                    "refresh_token": "acctB-rt",
-                },
-                {
-                    "id": "acctC",
-                    "label": "account-C",
-                    "source": "manual:device_code",
-                    "auth_type": "oauth",
-                    "access_token": "acctC-at",
-                    "refresh_token": "acctC-rt",
-                },
-            ],
-        },
-    }))
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    # The seeded singleton mirror of account A.
+                    {
+                        "id": "seeded",
+                        "label": "account-A",
+                        "source": "device_code",
+                        "auth_type": "oauth",
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    # Two INDEPENDENT manual entries added later via
+                    # ``hermes auth add openai-codex`` (account B and account C).
+                    # Each has its OWN distinct token material, unrelated to the
+                    # singleton.
+                    {
+                        "id": "acctB",
+                        "label": "account-B",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "access_token": "acctB-at",
+                        "refresh_token": "acctB-rt",
+                    },
+                    {
+                        "id": "acctC",
+                        "label": "account-C",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "access_token": "acctC-at",
+                        "refresh_token": "acctC-rt",
+                    },
+                ],
+            },
+        })
+    )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     # User re-authenticates account A — fresh device-code login produces new
@@ -520,40 +643,45 @@ def test_save_codex_tokens_still_refreshes_legacy_manual_alias(tmp_path, monkeyp
     """
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)
-    (hermes_home / "auth.json").write_text(json.dumps({
-        "version": 1,
-        "providers": {
-            "openai-codex": {
-                "tokens": {"access_token": "shared-at", "refresh_token": "shared-rt"},
-                "last_refresh": "2026-01-01T00:00:00Z",
-                "auth_mode": "chatgpt",
+    (hermes_home / "auth.json").write_text(
+        json.dumps({
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "shared-at",
+                        "refresh_token": "shared-rt",
+                    },
+                    "last_refresh": "2026-01-01T00:00:00Z",
+                    "auth_mode": "chatgpt",
+                },
             },
-        },
-        "credential_pool": {
-            "openai-codex": [
-                {
-                    "id": "seeded",
-                    "source": "device_code",
-                    "auth_type": "oauth",
-                    "access_token": "shared-at",
-                    "refresh_token": "shared-rt",
-                },
-                {
-                    "id": "legacy",
-                    "label": "legacy-alias",
-                    "source": "manual:device_code",
-                    "auth_type": "oauth",
-                    # Token material matches the singleton — this is a true
-                    # alias from the #33000 workaround era.
-                    "access_token": "shared-at",
-                    "refresh_token": "shared-rt",
-                    "last_status": "exhausted",
-                    "last_error_code": 401,
-                    "last_error_reason": "token_invalidated",
-                },
-            ],
-        },
-    }))
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "seeded",
+                        "source": "device_code",
+                        "auth_type": "oauth",
+                        "access_token": "shared-at",
+                        "refresh_token": "shared-rt",
+                    },
+                    {
+                        "id": "legacy",
+                        "label": "legacy-alias",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        # Token material matches the singleton — this is a true
+                        # alias from the #33000 workaround era.
+                        "access_token": "shared-at",
+                        "refresh_token": "shared-rt",
+                        "last_status": "exhausted",
+                        "last_error_code": 401,
+                        "last_error_reason": "token_invalidated",
+                    },
+                ],
+            },
+        })
+    )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     _save_codex_tokens(
@@ -579,7 +707,9 @@ def test_save_codex_tokens_still_refreshes_legacy_manual_alias(tmp_path, monkeyp
     assert legacy["last_error_reason"] is None
 
 
-def test_save_codex_tokens_handles_missing_previous_singleton_tokens(tmp_path, monkeypatch):
+def test_save_codex_tokens_handles_missing_previous_singleton_tokens(
+    tmp_path, monkeypatch
+):
     """First-ever Codex save (no prior singleton tokens) must not crash.
 
     Edge case: a user has only pool entries (e.g. via direct auth.json edit
@@ -591,22 +721,24 @@ def test_save_codex_tokens_handles_missing_previous_singleton_tokens(tmp_path, m
     """
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)
-    (hermes_home / "auth.json").write_text(json.dumps({
-        "version": 1,
-        "providers": {},
-        "credential_pool": {
-            "openai-codex": [
-                {
-                    "id": "preexisting",
-                    "label": "pre-existing-manual",
-                    "source": "manual:device_code",
-                    "auth_type": "oauth",
-                    "access_token": "preexisting-at",
-                    "refresh_token": "preexisting-rt",
-                },
-            ],
-        },
-    }))
+    (hermes_home / "auth.json").write_text(
+        json.dumps({
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "preexisting",
+                        "label": "pre-existing-manual",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "access_token": "preexisting-at",
+                        "refresh_token": "preexisting-rt",
+                    },
+                ],
+            },
+        })
+    )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     _save_codex_tokens(
@@ -633,26 +765,31 @@ def test_save_codex_tokens_alias_match_uses_access_token_only(tmp_path, monkeypa
     """
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)
-    (hermes_home / "auth.json").write_text(json.dumps({
-        "version": 1,
-        "providers": {
-            "openai-codex": {
-                "tokens": {"access_token": "shared-at", "refresh_token": "shared-rt"},
-                "auth_mode": "chatgpt",
-            },
-        },
-        "credential_pool": {
-            "openai-codex": [
-                {
-                    "id": "alias-no-refresh",
-                    "source": "manual:device_code",
-                    "auth_type": "oauth",
-                    "access_token": "shared-at",
-                    # No refresh_token at all — legacy schema.
+    (hermes_home / "auth.json").write_text(
+        json.dumps({
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "shared-at",
+                        "refresh_token": "shared-rt",
+                    },
+                    "auth_mode": "chatgpt",
                 },
-            ],
-        },
-    }))
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "alias-no-refresh",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "access_token": "shared-at",
+                        # No refresh_token at all — legacy schema.
+                    },
+                ],
+            },
+        })
+    )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     _save_codex_tokens(
@@ -668,7 +805,9 @@ def test_save_codex_tokens_alias_match_uses_access_token_only(tmp_path, monkeypa
     assert alias["refresh_token"] == "new-rt"
 
 
-def test_save_codex_tokens_clears_error_markers_only_on_refreshed_entries(tmp_path, monkeypatch):
+def test_save_codex_tokens_clears_error_markers_only_on_refreshed_entries(
+    tmp_path, monkeypatch
+):
     """Error markers must be cleared only on entries that were actually
     refreshed by this re-auth.  Independent ``manual:device_code`` entries
     with their own stale-error markers must be left alone (their stale state
@@ -676,38 +815,40 @@ def test_save_codex_tokens_clears_error_markers_only_on_refreshed_entries(tmp_pa
     """
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)
-    (hermes_home / "auth.json").write_text(json.dumps({
-        "version": 1,
-        "providers": {
-            "openai-codex": {
-                "tokens": {"access_token": "acctA-at", "refresh_token": "acctA-rt"},
-                "auth_mode": "chatgpt",
+    (hermes_home / "auth.json").write_text(
+        json.dumps({
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {"access_token": "acctA-at", "refresh_token": "acctA-rt"},
+                    "auth_mode": "chatgpt",
+                },
             },
-        },
-        "credential_pool": {
-            "openai-codex": [
-                {
-                    "id": "seeded",
-                    "source": "device_code",
-                    "auth_type": "oauth",
-                    "access_token": "acctA-at",
-                    "refresh_token": "acctA-rt",
-                    "last_status": "exhausted",
-                    "last_error_code": 401,
-                },
-                {
-                    "id": "acctB",
-                    "source": "manual:device_code",
-                    "auth_type": "oauth",
-                    "access_token": "acctB-at",
-                    "refresh_token": "acctB-rt",
-                    "last_status": "exhausted",
-                    "last_error_code": 429,
-                    "last_error_reason": "quota_exhausted",
-                },
-            ],
-        },
-    }))
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "seeded",
+                        "source": "device_code",
+                        "auth_type": "oauth",
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                        "last_status": "exhausted",
+                        "last_error_code": 401,
+                    },
+                    {
+                        "id": "acctB",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "access_token": "acctB-at",
+                        "refresh_token": "acctB-rt",
+                        "last_status": "exhausted",
+                        "last_error_code": 429,
+                        "last_error_reason": "quota_exhausted",
+                    },
+                ],
+            },
+        })
+    )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
     _save_codex_tokens(
@@ -736,9 +877,11 @@ def test_save_codex_tokens_clears_error_markers_only_on_refreshed_entries(tmp_pa
 def test_import_codex_cli_tokens(tmp_path, monkeypatch):
     codex_home = tmp_path / "codex-cli"
     codex_home.mkdir(parents=True, exist_ok=True)
-    (codex_home / "auth.json").write_text(json.dumps({
-        "tokens": {"access_token": "cli-at", "refresh_token": "cli-rt"},
-    }))
+    (codex_home / "auth.json").write_text(
+        json.dumps({
+            "tokens": {"access_token": "cli-at", "refresh_token": "cli-rt"},
+        })
+    )
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
 
     tokens = _import_codex_cli_tokens()
@@ -789,7 +932,9 @@ class _StubHTTPResponse:
         self.status_code = status_code
         self._payload = payload
         self.headers = headers or {}
-        self.text = json.dumps(payload) if isinstance(payload, (dict, list)) else str(payload)
+        self.text = (
+            json.dumps(payload) if isinstance(payload, (dict, list)) else str(payload)
+        )
 
     def json(self):
         if isinstance(self._payload, Exception):
@@ -920,7 +1065,12 @@ def test_refresh_429_classified_as_quota_not_auth_failure(monkeypatch):
 
     response = _StubHTTPResponse(
         429,
-        {"error": {"message": "You hit your usage limit.", "code": "usage_limit_reached"}},
+        {
+            "error": {
+                "message": "You hit your usage limit.",
+                "code": "usage_limit_reached",
+            }
+        },
         headers={"retry-after": "120"},
     )
     _patch_httpx(monkeypatch, response)
@@ -960,7 +1110,10 @@ def test_is_rate_limited_auth_error_distinguishes_credential_errors():
     from hermes_cli.auth import CODEX_RATE_LIMITED_CODE, is_rate_limited_auth_error
 
     rate_limited = AuthError(
-        "quota", provider="openai-codex", code=CODEX_RATE_LIMITED_CODE, relogin_required=False
+        "quota",
+        provider="openai-codex",
+        code=CODEX_RATE_LIMITED_CODE,
+        relogin_required=False,
     )
     missing_creds = AuthError(
         "No Codex credentials stored.",
@@ -999,13 +1152,20 @@ def test_login_openai_codex_force_new_login_skips_existing_reuse_prompt(monkeypa
         called["last_refresh"] = last_refresh
 
     monkeypatch.setattr("hermes_cli.auth._save_codex_tokens", _fake_save)
-    monkeypatch.setattr("hermes_cli.auth._update_config_for_provider", lambda *args, **kwargs: "/tmp/config.yaml")
+    monkeypatch.setattr(
+        "hermes_cli.auth._update_config_for_provider",
+        lambda *args, **kwargs: "/tmp/config.yaml",
+    )
     monkeypatch.setattr(
         "builtins.input",
-        lambda prompt="": (_ for _ in ()).throw(AssertionError("force_new_login should not prompt for reuse/import")),
+        lambda prompt="": (_ for _ in ()).throw(
+            AssertionError("force_new_login should not prompt for reuse/import")
+        ),
     )
 
-    _login_openai_codex(SimpleNamespace(), PROVIDER_REGISTRY["openai-codex"], force_new_login=True)
+    _login_openai_codex(
+        SimpleNamespace(), PROVIDER_REGISTRY["openai-codex"], force_new_login=True
+    )
 
     assert called["device_login"] == 1
     assert called["tokens"]["access_token"] == "fresh-at"


### PR DESCRIPTION
## What does this PR do?

Follow-up to f1422ffd7 (Refs #32790). That commit reclassified Codex OAuth token-endpoint 429s, but the pool-only setup path still misclassifies upstream quota exhaustion as a missing-credentials error.

When openai-codex tokens live only in `credential_pool.openai-codex` (the standard outcome of `hermes auth add openai-codex`, which does not populate `providers.openai-codex.tokens`) and every pool entry is in 429 cooldown, `resolve_codex_runtime_credentials` falls back to `_pool_codex_access_token`. That helper skips entries in cooldown and returns `""`, so the singleton's `AuthError("No Codex credentials stored. Run hermes auth to authenticate.", code="codex_auth_missing", relogin_required=True)` is re-raised verbatim.

The gateway then logs `Primary provider auth failed: No Codex credentials stored...` and surfaces the same string in the chat reply (when no `fallback_providers` is configured), which contradicts `hermes auth list` (`device_code rate-limited (429) (Xh Ym left)`) and panics operators into running `hermes auth` for a usage cap re-auth cannot lift.

This change adds `_pool_codex_rate_limit_remaining` and uses it to detect the all-in-429-cooldown case (token-bearing entries with `last_error_code == 429` and a future `last_error_reset_at`). When detected, `resolve_codex_runtime_credentials` raises a `CODEX_RATE_LIMITED_CODE` AuthError with the cooldown delta and a `Credentials are still valid` note, which `is_rate_limited_auth_error` already routes to the existing rate-limit log message in `gateway.run` and to `format_auth_error`'s non-re-auth remediation. 401/403 cooldowns are intentionally left as `codex_auth_missing` errors because re-auth IS the right remediation there.

## Related Issue

Refs #32790

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py`: add `_pool_codex_rate_limit_remaining` (longest 429 cooldown across token-bearing pool entries) and `_format_cooldown_wait` (HhMm/MmSs/Ss helper); update `resolve_codex_runtime_credentials` to raise `CODEX_RATE_LIMITED_CODE` when the singleton is missing and every token-bearing pool entry is in 429 cooldown.
- `tests/hermes_cli/test_auth_codex_provider.py`: add `test_resolve_codex_runtime_credentials_pool_all_rate_limited` (regression for the misclassification) and `test_resolve_codex_runtime_credentials_pool_401_remains_auth_error` (proves we don't suppress real auth failures).

## How to Test

1. Run the regression tests: `pytest tests/hermes_cli/test_auth_codex_provider.py -q`.
2. Simulate the bug locally: write `~/.hermes/auth.json` with `providers: {}` and one `credential_pool.openai-codex` entry whose `last_status == "exhausted"`, `last_error_code == 429`, and `last_error_reset_at` is in the future; then call `python -c "from hermes_cli.auth import resolve_codex_runtime_credentials as f; f()"` and confirm the raised `AuthError.code` is `codex_rate_limited` rather than `codex_auth_missing`.
3. Confirm `gateway/run.py:_resolve_runtime_agent_kwargs` reaches the `Primary provider rate-limited (429)` branch via `is_rate_limited_auth_error` instead of the `Primary provider auth failed` branch.

## What platforms tested on

- macOS 15.x on darwin-arm64 (local).
- Linux / Windows: not exercised locally; relying on CI. Code change is pure-Python without platform-conditional logic, paths, signals, or subprocess use; `scripts/check-windows-footguns.py --diff main` reports no findings.

## Checklist

- [x] My commit messages follow Conventional Commits (`fix(gateway): ...`)
- [x] I've run the relevant pytest selection (`tests/hermes_cli/`) and all tests pass
- [x] I've added tests for my changes
- [x] I've considered cross-platform impact (`scripts/check-windows-footguns.py --diff main` clean)

<!-- autocontrib:worker-id=issue-new-47b7add6 kind=pr-open -->