### PR TITLE
fix(browser): recover from Camofox tab creation 500

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -3,6 +3,8 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import requests
+
 
 from tools.browser_camofox import (
     camofox_back,
@@ -170,6 +172,49 @@ class TestCamofoxNavigate:
         result = json.loads(camofox_navigate("https://b.com", task_id="t2"))
         assert result["success"] is True
         assert result["url"] == "https://b.com"
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_retries_tab_creation_500_via_blank_tab_then_navigate(self, mock_post, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        server_error_response = _mock_response(status=500)
+        server_error_response.raise_for_status.side_effect = requests.HTTPError(
+            "500 Server Error: Internal Server Error for url: http://localhost:9377/tabs",
+            response=server_error_response,
+        )
+        mock_post.side_effect = [
+            server_error_response,
+            _mock_response(json_data={"tabId": "tab-retry", "url": "about:blank"}),
+            _mock_response(json_data={"ok": True, "url": "https://example.com", "title": "Example"}),
+        ]
+
+        result = json.loads(camofox_navigate("https://example.com", task_id="t_retry_tabs_500"))
+
+        assert result["success"] is True
+        assert result["url"] == "https://example.com"
+        assert result["title"] == "Example"
+        assert mock_post.call_args_list[0].kwargs["json"]["url"] == "https://example.com"
+        assert mock_post.call_args_list[1].kwargs["json"]["url"] == "about:blank"
+        assert mock_post.call_args_list[2].args[0] == "http://localhost:9377/tabs/tab-retry/navigate"
+        assert mock_post.call_args_list[2].kwargs["json"] == {
+            "userId": mock_post.call_args_list[0].kwargs["json"]["userId"],
+            "url": "https://example.com",
+        }
+
+    @patch("tools.browser_camofox.requests.post")
+    def test_tab_creation_4xx_is_not_retried(self, mock_post, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        client_error_response = _mock_response(status=400)
+        client_error_response.raise_for_status.side_effect = requests.HTTPError(
+            "400 Client Error: Bad Request for url: http://localhost:9377/tabs",
+            response=client_error_response,
+        )
+        mock_post.return_value = client_error_response
+
+        result = json.loads(camofox_navigate("https://example.com", task_id="t_no_retry_400"))
+
+        assert result["success"] is False
+        assert "Navigation failed" in result["error"]
+        assert mock_post.call_count == 1
 
     def test_connection_error_returns_helpful_message(self, monkeypatch):
         monkeypatch.setenv("CAMOFOX_URL", "http://localhost:19999")

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -356,6 +356,13 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
     return session
 
 
+def _is_camofox_server_error(exc: requests.HTTPError) -> bool:
+    """Return whether a Camofox HTTP error is likely server-side/transient."""
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    return isinstance(status_code, int) and 500 <= status_code < 600
+
+
 def _drop_session(task_id: Optional[str]) -> Optional[Dict[str, Any]]:
     """Remove and return session info."""
     task_id = task_id or "default"
@@ -426,9 +433,24 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
         browser_url, rewrite_info = _rewrite_loopback_url_for_camofox(url)
         session = _get_session(task_id)
         if not session["tab_id"]:
-            # Create tab with the target URL directly
-            session = _ensure_tab(task_id, browser_url)
-            data = {"ok": True, "url": browser_url}
+            # Prefer direct creation with the target URL, but some Camofox
+            # server builds can return a 500 from POST /tabs while trying to
+            # load the initial URL. In that case, create a blank tab first and
+            # use the dedicated navigate endpoint so browser_navigate does not
+            # fail before a recoverable page navigation even starts.
+            try:
+                session = _ensure_tab(task_id, browser_url)
+                data = {"ok": True, "url": browser_url}
+            except requests.HTTPError as exc:
+                if not _is_camofox_server_error(exc):
+                    raise
+                logger.debug("Camofox target-tab creation failed; retrying via about:blank", exc_info=True)
+                session = _ensure_tab(task_id, "about:blank")
+                data = _post(
+                    f"/tabs/{session['tab_id']}/navigate",
+                    {"userId": session["user_id"], "url": browser_url},
+                    timeout=60,
+                )
         else:
             # Navigate existing tab
             data = _post(


### PR DESCRIPTION
## Summary
- retry first-time Camofox navigation when POST /tabs returns a server-side 5xx
- recover by creating an about:blank tab, then using the dedicated /navigate endpoint
- keep 4xx tab creation failures non-retryable so bad requests still surface clearly

## Tests
- python -m pytest tests/tools/test_browser_camofox.py tests/tools/test_browser_camofox_persistence.py tests/tools/test_browser_hardening.py -q -o 'addopts='
- python -m ruff check tools/browser_camofox.py tests/tools/test_browser_camofox.py