### PR TITLE
fix(gateway): require line-start boundary for MEDIA: extraction to prevent stale attachments from serialized tool results

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2497,7 +2497,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''(?:\n|^)[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -361,6 +361,27 @@ class TestExtractMedia:
         assert "[[audio_as_voice]]" not in cleaned
         assert "[[as_document]]" not in cleaned
 
+    def test_media_inside_serialized_json_not_extracted(self):
+        """MEDIA: embedded in serialized JSON/tool-result text must not be
+        treated as an outbound attachment directive.  Regression test for #34375."""
+        # Compact JSON: MEDIA: preceded by backslash-quote (\n is literal \n in JSON)
+        json_content = '{"content":"previous reply MEDIA:/Users/example/.hermes/media/generated/stale.png\\nnot an attachment"}'
+        media, cleaned = BasePlatformAdapter.extract_media(json_content)
+        assert media == [], f"Should not extract MEDIA: from JSON string, got {media}"
+
+        # Pretty-printed JSON with MEDIA: mid-line after colon
+        json_content2 = '{"result": "MEDIA:/tmp/stale.png"}'
+        media2, _ = BasePlatformAdapter.extract_media(json_content2)
+        assert media2 == [], f"Should not extract MEDIA: from JSON value, got {media2}"
+
+    def test_media_at_line_start_in_multiline_still_extracted(self):
+        """MEDIA: at the start of a line (after \n) must still be extracted
+        even when other lines contain non-MEDIA text."""
+        content = "Here is the result:\nMEDIA:/tmp/output.png"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "/tmp/output.png"
+
 
 class TestMediaDeliveryPathValidation:
     def _patch_roots(self, monkeypatch, *roots):


### PR DESCRIPTION
## What does this PR do?

The `MEDIA:` regex in `BasePlatformAdapter.extract_media()` matched `MEDIA:` **anywhere** in the response text, including inside serialized JSON/tool-result strings from `session_search`. This caused stale files from prior sessions to be extracted and delivered as native attachments (e.g., Telegram photo).

### Root Cause

The `media_pattern` regex had no boundary constraint before `MEDIA:`, so it matched equally in:
- ✅ Standalone directives: `"Here is the image\nMEDIA:/tmp/output.png"`
- ❌ Serialized JSON: `'{"content":"previous reply MEDIA:/path/stale.png\\n..."}'`

When `session_search` returned historical tool results containing `MEDIA:` paths, those paths leaked into the final response context and were treated as outbound attachment directives.

## Related Issue

Fixes #34375

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence
- Analyzed: `BasePlatformAdapter.extract_media()` in `gateway/platforms/base.py:2461` (callers: 6 — gateway/run.py, gateway/platforms/base.py, gateway/platforms/weixin.py, tools/yuanbao_tools.py, tools/send_message_tool.py, cron/scheduler.py)
- Blast radius: LOW — regex boundary change only; all existing extraction patterns preserved
- Related patterns: `_clean_for_display()` in `stream_consumer.py` uses separate regex for display stripping (unaffected); `filter_media_delivery_paths()` does filesystem validation downstream (unaffected)
- Related issues: #16720, #14665 (same class of bug per alt-glitch)

Fixes #34375