### PR TITLE
fix(kanban): add --reason flag to unblock for symmetry with block (#30897)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -548,6 +548,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                             help="Additional task ids to schedule with the same reason (bulk mode)")
 
     p_unblock = sub.add_parser("unblock", help="Return one or more blocked/scheduled tasks to ready")
+    p_unblock.add_argument(
+        "--reason",
+        default=None,
+        help="Optional reason/note — recorded as a comment before unblocking. Quote multi-word reasons.",
+    )
     p_unblock.add_argument("task_ids", nargs="+")
 
     p_promote = sub.add_parser(
@@ -1978,14 +1983,20 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
     if not ids:
         print("at least one task_id is required", file=sys.stderr)
         return 1
+    reason = getattr(args, "reason", None)
+    if reason is not None:
+        reason = reason.strip() or None
+    author = _profile_author() if reason else None
     failed: list[str] = []
     with kb.connect_closing() as conn:
         for tid in ids:
+            if reason:
+                kb.add_comment(conn, tid, author, f"UNBLOCK: {reason}")
             if not kb.unblock_task(conn, tid):
                 failed.append(tid)
                 print(f"cannot unblock {tid} (not blocked/scheduled?)", file=sys.stderr)
             else:
-                print(f"Unblocked {tid}")
+                print(f"Unblocked {tid}" + (f": {reason}" if reason else ""))
     return 0 if not failed else 1
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -59,6 +59,7 @@ AUTHOR_MAP = {
     "wangpuv@hotmail.com": "wangpuv",
     "202622897+ticketclosed-wontfix@users.noreply.github.com": "ticketclosed-wontfix",
     "wuxuebin1993@gmail.com": "victorGPT",
+    "211828103+julio-cloudvisor@users.noreply.github.com": "julio-cloudvisor",
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "kenyon1977@gmail.com": "kenyonxu",


### PR DESCRIPTION
## Summary
`hermes kanban unblock <id> review-required: ...` quietly failed: every trailing word past the task id was parsed as another task_id (since `task_ids` is `nargs='+'`), then each non-existent id printed "cannot unblock <word> (not blocked/scheduled?)" on stderr with no signal that the reason was being misinterpreted.

`block <id> <reason...>` accepts positional reason words, so the asymmetry was surprising.

## Changes
- `hermes_cli/kanban.py`: add `--reason "..."` flag to `unblock`; when set, append `UNBLOCK: <reason>` as a comment before the unblock transition. Bulk syntax (`unblock t_a t_b t_c`) preserved.
- `scripts/release.py`: add AUTHOR_MAP entry for @julio-cloudvisor.

## Validation
| | Before | After |
|---|---|---|
| `unblock t_x review needed` | parses `review`, `needed` as task ids, prints "cannot unblock review (not blocked/scheduled?)" | (still parses as task ids — documented quoting convention) |
| `unblock t_x --reason "review needed"` | argparse: unknown flag | unblocks, records `UNBLOCK: review needed` comment |
| `unblock t_a t_b t_c` (bulk) | works | works (unchanged) |
| `unblock t_a t_b --reason "both green"` | argparse: unknown flag | bulk + reason both work |
| Existing kanban CLI suite | 46/46 pass | 46/46 pass |

Closes #30897. Credit @julio-cloudvisor for the report.

## Infographic

![kanban-unblock-reason](https://v3b.fal.media/files/b/0a9c1ef5/WOUa6FTeRkiB3LlNuwI3K_BqfrLNqE.png)
