### PR TITLE
fix(agent): strip schema-foreign keys from max-iterations summary request (#34436)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1283,6 +1283,18 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             agent._copy_reasoning_content_for_api(msg, api_msg)
             for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
                 api_msg.pop(internal_field, None)
+            # Strict OpenAI-compatible gateways (Fireworks-backed OpenCode Go,
+            # Mistral, Moonshot/Kimi) reject any message key outside the Chat
+            # Completions schema. The main loop drops these via
+            # ChatCompletionsTransport.convert_messages(), but the summary path
+            # hand-builds messages and calls chat.completions.create() directly,
+            # bypassing the transport — so mirror that sanitization here:
+            # tool_name (SQLite FTS bookkeeping), the codex_* reasoning carriers,
+            # and every Hermes-internal underscore-prefixed scaffolding key.
+            for schema_foreign in ("tool_name", "codex_reasoning_items", "codex_message_items"):
+                api_msg.pop(schema_foreign, None)
+            for internal_key in [k for k in api_msg if isinstance(k, str) and k.startswith("_")]:
+                api_msg.pop(internal_key, None)
             if _needs_sanitize:
                 agent._sanitize_tool_calls_for_strict_api(api_msg)
             api_messages.append(api_msg)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2754,6 +2754,40 @@ class TestHandleMaxIterations:
         ]
         assert len(stub_ids) >= 1, f"No stub result for assistant tool_call: {stub_ids}"
 
+    def test_summary_strips_strict_schema_foreign_fields(self, agent):
+        """Regression: the max-iterations summary request must NOT carry
+        Chat-Completions-schema-foreign keys — tool_name (SQLite FTS
+        bookkeeping), codex_* reasoning carriers, or internal _-prefixed
+        scaffolding. Strict gateways (Fireworks-backed OpenCode Go, Mistral,
+        Kimi) reject these with 'Extra inputs are not permitted, field:
+        messages[N].tool_name'. The transport's convert_messages() strips
+        them on the main loop; this hand-built summary path must mirror it."""
+        agent.client.chat.completions.create.return_value = _mock_response(content="Summary")
+        agent._cached_system_prompt = "You are helpful."
+        messages = [
+            {"role": "user", "content": "do stuff"},
+            {
+                "role": "assistant",
+                "tool_calls": [{"id": "call_1", "function": {"name": "execute_code", "arguments": "{}"}}],
+                "codex_reasoning_items": [{"id": "rs_1"}],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "result", "tool_name": "execute_code"},
+            {"role": "assistant", "content": "Done.", "_empty_recovery_synthetic": True},
+        ]
+
+        result = agent._handle_max_iterations(messages, 60)
+
+        assert result == "Summary"
+        sent_msgs = agent.client.chat.completions.create.call_args.kwargs.get("messages", [])
+        for m in sent_msgs:
+            assert "tool_name" not in m, m
+            assert "codex_reasoning_items" not in m, m
+            assert "codex_message_items" not in m, m
+            assert not any(isinstance(k, str) and k.startswith("_") for k in m), m
+        # Internal history is untouched — the path copies each message.
+        assert messages[2]["tool_name"] == "execute_code"
+        assert messages[1]["codex_reasoning_items"] == [{"id": "rs_1"}]
+
     def test_summary_omits_provider_preferences_for_non_openrouter(self, agent):
         agent.base_url = "https://api.openai.com/v1"
         agent._base_url_lower = agent.base_url.lower()


### PR DESCRIPTION
## Summary

Fixes #34436. The max-iterations **summary** request leaked Chat-Completions-schema-foreign message keys (`tool_name`, `codex_*`, internal `_`-prefixed scaffolding) to the wire, so strict gateways (Fireworks-backed OpenCode Go, Mistral, Moonshot/Kimi) returned HTTP 400 and a long tool-using session failed to summarise.

## Root cause

The main path sanitizes messages via `ChatCompletionsTransport.convert_messages()`, which drops `tool_name` (SQLite FTS bookkeeping), the `codex_*` reasoning carriers, and all `_`-prefixed keys. But `handle_max_iterations` hand-builds its message list and calls `chat.completions.create()` directly, bypassing the transport — its loop only popped `("reasoning", "finish_reason", "_thinking_prefill")`, so `tool_name` et al. reached the provider.

```
400 - Extra inputs are not permitted, field: 'messages[N].tool_name', value: 'browser_navigate' (×70)
```

## Fix

In the summary path's per-message loop, also drop `tool_name`, `codex_reasoning_items`, `codex_message_items`, and every `_`-prefixed key — mirroring `convert_messages()`. The path already copies each message, so internal history retains the fields for FTS / Codex-fallback.

## Tests

`TestHandleMaxIterations.test_summary_strips_strict_schema_foreign_fields` — asserts the summary request carries none of the schema-foreign keys and that internal history is untouched. Fails on `main` (leaks `codex_reasoning_items` / `tool_name`), passes with the fix.

```
scripts/run_tests.sh tests/run_agent/test_run_agent.py tests/agent/transports/test_chat_completions.py
→ 423/423 passing
scripts/check-windows-footguns.py <changed files> → clean
ruff check <changed files> → clean
```

## Scope

Only the chat_completions summary branch. Untouched: the `codex_responses` / `anthropic_messages` summary branches (different transports with their own sanitization), and the main-loop transport (already correct). No behavior change for permissive providers — they silently ignored the keys before.

## Follow-up

The schema-foreign key set is now duplicated in `convert_messages()` and this summary path. A shared helper would prevent the summary path from silently regressing if a new foreign key is later added to the transport. Left out here to keep the blast radius minimal; happy to extract one if preferred.



## Infographic

![max-iterations-schema-sanitization](https://v3b.fal.media/files/b/0a9c41a4/iZkAmaK2fR4C4Qa_CIqLE_mowbDQVW.png)
