### PR TITLE
fix: clarify protected file mutation refusals

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -697,13 +697,14 @@ def run_conversation(
     compression_attempts = 0
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
 
-    # Per-turn file-mutation verifier state.  Keyed by resolved path;
-    # each failed ``write_file`` / ``patch`` call records the error
-    # preview.  Later successful writes to the same path remove the
-    # entry (the model recovered).  At end-of-turn, any entries still
-    # present are surfaced in an advisory footer so the model cannot
-    # over-claim success while the file is actually unchanged on disk.
+    # Per-turn file-mutation verifier state. Keyed by the target path reported
+    # in the file-tool arguments.
+    # ``_turn_failed_file_mutations`` tracks normal edit failures that did not
+    # land. ``_turn_protected_file_refusals`` tracks deliberate guardrail blocks
+    # (for example /etc writes) separately so the final footer can explain both
+    # safety and task impact without conflating them.
     agent._turn_failed_file_mutations: Dict[str, Dict[str, Any]] = {}
+    agent._turn_protected_file_refusals: Dict[str, Dict[str, Any]] = {}
     
     # Record the execution thread so interrupt()/clear_interrupt() can
     # scope the tool-level interrupt signal to THIS agent's thread only.
@@ -4436,8 +4437,12 @@ def run_conversation(
     if final_response and not interrupted:
         try:
             _failed = getattr(agent, "_turn_failed_file_mutations", None) or {}
-            if _failed and agent._file_mutation_verifier_enabled():
-                footer = agent._format_file_mutation_failure_footer(_failed)
+            _protected = getattr(agent, "_turn_protected_file_refusals", None) or {}
+            if (_failed or _protected) and agent._file_mutation_verifier_enabled():
+                footer = agent._format_file_mutation_failure_footer(
+                    _failed,
+                    protected_refusals=_protected,
+                )
                 if footer:
                     final_response = final_response.rstrip() + "\n\n" + footer
         except Exception as _ver_err:

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -11,8 +11,9 @@ Pure module-level utilities extracted from ``run_agent.py``:
   ``_append_subdir_hint_to_multimodal`` — envelope helpers for the
   ``{"_multimodal": True, "content": [...], "text_summary": ...}`` dict
   shape returned by tools like ``computer_use``.
-* ``_extract_file_mutation_targets`` / ``_extract_error_preview`` —
-  per-turn file-mutation verifier inputs.
+* ``_extract_file_mutation_targets`` / ``_extract_error_preview`` /
+  ``_extract_file_mutation_refusal_reason`` — per-turn file-mutation
+  verifier inputs.
 * ``_trajectory_normalize_msg`` — strip image blobs from a message for
   trajectory saving.
 
@@ -269,6 +270,21 @@ def _extract_file_mutation_targets(tool_name: str, args: Dict[str, Any]) -> List
     return []
 
 
+def _decode_leading_json_object(text: str) -> dict[str, Any] | None:
+    """Decode a tool-result JSON object, tolerating appended guidance text."""
+    stripped = text.strip()
+    if not stripped.startswith("{"):
+        return None
+    try:
+        data = json.loads(stripped)
+    except Exception:
+        try:
+            data, _end = json.JSONDecoder().raw_decode(stripped)
+        except Exception:
+            return None
+    return data if isinstance(data, dict) else None
+
+
 def _extract_error_preview(result: Any, max_len: int = 180) -> str:
     """Pull a one-line error summary out of a tool result for footer display."""
     text = _multimodal_text_summary(result) if result is not None else ""
@@ -279,19 +295,30 @@ def _extract_error_preview(result: Any, max_len: int = 180) -> str:
             return ""
     # Try to parse JSON and pull the ``error`` field — tool handlers return
     # ``{"success": false, "error": "..."}``; raw string wins if parse fails.
-    stripped = text.strip()
-    if stripped.startswith("{"):
-        try:
-            data = json.loads(stripped)
-            if isinstance(data, dict) and isinstance(data.get("error"), str):
-                text = data["error"]
-        except Exception:
-            pass
+    # Tool-loop guidance may be appended after the JSON object on repeated
+    # failures, so accept a leading JSON object even when extra text follows.
+    data = _decode_leading_json_object(text)
+    if isinstance(data, dict) and isinstance(data.get("error"), str):
+        text = data["error"]
     # Collapse whitespace, trim to max_len.
     text = " ".join(text.split())
     if len(text) > max_len:
         text = text[: max_len - 1] + "…"
     return text
+
+
+def _extract_file_mutation_refusal_reason(result: Any) -> str:
+    """Return structured guardrail refusal reason when present."""
+    text = _multimodal_text_summary(result) if result is not None else ""
+    if not isinstance(text, str):
+        try:
+            text = str(text)
+        except Exception:
+            return "protected_refusal"
+    data = _decode_leading_json_object(text)
+    if isinstance(data, dict) and isinstance(data.get("refusal_reason"), str):
+        return data["refusal_reason"]
+    return "protected_refusal"
 
 
 def _trajectory_normalize_msg(msg: Dict[str, Any]) -> Dict[str, Any]:
@@ -412,6 +439,7 @@ __all__ = [
     "_append_subdir_hint_to_multimodal",
     "_extract_file_mutation_targets",
     "_extract_error_preview",
+    "_extract_file_mutation_refusal_reason",
     "_trajectory_normalize_msg",
     "make_tool_result_message",
 ]

--- a/agent/tool_result_classification.py
+++ b/agent/tool_result_classification.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import Enum
 import json
 from typing import Any
 
@@ -9,18 +10,61 @@ from typing import Any
 FILE_MUTATING_TOOL_NAMES = frozenset({"write_file", "patch"})
 
 
+class FileMutationOutcome(str, Enum):
+    """High-level outcome for a tool result from a file-mutating tool."""
+
+    LANDED = "landed"
+    PROTECTED_REFUSAL = "protected_refusal"
+    FAILED_EDIT = "failed_edit"
+
+
+def _decode_tool_result(result: Any) -> dict[str, Any] | None:
+    if not isinstance(result, str):
+        return None
+    stripped = result.strip()
+    if not stripped:
+        return None
+    try:
+        data = json.loads(stripped)
+    except Exception:
+        if not stripped.startswith("{"):
+            return None
+        try:
+            data, _end = json.JSONDecoder().raw_decode(stripped)
+        except Exception:
+            return None
+    return data if isinstance(data, dict) else None
+
+
+def classify_file_mutation_result(tool_name: str, result: Any) -> FileMutationOutcome:
+    """Classify whether a file mutation landed, was guardrail-blocked, or failed.
+
+    ``protected_refusal`` is reserved for deliberate Hermes file-tool guardrails
+    that block mutation before any write occurs (sensitive paths, cross-profile
+    guardrails, traversal guards, etc.). It is still unresolved work if the
+    target file was required, but it should not be conflated with a normal edit
+    failure such as a missing ``old_string``.
+    """
+    if tool_name not in FILE_MUTATING_TOOL_NAMES:
+        return FileMutationOutcome.FAILED_EDIT
+
+    data = _decode_tool_result(result)
+    if data is None:
+        return FileMutationOutcome.FAILED_EDIT
+
+    if data.get("file_mutation_status") == FileMutationOutcome.PROTECTED_REFUSAL.value:
+        return FileMutationOutcome.PROTECTED_REFUSAL
+
+    if data.get("error"):
+        return FileMutationOutcome.FAILED_EDIT
+
+    if tool_name == "write_file" and "bytes_written" in data:
+        return FileMutationOutcome.LANDED
+    if tool_name == "patch" and data.get("success") is True:
+        return FileMutationOutcome.LANDED
+    return FileMutationOutcome.FAILED_EDIT
+
+
 def file_mutation_result_landed(tool_name: str, result: Any) -> bool:
     """Return True when a file mutation result proves the write landed."""
-    if tool_name not in FILE_MUTATING_TOOL_NAMES or not isinstance(result, str):
-        return False
-    try:
-        data = json.loads(result.strip())
-    except Exception:
-        return False
-    if not isinstance(data, dict) or data.get("error"):
-        return False
-    if tool_name == "write_file":
-        return "bytes_written" in data
-    if tool_name == "patch":
-        return data.get("success") is True
-    return False
+    return classify_file_mutation_result(tool_name, result) is FileMutationOutcome.LANDED

--- a/run_agent.py
+++ b/run_agent.py
@@ -152,7 +152,8 @@ from agent.tool_guardrails import (
 )
 from agent.tool_result_classification import (
     FILE_MUTATING_TOOL_NAMES as _FILE_MUTATING_TOOLS,
-    file_mutation_result_landed,
+    FileMutationOutcome,
+    classify_file_mutation_result,
 )
 from agent.trajectory import (
     convert_scratchpad_to_think,
@@ -168,6 +169,7 @@ from agent.tool_dispatch_helpers import (
     _append_subdir_hint_to_multimodal,  # noqa: F401  # re-exported for tests that `from run_agent import _append_subdir_hint_to_multimodal`
     _extract_file_mutation_targets,
     _extract_error_preview,
+    _extract_file_mutation_refusal_reason,
     _trajectory_normalize_msg,  # noqa: F401  # re-exported for tests that `from run_agent import _trajectory_normalize_msg`
 )
 from utils import atomic_json_write, base_url_host_matches, base_url_hostname
@@ -2049,22 +2051,40 @@ class AIAgent:
     ) -> None:
         """Record a ``write_file`` / ``patch`` outcome for the turn-end verifier.
 
-        On failure, store ``{path: {error_preview, tool}}`` entries.  On
-        success, remove any prior failure entries for the same paths (the
-        model recovered within the turn).  Silently no-ops if the per-turn
-        state dict hasn't been initialised yet (e.g. a tool dispatched
-        outside ``run_conversation``).
+        Record the outcome of each ``write_file`` / ``patch`` call. Normal edit
+        failures are stored in ``_turn_failed_file_mutations``. Deliberate
+        file-tool guardrail blocks are stored in ``_turn_protected_file_refusals``
+        so final-response wording can distinguish safety refusals from broken
+        edits. A later successful write/patch to the same target clears either
+        unresolved entry.
         """
         if tool_name not in _FILE_MUTATING_TOOLS:
             return
         state = getattr(self, "_turn_failed_file_mutations", None)
+        protected_state = getattr(self, "_turn_protected_file_refusals", None)
         if state is None:
             return
+        if protected_state is None:
+            protected_state = {}
+            self._turn_protected_file_refusals = protected_state
         targets = _extract_file_mutation_targets(tool_name, args)
         if not targets:
             return
-        landed = file_mutation_result_landed(tool_name, result)
-        if is_error and not landed:
+        outcome = classify_file_mutation_result(tool_name, result)
+        if is_error and outcome is FileMutationOutcome.PROTECTED_REFUSAL:
+            preview = _extract_error_preview(result)
+            refusal_reason = _extract_file_mutation_refusal_reason(result)
+            if protected_state is not None:
+                for path in targets:
+                    state.pop(path, None)
+                    if path not in protected_state:
+                        protected_state[path] = {
+                            "tool": tool_name,
+                            "error_preview": preview,
+                            "refusal_reason": refusal_reason,
+                        }
+            return
+        if is_error and outcome is not FileMutationOutcome.LANDED:
             preview = _extract_error_preview(result)
             for path in targets:
                 # Keep the FIRST error we saw for a given path unless we
@@ -2075,9 +2095,13 @@ class AIAgent:
                         "tool": tool_name,
                         "error_preview": preview,
                     }
+                if protected_state is not None:
+                    protected_state.pop(path, None)
         else:
             for path in targets:
                 state.pop(path, None)
+                if protected_state is not None:
+                    protected_state.pop(path, None)
 
     def _file_mutation_verifier_enabled(self) -> bool:
         """Check whether the per-turn file-mutation verifier footer is on.
@@ -2107,35 +2131,71 @@ class AIAgent:
         return True  # safe default: verifier on
 
     @staticmethod
-    def _format_file_mutation_failure_footer(failed: Dict[str, Dict[str, Any]]) -> str:
-        """Render the per-turn failed-mutation dict as a user-facing footer.
+    def _format_file_mutation_failure_footer(
+        failed: Dict[str, Dict[str, Any]],
+        protected_refusals: Dict[str, Dict[str, Any]] | None = None,
+    ) -> str:
+        """Render unresolved per-turn file-mutation outcomes as a footer.
 
-        Displays up to 10 paths with their first error preview, then a
-        count of any additional failures.  Returns an empty string when
-        the dict is empty so callers can concatenate unconditionally.
+        ``failed`` means a normal edit attempt did not land.  ``protected_refusals``
+        means Hermes deliberately blocked a protected target before mutation.  Both
+        are unresolved if the task required that file change, but they should not
+        sound like the same class of failure to the user.
         """
-        if not failed:
+        protected_refusals = protected_refusals or {}
+        if not failed and not protected_refusals:
             return ""
-        lines = [
-            "⚠️ File-mutation verifier: "
-            f"{len(failed)} file(s) were NOT modified this turn despite any "
-            "wording above that may suggest otherwise. Run `git status` or "
-            "`read_file` to confirm."
-        ]
-        shown = 0
-        for path, info in failed.items():
-            if shown >= 10:
-                break
-            preview = (info.get("error_preview") or "").strip()
-            tool = info.get("tool") or "patch"
-            if preview:
-                lines.append(f"  • {path} — [{tool}] {preview}")
-            else:
-                lines.append(f"  • {path} — [{tool}] failed")
-            shown += 1
-        remaining = len(failed) - shown
-        if remaining > 0:
-            lines.append(f"  • … and {remaining} more")
+
+        lines: list[str] = []
+        if failed:
+            lines.append(
+                "⚠️ File-mutation verifier: "
+                f"{len(failed)} file(s) were NOT modified this turn despite any "
+                "wording above that may suggest otherwise. If any of these file "
+                "changes were required for the task, the task should be treated "
+                "as incomplete until they are fixed. Run `git status` or "
+                "`read_file` to confirm."
+            )
+            shown = 0
+            for path, info in failed.items():
+                if shown >= 10:
+                    break
+                preview = " ".join((info.get("error_preview") or "").split())
+                tool = info.get("tool") or "patch"
+                if preview:
+                    lines.append(f"  • {path} — [{tool}] {preview}")
+                else:
+                    lines.append(f"  • {path} — [{tool}] failed")
+                shown += 1
+            remaining = len(failed) - shown
+            if remaining > 0:
+                lines.append(f"  • … and {remaining} more")
+
+        if protected_refusals:
+            if lines:
+                lines.append("")
+            lines.append(
+                "ℹ️ Protected file-tool edit skipped: Hermes refused to edit "
+                f"{len(protected_refusals)} protected target(s) with the file tool. "
+                "The file tool did not change the protected target. If this "
+                "file-tool edit was required for the task, the plan is incomplete "
+                "until an approved alternate flow completes and verifies it."
+            )
+            shown = 0
+            for path, info in protected_refusals.items():
+                if shown >= 10:
+                    break
+                preview = " ".join((info.get("error_preview") or "").split())
+                tool = info.get("tool") or "write_file"
+                reason = info.get("refusal_reason") or "protected_refusal"
+                if preview:
+                    lines.append(f"  • {path} — [{tool}] {reason}: {preview}")
+                else:
+                    lines.append(f"  • {path} — [{tool}] {reason}")
+                shown += 1
+            remaining = len(protected_refusals) - shown
+            if remaining > 0:
+                lines.append(f"  • … and {remaining} more")
         return "\n".join(lines)
 
     def _apply_pending_steer_to_tool_results(self, messages: list, num_tool_msgs: int) -> None:

--- a/tests/agent/test_tool_result_classification.py
+++ b/tests/agent/test_tool_result_classification.py
@@ -2,7 +2,11 @@
 
 import json
 
-from agent.tool_result_classification import file_mutation_result_landed
+from agent.tool_result_classification import (
+    FileMutationOutcome,
+    classify_file_mutation_result,
+    file_mutation_result_landed,
+)
 
 
 def test_write_file_with_nested_lint_error_counts_as_landed():
@@ -11,6 +15,7 @@ def test_write_file_with_nested_lint_error_counts_as_landed():
         "lint": {"status": "error", "output": "SyntaxError: invalid syntax"},
     })
 
+    assert classify_file_mutation_result("write_file", result) is FileMutationOutcome.LANDED
     assert file_mutation_result_landed("write_file", result) is True
 
 
@@ -21,10 +26,34 @@ def test_patch_with_nested_lsp_diagnostics_counts_as_landed():
         "lsp_diagnostics": "<diagnostics>ERROR [1:1] type mismatch</diagnostics>",
     })
 
+    assert classify_file_mutation_result("patch", result) is FileMutationOutcome.LANDED
     assert file_mutation_result_landed("patch", result) is True
+
+
+def test_protected_refusal_metadata_classifies_separately_from_failed_edit():
+    result = json.dumps({
+        "error": "Refusing to write to sensitive system path: /etc/example.conf",
+        "file_mutation_status": "protected_refusal",
+        "refusal_reason": "sensitive_system_path",
+    })
+
+    assert classify_file_mutation_result("write_file", result) is FileMutationOutcome.PROTECTED_REFUSAL
+    assert file_mutation_result_landed("write_file", result) is False
+
+
+def test_protected_refusal_with_appended_tool_loop_warning_stays_protected():
+    result = json.dumps({
+        "error": "Refusing to write to sensitive system path: /etc/example.conf",
+        "file_mutation_status": "protected_refusal",
+        "refusal_reason": "sensitive_system_path",
+    }) + "\n\n[Tool loop warning: identical failed call repeated]"
+
+    assert classify_file_mutation_result("write_file", result) is FileMutationOutcome.PROTECTED_REFUSAL
+    assert file_mutation_result_landed("write_file", result) is False
 
 
 def test_top_level_file_mutation_error_does_not_count_as_landed():
     result = json.dumps({"success": True, "error": "post-write verification failed"})
 
+    assert classify_file_mutation_result("patch", result) is FileMutationOutcome.FAILED_EDIT
     assert file_mutation_result_landed("patch", result) is False

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -27,6 +27,7 @@ from run_agent import (
     AIAgent,
     _FILE_MUTATING_TOOLS,
     _extract_error_preview,
+    _extract_file_mutation_refusal_reason,
     _extract_file_mutation_targets,
 )
 
@@ -99,6 +100,16 @@ class TestExtractErrorPreview:
         raw = json.dumps({"success": False, "error": "Could not find old_string in /tmp/x"})
         assert _extract_error_preview(raw) == "Could not find old_string in /tmp/x"
 
+    def test_json_error_field_with_appended_tool_loop_warning_still_preferred(self):
+        raw = json.dumps({
+            "error": "Refusing to write to sensitive system path: /etc/example.conf",
+            "file_mutation_status": "protected_refusal",
+            "refusal_reason": "sensitive_system_path",
+        }) + "\n\n[Tool loop warning: identical failed call repeated]"
+
+        assert _extract_error_preview(raw) == "Refusing to write to sensitive system path: /etc/example.conf"
+        assert _extract_file_mutation_refusal_reason(raw) == "sensitive_system_path"
+
     def test_plain_string_falls_through(self):
         assert _extract_error_preview("Error executing tool: boom") == "Error executing tool: boom"
 
@@ -128,6 +139,7 @@ def _bare_agent() -> AIAgent:
     """
     agent = object.__new__(AIAgent)
     agent._turn_failed_file_mutations = {}
+    agent._turn_protected_file_refusals = {}
     return agent
 
 
@@ -216,6 +228,64 @@ class TestRecordFileMutationResult:
 
         assert agent._turn_failed_file_mutations == {}
 
+    def test_protected_refusal_recorded_separately_from_failed_edits(self):
+        agent = _bare_agent()
+        result = json.dumps({
+            "error": "Refusing to write to sensitive system path: /etc/example.conf",
+            "file_mutation_status": "protected_refusal",
+            "refusal_reason": "sensitive_system_path",
+        })
+
+        agent._record_file_mutation_result(
+            "write_file", {"path": "/etc/example.conf", "content": "x"},
+            result, is_error=True,
+        )
+
+        assert agent._turn_failed_file_mutations == {}
+        assert agent._turn_protected_file_refusals["/etc/example.conf"]["refusal_reason"] == "sensitive_system_path"
+
+    def test_repeated_protected_refusal_with_tool_loop_warning_stays_protected(self):
+        agent = _bare_agent()
+        refusal = json.dumps({
+            "error": "Refusing to write to sensitive system path: /etc/example.conf",
+            "file_mutation_status": "protected_refusal",
+            "refusal_reason": "sensitive_system_path",
+        })
+        args = {"path": "/etc/example.conf", "content": "x"}
+
+        agent._record_file_mutation_result("write_file", args, refusal, is_error=True)
+        agent._record_file_mutation_result(
+            "write_file",
+            args,
+            refusal + "\n\n[Tool loop warning: identical failed call repeated]",
+            is_error=True,
+        )
+
+        assert agent._turn_failed_file_mutations == {}
+        assert agent._turn_protected_file_refusals["/etc/example.conf"]["refusal_reason"] == "sensitive_system_path"
+
+    def test_success_removes_prior_protected_refusal(self):
+        agent = _bare_agent()
+        refusal = json.dumps({
+            "error": "Refusing to write to sensitive system path: /etc/example.conf",
+            "file_mutation_status": "protected_refusal",
+            "refusal_reason": "sensitive_system_path",
+        })
+        agent._record_file_mutation_result(
+            "write_file", {"path": "/etc/example.conf", "content": "x"},
+            refusal, is_error=True,
+        )
+        assert "/etc/example.conf" in agent._turn_protected_file_refusals
+
+        success = json.dumps({"bytes_written": 12})
+        agent._record_file_mutation_result(
+            "write_file", {"path": "/etc/example.conf", "content": "x"},
+            success, is_error=False,
+        )
+
+        assert agent._turn_protected_file_refusals == {}
+        assert agent._turn_failed_file_mutations == {}
+
     def test_repeated_failure_keeps_first_error(self):
         agent = _bare_agent()
         agent._record_file_mutation_result(
@@ -283,9 +353,45 @@ class TestFormatFooter:
             {"/tmp/a.md": {"tool": "patch", "error_preview": "Could not find old_string"}},
         )
         assert "1 file(s) were NOT modified" in out
+        assert "task should be treated as incomplete" in out
         assert "/tmp/a.md" in out
         assert "Could not find old_string" in out
         assert "git status" in out  # user-actionable hint
+
+    def test_protected_refusal_footer_is_informational_but_impact_aware(self):
+        out = AIAgent._format_file_mutation_failure_footer(
+            {},
+            protected_refusals={
+                "/etc/supervisor/conf.d/example.conf": {
+                    "tool": "write_file",
+                    "error_preview": "Refusing to write to sensitive system path: /etc/supervisor/conf.d/example.conf",
+                    "refusal_reason": "sensitive_system_path",
+                },
+            },
+        )
+
+        assert "Protected file-tool edit skipped" in out
+        assert "⚠️ File-mutation verifier" not in out
+        assert "/etc/supervisor/conf.d/example.conf" in out
+        assert "The file tool did not change the protected target" in out
+        assert "If this file-tool edit was required" in out
+
+    def test_mixed_failure_and_protected_refusal_renders_both_meanings(self):
+        out = AIAgent._format_file_mutation_failure_footer(
+            {"/tmp/a.md": {"tool": "patch", "error_preview": "Could not find old_string"}},
+            protected_refusals={
+                "/etc/example.conf": {
+                    "tool": "write_file",
+                    "error_preview": "Refusing to write to sensitive system path: /etc/example.conf",
+                    "refusal_reason": "sensitive_system_path",
+                },
+            },
+        )
+
+        assert "task should be treated as incomplete" in out
+        assert "Protected file-tool edit skipped" in out
+        assert "/tmp/a.md" in out
+        assert "/etc/example.conf" in out
 
     def test_truncation_at_10_entries(self):
         failed = {

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -139,6 +139,15 @@ class TestWriteFileHandler:
         assert "error" in result
         assert "string" in result["error"].lower() or "content" in result["error"].lower()
 
+    def test_sensitive_path_refusal_returns_structured_protected_metadata(self):
+        from tools.file_tools import write_file_tool
+        result = json.loads(write_file_tool("/etc/supervisor/conf.d/example.conf", "data"))
+
+        assert "error" in result
+        assert result["file_mutation_status"] == "protected_refusal"
+        assert result["refusal_reason"] == "sensitive_system_path"
+        assert "sensitive system path" in result["error"]
+
 
 class TestPatchHandler:
     @patch("tools.file_tools._get_file_ops")
@@ -209,6 +218,21 @@ class TestPatchHandler:
         assert "Unknown mode" in result["error"]
 
     @patch("tools.file_tools._get_file_ops")
+    def test_replace_sensitive_path_refusal_returns_structured_protected_metadata(self, mock_get):
+        from tools.file_tools import patch_tool
+        result = json.loads(patch_tool(
+            mode="replace",
+            path="/etc/supervisor/conf.d/example.conf",
+            old_string="old",
+            new_string="new",
+        ))
+
+        assert "error" in result
+        assert result["file_mutation_status"] == "protected_refusal"
+        assert result["refusal_reason"] == "sensitive_system_path"
+        mock_get.return_value.patch_replace.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
     def test_patch_v4a_rejects_traversal_in_update_header(self, mock_get):
         """V4A '*** Update File:' headers come from patch content, which can
         carry prompt-injection-controlled paths (skill content, web extract).
@@ -229,6 +253,8 @@ class TestPatchHandler:
         ))
         assert "error" in result
         assert "traversal" in result["error"].lower()
+        assert result["file_mutation_status"] == "protected_refusal"
+        assert result["refusal_reason"] == "v4a_traversal_guard"
         # patch_v4a must not be invoked when the header is rejected
         mock_get.return_value.patch_v4a.assert_not_called()
 
@@ -246,6 +272,26 @@ class TestPatchHandler:
         ))
         assert "error" in result
         assert "traversal" in result["error"].lower()
+        assert result["file_mutation_status"] == "protected_refusal"
+        assert result["refusal_reason"] == "v4a_traversal_guard"
+
+    @patch("tools.file_tools._check_cross_profile_path")
+    @patch("tools.file_tools._get_file_ops")
+    def test_replace_cross_profile_refusal_returns_structured_protected_metadata(self, mock_get, mock_cross_profile):
+        from tools.file_tools import patch_tool
+        mock_cross_profile.return_value = "Refusing to write to another Hermes profile path"
+
+        result = json.loads(patch_tool(
+            mode="replace",
+            path="/root/.hermes/profiles/chloe/skills/example/SKILL.md",
+            old_string="old",
+            new_string="new",
+        ))
+
+        assert "error" in result
+        assert result["file_mutation_status"] == "protected_refusal"
+        assert result["refusal_reason"] == "cross_profile_guard"
+        mock_get.return_value.patch_replace.assert_not_called()
 
 
 class TestSearchHandler:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -224,6 +224,15 @@ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | 
     return get_cross_profile_warning(resolved)
 
 
+def _protected_file_mutation_error(message: str, reason: str) -> str:
+    """Return a structured file-mutation guardrail refusal payload."""
+    return tool_error(
+        message,
+        file_mutation_status="protected_refusal",
+        refusal_reason=reason,
+    )
+
+
 def _is_expected_write_exception(exc: Exception) -> bool:
     """Return True for expected write denials that should not hit error logs."""
     if isinstance(exc, PermissionError):
@@ -893,11 +902,11 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     """
     sensitive_err = _check_sensitive_path(path, task_id)
     if sensitive_err:
-        return tool_error(sensitive_err)
+        return _protected_file_mutation_error(sensitive_err, "sensitive_system_path")
     if not cross_profile:
         cross_warning = _check_cross_profile_path(path, task_id)
         if cross_warning:
-            return tool_error(cross_warning)
+            return _protected_file_mutation_error(cross_warning, "cross_profile_guard")
     if _is_internal_file_status_text(content):
         return tool_error(
             "Refusing to write internal read_file status text as file content. "
@@ -977,20 +986,21 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             # because the agent uses relative ``..`` paths legitimately
             # (e.g. ``patch path="../other_module/x.py"`` from a worktree).
             if has_traversal_component(v4a_path):
-                return tool_error(
+                return _protected_file_mutation_error(
                     f"V4A patch header contains '..' traversal: {v4a_path!r}. "
                     "Use the agent's cwd-relative path (no '..') or an absolute "
-                    "path in '*** Update File:' / '*** Add File:' / '*** Delete File:' headers."
+                    "path in '*** Update File:' / '*** Add File:' / '*** Delete File:' headers.",
+                    "v4a_traversal_guard",
                 )
             _paths_to_check.append(v4a_path)
     for _p in _paths_to_check:
         sensitive_err = _check_sensitive_path(_p, task_id)
         if sensitive_err:
-            return tool_error(sensitive_err)
+            return _protected_file_mutation_error(sensitive_err, "sensitive_system_path")
         if not cross_profile:
             cross_warning = _check_cross_profile_path(_p, task_id)
             if cross_warning:
-                return tool_error(cross_warning)
+                return _protected_file_mutation_error(cross_warning, "cross_profile_guard")
     try:
         # Resolve paths for locking.  Ordered + deduplicated so concurrent
         # callers lock in the same order — prevents deadlock on overlapping


### PR DESCRIPTION
## Summary
- Split file-mutation verifier reporting for protected file-tool refusals vs. actual failed edits.
- Preserve JSON-result classification when verifier guidance is appended after a tool payload.
- Add tests covering protected refusal payloads, verifier footer wording, and file-tool refusal fields.

## Verification
- Targeted pytest passed locally before publishing:
  - tests/agent/test_tool_result_classification.py
  - tests/run_agent/test_file_mutation_verifier.py
  - tests/tools/test_file_tools.py
- py_compile passed locally for touched runtime modules.
- git diff --check passed locally before commit.
- Quick secret/risky-pattern grep over the staged diff found no obvious secret-like values.

## Notes
- Source branch published from fork: Policy-Guru:fix/file-mutation-protected-refusals
- Fork commit: https://github.com/Policy-Guru/hermes-agent/commit/64c3557f9b5481de9a4df6f354134b9950b23e71
