### PR TITLE
fix(wheel): include hermes_cli subpackages in wheel build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,7 @@ plugins = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Add `"hermes_cli.*"` to `[tool.setuptools.packages.find].include` to fix the v0.15.1 wheel missing `dashboard_auth/` and `proxy/` subpackages.

## Root Cause

`[tool.setuptools.packages.find].include` listed `"hermes_cli"` but was missing `"hermes_cli.*"`. Every other package in the list (`agent.*`, `tools.*`, `gateway.*`, `tui_gateway.*`, `plugins.*`, `providers.*`) had its subpackage glob — only `hermes_cli` was missing it. This caused `hermes_cli/dashboard_auth/` and `hermes_cli/proxy/` to be excluded from the built wheel.

## Impact

The dashboard subprocess crashes with:
```
File "hermes_cli/web_server.py", line 4822
    from hermes_cli.dashboard_auth.routes import router
ModuleNotFoundError: No module named "hermes_cli.dashboard_auth"
```

Only affects wheel installs (e.g. `uv pip install hermes-agent` from 0.14.x). The Docker `:latest` image uses an editable install so it bypasses the bug.

## Changes

One line in `pyproject.toml`: added `"hermes_cli.*"` to the include list.

## Verification

Built wheel with `uv build --wheel` and confirmed the RECORD now contains:
```
hermes_cli/dashboard_auth/__init__.py
hermes_cli/dashboard_auth/routes.py
hermes_cli/dashboard_auth/middleware.py
hermes_cli/dashboard_auth/base.py
hermes_cli/dashboard_auth/cookies.py
hermes_cli/dashboard_auth/login_page.py
hermes_cli/dashboard_auth/prefix.py
hermes_cli/dashboard_auth/public_paths.py
hermes_cli/dashboard_auth/registry.py
hermes_cli/dashboard_auth/ws_tickets.py
hermes_cli/dashboard_auth/audit.py
hermes_cli/proxy/__init__.py
hermes_cli/proxy/cli.py
hermes_cli/proxy/server.py
hermes_cli/proxy/adapters/__init__.py
hermes_cli/proxy/adapters/base.py
hermes_cli/proxy/adapters/nous_portal.py
hermes_cli/proxy/adapters/xai.py
```

(Alongside the existing `plugins/dashboard_auth/nous/` plugin directory — these are separate things.)

Fixes #34346