### PR TITLE
fix(docs): respect browser locale on first visit

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
+    "test": "node --test tests/*.test.cjs",
     "typecheck": "tsc",
     "lint:diagrams": "ascii-guard lint --exclude-code-blocks docs"
   },

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -271,6 +271,33 @@ pre.prism-code.language-ascii code {
     width: 85vw;
     max-width: 360px;
   }
+
+  /* Keep the locale switcher usable inside the mobile sidebar. */
+  .navbar-sidebar .dropdown > .navbar__link {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 44px;
+    padding: 0.75rem;
+  }
+
+  .navbar-sidebar .dropdown__menu {
+    position: static;
+    transform: none;
+    width: 100%;
+    margin: 0.25rem 0 0;
+    padding: 0.35rem;
+    border: 1px solid rgba(255, 215, 0, 0.08);
+    border-radius: 10px;
+    box-shadow: none;
+  }
+
+  .navbar-sidebar .dropdown__link {
+    min-height: 44px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+  }
 }
 
 /* Hero banner for docs landing if needed */

--- a/website/src/theme/Root.tsx
+++ b/website/src/theme/Root.tsx
@@ -1,0 +1,160 @@
+import React, {type ReactNode, useEffect} from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+const DEFAULT_LOCALE = 'en';
+const SUPPORTED_LOCALES = ['en', 'zh-Hans'] as const;
+const NON_DEFAULT_LOCALES = SUPPORTED_LOCALES.filter(
+  (locale) => locale !== DEFAULT_LOCALE,
+);
+const LOCALE_STORAGE_KEY = 'hermes-agent-docs-locale';
+const PENDING_LOCALE_STORAGE_KEY = 'hermes-agent-docs-pending-locale';
+
+function normalizeBaseUrl(baseUrl: string): string {
+  if (!baseUrl || baseUrl === '/') {
+    return '';
+  }
+
+  return `/${baseUrl.replace(/^\/+|\/+$/g, '')}`;
+}
+
+function stripBaseUrl(pathname: string, baseUrl: string): string {
+  const base = normalizeBaseUrl(baseUrl);
+
+  if (!base) {
+    return pathname || '/';
+  }
+
+  if (pathname === base) {
+    return '/';
+  }
+
+  if (pathname.startsWith(`${base}/`)) {
+    return pathname.slice(base.length) || '/';
+  }
+
+  return pathname || '/';
+}
+
+function getLocaleFromPath(pathname: string, baseUrl: string): string {
+  const pathWithoutBase = stripBaseUrl(pathname, baseUrl);
+  const firstSegment = pathWithoutBase.split('/').filter(Boolean)[0];
+
+  return NON_DEFAULT_LOCALES.includes(firstSegment as (typeof NON_DEFAULT_LOCALES)[number])
+    ? firstSegment
+    : DEFAULT_LOCALE;
+}
+
+function getPathForLocale(
+  pathname: string,
+  search: string,
+  hash: string,
+  baseUrl: string,
+  targetLocale: string,
+): string {
+  const base = normalizeBaseUrl(baseUrl);
+  const pathWithoutBase = stripBaseUrl(pathname, baseUrl);
+  const segments = pathWithoutBase.split('/').filter(Boolean);
+
+  if (NON_DEFAULT_LOCALES.includes(segments[0] as (typeof NON_DEFAULT_LOCALES)[number])) {
+    segments.shift();
+  }
+
+  const localizedSegments =
+    targetLocale === DEFAULT_LOCALE ? segments : [targetLocale, ...segments];
+  const localizedPath = `${base}/${localizedSegments.join('/')}`.replace(/\/+/g, '/');
+
+  return `${localizedPath === '' ? '/' : localizedPath}${search}${hash}`;
+}
+
+function getPreferredBrowserLocale(): string {
+  const browserLanguages = [
+    ...(navigator.languages ?? []),
+    navigator.language,
+  ].filter(Boolean);
+
+  for (const browserLanguage of browserLanguages) {
+    const normalizedLanguage = browserLanguage.toLowerCase();
+
+    if (normalizedLanguage === 'zh' || normalizedLanguage.startsWith('zh-')) {
+      return 'zh-Hans';
+    }
+
+    if (normalizedLanguage === 'en' || normalizedLanguage.startsWith('en-')) {
+      return 'en';
+    }
+  }
+
+  return DEFAULT_LOCALE;
+}
+
+function persistLocaleChoiceFromLocaleLinks(baseUrl: string): () => void {
+  const handleClick = (event: MouseEvent) => {
+    const target = event.target;
+
+    if (!(target instanceof Element)) {
+      return;
+    }
+
+    const anchor = target.closest<HTMLAnchorElement>('a[href]');
+
+    if (!anchor) {
+      return;
+    }
+
+    const label = anchor.textContent?.trim();
+    const isLocaleSwitcherLink = label === 'English' || label === '简体中文';
+
+    if (!isLocaleSwitcherLink) {
+      return;
+    }
+
+    const url = new URL(anchor.href, window.location.href);
+    const targetLocale = getLocaleFromPath(url.pathname, baseUrl);
+
+    window.localStorage.setItem(PENDING_LOCALE_STORAGE_KEY, targetLocale);
+  };
+
+  document.addEventListener('click', handleClick, true);
+
+  return () => document.removeEventListener('click', handleClick, true);
+}
+
+export default function Root({children}: {children: ReactNode}): ReactNode {
+  const {siteConfig} = useDocusaurusContext();
+  const baseUrl = siteConfig.baseUrl;
+
+  useEffect(() => {
+    const cleanup = persistLocaleChoiceFromLocaleLinks(baseUrl);
+    const currentLocale = getLocaleFromPath(window.location.pathname, baseUrl);
+    const pendingLocale = window.localStorage.getItem(PENDING_LOCALE_STORAGE_KEY);
+
+    if (pendingLocale === currentLocale) {
+      window.localStorage.setItem(LOCALE_STORAGE_KEY, currentLocale);
+      window.localStorage.removeItem(PENDING_LOCALE_STORAGE_KEY);
+      return cleanup;
+    }
+
+    const storedLocale = window.localStorage.getItem(LOCALE_STORAGE_KEY);
+    const preferredLocale = storedLocale || getPreferredBrowserLocale();
+
+    if (currentLocale !== preferredLocale) {
+      const preferredPath = getPathForLocale(
+        window.location.pathname,
+        window.location.search,
+        window.location.hash,
+        baseUrl,
+        preferredLocale,
+      );
+
+      if (preferredPath !== `${window.location.pathname}${window.location.search}${window.location.hash}`) {
+        window.location.replace(preferredPath);
+        return cleanup;
+      }
+    }
+
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, currentLocale);
+    return cleanup;
+  }, [baseUrl]);
+
+  return <>{children}</>;
+}

--- a/website/tests/locale.test.cjs
+++ b/website/tests/locale.test.cjs
@@ -1,0 +1,149 @@
+const assert = require('node:assert/strict');
+const {readFileSync} = require('node:fs');
+const {test} = require('node:test');
+const vm = require('node:vm');
+const ts = require('typescript');
+
+// Compile the real component, not a copy of its URL or preference logic.
+// Only React/Docusaurus and browser APIs are replaced by boundary adapters.
+const source = readFileSync(require.resolve('../src/theme/Root.tsx'), 'utf8');
+const {outputText} = ts.transpileModule(source, {
+  compilerOptions: {module: ts.ModuleKind.CommonJS, jsx: ts.JsxEmit.React},
+});
+const LOCALE = 'hermes-agent-docs-locale';
+const PENDING = 'hermes-agent-docs-pending-locale';
+
+function visit({baseUrl = '/docs/', path = '/docs/', languages = ['en'],
+  language = languages[0], storage = new Map()} = {}) {
+  const listeners = new Set();
+  const redirects = [];
+  let cleanup;
+  class Element {
+    constructor(anchor) { this.anchor = anchor; }
+    closest(selector) {
+      assert.equal(selector, 'a[href]');
+      return this.anchor;
+    }
+  }
+  const location = new URL(path, 'https://example.com');
+  location.replace = (url) => redirects.push(url);
+  const document = {
+    addEventListener(type, callback, capture) {
+      assert.equal(type, 'click');
+      assert.equal(capture, true);
+      listeners.add(callback);
+    },
+    removeEventListener(type, callback, capture) {
+      assert.equal(type, 'click');
+      assert.equal(capture, true);
+      listeners.delete(callback);
+    },
+  };
+  const exports = {};
+  vm.runInNewContext(outputText, {
+    exports, URL, Element, document,
+    navigator: {languages, language},
+    window: {location, localStorage: {
+      getItem: (key) => storage.get(key) ?? null,
+      setItem: (key, value) => storage.set(key, value),
+      removeItem: (key) => storage.delete(key),
+    }},
+    require(name) {
+      if (name === 'react') return {
+        default: {createElement: () => null},
+        useEffect: (effect) => { cleanup = effect(); },
+      };
+      if (name === '@docusaurus/useDocusaurusContext') return {
+        default: () => ({siteConfig: {baseUrl}}),
+      };
+      throw new Error(`Unexpected import: ${name}`);
+    },
+  }, {filename: 'Root.js'});
+  exports.default({children: null});
+  return {
+    redirects, storage, listeners, cleanup,
+    click(label, href) {
+      const target = new Element({textContent: label, href});
+      for (const listener of listeners) listener({target});
+    },
+  };
+}
+
+for (const baseUrl of ['/docs/', '/hermes-agent/docs/', '/']) {
+  for (const [languages, locale] of [
+    [['en'], 'en'], [['en-US'], 'en'], [['EN-gb'], 'en'],
+    [['zh'], 'zh-Hans'], [['zh-CN'], 'zh-Hans'],
+    [['zh-TW'], 'zh-Hans'], [['zh-Hant'], 'zh-Hans'],
+    [['ZH-hans'], 'zh-Hans'], [['ko', 'zh-CN'], 'zh-Hans'],
+    [['en', 'zh-CN'], 'en'], [['fr'], 'en'],
+  ]) {
+    test(`${baseUrl}: browser ${languages.join(',')} selects ${locale}`, () => {
+      const page = visit({baseUrl, path: `${baseUrl}guide?q=a%2Fb#install`, languages});
+      assert.deepEqual(page.redirects, locale === 'en'
+        ? [] : [`${baseUrl}zh-Hans/guide?q=a%2Fb#install`]);
+      if (locale === 'en') assert.equal(page.storage.get(LOCALE), 'en');
+      page.cleanup();
+      assert.equal(page.listeners.size, 0);
+    });
+  }
+  test(`${baseUrl}: strip current locale and preserve query/hash`, () => {
+    const page = visit({baseUrl, path: `${baseUrl}zh-Hans/guide?q=a%2Fb#install`});
+    assert.deepEqual(page.redirects, [`${baseUrl}guide?q=a%2Fb#install`]);
+  });
+  test(`${baseUrl}: keep current Chinese locale without doubling prefix`, () => {
+    const page = visit({baseUrl, path: `${baseUrl}zh-Hans/guide`, languages: ['zh-TW']});
+    assert.deepEqual(page.redirects, []);
+    assert.equal(page.storage.get(LOCALE), 'zh-Hans');
+  });
+  for (const [choice, label, opposite] of [
+    ['en', 'English', 'zh-Hans'], ['zh-Hans', '简体中文', 'en'],
+  ]) {
+    test(`${baseUrl}: explicit ${choice} choice survives navigation and later visits`, () => {
+      const storage = new Map([[LOCALE, opposite]]);
+      const initial = visit({baseUrl, storage, languages: [opposite],
+        path: `${baseUrl}${opposite === 'en' ? '' : 'zh-Hans/'}guide`});
+      const destination = `${baseUrl}${choice === 'en' ? '' : 'zh-Hans/'}guide?q=1#title`;
+      initial.click(` ${label} `, `https://example.com${destination}`);
+      assert.equal(storage.get(PENDING), choice);
+      assert.equal(storage.get(LOCALE), opposite);
+      initial.cleanup();
+      assert.equal(initial.listeners.size, 0);
+      const arrival = visit({baseUrl, storage, path: destination, languages: [opposite]});
+      assert.deepEqual(arrival.redirects, []);
+      assert.equal(storage.get(LOCALE), choice);
+      assert.equal(storage.has(PENDING), false);
+      arrival.cleanup();
+      const later = visit({baseUrl, storage, path: `${baseUrl}guide?q=1#title`, languages: [opposite]});
+      assert.deepEqual(later.redirects, choice === 'en' ? [] : [destination]);
+    });
+  }
+}
+
+for (const [baseUrl, path, expected] of [
+  ['/docs/', '/docs/', '/docs/zh-Hans'],
+  ['/docs/', '/docs', '/docs/zh-Hans'],
+  ['/hermes-agent/docs/', '/hermes-agent/docs/', '/hermes-agent/docs/zh-Hans'],
+  ['docs', '/docs/guide', '/docs/zh-Hans/guide'],
+]) {
+  test(`base boundary ${baseUrl} at ${path}`, () => {
+    assert.deepEqual(visit({baseUrl, path, languages: ['zh-CN']}).redirects, [expected]);
+  });
+}
+
+test('navigator.language fallback when languages is unavailable', () => {
+  assert.deepEqual(visit({languages: null, language: 'zh-CN'}).redirects, ['/docs/zh-Hans']);
+  assert.deepEqual(visit({languages: [], language: 'zh-CN'}).redirects, ['/docs/zh-Hans']);
+});
+
+test('ordinary document links do not persist a locale choice', () => {
+  const page = visit();
+  page.click('Getting started', 'https://example.com/docs/guide');
+  assert.equal(page.storage.has(PENDING), false);
+});
+
+test('pending choice is not committed on an unrelated locale page', () => {
+  const storage = new Map([[LOCALE, 'en'], [PENDING, 'zh-Hans']]);
+  visit({storage});
+  assert.equal(storage.get(LOCALE), 'en');
+  assert.equal(storage.get(PENDING), 'zh-Hans');
+});


### PR DESCRIPTION
## Summary
- Auto-detect the visitor's browser/OS language on first docs visit and route supported Chinese locales to /docs/zh-Hans/.
- Persist explicit locale switcher choices in localStorage so user preference wins over browser defaults.
- Improve the Docusaurus locale dropdown inside the mobile sidebar with touch-friendly targets.

## Test Plan
- npm ci
- npm run build
- Verified locale path mapping for zh-CN/zh-Hant/en browser preferences with a Node script.

Note: build emits existing zh-Hans broken link/anchor warnings, but completes successfully.