### PR TITLE
feat(cli): add HERMES_LLM_BASE_URL generic base-URL fallback for local proxies

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -407,6 +407,18 @@ def _resolve_runtime_from_pool_entry(
     # config.default was still a Claude model.
     effective_model = (target_model or model_cfg.get("default") or "")
     base_url = (getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or "").rstrip("/")
+    # MeshBoard stream-tap launcher sets HERMES_LLM_BASE_URL to a local
+    # loopback proxy URL when the stream-tap is active.  This env var
+    # must override the pool's default base_url so inference traffic
+    # is routed through the proxy and captured as JSONL for the
+    # dashboard.  Without this, Hermes bypasses the tap entirely and
+    # the dashboard shows "model silent" during active dispatches.
+    # However, OAuth providers (qwen-oauth, xai-oauth, etc.) carry
+    # tokens scoped to their own endpoints — do not redirect those.
+    _tap_url = os.getenv("HERMES_LLM_BASE_URL", "").strip().rstrip("/")
+    _oauth_providers = {"qwen-oauth", "xai-oauth", "google-gemini-cli", "minimax-oauth"}
+    if _tap_url and provider not in _oauth_providers:
+        base_url = _tap_url
     api_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
     api_mode = "chat_completions"
     if provider == "openai-codex":
@@ -1073,6 +1085,11 @@ def _resolve_openrouter_runtime(
 
     env_openrouter_base_url = _getenv("OPENROUTER_BASE_URL", "").strip()
     env_custom_base_url = _getenv("CUSTOM_BASE_URL", "").strip()
+    # MeshBoard stream-tap launcher sets HERMES_LLM_BASE_URL to a local
+    # proxy URL.  Honour it when the provider-specific env var is absent
+    # so the tap proxy actually receives inference traffic instead of
+    # being silently bypassed in favour of the default upstream URL.
+    env_hermes_llm_base_url = os.getenv("HERMES_LLM_BASE_URL", "").strip().rstrip("/")
 
     # Use config base_url when available and the provider context matches.
     # OPENAI_BASE_URL env var is no longer consulted — config.yaml is
@@ -1092,6 +1109,7 @@ def _resolve_openrouter_runtime(
         or env_custom_base_url
         or (cfg_base_url.strip() if use_config_base_url else "")
         or env_openrouter_base_url
+        or env_hermes_llm_base_url
         or OPENROUTER_BASE_URL
     ).rstrip("/")
 
@@ -1462,6 +1480,12 @@ def _resolve_explicit_runtime(
         env_url = ""
         if pconfig.base_url_env_var:
             env_url = _getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
+        # MeshBoard stream-tap launcher sets HERMES_LLM_BASE_URL to a local
+        # proxy URL.  Honour it when the provider-specific env var is absent
+        # so the tap proxy actually receives inference traffic instead of
+        # being silently bypassed in favour of the default upstream URL.
+        if not env_url:
+            env_url = os.getenv("HERMES_LLM_BASE_URL", "").strip().rstrip("/")
 
         base_url = explicit_base_url
         if not base_url:

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -3375,3 +3375,115 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     }
     assert resolved["api_key"] == "pooled-key"
     assert resolved["source"] == "pool:lmstudio-pool"
+
+
+class TestHermesLlmBaseUrl:
+    """Tests for HERMES_LLM_BASE_URL env var override (MeshBoard stream-tap).
+
+    HERMES_LLM_BASE_URL is set by the MeshBoard stream-tap launcher to a local
+    loopback proxy URL.  It must override the resolved base_url so inference
+    traffic is routed through the proxy and captured as JSONL for the dashboard.
+    """
+
+    def test_pool_entry_honors_hermes_llm_base_url(self, monkeypatch):
+        """HERMES_LLM_BASE_URL overrides pool entry base_url."""
+        class _Entry:
+            access_token = "pool-token"
+            source = "manual"
+            base_url = "https://pool.example.com/v1"
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def select(self):
+                return _Entry()
+
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+        monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+        monkeypatch.setenv("HERMES_LLM_BASE_URL", "http://127.0.0.1:9999/v1")
+
+        resolved = rp.resolve_runtime_provider(requested="openai-codex")
+
+        assert resolved["base_url"] == "http://127.0.0.1:9999/v1"
+        assert resolved["api_key"] == "pool-token"
+
+    def test_explicit_path_honors_hermes_llm_base_url(self, monkeypatch):
+        """HERMES_LLM_BASE_URL overrides explicit path when provider env var absent."""
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+        monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("HERMES_LLM_BASE_URL", "http://127.0.0.1:9999/v1")
+
+        resolved = rp.resolve_runtime_provider(
+            requested="openrouter",
+            explicit_api_key="test-key",
+        )
+
+        assert resolved["base_url"] == "http://127.0.0.1:9999/v1"
+        assert resolved["api_key"] == "test-key"
+
+    def test_provider_specific_env_var_wins_over_hermes_llm_base_url(self, monkeypatch):
+        """Provider-specific base_url_env_var takes precedence over HERMES_LLM_BASE_URL."""
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+        monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("CUSTOM_BASE_URL", raising=False)
+        monkeypatch.setenv("OPENROUTER_BASE_URL", "http://provider-specific.example/v1")
+        monkeypatch.setenv("HERMES_LLM_BASE_URL", "http://127.0.0.1:9999/v1")
+
+        resolved = rp.resolve_runtime_provider(
+            requested="openrouter",
+            explicit_api_key="test-key",
+        )
+
+        # Provider-specific env var (OPENROUTER_BASE_URL) takes priority
+        assert resolved["base_url"] == "http://provider-specific.example/v1"
+
+    def test_hermes_llm_base_url_trailing_slash_stripped(self, monkeypatch):
+        """Trailing slashes on HERMES_LLM_BASE_URL are stripped."""
+        class _Entry:
+            access_token = "pool-token"
+            source = "manual"
+            base_url = "https://pool.example.com/v1"
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def select(self):
+                return _Entry()
+
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+        monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+        monkeypatch.setenv("HERMES_LLM_BASE_URL", "http://127.0.0.1:9999/v1/")
+
+        resolved = rp.resolve_runtime_provider(requested="openai-codex")
+
+        assert resolved["base_url"] == "http://127.0.0.1:9999/v1"
+
+    def test_no_hermes_llm_base_url_uses_default(self, monkeypatch):
+        """Without HERMES_LLM_BASE_URL, normal resolution still works."""
+        class _Entry:
+            access_token = "pool-token"
+            source = "manual"
+            base_url = "https://pool.example.com/v1"
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def select(self):
+                return _Entry()
+
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+        monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+        monkeypatch.delenv("HERMES_LLM_BASE_URL", raising=False)
+
+        resolved = rp.resolve_runtime_provider(requested="openai-codex")
+
+        assert resolved["base_url"] == "https://pool.example.com/v1"


### PR DESCRIPTION
## Summary

Add `HERMES_LLM_BASE_URL` env var support so MeshBoard stream-tap launcher can intercept inference traffic via a local proxy.

## Scope

This PR is intentionally narrowed to runtime-provider base URL resolution only:

- `hermes_cli/runtime_provider.py`
- `tests/hermes_cli/test_runtime_provider_resolution.py`

The separate `HERMES_SKIP_PROFILE_OVERRIDE` escape hatch is handled in #35076.

## Changes

### `hermes_cli/runtime_provider.py`

- Pool entries: `HERMES_LLM_BASE_URL` overrides pool `base_url` for non-OAuth providers.
- OAuth provider pool entries are not redirected because those tokens are scoped to their own endpoints.
- `_resolve_openrouter_runtime`: uses `HERMES_LLM_BASE_URL` as a fallback after provider-specific/config endpoints.
- `_resolve_explicit_runtime`: uses `HERMES_LLM_BASE_URL` when provider-specific base URL env vars are absent.

## Precedence

Provider-specific env vars such as `OPENROUTER_BASE_URL` win over `HERMES_LLM_BASE_URL`. The generic env var is a fallback for launcher/tap routing, not a universal override.

## Tests

```bash
python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q
```

Result: `132 passed in 3.53s`.

Fixes `hermes-llm-base-url-env-override`.