### PR TITLE
fix(acp): preserve mixed content text chunks

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -231,6 +231,38 @@ def _render_message_content(content: Any) -> str:
     return str(content).strip()
 
 
+def _extract_acp_text_content(content: Any) -> str:
+    """Return text from ACP content blocks without treating tool metadata as text."""
+
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(_extract_acp_text_content(item) for item in content)
+    if not isinstance(content, dict):
+        return ""
+
+    content_type = str(content.get("type") or "").strip().lower()
+    if content_type in {"", "text", "markdown"}:
+        text = content.get("text")
+        if isinstance(text, str):
+            return text
+        nested_content = content.get("content")
+        if isinstance(nested_content, str):
+            return nested_content
+
+    parts: list[str] = []
+    for key in ("content", "delta"):
+        nested = content.get(key)
+        if nested is content:
+            continue
+        nested_text = _extract_acp_text_content(nested)
+        if nested_text:
+            parts.append(nested_text)
+    return "".join(parts)
+
+
 def _extract_tool_calls_from_text(text: str) -> tuple[list[SimpleNamespace], str]:
     if not isinstance(text, str) or not text.strip():
         return [], ""
@@ -613,9 +645,7 @@ class CopilotACPClient:
             update = params.get("update") or {}
             kind = str(update.get("sessionUpdate") or "").strip()
             content = update.get("content") or {}
-            chunk_text = ""
-            if isinstance(content, dict):
-                chunk_text = str(content.get("text") or "")
+            chunk_text = _extract_acp_text_content(content)
             if kind == "agent_message_chunk" and chunk_text and text_parts is not None:
                 text_parts.append(chunk_text)
             elif kind == "agent_thought_chunk" and chunk_text and reasoning_parts is not None:

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -205,3 +205,36 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+def test_agent_message_chunk_preserves_text_from_mixed_content_blocks(tmp_path):
+    client = CopilotACPClient(acp_cwd=str(tmp_path))
+    text_parts = []
+    reasoning_parts = []
+    process = _FakeProcess()
+
+    handled = client._handle_server_message(
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "sess_mixed",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": [
+                        {"type": "text", "text": "Removing both keys now."},
+                        {"type": "tool_use", "id": "call_1", "name": "terminal"},
+                    ],
+                },
+            },
+        },
+        process=process,
+        cwd=str(tmp_path),
+        text_parts=text_parts,
+        reasoning_parts=reasoning_parts,
+    )
+
+    assert handled is True
+    assert text_parts == ["Removing both keys now."]
+    assert reasoning_parts == []
+    assert process.stdin.getvalue() == ""


### PR DESCRIPTION
## Summary
- Preserve text from ACP `agent_message_chunk` content arrays, even when a chunk also contains tool-use metadata.
- Keep tool metadata out of the assistant narrative while allowing Hermes to store text alongside extracted tool calls.
- Add a regression for mixed text + `tool_use` ACP content blocks.

## Test Plan
- [x] RED: `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_copilot_acp_client.py::test_agent_message_chunk_preserves_text_from_mixed_content_blocks -q`
- [x] `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_copilot_acp_client.py -q`
- [x] `$HOME/.hermes/hermes-agent/venv/bin/python -m ruff check agent/copilot_acp_client.py tests/agent/test_copilot_acp_client.py`

Closes #33636
