### PR TITLE
fix(security): 6 hardening patches - env scrub, tirith fail-close, guard agent-created, approval injection sanitizers, API key length, CORS wildcard gate

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -759,7 +759,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if not origin or not self._cors_origins:
             return None
 
-        if "*" in self._cors_origins:
+        if "*" in self._cors_origins and os.getenv("API_SERVER_ALLOW_ANY_ORIGIN", "").lower() in ("1", "true"):
             headers = dict(_CORS_HEADERS)
             headers["Access-Control-Allow-Origin"] = "*"
             headers["Access-Control-Max-Age"] = "600"
@@ -4116,7 +4116,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if is_network_accessible(self._host) and self._api_key:
                 try:
                     from hermes_cli.auth import has_usable_secret
-                    if not has_usable_secret(self._api_key, min_length=8):
+                    if not has_usable_secret(self._api_key, min_length=32):
                         logger.error(
                             "[%s] Refusing to start: API_SERVER_KEY is set to a "
                             "placeholder value. Generate a real secret "

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -887,10 +887,14 @@ def _smart_approve(command: str, description: str) -> str:
     try:
         from agent.auxiliary_client import call_llm
 
+        # Sanitize: truncate to 200 chars, strip newlines to prevent prompt injection
+        _safe_cmd = command[:200].replace("\n", " ").replace("\r", " ")
+        _safe_desc = description[:200].replace("\n", " ").replace("\r", " ")
+
         prompt = f"""You are a security reviewer for an AI coding agent. A terminal command was flagged by pattern matching as potentially dangerous.
 
-Command: {command}
-Flagged reason: {description}
+Command: {_safe_cmd}
+Flagged reason: {_safe_desc}
 
 Assess the ACTUAL risk of this command. Many flagged commands are false positives — for example, `python -c "print('hello')"` is flagged as "script execution via -c flag" but is completely harmless.
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -78,8 +78,7 @@ MAX_STDERR_BYTES = 10_000    # 10 KB
 # match either a safe prefix or, on Windows, an OS-essential name.
 _SAFE_ENV_PREFIXES = ("PATH", "HOME", "USER", "LANG", "LC_", "TERM",
                       "TMPDIR", "TMP", "TEMP", "SHELL", "LOGNAME",
-                      "XDG_", "PYTHONPATH", "VIRTUAL_ENV", "CONDA",
-                      "HERMES_")
+                      "XDG_", "PYTHONPATH", "VIRTUAL_ENV", "CONDA")
 _SECRET_SUBSTRINGS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL",
                       "PASSWD", "AUTH")
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -57,19 +57,17 @@ except ImportError:
 
 
 def _guard_agent_created_enabled() -> bool:
-    """Read skills.guard_agent_created from config (default False).
+    """Read skills.guard_agent_created from config (default True).
 
-    Off by default because the agent can already execute the same code
-    paths via terminal() with no gate, so the scan adds friction without
-    meaningful security.  Users who want belt-and-suspenders can turn it
-    on via `hermes config set skills.guard_agent_created true`.
+    Enabled by default so agent-created skills are scanned for threats.  Users who want belt-and-suspenders can turn it
+    off via `hermes config set skills.guard_agent_created false`.
     """
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
         return is_truthy_value(
             cfg_get(cfg, "skills", "guard_agent_created"),
-            default=False,
+            default=True,
         )
     except Exception:
         return False

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -71,7 +71,7 @@ def _load_security_config() -> dict:
         "tirith_enabled": True,
         "tirith_path": "tirith",
         "tirith_timeout": 5,
-        "tirith_fail_open": True,
+        "tirith_fail_open": False,
     }
     try:
         from hermes_cli.config import load_config


### PR DESCRIPTION
## Security Hardening: 6 patches merged from open PRs

### Changes
1. **tools/code_execution_tool.py** - Remove HERMES_ from _SAFE_ENV_PREFIXES: prevents subprocess env leak of security control vars (HERMES_YOLO_MODE, HERMES_ACCEPT_HOOKS, HERMES_CRON_SESSION)
2. **tools/tirith_security.py** - Change tirith_fail_open default True→False: fail-closed is more secure when scanner is unavailable
3. **tools/skill_manager_tool.py** - Change guard_agent_created default False→True: agent-created skills should be scanned by default to catch prompt injection
4. **tools/approval.py** - Sanitize command/description in _smart_approve(): truncate to 200 chars + strip newlines to prevent prompt injection into LLM approval prompt
5. **gateway/platforms/api_server.py** - Increase API key min_length 8→32: reject weak placeholder keys
6. **gateway/platforms/api_server.py** - CORS wildcard requires API_SERVER_ALLOW_ANY_ORIGIN=1 env var: prevents accidental wildcard CORS exposure

### Sources
These patches were validated in open PRs but lacked review bandwidth:
- #31191 (approval injection sanitizers) - valid fix, open
- #31189 (CORS wildcard gate) - valid fix, open  
- #31188 (API key min length) - valid fix, open
- #31186 (remove HERMES_ env prefix) - valid fix, open
- #31183 (tirith fail-open default) - valid fix, open
- #31182 (guard agent-created default) - valid fix, open

### Risk Assessment
All 6 changes are additive hardening - they restrict behavior that was previously more permissive. No changes expand attack surface. All are config/logic-only with no new dependencies.