### PR TITLE
feat(tts): add pitch and ffmpeg post-processing to edge provider

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -904,15 +904,76 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
     edge_config = tts_config.get("edge", {})
     voice = edge_config.get("voice", DEFAULT_EDGE_VOICE)
     speed = float(edge_config.get("speed", tts_config.get("speed", 1.0)))
+    # Pitch shift in Hz. Accepts int/float (e.g. -6 -> "-6Hz") or string ("+8Hz", "-6Hz", "+0%").
+    pitch_raw = edge_config.get("pitch", tts_config.get("pitch"))
 
     kwargs = {"voice": voice}
     if speed != 1.0:
         pct = round((speed - 1.0) * 100)
         kwargs["rate"] = f"{pct:+d}%"
+    if pitch_raw is not None and pitch_raw != "" and pitch_raw != 0:
+        pitch_str: Optional[str] = None
+        if isinstance(pitch_raw, (int, float)):
+            pitch_str = f"{int(pitch_raw):+d}Hz"
+        else:
+            raw = str(pitch_raw).strip()
+            # Already a valid edge-tts pitch like "+8Hz" or "-6Hz"
+            if re.fullmatch(r"[+-]\d+Hz", raw):
+                pitch_str = raw
+            else:
+                # Numeric string like "-6", "8", "+8" → coerce to "<sign>NHz"
+                try:
+                    pitch_str = f"{int(float(raw)):+d}Hz"
+                except (TypeError, ValueError):
+                    logger.warning("Ignoring invalid tts.edge.pitch=%r", pitch_raw)
+        if pitch_str:
+            kwargs["pitch"] = pitch_str
 
     communicate = _edge_tts.Communicate(text, **kwargs)
     await communicate.save(output_path)
+
+    # Optional ffmpeg post-processing (e.g. EQ, reverb). Configure via
+    # tts.postprocess.ffmpeg_filter (global) or tts.edge.postprocess.ffmpeg_filter
+    # (edge-specific). Falls back silently if ffmpeg is unavailable.
+    postprocess_cfg = (
+        edge_config.get("postprocess")
+        or tts_config.get("postprocess")
+        or {}
+    )
+    ffmpeg_filter = postprocess_cfg.get("ffmpeg_filter") if isinstance(postprocess_cfg, dict) else None
+    if ffmpeg_filter:
+        try:
+            _apply_ffmpeg_filter(output_path, ffmpeg_filter)
+        except Exception as exc:  # pragma: no cover - best-effort post-fx
+            logger.warning("TTS post-processing failed (%s); using raw output", exc)
+
     return output_path
+
+
+def _apply_ffmpeg_filter(path: str, ffmpeg_filter: str) -> None:
+    """Apply an ffmpeg audio filter chain in-place to ``path``.
+
+    Resolves ffmpeg from PATH first, then falls back to the ``imageio-ffmpeg``
+    bundled binary if installed. Raises FileNotFoundError if neither is found.
+    """
+    ffmpeg_bin = shutil.which("ffmpeg")
+    if not ffmpeg_bin:
+        try:
+            import imageio_ffmpeg
+            ffmpeg_bin = imageio_ffmpeg.get_ffmpeg_exe()
+        except ImportError:
+            raise FileNotFoundError(
+                "ffmpeg not found. Install via `brew install ffmpeg` "
+                "or `pip install imageio-ffmpeg` to enable tts.postprocess."
+            )
+    tmp_out = f"{path}.fx.tmp{os.path.splitext(path)[1]}"
+    subprocess.run(
+        [ffmpeg_bin, "-y", "-i", path, "-af", ffmpeg_filter, tmp_out],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    os.replace(tmp_out, path)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Adds two new knobs to the Edge TTS provider so users can dial in character voices without writing custom code:

- **`tts.edge.pitch`** (or top-level `tts.pitch`) — shifts the voice pitch in Hz. Accepts `int`/`float` (e.g. `-6` → `"-6Hz"`), numeric strings (`"-6"`, `"+8"`), or pre-formatted edge-tts values (`"+8Hz"`). Forwarded to `edge_tts.Communicate` via its native `pitch` parameter.
- **`tts.edge.postprocess.ffmpeg_filter`** (or top-level `tts.postprocess.ffmpeg_filter`) — applies an arbitrary `ffmpeg -af` filter chain to the generated audio (EQ, reverb, compression, etc.). Resolves `ffmpeg` from `PATH` first, then falls back to the bundled binary from the optional `imageio-ffmpeg` package.

## Motivation

The current Edge provider exposes only `voice` and `speed`. For non-English voice work (e.g. crafting a Jarvis-style Russian narrator from `ru-RU-DmitryNeural`) pitch and a bit of EQ/reverb make a huge difference, but today you have to wrap the tool in a custom shell pipeline. These two fields move that capability into config.

## Example

```yaml
tts:
  provider: edge
  edge:
    voice: ru-RU-DmitryNeural
    speed: 1.35
    pitch: -6
    postprocess:
      # warm low-end + tamed highs, no reverb
      ffmpeg_filter: "equalizer=f=200:t=q:w=1:g=3,equalizer=f=6000:t=q:w=1:g=-4"
```

## Compatibility / dependencies

- **No new hard dependencies.** `imageio-ffmpeg` is imported lazily and only when a filter is configured.
- If neither system `ffmpeg` nor `imageio-ffmpeg` is available and a filter is configured, the raw Edge output is returned and a warning is logged — generation still succeeds.
- Behaviour is unchanged when `pitch` and `postprocess` are unset (default).

## Test plan

- Tested locally on macOS 13.7.8 with `edge-tts==7.2.3` and `imageio-ffmpeg`:
  - `pitch: -6` + `speed: 1.35` + EQ filter applied successfully (verified with `text_to_speech_tool` returning a 21 KB mp3, audible verification confirmed pitch shift and EQ).
  - Invalid pitch values (e.g. `"abc"`) log a warning and fall through without crashing.
  - With `postprocess.ffmpeg_filter` set but no ffmpeg available, the call still returns the raw mp3 and logs a warning.
- `python -m py_compile tools/tts_tool.py` clean.

Happy to add unit tests in `tests/` if the maintainers prefer — wanted to check the API shape first.
