### PR TITLE
fix: add curated 400k Codex OAuth context budgets

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1259,14 +1259,24 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
     return None
 
 
-# Known ChatGPT Codex OAuth context windows (observed via live
-# chatgpt.com/backend-api/codex/models probe, Apr 2026). These are the
-# `context_window` values, which are what Codex actually enforces — the
-# direct OpenAI API has larger limits for the same slugs, but Codex OAuth
-# caps lower (e.g. gpt-5.5 is 1.05M on the API, 272K on Codex).
+# Known ChatGPT Codex OAuth context budgets.
 #
-# Used as a fallback when the live probe fails (no token, network error).
+# The Codex /models endpoint reports ``context_window`` values around 272K for
+# several GPT-5.x slugs, but the Codex runtime also supports a larger native
+# prompt budget for selected models.  OpenClaw exposes this split as
+# ``contextWindow`` (native window) vs ``contextTokens`` (runtime/reporting
+# budget); Hermes has a single context-length knob, so keep a narrow curated
+# override for the models we intentionally run beyond the endpoint-reported
+# compatibility cap.  Users can still set ``model.context_length`` to override.
+#
 # Longest keys first so substring match picks the most specific entry.
+_CODEX_OAUTH_CONTEXT_OVERRIDES: Dict[str, int] = {
+    "gpt-5.4-mini": 400_000,
+    "gpt-5.5": 400_000,
+}
+
+# Fallback values used when the live probe fails (no token, network error) and
+# there is no curated runtime-budget override above.
 _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
     "gpt-5.1-codex-max": 272_000,
     "gpt-5.1-codex-mini": 272_000,
@@ -1284,6 +1294,18 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
     "gpt-5.2": 272_000,
     "gpt-5": 272_000,
 }
+
+
+def _resolve_codex_oauth_context_override(model: str) -> Optional[int]:
+    model_lower = _strip_provider_prefix(model).strip().lower()
+    if not model_lower:
+        return None
+    for slug, ctx in sorted(
+        _CODEX_OAUTH_CONTEXT_OVERRIDES.items(), key=lambda x: len(x[0]), reverse=True
+    ):
+        if slug in model_lower:
+            return ctx
+    return None
 
 
 _codex_oauth_context_cache: Dict[str, int] = {}
@@ -1354,18 +1376,21 @@ def _resolve_codex_oauth_context_length(
     if not model_bare:
         return None
 
+    override = _resolve_codex_oauth_context_override(model_bare)
+    if override:
+        return override
+
+    model_lower = model_bare.lower()
     if access_token:
         live = _fetch_codex_oauth_context_lengths(access_token)
         if model_bare in live:
             return live[model_bare]
         # Case-insensitive match in case casing drifts
-        model_lower = model_bare.lower()
         for slug, ctx in live.items():
             if slug.lower() == model_lower:
                 return ctx
 
     # Fallback: longest-key-first substring match over hardcoded defaults.
-    model_lower = model_bare.lower()
     for slug, ctx in sorted(
         _CODEX_OAUTH_CONTEXT_FALLBACK.items(), key=lambda x: len(x[0]), reverse=True
     ):
@@ -1507,6 +1532,11 @@ def get_model_context_length(
     # local servers actually know about.  Ollama "model:tag" colons are preserved.
     model = _strip_provider_prefix(model)
 
+    if provider == "openai-codex":
+        codex_override = _resolve_codex_oauth_context_override(model)
+        if codex_override:
+            return codex_override
+
     # 1. Check persistent cache (model+provider)
     # LM Studio is excluded — its loaded context length is transient (the
     # user can reload the model with a different context_length at any time
@@ -1514,12 +1544,11 @@ def get_model_context_length(
     if base_url and provider != "lmstudio":
         cached = get_cached_context_length(model, base_url)
         if cached is not None:
-            # Invalidate stale Codex OAuth cache entries: pre-PR #14935 builds
+            # Invalidate stale Codex cache entries: pre-PR #14935 builds
             # resolved gpt-5.x to the direct-API value (e.g. 1.05M) via
-            # models.dev and persisted it. Codex OAuth caps at 272K for every
-            # slug, so any cached Codex entry at or above 400K is a leftover
-            # from the old resolution path. Drop it and fall through to the
-            # live /models probe in step 5 below.
+            # models.dev and persisted it. Curated 400K runtime-budget
+            # overrides return before cache lookup, so any cached 400K+ value
+            # reaching this branch is stale for a non-overridden model.
             if provider == "openai-codex" and cached >= 400_000:
                 logger.info(
                     "Dropping stale Codex cache entry %s@%s -> %s (pre-fix value); "

--- a/tests/agent/test_codex_oauth_context_length.py
+++ b/tests/agent/test_codex_oauth_context_length.py
@@ -1,0 +1,89 @@
+from agent.model_metadata import get_model_context_length
+
+
+CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+
+
+def test_codex_gpt55_uses_curated_400k_context_even_when_live_probe_reports_272k(monkeypatch):
+    """Codex /models can report a 272K compatibility cap for GPT-5.5.
+
+    Hermes uses the curated runtime budget so compression does not start too
+    early for Codex OAuth sessions that can operate at 400K.
+    """
+
+    monkeypatch.setattr(
+        "agent.model_metadata._fetch_codex_oauth_context_lengths",
+        lambda access_token: {"gpt-5.5": 272_000},
+    )
+
+    assert (
+        get_model_context_length(
+            "gpt-5.5",
+            provider="openai-codex",
+            base_url=CODEX_BASE_URL,
+            api_key="x",
+        )
+        == 400_000
+    )
+
+
+def test_codex_gpt54_mini_uses_curated_400k_context_for_compression_lane(monkeypatch):
+    monkeypatch.setattr(
+        "agent.model_metadata._fetch_codex_oauth_context_lengths",
+        lambda access_token: {"gpt-5.4-mini": 272_000},
+    )
+
+    assert (
+        get_model_context_length(
+            "gpt-5.4-mini",
+            provider="openai-codex",
+            base_url=CODEX_BASE_URL,
+            api_key="x",
+        )
+        == 400_000
+    )
+
+
+def test_codex_non_overridden_models_keep_endpoint_reported_context(monkeypatch):
+    monkeypatch.setattr(
+        "agent.model_metadata._fetch_codex_oauth_context_lengths",
+        lambda access_token: {"gpt-5.3-codex": 272_000},
+    )
+
+    assert (
+        get_model_context_length(
+            "gpt-5.3-codex",
+            provider="openai-codex",
+            base_url=CODEX_BASE_URL,
+            api_key="x",
+        )
+        == 272_000
+    )
+
+
+def test_codex_non_overridden_models_invalidate_stale_400k_cache(monkeypatch):
+    invalidated = []
+
+    monkeypatch.setattr(
+        "agent.model_metadata.get_cached_context_length",
+        lambda model, base_url: 400_000,
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata._invalidate_cached_context_length",
+        lambda model, base_url: invalidated.append((model, base_url)),
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata._fetch_codex_oauth_context_lengths",
+        lambda access_token: {"gpt-5.3-codex": 272_000},
+    )
+
+    assert (
+        get_model_context_length(
+            "gpt-5.3-codex",
+            provider="openai-codex",
+            base_url=CODEX_BASE_URL,
+            api_key="x",
+        )
+        == 272_000
+    )
+    assert invalidated == [("gpt-5.3-codex", CODEX_BASE_URL)]


### PR DESCRIPTION
## Summary
- Add narrow curated 400K Codex OAuth context-budget overrides for `gpt-5.5` and `gpt-5.4-mini`.
- Keep non-overridden Codex models on endpoint/fallback-reported limits.
- Preserve stale-cache invalidation for cached 400K+ values that reach non-overridden Codex models.

## Why
PR #15078 correctly fixed stale 1.05M direct-API cache leakage for Codex OAuth. This PR does **not** restore that broad 1.05M behavior and does **not** treat every Codex slug as 400K.

The narrower issue is that selected Codex OAuth models can be operated with a 400K runtime budget even though the `/codex/models` endpoint may report a lower compatibility-style `context_window` around 272K. In practice, a 400K main session also needs the compression lane to use a matching budget: with the default `compression.threshold: 0.7`, compression starts around 280K tokens, so a smaller compression model window can fail exactly at the point where the 400K budget should still be usable.

This patch therefore pairs:
- `gpt-5.5` as the main 400K Codex OAuth model
- `gpt-5.4-mini` as the default compression lane with the same 400K budget

Everything else continues to resolve through the existing Codex endpoint/fallback path.

## Safety / scope
- No change to direct OpenAI, OpenRouter, Nous, Copilot, local, or custom provider resolution.
- No broad 1.05M Codex context restoration.
- Non-overridden Codex models still invalidate stale cached 400K+ values and resolve back to the endpoint/fallback value, e.g. 272K.
- User config override (`model.context_length`) still wins first.

## Test Plan
- `python -m pytest tests/agent/test_codex_oauth_context_length.py tests/run_agent/test_compression_feasibility.py -q -o 'addopts='`
- Independent pre-commit reviewer: passed; no security concerns or logic errors.
