### PR TITLE
fix(agent): strip stale encrypted reasoning state on provider switch (#34205)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1555,6 +1555,43 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     # ── Invalidate cached system prompt so it rebuilds next turn ──
     agent._cached_system_prompt = None
 
+    # ── Strip stale provider-specific reasoning state on provider switch ──
+    # #34205: encrypted_content blobs from one provider are opaque to
+    # another. After openai-codex → xai-oauth (or any cross-provider
+    # switch), the next request replays the OLD provider's encrypted
+    # reasoning items / reasoning_details and the NEW provider rejects
+    # the request with HTTP 400 invalid_encrypted_content. The session
+    # is poisoned until manually cleared.
+    #
+    # Strip codex_reasoning_items, codex_message_items, and
+    # reasoning_details from the live message history when the provider
+    # changes. Plain reasoning / reasoning_content strings are left
+    # intact — they're not provider-specific and harmless to replay.
+    if old_provider and new_provider and old_provider != new_provider:
+        _session_messages = getattr(agent, "_session_messages", None)
+        if isinstance(_session_messages, list) and _session_messages:
+            try:
+                stats = agent._strip_provider_specific_reasoning_state(_session_messages)
+                if stats.get("messages", 0):
+                    import logging as _logging
+                    _logging.getLogger(__name__).info(
+                        "Provider switch %s -> %s: stripped %d reasoning item(s) "
+                        "from %d assistant message(s) to prevent stale-blob 400s (#34205)",
+                        old_provider,
+                        new_provider,
+                        stats["items"],
+                        stats["messages"],
+                    )
+            except Exception as _strip_exc:  # noqa: BLE001
+                # Best-effort — if the stripper fails for any reason, fall
+                # back to the existing invalid_encrypted_content retry path.
+                import logging as _logging
+                _logging.getLogger(__name__).debug(
+                    "#34205 strip: best-effort stripping failed (%s); "
+                    "existing 400-retry path will still recover.",
+                    _strip_exc,
+                )
+
     # ── Update _primary_runtime so the change persists across turns ──
     _cc = agent.context_compressor if hasattr(agent, "context_compressor") and agent.context_compressor else None
     agent._primary_runtime = {

--- a/run_agent.py
+++ b/run_agent.py
@@ -911,6 +911,65 @@ class AIAgent:
         self._codex_reasoning_replay_enabled = False
         return {"messages": stripped_messages, "items": stripped_items}
 
+    def _strip_provider_specific_reasoning_state(
+        self,
+        messages: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, int]:
+        """Strip provider-specific encrypted reasoning state from messages.
+
+        Called from ``switch_model`` when the provider changes mid-session
+        (e.g. openai-codex → xai-oauth, anthropic → openrouter). Reasoning
+        blobs are opaque to providers other than the one that issued them,
+        so replaying them after a switch causes HTTP 400 ``invalid_encrypted_content``
+        on every subsequent turn until the session is manually cleared.
+        See #34205.
+
+        Strips three classes of provider-specific replay state:
+          * ``codex_reasoning_items``     — OpenAI Codex Responses encrypted blobs.
+          * ``codex_message_items``       — OpenAI Codex Responses message-item
+                                            metadata (``phase`` field). Safe to
+                                            drop — only meaningful to Codex.
+          * ``reasoning_details``         — OpenRouter/Anthropic structured
+                                            reasoning array containing
+                                            ``encrypted_content`` signatures.
+                                            Other providers (xAI/Grok, Gemini,
+                                            OpenAI direct) reject these.
+
+        ``reasoning`` and ``reasoning_content`` strings are intentionally
+        left intact — they are plain text and safe to replay across
+        providers; the new provider can ignore them harmlessly.
+
+        Also disables ``_codex_reasoning_replay_enabled`` so transports that
+        still see ``codex_reasoning_items`` (e.g. stale snapshots reloaded
+        from disk) don't try to replay them either.
+
+        Returns ``{"messages": <count>, "items": <count>}`` diagnostic stats.
+        """
+        stripped_messages = 0
+        stripped_items = 0
+        target_messages = messages if isinstance(messages, list) else []
+
+        for msg in target_messages:
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                continue
+            removed_any = False
+            for key in ("codex_reasoning_items", "codex_message_items", "reasoning_details"):
+                value = msg.pop(key, None)
+                if isinstance(value, list) and value:
+                    stripped_items += len(value)
+                    removed_any = True
+                elif value is not None:
+                    # Non-list truthy value (dict, etc.) — still counts as one.
+                    stripped_items += 1
+                    removed_any = True
+            if removed_any:
+                stripped_messages += 1
+
+        # Future codex_responses turns must not re-attach encrypted_content
+        # to outbound requests until a fresh session establishes new state.
+        self._codex_reasoning_replay_enabled = False
+        return {"messages": stripped_messages, "items": stripped_items}
+
     # Stream-diagnostic class header preserved for backward compat —
     # actual list lives in ``agent.stream_diag.STREAM_DIAG_HEADERS``.
     from agent.stream_diag import STREAM_DIAG_HEADERS as _STREAM_DIAG_HEADERS  # noqa: E402

--- a/tests/agent/test_provider_switch_strips_encrypted_state.py
+++ b/tests/agent/test_provider_switch_strips_encrypted_state.py
@@ -1,0 +1,237 @@
+"""Regression tests for #34205 — strip provider-specific reasoning state
+from session messages when the provider changes mid-session.
+
+Without this fix, encrypted_content blobs from one provider (e.g.
+codex_reasoning_items from openai-codex) survived a model switch and
+poisoned every subsequent request to the new provider (e.g. xai-oauth)
+with HTTP 400 invalid_encrypted_content.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_test_agent():
+    """Build a minimal AIAgent stub that has _strip_provider_specific_reasoning_state
+    plus the attributes switch_model touches."""
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.model = "gpt-5"
+    agent.provider = "openai-codex"
+    agent.base_url = "https://api.openai.com/v1"
+    agent.api_mode = "codex_responses"
+    agent.api_key = "sk-old"
+    agent._codex_reasoning_replay_enabled = True
+    agent._session_messages = []
+    return agent
+
+
+def test_strip_removes_codex_reasoning_items():
+    agent = _make_test_agent()
+    msgs = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "hello",
+            "codex_reasoning_items": [{"encrypted_content": "blob1"}, {"encrypted_content": "blob2"}],
+        },
+    ]
+    stats = agent._strip_provider_specific_reasoning_state(msgs)
+    assert stats["messages"] == 1
+    assert stats["items"] == 2
+    assert "codex_reasoning_items" not in msgs[1]
+
+
+def test_strip_removes_codex_message_items():
+    agent = _make_test_agent()
+    msgs = [
+        {
+            "role": "assistant",
+            "content": "hi",
+            "codex_message_items": [{"phase": "final"}],
+        },
+    ]
+    stats = agent._strip_provider_specific_reasoning_state(msgs)
+    assert stats["items"] == 1
+    assert "codex_message_items" not in msgs[0]
+
+
+def test_strip_removes_reasoning_details():
+    """reasoning_details is the OpenRouter/Anthropic structured-reasoning
+    array; it also carries encrypted_content. Other providers reject it."""
+    agent = _make_test_agent()
+    msgs = [
+        {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning_details": [
+                {"signature": "sig", "encrypted_content": "encB64"},
+            ],
+        },
+    ]
+    stats = agent._strip_provider_specific_reasoning_state(msgs)
+    assert stats["items"] == 1
+    assert "reasoning_details" not in msgs[0]
+
+
+def test_strip_preserves_plain_reasoning_string():
+    """`reasoning` and `reasoning_content` plain strings are NOT
+    provider-specific — they're safe to keep across providers."""
+    agent = _make_test_agent()
+    msgs = [
+        {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning": "step 1...",
+            "reasoning_content": "step 2...",
+            "codex_reasoning_items": [{"encrypted_content": "blob"}],
+        },
+    ]
+    agent._strip_provider_specific_reasoning_state(msgs)
+    assert "reasoning" in msgs[0], "plain `reasoning` string should NOT be stripped"
+    assert "reasoning_content" in msgs[0], "plain `reasoning_content` string should NOT be stripped"
+    assert "codex_reasoning_items" not in msgs[0]
+
+
+def test_strip_disables_codex_reasoning_replay_flag():
+    agent = _make_test_agent()
+    agent._codex_reasoning_replay_enabled = True
+    agent._strip_provider_specific_reasoning_state([])
+    assert agent._codex_reasoning_replay_enabled is False
+
+
+def test_strip_ignores_user_messages():
+    agent = _make_test_agent()
+    msgs = [
+        # User messages should never have reasoning_details, but the
+        # stripper should also never modify them.
+        {"role": "user", "content": "hi", "reasoning_details": [{"x": 1}]},
+    ]
+    stats = agent._strip_provider_specific_reasoning_state(msgs)
+    assert stats["messages"] == 0
+    # The stripper does not touch non-assistant messages even if they
+    # contain the key by mistake.
+    assert "reasoning_details" in msgs[0]
+
+
+def test_strip_handles_empty_list():
+    agent = _make_test_agent()
+    stats = agent._strip_provider_specific_reasoning_state([])
+    assert stats == {"messages": 0, "items": 0}
+
+
+def test_strip_handles_none_messages():
+    agent = _make_test_agent()
+    stats = agent._strip_provider_specific_reasoning_state(None)
+    assert stats == {"messages": 0, "items": 0}
+
+
+def test_strip_counts_multiple_messages():
+    agent = _make_test_agent()
+    msgs = [
+        {"role": "user", "content": "1"},
+        {"role": "assistant", "content": "a1", "codex_reasoning_items": [{"x": 1}]},
+        {"role": "user", "content": "2"},
+        {"role": "assistant", "content": "a2", "reasoning_details": [{"y": 2}, {"z": 3}]},
+        {"role": "user", "content": "3"},
+        {"role": "assistant", "content": "a3"},  # no replay state
+    ]
+    stats = agent._strip_provider_specific_reasoning_state(msgs)
+    assert stats["messages"] == 2
+    assert stats["items"] == 3
+
+
+def test_switch_model_strips_state_on_provider_change():
+    """End-to-end: switch_model() with a different provider should strip
+    encrypted reasoning state from _session_messages."""
+    from agent.agent_runtime_helpers import switch_model
+
+    agent = _make_test_agent()
+    agent._session_messages = [
+        {
+            "role": "assistant",
+            "content": "first response",
+            "codex_reasoning_items": [{"encrypted_content": "openai-blob"}],
+            "reasoning_details": [{"signature": "sig", "encrypted_content": "more-openai"}],
+        },
+    ]
+    # Stub out the heavy parts of switch_model so we can run it in
+    # isolation: model_metadata, transport rebuild, anthropic adapter.
+    agent._config_context_length = None
+    agent._client_kwargs = {}
+    agent._anthropic_client = None
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = ""
+    agent._is_anthropic_oauth = False
+    agent.client = None
+    agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
+    agent._ensure_lmstudio_runtime_loaded = MagicMock()
+    agent.context_compressor = None
+    agent._cached_system_prompt = "old"
+    agent._primary_runtime = {}
+    agent._create_openai_client = MagicMock(return_value=MagicMock())
+
+    with patch("hermes_cli.providers.determine_api_mode", return_value="chat_completions"):
+        switch_model(
+            agent,
+            new_model="grok-4.3",
+            new_provider="xai-oauth",
+            api_key="grok-key",
+            base_url="https://api.x.ai/v1",
+            api_mode="chat_completions",
+        )
+
+    # Encrypted state from the OpenAI provider is gone.
+    assert "codex_reasoning_items" not in agent._session_messages[0]
+    assert "reasoning_details" not in agent._session_messages[0]
+    # The non-encrypted parts of the message survived.
+    assert agent._session_messages[0]["content"] == "first response"
+    # The new provider was applied.
+    assert agent.model == "grok-4.3"
+    assert agent.provider == "xai-oauth"
+
+
+def test_switch_model_does_not_strip_when_provider_unchanged():
+    """If the user only changes model but keeps the same provider, the
+    encrypted state is still valid and must NOT be stripped."""
+    from agent.agent_runtime_helpers import switch_model
+
+    agent = _make_test_agent()
+    agent.provider = "openai-codex"
+    agent._session_messages = [
+        {
+            "role": "assistant",
+            "content": "first response",
+            "codex_reasoning_items": [{"encrypted_content": "blob"}],
+        },
+    ]
+    agent._config_context_length = None
+    agent._client_kwargs = {}
+    agent._anthropic_client = None
+    agent._anthropic_api_key = ""
+    agent._anthropic_base_url = ""
+    agent._is_anthropic_oauth = False
+    agent.client = None
+    agent._anthropic_prompt_cache_policy = MagicMock(return_value=(False, False))
+    agent._ensure_lmstudio_runtime_loaded = MagicMock()
+    agent.context_compressor = None
+    agent._cached_system_prompt = "old"
+    agent._primary_runtime = {}
+    agent._create_openai_client = MagicMock(return_value=MagicMock())
+
+    with patch("hermes_cli.providers.determine_api_mode", return_value="codex_responses"):
+        switch_model(
+            agent,
+            new_model="gpt-5.5",  # different model, same provider
+            new_provider="openai-codex",
+            api_key="sk-new",
+            base_url="https://api.openai.com/v1",
+            api_mode="codex_responses",
+        )
+
+    # Encrypted state preserved because provider didn't change.
+    assert "codex_reasoning_items" in agent._session_messages[0]


### PR DESCRIPTION
Closes #34205

## Problem

Switching providers mid-session (`openai-codex` → `xai-oauth` / `grok-4.3`) left provider-specific encrypted reasoning blobs in the session:

- `codex_reasoning_items` — OpenAI Codex Responses encrypted blobs
- `codex_message_items` — OpenAI Codex Responses message metadata
- `reasoning_details` — OpenRouter/Anthropic `encrypted_content`

These are provider-opaque. Every subsequent request to the new provider failed with HTTP 400 `invalid_encrypted_content`. The session was poisoned until the user manually set `suspended: true` and restarted the gateway.

Hermes already has an `invalid_encrypted_content` recovery path (`agent/conversation_loop.py:2459`) but it's gated on `api_mode == 'codex_responses'` AND only fires AFTER the 400. For cross-provider switches the gate mis-matches (new provider is on `chat_completions`) so users hit two 400s back-to-back before recovery would even help.

## Root cause

`agent.agent_runtime_helpers.switch_model` updates the client/model/provider/transport but doesn't clean up the in-memory `agent._session_messages`. The replay-fields whitelist in `gateway/run.py` was designed to PRESERVE these fields across CLI/gateway parity — without awareness that a mid-session provider switch invalidates them.

## Fix

1. New method `AIAgent._strip_provider_specific_reasoning_state` in `run_agent.py` (sister to the existing `_disable_codex_reasoning_replay`). Strips `codex_reasoning_items`, `codex_message_items`, `reasoning_details` from every assistant message; sets `_codex_reasoning_replay_enabled = False`. Plain-string `reasoning` / `reasoning_content` are left intact — they're not provider-specific.

2. `switch_model` in `agent/agent_runtime_helpers.py` calls the new method when `old_provider != new_provider`. Best-effort try/except so a stripper failure doesn't break the switch.

## Tests (11 in test_provider_switch_strips_encrypted_state.py)

Unit tests: each field removed correctly, plain reasoning string preserved, replay flag reset, user messages untouched, empty/None inputs handled, multi-message counting.

End-to-end via `switch_model`:
- `test_switch_model_strips_state_on_provider_change` — the #34205 repro: openai-codex → xai-oauth strips encrypted state.
- `test_switch_model_does_not_strip_when_provider_unchanged` — guard: model-only swap preserves replay state.

```bash
$ python -m pytest tests/agent/test_provider_switch_strips_encrypted_state.py
=== 11 passed in 0.58s ===
```

🎻 Co-authored-by: Cursor <cursoragent@cursor.com>