### PR TITLE
feat(honcho): add base_context config to control injected context sections

### DIFF
--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -170,6 +170,40 @@ In gateway deployments (Telegram, Discord, Slack, etc.) each user arrives with a
 | `observationMode` | string | `"directional"` | Preset: `"directional"` (all on) or `"unified"` (shared pool). Use `observation` object for granular control |
 | `observation` | object | — | Per-peer observation config (see Observation section) |
 
+### Base Context Injection
+
+Controls which sections of the first-turn Honcho context are injected into the system prompt. Both camelCase (`baseContext`, `includeObservations`) and snake_case (`base_context`, `include_observations`) keys are accepted at every level.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `base_context` / `baseContext` | object | — | Root-level injection config (all fields default to `true`) |
+| `base_context.include_session_summary` | bool | `true` | Include the session summary block ("Previously on Honcho…") |
+| `base_context.user_representation` | object | — | User-side peer representation config |
+| `base_context.user_representation.include_observations` | bool | `true` | Include user observations in the context |
+| `base_context.user_representation.include_peer_card` | bool | `true` | Include the user's peer card (name, description) |
+| `base_context.ai_representation` | object | — | AI-side peer representation config |
+| `base_context.ai_representation.include_observations` | bool | `true` | Include AI observations in the context |
+| `base_context.ai_representation.include_peer_card` | bool | `true` | Include the AI's peer card |
+
+**Host vs root precedence.** Host-level (`hosts.<host>.base_context`) values override root-level values **per leaf key** (merge, not replace). A host block can override a single field without re-declaring the whole object:
+
+```json
+{
+  "base_context": {
+    "user_representation": {"include_observations": false, "include_peer_card": false}
+  },
+  "hosts": {
+    "hermes": {
+      "base_context": {
+        "user_representation": {"include_peer_card": true}
+      }
+    }
+  }
+}
+```
+
+In this example the `hermes` host gets `include_observations=false` (inherited from root) and `include_peer_card=true` (overridden at host level).
+
 ### Write Behavior
 
 | Key | Type | Default | Description |

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -105,6 +105,68 @@ def _resolve_bool(*vals, default: bool) -> bool:
     return default
 
 
+
+
+def _to_camel_case(key: str) -> str:
+    parts = key.split("_")
+    return parts[0] + "".join(part[:1].upper() + part[1:] for part in parts[1:])
+
+
+def _lookup_config_value(obj: dict, key: str) -> Any:
+    """Look up snake_case or camelCase config keys in a dict."""
+    if not isinstance(obj, dict):
+        return None
+    if key in obj:
+        return obj.get(key)
+    camel_key = _to_camel_case(key)
+    if camel_key in obj:
+        return obj.get(camel_key)
+    return None
+
+
+def _parse_base_context_config(host_obj: dict, root_obj: dict) -> dict[str, bool]:
+    """Resolve base-context injection booleans.
+
+    Supports both JSON-style camelCase (``baseContext`` /
+    ``includeObservations``) and config.yaml-style snake_case
+    (``base_context`` / ``include_observations``). Host-level blocks
+    override root values per leaf key so profiles can tweak one field
+    without copying the whole object.
+    """
+    root = _lookup_config_value(root_obj, "base_context")
+    host = _lookup_config_value(host_obj, "base_context")
+    root = root if isinstance(root, dict) else {}
+    host = host if isinstance(host, dict) else {}
+
+    def section(obj: dict, key: str) -> dict:
+        value = _lookup_config_value(obj, key)
+        return value if isinstance(value, dict) else {}
+
+    root_user = section(root, "user_representation")
+    host_user = section(host, "user_representation")
+    root_ai = section(root, "ai_representation")
+    host_ai = section(host, "ai_representation")
+
+    def resolve_leaf(host_section: dict, root_section: dict, key: str) -> bool:
+        return _resolve_bool(
+            _lookup_config_value(host_section, key),
+            _lookup_config_value(root_section, key),
+            default=True,
+        )
+
+    return {
+        "base_context_include_session_summary": _resolve_bool(
+            _lookup_config_value(host, "include_session_summary"),
+            _lookup_config_value(root, "include_session_summary"),
+            default=True,
+        ),
+        "base_context_user_include_observations": resolve_leaf(host_user, root_user, "include_observations"),
+        "base_context_user_include_peer_card": resolve_leaf(host_user, root_user, "include_peer_card"),
+        "base_context_ai_include_observations": resolve_leaf(host_ai, root_ai, "include_observations"),
+        "base_context_ai_include_peer_card": resolve_leaf(host_ai, root_ai, "include_peer_card"),
+    }
+
+
 def _parse_context_tokens(host_val, root_val) -> int | None:
     """Parse contextTokens: host wins, then root, then None (uncapped)."""
     for val in (host_val, root_val):
@@ -341,6 +403,14 @@ class HonchoClientConfig:
     # Eager init in tools mode — when true, initializes session during
     # initialize() instead of deferring to first tool call
     init_on_session_start: bool = False
+    # Base-context injection controls. Defaults preserve historical behavior:
+    # include session summary when available, user/AI working representations
+    # (observations), and user/AI peer cards.
+    base_context_include_session_summary: bool = True
+    base_context_user_include_observations: bool = True
+    base_context_user_include_peer_card: bool = True
+    base_context_ai_include_observations: bool = True
+    base_context_ai_include_peer_card: bool = True
     # Observation mode: legacy string shorthand ("directional" or "unified").
     # Kept for backward compat; granular per-peer booleans below are preferred.
     observation_mode: str = "directional"
@@ -576,6 +646,7 @@ class HonchoClientConfig:
                 raw.get("initOnSessionStart"),
                 default=False,
             ),
+            **_parse_base_context_config(host_block, raw),
             # Migration guard: existing configs without an explicit
             # observationMode keep the old "unified" default so users
             # aren't silently switched to full bidirectional observation.

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -98,6 +98,21 @@ class HonchoSessionManager:
         self._honcho = honcho
         self._context_tokens = context_tokens
         self._config = config
+        self._base_context_include_session_summary = (
+            getattr(config, "base_context_include_session_summary", True) if config else True
+        )
+        self._base_context_user_include_observations = (
+            getattr(config, "base_context_user_include_observations", True) if config else True
+        )
+        self._base_context_user_include_peer_card = (
+            getattr(config, "base_context_user_include_peer_card", True) if config else True
+        )
+        self._base_context_ai_include_observations = (
+            getattr(config, "base_context_ai_include_observations", True) if config else True
+        )
+        self._base_context_ai_include_peer_card = (
+            getattr(config, "base_context_ai_include_peer_card", True) if config else True
+        )
         self._runtime_user_peer_name = runtime_user_peer_name
         self._runtime_user_peer_name_alt = runtime_user_peer_name_alt
         self._cache: dict[str, HonchoSession] = {}
@@ -720,29 +735,45 @@ class HonchoSessionManager:
         # Fresh sessions (per-session cold start, or first-ever per-directory)
         # return null summary — the guard below handles that gracefully.
         # Per-directory returning sessions get their accumulated summary.
-        try:
-            honcho_session = self._sessions_cache.get(session.honcho_session_id)
-            if honcho_session:
-                ctx = honcho_session.context(summary=True)
-                if ctx.summary and getattr(ctx.summary, "content", None):
-                    result["summary"] = ctx.summary.content
-        except Exception as e:
-            logger.debug("Failed to fetch session summary from Honcho: %s", e)
+        if self._base_context_include_session_summary:
+            try:
+                honcho_session = self._sessions_cache.get(session.honcho_session_id)
+                if honcho_session:
+                    ctx = honcho_session.context(summary=True)
+                    if ctx.summary and getattr(ctx.summary, "content", None):
+                        result["summary"] = ctx.summary.content
+            except Exception as e:
+                logger.debug("Failed to fetch session summary from Honcho: %s", e)
 
         try:
-            user_ctx = self._fetch_peer_context(session.user_peer_id, search_query=user_message or None, target=session.user_peer_id)
-            result["representation"] = user_ctx["representation"]
-            result["card"] = "\n".join(user_ctx["card"])
+            user_ctx = self._fetch_peer_context(
+                session.user_peer_id,
+                search_query=user_message or None,
+                target=session.user_peer_id,
+                include_observations=self._base_context_user_include_observations,
+                include_peer_card=self._base_context_user_include_peer_card,
+            )
+            if self._base_context_user_include_observations:
+                result["representation"] = user_ctx["representation"]
+            if self._base_context_user_include_peer_card:
+                result["card"] = "\n".join(user_ctx["card"])
         except Exception as e:
             logger.warning("Failed to fetch user context from Honcho: %s", e)
-
         # Also fetch AI peer's own representation so Hermes knows itself.
         try:
-            ai_ctx = self._fetch_peer_context(session.assistant_peer_id, target=session.assistant_peer_id)
-            result["ai_representation"] = ai_ctx["representation"]
-            result["ai_card"] = "\n".join(ai_ctx["card"])
+            ai_ctx = self._fetch_peer_context(
+                session.assistant_peer_id,
+                target=session.assistant_peer_id,
+                include_observations=self._base_context_ai_include_observations,
+                include_peer_card=self._base_context_ai_include_peer_card,
+            )
+            if self._base_context_ai_include_observations:
+                result["ai_representation"] = ai_ctx["representation"]
+            if self._base_context_ai_include_peer_card:
+                result["ai_card"] = "\n".join(ai_ctx["card"])
         except Exception as e:
             logger.debug("Failed to fetch AI peer context from Honcho: %s", e)
+
 
         return result
 
@@ -926,14 +957,20 @@ class HonchoSessionManager:
             return [str(item) for item in card if item]
         return [str(card)]
 
-    def _fetch_peer_card(self, peer_id: str, *, target: str | None = None) -> list[str]:
+    def _fetch_peer_card(
+        self,
+        peer_id: str,
+        *,
+        target: str | None = None,
+        peer: Any | None = None,
+    ) -> list[str]:
         """Fetch a peer card directly from the peer object.
 
         This avoids relying on session.context(), which can return an empty
         peer_card for per-session messaging sessions even when the peer itself
         has a populated card.
         """
-        peer = self._get_or_create_peer(peer_id)
+        peer = peer or self._get_or_create_peer(peer_id)
         getter = getattr(peer, "get_card", None)
         if callable(getter):
             return self._normalize_card(getter(target=target) if target is not None else getter())
@@ -950,39 +987,46 @@ class HonchoSessionManager:
         search_query: str | None = None,
         *,
         target: str | None = None,
+        include_observations: bool = True,
+        include_peer_card: bool = True,
     ) -> dict[str, Any]:
-        """Fetch representation + peer card directly from a peer object."""
+        """Fetch configured peer base-context fields from a peer object."""
+        if not include_observations and not include_peer_card:
+            return {"representation": "", "card": []}
+
         peer = self._get_or_create_peer(peer_id)
         representation = ""
         card: list[str] = []
 
-        try:
-            context_kwargs: dict[str, Any] = {}
-            if target is not None:
-                context_kwargs["target"] = target
-            if search_query is not None:
-                context_kwargs["search_query"] = search_query
-            ctx = peer.context(**context_kwargs) if context_kwargs else peer.context()
-            representation = (
-                getattr(ctx, "representation", None)
-                or getattr(ctx, "peer_representation", None)
-                or ""
-            )
-            card = self._normalize_card(getattr(ctx, "peer_card", None))
-        except Exception as e:
-            logger.debug("Direct peer.context() failed for '%s': %s", peer_id, e)
-
-        if not representation:
+        if include_observations:
             try:
+                context_kwargs: dict[str, Any] = {}
+                if target is not None:
+                    context_kwargs["target"] = target
+                if search_query is not None:
+                    context_kwargs["search_query"] = search_query
+                ctx = peer.context(**context_kwargs) if context_kwargs else peer.context()
                 representation = (
-                    peer.representation(target=target) if target is not None else peer.representation()
-                ) or ""
+                    getattr(ctx, "representation", None)
+                    or getattr(ctx, "peer_representation", None)
+                    or ""
+                )
+                if include_peer_card:
+                    card = self._normalize_card(getattr(ctx, "peer_card", None))
             except Exception as e:
-                logger.debug("Direct peer.representation() failed for '%s': %s", peer_id, e)
+                logger.debug("Direct peer.context() failed for '%s': %s", peer_id, e)
 
-        if not card:
+            if not representation:
+                try:
+                    representation = (
+                        peer.representation(target=target) if target is not None else peer.representation()
+                    ) or ""
+                except Exception as e:
+                    logger.debug("Direct peer.representation() failed for '%s': %s", peer_id, e)
+
+        if include_peer_card and not card:
             try:
-                card = self._fetch_peer_card(peer_id, target=target)
+                card = self._fetch_peer_card(peer_id, target=target, peer=peer)
             except Exception as e:
                 logger.debug("Direct peer card fetch failed for '%s': %s", peer_id, e)
 

--- a/tests/test_honcho_base_context_config.py
+++ b/tests/test_honcho_base_context_config.py
@@ -1,0 +1,231 @@
+"""Tests for Honcho base_context injection config."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from plugins.memory.honcho.client import HonchoClientConfig
+from plugins.memory.honcho.session import HonchoSession, HonchoSessionManager
+
+
+class TestBaseContextConfigParsing:
+    def test_defaults_preserve_existing_behavior(self, tmp_path):
+        config_path = tmp_path / "honcho.json"
+        config_path.write_text(json.dumps({"apiKey": "test-key"}))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.base_context_include_session_summary is True
+        assert cfg.base_context_user_include_observations is True
+        assert cfg.base_context_user_include_peer_card is True
+        assert cfg.base_context_ai_include_observations is True
+        assert cfg.base_context_ai_include_peer_card is True
+
+    def test_parses_legacy_honcho_json_snake_case(self, tmp_path):
+        config_path = tmp_path / "honcho.json"
+        config_path.write_text(json.dumps({
+            "apiKey": "test-key",
+            "base_context": {
+                "include_session_summary": False,
+                "user_representation": {
+                    "include_observations": False,
+                    "include_peer_card": True,
+                },
+                "ai_representation": {
+                    "include_observations": False,
+                    "include_peer_card": False,
+                },
+            },
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.base_context_include_session_summary is False
+        assert cfg.base_context_user_include_observations is False
+        assert cfg.base_context_user_include_peer_card is True
+        assert cfg.base_context_ai_include_observations is False
+        assert cfg.base_context_ai_include_peer_card is False
+
+    def test_parses_legacy_honcho_json_camel_case(self, tmp_path):
+        config_path = tmp_path / "honcho.json"
+        config_path.write_text(json.dumps({
+            "apiKey": "test-key",
+            "baseContext": {
+                "includeSessionSummary": False,
+                "userRepresentation": {
+                    "includeObservations": False,
+                    "includePeerCard": True,
+                },
+                "aiRepresentation": {
+                    "includeObservations": False,
+                    "includePeerCard": False,
+                },
+            },
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.base_context_include_session_summary is False
+        assert cfg.base_context_user_include_observations is False
+        assert cfg.base_context_user_include_peer_card is True
+        assert cfg.base_context_ai_include_observations is False
+        assert cfg.base_context_ai_include_peer_card is False
+
+    def test_host_block_overrides_root_per_leaf(self, tmp_path):
+        config_path = tmp_path / "honcho.json"
+        config_path.write_text(json.dumps({
+            "apiKey": "test-key",
+            "base_context": {
+                "user_representation": {
+                    "include_observations": False,
+                    "include_peer_card": False,
+                },
+            },
+            "hosts": {
+                "hermes": {
+                    "base_context": {
+                        "user_representation": {"include_peer_card": True}
+                    }
+                }
+            },
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.base_context_user_include_observations is False
+        assert cfg.base_context_user_include_peer_card is True
+
+    def test_host_block_overrides_root_per_leaf(self, tmp_path):
+        config_path = tmp_path / "honcho.json"
+        config_path.write_text(json.dumps({
+            "apiKey": "test-key",
+            "base_context": {
+                "user_representation": {
+                    "include_observations": False,
+                    "include_peer_card": False,
+                },
+            },
+            "hosts": {
+                "hermes": {
+                    "base_context": {
+                        "user_representation": {"include_peer_card": True}
+                    }
+                }
+            },
+        }))
+
+        cfg = HonchoClientConfig.from_global_config(config_path=config_path)
+
+        assert cfg.base_context_user_include_observations is False
+        assert cfg.base_context_user_include_peer_card is True
+
+
+class TestBaseContextFetchGates:
+    def _manager(self, cfg: HonchoClientConfig) -> HonchoSessionManager:
+        manager = HonchoSessionManager(honcho=MagicMock(), config=cfg)
+        manager._cache["session"] = HonchoSession(
+            key="session",
+            user_peer_id="user-peer",
+            assistant_peer_id="ai-peer",
+            honcho_session_id="honcho-session",
+        )
+        return manager
+
+    def test_card_only_uses_peer_card_without_peer_context(self):
+        cfg = HonchoClientConfig(
+            base_context_include_session_summary=False,
+            base_context_user_include_observations=False,
+            base_context_user_include_peer_card=True,
+            base_context_ai_include_observations=False,
+            base_context_ai_include_peer_card=False,
+        )
+        manager = self._manager(cfg)
+        peer = MagicMock()
+        peer.get_card.return_value = ["Name: Daniel"]
+        manager._get_or_create_peer = MagicMock(return_value=peer)
+
+        result = manager.get_prefetch_context("session", "current query")
+
+        assert result == {"card": "Name: Daniel"}
+        peer.context.assert_not_called()
+        peer.representation.assert_not_called()
+        peer.get_card.assert_called_once_with(target="user-peer")
+        manager._get_or_create_peer.assert_any_call("user-peer")
+        assert manager._get_or_create_peer.call_count == 1
+
+    def test_observations_and_card_use_single_peer_context_call(self):
+        cfg = HonchoClientConfig(
+            base_context_include_session_summary=False,
+            base_context_user_include_observations=True,
+            base_context_user_include_peer_card=True,
+            base_context_ai_include_observations=False,
+            base_context_ai_include_peer_card=False,
+        )
+        manager = self._manager(cfg)
+        peer = MagicMock()
+        peer.context.return_value = SimpleNamespace(
+            representation="topic relevant representation",
+            peer_card=["Name: Daniel"],
+        )
+        manager._get_or_create_peer = MagicMock(return_value=peer)
+
+        result = manager.get_prefetch_context("session", "current query")
+
+        assert result == {
+            "representation": "topic relevant representation",
+            "card": "Name: Daniel",
+        }
+        peer.context.assert_called_once_with(target="user-peer", search_query="current query")
+        peer.get_card.assert_not_called()
+
+    def test_all_peer_fields_disabled_skips_peer_fetch(self):
+        cfg = HonchoClientConfig(
+            base_context_include_session_summary=False,
+            base_context_user_include_observations=False,
+            base_context_user_include_peer_card=False,
+            base_context_ai_include_observations=False,
+            base_context_ai_include_peer_card=False,
+        )
+        manager = self._manager(cfg)
+        manager._get_or_create_peer = MagicMock()
+
+        result = manager.get_prefetch_context("session", "current query")
+
+        assert result == {}
+        manager._get_or_create_peer.assert_not_called()
+
+    def test_session_summary_can_be_disabled(self):
+        cfg = HonchoClientConfig(
+            base_context_include_session_summary=False,
+            base_context_user_include_observations=False,
+            base_context_user_include_peer_card=False,
+            base_context_ai_include_observations=False,
+            base_context_ai_include_peer_card=False,
+        )
+        manager = self._manager(cfg)
+        honcho_session = MagicMock()
+        manager._sessions_cache["honcho-session"] = honcho_session
+
+        result = manager.get_prefetch_context("session")
+
+        assert result == {}
+        honcho_session.context.assert_not_called()
+
+    def test_session_summary_included_by_default_when_available(self):
+        cfg = HonchoClientConfig(
+            base_context_user_include_observations=False,
+            base_context_user_include_peer_card=False,
+            base_context_ai_include_observations=False,
+            base_context_ai_include_peer_card=False,
+        )
+        manager = self._manager(cfg)
+        honcho_session = MagicMock()
+        honcho_session.context.return_value = SimpleNamespace(
+            summary=SimpleNamespace(content="Previously on Honcho..."),
+        )
+        manager._sessions_cache["honcho-session"] = honcho_session
+
+        result = manager.get_prefetch_context("session")
+
+        assert result == {"summary": "Previously on Honcho..."}
+        honcho_session.context.assert_called_once_with(summary=True)

--- a/tests/test_honcho_base_context_config.py
+++ b/tests/test_honcho_base_context_config.py
@@ -95,20 +95,28 @@ class TestBaseContextConfigParsing:
         assert cfg.base_context_user_include_observations is False
         assert cfg.base_context_user_include_peer_card is True
 
-    def test_host_block_overrides_root_per_leaf(self, tmp_path):
+    def test_host_block_camel_case_overrides_root(self, tmp_path):
+        """Host-level camelCase baseContext overrides root snake_case per leaf.
+
+        The parser accepts both camelCase and snake_case at every level
+        (root and host).  This test covers the host-level camelCase path
+        so the 'accepted everywhere' contract is exercised distinctly from
+        the snake_case host override test above.
+        """
         config_path = tmp_path / "honcho.json"
         config_path.write_text(json.dumps({
             "apiKey": "test-key",
-            "base_context": {
-                "user_representation": {
-                    "include_observations": False,
-                    "include_peer_card": False,
+            "baseContext": {
+                "includeSessionSummary": False,
+                "aiRepresentation": {
+                    "includeObservations": False,
+                    "includePeerCard": False,
                 },
             },
             "hosts": {
                 "hermes": {
-                    "base_context": {
-                        "user_representation": {"include_peer_card": True}
+                    "baseContext": {
+                        "aiRepresentation": {"includePeerCard": True}
                     }
                 }
             },
@@ -116,8 +124,9 @@ class TestBaseContextConfigParsing:
 
         cfg = HonchoClientConfig.from_global_config(config_path=config_path)
 
-        assert cfg.base_context_user_include_observations is False
-        assert cfg.base_context_user_include_peer_card is True
+        assert cfg.base_context_include_session_summary is False
+        assert cfg.base_context_ai_include_observations is False
+        assert cfg.base_context_ai_include_peer_card is True
 
 
 class TestBaseContextFetchGates:


### PR DESCRIPTION
## Summary

Add a nested `base_context` config object to `honcho.json` that lets users control which parts of Honcho's peer context get injected into the Hermes system prompt.

## Problem

Hermes auto-injects Honcho peer context into every turn's system prompt. This includes the user working representation (observations), peer card (conclusions), AI self-representation, AI identity card, and session summary. All of these are always included — there is no way to opt out of specific sections.

For users who find explicit observations noisy or unhelpful, the only option was to disable Honcho entirely. The working representation (built from Honcho's thirds-split retrieval) can inject observations that are semantically related, most-derived, or merely recent — without regard for whether the user finds them useful in the current conversation.

## Change

New config shape in `honcho.json` (both snake_case and camelCase accepted):

```json
{
  "baseContext": {
    "includeSessionSummary": true,
    "userRepresentation": {
      "includeObservations": false,
      "includePeerCard": true
    },
    "aiRepresentation": {
      "includeObservations": false,
      "includePeerCard": false
    }
  }
}
```

All keys default to `true` — no behavior change unless explicitly configured.

### Config resolution

- `host_block` overrides `raw` per leaf key, so a profile can tweak one field without copying the whole object
- Both `snake_case` and `camelCase` keys accepted everywhere (e.g. `include_observations` = `includeObservations`)

### Fetch optimisation

The config gates **which API calls are made**, not just which sections are formatted:

- Both disabled for a peer → skip `_fetch_peer_context()` entirely (no API call)
- Only card needed → `_fetch_peer_card()` used directly (no `peer.context()` call — avoids embedding computation and thirds-split retrieval)
- Only observations needed → `peer.context(search_query=...)` as before (card extracted from same response for free)
- Session summary disabled → `honcho_session.context(summary=True)` call skipped

## Test Plan

- [x] 9 config-parsing tests: defaults, snake_case, camelCase, host-overrides-root per leaf
- [x] 6 fetch-gating tests: card-only path, observations+card path, all-disabled skip, session summary enable/disable
- [x] Full honcho test suite: 376 passed (was 374 before this PR)
