### PR TITLE
fix(gateway): align MEDIA: regex whitelist with extract_local_files

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2521,7 +2521,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|bmp|tiff|svg|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|tar|gz|tgz|bz2|xz|7z|docx?|xlsx?|xls|ods|pptx?|ppt|odp|key|txt|md|csv|tsv|json|xml|ya?ml|odt|rtf|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()


### PR DESCRIPTION
## Summary

Align `extract_media`'s extension whitelist with the broader set supported by `extract_local_files`, fixing silent file drops for `.md`, `.json`, `.yaml`, and other formats.

## Problem

PR #28350 introduced a strict extension whitelist in `extract_media` but the cleanup regex on line 3709 (`MEDIA:\s*\S+`) unconditionally strips **all** `MEDIA:` tags from text — even those the strict regex didn't match. This creates a black hole where files with unsupported extensions are neither extracted nor detectable by the downstream `extract_local_files` fallback.

## Changes

Added missing extensions to `extract_media`'s regex: `md`, `json`, `xml`, `ya?ml`, `tsv`, `odt`, `rtf`, `bmp`, `tiff`, `svg`, `tar`, `gz`, `tgz`, `bz2`, `xz`, `xls`, `ods`, `ppt`, `odp`, `key`.

## Testing

- Verified `MEDIA:/tmp/paid_users_up_analysis.md` now matches
- `test_media_extraction.py`: 4 passed
- `test_platform_base.py`: 114 passed, 2 skipped

Fixes #34517