### PR TITLE
fix(bluebubbles): refresh stale helper_connected snapshot (#34371)

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -150,6 +150,33 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         res.raise_for_status()
         return res.json()
 
+    async def _helper_is_connected(self) -> bool:
+        """Whether the BB Private API helper is attached, refreshing the
+        cached snapshot if it was False.
+
+        ``_helper_connected`` is sampled once in connect(), but the helper
+        dylib injects into Messages.app a few hundred ms after the server
+        becomes reachable, so a connect() that wins that race caches False
+        forever — silencing typing, read receipts, and private-api reply
+        threading for the whole gateway lifetime (#34371). When the cached
+        value is False we re-poll /server/info once; the instant the helper
+        attaches the snapshot flips True and the early return below stops
+        further polls. A failed poll degrades to the last-known state
+        rather than raising — callers treat False as "skip".
+        """
+        if self._helper_connected:
+            return True
+        if not self._private_api_enabled or not self.client:
+            return False
+        try:
+            info = await self._api_get("/api/v1/server/info")
+            self._helper_connected = bool(
+                (info or {}).get("data", {}).get("helper_connected")
+            )
+        except Exception:
+            pass
+        return self._helper_connected
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -452,7 +479,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
                 "message": chunk,
             }
-            if reply_to and self._private_api_enabled and self._helper_connected:
+            if reply_to and await self._helper_is_connected():
                 payload["method"] = "private-api"
                 payload["selectedMessageGuid"] = reply_to
                 payload["partIndex"] = 0
@@ -603,7 +630,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
-        if not self._private_api_enabled or not self._helper_connected or not self.client:
+        if not await self._helper_is_connected():
             return
         try:
             guid = await self._resolve_chat_guid(chat_id)
@@ -616,7 +643,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             pass
 
     async def stop_typing(self, chat_id: str) -> None:
-        if not self._private_api_enabled or not self._helper_connected or not self.client:
+        if not await self._helper_is_connected():
             return
         try:
             guid = await self._resolve_chat_guid(chat_id)
@@ -633,7 +660,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def mark_read(self, chat_id: str) -> bool:
-        if not self._private_api_enabled or not self._helper_connected or not self.client:
+        # Shares the #34371 cold-boot race — re-poll the stale snapshot so
+        # read receipts aren't silenced for the gateway's lifetime.
+        if not await self._helper_is_connected():
             return False
         try:
             guid = await self._resolve_chat_guid(chat_id)

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -123,6 +123,8 @@ _PHONE_RE = re.compile(r"\+?\d{7,15}")
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
 
 _GUID_CACHE_SIZE = 500  # LRU cap for resolved chat-GUID lookups
+_HELPER_REFRESH_TIMEOUT_SECONDS = 1.0
+_HELPER_REFRESH_COOLDOWN_SECONDS = 2.0
 
 
 def _redact(text: str) -> str:
@@ -202,6 +204,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._runner = None
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
+        self._helper_refresh_lock = asyncio.Lock()
+        self._helper_refresh_after = 0.0
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
 
     # ------------------------------------------------------------------
@@ -257,6 +261,53 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         res = await self.client.post(self._api_url(path), json=payload)
         res.raise_for_status()
         return res.json()
+
+    async def _helper_is_connected(self) -> bool:
+        """Refresh a stale negative helper snapshot without blocking hot paths.
+
+        BlueBubbles can report ``helper_connected=False`` during gateway
+        startup while its macOS helper is still attaching. A one-time snapshot
+        would then disable private-API features for the entire process. Refresh
+        negative snapshots with a short timeout, a cooldown, and single-flight
+        locking; once the helper is observed connected, keep the monotonic
+        positive state.
+        """
+        if not self._private_api_enabled or not self.client:
+            return False
+        if self._helper_connected:
+            return True
+
+        loop = asyncio.get_running_loop()
+        if loop.time() < self._helper_refresh_after:
+            return False
+
+        async with self._helper_refresh_lock:
+            if not self._private_api_enabled or not self.client:
+                return False
+            if self._helper_connected:
+                return True
+            if loop.time() < self._helper_refresh_after:
+                return False
+            try:
+                info = await asyncio.wait_for(
+                    self._api_get("/api/v1/server/info"),
+                    timeout=_HELPER_REFRESH_TIMEOUT_SECONDS,
+                )
+                if bool((info or {}).get("data", {}).get("helper_connected")):
+                    self._helper_connected = True
+                    return True
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug(
+                    "[bluebubbles] helper status refresh failed: %s",
+                    type(exc).__name__,
+                )
+
+            self._helper_refresh_after = (
+                loop.time() + _HELPER_REFRESH_COOLDOWN_SECONDS
+            )
+            return False
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -554,6 +605,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 chunks.append(para)
             else:
                 chunks.extend(self.truncate_message(para, max_length=self.MAX_MESSAGE_LENGTH))
+        use_private_reply = bool(reply_to and await self._helper_is_connected())
         last = SendResult(success=True)
         for chunk in chunks:
             guid = await self._resolve_chat_guid(chat_id)
@@ -572,7 +624,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
                 "message": chunk,
             }
-            if reply_to and self._private_api_enabled and self._helper_connected:
+            if reply_to and use_private_reply:
                 payload["method"] = "private-api"
                 payload["selectedMessageGuid"] = reply_to
                 payload["partIndex"] = 0
@@ -726,28 +778,36 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
-        if not self._private_api_enabled or not self._helper_connected or not self.client:
+        if not await self._helper_is_connected():
+            return
+        client = self.client
+        if client is None:
             return
         try:
             guid = await self._resolve_chat_guid(chat_id)
             if guid:
                 encoded = quote(guid, safe="")
-                await self.client.post(
+                response = await client.post(
                     self._api_url(f"/api/v1/chat/{encoded}/typing"), timeout=5
                 )
+                response.raise_for_status()
         except Exception:
             pass
 
     async def stop_typing(self, chat_id: str) -> None:
-        if not self._private_api_enabled or not self._helper_connected or not self.client:
+        if not await self._helper_is_connected():
+            return
+        client = self.client
+        if client is None:
             return
         try:
             guid = await self._resolve_chat_guid(chat_id)
             if guid:
                 encoded = quote(guid, safe="")
-                await self.client.delete(
+                response = await client.delete(
                     self._api_url(f"/api/v1/chat/{encoded}/typing"), timeout=5
                 )
+                response.raise_for_status()
         except Exception:
             pass
 
@@ -756,15 +816,19 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def mark_read(self, chat_id: str) -> bool:
-        if not self._private_api_enabled or not self._helper_connected or not self.client:
+        if not await self._helper_is_connected():
+            return False
+        client = self.client
+        if client is None:
             return False
         try:
             guid = await self._resolve_chat_guid(chat_id)
             if guid:
                 encoded = quote(guid, safe="")
-                await self.client.post(
+                response = await client.post(
                     self._api_url(f"/api/v1/chat/{encoded}/read"), timeout=5
                 )
+                response.raise_for_status()
                 return True
         except Exception:
             pass

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -698,3 +698,207 @@ class TestBlueBubblesWebhookRegistration:
             adapter._unregister_webhook()
         )
         assert ok is False
+
+
+class TestBlueBubblesTypingIndicator:
+    """Cold-boot race (#34371): ``_helper_connected`` is sampled once at
+    connect() time, but the BB Private API helper injects into Messages.app
+    a few hundred ms after the server becomes reachable. A connect() that
+    wins that race caches False and never refreshes, silencing typing, read
+    receipts, and private-api reply threading for the whole gateway
+    lifetime. The adapter lazily re-polls /server/info while the snapshot is
+    False, so the moment the helper attaches the gate reopens — and stops
+    polling once it's True."""
+
+    @staticmethod
+    def _capturing_client(posts, deletes):
+        class _Resp:
+            def raise_for_status(self):
+                pass
+
+        class _MockClient:
+            async def post(self, url, **kwargs):
+                posts.append(url)
+                return _Resp()
+
+            async def delete(self, url, **kwargs):
+                deletes.append(url)
+                return _Resp()
+
+        return _MockClient()
+
+    @staticmethod
+    def _stub_server_info(adapter, *, helper_connected, poll_log=None):
+        async def _api_get(path):
+            if poll_log is not None:
+                poll_log.append(path)
+            return {"data": {"helper_connected": helper_connected}}
+
+        adapter._api_get = _api_get
+
+    # --- the shared refreshing gate -------------------------------------
+
+    def test_gate_short_circuits_when_already_connected(self, monkeypatch):
+        """Already-attached helper: True without a wasted /server/info poll."""
+        import asyncio
+
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+        adapter.client = object()
+        poll_log = []
+        self._stub_server_info(adapter, helper_connected=True, poll_log=poll_log)
+
+        assert asyncio.run(adapter._helper_is_connected()) is True
+        assert poll_log == []
+
+    def test_gate_refreshes_stale_false_snapshot(self, monkeypatch):
+        """Snapshot False but helper has since attached: re-poll flips it
+        True and persists so later calls short-circuit."""
+        import asyncio
+
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+        adapter.client = object()
+        poll_log = []
+        self._stub_server_info(adapter, helper_connected=True, poll_log=poll_log)
+
+        assert asyncio.run(adapter._helper_is_connected()) is True
+        assert adapter._helper_connected is True
+        assert poll_log == ["/api/v1/server/info"]
+
+    def test_gate_stays_false_when_helper_absent(self, monkeypatch):
+        """Helper genuinely not attached: re-poll confirms False."""
+        import asyncio
+
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+        adapter.client = object()
+        self._stub_server_info(adapter, helper_connected=False)
+
+        assert asyncio.run(adapter._helper_is_connected()) is False
+
+    def test_gate_skips_poll_when_private_api_disabled(self, monkeypatch):
+        """Private API off → no helper possible, don't even poll."""
+        import asyncio
+
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = False
+        adapter._helper_connected = False
+        adapter.client = object()
+        poll_log = []
+        self._stub_server_info(adapter, helper_connected=True, poll_log=poll_log)
+
+        assert asyncio.run(adapter._helper_is_connected()) is False
+        assert poll_log == []
+
+    def test_gate_swallows_poll_errors(self, monkeypatch):
+        """A failing /server/info re-poll must not raise — degrade to the
+        last-known (False) state."""
+        import asyncio
+
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+        adapter.client = object()
+
+        async def _boom(path):
+            raise ConnectionError("server blip")
+
+        adapter._api_get = _boom
+
+        assert asyncio.run(adapter._helper_is_connected()) is False
+
+    # --- consumers reopen once the helper attaches ----------------------
+
+    def test_send_typing_posts_after_helper_attaches(self, monkeypatch):
+        import asyncio
+
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False  # stale snapshot from early connect()
+        self._stub_server_info(adapter, helper_connected=True)
+        posts, deletes = [], []
+        adapter.client = self._capturing_client(posts, deletes)
+
+        asyncio.run(adapter.send_typing("iMessage;-;user@example.com"))
+
+        assert posts and "/typing" in posts[0]
+
+    def test_send_typing_noops_when_helper_truly_absent(self, monkeypatch):
+        """Don't fire typing at a helper that really isn't attached — the
+        re-poll confirms False, so we stay a no-op (no wasted POST)."""
+        import asyncio
+
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+        self._stub_server_info(adapter, helper_connected=False)
+        posts, deletes = [], []
+        adapter.client = self._capturing_client(posts, deletes)
+
+        asyncio.run(adapter.send_typing("iMessage;-;user@example.com"))
+
+        assert not posts
+
+    def test_stop_typing_deletes_after_helper_attaches(self, monkeypatch):
+        import asyncio
+
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+        self._stub_server_info(adapter, helper_connected=True)
+        posts, deletes = [], []
+        adapter.client = self._capturing_client(posts, deletes)
+
+        asyncio.run(adapter.stop_typing("iMessage;-;user@example.com"))
+
+        assert deletes and "/typing" in deletes[0]
+
+    def test_mark_read_posts_after_helper_attaches(self, monkeypatch):
+        """Read receipts share the same cold-boot race — the fix must
+        cover mark_read, not just typing (#34371)."""
+        import asyncio
+
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+        self._stub_server_info(adapter, helper_connected=True)
+        posts, deletes = [], []
+        adapter.client = self._capturing_client(posts, deletes)
+
+        ok = asyncio.run(adapter.mark_read("iMessage;-;user@example.com"))
+
+        assert ok is True
+        assert posts and "/read" in posts[0]
+
+    def test_reply_threading_recovers_after_helper_attaches(self, monkeypatch):
+        """The private-api reply gate also rode the stale snapshot; once
+        the helper attaches, replies regain their threading metadata."""
+        import asyncio
+
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = False
+        adapter.client = object()
+        self._stub_server_info(adapter, helper_connected=True)
+
+        captured = {}
+
+        async def _capture_post(path, payload):
+            captured.update(payload)
+            return {"data": {"guid": "sent-1"}}
+
+        adapter._api_post = _capture_post
+
+        result = asyncio.run(
+            adapter.send(
+                "iMessage;-;user@example.com", "hi", reply_to="orig-guid"
+            )
+        )
+
+        assert result.success is True
+        assert captured.get("method") == "private-api"
+        assert captured.get("selectedMessageGuid") == "orig-guid"

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -482,6 +482,250 @@ class TestBlueBubblesWebhookRegistration:
 
 
 # ---------------------------------------------------------------------------
+# Regression for #34371: BlueBubbles can report helper_connected=False while
+# its macOS helper is still attaching during gateway startup.
+# ---------------------------------------------------------------------------
+
+
+class TestBlueBubblesHelperRefresh:
+    @staticmethod
+    def _enable_private_api(adapter):
+        adapter._private_api_enabled = True
+        adapter.client = object()
+
+    @pytest.mark.asyncio
+    async def test_positive_cache_still_requires_private_api_and_client(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch)
+        adapter._helper_connected = True
+        adapter._private_api_enabled = True
+        adapter.client = None
+
+        assert await adapter._helper_is_connected() is False
+
+        adapter.client = object()
+        adapter._private_api_enabled = False
+        assert await adapter._helper_is_connected() is False
+
+    @pytest.mark.asyncio
+    async def test_negative_snapshot_refreshes_and_caches_success(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        self._enable_private_api(adapter)
+        calls = 0
+
+        async def fake_api_get(path):
+            nonlocal calls
+            calls += 1
+            assert path == "/api/v1/server/info"
+            return {"data": {"helper_connected": True}}
+
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+
+        assert await adapter._helper_is_connected() is True
+        assert await adapter._helper_is_connected() is True
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_negative_refresh_is_cooled_down(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        self._enable_private_api(adapter)
+        results = iter([False, True])
+        calls = 0
+
+        async def fake_api_get(path):
+            nonlocal calls
+            calls += 1
+            return {"data": {"helper_connected": next(results)}}
+
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+
+        assert await adapter._helper_is_connected() is False
+        assert await adapter._helper_is_connected() is False
+        assert calls == 1
+
+        adapter._helper_refresh_after = 0.0
+        assert await adapter._helper_is_connected() is True
+        assert calls == 2
+
+    @pytest.mark.asyncio
+    async def test_cancelled_refresh_propagates_without_cooldown(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        self._enable_private_api(adapter)
+
+        async def fake_api_get(path):
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+
+        with pytest.raises(asyncio.CancelledError):
+            await adapter._helper_is_connected()
+
+        assert adapter._helper_refresh_after == 0.0
+        assert adapter._helper_refresh_lock.locked() is False
+
+    @pytest.mark.asyncio
+    async def test_concurrent_refresh_is_single_flight(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        self._enable_private_api(adapter)
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        calls = 0
+
+        async def fake_api_get(path):
+            nonlocal calls
+            calls += 1
+            entered.set()
+            await release.wait()
+            return {"data": {"helper_connected": True}}
+
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+        tasks = [
+            asyncio.create_task(adapter._helper_is_connected())
+            for _ in range(5)
+        ]
+        await entered.wait()
+        release.set()
+
+        assert await asyncio.gather(*tasks) == [True] * 5
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_negative_refresh_is_single_flight(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        self._enable_private_api(adapter)
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        calls = 0
+
+        async def fake_api_get(path):
+            nonlocal calls
+            calls += 1
+            entered.set()
+            await release.wait()
+            return {"data": {"helper_connected": False}}
+
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+        tasks = [
+            asyncio.create_task(adapter._helper_is_connected())
+            for _ in range(5)
+        ]
+        await entered.wait()
+        release.set()
+
+        assert await asyncio.gather(*tasks) == [False] * 5
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_refresh_restores_typing_stop_and_read_receipt(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        requests = []
+
+        class Response:
+            def raise_for_status(self):
+                return None
+
+        class Client:
+            async def post(self, url, **kwargs):
+                requests.append(("POST", url, kwargs))
+                return Response()
+
+            async def delete(self, url, **kwargs):
+                requests.append(("DELETE", url, kwargs))
+                return Response()
+
+        adapter.client = Client()
+
+        async def fake_api_get(path):
+            return {"data": {"helper_connected": True}}
+
+        async def fake_resolve(chat_id):
+            return "iMessage;+;chat-123"
+
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+
+        await adapter.send_typing("chat")
+        await adapter.stop_typing("chat")
+        assert await adapter.mark_read("chat") is True
+
+        assert [method for method, _, _ in requests] == [
+            "POST",
+            "DELETE",
+            "POST",
+        ]
+        assert requests[0][1].endswith("/typing?password=secret")
+        assert requests[1][1].endswith("/typing?password=secret")
+        assert requests[2][1].endswith("/read?password=secret")
+
+    @pytest.mark.asyncio
+    async def test_http_failure_is_nonfatal_for_typing_and_read(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        adapter._helper_connected = True
+
+        class Response:
+            def raise_for_status(self):
+                raise RuntimeError("server rejected request")
+
+        class Client:
+            async def post(self, url, **kwargs):
+                return Response()
+
+            async def delete(self, url, **kwargs):
+                return Response()
+
+        adapter.client = Client()
+
+        async def fake_resolve(chat_id):
+            return "iMessage;+;chat-123"
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+
+        await adapter.send_typing("chat")
+        await adapter.stop_typing("chat")
+        assert await adapter.mark_read("chat") is False
+
+    @pytest.mark.asyncio
+    async def test_reply_refresh_runs_once_for_all_chunks(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        helper_calls = 0
+        payloads = []
+
+        async def fake_helper_is_connected():
+            nonlocal helper_calls
+            helper_calls += 1
+            return True
+
+        async def fake_resolve(chat_id):
+            return "iMessage;+;chat-123"
+
+        async def fake_api_post(path, payload):
+            payloads.append(payload)
+            return {"data": {"guid": f"message-{len(payloads)}"}}
+
+        monkeypatch.setattr(adapter, "_helper_is_connected", fake_helper_is_connected)
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send(
+            "chat",
+            "first paragraph\n\nsecond paragraph",
+            reply_to="original-message",
+        )
+
+        assert result.success is True
+        assert helper_calls == 1
+        assert len(payloads) == 2
+        assert all(payload["method"] == "private-api" for payload in payloads)
+        assert all(
+            payload["selectedMessageGuid"] == "original-message"
+            for payload in payloads
+        )
+
+
+# ---------------------------------------------------------------------------
 # Regression for #78183: httpx timeout exceptions stringify to "" which
 # defeats _is_timeout_error, causing the plain-text fallback to re-send an
 # already-delivered message (duplicate delivery).
@@ -565,5 +809,3 @@ class TestBlueBubblesTimeoutErrorNormalization:
 
         assert not result.success
         assert "500 Internal Server Error" in (result.error or "")
-
-


### PR DESCRIPTION
## Summary

Fixes #34371, the BlueBubbles cold-start race where a one-time
helper_connected=false snapshot can disable typing indicators, read receipts,
and private-API reply threading for the lifetime of the gateway.

## Fix

Refresh only negative helper snapshots and keep the hot path bounded:

- use a single-flight lock so concurrent consumers issue one server-info query;
- apply a short refresh timeout and a two-second cooldown after a negative or
  failed refresh;
- keep a successful helper observation cached, while still requiring Private
  API to be enabled and a live client to be present;
- calculate helper readiness once per multi-chunk send so reply behavior stays
  consistent across all chunks;
- check typing, stop-typing, and read-receipt HTTP statuses while preserving
  their non-fatal behavior.

This retains the original gate instead of sending private-API requests when the
helper is genuinely unavailable.

## Tests

- BlueBubbles adapter suite and typing timeout contract: 37 passed.
- Ruff: all checks passed.
- ty: no new diagnostics compared with current main; the file retains the same
  nine pre-existing diagnostics.

Coverage includes positive and negative single-flight refreshes, cooldown,
disconnect and Private API gates, cancellation, HTTP failure handling, typing,
stop typing, read receipts, and multi-chunk reply threading.
