### PR TITLE
fix(telegram): restrict markdown link URL schemes to safe allowlist

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4251,9 +4251,17 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # 3) Convert markdown links – escape the display text; inside the URL
         #    only ')' and '\' need escaping per the MarkdownV2 spec.
+        #    Reject dangerous URL schemes (javascript:, data:, vbscript:, etc.)
+        _SAFE_LINK_SCHEMES = {"http", "https", "mailto", "tel", "ftp"}
+
         def _convert_link(m):
             display = _escape_mdv2(m.group(1))
-            url = m.group(2).replace('\\', '\\\\').replace(')', '\\)')
+            url = m.group(2).strip()
+            # Block dangerous schemes
+            scheme = url.split(":", 1)[0].lower() if ":" in url else ""
+            if scheme and scheme not in _SAFE_LINK_SCHEMES:
+                return _ph(f"{display}")
+            url = url.replace('\\', '\\\\').replace(')', '\\)')
             return _ph(f'[{display}]({url})')
 
         text = re.sub(r'\[([^\]]+)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)', _convert_link, text)


### PR DESCRIPTION
## Summary

Block dangerous URL schemes (`javascript:`, `data:`, `vbscript:`, etc.) in Telegram markdown link conversion during MarkdownV2 formatting.

Only `http`, `https`, `mailto`, `tel`, and `ftp` schemes are allowed through. Unsafe links are rendered as plain display text (no clickable link).

## Problem

Telegram markdown link conversion (`_convert_link` in `to_markdown_v2`) passes through any URL scheme without validation. A malicious context file, poisoned web content, or compromised skill could inject a `javascript:` or `data:` URI that Telegram clients might execute when the user taps the link.

## Fix

Added a `_SAFE_LINK_SCHEMES` allowlist (`{"http", "https", "mailto", "tel", "ftp"}`). Links with unrecognized schemes are rendered as plain text (display text only, no clickable URL).

## Testing

- Syntax verified via `python3 -c "import ast; ast.parse(...)"` on modified file
- No new dependencies
- Minimal change: +9 lines in `gateway/platforms/telegram.py`

## Security Impact

Low-risk defense-in-depth. Prevents indirect injection via clickable links in Telegram responses.