### PR TITLE
fix(cli): pass custom_providers to context length display

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7444,12 +7444,16 @@ class HermesCLI:
         mi = result.model_info
         try:
             from hermes_cli.model_switch import resolve_display_context_length
+            from hermes_cli.config import load_config, get_compatible_custom_providers
+            _cp_cfg = load_config()
+            _cp_list = get_compatible_custom_providers(_cp_cfg)
             ctx = resolve_display_context_length(
                 result.new_model,
                 result.target_provider,
                 base_url=result.base_url or self.base_url or "",
                 api_key=result.api_key or self.api_key or "",
                 model_info=mi,
+                custom_providers=_cp_list,
                 config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None,
             )
             if ctx:
@@ -7678,12 +7682,16 @@ class HermesCLI:
         # (e.g. gpt-5.5 is 1.05M on openai but 272K on Codex OAuth).
         mi = result.model_info
         from hermes_cli.model_switch import resolve_display_context_length
+        from hermes_cli.config import load_config, get_compatible_custom_providers
+        _cp_cfg = load_config()
+        _cp_list = get_compatible_custom_providers(_cp_cfg)
         ctx = resolve_display_context_length(
             result.new_model,
             result.target_provider,
             base_url=result.base_url or self.base_url or "",
             api_key=result.api_key or self.api_key or "",
             model_info=mi,
+            custom_providers=_cp_list,
             config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None,
         )
         if ctx:


### PR DESCRIPTION
The two CLI `/model` display paths call `resolve_display_context_length()` without passing `custom_providers`, so even though the per-model `context_length` override is correctly resolved internally (the core fix in `model_metadata.py` is already upstream), the **displayed** value still shows the global `model.context_length` default.

**Changes:**
- Load `custom_providers` from config in both display paths
- Pass them to `resolve_display_context_length()` so per-model overrides are reflected in the CLI output

**Example:** If a custom provider defines `context_length: 272000` for a model, the display now correctly shows 272K instead of the global default.