### PR TITLE
fix(security): add bws_cache.json to file_safety read guard

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -249,6 +249,10 @@ def get_read_block_error(path: str) -> Optional[str]:
         ".env",
         "webhook_subscriptions.json",
         os.path.join("auth", "google_oauth.json"),
+        # Bitwarden Secrets Manager disk cache: stores plaintext secret values
+        # to avoid re-fetching across back-to-back CLI invocations. The file
+        # was introduced by #31968 but not added to this guard.
+        os.path.join("cache", "bws_cache.json"),
     )
     for hd in hermes_dirs:
         for name in credential_file_names:


### PR DESCRIPTION
Salvage of #32092 (@AhmetArif0). Clean cherry-pick — applies to current main.

## What it fixes
PR #31968 added a disk-persistent Bitwarden Secrets cache at `<hermes_home>/cache/bws_cache.json` containing **plaintext secret values** (API keys, DB passwords pulled from BSM projects). The file is chmod 0600, but `agent/file_safety.get_read_block_error()` was never updated to deny it — so the agent's `read_file` tool could harvest decrypted secrets directly while sibling stores (`.env`, `auth.json`, `.anthropic_oauth.json`, `mcp-tokens/`) were guarded.

## Mechanism
Single exact-name entry appended to the `credential_file_names` tuple in `agent/file_safety.py`. Matches the existing shape (`auth/google_oauth.json`, `.env`, etc.). Per-name loop builds `(hd / name).resolve()` against each `hermes_dir` (HERMES_HOME + global root), exact path equality — other `cache/*` files (images, audio, documents) remain readable.

## Validation
- 54/54 tests pass: `test_file_safety.py` + `test_file_safety_credentials.py` + `test_file_safety_cross_profile.py`
- E2E with plaintext-secrets bws_cache.json + legit screenshot.png/document.pdf in same cache dir: bws_cache blocked, image+document readable, .env still blocked

Closes #32092.