### PR TITLE
fix(streaming): gate stale-timer reset on content chunks (ignore keepalive pings)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1758,8 +1758,27 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         reasoning_parts: list = []
         usage_obj = None
         for chunk in stream:
-            last_chunk_time["t"] = time.time()
             agent._touch_activity("receiving stream response")
+            _now_chunk = time.time()
+            # Reset the stale-stream timer ONLY on chunks that carry real
+            # progress (content / reasoning / tool-call deltas).  A
+            # content-less SSE keepalive ping must NOT reset it: the
+            # ChatGPT codex backend (chatgpt.com/backend-api/codex) keeps a
+            # stalled stream alive with pings while delivering zero tokens.
+            # Resetting on every raw chunk (the previous behaviour) let
+            # those pings defeat both this detector AND the httpx read
+            # timeout, leaving a hung request alive until the backend gave
+            # up (~10 min) instead of killing+reconnecting at the stale
+            # threshold (the immediate retry succeeds in seconds).
+            _pg = chunk.choices[0].delta if chunk.choices else None
+            if _pg is not None and (
+                getattr(_pg, "content", None)
+                or getattr(_pg, "reasoning_content", None)
+                or getattr(_pg, "reasoning", None)
+                or getattr(_pg, "tool_calls", None)
+                or getattr(_pg, "function_call", None)
+            ):
+                last_chunk_time["t"] = _now_chunk
 
             # Update per-attempt diagnostic counters.  Best-effort —
             # failures are swallowed so the streaming hot path is never
@@ -1767,7 +1786,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             try:
                 _diag["chunks"] = int(_diag.get("chunks", 0)) + 1
                 if _diag.get("first_chunk_at") is None:
-                    _diag["first_chunk_at"] = last_chunk_time["t"]
+                    _diag["first_chunk_at"] = _now_chunk
                 # Approximate byte size from the chunk's repr — exact wire
                 # bytes aren't exposed by the SDK, but len(repr(chunk)) is
                 # a stable proxy for "how much content arrived" that

--- a/tests/agent/test_stream_stale_ping_gate.py
+++ b/tests/agent/test_stream_stale_ping_gate.py
@@ -1,0 +1,103 @@
+"""Regression guard: content-less SSE keepalive pings must NOT reset the
+stale-stream timer in the chat_completions streaming loop.
+
+Root cause (gpt-5.5 / openai-codex stall investigation):
+The ChatGPT codex backend (chatgpt.com/backend-api/codex) keeps a stalled
+stream alive with SSE keepalive pings while delivering zero content tokens.
+The old loop reset ``last_chunk_time`` on *every* chunk, so those pings
+defeated both the stale-stream detector AND the httpx read timeout — a hung
+request stayed alive until the backend gave up (~10 min) instead of being
+killed and retried at the stale threshold (the immediate retry succeeds in
+seconds). A trivial "pong" request was measured at 615s before the fix.
+
+The fix gates the ``last_chunk_time`` reset on chunks that carry real
+progress (content / reasoning / tool-call / function-call deltas).
+
+This test mirrors the EXACT predicate shape used in
+``agent/chat_completion_helpers.py``'s chunk loop so any future refactor
+must preserve the invariant:
+
+    keepalive ping (empty choices)      -> does NOT reset the stale timer
+    role-only / empty delta             -> does NOT reset the stale timer
+    content / reasoning / tool_calls    -> DOES reset the stale timer
+
+If you change the predicate in chat_completion_helpers.py, change it here
+too — or, better, refactor it into a shared helper that both sites import.
+"""
+from __future__ import annotations
+
+import time
+
+
+def _chunk_resets_stale_timer(chunk) -> bool:
+    """Exact shape of the chat_completion_helpers stale-timer gate.
+
+    Kept in lock-step with the source streaming loop.
+    """
+    _pg = chunk.choices[0].delta if chunk.choices else None
+    return bool(
+        _pg is not None
+        and (
+            getattr(_pg, "content", None)
+            or getattr(_pg, "reasoning_content", None)
+            or getattr(_pg, "reasoning", None)
+            or getattr(_pg, "tool_calls", None)
+            or getattr(_pg, "function_call", None)
+        )
+    )
+
+
+class _Delta:
+    def __init__(self, **kw):
+        for attr in ("content", "reasoning_content", "reasoning", "tool_calls", "function_call"):
+            setattr(self, attr, kw.get(attr))
+
+
+class _Choice:
+    def __init__(self, delta):
+        self.delta = delta
+
+
+class _Chunk:
+    def __init__(self, choices):
+        self.choices = choices
+
+
+class TestStreamStalePingGate:
+    def test_keepalive_ping_does_not_reset(self):
+        """A keepalive ping (no choices) must not count as progress."""
+        assert _chunk_resets_stale_timer(_Chunk([])) is False
+
+    def test_role_only_delta_does_not_reset(self):
+        """A role-only / empty delta carries no tokens — not progress."""
+        assert _chunk_resets_stale_timer(_Chunk([_Choice(_Delta())])) is False
+
+    def test_content_token_resets(self):
+        assert _chunk_resets_stale_timer(_Chunk([_Choice(_Delta(content="po"))])) is True
+
+    def test_reasoning_content_resets(self):
+        assert _chunk_resets_stale_timer(_Chunk([_Choice(_Delta(reasoning_content="think"))])) is True
+
+    def test_reasoning_alt_field_resets(self):
+        assert _chunk_resets_stale_timer(_Chunk([_Choice(_Delta(reasoning="think"))])) is True
+
+    def test_tool_call_delta_resets(self):
+        assert _chunk_resets_stale_timer(_Chunk([_Choice(_Delta(tool_calls=[object()]))])) is True
+
+    def test_legacy_function_call_resets(self):
+        assert _chunk_resets_stale_timer(_Chunk([_Choice(_Delta(function_call=object()))])) is True
+
+    def test_ping_only_stall_is_detected(self):
+        """A long run of pings must let ``stale_elapsed`` grow past the
+        threshold so the detector fires (kill + reconnect)."""
+        threshold = 90.0
+        last = {"t": time.time() - 200.0}  # last real content 200s ago
+        for _ in range(200):
+            ping = _Chunk([])
+            if _chunk_resets_stale_timer(ping):
+                last["t"] = time.time()
+        stale_elapsed = time.time() - last["t"]
+        assert stale_elapsed > threshold, (
+            f"ping-only stall not detected: stale_elapsed={stale_elapsed:.0f}s "
+            f"<= threshold={threshold:.0f}s"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes a 10-minute stream stall on the ChatGPT codex backend (`chatgpt.com/backend-api/codex`).

The `chat_completions` streaming loop in `agent/chat_completion_helpers.py` resets `last_chunk_time` on every chunk. That backend keeps a stalled stream alive with SSE keepalive pings while delivering zero content tokens. The unconditional reset defeats both this detector AND the httpx read timeout — a hung request stays alive until the backend gives up (~10 min) instead of being killed and retried at `HERMES_STREAM_STALE_TIMEOUT` (the immediate retry succeeds in seconds).

A trivial "pong" request was measured at **615 s** before the fix and **~4 s** with the immediate retry.

The fix gates the `last_chunk_time` reset on chunks that carry real progress (`content` / `reasoning` / `reasoning_content` / `tool_calls` / `function_call` deltas). Keepalive pings still drive the per-attempt diagnostic counters but no longer mask the stall.

## Related Issue

Fixes #

(No related issue — opening this PR to start that conversation. Happy to file one separately if preferred.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` (around the chat_completions stream loop, current upstream line ~1761) — replace the unconditional `last_chunk_time["t"] = time.time()` with a content-progress predicate that mirrors the OpenAI chunk shape: reset only when `choices[0].delta` has at least one of `content`, `reasoning_content`, `reasoning`, `tool_calls`, `function_call`. Diagnostic counters (`_diag["first_chunk_at"]`, `_diag["chunks"]`, `_diag["bytes"]`) still see every chunk.
- `tests/agent/test_stream_stale_ping_gate.py` — new file. 8 unit tests:
  - keepalive ping (no choices) → does NOT reset
  - role-only / empty delta → does NOT reset
  - content / reasoning_content / reasoning / tool_calls / function_call → DOES reset
  - 200-ping stall simulation → `stale_elapsed` correctly grows past 90 s threshold

## How to Test

1. `pytest tests/agent/test_stream_stale_ping_gate.py -q` — 8 tests pass.
2. `pytest tests/ -q` — passes (no regressions).
3. Manual: under a real ChatGPT codex backend session, trigger a long-running turn (e.g. heavy tool use). Before this fix, `HERMES_STREAM_STALE_TIMEOUT=90` would not fire if the backend was sending pings; after, the timer fires on the actual content stall and the retry loop reconnects.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(streaming):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and the suite passes
- [x] I've added tests for my changes (`tests/agent/test_stream_stale_ping_gate.py` — 8 tests)
- [x] I've tested on my platform: macOS 15.5 (Darwin 25.5.0), Python 3.11

### Documentation & Housekeeping

- [ ] Documentation — N/A (in-code comment explains the invariant)
- [ ] `cli-config.yaml.example` — N/A (no new config keys; `HERMES_STREAM_STALE_TIMEOUT` already exists)
- [ ] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — pure Python, no platform-specific calls
- [x] Tool descriptions/schemas — N/A

## Notes for reviewer

- The bug surfaced in a downstream fork against the older `run_agent.py` chunk loop (commit `53ba42ad4`). The fix is re-ported here onto the current `chat_completion_helpers.py` surface; the test file is placed next to the new location (not the legacy `tests/run_agent/` path).
- Three similar unconditional resets exist nearby (`chat_completion_helpers.py:1725`, `:1974`, `:1997`) on what look like Anthropic / different-provider paths. They're left untouched in this PR because the ping-stall pattern was only verified on `chatgpt.com/backend-api/codex`. Happy to widen the predicate if the maintainer wants symmetry; I'd suggest doing that as a follow-up so this PR stays scoped.
- The predicate is duplicated between source and test (with a comment to keep them in lock-step). If you'd prefer a shared helper module, I can refactor — just call it out.
