### PR TITLE
fix(qqbot): accept 'dm' session key in approval authorization (#34432)

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1081,7 +1081,11 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        # C2C (private) messages use chat_type="dm" in the session key
+        # built by build_session_key(), but the QQ API reports scene="c2c"
+        # for interaction events.  Accept both so approval clicks work
+        # regardless of which identifier was embedded in the button.
+        if chat_type in ("c2c", "dm"):
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1652,6 +1652,39 @@ class TestDefaultInteractionDispatch:
         assert resolve_calls == []
 
     @pytest.mark.asyncio
+    async def test_approval_click_accepts_dm_session_key(self):
+        """Approval clicks work when the session key uses 'dm' chat_type.
+
+        ``build_session_key()`` produces ``agent:main:qqbot:dm:<openid>``
+        for C2C messages (chat_type="dm"), but the QQ API reports
+        ``chat_type=2`` (scene="c2c") for interaction events.  The
+        authorization check must accept both identifiers.
+        """
+        adapter = self._make_adapter()
+        resolve_calls = []
+
+        def fake_resolve(session_key, choice, resolve_all=False):
+            resolve_calls.append((session_key, choice, resolve_all))
+            return 1
+
+        import tools.approval
+        orig = tools.approval.resolve_gateway_approval
+        tools.approval.resolve_gateway_approval = fake_resolve
+        try:
+            from gateway.platforms.qqbot.keyboards import parse_interaction_event
+            # chat_type=2 → scene="c2c" in InteractionEvent
+            # button_data uses "dm" session key (what build_session_key produces)
+            event = parse_interaction_event({
+                "id": "i", "chat_type": 2, "user_openid": "u-dm-test",
+                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:dm:u-dm-test:allow-once"}},
+            })
+            await adapter._default_interaction_dispatch(event)
+        finally:
+            tools.approval.resolve_gateway_approval = orig
+
+        assert resolve_calls == [("agent:main:qqbot:dm:u-dm-test", "once", False)]
+
+    @pytest.mark.asyncio
     async def test_update_prompt_click_writes_response_file(self, tmp_path, monkeypatch):
         """update_prompt:y click writes 'y' to ~/.hermes/.update_response."""
         adapter = self._make_adapter()


### PR DESCRIPTION
## Summary

When Hermes QQ Bot receives a C2C (private) message and the dangerous-command approval flow triggers, clicking the approval button is always rejected with:

```
WARNING Rejected unauthorized approval click for session agent:main:qqbot:dm:<openid> (operator=<openid>)
```

**Root cause:** `build_session_key()` produces `agent:main:qqbot:dm:<openid>` for C2C messages (chat_type="dm"), but `_is_authorized_interaction_for_session()` only checks `chat_type == "c2c"`. The `"dm"` identifier never matches, so every C2C approval click is rejected.

**Fix:** Accept both `"c2c"` and `"dm"` in the private-message authorization branch, since both identifiers refer to the same C2C conversation type — just from different code paths.

Fixes #34432

## Code Intelligence
- Analyzed: `gateway/platforms/qqbot/adapter.py` `_is_authorized_interaction_for_session()` and `_parse_gateway_session_key()` (line 1082-1085)
- Blast radius: LOW — single condition change in one adapter, backward-compatible (adds `"dm"` to accepted set without removing `"c2c"`)
- Related patterns: `build_session_key()` in `gateway/session.py` (line 631) produces `"dm"` for all DM chat types; `parse_interaction_event()` in `keyboards.py` (line 459) maps QQ API `chat_type=2` → `scene="c2c"`

## Changes
- `gateway/platforms/qqbot/adapter.py`: accept `"dm"` alongside `"c2c"` in `_is_authorized_interaction_for_session`
- `tests/gateway/test_qqbot.py`: regression test `test_approval_click_accepts_dm_session_key` verifying approval clicks work with `"dm"` format session keys

## Testing
```
160 passed in 5.28s (tests/gateway/test_qqbot.py)
```
