### PR TITLE
fix(telegram): apply DM topic recovery before session keying

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -472,6 +472,7 @@ def is_host_excluded_by_no_proxy(hostname: str, no_proxy_value: str | None = Non
     return False
 
 
+import dataclasses
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -1561,6 +1562,10 @@ class BasePlatformAdapter(ABC):
         self.config = config
         self.platform = platform
         self._message_handler: Optional[MessageHandler] = None
+        # Optional hook (e.g. Telegram DM topic recovery) that rewrites
+        # ``event.source.thread_id`` before session keying. Returns the
+        # corrected thread_id or None to leave the source untouched.
+        self._topic_recovery_fn: Optional[Callable[[Any], Optional[str]]] = None
         self._running = False
         self._fatal_error_code: Optional[str] = None
         self._fatal_error_message: Optional[str] = None
@@ -1815,6 +1820,40 @@ class BasePlatformAdapter(ABC):
         an optional response string.
         """
         self._message_handler = handler
+
+    def set_topic_recovery_fn(
+        self,
+        fn: Optional[Callable[[Any], Optional[str]]],
+    ) -> None:
+        """Install a thread_id-recovery hook (Telegram DM topic mode).
+
+        The hook is called with ``event.source`` before session keying;
+        a non-None return value replaces ``source.thread_id``. Pass
+        ``None`` to clear the hook.
+        """
+        # Guard against subclasses that initialize via ``object.__new__`` in
+        # tests and never run ``BasePlatformAdapter.__init__``.
+        self._topic_recovery_fn = fn  # type: ignore[attr-defined]
+
+    def _apply_topic_recovery(self, event: MessageEvent) -> None:
+        """Rewrite ``event.source.thread_id`` in place if the hook returns one."""
+        recover = getattr(self, "_topic_recovery_fn", None)
+        if recover is None:
+            return
+        source = getattr(event, "source", None)
+        if source is None:
+            return
+        try:
+            recovered = recover(source)
+        except Exception:
+            logger.debug("topic recovery hook failed", exc_info=True)
+            return
+        if recovered is None or str(recovered) == str(source.thread_id or ""):
+            return
+        try:
+            event.source = dataclasses.replace(source, thread_id=str(recovered))
+        except Exception:
+            logger.debug("topic recovery rewrite failed", exc_info=True)
 
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""
@@ -3332,7 +3371,12 @@ class BasePlatformAdapter(ABC):
             return
 
         coerce_plaintext_gateway_command(event)
-        
+
+        # Rewrite ``event.source.thread_id`` via the installed recovery hook
+        # (Telegram DM topic mode) so the session key, guard checks, and
+        # downstream delivery all agree on the same lane.
+        self._apply_topic_recovery(event)
+
         session_key = build_session_key(
             event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5027,37 +5027,19 @@ class TelegramAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     def _text_batch_key(self, event: MessageEvent) -> str:
-        """Session-scoped key for text message batching."""
+        """Session-scoped key for text message batching.
+
+        Applies the installed topic-recovery hook first so DM-topic batches
+        coalesce on (and dispatch to) the recovered lane rather than the
+        raw inbound ``message_thread_id`` Telegram may have attached.
+        """
         from gateway.session import build_session_key
-        source = self._normalize_text_batch_source(event)
+        self._apply_topic_recovery(event)
         return build_session_key(
-            source,
+            event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
-
-    def _normalize_text_batch_source(self, event: MessageEvent):
-        """Apply runner-side Telegram DM topic recovery before batching."""
-        source = getattr(event, "source", None)
-        if source is None:
-            return source
-        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
-        recover_fn = getattr(runner, "_recover_telegram_topic_thread_id", None)
-        if not callable(recover_fn):
-            return source
-        try:
-            recovered = recover_fn(source)
-        except Exception:
-            logger.debug("telegram text batch recovery failed", exc_info=True)
-            return source
-        if recovered is None or str(recovered) == str(source.thread_id or ""):
-            return source
-        normalized = dataclasses.replace(source, thread_id=str(recovered))
-        try:
-            event.source = normalized
-        except Exception:
-            pass
-        return normalized
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5029,11 +5029,35 @@ class TelegramAdapter(BasePlatformAdapter):
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Session-scoped key for text message batching."""
         from gateway.session import build_session_key
+        source = self._normalize_text_batch_source(event)
         return build_session_key(
-            event.source,
+            source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
+
+    def _normalize_text_batch_source(self, event: MessageEvent):
+        """Apply runner-side Telegram DM topic recovery before batching."""
+        source = getattr(event, "source", None)
+        if source is None:
+            return source
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        recover_fn = getattr(runner, "_recover_telegram_topic_thread_id", None)
+        if not callable(recover_fn):
+            return source
+        try:
+            recovered = recover_fn(source)
+        except Exception:
+            logger.debug("telegram text batch recovery failed", exc_info=True)
+            return source
+        if recovered is None or str(recovered) == str(source.thread_id or ""):
+            return source
+        normalized = dataclasses.replace(source, thread_id=str(recovered))
+        try:
+            event.source = normalized
+        except Exception:
+            pass
+        return normalized
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4159,6 +4159,7 @@ class GatewayRunner:
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+            adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
             adapter._busy_text_mode = self._busy_text_mode
             
             # Try to connect
@@ -5864,6 +5865,7 @@ class GatewayRunner:
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+                    adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
                     adapter._busy_text_mode = self._busy_text_mode
 
                     success = await self._connect_adapter_with_timeout(adapter, platform)

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -6,12 +6,14 @@ from the same session and aggregate them before dispatching.
 """
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+from gateway.session import build_session_key
 
 
 def _make_adapter():
@@ -119,3 +121,62 @@ class TestTextBatching:
 
         assert len(adapter._pending_text_batches) == 0
         assert len(adapter._pending_text_batch_tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_dm_topic_batching_recovers_thread_before_keying(self):
+        """DM-topic text batches should use the recovered topic lane."""
+        adapter = _make_adapter()
+
+        class _Runner:
+            def _recover_telegram_topic_thread_id(self, source):
+                return "222" if str(source.thread_id or "") == "1" else None
+
+            async def _handle_message(self, _event):
+                return None
+
+        runner = _Runner()
+        adapter._message_handler = runner._handle_message
+        event = MessageEvent(
+            text="hello from DM topic",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="12345",
+                chat_type="dm",
+                user_id="user-1",
+                thread_id="1",
+            ),
+        )
+
+        adapter._enqueue_text_event(event)
+
+        recovered_key = build_session_key(
+            SimpleNamespace(
+                platform=Platform.TELEGRAM,
+                chat_id="12345",
+                chat_type="dm",
+                thread_id="222",
+            ),
+            group_sessions_per_user=True,
+            thread_sessions_per_user=False,
+        )
+        stale_key = build_session_key(
+            SimpleNamespace(
+                platform=Platform.TELEGRAM,
+                chat_id="12345",
+                chat_type="dm",
+                thread_id="1",
+            ),
+            group_sessions_per_user=True,
+            thread_sessions_per_user=False,
+        )
+
+        assert recovered_key in adapter._pending_text_batches
+        assert stale_key not in adapter._pending_text_batches
+        assert event.source.thread_id == "222"
+
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.source.thread_id == "222"

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -126,16 +126,9 @@ class TestTextBatching:
     async def test_dm_topic_batching_recovers_thread_before_keying(self):
         """DM-topic text batches should use the recovered topic lane."""
         adapter = _make_adapter()
-
-        class _Runner:
-            def _recover_telegram_topic_thread_id(self, source):
-                return "222" if str(source.thread_id or "") == "1" else None
-
-            async def _handle_message(self, _event):
-                return None
-
-        runner = _Runner()
-        adapter._message_handler = runner._handle_message
+        adapter.set_topic_recovery_fn(
+            lambda source: "222" if str(source.thread_id or "") == "1" else None
+        )
         event = MessageEvent(
             text="hello from DM topic",
             message_type=MessageType.TEXT,
@@ -150,29 +143,20 @@ class TestTextBatching:
 
         adapter._enqueue_text_event(event)
 
-        recovered_key = build_session_key(
-            SimpleNamespace(
-                platform=Platform.TELEGRAM,
-                chat_id="12345",
-                chat_type="dm",
-                thread_id="222",
-            ),
-            group_sessions_per_user=True,
-            thread_sessions_per_user=False,
-        )
-        stale_key = build_session_key(
-            SimpleNamespace(
-                platform=Platform.TELEGRAM,
-                chat_id="12345",
-                chat_type="dm",
-                thread_id="1",
-            ),
-            group_sessions_per_user=True,
-            thread_sessions_per_user=False,
-        )
+        def _key(thread_id: str) -> str:
+            return build_session_key(
+                SimpleNamespace(
+                    platform=Platform.TELEGRAM,
+                    chat_id="12345",
+                    chat_type="dm",
+                    thread_id=thread_id,
+                ),
+                group_sessions_per_user=True,
+                thread_sessions_per_user=False,
+            )
 
-        assert recovered_key in adapter._pending_text_batches
-        assert stale_key not in adapter._pending_text_batches
+        assert _key("222") in adapter._pending_text_batches
+        assert _key("1") not in adapter._pending_text_batches
         assert event.source.thread_id == "222"
 
         await asyncio.sleep(0.2)


### PR DESCRIPTION
## Summary
Telegram DM-topic replies stop landing in the wrong lane after `/new`.

When a user creates a DM topic with `/new` and then sends in the main chat, Telegram attaches the just-created topic's `message_thread_id` to that main-chat update. The text-batch buffer keyed off the raw inbound thread id, so coalescence — and downstream session-key checks in `BasePlatformAdapter.handle_message` — dispatched against the stale topic. Recovery only ran later in `_handle_message`, after the wrong key was already set.

Salvaged from PR #32998 by @LeonSGP43 with the fix generalized.

Closes #32973.

## Changes
- `gateway/platforms/base.py`: `set_topic_recovery_fn()` setter + `_apply_topic_recovery(event)` helper. `handle_message` now applies recovery before `build_session_key` so the running-agent guard and pending queue see the same lane as the dispatched event.
- `gateway/platforms/telegram.py`: `_text_batch_key()` calls `self._apply_topic_recovery(event)` (replaces the `_message_handler.__self__` introspection trick).
- `gateway/run.py`: `adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)` at both adapter-init sites. Hook is gated internally to Telegram DM topic mode, harmless on other adapters.
- `tests/gateway/test_telegram_text_batching.py`: regression test installs the hook via `adapter.set_topic_recovery_fn(...)`.

## Validation
| | Before | After |
|---|---|---|
| `test_telegram_text_batching.py` | passes original PR's narrow case | 6/6 pass with cleaner setup |
| Full `tests/gateway/` (5,973 tests) | n/a | 100% pass |
| Coupling | adapter peeks at `_message_handler.__self__` | explicit setter |
| Coverage | text-batch coalescence only | text-batch + handle_message session keying |

## Authorship
LeonSGP43's commit preserved (cherry-picked). Refactor on top is mine. Rebase-merge.

## Infographic
![infographic](https://v3b.fal.media/files/b/0a9c1b2e/VcxywbirCeeHwlt04-0Zd_QJQ756As.png)
