### PR TITLE
fix(auth): skip non-graphical browser for Nous device login

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7755,12 +7755,14 @@ def _nous_device_code_login(
         print(f"  1. Open: {verification_url}")
         print(f"  2. If prompted, enter code: {user_code}")
 
-        if open_browser:
+        if open_browser and _can_open_graphical_browser():
             opened = webbrowser.open(verification_url)
             if opened:
                 print("  (Opened browser for verification)")
             else:
                 print("  Could not open browser automatically — use the URL above.")
+        elif open_browser:
+            print("  Browser auto-open skipped; use the URL above.")
 
         effective_interval = max(1, min(interval, DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS))
         print(f"Waiting for approval (polling every {effective_interval}s)...")

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -513,6 +513,56 @@ def test_nous_device_code_login_retries_legacy_scope_when_invoke_refused(monkeyp
     assert result["agent_key"] == "opaque-agent-key"
 
 
+def test_nous_device_code_login_skips_non_graphical_browser(monkeypatch):
+    import hermes_cli.auth as auth_mod
+
+    browser_calls = []
+
+    def _fake_request_device_code(*, client, portal_base_url, client_id, scope):
+        del client, portal_base_url, client_id, scope
+        return {
+            "device_code": "device",
+            "user_code": "user",
+            "verification_uri": "https://portal.example.com/device",
+            "verification_uri_complete": "https://portal.example.com/device?code=user",
+            "expires_in": 600,
+            "interval": 1,
+        }
+
+    def _fake_poll_for_token(**kwargs):
+        del kwargs
+        return {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "expires_in": 900,
+            "scope": auth_mod.DEFAULT_NOUS_SCOPE,
+        }
+
+    def _fake_refresh(state, **kwargs):
+        del kwargs
+        refreshed = dict(state)
+        refreshed["agent_key"] = "opaque-agent-key"
+        refreshed["agent_key_expires_at"] = _future_iso(1800)
+        return refreshed
+
+    monkeypatch.setattr(auth_mod, "_is_remote_session", lambda: False)
+    monkeypatch.setattr(auth_mod, "_can_open_graphical_browser", lambda: False)
+    monkeypatch.setattr(auth_mod, "_request_device_code", _fake_request_device_code)
+    monkeypatch.setattr(auth_mod, "_poll_for_token", _fake_poll_for_token)
+    monkeypatch.setattr(auth_mod, "refresh_nous_oauth_from_state", _fake_refresh)
+    monkeypatch.setattr(auth_mod.webbrowser, "open", lambda url: browser_calls.append(url))
+
+    result = auth_mod._nous_device_code_login(
+        portal_base_url="https://portal.example.com",
+        inference_base_url="https://inference.example.com/v1",
+        open_browser=True,
+        timeout_seconds=1,
+    )
+
+    assert browser_calls == []
+    assert result["agent_key"] == "opaque-agent-key"
+
+
 def test_forced_legacy_env_skips_invoke_scope_and_jwt_storage(tmp_path, monkeypatch):
     import hermes_cli.auth as auth_mod
 


### PR DESCRIPTION
Summary
- Gate Nous device-code browser auto-open behind _can_open_graphical_browser().
- Keep headless or console-browser environments on the printed verification URL path.
- Add a regression test for the Nous device-code login path.

Tests
- .venv\Scripts\python.exe -m pytest tests/hermes_cli/test_auth_nous_provider.py::test_nous_device_code_login_skips_non_graphical_browser tests/hermes_cli/test_graphical_browser_detection.py -q --tb=short --timeout-method=thread
- .venv\Scripts\ruff.exe check hermes_cli/auth.py tests/hermes_cli/test_auth_nous_provider.py
- .venv\Scripts\ruff.exe check . (passes; existing upstream run_agent.py comment warning remains unrelated)