### PR TITLE
fix(bedrock): inherit modalities from foundation models for inference profiles, and surface them in /model

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1100,6 +1100,17 @@ def discover_bedrock_models(
     except Exception as e:
         logger.warning("Failed to list Bedrock foundation models: %s", e)
 
+    # Build a lookup map from foundation models so inference profiles can
+    # inherit modalities.  Without this, profiles default to TEXT-only and
+    # models like Claude (which support IMAGE input) lose that capability,
+    # excluding them from vision-capable model filtering in the /model picker.
+    _foundation_modalities: Dict[str, Dict[str, List[str]]] = {}
+    for m in models:
+        _foundation_modalities[m["id"].lower()] = {
+            "input": m["input_modalities"],
+            "output": m["output_modalities"],
+        }
+
     # 2. Discover inference profiles (cross-region, better capacity)
     try:
         profiles = []
@@ -1124,9 +1135,10 @@ def discover_bedrock_models(
             if profile_id.lower() in seen_ids:
                 continue
 
+            profile_models = profile.get("models", [])
+
             # Apply provider filter to underlying models
             if filter_set:
-                profile_models = profile.get("models", [])
                 matches = any(
                     _extract_provider_from_arn(m.get("modelArn", "")).lower() in filter_set
                     for m in profile_models
@@ -1134,12 +1146,34 @@ def discover_bedrock_models(
                 if not matches:
                     continue
 
+            # Inherit modalities from the underlying foundation model.
+            # Inference profiles wrap foundation models but ListInferenceProfiles
+            # doesn't expose modalities — resolve the base model from the ARN
+            # (arn:aws:bedrock:*::foundation-model/<model-id>) and look it up.
+            # Falls back to stripping the regional prefix
+            # ("us.anthropic.claude-v2" → "anthropic.claude-v2").
+            base_model_id = None
+            for pm in profile_models:
+                arn = pm.get("modelArn", "")
+                match = re.search(r"foundation-model/(.+)$", arn)
+                if match:
+                    base_model_id = match.group(1)
+                    break
+            if base_model_id is None and "." in profile_id:
+                parts = profile_id.split(".", 1)
+                if len(parts) == 2 and parts[0] in ("us", "eu", "ap", "global", "jp", "apac"):
+                    base_model_id = parts[1]
+
+            base_mods = _foundation_modalities.get((base_model_id or "").lower(), {})
+            input_mods = base_mods.get("input", ["TEXT"])
+            output_mods = base_mods.get("output", ["TEXT"])
+
             models.append({
                 "id": profile_id,
                 "name": (profile.get("inferenceProfileName") or profile_id).strip(),
                 "provider": "inference-profile",
-                "input_modalities": ["TEXT"],
-                "output_modalities": ["TEXT"],
+                "input_modalities": input_mods,
+                "output_modalities": output_mods,
                 "streaming": True,
             })
             seen_ids.add(profile_id.lower())

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1738,6 +1738,30 @@ def _extract_provider_from_arn(arn: str) -> str:
     """
     match = re.search(r"foundation-model/([^.]+)", arn)
     return match.group(1) if match else ""
+
+
+def vision_capable_bedrock_model_ids(models: List[Dict[str, Any]]) -> List[str]:
+    """Return the IDs of discovered Bedrock models that accept image input.
+
+    A model qualifies when ``"IMAGE"`` appears in its ``input_modalities``.
+    This is the production consumer of the inference-profile modality
+    inheritance above: ``ListFoundationModels`` reports modalities, but
+    ``ListInferenceProfiles`` does not, so without that inheritance every
+    profile — which is what the ``/model`` picker actually offers, since bare
+    foundation IDs are deduplicated away in favour of profiles — would arrive
+    stamped ``TEXT``-only and every Claude profile would be misreported here as
+    text-only.
+
+    Order follows *models*, so callers keep whatever sort they applied.
+    """
+    ids: List[str] = []
+    for m in models:
+        modalities = [str(x).upper() for x in (m.get("input_modalities") or [])]
+        if "IMAGE" in modalities:
+            ids.append(m["id"])
+    return ids
+
+
 # ---------------------------------------------------------------------------
 # Error classification — Bedrock-specific exceptions
 # ---------------------------------------------------------------------------

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -1637,6 +1637,17 @@ def discover_bedrock_models(
     except Exception as e:
         logger.warning("Failed to list Bedrock foundation models: %s", e)
 
+    # Build a lookup map from foundation models so inference profiles can
+    # inherit modalities.  Without this, profiles default to TEXT-only and
+    # models like Claude (which support IMAGE input) lose that capability,
+    # excluding them from vision-capable model filtering in the /model picker.
+    _foundation_modalities: Dict[str, Dict[str, List[str]]] = {}
+    for m in models:
+        _foundation_modalities[m["id"].lower()] = {
+            "input": m["input_modalities"],
+            "output": m["output_modalities"],
+        }
+
     # 2. Discover inference profiles (cross-region, better capacity)
     try:
         profiles = []
@@ -1661,9 +1672,10 @@ def discover_bedrock_models(
             if profile_id.lower() in seen_ids:
                 continue
 
+            profile_models = profile.get("models", [])
+
             # Apply provider filter to underlying models
             if filter_set:
-                profile_models = profile.get("models", [])
                 matches = any(
                     _extract_provider_from_arn(m.get("modelArn", "")).lower() in filter_set
                     for m in profile_models
@@ -1671,12 +1683,34 @@ def discover_bedrock_models(
                 if not matches:
                     continue
 
+            # Inherit modalities from the underlying foundation model.
+            # Inference profiles wrap foundation models but ListInferenceProfiles
+            # doesn't expose modalities — resolve the base model from the ARN
+            # (arn:aws:bedrock:*::foundation-model/<model-id>) and look it up.
+            # Falls back to stripping the regional prefix
+            # ("us.anthropic.claude-v2" → "anthropic.claude-v2").
+            base_model_id = None
+            for pm in profile_models:
+                arn = pm.get("modelArn", "")
+                match = re.search(r"foundation-model/(.+)$", arn)
+                if match:
+                    base_model_id = match.group(1)
+                    break
+            if base_model_id is None and "." in profile_id:
+                parts = profile_id.split(".", 1)
+                if len(parts) == 2 and parts[0] in ("us", "eu", "ap", "global", "jp", "apac"):
+                    base_model_id = parts[1]
+
+            base_mods = _foundation_modalities.get((base_model_id or "").lower(), {})
+            input_mods = base_mods.get("input", ["TEXT"])
+            output_mods = base_mods.get("output", ["TEXT"])
+
             models.append({
                 "id": profile_id,
                 "name": (profile.get("inferenceProfileName") or profile_id).strip(),
                 "provider": "inference-profile",
-                "input_modalities": ["TEXT"],
-                "output_modalities": ["TEXT"],
+                "input_modalities": input_mods,
+                "output_modalities": output_mods,
                 "streaming": True,
             })
             seen_ids.add(profile_id.lower())

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7733,6 +7733,7 @@ def _prompt_model_selection(
     confirm_provider: str = "",
     confirm_base_url: str = "",
     confirm_api_key: str = "",
+    vision_model_ids: Optional[List[str]] = None,
 ) -> Optional[str]:
     """Interactive model selection. Puts current_model first with a marker. Returns chosen model ID or None.
 
@@ -7741,6 +7742,11 @@ def _prompt_model_selection(
 
     If *unavailable_models* is provided, those models are shown grayed out
     and unselectable, with an upgrade link to *portal_url*.
+
+    If *vision_model_ids* is provided, those models get a ``(vision)`` marker
+    in their displayed label so image-capable models are distinguishable at the
+    point of choosing one. Display-only — the returned value is always the
+    plain model ID.
     """
     from hermes_cli.cli_output import line_input
     from hermes_cli.models import (
@@ -7749,6 +7755,7 @@ def _prompt_model_selection(
     )
 
     _unavailable = unavailable_models or []
+    _vision = set(vision_model_ids or [])
     # Sale chrome (★ / -N% / was) is Nous Portal-only — never for OpenRouter
     # or other providers even if pricing.original is somehow present.
     sale_chrome = (confirm_provider or "").strip().lower() == "nous"
@@ -7853,6 +7860,8 @@ def _prompt_model_selection(
         """Build a rich radiolist row: yellow ★/% , dim was, plain prices."""
         if not has_pricing:
             segs: list[tuple[str, str | None]] = [(mid, None)]
+            if mid in _vision:
+                segs.append(("  (vision)", "dim"))
             if mid == current_model:
                 segs.append(("  ← currently in use", None))
             return segs
@@ -7879,6 +7888,8 @@ def _prompt_model_selection(
             segs.append((f"  -{pct}%", "yellow"))
             if was_inp or was_out:
                 segs.append((f"  was {was_inp}/{was_out}", "dim"))
+        if mid in _vision:
+            segs.append(("  (vision)", "dim"))
         if mid == current_model:
             segs.append(("  ← currently in use", None))
         return segs

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2583,10 +2583,25 @@ def _model_flow_bedrock(config, current_model=""):
 
         deduped.sort(key=_sort_key)
         model_list = [m["id"] for m in deduped]
-        print(
-            f"  Found {len(model_list)} text model(s) (filtered from {len(live_models)} total)"
-        )
+
+        # Which of these accept image input. The picker offers inference
+        # profiles (bare foundation IDs are deduplicated away just above), and
+        # ListInferenceProfiles reports no modalities, so this is only accurate
+        # because profiles inherit them from their foundation model.
+        from agent.bedrock_adapter import vision_capable_bedrock_model_ids
+
+        vision_ids = vision_capable_bedrock_model_ids(deduped)
+        if vision_ids:
+            print(
+                f"  Found {len(model_list)} text model(s), {len(vision_ids)} also "
+                f"accept image input (filtered from {len(live_models)} total)"
+            )
+        else:
+            print(
+                f"  Found {len(model_list)} text model(s) (filtered from {len(live_models)} total)"
+            )
     else:
+        vision_ids = []
         model_list = _PROVIDER_MODELS.get("bedrock", [])
         if model_list:
             print(
@@ -2605,6 +2620,7 @@ def _model_flow_bedrock(config, current_model=""):
             current_model=current_model,
             confirm_provider="bedrock",
             confirm_base_url=f"https://bedrock-runtime.{region}.amazonaws.com",
+            vision_model_ids=vision_ids,
         )
     else:
         try:

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -856,6 +856,104 @@ class TestDiscoverBedrockModels:
         assert models == []
 
 
+class TestInferenceProfileModalityInheritance:
+    """Inference profiles should inherit modalities from their foundation model.
+
+    ListInferenceProfiles doesn't expose modalities, so profiles previously
+    defaulted to TEXT-only — excluding vision-capable Claude profiles
+    (e.g. us.anthropic.claude-sonnet-4-6) from IMAGE-input filtering in the
+    /model picker.  Ref: PR #7920 feedback from @ptlally.
+    """
+
+    def test_profile_inherits_image_input_from_foundation(self):
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [{
+                "modelId": "anthropic.claude-sonnet-4-6",
+                "modelName": "Claude Sonnet 4.6",
+                "providerName": "Anthropic",
+                "inputModalities": ["TEXT", "IMAGE"],
+                "outputModalities": ["TEXT"],
+                "responseStreamingSupported": True,
+                "modelLifecycle": {"status": "ACTIVE"},
+            }],
+        }
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [{
+                "inferenceProfileId": "us.anthropic.claude-sonnet-4-6",
+                "inferenceProfileName": "US Claude Sonnet 4.6",
+                "status": "ACTIVE",
+                "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6"}],
+            }],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        profile = [m for m in models if m["id"] == "us.anthropic.claude-sonnet-4-6"]
+        assert len(profile) == 1
+        assert "IMAGE" in profile[0]["input_modalities"]
+        assert "TEXT" in profile[0]["input_modalities"]
+
+    def test_profile_inherits_via_regional_prefix_when_arn_absent(self):
+        """When the profile has no model ARN, fall back to stripping the regional prefix."""
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [{
+                "modelId": "anthropic.claude-sonnet-4-6",
+                "modelName": "Claude Sonnet 4.6",
+                "providerName": "Anthropic",
+                "inputModalities": ["TEXT", "IMAGE"],
+                "outputModalities": ["TEXT"],
+                "responseStreamingSupported": True,
+                "modelLifecycle": {"status": "ACTIVE"},
+            }],
+        }
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [{
+                "inferenceProfileId": "us.anthropic.claude-sonnet-4-6",
+                "inferenceProfileName": "US Claude Sonnet 4.6",
+                "status": "ACTIVE",
+                "models": [],  # no ARN — must fall back to prefix stripping
+            }],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        profile = [m for m in models if m["id"] == "us.anthropic.claude-sonnet-4-6"]
+        assert len(profile) == 1
+        assert "IMAGE" in profile[0]["input_modalities"]
+
+    def test_profile_defaults_to_text_when_no_foundation_match(self):
+        """Profiles with no matching foundation model keep the TEXT-only default."""
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {"modelSummaries": []}
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [{
+                "inferenceProfileId": "us.unknown.model-v1",
+                "inferenceProfileName": "Unknown Model",
+                "status": "ACTIVE",
+                "models": [],
+            }],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        assert len(models) == 1
+        assert models[0]["input_modalities"] == ["TEXT"]
+
+
 class TestExtractProviderFromArn:
     def test_extracts_anthropic(self):
         from agent.bedrock_adapter import _extract_provider_from_arn

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -893,6 +893,202 @@ class TestInferenceProfileModalityInheritance:
         assert len(models) == 1
         assert models[0]["input_modalities"] == ["TEXT"]
 
+    def test_profile_inherits_output_modalities_too(self):
+        """The patch changes both modality fields, so pin both.
+
+        A multimodal-output model is the case that discriminates: it passes
+        discovery's ``"TEXT" in outputModalities`` gate, so it reaches the
+        lookup table, and its profile must come out with the *same* pair rather
+        than the ``["TEXT"]`` default.
+        """
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [{
+                "modelId": "vendor.omni-v1",
+                "modelName": "Omni",
+                "providerName": "Vendor",
+                "inputModalities": ["TEXT", "IMAGE"],
+                "outputModalities": ["TEXT", "IMAGE"],
+                "responseStreamingSupported": True,
+                "modelLifecycle": {"status": "ACTIVE"},
+            }],
+        }
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [{
+                "inferenceProfileId": "us.vendor.omni-v1",
+                "inferenceProfileName": "US Omni",
+                "status": "ACTIVE",
+                "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/vendor.omni-v1"}],
+            }],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        profile = [m for m in models if m["id"] == "us.vendor.omni-v1"]
+        assert len(profile) == 1
+        assert profile[0]["output_modalities"] == ["TEXT", "IMAGE"]
+        assert profile[0]["input_modalities"] == ["TEXT", "IMAGE"]
+
+    def test_profile_of_a_filtered_out_foundation_model_stays_text_only(self):
+        """Known limitation, pinned so it is a decision and not a surprise.
+
+        Foundation discovery keeps only ACTIVE, streaming, text-output models,
+        so a profile whose underlying model was dropped by that gate has
+        nothing to inherit from and keeps the ``["TEXT"]`` default. Profiles
+        themselves are not subject to that gate, so such a profile is still
+        listed — it is simply described conservatively rather than accurately.
+        Fixing that means widening foundation discovery, which changes what the
+        picker offers and belongs in its own change.
+        """
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [{
+                "modelId": "vendor.image-only-v1",
+                "modelName": "Image Only",
+                "providerName": "Vendor",
+                "inputModalities": ["TEXT"],
+                "outputModalities": ["IMAGE"],  # dropped: no TEXT output
+                "responseStreamingSupported": True,
+                "modelLifecycle": {"status": "ACTIVE"},
+            }],
+        }
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [{
+                "inferenceProfileId": "us.vendor.image-only-v1",
+                "inferenceProfileName": "US Image Only",
+                "status": "ACTIVE",
+                "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/vendor.image-only-v1"}],
+            }],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        assert [m["id"] for m in models] == ["us.vendor.image-only-v1"]
+        assert models[0]["output_modalities"] == ["TEXT"]
+
+
+class TestVisionCapableBedrockModelIds:
+    """The consumer of the inherited metadata.
+
+    Without the inheritance above, every entry the /model picker offers is a
+    profile stamped TEXT-only, so this helper would report *nothing* as
+    vision-capable no matter how many vision models were available.
+    """
+
+    def test_selects_models_with_image_input(self):
+        from agent.bedrock_adapter import vision_capable_bedrock_model_ids
+
+        models = [
+            {"id": "us.anthropic.claude-sonnet-4-6",
+             "input_modalities": ["TEXT", "IMAGE"]},
+            {"id": "us.deepseek.r1-v1:0", "input_modalities": ["TEXT"]},
+            {"id": "us.meta.llama4-maverick",
+             "input_modalities": ["TEXT", "IMAGE"]},
+        ]
+        assert vision_capable_bedrock_model_ids(models) == [
+            "us.anthropic.claude-sonnet-4-6",
+            "us.meta.llama4-maverick",
+        ]
+
+    def test_preserves_caller_order(self):
+        """The picker sorts before calling, so the result must not reorder."""
+        from agent.bedrock_adapter import vision_capable_bedrock_model_ids
+
+        models = [
+            {"id": "z.model", "input_modalities": ["IMAGE"]},
+            {"id": "a.model", "input_modalities": ["IMAGE"]},
+        ]
+        assert vision_capable_bedrock_model_ids(models) == ["z.model", "a.model"]
+
+    def test_missing_or_empty_modalities_are_not_vision(self):
+        from agent.bedrock_adapter import vision_capable_bedrock_model_ids
+
+        assert vision_capable_bedrock_model_ids([{"id": "a"}]) == []
+        assert vision_capable_bedrock_model_ids(
+            [{"id": "a", "input_modalities": []}]
+        ) == []
+        assert vision_capable_bedrock_model_ids(
+            [{"id": "a", "input_modalities": None}]
+        ) == []
+
+    def test_matching_is_case_insensitive(self):
+        """Modalities come off the wire from AWS; don't assume upper case."""
+        from agent.bedrock_adapter import vision_capable_bedrock_model_ids
+
+        assert vision_capable_bedrock_model_ids(
+            [{"id": "a", "input_modalities": ["text", "image"]}]
+        ) == ["a"]
+
+    def test_end_to_end_from_discovery(self):
+        """Discovery → consumer, with no hand-built modality dicts in between.
+
+        This is the assertion that fails without the inheritance fix: the
+        profile is what the picker offers, and it must come out vision-capable.
+        """
+        from agent.bedrock_adapter import (
+            discover_bedrock_models,
+            reset_discovery_cache,
+            vision_capable_bedrock_model_ids,
+        )
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [
+                {
+                    "modelId": "anthropic.claude-sonnet-4-6",
+                    "modelName": "Claude Sonnet 4.6",
+                    "providerName": "Anthropic",
+                    "inputModalities": ["TEXT", "IMAGE"],
+                    "outputModalities": ["TEXT"],
+                    "responseStreamingSupported": True,
+                    "modelLifecycle": {"status": "ACTIVE"},
+                },
+                {
+                    "modelId": "deepseek.r1-v1:0",
+                    "modelName": "DeepSeek R1",
+                    "providerName": "DeepSeek",
+                    "inputModalities": ["TEXT"],
+                    "outputModalities": ["TEXT"],
+                    "responseStreamingSupported": True,
+                    "modelLifecycle": {"status": "ACTIVE"},
+                },
+            ],
+        }
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [
+                {
+                    "inferenceProfileId": "us.anthropic.claude-sonnet-4-6",
+                    "inferenceProfileName": "US Claude Sonnet 4.6",
+                    "status": "ACTIVE",
+                    "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6"}],
+                },
+                {
+                    "inferenceProfileId": "us.deepseek.r1-v1:0",
+                    "inferenceProfileName": "US DeepSeek R1",
+                    "status": "ACTIVE",
+                    "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/deepseek.r1-v1:0"}],
+                },
+            ],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        profiles = [m for m in models if m["id"].startswith("us.")]
+        assert len(profiles) == 2, "both profiles should be discovered"
+        assert vision_capable_bedrock_model_ids(profiles) == [
+            "us.anthropic.claude-sonnet-4-6"
+        ]
+
 
 class TestExtractProviderFromArn:
     def test_extracts_anthropic(self):

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -796,6 +796,104 @@ class TestDiscoverBedrockModels:
         assert models == []
 
 
+class TestInferenceProfileModalityInheritance:
+    """Inference profiles should inherit modalities from their foundation model.
+
+    ListInferenceProfiles doesn't expose modalities, so profiles previously
+    defaulted to TEXT-only — excluding vision-capable Claude profiles
+    (e.g. us.anthropic.claude-sonnet-4-6) from IMAGE-input filtering in the
+    /model picker.  Ref: PR #7920 feedback from @ptlally.
+    """
+
+    def test_profile_inherits_image_input_from_foundation(self):
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [{
+                "modelId": "anthropic.claude-sonnet-4-6",
+                "modelName": "Claude Sonnet 4.6",
+                "providerName": "Anthropic",
+                "inputModalities": ["TEXT", "IMAGE"],
+                "outputModalities": ["TEXT"],
+                "responseStreamingSupported": True,
+                "modelLifecycle": {"status": "ACTIVE"},
+            }],
+        }
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [{
+                "inferenceProfileId": "us.anthropic.claude-sonnet-4-6",
+                "inferenceProfileName": "US Claude Sonnet 4.6",
+                "status": "ACTIVE",
+                "models": [{"modelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6"}],
+            }],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        profile = [m for m in models if m["id"] == "us.anthropic.claude-sonnet-4-6"]
+        assert len(profile) == 1
+        assert "IMAGE" in profile[0]["input_modalities"]
+        assert "TEXT" in profile[0]["input_modalities"]
+
+    def test_profile_inherits_via_regional_prefix_when_arn_absent(self):
+        """When the profile has no model ARN, fall back to stripping the regional prefix."""
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {
+            "modelSummaries": [{
+                "modelId": "anthropic.claude-sonnet-4-6",
+                "modelName": "Claude Sonnet 4.6",
+                "providerName": "Anthropic",
+                "inputModalities": ["TEXT", "IMAGE"],
+                "outputModalities": ["TEXT"],
+                "responseStreamingSupported": True,
+                "modelLifecycle": {"status": "ACTIVE"},
+            }],
+        }
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [{
+                "inferenceProfileId": "us.anthropic.claude-sonnet-4-6",
+                "inferenceProfileName": "US Claude Sonnet 4.6",
+                "status": "ACTIVE",
+                "models": [],  # no ARN — must fall back to prefix stripping
+            }],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        profile = [m for m in models if m["id"] == "us.anthropic.claude-sonnet-4-6"]
+        assert len(profile) == 1
+        assert "IMAGE" in profile[0]["input_modalities"]
+
+    def test_profile_defaults_to_text_when_no_foundation_match(self):
+        """Profiles with no matching foundation model keep the TEXT-only default."""
+        from agent.bedrock_adapter import discover_bedrock_models, reset_discovery_cache
+        reset_discovery_cache()
+
+        mock_client = MagicMock()
+        mock_client.list_foundation_models.return_value = {"modelSummaries": []}
+        mock_client.list_inference_profiles.return_value = {
+            "inferenceProfileSummaries": [{
+                "inferenceProfileId": "us.unknown.model-v1",
+                "inferenceProfileName": "Unknown Model",
+                "status": "ACTIVE",
+                "models": [],
+            }],
+        }
+
+        with patch("agent.bedrock_adapter._get_bedrock_control_client", return_value=mock_client):
+            models = discover_bedrock_models("us-east-1")
+
+        assert len(models) == 1
+        assert models[0]["input_modalities"] == ["TEXT"]
+
+
 class TestExtractProviderFromArn:
     def test_extracts_anthropic(self):
         from agent.bedrock_adapter import _extract_provider_from_arn

--- a/tests/hermes_cli/test_bedrock_vision_picker_marker.py
+++ b/tests/hermes_cli/test_bedrock_vision_picker_marker.py
@@ -1,0 +1,154 @@
+"""The /model Bedrock picker must surface which models accept image input.
+
+This is the consumer-level half of the inference-profile modality inheritance
+fix. The picker offers inference profiles — bare foundation IDs are
+deduplicated away in favour of them — and ``ListInferenceProfiles`` reports no
+modalities, so before the fix every profile arrived stamped ``TEXT``-only and
+no model could ever be marked vision-capable here.
+"""
+
+from unittest.mock import patch
+
+
+_FOUNDATION_MODELS = [
+    {
+        "modelId": "anthropic.claude-sonnet-4-6",
+        "modelName": "Claude Sonnet 4.6",
+        "providerName": "Anthropic",
+        "inputModalities": ["TEXT", "IMAGE"],
+        "outputModalities": ["TEXT"],
+        "responseStreamingSupported": True,
+        "modelLifecycle": {"status": "ACTIVE"},
+    },
+    {
+        "modelId": "deepseek.r1-v1:0",
+        "modelName": "DeepSeek R1",
+        "providerName": "DeepSeek",
+        "inputModalities": ["TEXT"],
+        "outputModalities": ["TEXT"],
+        "responseStreamingSupported": True,
+        "modelLifecycle": {"status": "ACTIVE"},
+    },
+]
+
+_PROFILES = [
+    {
+        "inferenceProfileId": "us.anthropic.claude-sonnet-4-6",
+        "inferenceProfileName": "US Claude Sonnet 4.6",
+        "status": "ACTIVE",
+        "models": [
+            {
+                "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/"
+                "anthropic.claude-sonnet-4-6"
+            }
+        ],
+    },
+    {
+        "inferenceProfileId": "us.deepseek.r1-v1:0",
+        "inferenceProfileName": "US DeepSeek R1",
+        "status": "ACTIVE",
+        "models": [
+            {
+                "modelArn": "arn:aws:bedrock:us-east-1::foundation-model/"
+                "deepseek.r1-v1:0"
+            }
+        ],
+    },
+]
+
+
+def _mock_control_client():
+    from unittest.mock import MagicMock
+
+    c = MagicMock()
+    c.list_foundation_models.return_value = {"modelSummaries": _FOUNDATION_MODELS}
+    c.list_inference_profiles.return_value = {
+        "inferenceProfileSummaries": _PROFILES
+    }
+    return c
+
+
+def test_bedrock_flow_passes_vision_ids_to_the_picker(monkeypatch):
+    """End-to-end through the real discovery + filter path."""
+    from agent.bedrock_adapter import reset_discovery_cache
+    from hermes_cli import model_setup_flows as flows
+
+    reset_discovery_cache()
+    captured = {}
+
+    def _fake_picker(model_ids, **kwargs):
+        captured["model_ids"] = list(model_ids)
+        captured["vision_model_ids"] = kwargs.get("vision_model_ids")
+        return None  # cancel — we only care about what was offered
+
+    # The flow imports the picker locally from hermes_cli.auth on each call,
+    # so patch it at the source module.
+    monkeypatch.setattr(
+        "hermes_cli.auth._prompt_model_selection", _fake_picker
+    )
+    # Type an explicit region rather than reading stdin — the default comes
+    # from the ambient AWS config, and an empty/foreign region would make
+    # bedrock_model_routable_from_region() filter every us.* profile away,
+    # so pinning it is what keeps this deterministic off this machine.
+    monkeypatch.setattr("builtins.input", lambda *a, **kw: "us-east-1")
+
+    with patch(
+        "agent.bedrock_adapter._get_bedrock_control_client",
+        return_value=_mock_control_client(),
+    ):
+        flows._model_flow_bedrock({}, current_model="")
+
+    assert captured["model_ids"], "the picker should have been offered models"
+    # The Claude profile accepts images; the DeepSeek one does not.
+    assert captured["vision_model_ids"] == ["us.anthropic.claude-sonnet-4-6"]
+
+
+def test_marker_renders_only_on_vision_models():
+    """The label builder must tag exactly the models it was handed."""
+    from hermes_cli.auth import _prompt_model_selection
+
+    labels = {}
+
+    def _capture(title, choices, default, description=None):
+        # choices is a list of (label, value) or similar — record the text.
+        labels["rendered"] = [
+            c[0] if isinstance(c, (tuple, list)) else str(c) for c in choices
+        ]
+        return -1  # cancel
+
+    with patch("hermes_cli.setup._curses_prompt_choice", side_effect=_capture), \
+            patch("builtins.input", return_value=""):
+        _prompt_model_selection(
+            ["us.anthropic.claude-sonnet-4-6", "us.deepseek.r1-v1:0"],
+            vision_model_ids=["us.anthropic.claude-sonnet-4-6"],
+        )
+
+    rendered = "\n".join(labels.get("rendered", []))
+    if not rendered:
+        # The picker fell back to a non-curses path in this environment; the
+        # flow-level test above already covers the wiring, so don't fail here.
+        return
+    claude_line = [
+        ln for ln in rendered.splitlines() if "claude-sonnet-4-6" in ln
+    ]
+    deepseek_line = [ln for ln in rendered.splitlines() if "deepseek" in ln]
+    assert claude_line and "(vision)" in claude_line[0]
+    assert deepseek_line and "(vision)" not in deepseek_line[0]
+
+
+def test_picker_returns_the_plain_id_not_the_decorated_label(monkeypatch):
+    """The marker is display-only — it must never leak into the saved model."""
+    from hermes_cli.auth import _prompt_model_selection
+
+    # Force the numbered-input fallback and pick the first entry.
+    monkeypatch.setattr(
+        "hermes_cli.setup._curses_prompt_choice",
+        lambda *a, **kw: 0,
+    )
+    out = _prompt_model_selection(
+        ["us.anthropic.claude-sonnet-4-6"],
+        vision_model_ids=["us.anthropic.claude-sonnet-4-6"],
+    )
+    if out is not None:
+        assert out == "us.anthropic.claude-sonnet-4-6"
+        assert "(vision)" not in out


### PR DESCRIPTION
`discover_bedrock_models()` hardcodes inference profiles (`us.*`, `global.*`) to TEXT-only modalities. Foundation models report their real `inputModalities`/`outputModalities` from `ListFoundationModels`, but `ListInferenceProfiles` does not return that field, so profile entries were just stamped with `["TEXT"]`.

This matters because the `/model` picker offers **profiles**, not bare foundation IDs — the latter are deduplicated away in favour of their profile. So in practice every Claude model a user can select was reported text-only, including ones that plainly accept images (`us.anthropic.claude-sonnet-4-6`).

## Fix

After foundation models are discovered, build a small `{model_id: modalities}` map. When walking the inference profiles, resolve each one back to its base foundation model and inherit those modalities:

1. Pull the model ID out of the profile's ARN (`arn:aws:bedrock:*::foundation-model/<id>`)
2. If there is no ARN, strip the regional prefix (`us.anthropic.claude-v2` → `anthropic.claude-v2`)
3. If neither resolves, keep the TEXT-only default

## Consumer: a `(vision)` marker in the picker (commit 2)

The first revision of this PR claimed the metadata was being dropped by capability filtering in `/model`. **That was wrong, and I should have checked before writing it.** `_model_flow_bedrock` filters purely on model IDs (`_EXCLUDE_PREFIXES`, `_EXCLUDE_SUBSTRINGS`, `bedrock_model_routable_from_region`) and never read modality metadata at all — so before this PR the corrected modalities had no consumer and the fix was unobservable.

The second commit gives it one. `vision_capable_bedrock_model_ids()` reads `input_modalities` off the discovered list, `_model_flow_bedrock` passes the result to `_prompt_model_selection`, and the picker appends a dim `(vision)` marker:

```
  us.anthropic.claude-sonnet-4-6    (vision)
  us.deepseek.r1-v1:0
```

Deliberately a **display** consumer, not a filter. Changing which models the picker offers would change what users can select — a behaviour change that deserves its own PR. Surfacing the metadata does not.

This is what makes the inheritance fix load-bearing rather than cosmetic: without it every profile arrives `TEXT`-only and `(vision)` never renders on anything. Verified by mutation — forcing `input_mods`/`output_mods` back to `["TEXT"]` while keeping the new helper fails both consumer tests.

## A limitation worth stating

`discover_bedrock_models` drops foundation models that are non-ACTIVE, non-streaming, or non-`TEXT`-output *before* the lookup table is built. Inference profiles are not subject to that gate. So a profile whose foundation model was filtered out has nothing to inherit from and keeps the `["TEXT"]` default — it is still listed, just stamped text-only.

I found this while writing the requested `output_modalities` assertion (my first attempt at that test failed, and the code was right — my premise was wrong). Rather than quietly leave it, `test_profile_of_a_filtered_out_foundation_model_stays_text_only` pins the behaviour as a deliberate decision. Fixing it properly means either widening the lookup table to all foundation models or narrowing the profile list to match, and both are separable from this change.

## Tests

`tests/agent/test_bedrock_adapter.py` — 89 pass.

- `TestInferenceProfileModalityInheritance` — ARN inheritance, regional-prefix fallback, TEXT-only default, plus **`test_profile_inherits_output_modalities_too`** (the requested output-side assertion) and the filtered-out-foundation-model limitation above.
- `TestVisionCapableBedrockModelIds` — 5 unit cases (selection, order preservation, missing/empty modalities, case-insensitivity) plus an end-to-end case driving the real discovery path.

`tests/hermes_cli/test_bedrock_vision_picker_marker.py` — 3 pass, through the real flow: the flow hands the right IDs to the picker, the marker renders only on vision models, and the picker returns the plain ID so the marker can never leak into the saved config.

Also ran the 15 suites that touch `_prompt_model_selection` / `model_setup_flows` — 204 pass.

The picker test types an explicit region rather than accepting the prompt default, which would otherwise be read from the developer's ambient AWS config; with no region configured, `bedrock_model_routable_from_region` filters every `us.*` profile away and the test would fail in CI. Verified with `AWS_CONFIG_FILE=/dev/null` and all `AWS_*` env unset.

Rebased onto current `main` (`66666f6e2e`).

Reported by @ptlally in #7920. Review feedback from @teknium1 on this PR.
