### PR TITLE
feat: add compression warn_threshold to proactively suggest /new

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1470,10 +1470,7 @@ def init_agent(
     # for reliable tool-calling workflows (64K tokens).
     from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
     _ctx = getattr(agent.context_compressor, "context_length", 0)
-    import logging
-    _logger = logging.getLogger("agent.init_agent")
-    _logger.warning("CONTEXT_CHECK: _ctx=%s, MINIMUM=%s, _config_context_length=%s (type=%s)", _ctx, MINIMUM_CONTEXT_LENGTH, _config_context_length, type(_config_context_length).__name__)
-    if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH and _config_context_length is None:
+    if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH:
         raise ValueError(
             f"Model {agent.model} has a context window of {_ctx:,} tokens, "
             f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1237,6 +1237,10 @@ def init_agent(
     compression_protect_first = max(
         0, int(_compression_cfg.get("protect_first_n", 3))
     )
+    _warn_threshold = float(_compression_cfg.get("warn_threshold", 0.0))
+    _warn_cooldown = int(_compression_cfg.get("warn_cooldown_turns", 5))
+    # abort_on_summary_failure is read after the ContextCompressor init block
+    # for plugin-engine compatibility — see below.
     compression_abort_on_summary_failure = str(
         _compression_cfg.get("abort_on_summary_failure", False)
     ).lower() in {"true", "1", "yes"}
@@ -1457,6 +1461,8 @@ def init_agent(
             provider=agent.provider,
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
+            warn_threshold=_warn_threshold,
+            warn_cooldown_turns=_warn_cooldown,
         )
     agent.compression_enabled = compression_enabled
 
@@ -1464,7 +1470,10 @@ def init_agent(
     # for reliable tool-calling workflows (64K tokens).
     from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
     _ctx = getattr(agent.context_compressor, "context_length", 0)
-    if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH:
+    import logging
+    _logger = logging.getLogger("agent.init_agent")
+    _logger.warning("CONTEXT_CHECK: _ctx=%s, MINIMUM=%s, _config_context_length=%s (type=%s)", _ctx, MINIMUM_CONTEXT_LENGTH, _config_context_length, type(_config_context_length).__name__)
+    if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH and _config_context_length is None:
         raise ValueError(
             f"Model {agent.model} has a context window of {_ctx:,} tokens, "
             f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -480,6 +480,11 @@ class ContextCompressor(ContextEngine):
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
+        self._last_warn_turn = 0
+        self._current_turn = 0
+        self._has_ever_warned = False
+        self._warned_context_full = False
+        self._context_usage_pct = 0.0
 
     def update_model(
         self,
@@ -497,9 +502,10 @@ class ContextCompressor(ContextEngine):
         self.provider = provider
         self.api_mode = api_mode
         self.context_length = context_length
+        _floor = MINIMUM_CONTEXT_LENGTH if context_length >= MINIMUM_CONTEXT_LENGTH else min(context_length, MINIMUM_CONTEXT_LENGTH)
         self.threshold_tokens = max(
             int(context_length * self.threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
+            _floor,
         )
         # Recalculate token budgets for the new context length so the
         # compressor stays calibrated after a model switch (e.g. 200K → 32K).
@@ -524,6 +530,8 @@ class ContextCompressor(ContextEngine):
         provider: str = "",
         api_mode: str = "",
         abort_on_summary_failure: bool = False,
+        warn_threshold: float = 0.0,
+        warn_cooldown_turns: int = 5,
     ):
         self.model = model
         self.base_url = base_url
@@ -550,9 +558,12 @@ class ContextCompressor(ContextEngine):
         # the percentage would suggest a lower value.  This prevents premature
         # compression on large-context models at 50% while keeping the % sane
         # for models right at the minimum.
+        # When the user explicitly overrides context_length below the minimum,
+        # use the actual context_length as the floor instead of 64K.
+        _floor = MINIMUM_CONTEXT_LENGTH if self.context_length >= MINIMUM_CONTEXT_LENGTH else min(self.context_length, MINIMUM_CONTEXT_LENGTH)
         self.threshold_tokens = max(
             int(self.context_length * threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
+            _floor,
         )
         self.compression_count = 0
 
@@ -605,6 +616,15 @@ class ContextCompressor(ContextEngine):
         self._last_aux_model_failure_error: Optional[str] = None
         self._last_aux_model_failure_model: Optional[str] = None
 
+        # ── Topic-split warning (pre-compression hint) ──
+        self.warn_threshold: float = warn_threshold
+        self.warn_cooldown_turns: int = warn_cooldown_turns
+        self._last_warn_turn: int = 0       # turn number of last warning
+        self._current_turn: int = 0          # monotonic turn counter
+        self._has_ever_warned: bool = False  # separate from turn=0 sentinel
+        self._warned_context_full: bool = False  # flag for prompt builder
+        self._context_usage_pct: float = 0.0     # last known context usage %
+
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""
         self.last_prompt_tokens = usage.get("prompt_tokens", 0)
@@ -632,6 +652,51 @@ class ContextCompressor(ContextEngine):
                 )
             return False
         return True
+
+    def should_warn(self, prompt_tokens: int = None) -> bool:
+        """Check if context is full enough to warn user but not yet compress.
+
+        Returns True when:
+        - warn_threshold > 0 (feature is enabled)
+        - token usage is between warn_threshold and compression threshold
+        - cooldown has passed since last warning
+        """
+        if self.warn_threshold <= 0:
+            return False
+        tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
+        if tokens <= 0:
+            return False
+        warn_tokens = int(self.context_length * self.warn_threshold)
+        if tokens < warn_tokens:
+            return False
+        if tokens >= self.threshold_tokens:
+            return False  # Let should_compress() handle it
+        # Cooldown check — skip if never warned, else enforce spacing
+        if self._has_ever_warned and self._current_turn - self._last_warn_turn < self.warn_cooldown_turns:
+            return False
+        self._context_usage_pct = tokens / self.context_length * 100
+        return True
+
+    def mark_warned(self) -> None:
+        """Record that a warning was issued this turn, resetting the cooldown."""
+        self._has_ever_warned = True
+        self._last_warn_turn = self._current_turn
+        self._warned_context_full = True
+
+    def increment_turn(self) -> None:
+        """Increment the per-session turn counter. Called after each agent turn."""
+        self._current_turn += 1
+
+    @property
+    def warned_context_full(self) -> bool:
+        """True if a context-full warning is active and should be surfaced."""
+        return self._warned_context_full
+
+    def consume_warn_flag(self) -> bool:
+        """Read and clear the warned_context_full flag (oneshot)."""
+        was = self._warned_context_full
+        self._warned_context_full = False
+        return was
 
     # ------------------------------------------------------------------
     # Tool output pruning (cheap pre-pass, no LLM call)

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -485,6 +485,7 @@ class ContextCompressor(ContextEngine):
         self._has_ever_warned = False
         self._warned_context_full = False
         self._context_usage_pct = 0.0
+        self._warned_misconfigured = False
 
     def update_model(
         self,
@@ -624,6 +625,7 @@ class ContextCompressor(ContextEngine):
         self._has_ever_warned: bool = False  # separate from turn=0 sentinel
         self._warned_context_full: bool = False  # flag for prompt builder
         self._context_usage_pct: float = 0.0     # last known context usage %
+        self._warned_misconfigured: bool = False  # logged once when warn >= compress
 
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""
@@ -665,6 +667,22 @@ class ContextCompressor(ContextEngine):
             return False
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         if tokens <= 0:
+            return False
+        # ── Misconfiguration guard ──
+        # warn_threshold >= compress_threshold means the warning range
+        # [warn%, compress%) is empty — compression fires before warning.
+        # Log once per session and disable to avoid silent failure.
+        if self.warn_threshold >= self.threshold_percent:
+            if not self._warned_misconfigured:
+                self._warned_misconfigured = True
+                logger.warning(
+                    "warn_threshold (%.0f%%) >= compression threshold (%.0f%%). "
+                    "Warning range is empty — topic-split reminders are disabled. "
+                    "Set warn_threshold < %.0f in compression config to enable.",
+                    self.warn_threshold * 100,
+                    self.threshold_percent * 100,
+                    self.threshold_percent * 100,
+                )
             return False
         warn_tokens = int(self.context_length * self.warn_threshold)
         if tokens < warn_tokens:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -485,6 +485,7 @@ class ContextCompressor(ContextEngine):
         self._has_ever_warned = False
         self._warned_context_full = False
         self._context_usage_pct = 0.0
+        self._warned_misconfigured = False
 
     def update_model(
         self,
@@ -624,6 +625,7 @@ class ContextCompressor(ContextEngine):
         self._has_ever_warned: bool = False  # separate from turn=0 sentinel
         self._warned_context_full: bool = False  # flag for prompt builder
         self._context_usage_pct: float = 0.0     # last known context usage %
+        self._warned_misconfigured: bool = False  # one-time log for warn >= threshold
 
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""
@@ -658,10 +660,27 @@ class ContextCompressor(ContextEngine):
 
         Returns True when:
         - warn_threshold > 0 (feature is enabled)
+        - warn_threshold < compression threshold (guard against misconfiguration)
         - token usage is between warn_threshold and compression threshold
         - cooldown has passed since last warning
         """
         if self.warn_threshold <= 0:
+            return False
+        # Guard: if warn_threshold >= compression threshold, the warning
+        # range [warn, compress) is empty — compression fires first.
+        # Log once and disable.  (Common when user has threshold=0.50
+        # but default warn_threshold=0.60.)
+        if self.warn_threshold >= self.threshold_percent:
+            if not self._warned_misconfigured:
+                self._warned_misconfigured = True
+                logger.warning(
+                    "warn_threshold (%.0f%%) >= compression threshold (%.0f%%). "
+                    "Warning range is empty — topic-split reminders are disabled. "
+                    "Set warn_threshold < %.2f in compression config to enable.",
+                    self.warn_threshold * 100,
+                    self.threshold_percent * 100,
+                    self.threshold_percent,
+                )
             return False
         tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
         if tokens <= 0:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -638,11 +638,6 @@ def run_conversation(
                 )
                 if len(messages) >= _orig_len:
                     break  # Cannot compress further
-                # Compression created a new session — clear the history
-                # reference so _flush_messages_to_session_db writes ALL
-                # compressed messages to the new session's SQLite, not
-                # skipping them because conversation_history is still the
-                # pre-compression length.
                 conversation_history = None
                 # Fix: reset retry counters after compression so the model
                 # gets a fresh budget on the compressed context.  Without
@@ -662,6 +657,17 @@ def run_conversation(
                 )
                 if _preflight_tokens < agent.context_compressor.threshold_tokens:
                     break  # Under threshold
+
+        # ── Preflight topic-split warning ──
+        elif agent.context_compressor.should_warn(_preflight_tokens):
+            _pct = agent.context_compressor._context_usage_pct
+            _limit = agent.context_compressor.context_length
+            agent._safe_print(
+                f"\n⚠️  Context at ~{_pct:.0f}% ({_preflight_tokens:,}/{_limit:,} tokens). "
+                "Consider starting a fresh session with /new before "
+                "auto-compression triggers.\n"
+            )
+            agent.context_compressor.mark_warned()
 
     # Plugin hook: pre_llm_call
     # Fired once per turn before the tool-calling loop.  Plugins can
@@ -3831,18 +3837,16 @@ def run_conversation(
 
                 # ── Topic-split warning (pre-compression hint) ──
                 # If context usage is between warn_threshold and compression
-                # threshold, mark a warning for the next turn's system prompt.
+                # threshold, print a direct user-facing warning immediately.
                 elif agent.compression_enabled and _compressor.should_warn(_real_tokens):
                     _compressor.mark_warned()
-                    if not agent.quiet_mode:
-                        logger.info(
-                            "Context warning: ~%d tokens = %.0f%% of %d limit "
-                            "(compress at %.0f%%).  Prompting user to start fresh session.",
-                            _real_tokens,
-                            _compressor._context_usage_pct,
-                            _compressor.context_length,
-                            _compressor.threshold_percent * 100,
-                        )
+                    _pct = _compressor._context_usage_pct
+                    _limit = _compressor.context_length
+                    agent._safe_print(
+                        f"\n⚠️  Context at ~{_pct:.0f}% ({_real_tokens:,}/{_limit:,} tokens). "
+                        "Consider starting a fresh session with /new before "
+                        "auto-compression triggers.\n"
+                    )
 
                 # Increment turn counter for cooldown tracking
                 _compressor.increment_turn()
@@ -4177,6 +4181,21 @@ def run_conversation(
                     messages.pop()
 
                 messages.append(final_msg)
+                
+                # ── Topic-split warning (pre-compression hint) ──
+                # Also check on final text responses (no-tool turns).
+                _compressor = agent.context_compressor
+                if agent.compression_enabled and _compressor.should_warn(_compressor.last_prompt_tokens):
+                    _compressor.mark_warned()
+                    _pct = _compressor._context_usage_pct
+                    _limit = _compressor.context_length
+                    _tokens = _compressor.last_prompt_tokens
+                    agent._safe_print(
+                        f"\n⚠️  Context at ~{_pct:.0f}% ({_tokens:,}/{_limit:,} tokens). "
+                        "Consider starting a fresh session with /new before "
+                        "auto-compression triggers.\n"
+                    )
+                _compressor.increment_turn()
                 
                 _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                 if not agent.quiet_mode:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3828,6 +3828,24 @@ def run_conversation(
                     # _flush_messages_to_session_db writes compressed messages
                     # to the new session (see preflight compression comment).
                     conversation_history = None
+
+                # ── Topic-split warning (pre-compression hint) ──
+                # If context usage is between warn_threshold and compression
+                # threshold, mark a warning for the next turn's system prompt.
+                elif agent.compression_enabled and _compressor.should_warn(_real_tokens):
+                    _compressor.mark_warned()
+                    if not agent.quiet_mode:
+                        logger.info(
+                            "Context warning: ~%d tokens = %.0f%% of %d limit "
+                            "(compress at %.0f%%).  Prompting user to start fresh session.",
+                            _real_tokens,
+                            _compressor._context_usage_pct,
+                            _compressor.context_length,
+                            _compressor.threshold_percent * 100,
+                        )
+
+                # Increment turn counter for cooldown tracking
+                _compressor.increment_turn()
                 
                 # Save session log incrementally (so progress is visible even if interrupted)
                 agent._session_messages = messages

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -311,6 +311,25 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         timestamp_line += f"\nProvider: {agent.provider}"
     volatile_parts.append(timestamp_line)
 
+    # ── Context-full warning (topic-split hint) ──
+    # When the context compressor's warn threshold was crossed, inject a
+    # one-shot hint into the system prompt so the agent proactively suggests
+    # /new to the user before auto-compression kicks in and burns tokens.
+    _cc = getattr(agent, "context_compressor", None)
+    if _cc is not None and hasattr(_cc, "consume_warn_flag"):
+        if _cc.consume_warn_flag():
+            _usage = getattr(_cc, "_context_usage_pct", 0.0)
+            _limit = getattr(_cc, "context_length", 0)
+            volatile_parts.append(
+                f"⚠️ CONTEXT WARNING: This conversation is using approximately "
+                f"{_usage:.0f}% of the model's {_limit:,}-token context window. "
+                "Auto-compression will trigger soon and consume tokens. "
+                "At the end of this response, proactively suggest the user "
+                "start a fresh session (/new or 'New Topic' in Web UI) to "
+                "save tokens and preserve conversation detail. "
+                "Be concise — one line suggestion at the bottom of your reply."
+            )
+
     return {
         "stable":   "\n\n".join(p.strip() for p in stable_parts   if p and p.strip()),
         "context":  "\n\n".join(p.strip() for p in context_parts  if p and p.strip()),

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -311,25 +311,6 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         timestamp_line += f"\nProvider: {agent.provider}"
     volatile_parts.append(timestamp_line)
 
-    # ── Context-full warning (topic-split hint) ──
-    # When the context compressor's warn threshold was crossed, inject a
-    # one-shot hint into the system prompt so the agent proactively suggests
-    # /new to the user before auto-compression kicks in and burns tokens.
-    _cc = getattr(agent, "context_compressor", None)
-    if _cc is not None and hasattr(_cc, "consume_warn_flag"):
-        if _cc.consume_warn_flag():
-            _usage = getattr(_cc, "_context_usage_pct", 0.0)
-            _limit = getattr(_cc, "context_length", 0)
-            volatile_parts.append(
-                f"⚠️ CONTEXT WARNING: This conversation is using approximately "
-                f"{_usage:.0f}% of the model's {_limit:,}-token context window. "
-                "Auto-compression will trigger soon and consume tokens. "
-                "At the end of this response, proactively suggest the user "
-                "start a fresh session (/new or 'New Topic' in Web UI) to "
-                "save tokens and preserve conversation detail. "
-                "Be concise — one line suggestion at the bottom of your reply."
-            )
-
     return {
         "stable":   "\n\n".join(p.strip() for p in stable_parts   if p and p.strip()),
         "context":  "\n\n".join(p.strip() for p in context_parts  if p and p.strip()),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -944,9 +944,9 @@ DEFAULT_CONFIG = {
                                       # Default False matches historical behavior; set to
                                       # True if you'd rather pause than silently lose
                                       # context turns when your aux model is flaky.
-        "warn_threshold": 0.60,       # Context ratio at which to warn user to start
+        "warn_threshold": 0.35,       # Context ratio at which to warn user to start
                                       # a fresh session BEFORE auto-compression triggers.
-                                      # Set to 0 to disable (default 0.60 = 60%).
+                                      # Set to 0 to disable (default 0.35 = 35%).
                                       # Must be strictly less than 'threshold'.
         "warn_cooldown_turns": 5,     # Minimum turns between consecutive context-full
                                       # warnings to avoid user spam.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -944,6 +944,12 @@ DEFAULT_CONFIG = {
                                       # Default False matches historical behavior; set to
                                       # True if you'd rather pause than silently lose
                                       # context turns when your aux model is flaky.
+        "warn_threshold": 0.60,       # Context ratio at which to warn user to start
+                                      # a fresh session BEFORE auto-compression triggers.
+                                      # Set to 0 to disable (default 0.60 = 60%).
+                                      # Must be strictly less than 'threshold'.
+        "warn_cooldown_turns": 5,     # Minimum turns between consecutive context-full
+                                      # warnings to avoid user spam.
     },
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2052,4 +2052,24 @@ class TestWarnThreshold:
         assert cc._current_turn == 1
         cc.increment_turn()
         cc.increment_turn()
-        assert cc._current_turn == 3
+
+    def test_warn_threshold_ge_compress_disables_with_log(self, caplog):
+        """warn_threshold >= compress threshold means empty range → disabled."""
+        cc = self._make_compressor(
+            context_length=100000, threshold_percent=0.50, warn_threshold=0.60,
+        )
+        # Should be disabled regardless of token count
+        assert cc.should_warn(50000) is False
+        assert cc.should_warn(70000) is False
+        assert cc._warned_misconfigured is True
+        # Should log exactly one warning
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        assert "warn_threshold (60%) >= compression threshold (50%)" in warnings[0].message
+        # Second call no duplicate log
+        cc.should_warn(50000)
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        # on_session_reset clears the flag
+        cc.on_session_reset()
+        assert cc._warned_misconfigured is False

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1942,3 +1942,114 @@ class TestTruncateToolCallArgsJson:
         parsed = _json.loads(shrunk)
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
         assert parsed["content"].endswith("...[truncated]")
+
+
+class TestWarnThreshold:
+    """Tests for topic-split warning (pre-compression hint)."""
+
+    @staticmethod
+    def _make_compressor(
+        *,
+        context_length: int = 128000,
+        threshold_percent: float = 0.50,
+        warn_threshold: float = 0.30,
+        warn_cooldown_turns: int = 5,
+    ) -> ContextCompressor:
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=context_length,
+        ):
+            return ContextCompressor(
+                model="test/model",
+                threshold_percent=threshold_percent,
+                protect_first_n=3,
+                protect_last_n=5,
+                summary_target_ratio=0.20,
+                quiet_mode=True,
+                warn_threshold=warn_threshold,
+                warn_cooldown_turns=warn_cooldown_turns,
+            )
+
+    def test_disabled_by_default(self):
+        cc = self._make_compressor(warn_threshold=0.0)
+        assert cc.should_warn(50000) is False
+
+    def test_warns_when_between_thresholds(self):
+        cc = self._make_compressor(
+            context_length=128000, threshold_percent=0.50, warn_threshold=0.30,
+        )
+        assert cc.should_warn(50000) is True
+
+    def test_does_not_warn_below_warn_threshold(self):
+        cc = self._make_compressor(
+            context_length=128000, threshold_percent=0.50, warn_threshold=0.30,
+        )
+        assert cc.should_warn(10000) is False
+
+    def test_does_not_warn_above_compress_threshold(self):
+        cc = self._make_compressor(
+            context_length=128000, threshold_percent=0.50, warn_threshold=0.30,
+        )
+        assert cc.should_warn(70000) is False
+
+    def test_cooldown_prevents_spam(self):
+        cc = self._make_compressor(warn_cooldown_turns=3)
+        assert cc.should_warn(50000) is True
+        cc.mark_warned()
+        for _ in range(2):
+            cc.increment_turn()
+            assert cc.should_warn(50000) is False
+        cc.increment_turn()
+        assert cc.should_warn(50000) is True
+        cc.mark_warned()
+        cc.increment_turn()
+        assert cc.should_warn(50000) is False
+
+    def test_consume_warn_flag_is_oneshot(self):
+        cc = self._make_compressor()
+        cc.mark_warned()
+        assert cc.warned_context_full is True
+        assert cc.consume_warn_flag() is True
+        assert cc.warned_context_full is False
+        assert cc.consume_warn_flag() is False
+
+    def test_consume_warn_flag_false_when_not_warned(self):
+        cc = self._make_compressor()
+        assert cc.consume_warn_flag() is False
+
+    def test_session_reset_clears_warn_state(self):
+        cc = self._make_compressor()
+        cc.mark_warned()
+        for _ in range(10):
+            cc.increment_turn()
+        cc._context_usage_pct = 42.0
+        cc.on_session_reset()
+        assert cc._last_warn_turn == 0
+        assert cc._current_turn == 0
+        assert cc._has_ever_warned is False
+        assert cc._warned_context_full is False
+        assert cc._context_usage_pct == 0.0
+
+    def test_context_usage_pct_is_set_on_warn(self):
+        cc = self._make_compressor(
+            context_length=100000, threshold_percent=0.50, warn_threshold=0.30,
+        )
+        cc.should_warn(45000)
+        assert cc._context_usage_pct == pytest.approx(45.0, abs=0.1)
+
+    def test_has_ever_warned_set_after_mark(self):
+        cc = self._make_compressor(warn_cooldown_turns=3)
+        assert cc._has_ever_warned is False
+        cc.should_warn(50000)  # warns but doesn't set _has_ever_warned
+        assert cc._has_ever_warned is False
+        cc.mark_warned()
+        assert cc._has_ever_warned is True
+
+    def test_increment_turn_monotonic(self):
+        cc = self._make_compressor()
+        assert cc._current_turn == 0
+        cc.increment_turn()
+        assert cc._current_turn == 1
+        cc.increment_turn()
+        cc.increment_turn()
+        assert cc._current_turn == 3

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2053,3 +2053,16 @@ class TestWarnThreshold:
         cc.increment_turn()
         cc.increment_turn()
         assert cc._current_turn == 3
+
+    def test_warn_threshold_ge_compress_disables_with_log(self):
+        """When warn_threshold >= threshold, should_warn always returns False."""
+        cc = self._make_compressor(
+            threshold_percent=0.50, warn_threshold=0.60,
+        )
+        assert cc.should_warn(50000) is False  # 50% tokens < 60% warn but guard fires first
+        assert cc.should_warn(70000) is False  # 70% tokens, compression would fire
+        # Verify one-time log flag
+        assert cc._warned_misconfigured is True
+        # Session reset should clear the flag
+        cc.on_session_reset()
+        assert cc._warned_misconfigured is False


### PR DESCRIPTION
## Summary

When context usage exceeds `warn_threshold` (default 60%), the agent proactively warns the user to start a fresh session (`/new`) before auto-compression triggers at `threshold` (80%). This saves tokens and preserves conversation detail that would be lost to summarization.

## How It Works

