### PR TITLE
fix(browser-cdp-tool): remove unused import asyncio (F401)

### DIFF
--- a/tests/tools/test_lint_browser_cdp_tool.py
+++ b/tests/tools/test_lint_browser_cdp_tool.py
@@ -23,3 +23,18 @@ def test_browser_cdp_tool_has_zero_f401_violations():
         "tools/browser_cdp_tool.py has F401 violation(s):\n"
         + result.stdout
     )
+
+
+def test_env_probe_has_zero_f401_violations():
+    """tools/env_probe.py must have zero F401 (unused-import) violations."""
+    result = subprocess.run(
+        [sys.executable, "-m", "ruff", "check", "--select=F401",
+         "--output-format=concise", "tools/env_probe.py"],
+        capture_output=True, text=True, check=False,
+        cwd=str(PROJECT_ROOT),
+    )
+
+    assert result.returncode == 0, (
+        "tools/env_probe.py has F401 violation(s):\n"
+        + result.stdout
+    )

--- a/tests/tools/test_lint_browser_cdp_tool.py
+++ b/tests/tools/test_lint_browser_cdp_tool.py
@@ -1,0 +1,25 @@
+"""Lint regression tests for tools/browser_cdp_tool.py.
+
+Ensures specific rules have zero violations in this file.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def test_browser_cdp_tool_has_zero_f401_violations():
+    """tools/browser_cdp_tool.py must have zero F401 (unused-import) violations."""
+    result = subprocess.run(
+        [sys.executable, "-m", "ruff", "check", "--select=F401",
+         "--output-format=concise", "tools/browser_cdp_tool.py"],
+        capture_output=True, text=True, check=False,
+        cwd=str(PROJECT_ROOT),
+    )
+
+    assert result.returncode == 0, (
+        "tools/browser_cdp_tool.py has F401 violation(s):\n"
+        + result.stdout
+    )

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -33,7 +33,6 @@ import logging
 import os
 import shutil
 import subprocess
-import sys
 import threading
 from typing import Optional
 


### PR DESCRIPTION
## Summary

Adds a lint-regression test (`test_browser_cdp_tool_has_zero_f401_violations`) asserting zero F401 (unused-import) violations in `tools/browser_cdp_tool.py`.

### Context

The production code fix (`import asyncio as _asyncio` removal from `_browser_cdp_via_supervisor`) was already applied upstream in `origin/main` between the original PR authoring and the rebase in this tick. The remaining contribution is the regression test, which guards against reintroduction.

### Changes in this tick (2026-05-29)

- Rebranched from latest `origin/main`, cherry-picked the fix commit (verified: the import removal was already in origin/main)
- Verified the regression test passes against current `origin/main`
- Pushed rebased branch to the proper-fork

## Test Plan
- `pytest tests/tools/test_lint_browser_cdp_tool.py -v` — 1 passed
- `ruff check --select=F401 tools/browser_cdp_tool.py` — All checks passed

## CI Note
> CI may not auto-trigger because commits were pushed via a fine-grained PAT, which doesn't always fire GitHub Actions on push. If checks are pending, please trigger manually via `gh workflow run ci --ref fix/browser-cdp-tool-f401-unused-asyncio`.


> **Note:** The `needs-review` label could not be added automatically — the token lacks admin rights for label management on this upstream repo. A reviewer should add it manually.

### Changes in this tick (2026-05-29, tick 2)

- **tools/env_probe.py**: Removed unused `import sys` (F401 violation). The `sys` module was only referenced inside string literals passed to `subprocess.run`, not as a module-level reference.
- **tests/tools/test_lint_browser_cdp_tool.py**: Added `test_env_probe_has_zero_f401_violations` — a lint-regression test asserting zero F401 violations in `tools/env_probe.py`.
- TDD cycle: RED (test failed with 1 F401 violation) → GREEN (removed unused import) → both tests pass.
