### PR TITLE
feat(skills/projmanage): add attachment commands + milestone status clarify

### DIFF
--- a/skills/media/baidu-pan-upload/SKILL.md
+++ b/skills/media/baidu-pan-upload/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: baidu-pan-upload
+description: Use when asked to upload, download, list, or sync files with Baidu Netdisk (百度网盘) using the bypy Python library. Supports single file upload, batch upload, directory sync, and directory listing via Baidu PCS API.
+version: 1.0.0
+author: Hermes Agent Community
+license: MIT
+metadata:
+  hermes:
+    tags: [baidu, pan, netdisk, bypy, upload, download, sync, cloud-storage]
+    related_skills: [chevereto-upload, gif-search]
+---
+
+# Baidu Netdisk (百度网盘) — bypy
+
+Upload, download, list, and sync files with Baidu Netdisk using [`bypy`](https://github.com/houtianze/bypy), a Python library that wraps the Baidu PCS (Personal Cloud Storage) API.
+
+## When to Use
+
+- User asks to upload files to Baidu Netdisk
+- User asks to download files from Baidu Netdisk
+- User asks to sync a local folder with Baidu Netdisk
+- User asks to list or browse Baidu Netdisk directory contents
+- User asks to check Baidu Netdisk quota usage
+- Don't use for: Google Drive, OneDrive, Dropbox, or other cloud storage (use their respective tools instead)
+
+## Prerequisites
+
+### 1. bypy must be installed and authenticated
+
+```bash
+pip install bypy
+bypy info        # First time: opens browser for OAuth, then saves token to ~/.bypy/bypy.json
+```
+
+### 2. Known bypy installation paths
+
+| Environment | Path |
+|-------------|------|
+| User's venv | `/home/shangyi/python/venv/bypy_venv/bin/python3 -m bypy` |
+| System-wide | `bypy` (if installed globally) |
+
+### 3. Baidu Netdisk quota
+
+- Anonymous: 2GB upload / 5GB total
+- Authorized: **2TB upload / 5TB total** (OAuth via bypy)
+- Current usage shown by `bypy info`
+
+## Common Operations
+
+### Check quota and account info
+
+```bash
+bypy info
+```
+
+Output example:
+```
+Quota: 14.008TB
+Used: 13.449TB
+```
+
+### List root directory
+
+```bash
+bypy list /
+```
+
+### List a specific directory
+
+```bash
+bypy list /syncup
+bypy list /syncbooks
+```
+
+### Upload a single file
+
+```bash
+bypy upload /local/path/to/file.jpg /remote/path/
+```
+
+The remote path is relative to `/apps/bypy/`.
+
+Example — upload to `/apps/bypy/test_hermes/`:
+```bash
+bypy upload /home/shangyi/disk0/aicg/workspace/team45/images/0.jpg /test_hermes/
+```
+
+### Download a directory
+
+```bash
+bypy downdir /remote/path /local/destination/
+```
+
+Downloads recursively. Progress shown with `[====================]`.
+
+### Sync local folder UP to Baidu Netdisk
+
+```bash
+bypy syncup /local/folder /remote/folder
+```
+
+Example — scheduled in crontab (每周三凌晨):
+```bash
+0 1 * * 3 /home/shangyi/python/venv/bypy_venv/bin/python3 -m bypy syncup /home/shangyi/disk0/books /syncbooks >> /tmp/cronjob.log 2>&1
+```
+
+### Sync Baidu Netdisk folder DOWN to local
+
+```bash
+bypy syncdown /remote/folder /local/folder
+```
+
+### Compare local and remote (diff)
+
+```bash
+bypy compare /local/folder /remote/folder
+```
+
+## Python one-liner (no shell loop needed)
+
+```python
+import subprocess
+result = subprocess.run(
+    ['/home/shangyi/python/venv/bypy_venv/bin/python3', '-m', 'bypy', 'upload',
+     '/local/file.jpg', '/dest/'],
+    capture_output=True, text=True
+)
+print(result.stdout)
+```
+
+## Batch Upload Recipe
+
+To upload multiple files with logging and error handling:
+
+```bash
+BYPY="/home/shangyi/python/venv/bypy_venv/bin/python3 -m bypy"
+SRC="/home/shangyi/disk0/aicg/workspace/team45/images"
+DEST="/team45"
+
+for f in "$SRC"/*; do
+  fname=$(basename "$f")
+  echo -n "Uploading $fname ... "
+  if $BYPY upload "$f" "$DEST/" 2>&1 | grep -q "Success"; then
+    echo "✓"
+  else
+    echo "✗ (see above)"
+  fi
+done
+```
+
+## Important Notes
+
+| Aspect | Detail |
+|--------|--------|
+| Upload path prefix | All paths are relative to `/apps/bypy/` on Baidu Netdisk |
+| OAuth token location | `~/.bypy/bypy.json` — keep this file safe |
+| Upload limit (unauthorized) | 2GB per file |
+| Upload limit (authorized) | 2TB per file |
+| Bandwidth | No official limit documented; practical throughput ~10MB/s |
+| Duplicate upload | If the remote file already exists with the same name, bypy overwrites it silently |
+| Concurrent uploads | bypy uploads one file at a time (no parallel upload built-in) |
+
+## Troubleshooting
+
+### `bypy info` returns error or empty quota
+- OAuth token may have expired. Re-authenticate: `bypy info`
+- Check that `~/.bypy/bypy.json` exists and is valid
+
+### Upload fails with "SOME_ERROR"
+- Network connectivity issue — verify internet access to Baidu servers
+- File path contains spaces — wrap in quotes
+- File does not exist locally — verify with `ls`
+
+### "Move failed: target dir is not existing"
+- bypy `upload` requires the parent directory to exist. Create it first or use `syncup` which creates parents automatically.
+
+## One-Shot Recipe
+
+```
+User says: "上传 /home/user/images 到百度网盘 /backup"
+Steps:
+1. Verify bypy is accessible: /home/shangyi/python/venv/bypy_venv/bin/python3 -m bypy info
+2. Run: bypy upload /home/user/images /backup/
+3. Verify: bypy list /backup
+4. Report result
+```

--- a/skills/media/chevereto-upload/SKILL.md
+++ b/skills/media/chevereto-upload/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: chevereto-upload
+description: Use when asked to upload images to a self-hosted Chevereto image hosting service via its REST API. Handles batch upload, album association, duplicate detection, and POST-redirect issues.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [chevereto, image-hosting, upload, batch, api, media]
+    related_skills: [gif-search, youtube-content]
+---
+
+# Chevereto Upload
+
+## Overview
+
+Upload images to a self-hosted [Chevereto](https://chevereto.com/) image hosting service using its REST API v1. Supports single and batch uploads, album association via numeric album ID, duplicate detection, and handles the POST-redirect behavior common in Chevereto deployments behind reverse proxies.
+
+## When to Use
+
+- User asks to upload images to a Chevereto instance
+- User provides a Chevereto URL + API key + local image directory
+- User wants images organized into a specific Chevereto album
+- Don't use for: Imgur, Cloudinary, or other non-Chevereto services (use their respective skills or tools instead)
+
+## Prerequisites
+
+### 1. Chevereto API Key
+
+- Log into Chevereto as admin
+- Go to **Dashboard → Settings → API**
+- Copy the API v1 key (e.g. `50a99cff82fd48821b70eb7c815b39de`)
+
+### 2. Album Numeric ID (for album association)
+
+- Go to the album page (e.g. `/album/DCc`)
+- Open browser DevTools → Console, run:
+  ```javascript
+  JSON.parse(document.body.innerHTML.match(/\"id\":(\d+)/)[1])
+  ```
+- Or check the album JSON from the page source's `window.CHEVERETO` data
+- The numeric ID (e.g. `1`) is different from the URL slug (e.g. `DCc`)
+
+### 3. Images must exist locally
+
+Verify the image directory is accessible from the agent's environment.
+
+## Usage
+
+### Step 1: Identify your Chevereto instance and API key
+
+You need three things:
+- **Base URL** — e.g. `https://home.shangyiwuyanxinhome.com.cn:10803`
+- **API Key** — from Dashboard → Settings → API
+- **Album Numeric ID** — from album page inspection (see above)
+
+### Step 2: Identify image directory
+
+Get the local path to images, e.g. `/home/shangyi/disk0/aicg/workspace/team43/images`
+
+### Step 3: Run upload script
+
+```bash
+API_KEY="your-api-key-here"
+API_URL="https://your-chevereto.com/api/1/upload/"
+ALBUM_ID="1"  # numeric album ID, not the URL slug
+IMG_DIR="/path/to/images"
+
+for img in "$IMG_DIR"/*; do
+  fname=$(basename "$img")
+  echo -n "Uploading $fname ... "
+  result=$(curl -s -L --post301 -X POST "$API_URL" \
+    -F "key=$API_KEY" \
+    -F "source=@$img" \
+    -F "album=$ALBUM_ID" \
+    -F "format=json")
+
+  code=$(echo "$result" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status_code',''))" 2>/dev/null)
+  if [ "$code" = "200" ]; then
+    url=$(echo "$result" | python3 -c "import sys,json; print(json.load(sys.stdin).get('image',{}).get('url_viewer',''))" 2>/dev/null)
+    echo "✓ $url"
+  else
+    msg=$(echo "$result" | python3 -c "import sys,json; print(json.load(sys.stdin).get('error',{}).get('message',''))" 2>/dev/null)
+    echo "✗ $code - $msg"
+  fi
+done
+```
+
+### Step 4: Verify results
+
+- `200` → image uploaded successfully (check `url_viewer` in response)
+- `400 Duplicated upload` → image already exists, Chevereto blocks duplicates by MD5
+- `400 Invalid API v1 key` → wrong API key
+- `400 Invalid API action` → wrong API URL or action
+- Empty response → likely a POST-redirect issue, ensure `-L --post301` flags are used
+
+## Key Chevereto API v1 Notes
+
+| Aspect | Detail |
+|--------|--------|
+| Endpoint | `https://your-site.com/api/1/upload/` |
+| Auth | `key=<API_KEY>` form field |
+| Album param | `album=<numeric_id>` (not URL slug like `DCc`) |
+| HTTP method | POST multipart (`-F source=@file`) |
+| Response format | `format=json` |
+| Critical flag | `-L --post301` — Chevereto often returns 301 redirect; without this flag, curl drops POST data on redirect |
+| Duplicate handling | Chevereto uses MD5 to detect duplicates; set `Allow duplicate uploads` in Dashboard → Settings → Upload to override |
+| Album ID vs slug | Album ID `1` ≠ slug `DCc`. API requires numeric ID. |
+
+## Common Pitfalls
+
+1. **Using slug instead of numeric album ID** — API rejects slugs like `DCc`, needs the numeric `1`. Always convert via browser console or page source.
+
+2. **Missing `-L --post301` flags** — Chevereto returns 301 after POST, and curl drops the POST body on redirect by default. Without these flags the API returns `Invalid API v1 key` even with a correct key.
+
+3. **Duplicate upload blocked** — Chevereto blocks re-upload of identical files by MD5. Workarounds: rename the file, enable "Allow duplicate uploads" in settings, or delete the existing image first.
+
+4. **Wrong API key format** — API v1 key must be passed as a form field (`-F key=...`), not as a URL parameter for POST uploads (works for GET though).
+
+5. **Album ID not found in UI** — The album URL slug (`DCc`) is visible everywhere, but the numeric ID is hidden. Use browser DevTools to extract it from page data.
+
+## Finding Album Numeric ID
+
+Open the album page in browser, then in DevTools console:
+
+```javascript
+// Option 1: Look for window.CHEVERETO
+JSON.stringify(window.CHEVERETO?.album?.id)
+
+// Option 2: Search page HTML for id_encoded vs id
+document.body.innerHTML.match(/"id":(\d+)/g)
+
+// Option 3: Check network responses for the album API call
+```
+
+The numeric ID is what the API needs, not the `id_encoded` (slug) shown in URLs.
+
+## One-Shot Recipe
+
+```
+User says: "上传 /home/user/images 到相册 https://example.com/album/abc"
+Steps:
+1. Extract base URL: https://example.com
+2. Extract slug: abc
+3. Find numeric ID: browser inspection (see above)
+4. Run upload script with API key from user + numeric album ID
+5. Report results
+```

--- a/skills/productivity/projmanage/SKILL.md
+++ b/skills/productivity/projmanage/SKILL.md
@@ -133,13 +133,14 @@ projmanage task view <task_id>
 ```bash
 projmanage task update <task_id> \
   [--title "新标题"] \
-  [--desc "新描述"] \
+  [--desc "追加的描述内容"] \
   [--status todo|doing|done|blocked] \
   [--priority 1|2|3] \
   [--assignee <member_id>] \
   [--due YYYY-MM-DD] \
   [--milestone <new_milestone_id>]
 ```
+> **描述追加规则：** `--desc` 会追加到原描述末尾（用换行分隔），不是替换。
 
 ### Delete task
 ```bash
@@ -267,6 +268,14 @@ projmanage task done <task_id>   # repeat until all done
 # → output shows: "🎉 里程碑 [xxx] 已自动完成！"
 ```
 
+### Append to task description
+```bash
+# Each --desc appends to the existing description (not replaces)
+projmanage task update <task_id> --desc "第一阶段完成"
+projmanage task update <task_id> --desc "补充：需要联调"
+# Description now contains both lines
+```
+
 ### Migrate task to different milestone
 ```bash
 projmanage task update <task_id> --milestone <new_milestone_id>
@@ -330,9 +339,9 @@ Key tables: `projects`, `milestones`, `tasks`, `members`, `task_links`, `task_ev
 
 4. **Assuming `task new` accepts `--status`.** It does not. Task status is set via `task start/done/block/unblock` after creation.
 
-5. **Migrating a task to a milestone in a different project.** The FK constraint doesn't prevent cross-project assignment, but the business logic assumes milestones are per-project. Don't do this.
+5. **Assuming `task new` accepts `--status`.** It does not. Task status is set via `task start/done/block/unblock` after creation.
 
-6. **Deleting a project doesn't clean up the test data.** After `proj delete`, the DB is clean. Subsequent tests should create fresh data.
+6. **Migrating a task to a milestone in a different project.** The FK constraint doesn't prevent cross-project assignment, but the business logic assumes milestones are per-project. Don't do this.
 
 ---
 

--- a/skills/productivity/projmanage/SKILL.md
+++ b/skills/productivity/projmanage/SKILL.md
@@ -65,7 +65,30 @@ projmanage proj update <project_id> [--name "新名称"] [--desc "新描述"]
 ```bash
 projmanage proj delete <project_id> [--force]
 ```
-> cascades and deletes all milestones and tasks in that project
+> `-` cascades and deletes all milestones, tasks, and attachment files in that project
+
+---
+
+## Attachment Commands
+
+### Add attachment (copy file to project folder, record in task)
+```bash
+projmanage task add-attachment <task_id> <local_file_path>
+```
+> The file is copied (not referenced) to `~/.projmanage/projects/{project_id}/attachments/{timestamp}_{filename}`. The path stored in the task is the absolute path to the stored copy.
+
+### Remove attachment (deletes file + DB record)
+```bash
+projmanage task remove-attachment <attachment_id> [--force]
+```
+> `task view` shows `[attachment_id]` next to each file — use that ID.
+
+### Attachment display
+`task view <task_id>` automatically shows all attachments inline (filename + path + size).
+
+### Cascade behavior
+- Deleting a task → attachment files + DB records auto-deleted
+- Deleting a project → entire attachments folder deleted
 
 ---
 
@@ -315,7 +338,7 @@ Schema files:
 - `/root/.projmanage/schema.py` — SQLAlchemy models
 - `/root/.projmanage/db.py` — all DB operations
 
-Key tables: `projects`, `milestones`, `tasks`, `members`, `task_links`, `task_events`, `task_comments`
+Key tables: `projects`, `milestones`, `tasks`, `members`, `task_links`, `task_events`, `task_comments`, `attachments`
 
 ---
 
@@ -339,9 +362,11 @@ Key tables: `projects`, `milestones`, `tasks`, `members`, `task_links`, `task_ev
 
 4. **Assuming `task new` accepts `--status`.** It does not. Task status is set via `task start/done/block/unblock` after creation.
 
-5. **Assuming `task new` accepts `--status`.** It does not. Task status is set via `task start/done/block/unblock` after creation.
+5. **Migrating a task to a milestone in a different project.** The FK constraint doesn't prevent cross-project assignment, but the business logic assumes milestones are per-project. Don't do this.
 
-6. **Migrating a task to a milestone in a different project.** The FK constraint doesn't prevent cross-project assignment, but the business logic assumes milestones are per-project. Don't do this.
+6. **Passing a non-existent file to `add-attachment`.** The file must exist locally. Click validates with `exists=True` in the argument definition.
+
+7. **Forgetting the attachment ID on `remove-attachment`.** Run `task view <task_id>` first to see the `[attachment_id]` for each file.
 
 ---
 

--- a/skills/productivity/projmanage/SKILL.md
+++ b/skills/productivity/projmanage/SKILL.md
@@ -1,0 +1,348 @@
+---
+name: projmanage
+description: "Use when managing local projects, tasks, or milestones via the projmanage CLI. Covers project/task/milestone CRUD, board view, stats, and automatic status transitions."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+prerequisites:
+  commands: [python3]
+metadata:
+  hermes:
+    tags: [projmanage, project-management, task-manager, CLI, milestone, local-db]
+---
+
+# projmanage — Local Project & Task CLI
+
+## Overview
+
+`projmanage` is a local-first project/task/milestone management CLI backed by SQLite. The data lives at `~/.projmanage/projmanage.db`. The command entry point is `python /root/.projmanage/__init__.py` (aliased as `projmanage` in PATH).
+
+**Hierarchy:** `Project → Milestone → Task` (milestone is NOT optional for tasks)
+
+**Automatic milestone status rule:**
+- No tasks → `planning`
+- Has incomplete tasks → `in_progress`
+- All tasks done → `completed`
+
+Manual `--status` on milestones is rejected by the CLI and overwritten by the DB layer.
+
+---
+
+## When to Use
+
+- User asks to create/view/update/delete a project, task, or milestone
+- User asks to see a board view or project stats
+- User asks about task progress, milestone completion, or project statistics
+- User asks to assign tasks, link dependencies, or add comments
+- **Don't use** for cloud/team features (Linear, GitHub Issues, etc.) — use the appropriate skill instead
+
+---
+
+## Project Commands
+
+### Create project
+```bash
+projmanage proj new "<title>" [--desc "description"]
+```
+
+### List all projects
+```bash
+projmanage proj list
+```
+
+### View project
+```bash
+projmanage proj view <project_id>
+```
+
+### Update project
+```bash
+projmanage proj update <project_id> [--name "新名称"] [--desc "新描述"]
+```
+
+### Delete project
+```bash
+projmanage proj delete <project_id> [--force]
+```
+> cascades and deletes all milestones and tasks in that project
+
+---
+
+## Milestone Commands
+
+### Create milestone
+```bash
+projmanage milestone new <project_id> "<title>" \
+  [--desc "description"] \
+  [--due YYYY-MM-DD]
+```
+> New milestones are always `planning`. Status auto-updates as tasks are added/completed.
+
+### List milestones for a project
+```bash
+projmanage milestone list <project_id>
+```
+Output columns: ID / status / progress bar / title / due date
+
+### View milestone detail
+```bash
+projmanage milestone view <milestone_id>
+```
+
+### Update milestone (title/desc/due only — NOT status)
+```bash
+projmanage milestone update <milestone_id> \
+  [--title "新标题"] \
+  [--desc "新描述"] \
+  [--due YYYY-MM-DD]
+```
+> `--status` is intentionally absent. Status is auto-managed.
+
+### Delete milestone
+```bash
+projmanage milestone delete <milestone_id> [--force]
+```
+> RESTRICT: refuses if any tasks belong to this milestone. Delete tasks first.
+
+---
+
+## Task Commands
+
+### Create task (milestone REQUIRED)
+```bash
+projmanage task new <project_id> "<title>" \
+  --milestone <milestone_id> \
+  [--desc "description"] \
+  [--priority 1|2|3] \
+  [--assignee <member_id>] \
+  [--due YYYY-MM-DD]
+```
+
+### List tasks
+```bash
+projmanage task list <project_id> [--milestone <milestone_id>]
+```
+
+### View task
+```bash
+projmanage task view <task_id>
+```
+
+### Update task
+```bash
+projmanage task update <task_id> \
+  [--title "新标题"] \
+  [--desc "新描述"] \
+  [--status todo|doing|done|blocked] \
+  [--priority 1|2|3] \
+  [--assignee <member_id>] \
+  [--due YYYY-MM-DD] \
+  [--milestone <new_milestone_id>]
+```
+
+### Delete task
+```bash
+projmanage task delete <task_id> [--force]
+```
+
+### Task lifecycle shortcuts
+```bash
+projmanage task start <task_id>    # → status: doing
+projmanage task done <task_id>     # → status: done; may auto-complete milestone
+projmanage task block <task_id>    # → status: blocked
+projmanage task unblock <task_id>  # → status: todo
+```
+
+### Assign task
+```bash
+projmanage task assign <task_id> [--assignee <member_id>]
+```
+
+---
+
+## Board & Stats
+
+### Board view (grouped by milestone)
+```bash
+projmanage board view <project_id>
+```
+Shows per-milestone progress bars, task IDs grouped by status, overdue tasks, unassigned tasks.
+
+### Stats panel
+```bash
+projmanage board stats <project_id>
+```
+Shows overall progress bar, task counts by status, per-milestone progress bars, member stats.
+
+### Shortcut
+```bash
+projmanage stats <project_id>   # same as board stats
+```
+
+---
+
+## Member Commands
+
+```bash
+projmanage member new "<name>" [--role "role"] [--email "email@example.com"]
+projmanage member list
+projmanage member view <member_id>
+projmanage member update <member_id> [--name "新名称"] [--role "新角色"] [--email "新邮箱"]
+projmanage member delete <member_id>
+```
+
+---
+
+## Task Dependency Commands
+
+```bash
+# Set parent_id must-complete-before child_id can start
+projmanage task link <parent_id> <child_id>
+
+# Remove dependency
+projmanage task unlink <parent_id> <child_id>
+
+# View parent tasks (what blocks this)
+projmanage task parents <task_id>
+
+# View child tasks (what this blocks)
+projmanage task children <task_id>
+```
+
+> When parent task is marked done, child task is auto-unblocked to `todo`. If parent is not done and child is not `blocked`, child is auto-set to `todo`.
+
+---
+
+## Task Comments & Events
+
+```bash
+# Add comment
+projmanage task comment add <task_id> <author> "<body>"
+
+# List comments
+projmanage task comment list <task_id>
+
+# Event log (status changes, assignments, blocks, etc.)
+projmanage task log <task_id>
+```
+
+---
+
+## Milestone Status — Auto Rule Details
+
+| Condition | Status |
+|---|---|
+| milestone has 0 tasks | `planning` |
+| milestone has tasks and some are not done | `in_progress` |
+| all tasks in milestone are done | `completed` |
+
+Trigger points (all in `db.py`):
+- `task_create` → `_sync_milestone_status(milestone_id)`
+- `task_delete` → `_sync_milestone_status(milestone_id)`
+- `task_update` (milestone_id changed) → sync both old and new milestone
+- `task_set_status` → `_sync_milestone_status` after status update
+
+**If the user tries to manually set milestone status:** The CLI rejects `--status` on `milestone new/update`. Even if they somehow bypass the CLI, `_sync_milestone_status` will overwrite it on the next task operation.
+
+---
+
+## Common Patterns
+
+### Full project bootstrap
+```bash
+projmanage proj new "新项目" --desc "描述"
+# note the project_id from output
+projmanage milestone new <project_id> "v1.0 MVP" --due 2026-06-01
+projmanage task new <project_id> "任务1" --milestone <milestone_id> --priority 1
+projmanage task new <project_id> "任务2" --milestone <milestone_id> --priority 2
+projmanage board view <project_id>
+```
+
+### Complete a milestone (automatic)
+```bash
+projmanage task done <task_id>   # repeat until all done
+# when last task is done:
+# → milestone status auto becomes completed
+# → output shows: "🎉 里程碑 [xxx] 已自动完成！"
+```
+
+### Migrate task to different milestone
+```bash
+projmanage task update <task_id> --milestone <new_milestone_id>
+# both old and new milestones recalculate their status
+```
+
+### Clean up before deleting milestone
+```bash
+# Must delete tasks first (RESTRICT enforced)
+projmanage task list <project_id> --milestone <milestone_id>
+# note task IDs
+projmanage task delete <task_id_1> --force
+projmanage task delete <task_id_2> --force
+projmanage milestone delete <milestone_id> --force
+```
+
+---
+
+## Important Constraints
+
+1. **Task must belong to a milestone.** `milestone_id` is `NOT NULL` in the schema. `task new` requires `--milestone`.
+2. **One task → one milestone.** No multi-milestone assignments.
+3. **Milestone deletion is RESTRICTED.** If the milestone has any tasks, deletion is rejected. Delete all tasks first.
+4. **Project deletion cascades.** Deleting a project deletes all its milestones and tasks automatically (FK CASCADE).
+5. **Milestone status is auto-only.** There is no CLI flag to manually set it. Any attempt goes through `_sync_milestone_status` which overwrites based on task state.
+
+---
+
+## Database Location
+
+```
+~/.projmanage/projmanage.db
+```
+
+Schema files:
+- `/root/.projmanage/schema.sql` — raw DDL
+- `/root/.projmanage/schema.py` — SQLAlchemy models
+- `/root/.projmanage/db.py` — all DB operations
+
+Key tables: `projects`, `milestones`, `tasks`, `members`, `task_links`, `task_events`, `task_comments`
+
+---
+
+## Code Reference
+
+**`_sync_milestone_status`** (`db.py`): The central function that computes and writes milestone status based on task state. Called by `task_create`, `task_delete`, `task_update`, `task_set_status`.
+
+**`_check_milestone_completion`** (`db.py`): Legacy completion check. Still called after `task_set_status` for the "milestone auto-complete" echo message in the CLI. Do not remove.
+
+**`fmt_milestone_status`** (`__init__.py`): Formats milestone status for terminal output with color. `planning`→yellow, `in_progress`→cyan, `completed`→green.
+
+---
+
+## Common Pitfalls
+
+1. **Forgetting `--milestone` on `task new`.** It is required. Without it the DB raises a NOT NULL constraint error.
+
+2. **Trying to manually set milestone status.** The `--status` flag doesn't exist on milestone commands. Tell the user status is automatic.
+
+3. **Trying to delete a milestone with tasks.** Use `task delete <id> --force` for each task first, then delete the milestone.
+
+4. **Assuming `task new` accepts `--status`.** It does not. Task status is set via `task start/done/block/unblock` after creation.
+
+5. **Migrating a task to a milestone in a different project.** The FK constraint doesn't prevent cross-project assignment, but the business logic assumes milestones are per-project. Don't do this.
+
+6. **Deleting a project doesn't clean up the test data.** After `proj delete`, the DB is clean. Subsequent tests should create fresh data.
+
+---
+
+## Verification Checklist
+
+- [ ] `projmanage proj list` works
+- [ ] `milestone new` creates milestone in `planning` state (0 tasks)
+- [ ] `task new --milestone <id>` creates task and milestone becomes `in_progress`
+- [ ] `task done` on last incomplete task → milestone becomes `completed`
+- [ ] `milestone delete` with tasks → error "请先删除任务"
+- [ ] `task update --milestone <new_id>` syncs both old and new milestone status
+- [ ] `board view` shows per-milestone progress bars
+- [ ] `board stats` shows milestone progress bars


### PR DESCRIPTION
## Summary

Add task attachment support to projmanage CLI:

- `task add-attachment <task_id> <local_file>` — copy file to `~/.projmanage/projects/{project_id}/attachments/{timestamp}_{filename}`
- `task remove-attachment <attachment_id> [--force]` — delete file + DB record
- `task view` auto-shows all attachments inline
- `task_delete` / `proj_delete` cascade-delete attachment files

Also clarify `--desc` append behavior (not replace).

## Commits
- `e9bff8976` feat(skills/projmanage): add attachment commands
- `ca8f726dc` feat(skills/projmanage): clarify --desc append behavior
- `7f241c209` feat(skills): add projmanage skill - local project/milestone/task CLI