### PR TITLE
fix(auxiliary): send max_completion_tokens to GitHub Copilot for GPT-5 models

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4738,7 +4738,7 @@ def _build_call_kwargs(
             pass  # ZAI vision models do not accept max_tokens
         elif provider == "custom":
             custom_base = base_url or _current_custom_base_url()
-            if base_url_hostname(custom_base) == "api.openai.com":
+            if base_url_hostname(custom_base) in {"api.openai.com", "api.githubcopilot.com"}:
                 kwargs["max_completion_tokens"] = max_tokens
             else:
                 kwargs["max_tokens"] = max_tokens

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2980,6 +2980,78 @@ class TestAuxiliaryClientPoisonedCacheEviction:
                 _client_cache.clear()
 
 
+
+# ---------------------------------------------------------------------------
+# _build_call_kwargs — Copilot max_completion_tokens fix (#34530)
+# ---------------------------------------------------------------------------
+
+class TestBuildCallKwargsCopilotMaxTokens:
+    """_build_call_kwargs must send max_completion_tokens (not max_tokens)
+    for GitHub Copilot's api.githubcopilot.com endpoint, matching the
+    existing api.openai.com behavior.  Newer OpenAI models (gpt-5.x)
+    reject max_tokens with HTTP 400.
+    See: https://github.com/NousResearch/hermes-agent/issues/34530
+    """
+
+    def test_copilot_custom_base_uses_max_completion_tokens(self):
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=2000,
+            base_url="https://api.githubcopilot.com/chat/completions",
+        )
+        assert kwargs.get("max_completion_tokens") == 2000
+        assert "max_tokens" not in kwargs
+
+    def test_copilot_custom_base_no_path_uses_max_completion_tokens(self):
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=4096,
+            base_url="https://api.githubcopilot.com",
+        )
+        assert kwargs.get("max_completion_tokens") == 4096
+        assert "max_tokens" not in kwargs
+
+    def test_openai_custom_base_still_uses_max_completion_tokens(self):
+        """Regression guard: api.openai.com must keep working."""
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=1024,
+            base_url="https://api.openai.com/v1",
+        )
+        assert kwargs.get("max_completion_tokens") == 1024
+        assert "max_tokens" not in kwargs
+
+    def test_other_custom_base_uses_max_tokens(self):
+        """Non-OpenAI/Copilot custom endpoints should still use max_tokens."""
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model="some-model",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=1024,
+            base_url="https://api.together.xyz/v1",
+        )
+        assert kwargs.get("max_tokens") == 1024
+        assert "max_completion_tokens" not in kwargs
+
+    def test_none_max_tokens_not_included(self):
+        """When max_tokens is None, neither key should appear."""
+        kwargs = _build_call_kwargs(
+            provider="custom",
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=None,
+            base_url="https://api.githubcopilot.com",
+        )
+        assert "max_tokens" not in kwargs
+        assert "max_completion_tokens" not in kwargs
+
+
 # ---------------------------------------------------------------------------
 # _build_call_kwargs — tool dedup at API boundary
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes `_build_call_kwargs` in `agent/auxiliary_client.py` to send `max_completion_tokens` (instead of `max_tokens`) when the auxiliary client targets GitHub Copilot's `api.githubcopilot.com` endpoint. Newer OpenAI models (gpt-5.x) reject `max_tokens` with HTTP 400, causing context compression to silently fall back to a static marker and lose conversation history.

## Related Issue

Fixes #34530

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: Add `api.githubcopilot.com` to the hostname set that triggers `max_completion_tokens` in `_build_call_kwargs`, alongside the existing `api.openai.com` check.
- `tests/agent/test_auxiliary_client.py`: Add `TestBuildCallKwargsCopilotMaxTokens` class with 5 tests covering Copilot base URL, OpenAI regression guard, other custom endpoints, and None max_tokens.

## How to Test

1. Configure `auxiliary.compression.provider: copilot` with a GPT-5.x model in `config.yaml`
2. Let a conversation grow until automatic context compression triggers
3. Verify compression summary succeeds (no HTTP 400 error about `max_tokens`)
4. Run `pytest tests/agent/test_auxiliary_client.py -k TestBuildCallKwargsCopilotMaxTokens -v` — all 5 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/auxiliary_client.py:_build_call_kwargs` (called by `call_llm` and `async_call_llm` for every auxiliary LLM request)
- Blast radius: LOW — single conditional change in one function, only affects `provider == "custom"` code path
- Related patterns: `auxiliary_max_tokens_param()` at line 3996 already handles `api.githubcopilot.com` correctly; this fix brings `_build_call_kwargs` into parity
