### PR TITLE
fix(agent): emit response-shape diagnostics on empty-response retry (#34246)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4084,10 +4084,27 @@ def run_conversation(
                     )
                     if _truly_empty and (not _has_structured or _prefill_exhausted) and agent._empty_content_retries < 3:
                         agent._empty_content_retries += 1
+                        # #34246: when users report 'response was non-empty per
+                        # curl but Hermes treats it as empty' on custom OpenAI-
+                        # compatible endpoints, the most useful debug signal
+                        # is the SHAPE of what arrived. Log content type/len
+                        # so the user can see if the API returned None vs ''
+                        # vs only think-blocks vs structured-reasoning-only.
+                        _raw_content = getattr(assistant_message, "content", None)
+                        _content_type = type(_raw_content).__name__
+                        _content_len = len(_raw_content) if isinstance(_raw_content, str) else None
+                        _content_preview = (
+                            _raw_content[:80] if isinstance(_raw_content, str) and _raw_content
+                            else repr(_raw_content)[:80]
+                        )
                         logger.warning(
                             "Empty response (no content or reasoning) — "
-                            "retry %d/3 (model=%s)",
+                            "retry %d/3 (model=%s, content_type=%s, "
+                            "content_len=%s, content_preview=%r, "
+                            "has_structured=%s, prefill_retries=%d)",
                             agent._empty_content_retries, agent.model,
+                            _content_type, _content_len, _content_preview,
+                            _has_structured, agent._thinking_prefill_retries,
                         )
                         agent._buffer_status(
                             f"⚠️ Empty response from model — retrying "

--- a/tests/agent/test_empty_response_diagnostic_log.py
+++ b/tests/agent/test_empty_response_diagnostic_log.py
@@ -1,0 +1,77 @@
+"""Regression tests for #34246 empty-response diagnostic logging.
+
+When a custom OpenAI-compatible endpoint returns content but Hermes
+treats it as empty, the user has no way to debug the discrepancy. The
+warning log now includes content_type / content_len / content_preview /
+has_structured / prefill_retries so the cause is visible from the log.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+
+
+def _read_warning_format() -> str:
+    """Pull the actual warning format string out of conversation_loop.py
+    so the test breaks if someone removes the diagnostic fields rather
+    than testing a fake duplicate string."""
+    from pathlib import Path
+
+    src = Path("agent/conversation_loop.py").read_text(encoding="utf-8")
+    # Find the # #34246 block and extract the format string
+    match = re.search(
+        r'#34246:.*?logger\.warning\(\s*"([^"]+)"',
+        src,
+        re.DOTALL,
+    )
+    assert match, "Could not find the #34246 diagnostic warning in conversation_loop.py"
+    # The next consecutive string concatenation in the same call
+    fmt_block = re.search(
+        r'#34246:.*?logger\.warning\(\s*(?P<strs>(?:"[^"]+"\s*)+)',
+        src,
+        re.DOTALL,
+    )
+    assert fmt_block, "Could not extract concatenated format string"
+    # Join consecutive Python string literals
+    strs = re.findall(r'"([^"]+)"', fmt_block.group("strs"))
+    return "".join(strs)
+
+
+def test_diagnostic_log_format_includes_content_type():
+    fmt = _read_warning_format()
+    assert "content_type=%s" in fmt, fmt
+
+
+def test_diagnostic_log_format_includes_content_len():
+    fmt = _read_warning_format()
+    assert "content_len=%s" in fmt, fmt
+
+
+def test_diagnostic_log_format_includes_content_preview():
+    fmt = _read_warning_format()
+    assert "content_preview=" in fmt, fmt
+
+
+def test_diagnostic_log_format_includes_has_structured():
+    fmt = _read_warning_format()
+    assert "has_structured=%s" in fmt, fmt
+
+
+def test_diagnostic_log_format_includes_prefill_retries():
+    fmt = _read_warning_format()
+    assert "prefill_retries=%d" in fmt, fmt
+
+
+def test_diagnostic_log_format_still_mentions_model():
+    """Don't regress the existing model= field that downstream log scrapers
+    might already match on."""
+    fmt = _read_warning_format()
+    assert "model=%s" in fmt, fmt
+
+
+def test_diagnostic_log_format_still_mentions_retry_count():
+    fmt = _read_warning_format()
+    assert "retry %d/3" in fmt, fmt


### PR DESCRIPTION
Refs #34246

## Context

#34246 reports a custom OpenAI-compatible endpoint (`chatgpt.58corp.com`) where curl returns valid `choices[0].message.content` but Hermes treats the response as empty and exhausts the retry loop. The bug is real-world hard to reproduce without that specific endpoint, but I can make it **debuggable** without it.

## Why this is the right next step

Before this PR, the warning logged only `Empty response (no content or reasoning) — retry %d/3 (model=%s)` — no way to distinguish:

- `content` is `None` (transport-side issue)
- `content` is `""` (provider returned empty string)
- `content` is only `<think>...</think>` (stripped to empty by `_strip_think_blocks`)
- `content` is a list/dict that the OpenAI SDK didn't normalize despite the line 3413 normalization layer
- structured `reasoning_content` but no visible content AND prefill retries exhausted

After this PR, a single log line tells the user (and bug triage) which of those cases applied.

## Sample output

```
Empty response (no content or reasoning) — retry 1/3
(model=chatling-plus-1126, content_type=NoneType, content_len=None,
 content_preview='None', has_structured=False, prefill_retries=0)
```

## Behavior change

**None.** Logging-only. Existing scrapers matching on `retry %d/3` or `model=%s` still work — those fields are preserved.

## Tests (7 in test_empty_response_diagnostic_log.py)

Each test pulls the actual format string from `agent/conversation_loop.py` (not a duplicate in the test) and verifies each diagnostic field is present — breaks if a future refactor silently removes a field.

```bash
$ python -m pytest tests/agent/test_empty_response_diagnostic_log.py
=== 7 passed in 0.11s ===
```

## Not yet closing #34246

This is a partial fix — it enables triage but doesn't yet fix the underlying empty-response detection for this endpoint. Once the affected user reports back the diagnostic output, the root cause becomes addressable (likely one of the 5 shape cases listed above). Marking as 'Refs' rather than 'Closes' to keep the issue open until the actual fix lands.

🎻 Co-authored-by: Cursor <cursoragent@cursor.com>