### PR TITLE
fix(cli): show_reasoning works independently of streaming setting (#34209)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4021,9 +4021,31 @@ class HermesCLI:
     # ── Streaming display ────────────────────────────────────────────────
 
     def _current_reasoning_callback(self):
-        """Return the active reasoning display callback for the current mode."""
+        """Return the active reasoning display callback for the current mode.
+
+        Combinations:
+        - show_reasoning=True, streaming=True  → token-by-token live reasoning
+          box rendered inline above the response (_stream_reasoning_delta).
+        - show_reasoning=True, streaming=False → buffered preview that flushes
+          on natural boundaries (_on_reasoning + _flush_reasoning_preview).
+          Previously this combination returned None, so users with
+          streaming=False never saw reasoning even with show_reasoning=True
+          (#34209). The buffered preview path already exists for the
+          verbose-without-show_reasoning case; reusing it gives the
+          non-streaming user a real reasoning render without changing the
+          rest of their CLI output behavior.
+        - verbose=True, show_reasoning=False   → minimal preview so users
+          see *that* the model is thinking without a full reasoning dump.
+        - otherwise                            → no reasoning callback.
+        """
         if self.show_reasoning and self.streaming_enabled:
             return self._stream_reasoning_delta
+        if self.show_reasoning and not self.streaming_enabled:
+            # #34209: non-streaming CLI users still want reasoning visible.
+            # _on_reasoning buffers tokens and _flush_reasoning_preview
+            # emits them as compact [thinking] blocks — the same render
+            # path used today by the verbose+!show_reasoning branch below.
+            return self._on_reasoning
         if self.verbose and not self.show_reasoning:
             return self._on_reasoning
         return None

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -386,10 +386,18 @@ class TestReasoningDisplayModeSelection(unittest.TestCase):
         cli._on_reasoning = lambda text: ("preview", text)
         return cli
 
-    def test_show_reasoning_non_streaming_uses_final_box_only(self):
+    def test_show_reasoning_non_streaming_uses_buffered_preview(self):
+        """#34209 regression: when show_reasoning=True and streaming=False,
+        the CLI should use the buffered preview callback (_on_reasoning)
+        so reasoning content is still rendered. Previously this returned
+        None, leaving non-streaming users unable to see reasoning at all.
+        """
         cli = self._make_cli(show_reasoning=True, streaming_enabled=False, verbose=False)
 
-        self.assertIsNone(cli._current_reasoning_callback())
+        callback = cli._current_reasoning_callback()
+        self.assertIsNotNone(callback)
+        # Routes to the buffered-preview path, NOT the live-stream path.
+        self.assertEqual(callback("x"), ("preview", "x"))
 
     def test_show_reasoning_streaming_uses_live_reasoning_box(self):
         cli = self._make_cli(show_reasoning=True, streaming_enabled=True, verbose=False)
@@ -404,6 +412,28 @@ class TestReasoningDisplayModeSelection(unittest.TestCase):
         callback = cli._current_reasoning_callback()
         self.assertIsNotNone(callback)
         self.assertEqual(callback("x"), ("preview", "x"))
+
+    def test_no_callback_when_all_options_off(self):
+        """Default state (no reasoning options) should return no callback."""
+        cli = self._make_cli(show_reasoning=False, streaming_enabled=False, verbose=False)
+        self.assertIsNone(cli._current_reasoning_callback())
+
+    def test_no_callback_when_streaming_only(self):
+        """Streaming on but show_reasoning + verbose off — no reasoning render."""
+        cli = self._make_cli(show_reasoning=False, streaming_enabled=True, verbose=False)
+        self.assertIsNone(cli._current_reasoning_callback())
+
+    def test_show_reasoning_takes_precedence_over_verbose(self):
+        """When both show_reasoning and verbose are True, show_reasoning
+        wins (caller gets the show_reasoning render, not the minimal verbose
+        preview). Both paths use _on_reasoning in non-streaming mode, but
+        the precedence ordering still matters when streaming is on.
+        """
+        cli = self._make_cli(show_reasoning=True, streaming_enabled=True, verbose=True)
+        # show_reasoning + streaming → live stream, not the verbose preview.
+        callback = cli._current_reasoning_callback()
+        self.assertIsNotNone(callback)
+        self.assertEqual(callback("x"), ("stream", "x"))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #34209

## Problem

In CLI mode, `show_reasoning=true` only displayed reasoning when `streaming=true`. Users who prefer non-streaming output (`streaming: false`) couldn't see reasoning content even with `show_reasoning: true` explicitly set.

```python
# cli.py::_current_reasoning_callback (before)
if self.show_reasoning and self.streaming_enabled:
    return self._stream_reasoning_delta
# show_reasoning=True, streaming=False fell through to None
```

The agent had no reasoning sink and reasoning tokens were silently dropped.

## Fix

The CLI already has a buffered-preview render path (`_on_reasoning` + `_flush_reasoning_preview`) used today for `verbose=True, show_reasoning=False` — emits compact `[thinking]` blocks on natural boundaries.

Reusing it for the non-streaming show_reasoning case restores expected behavior without changing the user's CLI output preferences.

## Coverage matrix after fix

| show_reasoning | streaming | verbose | reasoning render |
|---|---|---|---|
| True  | True  | any  | live token-by-token box |
| True  | False | any  | **buffered `[thinking]` preview ← #34209** |
| False | any   | True | minimal `[thinking]` preview |
| False | any   | False| no reasoning render |

## Tests

- **Updated** `test_show_reasoning_non_streaming_uses_final_box_only` → `...uses_buffered_preview`. The old assertion enshrined the bug (`assertIsNone`); the new one locks in the fix.
- 3 new tests: `test_no_callback_when_all_options_off`, `test_no_callback_when_streaming_only`, `test_show_reasoning_takes_precedence_over_verbose`.

```bash
$ python -m pytest tests/cli/test_reasoning_command.py
=== 58 passed in 1.11s ===
```

🎻 Co-authored-by: Cursor <cursoragent@cursor.com>