### PR TITLE
fix(ntfy): prevent echo loop by tagging outgoing messages

### DIFF
--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -81,6 +81,7 @@ DEDUP_WINDOW_SECONDS = 300
 DEDUP_MAX_SIZE = 1000
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 STREAM_TIMEOUT_SECONDS = 90  # ntfy keepalive default is 55s; give margin
+_ECHO_TAG = "hermes-agent"  # tag added to outgoing messages for echo-loop prevention
 
 
 def _build_auth_header(token: str) -> Dict[str, str]:
@@ -311,6 +312,12 @@ class NtfyAdapter(BasePlatformAdapter):
             logger.debug("[%s] Duplicate message %s, skipping", self.name, msg_id)
             return
 
+        # Echo-loop prevention: skip messages tagged by this adapter.
+        tags = event.get("tags") or []
+        if _ECHO_TAG in tags:
+            logger.debug("[%s] Skipping own message (echo tag)", self.name)
+            return
+
         text = (event.get("message") or "").strip()
         if not text:
             logger.debug("[%s] Empty message body, skipping", self.name)
@@ -387,7 +394,11 @@ class NtfyAdapter(BasePlatformAdapter):
 
         url = f"{self._server}/{publish_topic}"
         markdown_enabled = (self.config.extra or {}).get("markdown", False)
-        headers = {**self._auth_headers(), "Content-Type": "text/plain; charset=utf-8"}
+        headers = {
+            **self._auth_headers(),
+            "Content-Type": "text/plain; charset=utf-8",
+            "X-Tags": _ECHO_TAG,
+        }
         if markdown_enabled:
             headers["X-Markdown"] = "true"
 


### PR DESCRIPTION
## Problem

When `publish_topic` equals the subscribe topic (the default when `NTFY_PUBLISH_TOPIC` is not set), the agent's own outgoing replies are echoed back by ntfy as incoming messages. The gateway treats these echoed messages as new user input, triggering another agent response — creating an infinite reply spiral.

## Fix

Tag outgoing messages with `X-Tags: hermes-agent` header, and filter incoming messages that carry this tag in `_on_message()`. This is zero-config and works automatically regardless of topic configuration.

**3 changes in `plugins/platforms/ntfy/adapter.py`:**
1. Add `_ECHO_TAG = "hermes-agent"` constant
2. Add `"X-Tags": _ECHO_TAG` to outgoing POST headers in `send()`
3. Check `event.get("tags")` for `_ECHO_TAG` in `_on_message()` and skip if present

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| publish_topic == subscribe_topic | Infinite echo loop | Echo filtered, no loop |
| publish_topic != subscribe_topic | Works (no echo) | Works (tag ignored) |
| Message from real user | Processed normally | Processed normally (no tag) |

Fixes #34447