### PR TITLE
fix(gateway): refresh systemd units before update restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -938,7 +938,9 @@ def _read_systemd_unit_environment(system: bool = False) -> dict[str, str]:
     return parsed
 
 
-def _hermes_home_from_systemd_unit_file(system: bool = False) -> str | None:
+def _hermes_home_from_systemd_unit_file(
+    system: bool = False, service_name: str | None = None
+) -> str | None:
     """Read ``HERMES_HOME`` from the on-disk unit file (not ``systemctl show``).
 
     Prefer the file when refreshing/comparing: under ``sudo``, ``systemctl``
@@ -946,7 +948,11 @@ def _hermes_home_from_systemd_unit_file(system: bool = False) -> str | None:
     ``systemd_unit_is_current`` / ``refresh_systemd_unit_if_needed`` already
     compare against.
     """
-    unit_path = get_systemd_unit_path(system=system)
+    unit_path = (
+        get_systemd_unit_path(system=system)
+        if service_name is None
+        else get_systemd_unit_path(system=system, service_name=service_name)
+    )
     if not unit_path.exists():
         return None
     try:
@@ -1788,8 +1794,20 @@ def get_service_name() -> str:
     return f"{_SERVICE_BASE}-{suffix}"
 
 
-def get_systemd_unit_path(system: bool = False) -> Path:
-    name = get_service_name()
+def get_systemd_unit_path(
+    system: bool = False, service_name: str | None = None
+) -> Path:
+    """Return a gateway unit path, optionally for an explicitly discovered unit.
+
+    Explicit names are restricted to Hermes' generated service-name grammar so
+    a value parsed from ``systemctl list-units`` can never escape the systemd
+    unit directory.
+    """
+    import re
+
+    name = service_name or get_service_name()
+    if not re.fullmatch(r"hermes-gateway(?:-[a-z0-9][a-z0-9_-]{0,63})?", name):
+        raise ValueError(f"Invalid Hermes gateway service name: {name!r}")
     if system:
         return Path("/etc/systemd/system") / f"{name}.service"
     return Path.home() / ".config" / "systemd" / "user" / f"{name}.service"
@@ -2722,6 +2740,11 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     _drain_timeout = int(_get_restart_drain_timeout() or 0)
     restart_timeout = max(60, _drain_timeout) + 30
 
+    # Exit 75 is Hermes' intentional "drained; please respawn me" code for
+    # service-managed gateway restarts.  RestartForceExitStatus makes
+    # older/non-`Restart=always` units relaunch on 75, while SuccessExitStatus
+    # keeps planned update/restart handoffs from being recorded as failed units
+    # (#31048).  Keep both directives in user and system units.
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
         hermes_home = _hermes_home_for_target_user(home_dir)
@@ -2761,6 +2784,7 @@ Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
+SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
@@ -2795,6 +2819,7 @@ Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
+SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
@@ -2951,55 +2976,83 @@ def _refuse_temp_home_service_write(definition: str, kind: str) -> bool:
     return True
 
 
-def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
-    """Rewrite the installed systemd unit when the generated definition has changed."""
-    unit_path = get_systemd_unit_path(system=system)
+def refresh_systemd_unit_if_needed(
+    system: bool = False, service_name: str | None = None
+) -> bool:
+    """Rewrite an installed systemd unit when its definition has changed.
+
+    An explicit ``service_name`` is used by ``hermes update`` for units found
+    by the same discovery loop that restarts them. Its pinned ``HERMES_HOME``
+    is adopted only while regenerating that unit, so named profiles are updated
+    independently and the caller's active profile is restored afterwards.
+    """
+    unit_path = (
+        get_systemd_unit_path(system=system)
+        if service_name is None
+        else get_systemd_unit_path(system=system, service_name=service_name)
+    )
     if not unit_path.exists():
         return False
 
-    # The gate below funnels through ``systemd_unit_is_current``, which is the
-    # single HERMES_HOME-sync chokepoint (adopts the unit's pinned home before
-    # any compare/regenerate). No separate pre-sync needed here — and the env
-    # mutation it performs persists for the regenerate path below.
-    if systemd_unit_is_current(system=system):
-        return False
+    previous_home = os.environ.get("HERMES_HOME")
+    try:
+        if service_name is None:
+            # Preserve the normal gateway-command path's HERMES_HOME sync
+            # semantics, notably for sudo/system-scope operations.
+            if systemd_unit_is_current(system=system):
+                return False
+        else:
+            unit_home = _hermes_home_from_systemd_unit_file(
+                system=system, service_name=service_name
+            )
+            if not unit_home:
+                logger.debug(
+                    "Skipping refresh of %s: installed unit has no HERMES_HOME",
+                    service_name,
+                )
+                return False
+            os.environ["HERMES_HOME"] = unit_home
 
-    expected_user = _read_systemd_user_from_unit(unit_path) if system else None
-    new_unit = generate_systemd_unit(system=system, run_as_user=expected_user)
+            installed = unit_path.read_text(encoding="utf-8")
+            expected_user = _read_systemd_user_from_unit(unit_path) if system else None
+            expected = generate_systemd_unit(
+                system=system, run_as_user=expected_user
+            )
+            norm_installed = _normalize_service_definition(
+                _strip_optional_systemd_directives(installed)
+            )
+            norm_expected = _normalize_service_definition(
+                _strip_optional_systemd_directives(expected)
+            )
+            if norm_installed == norm_expected:
+                return False
 
-    # ── Test-environment safety belt ─────────────────────────────────────
-    # The user-scope unit path resolves under ``Path.home()``, which is NOT
-    # sandboxed by the test conftest (only HERMES_HOME is). If a test
-    # exercises ``run_gateway()`` with a pytest-tmp HERMES_HOME, the freshly
-    # generated unit bakes that ``/tmp/pytest-of-.../hermes_test`` path into
-    # ``Environment="HERMES_HOME=..."``. Writing that to the developer's
-    # real user systemd unit file silently breaks their gateway on the next
-    # reboot (systemd loads the polluted env, the gateway looks at an empty
-    # tmp dir, and Telegram/Discord/etc. all show as "not configured").
-    # Refuse to write when the generated unit references a pytest tmpdir.
-    # Detection sniffs the unit body — tests that legitimately exercise the
-    # refresh flow patch ``generate_systemd_unit`` to return synthetic
-    # content (``"new unit\n"``) which doesn't contain these markers and
-    # still works.
-    if not system and (
-        "/pytest-of-" in new_unit
-        or '/hermes_test"' in new_unit
-        or "/hermes_test/" in new_unit
-    ):
-        return False
+        expected_user = _read_systemd_user_from_unit(unit_path) if system else None
+        new_unit = generate_systemd_unit(system=system, run_as_user=expected_user)
 
-    # Structural variant of the same belt: refuse to bake ANY temp-dir
-    # HERMES_HOME into the unit (manual E2E homes like /tmp/hermes-e2e-NNN
-    # don't carry the pytest markers above but poison the unit identically).
-    if _refuse_temp_home_service_write(new_unit, "systemd unit"):
-        return False
+        # Never let a test/E2E HERMES_HOME poison a real user unit. The
+        # structural check also catches manual /tmp and /var/tmp homes.
+        if not system and (
+            "/pytest-of-" in new_unit
+            or '/hermes_test"' in new_unit
+            or "/hermes_test/" in new_unit
+        ):
+            return False
+        if _refuse_temp_home_service_write(new_unit, "systemd unit"):
+            return False
 
-    unit_path.write_text(new_unit, encoding="utf-8")
-    _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
-    print(
-        f"↻ Updated gateway {_service_scope_label(system)} service definition to match the current Hermes install"
-    )
-    return True
+        unit_path.write_text(new_unit, encoding="utf-8")
+        _run_systemctl(["daemon-reload"], system=system, check=True, timeout=30)
+        print(
+            f"↻ Updated gateway {_service_scope_label(system)} service definition to match the current Hermes install"
+        )
+        return True
+    finally:
+        if service_name is not None:
+            if previous_home is None:
+                os.environ.pop("HERMES_HOME", None)
+            else:
+                os.environ["HERMES_HOME"] = previous_home
 
 
 def _print_linger_enable_warning(username: str, detail: str | None = None) -> None:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10375,6 +10375,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 find_gateway_pids,
                 find_profile_gateway_processes,
                 launch_detached_profile_gateway_restart,
+                refresh_systemd_unit_if_needed,
                 _get_service_pids,
                 _graceful_restart_via_sigusr1,
                 _wait_for_gateway_exit,
@@ -10602,6 +10603,25 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             )
                             if check.stdout.strip() != "active":
                                 continue
+
+                            # Refresh exactly the unit this discovery loop is
+                            # about to signal/restart. Named profiles carry
+                            # their own pinned HERMES_HOME; the refresh helper
+                            # scopes that environment while regenerating. Keep
+                            # this best-effort so a stale/unwritable unit never
+                            # prevents the existing restart path.
+                            try:
+                                if refresh_systemd_unit_if_needed(
+                                    system=scope == "system",
+                                    service_name=svc_name,
+                                ):
+                                    print(f"  ✓ Refreshed gateway systemd unit: {svc_name}")
+                            except Exception as exc:
+                                logger.debug(
+                                    "Could not refresh %s gateway unit before update restart: %s",
+                                    svc_name,
+                                    exc,
+                                )
 
                             # Resolve how we may run manage-units verbs
                             # (reset-failed/start/restart) for this scope.

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -243,6 +243,64 @@ class TestSystemdServiceRefresh:
         assert unit_path.read_text(encoding="utf-8") == "new unit\n"
         assert ["systemctl", "--user", "daemon-reload"] in calls
 
+    def test_refreshes_each_named_profile_unit_from_its_pinned_home(
+        self, tmp_path, monkeypatch
+    ):
+        """An update can refresh default and named-profile units independently."""
+        default_unit = tmp_path / "hermes-gateway.service"
+        coder_unit = tmp_path / "hermes-gateway-coder.service"
+        default_unit.write_text(
+            '[Service]\nEnvironment="HERMES_HOME=/home/alice/.hermes"\nOld=yes\n',
+            encoding="utf-8",
+        )
+        coder_unit.write_text(
+            '[Service]\nEnvironment="HERMES_HOME=/home/alice/.hermes/profiles/coder"\nOld=yes\n',
+            encoding="utf-8",
+        )
+        paths = {
+            "hermes-gateway": default_unit,
+            "hermes-gateway-coder": coder_unit,
+        }
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_systemd_unit_path",
+            lambda system=False, service_name=None: paths[service_name],
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "generate_systemd_unit",
+            lambda system=False, run_as_user=None: (
+                f'[Service]\nEnvironment="HERMES_HOME={os.environ["HERMES_HOME"]}"\n'
+            ),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_run_systemctl",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+        monkeypatch.setenv("HERMES_HOME", "/home/alice/.hermes")
+
+        assert gateway_cli.refresh_systemd_unit_if_needed(
+            system=False, service_name="hermes-gateway"
+        )
+        assert gateway_cli.refresh_systemd_unit_if_needed(
+            system=False, service_name="hermes-gateway-coder"
+        )
+
+        default_text = default_unit.read_text(encoding="utf-8")
+        coder_text = coder_unit.read_text(encoding="utf-8")
+        assert "Old=yes" not in default_text
+        assert "Old=yes" not in coder_text
+        assert 'HERMES_HOME=/home/alice/.hermes"' in default_text
+        assert 'HERMES_HOME=/home/alice/.hermes/profiles/coder"' in coder_text
+        assert os.environ["HERMES_HOME"] == "/home/alice/.hermes"
+
+    def test_explicit_service_name_cannot_escape_systemd_unit_directory(self):
+        with pytest.raises(ValueError, match="Invalid Hermes gateway service name"):
+            gateway_cli.get_systemd_unit_path(
+                system=False, service_name="hermes-gateway-../../pwned"
+            )
+
     def test_refresh_refuses_to_bake_pytest_tmpdir_into_real_user_unit(
         self, tmp_path, monkeypatch
     ):
@@ -435,6 +493,7 @@ class TestGeneratedSystemdUnits:
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        assert f"SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
         # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.
@@ -540,12 +599,18 @@ class TestGeneratedSystemdUnits:
             "_get_restart_drain_timeout",
             lambda: DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
         )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
         unit = gateway_cli.generate_systemd_unit(system=True)
 
         assert "ExecStart=" in unit
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        assert f"SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
         # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.


### PR DESCRIPTION
## Summary

- Mark the Gateway systemd drain exit code 75 as a successful service exit status.
- Before `hermes update` restarts Gateway services, refresh every discovered `hermes-gateway*.service` unit rather than only the active profile.
- Read each installed unit’s pinned `HERMES_HOME`, regenerate that unit in its own profile scope, and restore the caller environment afterwards.
- Keep refresh best-effort for permission-limited system services.
- Reject explicit service names that could escape the systemd unit directory.

## Why

An update can pull the fix for a stale unit but still restart through that stale unit. With multiple profiles, refreshing only the caller’s unit leaves `hermes-gateway-coder`, `hermes-gateway-assistant`, and other discovered services stale before they are signaled. This change refreshes each exact unit before restarting it.

Fixes #31048.

## Review resolution

The multi-profile review is addressed in `ff7b1f2fd501`: the regression test installs default and `coder` units with different pinned homes, refreshes both by service name, and asserts that each generated unit retains its own home. A separate test covers traversal-style explicit service names. The review thread has been replied to and resolved.

## Validation

```text
Focused update/systemd suite: 38 passed
Ruff: passed
py_compile: passed
git diff --check: passed
Independent re-review: PASS
GitHub checks: 23 success, 7 skipped, 1 neutral, no failure/pending
```

Rebased head: `ff7b1f2fd501`; `main` base: `c44de9985`.
