### PR TITLE
fix(security): deny entire HERMES_HOME tree in media delivery denylist

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -947,11 +947,14 @@ def _media_delivery_denied_paths() -> List[Path]:
     home = Path(os.path.expanduser("~"))
     for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS:
         denied.append(home / sub)
-    # The Hermes home itself contains credentials (auth.json, .env) — only the
-    # cache subdirectories under it are explicitly allowlisted above.
-    denied.append(_HERMES_HOME / ".env")
-    denied.append(_HERMES_HOME / "auth.json")
-    denied.append(_HERMES_HOME / "credentials")
+    # Deny the entire Hermes home directory tree. It contains credentials
+    # (auth.json, .env, mcp-tokens/, pairing/, .anthropic_oauth.json, etc.)
+    # that must never be delivered as gateway attachments regardless of mtime.
+    # Cache subdirectories within HERMES_HOME (image_cache/, cache/documents/,
+    # etc.) live in MEDIA_DELIVERY_SAFE_ROOTS and are returned by the allowlist
+    # check before this denylist is ever consulted — denying HERMES_HOME here
+    # does not affect legitimate cache deliveries.
+    denied.append(_HERMES_HOME)
     return denied
 
 


### PR DESCRIPTION
Salvage of #32090 (@AhmetArif0). Clean cherry-pick — applies to current main.

## What it fixes
`_media_delivery_denied_paths()` (introduced in #32060) listed only three specific files under HERMES_HOME: `.env`, `auth.json`, and `credentials`. Everything else under `~/.hermes` was unprotected from the recency-trust delivery path:

- `mcp-tokens/<server>.json` — OAuth tokens for MCP servers
- `pairing/telegram-approved.json` — platform pairing tokens
- `.anthropic_oauth.json` — Anthropic OAuth refresh tokens
- `skills/.hub/lock.json` — provenance ledger
- `logs/*.log` — session content

These were all in the file_safety **write** guard already; the media-delivery (read/exfil) side never caught up. A freshly written OAuth refresh (mtime seconds ago) easily passed the 600 s recency window and got delivered as an attachment.

## Mechanism
Replaces the 3 explicit appends with `denied.append(_HERMES_HOME)`. Allowlist runs FIRST in `validate_media_delivery_path` (lines 1037–1045 return immediately on hit; denylist at 1052 is only reached if no allowed root matched), so the existing `MEDIA_DELIVERY_SAFE_ROOTS` (IMAGE/AUDIO/VIDEO/DOCUMENT/SCREENSHOT cache dirs, both `get_hermes_dir` variants and legacy `_HERMES_HOME/image_cache` etc) still works. Operators can still allow specific subdirs via `HERMES_MEDIA_ALLOW_DIRS`.

## Validation
- 111/111 tests pass in `tests/gateway/test_platform_base.py`
- E2E: planted secrets at mcp-tokens/, pairing/, .anthropic_oauth.json, skills/.hub/lock.json, logs/agent.log — all 5 blocked. Legit `image_cache/screenshot.png` still delivered (allowlist wins).

Closes #32090.