### PR TITLE
fix(gateway): surface platform registry lookup failures at WARNING level

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6348,7 +6348,7 @@ class GatewayRunner:
                 )
                 return None
         except Exception as e:
-            logger.debug("Platform registry lookup for '%s' failed: %s", platform.value, e)
+            logger.warning("Platform registry lookup for '%s' failed: %s", platform.value, e)
         # Fall through to built-in adapters below
 
         if platform == Platform.TELEGRAM:


### PR DESCRIPTION
## Problem

When the `platform_registry` lookup raises an exception (e.g. `ImportError` from a broken dependency), the error is logged at `DEBUG` level (line 6351 in `gateway/run.py`). In production, DEBUG messages are typically invisible, so users get no feedback about why their configured platform isn't loading.

**User experience**: The gateway silently skips the plugin adapter, falls through to built-in adapters (which don't exist for plugin platforms), and returns `None`. The user sees only `No adapter available for discord` with no indication that the platform registry itself failed.

## Fix

Change `logger.debug` to `logger.warning` at `gateway/run.py:6351`, matching the log level used for similar failures in the built-in adapter checks (e.g. line 6357: `logger.warning("Telegram: python-telegram-bot not installed")`).

Single-line change: `debug` → `warning`.

## Before vs After

| Scenario | Before (DEBUG) | After (WARNING) |
|----------|----------------|-----------------|
| Plugin dep missing | Silent skip, generic "No adapter" | Shows actual ImportError |
| Plugin broken import | Silent skip | Shows import failure details |
| Platform config error | Silent skip | Shows registry error |

## Related Issues

- #34511 (Discord adapter not discovered) — same class of silent-failure bugs
- #34034 (plugin.yaml missing) — similar symptom, different root cause