### PR TITLE
docs(xai-oauth): note bare-code manual-paste form (#33917)

### DIFF
--- a/website/docs/guides/oauth-over-ssh.md
+++ b/website/docs/guides/oauth-over-ssh.md
@@ -40,7 +40,7 @@ hermes auth add xai-oauth --manual-paste
 # → Paste it back into the terminal at the "Callback URL:" prompt.
 ```
 
-The same flag works on `hermes model --manual-paste` for the integrated model picker. A bare `?code=...&state=...` query fragment is accepted too if you don't want to paste the whole URL.
+The same flag works on `hermes model --manual-paste` for the integrated model picker. Hermes accepts three callback paste forms interchangeably: the full URL, a bare `?code=...&state=...` query fragment, or — when the upstream consent page renders the authorization code in-page instead of redirecting (xAI's current behavior on browser-based consoles) — just the bare code value on its own.
 
 Hermes uses the **same PKCE verifier, state and nonce** for both paths, so the upstream OAuth flow is byte-identical — `--manual-paste` is purely a transport change for the callback hop and is not a security downgrade.
 

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -94,6 +94,8 @@ hermes model --manual-paste
 
 See [OAuth over SSH / Remote Hosts](./oauth-over-ssh.md#browser-only-remote-cloud-shell--codespaces--ec2-instance-connect) for the full walkthrough. Regression fix for [#26923](https://github.com/NousResearch/hermes-agent/issues/26923).
 
+If the consent page renders the authorization code directly on the page (xAI's current behavior on browser-based consoles) instead of redirecting to your `127.0.0.1:56121/callback`, paste **just the bare code value** at the `Callback URL:` prompt — Hermes accepts the full URL, a bare `?code=...&state=...` query fragment, or a bare code interchangeably.
+
 ## How the Login Works
 
 1. Hermes opens your browser to `accounts.x.ai`.


### PR DESCRIPTION
## Summary

Tiny docs catch-up — the existing user-facing guides for `--manual-paste` mentioned the full URL and the bare `?code=...&state=...` query string forms but didn't mention the third form (bare code, no state) that #33880 shipped in `_parse_pasted_callback`. xAI's current browser-based-console flow (Cloud Shell, Codespaces, EC2 Instance Connect, Gitpod) renders the auth code in-page instead of redirecting, so users on those surfaces need the bare-code form and were getting stale instructions.

Salvages PR #33917 (@r266-tech).

## Salvage detail

@r266-tech's PR body described updates to two files (`oauth-over-ssh.md` and `xai-grok-oauth.md`), but the actual commit on the branch only modified `oauth-over-ssh.md`. The salvage adds the matching paragraph to `xai-grok-oauth.md` so users reading the primary entry point don't miss it.

## Changes

- `website/docs/guides/oauth-over-ssh.md` — @r266-tech's original edit (cherry-picked verbatim): expanded the one-liner about manual-paste forms to mention all three (full URL, bare query string, bare code).
- `website/docs/guides/xai-grok-oauth.md` — follow-up: add the bare-code paragraph after the existing `--manual-paste` walkthrough.

## Validation

Pure docs, no tests. The in-CLI prompt (`hermes_cli/auth.py` `_parse_pasted_callback` docstring at L3118-3133) already documents the three accepted forms, so docs now match runtime behavior.

## Credit

@r266-tech — caught a real documentation gap. The bare-code form is the load-bearing case for browser-only-console users today (the only path that works against current xAI consent-page behavior), and missing it from the docs left a discoverability hole.
