### PR TITLE
fix(tools): clarify cronjob required-params to prevent missing-schedule errors

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -59,6 +59,7 @@ AUTHOR_MAP = {
     "wangpuv@hotmail.com": "wangpuv",
     "202622897+ticketclosed-wontfix@users.noreply.github.com": "ticketclosed-wontfix",
     "wuxuebin1993@gmail.com": "victorGPT",
+    "teixeira.zeus@gmail.com": "teixeirazeus",
     "211828103+julio-cloudvisor@users.noreply.github.com": "julio-cloudvisor",
     "17778+kweiner@users.noreply.github.com": "kweiner",
     "223516181+faisfamilytravel@users.noreply.github.com": "faisfamilytravel",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -446,9 +446,16 @@ def cronjob(
         normalized = (action or "").strip().lower()
 
         if normalized == "create":
-            if not schedule:
-                return tool_error("schedule is required for create", success=False)
             canonical_skills = _canonical_skills(skill, skills)
+            if not schedule:
+                return tool_error(
+                    "schedule is required for create. schedule must be a non-empty string "
+                    "(e.g. '30m', 'every 2h', '0 9 * * *', or an ISO timestamp). "
+                    f"Received: action=create, schedule={schedule!r}, "
+                    f"prompt={prompt!r}, skills={canonical_skills!r} "
+                    "— review your tool call and ensure schedule is included.",
+                    success=False,
+                )
             _no_agent = bool(no_agent)
             # Job-shape validation differs by mode:
             #   - no_agent=True → script is the job; prompt/skills are optional
@@ -704,7 +711,13 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
         "properties": {
             "action": {
                 "type": "string",
-                "description": "One of: create, list, update, pause, resume, remove, run. When action=create, the 'schedule' and 'prompt' fields are REQUIRED."
+                "description": "One of: create, list, update, pause, resume, remove, run. "
+                               "REQUIRED PARAMETERS per action: "
+                               "create => schedule (REQUIRED) + prompt (unless skills is set); "
+                               "list => no extra params needed; "
+                               "update => schedule (REQUIRED) + job_id (REQUIRED); "
+                               "pause/resume/remove/run => job_id (REQUIRED). "
+                               "Always include schedule when action is create or update."
             },
             "job_id": {
                 "type": "string",
@@ -712,11 +725,16 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "prompt": {
                 "type": "string",
-                "description": "For create: the full self-contained prompt. If skills are also provided, this becomes the task instruction paired with those skills."
+                "description": "REQUIRED for create (unless skills is set). The full self-contained prompt. If skills are also provided, this becomes the task instruction paired with those skills."
             },
             "schedule": {
                 "type": "string",
-                "description": "REQUIRED for action=create. For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp. Examples: '30m' (every 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (one-shot). You MUST include this field when action=create."
+                "description": "REQUIRED for create/update (ALWAYS include this when action is create or update). "
+                               "'30m', 'every 2h', '0 9 * * *', or ISO timestamp. "
+                               "Examples: '30m' (every 30 minutes), 'every 2h' (every 2 hours), "
+                               "'0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (one-shot). "
+                               "CRITICAL: If you omit schedule on a create or update call, "
+                               "the tool will reject the request."
             },
             "name": {
                 "type": "string",
@@ -733,7 +751,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             "skills": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "Optional ordered list of skill names to load before executing the cron prompt. On update, pass an empty array to clear attached skills."
+                "description": "Optional ordered list of skill names to load before executing the cron prompt. On create, at least one of prompt or skills is required. On update, pass an empty array to clear attached skills."
             },
             "model": {
                 "type": "object",


### PR DESCRIPTION
## Summary
Weak models (Grok 4.3, per #34120) no longer omit `schedule` on `cronjob action=create` because the tool's parameter descriptions now spell out which params each action requires.

Root cause: the schema used a top-level `allOf` if/then to conditionally require `schedule`, but `tools/schema_sanitizer.py` strips `allOf`/`anyOf`/`oneOf` from the top-level `parameters` object (for OpenAI Codex strict-schema compat). The hint was discarded before reaching the LLM, so the model saw only `required: ["action"]` and treated `schedule` as optional, then hit the rejection.

## Changes
- `tools/cronjob_tools.py`: `action`/`schedule`/`prompt`/`skills` descriptions now state per-action required params; the create rejection echoes received values for debugging. All metadata-only — survives sanitization, reaches every backend.
- `scripts/release.py`: AUTHOR_MAP entry for the contributor.

## Validation
| | Before | After |
|---|---|---|
| sanitized schema seen by LLM | only `required:[action]`, no schedule hint | descriptions carry create⇒schedule(REQUIRED) hint |
| `tests/tools/test_cronjob_tools.py` | — | 56/56 pass |
| E2E: missing-schedule create | terse error | error echoes received values |

Salvaged from #34173 by @teixeirazeus. Dropped the re-added top-level `allOf` block (stripped by the sanitizer — same dead-on-arrival path as the original) and the issue-specific repro script; kept the effective metadata edits.

Fixes #34120.
