### PR TITLE
Harden cron context payloads and workspace path hints

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -57,6 +57,138 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+def _parse_positive_int(value) -> int | None:
+    """Parse a positive integer config value."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _parse_nonnegative_float(value) -> float | None:
+    """Parse a non-negative float config value."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _resolve_cron_context_from_max_chars(cfg: dict | None = None) -> int:
+    """Maximum characters copied from upstream cron outputs into a prompt."""
+    env_value = os.getenv("HERMES_CRON_CONTEXT_FROM_MAX_CHARS", "").strip()
+    if env_value:
+        return _parse_positive_int(env_value) or 8000
+
+    if cfg is None:
+        try:
+            cfg = load_config() or {}
+        except Exception:
+            cfg = {}
+    cron_cfg = (cfg or {}).get("cron") or {}
+    return _parse_positive_int(cron_cfg.get("context_from_max_chars")) or 8000
+
+
+def _extract_cron_context_payload(output: str) -> str:
+    """Return the useful payload from a stored cron output artifact."""
+    text = (output or "").strip()
+    if not text:
+        return ""
+
+    if "\n## Response\n" in text:
+        payload = text.rsplit("\n## Response\n", 1)[1].strip()
+        return "" if payload == "(No response generated)" else payload
+
+    if "\n## Error\n" in text:
+        payload = text.rsplit("\n## Error\n", 1)[1].strip()
+        header = []
+        for line in text.splitlines():
+            if line.startswith("# Cron Job:") or line.startswith("**Job ID:**"):
+                header.append(line)
+            elif line.startswith("**Run Time:**") or line.startswith("**Schedule:**"):
+                header.append(line)
+        prefix = "\n".join(header).strip()
+        if prefix:
+            return f"{prefix}\n\n## Error\n\n{payload}".strip()
+        return f"## Error\n\n{payload}".strip()
+
+    return text
+
+
+def _derive_shared_workspace_root(workdir: str) -> str:
+    """Return the broad host workspace root for a cron workdir."""
+    path = Path(workdir).expanduser()
+    parts = path.parts
+    for idx in range(len(parts) - 2):
+        if parts[idx] == "Users" and parts[idx + 2] == "code":
+            return str(Path(*parts[: idx + 3]))
+    return str(path)
+
+
+def _build_workdir_path_hint(job: dict) -> str:
+    """Tell cron agents how host paths map inside container-backed tools."""
+    workdir = str(job.get("workdir") or "").strip()
+    if not workdir:
+        return ""
+    workspace_root = _derive_shared_workspace_root(workdir)
+    return (
+        "## Cron Path Context\n"
+        f"- Configured host workdir: {workdir}\n"
+        f"- Shared workspace root: {workspace_root}\n"
+        "- Prefer absolute paths under the shared workspace root for file reads. "
+        "Do not expand `~/code` to `/root/code` in container-backed cron tools; "
+        "treat `~/code/...` project instructions as paths under the shared "
+        "workspace root above.\n\n"
+    )
+
+
+def _resolve_cron_max_iterations(cfg: dict) -> int:
+    """Cron-specific max turns, falling back to existing agent defaults."""
+    cfg = cfg or {}
+    cron_cfg = cfg.get("cron") or {}
+    agent_cfg = cfg.get("agent") or {}
+    for value in (
+        cron_cfg.get("max_turns"),
+        cron_cfg.get("max_iterations"),
+        agent_cfg.get("max_turns"),
+        cfg.get("max_turns"),
+    ):
+        parsed = _parse_positive_int(value)
+        if parsed is not None:
+            return parsed
+    return 90
+
+
+def _resolve_cron_inactivity_timeout(cfg: dict) -> float:
+    """Resolve cron inactivity timeout in seconds; 0 means unlimited."""
+    env_value = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
+    if env_value:
+        parsed = _parse_nonnegative_float(env_value)
+        if parsed is not None:
+            return parsed
+        logger.warning(
+            "Invalid HERMES_CRON_TIMEOUT=%r; using default 600s",
+            env_value,
+        )
+        return 600.0
+
+    cron_cfg = (cfg or {}).get("cron") or {}
+    for key in ("inactivity_timeout_seconds", "timeout_seconds"):
+        parsed = _parse_nonnegative_float(cron_cfg.get(key))
+        if parsed is not None:
+            return parsed
+    return 600.0
+
+
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
@@ -1046,6 +1178,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     context_from = job.get("context_from")
     if context_from:
         from cron.jobs import OUTPUT_DIR
+        max_context_chars = _resolve_cron_context_from_max_chars()
         if isinstance(context_from, str):
             context_from = [context_from]
         for source_job_id in context_from:
@@ -1070,11 +1203,11 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 )
                 if not output_files:
                     continue  # silent skip — no output yet
-                latest_output = output_files[0].read_text(encoding="utf-8").strip()
-                # Truncate to 8K characters to avoid prompt bloat
-                _MAX_CONTEXT_CHARS = 8000
-                if len(latest_output) > _MAX_CONTEXT_CHARS:
-                    latest_output = latest_output[:_MAX_CONTEXT_CHARS] + "\n\n[... output truncated ...]"
+                latest_output = _extract_cron_context_payload(
+                    output_files[0].read_text(encoding="utf-8")
+                )
+                if len(latest_output) > max_context_chars:
+                    latest_output = latest_output[:max_context_chars] + "\n\n[... output truncated ...]"
                 if latest_output:
                     prompt = (
                         f"## Output from job '{source_job_id}'\n"
@@ -1102,7 +1235,7 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         "Never combine [SILENT] with content — either report your "
         "findings normally, or say [SILENT] and nothing more.]\n\n"
     )
-    prompt = cron_hint + prompt
+    prompt = cron_hint + _build_workdir_path_hint(job) + prompt
     if skills is None:
         legacy = job.get("skill")
         skills = [legacy] if legacy else []
@@ -1534,8 +1667,8 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     logger.warning("Job '%s': failed to parse prefill messages file '%s': %s", job_id, pfpath, e)
                     prefill_messages = None
 
-        # Max iterations
-        max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 90
+        # Cron jobs use tighter turn budgets than interactive Hermes sessions.
+        max_iterations = _resolve_cron_max_iterations(_cfg)
 
         # Provider routing
         pr = _cfg.get("provider_routing", {})
@@ -1573,7 +1706,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     if entry.get("api_key"):
                         fb_kwargs["explicit_api_key"] = entry["api_key"]
                     runtime = resolve_runtime_provider(**fb_kwargs)
-                    logger.info("Job '%s': fallback resolved to %s", job_id, runtime.get("provider"))
+                    if entry.get("model"):
+                        model = entry.get("model")
+                    logger.info("Job '%s': fallback resolved to %s (model: %s)", job_id, runtime.get("provider"), model)
                     break
                 except Exception as fb_exc:
                     logger.debug("Job '%s': fallback %s failed: %s", job_id, entry.get("provider"), fb_exc)
@@ -1659,22 +1794,11 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # for hours if it's actively calling tools / receiving stream tokens,
         # but a hung API call or stuck tool with no activity for the configured
         # duration is caught and killed.  Default 600s (10 min inactivity);
-        # override via HERMES_CRON_TIMEOUT env var.  0 = unlimited.
+        # override via cron config or HERMES_CRON_TIMEOUT env var.  0 = unlimited.
         #
         # Uses the agent's built-in activity tracker (updated by
         # _touch_activity() on every tool call, API call, and stream delta).
-        _raw_cron_timeout = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
-        if _raw_cron_timeout:
-            try:
-                _cron_timeout = float(_raw_cron_timeout)
-            except (ValueError, TypeError):
-                logger.warning(
-                    "Invalid HERMES_CRON_TIMEOUT=%r; using default 600s",
-                    _raw_cron_timeout,
-                )
-                _cron_timeout = 600.0
-        else:
-            _cron_timeout = 600.0
+        _cron_timeout = _resolve_cron_inactivity_timeout(_cfg)
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
         _POLL_INTERVAL = 5.0
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -102,6 +102,119 @@ class TestBuildJobPromptContextFrom:
         assert "Today's top story: AI is everywhere." in prompt
         assert f"Output from job '{job_a['id']}'" in prompt
 
+    def test_context_from_extracts_response_from_cron_artifact(self, cron_env):
+        """Downstream jobs should not inherit upstream prompts or cron hints."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find news", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-04-22_10-00-00.md").write_text(
+            """# Cron Job: upstream
+
+**Job ID:** abc123
+**Run Time:** 2026-04-22 10:00:00
+**Schedule:** every 1h
+
+## Prompt
+
+[IMPORTANT: internal delivery instruction]
+
+Find private setup details.
+
+## Response
+
+Actionable upstream result.
+""",
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Summarize the news",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "Actionable upstream result." in prompt
+        assert "Find private setup details" not in prompt
+        assert prompt.count("[IMPORTANT:") == 1
+
+    def test_context_from_uses_outer_response_for_chained_artifact(self, cron_env):
+        """Nested upstream artifacts should not make context extraction stop early."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Validate", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-04-22_10-00-00.md").write_text(
+            """# Cron Job: validation
+
+## Prompt
+
+```
+# Cron Job: review
+
+## Response
+
+Nested review response.
+```
+
+## Response
+
+Final validation response.
+""",
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Queue actions",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "Final validation response." in prompt
+        assert "Nested review response." not in prompt
+
+    def test_context_from_extracts_error_from_failed_cron_artifact(self, cron_env):
+        """Failed upstream jobs should pass the failure, not the failed prompt."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find news", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-04-22_10-00-00.md").write_text(
+            """# Cron Job: upstream (FAILED)
+
+**Job ID:** abc123
+
+## Prompt
+
+Run broad analysis.
+
+## Error
+
+```
+RuntimeError: upstream failed
+```
+""",
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Summarize the news",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "RuntimeError: upstream failed" in prompt
+        assert "Run broad analysis" not in prompt
+
     def test_uses_most_recent_output(self, cron_env):
         from cron.jobs import create_job, OUTPUT_DIR
         from cron.scheduler import _build_job_prompt
@@ -198,6 +311,31 @@ class TestBuildJobPromptContextFrom:
         prompt = _build_job_prompt(job_b)
         assert "truncated" in prompt
         assert "x" * 10000 not in prompt
+
+    def test_output_truncated_at_configured_context_limit(self, cron_env, monkeypatch):
+        """Configured cron context limits should reduce upstream prompt bloat."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        monkeypatch.setattr(
+            "cron.scheduler.load_config",
+            lambda: {"cron": {"context_from_max_chars": 1200}},
+        )
+
+        job_a = create_job(prompt="Find data", schedule="every 1h")
+        out_dir = OUTPUT_DIR / job_a["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        big_output = "x" * 5000
+        (out_dir / "2026-04-22_10-00-00.md").write_text(big_output, encoding="utf-8")
+
+        job_b = create_job(
+            prompt="Process", schedule="every 2h", context_from=job_a["id"]
+        )
+        prompt = _build_job_prompt(job_b)
+        assert "truncated" in prompt
+        assert "x" * 5000 not in prompt
+        assert "x" * 1200 in prompt
+        assert "x" * 1201 not in prompt
 
     def test_graceful_when_file_deleted_between_listing_and_reading(self, cron_env):
         """Job should not crash if output file is deleted mid-read."""

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -248,6 +248,29 @@ class TestTickWorkdirPartition:
 # scheduler.run_job: TERMINAL_CWD + skip_context_files wiring
 # ---------------------------------------------------------------------------
 
+class TestBuildJobPromptWorkdirPathHint:
+    def test_workdir_prompt_warns_about_container_home_expansion(self, tmp_path):
+        import cron.scheduler as sched
+
+        code_root = tmp_path / "Users" / "bryan" / "code"
+        code_root.mkdir(parents=True)
+        workdir = code_root / "obsidian-vault"
+        workdir.mkdir()
+
+        prompt = sched._build_job_prompt(
+            {
+                "id": "abc123abc123",
+                "name": "path-aware-job",
+                "prompt": "Inspect shared memory.",
+                "workdir": str(workdir),
+            }
+        )
+
+        assert f"Configured host workdir: {workdir}" in prompt
+        assert f"Shared workspace root: {code_root}" in prompt
+        assert "Do not expand `~/code` to `/root/code`" in prompt
+
+
 class TestRunJobTerminalCwd:
     """
     run_job sets TERMINAL_CWD + flips skip_context_files=False when workdir


### PR DESCRIPTION
## Summary
- extract only final cron response/error payloads for context_from injection
- add configurable context_from truncation and cron inactivity/max-turn helpers
- add Cron Path Context prompt hints so Docker-backed tools do not expand ~/code to /root/code

## Verification
- /Users/bryanmassenzo/.hermes/hermes-agent/venv/bin/python -m pytest tests/cron/test_cron_workdir.py tests/cron/test_cron_context_from.py -q => 47 passed
- trading-analyst gateway restarted locally after patch

## Safety
- No broker, order-placement, credential, account, kill-switch, or trading-parameter code touched.
- Fix is prompt/context handling for scheduled read-only cron agents.