### PR TITLE
fix(agent): merge consecutive assistant tool_calls messages on session replay

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -356,6 +356,11 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
          any preceding assistant tool_call — dropped.
       2. Consecutive ``user`` messages — merged with newline separator
          so no user input is lost.
+      3. Consecutive ``assistant`` messages with ``tool_calls`` — merged
+         into a single assistant message containing all tool calls. Some
+         providers (e.g. DeepSeek v4) reject consecutive assistant tool_call
+         messages because each ``assistant(tool_calls)`` must be immediately
+         followed by ``tool`` responses. See #29148.
 
     Deliberately does NOT rewind orphan ``assistant(tool_calls)+tool``
     pairs that precede a user message — that pattern IS valid when the
@@ -429,10 +434,40 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
                 continue
         merged.append(msg)
 
+    # Pass 3: merge consecutive assistant messages with tool_calls.
+    # Some providers (e.g. DeepSeek v4) enforce strict alternation:
+    # every assistant(tool_calls) must be immediately followed by
+    # tool(response) messages before another assistant message can
+    # appear. Consecutive assistant tool_call messages — produced by
+    # certain streaming paths (Codex, event-projectors) — violate this
+    # and cause HTTP 400 on session replay.
+    merged2: List[Dict] = []
+    for msg in merged:
+        if (
+            merged2
+            and isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and msg.get("tool_calls")
+            and isinstance(merged2[-1], dict)
+            and merged2[-1].get("role") == "assistant"
+            and merged2[-1].get("tool_calls")
+        ):
+            prev = merged2[-1]
+            prev["tool_calls"].extend(msg["tool_calls"])
+            # Keep content from whichever message has it (usually empty)
+            if not prev.get("content") and msg.get("content"):
+                prev["content"] = msg["content"]
+            # Keep finish_reason from the latest message
+            if msg.get("finish_reason"):
+                prev["finish_reason"] = msg["finish_reason"]
+            repairs += 1
+            continue
+        merged2.append(msg)
+
     if repairs > 0:
         # Rewrite in place so downstream paths (persistence, return
         # value, session DB flush) see the repaired sequence.
-        messages[:] = merged
+        messages[:] = merged2
 
     return repairs
 


### PR DESCRIPTION
## Summary

Fixes #29148 — consecutive assistant messages with `tool_calls` break session replay on providers that enforce strict role alternation (DeepSeek v4, Anthropic, etc.).

### Problem

When parallel tool calls are produced by certain streaming/event-projection paths, the session file can contain consecutive assistant messages with `tool_calls`:

```
{"role": "assistant", "tool_calls": [{"id": "call_A"}]},
{"role": "assistant", "tool_calls": [{"id": "call_B"}]},
{"role": "tool", "tool_call_id": "call_A"},
{"role": "tool", "tool_call_id": "call_B"}
```

DeepSeek v4 API requires that each `assistant(tool_calls)` message is immediately followed by its `tool` responses. On session replay, this malformed sequence causes HTTP 400:

> "An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'."

### Fix

Adds **Pass 3** to `repair_message_sequence()` in `agent/agent_runtime_helpers.py`, which runs as a defensive belt before every API call. It detects consecutive assistant messages with `tool_calls` and merges them into a single message containing all tool calls:

```
{"role": "assistant", "tool_calls": [{"id": "call_A"}, {"id": "call_B"}]},
{"role": "tool", "tool_call_id": "call_A"},
{"role": "tool", "tool_call_id": "call_B"}
```

### Testing

- [ ] Existing tests pass (`pytest tests/run_agent/ -x -q`)
- [x] Consecutive assistant tool_call messages are correctly merged
- [x] Non-tool assistant messages are never affected
- [x] Single assistant tool_call messages pass through unchanged
