### PR TITLE
fix(cli): discover pip-installed plugins via entry points in list/enable/disable

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -725,6 +725,24 @@ def _plugin_exists(name: str) -> bool:
             or (candidate / "plugin.yml").exists()
         ):
             return True
+    # Entry-point plugins (pip-installed)
+    try:
+        import importlib.metadata
+        from hermes_cli.plugins import ENTRY_POINTS_GROUP
+
+        eps = importlib.metadata.entry_points()
+        if hasattr(eps, "select"):
+            group_eps = eps.select(group=ENTRY_POINTS_GROUP)
+        elif isinstance(eps, dict):
+            group_eps = eps.get(ENTRY_POINTS_GROUP, [])
+        else:
+            group_eps = [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
+
+        for ep in group_eps:
+            if ep.name == name:
+                return True
+    except Exception:
+        pass
     return False
 
 
@@ -807,6 +825,26 @@ def _discover_all_plugins() -> list:
     from hermes_cli.plugins import get_bundled_plugins_dir
     _scan(get_bundled_plugins_dir(), "bundled", "", 0)
     _scan(_plugins_dir(), "user", "", 0)
+
+    # Also discover pip-installed plugins via entry points so that
+    # ``hermes plugins list`` matches what the runtime loader sees.
+    try:
+        import importlib.metadata
+        from hermes_cli.plugins import ENTRY_POINTS_GROUP
+
+        eps = importlib.metadata.entry_points()
+        if hasattr(eps, "select"):
+            group_eps = eps.select(group=ENTRY_POINTS_GROUP)
+        elif isinstance(eps, dict):
+            group_eps = eps.get(ENTRY_POINTS_GROUP, [])
+        else:
+            group_eps = [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
+
+        for ep in group_eps:
+            if ep.name not in seen:
+                seen[ep.name] = (ep.name, "", "", "entrypoint", None)
+    except Exception:
+        pass  # Best-effort; entry-point scan failure shouldn't break the command
 
     return list(seen.values())
 


### PR DESCRIPTION
## Problem

The runtime `PluginManager.discover_and_load()` scans `importlib.metadata` entry points (`hermes_agent.plugins` group) to find pip-installed plugins, but the CLI commands (`hermes plugins list`, `enable`, `disable`) only scanned bundled and user filesystem directories.

This caused pip-installed plugins to be invisible in CLI output and impossible to enable/disable by name, even though they loaded correctly at runtime. Users installing platform adapters (discord, mattermost, etc.) via `pip install hermes-agent[discord]` would see `No adapter available for discord` in `hermes gateway run` but couldn't diagnose via `hermes plugins list` because the plugin didn't appear.

## Fix

Add entry-point scanning to both `_discover_all_plugins()` and `_plugin_exists()` in `hermes_cli/plugins_cmd.py`:

1. **`_discover_all_plugins()`** — After scanning bundled and user directories, also check `importlib.metadata.entry_points(group="hermes_agent.plugins")` and add any entries not already found via filesystem scan.

2. **`_plugin_exists()`** — After checking bundled and user directories, also check entry points so `hermes plugins enable <name>` works for pip-installed plugins.

Both additions use the same entry-point selection pattern as `PluginManager._scan_entry_points()` (Python 3.12+ `select()` / dict fallback / list comprehension), wrapped in `try/except Exception` for graceful degradation.

## Before vs After

| Command | Before | After |
|---------|--------|-------|
| `hermes plugins list` | Only bundled + user dir plugins | Also shows pip-installed entry-point plugins |
| `hermes plugins enable discord` | `Plugin 'discord' not found` | Works if pip-installed with entry point |
| `hermes plugins info discord` | Not found | Shows entry-point plugin info |

## Tests

No new tests added — the fix is mechanical (adds a discovery source that already exists in the runtime loader). Existing plugin CLI tests should continue to pass since the change is additive.

Fixes #34511 (related — same class of discovery gap, though that specific issue was about missing plugin.yaml manifests in the PyPI wheel).