### PR TITLE
[FIX] Keep Slack replies top-level by default

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -828,6 +828,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
                 if "reply_in_thread" in platform_cfg:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
+                if plat == Platform.SLACK and "force_top_level_replies" in platform_cfg:
+                    bridged["force_top_level_replies"] = platform_cfg["force_top_level_replies"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if plat == Platform.TELEGRAM and "allowed_chats" in platform_cfg:

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -339,6 +339,8 @@ class DeliveryRouter:
                 send_metadata["telegram_dm_topic_reply_fallback"] = True
             elif "thread_id" not in send_metadata and "message_thread_id" not in send_metadata and not has_explicit_direct_topic:
                 send_metadata["thread_id"] = target_thread_id
+            if target.platform == Platform.SLACK and target.is_explicit:
+                send_metadata["reply_in_thread"] = True
         result = await adapter.send(target.chat_id, content, metadata=send_metadata or None)
         if _send_result_failed(result):
             if (

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -909,12 +909,10 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return
 
-        thread_ts = None
-        if metadata:
-            thread_ts = metadata.get("thread_id") or metadata.get("thread_ts")
+        thread_ts = self._resolve_thread_ts(None, metadata)
 
         if not thread_ts:
-            return  # Can only set status in a thread context
+            return  # Can only set status in an explicitly threaded context
 
         self._active_status_threads[chat_id] = thread_ts
         try:
@@ -965,35 +963,41 @@ class SlackAdapter(BasePlatformAdapter):
     ) -> Optional[str]:
         """Resolve the correct thread_ts for a Slack API call.
 
-        Prefers metadata thread_id (the thread parent's ts, set by the
-        gateway) over reply_to (which may be a child message's ts).
+        Slack is top-level-by-default: ambient gateway routing fields such as
+        ``source.thread_id``, ``metadata.thread_id`` and ``reply_to`` are used
+        for session context, but they must not automatically make a visible
+        Slack thread reply. Threaded Slack delivery is opt-in via metadata
+        (``reply_in_thread``/``slack_reply_in_thread``) or an explicit platform
+        config override (``reply_in_thread: true``).
 
-        When ``reply_in_thread`` is ``false`` in the platform extra config,
-        top-level channel messages receive direct channel replies instead of
-        thread replies.  Messages that originate inside an existing thread are
-        always replied to in-thread to preserve conversation context.
+        When threading is explicitly enabled, prefer metadata thread_id (the
+        thread parent's ts, set by the gateway) over reply_to (which may be a
+        child message's ts).
         """
-        # When reply_in_thread is disabled (default: True for backward compat),
-        # only thread messages that are already part of an existing thread.
-        # For top-level channel messages, the inbound handler sets
-        # metadata.thread_id to the message's own ts as a session-keying
-        # fallback (see the `thread_ts = event.get("thread_ts") or ts` branch),
-        # so metadata alone can't distinguish a real thread reply from a
-        # top-level message. reply_to is the incoming message's own id, so
-        # when thread_id == reply_to the "thread" is synthetic and we reply
-        # directly in the channel instead.
-        if not self.config.extra.get("reply_in_thread", True):
-            md = metadata or {}
-            existing_thread = md.get("thread_id") or md.get("thread_ts")
-            if existing_thread and reply_to and existing_thread == reply_to:
-                existing_thread = None
-            return existing_thread or None
+        if self.config.extra.get("force_top_level_replies"):
+            return None
 
-        if metadata:
-            if metadata.get("thread_id"):
-                return metadata["thread_id"]
-            if metadata.get("thread_ts"):
-                return metadata["thread_ts"]
+        md = metadata or {}
+
+        def _truthy(value: Any) -> bool:
+            if isinstance(value, str):
+                return value.strip().lower() in {"1", "true", "yes", "on"}
+            return bool(value)
+
+        explicit_thread_reply = (
+            _truthy(md.get("reply_in_thread"))
+            or _truthy(md.get("slack_reply_in_thread"))
+            or _truthy(md.get("slack_thread_explicit"))
+            or _truthy(md.get("threaded_reply"))
+            or _truthy(self.config.extra.get("reply_in_thread"))
+        )
+        if not explicit_thread_reply:
+            return None
+
+        if md.get("thread_id"):
+            return md["thread_id"]
+        if md.get("thread_ts"):
+            return md["thread_ts"]
         return reply_to
 
     async def _upload_file(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16266,14 +16266,18 @@ class GatewayRunner:
         # Accumulates tool lines into a single message that gets edited.
         #
         # Threading metadata is platform-specific:
-        # - Slack DM threading needs event_message_id fallback (reply thread)
+        # - Slack is top-level-by-default. Ambient Slack thread_ts/source.thread_id
+        #   is session context only; progress/status messages enter a Slack thread
+        #   only when the adapter config explicitly opts in with reply_in_thread.
         # - Telegram forum topics use message_thread_id; Hermes-created private
         #   DM topic lanes require both thread metadata and a reply anchor
         # - Feishu only honors reply_in_thread when sending a reply, so topic
         #   progress uses the triggering event message as the reply target
         # - Other platforms should use explicit source.thread_id only
         if source.platform == Platform.SLACK:
-            _progress_thread_id = source.thread_id or event_message_id
+            _slack_adapter = self.adapters.get(source.platform)
+            _slack_extra = getattr(getattr(_slack_adapter, "config", None), "extra", {}) or {}
+            _progress_thread_id = source.thread_id if _slack_extra.get("reply_in_thread") else None
         else:
             _progress_thread_id = source.thread_id
         _progress_metadata = (

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -564,6 +564,7 @@ class TestSendDocument:
             chat_id="C123",
             file_path=str(test_file),
             reply_to="1234567890.123456",
+            metadata={"reply_in_thread": True},
         )
 
         assert result.success
@@ -580,7 +581,7 @@ class TestSendDocument:
         await adapter.send_document(
             chat_id="C123",
             file_path=str(test_file),
-            metadata={"thread_id": "1234567890.123456"},
+            metadata={"thread_id": "1234567890.123456", "reply_in_thread": True},
         )
 
         assert "1234567890.123456" in adapter._bot_message_ts
@@ -614,7 +615,7 @@ class TestSendPrivateNotice:
             chat_id="C123",
             user_id="U123",
             content="private hello",
-            metadata={"thread_id": "1234567890.123456"},
+            metadata={"thread_id": "1234567890.123456", "reply_in_thread": True},
         )
 
         assert result.success
@@ -1257,7 +1258,7 @@ class TestSendTyping:
     @pytest.mark.asyncio
     async def test_sets_status_in_thread(self, adapter):
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        await adapter.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        await adapter.send_typing("C123", metadata={"thread_id": "parent_ts", "reply_in_thread": True})
         adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
             channel_id="C123",
             thread_ts="parent_ts",
@@ -1276,12 +1277,12 @@ class TestSendTyping:
             side_effect=Exception("missing_scope")
         )
         # Should not raise
-        await adapter.send_typing("C123", metadata={"thread_id": "ts1"})
+        await adapter.send_typing("C123", metadata={"thread_id": "ts1", "reply_in_thread": True})
 
     @pytest.mark.asyncio
     async def test_uses_thread_ts_fallback(self, adapter):
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        await adapter.send_typing("C123", metadata={"thread_ts": "fallback_ts"})
+        await adapter.send_typing("C123", metadata={"thread_ts": "fallback_ts", "reply_in_thread": True})
         adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
             channel_id="C123",
             thread_ts="fallback_ts",
@@ -1291,9 +1292,9 @@ class TestSendTyping:
     @pytest.mark.asyncio
     async def test_stop_typing_clears_tracked_thread(self, adapter):
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        await adapter.send_typing("C123", metadata={"thread_id": "parent_ts"})
+        await adapter.send_typing("C123", metadata={"thread_id": "parent_ts", "reply_in_thread": True})
 
-        await adapter.stop_typing("C123", metadata={"thread_id": "parent_ts"})
+        await adapter.stop_typing("C123", metadata={"thread_id": "parent_ts", "reply_in_thread": True})
 
         assert adapter._app.client.assistant_threads_setStatus.call_args_list[1] == call(
             channel_id="C123",
@@ -1332,7 +1333,7 @@ class TestSendTyping:
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
         adapter._active_status_threads["C123"] = "parent_ts"
 
-        result = await adapter.send("C123", "done", metadata={"thread_id": "parent_ts"})
+        result = await adapter.send("C123", "done", metadata={"thread_id": "parent_ts", "reply_in_thread": True})
 
         assert result.success
         adapter._app.client.chat_postMessage.assert_called_once()
@@ -2484,7 +2485,11 @@ class TestReplyBroadcast:
         adapter._app.client.chat_postMessage = AsyncMock(
             return_value={"ts": "ts1"}
         )
-        await adapter.send("C123", "hi", metadata={"thread_id": "parent_ts"})
+        await adapter.send(
+            "C123",
+            "hi",
+            metadata={"thread_id": "parent_ts", "reply_in_thread": True},
+        )
         kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
         assert "reply_broadcast" not in kwargs
 
@@ -2494,9 +2499,50 @@ class TestReplyBroadcast:
         adapter._app.client.chat_postMessage = AsyncMock(
             return_value={"ts": "ts1"}
         )
-        await adapter.send("C123", "hi", metadata={"thread_id": "parent_ts"})
+        await adapter.send(
+            "C123",
+            "hi",
+            metadata={"thread_id": "parent_ts", "reply_in_thread": True},
+        )
         kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
         assert kwargs.get("reply_broadcast") is True
+
+
+# ---------------------------------------------------------------------------
+# TestSlackTopLevelReplyDefault
+# ---------------------------------------------------------------------------
+
+
+class TestSlackTopLevelReplyDefault:
+    """Slack final/main replies should not inherit thread routing implicitly."""
+
+    @pytest.mark.asyncio
+    async def test_thread_origin_posts_top_level_by_default(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+
+        await adapter.send(
+            "C123",
+            "final reply",
+            reply_to="child_ts",
+            metadata={"thread_id": "parent_ts"},
+        )
+
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert "thread_ts" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_explicit_threaded_reply_still_uses_thread(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+
+        await adapter.send(
+            "C123",
+            "thread reply",
+            reply_to="child_ts",
+            metadata={"thread_id": "parent_ts", "reply_in_thread": True},
+        )
+
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs.get("thread_ts") == "parent_ts"
 
 
 # ---------------------------------------------------------------------------
@@ -2520,7 +2566,7 @@ class TestFallbackPreservesThreadContext:
             return_value={"ts": "msg_ts"}
         )
 
-        metadata = {"thread_id": "parent_ts_123"}
+        metadata = {"thread_id": "parent_ts_123", "reply_in_thread": True}
         await adapter.send_image_file(
             chat_id="C123",
             image_path=str(test_file),
@@ -2543,7 +2589,7 @@ class TestFallbackPreservesThreadContext:
             return_value={"ts": "msg_ts"}
         )
 
-        metadata = {"thread_id": "parent_ts_456"}
+        metadata = {"thread_id": "parent_ts_456", "reply_in_thread": True}
         await adapter.send_video(
             chat_id="C123",
             video_path=str(test_file),
@@ -2565,7 +2611,7 @@ class TestFallbackPreservesThreadContext:
             return_value={"ts": "msg_ts"}
         )
 
-        metadata = {"thread_id": "parent_ts_789"}
+        metadata = {"thread_id": "parent_ts_789", "reply_in_thread": True}
         await adapter.send_document(
             chat_id="C123",
             file_path=str(test_file),
@@ -2688,7 +2734,7 @@ class TestSendImageSSRFGuards:
                 chat_id="C123",
                 image_url="https://public.example/image.png",
                 caption="see this",
-                metadata={"thread_id": "parent_ts_789"},
+                metadata={"thread_id": "parent_ts_789", "reply_in_thread": True},
             )
 
         call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
@@ -2752,7 +2798,7 @@ class TestProgressMessageThread:
         result = await adapter.send(
             chat_id="D_DM",
             content="⚙️ working...",
-            metadata={"thread_id": msg_event.message_id},
+            metadata={"thread_id": msg_event.message_id, "reply_in_thread": True},
         )
         assert result.success
         call_kwargs = adapter._app.client.chat_postMessage.call_args[1]

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -8,6 +8,8 @@ import sys
 from unittest.mock import MagicMock
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import _thread_metadata_for_source
+from gateway.session import SessionSource
 
 
 # ---------------------------------------------------------------------------
@@ -487,12 +489,78 @@ def test_config_bridges_slack_reply_in_thread(monkeypatch, tmp_path):
         metadata={"thread_id": "171.000"},
     ) is None
 
-    # Real thread replies (reply_to differs from thread parent) must still
-    # resolve to the parent thread so conversation context is preserved.
+    # Real thread replies should also stay top-level when reply_in_thread=false;
+    # the Slack thread timestamp is ambient routing context, not an opt-in.
+    assert adapter._resolve_thread_ts(
+        reply_to="171.500",
+        metadata={"thread_id": "171.000"},
+    ) is None
+
+
+def test_slack_thread_message_replies_top_level_by_default():
+    adapter = _make_adapter()
+
+    assert adapter._resolve_thread_ts(
+        reply_to="171.500",
+        metadata={"thread_id": "171.000"},
+    ) is None
+
+
+def test_slack_explicit_thread_metadata_still_replies_in_thread():
+    adapter = _make_adapter()
+
+    assert adapter._resolve_thread_ts(
+        reply_to="171.500",
+        metadata={"thread_id": "171.000", "slack_thread_explicit": True},
+    ) == "171.000"
+
+
+def test_slack_reply_in_thread_config_is_explicit_thread_opt_in():
+    adapter = _make_adapter()
+    adapter.config.extra["reply_in_thread"] = True
+
     assert adapter._resolve_thread_ts(
         reply_to="171.500",
         metadata={"thread_id": "171.000"},
     ) == "171.000"
+
+
+def test_non_slack_thread_metadata_unchanged():
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="123456789012345678",
+        chat_type="channel",
+        thread_id="987654321098765432",
+    )
+
+    assert _thread_metadata_for_source(source) == {"thread_id": "987654321098765432"}
+
+
+def test_config_bridges_slack_force_top_level_replies(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  force_top_level_replies: true\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
+
+    config = load_gateway_config()
+
+    assert config is not None
+    slack_config = config.platforms[Platform.SLACK]
+    assert slack_config.extra.get("force_top_level_replies") is True
+
+    adapter = SlackAdapter(slack_config)
+    assert adapter._resolve_thread_ts(
+        reply_to="171.500",
+        metadata={"thread_id": "171.000"},
+    ) is None
 
 
 def test_config_bridges_slack_strict_mention(monkeypatch, tmp_path):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -501,6 +501,8 @@ async def _send_via_adapter(
         if adapter is not None:
             try:
                 metadata = {"thread_id": thread_id} if thread_id else None
+                if metadata and platform_name == "slack":
+                    metadata["slack_thread_explicit"] = True
                 result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
             except asyncio.CancelledError:
                 raise


### PR DESCRIPTION
## Summary
- Makes Slack replies top-level by default instead of inheriting ambient thread routing metadata.
- Keeps explicit threaded replies working through Slack metadata/config opt-ins.
- Preserves non-Slack thread metadata behavior.

## Testing
- `env -u SLACK_ALLOWED_CHANNELS -u SLACK_FREE_RESPONSE_CHANNELS -u SLACK_REQUIRE_MENTION venv/bin/python -m pytest tests/gateway/test_slack.py tests/gateway/test_slack_mention.py -o 'addopts=' -q`

## Screenshots
N/A, gateway routing behavior and tests only.
