### PR TITLE
fix(cli): clean node_modules when npm ci fails before install fallback

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4853,6 +4853,16 @@ def _run_npm_install_deterministic(
         )
         if ci_result.returncode == 0:
             return ci_result
+        # ``npm ci`` failed — it may have partially mutated node_modules
+        # (e.g. downloaded some tarballs before hitting a checksum mismatch
+        # or a transient network error).  Left in place, the half-installed
+        # tree causes the subsequent ``npm install`` fallback to trip over
+        # missing or mismatched packages (issue #34312).  Remove it so the
+        # fallback starts from a clean slate — ``npm ci`` itself would have
+        # done the same thing had it succeeded.
+        nm_dir = cwd / "node_modules"
+        if nm_dir.exists():
+            shutil.rmtree(nm_dir)
         # Fall through to `npm install` — lockfile may be out of sync on a
         # WIP fork/branch, or `npm ci` may not be available on very old npm.
     install_cmd = [npm, "install", *extra_args]

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -335,3 +335,62 @@ class TestBuildWebUIRetryAndStaleFallback:
         assert "Web UI build failed" in out
         assert "vite ENOMEM" in out
         assert "Run manually" in out
+
+class TestNpmCiCleansNodeModules:
+    """When ``npm ci`` fails, ``node_modules`` must be removed before the
+    ``npm install`` fallback runs (issue #34312)."""
+
+    def test_ci_failure_removes_node_modules_before_install(self, tmp_path):
+        web_dir = tmp_path / "web"
+        web_dir.mkdir()
+        (web_dir / "package.json").write_text("{}")
+        (web_dir / "package-lock.json").write_text("{}")
+        nm = web_dir / "node_modules"
+        nm.mkdir()
+        (nm / ".package-lock.json").write_text("{}")  # stale marker
+
+        Subprocess = __import__("subprocess")
+        ci_fail = Subprocess.CompletedProcess([], 1, stdout="", stderr="ERESOLVE")
+        install_ok = Subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+        calls = []
+        node_modules_existed_at_install = None
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[1] == "ci":
+                return ci_fail
+            # Record whether node_modules exists when install is called
+            if cmd[1] == "install":
+                nonlocal node_modules_existed_at_install
+                node_modules_existed_at_install = nm.exists()
+            return install_ok
+
+        with patch("hermes_cli.main.subprocess.run", side_effect=mock_run):
+            _run_npm_install_deterministic("/usr/bin/npm", web_dir)
+
+        assert calls[0][1] == "ci"
+        assert calls[1][1] == "install"
+        # node_modules was removed between ci failure and install
+        assert not nm.exists()
+        # Cleanup happened before the install command
+        assert node_modules_existed_at_install is False, (
+            "node_modules should not exist when install is called; "
+            "this verifies cleanup occurred before the fallback"
+        )
+
+    def test_ci_success_does_not_remove_node_modules(self, tmp_path):
+        web_dir = tmp_path / "web"
+        web_dir.mkdir()
+        (web_dir / "package.json").write_text("{}")
+        (web_dir / "package-lock.json").write_text("{}")
+        nm = web_dir / "node_modules"
+        nm.mkdir()
+
+        Subprocess = __import__("subprocess")
+        ci_ok = Subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+        with patch("hermes_cli.main.subprocess.run", return_value=ci_ok):
+            _run_npm_install_deterministic("/usr/bin/npm", web_dir)
+
+        assert nm.exists()  # not touched on success
+


### PR DESCRIPTION
## What does this PR do?

After `hermes update`, the dashboard service enters a permanent crash-loop:

```
✗ Web UI npm install failed
```

The reporter identified two symptoms from the same root cause:
1. `tsc` missing from `node_modules/.bin/`
2. `lucide-react` partial install — icons file layout doesn't match what's on disk

Both are classic symptoms of `npm install` running on a corrupted `node_modules` tree where dependency versions changed across the update (lucide-react upgrade shifts its icons file layout in newer versions).

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence
- Analyzed: `_run_npm_install_deterministic` (callers: 3 — `_build_web_ui`, `_update_node_dependencies` × 2 paths)
- Blast radius: LOW — only affects the `npm ci` failure fallback path
- Related patterns: `_build_web_ui` handles build retry + stale dist fallback separately