### PR TITLE
fix(web): SearXNG honors SEARXNG_URL set via hermes config (#34290)

### DIFF
--- a/plugins/web/searxng/provider.py
+++ b/plugins/web/searxng/provider.py
@@ -31,6 +31,33 @@ from agent.web_search_provider import WebSearchProvider
 logger = logging.getLogger(__name__)
 
 
+def _resolve_searxng_url() -> str:
+    """Resolve ``SEARXNG_URL`` from Hermes config first, then process env.
+
+    Hermes supports declaring env values inside ~/.hermes/config.yaml (via
+    ``env:`` section) and the per-profile .env file. Those values are
+    visible through ``hermes_cli.config.get_env_value()`` but are NOT
+    necessarily exported to the live process environment that
+    ``os.getenv()`` sees — the gateway, the agent runtime, and shell
+    invocations may all see different snapshots.
+
+    Falling back to ``os.getenv()`` last preserves the existing behavior
+    for users who set SEARXNG_URL purely via shell exports / systemd
+    unit Environment=. See #34290.
+    """
+    # 1. Hermes config / .env handling (the source the user most likely
+    #    edited via ``hermes config set`` or ``hermes tools``).
+    try:
+        from hermes_cli.config import get_env_value
+        val = get_env_value("SEARXNG_URL")
+        if val:
+            return val.strip()
+    except Exception:  # noqa: BLE001 — fall back silently to process env
+        pass
+    # 2. Process environment (legacy / shell / systemd Environment=).
+    return os.getenv("SEARXNG_URL", "").strip()
+
+
 class SearXNGWebSearchProvider(WebSearchProvider):
     """Search via a user-hosted SearXNG instance."""
 
@@ -43,8 +70,8 @@ class SearXNGWebSearchProvider(WebSearchProvider):
         return "SearXNG"
 
     def is_available(self) -> bool:
-        """Return True when ``SEARXNG_URL`` is set."""
-        return bool(os.getenv("SEARXNG_URL", "").strip())
+        """Return True when ``SEARXNG_URL`` is set (config or env)."""
+        return bool(_resolve_searxng_url())
 
     def supports_search(self) -> bool:
         return True
@@ -56,7 +83,7 @@ class SearXNGWebSearchProvider(WebSearchProvider):
         """Execute a search against the configured SearXNG instance."""
         import httpx
 
-        base_url = os.getenv("SEARXNG_URL", "").strip().rstrip("/")
+        base_url = _resolve_searxng_url().rstrip("/")
         if not base_url:
             return {"success": False, "error": "SEARXNG_URL is not set"}
 

--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -329,3 +329,98 @@ class TestSearXNGOnlyExtractCrawlErrors:
         result = json.loads(result_str)
         assert result["success"] is False
         assert "search-only" in result["error"].lower() or "SearXNG" in result["error"]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #34290 — SEARXNG_URL resolution prefers Hermes config over process env
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestSearXNGConfigAwareEnvResolution:
+    """Regression tests for #34290.
+
+    Before this fix, SearXNG provider read os.getenv('SEARXNG_URL') only.
+    Users who set the URL via `hermes config set` (which writes to the
+    Hermes-managed config / .env layer) got 'SEARXNG_URL is not set'
+    because the live process env was unchanged.
+    """
+
+    def test_provider_uses_config_value_when_process_env_empty(self, monkeypatch):
+        """Provider sees the URL from get_env_value() even when os.environ
+        does NOT have SEARXNG_URL set."""
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        monkeypatch.delenv("SEARXNG_URL", raising=False)
+
+        def fake_get_env_value(name):
+            if name == "SEARXNG_URL":
+                return "https://configured.example.com"
+            return None
+
+        # Patch hermes_cli.config.get_env_value
+        import hermes_cli.config as _cfg
+        monkeypatch.setattr(_cfg, "get_env_value", fake_get_env_value, raising=False)
+
+        provider = SearXNGWebSearchProvider()
+        assert provider.is_available() is True
+
+    def test_provider_falls_back_to_process_env(self, monkeypatch):
+        """If Hermes config has no SEARXNG_URL, fall back to process env
+        (preserves legacy / shell-export behavior)."""
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        monkeypatch.setenv("SEARXNG_URL", "https://from-env.example.com")
+
+        # Hermes config layer returns None
+        import hermes_cli.config as _cfg
+        monkeypatch.setattr(_cfg, "get_env_value", lambda _n: None, raising=False)
+
+        provider = SearXNGWebSearchProvider()
+        assert provider.is_available() is True
+
+    def test_provider_reports_unavailable_when_neither_set(self, monkeypatch):
+        from plugins.web.searxng.provider import SearXNGWebSearchProvider
+
+        monkeypatch.delenv("SEARXNG_URL", raising=False)
+
+        import hermes_cli.config as _cfg
+        monkeypatch.setattr(_cfg, "get_env_value", lambda _n: None, raising=False)
+
+        provider = SearXNGWebSearchProvider()
+        assert provider.is_available() is False
+
+    def test_resolve_helper_prefers_config_over_env(self, monkeypatch):
+        """When BOTH config and process env have a value, config wins —
+        because the user most likely intended `hermes config set` to be
+        authoritative."""
+        from plugins.web.searxng.provider import _resolve_searxng_url
+
+        monkeypatch.setenv("SEARXNG_URL", "https://from-env.example.com")
+
+        import hermes_cli.config as _cfg
+        monkeypatch.setattr(
+            _cfg,
+            "get_env_value",
+            lambda n: "https://from-config.example.com" if n == "SEARXNG_URL" else None,
+            raising=False,
+        )
+
+        assert _resolve_searxng_url() == "https://from-config.example.com"
+
+    def test_has_env_helper_in_web_tools_is_config_aware(self, monkeypatch):
+        """_has_env('SEARXNG_URL') in tools/web_tools.py must also honor
+        Hermes config, not just process env. Otherwise the backend
+        selection logic at line 156 keeps reporting SearXNG unavailable."""
+        from tools.web_tools import _has_env
+
+        monkeypatch.delenv("SEARXNG_URL", raising=False)
+
+        import hermes_cli.config as _cfg
+        monkeypatch.setattr(
+            _cfg,
+            "get_env_value",
+            lambda n: "https://x" if n == "SEARXNG_URL" else None,
+            raising=False,
+        )
+
+        assert _has_env("SEARXNG_URL") is True

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -121,6 +121,24 @@ logger = logging.getLogger(__name__)
 # ─── Backend Selection ────────────────────────────────────────────────────────
 
 def _has_env(name: str) -> bool:
+    """Return True when *name* has a non-empty value visible via Hermes
+    config OR the process environment.
+
+    Hermes' config layer (~/.hermes/config.yaml + .env) supplies values
+    that the live os.environ doesn't necessarily see (a gateway worker
+    spawned via systemd has a different env than the CLI). See #34290 —
+    SearXNG appeared unavailable because os.getenv("SEARXNG_URL") was
+    empty even though the user had set it via ``hermes config set``.
+    """
+    # 1. Hermes config-aware lookup (what the user most likely set).
+    try:
+        from hermes_cli.config import get_env_value
+        val = get_env_value(name)
+        if val and val.strip():
+            return True
+    except Exception:  # noqa: BLE001
+        pass
+    # 2. Process environment fallback.
     val = os.getenv(name)
     return bool(val and val.strip())
 
@@ -1175,7 +1193,16 @@ if __name__ == "__main__":
         elif backend == "tavily":
             print("   Using Tavily API (https://tavily.com)")
         elif backend == "searxng":
-            print(f"   Using SearXNG (search only): {os.getenv('SEARXNG_URL', '').strip()}")
+            # Resolve via Hermes config-first lookup (#34290) so the diagnostic
+            # print matches what the provider actually sees, not just shell env.
+            try:
+                from hermes_cli.config import get_env_value
+                _sxng_url = (get_env_value("SEARXNG_URL") or "").strip()
+            except Exception:  # noqa: BLE001
+                _sxng_url = ""
+            if not _sxng_url:
+                _sxng_url = os.getenv("SEARXNG_URL", "").strip()
+            print(f"   Using SearXNG (search only): {_sxng_url}")
         elif backend == "brave-free":
             print("   Using Brave Search free tier (search only)")
         elif backend == "ddgs":


### PR DESCRIPTION
Closes #34290

## Problem

SearXNG provider read `os.getenv(SEARXNG_URL)` only. Users who set the URL via `hermes config set SEARXNG_URL ...` or the Hermes-managed `.env` file got `SEARXNG_URL is not set` — those values are visible through `hermes_cli.config.get_env_value()` but NOT necessarily exported to the running process env (gateway worker spawned via systemd, etc.).

Same blind spot in `tools/web_tools.py::_has_env` (drives auto-backend selection at line 156).

## Fix

1. `plugins/web/searxng/provider.py` — new `_resolve_searxng_url()` helper: `get_env_value()` first, `os.getenv()` fallback. Used by both `is_available()` and `search()` so they can never disagree.

2. `tools/web_tools.py` — same config-first lookup in `_has_env`. Diagnostic print at line 1196 also config-aware.

POSIX behavior preserved for users who set via shell exports / systemd `Environment=`.

## Tests (5 new)

- Provider picks up SEARXNG_URL from `get_env_value()` when os.environ empty (the #34290 repro)
- Provider falls back to process env when config empty (legacy)
- Provider reports unavailable when neither set
- `_resolve_searxng_url` prefers config over env when both set
- `_has_env` in web_tools is also config-aware

```bash
$ python -m pytest tests/tools/test_web_providers_searxng.py
=== 29 passed in 0.35s ===
```

🎻 Co-authored-by: Cursor <cursoragent@cursor.com>