### PR TITLE
fix(gateway): flush pending tool-progress before __reset__ clears state

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16402,6 +16402,20 @@ class GatewayRunner:
                         # order. Mirrors GatewayStreamConsumer.on_segment_break
                         # on the content side. (Issue: tool + content
                         # linearization regression after PR #7885.)
+                        #
+                        # Flush any pending tail before clearing: a tool event
+                        # that arrived inside the edit-throttle window is in
+                        # progress_lines but has not been edited onto the
+                        # platform yet. Clearing here without flushing drops it,
+                        # so the user sees N-1 tool lines even though every tool
+                        # ran (#29371). The drain-path __reset__ handler below
+                        # already flushes before clearing — mirror it here.
+                        if can_edit and progress_lines and progress_msg_id:
+                            _pending_text = _progress_text(progress_lines)
+                            try:
+                                await _edit_progress_message(progress_msg_id, _pending_text)
+                            except Exception:
+                                pass
                         progress_msg_id = None
                         progress_lines = []
                         last_progress_msg[0] = None

--- a/tests/gateway/test_progress_reset_flush.py
+++ b/tests/gateway/test_progress_reset_flush.py
@@ -1,0 +1,140 @@
+"""Regression tests for the hot-loop ``__reset__`` handler in
+``send_progress_messages`` (gateway/run.py).
+
+Issue: #29371
+
+When the last tool event of a turn arrives inside the edit-throttle window
+(``_PROGRESS_EDIT_INTERVAL`` = 1.5s) and no further event follows, that line
+sits in ``progress_lines`` having been appended but not yet edited onto the
+platform. The gateway then enqueues ``__reset__`` once the final content
+bubble lands. The hot-loop ``__reset__`` handler used to clear
+``progress_lines`` *without* flushing first, so the pending tail line was
+silently dropped — the user saw N-1 tool lines even though every tool ran.
+
+The drain-path ``__reset__`` handler at the bottom of the consumer already
+flushes pending progress before clearing; the hot loop must mirror it.
+
+``send_progress_messages`` is a local closure inside ``run_conversation`` and
+cannot be imported and driven directly, so the behavioural tests mirror the
+handler logic — the same approach
+``tests/gateway/test_telegram_progress_edit_transient.py`` uses for #27828.
+``test_both_reset_handlers_flush_before_clear_source_invariant`` additionally
+asserts the fix against the real source, so removing the flush is caught.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from typing import Awaitable, Callable, List, Optional, Tuple
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Behavioural mirror of the hot-loop __reset__ handler
+# (gateway/run.py send_progress_messages). Returns the (progress_lines,
+# progress_msg_id) state after the handler runs.
+# ---------------------------------------------------------------------------
+async def _run_reset_handler(
+    *,
+    can_edit: bool,
+    progress_lines: List[str],
+    progress_msg_id: Optional[str],
+    edit_fn: Callable[[str, str], Awaitable[object]],
+    progress_text: Callable[[List[str]], str] = lambda lines: "\n".join(lines),
+) -> Tuple[List[str], Optional[str]]:
+    if can_edit and progress_lines and progress_msg_id:
+        _pending_text = progress_text(progress_lines)
+        try:
+            await edit_fn(progress_msg_id, _pending_text)
+        except Exception:
+            pass
+    return [], None
+
+
+@pytest.mark.asyncio
+async def test_reset_flushes_pending_tail_before_clearing():
+    """The load-bearing case: a tail line MUST be flushed before reset clears."""
+    edit_fn = AsyncMock()
+    lines, msg_id = await _run_reset_handler(
+        can_edit=True,
+        progress_lines=["tool A", "tool B", "tool C (arrived in throttle window)"],
+        progress_msg_id="msg-1",
+        edit_fn=edit_fn,
+    )
+    edit_fn.assert_awaited_once_with(
+        "msg-1", "tool A\ntool B\ntool C (arrived in throttle window)"
+    )
+    assert lines == []
+    assert msg_id is None
+
+
+@pytest.mark.asyncio
+async def test_reset_no_flush_when_no_pending_lines():
+    """Nothing pending → don't edit an empty bubble."""
+    edit_fn = AsyncMock()
+    lines, msg_id = await _run_reset_handler(
+        can_edit=True, progress_lines=[], progress_msg_id="msg-1", edit_fn=edit_fn
+    )
+    edit_fn.assert_not_awaited()
+    assert lines == []
+    assert msg_id is None
+
+
+@pytest.mark.asyncio
+async def test_reset_no_flush_when_editing_disabled():
+    """Platform doesn't support edits (can_edit False) → no flush attempt."""
+    edit_fn = AsyncMock()
+    await _run_reset_handler(
+        can_edit=False, progress_lines=["tool A"], progress_msg_id="msg-1", edit_fn=edit_fn
+    )
+    edit_fn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reset_no_flush_without_message_id():
+    """No bubble created yet (msg_id None) → nothing to edit."""
+    edit_fn = AsyncMock()
+    await _run_reset_handler(
+        can_edit=True, progress_lines=["tool A"], progress_msg_id=None, edit_fn=edit_fn
+    )
+    edit_fn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reset_flush_swallows_edit_errors_and_still_clears():
+    """A transient edit failure during flush must not break the reset path."""
+    edit_fn = AsyncMock(side_effect=RuntimeError("transient network error"))
+    lines, msg_id = await _run_reset_handler(
+        can_edit=True, progress_lines=["tool A"], progress_msg_id="msg-1", edit_fn=edit_fn
+    )
+    edit_fn.assert_awaited_once()
+    assert lines == []
+    assert msg_id is None
+
+
+def test_both_reset_handlers_flush_before_clear_source_invariant():
+    """Real-source guard against regressing #29371.
+
+    Every ``__reset__`` handler in ``send_progress_messages`` must flush
+    (call ``_edit_progress_message``) before it clears ``progress_lines``.
+    This fails if the hot-loop flush is removed, which the behavioural mirrors
+    above cannot catch (the closure can't be driven directly).
+    """
+    import gateway.run as run_module
+
+    src = inspect.getsource(run_module)
+    markers = [m.start() for m in re.finditer(r'raw\[0\] == "__reset__"', src)]
+    assert len(markers) >= 2, (
+        f"expected >=2 __reset__ handlers in gateway/run.py, found {len(markers)}"
+    )
+    for start in markers:
+        clear_at = src.find("progress_lines = []", start)
+        assert clear_at != -1, "no progress_lines clear found after a __reset__ handler"
+        block = src[start:clear_at]
+        assert "_edit_progress_message" in block, (
+            "a __reset__ handler clears progress_lines without flushing the "
+            "pending tail first — regression of #29371"
+        )


### PR DESCRIPTION
## What does this PR do?

The hot-loop `__reset__` handler in `send_progress_messages` (`gateway/run.py`) cleared `progress_lines` **without flushing them to the platform first**.

When the last tool event of a turn arrives inside the edit-throttle window (`_PROGRESS_EDIT_INTERVAL`, 1.5s) and no further event follows, it is appended to `progress_lines` but not yet edited onto the platform. The gateway then enqueues `__reset__` once the final content bubble lands — and the handler cleared the list before any edit fired, so the **pending tail line was silently dropped**. The user sees N-1 tool lines in the progress bubble even though every tool ran and is recorded in the audit log.

The **drain-path `__reset__` handler** at the bottom of the same consumer already flushes pending progress before clearing. This makes the hot-loop handler mirror it — both handlers process the same `__reset__` marker and should behave consistently.

## Related Issue

Fixes #29371

> Credit: the root cause and a fix direction were first explored by @briandevans in #29412, which the author closed to focus on other work ("happy to reopen if maintainers want this picked up"). This continues that fix by mirroring the existing drain-path flush, and adds a source-level regression guard.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: in the hot-loop `__reset__` handler of `send_progress_messages`, flush pending `progress_lines` via `_edit_progress_message` before clearing — identical to the drain-path handler a few lines below.
- `tests/gateway/test_progress_reset_flush.py`: new regression tests (behavioural mirrors + a source-level invariant guard).

## How to Test

Manual (matches the repro in #29371):
1. Telegram (or any edit-capable platform) with `display.tool_progress: all`.
2. Prompt the agent to fire several tools in one turn where the **last** tool's progress event lands within 1.5s of the previous progress edit.
3. Before: the bubble ends with N-1 lines (last tool missing). After: all N lines appear.

Automated:
```
$ .venv/bin/python -m pytest tests/gateway/test_progress_reset_flush.py -q
6 passed
$ .venv/bin/python -m pytest tests/gateway/ -k progress -q
90 passed, 1 skipped
```
Reverting the guard makes `test_both_reset_handlers_flush_before_clear_source_invariant` fail, confirming it actually guards the regression.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (no open PR; #29412 was closed by its author)
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` for the affected area: `tests/gateway/ -k progress` → 90 passed/1 skipped, plus the new file → 6 passed (the full 5.9k-test suite needs every platform SDK to run locally)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (unit tests; the fix mirrors the already-shipped drain-path flush)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior-only fix in one handler)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — edit-based progress affects all platforms equally; no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — see the detailed reproduction and before/after in #29371.

Made with [Cursor](https://cursor.com)