### PR TITLE
fix(dashboard): allow non-loopback WebSocket clients in insecure mode

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3389,8 +3389,16 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     OAuth gate + single-use ``?ticket=`` is the auth at that point; the
     Host/Origin guard in :func:`_ws_host_origin_is_allowed` is what
     blocks DNS-rebinding here, not the peer IP.
+
+    Insecure mode (``--insecure``, bound to ``0.0.0.0`` / ``::``): any
+    peer is allowed — the operator explicitly opted into all-interfaces
+    access; the ``?token=`` check on each endpoint is the auth at that
+    point, same as loopback mode but without the peer-IP restriction.
     """
     if getattr(app.state, "auth_required", False):
+        return True
+    bound_host = getattr(app.state, "bound_host", None)
+    if bound_host in {"0.0.0.0", "::"}:
         return True
     client_host = ws.client.host if ws.client else ""
     if not client_host:

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -80,6 +80,25 @@ def loopback_app():
     web_server.app.state.auth_required = prev_required
 
 
+@pytest.fixture
+def insecure_app():
+    """web_server.app configured for insecure mode (--insecure, 0.0.0.0)."""
+    _reset_for_tests()
+    clear_providers()
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "0.0.0.0"
+    web_server.app.state.bound_port = 9119
+    web_server.app.state.auth_required = False
+    client = TestClient(web_server.app, base_url="http://0.0.0.0:9119")
+    yield client
+    _reset_for_tests()
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
 def _logged_in(client: TestClient) -> None:
     """Drive the stub OAuth round trip so the client holds session cookies."""
     r1 = client.get("/auth/login?provider=stub", follow_redirects=False)
@@ -288,6 +307,29 @@ class TestWsRequestIsAllowedGated:
         ws = _fake_ws(query={}, client_host="203.0.113.7")
         ws.headers = {"host": "evil.example.com"}
         assert web_server._ws_request_is_allowed(ws) is False
+
+    def test_non_loopback_peer_allowed_in_insecure_mode(self, insecure_app):
+        """Insecure mode (--insecure, bound to 0.0.0.0) must allow
+        non-loopback peers — the operator explicitly opted into
+        all-interfaces access."""
+        ws = _fake_ws(query={}, client_host="192.168.1.42")
+        ws.headers = {"host": "192.168.1.42:9119"}
+        assert web_server._ws_request_is_allowed(ws) is True
+
+    def test_loopback_peer_allowed_in_insecure_mode(self, insecure_app):
+        ws = _fake_ws(query={}, client_host="127.0.0.1")
+        ws.headers = {"host": "127.0.0.1:9119"}
+        assert web_server._ws_request_is_allowed(ws) is True
+
+    def test_host_origin_guard_bypassed_in_insecure_mode(self, insecure_app):
+        """When bound to 0.0.0.0 (--insecure), the Host header guard
+        accepts any hostname — consistent with host_header_middleware
+        which also returns True for 0.0.0.0 binds.  The operator has
+        explicitly opted into all-interfaces access; DNS-rebinding
+        protection is not possible at this layer."""
+        ws = _fake_ws(query={}, client_host="192.168.1.42")
+        ws.headers = {"host": "evil.example.com"}
+        assert web_server._ws_request_is_allowed(ws) is True
 
 
 class TestSidecarUrl:


### PR DESCRIPTION
## What does this PR do?

When the dashboard is bound to `0.0.0.0` via `--insecure`, WebSocket endpoints (`/api/ws`, `/api/events`, `/api/pub`, `/api/pty`) reject non-loopback clients with close code `4403`. HTTP REST endpoints work fine because `auth_middleware` checks the session token (injected into the SPA), not the client IP.

**Root cause:** `_ws_client_is_allowed()` only permits loopback IPs (`127.0.0.1`, `::1`, `localhost`) in non-gated mode. It doesn't account for insecure mode where the operator explicitly opted into all-interfaces access.

**Fix:** Check `app.state.bound_host` — when bound to `0.0.0.0` or `::`, allow any peer. This is consistent with:
- `_ws_host_origin_is_allowed()` which returns `True` for `0.0.0.0` binds
- `host_header_middleware` which accepts any host when bound to `0.0.0.0`

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: Add `bound_host` check in `_ws_client_is_allowed()` before the loopback peer guard
- `tests/hermes_cli/test_dashboard_auth_ws_auth.py`: Add `insecure_app` fixture + 3 regression tests

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A



## Code Intelligence
- Analyzed: `_ws_client_is_allowed` in `hermes_cli/web_server.py` (called by `_ws_request_is_allowed`, used by all 4 WS endpoints)
- Blast radius: LOW — single guard function, additive condition only
- Related patterns: `_ws_host_origin_is_allowed` (same `0.0.0.0` bypass), `host_header_middleware` (same pattern)