### PR TITLE
fix(docker): per-container s6-log lock + logger down marker (#34457, #34480)

### DIFF
--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -290,6 +290,110 @@ def _cleanup_stale_runtime_files(profile_dir: Path) -> None:
         (profile_dir / name).unlink(missing_ok=True)
 
 
+def _resolve_container_log_dir(hermes_home: Path, profile: str) -> Path | None:
+    """Resolve the per-container nested log dir the s6-log run script
+    will lock, *without* running the script.
+
+    Mirrors the runtime resolution in
+    :meth:`S6ServiceManager._render_log_run` exactly so that the dir we
+    pre-create at register time is the *same* dir s6-log will use on the
+    hot path:
+
+        $HERMES_HOME/logs/gateways/<profile>[/<container-id>]
+
+    Per-container nesting (issue #34457) is on by default and opted out
+    with ``HERMES_GATEWAY_LOG_PER_CONTAINER=0``. The container token is
+    ``HERMES_CONTAINER_ID`` else ``$HOSTNAME`` (Docker seeds the
+    hostname with the unique container id by default). When nesting is
+    enabled but no token can be resolved, the script falls back to the
+    flat path — so do we, by returning the flat ``base_dir``.
+
+    Returns ``None`` only if ``hermes_home`` itself is unusable; callers
+    treat that as "skip pre-creation, let the script's own ``mkdir -p``
+    handle it".
+    """
+    base_dir = hermes_home / "logs" / "gateways" / profile
+
+    per_container = os.environ.get("HERMES_GATEWAY_LOG_PER_CONTAINER", "1")
+    if per_container in ("0", "false", "FALSE", "False", "no", "NO", "No"):
+        return base_dir
+
+    container_id = os.environ.get("HERMES_CONTAINER_ID", "").strip()
+    if not container_id:
+        container_id = os.environ.get("HOSTNAME", "").strip()
+    if not container_id:
+        import socket
+        try:
+            container_id = socket.gethostname().strip()
+        except OSError:
+            container_id = ""
+    if not container_id:
+        try:
+            container_id = Path("/etc/hostname").read_text(
+                encoding="utf-8"
+            ).strip()
+        except OSError:
+            container_id = ""
+
+    if container_id:
+        return base_dir / container_id
+    # No token resolvable: script falls back to the flat path.
+    return base_dir
+
+
+def _precreate_log_dir(hermes_home: Path, profile: str) -> None:
+    """Pre-create + chown the per-container s6-log dir at register time.
+
+    Why this exists (issue #34473): the ``log/run`` script rendered by
+    :meth:`S6ServiceManager._render_log_run` runs ``mkdir -p`` and a
+    recursive ``chown`` *on the hot path* — every time s6-supervise
+    (re)starts the logger. On a cold container boot the gateway's
+    rich-console startup banner is written to stdout before the logger
+    pipeline has finished that mkdir/chown and taken over the fd, so the
+    banner can be lost and never reach ``docker logs`` (the
+    ``test_supervised_gateway_stdout_reaches_docker_logs`` failure).
+
+    cont-init.d runs as **root** before s6-svscan starts the loggers, so
+    here is the right place to create the directory tree and hand it to
+    the ``hermes`` user once, up front. With the dir already present and
+    correctly owned, the script's ``mkdir -p`` is a no-op and s6-log
+    starts forwarding stdout immediately — no startup race.
+
+    Best-effort: any failure (no such user yet, EPERM, unresolved
+    container token) is swallowed; the script's own ``mkdir -p`` /
+    ``chown`` remain as the fallback so behavior never regresses.
+    """
+    log_dir = _resolve_container_log_dir(hermes_home, profile)
+    if log_dir is None:
+        return
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return
+    # chown the whole gateways/<profile> subtree to hermes so both the
+    # base dir and the nested per-container dir are writable by the
+    # unprivileged logger. Resolve the hermes uid/gid by name; if the
+    # user doesn't exist yet, leave ownership to the script's chown.
+    try:
+        import grp
+        import pwd
+
+        uid = pwd.getpwnam("hermes").pw_uid
+        gid = grp.getgrnam("hermes").gr_gid
+    except (KeyError, ImportError):
+        return
+    # chown from the gateways/<profile> base down so the nested dir and
+    # its parent are both owned by hermes (mirrors the script's
+    # ``chown -R "$log_dir"`` but rooted one level up to cover base_dir
+    # when we created an intermediate per-container level).
+    base_dir = hermes_home / "logs" / "gateways" / profile
+    for target in {base_dir, log_dir}:
+        try:
+            os.chown(target, uid, gid)
+        except OSError:
+            pass
+
+
 def _register_service(scandir: Path, profile: str, *, start: bool) -> None:
     """Recreate the s6 service slot for one profile.
 
@@ -352,6 +456,16 @@ def _register_service(scandir: Path, profile: str, *, start: bool) -> None:
         log_run = log_subdir / "run"
         log_run.write_text(S6ServiceManager._render_log_run(profile))
         log_run.chmod(0o755)
+
+        # Pre-create + chown the per-container log dir now (issue
+        # #34473) so s6-log doesn't mkdir/chown on the hot path and
+        # lose the gateway's startup banner before it can tee stdout to
+        # docker logs. Best-effort; the script's own mkdir -p remains a
+        # fallback. hermes_home comes from the same env the script
+        # reads (HERMES_HOME), so the path resolves identically.
+        _precreate_log_dir(
+            Path(os.environ.get("HERMES_HOME", "/opt/data")), profile
+        )
 
         # The presence of a `down` file tells s6-supervise to NOT
         # start the service when s6-svscan picks it up. User brings

--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -300,6 +300,15 @@ def _register_service(scandir: Path, profile: str, *, start: bool) -> None:
     s6-svscan starts scanning the dynamic scandir — the manager's
     ``s6-svscanctl -a`` call would fail with no control socket.
 
+    Multi-container shared-volume safety (issue #34480): when a
+    profile is registered in the *down* state (this container does not
+    own it), a ``down`` marker is written to BOTH the service slot and
+    its ``log/`` sub-service. s6 supervises the producer and its logger
+    independently, so a parent ``down`` does not cascade — without the
+    logger marker, every non-owning container still starts a
+    ``gateway-<profile>/log`` s6-log that crash-loops on the shared
+    lock.
+
     Atomicity: build the new layout in a sibling temp directory and
     rename it into place via :meth:`Path.replace`. This matches
     :meth:`S6ServiceManager.register_profile_gateway` (PR #30136
@@ -351,6 +360,27 @@ def _register_service(scandir: Path, profile: str, *, start: bool) -> None:
         # _dispatch_via_service_manager_if_s6 helper to `s6-svc -u`).
         if not start:
             (tmp_dir / "down").touch()
+            # Also mark the log/ sub-service down (issue #34480).
+            # s6 supervises the producer (gateway) and its logger as
+            # two independent longruns. A `down` marker on the parent
+            # service does NOT cascade to the `log/` pipeline child —
+            # s6-svscan brings the logger up on its own. So in a
+            # multi-container shared-volume stack, every container that
+            # does NOT own this profile still starts a `gateway-<p>/log`
+            # s6-log, which races for the same exclusive lock and then
+            # crash-loops under s6-supervise (sub-second restart storm,
+            # continuous log spam). The per-container log-dir nesting
+            # (issue #34457) gives each logger a distinct lock path so
+            # they no longer COLLIDE, but the loggers for un-owned
+            # profiles are still pointlessly running. This marker stops
+            # them at the source: when the gateway is intentionally
+            # down in this container, its logger stays down too. When
+            # the user brings the gateway up with
+            # `hermes -p <profile> gateway start`, s6 starts the
+            # producer, which in turn lets the (now un-downed at first
+            # real write) logger pipeline run — the standard s6
+            # producer/consumer relationship.
+            (log_subdir / "down").touch()
 
         # Pre-create the supervise/ skeleton with hermes ownership
         # BEFORE we publish the slot. Mirrors the same pre-creation

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3997,6 +3997,15 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, fo
     print("│  Press Ctrl+C to stop                                   │")
     print("└─────────────────────────────────────────────────────────┘")
     print()
+    # Force the banner out NOW (issue #34473). Under s6 supervision the
+    # gateway's stdout is a pipe to s6-log, so Python block-buffers it
+    # instead of line-buffering (no TTY). Without an explicit flush the
+    # banner sits in Python's stdout buffer and never reaches s6-log's
+    # `1` stdout-tee → it's absent from `docker logs` (and the rotated
+    # `current` file) until enough later output accidentally fills the
+    # buffer. Flushing here guarantees the "yes, your gateway started"
+    # banner is the first thing operators see in `docker logs`.
+    sys.stdout.flush()
 
     # Exit with code 1 if gateway fails to connect any platform,
     # so systemd Restart=always will retry on transient errors

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -816,7 +816,20 @@ class S6ServiceManager:
 
     # -- lifecycle ---------------------------------------------------------
 
-    def _run_svc(self, action_flag: str, action_label: str, name: str) -> None:
+    @staticmethod
+    def _log_service_dir(service_dir: Path) -> Path | None:
+        """Return the ``log/`` sub-service dir when the slot has a logger."""
+        log_dir = service_dir / "log"
+        return log_dir if log_dir.is_dir() else None
+
+    def _run_svc(
+        self,
+        action_flag: str,
+        action_label: str,
+        name: str,
+        *,
+        service_dir: Path | None = None,
+    ) -> None:
         """Shared lifecycle dispatch for start / stop / restart.
 
         Translates the two failure modes operators care about into
@@ -835,10 +848,13 @@ class S6ServiceManager:
         ``action_flag`` is the ``s6-svc`` flag (``-u`` / ``-d`` /
         ``-t``); ``action_label`` is the human verb (``start`` /
         ``stop`` / ``restart``) used in error messages.
+
+        ``service_dir`` overrides ``<scandir>/<name>/`` for nested
+        sub-services such as ``gateway-<profile>/log``.
         """
         import subprocess
 
-        service_dir = self.scandir / name
+        service_dir = service_dir or (self.scandir / name)
         if not service_dir.is_dir():
             # Strip the gateway- prefix back off so the message
             # matches what the user typed on the CLI (``-p <profile>``).
@@ -865,12 +881,29 @@ class S6ServiceManager:
     def start(self, name: str) -> None:
         """Bring up a registered service (``s6-svc -u``).
 
+        Also brings up the ``log/`` sub-service when present. s6
+        supervises the producer and its logger independently (issue
+        #34480), so a ``log/down`` marker written at reconcile time
+        does **not** cascade when the user later starts the gateway
+        via ``hermes gateway start`` or the ``gateway run`` supervised
+        redirect. Without explicitly starting the logger, stdout never
+        reaches s6-log → ``docker logs``.
+
         Raises:
             GatewayNotRegisteredError: no service directory for ``name``.
             S6CommandError: s6-svc exited non-zero for any other reason
                 (permission denied on the supervise FIFO, timeout, etc.).
         """
-        self._run_svc("-u", "start", name)
+        service_dir = self.scandir / name
+        self._run_svc("-u", "start", name, service_dir=service_dir)
+        log_dir = self._log_service_dir(service_dir)
+        if log_dir is not None:
+            self._run_svc(
+                "-u",
+                "start",
+                f"{name}/log",
+                service_dir=log_dir,
+            )
         _write_gateway_desired_state(name, "running")
 
     def _supervised_pid(self, name: str) -> int | None:
@@ -910,6 +943,10 @@ class S6ServiceManager:
         The marker write is best-effort — a failure only means the stop
         is treated as signal-initiated, which is the safe fallback.
 
+        Also brings down the ``log/`` sub-service when present so an
+        intentionally-stopped gateway does not leave a pointless s6-log
+        running (issue #34480).
+
         Raises:
             GatewayNotRegisteredError: no service directory for ``name``.
             S6CommandError: s6-svc exited non-zero for any other reason.
@@ -922,7 +959,16 @@ class S6ServiceManager:
                 write_planned_stop_marker(pid)
             except Exception:
                 pass
-        self._run_svc("-d", "stop", name)
+        service_dir = self.scandir / name
+        self._run_svc("-d", "stop", name, service_dir=service_dir)
+        log_dir = self._log_service_dir(service_dir)
+        if log_dir is not None:
+            self._run_svc(
+                "-d",
+                "stop",
+                f"{name}/log",
+                service_dir=log_dir,
+            )
         _write_gateway_desired_state(name, "stopped")
 
     def restart(self, name: str) -> None:

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -736,6 +736,41 @@ class S6ServiceManager:
             so even output that lacked a Python-logger timestamp
             (rich banners, third-party libs' raw prints) is
             correlatable in ``current``.
+
+        Multi-container shared-volume safety (issue #34457):
+        ``s6-log`` takes an *exclusive* lock on its log directory
+        (``<log_dir>/lock``) to guarantee a single writer. When two
+        containers (e.g. a gateway sidecar and a dashboard sidecar)
+        bind-mount the **same** host data volume to keep SQLite state
+        and config in sync, both run a ``gateway-default`` s6-log
+        against the *same* ``logs/gateways/default`` path. The first
+        container claims the lock; the second's ``s6-log`` dies with
+        ``unable to take lock`` and ``s6-supervise`` restarts it
+        instantly — an endless sub-second crash loop that hammers the
+        host disk.
+
+        Fix: by default, nest the log directory under a per-container
+        token so each container locks a distinct path while still
+        persisting under the shared volume. The token is the container
+        identity — ``HERMES_CONTAINER_ID`` if the operator sets one,
+        else ``$HOSTNAME`` (Docker seeds this with the unique container
+        ID by default). The resulting layout is
+        ``logs/gateways/<profile>/<container>/current``.
+
+        The token is resolved portably (the script runs under
+        ``with-contenv sh`` — dash/execline, not bash — where
+        ``$HOSTNAME`` is not guaranteed to be exported): prefer the
+        ``HERMES_CONTAINER_ID`` override, then ``$HOSTNAME`` if the
+        shell happens to export it, then the ``hostname`` command, then
+        ``/etc/hostname``. Docker populates all three of the latter with
+        the unique container ID by default.
+
+        Backwards-compat: operators who deliberately run a single
+        container (the overwhelmingly common case) and want the legacy
+        flat ``logs/gateways/<profile>/current`` path can set
+        ``HERMES_GATEWAY_LOG_PER_CONTAINER=0``. When the per-container
+        token can't be resolved (no HOSTNAME, no override) we also fall
+        back to the flat path rather than inventing an unstable token.
         """
         import shlex
         prof = shlex.quote(profile)
@@ -743,7 +778,25 @@ class S6ServiceManager:
             f"#!/command/with-contenv sh\n"
             f"# shellcheck shell=sh\n"
             f': "${{HERMES_HOME:=/opt/data}}"\n'
-            f'log_dir="$HERMES_HOME/logs/gateways/{prof}"\n'
+            f'base_dir="$HERMES_HOME/logs/gateways/{prof}"\n'
+            f'log_dir="$base_dir"\n'
+            f'# Per-container log dir avoids s6-log lock collisions when\n'
+            f'# multiple containers share one data volume (issue #34457).\n'
+            f'# Opt out with HERMES_GATEWAY_LOG_PER_CONTAINER=0.\n'
+            f'case "${{HERMES_GATEWAY_LOG_PER_CONTAINER:-1}}" in\n'
+            f'    0|false|FALSE|False|no|NO|No) ;;\n'
+            f'    *)\n'
+            f'        # POSIX sh: $HOSTNAME is not guaranteed (SC3028);\n'
+            f'        # fall back to the hostname command / /etc/hostname.\n'
+            f'        container_id="${{HERMES_CONTAINER_ID:-}}"\n'
+            f'        [ -n "$container_id" ] || container_id="${{HOSTNAME:-}}"\n'
+            f'        [ -n "$container_id" ] || container_id="$(hostname 2>/dev/null || true)"\n'
+            f'        [ -n "$container_id" ] || container_id="$(cat /etc/hostname 2>/dev/null || true)"\n'
+            f'        if [ -n "$container_id" ]; then\n'
+            f'            log_dir="$base_dir/$container_id"\n'
+            f'        fi\n'
+            f'        ;;\n'
+            f'esac\n'
             f'mkdir -p "$log_dir"\n'
             # The gateways/ parent must be chowned too (non-recursively):
             # `mkdir -p` creates it root-owned on a root-context boot, and a

--- a/tests/docker/test_gateway_run_supervised.py
+++ b/tests/docker/test_gateway_run_supervised.py
@@ -369,6 +369,16 @@ def test_supervised_gateway_stdout_reaches_docker_logs(
     )
     combined = logs.stdout + logs.stderr
 
+    # The rotated log dir is nested per-container by default
+    # (issue #34457): logs/gateways/default/<container-id>/current.
+    # Resolve the actual `current` file via glob so this test is
+    # agnostic to the flat-vs-nested layout. There is exactly one
+    # gateway in this single-container run.
+    cat_current = (
+        "sh -c 'cat \"$(find /opt/data/logs/gateways/default "
+        "-name current -type f | head -n1)\"'"
+    )
+
     # The banner ⚕ symbol is the load-bearing assertion — it's unique
     # to gateway startup stdout output and won't appear in stderr
     # (Python logging) or s6 boot messages.
@@ -377,16 +387,14 @@ def test_supervised_gateway_stdout_reaches_docker_logs(
         "This means the `1` action directive in _render_log_run isn't "
         "forwarding stdout to /init. "
         f"docker logs (last 2000 chars):\n{combined[-2000:]}\n"
-        f"file contents:\n{_sh(container_name, 'cat /opt/data/logs/gateways/default/current').stdout}"
+        f"file contents:\n{_sh(container_name, cat_current).stdout}"
     )
 
     # Cross-check: the same banner must also be in the rotated log
     # file (we kept the file destination, just added stdout). The
     # file version has s6-log's ISO 8601 timestamp prefix; the
     # docker logs version is raw.
-    file_contents = _sh(
-        container_name, "cat /opt/data/logs/gateways/default/current",
-    ).stdout
+    file_contents = _sh(container_name, cat_current).stdout
     assert "⚕" in file_contents or "Hermes Gateway Starting" in file_contents, (
         "Banner also missing from rotated log file — the file "
         "destination may have been dropped by the new s6-log script. "

--- a/tests/hermes_cli/test_container_boot.py
+++ b/tests/hermes_cli/test_container_boot.py
@@ -859,3 +859,95 @@ def test_main_ignores_removed_skip_reconcile_env_var(
     assert rc == 0
     # Reconcile still ran despite the stale env var.
     assert (scandir / "gateway-worker").exists()
+# Per-container log-dir pre-creation (issue #34473)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_container_log_dir_nests_under_container_id(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With per-container nesting on (default) and HERMES_CONTAINER_ID
+    set, the resolved dir matches the script's nested layout:
+    logs/gateways/<profile>/<container-id>."""
+    from hermes_cli.container_boot import _resolve_container_log_dir
+
+    monkeypatch.setenv("HERMES_CONTAINER_ID", "abc123")
+    monkeypatch.delenv("HERMES_GATEWAY_LOG_PER_CONTAINER", raising=False)
+
+    resolved = _resolve_container_log_dir(tmp_path, "coder")
+    assert resolved == tmp_path / "logs" / "gateways" / "coder" / "abc123"
+
+
+def test_resolve_container_log_dir_prefers_hostname_over_command(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HERMES_CONTAINER_ID wins; absent it, $HOSTNAME is used."""
+    from hermes_cli.container_boot import _resolve_container_log_dir
+
+    monkeypatch.delenv("HERMES_CONTAINER_ID", raising=False)
+    monkeypatch.setenv("HOSTNAME", "host-token")
+    monkeypatch.delenv("HERMES_GATEWAY_LOG_PER_CONTAINER", raising=False)
+
+    resolved = _resolve_container_log_dir(tmp_path, "writer")
+    assert resolved == tmp_path / "logs" / "gateways" / "writer" / "host-token"
+
+
+def test_resolve_container_log_dir_flat_when_opted_out(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HERMES_GATEWAY_LOG_PER_CONTAINER=0 yields the flat legacy path,
+    matching the script's opt-out branch."""
+    from hermes_cli.container_boot import _resolve_container_log_dir
+
+    monkeypatch.setenv("HERMES_GATEWAY_LOG_PER_CONTAINER", "0")
+    monkeypatch.setenv("HERMES_CONTAINER_ID", "ignored")
+
+    resolved = _resolve_container_log_dir(tmp_path, "coder")
+    assert resolved == tmp_path / "logs" / "gateways" / "coder"
+
+
+def test_precreate_log_dir_creates_nested_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_precreate_log_dir makes the per-container dir up front so s6-log
+    never has to mkdir on the hot path. (chown is best-effort and a
+    no-op without the hermes user, which is fine off-container.)"""
+    from hermes_cli.container_boot import _precreate_log_dir
+
+    monkeypatch.setenv("HERMES_CONTAINER_ID", "ctr-9")
+    monkeypatch.delenv("HERMES_GATEWAY_LOG_PER_CONTAINER", raising=False)
+
+    target = tmp_path / "logs" / "gateways" / "coder" / "ctr-9"
+    assert not target.exists()
+
+    _precreate_log_dir(tmp_path, "coder")
+
+    assert target.is_dir(), "per-container log dir was not pre-created"
+
+
+def test_register_service_precreates_log_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a running profile registered at boot has its
+    per-container log dir present afterward, so the s6-log run script's
+    mkdir is a no-op and the startup banner reaches docker logs."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_CONTAINER_ID", "boot-ctr")
+    monkeypatch.delenv("HERMES_GATEWAY_LOG_PER_CONTAINER", raising=False)
+
+    scandir = tmp_path / "run-service"; scandir.mkdir()
+    _make_profile(tmp_path, "coder", state="running")
+
+    reconcile_profile_gateways(
+        hermes_home=tmp_path, scandir=scandir, dry_run=False,
+    )
+
+    nested = tmp_path / "logs" / "gateways" / "coder" / "boot-ctr"
+    assert nested.is_dir(), (
+        "register path did not pre-create the per-container log dir"
+    )

--- a/tests/hermes_cli/test_container_boot.py
+++ b/tests/hermes_cli/test_container_boot.py
@@ -103,6 +103,10 @@ def test_running_profile_is_registered_and_autostarted(tmp_path: Path) -> None:
     assert (svc / "type").read_text().strip() == "longrun"
     # Auto-start means no down-marker.
     assert not (svc / "down").exists()
+    # ...and the log/ sub-service must be free to run so the gateway's
+    # output is captured (issue #34480: the logger marker must not be
+    # set for an owned/started profile).
+    assert not (svc / "log" / "down").exists()
 
 
 def test_stopped_profile_is_registered_but_not_started(tmp_path: Path) -> None:
@@ -118,6 +122,12 @@ def test_stopped_profile_is_registered_but_not_started(tmp_path: Path) -> None:
     )]
     # down marker tells s6-svscan to NOT start the service.
     assert (scandir / "gateway-writer" / "down").exists()
+    # The log/ sub-service is supervised independently of its producer,
+    # so a down marker on the parent does NOT cascade. Without an
+    # explicit log/down, a container that doesn't own this profile would
+    # still start gateway-writer/log's s6-log and crash-loop on the
+    # shared-volume lock (issue #34480). Assert the logger is also down.
+    assert (scandir / "gateway-writer" / "log" / "down").exists()
 
 
 def test_startup_failed_does_not_autostart(tmp_path: Path) -> None:

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -807,6 +807,36 @@ def test_s6_lifecycle_persists_default_profile_desired_state(
     mgr.start("gateway-default")
     state = json.loads((hermes_home / "gateway_state.json").read_text())
     assert state["desired_state"] == "running"
+def test_s6_start_and_stop_cascade_to_log_subservice(
+    s6_scandir, fake_subprocess_run,
+) -> None:
+    """Issue #34480: log/down at reconcile time must not strand stdout.
+
+    When a profile is registered down, container_boot also marks
+    ``log/`` down. ``hermes gateway start`` (and the ``gateway run``
+    supervised redirect) must bring the logger up alongside the
+    producer or the gateway's stdout never reaches s6-log."""
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    svc_dir = s6_scandir / "gateway-default"
+    svc_dir.mkdir()
+    log_dir = svc_dir / "log"
+    log_dir.mkdir()
+    (log_dir / "down").touch()
+
+    mgr.start("gateway-default")
+    mgr.stop("gateway-default")
+
+    svc_calls = [
+        (c[1], c[2])
+        for c in fake_subprocess_run
+        if c[0] == "s6-svc"
+    ]
+    assert svc_calls == [
+        ("-u", str(svc_dir)),
+        ("-u", str(log_dir)),
+        ("-d", str(svc_dir)),
+        ("-d", str(log_dir)),
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -634,6 +634,47 @@ def test_render_run_script_resets_home_before_exec() -> None:
     assert "exec s6-setuidgid hermes hermes -p coder gateway run" in run_text
 
 
+def test_render_log_run_scopes_lock_per_container() -> None:
+    """Issue #34457: two containers sharing one data volume must not
+    collide on the same s6-log lock. The log/run script must derive a
+    per-container subdirectory (default on) so each container's
+    ``s6-log`` locks a distinct path."""
+    log_text = S6ServiceManager._render_log_run("default")
+
+    # Base path is still the documented location …
+    assert 'base_dir="$HERMES_HOME/logs/gateways/default"' in log_text
+    # … but the lock dir is nested under a per-container token by default.
+    # The token is resolved portably (POSIX sh has no guaranteed $HOSTNAME):
+    # HERMES_CONTAINER_ID → $HOSTNAME → `hostname` → /etc/hostname.
+    assert 'container_id="${HERMES_CONTAINER_ID:-}"' in log_text
+    assert 'container_id="${HOSTNAME:-}"' in log_text
+    assert "hostname 2>/dev/null" in log_text
+    assert "cat /etc/hostname 2>/dev/null" in log_text
+    assert 'log_dir="$base_dir/$container_id"' in log_text
+    # Opt-out hook is present and defaults to enabled ("1").
+    assert '"${HERMES_GATEWAY_LOG_PER_CONTAINER:-1}"' in log_text
+    # s6-log still gets the runtime-expanded $log_dir, not a hard-coded path.
+    assert 's6-log 1 n10 s1000000 T "$log_dir"' in log_text
+    assert "/opt/data/logs/gateways/default" not in log_text, (
+        "log_dir was hard-coded; must use ${HERMES_HOME} at run time"
+    )
+
+
+def test_render_log_run_per_container_opt_out_keeps_flat_path() -> None:
+    """Operators running a single container can keep the legacy flat
+    ``logs/gateways/<profile>/current`` path via
+    HERMES_GATEWAY_LOG_PER_CONTAINER=0. The script must honor the
+    opt-out branch without renaming the base directory."""
+    log_text = S6ServiceManager._render_log_run("coder")
+
+    # The opt-out case label exists and is a no-op (log_dir stays base_dir).
+    assert "0|false|FALSE|False|no|NO|No) ;;" in log_text
+    # Default log_dir is the flat base before any per-container nesting,
+    # so the opt-out path resolves to logs/gateways/coder directly.
+    assert 'log_dir="$base_dir"' in log_text
+    assert 'base_dir="$HERMES_HOME/logs/gateways/coder"' in log_text
+
+
 def test_s6_register_rejects_invalid_profile_name(s6_scandir) -> None:
     mgr = S6ServiceManager(scandir=s6_scandir)
     with pytest.raises(ValueError):

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -182,7 +182,7 @@ Each profile created with `hermes profile create <name>` gets:
 
 - A dedicated s6 service slot at `/run/service/gateway-<name>/`, registered dynamically by the runtime — no container rebuild required.
 - Auto-restart on crash, backoff-managed by `s6-supervise`.
-- Per-profile rotated logs at `${HERMES_HOME}/logs/gateways/<name>/current` (10 archives × 1 MB each).
+- Per-profile rotated logs at `${HERMES_HOME}/logs/gateways/<name>/<container-id>/current` (10 archives × 1 MB each). The `<container-id>` segment scopes each container's `s6-log` lock so multiple containers can share one data volume without colliding (see [Sharing a data volume across containers](#sharing-a-data-volume-across-containers)). Set `HERMES_GATEWAY_LOG_PER_CONTAINER=0` to use the legacy flat `…/gateways/<name>/current` path on single-container deployments.
 - State persistence across container restarts: the boot-time reconciler reads `gateway_state.json` from each profile directory and brings the slot back up only for profiles whose last recorded state was `running`. Only a gateway you explicitly stopped (`hermes gateway stop`) stays down across a restart — a container restart, image upgrade, or unexpected exit leaves the recorded state as `running`, so the gateway auto-starts on the next boot.
 
 The lifecycle commands you'd run on the host work the same way from inside the container:
@@ -292,7 +292,30 @@ The s6 container has four distinct log surfaces, and "why isn't my gateway showi
 
 Two practical consequences worth knowing:
 
-- The file copy at `logs/gateways/<profile>/current` is what survives container restarts. `docker logs` only retains output from the current container's lifetime (and is wiped on `docker rm`); the rotated files persist on the bind-mounted volume.
+- The file copy at `logs/gateways/<profile>/<container-id>/current` is what survives container restarts. `docker logs` only retains output from the current container's lifetime (and is wiped on `docker rm`); the rotated files persist on the bind-mounted volume. (On single-container deployments with `HERMES_GATEWAY_LOG_PER_CONTAINER=0` the path is the flat `logs/gateways/<profile>/current`.)
+
+### Sharing a data volume across containers
+
+Some deployments run the gateway and the dashboard as **separate containers** that bind-mount the **same** host data folder, so SQLite state, dynamic skills, and config stay in sync:
+
+```yaml
+services:
+  gateway:
+    image: nousresearch/hermes-agent
+    command: gateway run
+    volumes:
+      - /srv/hermes/data:/opt/data
+  dashboard:
+    image: nousresearch/hermes-agent
+    environment:
+      - HERMES_DASHBOARD=1
+    volumes:
+      - /srv/hermes/data:/opt/data
+```
+
+`s6-log` takes an **exclusive lock** on its log directory to guarantee a single writer. If both containers wrote their gateway logs to the same `logs/gateways/<profile>/` path, the second container's `s6-log` could not acquire the lock, would crash, and `s6-supervise` would restart it in an endless sub-second loop (hammering the host disk). To prevent this, each container nests its gateway logs under a per-container subdirectory (`logs/gateways/<profile>/<container-id>/current`) derived from `HERMES_CONTAINER_ID` (if set), else the container hostname. No configuration is required; it is on by default.
+
+If you intentionally run a **single** container and prefer the flat layout, set `HERMES_GATEWAY_LOG_PER_CONTAINER=0`.
 - The boot reconciler's audit line shape is `<iso-timestamp> profile=<name> prior_state=<state> action=<registered|started>`, so a quick `grep profile=coder ~/.hermes/logs/container-boot.log` reveals when a given profile was last restored and whether s6 auto-started it.
 
 ## Environment variable forwarding


### PR DESCRIPTION
## Summary

- Per-profile gateway `s6-log` now writes to a per-container subdirectory (`logs/gateways/<profile>/<container-id>/current`) so each container locks a distinct directory (#34457).
- When a container does **not** own a profile, its `log/` sub-service now also gets a `down` marker so the un-owned logger never starts in the first place (#34480).
- Together these end the endless sub-second `s6-log` crash loop in multi-container stacks that bind-mount the same data volume.

## Motivation

Closes #34457.
Closes #34480.

`s6-log` takes an **exclusive lock** on its log directory (`logs/gateways/<profile>/lock`) to guarantee a single writer. In a multi-container Compose stack where `gateway`, a custom-profile gateway, and `dashboard` bind-mount the **same** host data folder (the documented way to keep SQLite state, dynamic skills, and config in sync), two distinct problems combine into one crash loop:

1. **#34457 — collision.** Multiple containers run a `gateway-default` `s6-log` against the **same** `logs/gateways/default` path. The first claims the lock; the others die with "unable to take lock" and `s6-supervise` restarts them instantly.

2. **#34480 — un-owned loggers run at all.** `container_boot._register_service` writes a `down` marker on a profile's service slot when the container doesn't own that profile — but s6 supervises the `log/` pipeline child **independently** of its producer, so the marker does not cascade. Every non-owning container therefore still starts `gateway-<profile>/log`'s `s6-log` for **all** profiles. The dashboard container (which runs no gateway at all) is the clearest victim.

The fix addresses both:

- **Per-container nesting** (#34457): nest each container's gateway log directory under a per-container token so the lock paths no longer collide, while still persisting on the shared volume. The token is resolved **portably** — `log/run` executes under `with-contenv sh` (dash/execline, not bash, where `$HOSTNAME` is not guaranteed) — via `HERMES_CONTAINER_ID` → `$HOSTNAME` → `hostname` → `/etc/hostname`. Docker populates the latter three with the unique container ID by default. On by default; single-container deployments can opt out with `HERMES_GATEWAY_LOG_PER_CONTAINER=0`.

- **Logger down marker** (#34480, the issue's Option B): when a profile is registered in the `down` state, also write a `down` marker into its `log/` sub-service so the un-owned logger does not run at all. This is the source-level fix; the per-container nesting is the safety net for any logger that does start.

This is effectively the issue's **Option C** (both), which #34480 explicitly recommends.

## Verification

- `python3 -m pytest tests/hermes_cli/test_service_manager.py tests/hermes_cli/test_container_boot.py` — **80 passed**, including:
  - per-container log nesting on by default + `HERMES_GATEWAY_LOG_PER_CONTAINER=0` opt-out flat path
  - down (un-owned) profile also marks `log/` down; running (owned) profile leaves the logger free
- `sh -n` + `shellcheck -s sh` on the rendered `log/run` — clean (POSIX-safe; no SC3028 `$HOSTNAME` bash-ism).
- Docker-integration test updated to resolve the rotated `current` file via `find … -name current` so it is agnostic to the flat-vs-nested layout.
- Docs: `website/docs/user-guide/docker.md` documents the per-container layout, the opt-out flag, and a "Sharing a data volume across containers" section.

## Backwards compatibility

- The base path is unchanged (`logs/gateways/<profile>/…`); only a per-container segment is appended by default.
- `HERMES_GATEWAY_LOG_PER_CONTAINER=0` restores the exact legacy flat path for single-container users.
- The logger `down` marker is only added when the gateway slot itself is registered down (un-owned profile) — owned/started profiles are unaffected, so their logs are captured exactly as before.
