### PR TITLE
fix(gateway): honor config-driven access policies over legacy env fallbacks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6515,6 +6515,210 @@ class GatewayRunner:
             return YuanbaoAdapter(config)
 
         return None
+
+    @staticmethod
+    def _coerce_access_list(value: Any) -> list[str]:
+        """Coerce config allowlist values into a trimmed string list."""
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(",") if item.strip()]
+        if isinstance(value, (list, tuple, set)):
+            return [str(item).strip() for item in value if str(item).strip()]
+        text = str(value).strip()
+        return [text] if text else []
+
+    @staticmethod
+    def _match_access_list(
+        entries: list[str],
+        target: str,
+        *,
+        case_insensitive: bool = False,
+        strip_prefixes: tuple[str, ...] = (),
+    ) -> bool:
+        """Return True when *target* matches any configured allowlist entry."""
+        candidate = str(target or "").strip()
+        if not candidate:
+            return False
+        if case_insensitive:
+            candidate = candidate.lower()
+        for entry in entries:
+            normalized = str(entry or "").strip()
+            if not normalized:
+                continue
+            if strip_prefixes:
+                lowered = normalized.lower()
+                for prefix in strip_prefixes:
+                    if lowered.startswith(prefix):
+                        normalized = normalized[len(prefix):].strip()
+                        lowered = normalized.lower()
+                        break
+            if case_insensitive:
+                normalized = normalized.lower()
+            if normalized == "*" or normalized == candidate:
+                return True
+        return False
+
+    def _authorize_via_platform_access_policy(self, source: SessionSource) -> Optional[bool]:
+        """Evaluate config-driven DM/group policies before falling back to env allowlists.
+
+        Several adapters expose documented access controls through
+        ``PlatformConfig.extra`` (for example ``dm_policy`` / ``allow_from`` /
+        ``group_policy`` / ``group_allow_from``).  Gateway auth runs before the
+        adapter, so if we ignore those keys here the request is denied before the
+        adapter's own policy has a chance to run.
+
+        Returns:
+          - ``True`` / ``False`` when the platform declares an explicit policy.
+          - ``None`` when the platform does not use this policy surface and the
+            caller should keep evaluating the legacy env-based allowlists.
+        """
+        config = getattr(self, "config", None)
+        platforms = getattr(config, "platforms", None)
+        if not isinstance(platforms, dict):
+            return None
+        platform_cfg = platforms.get(source.platform)
+        extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
+        if not isinstance(extra, dict) or not extra:
+            return None
+
+        platform = source.platform
+        chat_type = str(source.chat_type or "").lower()
+        is_dm = chat_type == "dm"
+        is_groupish = chat_type in {"group", "forum", "channel"}
+
+        if platform == Platform.WECOM:
+            if is_dm and "dm_policy" in extra:
+                policy = str(extra.get("dm_policy") or "").strip().lower()
+                allow_from = self._coerce_access_list(
+                    extra.get("allow_from") or extra.get("allowFrom")
+                )
+                if policy == "disabled":
+                    return False
+                if policy == "allowlist":
+                    return self._match_access_list(
+                        allow_from,
+                        str(source.user_id or ""),
+                        case_insensitive=True,
+                        strip_prefixes=("wecom:", "user:", "group:"),
+                    )
+                if policy == "pairing":
+                    return False
+                if policy == "open":
+                    return True
+                return None
+            if is_groupish and "group_policy" in extra:
+                policy = str(extra.get("group_policy") or "").strip().lower()
+                group_allow = self._coerce_access_list(
+                    extra.get("group_allow_from") or extra.get("groupAllowFrom")
+                )
+                if policy == "disabled":
+                    return False
+                if policy == "allowlist" and not self._match_access_list(
+                    group_allow,
+                    str(source.chat_id or ""),
+                    case_insensitive=True,
+                    strip_prefixes=("wecom:", "group:", "user:"),
+                ):
+                    return False
+                groups_cfg = extra.get("groups") if isinstance(extra.get("groups"), dict) else {}
+                group_cfg = groups_cfg.get(str(source.chat_id or "")) or groups_cfg.get("*") or {}
+                sender_allow = self._coerce_access_list(
+                    group_cfg.get("allow_from") or group_cfg.get("allowFrom")
+                ) if isinstance(group_cfg, dict) else []
+                if sender_allow:
+                    return self._match_access_list(
+                        sender_allow,
+                        str(source.user_id or ""),
+                        case_insensitive=True,
+                        strip_prefixes=("wecom:", "user:", "group:"),
+                    )
+                if policy in {"open", "allowlist"}:
+                    return True
+                return None
+
+        if platform == Platform.WEIXIN:
+            if is_dm and "dm_policy" in extra:
+                policy = str(extra.get("dm_policy") or "").strip().lower()
+                allow_from = self._coerce_access_list(extra.get("allow_from"))
+                if policy == "disabled":
+                    return False
+                if policy == "allowlist":
+                    return self._match_access_list(allow_from, str(source.user_id or ""))
+                if policy == "pairing":
+                    return False
+                if policy == "open":
+                    return True
+                return None
+            if is_groupish and "group_policy" in extra:
+                policy = str(extra.get("group_policy") or "").strip().lower()
+                group_allow = self._coerce_access_list(extra.get("group_allow_from"))
+                if policy == "disabled":
+                    return False
+                if policy == "allowlist":
+                    return self._match_access_list(group_allow, str(source.chat_id or ""))
+                if policy == "open":
+                    return True
+                return None
+
+        if platform == Platform.YUANBAO:
+            if is_dm and "dm_policy" in extra:
+                policy = str(extra.get("dm_policy") or "").strip().lower()
+                allow_from = self._coerce_access_list(extra.get("dm_allow_from"))
+                if policy == "disabled":
+                    return False
+                if policy == "allowlist":
+                    return self._match_access_list(allow_from, str(source.user_id or ""))
+                if policy == "open":
+                    return True
+                return None
+            if is_groupish and "group_policy" in extra:
+                policy = str(extra.get("group_policy") or "").strip().lower()
+                group_allow = self._coerce_access_list(extra.get("group_allow_from"))
+                if policy == "disabled":
+                    return False
+                if policy == "allowlist":
+                    return self._match_access_list(group_allow, str(source.chat_id or ""))
+                if policy == "open":
+                    return True
+                return None
+
+        if platform == Platform.QQBOT:
+            if is_dm and "dm_policy" in extra:
+                policy = str(extra.get("dm_policy") or "").strip().lower()
+                allow_from = self._coerce_access_list(
+                    extra.get("allow_from") or extra.get("allowFrom")
+                )
+                if policy == "disabled":
+                    return False
+                if policy == "allowlist":
+                    return self._match_access_list(
+                        allow_from,
+                        str(source.user_id or ""),
+                        case_insensitive=True,
+                    )
+                if policy == "open":
+                    return True
+                return None
+            if is_groupish and "group_policy" in extra:
+                policy = str(extra.get("group_policy") or "").strip().lower()
+                group_allow = self._coerce_access_list(
+                    extra.get("group_allow_from") or extra.get("groupAllowFrom")
+                )
+                if policy == "disabled":
+                    return False
+                if policy == "allowlist":
+                    return self._match_access_list(
+                        group_allow,
+                        str(source.chat_id or ""),
+                        case_insensitive=True,
+                    )
+                if policy == "open":
+                    return True
+                return None
+
+        return None
+
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
         Check if a user is authorized to use the bot.
@@ -6654,6 +6858,9 @@ class GatewayRunner:
         global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
 
         if not platform_allowlist and not group_user_allowlist and not group_chat_allowlist and not global_allowlist:
+            policy_result = self._authorize_via_platform_access_policy(source)
+            if policy_result is not None:
+                return policy_result
             # No allowlists configured -- check global allow-all flag
             return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
 
@@ -6760,6 +6967,16 @@ class GatewayRunner:
         if config and hasattr(config, "unauthorized_dm_behavior"):
             if config.unauthorized_dm_behavior != "pair":  # non-default → explicit override
                 return config.unauthorized_dm_behavior
+
+        if platform and config and hasattr(config, "platforms"):
+            platform_cfg = config.platforms.get(platform)
+            extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
+            if isinstance(extra, dict):
+                dm_policy = str(extra.get("dm_policy") or "").strip().lower()
+                if dm_policy == "pairing":
+                    return "pair"
+                if dm_policy in {"allowlist", "disabled"}:
+                    return "ignore"
 
         # No explicit override.  Fall back to allowlist-aware default:
         # if any allowlist is configured for this platform, silently drop

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -24,6 +24,8 @@ def _clear_auth_env(monkeypatch) -> None:
         "MATRIX_ALLOWED_USERS",
         "DINGTALK_ALLOWED_USERS", "FEISHU_ALLOWED_USERS", "WECOM_ALLOWED_USERS",
         "QQ_ALLOWED_USERS", "QQ_GROUP_ALLOWED_USERS",
+        "WEIXIN_ALLOWED_USERS",
+        "YUANBAO_ALLOWED_USERS",
         "GATEWAY_ALLOWED_USERS",
         "TELEGRAM_ALLOW_ALL_USERS",
         "DISCORD_ALLOW_ALL_USERS",
@@ -36,6 +38,8 @@ def _clear_auth_env(monkeypatch) -> None:
         "MATRIX_ALLOW_ALL_USERS",
         "DINGTALK_ALLOW_ALL_USERS", "FEISHU_ALLOW_ALL_USERS", "WECOM_ALLOW_ALL_USERS",
         "QQ_ALLOW_ALL_USERS",
+        "WEIXIN_ALLOW_ALL_USERS",
+        "YUANBAO_ALLOW_ALL_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
     ):
         monkeypatch.delenv(key, raising=False)
@@ -178,6 +182,222 @@ def test_qq_group_allowlist_does_not_authorize_other_groups(monkeypatch):
     )
 
     assert runner._is_user_authorized(source) is False
+
+
+def test_wecom_config_dm_allowlist_authorizes_without_env_allowlist(monkeypatch):
+    _clear_auth_env(monkeypatch)
+
+    runner, _adapter = _make_runner(
+        Platform.WECOM,
+        GatewayConfig(
+            platforms={
+                Platform.WECOM: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "dm_policy": "allowlist",
+                        "allow_from": ["user-1"],
+                    },
+                )
+            }
+        ),
+    )
+
+    source = SessionSource(
+        platform=Platform.WECOM,
+        user_id="user-1",
+        chat_id="dm-chat-1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
+@pytest.mark.asyncio
+async def test_wecom_config_dm_allowlist_rejects_without_pairing_prompt(monkeypatch):
+    _clear_auth_env(monkeypatch)
+
+    config = GatewayConfig(
+        platforms={
+            Platform.WECOM: PlatformConfig(
+                enabled=True,
+                extra={
+                    "dm_policy": "allowlist",
+                    "allow_from": ["user-1"],
+                },
+            )
+        }
+    )
+    runner, adapter = _make_runner(Platform.WECOM, config)
+
+    result = await runner._handle_message(
+        _make_event(
+            Platform.WECOM,
+            "user-2",
+            "dm-chat-2",
+        )
+    )
+
+    assert result is None
+    runner.pairing_store.generate_code.assert_not_called()
+    adapter.send.assert_not_awaited()
+
+
+def test_weixin_config_group_allowlist_authorizes_without_env_allowlist(monkeypatch):
+    _clear_auth_env(monkeypatch)
+
+    runner, _adapter = _make_runner(
+        Platform.WEIXIN,
+        GatewayConfig(
+            platforms={
+                Platform.WEIXIN: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "group_policy": "allowlist",
+                        "group_allow_from": ["group-1"],
+                    },
+                )
+            }
+        ),
+    )
+
+    source = SessionSource(
+        platform=Platform.WEIXIN,
+        user_id="wxid-user-1",
+        chat_id="group-1",
+        user_name="tester",
+        chat_type="group",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
+def test_wecom_config_group_sender_allowlist_authorizes_without_env_allowlist(monkeypatch):
+    _clear_auth_env(monkeypatch)
+
+    runner, _adapter = _make_runner(
+        Platform.WECOM,
+        GatewayConfig(
+            platforms={
+                Platform.WECOM: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "group_policy": "allowlist",
+                        "group_allow_from": ["group-1"],
+                        "groups": {
+                            "group-1": {
+                                "allow_from": ["user-1"],
+                            }
+                        },
+                    },
+                )
+            }
+        ),
+    )
+
+    source = SessionSource(
+        platform=Platform.WECOM,
+        user_id="user-1",
+        chat_id="group-1",
+        user_name="tester",
+        chat_type="group",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
+def test_yuanbao_config_dm_open_authorizes_without_env_allowlist(monkeypatch):
+    _clear_auth_env(monkeypatch)
+
+    runner, _adapter = _make_runner(
+        Platform.YUANBAO,
+        GatewayConfig(
+            platforms={
+                Platform.YUANBAO: PlatformConfig(
+                    enabled=True,
+                    extra={"dm_policy": "open"},
+                )
+            }
+        ),
+    )
+
+    source = SessionSource(
+        platform=Platform.YUANBAO,
+        user_id="account-1",
+        chat_id="direct:account-1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
+def test_qq_config_group_allowlist_authorizes_without_env_allowlist(monkeypatch):
+    _clear_auth_env(monkeypatch)
+
+    runner, _adapter = _make_runner(
+        Platform.QQBOT,
+        GatewayConfig(
+            platforms={
+                Platform.QQBOT: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "group_policy": "allowlist",
+                        "group_allow_from": ["group-openid-1"],
+                    },
+                )
+            }
+        ),
+    )
+
+    source = SessionSource(
+        platform=Platform.QQBOT,
+        user_id="member-openid-999",
+        chat_id="group-openid-1",
+        user_name="tester",
+        chat_type="group",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
+def test_get_unauthorized_dm_behavior_uses_config_dm_allowlist(monkeypatch):
+    _clear_auth_env(monkeypatch)
+
+    config = GatewayConfig(
+        platforms={
+            Platform.WECOM: PlatformConfig(
+                enabled=True,
+                extra={
+                    "dm_policy": "allowlist",
+                    "allow_from": ["user-1"],
+                },
+            )
+        },
+    )
+    runner, _adapter = _make_runner(Platform.WECOM, config)
+
+    behavior = runner._get_unauthorized_dm_behavior(Platform.WECOM)
+    assert behavior == "ignore"
+
+
+def test_get_unauthorized_dm_behavior_uses_config_pairing_policy(monkeypatch):
+    _clear_auth_env(monkeypatch)
+
+    config = GatewayConfig(
+        platforms={
+            Platform.WECOM: PlatformConfig(
+                enabled=True,
+                extra={
+                    "dm_policy": "pairing",
+                },
+            )
+        },
+    )
+    runner, _adapter = _make_runner(Platform.WECOM, config)
+
+    behavior = runner._get_unauthorized_dm_behavior(Platform.WECOM)
+    assert behavior == "pair"
 
 
 def test_telegram_group_user_allowlist_authorizes_forum_sender_without_dm_allowlist(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes gateway authorization so config-driven access policies are enforced before the legacy env-based fallback.

Before this change, documented platform policies such as `dm_policy`, `allow_from`, `group_policy`, and `group_allow_from` could be ignored when no env allowlist was set, causing the gateway to deny requests before adapter-level policy logic could run. This PR aligns gateway auth with the configured platform policy surface and keeps unauthorized DM behavior consistent with those policies.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Added gateway-side evaluation for config-driven access policies in `gateway/run.py`
- Applied config policy handling for `WECOM`, `WEIXIN`, `YUANBAO`, and `QQBOT`
- Updated unauthorized DM behavior resolution so `allowlist` / `disabled` policies do not fall through to pairing
- Added regression coverage in `tests/gateway/test_unauthorized_dm_behavior.py` for:
  - WeCom DM allowlist authorization
  - WeCom unauthorized DM ignore behavior
  - WeCom per-group sender allowlist authorization
  - Weixin group allowlist authorization
  - Yuanbao open DM authorization
  - QQ group allowlist authorization
  - Config-driven unauthorized DM behavior resolution

## How to Test

1. Run the targeted gateway/platform regression suite:
   - `tests/gateway/test_unauthorized_dm_behavior.py`
   - `tests/gateway/test_wecom.py`
   - `tests/gateway/test_weixin.py`
   - `tests/gateway/test_qqbot.py`
   - `tests/gateway/test_platform_registry.py`
   - `tests/gateway/test_telegram_group_gating.py`
   - `tests/gateway/test_whatsapp_group_gating.py`
   - `tests/test_yuanbao_pipeline.py`
2. Confirm that config-only access policies authorize the expected DM/group flows without requiring env allowlists.
3. Confirm that unauthorized DMs under config allowlists are ignored instead of triggering pairing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)


### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Test result for the targeted regression/platform suite:

- `505 passed, 4 warnings`

Warnings were pre-existing runtime warnings in `tests/gateway/test_qqbot.py` and are not caused by this change.