### PR TITLE
fix: recover codex responses output truncation

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -960,7 +960,7 @@ def _extract_responses_message_text(item: Any) -> str:
         text = getattr(part, "text", None)
         if isinstance(text, str) and text:
             chunks.append(text)
-    return "".join(chunks).strip()
+    return "".join(chunks)
 
 
 def _extract_responses_reasoning_text(item: Any) -> str:
@@ -1194,7 +1194,7 @@ def _normalize_codex_response(
                 function=SimpleNamespace(name=fn_name, arguments=arguments),
             ))
 
-    final_text = "\n".join([p for p in content_parts if p]).strip()
+    final_text = "\n".join([p for p in content_parts if p])
     if not final_text and hasattr(response, "output_text"):
         out_text = getattr(response, "output_text", "")
         if isinstance(out_text, str):

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -63,6 +63,35 @@ from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
 
+TEXT_CONTINUATION_API_MODES = frozenset({
+    "chat_completions",
+    "bedrock_converse",
+    "anthropic_messages",
+    "codex_responses",
+})
+TRUNCATED_TOOL_CALL_API_MODES = TEXT_CONTINUATION_API_MODES
+TRUNCATED_TOOL_CALL_MAX_RETRIES = 3
+CODEX_LENGTH_REASONS = frozenset({"max_output_tokens", "length"})
+
+
+def _response_incomplete_reason(response: Any) -> Optional[str]:
+    incomplete_details = getattr(response, "incomplete_details", None)
+    if isinstance(incomplete_details, dict):
+        reason = incomplete_details.get("reason")
+    else:
+        reason = getattr(incomplete_details, "reason", None)
+    return reason if isinstance(reason, str) else None
+
+
+def _response_has_raw_tool_call_item(response: Any) -> bool:
+    output = getattr(response, "output", None)
+    if not isinstance(output, list):
+        return False
+    return any(
+        getattr(item, "type", None) in {"function_call", "custom_tool_call"}
+        for item in output
+    )
+
 
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
@@ -1508,15 +1537,11 @@ def run_conversation(
                     continue  # Retry the API call
 
                 # Check finish_reason before proceeding
+                codex_incomplete_reason = None
                 if agent.api_mode == "codex_responses":
                     status = getattr(response, "status", None)
-                    incomplete_details = getattr(response, "incomplete_details", None)
-                    incomplete_reason = None
-                    if isinstance(incomplete_details, dict):
-                        incomplete_reason = incomplete_details.get("reason")
-                    else:
-                        incomplete_reason = getattr(incomplete_details, "reason", None)
-                    if status == "incomplete" and incomplete_reason in {"max_output_tokens", "length"}:
+                    codex_incomplete_reason = _response_incomplete_reason(response)
+                    if status == "incomplete" and codex_incomplete_reason in CODEX_LENGTH_REASONS:
                         finish_reason = "length"
                     else:
                         finish_reason = "stop"
@@ -1561,10 +1586,10 @@ def run_conversation(
                     # Normalize the truncated response to a single OpenAI-style
                     # message shape so text-continuation and tool-call retry
                     # work uniformly across chat_completions, bedrock_converse,
-                    # and anthropic_messages.  For Anthropic we use the same
-                    # adapter the agent loop already relies on so the rebuilt
-                    # interim assistant message is byte-identical to what
-                    # would have been appended in the non-truncated path.
+                    # anthropic_messages, and codex_responses.  For Anthropic
+                    # we use the same adapter the agent loop already relies on
+                    # so the rebuilt interim assistant message is byte-identical
+                    # to what would have been appended in the non-truncated path.
                     _trunc_msg = None
                     _trunc_transport = agent._get_transport()
                     if agent.api_mode == "anthropic_messages":
@@ -1576,7 +1601,13 @@ def run_conversation(
                     _trunc_msg = _trunc_result
 
                     _trunc_content = getattr(_trunc_msg, "content", None) if _trunc_msg else None
-                    _trunc_has_tool_calls = bool(getattr(_trunc_msg, "tool_calls", None)) if _trunc_msg else False
+                    _codex_raw_tool_call = (
+                        agent.api_mode == "codex_responses"
+                        and _response_has_raw_tool_call_item(response)
+                    )
+                    _trunc_has_tool_calls = (
+                        bool(getattr(_trunc_msg, "tool_calls", None)) if _trunc_msg else False
+                    ) or _codex_raw_tool_call
 
                     # ── Detect thinking-budget exhaustion ──────────────
                     # When the model spends ALL output tokens on reasoning
@@ -1639,7 +1670,40 @@ def run_conversation(
                             "error": _exhaust_error,
                         }
 
-                    if agent.api_mode in {"chat_completions", "bedrock_converse", "anthropic_messages"}:
+                    if (
+                        agent.api_mode == "codex_responses"
+                        and not _trunc_has_tool_calls
+                        and not ((_trunc_content or "").strip())
+                    ):
+                        _reason = codex_incomplete_reason or "unknown"
+                        interim_msg = agent._build_assistant_message(_trunc_msg, "incomplete")
+                        if (
+                            interim_msg.get("reasoning")
+                            or interim_msg.get("codex_reasoning_items")
+                            or interim_msg.get("codex_message_items")
+                        ):
+                            messages.append(interim_msg)
+                        _no_output_error = (
+                            "codex_responses max_output_tokens response produced "
+                            f"no visible output (reason={_reason})"
+                        )
+                        agent._vprint(
+                            f"{agent.log_prefix}⚠️  Codex Responses exhausted output budget "
+                            "before producing visible text.",
+                            force=True,
+                        )
+                        agent._cleanup_task_resources(effective_task_id)
+                        agent._persist_session(messages, conversation_history)
+                        return {
+                            "final_response": None,
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "partial": True,
+                            "error": _no_output_error,
+                        }
+
+                    if agent.api_mode in TEXT_CONTINUATION_API_MODES:
                         assistant_message = _trunc_msg
                         if assistant_message is not None and not _trunc_has_tool_calls:
                             length_continue_retries += 1
@@ -1700,13 +1764,15 @@ def run_conversation(
                                 "error": "Response remained truncated after 3 continuation attempts",
                             }
 
-                    if agent.api_mode in {"chat_completions", "bedrock_converse", "anthropic_messages"}:
+                    if agent.api_mode in TRUNCATED_TOOL_CALL_API_MODES:
                         assistant_message = _trunc_msg
                         if assistant_message is not None and _trunc_has_tool_calls:
-                            if truncated_tool_call_retries < 1:
+                            if truncated_tool_call_retries < TRUNCATED_TOOL_CALL_MAX_RETRIES:
                                 truncated_tool_call_retries += 1
                                 agent._buffer_vprint(
-                                    f"⚠️  Truncated tool call detected — retrying API call..."
+                                    "⚠️  Truncated tool call detected — retrying "
+                                    f"API call ({truncated_tool_call_retries}/"
+                                    f"{TRUNCATED_TOOL_CALL_MAX_RETRIES})..."
                                 )
                                 # Don't append the broken response to messages;
                                 # just re-run the same API call from the current
@@ -1719,13 +1785,20 @@ def run_conversation(
                             )
                             agent._cleanup_task_resources(effective_task_id)
                             agent._persist_session(messages, conversation_history)
+                            _tool_error = (
+                                "Codex Responses max_output_tokens response contained "
+                                "a truncated tool call; refusing to execute incomplete "
+                                "tool arguments"
+                                if agent.api_mode == "codex_responses"
+                                else "Response truncated due to output length limit"
+                            )
                             return {
                                 "final_response": None,
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
-                                "error": "Response truncated due to output length limit",
+                                "error": _tool_error,
                             }
 
                     # If we have prior messages, roll back to last complete state

--- a/tests/run_agent/test_anthropic_truncation_continuation.py
+++ b/tests/run_agent/test_anthropic_truncation_continuation.py
@@ -100,15 +100,21 @@ class TestTruncatedAnthropicResponseNormalization:
 
 
 class TestContinuationLogicBranching:
-    """Symbolic check that the api_mode gate now includes anthropic_messages."""
+    """Symbolic check that the api_mode gate includes all shared continuation modes."""
 
-    @pytest.mark.parametrize("api_mode", ["chat_completions", "bedrock_converse", "anthropic_messages"])
-    def test_all_three_api_modes_hit_continuation_branch(self, api_mode):
-        # The guard in run_agent.py is:
-        #   if self.api_mode in ("chat_completions", "bedrock_converse", "anthropic_messages"):
-        assert api_mode in {"chat_completions", "bedrock_converse", "anthropic_messages"}
+    @pytest.mark.parametrize(
+        "api_mode",
+        ["chat_completions", "bedrock_converse", "anthropic_messages", "codex_responses"],
+    )
+    def test_all_supported_api_modes_hit_continuation_branch(self, api_mode):
+        from agent.conversation_loop import TEXT_CONTINUATION_API_MODES
 
-    def test_codex_responses_still_excluded(self):
-        # codex_responses has its own truncation path (not continuation-based)
-        # and should NOT be routed through the shared block.
-        assert "codex_responses" not in {"chat_completions", "bedrock_converse", "anthropic_messages"}
+        assert api_mode in TEXT_CONTINUATION_API_MODES
+
+    def test_truncated_tool_call_modes_match_text_continuation_modes(self):
+        from agent.conversation_loop import (
+            TEXT_CONTINUATION_API_MODES,
+            TRUNCATED_TOOL_CALL_API_MODES,
+        )
+
+        assert TRUNCATED_TOOL_CALL_API_MODES == TEXT_CONTINUATION_API_MODES

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -108,6 +108,58 @@ def _codex_tool_call_response():
     )
 
 
+def _codex_max_output_message_response(text: str):
+    return SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                id="msg_partial",
+                status="incomplete",
+                content=[SimpleNamespace(type="output_text", text=text)],
+            )
+        ],
+        usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+        status="incomplete",
+        incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+        model="gpt-5-codex",
+    )
+
+
+def _codex_max_output_tool_call_response(arguments: str):
+    return SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="function_call",
+                id="fc_1",
+                call_id="call_1",
+                name="terminal",
+                arguments=arguments,
+            )
+        ],
+        usage=SimpleNamespace(input_tokens=12, output_tokens=4, total_tokens=16),
+        status="incomplete",
+        incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+        model="gpt-5-codex",
+    )
+
+
+def _codex_max_output_reasoning_only_response():
+    return SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="reasoning",
+                id="rs_1",
+                encrypted_content="encrypted-reasoning-state",
+                summary=[SimpleNamespace(type="summary_text", text="Still reasoning")],
+            )
+        ],
+        usage=SimpleNamespace(input_tokens=8, output_tokens=4, total_tokens=12),
+        status="incomplete",
+        incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+        model="gpt-5-codex",
+    )
+
+
 def _codex_incomplete_message_response(text: str):
     return SimpleNamespace(
         output=[
@@ -684,6 +736,134 @@ def test_run_conversation_codex_plain_text(monkeypatch):
     assert result["final_response"] == "OK"
     assert result["messages"][-1]["role"] == "assistant"
     assert result["messages"][-1]["content"] == "OK"
+
+
+def test_run_conversation_codex_incomplete_text_continuation(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    responses = [
+        _codex_max_output_message_response("Part 1 "),
+        _codex_message_response("Part 2"),
+    ]
+    requests = []
+
+    def _fake_api_call(api_kwargs):
+        requests.append(api_kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    result = agent.run_conversation("Write a long answer")
+
+    assert result["completed"] is True
+    assert result["api_calls"] == 2
+    assert result["final_response"] == "Part 1 Part 2"
+    assert len(requests) == 2
+
+    second_input = requests[1]["input"]
+    assert second_input[-1]["role"] == "user"
+    assert "truncated by the output length limit" in second_input[-1]["content"]
+    assert any(
+        item.get("type") == "message" and item.get("status") == "incomplete"
+        for item in second_input
+    )
+
+
+def test_run_conversation_codex_incomplete_tool_call_fail_closed(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    bad_response = _codex_max_output_tool_call_response('{"cmd": "printf partial')
+    calls = {"api": 0, "tool": 0}
+
+    def _fake_api_call(api_kwargs):
+        calls["api"] += 1
+        return bad_response
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    def _fake_handle_function_call(*args, **kwargs):
+        calls["tool"] += 1
+        return "{}"
+
+    monkeypatch.setattr(run_agent, "handle_function_call", _fake_handle_function_call)
+
+    result = agent.run_conversation("Run a command")
+
+    assert result["completed"] is False
+    assert result["partial"] is True
+    assert "Codex" in result["error"]
+    assert "max_output_tokens" in result["error"]
+    assert "truncated tool call" in result["error"]
+    assert calls["api"] == 4
+    assert not any(
+        msg.get("role") == "assistant" and msg.get("tool_calls")
+        for msg in result["messages"]
+    )
+    assert calls["tool"] == 0
+
+
+def test_run_conversation_codex_truncated_tool_call_retries_until_valid(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    responses = [
+        _codex_max_output_tool_call_response('{"cmd": "printf partial'),
+        _codex_max_output_tool_call_response('{"cmd": "printf still partial'),
+        _codex_tool_call_response(),
+        _codex_message_response("done"),
+    ]
+    requests = []
+
+    def _fake_api_call(api_kwargs):
+        requests.append(api_kwargs)
+        return responses.pop(0)
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api_call)
+
+    calls = {"tool": 0}
+
+    def _fake_handle_function_call(tool_name, args, task_id=None, **kwargs):
+        calls["tool"] += 1
+        assert tool_name == "terminal"
+        assert args == {}
+        return '{"ok": true}'
+
+    monkeypatch.setattr(run_agent, "handle_function_call", _fake_handle_function_call)
+
+    result = agent.run_conversation("Run a command")
+
+    assert result["completed"] is True
+    assert len(requests) == 4
+    assert result["final_response"] == "done"
+    assert calls["tool"] == 1
+    assert any(msg.get("role") == "tool" and msg.get("tool_call_id") == "call_1" for msg in result["messages"])
+
+
+def test_run_conversation_codex_incomplete_no_visible_output_returns_recoverable_error(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    persisted = {"count": 0}
+
+    def _persist(messages, history=None):
+        persisted["count"] += 1
+
+    agent._persist_session = _persist
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: _codex_max_output_reasoning_only_response(),
+    )
+
+    result = agent.run_conversation("Think silently")
+
+    assert result["completed"] is False
+    assert result["partial"] is True
+    assert persisted["count"] == 1
+    assert "codex_responses" in result["error"]
+    assert "max_output_tokens" in result["error"]
+    assert "no visible output" in result["error"]
+    preserved_reasoning = [
+        msg.get("codex_reasoning_items")
+        for msg in result["messages"]
+        if msg.get("role") == "assistant" and msg.get("codex_reasoning_items")
+    ]
+    assert preserved_reasoning
+    assert preserved_reasoning[-1][0]["encrypted_content"] == "encrypted-reasoning-state"
 
 
 def test_run_conversation_codex_empty_output_with_output_text(monkeypatch):


### PR DESCRIPTION
## Summary
- Add Codex Responses `incomplete/max_output_tokens` recovery to the existing length-continuation path.
- Fail closed for truncated raw tool-call output instead of executing partial tool arguments.
- Preserve Codex response text boundaries and reasoning state for recoverable no-visible-output cases.
- Add focused regression coverage for Codex Responses truncation behavior and continuation-mode branching.

## Test Plan
- `HERMES_HOME=/private/tmp/hermes-agent-test-home-codex-truncation-main python -m pytest tests/run_agent/test_run_agent_codex_responses.py -k 'incomplete_text_continuation or incomplete_tool_call_fail_closed or truncated_tool_call_retries_until_valid or incomplete_no_visible_output' -q -o 'addopts='`
- `python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='`
- `python -m pytest tests/run_agent/test_anthropic_truncation_continuation.py -q -o 'addopts='`
- `python -m pytest tests/run_agent/test_run_agent.py -k 'length_finish_reason_requests_continuation or length_thinking_exhausted or truncated_tool_call' -q -o 'addopts='`
- `python -m py_compile agent/conversation_loop.py agent/codex_responses_adapter.py agent/codex_runtime.py`
- `git diff --check`
- static added-line scan: 0 findings

## Notes
- Does not lower `reasoning_effort`.
- Does not change Codex transport max-token plumbing; this is a recovery/fail-closed fix.
