### PR TITLE
feat: compact prompt skill and tool schemas

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -17,6 +17,7 @@ from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
 from typing import List, Optional
 
 from agent.runtime_cwd import resolve_agent_cwd
+from agent.prompt_overhead import current_prompt_platform, get_prompt_overhead_modes
 from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS,
     ORG_ACTIVE_MARKER,
@@ -1663,18 +1664,37 @@ def _skill_should_show(
 
 def _current_session_platform_hint() -> str:
     """Return the active platform without importing the gateway package on CLI startup."""
-    platform = os.environ.get("HERMES_PLATFORM") or os.environ.get("HERMES_SESSION_PLATFORM")
-    if platform:
-        return platform
+    return current_prompt_platform()
 
-    session_context = sys.modules.get("gateway.session_context")
-    get_session_env = getattr(session_context, "get_session_env", None) if session_context else None
-    if get_session_env is None:
+
+def _compact_prompt_description(text: str, max_chars: int = 60) -> str:
+    """Collapse verbose catalog prose while preserving its leading trigger."""
+    compact = " ".join(str(text or "").split()).strip()
+    if not compact:
         return ""
-    try:
-        return get_session_env("HERMES_SESSION_PLATFORM") or ""
-    except Exception:
-        return ""
+    lowered = compact.lower()
+    for prefix in ("use when ", "use for ", "skills for ", "skill for "):
+        if lowered.startswith(prefix):
+            compact = compact[len(prefix) :]
+            break
+    first_sentence = compact.split(". ", 1)[0].strip(" .")
+    if first_sentence:
+        compact = first_sentence
+    if len(compact) <= max_chars:
+        return compact
+    cut = compact[: max_chars + 1]
+    boundary = max(
+        cut.rfind(";"),
+        cut.rfind(","),
+        cut.rfind(" — "),
+        cut.rfind(" - "),
+        cut.rfind(" "),
+    )
+    if boundary >= max_chars // 2:
+        cut = cut[:boundary]
+    else:
+        cut = compact[:max_chars]
+    return cut.rstrip(" ,;:-—") + "…"
 
 
 def build_skills_system_prompt(
@@ -1712,6 +1732,7 @@ def build_skills_system_prompt(
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
     _platform_hint = _current_session_platform_hint()
+    index_mode = get_prompt_overhead_modes(platform=_platform_hint).skill_index_mode
     disabled = get_disabled_skill_names(_platform_hint or None)
     cache_key = (
         str(skills_dir),
@@ -1719,6 +1740,7 @@ def build_skills_system_prompt(
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
+        index_mode,
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
     )
@@ -1895,9 +1917,11 @@ def build_skills_system_prompt(
         cat for cat in skills_by_category
         if cat.split("/", 1)[0] in (compact_categories or frozenset())
     )
+    if index_mode == "minimal":
+        demoted = frozenset(skills_by_category)
 
     hidden_note = ""
-    if demoted:
+    if demoted and index_mode != "minimal":
         hidden_note = (
             "\n(Categories marked [names only] are outside the current coding "
             "context, so their descriptions are omitted — the skills work "
@@ -1916,6 +1940,8 @@ def build_skills_system_prompt(
                 index_lines.append(f"  {category} [names only]: {', '.join(names)}")
                 continue
             cat_desc = category_descriptions.get(category, "")
+            if index_mode == "compact":
+                cat_desc = _compact_prompt_description(cat_desc)
             if cat_desc:
                 index_lines.append(f"  {category}: {cat_desc}")
             else:
@@ -1925,39 +1951,55 @@ def build_skills_system_prompt(
                     continue
                 seen.add(name)
                 if desc:
-                    index_lines.append(f"    - {name}: {desc}")
+                    rendered_desc = (
+                        _compact_prompt_description(desc)
+                        if index_mode == "compact"
+                        else desc
+                    )
+                    index_lines.append(f"    - {name}: {rendered_desc}")
                 else:
                     index_lines.append(f"    - {name}")
 
-        result = (
-            "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
-            "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
-            "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
-            "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
-            "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
-            "`hermes setup`) so you don't have to guess or invent workarounds.\n"
-            "If a skill has issues, fix it with skill_manage(action='patch').\n"
-            "After difficult/iterative tasks, offer to save as a skill. "
-            "If a skill you loaded was missing steps, had wrong commands, or needed "
-            "pitfalls you discovered, update it before finishing.\n"
-            "\n"
-            "<available_skills>\n"
-            + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
-            "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
-            + hidden_note
-        )
+        skills_index = "\n".join(index_lines) + "\n"
+        if index_mode == "full":
+            result = (
+                "## Skills (mandatory)\n"
+                "Before replying, scan the skills below. If a skill matches or is even partially relevant "
+                "to your task, you MUST load it with skill_view(name) and follow its instructions. "
+                "Err on the side of loading — it is always better to have context you don't need "
+                "than to miss critical steps, pitfalls, or established workflows. "
+                "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
+                "and proven workflows that outperform general-purpose approaches. Load the skill "
+                "even if you think you could handle the task with basic tools like web_search or terminal. "
+                "Skills also encode the user's preferred approach, conventions, and quality standards "
+                "for tasks like code review, planning, and testing — load them even for tasks you "
+                "already know how to do, because the skill defines how it should be done here.\n"
+                "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
+                "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
+                "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
+                "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
+                "`hermes setup`) so you don't have to guess or invent workarounds.\n"
+                "If a skill has issues, fix it with skill_manage(action='patch').\n"
+                "After difficult/iterative tasks, offer to save as a skill. "
+                "If a skill you loaded was missing steps, had wrong commands, or needed "
+                "pitfalls you discovered, update it before finishing.\n"
+                "\n"
+                "<available_skills>\n" + skills_index + "</available_skills>\n"
+                "\n"
+                "Only proceed without loading a skill if genuinely none are relevant to the task."
+                + hidden_note
+            )
+        else:
+            result = (
+                "## Skills (mandatory, compact index)\n"
+                "Scan this index before replying. Load the full SKILL.md with "
+                "skill_view(name) whenever a name or trigger matches; compacting "
+                "the index does not disable any skill. For Hermes Agent setup or "
+                "configuration, load `hermes-agent`.\n"
+                "<available_skills>\n" + skills_index + "</available_skills>\n"
+                "Only proceed without loading a skill if genuinely none are relevant."
+                + hidden_note
+            )
 
     # ── Store in LRU cache ────────────────────────────────────────────
     with _SKILLS_PROMPT_CACHE_LOCK:

--- a/agent/prompt_overhead.py
+++ b/agent/prompt_overhead.py
@@ -1,0 +1,119 @@
+"""Resolve model-facing prompt compaction settings.
+
+The resolver is intentionally independent from prompt and tool assembly so
+both paths apply the same platform precedence and validation rules.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+
+_SKILL_INDEX_MODES = frozenset({"full", "compact", "minimal"})
+_TOOL_SCHEMA_MODES = frozenset({"full", "compact", "minimal"})
+
+
+@dataclass(frozen=True)
+class PromptOverheadModes:
+    """Resolved compaction modes for one platform/session."""
+
+    skill_index_mode: str = "full"
+    tool_schema_mode: str = "full"
+    platform: str = ""
+
+
+def current_prompt_platform() -> str:
+    """Return the active platform without eagerly importing the gateway."""
+    platform = os.environ.get("HERMES_PLATFORM") or os.environ.get(
+        "HERMES_SESSION_PLATFORM"
+    )
+    if platform:
+        return str(platform).strip().lower()
+
+    session_context = sys.modules.get("gateway.session_context")
+    get_session_env = (
+        getattr(session_context, "get_session_env", None)
+        if session_context is not None
+        else None
+    )
+    if get_session_env is None:
+        return ""
+    try:
+        return str(get_session_env("HERMES_SESSION_PLATFORM") or "").strip().lower()
+    except Exception:
+        return ""
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _valid_mode(value: Any, allowed: frozenset[str], fallback: str) -> str:
+    candidate = str(value or "").strip().lower()
+    return candidate if candidate in allowed else fallback
+
+
+def resolve_prompt_overhead_modes(
+    config: Optional[Mapping[str, Any]] = None,
+    *,
+    platform: Optional[str] = None,
+) -> PromptOverheadModes:
+    """Resolve global modes, then override individual keys for a platform.
+
+    Invalid global values fall back to ``full``. Invalid or missing platform
+    values fall back to the corresponding resolved global value.
+    """
+    root = _mapping(config)
+    prompt_cfg = _mapping(root.get("prompt_overhead"))
+    resolved_platform = (
+        str(current_prompt_platform() if platform is None else platform).strip().lower()
+    )
+
+    global_skill = _valid_mode(
+        prompt_cfg.get("skill_index_mode"), _SKILL_INDEX_MODES, "full"
+    )
+    global_tools = _valid_mode(
+        prompt_cfg.get("tool_schema_mode"), _TOOL_SCHEMA_MODES, "full"
+    )
+
+    platform_cfg: Mapping[str, Any] = {}
+    for name, value in _mapping(prompt_cfg.get("platforms")).items():
+        if str(name).strip().lower() == resolved_platform:
+            platform_cfg = _mapping(value)
+            break
+
+    return PromptOverheadModes(
+        skill_index_mode=_valid_mode(
+            platform_cfg.get("skill_index_mode"), _SKILL_INDEX_MODES, global_skill
+        ),
+        tool_schema_mode=_valid_mode(
+            platform_cfg.get("tool_schema_mode"), _TOOL_SCHEMA_MODES, global_tools
+        ),
+        platform=resolved_platform,
+    )
+
+
+def _load_config() -> Mapping[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        loaded = load_config() or {}
+        return loaded if isinstance(loaded, Mapping) else {}
+    except Exception:
+        return {}
+
+
+def get_prompt_overhead_modes(*, platform: Optional[str] = None) -> PromptOverheadModes:
+    """Load config and resolve the modes for the active platform."""
+    return resolve_prompt_overhead_modes(_load_config(), platform=platform)
+
+
+__all__ = [
+    "PromptOverheadModes",
+    "current_prompt_platform",
+    "get_prompt_overhead_modes",
+    "resolve_prompt_overhead_modes",
+]

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -821,6 +821,15 @@ DEFAULT_CONFIG = {
         "cache_ttl": "5m",
     },
 
+    # Model-facing prompt/schema compaction. Defaults preserve the historical
+    # full skill index and full eager-tool schemas. Platform entries override
+    # only the keys they specify; all modes are full | compact | minimal.
+    "prompt_overhead": {
+        "skill_index_mode": "full",
+        "tool_schema_mode": "full",
+        "platforms": {},
+    },
+
     # OpenRouter-specific settings.
     # response_cache: enable OpenRouter response caching (X-OpenRouter-Cache header).
     #   When enabled, identical requests return cached responses for free (zero billing).

--- a/model_tools.py
+++ b/model_tools.py
@@ -20,6 +20,7 @@ Public API (signatures preserved from the original 2,400-line version):
     check_tool_availability(quiet) -> tuple
 """
 
+import copy
 import os
 import json
 import re
@@ -37,6 +38,7 @@ from tools.registry import (
     tool_error,
 )
 from toolsets import resolve_toolset, validate_toolset
+from agent.prompt_overhead import get_prompt_overhead_modes
 
 logger = logging.getLogger(__name__)
 
@@ -302,6 +304,80 @@ def _clear_tool_defs_cache() -> None:
     _tool_defs_cache.clear()
 
 
+def _shorten_schema_text(text: str, max_chars: int) -> str:
+    """Shorten schema prose while preserving the leading instruction."""
+    cleaned = re.sub(r"\s+", " ", str(text or "")).strip()
+    if not cleaned or len(cleaned) <= max_chars:
+        return cleaned
+    first_sentence = re.split(r"(?<=[.!?。！？])\s+", cleaned, maxsplit=1)[0].strip()
+    if 12 <= len(first_sentence) <= max_chars:
+        return first_sentence
+    cut = cleaned[: max_chars + 1]
+    boundary = max(
+        cut.rfind(";"),
+        cut.rfind(","),
+        cut.rfind(" — "),
+        cut.rfind(" - "),
+        cut.rfind(" "),
+    )
+    if boundary >= max_chars // 2:
+        cut = cut[:boundary]
+    else:
+        cut = cleaned[:max_chars]
+    return cut.rstrip(" ,;:-—") + "…"
+
+
+def _compact_schema_node(node: Any, mode: str) -> Any:
+    """Recursively compact JSON-schema descriptions without changing shape."""
+    if isinstance(node, list):
+        return [_compact_schema_node(item, mode) for item in node]
+    if not isinstance(node, dict):
+        return node
+
+    result: Dict[str, Any] = {}
+    for key, value in node.items():
+        if key == "description" and isinstance(value, str):
+            if mode == "compact":
+                result[key] = _shorten_schema_text(value, 56)
+            # Minimal keeps function descriptions but drops parameter prose.
+            continue
+        result[key] = _compact_schema_node(value, mode)
+    return result
+
+
+def _compact_tool_definitions(
+    tool_defs: List[Dict[str, Any]], mode: str
+) -> List[Dict[str, Any]]:
+    """Return compact model-facing copies of OpenAI-format tool definitions.
+
+    Tool Search's bridge schemas already own a bounded disclosure budget and
+    must retain their catalog instructions. The full pre-assembly list is
+    never passed here, so ``tool_describe`` continues to read full schemas.
+    """
+    if mode == "full":
+        return tool_defs
+
+    bridge_names = frozenset({"tool_search", "tool_describe", "tool_call"})
+    compacted: List[Dict[str, Any]] = []
+    for tool_def in tool_defs:
+        function = tool_def.get("function") if isinstance(tool_def, dict) else None
+        if isinstance(function, dict) and function.get("name") in bridge_names:
+            compacted.append(tool_def)
+            continue
+        cloned = copy.deepcopy(tool_def)
+        function = cloned.get("function") if isinstance(cloned, dict) else None
+        if isinstance(function, dict):
+            if isinstance(function.get("description"), str):
+                function["description"] = _shorten_schema_text(
+                    function["description"], 120 if mode == "compact" else 72
+                )
+            parameters = function.get("parameters")
+            if isinstance(parameters, dict):
+                function["parameters"] = _compact_schema_node(parameters, mode)
+        compacted.append(cloned)
+    return compacted
+
+
 def get_tool_definitions(
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
@@ -335,6 +411,8 @@ def get_tool_definitions(
     # mode, discord action allowlist, etc.) without needing an explicit
     # invalidate hook on every config-writer.
     cache_key = None
+    prompt_modes = get_prompt_overhead_modes()
+    schema_mode = prompt_modes.tool_schema_mode
     if quiet_mode:
         try:
             from hermes_cli.config import get_config_path
@@ -355,6 +433,8 @@ def get_tool_definitions(
                 _is_delegated_child_context(),
                 _is_dispatcher_owned_worker(),
                 profile_scope,
+                prompt_modes.platform,
+                schema_mode,
             )
         cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None
         if cached is not None:
@@ -366,8 +446,14 @@ def get_tool_definitions(
             # schemas are treated as read-only by all known callers.
             return list(cached)
 
-    result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
+    result = _compute_tool_definitions(
+        enabled_toolsets,
+        disabled_toolsets,
+        quiet_mode,
+        skip_tool_search_assembly=skip_tool_search_assembly,
+    )
+    if not skip_tool_search_assembly:
+        result = _compact_tool_definitions(result, schema_mode)
     if quiet_mode and cache_key is not None:
         # Cache the freshly-computed list, but hand callers a shallow copy so
         # downstream mutations (e.g. run_agent appending memory/LCM tool

--- a/tests/agent/test_prompt_overhead.py
+++ b/tests/agent/test_prompt_overhead.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from agent.prompt_overhead import resolve_prompt_overhead_modes
+
+
+def test_prompt_overhead_defaults_are_full():
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    modes = resolve_prompt_overhead_modes({}, platform="cli")
+
+    assert DEFAULT_CONFIG["prompt_overhead"] == {
+        "skill_index_mode": "full",
+        "tool_schema_mode": "full",
+        "platforms": {},
+    }
+    assert modes.skill_index_mode == "full"
+    assert modes.tool_schema_mode == "full"
+    assert modes.platform == "cli"
+
+
+def test_platform_overrides_have_per_key_precedence():
+    modes = resolve_prompt_overhead_modes(
+        {
+            "prompt_overhead": {
+                "skill_index_mode": "compact",
+                "tool_schema_mode": "minimal",
+                "platforms": {
+                    "FeiShu": {
+                        "skill_index_mode": "minimal",
+                    }
+                },
+            }
+        },
+        platform="feishu",
+    )
+
+    assert modes.skill_index_mode == "minimal"
+    assert modes.tool_schema_mode == "minimal"
+
+
+def test_invalid_values_fall_back_to_global_then_full():
+    modes = resolve_prompt_overhead_modes(
+        {
+            "prompt_overhead": {
+                "skill_index_mode": "unknown",
+                "tool_schema_mode": "compact",
+                "platforms": {
+                    "slack": {
+                        "skill_index_mode": "invalid",
+                        "tool_schema_mode": "invalid",
+                    }
+                },
+            }
+        },
+        platform="slack",
+    )
+
+    assert modes.skill_index_mode == "full"
+    assert modes.tool_schema_mode == "compact"
+
+
+def test_skill_index_modes_use_separate_cache_entries(monkeypatch, tmp_path):
+    from agent import prompt_overhead
+    from agent.prompt_builder import (
+        build_skills_system_prompt,
+        clear_skills_system_prompt_cache,
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    skill_dir = tmp_path / "skills" / "tools" / "verbose-skill"
+    skill_dir.mkdir(parents=True)
+    description = (
+        "Use when investigating a deliberately verbose workflow with several "
+        "important constraints and a unique full-description tail"
+    )
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: verbose-skill\ndescription: {description}\n---\n"
+    )
+
+    state = {"mode": "compact"}
+    monkeypatch.setattr(
+        prompt_overhead,
+        "_load_config",
+        lambda: {"prompt_overhead": {"skill_index_mode": state["mode"]}},
+    )
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    try:
+        compact = build_skills_system_prompt()
+        state["mode"] = "minimal"
+        minimal = build_skills_system_prompt()
+        state["mode"] = "full"
+        full = build_skills_system_prompt()
+    finally:
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+
+    assert "verbose-skill" in compact
+    assert "unique full-description tail" not in compact
+    assert "verbose-skill" in minimal
+    assert description not in minimal
+    assert "Use when investigating a deliberately verbose workflow" in full
+    assert full != compact
+    assert len(minimal) < len(compact) < len(full)

--- a/tests/tools/test_prompt_overhead.py
+++ b/tests/tools/test_prompt_overhead.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import json
+
+from agent.prompt_overhead import PromptOverheadModes
+
+
+def _tool_def(name: str, description: str, parameter_description: str):
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": parameter_description,
+                    }
+                },
+                "required": ["query"],
+            },
+        },
+    }
+
+
+def test_tool_schema_modes_use_separate_cache_entries(monkeypatch):
+    import model_tools
+
+    description = "Perform a deliberately verbose operation. " + "details " * 30
+    parameter_description = "A deliberately verbose parameter. " + "details " * 20
+    calls = []
+    state = {"mode": "minimal"}
+
+    def compute(*args, **kwargs):
+        calls.append((args, kwargs))
+        return [_tool_def("cache_mode_tool", description, parameter_description)]
+
+    monkeypatch.setattr(model_tools, "_compute_tool_definitions", compute)
+    monkeypatch.setattr(
+        model_tools,
+        "get_prompt_overhead_modes",
+        lambda: PromptOverheadModes(
+            tool_schema_mode=state["mode"], platform="test-platform"
+        ),
+    )
+    model_tools._clear_tool_defs_cache()
+    try:
+        minimal = model_tools.get_tool_definitions(quiet_mode=True)
+        state["mode"] = "full"
+        full = model_tools.get_tool_definitions(quiet_mode=True)
+    finally:
+        model_tools._clear_tool_defs_cache()
+
+    assert len(calls) == 2
+    assert (
+        "description" not in minimal[0]["function"]["parameters"]["properties"]["query"]
+    )
+    assert full[0]["function"]["description"] == description
+    assert (
+        full[0]["function"]["parameters"]["properties"]["query"]["description"]
+        == parameter_description
+    )
+
+
+def test_tool_describe_keeps_full_session_scoped_available_schema(monkeypatch):
+    import model_tools
+    from tools.registry import registry
+
+    full_description = (
+        "Perform a connected-service operation. FULL_SCHEMA_DESCRIPTION_SENTINEL"
+    )
+    parameter_description = (
+        "The complete query syntax. FULL_PARAMETER_DESCRIPTION_SENTINEL"
+    )
+
+    def register(name, toolset, *, available=True):
+        registry.register(
+            name=name,
+            toolset=toolset,
+            handler=lambda args, **kwargs: json.dumps({"ok": True}),
+            check_fn=lambda: available,
+            schema=_tool_def(name, full_description, parameter_description)["function"],
+        )
+
+    register("mcp_prompt_visible", "mcp-prompt-visible")
+    register("mcp_prompt_out_of_scope", "mcp-prompt-other")
+    register("mcp_prompt_unavailable", "mcp-prompt-visible", available=False)
+    monkeypatch.setattr(
+        model_tools,
+        "get_prompt_overhead_modes",
+        lambda: PromptOverheadModes(
+            tool_schema_mode="minimal", platform="test-platform"
+        ),
+    )
+    model_tools._clear_tool_defs_cache()
+
+    visible = json.loads(
+        model_tools.handle_function_call(
+            function_name="tool_describe",
+            function_args={"name": "mcp_prompt_visible"},
+            enabled_toolsets=["mcp-prompt-visible"],
+        )
+    )
+    out_of_scope = json.loads(
+        model_tools.handle_function_call(
+            function_name="tool_describe",
+            function_args={"name": "mcp_prompt_out_of_scope"},
+            enabled_toolsets=["mcp-prompt-visible"],
+        )
+    )
+    unavailable = json.loads(
+        model_tools.handle_function_call(
+            function_name="tool_describe",
+            function_args={"name": "mcp_prompt_unavailable"},
+            enabled_toolsets=["mcp-prompt-visible"],
+        )
+    )
+
+    assert visible["description"] == full_description
+    assert (
+        visible["parameters"]["properties"]["query"]["description"]
+        == parameter_description
+    )
+    assert "not currently available" in out_of_scope["error"]
+    assert "not currently available" in unavailable["error"]

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -647,6 +647,40 @@ hermes config set skills.config.myplugin.path ~/myplugin-data
 
 For details on declaring config settings in your own skills, see [Creating Skills — Config Settings](/developer-guide/creating-skills#config-settings-configyaml).
 
+## Prompt Overhead
+
+Hermes keeps the full skill index and eager-tool schemas by default. For
+small-context models or messaging platforms where the fixed prompt payload is
+expensive, `prompt_overhead` can shorten the model-facing catalog without
+disabling skills or tools:
+
+```yaml
+prompt_overhead:
+  skill_index_mode: full   # full | compact | minimal
+  tool_schema_mode: full   # full | compact | minimal
+  platforms:
+    feishu:
+      skill_index_mode: compact
+      tool_schema_mode: minimal
+```
+
+| Mode | Skill index | Eager-tool schemas |
+| --- | --- | --- |
+| `full` | Existing instructions and descriptions | Complete function and parameter descriptions |
+| `compact` | Short instructions and clipped trigger descriptions | Short function and parameter descriptions |
+| `minimal` | Skill names grouped by category | Short function descriptions; parameter descriptions omitted |
+
+Platform keys are case-insensitive. Hermes resolves the two global modes
+first, then a matching `platforms.<name>` block overrides each key it
+specifies. Missing or invalid platform values fall back to the resolved global
+value; missing or invalid global values fall back to `full`.
+
+This setting compacts only what the model sees initially. Tool filtering still
+honors the session's enabled/disabled toolsets and availability checks. When
+[Tool Search](/user-guide/features/tool-search) defers an MCP or plugin tool,
+`tool_describe` still returns that tool's complete, session-scoped schema. The
+Tool Search bridge instructions and bounded catalog listing are not compacted.
+
 ### Guard on agent-created skill writes
 
 When the agent uses `skill_manage` to create, edit, patch, or delete a skill, Hermes can optionally scan the new/updated content for dangerous keyword patterns (credential harvesting, obvious prompt injection, exfil instructions). The scanner is **off by default** — real agent workflows that legitimately touch `~/.ssh/` or mention `$OPENAI_API_KEY` were tripping the heuristic too often. Turn it back on if you want the scanner to prompt you before the agent's skill writes land:

--- a/website/docs/user-guide/features/tool-search.md
+++ b/website/docs/user-guide/features/tool-search.md
@@ -123,6 +123,14 @@ eager loading's task success while costing less than the bare bridge.
 If you want the old always-eager behavior for a small toolset, set
 `enabled: off`.
 
+## Prompt schema compaction
+
+`prompt_overhead.tool_schema_mode` can separately shorten the schemas of
+tools that remain eager. It runs after Tool Search assembly, leaves the three
+bridge schemas intact, and never changes the full session-scoped definitions
+used by `tool_describe`. See [Prompt Overhead in the configuration
+guide](/user-guide/configuration#prompt-overhead).
+
 ## Trade-offs that don't go away
 
 These come from the prompt-cache integrity invariant — they are inherent


### PR DESCRIPTION
## Summary
- add platform-aware `full` / `compact` / `minimal` modes for the skill index and eager-tool schemas
- resolve prompt-overhead settings through one shared config path with per-platform overrides
- build compaction on the current session-scoped Tool Search catalog so `tool_describe` keeps returning complete schemas
- add default config wiring, user documentation, and regression coverage

## Review follow-up
- removed the original global-registry `tool_help` approach; disabled, out-of-scope, and unavailable tools are not exposed
- apply eager-schema compaction only after Tool Search assembly and leave bridge schemas/catalog instructions intact
- keep `get_tool_definitions(skip_tool_search_assembly=True)` full and session-scoped for `tool_describe`
- include prompt mode and platform in cache keys so gateway sessions cannot share the wrong compacted result
- preserve existing behavior by defaulting both modes to `full`

## Test Plan
- `scripts/run_tests.sh tests/agent/test_prompt_overhead.py tests/tools/test_prompt_overhead.py tests/agent/test_prompt_builder.py tests/tools/test_tool_search.py -q` — 96 passed, 1 skipped
- `scripts/run_tests.sh tests/tools/test_terminal_tool_requirements.py tests/hermes_cli/test_prompt_size.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_validation.py -q` — 97 passed
- `ruff check` on changed Python files
- `python3 -m py_compile` on changed Python files