### PR TITLE
fix(stream): extend large-prefill TTFB exemption to direct Copilot (#34179)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -130,6 +130,18 @@ def estimate_request_context_tokens(api_payload: Any) -> int:
 
 
 def _is_openai_codex_backend(agent) -> bool:
+    """Identify Codex-Responses backends that legitimately take >12s before
+    emitting their first SSE event on large prefills.
+
+    Includes:
+      * provider='openai-codex' (the canonical ChatGPT-account Codex path)
+      * chatgpt.com/backend-api/codex (same backend, different routing)
+      * provider='copilot' or api.githubcopilot.com (direct GitHub Copilot
+        on /v1/responses — same subscription/admission queue model;
+        large gpt-5.5 resumes can sit 30-60s waiting for the first byte;
+        the 12s TTFB watchdog was killing the stream before Copilot's
+        admission completed). See #34179.
+    """
     base_url_lower = str(getattr(agent, "_base_url_lower", "") or "")
     base_url_hostname = str(getattr(agent, "_base_url_hostname", "") or "")
     return (
@@ -138,6 +150,12 @@ def _is_openai_codex_backend(agent) -> bool:
             base_url_hostname == "chatgpt.com"
             and "/backend-api/codex" in base_url_lower
         )
+        # #34179: direct GitHub Copilot on /v1/responses also hits the same
+        # large-prefill admission queue. Treat as a codex-like backend so
+        # the TTFB exemption above HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS
+        # applies here too.
+        or getattr(agent, "provider", None) == "copilot"
+        or base_url_hostname == "api.githubcopilot.com"
     )
 
 

--- a/tests/agent/test_copilot_ttfb_watchdog.py
+++ b/tests/agent/test_copilot_ttfb_watchdog.py
@@ -1,0 +1,87 @@
+"""Regression tests for #34179 — direct Copilot gpt-5.5 large resumes
+were killed by the 12s TTFB watchdog before Copilot's admission queue
+released the first SSE event.
+
+Fix: extend _is_openai_codex_backend to recognize provider='copilot'
+and api.githubcopilot.com so the large-prefill TTFB exemption applies
+to them too.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _make_agent(provider: str = "", base_url: str = "", api_mode: str = "codex_responses"):
+    """Build a minimal agent stub with the fields _is_openai_codex_backend reads."""
+    agent = SimpleNamespace(
+        provider=provider,
+        api_mode=api_mode,
+        base_url=base_url,
+        _base_url_lower=base_url.lower(),
+        _base_url_hostname=base_url.replace("https://", "").replace("http://", "").split("/")[0].lower(),
+    )
+    return agent
+
+
+def test_openai_codex_provider_recognized():
+    """Pre-existing behavior: provider='openai-codex' is still treated as
+    a codex backend."""
+    from agent.chat_completion_helpers import _is_openai_codex_backend
+
+    agent = _make_agent(provider="openai-codex", base_url="https://chatgpt.com/backend-api/codex")
+    assert _is_openai_codex_backend(agent) is True
+
+
+def test_chatgpt_codex_url_recognized():
+    """Pre-existing behavior: chatgpt.com/backend-api/codex URL is still
+    treated as a codex backend even without the provider name."""
+    from agent.chat_completion_helpers import _is_openai_codex_backend
+
+    agent = _make_agent(provider="custom", base_url="https://chatgpt.com/backend-api/codex/v1")
+    assert _is_openai_codex_backend(agent) is True
+
+
+def test_copilot_provider_now_recognized():
+    """#34179 fix: provider='copilot' is now treated as a codex-like backend
+    so the large-prefill TTFB exemption applies."""
+    from agent.chat_completion_helpers import _is_openai_codex_backend
+
+    agent = _make_agent(provider="copilot", base_url="https://api.githubcopilot.com")
+    assert _is_openai_codex_backend(agent) is True
+
+
+def test_githubcopilot_url_now_recognized():
+    """#34179 fix: api.githubcopilot.com URL is now treated as codex-like
+    even when the provider name is generic ('custom', 'openai', etc.)."""
+    from agent.chat_completion_helpers import _is_openai_codex_backend
+
+    agent = _make_agent(provider="custom", base_url="https://api.githubcopilot.com/v1")
+    assert _is_openai_codex_backend(agent) is True
+
+
+def test_unrelated_backend_still_false():
+    """Don't regress: OpenAI direct, OpenRouter, etc. are NOT codex backends."""
+    from agent.chat_completion_helpers import _is_openai_codex_backend
+
+    for provider, base_url in [
+        ("openai", "https://api.openai.com/v1"),
+        ("openrouter", "https://openrouter.ai/api/v1"),
+        ("anthropic", "https://api.anthropic.com"),
+        ("xai-oauth", "https://api.x.ai/v1"),
+        ("custom", "https://my-self-hosted.example.com/v1"),
+    ]:
+        agent = _make_agent(provider=provider, base_url=base_url)
+        assert _is_openai_codex_backend(agent) is False, (
+            f"{provider} @ {base_url} should NOT be treated as codex backend"
+        )
+
+
+def test_empty_agent_safe():
+    """Defensive: empty provider + empty base_url returns False without crashing."""
+    from agent.chat_completion_helpers import _is_openai_codex_backend
+
+    agent = _make_agent(provider="", base_url="")
+    assert _is_openai_codex_backend(agent) is False


### PR DESCRIPTION
Closes #34179

## Problem

Direct GitHub Copilot `gpt-5.5` large-context resumes were killed by the default 12s no-first-byte watchdog before Copilot's admission queue released the first SSE event. Sanitized repro: 79 messages, ~150,813 prompt tokens, 3 retries all hitting 12s timeout, then 'API call failed after 3 retries'.

The fix for the same problem on hosted openai-codex (chatgpt.com/backend-api/codex) already exists — `_is_openai_codex_backend` gates the `HERMES_CODEX_TTFB_DISABLE_ABOVE_TOKENS` exemption. The user's local workaround (`HERMES_CODEX_TTFB_TIMEOUT_SECONDS=0`) confirmed the codex-side fix path worked end-to-end — only the backend detection missed Copilot.

## Fix

Extend `_is_openai_codex_backend` to recognize:
- `provider='copilot'`
- `api.githubcopilot.com` hostname

Both hit the same /v1/responses admission queue. Large prefills legitimately take tens of seconds on subscription backends. With this fix the large-request TTFB exemption applies to direct Copilot the same way it already applies to hosted Codex.

**No behavior change for any provider that isn't copilot/Codex.**

## Tests (6)

- `openai-codex` provider still recognized (preserved)
- `chatgpt.com/backend-api/codex` URL still recognized (preserved)
- `copilot` provider now recognized (the #34179 fix)
- `api.githubcopilot.com` URL now recognized (the #34179 fix)
- openai/openrouter/anthropic/xai-oauth/custom still return False
- Empty provider + empty base_url doesn't crash

```bash
$ python -m pytest tests/agent/test_copilot_ttfb_watchdog.py
=== 6 passed in 0.20s ===
```

🎻 Co-authored-by: Cursor <cursoragent@cursor.com>