### PR TITLE
feat(cli): auto-detect image paths typed anywhere in terminal input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2606,11 +2606,16 @@ def _detect_inline_image_paths(user_input: str) -> "dict | None":
 
         if suffix in _IMAGE_EXTENSIONS:
             resolved = _resolve_attachment_path(core)
-            if resolved is not None and str(resolved) not in seen:
-                seen.add(str(resolved))
-                images.append(resolved)
-                # Drop the path token from the prompt; preserve trailing
-                # punctuation so the remaining sentence still reads naturally.
+            if resolved is not None:
+                # Consume every successfully resolved image token (drop it
+                # from the prompt), but attach it only on first occurrence so
+                # a repeated path yields a single attachment and neither copy
+                # lingers in the remainder.
+                if str(resolved) not in seen:
+                    seen.add(str(resolved))
+                    images.append(resolved)
+                # Preserve trailing punctuation so the remaining sentence
+                # still reads naturally.
                 if trailing:
                     kept_tokens.append(trailing)
                 continue

--- a/cli.py
+++ b/cli.py
@@ -2542,6 +2542,87 @@ def _detect_file_drop(user_input: str) -> "dict | None":
     }
 
 
+def _detect_inline_image_paths(user_input: str) -> "dict | None":
+    """Detect image file paths *anywhere* in *user_input*, not just leading.
+
+    ``_detect_file_drop`` only recognises a path when it is the first token
+    (drag-and-drop / paste gesture). This helper covers the natural-language
+    case the user actually types, e.g.::
+
+        look at screenshot.png and tell me what's wrong
+        compare ~/a.png and "/tmp/My Shot.png"
+        whats in /tmp/diagram.jpg ?
+
+    It scans whitespace-delimited tokens (plus quoted spans) for ones that
+    end in a known image extension and resolve to a real image file. Matched
+    path tokens are removed from the text so the agent receives a clean
+    prompt alongside the attached images.
+
+    Returns a dict on match::
+
+        {
+            "images": [Path, ...],   # resolved, de-duplicated image paths
+            "remainder": str,        # input text with path tokens removed
+        }
+
+    Returns ``None`` when no inline image path is found. Conservative by
+    design: only tokens whose suffix is in ``_IMAGE_EXTENSIONS`` *and* that
+    resolve to an existing file are matched, so ordinary prose, URLs, and
+    non-image paths are left untouched.
+    """
+    if not isinstance(user_input, str):
+        return None
+
+    stripped = user_input.strip()
+    if not stripped:
+        return None
+
+    # Never reinterpret slash commands as image carriers.
+    if _looks_like_slash_command(stripped):
+        return None
+
+    # Tokenise while keeping quoted spans intact. Quotes commonly wrap paths
+    # that contain spaces (e.g. macOS screenshots).
+    token_re = re.compile(r'"[^"]*"|\'[^\']*\'|\S+')
+    images: list[Path] = []
+    seen: set[str] = set()
+    kept_tokens: list[str] = []
+
+    for match in token_re.finditer(stripped):
+        token = match.group(0)
+        # Strip trailing sentence punctuation that often follows a path in
+        # natural language ("what is in foo.png?" / "see a.png,").
+        core = token
+        trailing = ""
+        if core and core[-1] not in {'"', "'"}:
+            while core and core[-1] in {".", ",", "?", "!", ";", ":", ")"}:
+                trailing = core[-1] + trailing
+                core = core[:-1]
+
+        unquoted = core
+        if len(unquoted) >= 2 and unquoted[0] in {'"', "'"} and unquoted[-1] == unquoted[0]:
+            unquoted = unquoted[1:-1]
+        suffix = os.path.splitext(unquoted)[1].lower()
+
+        if suffix in _IMAGE_EXTENSIONS:
+            resolved = _resolve_attachment_path(core)
+            if resolved is not None and str(resolved) not in seen:
+                seen.add(str(resolved))
+                images.append(resolved)
+                # Drop the path token from the prompt; preserve trailing
+                # punctuation so the remaining sentence still reads naturally.
+                if trailing:
+                    kept_tokens.append(trailing)
+                continue
+        kept_tokens.append(token)
+
+    if not images:
+        return None
+
+    remainder = re.sub(r"\s+", " ", " ".join(kept_tokens)).strip()
+    return {"images": images, "remainder": remainder}
+
+
 def _format_image_attachment_badges(attached_images: list[Path], image_counter: int, width: int | None = None) -> str:
     """Format the attached-image badge row for the interactive CLI.
 
@@ -13020,7 +13101,31 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                             user_input = _seed
                         else:
                             continue
-                    
+
+                    # Auto-detect image paths typed anywhere in the input
+                    # (not just a leading drag/paste handled by _file_drop
+                    # above). Lets users write naturally, e.g.
+                    #   "look at screenshot.png and tell me what's wrong"
+                    # The matched path tokens are attached as images and
+                    # stripped from the prompt. Skipped for slash commands
+                    # and when a leading file-drop already matched.
+                    if (
+                        not _file_drop
+                        and isinstance(user_input, str)
+                        and not _looks_like_slash_command(user_input)
+                    ):
+                        _inline = _detect_inline_image_paths(user_input)
+                        if _inline:
+                            _inline_imgs = _inline["images"]
+                            submit_images.extend(_inline_imgs)
+                            for _img in _inline_imgs:
+                                _cprint(f"  📎 Auto-attached image: {_img.name}")
+                            user_input = _inline["remainder"] or (
+                                f"[User attached image: {_inline_imgs[0].name}]"
+                                if len(_inline_imgs) == 1
+                                else f"[User attached {len(_inline_imgs)} images]"
+                            )
+
                     # Expand paste references back to full content
                     _paste_ref_re = re.compile(r'\[Pasted text #\d+: \d+ lines \u2192 (.+?)\]')
                     paste_refs = list(_paste_ref_re.finditer(user_input)) if isinstance(user_input, str) else []

--- a/tests/cli/test_cli_inline_image_paths.py
+++ b/tests/cli/test_cli_inline_image_paths.py
@@ -1,0 +1,160 @@
+"""Tests for _detect_inline_image_paths — auto-detecting image file paths
+typed anywhere in CLI input (not just a leading drag/paste), so terminal
+users get rough parity with chat platforms (closes #34542)."""
+
+
+import pytest
+
+from cli import _detect_inline_image_paths
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def tmp_image(tmp_path):
+    img = tmp_path / "screenshot.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n")
+    return img
+
+
+@pytest.fixture()
+def tmp_image2(tmp_path):
+    img = tmp_path / "diagram.jpg"
+    img.write_bytes(b"\xff\xd8\xff\xe0")  # minimal JPEG header
+    return img
+
+
+@pytest.fixture()
+def tmp_image_with_spaces(tmp_path):
+    img = tmp_path / "My Shot.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n")
+    return img
+
+
+@pytest.fixture()
+def tmp_text(tmp_path):
+    f = tmp_path / "main.py"
+    f.write_text("print('hello')\n")
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Tests: returns None when nothing to attach
+# ---------------------------------------------------------------------------
+
+class TestNoMatch:
+    def test_empty_string(self):
+        assert _detect_inline_image_paths("") is None
+
+    def test_whitespace_only(self):
+        assert _detect_inline_image_paths("   ") is None
+
+    def test_non_string(self):
+        assert _detect_inline_image_paths(42) is None
+
+    def test_plain_prose(self):
+        assert _detect_inline_image_paths("how do I center a div") is None
+
+    def test_slash_command_untouched(self):
+        assert _detect_inline_image_paths("/help") is None
+
+    def test_slash_command_with_image_word_untouched(self):
+        # A real slash command should never be reinterpreted, even if it
+        # mentions something image-like that isn't a real file.
+        assert _detect_inline_image_paths("/model gpt-image.png") is None
+
+    def test_nonexistent_image_path(self):
+        assert _detect_inline_image_paths("look at /nope/missing.png") is None
+
+    def test_image_extension_word_but_not_a_file(self):
+        # "logo.png" with no such file on disk must not match.
+        assert _detect_inline_image_paths("our logo.png is blue") is None
+
+    def test_non_image_file_not_matched(self, tmp_text):
+        # Only image files are auto-attached here; code files are out of scope.
+        assert _detect_inline_image_paths(f"review {tmp_text}") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: image detection anywhere in the line
+# ---------------------------------------------------------------------------
+
+class TestInlineDetection:
+    def test_image_in_middle(self, tmp_image):
+        result = _detect_inline_image_paths(
+            f"look at {tmp_image} and tell me what's wrong"
+        )
+        assert result is not None
+        assert result["images"] == [tmp_image]
+        assert result["remainder"] == "look at and tell me what's wrong"
+
+    def test_image_at_end_with_question_mark(self, tmp_image):
+        result = _detect_inline_image_paths(f"whats in {tmp_image}?")
+        assert result is not None
+        assert result["images"] == [tmp_image]
+        # Trailing punctuation is preserved on the cleaned prompt.
+        assert result["remainder"] == "whats in ?"
+
+    def test_image_at_start_still_works(self, tmp_image):
+        result = _detect_inline_image_paths(f"{tmp_image} describe it")
+        assert result is not None
+        assert result["images"] == [tmp_image]
+        assert result["remainder"] == "describe it"
+
+    def test_two_images(self, tmp_image, tmp_image2):
+        result = _detect_inline_image_paths(
+            f"compare {tmp_image} and {tmp_image2}"
+        )
+        assert result is not None
+        assert result["images"] == [tmp_image, tmp_image2]
+        assert result["remainder"] == "compare and"
+
+    def test_duplicate_image_deduped(self, tmp_image):
+        result = _detect_inline_image_paths(
+            f"is {tmp_image} the same as {tmp_image}"
+        )
+        assert result is not None
+        assert result["images"] == [tmp_image]
+
+    def test_quoted_path_with_spaces(self, tmp_image_with_spaces):
+        result = _detect_inline_image_paths(
+            f'what is in "{tmp_image_with_spaces}" exactly'
+        )
+        assert result is not None
+        assert result["images"] == [tmp_image_with_spaces]
+        assert result["remainder"] == "what is in exactly"
+
+    def test_tilde_path(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        img = home / "Pictures" / "cat.png"
+        img.parent.mkdir(parents=True, exist_ok=True)
+        img.write_bytes(b"\x89PNG\r\n\x1a\n")
+        monkeypatch.setenv("HOME", str(home))
+        result = _detect_inline_image_paths("describe ~/Pictures/cat.png please")
+        assert result is not None
+        assert result["images"] == [img]
+        assert result["remainder"] == "describe please"
+
+    def test_only_image_path_no_other_text(self, tmp_image):
+        result = _detect_inline_image_paths(f"{tmp_image}")
+        assert result is not None
+        assert result["images"] == [tmp_image]
+        assert result["remainder"] == ""
+
+    @pytest.mark.parametrize("ext", [".png", ".jpg", ".jpeg", ".gif", ".webp"])
+    def test_common_extensions(self, tmp_path, ext):
+        img = tmp_path / f"shot{ext}"
+        img.write_bytes(b"fake")
+        result = _detect_inline_image_paths(f"see shot{ext}".replace("shot" + ext, str(img)))
+        assert result is not None
+        assert result["images"] == [img]
+
+    def test_uppercase_extension(self, tmp_path):
+        img = tmp_path / "PHOTO.JPG"
+        img.write_bytes(b"fake")
+        result = _detect_inline_image_paths(f"check {img} out")
+        assert result is not None
+        assert result["images"] == [img]
+        assert result["remainder"] == "check out"

--- a/tests/cli/test_cli_inline_image_paths.py
+++ b/tests/cli/test_cli_inline_image_paths.py
@@ -116,7 +116,11 @@ class TestInlineDetection:
             f"is {tmp_image} the same as {tmp_image}"
         )
         assert result is not None
+        # Repeated path -> single attachment, and BOTH occurrences are
+        # stripped from the remainder (neither copy lingers in the prompt).
         assert result["images"] == [tmp_image]
+        assert str(tmp_image) not in result["remainder"]
+        assert result["remainder"] == "is the same as"
 
     def test_quoted_path_with_spaces(self, tmp_image_with_spaces):
         result = _detect_inline_image_paths(


### PR DESCRIPTION
## Summary

- Auto-detect image file paths typed **anywhere** in interactive CLI input and attach them automatically.
- Terminal users get the "just mention the image" parity that Telegram/Discord already have — no need to put the path first or use a slash command.

## Motivation

Closes #34542.

CLI mode only attached an image when the path was the **leading** token of the
input — the drag-and-drop / paste gesture handled by `_detect_file_drop`.
Natural phrasing like `look at screenshot.png and tell me what's wrong` or
`compare a.png and b.png` left the image unattached, so the user had to know
the exact path *and* lead with it. Chat platforms just see the image; the CLI
should feel close to that.

This implements the issue's primary ask (idea #1, "auto-detect image paths in
input"). The clipboard-paste stretch goal (idea #2) is out of scope here and is
already being worked on in #27900.

## What changed

- New helper `_detect_inline_image_paths(user_input)`:
  - Scans whitespace-delimited tokens (and quoted spans, for paths with spaces)
    anywhere in the input.
  - Matches only tokens whose suffix is in `_IMAGE_EXTENSIONS` **and** that
    resolve (via the existing `_resolve_attachment_path`) to a real file.
  - Strips matched path tokens from the prompt, preserving trailing sentence
    punctuation, and returns the cleaned text + de-duplicated `Path` list.
- Wired into the interactive loop as a **fallback** after the slash-command and
  leading file-drop (`_detect_file_drop`) checks, so all existing behavior is
  untouched. Detected images are appended to `submit_images` with the same
  `📎 Auto-attached image:` UX already used for drops.

Conservative by design: ordinary prose, URLs, non-image paths, nonexistent
files, and slash commands are all left alone (existing files only match).

## Verification

- `python3 -m pytest tests/cli/test_cli_inline_image_paths.py` — 23 passed (new)
- `python3 -m pytest tests/cli/test_cli_file_drop.py` — 35 passed (no regression)
- `python3 -m pytest tests/cli/test_cli_image_command.py` — 9 passed
- `python3 -m py_compile cli.py` — clean
- Did **not** change `_detect_file_drop`, the slash-command guard, or any
  leading-path behavior — the new detector only runs when neither already matched.
