### PR TITLE
feat(swarm): per-swarm verifier + synthesizer body and skills overrides (#34273)

### DIFF
--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import json
 import sqlite3
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Optional, Tuple
 
 from hermes_cli import kanban_db as kb
 
@@ -74,6 +74,20 @@ def _swarm_context(root_id: str, goal: str) -> str:
     )
 
 
+_DEFAULT_VERIFIER_BODY = (
+    "Review every worker handoff and blackboard update. Gate the swarm: "
+    "complete only with metadata {\"gate\": \"pass\"} when evidence is "
+    "sufficient; otherwise block with exact missing work."
+)
+_DEFAULT_VERIFIER_SKILLS: Tuple[str, ...] = ("requesting-code-review",)
+
+_DEFAULT_SYNTHESIZER_BODY = (
+    "Synthesize the verified worker outputs into the final deliverable. "
+    "Do not start until the verifier has passed the gate."
+)
+_DEFAULT_SYNTHESIZER_SKILLS: Tuple[str, ...] = ("humanizer",)
+
+
 def create_swarm(
     conn: sqlite3.Connection,
     *,
@@ -90,12 +104,30 @@ def create_swarm(
     workspace_path: Optional[str] = None,
     priority: int = 0,
     idempotency_key: Optional[str] = None,
+    # #34273: per-swarm overrides for the verifier + synthesizer task body
+    # and skills. None preserves the current defaults (code-review verifier,
+    # humanizer synthesizer) so existing callers see no behavior
+    # change. The swarm context_suffix is appended to the custom body so
+    # workers still see the swarm protocol metadata.
+    verifier_body: Optional[str] = None,
+    verifier_skills: Optional[Iterable[str]] = None,
+    synthesizer_body: Optional[str] = None,
+    synthesizer_skills: Optional[Iterable[str]] = None,
 ) -> SwarmCreated:
     """Create a durable Kanban swarm graph.
 
     The returned graph is immediately dispatchable: the planning root is marked
     ``done`` with topology metadata, parallel workers are ``ready``, the verifier
     waits for every worker, and the synthesizer waits for the verifier.
+
+    The verifier and synthesizer task bodies default to a code-review-style
+    flow that suits 'parallel workers → review → final write-up' pipelines.
+    Callers with different semantics (e.g. parallel scrapers → merge step →
+    process step) can override ``verifier_body``, ``verifier_skills``,
+    ``synthesizer_body``, ``synthesizer_skills``. When omitted, the defaults
+    are preserved. The swarm context suffix is appended to any custom body
+    so the verifier/synthesizer worker still sees the swarm protocol notes.
+    See #34273.
     """
 
     goal = _require_text(goal, "goal")
@@ -173,16 +205,23 @@ def create_swarm(
         )
         worker_ids.append(worker_id)
 
-    verifier_body = (
-        "Review every worker handoff and blackboard update. Gate the swarm: "
-        "complete only with metadata {\"gate\": \"pass\"} when evidence is "
-        "sufficient; otherwise block with exact missing work."
-        + context_suffix
+    # #34273: build verifier / synthesizer bodies + skills with per-swarm
+    # overrides falling back to the historical defaults. The context
+    # suffix is appended to any custom body so the worker still gets the
+    # swarm protocol notes (goal, root_id, blackboard usage).
+    _verifier_body_base = (
+        verifier_body if verifier_body is not None else _DEFAULT_VERIFIER_BODY
+    )
+    final_verifier_body = _verifier_body_base + context_suffix
+    final_verifier_skills = (
+        list(verifier_skills)
+        if verifier_skills is not None
+        else list(_DEFAULT_VERIFIER_SKILLS)
     )
     verifier = kb.create_task(
         conn,
         title=verifier_title,
-        body=verifier_body,
+        body=final_verifier_body,
         assignee=verifier_assignee,
         created_by=created_by,
         parents=worker_ids,
@@ -190,18 +229,22 @@ def create_swarm(
         priority=priority,
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
-        skills=["requesting-code-review"],
+        skills=final_verifier_skills or None,
     )
 
-    synthesizer_body = (
-        "Synthesize the verified worker outputs into the final deliverable. "
-        "Do not start until the verifier has passed the gate."
-        + context_suffix
+    _synthesizer_body_base = (
+        synthesizer_body if synthesizer_body is not None else _DEFAULT_SYNTHESIZER_BODY
+    )
+    final_synthesizer_body = _synthesizer_body_base + context_suffix
+    final_synthesizer_skills = (
+        list(synthesizer_skills)
+        if synthesizer_skills is not None
+        else list(_DEFAULT_SYNTHESIZER_SKILLS)
     )
     synthesizer = kb.create_task(
         conn,
         title=synthesizer_title,
-        body=synthesizer_body,
+        body=final_synthesizer_body,
         assignee=synthesizer_assignee,
         created_by=created_by,
         parents=[verifier],
@@ -209,7 +252,7 @@ def create_swarm(
         priority=priority,
         workspace_kind=workspace_kind,
         workspace_path=workspace_path,
-        skills=["humanizer"],
+        skills=final_synthesizer_skills or None,
     )
 
     created = SwarmCreated(root, worker_ids, verifier, synthesizer)

--- a/tests/hermes_cli/test_kanban_swarm.py
+++ b/tests/hermes_cli/test_kanban_swarm.py
@@ -116,3 +116,145 @@ def test_swarm_verifier_and_synthesis_are_dependency_gated(tmp_path):
         assert kb.get_task(conn, created.synthesizer_id).status == "ready"
     finally:
         conn.close()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #34273 — per-swarm verifier / synthesizer body + skills overrides
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_create_swarm_uses_default_verifier_body_when_unset(tmp_path):
+    """Backward compat: with no overrides, the verifier body matches the
+    historical code-review default."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="goal",
+            workers=[SwarmWorkerSpec(profile="w", title="t", body="b")],
+            verifier_assignee="v",
+            synthesizer_assignee="s",
+            created_by="orch",
+        )
+        verifier = kb.get_task(conn, created.verifier_id)
+        assert "Review every worker handoff" in verifier.body
+        # And the historical skill is still attached.
+        assert "requesting-code-review" in (verifier.skills or [])
+    finally:
+        conn.close()
+
+
+def test_create_swarm_accepts_custom_verifier_body(tmp_path):
+    """#34273: caller can supply a custom verifier body (e.g. 'run
+    merge_scraped.py'). The swarm context suffix is still appended."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        custom = "Run merge_scraped.py to combine outputs. Validate. Gate pass/block."
+        created = create_swarm(
+            conn,
+            goal="goal",
+            workers=[SwarmWorkerSpec(profile="w", title="t", body="b")],
+            verifier_assignee="v",
+            synthesizer_assignee="s",
+            verifier_body=custom,
+            created_by="orch",
+        )
+        verifier = kb.get_task(conn, created.verifier_id)
+        # Custom body present.
+        assert "Run merge_scraped.py" in verifier.body
+        # Swarm context suffix is still appended (root_id reference).
+        assert created.root_id in verifier.body
+        # Original code-review default phrasing is NOT present.
+        assert "Review every worker handoff" not in verifier.body
+    finally:
+        conn.close()
+
+
+def test_create_swarm_accepts_custom_verifier_skills(tmp_path):
+    """#34273: caller can override verifier skills."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="goal",
+            workers=[SwarmWorkerSpec(profile="w", title="t", body="b")],
+            verifier_assignee="v",
+            synthesizer_assignee="s",
+            verifier_skills=["kanban-worker", "data-merge"],
+            created_by="orch",
+        )
+        verifier = kb.get_task(conn, created.verifier_id)
+        # Custom skills present, historical default NOT.
+        skills = set(verifier.skills or [])
+        assert "kanban-worker" in skills
+        assert "data-merge" in skills
+        assert "requesting-code-review" not in skills
+    finally:
+        conn.close()
+
+
+def test_create_swarm_accepts_custom_synthesizer_body(tmp_path):
+    """#34273: caller can supply a custom synthesizer body."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        custom = "Run process_reviews.py, then generate_report.py, then push."
+        created = create_swarm(
+            conn,
+            goal="goal",
+            workers=[SwarmWorkerSpec(profile="w", title="t", body="b")],
+            verifier_assignee="v",
+            synthesizer_assignee="s",
+            synthesizer_body=custom,
+            created_by="orch",
+        )
+        synth = kb.get_task(conn, created.synthesizer_id)
+        assert "process_reviews.py" in synth.body
+        # Original phrasing absent.
+        assert "Synthesize the verified worker outputs" not in synth.body
+    finally:
+        conn.close()
+
+
+def test_create_swarm_accepts_custom_synthesizer_skills(tmp_path):
+    """#34273: caller can override synthesizer skills."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="goal",
+            workers=[SwarmWorkerSpec(profile="w", title="t", body="b")],
+            verifier_assignee="v",
+            synthesizer_assignee="s",
+            synthesizer_skills=["kanban-worker"],
+            created_by="orch",
+        )
+        synth = kb.get_task(conn, created.synthesizer_id)
+        skills = set(synth.skills or [])
+        assert "kanban-worker" in skills
+        assert "humanizer" not in skills
+    finally:
+        conn.close()
+
+
+def test_create_swarm_independent_verifier_and_synthesizer_overrides(tmp_path):
+    """#34273: overriding only the verifier leaves the synthesizer default,
+    and vice versa."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="goal",
+            workers=[SwarmWorkerSpec(profile="w", title="t", body="b")],
+            verifier_assignee="v",
+            synthesizer_assignee="s",
+            verifier_body="Custom verifier only",
+            # synthesizer untouched — should keep historical default
+            created_by="orch",
+        )
+        verifier = kb.get_task(conn, created.verifier_id)
+        synth = kb.get_task(conn, created.synthesizer_id)
+        assert "Custom verifier only" in verifier.body
+        # Synthesizer still uses the default text.
+        assert "Synthesize the verified worker outputs" in synth.body
+    finally:
+        conn.close()


### PR DESCRIPTION
Closes #34273

## Problem

`hermes kanban swarm` hardcoded the verifier + synthesizer task bodies to a code-review flow (`requesting-code-review` + `avoid-ai-writing` skills). That fits 'parallel workers → review → final write-up' pipelines but not other valid verifier/synthesizer splits — e.g. the music-daily-recs pipeline cited in the issue uses parallel Camoufox scrapers → `merge_scraped.py` validation → `process_reviews.py` final step.

Users with non-code-review semantics dropped back to direct `kb.create_task()` calls and rebuilt the swarm topology by hand, losing the orchestration helpers.

## Fix

Four optional parameters added to `create_swarm()` matching the issue's API spec:

```python
create_swarm(
    ...,
    verifier_body: Optional[str] = None,
    verifier_skills: Optional[Iterable[str]] = None,
    synthesizer_body: Optional[str] = None,
    synthesizer_skills: Optional[Iterable[str]] = None,
)
```

- `None` = historical defaults (backward compatible)
- Custom body is appended with the same swarm `context_suffix` (goal, root_id, protocol notes) so the worker still sees swarm metadata
- Module-level constants `_DEFAULT_VERIFIER_BODY`, `_DEFAULT_VERIFIER_SKILLS`, etc. exposed so future tests + consumers can assert symbolically

**CLI flags intentionally deferred** — the Python API + constants are the foundation; CLI surface area design can be reviewed separately so this PR stays focused on the API contract.

## Tests (6 new + 3 existing = 9 total)

- Default verifier body when unset (backward compat)
- Custom verifier body replaces default + suffix preserved
- Custom verifier skills replace default list
- Custom synthesizer body
- Custom synthesizer skills
- Independent overrides (set verifier only, synthesizer keeps default)

```bash
$ python -m pytest tests/hermes_cli/test_kanban_swarm.py
=== 9 passed in 0.21s ===
```

🎻 Co-authored-by: Cursor <cursoragent@cursor.com>