### PR TITLE
fix(voice): make voice.max_recording_seconds actually take effect

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11198,6 +11198,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._voice_recorder._silence_duration = (
             _duration if isinstance(_duration, (int, float)) and not isinstance(_duration, bool) else 3.0
         )
+        # voice.max_recording_seconds — hard cap on a single recording's length.
+        # Same numeric guard as the silence params (bool excluded: a hand-edited
+        # ``max_recording_seconds: true`` must not become ``1``). <= 0 disables
+        # the cap. Previously this documented key was never read, so the setting
+        # had no effect (dead config); wiring it here makes it take effect.
+        _max_rec = voice_cfg.get("max_recording_seconds")
+        self._voice_recorder._max_recording_seconds = (
+            _max_rec
+            if isinstance(_max_rec, (int, float)) and not isinstance(_max_rec, bool) and _max_rec > 0
+            else 0.0
+        )
 
         def _on_silence():
             """Called by AudioRecorder when silence is detected after speech."""

--- a/cli.py
+++ b/cli.py
@@ -11200,14 +11200,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         )
         # voice.max_recording_seconds — hard cap on a single recording's length.
         # Same numeric guard as the silence params (bool excluded: a hand-edited
-        # ``max_recording_seconds: true`` must not become ``1``). <= 0 disables
-        # the cap. Previously this documented key was never read, so the setting
-        # had no effect (dead config); wiring it here makes it take effect.
+        # ``max_recording_seconds: true`` must not become ``1`` — it falls back
+        # to the documented 120 default, mirroring the silence-param handling).
+        # An explicit numeric value <= 0 disables the cap. Previously this
+        # documented key was never read (dead config); wiring it here makes it
+        # take effect.
         _max_rec = voice_cfg.get("max_recording_seconds")
         self._voice_recorder._max_recording_seconds = (
-            _max_rec
-            if isinstance(_max_rec, (int, float)) and not isinstance(_max_rec, bool) and _max_rec > 0
-            else 0.0
+            (_max_rec if _max_rec > 0 else 0.0)
+            if isinstance(_max_rec, (int, float)) and not isinstance(_max_rec, bool)
+            else 120.0
         )
 
         def _on_silence():

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -373,6 +373,7 @@ def start_continuous(
     silence_threshold: int = 200,
     silence_duration: float = 3.0,
     auto_restart: bool = True,
+    max_recording_seconds: float = 0.0,
 ) -> bool:
     """Start a VAD-driven continuous recording loop.
 
@@ -390,6 +391,10 @@ def start_continuous(
 
     ``on_status`` is called with ``"listening"`` / ``"transcribing"`` /
     ``"idle"`` so the UI can show a live indicator.
+
+    ``max_recording_seconds`` is the hard cap on a single recording's length
+    (``voice.max_recording_seconds``); any non-positive or non-numeric value
+    disables the cap, preserving the previous unbounded behaviour.
     """
     global _continuous_active, _continuous_recorder, _continuous_auto_restart
     global _continuous_on_transcript, _continuous_on_status, _continuous_on_silent_limit
@@ -415,6 +420,15 @@ def start_continuous(
 
         _continuous_recorder._silence_threshold = silence_threshold
         _continuous_recorder._silence_duration = silence_duration
+        # Same numeric-with-bool-excluded guard as the CLI wiring in
+        # cli.py:_voice_start_recording — <= 0 (or garbage) disables the cap.
+        _continuous_recorder._max_recording_seconds = (
+            max_recording_seconds
+            if isinstance(max_recording_seconds, (int, float))
+            and not isinstance(max_recording_seconds, bool)
+            and max_recording_seconds > 0
+            else 0.0
+        )
         rec = _continuous_recorder
 
     _debug(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -638,6 +638,55 @@ def test_voice_record_start_handles_non_dict_voice_cfg(monkeypatch):
         assert captured["auto_restart"] is False
 
 
+def test_voice_record_start_forwards_max_recording_seconds(monkeypatch):
+    """voice.max_recording_seconds must reach start_continuous from the TUI.
+
+    The CLI wiring alone doesn't cover TUI recordings: the gateway forwards
+    recorder params explicitly, so a missing kwarg here silently leaves the
+    cap dead in the TUI while CLI tests stay green. Semantics mirror the
+    silence params: non-numeric / bool / missing falls back to the documented
+    120 default, an explicit numeric value <= 0 disables the cap.
+    """
+    captured: dict = {}
+
+    def fake_start_continuous(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.voice",
+        types.SimpleNamespace(
+            start_continuous=fake_start_continuous, stop_continuous=lambda: None
+        ),
+    )
+    monkeypatch.setenv("HERMES_VOICE", "1")
+
+    for cfg, expected in (
+        ({"max_recording_seconds": 45}, 45),        # explicit cap forwarded as-is
+        ({"max_recording_seconds": 0}, 0.0),        # explicit 0 = disabled
+        ({"max_recording_seconds": -5}, 0.0),       # negative = disabled
+        ({}, 120.0),                                # missing = documented default
+        ({"max_recording_seconds": True}, 120.0),   # bool must not become 1s cap
+        ({"max_recording_seconds": "long"}, 120.0), # garbage = documented default
+    ):
+        captured.clear()
+        monkeypatch.setattr(server, "_load_cfg", lambda c=cfg: {"voice": c})
+
+        resp = server.dispatch(
+            {
+                "id": "voice-record-cap",
+                "method": "voice.record",
+                "params": {"action": "start"},
+            }
+        )
+
+        assert "result" in resp, f"voice.record raised for cfg={cfg!r}: {resp.get('error')}"
+        assert resp["result"]["status"] == "recording"
+        assert (
+            captured["max_recording_seconds"] == expected
+        ), f"cfg={cfg!r} forwarded {captured.get('max_recording_seconds')!r}, expected {expected!r}"
+
+
 def test_voice_record_stop_forces_transcription(monkeypatch):
     captured: dict = {}
 

--- a/tests/test_voice_max_recording_seconds.py
+++ b/tests/test_voice_max_recording_seconds.py
@@ -1,0 +1,32 @@
+"""Regression test: voice.max_recording_seconds is actually enforced.
+
+Before this fix, ``voice.max_recording_seconds`` was defined in the default
+config (hermes_cli/config.py) and documented, but no code read it — the
+AudioRecorder had no total-length cap, so the setting was dead config. This
+test pins the enforcement contract on the recorder:
+
+* cap disabled (0 / unset) → never auto-stops on duration (previous behaviour),
+* cap set to N>0 → auto-stop condition becomes true once elapsed >= N.
+"""
+from tools.voice_mode import AudioRecorder
+
+
+def test_cap_disabled_by_default():
+    r = AudioRecorder()
+    assert r._max_recording_seconds == 0.0
+    # No cap → duration trigger never fires, even at absurd elapsed times.
+    assert r._max_duration_reached(10_000.0) is False
+
+
+def test_cap_enforced_when_set():
+    r = AudioRecorder()
+    r._max_recording_seconds = 120
+    assert r._max_duration_reached(119.9) is False
+    assert r._max_duration_reached(120.0) is True
+    assert r._max_duration_reached(300.0) is True
+
+
+def test_zero_means_unlimited():
+    r = AudioRecorder()
+    r._max_recording_seconds = 0
+    assert r._max_duration_reached(99_999.0) is False

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -987,6 +987,59 @@ class TestVoiceBeepConfigReal:
         mock_beep.assert_not_called()
 
 
+class TestMaxRecordingSecondsConfigReal:
+    """voice.max_recording_seconds must reach the recorder from config.
+
+    Regression for the dead-config fix: the predicate alone can stay green
+    while the CLI wiring regresses, so pin the actual assignment made by
+    ``_voice_start_recording`` for the valid / disabled / corrupted cases.
+    """
+
+    def _start_with_voice_cfg(self, voice_cfg):
+        with patch("cli._cprint"), \
+             patch("cli.threading.Thread", return_value=MagicMock(start=MagicMock())), \
+             patch("tools.voice_mode.play_beep"), \
+             patch("tools.voice_mode.create_audio_recorder") as mock_create, \
+             patch(
+                 "tools.voice_mode.check_voice_requirements",
+                 return_value={
+                     "available": True,
+                     "audio_available": True,
+                     "stt_available": True,
+                     "details": "OK",
+                     "missing_packages": [],
+                 },
+             ), \
+             patch("hermes_cli.config.load_config", return_value={"voice": voice_cfg}):
+            recorder = MagicMock()
+            recorder.supports_silence_autostop = True
+            mock_create.return_value = recorder
+
+            cli = _make_voice_cli()
+            cli._voice_start_recording()
+
+        return recorder
+
+    def test_configured_cap_reaches_recorder(self):
+        recorder = self._start_with_voice_cfg({"max_recording_seconds": 45})
+        assert recorder._max_recording_seconds == 45
+
+    def test_non_positive_value_disables_cap(self):
+        recorder = self._start_with_voice_cfg({"max_recording_seconds": 0})
+        assert recorder._max_recording_seconds == 0.0
+
+    def test_bool_falls_back_to_documented_default(self):
+        # bool is a subclass of int — ``max_recording_seconds: true`` must not
+        # become a 1-second cap; it falls back to the documented 120 default,
+        # mirroring the silence-param corruption handling.
+        recorder = self._start_with_voice_cfg({"max_recording_seconds": True})
+        assert recorder._max_recording_seconds == 120.0
+
+    def test_garbage_falls_back_to_documented_default(self):
+        recorder = self._start_with_voice_cfg({"max_recording_seconds": "long"})
+        assert recorder._max_recording_seconds == 120.0
+
+
 class TestDisableVoiceModeReal:
     """Tests _disable_voice_mode with real CLI instance."""
 

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -1175,6 +1175,92 @@ class TestSilenceDetection:
 
 
 # ============================================================================
+# Max recording length cap (voice.max_recording_seconds)
+# ============================================================================
+
+class TestMaxRecordingCap:
+    """The hard cap must auto-stop through the real InputStream-callback
+    path — not just the predicate — and fire the one-shot callback exactly
+    once, independent of the silence-detection branches."""
+
+    def _get_stream_callback(self, mock_sd):
+        callback = mock_sd.InputStream.call_args.kwargs.get("callback")
+        if callback is None:
+            callback = mock_sd.InputStream.call_args[1]["callback"]
+        return callback
+
+    def test_cap_fires_one_shot_callback_during_continuous_speech(self, mock_sd):
+        np = pytest.importorskip("numpy")
+        import threading
+
+        mock_sd.InputStream.return_value = MagicMock()
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder._max_recording_seconds = 0.1
+        # Park the other auto-stop branches far away so only the cap can fire:
+        # loud frames keep the silence branch off, and max_wait covers the
+        # no-speech branch.
+        recorder._silence_duration = 60.0
+        recorder._max_wait = 60.0
+
+        fires = []
+        fired = threading.Event()
+
+        def on_stop():
+            fires.append(1)
+            fired.set()
+
+        recorder.start(on_silence_stop=on_stop)
+        callback = self._get_stream_callback(mock_sd)
+
+        loud_frame = np.full((1600, 1), 5000, dtype="int16")
+        callback(loud_frame, 1600, None, None)
+        assert not fired.is_set(), "cap must not fire before the limit elapses"
+
+        # Cross the cap while the user is STILL speaking — the silence branch
+        # can never fire here, so a hit proves the cap path.
+        time.sleep(0.12)
+        callback(loud_frame, 1600, None, None)
+        assert fired.wait(timeout=1.0) is True
+
+        # One-shot: the handler cleared _on_silence_stop, further frames past
+        # the cap must not fire again.
+        assert recorder._on_silence_stop is None
+        callback(loud_frame, 1600, None, None)
+        time.sleep(0.05)
+        assert len(fires) == 1
+
+        recorder.cancel()
+
+    def test_disabled_cap_never_fires_on_duration(self, mock_sd):
+        np = pytest.importorskip("numpy")
+        import threading
+
+        mock_sd.InputStream.return_value = MagicMock()
+
+        from tools.voice_mode import AudioRecorder
+
+        recorder = AudioRecorder()
+        recorder._max_recording_seconds = 0.0  # disabled (previous behaviour)
+        recorder._silence_duration = 60.0
+        recorder._max_wait = 60.0
+
+        fired = threading.Event()
+        recorder.start(on_silence_stop=lambda: fired.set())
+        callback = self._get_stream_callback(mock_sd)
+
+        loud_frame = np.full((1600, 1), 5000, dtype="int16")
+        callback(loud_frame, 1600, None, None)
+        time.sleep(0.12)
+        callback(loud_frame, 1600, None, None)
+
+        assert fired.wait(timeout=0.2) is False
+        recorder.cancel()
+
+
+# ============================================================================
 # Playback interrupt
 # ============================================================================
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -497,10 +497,24 @@ class AudioRecorder:
         self._silence_threshold: int = SILENCE_RMS_THRESHOLD
         self._silence_duration: float = SILENCE_DURATION_SECONDS
         self._max_wait: float = 15.0  # Max seconds to wait for speech before auto-stop
+        # Hard cap on total recording length, wired from voice.max_recording_seconds
+        # by the CLI before each recording. 0 (or unset) = no cap (previous behaviour).
+        self._max_recording_seconds: float = 0.0
         # Peak RMS seen during recording (for speech presence check in stop())
         self._peak_rms: int = 0
         # Live audio level (read by UI for visual feedback)
         self._current_rms: int = 0
+
+    def _max_duration_reached(self, elapsed: float) -> bool:
+        """Whether the configured hard recording-length cap has elapsed.
+
+        ``voice.max_recording_seconds`` is applied by the CLI before each
+        recording (see ``HermesCLI._voice_start_recording``). A value <= 0
+        (or unset) disables the cap, preserving the previous unbounded
+        behaviour.
+        """
+        cap = self._max_recording_seconds
+        return bool(cap and cap > 0 and elapsed >= cap)
 
     # -- public properties ---------------------------------------------------
 
@@ -616,6 +630,14 @@ class AudioRecorder:
                 elif not self._has_spoken and elapsed >= self._max_wait:
                     logger.info("No speech within %.0fs, auto-stopping",
                                 self._max_wait)
+                    should_fire = True
+
+                # 3. Hard cap on total recording length (voice.max_recording_seconds).
+                #    Independent of speech/silence so a continuous speaker past the
+                #    configured limit still auto-stops instead of recording forever.
+                if not should_fire and self._max_duration_reached(elapsed):
+                    logger.info("Max recording length reached (%.0fs), auto-stopping",
+                                self._max_recording_seconds)
                     should_fire = True
 
                 if should_fire:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13467,6 +13467,16 @@ def _(rid, params: dict) -> dict:
                 if isinstance(duration, (int, float)) and not isinstance(duration, bool)
                 else 3.0
             )
+            # voice.max_recording_seconds — hard cap on a single recording's
+            # length. Same guard as the silence params: non-numeric / bool /
+            # missing falls back to the documented 120 default, while an
+            # explicit numeric value <= 0 disables the cap (0.0).
+            max_rec = voice_cfg.get("max_recording_seconds")
+            safe_max_rec = (
+                (max_rec if max_rec > 0 else 0.0)
+                if isinstance(max_rec, (int, float)) and not isinstance(max_rec, bool)
+                else 120.0
+            )
             started = start_continuous(
                 on_transcript=lambda t: _voice_emit("voice.transcript", {"text": t}),
                 on_status=lambda s: _voice_emit("voice.status", {"state": s}),
@@ -13476,6 +13486,7 @@ def _(rid, params: dict) -> dict:
                 silence_threshold=safe_threshold,
                 silence_duration=safe_duration,
                 auto_restart=False,
+                max_recording_seconds=safe_max_rec,
             )
             if started is False:
                 return _ok(rid, {"status": "busy"})


### PR DESCRIPTION
# fix(voice): make `voice.max_recording_seconds` actually take effect

**Branch:** `fix/voice-max-recording-seconds`
**Commit:** `fix(voice): enforce voice.max_recording_seconds (was dead config)`

## What

Wire the documented `voice.max_recording_seconds` config key into the audio
recorder so it actually caps a single recording's length. Currently the key is
defined in the default config and documented, but **no code reads it** — it is
dead config and has no effect.

## Why

`hermes_cli/config.py` ships `voice.max_recording_seconds: 120` and every other
key in the `voice` section is consumed in `HermesCLI._voice_start_recording`
(`silence_threshold`, `silence_duration`, `beep_enabled`, `auto_tts`,
`record_key`). `max_recording_seconds` is the only one never read anywhere, and
`AudioRecorder` has no total-length cap (only `_max_wait`, the *pre-speech*
no-speech timeout). Result: a user who sets `voice.max_recording_seconds` sees
no effect, and a continuous speaker is never auto-stopped by length.

Found via a config audit (key defined in defaults but referenced nowhere as a
literal). No existing issue.

## Change

- `tools/voice_mode.py`
  - `AudioRecorder.__init__`: add `self._max_recording_seconds: float = 0.0` (0 / unset = no cap → previous behaviour).
  - add `AudioRecorder._max_duration_reached(elapsed)` helper.
  - in the audio callback's auto-stop logic, fire the existing silence/auto-stop path when the cap is reached. The check is independent of speech/silence so a continuous speaker past the limit still auto-stops (and the recording is transcribed via the normal path, not discarded).
- `cli.py` (`_voice_start_recording`): read `voice.max_recording_seconds` with the same numeric guard as the silence params (`bool` excluded), apply it to the recorder; values `<= 0` / invalid disable the cap.

## Behaviour note (please confirm)

The shipped default is `120`, so this makes that 120s cap **active** where
recordings were previously unbounded in continuous/auto-stop mode. That matches
the documented intent of the key, and `voice.max_recording_seconds: 0` is an
escape hatch for unlimited. If maintainers prefer the default to remain
effectively unlimited, I can flip the CLI fallback so the cap only applies when
a user sets a positive value explicitly. Happy to adjust.

Scope note: the cap is enforced in the `AudioRecorder` auto-stop path
(continuous mode). Push-to-talk (no silence callback) is user-controlled and
intentionally left unbounded; `TermuxAudioRecorder` has no live callback and is
out of scope.

## How to test

```bash
pytest tests/test_voice_max_recording_seconds.py -v
# or, matching CI:
scripts/run_tests.sh tests/test_voice_max_recording_seconds.py
```

The added test pins the enforcement contract on `AudioRecorder`
(`_max_duration_reached`): disabled at 0/unset, fires once `elapsed >= cap`.
It **fails on current `main`** (`AttributeError` — no cap existed) and passes
with this change.

Manual: set `voice.max_recording_seconds: 5` in `config.yaml`, start continuous
voice, speak past 5s → recording auto-stops and transcribes at the cap.

## Verification done

- New test: 3 pass with fix, fails on `main`.
- `tests/tools/test_voice_mode.py` (recorder suite): 67/67 pass — no regression.
- `tests/tools/test_voice_cli_integration.py`: identical pass/fail set with and without this change (its failures are unrelated to this PR / environment-bound).

## Platforms

Linux (Python 3.11/3.13). Pure-Python timing logic; no platform-specific paths.
