### PR TITLE
fix(acp): advertise MCP server capabilities

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -33,6 +33,7 @@ from acp.schema import (
     InitializeResponse,
     ListSessionsResponse,
     LoadSessionResponse,
+    McpCapabilities,
     McpServerHttp,
     McpServerSse,
     McpServerStdio,
@@ -842,6 +843,7 @@ class HermesACPAgent(acp.Agent):
             agent_info=Implementation(name="hermes-agent", version=HERMES_VERSION),
             agent_capabilities=AgentCapabilities(
                 load_session=True,
+                mcp_capabilities=McpCapabilities(http=True, sse=True),
                 prompt_capabilities=PromptCapabilities(image=True),
                 session_capabilities=SessionCapabilities(
                     fork=SessionForkCapabilities(),

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -110,6 +110,9 @@ class TestInitialize:
         caps = resp.agent_capabilities
         assert isinstance(caps, AgentCapabilities)
         assert caps.load_session is True
+        assert caps.mcp_capabilities is not None
+        assert caps.mcp_capabilities.http is True
+        assert caps.mcp_capabilities.sse is True
         assert caps.session_capabilities is not None
         assert caps.session_capabilities.fork is not None
         assert caps.session_capabilities.list is not None
@@ -121,6 +124,7 @@ class TestInitialize:
         resp = await agent.initialize(protocol_version=1)
         payload = resp.agent_capabilities.model_dump(by_alias=True, exclude_none=True)
         assert payload["loadSession"] is True
+        assert payload["mcpCapabilities"] == {"http": True, "sse": True}
         session_caps = payload["sessionCapabilities"]
         assert "fork" in session_caps
         assert "list" in session_caps


### PR DESCRIPTION
## Why
Tidewave.ai was unable to recognize the Hermes endpoint (openai compatible) as ACP enabled.

This change fixes that, which means now Tidewave can detect the endpoint as ACP capable.

## Summary
- Advertise ACP MCP capabilities for HTTP and SSE during `initialize`
- Cover the capability object and JSON wire format in ACP initialize tests

## Context
Some ACP clients use `agentCapabilities.mcpCapabilities` to decide whether an external agent supports MCP server handoff. Hermes already accepts ACP-provided stdio, HTTP, and SSE MCP server configs when creating sessions, but did not advertise HTTP/SSE support in the initialize response.

## Before and After

<img width="889" height="402" alt="Screenshot 2026-06-03 at 10 41 35" src="https://github.com/user-attachments/assets/8e8c54e3-19b7-4284-acfb-6500a0c6a2cc" />

<img width="889" height="402" alt="Screenshot 2026-06-03 at 11 05 43" src="https://github.com/user-attachments/assets/39ddfe78-7e20-46e5-b6c5-a7a6d25f4a40" />


## Test Plan
- `git diff --check`
- `.venv/bin/python -m py_compile acp_adapter/server.py tests/acp/test_server.py`
- `scripts/run_tests.sh tests/acp/test_server.py tests/acp_adapter/test_acp_images.py`
