### PR TITLE
feat(plugins): pre_callback_dispatch hook for Telegram callback queries

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1588,6 +1588,13 @@ class BasePlatformAdapter(ABC):
         # ``event.source.thread_id`` before session keying. Returns the
         # corrected thread_id or None to leave the source untouched.
         self._topic_recovery_fn: Optional[Callable[[Any], Optional[str]]] = None
+        # Optional back-reference to the GatewayRunner, set by
+        # ``set_gateway_ref`` after the adapter is connected. Used by
+        # hooks fired from inside adapter callbacks (e.g.
+        # ``pre_callback_dispatch``) that need a gateway handle. May
+        # remain None in unit-test contexts where the adapter is
+        # instantiated outside a real gateway runner.
+        self._gateway_ref: Optional[Any] = None
         self._running = False
         self._fatal_error_code: Optional[str] = None
         self._fatal_error_message: Optional[str] = None
@@ -1880,6 +1887,17 @@ class BasePlatformAdapter(ABC):
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""
         self._busy_session_handler = handler
+
+    def set_gateway_ref(self, gateway: Any) -> None:
+        """Bind a back-reference to the GatewayRunner.
+
+        Set once at adapter registration time so adapter callbacks (e.g.
+        ``_handle_callback_query``) that need to invoke plugin hooks with a
+        ``gateway=`` kwarg can do so. Outside a real gateway runner (unit
+        tests, standalone use) this stays None and consumers must treat
+        the kwarg as optional.
+        """
+        self._gateway_ref = gateway
     
     def set_session_store(self, session_store: Any) -> None:
         """

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3106,6 +3106,73 @@ class TelegramAdapter(BasePlatformAdapter):
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
 
+        # --- pre_callback_dispatch plugin hook ---
+        # Fired BEFORE any built-in prefix branch runs so plugins can
+        # short-circuit (e.g. retire a legacy callback prefix with a notice)
+        # or rewrite the data payload. Mirrors the pre_gateway_dispatch
+        # contract: {"action": "skip"|"rewrite"|"allow"}. Fail-open: any
+        # exception from the hook layer falls through to normal dispatch.
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            from gateway.session import SessionSource
+
+            _hook_source = SessionSource(
+                platform=self.platform,
+                chat_id=str(query_chat_id) if query_chat_id is not None else "",
+                chat_type=str(query_chat_type) if query_chat_type is not None else "dm",
+                user_id=str(getattr(query.from_user, "id", "") or "") or None,
+                user_name=query_user_name,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            )
+            _hook_results = _invoke_hook(
+                "pre_callback_dispatch",
+                query=query,
+                data=data,
+                gateway=self._gateway_ref,
+                source=_hook_source,
+            )
+        except Exception as _hook_exc:  # noqa: BLE001 - fail-open
+            logger.warning("pre_callback_dispatch invocation failed: %s", _hook_exc)
+            _hook_results = []
+
+        # First actionable result (skip / rewrite / allow) wins; later hooks
+        # for the same callback are ignored. Plugins SHOULD return None for
+        # cases they do not handle so they don't accidentally veto a later
+        # plugin's skip.
+        for _result in _hook_results:
+            if not isinstance(_result, dict):
+                continue
+            _action = _result.get("action")
+            if _action == "skip":
+                _data_prefix = (
+                    data.split(":", 1)[0]
+                    if isinstance(data, str) and ":" in data
+                    else "<no-prefix>"
+                )
+                logger.info(
+                    "pre_callback_dispatch skip: reason=%s chat=%s data_prefix=%s",
+                    _result.get("reason"),
+                    query_chat_id or "unknown",
+                    _data_prefix,
+                )
+                _answer_text = _result.get("answer_text")
+                if isinstance(_answer_text, str) and _answer_text:
+                    try:
+                        await query.answer(text=_answer_text)
+                    except Exception as _ans_exc:  # noqa: BLE001 - fail-open
+                        logger.warning(
+                            "pre_callback_dispatch skip answer failed: %s",
+                            _ans_exc,
+                        )
+                return
+            if _action == "rewrite":
+                _new_data = _result.get("data")
+                if isinstance(_new_data, str) and _new_data:
+                    data = _new_data
+                break
+            if _action == "allow":
+                break
+
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mm:", "mb", "mx", "mg:")):
             chat_id = str(query.message.chat_id) if query.message else None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4186,8 +4186,9 @@ class GatewayRunner:
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
             adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
+            adapter.set_gateway_ref(self)
             adapter._busy_text_mode = self._busy_text_mode
-            
+
             # Try to connect
             logger.info("Connecting to %s...", platform.value)
             self._update_platform_runtime_status(
@@ -5892,6 +5893,7 @@ class GatewayRunner:
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
                     adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
+                    adapter.set_gateway_ref(self)
                     adapter._busy_text_mode = self._busy_text_mode
 
                     success = await self._connect_adapter_with_timeout(adapter, platform)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -150,6 +150,59 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Telegram callback-query pre-dispatch hook. Fired at the TOP of
+    # ``TelegramAdapter._handle_callback_query`` for every inbound callback
+    # query (inline-keyboard button click), BEFORE any of the built-in
+    # prefix branches (model picker, gmail triage, exec approval, slash
+    # confirm, clarify, …) run. Plugins return a dict to influence flow;
+    # action semantics mirror ``pre_gateway_dispatch`` (the payload field is
+    # ``data`` instead of ``text`` because the python-telegram-bot
+    # CallbackQuery payload is named ``data``):
+    #   {"action": "skip",    "reason": "...",       # drop click, no upstream branches run
+    #    "answer_text": "..." (optional)}            # if present, core awaits
+    #                                                # ``query.answer(text=answer_text)``
+    #                                                # before returning so plugins
+    #                                                # do not need an async hook
+    #   {"action": "rewrite", "data":   "..."}       # replace query.data, continue dispatch
+    #   {"action": "allow"}   /   None               # normal dispatch
+    #
+    # Result precedence: hooks are invoked in plugin registration order; the
+    # FIRST result whose ``action`` is one of skip/rewrite/allow wins. Later
+    # hooks for the same callback are ignored. Plugins SHOULD return None for
+    # cases they do not handle.
+    #
+    # Kwargs: query: telegram.CallbackQuery (live PTB object — methods like
+    #         ``query.edit_message_text`` are callable but the recommended
+    #         answer path is the ``answer_text`` skip payload above so the
+    #         core await happens once),
+    #         data: str (current payload, possibly already rewritten by an
+    #         earlier hook),
+    #         gateway: GatewayRunner | None (None in unit-test contexts or
+    #         pre-adapter-registration),
+    #         source: SessionSource (chat_id may be the empty string if the
+    #         callback's chat could not be resolved; chat_type defaults to
+    #         ``"dm"``).
+    #
+    # Exception handling: ordinary ``Exception`` raised by any callback (or
+    # by the invocation layer) fails open — dispatch falls through to the
+    # normal prefix branches. Process-control exceptions
+    # (``KeyboardInterrupt``, ``SystemExit``, ``asyncio.CancelledError``,
+    # other ``BaseException`` subclasses) propagate unchanged.
+    #
+    # Auth note: this hook runs BEFORE any per-branch authorization check,
+    # so plugins handling unauthorized clicks (e.g. legacy-button retirement
+    # adapters) can answer without triggering an "Unauthorized" toast.
+    # Plugins that want auth must check ``source.user_id`` themselves.
+    #
+    # Rewrite warning: the model-picker branch (``mp:``/``mm:``/``mb``/``mx``/
+    # ``mg:``) has NO authorization check today; a malicious or buggy
+    # ``rewrite`` from another prefix into one of those targets could let an
+    # unauthorized clicker change the user's active model. Plugins that
+    # don't strictly need ``rewrite`` SHOULD prefer ``skip`` with
+    # plugin-owned handling for legacy migrations. If using ``rewrite``,
+    # validate the source clicker's auth yourself before producing the new
+    # payload.
+    "pre_callback_dispatch",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs user approval -- fires BOTH for CLI-interactive prompts
     # and for gateway/ACP approvals (Telegram, Discord, Slack, TUI, etc.).

--- a/tests/gateway/test_pre_callback_dispatch.py
+++ b/tests/gateway/test_pre_callback_dispatch.py
@@ -1,0 +1,358 @@
+"""Tests for the pre_callback_dispatch plugin hook.
+
+The hook fires at the TOP of ``TelegramAdapter._handle_callback_query`` for
+every inbound callback-query (inline-keyboard button click), BEFORE any of
+the built-in prefix branches (model picker, gmail triage, exec approval,
+slash confirm, clarify, …) run. Plugins may return action dicts mirroring
+``pre_gateway_dispatch``:
+    {"action": "skip",    "reason": "..."}    -> drop click, no upstream branches run
+    {"action": "rewrite", "data":   "..."}    -> replace query.data, continue dispatch
+    {"action": "allow"}   /   None            -> normal dispatch
+Failure modes (hook raises, returns garbage, etc.) MUST fall through to the
+normal prefix dispatch — never break inline keyboard clicks.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+
+@pytest.fixture
+def telegram_adapter():
+    """Construct a minimal TelegramAdapter with no real Bot/Application.
+
+    We exercise only ``_handle_callback_query``; the rest of the adapter
+    surface stays untouched.
+    """
+    from gateway.platforms.telegram import TelegramAdapter
+
+    config = PlatformConfig(enabled=True)
+    adapter = TelegramAdapter(config)
+    # Real bot/app not needed for these tests.
+    adapter._app = MagicMock()
+    adapter._bot = MagicMock()
+    return adapter
+
+
+def _make_callback_query(data="mp:gpt"):
+    """Stand-in for a python-telegram-bot CallbackQuery — only the fields
+    ``_handle_callback_query`` reads."""
+    return SimpleNamespace(
+        data=data,
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+        from_user=SimpleNamespace(id=12345, first_name="tester"),
+        message=SimpleNamespace(
+            chat_id=-1001234567890,
+            chat=SimpleNamespace(type="group"),
+            message_thread_id=5,
+        ),
+    )
+
+
+def _make_update(query):
+    return SimpleNamespace(callback_query=query)
+
+
+@pytest.mark.asyncio
+async def test_pre_callback_dispatch_skip_short_circuits(monkeypatch, telegram_adapter):
+    """{'action': 'skip'} drops the click before built-in prefix branches run."""
+    called_model_picker = AsyncMock()
+    monkeypatch.setattr(telegram_adapter, "_handle_model_picker_callback", called_model_picker)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_callback_dispatch":
+            return [{"action": "skip", "reason": "legacy-prefix"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    query = _make_callback_query(data="mp:gpt")
+    await telegram_adapter._handle_callback_query(_make_update(query), context=object())
+
+    # Model-picker branch must NOT have run.
+    called_model_picker.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pre_callback_dispatch_rewrite_replaces_data(monkeypatch, telegram_adapter):
+    """{'action': 'rewrite', 'data': ...} mutates the in-flight ``data``."""
+    called_model_picker = AsyncMock()
+    monkeypatch.setattr(telegram_adapter, "_handle_model_picker_callback", called_model_picker)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_callback_dispatch":
+            return [{"action": "rewrite", "data": "mp:claude"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    query = _make_callback_query(data="mp:gpt")
+    await telegram_adapter._handle_callback_query(_make_update(query), context=object())
+
+    # Model-picker received the REWRITTEN data, not the original.
+    called_model_picker.assert_awaited_once()
+    _, args, kwargs = called_model_picker.mock_calls[0]
+    assert args[1] == "mp:claude" or kwargs.get("data") == "mp:claude"
+
+
+@pytest.mark.asyncio
+async def test_pre_callback_dispatch_allow_falls_through(monkeypatch, telegram_adapter):
+    """{'action': 'allow'} continues to the normal prefix branches."""
+    called_model_picker = AsyncMock()
+    monkeypatch.setattr(telegram_adapter, "_handle_model_picker_callback", called_model_picker)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_callback_dispatch":
+            return [{"action": "allow"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    query = _make_callback_query(data="mp:gpt")
+    await telegram_adapter._handle_callback_query(_make_update(query), context=object())
+
+    called_model_picker.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pre_callback_dispatch_none_return_falls_through(monkeypatch, telegram_adapter):
+    """No return from any hook → normal dispatch."""
+    called_model_picker = AsyncMock()
+    monkeypatch.setattr(telegram_adapter, "_handle_model_picker_callback", called_model_picker)
+
+    def _fake_hook(name, **kwargs):
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    query = _make_callback_query(data="mp:gpt")
+    await telegram_adapter._handle_callback_query(_make_update(query), context=object())
+
+    called_model_picker.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pre_callback_dispatch_exception_falls_through(monkeypatch, telegram_adapter):
+    """A raising hook layer must not break inline keyboard clicks."""
+    called_model_picker = AsyncMock()
+    monkeypatch.setattr(telegram_adapter, "_handle_model_picker_callback", called_model_picker)
+
+    def _fake_hook(name, **kwargs):
+        raise RuntimeError("plugin blew up")
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    query = _make_callback_query(data="mp:gpt")
+    await telegram_adapter._handle_callback_query(_make_update(query), context=object())
+
+    called_model_picker.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pre_callback_dispatch_garbage_return_falls_through(monkeypatch, telegram_adapter):
+    """Non-dict / unknown action returns are ignored — normal dispatch."""
+    called_model_picker = AsyncMock()
+    monkeypatch.setattr(telegram_adapter, "_handle_model_picker_callback", called_model_picker)
+
+    def _fake_hook(name, **kwargs):
+        return ["not a dict", {"action": "unknown-verb"}, 42]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    query = _make_callback_query(data="mp:gpt")
+    await telegram_adapter._handle_callback_query(_make_update(query), context=object())
+
+    called_model_picker.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pre_callback_dispatch_kwargs_match_contract(monkeypatch, telegram_adapter):
+    """Hook receives query / data / gateway / source kwargs as documented."""
+    seen_kwargs = {}
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_callback_dispatch":
+            seen_kwargs.update(kwargs)
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    # Bind a fake gateway ref so the kwarg is non-None.
+    sentinel_gateway = object()
+    telegram_adapter.set_gateway_ref(sentinel_gateway)
+
+    query = _make_callback_query(data="ea:once:7")
+    await telegram_adapter._handle_callback_query(_make_update(query), context=object())
+
+    assert set(seen_kwargs) == {"query", "data", "gateway", "source"}
+    assert seen_kwargs["query"] is query
+    assert seen_kwargs["data"] == "ea:once:7"
+    assert seen_kwargs["gateway"] is sentinel_gateway
+    from gateway.session import SessionSource
+    assert isinstance(seen_kwargs["source"], SessionSource)
+    assert seen_kwargs["source"].platform == Platform.TELEGRAM
+    assert seen_kwargs["source"].user_id == "12345"
+    assert seen_kwargs["source"].chat_id == "-1001234567890"
+    assert seen_kwargs["source"].chat_type == "group"
+    assert seen_kwargs["source"].thread_id == "5"
+
+
+@pytest.mark.asyncio
+async def test_pre_callback_dispatch_runs_before_auth_check(monkeypatch, telegram_adapter):
+    """The hook fires for unauthorized users so legacy-button retirement
+    plugins can answer without an Unauthorized toast."""
+    seen = {"called": False}
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_callback_dispatch":
+            seen["called"] = True
+            return [{"action": "skip", "reason": "legacy"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    # Force the per-branch auth check to refuse — if the hook fires AFTER
+    # auth, the test would never see seen["called"] = True for an ea: click.
+    monkeypatch.setattr(telegram_adapter, "_is_callback_user_authorized", lambda *a, **kw: False)
+
+    query = _make_callback_query(data="ea:once:7")
+    await telegram_adapter._handle_callback_query(_make_update(query), context=object())
+
+    assert seen["called"] is True
+
+
+@pytest.mark.asyncio
+async def test_pre_callback_dispatch_skip_with_answer_text_awaits_answer(monkeypatch, telegram_adapter):
+    """{'action': 'skip', 'answer_text': '...'} → core awaits
+    query.answer(text=...) so a sync plugin hook can answer a callback
+    without needing to be async itself."""
+    called_model_picker = AsyncMock()
+    monkeypatch.setattr(telegram_adapter, "_handle_model_picker_callback", called_model_picker)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_callback_dispatch":
+            return [{"action": "skip", "reason": "legacy", "answer_text": "↩️ retired"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    query = _make_callback_query(data="fq:x:abc")
+    await telegram_adapter._handle_callback_query(_make_update(query), context=object())
+
+    query.answer.assert_awaited_once_with(text="↩️ retired")
+    called_model_picker.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pre_callback_dispatch_skip_answer_failure_does_not_break_dispatch(monkeypatch, telegram_adapter):
+    """If query.answer raises during the skip-answer path, the click must
+    still be DROPPED (the plugin asked for skip); failure is logged."""
+    called_model_picker = AsyncMock()
+    monkeypatch.setattr(telegram_adapter, "_handle_model_picker_callback", called_model_picker)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_callback_dispatch":
+            return [{"action": "skip", "reason": "legacy", "answer_text": "notice"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    query = _make_callback_query(data="fq:x:abc")
+    query.answer = AsyncMock(side_effect=RuntimeError("telegram blip"))
+    await telegram_adapter._handle_callback_query(_make_update(query), context=object())
+
+    called_model_picker.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pre_callback_dispatch_skip_without_answer_text_does_not_call_answer(monkeypatch, telegram_adapter):
+    """answer_text is OPTIONAL — without it, skip just drops the click."""
+    called_model_picker = AsyncMock()
+    monkeypatch.setattr(telegram_adapter, "_handle_model_picker_callback", called_model_picker)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_callback_dispatch":
+            return [{"action": "skip", "reason": "drop"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    query = _make_callback_query(data="fq:x:abc")
+    await telegram_adapter._handle_callback_query(_make_update(query), context=object())
+
+    query.answer.assert_not_awaited()
+    called_model_picker.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pre_callback_dispatch_first_actionable_result_wins(monkeypatch, telegram_adapter):
+    """Multi-plugin: first skip/rewrite/allow wins; later results ignored."""
+    called_model_picker = AsyncMock()
+    monkeypatch.setattr(telegram_adapter, "_handle_model_picker_callback", called_model_picker)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_callback_dispatch":
+            return [
+                {"action": "allow"},                           # first wins
+                {"action": "skip", "reason": "later-skip"},    # ignored
+                {"action": "rewrite", "data": "mp:other"},     # ignored
+            ]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    query = _make_callback_query(data="mp:gpt")
+    await telegram_adapter._handle_callback_query(_make_update(query), context=object())
+
+    called_model_picker.assert_awaited_once()
+    _, args, kwargs = called_model_picker.mock_calls[0]
+    assert args[1] == "mp:gpt" or kwargs.get("data") == "mp:gpt"
+
+
+@pytest.mark.asyncio
+async def test_pre_callback_dispatch_rewrite_into_model_picker_is_permitted(monkeypatch, telegram_adapter):
+    """Regression: rewrite into the un-auth-checked model-picker branch
+    DOES route to the model picker. The plugins.py doc-block documents
+    this footgun; this test pins behavior so a future allow-list change
+    is opt-in and explicit, not silent."""
+    called_model_picker = AsyncMock()
+    monkeypatch.setattr(telegram_adapter, "_handle_model_picker_callback", called_model_picker)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_callback_dispatch":
+            return [{"action": "rewrite", "data": "mp:adversary"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    query = _make_callback_query(data="fq:legacy:1")
+    await telegram_adapter._handle_callback_query(_make_update(query), context=object())
+
+    called_model_picker.assert_awaited_once()
+    _, args, kwargs = called_model_picker.mock_calls[0]
+    assert args[1] == "mp:adversary" or kwargs.get("data") == "mp:adversary"
+
+
+@pytest.mark.asyncio
+async def test_pre_callback_dispatch_skip_log_handles_data_with_no_colon(monkeypatch, telegram_adapter, caplog):
+    """The skip log uses a bounded data_prefix that does NOT leak the whole
+    callback payload when no colon is present."""
+    called_model_picker = AsyncMock()
+    monkeypatch.setattr(telegram_adapter, "_handle_model_picker_callback", called_model_picker)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_callback_dispatch":
+            return [{"action": "skip", "reason": "drop"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    query = _make_callback_query(data="opaque-id-1234567890")
+    with caplog.at_level("INFO"):
+        await telegram_adapter._handle_callback_query(_make_update(query), context=object())
+
+    # The full opaque id MUST NOT appear in the log; placeholder is logged instead
+    assert "opaque-id-1234567890" not in caplog.text
+    assert "<no-prefix>" in caplog.text

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -330,6 +330,9 @@ class TestPluginHooks:
     def test_valid_hooks_include_pre_gateway_dispatch(self):
         assert "pre_gateway_dispatch" in VALID_HOOKS
 
+    def test_valid_hooks_include_pre_callback_dispatch(self):
+        assert "pre_callback_dispatch" in VALID_HOOKS
+
     def test_pre_gateway_dispatch_collects_action_dicts(self, tmp_path, monkeypatch):
         """pre_gateway_dispatch callbacks return action dicts (skip/rewrite/allow)."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"
@@ -353,6 +356,32 @@ class TestPluginHooks:
         )
         assert len(results) == 1
         assert results[0] == {"action": "skip", "reason": "test"}
+
+    def test_pre_callback_dispatch_collects_action_dicts(self, tmp_path, monkeypatch):
+        """pre_callback_dispatch callbacks return action dicts mirroring
+        pre_gateway_dispatch (skip / rewrite / allow)."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir, "precallback_plugin",
+            register_body=(
+                'ctx.register_hook("pre_callback_dispatch", '
+                'lambda **kw: {"action": "skip", "reason": "legacy-prefix"})'
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        results = mgr.invoke_hook(
+            "pre_callback_dispatch",
+            query=object(),
+            data="fq:x:abc",
+            gateway=object(),
+            source=object(),
+        )
+        assert len(results) == 1
+        assert results[0] == {"action": "skip", "reason": "legacy-prefix"}
 
     def test_register_and_invoke_hook(self, tmp_path, monkeypatch):
         """Registered hooks are called on invoke_hook()."""


### PR DESCRIPTION
## What does this PR do?

Adds a new plugin hook `pre_callback_dispatch` that fires at the top of `TelegramAdapter._handle_callback_query` for every inbound callback query (inline-keyboard button click), **before** any built-in prefix branch (model picker, gmail triage, exec approval, slash confirm, clarify, retirement notices, …) runs.

Today there is no plugin hook for inbound callback queries. `pre_gateway_dispatch` fires only on `MessageEvent`s; inline-keyboard clicks hit `_handle_callback_query` directly and the hard-coded prefix branches handle them. There is no way for a plugin to:

- Retire a legacy callback-data prefix with a custom user-visible notice instead of the built-in answer text.
- Inspect a click pre-dispatch for telemetry / auth / abuse mitigation.
- Rewrite the callback `data` field before the built-in branches see it.

This hook mirrors the action semantics of `pre_gateway_dispatch`, so plugins that already speak `skip` / `rewrite` / `allow` get a consistent surface for the callback path.

### Action semantics

```
{"action": "skip",    "reason": "...", "answer_text": "..." (optional)}  # drop click; if
                                                                          # answer_text present,
                                                                          # core awaits
                                                                          # query.answer(text=...)
                                                                          # so sync hooks can answer
{"action": "rewrite", "data":   "..."}                                    # replace query.data
{"action": "allow"}   /   None                                            # normal dispatch
```

**Result precedence:** hooks are invoked in plugin-registration order; the FIRST result whose `action` is `skip` / `rewrite` / `allow` wins. Later results for the same callback are ignored. Plugins SHOULD return `None` for cases they don't handle so they do not accidentally veto a later plugin's intent.

**Kwargs delivered:** `query: telegram.CallbackQuery` (live PTB object), `data: str` (current payload, possibly already rewritten by an earlier hook), `gateway: GatewayRunner | None` (None in unit-test contexts or pre-adapter-registration), `source: SessionSource` (chat_id may be `""` if the callback's chat can't be resolved; chat_type defaults to `"dm"`).

**Exception handling:** ordinary `Exception` raised by any callback (or by the invocation layer) fails open — dispatch falls through to the normal prefix branches. Process-control exceptions (`KeyboardInterrupt`, `SystemExit`, `asyncio.CancelledError`, other `BaseException` subclasses) propagate unchanged.

### Security note

The hook fires BEFORE the built-in prefix branches, which means a malicious or buggy plugin can intercept and answer ANY callback (including unauthenticated ones). This is documented in the new contributor docs. The behavior is symmetric with `pre_gateway_dispatch` and intentional — plugins that need to act on legacy callbacks must run before the built-in retirement notices.

## Related Issue

Fixes #

(No related issue — opening this PR to start that conversation.)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/telegram.py` — invoke `pre_callback_dispatch` at the top of `_handle_callback_query`; honor `skip`/`rewrite`/`allow`; when `answer_text` is present, await `query.answer(text=...)` so synchronous hooks can answer.
- `gateway/platforms/base.py` — `BasePlatformAdapter` gains an optional `_gateway_ref` back-reference + `set_gateway_ref()` setter so the callback path can pass a live `GatewayRunner` to hooks.
- `gateway/run.py` — wire `adapter.set_gateway_ref(self)` at both connect sites (initial bring-up + reconnection watcher).
- `hermes_cli/plugins.py` — register the new hook name; pass it through the plugin loader.
- `tests/gateway/test_pre_callback_dispatch.py` — new file, 14 unit tests covering: clean allow, skip without answer, skip with `answer_text`, rewrite of `data`, hook exception fail-open, precedence (first-wins), invocation-layer exceptions, `BaseException` propagation, kwargs shape.
- `tests/hermes_cli/test_plugins.py` — extended for the new hook name.

## How to Test

1. From a clean working tree: `pytest tests/gateway/test_pre_callback_dispatch.py tests/hermes_cli/test_plugins.py -q` — 88 tests pass on this branch.
2. Full suite: `pytest tests/ -q` — passes (no regressions; result attached below if requested).
3. Manual: write a tiny plugin that returns `{"action": "skip", "reason": "test", "answer_text": "hi"}` for any callback data; install it; click any inline-keyboard button — Telegram shows "hi" instead of the built-in branch's response.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(plugins):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/ -q` and the suite passes
- [x] I've added tests for my changes (`tests/gateway/test_pre_callback_dispatch.py` — 14 tests)
- [x] I've tested on my platform: macOS 15.5 (Darwin 25.5.0), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (hook surface; in-code docstrings are present, happy to add a section to `docs/PLUGINS.md` if the maintainer wants it)
- [ ] `cli-config.yaml.example` — N/A (no new config keys)
- [ ] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change beyond the new hook name)
- [x] Cross-platform considered — pure async/dict API, no platform-specific calls added
- [x] Tool descriptions/schemas — N/A (no tool changes)

## Notes for reviewer

- The hook intentionally mirrors `pre_gateway_dispatch` action semantics (`skip` / `rewrite` / `allow`). If a different shape is preferred for callback queries (e.g. `answer_callback_query` instead of `answer_text`), happy to rename in this PR.
- I have a downstream plugin (legacy callback-data retirement notices) that depends on this hook today and is currently using a monkey-patch as a stop-gap. Landing this hook removes the monkey-patch.
