### PR TITLE
feat: add delivery_retry for cron jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -565,6 +565,7 @@ def create_job(
     workdir: Optional[str] = None,
     profile: Optional[str] = None,
     no_agent: bool = False,
+    delivery_retry: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -614,6 +615,13 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        delivery_retry: Optional dict with ``max_attempts`` (1-10, default 3)
+                and ``delay_seconds`` (>=5, default 300). When set, the
+                scheduler retries delivery on transient failures (rate
+                limits, timeouts, connection errors). Non-retryable errors
+                (invalid credentials, misconfigured platforms) fail
+                immediately. Without this field, delivery is one-shot
+                (backward-compatible).
 
     Returns:
         The created job dict
@@ -649,6 +657,17 @@ def create_job(
     normalized_workdir = _normalize_workdir(workdir)
     normalized_profile = _normalize_profile(profile)
     normalized_no_agent = bool(no_agent)
+
+    # Normalize delivery_retry: accept None, dict, or falsy values.
+    # Valid keys: max_attempts (1-10), delay_seconds (>=5).
+    normalized_delivery_retry: Optional[Dict[str, Any]] = None
+    if isinstance(delivery_retry, dict) and delivery_retry:
+        max_a = delivery_retry.get("max_attempts", 3)
+        delay_s = delivery_retry.get("delay_seconds", 300)
+        normalized_delivery_retry = {
+            "max_attempts": min(max(int(max_a), 1), 10),
+            "delay_seconds": max(int(delay_s), 5),
+        }
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -703,6 +722,7 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
         "profile": normalized_profile,
+        "delivery_retry": normalized_delivery_retry,
     }
 
     jobs = load_jobs()
@@ -800,6 +820,17 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 updates["profile"] = None
             else:
                 updates["profile"] = _normalize_profile(_profile)
+
+        # Validate / normalize delivery_retry if present in updates.
+        if "delivery_retry" in updates:
+            _dr = updates["delivery_retry"]
+            if _dr in {None, False} or (_dr == {}):
+                updates["delivery_retry"] = None
+            elif isinstance(_dr, dict):
+                updates["delivery_retry"] = {
+                    "max_attempts": min(max(int(_dr.get("max_attempts", 3)), 1), 10),
+                    "delay_seconds": max(int(_dr.get("delay_seconds", 300)), 5),
+                }
 
         updated = _apply_skill_fields({**job, **updates})
         schedule_changed = "schedule" in updates

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -19,6 +19,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 from contextlib import contextmanager
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
@@ -914,6 +915,94 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     if delivery_errors:
         return "; ".join(delivery_errors)
     return None
+
+
+# ── Delivery retry helpers ──────────────────────────────────────────────
+
+# Error substrings that indicate a transient failure worth retrying.
+# Permanent errors (invalid credentials, blocked, misconfigured) are NOT
+# listed — retrying those just wastes time.
+_RETRYABLE_ERRORS = [
+    "rate limit", "rate limited", "too many requests",
+    "timeout", "timed out",
+    "connection", "refused", "reset", "unreachable",
+    "dns", "name resolution",
+    "temporary", "try again", "retry",
+    "broken pipe",
+]
+
+
+def _is_retryable(error: str) -> bool:
+    """Return True if *error* looks like a transient delivery failure."""
+    if not error:
+        return False
+    error_lower = error.lower()
+    return any(pattern in error_lower for pattern in _RETRYABLE_ERRORS)
+
+
+def _deliver_with_retry(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+    """Deliver job output, retrying on transient failures when the job
+    has a ``delivery_retry`` config.
+
+    Without ``delivery_retry`` the behaviour is identical to the old
+    one-shot ``_deliver_result`` call — fully backward-compatible.
+
+    Returns ``None`` on success, or the last error string on failure.
+    """
+    retry_config = job.get("delivery_retry")
+    if not isinstance(retry_config, dict) or not retry_config:
+        # No retry configured — one-shot (backward compatible path)
+        try:
+            return _deliver_result(job, content, adapters=adapters, loop=loop)
+        except Exception as exc:
+            logger.error("Delivery failed for job %s: %s", job["id"], exc)
+            return str(exc)
+
+    max_attempts = min(max(int(retry_config.get("max_attempts", 3)), 1), 10)
+    delay = max(int(retry_config.get("delay_seconds", 300)), 5)
+
+    last_error: Optional[str] = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            error = _deliver_result(job, content, adapters=adapters, loop=loop)
+        except Exception as exc:
+            error = str(exc)
+            logger.error("Delivery exception for job %s (attempt %d/%d): %s",
+                         job["id"], attempt, max_attempts, exc)
+
+        if not error:
+            if attempt > 1:
+                logger.info("Job '%s': delivery succeeded on attempt %d/%d",
+                            job["id"], attempt, max_attempts)
+            return None
+
+        last_error = error
+
+        if not _is_retryable(error):
+            logger.warning("Job '%s': delivery failed with non-retryable error "
+                           "(attempt %d/%d): %s",
+                           job["id"], attempt, max_attempts, _truncate_err(error))
+            return error
+
+        if attempt < max_attempts:
+            logger.warning(
+                "Job '%s': delivery failed (retryable), "
+                "retrying in %ds (attempt %d/%d): %s",
+                job["id"], delay, attempt, max_attempts, _truncate_err(error),
+            )
+            time.sleep(delay)
+        else:
+            logger.error("Job '%s': delivery failed after %d attempts: %s",
+                         job["id"], max_attempts, _truncate_err(error))
+
+    return last_error
+
+
+def _truncate_err(error: str, max_len: int = 200) -> str:
+    """Truncate error for log lines."""
+    if len(error) <= max_len:
+        return error
+    return error[:max_len] + "…"
 
 
 _DEFAULT_SCRIPT_TIMEOUT = 120  # seconds
@@ -2113,11 +2202,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
 
                 delivery_error = None
                 if should_deliver:
-                    try:
-                        delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
-                    except Exception as de:
-                        delivery_error = str(de)
-                        logger.error("Delivery failed for job %s: %s", job["id"], de)
+                    delivery_error = _deliver_with_retry(job, deliver_content, adapters=adapters, loop=loop)
 
                 # Treat empty final_response as a soft failure so last_status
                 # is not "ok" — the agent ran but produced nothing useful.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1488,6 +1488,7 @@ AUTHOR_MAP = {
     "leonard@sellem.me": "leonardsellem",  # PR #37405 (desktop WS origin guard on remote/Tailscale binds)
     "42903577+ohMyJason@users.noreply.github.com": "ohMyJason",  # PR #29810 (discover_models in custom_providers section 4)
     "singhsanidhya741@gmail.com": "sanidhyasin",  # PR #40403 salvage (model.default_headers for custom OpenAI-compatible providers, #40033)
+    "mos077014@gmail.com": "MottledShadow",  # PR #34553 (cron delivery_retry)
 }
 
 

--- a/tests/cron/test_delivery_retry.py
+++ b/tests/cron/test_delivery_retry.py
@@ -1,0 +1,204 @@
+"""Tests for delivery_retry — transient failure retry in cron job delivery."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cron.scheduler import _is_retryable, _deliver_with_retry, _truncate_err
+
+
+# =========================================================================
+# _is_retryable
+# =========================================================================
+
+class TestIsRetryable:
+    @pytest.mark.parametrize("error", [
+        "rate limited",
+        "rate limit exceeded",
+        "429 Too Many Requests — rate limited",
+        "timeout",
+        "connection timed out",
+        "connection refused",
+        "connection reset by peer",
+        "host unreachable",
+        "dns resolution failed",
+        "temporary failure",
+        "please try again later",
+        "broken pipe",
+    ])
+    def test_retryable_errors(self, error):
+        assert _is_retryable(error), f"should be retryable: {error!r}"
+
+    @pytest.mark.parametrize("error", [
+        "invalid credentials",
+        "authentication failed",
+        "blocked",
+        "platform not configured",
+        "bad request",
+        "forbidden",
+        "not found",
+        "",
+    ])
+    def test_non_retryable_errors(self, error):
+        assert not _is_retryable(error), f"should NOT be retryable: {error!r}"
+
+    def test_none_or_empty_handled(self):
+        assert not _is_retryable("")  # type: ignore[arg-type]
+        # None should be handled gracefully too
+        assert not _is_retryable(None if False else "")  # pass empty string
+
+    def test_case_insensitive(self):
+        assert _is_retryable("Rate Limited")
+        assert _is_retryable("TIMEOUT")
+        assert _is_retryable("Connection Refused")
+
+
+# =========================================================================
+# _truncate_err
+# =========================================================================
+
+class TestTruncateErr:
+    def test_short_error_passes_through(self):
+        assert _truncate_err("short") == "short"
+        assert _truncate_err("") == ""
+
+    def test_long_error_truncated(self):
+        long_err = "x" * 500
+        result = _truncate_err(long_err, max_len=200)
+        assert len(result) == 201  # 200 chars + "…"
+        assert result.endswith("…")
+
+    def test_default_max_len(self):
+        err = "x" * 300
+        result = _truncate_err(err)
+        assert len(result) == 201  # default 200 + "…"
+
+
+# =========================================================================
+# _deliver_with_retry
+# =========================================================================
+
+class TestDeliverWithRetry:
+    """Tests for the delivery retry wrapper."""
+
+    @staticmethod
+    def _make_job(delivery_retry=None):
+        return {
+            "id": "test-job-001",
+            "name": "test-job",
+            "delivery_retry": delivery_retry,
+        }
+
+    def test_no_retry_config_calls_once(self):
+        """Without delivery_retry, should call _deliver_result exactly once."""
+        job = self._make_job(delivery_retry=None)
+        with patch("cron.scheduler._deliver_result", return_value=None) as mock_deliver:
+            result = _deliver_with_retry(job, "test content")
+            assert result is None
+            mock_deliver.assert_called_once()
+
+    def test_no_retry_config_propagates_exception(self):
+        """Without delivery_retry, exception is caught and returned as string."""
+        job = self._make_job(delivery_retry=None)
+        with patch("cron.scheduler._deliver_result", side_effect=RuntimeError("boom")):
+            result = _deliver_with_retry(job, "test content")
+            assert "boom" in result
+
+    def test_retry_on_rate_limit_succeeds_second_attempt(self):
+        """Retryable error → retry → success on second attempt."""
+        job = self._make_job(delivery_retry={"max_attempts": 3, "delay_seconds": 0})
+
+        call_count = [0]
+
+        def flaky_deliver(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return "rate limited"
+            return None  # success
+
+        with patch("cron.scheduler._deliver_result", side_effect=flaky_deliver):
+            result = _deliver_with_retry(job, "test content")
+            assert result is None
+            assert call_count[0] == 2  # first attempt failed, second succeeded
+
+    def test_non_retryable_error_stops_immediately(self):
+        """Non-retryable error → fail immediately, no retry."""
+        job = self._make_job(delivery_retry={"max_attempts": 3, "delay_seconds": 0})
+
+        with patch("cron.scheduler._deliver_result", return_value="invalid credentials") as mock_deliver:
+            result = _deliver_with_retry(job, "test content")
+            assert "invalid credentials" in result
+            mock_deliver.assert_called_once()  # no retry
+
+    def test_all_attempts_exhausted(self):
+        """All attempts fail → return last error."""
+        job = self._make_job(delivery_retry={"max_attempts": 3, "delay_seconds": 0})
+
+        with patch("cron.scheduler._deliver_result", return_value="rate limited") as mock_deliver:
+            result = _deliver_with_retry(job, "test content")
+            assert "rate limited" in result
+            assert mock_deliver.call_count == 3
+
+    def test_success_on_first_attempt_no_retry(self):
+        """Success on first attempt → return immediately, no extra calls."""
+        job = self._make_job(delivery_retry={"max_attempts": 3, "delay_seconds": 0})
+
+        with patch("cron.scheduler._deliver_result", return_value=None) as mock_deliver:
+            result = _deliver_with_retry(job, "test content")
+            assert result is None
+            mock_deliver.assert_called_once()
+
+    def test_exception_treated_as_retryable(self):
+        """Exception in delivery is retried (treated as potentially transient)."""
+        job = self._make_job(delivery_retry={"max_attempts": 2, "delay_seconds": 0})
+
+        with patch("cron.scheduler._deliver_result", side_effect=OSError("connection reset")):
+            result = _deliver_with_retry(job, "test content")
+            assert "connection reset" in result
+
+    def test_empty_dict_disables_retry(self):
+        """Empty delivery_retry dict → treated as no config (backward compat)."""
+        job = self._make_job(delivery_retry={})
+
+        with patch("cron.scheduler._deliver_result", return_value="rate limited") as mock_deliver:
+            result = _deliver_with_retry(job, "test content")
+            assert "rate limited" in result
+            mock_deliver.assert_called_once()  # no retry
+
+    def test_retry_with_actual_sleep(self):
+        """Verify delay_seconds is respected between attempts."""
+        job = self._make_job(delivery_retry={"max_attempts": 2, "delay_seconds": 0})
+
+        call_count = [0]
+
+        def flaky(*args, **kwargs):
+            call_count[0] += 1
+            return "rate limited"
+
+        with patch("cron.scheduler._deliver_result", side_effect=flaky):
+            with patch("time.sleep") as mock_sleep:
+                _deliver_with_retry(job, "test content")
+                # delay_seconds=0 → should still call sleep(0) once
+                mock_sleep.assert_called()
+
+    def test_clamped_max_attempts(self):
+        """Values outside 1-10 range should be clamped by create_job, but
+        _deliver_with_retry also clamps for safety."""
+        # max_attempts=0 should be clamped to 1 by _deliver_with_retry
+        job = self._make_job(delivery_retry={"max_attempts": 0, "delay_seconds": 0})
+
+        with patch("cron.scheduler._deliver_result", return_value="rate limited") as mock_deliver:
+            _deliver_with_retry(job, "test content")
+            assert mock_deliver.call_count == 1  # clamped: max(0, 1) = 1 attempt
+
+    def test_retry_mixed_errors(self):
+        """First error is retryable, second is not → stop after second."""
+        job = self._make_job(delivery_retry={"max_attempts": 3, "delay_seconds": 0})
+
+        errors = iter(["rate limited", "invalid credentials"])
+
+        with patch("cron.scheduler._deliver_result", side_effect=lambda *a, **kw: next(errors)) as mock_deliver:
+            result = _deliver_with_retry(job, "test content")
+            assert "invalid credentials" in result
+            assert mock_deliver.call_count == 2  # first retryable, second stopped

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -477,6 +477,7 @@ def cronjob(
     workdir: Optional[str] = None,
     profile: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    delivery_retry: Optional[Dict[str, Any]] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -544,6 +545,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 profile=_normalize_optional_job_value(profile),
                 no_agent=_no_agent,
+                delivery_retry=delivery_retry,
             )
             return json.dumps(
                 {
@@ -695,6 +697,9 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if delivery_retry is not None:
+                # Pass through — update_job() validates/normalizes
+                updates["delivery_retry"] = delivery_retry
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -812,6 +817,30 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                     "WHEN TO USE False (default): anything that needs reasoning — summarize a feed, draft a daily briefing, pick interesting items, rephrase data for a human, follow conditional logic based on content."
                 ),
             },
+            "delivery_retry": {
+                "type": "object",
+                "description": (
+                    "Optional retry config for job delivery. When set, the scheduler "
+                    "retries delivery on transient failures (rate limits, timeouts, "
+                    "connection errors). Non-retryable errors (invalid credentials, "
+                    "misconfigured platforms) fail immediately. Without this field, "
+                    "delivery is one-shot (backward-compatible). On update, pass an "
+                    "empty object ``{}`` to clear.\n\n"
+                    "Keys:\n"
+                    "- ``max_attempts`` (int, 1-10, default 3): total delivery attempts.\n"
+                    "- ``delay_seconds`` (int, >=5, default 300): seconds between retries."
+                ),
+                "properties": {
+                    "max_attempts": {
+                        "type": "integer", "minimum": 1, "maximum": 10,
+                        "default": 3,
+                    },
+                    "delay_seconds": {
+                        "type": "integer", "minimum": 5,
+                        "default": 300,
+                    },
+                },
+            },
             "context_from": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -894,6 +923,7 @@ registry.register(
         workdir=args.get("workdir"),
         profile=args.get("profile"),
         no_agent=args.get("no_agent"),
+        delivery_retry=args.get("delivery_retry"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
Add configurable delivery retry for cron job output. When a job has
a `delivery_retry` config, the scheduler retries delivery on transient
failures (rate limits, timeouts, connection errors) with configurable
`max_attempts` (1-10, default 3) and `delay_seconds` (>=5, default 300).

Non-retryable errors (invalid credentials, misconfigured platforms)
fail immediately. Without `delivery_retry`, behavior is unchanged —
fully backward-compatible.

## Changes

- `cron/scheduler.py`: `_deliver_with_retry()`, `_is_retryable()`, `_truncate_err()` — replaces one-shot delivery with configurable retry loop
- `cron/jobs.py`: `create_job()` and `update_job()` accept `delivery_retry` dict with `max_attempts` and `delay_seconds`
- `tools/cronjob_tools.py`: expose `delivery_retry` in the cronjob tool schema so agents can configure it
- `tests/cron/test_delivery_retry.py`: 36 tests covering retry logic, error classification, clamping, and backward compatibility

## Usage

```json
"delivery_retry": {
    "max_attempts": 3,
    "delay_seconds": 300
}
```