### PR TITLE
fix(opencode-go): cap mimo-v2.5-pro max_tokens at 131072

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -476,13 +476,17 @@ class ChatCompletionsTransport(ProviderTransport):
         ephemeral = params.get("ephemeral_max_output_tokens")
         user_max = params.get("max_tokens")
         anthropic_max = params.get("anthropic_max_output")
+        # Per-model default cap — profiles override get_max_tokens() when
+        # they front several backends with different completion-token limits
+        # (e.g. opencode-go: mimo-v2.5-pro = 131072).
+        profile_max = profile.get_max_tokens(model)
 
         if ephemeral is not None and max_tokens_fn:
             api_kwargs.update(max_tokens_fn(ephemeral))
         elif user_max is not None and max_tokens_fn:
             api_kwargs.update(max_tokens_fn(user_max))
-        elif profile.default_max_tokens and max_tokens_fn:
-            api_kwargs.update(max_tokens_fn(profile.default_max_tokens))
+        elif profile_max and max_tokens_fn:
+            api_kwargs.update(max_tokens_fn(profile_max))
         elif anthropic_max is not None:
             api_kwargs["max_tokens"] = anthropic_max
 

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -34,6 +34,21 @@ def _is_deepseek_thinking_model(model: str | None) -> bool:
 class OpenCodeGoProfile(ProviderProfile):
     """OpenCode Go - model-specific reasoning controls."""
 
+    # Per-model completion-token cap. The opencode-go relay's default is
+    # too large for mimo-v2.5-pro — it sends max_tokens=262144 but Xiaomi
+    # only supports 131072 completion tokens and 400s the request.
+    # Setting an explicit cap here prevents the relay default from being
+    # applied. Keys are normalized via _flat_model_name().
+    _MODEL_MAX_TOKENS: dict[str, int] = {
+        "mimo-v2.5-pro": 131072,
+    }
+
+    def get_max_tokens(self, model: str | None) -> int | None:
+        cap = self._MODEL_MAX_TOKENS.get(_flat_model_name(model))
+        if cap is not None:
+            return cap
+        return self.default_max_tokens
+
     def build_api_kwargs_extras(
         self, *, reasoning_config: dict | None = None, model: str | None = None, **context
     ) -> tuple[dict[str, Any], dict[str, Any]]:

--- a/providers/base.py
+++ b/providers/base.py
@@ -129,6 +129,20 @@ class ProviderProfile:
         """
         return {}, {}
 
+    def get_max_tokens(self, model: str | None) -> int | None:
+        """Return the default max_tokens cap for *model*.
+
+        Overrideable hook for providers that need per-model output caps —
+        e.g. a relay that fronts several upstream backends, each with a
+        different completion-token limit. The transport calls this when
+        the user hasn't set an explicit max_tokens.
+
+        Default: return self.default_max_tokens (the static profile field),
+        ignoring the model name. Override in a subclass to vary the cap
+        per-model.
+        """
+        return self.default_max_tokens
+
     def fetch_models(
         self,
         *,


### PR DESCRIPTION
## Summary
`hermes chat` with `mimo-v2.5-pro` on `opencode-go` now sends `max_tokens=131072` instead of relying on the relay's broken `262144` default, so first-call 400s with `"max_tokens is too large: 262144"` stop happening.

Root cause: the opencode-go relay fills in `max_tokens=262144` when none is sent, but Xiaomi's `mimo-v2.5-pro` only supports 131072 completion tokens. We had no per-model way to override.

## Changes
- `providers/base.py`: new `get_max_tokens(model)` hook on `ProviderProfile`, default returns `self.default_max_tokens` (no behavior change for any existing provider)
- `agent/transports/chat_completions.py`: read profile cap via `get_max_tokens(model)` instead of the static `default_max_tokens` field
- `plugins/model-providers/opencode-zen/__init__.py`: `OpenCodeGoProfile` overrides `get_max_tokens()` with a one-entry table — `mimo-v2.5-pro=131072`. Every other model returns None → unchanged.

## Validation
| | Before | After |
|---|---|---|
| `mimo-v2.5-pro` first request | 400 — `max_tokens is too large: 262144` | `max_tokens=131072` sent, accepted |
| Other opencode-go models (kimi, glm, qwen, minimax) | no max_tokens sent | no max_tokens sent (unchanged) |
| opencode-zen, other providers | no behavior change | no behavior change |
| `tests/agent/transports/` + `tests/providers/` | — | 176/176 pass |

Confirmed via repro that `_build_kwargs_from_profile()` now puts `max_tokens=131072` in the api_kwargs for `mimo-v2.5-pro` on opencode-go, and `None` for every other model on the same provider.

## Infographic
https://v3b.fal.media/files/b/0a9c1a8c/YSg5cTdZL0yzCD7TRX72P_CfCtZSso.png
