### PR TITLE
fix(memory/hindsight): honor configured retain_async on manual hindsight_retain

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1525,6 +1525,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     content,
                     context=context,
                     tags=args.get("tags"),
+                    retain_async=self._retain_async,
                 )
                 logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
                              self._bank_id, len(content), context)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -471,6 +471,14 @@ class TestToolHandlers:
         assert call_kwargs["bank_id"] == "test-bank"
         assert call_kwargs["content"] == "user likes dark mode"
 
+    def test_manual_retain_uses_configured_async_mode(self, provider_with_config):
+        p = provider_with_config(retain_async=True)
+        result = json.loads(p.handle_tool_call(
+            "hindsight_retain", {"content": "user likes dark mode"}
+        ))
+        assert result["result"] == "Memory stored successfully."
+        assert p._client.aretain.call_args.kwargs["retain_async"] is True
+
     def test_retain_with_tags(self, provider_with_config):
         p = provider_with_config(retain_tags=["pref", "ui"])
         p.handle_tool_call("hindsight_retain", {"content": "likes dark mode"})


### PR DESCRIPTION
## Problem

The manual `hindsight_retain` tool path in `HindsightMemoryProvider.handle_tool_call` builds its retain kwargs **without** passing `retain_async`:

```python
retain_kwargs = self._build_retain_kwargs(
    content,
    context=context,
    tags=args.get("tags"),
)
...
self._run_hindsight_operation(lambda client: client.aretain(**retain_kwargs))
```

`_build_retain_kwargs` only inserts `retain_async` into the dict when the arg is not `None` (it defaults to `None`), so the key is omitted and `client.aretain(**kwargs)` falls back to the **client default `retain_async=False`** — running the retain **server-sync**.

That's inconsistent with the rest of the provider:
- the provider default is `self._retain_async = config.get("retain_async", True)` (i.e. `True`), and
- the gateway auto-retain paths (`_do_retain` and the flush-on-switch path) both pass the configured flag to `aretain_batch(..., retain_async=retain_async_flag)`.

So only the **manual tool** runs synchronously.

## Impact

- A manual `hindsight_retain` blocks the turn while the server performs synchronous fact extraction (~15-40s under a slow/loaded extraction LLM).
- It's fragile to daemon lifecycle: an in-flight sync retain can be cancelled if the daemon is torn down, surfacing to the client as a bare `500`. The server-side traceback in that case is:

  ```
  ERROR: Cancel 1 running task(s), timeout graceful shutdown exceeded
  ERROR: Exception in ASGI application
  asyncio.exceptions.CancelledError: Task cancelled, timeout graceful shutdown exceeded
  ```

  In a long-lived gateway the same defect manifests as "the manual tool blocks the turn / occasionally errors," rather than a 500.

## Fix

Pass `retain_async=self._retain_async` from the tool path, mirroring the auto-retain path. The tool response is unchanged. Applies to all profiles.

## Test

Adds `test_manual_retain_uses_configured_async_mode`, asserting the configured async flag reaches `aretain`. Full file suite passes:

```
python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='
101 passed
```