### PR TITLE
fix(security): validate Telegram send_message media paths

### DIFF
--- a/tests/tools/test_send_message_telegram_media_validation.py
+++ b/tests/tools/test_send_message_telegram_media_validation.py
@@ -1,0 +1,62 @@
+"""Regression tests for standalone Telegram media delivery validation."""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from tools.send_message_tool import _send_telegram
+
+
+def _install_telegram_mock(monkeypatch, bot):
+    parse_mode = SimpleNamespace(MARKDOWN_V2="MarkdownV2", HTML="HTML")
+    constants_mod = SimpleNamespace(ParseMode=parse_mode)
+    telegram_mod = SimpleNamespace(
+        Bot=lambda token: bot,
+        MessageEntity=lambda **kw: SimpleNamespace(**kw),
+        constants=constants_mod,
+    )
+    monkeypatch.setitem(sys.modules, "telegram", telegram_mod)
+    monkeypatch.setitem(sys.modules, "telegram.constants", constants_mod)
+
+
+def test_send_telegram_skips_unsafe_media_path_before_upload(tmp_path, monkeypatch):
+    secret_path = tmp_path / "secret.txt"
+    secret_path.write_text("token", encoding="utf-8")
+
+    bot = MagicMock()
+    bot.send_message = AsyncMock()
+    bot.send_photo = AsyncMock()
+    bot.send_video = AsyncMock()
+    bot.send_voice = AsyncMock()
+    bot.send_audio = AsyncMock()
+    bot.send_document = AsyncMock()
+    _install_telegram_mock(monkeypatch, bot)
+
+    def deny_media_path(path):
+        assert path == str(secret_path)
+        return None
+
+    monkeypatch.setattr(
+        "gateway.platforms.base.validate_media_delivery_path",
+        deny_media_path,
+    )
+
+    result = asyncio.run(
+        _send_telegram(
+            "token",
+            "12345",
+            "",
+            media_files=[(str(secret_path), False)],
+        )
+    )
+
+    assert "error" in result
+    assert "No deliverable text or media remained" in result["error"]
+    assert any("Skipping unsafe media path" in warning for warning in result["warnings"])
+    bot.send_message.assert_not_awaited()
+    bot.send_photo.assert_not_awaited()
+    bot.send_video.assert_not_awaited()
+    bot.send_voice.assert_not_awaited()
+    bot.send_audio.assert_not_awaited()
+    bot.send_document.assert_not_awaited()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -950,6 +950,15 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 warnings.append(warning)
                 continue
 
+            from gateway.platforms.base import validate_media_delivery_path
+            safe_media_path = validate_media_delivery_path(media_path)
+            if not safe_media_path:
+                warning = f"Skipping unsafe media path outside allowed roots: {media_path}"
+                logger.warning(warning)
+                warnings.append(warning)
+                continue
+
+            media_path = safe_media_path
             ext = os.path.splitext(media_path)[1].lower()
             try:
                 with open(media_path, "rb") as f:


### PR DESCRIPTION
## Summary
- re-validate standalone Telegram `send_message` media paths immediately before opening/uploading them
- normalize accepted media paths through `validate_media_delivery_path()` so the standalone path matches the gateway delivery guard
- add a regression test that runs without the optional `python-telegram-bot` package by mocking the Telegram module locally

Closes #34270.

## Tests
- `python -m ruff check .`
- `python -m ruff check tools/send_message_tool.py tests/tools/test_send_message_telegram_media_validation.py`
- `python scripts/run_tests_parallel.py tests/tools/test_send_message_telegram_media_validation.py -- --tb=short --timeout-method=thread`