### PR TITLE
fix(cli): treat model.name as alias for model.default

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1471,7 +1471,12 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     if isinstance(model_cfg, str):
         return model_cfg
     elif isinstance(model_cfg, dict):
-        return model_cfg.get("default") or model_cfg.get("model") or ""
+        # Accept "name" as an alias for "default"/"model" so a config like
+        # ``model: {name: <id>, provider: <custom>}`` does not resolve to an
+        # empty model (which would send ``model=`` to the backend). Mirrors
+        # the CLI runtime path in hermes_cli.runtime_provider._get_model_config
+        # and the display paths in `hermes status` / `hermes dump`. See #34500.
+        return model_cfg.get("default") or model_cfg.get("model") or model_cfg.get("name") or ""
     return ""
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -185,9 +185,17 @@ def _get_model_config() -> Dict[str, Any]:
     model_cfg = config.get("model")
     if isinstance(model_cfg, dict):
         cfg = dict(model_cfg)
-        # Accept "model" as alias for "default" (users intuitively write model.model)
-        if not cfg.get("default") and cfg.get("model"):
-            cfg["default"] = cfg["model"]
+        # Accept "model" / "name" as aliases for "default". Users intuitively
+        # write model.model or model.name (the latter mirrors the per-entry
+        # ``name`` field used by custom_providers and is already honoured by
+        # display paths such as `hermes status` / `hermes dump`). Without this,
+        # a config like ``model: {name: <id>, provider: <custom>}`` resolves to
+        # an empty model and the API request goes out with ``model=`` (HTTP
+        # 400 from OpenAI-compatible backends). See issue #34500.
+        if not cfg.get("default"):
+            alias = cfg.get("model") or cfg.get("name")
+            if alias:
+                cfg["default"] = alias
         default = (cfg.get("default") or "").strip()
         base_url = (cfg.get("base_url") or "").strip()
         is_local = "localhost" in base_url or "127.0.0.1" in base_url

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2657,3 +2657,55 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+
+class TestGetModelConfigNameAlias:
+    """Regression tests for issue #34500 — ``model.name`` must resolve to a
+    non-empty model so custom providers don't send ``model=`` to the backend.
+
+    ``_get_model_config`` already aliases ``model`` → ``default``; these tests
+    extend that to ``name`` so a config like::
+
+        model:
+          name: claude-sonnet-4-20250514
+          provider: my-litellm
+
+    resolves the model name instead of silently dropping it.
+    """
+
+    def test_name_aliases_default(self, monkeypatch):
+        monkeypatch.setattr(
+            rp,
+            "load_config",
+            lambda: {"model": {"name": "claude-sonnet-4-20250514", "provider": "my-litellm"}},
+        )
+        cfg = rp._get_model_config()
+        assert cfg["default"] == "claude-sonnet-4-20250514"
+
+    def test_explicit_default_wins_over_name(self, monkeypatch):
+        monkeypatch.setattr(
+            rp,
+            "load_config",
+            lambda: {"model": {"default": "real-model", "name": "ignored-model"}},
+        )
+        cfg = rp._get_model_config()
+        assert cfg["default"] == "real-model"
+
+    def test_model_alias_still_wins_over_name(self, monkeypatch):
+        # ``model`` is checked before ``name`` to preserve existing precedence.
+        monkeypatch.setattr(
+            rp,
+            "load_config",
+            lambda: {"model": {"model": "model-key", "name": "name-key"}},
+        )
+        cfg = rp._get_model_config()
+        assert cfg["default"] == "model-key"
+
+    def test_no_model_keys_stays_empty(self, monkeypatch):
+        monkeypatch.setattr(
+            rp,
+            "load_config",
+            lambda: {"model": {"provider": "my-litellm"}},
+        )
+        cfg = rp._get_model_config()
+        assert (cfg.get("default") or "") == ""

--- a/tests/test_empty_model_fallback.py
+++ b/tests/test_empty_model_fallback.py
@@ -106,6 +106,19 @@ class TestResolveGatewayModel:
         from gateway.run import _resolve_gateway_model
         assert _resolve_gateway_model({"model": {"model": "gpt-5.4"}}) == "gpt-5.4"
 
+    def test_returns_name_key_fallback(self):
+        """Regression for #34500 — ``model.name`` resolves instead of empty."""
+        from gateway.run import _resolve_gateway_model
+        assert _resolve_gateway_model(
+            {"model": {"name": "claude-sonnet-4-20250514", "provider": "my-litellm"}}
+        ) == "claude-sonnet-4-20250514"
+
+    def test_default_wins_over_name(self):
+        from gateway.run import _resolve_gateway_model
+        assert _resolve_gateway_model(
+            {"model": {"default": "real-model", "name": "ignored"}}
+        ) == "real-model"
+
     def test_returns_empty_when_missing(self):
         from gateway.run import _resolve_gateway_model
         assert _resolve_gateway_model({"model": {}}) == ""


### PR DESCRIPTION
## Summary

- Accept `model.name` as an alias for `model.default` in the two runtime model-resolution chokepoints (`hermes_cli.runtime_provider._get_model_config` and `gateway.run._resolve_gateway_model`).
- Fixes the empty `model=` field sent to OpenAI-compatible backends when a config uses `model.name` (common with `custom_providers`), which produced HTTP 400 errors.

## Motivation

Closes #34500.

A config like the one in the issue:

```yaml
model:
  name: claude-sonnet-4-20250514
  provider: my-litellm
custom_providers:
  - name: my-litellm
    base_url: http://litellm-proxy:4000/v1
    api_key: sk-...
    models:
      - claude-sonnet-4-20250514
```

resolved the model to an empty string and the request went out with `model=`, causing `HTTP 400: Invalid model name passed in model=`.

**Root cause (refined from the issue):** the empty `model=` does not originate in `provider_model_ids()` (that only feeds the `/model` picker catalog). It comes from the runtime model resolver. `_get_model_config()` already aliases `model` → `default` (`if not cfg.get("default") and cfg.get("model"): cfg["default"] = cfg["model"]`) but does **not** accept `name`. The gateway twin `_resolve_gateway_model()` has the same gap. As a result `model.name` is silently dropped at runtime even though display paths (`hermes status` at `status.py:67`, `hermes dump` at `dump.py:157`) already read `name` as a model alias. This inconsistency is what makes the failure silent.

The fix makes the runtime paths consistent with the display paths by honoring `name` as a last-resort alias, with precedence `default` > `model` > `name`, so existing configs are unaffected.

## Verification

- `python3 -m pytest tests/hermes_cli/test_runtime_provider_resolution.py tests/test_empty_model_fallback.py tests/hermes_cli/test_custom_provider_model_switch.py -q` — **157 passed**
- New tests:
  - `TestGetModelConfigNameAlias` (4 tests) — CLI path: `name` aliases `default`; explicit `default`/`model` still win; empty stays empty.
  - `TestResolveGatewayModel::test_returns_name_key_fallback` + `test_default_wins_over_name` — gateway path.
- `python3 -m py_compile hermes_cli/runtime_provider.py gateway/run.py` — OK
- Precedence preserved: `default` > `model` > `name`, so no behavior change for existing configs.
