### PR TITLE
fix(model-switch): resolve provider-module plugin providers in switch path

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -390,6 +390,13 @@ TRANSPORT_TO_API_MODE: Dict[str, str] = {
     "bedrock_converse": "bedrock_converse",
 }
 
+# Inverse of TRANSPORT_TO_API_MODE — provider-module plugins declare api_mode
+# directly (ProviderProfile.api_mode), so map it back to the ProviderDef
+# transport vocabulary. Unknown api_modes fall back to "openai_chat".
+_API_MODE_TO_TRANSPORT: Dict[str, str] = {
+    v: k for k, v in TRANSPORT_TO_API_MODE.items()
+}
+
 
 # -- Helper functions ---------------------------------------------------------
 
@@ -683,6 +690,18 @@ def resolve_provider_full(
     if pdef is not None:
         return pdef
 
+    # 1b. Provider-module plugins (plugins/model-providers/<name>/).
+    #     These are the same profiles that hermes_cli.auth.PROVIDER_REGISTRY
+    #     auto-extends from at import time, so the model-switch path must see
+    #     them too — otherwise a provider that resolves fine at startup (e.g.
+    #     a local Anthropic proxy declared only as a plugin profile) is
+    #     rejected with "Unknown provider" when the user tries to /model into
+    #     it. resolve_provider_full and runtime startup resolution were
+    #     consulting two different registries; this reunifies them.
+    plugin_pdef = _resolve_plugin_provider(canonical, name)
+    if plugin_pdef is not None:
+        return plugin_pdef
+
     # 2. User-defined providers from config
     if user_providers:
         # Try canonical name
@@ -716,3 +735,56 @@ def resolve_provider_full(
         pass
 
     return None
+
+
+def _resolve_plugin_provider(canonical: str, original: str) -> Optional[ProviderDef]:
+    """Resolve a provider declared as a provider-module plugin profile.
+
+    Provider plugins live in ``plugins/model-providers/<name>/`` (bundled) or
+    ``$HERMES_HOME/plugins/model-providers/<name>/`` (user). They register a
+    ``ProviderProfile`` carrying name/aliases/base_url/env_vars/api_mode.
+    ``hermes_cli.auth.PROVIDER_REGISTRY`` already auto-extends from this same
+    source, which is why such providers resolve correctly during runtime
+    startup. The model-switch resolver historically did not, producing the
+    "Unknown provider" failure for plugin-only providers.
+
+    Translates a ``ProviderProfile`` into a ``ProviderDef`` so the rest of the
+    switch path is unchanged. ``api_mode`` maps back to ``transport`` via the
+    inverse of ``TRANSPORT_TO_API_MODE`` (default ``openai_chat``).
+    """
+    try:
+        from providers import get_provider_profile
+    except Exception:
+        return None
+
+    profile = None
+    try:
+        profile = get_provider_profile(canonical) or get_provider_profile(
+            (original or "").strip().lower()
+        )
+    except Exception:
+        profile = None
+    if profile is None:
+        return None
+
+    api_mode = getattr(profile, "api_mode", "") or "chat_completions"
+    transport = _API_MODE_TO_TRANSPORT.get(api_mode, "openai_chat")
+
+    env_vars = tuple(getattr(profile, "env_vars", ()) or ())
+    api_key_env_vars = tuple(
+        v for v in env_vars if not v.endswith("_BASE_URL") and not v.endswith("_URL")
+    ) or env_vars
+    base_url_env_var = next(
+        (v for v in env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")), ""
+    )
+
+    return ProviderDef(
+        id=getattr(profile, "name", canonical),
+        name=getattr(profile, "display_name", "") or getattr(profile, "name", canonical),
+        transport=transport,
+        api_key_env_vars=api_key_env_vars,
+        base_url=getattr(profile, "base_url", "") or "",
+        base_url_env_var=base_url_env_var,
+        auth_type=getattr(profile, "auth_type", "api_key") or "api_key",
+        source="plugin",
+    )


### PR DESCRIPTION
## Summary

`resolve_provider_full()` — the resolver behind `/model <name>`, `--provider`, and the interactive model picker — consults the models.dev catalog, Hermes overlays, and config.yaml `providers:` / `custom_providers:`. It **never consults the provider-module plugin registry** (`plugins/model-providers/<name>/`), even though `hermes_cli.auth.PROVIDER_REGISTRY` auto-extends from that same source at import time.

The two paths therefore use two different provider registries:

- **Startup / default-model resolution** → `runtime_provider` → `auth.PROVIDER_REGISTRY` → **knows** plugin providers.
- **`/model` switch resolution** → `resolve_provider_full` → `get_provider()` + config only → **does not** know plugin providers.

## Symptom

A provider declared only as a plugin profile (e.g. a local Anthropic-compatible proxy registered via `providers/`) works fine as the **configured default model** — startup resolves it correctly — but **switching into it** via `/model` (or selecting it in the Discord/Telegram picker) fails with:

```
Unknown provider '<name>'. Check 'hermes model' for available providers,
or define it in config.yaml under 'providers:'.
```

## Reproduction (pre-fix)

With a plugin provider under `plugins/model-providers/<name>/` declaring `api_mode="anthropic_messages"`:

```python
from hermes_cli.model_switch import switch_model
r = switch_model(
    raw_input="my-proxy/some-model",
    current_provider="openrouter", current_model="x",
    current_base_url="", current_api_key="",
    is_global=False, explicit_provider="my-proxy",
)
assert r.success  # -> False: "Unknown provider 'my-proxy'"
```

## Fix

Add resolution step **1b** in `resolve_provider_full` that consults the `providers/` plugin registry via `get_provider_profile()`, translating the `ProviderProfile` into a `ProviderDef`. `api_mode` maps back to `transport` via the inverse of `TRANSPORT_TO_API_MODE` (default `openai_chat`). Env-var splitting mirrors the same `_BASE_URL`/`_URL` heuristic `auth.py` already uses when it auto-extends the registry.

This reunifies the switch path with the startup path: a provider that works as a default now also works as a `/model` target. Built-in/models.dev/config resolution order is unchanged — the plugin layer slots in after built-ins and before config providers, matching the precedence `auth.py` uses.

## Scope

- **IN** — make the switch resolver see provider-module plugin providers.
- **OUT** — collapsing the two provider registries into one. That's a larger refactor with its own tradeoffs; this PR keeps both registries but makes the switch path layer the plugin registry the same way `auth.py` does.

## Verification

A standalone assertion script confirms:
- `resolve_provider_full("<plugin-provider>")` returns a `ProviderDef` with correct `transport` (mapped from `api_mode`), `base_url`, and key env vars.
- `switch_model(... explicit_provider="<plugin-provider>")` succeeds end-to-end with the right `api_mode`/`base_url`.
- A genuinely unknown provider still resolves to `None` / fails (no over-broad matching).

Targeted suites pass (`test_user_providers_model_switch`, `test_model_switch_opencode_anthropic`, `test_api_key_providers`, `test_runtime_provider_resolution`, etc.). Three pre-existing failures in `test_model_switch_custom_providers.py` are caused by a model-catalog `403` in the sandbox and fail identically on `origin/main` with this change reverted — unrelated to this PR.
