### PR TITLE
fix(install): detect installed NeuTTS in setup summary and tts flow

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -498,7 +498,6 @@ def _print_setup_summary(config: dict, hermes_home):
             tool_status.append(("Text-to-Speech (NeuTTS — not installed)", False, "run 'hermes setup tts'"))
     elif tts_provider == "kittentts":
         try:
-            import importlib.util
             kittentts_ok = importlib.util.find_spec("kittentts") is not None
         except Exception:
             kittentts_ok = False
@@ -1251,7 +1250,6 @@ def _setup_tts_provider(config: dict):
     elif selected == "kittentts":
         # Check if already installed
         try:
-            import importlib.util
             already_installed = importlib.util.find_spec("kittentts") is not None
         except Exception:
             already_installed = False

--- a/tests/hermes_cli/test_setup_neutts_detection.py
+++ b/tests/hermes_cli/test_setup_neutts_detection.py
@@ -1,0 +1,43 @@
+"""Regression test: NeuTTS install detection in setup summary.
+
+Guards against the bug where a redundant function-local
+``import importlib.util`` inside ``_print_setup_summary`` /
+``_setup_tts_provider`` made ``importlib`` a function-local for the whole
+function. The earlier ``importlib.util.find_spec("neutts")`` reference then
+raised ``UnboundLocalError``, which the surrounding ``except Exception``
+silently swallowed -> NeuTTS was *always* reported as "not installed",
+even when the package was importable. ``find_spec`` never actually ran.
+
+See: fix(install) — remove redundant local `import importlib.util`.
+"""
+import importlib.util
+
+from hermes_cli import setup as setup_mod
+
+
+def test_print_setup_summary_detects_installed_neutts(monkeypatch, capsys):
+    # Make NeuTTS look importable and record whether find_spec is reached.
+    calls = []
+    real_find_spec = importlib.util.find_spec
+
+    def spy_find_spec(name, *args, **kwargs):
+        calls.append(name)
+        if name == "neutts":
+            return object()  # pretend the package is installed
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, "find_spec", spy_find_spec)
+
+    config = {"tts": {"provider": "neutts"}}
+    setup_mod._print_setup_summary(config, "/tmp")
+
+    out = capsys.readouterr().out
+
+    # The detection probe must actually run (it never did with the bug).
+    assert "neutts" in calls, (
+        "importlib.util.find_spec('neutts') was never called — the "
+        "UnboundLocalError was swallowed by `except Exception`."
+    )
+    # And an installed NeuTTS must be reported as available, not missing.
+    assert "NeuTTS local" in out
+    assert "NeuTTS — not installed" not in out


### PR DESCRIPTION
# fix(install): NeuTTS is always reported "not installed" (swallowed UnboundLocalError)

**Branch:** `fix/setup-neutts-detection`
**Commit:** `fix(install): detect installed NeuTTS in setup summary and tts flow`

## What

Remove two redundant function-local `import importlib.util` statements in
`hermes_cli/setup.py` (inside `_print_setup_summary` and `_setup_tts_provider`).
`importlib.util` is already imported at module top (line 14).

## Why

Because each function re-imported `importlib.util` locally (in the `kittentts`
branch), Python treated `importlib` as a **function-local** for the entire
function body. The earlier `neutts` branch references
`importlib.util.find_spec("neutts")` *before* that local import, so it raised
`UnboundLocalError`.

That error was then silently swallowed by the surrounding `except Exception:`,
which set the probe result to `False`. Net effect:

- `_print_setup_summary` always shows **"Text-to-Speech (NeuTTS — not installed)"**, even when the `neutts` package is importable.
- `_setup_tts_provider` always treats NeuTTS as not installed (`already_installed = False`) and re-runs the install flow every time.

`find_spec` was never actually executed for the `neutts` path.

This is a real functional bug for NeuTTS users; the `kittentts` branch was
unaffected only by accident (its reference comes *after* the local import).

## How to test

```bash
# Reproduce conceptually: with the neutts package importable, run `hermes setup`
# (or the setup summary) — before the fix it reports NeuTTS as "not installed".

# Automated regression test (added in this PR):
scripts/run_tests.sh tests/hermes_cli/test_setup_neutts_detection.py
# or:
pytest tests/hermes_cli/test_setup_neutts_detection.py -v
```

The new test monkeypatches `importlib.util.find_spec` to (a) make `neutts`
appear installed and (b) record whether the probe is reached. It asserts the
probe actually runs and that the summary reports NeuTTS as available. The test
**fails on the current `main`** (probe never called, "not installed" printed)
and **passes with this fix**.

## Platforms tested

Linux (Python 3.11). Change is pure name-resolution / stdlib import — no
platform-specific behavior.

## Scope

One logical change: the fix plus its regression test. No refactor, no
unrelated cleanup.

---

### Diff summary

```
hermes_cli/setup.py                              | 2 --
tests/hermes_cli/test_setup_neutts_detection.py  | 43 +++++++++++++ (new)
```