### PR TITLE
fix(cli): scope docker install detection to the official image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -237,6 +237,14 @@ COPY --chmod=0755 docker/cont-init.d/02-reconcile-profiles /etc/cont-init.d/02-r
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
 
+# Mark this as the official published image so `detect_install_method`
+# routes `hermes update` to the `docker pull` guidance ONLY here — not in a
+# user's own container running a regular git/pip install. Being inside *some*
+# container is not enough to assume "can't git-pull"; the baked-in
+# .hermes_build_sha (written via the HERMES_GIT_SHA build-arg below) is the
+# implicit marker, and this env var is the explicit, fork-friendly signal.
+ENV HERMES_DOCKER_IMAGE=1
+
 # `docker exec` privilege-drop shim. When operators run
 # `docker exec <c> hermes ...` they default to root, and any file the
 # command writes under $HERMES_HOME (auth.json, .env, config.yaml) ends

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -279,13 +279,48 @@ def get_managed_update_command() -> Optional[str]:
     return None
 
 
+def _is_official_docker_image() -> bool:
+    """True only for the official published ``nousresearch/hermes-agent`` image.
+
+    Being inside *some* container (``is_container()``) is NOT the same as being
+    the published image — users routinely run a regular git/pip install inside
+    their own Docker container.  Only the published image can't ``git pull``
+    itself (``.dockerignore`` excludes ``.git``), so only it should route
+    ``hermes update`` to the ``docker pull`` guidance.
+
+    Discriminators (most-specific first):
+
+    1. ``HERMES_DOCKER_IMAGE`` env opt-in — explicit signal for the published
+       image and for forks that build an equivalent image.
+    2. The baked-in ``.hermes_build_sha`` marker — written exclusively by this
+       repo's ``Dockerfile`` via the ``HERMES_GIT_SHA`` build-arg, and absent
+       from any source checkout or pip install (``.dockerignore`` excludes
+       ``.git``, and the file is never committed).
+
+    A generic container with neither marker falls through to normal git/pip
+    detection, so ``hermes update`` keeps working there.
+    """
+    if os.environ.get("HERMES_DOCKER_IMAGE", "").strip().lower() in _MANAGED_TRUE_VALUES:
+        return True
+    try:
+        from hermes_cli.build_info import get_build_sha
+        if get_build_sha():
+            return True
+    except Exception:
+        pass
+    return False
+
+
 def detect_install_method(project_root: Optional[Path] = None) -> str:
     """Detect how Hermes was installed: 'docker', 'nixos', 'homebrew', 'git', or 'pip'.
 
     Resolution order:
     1. Stamped ``~/.hermes/.install_method`` file (written by installers)
     2. HERMES_MANAGED env / .managed marker (NixOS, Homebrew)
-    3. Container detection (/.dockerenv, /run/.containerenv, cgroup)
+    3. Official published-image markers (HERMES_DOCKER_IMAGE / baked build SHA)
+       -> 'docker'.  NOTE: merely running inside a container is not enough —
+       a regular git/pip install in a user's own container still updates via
+       git/pip (see ``_is_official_docker_image``).
     4. .git directory presence -> 'git'
     5. Fallback -> 'pip'
     """
@@ -299,8 +334,7 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
     managed = get_managed_system()
     if managed:
         return managed.lower().replace(" ", "-")
-    from hermes_constants import is_container
-    if is_container():
+    if _is_official_docker_image():
         return "docker"
     if project_root is None:
         project_root = Path(__file__).parent.parent.resolve()

--- a/tests/hermes_cli/test_pip_install_detection.py
+++ b/tests/hermes_cli/test_pip_install_detection.py
@@ -48,12 +48,59 @@ def test_stamp_file_takes_precedence(tmp_path):
         assert detect_install_method(project_root=tmp_path) == "docker"
 
 
-def test_docker_detected_via_dockerenv(tmp_path):
+def test_official_docker_image_detected_via_build_sha(tmp_path):
+    """The official published image is identified by its baked-in build SHA.
+
+    ``.hermes_build_sha`` is written only by this repo's Dockerfile, so its
+    presence is a reliable "this is the published image" signal even when the
+    container has no ``.git`` tree.
+    """
     with patch("hermes_cli.config.get_managed_system", return_value=None), \
          patch("hermes_cli.config.get_hermes_home", return_value=tmp_path), \
-         patch("hermes_constants.is_container", return_value=True):
+         patch("hermes_cli.build_info.get_build_sha", return_value="a1eaad2f"):
         from hermes_cli.config import detect_install_method
         assert detect_install_method(project_root=tmp_path) == "docker"
+
+
+def test_official_docker_image_detected_via_env(tmp_path):
+    """HERMES_DOCKER_IMAGE=1 is the explicit, fork-friendly published-image signal."""
+    with patch("hermes_cli.config.get_managed_system", return_value=None), \
+         patch("hermes_cli.config.get_hermes_home", return_value=tmp_path), \
+         patch("hermes_cli.build_info.get_build_sha", return_value=None), \
+         patch.dict("os.environ", {"HERMES_DOCKER_IMAGE": "1"}):
+        from hermes_cli.config import detect_install_method
+        assert detect_install_method(project_root=tmp_path) == "docker"
+
+
+def test_generic_container_with_git_is_not_docker(tmp_path):
+    """Regression for #34397: a regular git install inside a user's own
+    container must NOT be classified as the published Docker image —
+    otherwise ``hermes update`` wrongly refuses to update.
+    """
+    (tmp_path / ".git").mkdir()
+    with patch("hermes_cli.config.get_managed_system", return_value=None), \
+         patch("hermes_cli.config.get_hermes_home", return_value=tmp_path), \
+         patch("hermes_cli.build_info.get_build_sha", return_value=None), \
+         patch.dict("os.environ", {}, clear=False), \
+         patch("hermes_constants.is_container", return_value=True):
+        import os
+        os.environ.pop("HERMES_DOCKER_IMAGE", None)
+        from hermes_cli.config import detect_install_method
+        assert detect_install_method(project_root=tmp_path) == "git"
+
+
+def test_generic_container_without_git_is_pip(tmp_path):
+    """A pip install inside a user's own container resolves to 'pip', so
+    ``hermes update`` routes to pip upgrade rather than the docker bail-out.
+    """
+    with patch("hermes_cli.config.get_managed_system", return_value=None), \
+         patch("hermes_cli.config.get_hermes_home", return_value=tmp_path), \
+         patch("hermes_cli.build_info.get_build_sha", return_value=None), \
+         patch("hermes_constants.is_container", return_value=True):
+        import os
+        os.environ.pop("HERMES_DOCKER_IMAGE", None)
+        from hermes_cli.config import detect_install_method
+        assert detect_install_method(project_root=tmp_path) == "pip"
 
 
 def test_recommended_update_command_docker():


### PR DESCRIPTION
## Summary

- `detect_install_method()` no longer reports `"docker"` for *any* container — only for the official published `nousresearch/hermes-agent` image.
- A regular git/pip install running inside a user's own Docker container can now `hermes update` normally again.

## Motivation

Closes #34397.

`detect_install_method()` returned `"docker"` whenever `is_container()` was true. But being inside *some* container is not the same as being the published image — plenty of users run a normal git or pip install inside their own Docker container. After the recent update that routes `"docker"` installs to the `docker pull` guidance, those users hit `✗ hermes update doesn't apply inside the Docker container` and `update` refused to run, even though their checkout could update fine.

The fix matches the reporter's own root-cause suggestion ("pass it as a flag in the actual docker image"): the `"docker"` result is now gated on an explicit published-image signal rather than mere container presence.

A new helper `_is_official_docker_image()` recognizes the official image two ways (most-specific first):

1. **`HERMES_DOCKER_IMAGE=1`** env var — explicit, fork-friendly signal, now set in the official `Dockerfile`.
2. **The baked-in `.hermes_build_sha` marker** — written exclusively by this repo's `Dockerfile` via the `HERMES_GIT_SHA` build-arg (and never present in a source checkout or pip install, since `.dockerignore` excludes `.git`). This makes the fix work even for already-built images that predate the env var.

A generic container with neither marker falls through to the existing `.git`→`git` / fallback→`pip` detection, so `hermes update` keeps working there.

## Verification

- `python3 -m pytest tests/hermes_cli/test_pip_install_detection.py tests/hermes_cli/test_cmd_update_docker.py tests/hermes_cli/test_managed_installs.py` — 22 passed
- `python3 -m pytest tests/hermes_cli/test_cmd_update.py tests/docker/test_dump_build_sha.py` — 21 passed, 1 skipped
- New tests cover: official image via build SHA, official image via env var, **generic container + `.git` → `git` (the #34397 regression)**, generic container + no `.git` → `pip`.
- Updated the pre-existing `test_docker_detected_via_dockerenv` test, which encoded the buggy "any container = docker" behavior, to the corrected semantics.
- Did NOT change the `_secure_file`/`_is_container` permissions logic in `config.py` — that intentionally relaxes chmod inside *any* container and is unrelated to install-method detection.
