### PR TITLE
fix(matrix): block unsafe image redirects

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -34,6 +34,7 @@ import os
 import re
 import time
 from dataclasses import dataclass
+from urllib.parse import urljoin
 
 from html import escape as _html_escape
 from pathlib import Path
@@ -102,6 +103,7 @@ from gateway.platforms.base import (
     SendResult,
     resolve_proxy_url,
     proxy_kwargs_for_aiohttp,
+    _ssrf_redirect_guard,
 )
 from gateway.platforms.helpers import ThreadParticipationTracker
 
@@ -502,6 +504,16 @@ class MatrixAdapter(BasePlatformAdapter):
         self._processed_events.append(event_id)
         self._processed_events_set.add(event_id)
         return False
+
+    @staticmethod
+    def _safe_redirect_url(current_url: str, location: str) -> str:
+        """Resolve and validate a Matrix media redirect target."""
+        from tools.url_safety import is_safe_url
+
+        next_url = urljoin(current_url, location)
+        if not is_safe_url(next_url):
+            raise ValueError("Blocked unsafe Matrix image redirect")
+        return next_url
 
     @staticmethod
     def _parse_thread_require_mention(config) -> bool:
@@ -1171,22 +1183,36 @@ class MatrixAdapter(BasePlatformAdapter):
                 import aiohttp as _aiohttp
                 _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(self._proxy_url)
                 async with _aiohttp.ClientSession(**_sess_kw) as http:
-                    async with http.get(
-                        image_url,
-                        timeout=_aiohttp.ClientTimeout(total=30),
-                        **_req_kw,
-                    ) as resp:
-                        resp.raise_for_status()
-                        data = await resp.read()
-                        ct = resp.content_type or "image/png"
-                        fname = (
-                            image_url.rsplit("/", 1)[-1].split("?")[0] or "image.png"
-                        )
+                    fetch_url = image_url
+                    for _ in range(20):
+                        async with http.get(
+                            fetch_url,
+                            timeout=_aiohttp.ClientTimeout(total=30),
+                            allow_redirects=False,
+                            **_req_kw,
+                        ) as resp:
+                            if resp.status in {301, 302, 303, 307, 308}:
+                                location = resp.headers.get("Location")
+                                if not location:
+                                    raise ValueError("Matrix image redirect missing Location")
+                                fetch_url = self._safe_redirect_url(fetch_url, location)
+                                continue
+                            resp.raise_for_status()
+                            data = await resp.read()
+                            ct = resp.content_type or "image/png"
+                            fname = (
+                                fetch_url.rsplit("/", 1)[-1].split("?")[0]
+                                or "image.png"
+                            )
+                            break
+                    else:
+                        raise ValueError("Too many Matrix image redirects")
             except ImportError:
                 import httpx
                 _httpx_kw: dict = {}
                 if self._proxy_url:
                     _httpx_kw["proxy"] = self._proxy_url
+                _httpx_kw["event_hooks"] = {"response": [_ssrf_redirect_guard]}
                 async with httpx.AsyncClient(**_httpx_kw) as http:
                     resp = await http.get(image_url, follow_redirects=True, timeout=30)
                     resp.raise_for_status()

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1365,6 +1365,111 @@ class TestMatrixUploadAndSend:
         assert sent["file"]["url"] == "mxc://example.org/enc"
 
 
+class TestMatrixSendImageSecurity:
+    @pytest.mark.asyncio
+    async def test_aiohttp_send_image_blocks_unsafe_redirect(self):
+        """Matrix should not follow public image URLs into private networks."""
+        from gateway.platforms.base import SendResult
+
+        adapter = _make_adapter()
+        adapter._upload_and_send = AsyncMock()
+        adapter.send = AsyncMock(return_value=SendResult(success=True))
+        calls = []
+
+        class FakeTimeout:
+            def __init__(self, **_kwargs):
+                pass
+
+        class FakeResponse:
+            status = 302
+            headers = {"Location": "http://169.254.169.254/latest/meta-data/"}
+            content_type = "image/png"
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def raise_for_status(self):
+                pass
+
+            async def read(self):
+                return b"should-not-upload"
+
+        class FakeSession:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            def get(self, url, **kwargs):
+                calls.append((url, kwargs))
+                return FakeResponse()
+
+        fake_aiohttp = types.SimpleNamespace(
+            ClientSession=FakeSession,
+            ClientTimeout=FakeTimeout,
+        )
+
+        with patch.dict("sys.modules", {"aiohttp": fake_aiohttp}):
+            result = await adapter.send_image(
+                "!room:example.org",
+                "http://93.184.216.34/public.png",
+            )
+
+        assert result.success is True
+        assert len(calls) == 1
+        assert calls[0][1]["allow_redirects"] is False
+        adapter._upload_and_send.assert_not_awaited()
+        adapter.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_httpx_fallback_installs_redirect_guard(self):
+        """The httpx fallback should also re-check redirect targets."""
+        from gateway.platforms.base import SendResult, _ssrf_redirect_guard
+
+        adapter = _make_adapter()
+        adapter._upload_and_send = AsyncMock(return_value=SendResult(success=True))
+        clients = []
+
+        class FakeResponse:
+            content = b"image"
+            headers = {"content-type": "image/png"}
+
+            def raise_for_status(self):
+                pass
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                clients.append(self)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            async def get(self, *_args, **_kwargs):
+                return FakeResponse()
+
+        with patch.dict("sys.modules", {"aiohttp": None}):
+            with patch("httpx.AsyncClient", FakeClient):
+                result = await adapter.send_image(
+                    "!room:example.org",
+                    "http://93.184.216.34/public.png",
+                )
+
+        assert result.success is True
+        assert clients[0].kwargs["event_hooks"]["response"] == [_ssrf_redirect_guard]
+        adapter._upload_and_send.assert_awaited_once()
+
+
 class TestMatrixEncryptedSendFallback:
     @pytest.mark.asyncio
     async def test_send_retries_after_e2ee_error(self):


### PR DESCRIPTION
  ## Summary

  Fix Matrix outbound image downloads so redirects cannot bypass SSRF protection.

  Matrix `send_image()` already checked the initial image URL with `is_safe_url()`, but the aiohttp/httpx download paths still followed redirects without re-validating the redirect target. A public-looking URL could redirect the gateway toward loopback, private-network, or metadata endpoints.

  ## Changes

  - Resolve Matrix aiohttp image redirects manually with `allow_redirects=False`.
  - Validate every redirect `Location` with the existing `is_safe_url()` policy.
  - Add the shared `_ssrf_redirect_guard` to the httpx fallback path.
  - Add regression tests for unsafe redirect blocking and httpx guard wiring.

  ## Validation

  - `pytest -o addopts='' tests/gateway/test_matrix.py::TestMatrixSendImageSecurity -q`
  - `pytest -o addopts='' tests/gateway/test_matrix.py -q`
  - `ruff check gateway/platforms/matrix.py tests/gateway/test_matrix.py`

  Results:
  - `2 passed`
  - `152 passed`
  - `ruff` passed
