### PR TITLE
fix(cli): invalidate update-check cache when installed version changes

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -232,7 +232,12 @@ def check_for_updates() -> Optional[int]:
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
 
-    # Read cache — invalidate if the embedded rev has changed since last check
+    # Read cache — invalidate if either the embedded rev or the installed
+    # version has changed since the last check. The version guard matters for
+    # pip/uv installs: there ``embedded_rev`` is always ``None``, so the rev
+    # comparison alone (``None == None``) never invalidates the cache, and a
+    # stale "N commits behind" result would persist for the full TTL after an
+    # upgrade.
     now = time.time()
     try:
         if cache_file.exists():
@@ -240,6 +245,7 @@ def check_for_updates() -> Optional[int]:
             if (
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
                 and cached.get("rev") == embedded_rev
+                and cached.get("version") == VERSION
             ):
                 return cached.get("behind")
     except Exception:
@@ -260,7 +266,11 @@ def check_for_updates() -> Optional[int]:
             behind = _check_via_local_git(repo_dir)
 
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev}))
+        cache_file.write_text(
+            json.dumps(
+                {"ts": now, "behind": behind, "rev": embedded_rev, "version": VERSION}
+            )
+        )
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -17,8 +17,8 @@ def test_version_string_no_v_prefix():
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
-    from hermes_cli.banner import check_for_updates
+    """When cache is fresh (same version), check_for_updates returns cached value without calling git."""
+    from hermes_cli.banner import check_for_updates, VERSION
 
     # Create a fake git repo and fresh cache
     repo_dir = tmp_path / "hermes-agent"
@@ -26,7 +26,7 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "version": VERSION}))
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     with patch("hermes_cli.banner.subprocess.run") as mock_run:
@@ -34,6 +34,56 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
 
     assert result == 3
     mock_run.assert_not_called()
+
+
+def test_check_for_updates_invalidates_on_version_change(tmp_path, monkeypatch):
+    """Regression for stale 'N commits behind' after a pip/uv upgrade.
+
+    For pip installs ``HERMES_REVISION`` is unset, so the embedded-rev guard
+    (``None == None``) never invalidates the cache. A cache written by the old
+    version must therefore be invalidated by the version mismatch, forcing a
+    fresh git check instead of returning the stale ``behind`` value.
+    """
+    from hermes_cli.banner import check_for_updates
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    # Fresh-by-time cache, but written by a DIFFERENT (older) version.
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(
+        json.dumps({"ts": time.time(), "behind": 1, "rev": None, "version": "0.0.0-old"})
+    )
+
+    # git now reports up-to-date.
+    mock_result = MagicMock(returncode=0, stdout="0\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
+        result = check_for_updates()
+
+    # The stale cached value (1) must NOT be returned; a fresh check ran.
+    assert result == 0
+    assert mock_run.call_count >= 1
+
+
+def test_check_for_updates_writes_version_to_cache(tmp_path, monkeypatch):
+    """A fresh check must persist the current VERSION so subsequent upgrades invalidate."""
+    from hermes_cli.banner import check_for_updates, VERSION
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    mock_result = MagicMock(returncode=0, stdout="0\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    with patch("hermes_cli.banner.subprocess.run", return_value=mock_result):
+        check_for_updates()
+
+    cached = json.loads((tmp_path / ".update_check").read_text())
+    assert cached.get("version") == VERSION
 
 
 def test_check_for_updates_expired_cache(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- Add the installed `VERSION` to the update-check cache payload and require it to match on read.
- Fixes a stale "N commits behind" banner that persisted for up to 6 hours after a pip/uv upgrade.

## Motivation

Closes #34491.

For pip/uv installs, `HERMES_REVISION` is unset, so `embedded_rev` is always `None` in `check_for_updates()`. The cache-validity check only compared the cached `rev` to `embedded_rev` (`None == None`), which never invalidated the cache. After upgrading (e.g. `0.14.0 → 0.15.1`), the old cache's `behind` count stayed valid until the 6h TTL expired, so `hermes --version` kept reporting a stale "1 commit behind" even though the user was up to date.

The fix adds `"version": VERSION` to the cache payload and requires `cached.get("version") == VERSION` on read, so a version change forces a fresh check. The nix path (`embedded_rev` set) is unaffected — it now simply has an additional, always-satisfied guard.

## Verification

- `python3 -m pytest tests/hermes_cli/test_update_check.py` — 10 passed
- New regression test `test_check_for_updates_invalidates_on_version_change` reproduces the bug: it fails on current `main` (returns the stale `1`) and passes with this fix (returns a fresh `0`).
- New `test_check_for_updates_writes_version_to_cache` asserts the version is persisted so future upgrades invalidate correctly.
- Updated `test_check_for_updates_uses_cache` to write the current `VERSION` (a same-version cache is still honored — no extra git calls).

## Reproduce (from the issue)

1. Install `0.14.0`, run `hermes --version` (writes cache with `behind: 1`)
2. `uv pip install --upgrade hermes-agent` to `0.15.1`
3. Before: still shows "1 commit behind" for up to 6h. After: correctly shows "Up to date".
