### PR TITLE
feat(dashboard): add theme navigation config

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4014,6 +4014,74 @@ _THEME_LAYOUT_VARIANTS = {"standard", "cockpit", "tiled"}
 # practical reskin (the Strike Freedom demo is ~2 KiB).
 _THEME_CUSTOM_CSS_MAX = 32 * 1024
 
+_THEME_NAV_UNLISTED_MODES = {"append", "hide"}
+
+
+def _normalise_theme_nav_item(item: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(item, dict):
+        return None
+    path = item.get("path")
+    if not isinstance(path, str) or not path.startswith("/"):
+        return None
+    out: Dict[str, Any] = {"path": path.strip()}
+    label = item.get("label")
+    if isinstance(label, str) and label.strip():
+        out["label"] = label.strip()
+    icon = item.get("icon")
+    if isinstance(icon, str) and icon.strip():
+        out["icon"] = icon.strip()
+    match_src = item.get("match")
+    if isinstance(match_src, list):
+        matches = [m.strip() for m in match_src if isinstance(m, str) and m.strip().startswith("/")]
+        if matches:
+            out["match"] = matches
+    return out
+
+
+def _normalise_theme_navigation(data: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(data, dict):
+        return None
+    nav: Dict[str, Any] = {}
+
+    primary_src = data.get("primary")
+    if isinstance(primary_src, list):
+        primary = [item for item in (_normalise_theme_nav_item(i) for i in primary_src) if item]
+        if primary:
+            nav["primary"] = primary
+
+    groups_src = data.get("groups")
+    if isinstance(groups_src, list):
+        groups = []
+        for group_src in groups_src:
+            if not isinstance(group_src, dict):
+                continue
+            items_src = group_src.get("items")
+            if not isinstance(items_src, list):
+                continue
+            items = [item for item in (_normalise_theme_nav_item(i) for i in items_src) if item]
+            if not items:
+                continue
+            group_id = group_src.get("id")
+            label = group_src.get("label")
+            clean_group: Dict[str, Any] = {
+                "id": group_id.strip() if isinstance(group_id, str) and group_id.strip() else f"group-{len(groups) + 1}",
+                "label": label.strip() if isinstance(label, str) and label.strip() else "More",
+                "items": items,
+            }
+            groups.append(clean_group)
+        if groups:
+            nav["groups"] = groups
+
+    unlisted = data.get("unlisted")
+    if isinstance(unlisted, str) and unlisted in _THEME_NAV_UNLISTED_MODES:
+        nav["unlisted"] = unlisted
+
+    plugin_label = data.get("pluginSectionLabel")
+    if isinstance(plugin_label, str) and plugin_label.strip():
+        nav["pluginSectionLabel"] = plugin_label.strip()
+
+    return nav or None
+
 
 def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Normalise a user theme YAML into the wire format `ThemeProvider`
@@ -4140,6 +4208,8 @@ def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]
         else "standard"
     )
 
+    navigation = _normalise_theme_navigation(data.get("navigation"))
+
     result: Dict[str, Any] = {
         "name": name,
         "label": data.get("label") or name,
@@ -4149,6 +4219,8 @@ def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]
         "layout": layout,
         "layoutVariant": layout_variant,
     }
+    if navigation:
+        result["navigation"] = navigation
     if color_overrides:
         result["colorOverrides"] = color_overrides
     if assets_out:

--- a/tests/hermes_cli/test_dashboard_loopback_auth_probe_reload.py
+++ b/tests/hermes_cli/test_dashboard_loopback_auth_probe_reload.py
@@ -1,0 +1,25 @@
+"""Regression coverage for loopback dashboard auth probe reload behavior.
+
+The sidebar AuthWidget probes /api/auth/me even when the dashboard is running in
+local loopback mode. In that mode the endpoint legitimately returns a plain 401
+so the widget can hide itself. The stale session-token reload helper must not
+turn that expected 401 into a full-page reload loop, otherwise dashboard plugins
+never finish loading.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+API_TS = Path(__file__).resolve().parents[2] / "web" / "src" / "lib" / "api.ts"
+
+
+def _api_source() -> str:
+    return API_TS.read_text(encoding="utf-8")
+
+
+def test_loopback_auth_me_probe_does_not_trigger_stale_token_reload():
+    source = _api_source()
+
+    assert 'const isLoopbackAuthProbe = url === "/api/auth/me";' in source
+    assert "!window.__HERMES_AUTH_REQUIRED__ && !isLoopbackAuthProbe" in source
+    assert "reloading there causes a dashboard" in source

--- a/tests/hermes_cli/test_dashboard_navigation_config.py
+++ b/tests/hermes_cli/test_dashboard_navigation_config.py
@@ -1,0 +1,95 @@
+"""Regression coverage for theme-driven dashboard navigation grouping.
+
+Cockpit/product themes need a native way to present operator workspaces in the
+left rail without CSS-hiding Hermes admin routes or creating fake redirect tabs.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+APP_TSX = ROOT / "web" / "src" / "App.tsx"
+THEME_TYPES = ROOT / "web" / "src" / "themes" / "types.ts"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_theme_schema_supports_navigation_config():
+    source = _read(THEME_TYPES)
+
+    assert "export interface ThemeNavigationItem" in source
+    assert "export interface ThemeNavigationGroup" in source
+    assert "export interface ThemeNavigationConfig" in source
+    assert "navigation?: ThemeNavigationConfig" in source
+
+
+def test_sidebar_applies_theme_navigation_without_dom_hacks():
+    source = _read(APP_TSX)
+
+    assert "function applyNavigationConfig" in source
+    assert "theme.navigation" in source
+    assert "sidebarNav.groups" in source
+    assert "function SidebarNavGroup" in source
+    assert "MutationObserver" not in source
+    assert "querySelector(\"#app-sidebar\")" not in source
+
+
+def test_nav_items_can_target_hash_workspaces_and_stay_active():
+    source = _read(APP_TSX)
+
+    assert "function isNavItemActive" in source
+    assert "location.hash" in source
+    assert "currentFull === targetFull" in source
+    assert "item.match" in source
+
+
+def test_backend_normalises_navigation_config():
+    from hermes_cli.web_server import _normalise_theme_definition
+
+    theme = _normalise_theme_definition({
+        "name": "cockpit",
+        "label": "Cockpit",
+        "navigation": {
+            "primary": [
+                {"path": "/reinforce#home", "label": "Home", "icon": "Activity", "match": ["/reinforce", "/reinforce#home"]},
+                {"path": "not-a-path", "label": "Bad"},
+            ],
+            "groups": [
+                {
+                    "id": "system",
+                    "label": "System / Settings",
+                    "items": [
+                        {"path": "/sessions", "label": "Sessions", "icon": "MessageSquare"},
+                        {"path": "docs", "label": "Bad docs"},
+                    ],
+                }
+            ],
+            "unlisted": "hide",
+            "pluginSectionLabel": "Extensions",
+        },
+    })
+
+    assert theme is not None
+    nav = theme["navigation"]
+    assert nav["primary"] == [
+        {
+            "path": "/reinforce#home",
+            "label": "Home",
+            "icon": "Activity",
+            "match": ["/reinforce", "/reinforce#home"],
+        }
+    ]
+    assert nav["groups"] == [
+        {
+            "id": "system",
+            "label": "System / Settings",
+            "items": [
+                {"path": "/sessions", "label": "Sessions", "icon": "MessageSquare"},
+            ],
+        }
+    ]
+    assert nav["unlisted"] == "hide"
+    assert nav["pluginSectionLabel"] == "Extensions"

--- a/tests/hermes_cli/test_dashboard_plugin_home_override.py
+++ b/tests/hermes_cli/test_dashboard_plugin_home_override.py
@@ -1,0 +1,75 @@
+"""Regression coverage for dashboard plugin route overrides.
+
+The dashboard discovers plugin manifests asynchronously in the browser. A plugin
+that overrides `/` must not lose the initial home-page navigation to the
+built-in `/sessions` redirect while manifests are still loading.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+APP_TSX = Path(__file__).resolve().parents[2] / "web" / "src" / "App.tsx"
+TITLE_RESOLVER = Path(__file__).resolve().parents[2] / "web" / "src" / "lib" / "resolve-page-title.ts"
+
+
+def _app_source() -> str:
+    return APP_TSX.read_text(encoding="utf-8")
+
+
+def _title_resolver_source() -> str:
+    return TITLE_RESOLVER.read_text(encoding="utf-8")
+
+
+def _section(source: str, start: str, end: str) -> str:
+    start_idx = source.index(start)
+    end_idx = source.index(end, start_idx)
+    return source[start_idx:end_idx]
+
+
+def test_root_redirect_waits_for_plugin_manifest_load_window():
+    """Root overrides must be able to claim `/` before RootRedirect fires."""
+    source = _app_source()
+
+    assert "function RootPending()" in source
+    assert "pluginsLoading ? RootPending : RootRedirect" in source
+    assert "buildRoutes(builtinRoutes, manifests, pluginsLoading)" in source
+
+
+def test_override_plugins_remain_navigable_in_sidebar():
+    """Override plugins should replace/insert nav items instead of disappearing."""
+    source = _app_source()
+    build_nav = _section(source, "function buildNavItems", "/** Split merged nav")
+
+    assert "if (manifest.tab.override) continue;" not in build_nav
+    assert "const itemPath = manifest.tab.override ?? manifest.tab.path" in build_nav
+    assert "const existingIdx = items.findIndex((i) => i.path === itemPath)" in build_nav
+    assert "items.splice(existingIdx, 1, pluginItem)" in build_nav
+
+
+def test_sidebar_plugin_slot_is_rendered_in_cockpit_layout():
+    """Declared `sidebar` slots must not be dead declarations."""
+    source = _app_source()
+
+    assert 'layoutVariant === "cockpit"' in source
+    assert '<PluginSlot name="sidebar" />' in source
+
+
+def test_override_plugin_tab_path_mounts_same_component():
+    """A plugin with both `tab.override` and `tab.path` should render at both routes."""
+    source = _app_source()
+    build_routes = _section(source, "function buildRoutes", "const SIDEBAR_COLLAPSED_KEY")
+
+    assert "const pluginPaths = [m.tab.override, m.tab.path]" in build_routes
+    assert "for (const path of pluginPaths)" in build_routes
+    assert "key: `plugin:${m.name}:${path}`" in build_routes
+
+
+def test_root_title_prefers_plugin_override_before_sessions_default():
+    """A plugin overriding `/` should own the chrome title as well as content."""
+    source = _title_resolver_source()
+
+    plugin_lookup = 'const plugin = pluginTabs.find((p) => p.path === normalized);'
+    sessions_default = 'if (normalized === "/") {'
+    assert source.index(plugin_lookup) < source.index(sessions_default)
+    assert 'return plugin.label;' in source

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -80,12 +80,26 @@ import type { Translations } from "@/i18n/types";
 import { PluginPage, PluginSlot, usePlugins } from "@/plugins";
 import type { PluginManifest } from "@/plugins";
 import { useTheme } from "@/themes";
+import type { ThemeNavigationConfig, ThemeNavigationGroup, ThemeNavigationItem } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
 import { api } from "@/lib/api";
 import type { StatusResponse } from "@/lib/api";
 
 function RootRedirect() {
   return <Navigate to="/sessions" replace />;
+}
+
+function RootPending() {
+  return (
+    <div
+      aria-busy="true"
+      aria-live="polite"
+      className="flex min-h-[12rem] items-center justify-center gap-2 text-sm text-muted-foreground"
+    >
+      <Spinner className="shrink-0" />
+      <span>Loading dashboard plugins…</span>
+    </div>
+  );
 }
 
 function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {
@@ -205,14 +219,20 @@ function buildNavItems(
   const items = [...builtIn];
 
   for (const manifest of manifests) {
-    if (manifest.tab.override) continue;
     if (manifest.tab.hidden) continue;
 
+    const itemPath = manifest.tab.override ?? manifest.tab.path;
     const pluginItem: NavItem = {
-      path: manifest.tab.path,
+      path: itemPath,
       label: manifest.label,
       icon: resolveIcon(manifest.icon),
     };
+
+    const existingIdx = items.findIndex((i) => i.path === itemPath);
+    if (existingIdx >= 0) {
+      items.splice(existingIdx, 1, pluginItem);
+      continue;
+    }
 
     const pos = manifest.tab.position ?? "end";
     if (pos === "end") {
@@ -233,38 +253,135 @@ function buildNavItems(
   return items;
 }
 
+function normalisePathname(pathname: string): string {
+  return pathname.replace(/\/$/, "") || "/";
+}
+
+function splitNavTarget(target: string): { full: string; pathname: string } {
+  try {
+    const url = new URL(target, "http://hermes.local");
+    const pathname = normalisePathname(url.pathname);
+    return {
+      full: `${pathname}${url.search}${url.hash}`,
+      pathname,
+    };
+  } catch {
+    const [rawPath = target] = target.split(/[?#]/, 1);
+    const pathname = normalisePathname(rawPath || "/");
+    return { full: target, pathname };
+  }
+}
+
+function navItemFromThemeSpec(
+  spec: ThemeNavigationItem,
+  knownItems: Map<string, NavItem>,
+): NavItem | null {
+  if (!spec.path || !spec.path.startsWith("/")) return null;
+  const target = splitNavTarget(spec.path);
+  const known = knownItems.get(spec.path) ?? knownItems.get(target.pathname);
+  return {
+    path: spec.path,
+    label: spec.label ?? known?.label ?? (target.pathname.replace(/^\//, "") || "Home"),
+    labelKey: spec.label ? undefined : known?.labelKey,
+    icon: spec.icon ? resolveIcon(spec.icon) : (known?.icon ?? Puzzle),
+    match: spec.match,
+  };
+}
+
+function applyNavigationConfig(
+  mergedItems: NavItem[],
+  builtIn: NavItem[],
+  navigation?: ThemeNavigationConfig,
+): SidebarNavModel {
+  const builtinPaths = new Set(builtIn.map((i) => i.path));
+  const defaultCoreItems: NavItem[] = [];
+  const defaultPluginItems: NavItem[] = [];
+  for (const item of mergedItems) {
+    if (builtinPaths.has(item.path)) defaultCoreItems.push(item);
+    else defaultPluginItems.push(item);
+  }
+
+  if (!navigation || (!navigation.primary && !navigation.groups)) {
+    return { coreItems: defaultCoreItems, groups: [], pluginItems: defaultPluginItems };
+  }
+
+  const knownItems = new Map<string, NavItem>();
+  for (const item of mergedItems) {
+    knownItems.set(item.path, item);
+    knownItems.set(splitNavTarget(item.path).pathname, item);
+  }
+
+  const consumed = new Set<string>();
+  const remember = (item: NavItem) => {
+    const target = splitNavTarget(item.path);
+    consumed.add(item.path);
+    consumed.add(target.pathname);
+    for (const match of item.match ?? []) {
+      const m = splitNavTarget(match);
+      consumed.add(match);
+      consumed.add(m.pathname);
+    }
+  };
+
+  const configuredPrimary = (navigation.primary ?? [])
+    .map((spec) => navItemFromThemeSpec(spec, knownItems))
+    .filter((item): item is NavItem => Boolean(item));
+  configuredPrimary.forEach(remember);
+
+  const groups = (navigation.groups ?? [])
+    .map((group: ThemeNavigationGroup, index) => {
+      const items = group.items
+        .map((spec) => navItemFromThemeSpec(spec, knownItems))
+        .filter((item): item is NavItem => Boolean(item));
+      items.forEach(remember);
+      return {
+        id: group.id || `group-${index + 1}`,
+        label: group.label || "More",
+        items,
+      };
+    })
+    .filter((group) => group.items.length > 0);
+
+  const unlisted = navigation.unlisted ?? "append";
+  const pluginItems = unlisted === "hide"
+    ? []
+    : mergedItems.filter((item) => {
+      const target = splitNavTarget(item.path);
+      return !consumed.has(item.path) && !consumed.has(target.pathname);
+    });
+
+  return {
+    coreItems: configuredPrimary.length > 0 ? configuredPrimary : defaultCoreItems,
+    groups,
+    pluginItems,
+    pluginSectionLabel: navigation.pluginSectionLabel,
+  };
+}
+
 /** Split merged nav into built-in sidebar entries vs plugin tabs, preserving plugin order hints. */
 function partitionSidebarNav(
   builtIn: NavItem[],
   manifests: PluginManifest[],
-): { coreItems: NavItem[]; pluginItems: NavItem[] } {
+  navigation?: ThemeNavigationConfig,
+): SidebarNavModel {
   const merged = buildNavItems(builtIn, manifests);
-  const builtinPaths = new Set(builtIn.map((i) => i.path));
-  const coreItems: NavItem[] = [];
-  const pluginItems: NavItem[] = [];
-  for (const item of merged) {
-    if (builtinPaths.has(item.path)) coreItems.push(item);
-    else pluginItems.push(item);
-  }
-  return { coreItems, pluginItems };
+  return applyNavigationConfig(merged, builtIn, navigation);
 }
 
 function buildRoutes(
   builtinRoutes: Record<string, ComponentType>,
   manifests: PluginManifest[],
+  pluginsLoading: boolean,
 ): Array<{
   key: string;
   path: string;
   element: ReactNode;
 }> {
   const byOverride = new Map<string, PluginManifest>();
-  const addons: PluginManifest[] = [];
 
   for (const m of manifests) {
     if (m.tab.override) {
       byOverride.set(m.tab.override, m);
-    } else {
-      addons.push(m);
     }
   }
 
@@ -273,6 +390,7 @@ function buildRoutes(
     path: string;
     element: ReactNode;
   }> = [];
+  const routedPaths = new Set<string>();
 
   for (const [path, Component] of Object.entries(builtinRoutes)) {
     const om = byOverride.get(path);
@@ -283,30 +401,26 @@ function buildRoutes(
         element: <PluginPage name={om.name} />,
       });
     } else {
-      routes.push({ key: `builtin:${path}`, path, element: <Component /> });
+      const RouteComponent = path === "/" && pluginsLoading ? RootPending : Component;
+      routes.push({ key: `builtin:${path}`, path, element: <RouteComponent /> });
     }
-  }
-
-  for (const m of addons) {
-    if (m.tab.hidden) continue;
-    if (m.tab.path === "/plugins") continue;
-    if (builtinRoutes[m.tab.path]) continue;
-    routes.push({
-      key: `plugin:${m.name}`,
-      path: m.tab.path,
-      element: <PluginPage name={m.name} />,
-    });
+    routedPaths.add(path);
   }
 
   for (const m of manifests) {
-    if (!m.tab.hidden) continue;
-    if (m.tab.path === "/plugins") continue;
-    if (builtinRoutes[m.tab.path] || m.tab.override) continue;
-    routes.push({
-      key: `plugin:hidden:${m.name}`,
-      path: m.tab.path,
-      element: <PluginPage name={m.name} />,
-    });
+    const pluginPaths = [m.tab.override, m.tab.path]
+      .filter((path): path is string => Boolean(path));
+    for (const path of pluginPaths) {
+      if (path === "/plugins") continue;
+      if (routedPaths.has(path)) continue;
+      if (builtinRoutes[path]) continue;
+      routes.push({
+        key: `plugin:${m.name}:${path}`,
+        path,
+        element: <PluginPage name={m.name} />,
+      });
+      routedPaths.add(path);
+    }
   }
 
   return routes;
@@ -389,9 +503,10 @@ export default function App() {
   const builtinRoutes = useMemo(
     () => ({
       ...BUILTIN_ROUTES_CORE,
+      "/": pluginsLoading ? RootPending : RootRedirect,
       ...(embeddedChat ? { "/chat": ChatRouteSink } : {}),
     }),
-    [embeddedChat],
+    [embeddedChat, pluginsLoading],
   );
 
   const builtinNav = useMemo(() => {
@@ -404,21 +519,25 @@ export default function App() {
   }, [embeddedChat, showTokenAnalytics]);
 
   const sidebarNav = useMemo(
-    () => partitionSidebarNav(builtinNav, manifests),
-    [builtinNav, manifests],
+    () => partitionSidebarNav(builtinNav, manifests, theme.navigation),
+    [builtinNav, manifests, theme.navigation],
   );
   const routes = useMemo(
-    () => buildRoutes(builtinRoutes, manifests),
-    [builtinRoutes, manifests],
+    () => buildRoutes(builtinRoutes, manifests, pluginsLoading),
+    [builtinRoutes, manifests, pluginsLoading],
   );
   const pluginTabMeta = useMemo(
     () =>
       manifests
         .filter((m) => !m.tab.hidden)
-        .map((m) => ({
-          path: m.tab.override ?? m.tab.path,
-          label: m.label,
-        })),
+        .flatMap((m) => {
+          const paths = [m.tab.override, m.tab.path]
+            .filter((path): path is string => Boolean(path));
+          return Array.from(new Set(paths)).map((path) => ({
+            path,
+            label: m.label,
+          }));
+        }),
     [manifests],
   );
 
@@ -593,6 +712,17 @@ export default function App() {
                 ))}
               </ul>
 
+              {sidebarNav.groups.map((group) => (
+                <SidebarNavGroup
+                  closeMobile={closeMobile}
+                  collapsed={isDesktopCollapsed}
+                  group={group}
+                  key={group.id}
+                  t={t}
+                  tooltipWarmRef={tooltipWarmRef}
+                />
+              ))}
+
               {sidebarNav.pluginItems.length > 0 && (
                 <div
                   aria-labelledby="hermes-sidebar-plugin-nav-heading"
@@ -607,7 +737,7 @@ export default function App() {
                     )}
                     id="hermes-sidebar-plugin-nav-heading"
                   >
-                    {t.app.pluginNavSection}
+                    {sidebarNav.pluginSectionLabel ?? t.app.pluginNavSection}
                   </span>
 
                   <ul className="flex flex-col">
@@ -632,6 +762,8 @@ export default function App() {
               status={sidebarStatus}
               tooltipWarmRef={tooltipWarmRef}
             />
+
+            {layoutVariant === "cockpit" && <PluginSlot name="sidebar" />}
 
             <div
               className={cn(
@@ -752,6 +884,65 @@ export default function App() {
   );
 }
 
+function SidebarNavGroup({
+  closeMobile,
+  collapsed,
+  group,
+  tooltipWarmRef,
+  t,
+}: SidebarNavGroupProps) {
+  return (
+    <div
+      aria-labelledby={`hermes-sidebar-nav-group-${group.id}`}
+      className="flex flex-col border-t border-current/10 pb-2"
+      role="group"
+    >
+      <span
+        className={cn(
+          "px-5 pt-2.5 pb-1",
+          "font-mondwest text-display text-xs tracking-[0.12em] text-text-tertiary",
+          collapsed && "lg:hidden",
+        )}
+        id={`hermes-sidebar-nav-group-${group.id}`}
+      >
+        {group.label}
+      </span>
+
+      <ul className="flex flex-col">
+        {group.items.map((item) => (
+          <SidebarNavLink
+            closeMobile={closeMobile}
+            collapsed={collapsed}
+            item={item}
+            key={item.path}
+            t={t}
+            tooltipWarmRef={tooltipWarmRef}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function isNavItemActive(
+  item: NavItem,
+  location: { pathname: string; search: string; hash: string },
+): boolean {
+  const currentPath = normalisePathname(location.pathname);
+  const currentFull = `${currentPath}${location.search}${location.hash}`;
+  const target = splitNavTarget(item.path);
+  const targetFull = target.full;
+  if (currentFull === targetFull) return true;
+  for (const match of item.match ?? []) {
+    const candidate = splitNavTarget(match);
+    if (currentFull === candidate.full || currentPath === candidate.pathname) {
+      return true;
+    }
+  }
+  const hasExplicitSubroute = item.path.includes("?") || item.path.includes("#");
+  return !hasExplicitSubroute && currentPath === target.pathname;
+}
+
 function SidebarNavLink({
   closeMobile,
   collapsed,
@@ -760,6 +951,8 @@ function SidebarNavLink({
   t,
 }: SidebarNavLinkProps) {
   const { path, label, labelKey, icon: Icon } = item;
+  const location = useLocation();
+  const active = isNavItemActive(item, location);
   const liRef = useRef<HTMLLIElement>(null);
   const [hovered, setHovered] = useState(false);
 
@@ -777,17 +970,18 @@ function SidebarNavLink({
         to={path}
         end={path === "/sessions"}
         onClick={closeMobile}
+        aria-current={active ? "page" : undefined}
         aria-label={collapsed ? navLabel : undefined}
         onFocus={collapsed ? () => setHovered(true) : undefined}
         onBlur={collapsed ? () => setHovered(false) : undefined}
-        className={({ isActive }) =>
+        className={() =>
           cn(
             "group/nav relative flex items-center gap-3",
             "px-5 py-2.5",
             "font-mondwest text-display uppercase text-sm tracking-[0.12em]",
             "whitespace-nowrap transition-colors cursor-pointer",
             "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-midground",
-            isActive
+            active
               ? "text-midground"
               : "text-text-secondary hover:text-midground",
           )
@@ -796,7 +990,7 @@ function SidebarNavLink({
           clipPath: "var(--component-tab-clip-path)",
         }}
       >
-        {({ isActive }) => (
+        {() => (
           <>
             <Icon className="h-3.5 w-3.5 shrink-0" />
 
@@ -814,7 +1008,7 @@ function SidebarNavLink({
               className="absolute inset-y-0.5 left-1.5 right-1.5 bg-midground opacity-0 pointer-events-none transition-opacity duration-200 group-hover/nav:opacity-5"
             />
 
-            {isActive && (
+            {active && (
               <span
                 aria-hidden
                 className="absolute left-0 top-0 bottom-0 w-px bg-midground"
@@ -1125,13 +1319,35 @@ interface NavItem {
   icon: ComponentType<{ className?: string }>;
   label: string;
   labelKey?: string;
+  match?: string[];
   path: string;
+}
+
+interface SidebarNavGroupModel {
+  id: string;
+  items: NavItem[];
+  label: string;
+}
+
+interface SidebarNavModel {
+  coreItems: NavItem[];
+  groups: SidebarNavGroupModel[];
+  pluginItems: NavItem[];
+  pluginSectionLabel?: string;
 }
 
 interface SidebarIconWithTooltipProps {
   children: ReactNode;
   collapsed: boolean;
   label: string;
+  tooltipWarmRef: TooltipWarmRef;
+}
+
+interface SidebarNavGroupProps {
+  closeMobile: () => void;
+  collapsed: boolean;
+  group: SidebarNavGroupModel;
+  t: Translations;
   tooltipWarmRef: TooltipWarmRef;
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -52,6 +52,7 @@ export async function fetchJSON<T>(
   if (token) {
     setSessionHeader(headers, token);
   }
+  const isLoopbackAuthProbe = url === "/api/auth/me";
   const res = await fetch(`${BASE}${url}`, {
     ...init,
     headers,
@@ -99,12 +100,15 @@ export async function fetchJSON<T>(
     // (``hermes update``, ``hermes gateway restart``, etc.). A tab kept
     // open across the restart holds the OLD token in
     // ``window.__HERMES_SESSION_TOKEN__`` from the previous HTML render,
-    // so every fetch returns 401. The HTML is served ``Cache-Control:
-    // no-store`` so a reload picks up the freshly-injected token. Trigger
-    // that reload once on the first stale-token 401 — gated mode is
-    // handled above, so reaching here in gated mode means a real
-    // middleware failure that should not reload-loop.
-    if (!window.__HERMES_AUTH_REQUIRED__ && !options?.allowUnauthorized) {
+    // so protected fetches return 401. The HTML is served
+    // ``Cache-Control: no-store`` so a reload picks up the freshly-injected
+    // token. Trigger that reload once on the first stale-token 401 — but
+    // do not do this for the optional ``/api/auth/me`` sidebar identity
+    // probe. In loopback mode that endpoint legitimately returns a plain
+    // 401 so AuthWidget can hide itself; reloading there causes a dashboard
+    // reload loop before plugins finish loading. Per-call probes can also
+    // opt out via ``allowUnauthorized``.
+    if (!window.__HERMES_AUTH_REQUIRED__ && !isLoopbackAuthProbe && !options?.allowUnauthorized) {
       let alreadyReloaded = false;
       try {
         alreadyReloaded =

--- a/web/src/lib/resolve-page-title.ts
+++ b/web/src/lib/resolve-page-title.ts
@@ -21,12 +21,12 @@ export function resolvePageTitle(
   pluginTabs: { path: string; label: string }[],
 ): string {
   const normalized = pathname.replace(/\/$/, "") || "/";
-  if (normalized === "/") {
-    return t.app.nav.sessions;
-  }
   const plugin = pluginTabs.find((p) => p.path === normalized);
   if (plugin) {
     return plugin.label;
+  }
+  if (normalized === "/") {
+    return t.app.nav.sessions;
   }
   const key = BUILTIN[normalized];
   if (key) {

--- a/web/src/themes/index.ts
+++ b/web/src/themes/index.ts
@@ -1,3 +1,12 @@
 export { ThemeProvider, useTheme } from "./context";
 export { BUILTIN_THEMES, defaultTheme } from "./presets";
-export type { DashboardTheme, ThemeLayer, ThemeListEntry, ThemeListResponse, ThemePalette } from "./types";
+export type {
+  DashboardTheme,
+  ThemeLayer,
+  ThemeListEntry,
+  ThemeListResponse,
+  ThemeNavigationConfig,
+  ThemeNavigationGroup,
+  ThemeNavigationItem,
+  ThemePalette,
+} from "./types";

--- a/web/src/themes/types.ts
+++ b/web/src/themes/types.ts
@@ -143,6 +143,36 @@ export interface ThemeColorOverrides {
   ring?: string;
 }
 
+export interface ThemeNavigationItem {
+  /** Link target. May include a query string or hash for plugin workspaces. */
+  path: string;
+  /** Display label. When omitted, a known built-in/plugin label is reused. */
+  label?: string;
+  /** Optional Lucide icon name. Unknown names fall back to the plugin icon. */
+  icon?: string;
+  /** Additional active-match targets, also allowing query/hash fragments. */
+  match?: string[];
+}
+
+export interface ThemeNavigationGroup {
+  /** Stable identifier for tests/accessibility. */
+  id: string;
+  /** Visible group label in the sidebar. */
+  label: string;
+  items: ThemeNavigationItem[];
+}
+
+export interface ThemeNavigationConfig {
+  /** Primary operator rail items. When absent, Hermes keeps the default nav. */
+  primary?: ThemeNavigationItem[];
+  /** Secondary grouped route lists, e.g. System / Settings. */
+  groups?: ThemeNavigationGroup[];
+  /** Where routes not declared above should appear. Defaults to `append`. */
+  unlisted?: "append" | "hide";
+  /** Label for any appended plugin/unlisted section. */
+  pluginSectionLabel?: string;
+}
+
 export interface DashboardTheme {
   description: string;
   label: string;
@@ -152,6 +182,8 @@ export interface DashboardTheme {
   layout: ThemeLayout;
   /** Overall shell layout. Defaults to `"standard"` when absent. */
   layoutVariant?: ThemeLayoutVariant;
+  /** Optional native sidebar IA contract for cockpit/product themes. */
+  navigation?: ThemeNavigationConfig;
   /** Named + custom asset URLs exposed as CSS vars on theme apply. */
   assets?: ThemeAssets;
   /** Raw CSS injected as a scoped `<style>` tag on theme apply, cleaned up


### PR DESCRIPTION
## Summary
- Adds theme-driven dashboard navigation configuration for native sidebar grouping.
- Supports primary items, grouped System/Settings links, hash/query workspace targets, plugin section labels, and unlisted-route handling.
- Preserves hidden plugin routes as routable while allowing themes to control sidebar visibility.

## Test Plan
- python3 -m py_compile hermes_cli/web_server.py
- npm --prefix web run build
- /Users/marcus/Developer/ReinforceOS/.venv/bin/python -m pytest -c /dev/null -o cache_dir=/tmp/hermes-pytest-cache tests/hermes_cli/test_dashboard_navigation_config.py tests/hermes_cli/test_dashboard_loopback_auth_probe_reload.py tests/hermes_cli/test_dashboard_plugin_home_override.py -q