### PR TITLE
fix(kanban): bridge worker runtime activity to board heartbeat (#31752)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2144,9 +2144,26 @@ class AIAgent:
         return apply_pending_steer_to_tool_results(self, messages, num_tool_msgs)
 
     def _touch_activity(self, desc: str) -> None:
-        """Update the last-activity timestamp and description (thread-safe)."""
+        """Update the last-activity timestamp and description (thread-safe).
+
+        Also bridges to the kanban board's heartbeat fields when this
+        process is a dispatcher-spawned worker (HERMES_KANBAN_TASK set),
+        so the dispatcher watchdog doesn't reclaim an actively-running
+        worker as stale (#31752). Bridge is rate-limited (60s) and
+        best-effort — it never raises into the agent loop.
+        """
         self._last_activity_ts = time.time()
         self._last_activity_desc = desc
+        if os.environ.get("HERMES_KANBAN_TASK"):
+            try:
+                from tools.kanban_tools import heartbeat_current_worker_from_env
+                heartbeat_current_worker_from_env()
+            except Exception:
+                # Never let the bridge break the agent loop.  The function
+                # already swallows exceptions internally; this outer guard
+                # covers import-time failures (kanban_tools unavailable,
+                # etc.) on niche deployment surfaces.
+                pass
 
     def _capture_rate_limits(self, http_response: Any) -> None:
         """Parse x-ratelimit-* headers from an HTTP response and cache the state.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -61,6 +61,7 @@ AUTHOR_MAP = {
     "wuxuebin1993@gmail.com": "victorGPT",
     "211828103+julio-cloudvisor@users.noreply.github.com": "julio-cloudvisor",
     "17778+kweiner@users.noreply.github.com": "kweiner",
+    "223516181+faisfamilytravel@users.noreply.github.com": "faisfamilytravel",
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "kenyon1977@gmail.com": "kenyonxu",

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -176,6 +176,90 @@ def _connect(board: Optional[str] = None):
     return kb, kb.connect(board=board)
 
 
+# ---------------------------------------------------------------------------
+# Runtime-activity → board-heartbeat bridge (#31752)
+# ---------------------------------------------------------------------------
+# When the agent ticks ``_touch_activity`` during normal work (between
+# tool calls, mid-stream chunks, etc.), we want the kanban board's
+# ``last_heartbeat_at`` columns to reflect that liveness so the dispatcher
+# watchdog (which reads ``tasks.last_heartbeat_at``, not the agent's
+# in-process timestamp) doesn't reclaim an actively-running worker as
+# stale. The model is not required to call the explicit ``kanban_heartbeat``
+# tool for this to work — that tool stays available for workers that want
+# to attach a note or pre-emptively extend a claim across a known-long op.
+#
+# Constraints:
+#   - Best-effort: never raise. The agent loop must not care if the bridge
+#     fails (board missing, DB locked, etc.).
+#   - Rate-limited to one DB write per 60s per-process; runtime activity
+#     can tick on every chunk/tool result and we don't need that resolution.
+#   - No-op outside dispatcher-spawned worker context (no ``HERMES_KANBAN_TASK``).
+#   - No durable note on these auto-heartbeats; that's reserved for the
+#     explicit tool which carries a model-supplied note.
+
+_AUTO_HEARTBEAT_MIN_INTERVAL_SECONDS = 60.0
+_auto_heartbeat_last_attempt: float = 0.0
+
+
+def heartbeat_current_worker_from_env() -> bool:
+    """Best-effort: extend the kanban claim + bump board heartbeat for the
+    current dispatcher-spawned worker, using identity from env vars.
+
+    Returns True if a write was attempted (whether or not it succeeded);
+    False if the call was skipped (not a kanban worker, rate-limited, or
+    swallowed exception). The boolean is informational — callers should
+    not branch on it.
+
+    Identity comes from:
+      * ``HERMES_KANBAN_TASK`` — task id (required; absence means no-op)
+      * ``HERMES_KANBAN_RUN_ID`` — pins the run row so we don't heartbeat
+        a stale run that may have already been reclaimed
+      * ``HERMES_KANBAN_CLAIM_LOCK`` — claim lock for ``heartbeat_claim``;
+        falls back to the default ``_claimer_id()`` for locally-driven
+        workers that never went through the dispatcher path
+
+    Rate-limited via the module-level ``_auto_heartbeat_last_attempt``
+    timestamp (monotonic clock); not thread-safe in the strict sense, but
+    the worst case is one extra DB write per race, which is harmless.
+    """
+    global _auto_heartbeat_last_attempt
+    tid = os.environ.get("HERMES_KANBAN_TASK")
+    if not tid:
+        return False
+    import time as _time
+    now = _time.monotonic()
+    if (now - _auto_heartbeat_last_attempt) < _AUTO_HEARTBEAT_MIN_INTERVAL_SECONDS:
+        return False
+    _auto_heartbeat_last_attempt = now
+    try:
+        kb, conn = _connect()
+        try:
+            claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
+            try:
+                kb.heartbeat_claim(conn, tid, claimer=claim_lock)
+            except Exception:
+                logger.debug("auto-heartbeat: heartbeat_claim failed", exc_info=True)
+            run_id_raw = os.environ.get("HERMES_KANBAN_RUN_ID")
+            run_id: Optional[int]
+            try:
+                run_id = int(run_id_raw) if run_id_raw else None
+            except (TypeError, ValueError):
+                run_id = None
+            try:
+                kb.heartbeat_worker(conn, tid, note=None, expected_run_id=run_id)
+            except Exception:
+                logger.debug("auto-heartbeat: heartbeat_worker failed", exc_info=True)
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+        return True
+    except Exception:
+        logger.debug("auto-heartbeat: bridge failed", exc_info=True)
+        return False
+
+
 def _ok(**fields: Any) -> str:
     return json.dumps({"ok": True, **fields})
 


### PR DESCRIPTION
## Summary
The dispatcher watchdog (`release_stale_claims`) reads `tasks.last_heartbeat_at` to decide whether to reclaim a running task. The agent already maintains an in-process `_last_activity_ts` updated on every chunk and tool result, but those liveness ticks never reach the board unless the model explicitly calls `kanban_heartbeat` — so a worker actively executing a long run without tool-level heartbeats can be reclaimed mid-flight, returning the task to ready and orphaning the in-flight worker's progress.

## Changes
- `tools/kanban_tools.py` — new `heartbeat_current_worker_from_env()` helper: rate-limited (60s), best-effort (never raises), no-op outside dispatcher-spawned worker context. Identity from `HERMES_KANBAN_TASK` + `HERMES_KANBAN_RUN_ID` + `HERMES_KANBAN_CLAIM_LOCK`.
- `run_agent.py` `_touch_activity` — calls the helper when `HERMES_KANBAN_TASK` is set. Lazy import so non-kanban runs pay zero cost.
- `scripts/release.py` — AUTHOR_MAP entries for @faisfamilytravel and @kweiner.

The explicit `kanban_heartbeat` tool stays unchanged for workers that want to attach a note or pre-emptively extend a claim across a known-long single tool call. No durable note on auto-heartbeats (that's the tool's job).

## Validation
E2E test verified:
| | Result |
|---|---|
| No `HERMES_KANBAN_TASK` → no-op | ✓ `last_heartbeat_at` stays null |
| With env → board heartbeat + claim extended | ✓ `last_heartbeat_at` set, `claim_expires` pushed +900s |
| Rate limit (immediate retry) | ✓ skipped, no DB write |
| Garbage `HERMES_KANBAN_RUN_ID` | ✓ ignored, doesn't crash |
| Stale run_id | ✓ swallowed at heartbeat_worker level |
| `_touch_activity` wiring | ✓ in-process state still updated + board write fires |
| Targeted suites: kanban_tools, kanban_db, kanban_cli, approval_heartbeat, delegate | 470 tests pass |

Closes #31752. Credit @faisfamilytravel for the diagnosis and the patch outline.

## Infographic

![kanban-heartbeat-bridge](https://v3b.fal.media/files/b/0a9c1f0b/53o29IHt4XxI02W15TFT2_v5bJ6vM7.png)
