### PR TITLE
fix(browser): honor ignore_https_errors via agent-browser CLI flag

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -365,6 +365,10 @@ browser:
   # Inactivity timeout in seconds - browser sessions are automatically closed
   # after this period of no activity between agent loops (default: 120 = 2 minutes)
   inactivity_timeout: 120
+  # Ignore TLS/SSL certificate errors (self-signed, expired, hostname mismatch).
+  # When true, agent-browser gets --ignore-https-errors so internal services
+  # with self-signed certs can be navigated. Default false.
+  # ignore_https_errors: false
 
 # =============================================================================
 # Tool Loop Guardrails

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1269,6 +1269,11 @@ DEFAULT_CONFIG = {
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)
         "record_sessions": False,  # Auto-record browser sessions as WebM videos
         "allow_private_urls": False,  # Allow navigating to private/internal IPs (localhost, 192.168.x.x, etc.)
+        # Ignore TLS/SSL certificate errors (self-signed certs, expired, etc.).
+        # When true, agent-browser is invoked with --ignore-https-errors so
+        # internal services (Proxmox, homelab dashboards) with self-signed
+        # certs can be navigated. Default false for security.
+        "ignore_https_errors": False,
         # Browser engine for local mode.  Passed as ``--engine <value>`` to
         # agent-browser v0.25.3+.
         # "auto"       — use Chrome (default, don't pass --engine at all)

--- a/tests/tools/test_browser_hardening.py
+++ b/tests/tools/test_browser_hardening.py
@@ -17,6 +17,8 @@ def _reset_caches():
     bt._agent_browser_resolved = False
     bt._cached_command_timeout = None
     bt._command_timeout_resolved = False
+    bt._cached_ignore_https_errors = None
+    bt._ignore_https_errors_resolved = False
     # lru_cache for _discover_homebrew_node_dirs
     if hasattr(bt._discover_homebrew_node_dirs, "cache_clear"):
         bt._discover_homebrew_node_dirs.cache_clear()
@@ -114,6 +116,50 @@ class TestCommandTimeoutCache:
             _get_command_timeout()
             _get_command_timeout()
         mock_read.assert_called_once()
+
+
+class TestIgnoreHttpsErrorsConfig:
+    """Config reader + cache for browser.ignore_https_errors."""
+
+    def test_default_is_false(self):
+        from tools.browser_tool import _get_ignore_https_errors_config
+        with patch("hermes_cli.config.read_raw_config", return_value={}):
+            assert _get_ignore_https_errors_config() is False
+
+    def test_default_matches_default_config(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        from tools.browser_tool import _get_ignore_https_errors_config
+        assert DEFAULT_CONFIG["browser"]["ignore_https_errors"] is False
+        with patch("hermes_cli.config.read_raw_config", return_value={}):
+            assert _get_ignore_https_errors_config() is False
+
+    def test_reads_true_from_config(self):
+        from tools.browser_tool import _get_ignore_https_errors_config
+        cfg = {"browser": {"ignore_https_errors": True}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert _get_ignore_https_errors_config() is True
+
+    def test_reads_false_from_config(self):
+        from tools.browser_tool import _get_ignore_https_errors_config
+        cfg = {"browser": {"ignore_https_errors": False}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert _get_ignore_https_errors_config() is False
+
+    def test_cached_after_first_call(self):
+        from tools.browser_tool import _get_ignore_https_errors_config
+        mock_read = MagicMock(return_value={"browser": {"ignore_https_errors": True}})
+        with patch("hermes_cli.config.read_raw_config", mock_read):
+            assert _get_ignore_https_errors_config() is True
+            assert _get_ignore_https_errors_config() is True
+        mock_read.assert_called_once()
+
+    def test_cache_cleared_by_cleanup(self):
+        import tools.browser_tool as bt
+        bt._cached_ignore_https_errors = True
+        bt._ignore_https_errors_resolved = True
+        bt.cleanup_all_browsers()
+        assert bt._ignore_https_errors_resolved is False
+        assert bt._cached_ignore_https_errors is None
 
 
 class TestSessionInactivityTimeout:

--- a/tests/tools/test_browser_hardening.py
+++ b/tests/tools/test_browser_hardening.py
@@ -145,6 +145,19 @@ class TestIgnoreHttpsErrorsConfig:
         with patch("hermes_cli.config.read_raw_config", return_value=cfg):
             assert _get_ignore_https_errors_config() is False
 
+    def test_string_false_stays_false(self):
+        """bool('false') is True — must use is_truthy_value."""
+        from tools.browser_tool import _get_ignore_https_errors_config
+        cfg = {"browser": {"ignore_https_errors": "false"}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert _get_ignore_https_errors_config() is False
+
+    def test_string_true_is_true(self):
+        from tools.browser_tool import _get_ignore_https_errors_config
+        cfg = {"browser": {"ignore_https_errors": "true"}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert _get_ignore_https_errors_config() is True
+
     def test_cached_after_first_call(self):
         from tools.browser_tool import _get_ignore_https_errors_config
         mock_read = MagicMock(return_value={"browser": {"ignore_https_errors": True}})

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -23,10 +23,14 @@ def _clear_browser_caches():
     _discover_homebrew_node_dirs.cache_clear()
     _bt._cached_agent_browser = None
     _bt._agent_browser_resolved = False
+    _bt._cached_ignore_https_errors = None
+    _bt._ignore_https_errors_resolved = False
     yield
     _discover_homebrew_node_dirs.cache_clear()
     _bt._cached_agent_browser = None
     _bt._agent_browser_resolved = False
+    _bt._cached_ignore_https_errors = None
+    _bt._ignore_https_errors_resolved = False
 
 
 class TestSanePath:
@@ -351,6 +355,80 @@ class TestRunBrowserCommandPathConstruction:
         assert captured_cmd[0].endswith("npx") or captured_cmd[0] == "npx"
         assert captured_cmd[1] == "agent-browser"
         assert captured_cmd[2:6] == [
+            "--session",
+            "test-session",
+            "--json",
+            "navigate",
+        ]
+
+    def _run_and_capture_cmd(self, tmp_path, *, ignore_https_errors: bool):
+        """Helper: run navigate once and return the Popen argv list."""
+        from tools.browser_tool import _run_browser_command
+        import tools.browser_tool as bt
+
+        bt._cached_ignore_https_errors = None
+        bt._ignore_https_errors_resolved = False
+
+        captured_cmd = None
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+
+        def capture_popen(cmd, **kwargs):
+            nonlocal captured_cmd
+            captured_cmd = cmd
+            return mock_proc
+
+        fake_session = {
+            "session_name": "test-session",
+            "session_id": "test-id",
+            "cdp_url": None,
+        }
+        fake_json = json.dumps({"success": True})
+        browser_path = "/usr/local/bin/agent-browser"
+        hermes_home = str(tmp_path / "hermes-home")
+        cfg = {"browser": {"ignore_https_errors": ignore_https_errors}}
+
+        with patch("tools.browser_tool._find_agent_browser", return_value=browser_path), \
+             patch("tools.browser_tool._chromium_installed", return_value=True), \
+             patch("tools.browser_tool._get_session_info", return_value=fake_session), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._discover_homebrew_node_dirs", return_value=[]), \
+             patch("hermes_constants.Path.home", return_value=tmp_path), \
+             patch("hermes_cli.config.read_raw_config", return_value=cfg), \
+             patch("subprocess.Popen", side_effect=capture_popen), \
+             patch("os.open", return_value=99), \
+             patch("os.close"), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.dict(
+                 os.environ,
+                 {
+                     "PATH": "/usr/bin:/bin",
+                     "HOME": "/home/test",
+                     "HERMES_HOME": hermes_home,
+                 },
+                 clear=True,
+             ):
+            with patch("builtins.open", mock_open(read_data=fake_json)):
+                _run_browser_command("test-task", "navigate", ["https://example.com"])
+
+        return captured_cmd
+
+    def test_ignore_https_errors_enabled_injects_flag(self, tmp_path):
+        """When browser.ignore_https_errors is true, argv includes the flag."""
+        captured_cmd = self._run_and_capture_cmd(tmp_path, ignore_https_errors=True)
+        assert captured_cmd is not None
+        assert "--ignore-https-errors" in captured_cmd
+        # Flag must land between backend args and --json (agent-browser global opts).
+        assert captured_cmd.index("--ignore-https-errors") < captured_cmd.index("--json")
+        assert captured_cmd[-2:] == ["navigate", "https://example.com"]
+
+    def test_ignore_https_errors_disabled_omits_flag(self, tmp_path):
+        """When browser.ignore_https_errors is false/default, argv has no flag."""
+        captured_cmd = self._run_and_capture_cmd(tmp_path, ignore_https_errors=False)
+        assert captured_cmd is not None
+        assert "--ignore-https-errors" not in captured_cmd
+        assert captured_cmd[1:5] == [
             "--session",
             "test-session",
             "--json",

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -290,15 +290,16 @@ def _get_ignore_https_errors_config() -> bool:
     """
     global _cached_ignore_https_errors, _ignore_https_errors_resolved
     if _ignore_https_errors_resolved and _cached_ignore_https_errors is not None:
-        return _cached_ignore_https_errors
+        return bool(_cached_ignore_https_errors)
 
     result = False
     try:
         from hermes_cli.config import read_raw_config
         cfg = read_raw_config()
         val = cfg_get(cfg, "browser", "ignore_https_errors")
-        if val is not None:
-            result = bool(val)
+        # Use is_truthy_value so string "false"/"0"/"no" stay false
+        # (bool("false") is True — common YAML/env footgun).
+        result = is_truthy_value(val, default=False)
     except Exception as e:
         logger.debug("Could not read ignore_https_errors from config: %s", e)
     # Cache before flipping resolved (same race discipline as timeout cache).
@@ -2388,9 +2389,9 @@ def _run_browser_command(
 
     extra_args: list[str] = []
     if _get_ignore_https_errors_config():
-        # Global agent-browser flag; also settable via
-        # AGENT_BROWSER_IGNORE_HTTPS_ERRORS. Lets local Chromium open
-        # self-signed / internal HTTPS endpoints.
+        # Global agent-browser flag (also exists as env
+        # AGENT_BROWSER_IGNORE_HTTPS_ERRORS outside Hermes). Lets local
+        # Chromium open self-signed / internal HTTPS endpoints.
         extra_args.append("--ignore-https-errors")
 
     cmd_parts = cmd_prefix + backend_args + extra_args + [

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -237,6 +237,8 @@ _EMPTY_OK_COMMANDS: frozenset = frozenset({"close", "record"})
 
 _cached_command_timeout: Optional[int] = None
 _command_timeout_resolved = False
+_cached_ignore_https_errors: Optional[bool] = None
+_ignore_https_errors_resolved = False
 
 
 def _sanitize_url_for_logs(value: object) -> str:
@@ -276,6 +278,32 @@ def _get_command_timeout() -> int:
     # is still ``None`` (see issue #14331).
     _cached_command_timeout = result
     _command_timeout_resolved = True
+    return result
+
+
+def _get_ignore_https_errors_config() -> bool:
+    """Return whether to ignore HTTPS certificate errors from config.yaml.
+
+    Reads ``config["browser"]["ignore_https_errors"]`` and falls back to
+    ``False`` if unset or unreadable. Result is cached after the first call
+    and cleared by ``cleanup_all_browsers()``.
+    """
+    global _cached_ignore_https_errors, _ignore_https_errors_resolved
+    if _ignore_https_errors_resolved and _cached_ignore_https_errors is not None:
+        return _cached_ignore_https_errors
+
+    result = False
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        val = cfg_get(cfg, "browser", "ignore_https_errors")
+        if val is not None:
+            result = bool(val)
+    except Exception as e:
+        logger.debug("Could not read ignore_https_errors from config: %s", e)
+    # Cache before flipping resolved (same race discipline as timeout cache).
+    _cached_ignore_https_errors = result
+    _ignore_https_errors_resolved = True
     return result
 
 
@@ -2358,7 +2386,14 @@ def _run_browser_command(
     else:
         cmd_prefix = [browser_cmd]
 
-    cmd_parts = cmd_prefix + backend_args + [
+    extra_args: list[str] = []
+    if _get_ignore_https_errors_config():
+        # Global agent-browser flag; also settable via
+        # AGENT_BROWSER_IGNORE_HTTPS_ERRORS. Lets local Chromium open
+        # self-signed / internal HTTPS endpoints.
+        extra_args.append("--ignore-https-errors")
+
+    cmd_parts = cmd_prefix + backend_args + extra_args + [
         "--json",
         command
     ] + args
@@ -4380,6 +4415,7 @@ def cleanup_all_browsers() -> None:
     # Reset cached lookups so they are re-evaluated on next use.
     global _cached_agent_browser, _agent_browser_resolved
     global _cached_command_timeout, _command_timeout_resolved
+    global _cached_ignore_https_errors, _ignore_https_errors_resolved
     global _cached_chromium_installed
     global _cached_browser_engine, _browser_engine_resolved
     _cached_agent_browser = None
@@ -4389,6 +4425,8 @@ def cleanup_all_browsers() -> None:
     # reader never sees ``resolved=True`` with ``cache=None`` (#14331).
     _command_timeout_resolved = False
     _cached_command_timeout = None
+    _ignore_https_errors_resolved = False
+    _cached_ignore_https_errors = None
     _cached_chromium_installed = None
     global _chromium_autoinstall_attempted
     _chromium_autoinstall_attempted = False

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1776,6 +1776,7 @@ browser:
   # When true, agent-browser is invoked with --ignore-https-errors so internal
   # services with self-signed certs (Proxmox, homelab dashboards) can be opened.
   # Default false. Prefer proper certs in production.
+  # For LAN/self-signed targets you typically also need allow_private_urls: true.
   ignore_https_errors: false
   # Optional CDP override — when set, Hermes attaches directly to your own
   # Chromium-family browser (via /browser connect) rather than starting a headless browser.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1772,6 +1772,11 @@ browser:
   inactivity_timeout: 120        # Seconds before auto-closing idle sessions
   command_timeout: 30             # Timeout in seconds for browser commands (screenshot, navigate, etc.)
   record_sessions: false         # Auto-record browser sessions as WebM videos to ~/.hermes/browser_recordings/
+  # Ignore TLS/SSL certificate errors (self-signed, expired, hostname mismatch).
+  # When true, agent-browser is invoked with --ignore-https-errors so internal
+  # services with self-signed certs (Proxmox, homelab dashboards) can be opened.
+  # Default false. Prefer proper certs in production.
+  ignore_https_errors: false
   # Optional CDP override — when set, Hermes attaches directly to your own
   # Chromium-family browser (via /browser connect) rather than starting a headless browser.
   cdp_url: ""


### PR DESCRIPTION
## Summary

`browser.ignore_https_errors` is now a first-class config option that actually works.

Previously the setting was not in `DEFAULT_CONFIG`, not documented, and never passed to `agent-browser`. Self-signed internal HTTPS endpoints (Proxmox, homelab dashboards) could not be navigated even if a user tried to enable it via raw config.

## Changes

- **DEFAULT_CONFIG** — `browser.ignore_https_errors: false` (safe default)
- **Docs** — Browser section in `website/docs/user-guide/configuration.md` + commented example in `cli-config.yaml.example`
- **Runtime** — `_get_ignore_https_errors_config()` with race-safe cache; injects `--ignore-https-errors` into agent-browser argv in `_run_browser_command`
- **Parsing** — uses `is_truthy_value` (not bare `bool()`) so string `"false"`/`"0"`/`"no"` stay disabled
- **Cache cleanup** — cleared in `cleanup_all_browsers()`
- **Tests** — config default/read/cache + string true/false + enabled/disabled argv assertions

## Usage

```yaml
browser:
  ignore_https_errors: true
  # For LAN/self-signed targets you typically also need:
  allow_private_urls: true
```

## Test plan

- [x] `pytest tests/tools/test_browser_hardening.py tests/tools/test_browser_homebrew_paths.py`
- [x] Confirmed `agent-browser` exposes global `--ignore-https-errors` flag
- [ ] CI green
