### PR TITLE
feat(cli): display prompt in cron list output

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -93,6 +93,10 @@ def cron_list(show_all: bool = False):
         script = job.get("script")
         if script:
             print(f"    Script:    {script}")
+        prompt = job.get("prompt")
+        if prompt:
+            prompt_display = prompt[:80] + "..." if len(prompt) > 80 else prompt
+            print(f"    Prompt:    {prompt_display}")
         if job.get("no_agent"):
             print(f"    Mode:      {color('no-agent', Colors.DIM)} (script stdout delivered directly)")
         workdir = job.get("workdir")


### PR DESCRIPTION
## What does this PR do?

Adds the `prompt` field to `cron list` output, so users can see what each cron job does at a glance. Prompts longer than 80 characters are truncated with an ellipsis (`...`).

## Related Issue

N/A

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/cron.py`: Added prompt display in `cron_list()` function, with 80-char truncation

## How to Test

1. Create a cron job with a prompt: `/cron add 0 9 * * * "Check system health and report status"`
2. Run `/cron list` or `hermes cron list`
3. Verify the prompt is displayed in the job details
4. Create a cron job with a long prompt (>80 chars) and verify it's truncated with `...`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/nousresearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/nousresearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] N/A — no config, docs, or architecture changes
- [x] N/A
- [x] N/A
- [x] N/A — no cross-platform concerns (uses standard Python string operations)
- [x] N/A

## For New Skills

*(Delete this section — not a skill)*

## Screenshots / Logs

*(Optional — paste `cron list` output showing the new prompt field if you want)*
