### PR TITLE
feat(kanban): resume parent worker session for follow-up tasks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5367,7 +5367,7 @@ def dispatch_once(
       3. Reclaim crashed running tasks (host-local PID no longer alive).
       3. Promote todo -> ready where all parents are done.
       4. For each ready task with an assignee, atomically claim and call
-         ``spawn_fn(task, workspace_path, board) -> Optional[int]``. The
+         ``spawn_fn(task, workspace_path, board, conn) -> Optional[int]``. The
          return value (if any) is recorded as ``worker_pid`` so subsequent
          ticks can detect crashes before the TTL expires.
 
@@ -5614,14 +5614,17 @@ def dispatch_once(
         try:
             # Back-compat: older spawn_fn signatures accept only
             # (task, workspace). Test stubs in the suite rely on that.
-            # Introspect the callable and pass `board` only when supported.
+            # Introspect the callable and pass `board` / `conn` only when
+            # supported.
             import inspect
             try:
                 sig = inspect.signature(_spawn)
+                kwargs = {}
                 if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
-                else:
-                    pid = _spawn(claimed, str(workspace))
+                    kwargs["board"] = board
+                if "conn" in sig.parameters:
+                    kwargs["conn"] = conn
+                pid = _spawn(claimed, str(workspace), **kwargs)
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
             if pid:
@@ -5707,10 +5710,12 @@ def dispatch_once(
             import inspect
             try:
                 sig = inspect.signature(_spawn)
+                kwargs = {}
                 if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
-                else:
-                    pid = _spawn(claimed, str(workspace))
+                    kwargs["board"] = board
+                if "conn" in sig.parameters:
+                    kwargs["conn"] = conn
+                pid = _spawn(claimed, str(workspace), **kwargs)
             except (TypeError, ValueError):
                 pid = _spawn(claimed, str(workspace))
             if pid:
@@ -5995,6 +6000,7 @@ def _default_spawn(
     workspace: str,
     *,
     board: Optional[str] = None,
+    conn: Optional[sqlite3.Connection] = None,
 ) -> Optional[int]:
     """Fire-and-forget ``hermes -p <profile> chat -q ...`` subprocess.
 
@@ -6087,6 +6093,11 @@ def _default_spawn(
         # profile-local worker sessions still register configured hooks.
         "--accept-hooks",
     ]
+    resume_session_id: Optional[str] = None
+    if conn is not None:
+        resume_session_id = _resume_session_id_for_task(conn, task.id)
+    if resume_session_id:
+        cmd.extend(["--resume", resume_session_id])
     # Auto-load the kanban-worker skill so every dispatched worker
     # has the pattern library (good summary/metadata shapes, retry
     # diagnostics, block-reason examples) in its context, even if
@@ -6974,6 +6985,48 @@ def latest_summary(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
         (task_id,),
     ).fetchone()
     return row["summary"] if row else None
+
+
+def _resume_session_id_for_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+) -> Optional[str]:
+    """Return a worker session id from the parent chain suitable for resume.
+
+    Reverse rework tasks benefit disproportionately from resuming the prior
+    reverse worker's session: the workspace and task artifacts capture the
+    explicit outputs, but detailed local reasoning context often lives only in
+    the worker's chat transcript. We therefore mine the task ancestry for the
+    newest completed run that stamped ``metadata.worker_session_id``.
+    """
+    try:
+        seen: set[str] = set()
+        queue: list[str] = list(parent_ids(conn, task_id))
+        while queue:
+            parent_tid = queue.pop(0)
+            if not parent_tid or parent_tid in seen:
+                continue
+            seen.add(parent_tid)
+
+            runs = list_runs(
+                conn,
+                parent_tid,
+                include_active=False,
+                state_type="outcome",
+                state_name="completed",
+            )
+            for run in reversed(runs):
+                metadata = run.metadata or {}
+                if not isinstance(metadata, dict):
+                    continue
+                session_id = metadata.get("worker_session_id")
+                if isinstance(session_id, str) and session_id.strip():
+                    return session_id.strip()
+
+            queue.extend(parent_ids(conn, parent_tid))
+    except Exception:
+        return None
+    return None
 
 
 def latest_summaries(

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2759,6 +2759,119 @@ def test_default_spawn_auto_loads_kanban_worker_skill(kanban_home, monkeypatch):
     assert env.get("HERMES_PROFILE") == "some-profile"
 
 
+def test_default_spawn_resumes_parent_worker_session_when_available(
+    kanban_home, monkeypatch
+):
+    """Follow-up tasks should resume the newest completed parent worker session."""
+    monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+
+    captured = {}
+
+    class FakeProc:
+        def __init__(self):
+            self.pid = 100001
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent reverse", assignee="rev")
+        kb.claim_task(conn, parent)
+        kb.complete_task(
+            conn,
+            parent,
+            summary="done",
+            metadata={"worker_session_id": "sess-parent-123"},
+        )
+        child = kb.create_task(
+            conn,
+            title="child rework",
+            assignee="rev",
+            parents=[parent],
+        )
+        task = kb.get_task(conn, child)
+        workspace = kb.resolve_workspace(task)
+        pid = kb._default_spawn(task, str(workspace), conn=conn)
+        assert pid == 100001
+    finally:
+        conn.close()
+
+    cmd = captured["cmd"]
+    assert "--resume" in cmd, f"spawn argv missing --resume: {cmd}"
+    idx = cmd.index("--resume")
+    assert cmd[idx + 1] == "sess-parent-123"
+
+
+def test_default_spawn_skips_resume_without_parent_worker_session(
+    kanban_home, monkeypatch
+):
+    """Fresh workers remain the fallback when no stamped parent session exists."""
+    monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+
+    captured = {}
+
+    class FakeProc:
+        def __init__(self):
+            self.pid = 100002
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent reverse", assignee="rev")
+        kb.claim_task(conn, parent)
+        kb.complete_task(conn, parent, summary="done")
+        child = kb.create_task(
+            conn,
+            title="child rework",
+            assignee="rev",
+            parents=[parent],
+        )
+        task = kb.get_task(conn, child)
+        workspace = kb.resolve_workspace(task)
+        kb._default_spawn(task, str(workspace), conn=conn)
+    finally:
+        conn.close()
+
+    cmd = captured["cmd"]
+    assert "--resume" not in cmd, f"spawn argv unexpectedly resumed: {cmd}"
+
+
+def test_dispatch_once_passes_conn_to_spawn_fn_when_supported(
+    kanban_home, monkeypatch
+):
+    """dispatch_once should pass the live DB handle to modern spawn fns."""
+    conn = kb.connect()
+    captured = {}
+    try:
+        tid = kb.create_task(conn, title="needs conn", assignee="rev")
+
+        monkeypatch.setattr(
+            "hermes_cli.profiles.profile_exists",
+            lambda _name: True,
+        )
+
+        def _spawn(task, workspace, *, conn=None, board=None):
+            captured["task_id"] = task.id
+            captured["workspace"] = workspace
+            captured["conn_is_present"] = conn is not None
+            return 424242
+
+        kb.dispatch_once(conn, spawn_fn=_spawn)
+        assert captured["task_id"] == tid
+        assert captured["conn_is_present"] is True
+    finally:
+        conn.close()
+
+
 def test_default_spawn_raises_terminal_timeout_to_task_runtime(kanban_home, monkeypatch):
     """A task runtime cap should raise the worker's terminal default.
 


### PR DESCRIPTION
# Summary

Follow-up kanban work often needs the reasoning continuity of the previous worker session, not just the saved workspace artifacts. This change teaches kanban dispatch to resume an appropriate parent worker session for reverse/rework tasks when that context is available.

## Motivation

Reverse and rework tasks usually inherit more than files and summaries:

- the prior worker may have already explored dead ends, hypotheses, and local constraints
- that context often lives only in the worker session transcript
- starting every follow-up task from a fresh session forces repeated rediscovery and increases drift across iterative reverse/rework chains

Resuming the parent worker session preserves continuity and makes follow-up execution more reliable and efficient.

## Implementation

### Dispatcher updates

`dispatch_once()` now forwards the live SQLite connection to `spawn_fn` when the callable supports it, while preserving backward compatibility for older spawn function signatures.

- existing introspection for optional `board` support is extended to optional `conn`
- legacy spawn functions that only accept `(task, workspace)` still work unchanged

### Default spawn behavior

`_default_spawn()` now accepts `conn` and, when present, attempts to add:

```bash
--resume <worker_session_id>
```

It does this via a new helper:

- `_resume_session_id_for_task(conn, task_id)`

That helper:

- walks the task’s parent chain
- looks at completed runs only
- finds the newest run whose metadata contains `worker_session_id`
- returns that session id for reuse by the child/follow-up task

If no resumable parent session is found, spawn behavior remains unchanged.

## Why this matters for kanban reverse/rework continuity

This directly improves continuity for multi-step reverse engineering and rework flows:

- child tasks can inherit the parent’s investigative context
- follow-up workers spend less time re-deriving prior understanding
- iterative correction/rework is more consistent across task boundaries
- kanban lineage becomes more useful as an execution context bridge, not just a dependency graph

In practice, this should reduce duplicated effort and help preserve momentum across chained reverse/rework tasks.

## Test Plan

Verified with:

```bash
pytest -q tests/hermes_cli/test_kanban_core_functionality.py
```

Result:

- `170 passed`

Added coverage for:

- resuming the newest completed parent worker session when available
- skipping `--resume` when no parent session id is stamped
- passing `conn` through `dispatch_once()` to modern spawn functions that support it

## Risks / Limitations

- Resume only happens when a completed parent-chain run stamped `metadata.worker_session_id`.
- The default spawn path needs a live DB connection; without `conn`, behavior falls back to fresh-session spawning.
- In graphs with multiple ancestors, the selected session is the newest completed run encountered in parent-chain traversal, which may not always be the only plausible continuation point.
- This preserves backward compatibility for older custom spawn functions, but only newer signatures can take advantage of resume-aware spawning.

## Notes

- This PR is limited to the kanban session-resume work in `hermes_cli/kanban_db.py` and its tests.
- Unrelated local changes such as `web/package-lock.json` remain out of scope for this PR.
