### PR TITLE
fix(security): extend /proc read block to maps siblings + auxv + pagemap

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -93,7 +93,7 @@ class TestDevicePathBlocking(unittest.TestCase):
         self.assertFalse(_is_blocked_device_path("/proc/self/fd/3"))
 
     def test_proc_sensitive_pseudo_files_blocked(self):
-        """environ/cmdline/maps under /proc/<pid> must be blocked (issue #4427)."""
+        """environ/cmdline/maps (and maps variants) under /proc/<pid> must be blocked (issue #4427)."""
         for path in (
             "/proc/self/environ",
             "/proc/12345/environ",
@@ -101,6 +101,14 @@ class TestDevicePathBlocking(unittest.TestCase):
             "/proc/99/cmdline",
             "/proc/self/maps",
             "/proc/1/maps",
+            "/proc/self/smaps",
+            "/proc/12345/smaps",
+            "/proc/self/smaps_rollup",
+            "/proc/99/smaps_rollup",
+            "/proc/self/numa_maps",
+            "/proc/1/numa_maps",
+            "/proc/self/mem",
+            "/proc/12345/mem",
         ):
             self.assertTrue(_is_blocked_device(path), f"{path} should be blocked")
 

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -107,6 +107,10 @@ class TestDevicePathBlocking(unittest.TestCase):
             "/proc/99/smaps_rollup",
             "/proc/self/numa_maps",
             "/proc/1/numa_maps",
+            "/proc/self/auxv",
+            "/proc/12345/auxv",
+            "/proc/self/pagemap",
+            "/proc/99/pagemap",
             "/proc/self/mem",
             "/proc/12345/mem",
         ):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -140,10 +140,14 @@ def _is_blocked_device_path(path: str) -> bool:
     # /proc/*/environ, /proc/*/cmdline, /proc/*/maps (and the maps variants
     # smaps, smaps_rollup, numa_maps) can leak secrets, command-line args, and
     # memory layout (ASLR bypass) from the host process (issue #4427).
+    # /proc/*/auxv contains AT_RANDOM (stack canary) and AT_BASE/AT_PHDR
+    # (interpreter/program load addresses) — direct ASLR oracle.
+    # /proc/*/pagemap exposes virtual→physical translations — address leak.
     # /proc/*/mem exposes raw process memory; block it as defense-in-depth even
     # though it requires address knowledge to exploit usefully.
     if normalized.startswith("/proc/") and normalized.endswith(
-        ("/environ", "/cmdline", "/maps", "/smaps", "/smaps_rollup", "/numa_maps", "/mem")
+        ("/environ", "/cmdline", "/maps", "/smaps", "/smaps_rollup",
+         "/numa_maps", "/auxv", "/pagemap", "/mem")
     ):
         return True
     return False

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -137,10 +137,13 @@ def _is_blocked_device_path(path: str) -> bool:
         ("/fd/0", "/fd/1", "/fd/2")
     ):
         return True
-    # /proc/*/environ, /proc/*/cmdline, /proc/*/maps can leak secrets,
-    # command-line args, and memory layout from the host process (issue #4427)
+    # /proc/*/environ, /proc/*/cmdline, /proc/*/maps (and the maps variants
+    # smaps, smaps_rollup, numa_maps) can leak secrets, command-line args, and
+    # memory layout (ASLR bypass) from the host process (issue #4427).
+    # /proc/*/mem exposes raw process memory; block it as defense-in-depth even
+    # though it requires address knowledge to exploit usefully.
     if normalized.startswith("/proc/") and normalized.endswith(
-        ("/environ", "/cmdline", "/maps")
+        ("/environ", "/cmdline", "/maps", "/smaps", "/smaps_rollup", "/numa_maps", "/mem")
     ):
         return True
     return False


### PR DESCRIPTION
Salvage of #32238 (@AhmetArif0) plus a small extension.

## What it fixes
`_is_blocked_device()` in `tools/file_tools.py` previously only matched `endswith(("/environ", "/cmdline", "/maps"))`. The other paths that leak the same ASLR information slipped through:

| Path | Leak | Was blocked? |
|------|------|--------------|
| `/proc/*/smaps` | Superset of maps with full VMA list + addresses | ❌ |
| `/proc/*/smaps_rollup` | Aggregated VMA addresses | ❌ |
| `/proc/*/numa_maps` | VMA dump + NUMA annotations | ❌ |
| `/proc/*/mem` | Raw RW process memory | ❌ |
| `/proc/*/auxv` | AT_RANDOM stack canary + AT_BASE/AT_PHDR load addresses | ❌ |
| `/proc/*/pagemap` | Virtual→physical translation | ❌ |

So `read_file("/proc/self/smaps")` or `/proc/self/auxv` leaked the same ASLR layout that #4609 was supposed to hide.

## Mechanism
Two commits:

1. **@AhmetArif0's commit** — adds smaps / smaps_rollup / numa_maps / mem to the existing endswith tuple. Direct extension of #4609's pattern.
2. **Follow-up commit** — adds auxv + pagemap. The audit flagged these as the glaring miss; auxv is on par with maps for ASLR oracle severity.

Same fragile suffix-tuple pattern as #4609 — works for both `/proc/<pid>/X` and `/proc/<pid>/task/<tid>/X` (endswith catches both). A refactor to a regex/set across all /proc leak vectors (stack, syscall, wchan, kallsyms, etc.) is worth a follow-up but out of scope for closing this immediate gap.

## Validation
- 39/39 tests pass in `tests/tools/test_file_read_guards.py` (PR's 4 new + 4 added in the follow-up)
- E2E: all 9 sensitive /proc paths blocked (environ, cmdline, maps, smaps, smaps_rollup, numa_maps, auxv, pagemap, mem); legit /proc paths (cpuinfo, meminfo, version, status) still readable

Closes #32238.