### PR TITLE
feat(agent): add opt-in completion-claim gate

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1055,6 +1055,24 @@ def init_agent(
         )
     except Exception as _tlg_err:
         _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)
+
+    agent._completion_claim_gate_config = {
+        "enabled": False,
+        "require_report_for_done": True,
+        "allowed_roots": ["."],
+        "report_path_regex": r"(?P<path>(?:~|/|\.)?[^\s`'\"]*(?:report|verification)[^\s`'\"]*\.(?:md|txt|json))",
+        "pass_regex": r"^\s*(?:Gate|Status|Result)\s*:\s*PASS(?:ED)?\s*$",
+        "remediation_command": "",
+    }
+    try:
+        from agent.completion_claim_gate import (
+            config_from_mapping as _ccg_config_from_mapping,
+        )
+
+        agent._completion_claim_gate_config = _ccg_config_from_mapping(_agent_cfg)
+    except Exception as _ccg_err:
+        _ra().logger.warning("Completion claim gate config ignored: %s", _ccg_err)
+
     # Cache only the derived auxiliary compression context override that is
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.

--- a/agent/completion_claim_gate.py
+++ b/agent/completion_claim_gate.py
@@ -1,0 +1,323 @@
+"""Framework-level final-response gate for completion claims.
+
+When enabled, Hermes can withhold a Done/completed claim unless the final
+response explicitly references a verification report within configured roots
+that contains a passing marker. The feature is off by default and only
+activates when configured.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import os
+import re
+
+_EXPLICIT_DONE_PATTERNS = [
+    r"^done(?:[.!,:-]|\s*$)",
+    r"^completed(?:[.!,:-]|\s*$)",
+    r"^complete(?:[.!,:-]|\s*$)",
+    r"^finished(?:[.!,:-]|\s*$)",
+    r"^implemented(?:[.!,:-]|\s*$)",
+    r"^shipped(?:[.!,:-]|\s*$)",
+    r"^i(?:'ve| have)?\s+(?:completed|finished|implemented|shipped)\b",
+    r"^(?:the\s+)?(?:task|work|job|request|fix|implementation)\s+(?:is|was|has\s+been)?\s*(?:done|complete|completed|finished)\b",
+    r"^已完成",
+    r"^已经完成",
+    r"^任务完成",
+    r"^交付完成",
+    r"^修复完成",
+    r"^已修复",
+    r"^已交付",
+    r"^搞定(?:了)?",
+]
+
+_NEGATING_PATTERNS = [
+    r"\bnot\s+(?:done|complete|completed|finished)\b",
+    r"\b(?:isn't|is not|wasn't|was not)\s+(?:done|complete|completed|finished)\b",
+    r"\b(?:pending|blocked|in progress|wip)\b",
+    r"\b(?:done|complete|completed|finished)\s+(?:once|when|after|if|until)\b",
+    r"未完成",
+    r"尚未完成",
+    r"还没完成",
+    r"进行中",
+    r"待验证",
+    r"待处理",
+]
+
+_WITHHELD_PATTERNS = [
+    r"completion claim withheld",
+    r"pending verification",
+    r"not verified",
+    r"unverified",
+    r"未验证",
+    r"无法验证",
+    r"阻塞",
+]
+
+_DEFAULT_ALLOWED_ROOTS = ["."]
+_DEFAULT_REPORT_PATH_REGEX = (
+    r"(?P<path>(?:~|/|\.)?[^\s`'\"]*(?:report|verification)[^\s`'\"]*\.(?:md|txt|json))"
+)
+_DEFAULT_PASS_REGEX = (
+    r"(?:^\s*(?:Gate|Status|Result)\s*:\s*PASS(?:ED)?\s*$|\"(?:gate|status|result)\"\s*:\s*\"PASS(?:ED)?\")"
+)
+
+
+@dataclass
+class CompletionClaimGateResult:
+    """Result of evaluating/applying the final-response completion gate."""
+
+    response: str
+    changed: bool
+    status: str
+    reason: str = ""
+    report_paths: list[str] = field(default_factory=list)
+
+
+def _as_bool(value: object, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on", "enabled"}
+    return default
+
+
+def _normalize_allowed_roots(value: object) -> list[str]:
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list):
+        return list(_DEFAULT_ALLOWED_ROOTS)
+    normalized = [str(item) for item in value if str(item).strip()]
+    return normalized or list(_DEFAULT_ALLOWED_ROOTS)
+
+
+def config_from_mapping(mapping: dict | None) -> dict:
+    """Normalize ``agent.completion_claim_gate`` config from config.yaml."""
+
+    agent_cfg = mapping.get("agent", {}) if isinstance(mapping, dict) else {}
+    if not isinstance(agent_cfg, dict):
+        agent_cfg = {}
+    section = agent_cfg.get("completion_claim_gate", {})
+    if not isinstance(section, dict):
+        section = {}
+
+    report_path_regex = section.get("report_path_regex") or _DEFAULT_REPORT_PATH_REGEX
+    pass_regex = section.get("pass_regex") or _DEFAULT_PASS_REGEX
+    remediation_command = section.get("remediation_command") or ""
+
+    return {
+        "enabled": _as_bool(section.get("enabled"), False),
+        "require_report_for_done": _as_bool(section.get("require_report_for_done"), True),
+        "allowed_roots": _normalize_allowed_roots(section.get("allowed_roots", _DEFAULT_ALLOWED_ROOTS)),
+        "report_path_regex": str(report_path_regex),
+        "pass_regex": str(pass_regex),
+        "remediation_command": str(remediation_command),
+    }
+
+
+def _candidate_segments(response: str) -> list[str]:
+    visible = (response or "").strip()
+    if not visible:
+        return []
+    window = visible[:400]
+    segments = re.split(r"(?<=[.!?。！？])\s+|\n+", window)
+    cleaned = [segment.strip() for segment in segments if segment.strip()]
+    return cleaned[:6]
+
+
+def _contains_done_claim(response: str) -> bool:
+    visible = (response or "").strip()
+    if not visible:
+        return False
+    lowered = visible.lower()
+    if any(re.search(pattern, lowered, re.IGNORECASE) for pattern in _WITHHELD_PATTERNS):
+        return False
+
+    for segment in _candidate_segments(visible):
+        lowered_segment = segment.lower()
+        if any(re.search(pattern, lowered_segment, re.IGNORECASE) for pattern in _NEGATING_PATTERNS):
+            continue
+        if any(re.search(pattern, lowered_segment, re.IGNORECASE) for pattern in _EXPLICIT_DONE_PATTERNS):
+            return True
+    return False
+
+
+def _resolve_allowed_roots(allowed_roots: list[str]) -> list[Path]:
+    resolved: list[Path] = []
+    for raw in allowed_roots or _DEFAULT_ALLOWED_ROOTS:
+        try:
+            resolved.append(Path(os.path.expanduser(raw)).resolve())
+        except Exception:
+            continue
+    return resolved or [Path.cwd().resolve()]
+
+
+def _path_is_within_roots(path: Path, allowed_roots: list[Path]) -> bool:
+    for root in allowed_roots:
+        try:
+            path.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _extract_report_paths(response: str, report_path_regex: str, allowed_roots: list[str]) -> list[Path]:
+    pattern = re.compile(report_path_regex)
+    roots = _resolve_allowed_roots(allowed_roots)
+    paths: list[Path] = []
+    seen: set[str] = set()
+    for match in pattern.finditer(response or ""):
+        raw_path = str(match.group("path") or "").strip()
+        if not raw_path:
+            continue
+        candidates: list[Path] = []
+        try:
+            expanded = Path(os.path.expanduser(raw_path))
+        except Exception:
+            continue
+        if expanded.is_absolute():
+            candidates.append(expanded.resolve())
+        else:
+            for root in roots:
+                candidates.append((root / expanded).resolve())
+        for path in candidates:
+            if not _path_is_within_roots(path, roots):
+                continue
+            key = str(path)
+            if key not in seen:
+                paths.append(path)
+                seen.add(key)
+    return paths
+
+
+def _report_is_passing(path: Path, pass_regex: str) -> bool:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return bool(re.search(pass_regex, text, flags=re.IGNORECASE | re.MULTILINE))
+
+
+def _downgrade_response(original: str, reason: str, remediation_command: str) -> str:
+    lines = [
+        "## Completion claim withheld pending verification",
+        "",
+        "Hermes detected a Done/completed claim, but could not verify a referenced report with a passing marker.",
+        "",
+        f"Reason: {reason}",
+        "",
+    ]
+    if remediation_command:
+        lines.extend(
+            [
+                "Configured remediation command:",
+                f"```bash\n{remediation_command}\n```",
+                "",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "To preserve a completion claim, reference a verification report file in the final reply and include a passing status marker such as `Status: PASS` or `\"status\": \"PASS\"`.",
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "The original completion claim was withheld from the user-facing response.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def evaluate_completion_claim_gate(
+    response: str,
+    *,
+    enabled: bool,
+    require_report_for_done: bool = True,
+    allowed_roots: list[str] | None = None,
+    report_path_regex: str = _DEFAULT_REPORT_PATH_REGEX,
+    pass_regex: str = _DEFAULT_PASS_REGEX,
+    remediation_command: str = "",
+) -> CompletionClaimGateResult:
+    """Evaluate whether a final response needs completion-claim downgrading."""
+
+    original = response or ""
+    if not enabled:
+        return CompletionClaimGateResult(original, False, "disabled")
+    if not require_report_for_done:
+        return CompletionClaimGateResult(original, False, "not_required")
+    if not _contains_done_claim(original):
+        return CompletionClaimGateResult(original, False, "not_a_done_claim")
+
+    try:
+        re.compile(report_path_regex)
+        re.compile(pass_regex)
+    except re.error as exc:
+        downgraded = _downgrade_response(
+            original,
+            f"completion-claim gate configuration is invalid: {exc}",
+            remediation_command,
+        )
+        return CompletionClaimGateResult(
+            downgraded,
+            True,
+            "completion_withheld",
+            reason=f"invalid_gate_config: {exc}",
+        )
+
+    report_paths = _extract_report_paths(
+        original,
+        report_path_regex,
+        _normalize_allowed_roots(allowed_roots or _DEFAULT_ALLOWED_ROOTS),
+    )
+    report_strings = [str(path) for path in report_paths]
+    if report_paths and any(_report_is_passing(path, pass_regex) for path in report_paths):
+        return CompletionClaimGateResult(
+            original,
+            False,
+            "completion_verified",
+            report_paths=report_strings,
+        )
+
+    reason = "no passing verification report was found within the allowed roots"
+    if report_paths:
+        reason = "referenced verification report did not contain a passing marker"
+
+    downgraded = _downgrade_response(original, reason, remediation_command)
+    return CompletionClaimGateResult(
+        downgraded,
+        True,
+        "completion_withheld",
+        reason=reason,
+        report_paths=report_strings,
+    )
+
+
+def apply_completion_claim_gate(
+    response: str,
+    *,
+    enabled: bool,
+    require_report_for_done: bool = True,
+    allowed_roots: list[str] | None = None,
+    report_path_regex: str = _DEFAULT_REPORT_PATH_REGEX,
+    pass_regex: str = _DEFAULT_PASS_REGEX,
+    remediation_command: str = "",
+) -> CompletionClaimGateResult:
+    """Apply the gate and return the possibly modified final response."""
+
+    return evaluate_completion_claim_gate(
+        response,
+        enabled=enabled,
+        require_report_for_done=require_report_for_done,
+        allowed_roots=allowed_roots,
+        report_path_regex=report_path_regex,
+        pass_regex=pass_regex,
+        remediation_command=remediation_command,
+    )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4444,6 +4444,7 @@ def run_conversation(
             logger.debug("file-mutation verifier footer failed: %s", _ver_err)
 
     _response_transformed = False
+    _completion_claim_gate = None
 
     # Plugin hook: transform_llm_output
     # Fired once per turn after the tool-calling loop completes.
@@ -4466,6 +4467,27 @@ def run_conversation(
                     break  # First non-empty string wins
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
+
+    if final_response and not interrupted:
+        try:
+            from agent.completion_claim_gate import (
+                apply_completion_claim_gate as _apply_completion_claim_gate,
+            )
+
+            _ccg_cfg = getattr(agent, "_completion_claim_gate_config", {}) or {}
+            _completion_claim_gate = _apply_completion_claim_gate(
+                final_response,
+                enabled=bool(_ccg_cfg.get("enabled", False)),
+                require_report_for_done=bool(_ccg_cfg.get("require_report_for_done", True)),
+                allowed_roots=list(_ccg_cfg.get("allowed_roots", ["."]) or ["."]),
+                report_path_regex=str(_ccg_cfg.get("report_path_regex", "") or ""),
+                pass_regex=str(_ccg_cfg.get("pass_regex", "") or ""),
+                remediation_command=str(_ccg_cfg.get("remediation_command", "") or ""),
+            )
+            final_response = _completion_claim_gate.response
+            _response_transformed = _response_transformed or _completion_claim_gate.changed
+        except Exception as _ccg_err:
+            logger.warning("completion claim gate failed: %s", _ccg_err)
 
     # Plugin hook: post_llm_call
     # Fired once per turn after the tool-calling loop completes.
@@ -4535,6 +4557,12 @@ def run_conversation(
     }
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
+    if _completion_claim_gate is not None:
+        result["completion_claim_gate"] = {
+            "status": _completion_claim_gate.status,
+            "changed": _completion_claim_gate.changed,
+            "report_paths": list(_completion_claim_gate.report_paths),
+        }
     # If a /steer landed after the final assistant turn (no more tool
     # batches to drain into), hand it back to the caller so it can be
     # delivered as the next user turn instead of being silently lost.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -690,6 +690,20 @@ DEFAULT_CONFIG = {
         # identity slot (SOUL.md). Empty by default. The HERMES_ENVIRONMENT_HINT
         # env var overrides this (build-time/container mechanism).
         "environment_hint": "",
+        # Optional final-response gate for teams that require explicit
+        # verification evidence before Hermes is allowed to claim a task is
+        # Done/completed. Disabled by default; when enabled, the final reply
+        # must reference a verification report file whose contents match
+        # ``pass_regex`` or Hermes will rewrite the completion claim into a
+        # withheld-pending-verification notice.
+        "completion_claim_gate": {
+            "enabled": False,
+            "require_report_for_done": True,
+            "allowed_roots": ["."],
+            "report_path_regex": r"(?P<path>(?:~|/|\.)?[^\s`'\"]*(?:report|verification)[^\s`'\"]*\.(?:md|txt|json))",
+            "pass_regex": r"^\s*(?:Gate|Status|Result)\s*:\s*PASS(?:ED)?\s*$",
+            "remediation_command": "",
+        },
         # Staged inactivity warning: send a warning to the user at this
         # threshold before escalating to a full timeout.  The warning fires
         # once per run and does not interrupt the agent.  0 = disable warning.

--- a/tests/test_completion_claim_gate.py
+++ b/tests/test_completion_claim_gate.py
@@ -1,0 +1,301 @@
+from pathlib import Path
+
+from agent.completion_claim_gate import (
+    apply_completion_claim_gate,
+    config_from_mapping,
+    evaluate_completion_claim_gate,
+)
+
+
+def _write_report(path: Path, status_line: str = "Status: PASS") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(
+            [
+                "# Verification Report",
+                status_line,
+                "## Evidence",
+                "- tests: unit tests — exit=0 — passed",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_unverified_done_response_is_withheld():
+    response = "Done. I created the files and everything is complete."
+
+    result = apply_completion_claim_gate(
+        response,
+        enabled=True,
+        require_report_for_done=True,
+    )
+
+    assert result.changed is True
+    assert result.status == "completion_withheld"
+    assert result.response.startswith("## Completion claim withheld pending verification")
+    assert "could not verify a referenced report" in result.response
+    assert "Done. I created" not in result.response
+
+
+def test_done_response_with_passing_report_is_preserved(tmp_path):
+    workspace = tmp_path / "workspace"
+    report = workspace / "verification-report.md"
+    _write_report(report, "Status: PASS")
+    response = "Done. Verification report: ./verification-report.md"
+
+    result = apply_completion_claim_gate(
+        response,
+        enabled=True,
+        require_report_for_done=True,
+        allowed_roots=[str(workspace)],
+    )
+
+    assert result.changed is False
+    assert result.status == "completion_verified"
+    assert result.response == response
+    assert str(report.resolve()) in result.report_paths
+
+
+def test_non_completion_response_is_not_changed():
+    response = "I inspected the repository and found the relevant files."
+
+    result = apply_completion_claim_gate(
+        response,
+        enabled=True,
+        require_report_for_done=True,
+    )
+
+    assert result.changed is False
+    assert result.status == "not_a_done_claim"
+    assert result.response == response
+
+
+def test_gate_disabled_is_noop():
+    response = "Done. Complete."
+
+    result = apply_completion_claim_gate(
+        response,
+        enabled=False,
+        require_report_for_done=True,
+    )
+
+    assert result.changed is False
+    assert result.status == "disabled"
+    assert result.response == response
+
+
+def test_passing_report_must_be_referenced_not_just_present(tmp_path):
+    report = tmp_path / "verification-report.md"
+    _write_report(report, "Status: PASS")
+    response = "Done. The work is complete."
+
+    result = evaluate_completion_claim_gate(
+        response,
+        enabled=True,
+        require_report_for_done=True,
+    )
+
+    assert result.status == "completion_withheld"
+    assert result.changed is True
+    assert result.report_paths == []
+
+
+def test_config_mapping_uses_defaults_and_overrides():
+    cfg = config_from_mapping(
+        {
+            "agent": {
+                "completion_claim_gate": {
+                    "enabled": True,
+                    "require_report_for_done": False,
+                    "allowed_roots": [".", "./artifacts"],
+                    "report_path_regex": r"(?P<path>.+\\.proof)",
+                    "pass_regex": r"^OK$",
+                    "remediation_command": "make verify",
+                }
+            }
+        }
+    )
+    assert cfg == {
+        "enabled": True,
+        "require_report_for_done": False,
+        "allowed_roots": [".", "./artifacts"],
+        "report_path_regex": r"(?P<path>.+\\.proof)",
+        "pass_regex": r"^OK$",
+        "remediation_command": "make verify",
+    }
+
+
+def test_failed_report_still_withholds(tmp_path):
+    report = tmp_path / "verification-report.md"
+    _write_report(report, "Status: FAIL")
+    response = f"Done. Verification report: {report}"
+
+    result = evaluate_completion_claim_gate(
+        response,
+        enabled=True,
+        require_report_for_done=True,
+        allowed_roots=[str(tmp_path)],
+    )
+
+    assert result.status == "completion_withheld"
+    assert result.changed is True
+    assert str(report.resolve()) in result.report_paths
+
+
+def test_default_pass_regex_accepts_json_reports(tmp_path):
+    report = tmp_path / "verification-report.json"
+    report.write_text('{"status": "PASS", "details": ["pytest ok"]}\n', encoding="utf-8")
+    response = f"Done. Verification report: {report}"
+
+    result = evaluate_completion_claim_gate(
+        response,
+        enabled=True,
+        require_report_for_done=True,
+        allowed_roots=[str(tmp_path)],
+    )
+
+    assert result.changed is False
+    assert result.status == "completion_verified"
+    assert str(report.resolve()) in result.report_paths
+
+
+def test_chinese_analysis_text_with_wanchengdu_is_not_treated_as_done():
+    response = "一、产品完成度雷达图\n\n这里是当前系统的成熟度与完成度分析。"
+
+    result = evaluate_completion_claim_gate(
+        response,
+        enabled=True,
+        require_report_for_done=True,
+    )
+
+    assert result.changed is False
+    assert result.status == "not_a_done_claim"
+    assert result.response == response
+
+
+def test_explicit_chinese_completion_claim_still_triggers_gate():
+    response = "已完成修复，请验收。"
+
+    result = evaluate_completion_claim_gate(
+        response,
+        enabled=True,
+        require_report_for_done=True,
+    )
+
+    assert result.changed is True
+    assert result.status == "completion_withheld"
+    assert result.response.startswith("## Completion claim withheld pending verification")
+
+
+def test_custom_regexes_support_non_default_report_and_pass_markers(tmp_path):
+    report = tmp_path / "proof.txt"
+    _write_report(report, "Result: PASSED")
+    response = f"Done. Evidence file: {report}"
+
+    result = evaluate_completion_claim_gate(
+        response,
+        enabled=True,
+        require_report_for_done=True,
+        allowed_roots=[str(tmp_path)],
+        report_path_regex=r"(?P<path>(?:~|/|\.)?[^\s`'\"]*proof\.txt)",
+        pass_regex=r"^Result:\s*PASSED$",
+        remediation_command="make verify",
+    )
+
+    assert result.changed is False
+    assert result.status == "completion_verified"
+    assert str(report.resolve()) in result.report_paths
+
+
+def test_custom_remediation_command_is_rendered_in_withheld_message():
+    response = "Done. Everything is complete."
+
+    result = evaluate_completion_claim_gate(
+        response,
+        enabled=True,
+        require_report_for_done=True,
+        remediation_command="make verify",
+    )
+
+    assert result.changed is True
+    assert "```bash\nmake verify\n```" in result.response
+
+
+def test_unrelated_pass_file_outside_allowed_roots_does_not_bypass_gate(tmp_path):
+    inside = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    outside_report = outside / "verification-report.md"
+    _write_report(outside_report, "Status: PASS")
+    response = f"Done. Verification report: {outside_report}"
+
+    result = evaluate_completion_claim_gate(
+        response,
+        enabled=True,
+        require_report_for_done=True,
+        allowed_roots=[str(inside)],
+    )
+
+    assert result.changed is True
+    assert result.status == "completion_withheld"
+    assert result.report_paths == []
+
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        "I created a plan for the implementation.",
+        "I fixed the typo in my explanation above.",
+        "Work is not done yet.",
+        "This report describes completed requests historically.",
+        "The task is complete once tests pass.",
+        "Complete these steps to reproduce.",
+    ],
+)
+def test_false_positive_phrasings_are_not_treated_as_done_claims(response):
+    result = evaluate_completion_claim_gate(
+        response,
+        enabled=True,
+        require_report_for_done=True,
+    )
+
+    assert result.changed is False
+    assert result.status == "not_a_done_claim"
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        "Done. If you want, I can also summarize the diff.",
+        "Completed. When ready, I can open a follow-up PR.",
+        "Finished. After you review it, I can clean up the branch.",
+        "Here is a summary of changes.\n\nDone. Verification report pending.",
+        "Summary first line. Done.\nMore detail follows.",
+    ],
+)
+def test_done_claims_with_follow_up_or_leading_summary_still_trigger_gate(response):
+    result = evaluate_completion_claim_gate(
+        response,
+        enabled=True,
+        require_report_for_done=True,
+    )
+
+    assert result.changed is True
+    assert result.status == "completion_withheld"
+
+
+def test_invalid_regex_config_fails_closed():
+    result = evaluate_completion_claim_gate(
+        "Done.",
+        enabled=True,
+        require_report_for_done=True,
+        report_path_regex="(",
+    )
+
+    assert result.changed is True
+    assert result.status == "completion_withheld"
+    assert "invalid_gate_config" in result.reason


### PR DESCRIPTION
## Summary
- add an opt-in `agent.completion_claim_gate` that withholds Done/completed claims unless the final reply references a passing verification report
- constrain verification report resolution to configured roots and mark gated rewrites as `response_transformed` so streamed clients receive the edited final text
- add focused tests for verification markers, false-positive/false-negative phrasing, JSON reports, invalid regex configs, and streamed-response delivery paths

## Why
Some deployments want a lightweight, framework-level safety rail against premature completion claims, but the local verified-delivery implementation was too environment-specific to upstream as-is. This version keeps the feature disabled by default and makes it generic/configurable.

## Config
```yaml
agent:
  completion_claim_gate:
    enabled: true
    require_report_for_done: true
    allowed_roots: ["/path/to/workspace"]
    remediation_command: "make verify"
```

## Validation
- `python -m py_compile agent/completion_claim_gate.py agent/agent_init.py agent/conversation_loop.py tests/test_completion_claim_gate.py`
- `python -m pytest -o addopts='' -q tests/test_completion_claim_gate.py tests/gateway/test_run_progress_topics.py::test_transformed_response_edits_streamed_message_in_place tests/acp/test_server.py::TestPrompt::test_prompt_delivers_transformed_response_after_streaming`
