### PR TITLE
fix(codex): handle response.completed with output=None on chatgpt.com backend

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5234,6 +5234,38 @@ class AIAgent:
                     exc,
                 )
                 return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
+            except TypeError as exc:
+                # The chatgpt.com/backend-api/codex endpoint sends
+                # response.completed with output=None, which causes the
+                # OpenAI SDK's parse_response() to fail with
+                # "TypeError: 'NoneType' object is not iterable".
+                # All content has already arrived via response.output_item.done
+                # events (collected in collected_output_items) and text deltas
+                # (in self._codex_streamed_text_parts). Build a synthetic
+                # response from that collected data instead of failing.
+                if "'NoneType' object is not iterable" not in str(exc):
+                    raise
+                logger.debug(
+                    "Codex stream: response.completed had output=None; "
+                    "building response from %d collected output items "
+                    "and %d text-delta parts. %s",
+                    len(collected_output_items),
+                    len(self._codex_streamed_text_parts),
+                    self._client_log_context(),
+                )
+                synthetic = SimpleNamespace(output=[], status="completed", output_text=None)
+                if collected_output_items:
+                    synthetic.output = list(collected_output_items)
+                elif self._codex_streamed_text_parts and not has_tool_calls:
+                    assembled = "".join(self._codex_streamed_text_parts)
+                    synthetic.output = [SimpleNamespace(
+                        type="message",
+                        role="assistant",
+                        status="completed",
+                        content=[SimpleNamespace(type="output_text", text=assembled)],
+                    )]
+                    synthetic.output_text = assembled
+                return synthetic
             except RuntimeError as exc:
                 err_text = str(exc)
                 missing_completed = "response.completed" in err_text


### PR DESCRIPTION
## Summary

- The `chatgpt.com/backend-api/codex` endpoint sends `response.completed` with `output=None` instead of a list
- The OpenAI SDK's `parse_response()` does `for output in response.output:` which raises `TypeError: 'NoneType' object is not iterable`
- This was classified as a non-retryable local validation error, causing **every request** to the `openai-codex` provider to abort immediately

## Root cause

In `_run_codex_stream`, the stream event loop calls `self._state.handle_event(sse_event)` for each event. When `response.completed` arrives, `ResponseStreamState.accumulate_event()` calls `parse_response()` which iterates over `response.output`. On the chatgpt.com backend this field is `None`, triggering the TypeError.

The existing `except` handlers only caught `_httpx` transport errors and `RuntimeError` — `TypeError` propagated up to the retry loop where `is_local_validation_error = isinstance(api_error, TypeError)` caused immediate abort.

## Fix

Catch `TypeError` with `'NoneType' object is not iterable` in `_run_codex_stream`. By the time `response.completed` fires, all content has already arrived:
- Output items via `response.output_item.done` events → `collected_output_items`
- Text content via delta events → `self._codex_streamed_text_parts`

Build a synthetic response from that collected data and return normally, reusing the same backfill pattern already present in the function.

## Test plan

- [ ] Configure hermes with `provider: openai-codex` and `model: gpt-5.5` pointing to `https://chatgpt.com/backend-api/codex`
- [ ] Send any message — previously errored immediately with `TypeError: 'NoneType' object is not iterable`
- [ ] Verify the response is received correctly after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)