### PR TITLE
feat(web): add web.prefer_fetch_over_browser toggle for simple fetches

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -340,6 +340,7 @@ def get_tool_definitions(
                 registry._generation,
                 cfg_fp,
                 bool(os.environ.get("HERMES_KANBAN_TASK")),
+                os.environ.get("HERMES_PREFER_FETCH_OVER_BROWSER"),
                 bool(skip_tool_search_assembly),
                 _is_delegated_child_context(),
                 profile_scope,
@@ -537,6 +538,31 @@ def _compute_tool_definitions(
                         "function": {**td["function"], "description": desc},
                     }
                     break
+        elif "web_extract" in available_tool_names and _prefer_fetch_over_browser():
+            # web.prefer_fetch_over_browser (issue #34545): the static schema's
+            # "prefer web_extract" line is only advisory and the model often
+            # ignores it when both tools are present. When the user opts in,
+            # upgrade the advisory hint to a directive so non-interactive URL
+            # fetches route to the cheaper/faster web_extract path. Browser
+            # tools stay available for genuinely interactive pages.
+            directive = (
+                " IMPORTANT: this deployment is configured to prefer web_extract"
+                " for non-interactive content retrieval. Use web_extract to fetch"
+                " page or document content from a URL. Only use browser_navigate"
+                " when the task requires interaction the fetch tools cannot do —"
+                " logging in, clicking, filling/submitting forms, JS-rendered or"
+                " scroll-dependent content."
+            )
+            for i, td in enumerate(filtered_tools):
+                if td.get("function", {}).get("name") == "browser_navigate":
+                    desc = td["function"].get("description", "")
+                    if directive.strip() not in desc:
+                        desc = desc + directive
+                    filtered_tools[i] = {
+                        "type": "function",
+                        "function": {**td["function"], "description": desc},
+                    }
+                    break
 
     if not quiet_mode:
         if filtered_tools:
@@ -596,6 +622,31 @@ def _compute_tool_definitions(
         logger.warning("Tool search assembly skipped: %s", e)
 
     return filtered_tools
+
+
+
+def _prefer_fetch_over_browser() -> bool:
+    """Whether the user asked browser_navigate to defer to web_extract.
+
+    Reads ``web.prefer_fetch_over_browser`` from ~/.hermes/config.yaml
+    (Option A from issue #34545). The env var ``HERMES_PREFER_FETCH_OVER_BROWSER``
+    overrides config when set, matching the override convention used by the
+    rest of the tool layer. Any failure resolves to ``False`` so the default
+    behaviour (advisory-only hint) is preserved.
+    """
+    env = os.environ.get("HERMES_PREFER_FETCH_OVER_BROWSER")
+    if env is not None:
+        return env.strip().lower() in {"1", "true", "yes", "on"}
+    try:
+        from hermes_cli.config import load_config as _load
+        cfg = _load() or {}
+        web_cfg = cfg.get("web")
+        if not isinstance(web_cfg, dict):
+            return False
+        return bool(web_cfg.get("prefer_fetch_over_browser", False))
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("Could not resolve web.prefer_fetch_over_browser: %s", e)
+        return False
 
 
 def _resolve_active_context_length() -> int:

--- a/model_tools.py
+++ b/model_tools.py
@@ -370,6 +370,7 @@ def get_tool_definitions(
                 registry._generation,
                 cfg_fp,
                 bool(os.environ.get("HERMES_KANBAN_TASK")),
+                os.environ.get("HERMES_PREFER_FETCH_OVER_BROWSER"),
                 bool(skip_tool_search_assembly),
                 _is_delegated_child_context(),
                 _is_dispatcher_owned_worker(),
@@ -576,6 +577,31 @@ def _compute_tool_definitions(
                         "function": {**td["function"], "description": desc},
                     }
                     break
+        elif "web_extract" in available_tool_names and _prefer_fetch_over_browser():
+            # web.prefer_fetch_over_browser (issue #34545): the static schema's
+            # "prefer web_extract" line is only advisory and the model often
+            # ignores it when both tools are present. When the user opts in,
+            # upgrade the advisory hint to a directive so non-interactive URL
+            # fetches route to the cheaper/faster web_extract path. Browser
+            # tools stay available for genuinely interactive pages.
+            directive = (
+                " IMPORTANT: this deployment is configured to prefer web_extract"
+                " for non-interactive content retrieval. Use web_extract to fetch"
+                " page or document content from a URL. Only use browser_navigate"
+                " when the task requires interaction the fetch tools cannot do —"
+                " logging in, clicking, filling/submitting forms, JS-rendered or"
+                " scroll-dependent content."
+            )
+            for i, td in enumerate(filtered_tools):
+                if td.get("function", {}).get("name") == "browser_navigate":
+                    desc = td["function"].get("description", "")
+                    if directive.strip() not in desc:
+                        desc = desc + directive
+                    filtered_tools[i] = {
+                        "type": "function",
+                        "function": {**td["function"], "description": desc},
+                    }
+                    break
 
     # browser_exec (Browser Use mode) runs arbitrary Python on the host via
     # the browser-use CLI subprocess.  A session whose toolset selection
@@ -698,6 +724,31 @@ def _compute_tool_definitions(
         logger.warning("Tool search assembly skipped: %s", e)
 
     return filtered_tools
+
+
+
+def _prefer_fetch_over_browser() -> bool:
+    """Whether the user asked browser_navigate to defer to web_extract.
+
+    Reads ``web.prefer_fetch_over_browser`` from ~/.hermes/config.yaml
+    (Option A from issue #34545). The env var ``HERMES_PREFER_FETCH_OVER_BROWSER``
+    overrides config when set, matching the override convention used by the
+    rest of the tool layer. Any failure resolves to ``False`` so the default
+    behaviour (advisory-only hint) is preserved.
+    """
+    env = os.environ.get("HERMES_PREFER_FETCH_OVER_BROWSER")
+    if env is not None:
+        return env.strip().lower() in {"1", "true", "yes", "on"}
+    try:
+        from hermes_cli.config import load_config as _load
+        cfg = _load() or {}
+        web_cfg = cfg.get("web")
+        if not isinstance(web_cfg, dict):
+            return False
+        return bool(web_cfg.get("prefer_fetch_over_browser", False))
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("Could not resolve web.prefer_fetch_over_browser: %s", e)
+        return False
 
 
 def _resolve_active_context_length() -> int:

--- a/tests/test_prefer_fetch_over_browser.py
+++ b/tests/test_prefer_fetch_over_browser.py
@@ -1,0 +1,159 @@
+"""Tests for the ``web.prefer_fetch_over_browser`` toggle (issue #34545).
+
+When both ``browser_navigate`` and ``web_extract`` are available the model
+picks which to use, and it often reaches for the (slower, costlier) browser
+even though ``browser_navigate``'s own description advises preferring the web
+tools. The advisory hint is non-binding.
+
+This toggle, when enabled, rewrites the ``browser_navigate`` description from
+an advisory hint into a directive so non-interactive fetches route to
+``web_extract``. The browser tools stay registered.
+
+These tests pin:
+- ``_prefer_fetch_over_browser`` reads config + honours the env override
+- the directive is appended only when the flag is on AND web_extract exists
+- default behaviour (flag off) leaves the description untouched
+- the directive is never duplicated on repeated computation
+"""
+from __future__ import annotations
+
+import pytest
+
+import model_tools
+
+
+_BROWSER_DESC = (
+    "Navigate to a URL in the browser. For simple information retrieval, "
+    "prefer web_search or web_extract (faster, cheaper)."
+)
+
+
+def _fake_definitions():
+    """Minimal browser_navigate + web_extract schemas for the rewrite path."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "browser_navigate",
+                "description": _BROWSER_DESC,
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "web_extract",
+                "description": "Extract content from a URL.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+    ]
+
+
+def _compute(monkeypatch, prefer: bool):
+    """Run the uncached computation with a controlled registry + flag."""
+    monkeypatch.setattr(
+        model_tools.registry,
+        "get_definitions",
+        lambda *a, **k: _fake_definitions(),
+    )
+    monkeypatch.setattr(
+        model_tools, "_prefer_fetch_over_browser", lambda: prefer
+    )
+    defs = model_tools._compute_tool_definitions(
+        enabled_toolsets=["web", "browser"],
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+    )
+    by_name = {d["function"]["name"]: d for d in defs}
+    return by_name["browser_navigate"]["function"]["description"]
+
+
+class TestPreferFetchHelper:
+    def test_env_truthy_overrides_config(self, monkeypatch):
+        monkeypatch.setenv("HERMES_PREFER_FETCH_OVER_BROWSER", "1")
+        assert model_tools._prefer_fetch_over_browser() is True
+        monkeypatch.setenv("HERMES_PREFER_FETCH_OVER_BROWSER", "true")
+        assert model_tools._prefer_fetch_over_browser() is True
+
+    def test_env_falsy_overrides_config(self, monkeypatch):
+        # Even if config said true, an explicit env "0" wins.
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"web": {"prefer_fetch_over_browser": True}},
+        )
+        monkeypatch.setenv("HERMES_PREFER_FETCH_OVER_BROWSER", "0")
+        assert model_tools._prefer_fetch_over_browser() is False
+
+    def test_config_true_when_no_env(self, monkeypatch):
+        monkeypatch.delenv("HERMES_PREFER_FETCH_OVER_BROWSER", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"web": {"prefer_fetch_over_browser": True}},
+        )
+        assert model_tools._prefer_fetch_over_browser() is True
+
+    def test_default_false(self, monkeypatch):
+        monkeypatch.delenv("HERMES_PREFER_FETCH_OVER_BROWSER", raising=False)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+        assert model_tools._prefer_fetch_over_browser() is False
+
+    def test_config_load_failure_is_false(self, monkeypatch):
+        monkeypatch.delenv("HERMES_PREFER_FETCH_OVER_BROWSER", raising=False)
+
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr("hermes_cli.config.load_config", _boom)
+        assert model_tools._prefer_fetch_over_browser() is False
+
+
+class TestBrowserNavigateDescriptionRewrite:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        model_tools._tool_defs_cache.clear()
+        yield
+        model_tools._tool_defs_cache.clear()
+
+    def test_directive_appended_when_enabled(self, monkeypatch):
+        desc = _compute(monkeypatch, prefer=True)
+        assert "prefer web_extract" in desc  # directive text
+        assert "configured to prefer web_extract" in desc
+        # Original advisory text is retained alongside the directive.
+        assert "faster, cheaper" in desc
+
+    def test_directive_absent_when_disabled(self, monkeypatch):
+        desc = _compute(monkeypatch, prefer=False)
+        assert "configured to prefer web_extract" not in desc
+        # Untouched advisory description.
+        assert desc == _BROWSER_DESC
+
+    def test_directive_not_duplicated(self, monkeypatch):
+        # Computing twice must not stack the directive twice.
+        monkeypatch.setattr(
+            model_tools.registry,
+            "get_definitions",
+            lambda *a, **k: _fake_definitions(),
+        )
+        monkeypatch.setattr(
+            model_tools, "_prefer_fetch_over_browser", lambda: True
+        )
+        defs1 = model_tools._compute_tool_definitions(
+            enabled_toolsets=["web", "browser"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        # Feed the (already-rewritten) output back in as the registry result.
+        rewritten = [dict(d) for d in defs1]
+        monkeypatch.setattr(
+            model_tools.registry, "get_definitions", lambda *a, **k: rewritten
+        )
+        defs2 = model_tools._compute_tool_definitions(
+            enabled_toolsets=["web", "browser"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        desc = {d["function"]["name"]: d for d in defs2}[
+            "browser_navigate"
+        ]["function"]["description"]
+        assert desc.count("configured to prefer web_extract") == 1

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -438,3 +438,24 @@ This adds a skill that teaches the agent how to:
 - Filter by category (`general`, `news`, `science`, etc.)
 - Handle pagination and error cases
 - Fall back gracefully when SearXNG is unreachable
+
+
+## Prefer `web_extract` over the browser for simple fetches
+
+When both `browser_navigate` and `web_extract` are available, the model chooses
+which to use. For plain content retrieval it often spins up the browser even
+though `web_extract` is faster and cheaper.
+
+Opt in with:
+
+```yaml
+web:
+  prefer_fetch_over_browser: true   # default: false
+```
+
+Or for a single run: `HERMES_PREFER_FETCH_OVER_BROWSER=1`.
+
+When enabled, Hermes rewrites the `browser_navigate` tool description into a
+directive: use `web_extract` for non-interactive URL fetches, and reserve the
+browser for login, clicks, forms, and JS-rendered/scroll-dependent content.
+Browser tools stay registered — only the routing guidance changes.

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -487,3 +487,24 @@ This adds a skill that teaches the agent how to:
 - Filter by category (`general`, `news`, `science`, etc.)
 - Handle pagination and error cases
 - Fall back gracefully when SearXNG is unreachable
+
+
+## Prefer `web_extract` over the browser for simple fetches
+
+When both `browser_navigate` and `web_extract` are available, the model chooses
+which to use. For plain content retrieval it often spins up the browser even
+though `web_extract` is faster and cheaper.
+
+Opt in with:
+
+```yaml
+web:
+  prefer_fetch_over_browser: true   # default: false
+```
+
+Or for a single run: `HERMES_PREFER_FETCH_OVER_BROWSER=1`.
+
+When enabled, Hermes rewrites the `browser_navigate` tool description into a
+directive: use `web_extract` for non-interactive URL fetches, and reserve the
+browser for login, clicks, forms, and JS-rendered/scroll-dependent content.
+Browser tools stay registered — only the routing guidance changes.


### PR DESCRIPTION
## Summary

- Adds a `web.prefer_fetch_over_browser` config toggle (default `false`).
- When enabled and `web_extract` is available, the `browser_navigate` tool description is rewritten from an *advisory* hint into a *directive* so the model routes non-interactive URL fetches to the cheaper/faster `web_extract` path instead of spinning up a browser.

## Motivation

Closes #34545.

When both `browser_navigate` and `web_extract` are present, the model decides which to use. For plain content retrieval (docs, APIs, raw files) it frequently picks the browser even though `web_extract` is faster and cheaper — headless browser startup/session latency plus full accessibility-tree snapshots vs. compressed markdown. `browser_navigate`'s description already says to *prefer* the web tools, but that text is only advisory and the model ignores it when both tools are available.

This implements **Option A** from the issue (web-side flag):

```yaml
web:
  prefer_fetch_over_browser: true   # default: false
```

When enabled, Hermes appends a directive to the existing `browser_navigate` description: use `web_extract` for non-interactive content retrieval, and reserve `browser_navigate` for tasks the fetch tools can't do — login, clicks, form fill/submit, JS-rendered or scroll-dependent content. **Browser tools stay registered and available** — only the routing guidance changes (no tool is removed). The env var `HERMES_PREFER_FETCH_OVER_BROWSER=1` overrides config for a single run, matching the tool layer's existing override convention.

The augmentation hooks into the same `_compute_tool_definitions` block that already strips the web cross-reference from `browser_navigate` when web tools are absent — so the description is only touched when `web_extract` is actually available (when it isn't, the toggle is a no-op since the browser is the only fetch path). The env override is added to the `quiet_mode` memoization cache key so the rewrite isn't cached across runs with different settings.

## Verification

- `python3 -m pytest tests/test_prefer_fetch_over_browser.py` — 8 passed
  - helper reads config + honours env override (truthy/falsy/default/load-failure)
  - directive appended only when flag on AND `web_extract` available
  - flag off leaves description byte-for-byte unchanged
  - directive never duplicated across repeated computation
- `python3 -m pytest tests/test_model_tools.py tests/test_get_tool_definitions_cache_isolation.py` — 29 passed (no regressions)
- Docs: new "Prefer `web_extract` over the browser for simple fetches" section in `website/docs/user-guide/features/web-search.md`.
- Did NOT change: the existing web-tools-absent stripping behavior, or browser tool registration/availability.
