### PR TITLE
fix(gateway): finalize active status/progress messages on restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1729,6 +1729,11 @@ class GatewayRunner:
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
+        # Last editable status/progress bubbles per running session.  Used at
+        # shutdown/restart time to replace transient "Still working"/tool
+        # progress messages with a terminal state so users never see a stale
+        # in-progress bubble after the gateway process exits.
+        self._active_status_messages: Dict[str, List[Dict[str, Any]]] = {}
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
         # Overflow buffer for explicit /queue commands.  The adapter-level
         # _pending_messages dict is a single slot per session (designed for
@@ -2717,6 +2722,111 @@ class GatewayRunner:
             logger.debug("goal continuation: active-state recheck failed: %s", exc)
             return False
 
+    def _register_active_status_message(
+        self,
+        *,
+        session_key: str,
+        platform: Platform,
+        chat_id: str,
+        message_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        kind: str = "status",
+    ) -> None:
+        """Track an editable in-progress bubble for shutdown/restart finalization."""
+        if not session_key or not message_id:
+            return
+        records = getattr(self, "_active_status_messages", None)
+        if records is None:
+            self._active_status_messages = {}
+            records = self._active_status_messages
+        entry = {
+            "platform": platform,
+            "chat_id": str(chat_id),
+            "message_id": str(message_id),
+            "metadata": metadata,
+            "kind": kind,
+        }
+        bucket = records.setdefault(session_key, [])
+        # One latest editable bubble per kind is enough; replacing avoids
+        # editing old progress bubbles after stream segment resets.
+        bucket[:] = [item for item in bucket if item.get("kind") != kind]
+        bucket.append(entry)
+
+    def _clear_active_status_messages(self, session_key: str) -> None:
+        records = getattr(self, "_active_status_messages", None)
+        if records is not None and session_key:
+            records.pop(session_key, None)
+
+    async def _finalize_active_status_messages(
+        self,
+        session_keys: Optional[set[str]] = None,
+    ) -> None:
+        """Edit active progress/status bubbles to a terminal restart/shutdown state.
+
+        This runs while adapters are still connected.  It prevents Telegram (and
+        other editable platforms) from being left with a forever-visible
+        "Still working" or tool-progress message if a restart interrupts the
+        final response delivery path.
+        """
+        records = getattr(self, "_active_status_messages", None) or {}
+        if not records:
+            return
+        keys = set(session_keys or records.keys())
+        action = "restarting" if self._restart_requested else "shutting down"
+        if self._restart_requested:
+            content = (
+                "⚠️ Gateway restarting — progress reporting paused; the gateway "
+                "is restarting now. Send any message after restart and I'll "
+                "resume from the saved session."
+            )
+        else:
+            content = (
+                "⚠️ Gateway shutting down — progress reporting stopped because "
+                "the gateway is shutting down."
+            )
+
+        for session_key in list(keys):
+            bucket = list(records.get(session_key, []))
+            for item in bucket:
+                try:
+                    platform = item.get("platform")
+                    if not isinstance(platform, Platform):
+                        platform = Platform(str(platform))
+                    adapter = self.adapters.get(platform)
+                    if not adapter:
+                        continue
+                    chat_id = item.get("chat_id")
+                    message_id = item.get("message_id")
+                    if not chat_id or not message_id:
+                        continue
+                    result = await adapter.edit_message(
+                        chat_id=chat_id,
+                        message_id=message_id,
+                        content=content,
+                    )
+                    if result is not None and getattr(result, "success", True) is False:
+                        logger.debug(
+                            "Failed to edit active %s message during gateway %s: %s",
+                            item.get("kind") or "status",
+                            action,
+                            getattr(result, "error", "edit returned success=False"),
+                        )
+                        # Fallback: send a terminal bubble so the user still sees
+                        # a current state even if the old message is not editable.
+                        await adapter.send(
+                            chat_id,
+                            content,
+                            metadata=item.get("metadata"),
+                        )
+                except Exception as e:
+                    logger.debug(
+                        "Failed to finalize active status message for %s during gateway %s: %s",
+                        session_key,
+                        action,
+                        e,
+                    )
+            records.pop(session_key, None)
+
     def _update_runtime_status(self, gateway_state: Optional[str] = None, exit_reason: Optional[str] = None) -> None:
         try:
             from gateway.status import write_runtime_status
@@ -3417,6 +3527,7 @@ class GatewayRunner:
         logged and swallowed so they never block the shutdown sequence.
         """
         active = self._snapshot_running_agents()
+        await self._finalize_active_status_messages(set(active.keys()))
 
         action = "restarting" if self._restart_requested else "shutting down"
         hint = (
@@ -16562,6 +16673,15 @@ class GatewayRunner:
                             progress_msg_id = result.message_id
                             if _cleanup_progress:
                                 _cleanup_msg_ids.append(str(result.message_id))
+                            if session_key:
+                                self._register_active_status_message(
+                                    session_key=session_key,
+                                    platform=source.platform,
+                                    chat_id=str(source.chat_id),
+                                    message_id=str(progress_msg_id),
+                                    metadata=_progress_metadata,
+                                    kind="tool_progress",
+                                )
 
                     _last_edit_ts = time.monotonic()
 
@@ -17740,6 +17860,20 @@ class GatewayRunner:
                             _heartbeat_msg_id = str(_notify_res.message_id)
                             if _cleanup_progress:
                                 _cleanup_msg_ids.append(_heartbeat_msg_id)
+                    if (
+                        session_key
+                        and _notify_res is not None
+                        and getattr(_notify_res, "success", True)
+                        and (_heartbeat_msg_id or getattr(_notify_res, "message_id", None))
+                    ):
+                        self._register_active_status_message(
+                            session_key=session_key,
+                            platform=source.platform,
+                            chat_id=str(source.chat_id),
+                            message_id=str(_heartbeat_msg_id or _notify_res.message_id),
+                            metadata=_status_thread_metadata,
+                            kind="long_running",
+                        )
                 except Exception as _ne:
                     logger.debug("Long-running notification error: %s", _ne)
 
@@ -18200,6 +18334,8 @@ class GatewayRunner:
                 self._release_running_agent_state(
                     session_key, run_generation=run_generation
                 )
+                if not self._draining:
+                    self._clear_active_status_messages(session_key)
             if self._draining:
                 self._update_runtime_status("draining")
             

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -14,6 +14,7 @@ class RestartTestAdapter(BasePlatformAdapter):
         super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
         self.sent: list[str] = []
         self.sent_calls: list[tuple[str, str, object]] = []
+        self.edited_calls: list[tuple[str, str, str]] = []
 
     async def connect(self):
         return True
@@ -28,6 +29,10 @@ class RestartTestAdapter(BasePlatformAdapter):
 
     async def send_typing(self, chat_id, metadata=None):
         return None
+
+    async def edit_message(self, chat_id, message_id, content):
+        self.edited_calls.append((chat_id, message_id, content))
+        return SendResult(success=True, message_id=message_id)
 
     async def get_chat_info(self, chat_id):
         return {"id": chat_id}
@@ -59,6 +64,7 @@ def make_restart_runner(
     runner._exit_reason = None
     runner._exit_code = None
     runner._running_agents = {}
+    runner._active_status_messages = {}
     runner._running_agents_ts = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
@@ -123,6 +129,15 @@ def make_restart_runner(
     )
     runner._get_cached_session_source = GatewayRunner._get_cached_session_source.__get__(
         runner, GatewayRunner
+    )
+    runner._register_active_status_message = (
+        GatewayRunner._register_active_status_message.__get__(runner, GatewayRunner)
+    )
+    runner._clear_active_status_messages = (
+        GatewayRunner._clear_active_status_messages.__get__(runner, GatewayRunner)
+    )
+    runner._finalize_active_status_messages = (
+        GatewayRunner._finalize_active_status_messages.__get__(runner, GatewayRunner)
     )
     runner._launch_detached_restart_command = GatewayRunner._launch_detached_restart_command.__get__(
         runner, GatewayRunner

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -336,6 +336,40 @@ async def test_send_home_channel_startup_notification_ignores_false_send_result(
     adapter.send.assert_called_once()
 
 
+# ── active status/progress finalization during restart ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_restart_finalizes_active_status_messages_before_shutdown_notice():
+    """A restart edits active 'Still working' bubbles so they cannot remain stale forever."""
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    source = make_restart_source(chat_id="42", thread_id="topic_7")
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = object()
+
+    runner._register_active_status_message(
+        session_key=session_key,
+        platform=Platform.TELEGRAM,
+        chat_id="42",
+        message_id="still_1",
+        metadata={"thread_id": "topic_7"},
+        kind="long_running",
+    )
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert adapter.edited_calls == [
+        (
+            "42",
+            "still_1",
+            "⚠️ Gateway restarting — progress reporting paused; the gateway is restarting now. Send any message after restart and I'll resume from the saved session.",
+        )
+    ]
+    assert "Gateway restarting" in adapter.sent[-1]
+    assert runner._active_status_messages == {}
+
+
 # ── _send_restart_notification ───────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- track the latest editable in-progress/status bubble per session
- finalize those bubbles to a terminal restart/shutdown state before adapters disconnect
- add regression coverage for restart notification helpers and status finalization behavior

## Why
When the gateway restarts while a session is still showing an editable progress bubble, users can be left staring at a stale "Still working" style message even though the gateway process has already exited. This change turns that transient UI into a terminal state during restart/shutdown so the chat reflects reality.

## Test Plan
- [x] `python -m py_compile gateway/run.py tests/gateway/restart_test_helpers.py tests/gateway/test_restart_notification.py`
- [x] `python -m pytest -o addopts='' -q tests/gateway/test_restart_notification.py`

## Notes
- observed and validated on a Telegram gateway setup, but the logic is adapter-agnostic and falls back to sending a terminal bubble when edit-in-place is unavailable
