### PR TITLE
fix(agent): scope memory/context tools into tool_call bridge

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -254,6 +254,18 @@ def _tool_search_scoped_names(agent) -> frozenset:
     set: the deferrable subset of the session's own enabled/disabled toolset
     scope.
 
+    Provider-injected tools (memory providers such as ``fact_store`` /
+    ``fact_feedback``, and context-engine tools such as ``lcm_grep``) live
+    outside ``tools.registry`` — they are appended straight onto
+    ``agent.tools`` in ``agent_init`` and dispatched via the memory manager /
+    context compressor, not the registry.  ``scoped_deferrable_names`` only
+    sees registry-backed tools, so without an explicit union these granted
+    tools are wrongly treated as out-of-scope and a model that reaches them
+    through the ``tool_call`` bridge gets "'<tool>' is not available in this
+    session".  This is provider-dependent: only models/providers routed
+    through Tool Search assembly use the bridge, which is why memory tools
+    appear to vanish after switching to such a provider (issue #34520).
+
     Result is cached on the agent and refreshed when the tool registry's
     generation changes (e.g. an MCP server reconnects), so the common case is
     a dict lookup, not a full tool-defs rebuild on every tool call.
@@ -267,10 +279,33 @@ def _tool_search_scoped_names(agent) -> frozenset:
 
     enabled = getattr(agent, "enabled_toolsets", None)
     disabled = getattr(agent, "disabled_toolsets", None)
+
+    # Provider-injected tools granted to this session but invisible to the
+    # registry-based scope computation.  Memory tools are resolved via the
+    # manager's own membership check (same source of truth the dispatcher
+    # uses); context-engine tools are tracked in a dedicated set at init.
+    #
+    # The memory-name union mirrors the injection gate in ``agent_init`` so
+    # the bridge path can't reintroduce the #5544 leak: tools are only in
+    # scope when they were actually injected (``enabled_toolsets`` is None,
+    # or names "memory").  ``_context_engine_tool_names`` is already only
+    # populated when its own gate passed, so it is safe to union directly.
+    _provider_names: set = set()
+    _mem_mgr = getattr(agent, "_memory_manager", None)
+    if _mem_mgr is not None and (enabled is None or "memory" in enabled):
+        try:
+            _provider_names.update(_mem_mgr.get_all_tool_names())
+        except Exception:
+            pass
+    _ce_names = getattr(agent, "_context_engine_tool_names", None)
+    if _ce_names:
+        _provider_names.update(_ce_names)
+
     cache_key = (
         getattr(_registry, "_generation", 0),
         frozenset(enabled) if enabled is not None else None,
         frozenset(disabled) if disabled is not None else None,
+        frozenset(_provider_names),
     )
     cached = getattr(agent, "_tool_search_scope_cache", None)
     if cached is not None and cached[0] == cache_key:
@@ -285,6 +320,8 @@ def _tool_search_scoped_names(agent) -> frozenset:
         names = _ts.scoped_deferrable_names(scoped_defs)
     except Exception:
         names = frozenset()
+    if _provider_names:
+        names = frozenset(names | _provider_names)
     try:
         agent._tool_search_scope_cache = (cache_key, names)
     except Exception:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -741,9 +741,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         try:
             from tools import tool_search as _ts
             if function_name == _ts.TOOL_CALL_NAME:
-                _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
+                _scoped = _tool_search_scoped_names(agent)
+                _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args, allowed_names=_scoped)
                 if not _err and _underlying:
-                    if _underlying in _tool_search_scoped_names(agent):
+                    if _underlying in _scoped:
                         # Probe-validate before unwrapping (ironclaw#5149):
                         # missing required args return the parameter schema
                         # instead of dispatching into an opaque failure.
@@ -1412,9 +1413,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         try:
             from tools import tool_search as _ts
             if function_name == _ts.TOOL_CALL_NAME:
-                _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
+                _scoped = _tool_search_scoped_names(agent)
+                _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args, allowed_names=_scoped)
                 if not _err and _underlying:
-                    if _underlying in _tool_search_scoped_names(agent):
+                    if _underlying in _scoped:
                         # Probe-validate before unwrapping (ironclaw#5149):
                         # missing required args return the parameter schema
                         # instead of dispatching into an opaque failure.

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -995,6 +995,14 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
     * the display layer (so the activity feed shows the underlying tool),
     * the trajectory recorder.
 
+    ``allowed_names`` is the caller's validated provider-tool scope (e.g. the
+    session's ``_tool_search_scoped_names``). Names in that set are admitted
+    even when they are not registry-registered — this is how provider-injected
+    tools (``fact_store``/``fact_feedback``, ``lcm_*``) reach the unwrap path,
+    since ``is_deferrable_tool_name`` returns False for them (no registry
+    entry). The caller still enforces its own scope gate after resolution, so
+    the #5544 toolset gates are preserved; this only stops a premature reject.
+
     On parse error, returns ``(None, {}, error_message)``.
     """
     name = str(args.get("name") or "").strip()
@@ -1013,6 +1021,12 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
     if not is_deferrable_tool_name(name):
+        # Provider-injected tools have no registry entry, so
+        # ``is_deferrable_tool_name`` reports False for them. Admit them only
+        # when the caller vouches for them via ``allowed_names`` (its
+        # validated provider-tool scope); the caller re-checks scope after.
+        if allowed_names is not None and name in allowed_names:
+            return name, raw_args, None
         return None, {}, (
             f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
             "list already, call it directly instead of via tool_call."

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -987,7 +987,7 @@ def validate_deferred_call_args(name: str, args: Dict[str, Any]) -> Optional[str
         return None
 
 
-def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
+def resolve_underlying_call(args: Dict[str, Any], allowed_names: Optional[Any] = None) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
     """Parse a ``tool_call`` invocation into (underlying_name, args, error_msg).
 
     Used by:
@@ -1025,7 +1025,14 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
         # ``is_deferrable_tool_name`` reports False for them. Admit them only
         # when the caller vouches for them via ``allowed_names`` (its
         # validated provider-tool scope); the caller re-checks scope after.
-        if allowed_names is not None and name in allowed_names:
+        # Core/bridge tools stay rejected even if mistakenly listed in
+        # ``allowed_names`` — they must be invoked directly, never via bridge.
+        if (
+            allowed_names is not None
+            and name in allowed_names
+            and name not in BRIDGE_TOOL_NAMES
+            and name not in _core_tool_names()
+        ):
             return name, raw_args, None
         return None, {}, (
             f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "


### PR DESCRIPTION
## Summary

- Provider-injected tools (holographic memory `fact_store`/`fact_feedback`, context-engine `lcm_*`) are now in scope for the `tool_call` bridge.
- Memory tools no longer "vanish" after switching to a provider routed through Tool Search assembly — memory continuity is preserved across providers.

## Motivation

Closes #34520.

Holographic memory tools (`fact_store`/`fact_feedback`) and context-engine tools (`lcm_*`) are appended directly onto `agent.tools` in `agent_init` and dispatched via the memory manager / context compressor — they are **never** registered in `tools.registry`. `_tool_search_scoped_names()` derived the invocable set from the registry alone, so when a model reached one of these tools through the `tool_call` bridge, the unwrap rejected it with `"'fact_store' is not available in this session"`. This is provider-dependent: only models/providers routed through Tool Search assembly use the bridge, which is exactly why the reporter saw memory tools become unavailable after switching providers. The standard dispatch path (`switch_model` preserves `agent.tools`; `_memory_manager.has_tool()` routes the call) was already provider-agnostic — the gap was solely in the bridge scope gate.

The fix unions the agent's provider-injected tool names into the bridge scope. The memory-name union mirrors the `agent_init` injection gate (memory tools only when `enabled_toolsets` is `None` or names `"memory"`) so the #5544 toolset-leak fix is **not** reintroduced through the bridge path. `_context_engine_tool_names` is already only populated when its own gate passed, so it is unioned directly. Provider names are folded into the scope cache key so a stale cached scope is never served after the provider tool set changes.

## Verification

- `python3 -m pytest tests/tools/test_tool_search.py` — 46 passed, 0 failed (7 new in `TestRegression_ProviderToolsBridgeScope`)
- `python3 -m pytest tests/agent/test_memory_provider.py` — 76 passed, 0 failed (confirms #5544 toolset gate still holds)
- New tests cover: memory tools in scope when unfiltered / `memory`-enabled; excluded when memory not opted-in / toolsets empty (#5544 guard); context-engine tools always in scope; no-provider no-op; cache-key separates provider scopes.
- Did NOT change: the registry-based scope for normal/MCP tools, the `switch_model` path, or the memory dispatch path — only the bridge-unwrap scope gate is widened, and only for already-granted provider tools.
