### PR TITLE
fix(ntfy): prevent echo loop by deduplicating outgoing message IDs (#34446)

### DIFF
--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -408,6 +408,12 @@ class NtfyAdapter(BasePlatformAdapter):
                     returned_id = data.get("id") or uuid.uuid4().hex[:12]
                 except Exception:
                     returned_id = uuid.uuid4().hex[:12]
+                # Prevent echo loop: when publish_topic == subscribe_topic,
+                # ntfy echoes the agent's own reply back as an incoming
+                # message.  Register the outgoing message ID in the dedup
+                # set so _on_message() skips the echo.
+                if publish_topic == self._topic:
+                    self._seen_messages[returned_id] = time.time()
                 return SendResult(success=True, message_id=returned_id)
             body_text = resp.text
             logger.warning("[%s] Send failed HTTP %d: %s", self.name, resp.status_code, body_text[:200])

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -492,6 +492,45 @@ class TestSend:
 # ---------------------------------------------------------------------------
 
 
+
+    def test_send_registers_outgoing_id_for_echo_prevention(self):
+        """When publish_topic == subscribe_topic, the outgoing message ID
+        should be registered in the dedup set so that the echoed message
+        from ntfy is skipped by _on_message()."""
+        adapter = self._make_adapter(topic="hermes-in")  # publish_topic falls back to topic
+        assert adapter._publish_topic == "hermes-in"
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"id": "echo-test-id"}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        adapter._http_client = mock_client
+
+        result = _run(adapter.send("hermes-in", "Hello!"))
+        assert result.success is True
+        assert result.message_id == "echo-test-id"
+        # The outgoing ID must be in the dedup set
+        assert "echo-test-id" in adapter._seen_messages
+
+    def test_send_does_not_register_id_when_topics_differ(self):
+        """When publish_topic != subscribe_topic, no echo is possible,
+        so the outgoing ID should NOT be added to the dedup set."""
+        adapter = self._make_adapter(topic="hermes-in", publish_topic="hermes-out")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"id": "no-echo-id"}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        adapter._http_client = mock_client
+
+        result = _run(adapter.send("hermes-in", "Hello!"))
+        assert result.success is True
+        assert "no-echo-id" not in adapter._seen_messages
+
 class TestOnMessage:
 
     def _make_adapter(self):


### PR DESCRIPTION
## What does this PR do?

Prevents an infinite echo loop in the ntfy platform adapter. When `publish_topic` equals the subscribe topic (the default), ntfy echoes the agent's own replies back as incoming messages. The adapter then processes each echo as new user input, triggering another reply — an infinite loop. The fix registers outgoing message IDs in the existing dedup set so echoed messages are skipped.

## Related Issue

Fixes #34446

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/ntfy/adapter.py`: After a successful send, register the outgoing message ID in `_seen_messages` when `publish_topic == subscribe_topic`, so `_is_duplicate()` catches the echoed message
- `tests/gateway/test_ntfy_plugin.py`: Two new tests — one verifying the echo ID is registered when topics match, one verifying it is NOT registered when topics differ

## How to Test

1. Configure ntfy with the same topic for both subscribe and publish (the default behavior)
2. Send a message via ntfy — the agent should reply exactly once without looping
3. Run `pytest tests/gateway/test_ntfy_plugin.py -q` — all 80 tests should pass
4. Verify that when `publish_topic != subscribe_topic`, outgoing IDs are NOT added to the dedup set (no unnecessary dedup pollution)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_ntfy_plugin.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/platforms/ntfy/adapter.py:NtfyAdapter.send()` (caller: gateway message dispatch, cron delivery)
- Blast radius: LOW — isolated to ntfy adapter; no cross-module side effects
- Related patterns: reuses existing `_seen_messages` / `_is_duplicate()` dedup mechanism; same pattern used for inbound dedup (line 360-370)
