### PR TITLE
fix: make API runs idempotent by client run id

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3522,17 +3522,40 @@ class APIServerAdapter(BasePlatformAdapter):
         if key_err is not None:
             return key_err
 
-        # Enforce concurrency limit
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+
+        raw_client_run_id = body.get("run_id")
+        if raw_client_run_id is not None:
+            if not isinstance(raw_client_run_id, str) or not re.fullmatch(
+                r"run_[A-Za-z0-9_-]{1,128}", raw_client_run_id
+            ):
+                return web.json_response(
+                    _openai_error(
+                        "Invalid 'run_id'; expected run_[A-Za-z0-9_-]{1,128}",
+                        code="invalid_run_id",
+                    ),
+                    status=400,
+                )
+            existing_status = self._run_statuses.get(raw_client_run_id)
+            if existing_status is not None:
+                return web.json_response(
+                    {
+                        "run_id": raw_client_run_id,
+                        "status": existing_status.get("status", "running"),
+                    },
+                    status=202,
+                )
+
+        # Enforce concurrency limit after idempotent replay checks so clients can
+        # reattach to an existing run even when the active-run ceiling is full.
         if len(self._run_streams) >= self._MAX_CONCURRENT_RUNS:
             return web.json_response(
                 _openai_error(f"Too many concurrent runs (max {self._MAX_CONCURRENT_RUNS})", code="rate_limit_exceeded"),
                 status=429,
             )
-
-        try:
-            body = await request.json()
-        except Exception:
-            return web.json_response(_openai_error("Invalid JSON"), status=400)
 
         raw_input = body.get("input")
         if not raw_input:
@@ -3589,7 +3612,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
-        run_id = f"run_{uuid.uuid4().hex}"
+        run_id = raw_client_run_id or f"run_{uuid.uuid4().hex}"
         session_id = body.get("session_id") or stored_session_id or run_id
         approval_session_key = gateway_session_key or session_id or run_id
         ephemeral_system_prompt = instructions

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -189,6 +189,48 @@ class TestStartRun:
                 )
                 assert resp.status == 202
 
+    @pytest.mark.asyncio
+    async def test_start_accepts_client_run_id_and_reuses_active_run(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            mock_agent, ready, interrupted = _make_slow_agent()
+            with patch.object(adapter, "_create_agent", return_value=mock_agent):
+                first = await cli.post(
+                    "/v1/runs",
+                    json={"input": "long task", "run_id": "run_agent_run_1"},
+                )
+                assert first.status == 202
+                first_data = await first.json()
+                assert first_data == {"run_id": "run_agent_run_1", "status": "started"}
+                assert ready.wait(timeout=2)
+
+                second = await cli.post(
+                    "/v1/runs",
+                    json={"input": "long task", "run_id": "run_agent_run_1"},
+                )
+                assert second.status == 202
+                second_data = await second.json()
+                assert second_data == {"run_id": "run_agent_run_1", "status": "running"}
+
+                mock_agent.run_conversation.assert_called_once()
+                stop = await cli.post("/v1/runs/run_agent_run_1/stop")
+                assert stop.status == 200
+                assert interrupted.wait(timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_start_rejects_invalid_client_run_id(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/runs",
+                json={"input": "hello", "run_id": "../../oops"},
+            )
+            assert resp.status == 400
+            data = await resp.json()
+        assert "run_id" in data["error"]["message"]
+        assert adapter._run_streams == {}
+        assert adapter._run_statuses == {}
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/runs/{run_id} — poll run status


### PR DESCRIPTION
## Summary

Makes `POST /v1/runs` idempotent when clients supply a stable `run_id`.

This is needed for request-detached integrations like AICoven: if the cloud worker disconnects and later retries the same logical run, Hermes should return the existing run instead of silently starting a duplicate agent task.

## Changes

- Accept client-supplied run ids matching `run_[A-Za-z0-9_-]{1,128}`.
- Reject invalid client run ids before allocating run state.
- If a supplied `run_id` already exists, return the current pollable run status with `202` instead of starting another agent.
- Run the concurrency limit after idempotent replay checks, so reattaching to an existing run still works when the active-run ceiling is full.
- Preserve generated run ids for clients that do not pass `run_id`.

## Verification

- `python -m pytest tests/gateway/test_api_server_runs.py -q`
- `python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server_runs.py`
- `git diff --check`

## Notes

This pairs with AICoven PR lepapillonterrible/aicoven#380, where AICoven passes deterministic Hermes run ids derived from its logical `agent_run_id`. With this Hermes behavior, AICoven does not need a database migration just to survive process-local mapping loss; retrying `POST /v1/runs` with the same deterministic id reattaches to the existing Hermes run.
