### PR TITLE
docs(skill): himalaya: add 163/126 IMAP ID pitfall

### DIFF
--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -296,6 +296,13 @@ Full trace with backtrace:
 RUST_LOG=trace RUST_BACKTRACE=1 himalaya envelope list
 ```
 
+## Pitfalls
+
+- **Encryption format is `backend.encryption.type = "tls"`, NOT `backend.encryption = "tls"`**. The value `tls` for 993/port, `start-tls` for 587/port. Using `ssl` or bare `encryption` key causes `internally tagged enum Encryption` parse errors.
+- **NetEase 163/126 IMAP "Unsafe Login"**: Himalaya does not support NetEase 163/126 accounts. `LOGIN` succeeds, but `SELECT` and `SEARCH` fail with `BYE Unsafe Login`. NetEase requires clients to send the IMAP ID command (RFC 2971) after `LOGIN`, but Himalaya neither sends the command nor exposes a way to configure it. Use Hermes' built-in Email platform instead; after configuring the `EMAIL_*` environment variables and restarting the gateway, it sends IMAP ID automatically.
+- **163 folder names**: Uses "Sent Messages" and "Deleted Messages", not "Sent" / "Trash". Always set `folder.aliases`.
+
+
 ## Tips
 
 - Use `himalaya --help` or `himalaya <command> --help` for detailed usage.


### PR DESCRIPTION
## Problem

Himalaya does not send the IMAP ID command (RFC 2971) after `LOGIN`. NetEase 163/126 accepts authentication but can return `BYE Unsafe Login` when `SELECT` or `SEARCH` follows without that command.

## Solution

Document the limitation in the Himalaya skill and recommend Hermes' built-in Email platform, whose current adapter sends IMAP ID after login. The same focused Pitfalls section also records the correct encryption shape and NetEase folder aliases.

## Changes

- Updated `skills/email/himalaya/SKILL.md`.
- Added one focused `## Pitfalls` section (7 documentation lines).
- Kept all prose in English, following reviewer feedback.
- Rebased the branch onto the latest `main`.

## Testing

```text
scripts/run_tests.sh tests/website/test_generate_skill_docs.py tests/website/test_extract_skills.py tests/agent/test_external_skills.py tests/tools/test_skill_size_limits.py -q
```

Result: 36 tests passed. `git diff --check` also passes.