### PR TITLE
fix(tools): make _last_resolved_tool_names per-context (#34442)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -21,9 +21,11 @@ Public API (signatures preserved from the original 2,400-line version):
 """
 
 import os
+import sys
 import json
 import re
 import asyncio
+import contextvars
 import logging
 import threading
 import time
@@ -210,7 +212,20 @@ TOOLSET_REQUIREMENTS: Dict[str, dict] = registry.get_toolset_requirements()
 
 # Resolved tool names from the last get_tool_definitions() call.
 # Used by code_execution_tool to know which tools are available in this session.
-_last_resolved_tool_names: List[str] = []
+#
+# Concurrency (issue #34442): this is per-context, NOT process-global. When
+# two sessions run concurrently in the same gateway process (e.g. two
+# Telegram/Feishu users messaging from different chats), each asyncio task
+# carries its own copy via a ContextVar, so session A's get_tool_definitions()
+# no longer clobbers session B's resolved tool list. Reads and assignments of
+# the module attribute ``model_tools._last_resolved_tool_names`` are routed
+# through the ContextVar transparently (see the PEP 562 ``__getattr__`` and the
+# module ``__setattr__`` proxy at the bottom of this file), so every existing
+# caller — including delegate_tool.py's save/restore and the test suite —
+# keeps working unchanged while gaining per-context isolation.
+_last_resolved_tool_names_var: "contextvars.ContextVar[List[str]]" = (
+    contextvars.ContextVar("_last_resolved_tool_names", default=[])
+)
 
 
 # =============================================================================
@@ -305,9 +320,11 @@ def get_tool_definitions(
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:
             # Update _last_resolved_tool_names so downstream callers see
-            # consistent state even on a cache hit.
-            global _last_resolved_tool_names
-            _last_resolved_tool_names = [t["function"]["name"] for t in cached]
+            # consistent state even on a cache hit. Set the per-context
+            # ContextVar (issue #34442) so concurrent sessions stay isolated.
+            _last_resolved_tool_names_var.set(
+                [t["function"]["name"] for t in cached]
+            )
             # Return a shallow copy of the list but share the dict references —
             # schemas are treated as read-only by all known callers.
             return list(cached)
@@ -466,8 +483,9 @@ def _compute_tool_definitions(
         else:
             print("🛠️  No tools selected (all filtered out or unavailable)")
 
-    global _last_resolved_tool_names
-    _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
+    _last_resolved_tool_names_var.set(
+        [t["function"]["name"] for t in filtered_tools]
+    )
 
     # Sanitize schemas for broad backend compatibility. llama.cpp's
     # json-schema-to-grammar converter (used by its OAI server to build
@@ -832,7 +850,10 @@ def handle_function_call(
         if function_name == "execute_code":
             # Prefer the caller-provided list so subagents can't overwrite
             # the parent's tool set via the process-global.
-            sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
+            sandbox_enabled = (
+                enabled_tools if enabled_tools is not None
+                else _last_resolved_tool_names_var.get()
+            )
             result = registry.dispatch(
                 function_name, function_args,
                 task_id=task_id,
@@ -921,3 +942,50 @@ def check_toolset_requirements() -> Dict[str, bool]:
 def check_tool_availability(quiet: bool = False) -> Tuple[List[str], List[dict]]:
     """Return (available_toolsets, unavailable_info)."""
     return registry.check_tool_availability(quiet=quiet)
+
+
+# =============================================================================
+# Per-context _last_resolved_tool_names proxy  (issue #34442)
+# =============================================================================
+#
+# Historically ``_last_resolved_tool_names`` was a process-global ``list``.
+# That is a race condition: two sessions running concurrently in one gateway
+# process overwrite each other's resolved tool list, so a tool call from
+# session A can be checked against session B's tool set.
+#
+# We back the attribute with a ContextVar (declared above) so each asyncio
+# task / session gets its own copy. To avoid touching the ~9 call sites in
+# delegate_tool.py, the test suite, and code_execution that read or assign
+# ``model_tools._last_resolved_tool_names`` directly, we route attribute
+# access through the ContextVar transparently:
+#
+#   * reads  -> ``__getattr__`` (PEP 562) returns the current context's value
+#   * writes -> a ``ModuleType`` subclass ``__setattr__`` updates the ContextVar
+#
+# Net effect: every existing caller keeps using the plain attribute and gets
+# per-context isolation for free; nothing else in the module changes.
+
+from types import ModuleType as _ModuleType
+
+
+class _ModelToolsModule(_ModuleType):
+    """Module subclass that proxies ``_last_resolved_tool_names`` through the
+    per-context ContextVar so concurrent sessions stay isolated (#34442)."""
+
+    def __getattr__(self, name):  # only called when normal lookup misses
+        if name == "_last_resolved_tool_names":
+            return _last_resolved_tool_names_var.get()
+        raise AttributeError(
+            f"module {self.__name__!r} has no attribute {name!r}"
+        )
+
+    def __setattr__(self, name, value):
+        if name == "_last_resolved_tool_names":
+            _last_resolved_tool_names_var.set(value)
+            return
+        super().__setattr__(name, value)
+
+
+# Swap this module's type so the proxy above takes effect for the live module
+# object that every importer shares.
+sys.modules[__name__].__class__ = _ModelToolsModule

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -510,6 +510,54 @@ class TestToolNamePreservation(unittest.TestCase):
         self.assertEqual(captured["saved"], expected_tools)
 
 
+class TestLastResolvedToolNamesConcurrency(unittest.TestCase):
+    """Regression for #34442: model_tools._last_resolved_tool_names must be
+    per-context, not process-global, so concurrent sessions in one gateway
+    process don't clobber each other's resolved tool list."""
+
+    def test_attribute_read_write_roundtrip(self):
+        """The attribute is still readable/assignable like a plain list, so
+        all existing callers (delegate save/restore, tests) keep working."""
+        import model_tools
+
+        model_tools._last_resolved_tool_names = ["terminal", "read_file"]
+        self.assertEqual(
+            model_tools._last_resolved_tool_names, ["terminal", "read_file"]
+        )
+        # Save/restore pattern used by delegate_tool.py around subagents.
+        saved = list(model_tools._last_resolved_tool_names)
+        model_tools._last_resolved_tool_names = ["child_only"]
+        self.assertEqual(model_tools._last_resolved_tool_names, ["child_only"])
+        model_tools._last_resolved_tool_names = list(saved)
+        self.assertEqual(
+            model_tools._last_resolved_tool_names, ["terminal", "read_file"]
+        )
+
+    def test_concurrent_sessions_do_not_clobber_each_other(self):
+        """Two concurrent asyncio tasks each set their own tool list and must
+        continue to observe their own value across an await boundary."""
+        import asyncio
+        import model_tools
+
+        async def session(tools, hold):
+            model_tools._last_resolved_tool_names = tools
+            # Yield control so the other session runs and sets its own list.
+            await asyncio.sleep(hold)
+            return list(model_tools._last_resolved_tool_names)
+
+        async def run():
+            return await asyncio.gather(
+                session(["toolA1", "toolA2"], 0.02),
+                session(["toolB1"], 0.01),
+            )
+
+        seen_a, seen_b = asyncio.run(run())
+        # Before the fix, session A would observe session B's list (or vice
+        # versa) because the value was a single process-global.
+        self.assertEqual(seen_a, ["toolA1", "toolA2"])
+        self.assertEqual(seen_b, ["toolB1"])
+
+
 class TestDelegateObservability(unittest.TestCase):
     """Tests for enriched metadata returned by _run_single_child."""
 


### PR DESCRIPTION
## Summary

- Make `model_tools._last_resolved_tool_names` per-context (backed by a `ContextVar`) instead of a process-global list.
- Fixes the race where two concurrent sessions in one gateway process clobber each other's resolved tool list, which can cause valid tool calls to be rejected as "tool not available".

## Motivation

Closes #34442.

`_last_resolved_tool_names` (model_tools.py:213) was a module-level `List[str]`. When two sessions run concurrently in the same gateway process (e.g. two Telegram/Feishu users messaging from different chats), each session's `get_tool_definitions()` overwrites this global, so session A's `handle_function_call()` can check against session B's tool list. The existing `delegate_tool.py` save/restore only covers the delegation chain within a single session, not concurrent top-level sessions (as the issue notes).

This implements the issue's suggested **Option A**: a `ContextVar[List[str]]`, so each asyncio task / session carries its own copy.

To keep the fix surgical, the module attribute `model_tools._last_resolved_tool_names` is preserved as a transparently-proxied read/write surface (PEP 562 `__getattr__` + a `ModuleType` subclass `__setattr__` that route through the `ContextVar`). That means the ~9 existing call sites in `delegate_tool.py`, `code_execution`, and the test suite that read or assign the attribute directly keep working unchanged — they simply gain per-context isolation. No public signature changes.

## Verification

- `python3 -m pytest tests/tools/test_delegate.py` — 134 passed, 1 deselected (the deselected `test_heartbeat_does_not_trip_idle_stale_while_inside_tool` is a pre-existing wall-clock timing flake that also fails on clean `origin/main` without this change).
- New tests in `tests/tools/test_delegate.py::TestLastResolvedToolNamesConcurrency`:
  - `test_attribute_read_write_roundtrip` — attribute still behaves like a plain list (incl. the delegate save/restore pattern).
  - `test_concurrent_sessions_do_not_clobber_each_other` — two concurrent asyncio tasks each retain their own tool list across an `await` boundary (fails before this change).
- Existing `TestToolNamePreservation` (delegate save/restore) — still passes.
- `python3 -m py_compile model_tools.py` — clean.

## Did NOT change

- The `enabled_tools` parameter on `handle_function_call()` remains the preferred path for `execute_code`; the per-context value is still only the fallback, exactly as before.
- `delegate_tool.py` save/restore logic is untouched (it now restores into the calling context, which is the correct scope).
