### PR TITLE
fix(agent): fall through to aggregator when a provider's vision model isn't entitled

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2919,6 +2919,32 @@ def _nous_portal_account_has_fresh_paid_access() -> bool:
         return False
 
 
+def _is_zai_model_not_entitled(exc: Exception, provider: Optional[str]) -> bool:
+    """True for Z.AI's "model not in your plan" error (HTTP 429, code 1311).
+
+    GLM Coding/Lite plans reject models outside the plan (e.g. the
+    glm-5v-turbo vision model) with code 1311 ("当前订阅套餐暂未开放 <model> 权限").
+    This is NOT auth (key rejected) or payment (credit exhaustion): the
+    provider is healthy for its other models — glm-5.1 chat works — so callers
+    MUST NOT mark it unhealthy; they re-resolve onto a vision-capable
+    aggregator for this one request.
+
+    Scoped to provider ``zai`` and matched on the structured error code
+    (``exc.code`` / parsed ``exc.body``, as :func:`_summarize_api_error` reads
+    the message) rather than the localized message text — so it can't misfire
+    on an auth/quota error or on another vendor that happens to reuse 1311.
+    """
+    if (provider or "").strip().lower() != "zai":
+        return False
+    code = getattr(exc, "code", None)
+    if code is None:
+        body = getattr(exc, "body", None)
+        if isinstance(body, dict):
+            err = body.get("error")
+            code = err.get("code") if isinstance(err, dict) else body.get("code")
+    return str(code) == "1311"
+
+
 def _is_rate_limit_error(exc: Exception) -> bool:
     """Detect rate-limit errors that warrant provider fallback.
 
@@ -5322,6 +5348,7 @@ def resolve_vision_provider_client(
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
     async_mode: bool = False,
+    exclude_providers: Optional[frozenset] = None,
 ) -> Tuple[Optional[str], Optional[Any], Optional[str]]:
     """Resolve the client actually used for vision tasks.
 
@@ -5329,7 +5356,13 @@ def resolve_vision_provider_client(
     provider overrides still use the generic provider router for non-standard
     backends, so users can intentionally force experimental providers. Auto mode
     stays conservative and only tries vision backends known to work today.
+
+    ``exclude_providers`` lets a caller re-resolve vision while skipping a
+    provider whose vision model just failed (e.g. a Z.AI Coding plan that is
+    not licensed for ``glm-5v-turbo``), so auto-detect lands on the next
+    vision-capable aggregator instead of the broken main provider.
     """
+    exclude_providers = exclude_providers or frozenset()
     requested, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         "vision", provider, model, base_url, api_key
     )
@@ -5380,7 +5413,11 @@ def resolve_vision_provider_client(
         #   5. Stop
         main_provider = _read_main_provider()
         main_model = _read_main_model()
-        if main_provider and main_provider not in {"auto", ""}:
+        if (
+            main_provider
+            and main_provider not in {"auto", ""}
+            and main_provider not in exclude_providers
+        ):
             # A provider-specific vision default wins over the user's chat model:
             # static overrides (xiaomi/zai) and catalog-backed discovery (the
             # DeepInfra profile hook) both yield a *known* vision-capable model,
@@ -5473,6 +5510,8 @@ def resolve_vision_provider_client(
         for candidate in _VISION_AUTO_PROVIDER_ORDER:
             if candidate == main_provider:
                 continue  # already tried above
+            if candidate in exclude_providers:
+                continue  # caller asked to skip this provider (vision model failed)
             sync_client, default_model = _resolve_strict_vision_backend(candidate)
             if sync_client is not None:
                 return _finalize(candidate, sync_client, default_model)
@@ -6357,6 +6396,42 @@ def _build_call_kwargs(
     return kwargs
 
 
+def _resolve_zai_vision_entitlement_fallback(
+    *,
+    messages: list,
+    temperature: Optional[float],
+    max_tokens: Optional[int],
+    tools: Optional[list],
+    timeout: float,
+    extra_body: Optional[dict],
+    async_mode: bool,
+) -> Tuple[Optional[Any], Optional[dict]]:
+    """Build an aggregator request without retrying the unentitled Z.AI model."""
+    _, client, model = resolve_vision_provider_client(
+        provider="auto",
+        async_mode=async_mode,
+        exclude_providers=frozenset({"zai"}),
+    )
+    if client is None:
+        return None, None
+
+    base_url = str(getattr(client, "base_url", "") or "")
+    kwargs = _build_call_kwargs(
+        "auto",
+        model,
+        messages,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        tools=tools,
+        timeout=timeout,
+        extra_body=extra_body,
+        base_url=base_url,
+    )
+    if _is_anthropic_compat_endpoint("auto", base_url):
+        kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
+    return client, kwargs
+
+
 def _validate_llm_response(response: Any, task: str = None) -> Any:
     """Validate that an LLM response has the expected .choices[0].message shape.
 
@@ -6672,6 +6747,29 @@ def call_llm(
             # Retries exhausted — fall through to first_err fallback handling.
             raise _last_transient
     except Exception as first_err:
+        # Z.AI uses 429/code 1311 when the account can use the provider but is
+        # not entitled to its dedicated vision model. Retrying or rotating a
+        # credential cannot change that model-level entitlement, so reroute
+        # before the generic 429 recovery path can penalize the healthy pool.
+        if task == "vision" and _is_zai_model_not_entitled(first_err, resolved_provider):
+            fallback_client, fallback_kwargs = _resolve_zai_vision_entitlement_fallback(
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                tools=tools,
+                timeout=effective_timeout,
+                extra_body=effective_extra_body,
+                async_mode=False,
+            )
+            if fallback_client is None or fallback_kwargs is None:
+                raise
+            logger.info(
+                "Auxiliary vision: Z.AI model unavailable on plan; trying vision aggregator"
+            )
+            return _validate_llm_response(
+                fallback_client.chat.completions.create(**fallback_kwargs), task
+            )
+
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
             retry_kwargs = dict(kwargs)
             retry_kwargs.pop("temperature", None)
@@ -7227,6 +7325,29 @@ async def async_call_llm(
             return _validate_llm_response(
                 await client.chat.completions.create(**kwargs), task)
     except Exception as first_err:
+        # Keep model-level entitlement failures out of generic 429 pool
+        # recovery. A different credential on the same Z.AI plan cannot make
+        # glm-5v-turbo available, but a configured vision aggregator can.
+        if task == "vision" and _is_zai_model_not_entitled(first_err, resolved_provider):
+            fallback_client, fallback_kwargs = _resolve_zai_vision_entitlement_fallback(
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                tools=tools,
+                timeout=effective_timeout,
+                extra_body=effective_extra_body,
+                async_mode=True,
+            )
+            if fallback_client is None or fallback_kwargs is None:
+                raise
+            logger.info(
+                "Auxiliary vision (async): Z.AI model unavailable on plan; "
+                "trying vision aggregator"
+            )
+            return _validate_llm_response(
+                await fallback_client.chat.completions.create(**fallback_kwargs), task
+            )
+
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
             retry_kwargs = dict(kwargs)
             retry_kwargs.pop("temperature", None)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2929,13 +2929,39 @@ def _is_zai_model_not_entitled(exc: Exception, provider: Optional[str]) -> bool:
     MUST NOT mark it unhealthy; they re-resolve onto a vision-capable
     aggregator for this one request.
 
-    Scoped to provider ``zai`` and matched on the structured error code
-    (``exc.code`` / parsed ``exc.body``, as :func:`_summarize_api_error` reads
-    the message) rather than the localized message text — so it can't misfire
-    on an auth/quota error or on another vendor that happens to reuse 1311.
+    Scoped to provider ``zai`` (after :func:`_normalize_aux_provider`, so the
+    documented aliases — ``glm``, ``z-ai``, ``z.ai``, ``zhipu`` — and a
+    ``main`` route that resolves to Z.AI all match) and matched on the
+    structured error code (``exc.code`` / parsed ``exc.body``, as
+    :func:`_summarize_api_error` reads the message) rather than the localized
+    message text — so it can't misfire on an auth/quota error or on another
+    vendor that happens to reuse 1311.
+
+    User-defined endpoints are never classified as Z.AI, whatever their label
+    normalizes to: ``custom`` / ``custom:<name>`` routes, and an alias label
+    shadowed by a ``custom_providers`` entry of the same name (an entry
+    literally named ``glm`` is the user's own gateway, not Z.AI). An explicit
+    endpoint pin is a user choice callers must never reroute away from —
+    the reroute decision additionally refuses any route with a configured
+    ``base_url`` (see :func:`_zai_vision_reroute_exclusions`).
     """
-    if (provider or "").strip().lower() != "zai":
+    label = (provider or "").strip().lower()
+    if label.startswith("custom"):
         return False
+    if _normalize_aux_provider(label) != "zai":
+        return False
+    if label != "zai":
+        # Alias label — make sure a user-defined custom_providers entry of
+        # the same name isn't the actual route (entries matching a canonical
+        # provider name defer to the built-in, so "zai" itself can't shadow).
+        try:
+            from hermes_cli.runtime_provider import _get_named_custom_provider
+            if _get_named_custom_provider(label) is not None:
+                return False
+        except Exception:
+            logger.debug(
+                "custom_providers shadow check failed for %s", label, exc_info=True
+            )
     code = getattr(exc, "code", None)
     if code is None:
         body = getattr(exc, "body", None)
@@ -2943,6 +2969,50 @@ def _is_zai_model_not_entitled(exc: Exception, provider: Optional[str]) -> bool:
             err = body.get("error")
             code = err.get("code") if isinstance(err, dict) else body.get("code")
     return str(code) == "1311"
+
+
+def _zai_vision_reroute_exclusions(
+    task: Optional[str],
+    exc: Exception,
+    resolved_provider: Optional[str],
+    exclude_vision_providers: Optional[frozenset],
+    *,
+    resolved_base_url: Optional[str] = None,
+    async_mode: bool,
+) -> Optional[frozenset]:
+    """Decide whether a failed vision call should re-enter with zai excluded.
+
+    Returns the exclusion set for the re-entry, or ``None`` to fall through to
+    the standard except-chain handling (pool guard, configured fallback_chain,
+    final re-raise of the original error). Shared by call_llm/async_call_llm so
+    the sync and async 1311 branches cannot drift.
+
+    A route with a configured ``base_url`` never reroutes, even when the
+    provider label is ``zai``: pinning an endpoint (data residency, a private
+    gateway) is a user choice an image payload must not be routed away from.
+
+    Caller exclusions are preserved (unioned with zai); if zai is already
+    excluded this returns ``None`` — that is the re-entry's own failure, which
+    must not re-fire the reroute (recursion guard).
+    """
+    if task != "vision" or resolved_base_url:
+        return None
+    if not _is_zai_model_not_entitled(exc, resolved_provider):
+        return None
+    prior = frozenset(exclude_vision_providers or ())
+    exclusions = prior | frozenset({"zai"})
+    if exclusions == prior:
+        return None
+    # Probe availability so the reroute only fires when a strict vision
+    # aggregator actually exists; otherwise the caller falls through to the
+    # generic chain (which consults the user's configured fallback_chain and
+    # ultimately re-raises the original 1311 — the actionable error). The
+    # probe duplicates the re-entered call's resolution: one extra resolve on
+    # an already-failed turn, in exchange for not masking that 1311.
+    _, probe, _ = resolve_vision_provider_client(
+        provider="auto", async_mode=async_mode, exclude_providers=exclusions
+    )
+    return exclusions if probe is not None else None
 
 
 def _is_rate_limit_error(exc: Exception) -> bool:
@@ -5360,7 +5430,11 @@ def resolve_vision_provider_client(
     ``exclude_providers`` lets a caller re-resolve vision while skipping a
     provider whose vision model just failed (e.g. a Z.AI Coding plan that is
     not licensed for ``glm-5v-turbo``), so auto-detect lands on the next
-    vision-capable aggregator instead of the broken main provider.
+    vision-capable aggregator instead of the broken main provider. Under
+    exclusion, a config-pinned ``auxiliary.vision.model`` is treated as
+    belonging to the failed route: every candidate resolves with its own
+    default model rather than the pin (which the surviving provider would
+    otherwise 404 on).
     """
     exclude_providers = exclude_providers or frozenset()
     requested, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
@@ -5371,7 +5445,15 @@ def resolve_vision_provider_client(
     def _finalize(resolved_provider: str, sync_client: Any, default_model: Optional[str]):
         if sync_client is None:
             return resolved_provider, None, None
-        final_model = resolved_model or default_model
+        # Under exclusion (a reroute away from a failed vision provider), a
+        # config-pinned model belongs to the failed route — sending it to a
+        # different provider that doesn't host it would 404. Every candidate
+        # (main-provider shortcut or aggregator chain) uses its own known-good
+        # default instead; the pin only applies when no provider is excluded.
+        if exclude_providers:
+            final_model = default_model or resolved_model
+        else:
+            final_model = resolved_model or default_model
         if async_mode:
             async_client, async_model = _to_async_client(sync_client, final_model, is_vision=True)
             return resolved_provider, async_client, async_model
@@ -5416,7 +5498,10 @@ def resolve_vision_provider_client(
         if (
             main_provider
             and main_provider not in {"auto", ""}
-            and main_provider not in exclude_providers
+            # Normalize before the membership test: exclude_providers holds
+            # canonical ids ("zai"), while main_provider may be a config alias
+            # ("glm", "z.ai", "zhipu") that resolves to the same backend.
+            and _normalize_aux_provider(main_provider) not in exclude_providers
         ):
             # A provider-specific vision default wins over the user's chat model:
             # static overrides (xiaomi/zai) and catalog-backed discovery (the
@@ -6396,42 +6481,6 @@ def _build_call_kwargs(
     return kwargs
 
 
-def _resolve_zai_vision_entitlement_fallback(
-    *,
-    messages: list,
-    temperature: Optional[float],
-    max_tokens: Optional[int],
-    tools: Optional[list],
-    timeout: float,
-    extra_body: Optional[dict],
-    async_mode: bool,
-) -> Tuple[Optional[Any], Optional[dict]]:
-    """Build an aggregator request without retrying the unentitled Z.AI model."""
-    _, client, model = resolve_vision_provider_client(
-        provider="auto",
-        async_mode=async_mode,
-        exclude_providers=frozenset({"zai"}),
-    )
-    if client is None:
-        return None, None
-
-    base_url = str(getattr(client, "base_url", "") or "")
-    kwargs = _build_call_kwargs(
-        "auto",
-        model,
-        messages,
-        temperature=temperature,
-        max_tokens=max_tokens,
-        tools=tools,
-        timeout=timeout,
-        extra_body=extra_body,
-        base_url=base_url,
-    )
-    if _is_anthropic_compat_endpoint("auto", base_url):
-        kwargs["messages"] = _convert_openai_images_to_anthropic(kwargs["messages"])
-    return client, kwargs
-
-
 def _validate_llm_response(response: Any, task: str = None) -> Any:
     """Validate that an LLM response has the expected .choices[0].message shape.
 
@@ -6541,6 +6590,7 @@ def call_llm(
     api_mode: str = None,
     stream: bool = False,
     stream_options: dict = None,
+    exclude_vision_providers: Optional[frozenset] = None,
 ) -> Any:
     """Centralized synchronous LLM call.
 
@@ -6567,6 +6617,12 @@ def call_llm(
             output can stream to the user.
         stream_options: Passed through to the request when stream is True
             (e.g. {"include_usage": True}).
+        exclude_vision_providers: Vision-task providers (canonical ids) to
+            skip during resolution. Set internally when re-routing after a
+            provider's vision model turned out to be unentitled (Z.AI 1311);
+            the reroute unions its own exclusion into whatever the caller
+            passed, and never re-fires for a provider already excluded (the
+            recursion guard).
 
     Returns:
         Response object with .choices[0].message.content, OR — when stream=True —
@@ -6589,6 +6645,7 @@ def call_llm(
             base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key,
             async_mode=False,
+            exclude_providers=exclude_vision_providers,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
             logger.warning(
@@ -6599,6 +6656,7 @@ def call_llm(
                 provider="auto",
                 model=resolved_model,
                 async_mode=False,
+                exclude_providers=exclude_vision_providers,
             )
         if client is None:
             raise RuntimeError(
@@ -6751,24 +6809,44 @@ def call_llm(
         # not entitled to its dedicated vision model. Retrying or rotating a
         # credential cannot change that model-level entitlement, so reroute
         # before the generic 429 recovery path can penalize the healthy pool.
-        if task == "vision" and _is_zai_model_not_entitled(first_err, resolved_provider):
-            fallback_client, fallback_kwargs = _resolve_zai_vision_entitlement_fallback(
-                messages=messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                tools=tools,
-                timeout=effective_timeout,
-                extra_body=effective_extra_body,
-                async_mode=False,
-            )
-            if fallback_client is None or fallback_kwargs is None:
-                raise
+        # Re-entering call_llm (instead of issuing a bare aggregator create())
+        # gives the rerouted attempt the same transient-retry, parameter-strip,
+        # and fallback machinery as any other vision call; the exclusion set
+        # makes the resolver skip zai and disarms the reroute (no recursion).
+        # When no aggregator exists the helper returns None and this falls
+        # through to the generic chain below — pool rotation is skipped by the
+        # entitlement guard, the user's configured fallback_chain still gets
+        # consulted, and the original 1311 is what ultimately re-raises.
+        _reroute_exclusions = _zai_vision_reroute_exclusions(
+            task, first_err, resolved_provider, exclude_vision_providers,
+            resolved_base_url=resolved_base_url,
+            async_mode=False,
+        )
+        if _reroute_exclusions is not None:
             logger.info(
-                "Auxiliary vision: Z.AI model unavailable on plan; trying vision aggregator"
+                "Auxiliary vision: Z.AI model unavailable on plan; "
+                "re-routing through vision aggregator chain"
             )
-            return _validate_llm_response(
-                fallback_client.chat.completions.create(**fallback_kwargs), task
-            )
+            try:
+                return call_llm(
+                    task="vision",
+                    provider="auto",
+                    main_runtime=main_runtime,
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    timeout=timeout,
+                    extra_body=extra_body,
+                    exclude_vision_providers=_reroute_exclusions,
+                )
+            except RuntimeError as reentry_err:
+                # The aggregator vanished between the probe and the re-entry
+                # (transient resolve failure, concurrent unhealthy-marking):
+                # surface the actionable 1311 — the plan lacks this model —
+                # instead of a generic "no provider configured" error. The
+                # re-entry failure stays visible as the exception's cause.
+                raise first_err from reentry_err
 
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
             retry_kwargs = dict(kwargs)
@@ -6949,7 +7027,19 @@ def call_llm(
         # between this call and recovery (which leaves current()=None and makes
         # _select_unlocked() return the NEXT key by mistake).
         _client_api_key = str(getattr(client, "api_key", "") or "")
-        if pool_provider and (_is_auth_error(first_err) or _is_payment_error(first_err) or _is_rate_limit_error(first_err)):
+        # A Z.AI 1311 is a model-entitlement error, not a credential problem:
+        # rotating the pool cannot help, and the pool is healthy for the plan's
+        # other models. Skip rotation (and the extra same-key retry) and let
+        # the capacity fallback below reroute instead. Keyed on pool_provider —
+        # the pool actually rotated — not the route label, so auto-routed and
+        # alias-configured Z.AI clients are covered too. Guards non-vision
+        # tasks pinned to an unentitled Z.AI model, plus the vision case where
+        # no aggregator existed and the reroute above fell through.
+        if (
+            pool_provider
+            and (_is_auth_error(first_err) or _is_payment_error(first_err) or _is_rate_limit_error(first_err))
+            and not _is_zai_model_not_entitled(first_err, pool_provider)
+        ):
             recovery_err = first_err
             # Skip the extra retry for clear payment/quota errors — the endpoint
             # won't accept another request with the same exhausted key.
@@ -7212,6 +7302,7 @@ async def async_call_llm(
     tools: list = None,
     timeout: float = None,
     extra_body: dict = None,
+    exclude_vision_providers: Optional[frozenset] = None,
 ) -> Any:
     """Centralized asynchronous LLM call.
 
@@ -7229,6 +7320,7 @@ async def async_call_llm(
             base_url=resolved_base_url or base_url,
             api_key=resolved_api_key or api_key,
             async_mode=True,
+            exclude_providers=exclude_vision_providers,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
             logger.warning(
@@ -7239,6 +7331,7 @@ async def async_call_llm(
                 provider="auto",
                 model=resolved_model,
                 async_mode=True,
+                exclude_providers=exclude_vision_providers,
             )
         if client is None:
             raise RuntimeError(
@@ -7328,25 +7421,35 @@ async def async_call_llm(
         # Keep model-level entitlement failures out of generic 429 pool
         # recovery. A different credential on the same Z.AI plan cannot make
         # glm-5v-turbo available, but a configured vision aggregator can.
-        if task == "vision" and _is_zai_model_not_entitled(first_err, resolved_provider):
-            fallback_client, fallback_kwargs = _resolve_zai_vision_entitlement_fallback(
-                messages=messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                tools=tools,
-                timeout=effective_timeout,
-                extra_body=effective_extra_body,
-                async_mode=True,
-            )
-            if fallback_client is None or fallback_kwargs is None:
-                raise
+        # See the sync twin in call_llm for the full rationale; the shared
+        # helper keeps the two branches from drifting.
+        _reroute_exclusions = _zai_vision_reroute_exclusions(
+            task, first_err, resolved_provider, exclude_vision_providers,
+            resolved_base_url=resolved_base_url,
+            async_mode=True,
+        )
+        if _reroute_exclusions is not None:
             logger.info(
                 "Auxiliary vision (async): Z.AI model unavailable on plan; "
-                "trying vision aggregator"
+                "re-routing through vision aggregator chain"
             )
-            return _validate_llm_response(
-                await fallback_client.chat.completions.create(**fallback_kwargs), task
-            )
+            try:
+                return await async_call_llm(
+                    task="vision",
+                    provider="auto",
+                    main_runtime=main_runtime,
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    timeout=timeout,
+                    extra_body=extra_body,
+                    exclude_vision_providers=_reroute_exclusions,
+                )
+            except RuntimeError as reentry_err:
+                # See the sync twin: probe/re-entry divergence must surface
+                # the actionable 1311, not a generic no-provider error.
+                raise first_err from reentry_err
 
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
             retry_kwargs = dict(kwargs)
@@ -7515,7 +7618,19 @@ async def async_call_llm(
         # ── Same-provider credential-pool recovery (mirrors sync) ─────
         pool_provider = _recoverable_pool_provider(resolved_provider, client, main_runtime=main_runtime)
         _client_api_key = str(getattr(client, "api_key", "") or "")
-        if pool_provider and (_is_auth_error(first_err) or _is_payment_error(first_err) or _is_rate_limit_error(first_err)):
+        # A Z.AI 1311 is a model-entitlement error, not a credential problem:
+        # rotating the pool cannot help, and the pool is healthy for the plan's
+        # other models. Skip rotation (and the extra same-key retry) and let
+        # the capacity fallback below reroute instead. Keyed on pool_provider —
+        # the pool actually rotated — not the route label, so auto-routed and
+        # alias-configured Z.AI clients are covered too. Guards non-vision
+        # tasks pinned to an unentitled Z.AI model, plus the vision case where
+        # no aggregator existed and the reroute above fell through.
+        if (
+            pool_provider
+            and (_is_auth_error(first_err) or _is_payment_error(first_err) or _is_rate_limit_error(first_err))
+            and not _is_zai_model_not_entitled(first_err, pool_provider)
+        ):
             recovery_err = first_err
             # Skip the extra retry for clear payment/quota errors — the endpoint
             # won't accept another request with the same exhausted key.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1943,6 +1943,42 @@ class TestIsZaiModelNotEntitled:
         exc = self._exc(code="1311")
         assert _is_zai_model_not_entitled(exc, "openai") is False
 
+    def test_zai_aliases_normalized(self):
+        """Config aliases for Z.AI ("glm", "z.ai", "zhipu") reach the same
+        backend and must match — the raw route label is not the identity."""
+        exc = self._exc(code="1311")
+        # Pin the shadow lookup so the assertions don't depend on the local
+        # config having (or not having) alias-named custom_providers entries.
+        with patch(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            return_value=None,
+        ):
+            for alias in ("glm", "z-ai", "z.ai", "zhipu", " ZAI "):
+                assert _is_zai_model_not_entitled(exc, alias) is True, alias
+        # base_url-configured Z.AI resolves to the "custom" label — an explicit
+        # endpoint pin the reroute deliberately does not match.
+        assert _is_zai_model_not_entitled(exc, "custom") is False
+        assert _is_zai_model_not_entitled(exc, None) is False
+
+    def test_named_custom_routes_never_match(self):
+        """User-defined endpoints must never be classified as Z.AI, even when
+        their name normalizes to it: "custom:glm" routes and custom_providers
+        entries shadowing an alias name are the user's own gateway."""
+        exc = self._exc(code="1311")
+        assert _is_zai_model_not_entitled(exc, "custom:glm") is False
+        # A custom_providers entry literally named "glm" shadows the alias.
+        with patch(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            return_value={"base_url": "https://proxy.internal/v1"},
+        ):
+            assert _is_zai_model_not_entitled(exc, "glm") is False
+        # No shadowing entry → the alias is the first-class Z.AI backend.
+        with patch(
+            "hermes_cli.runtime_provider._get_named_custom_provider",
+            return_value=None,
+        ):
+            assert _is_zai_model_not_entitled(exc, "glm") is True
+
     def test_other_zai_code_not_matched(self):
         """A different Z.AI code (e.g. 1305 overload) is not plan-entitlement."""
         exc = self._exc(code="1305")
@@ -1968,12 +2004,29 @@ class TestIsZaiModelNotEntitled:
 
 
 class TestZaiVisionEntitlementFallback:
+    """The 1311 reroute re-enters call_llm/async_call_llm with zai excluded.
+
+    Resolve sequence per reroute: [0] original vision resolve (lands on zai),
+    [1] the aggregator-availability probe, [2] the re-entered call's resolve.
+    Re-entry (rather than a bare aggregator create()) is what gives the
+    rerouted attempt the normal recovery machinery — covered explicitly by
+    test_sync_reroute_gets_parameter_strip_recovery.
+    """
+
     @staticmethod
     def _entitlement_error():
         exc = Exception("model unavailable on subscription")
         exc.status_code = 429
         exc.body = {"error": {"code": "1311"}}
         return exc
+
+    @staticmethod
+    def _vision_resolves(zai_client, aggregator_client, model):
+        return [
+            ("zai", zai_client, "glm-5v-turbo"),
+            ("openrouter", aggregator_client, model),  # probe
+            ("openrouter", aggregator_client, model),  # re-entered resolve
+        ]
 
     def test_sync_reroutes_before_pool_recovery(self):
         zai_client = MagicMock()
@@ -1993,10 +2046,9 @@ class TestZaiVisionEntitlementFallback:
             ),
             patch(
                 "agent.auxiliary_client.resolve_vision_provider_client",
-                side_effect=[
-                    ("zai", zai_client, "glm-5v-turbo"),
-                    ("openrouter", aggregator_client, "google/gemini-3-flash-preview"),
-                ],
+                side_effect=self._vision_resolves(
+                    zai_client, aggregator_client, "google/gemini-3-flash-preview"
+                ),
             ) as resolve_vision,
             patch("agent.auxiliary_client._recover_provider_pool") as recover_pool,
         ):
@@ -2008,11 +2060,16 @@ class TestZaiVisionEntitlementFallback:
         assert response.choices[0].message.content == "aggregator-sync"
         assert zai_client.chat.completions.create.call_count == 1
         recover_pool.assert_not_called()
+        # The probe resolves the aggregator chain with zai excluded...
         assert resolve_vision.call_args_list[1].kwargs == {
             "provider": "auto",
             "async_mode": False,
             "exclude_providers": frozenset({"zai"}),
         }
+        # ...and the re-entered call keeps the exclusion (no recursion).
+        reentry_kwargs = resolve_vision.call_args_list[2].kwargs
+        assert reentry_kwargs["provider"] == "auto"
+        assert reentry_kwargs["exclude_providers"] == frozenset({"zai"})
         assert aggregator_client.chat.completions.create.call_args.kwargs["model"] == (
             "google/gemini-3-flash-preview"
         )
@@ -2038,10 +2095,9 @@ class TestZaiVisionEntitlementFallback:
             ),
             patch(
                 "agent.auxiliary_client.resolve_vision_provider_client",
-                side_effect=[
-                    ("zai", zai_client, "glm-5v-turbo"),
-                    ("openrouter", aggregator_client, "google/gemini-3-flash-preview"),
-                ],
+                side_effect=self._vision_resolves(
+                    zai_client, aggregator_client, "google/gemini-3-flash-preview"
+                ),
             ) as resolve_vision,
             patch("agent.auxiliary_client._recover_provider_pool") as recover_pool,
         ):
@@ -2058,9 +2114,331 @@ class TestZaiVisionEntitlementFallback:
             "async_mode": True,
             "exclude_providers": frozenset({"zai"}),
         }
+        reentry_kwargs = resolve_vision.call_args_list[2].kwargs
+        assert reentry_kwargs["provider"] == "auto"
+        assert reentry_kwargs["exclude_providers"] == frozenset({"zai"})
         assert aggregator_client.chat.completions.create.call_args.kwargs["model"] == (
             "google/gemini-3-flash-preview"
         )
+
+    def test_sync_reroute_gets_parameter_strip_recovery(self):
+        """The rerouted attempt runs through call_llm's normal except chain:
+        an aggregator that rejects ``temperature`` gets the parameter-strip
+        retry instead of hard-failing the vision turn (the old bare-create()
+        reroute skipped all recovery machinery)."""
+        zai_client = MagicMock()
+        zai_client.base_url = "https://api.z.ai/api/paas/v4"
+        zai_client.chat.completions.create.side_effect = self._entitlement_error()
+
+        aggregator_client = MagicMock()
+        aggregator_client.base_url = OPENROUTER_BASE_URL
+        aggregator_client.chat.completions.create.side_effect = [
+            Exception("Unsupported parameter: 'temperature' is not supported"),
+            _DummyResponse("aggregator-recovered"),
+        ]
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("auto", None, None, None, None),
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_vision_provider_client",
+                side_effect=self._vision_resolves(
+                    zai_client, aggregator_client, "agg/vision-test"
+                ),
+            ),
+            patch("agent.auxiliary_client._recover_provider_pool") as recover_pool,
+        ):
+            response = call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "describe image"}],
+                temperature=0.2,
+            )
+
+        assert response.choices[0].message.content == "aggregator-recovered"
+        agg_calls = aggregator_client.chat.completions.create.call_args_list
+        assert len(agg_calls) == 2
+        assert agg_calls[0].kwargs["temperature"] == 0.2
+        assert "temperature" not in agg_calls[1].kwargs
+        recover_pool.assert_not_called()
+
+    def test_sync_no_aggregator_raises_original_1311(self):
+        """With no vision aggregator and no configured fallback, the original
+        1311 (the actionable error: the plan lacks this model) propagates —
+        via fall-through to the generic chain's final re-raise, without
+        rotating the pool along the way."""
+        err = self._entitlement_error()
+        zai_client = MagicMock()
+        zai_client.base_url = "https://api.z.ai/api/paas/v4"
+        zai_client.chat.completions.create.side_effect = err
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("auto", None, None, None, None),
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_vision_provider_client",
+                side_effect=[
+                    ("zai", zai_client, "glm-5v-turbo"),
+                    (None, None, None),  # probe: nothing but zai available
+                ],
+            ),
+            patch(
+                "agent.auxiliary_client._recoverable_pool_provider",
+                return_value="zai",
+            ),
+            patch("agent.auxiliary_client._recover_provider_pool") as recover_pool,
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(None, None, ""),
+            ),
+            patch(
+                "agent.auxiliary_client._try_main_agent_model_fallback",
+                return_value=(None, None, ""),
+            ),
+        ):
+            with pytest.raises(Exception) as excinfo:
+                call_llm(
+                    task="vision",
+                    messages=[{"role": "user", "content": "describe image"}],
+                )
+
+        assert excinfo.value is err
+        # The entitlement guard (keyed on the pool actually rotated) skips
+        # rotation and the extra same-key retry even though a pool exists.
+        recover_pool.assert_not_called()
+        assert zai_client.chat.completions.create.call_count == 1
+
+    def test_sync_no_aggregator_still_consults_configured_fallback_chain(self):
+        """A user whose only vision fallback is auxiliary.vision.fallback_chain
+        (no OpenRouter/Nous/DeepInfra key) must still be served: the probe
+        miss falls through to the generic capacity path, which consults the
+        configured chain — it must not bare-raise past it."""
+        err = self._entitlement_error()
+        zai_client = MagicMock()
+        zai_client.base_url = "https://api.z.ai/api/paas/v4"
+        zai_client.chat.completions.create.side_effect = err
+
+        fb_client = MagicMock()
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("auto", None, None, None, None),
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_vision_provider_client",
+                side_effect=[
+                    ("zai", zai_client, "glm-5v-turbo"),
+                    (None, None, None),  # probe: no strict aggregator
+                ],
+            ),
+            patch(
+                "agent.auxiliary_client._recoverable_pool_provider",
+                return_value="zai",
+            ),
+            patch("agent.auxiliary_client._recover_provider_pool") as recover_pool,
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(fb_client, "custom-vision-model", "custom-fb"),
+            ) as configured_chain,
+            patch(
+                "agent.auxiliary_client._call_fallback_candidate_sync",
+                return_value=_DummyResponse("fallback-chain-serves"),
+            ),
+        ):
+            response = call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "describe image"}],
+            )
+
+        assert response.choices[0].message.content == "fallback-chain-serves"
+        configured_chain.assert_called_once()
+        recover_pool.assert_not_called()
+
+    def test_sync_base_url_pin_never_reroutes(self):
+        """provider: zai + an explicit base_url is an endpoint pin (data
+        residency, private gateway): the image payload must not be rerouted
+        to a public aggregator. No probe fires; the 1311 surfaces via the
+        generic chain's final re-raise."""
+        err = self._entitlement_error()
+        zai_client = MagicMock()
+        zai_client.base_url = "https://open.bigmodel.cn/api/paas/v4"
+        zai_client.chat.completions.create.side_effect = err
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=(
+                    "zai", None, "https://open.bigmodel.cn/api/paas/v4", "sk-x", None,
+                ),
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_vision_provider_client",
+                return_value=("zai", zai_client, "glm-5v-turbo"),
+            ) as resolve_vision,
+            patch(
+                "agent.auxiliary_client._recoverable_pool_provider",
+                return_value=None,
+            ),
+            patch("agent.auxiliary_client._recover_provider_pool") as recover_pool,
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(None, None, ""),
+            ),
+            patch(
+                "agent.auxiliary_client._try_main_agent_model_fallback",
+                return_value=(None, None, ""),
+            ),
+        ):
+            with pytest.raises(Exception) as excinfo:
+                call_llm(
+                    task="vision",
+                    messages=[{"role": "user", "content": "describe image"}],
+                )
+
+        assert excinfo.value is err
+        # Exactly one resolve — the original route. No aggregator probe.
+        assert resolve_vision.call_count == 1
+        recover_pool.assert_not_called()
+
+    def test_sync_reentry_resolve_divergence_surfaces_1311(self):
+        """If the aggregator vanishes between the probe and the re-entered
+        call's own resolve (transient blip, concurrent unhealthy-marking),
+        the actionable 1311 must surface — not the re-entry's generic
+        "no provider configured" RuntimeError."""
+        err = self._entitlement_error()
+        zai_client = MagicMock()
+        zai_client.base_url = "https://api.z.ai/api/paas/v4"
+        zai_client.chat.completions.create.side_effect = err
+
+        aggregator_client = MagicMock()
+        aggregator_client.base_url = OPENROUTER_BASE_URL
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("auto", None, None, None, None),
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_vision_provider_client",
+                side_effect=[
+                    ("zai", zai_client, "glm-5v-turbo"),
+                    ("openrouter", aggregator_client, "agg-model"),  # probe OK
+                    (None, None, None),  # re-entry resolve: aggregator gone
+                ],
+            ),
+            patch("agent.auxiliary_client._recover_provider_pool") as recover_pool,
+        ):
+            with pytest.raises(Exception) as excinfo:
+                call_llm(
+                    task="vision",
+                    messages=[{"role": "user", "content": "describe image"}],
+                )
+
+        assert excinfo.value is err
+        # The re-entry's RuntimeError remains visible as the cause chain.
+        assert isinstance(excinfo.value.__cause__, RuntimeError)
+        recover_pool.assert_not_called()
+
+    def test_sync_non_vision_1311_skips_pool_rotation(self):
+        """A non-vision task that lands on an unentitled Z.AI model must not
+        rotate/penalize the healthy credential pool: 1311 is a model-level
+        entitlement error, so rotation cannot help. Uses the *auto* route —
+        resolved_provider stays "auto" while the pool being rotated is "zai" —
+        so this only passes if the guard keys on pool_provider, not the route
+        label. The generic capacity fallback still runs (and here finds
+        nothing, so the 1311 surfaces)."""
+        err = self._entitlement_error()
+        zai_client = MagicMock()
+        zai_client.base_url = "https://api.z.ai/api/paas/v4"
+        zai_client.chat.completions.create.side_effect = err
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("auto", "glm-5.1", None, None, None),
+            ),
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                return_value=(zai_client, "glm-5.1"),
+            ),
+            patch(
+                "agent.auxiliary_client._recoverable_pool_provider",
+                return_value="zai",
+            ),
+            patch("agent.auxiliary_client._recover_provider_pool") as recover_pool,
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(None, None, ""),
+            ),
+            patch(
+                "agent.auxiliary_client._try_main_fallback_chain",
+                return_value=(None, None, ""),
+            ),
+            patch(
+                "agent.auxiliary_client._try_payment_fallback",
+                return_value=(None, None, ""),
+            ),
+        ):
+            with pytest.raises(Exception) as excinfo:
+                call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "summarize"}],
+                )
+
+        assert excinfo.value is err
+        # No rotation, and no doubled same-key retry against the same plan.
+        recover_pool.assert_not_called()
+        assert zai_client.chat.completions.create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_async_non_vision_1311_skips_pool_rotation(self):
+        """Async mirror of the pool-rotation guard (the async except chain is
+        separate code)."""
+        err = self._entitlement_error()
+        zai_client = MagicMock()
+        zai_client.base_url = "https://api.z.ai/api/paas/v4"
+        zai_client.chat.completions.create = AsyncMock(side_effect=err)
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("auto", "glm-5.1", None, None, None),
+            ),
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                return_value=(zai_client, "glm-5.1"),
+            ),
+            patch(
+                "agent.auxiliary_client._recoverable_pool_provider",
+                return_value="zai",
+            ),
+            patch("agent.auxiliary_client._recover_provider_pool") as recover_pool,
+            patch(
+                "agent.auxiliary_client._try_configured_fallback_chain",
+                return_value=(None, None, ""),
+            ),
+            patch(
+                "agent.auxiliary_client._try_main_fallback_chain",
+                return_value=(None, None, ""),
+            ),
+            patch(
+                "agent.auxiliary_client._try_payment_fallback",
+                return_value=(None, None, ""),
+            ),
+        ):
+            with pytest.raises(Exception) as excinfo:
+                await async_call_llm(
+                    task="compression",
+                    messages=[{"role": "user", "content": "summarize"}],
+                )
+
+        assert excinfo.value is err
+        recover_pool.assert_not_called()
+        assert zai_client.chat.completions.create.await_count == 1
 
 
 class TestIsRateLimitError:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -21,6 +21,7 @@ from agent.auxiliary_client import (
     _read_codex_access_token,
     _get_provider_chain,
     _is_payment_error,
+    _is_zai_model_not_entitled,
     _is_rate_limit_error,
     _is_model_not_found_error,
     _is_model_incompatible_error,
@@ -1899,6 +1900,167 @@ class TestRefreshNousRecommendedModel:
         out = _refresh_nous_recommended_model(
             vision=False, stale_model="google/gemini-3-flash-preview")
         assert out is None
+
+
+class TestIsZaiModelNotEntitled:
+    """_is_zai_model_not_entitled matches Z.AI's *structured* error code 1311
+    (not message substrings) and only for provider ``zai``. Distinct from
+    payment (credit exhaustion) and auth (key rejected): the credentials are
+    valid but the plan excludes this one model.
+    """
+
+    @staticmethod
+    def _exc(code=None, *, body=None, status=429, msg="error"):
+        """Build an OpenAI-SDK-shaped error.
+
+        ``body`` mirrors the SDK's parsed JSON body; ``code`` is a shortcut for
+        the common ``{'error': {'code': code}}`` shape.
+        """
+        exc = Exception(msg)
+        exc.status_code = status
+        if body is not None:
+            exc.body = body
+        elif code is not None:
+            exc.body = {"error": {"code": code}}
+        return exc
+
+    def test_zai_1311_structured_body(self):
+        """Z.AI Coding/Lite plan lacking glm-5v-turbo → 429 with code 1311."""
+        exc = self._exc(body={"error": {"code": "1311",
+                                        "message": "当前订阅套餐暂未开放GLM-5V-Turbo权限"}})
+        assert _is_zai_model_not_entitled(exc, "zai") is True
+
+    def test_matches_via_exc_code_attribute(self):
+        """Uses the SDK's own ``.code`` attribute when present."""
+        exc = Exception("error")
+        exc.status_code = 429
+        exc.code = "1311"
+        assert _is_zai_model_not_entitled(exc, "zai") is True
+
+    def test_only_for_zai_provider(self):
+        """Scoped to zai — a 1311 from another provider must not match (codes
+        are vendor-defined and another vendor could reuse 1311)."""
+        exc = self._exc(code="1311")
+        assert _is_zai_model_not_entitled(exc, "openai") is False
+
+    def test_other_zai_code_not_matched(self):
+        """A different Z.AI code (e.g. 1305 overload) is not plan-entitlement."""
+        exc = self._exc(code="1305")
+        assert _is_zai_model_not_entitled(exc, "zai") is False
+
+    def test_no_structured_code_not_matched(self):
+        """No structured code → no match (we do not substring-scan messages,
+        which would risk misclassifying auth/quota errors)."""
+        exc = Exception("This model is not available on your plan")
+        exc.status_code = 403
+        assert _is_zai_model_not_entitled(exc, "zai") is False
+
+    def test_auth_error_not_matched(self):
+        exc = self._exc(code="401", status=401)
+        assert _is_zai_model_not_entitled(exc, "zai") is False
+
+    def test_1311_is_not_a_payment_error(self):
+        """The 1311 error must NOT be treated as payment — otherwise the
+        provider would be wrongly marked unhealthy for all its other models."""
+        exc = self._exc(body={"error": {"code": "1311",
+                                        "message": "当前订阅套餐暂未开放GLM-5V-Turbo权限"}})
+        assert _is_payment_error(exc) is False
+
+
+class TestZaiVisionEntitlementFallback:
+    @staticmethod
+    def _entitlement_error():
+        exc = Exception("model unavailable on subscription")
+        exc.status_code = 429
+        exc.body = {"error": {"code": "1311"}}
+        return exc
+
+    def test_sync_reroutes_before_pool_recovery(self):
+        zai_client = MagicMock()
+        zai_client.base_url = "https://api.z.ai/api/paas/v4"
+        zai_client.chat.completions.create.side_effect = self._entitlement_error()
+
+        aggregator_client = MagicMock()
+        aggregator_client.base_url = OPENROUTER_BASE_URL
+        aggregator_client.chat.completions.create.return_value = _DummyResponse(
+            "aggregator-sync"
+        )
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("auto", None, None, None, None),
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_vision_provider_client",
+                side_effect=[
+                    ("zai", zai_client, "glm-5v-turbo"),
+                    ("openrouter", aggregator_client, "google/gemini-3-flash-preview"),
+                ],
+            ) as resolve_vision,
+            patch("agent.auxiliary_client._recover_provider_pool") as recover_pool,
+        ):
+            response = call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "describe image"}],
+            )
+
+        assert response.choices[0].message.content == "aggregator-sync"
+        assert zai_client.chat.completions.create.call_count == 1
+        recover_pool.assert_not_called()
+        assert resolve_vision.call_args_list[1].kwargs == {
+            "provider": "auto",
+            "async_mode": False,
+            "exclude_providers": frozenset({"zai"}),
+        }
+        assert aggregator_client.chat.completions.create.call_args.kwargs["model"] == (
+            "google/gemini-3-flash-preview"
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_reroutes_before_pool_recovery(self):
+        zai_client = MagicMock()
+        zai_client.base_url = "https://api.z.ai/api/paas/v4"
+        zai_client.chat.completions.create = AsyncMock(
+            side_effect=self._entitlement_error()
+        )
+
+        aggregator_client = MagicMock()
+        aggregator_client.base_url = OPENROUTER_BASE_URL
+        aggregator_client.chat.completions.create = AsyncMock(
+            return_value=_DummyResponse("aggregator-async")
+        )
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("auto", None, None, None, None),
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_vision_provider_client",
+                side_effect=[
+                    ("zai", zai_client, "glm-5v-turbo"),
+                    ("openrouter", aggregator_client, "google/gemini-3-flash-preview"),
+                ],
+            ) as resolve_vision,
+            patch("agent.auxiliary_client._recover_provider_pool") as recover_pool,
+        ):
+            response = await async_call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": "describe image"}],
+            )
+
+        assert response.choices[0].message.content == "aggregator-async"
+        assert zai_client.chat.completions.create.await_count == 1
+        recover_pool.assert_not_called()
+        assert resolve_vision.call_args_list[1].kwargs == {
+            "provider": "auto",
+            "async_mode": True,
+            "exclude_providers": frozenset({"zai"}),
+        }
+        assert aggregator_client.chat.completions.create.call_args.kwargs["model"] == (
+            "google/gemini-3-flash-preview"
+        )
 
 
 class TestIsRateLimitError:

--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -229,6 +229,106 @@ model:
         assert client_excl is or_client
         assert provider_excl == "openrouter"
 
+    def test_exclude_providers_matches_alias_main_provider(self, monkeypatch):
+        """Exclusion sets hold canonical ids; a main provider configured via a
+        Z.AI alias ("glm") must still be skipped when "zai" is excluded —
+        otherwise the reroute lands straight back on the broken provider."""
+        _fresh_modules()
+        import agent.auxiliary_client as ac
+
+        class _FakeClient:
+            def __init__(self, label):
+                self.base_url = f"https://{label}.example/v1"
+
+        or_client = _FakeClient("openrouter")
+
+        monkeypatch.setattr(
+            ac, "_resolve_task_provider_model",
+            lambda *a, **k: ("auto", "", "", "", "chat_completions"))
+        monkeypatch.setattr(ac, "_read_main_provider", lambda: "glm")
+        monkeypatch.setattr(ac, "_read_main_model", lambda: "glm-5.1")
+        monkeypatch.setattr(
+            ac, "_resolve_strict_vision_backend",
+            lambda candidate, *a, **k: (or_client, "openrouter-vision") if candidate == "openrouter" else (None, None))
+
+        provider, client, _ = ac.resolve_vision_provider_client(
+            provider="auto", exclude_providers=frozenset({"zai"})
+        )
+        assert client is or_client
+        assert provider == "openrouter"
+
+    def test_exclude_providers_does_not_leak_pinned_model_to_aggregator(self, monkeypatch):
+        """On a reroute, a config-pinned vision model belongs to the excluded
+        provider — the aggregator must get its own known-good default, not a
+        zai-only slug it would 404 on."""
+        _fresh_modules()
+        import agent.auxiliary_client as ac
+
+        class _FakeClient:
+            def __init__(self, label):
+                self.base_url = f"https://{label}.example/v1"
+
+        or_client = _FakeClient("openrouter")
+
+        # Config pins auxiliary.vision.model to the zai vision model.
+        monkeypatch.setattr(
+            ac, "_resolve_task_provider_model",
+            lambda *a, **k: ("auto", "glm-5v-turbo", "", "", "chat_completions"))
+        monkeypatch.setattr(ac, "_read_main_provider", lambda: "zai")
+        monkeypatch.setattr(ac, "_read_main_model", lambda: "glm-5.1")
+        monkeypatch.setattr(
+            ac, "_resolve_strict_vision_backend",
+            lambda candidate, *a, **k: (or_client, "openrouter-vision") if candidate == "openrouter" else (None, None))
+
+        provider, client, model = ac.resolve_vision_provider_client(
+            provider="auto", exclude_providers=frozenset({"zai"})
+        )
+        assert provider == "openrouter"
+        assert client is or_client
+        assert model == "openrouter-vision"
+
+    def test_exclude_providers_does_not_leak_pinned_model_to_main_provider(self, monkeypatch):
+        """The pin-vs-default rule must hold on the Step-1 main-provider path
+        too, not just the aggregator loop: rerouting with a pinned zai model
+        onto a vision-capable non-zai main provider must use that provider's
+        own vision default, not the zai-only slug (which it would 404 on)."""
+        _fresh_modules()
+        import agent.auxiliary_client as ac
+
+        class _FakeClient:
+            def __init__(self, label):
+                self.base_url = f"https://{label}.example/v1"
+
+        gem_client = _FakeClient("gemini")
+
+        # Config pins auxiliary.vision.model to the zai vision model; the
+        # main provider is a different, vision-capable backend.
+        monkeypatch.setattr(
+            ac, "_resolve_task_provider_model",
+            lambda *a, **k: ("auto", "glm-5v-turbo", "", "", "chat_completions"))
+        monkeypatch.setattr(ac, "_read_main_provider", lambda: "gemini")
+        monkeypatch.setattr(ac, "_read_main_model", lambda: "gemini-3-pro")
+        monkeypatch.setattr(
+            ac, "_resolve_provider_vision_default",
+            lambda provider: "gemini-vision-default")
+        monkeypatch.setattr(ac, "_main_model_supports_vision", lambda p, m: True)
+        monkeypatch.setattr(
+            ac, "resolve_provider_client",
+            lambda provider, model=None, **k: (gem_client, model))
+
+        # Under exclusion the main provider serves with its own default...
+        provider, client, model = ac.resolve_vision_provider_client(
+            provider="auto", exclude_providers=frozenset({"zai"})
+        )
+        assert provider == "gemini"
+        assert client is gem_client
+        assert model == "gemini-vision-default"
+
+        # ...while without exclusion the config pin still applies as before.
+        provider, _, model = ac.resolve_vision_provider_client(provider="auto")
+        assert provider == "gemini"
+        assert model == "glm-5v-turbo"
+
     def test_unknown_capability_does_not_block(self, isolated_home, monkeypatch):
         """When models.dev has no entry, fall back to permissive (attempt the call).
 

--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -180,6 +180,55 @@ model:
         assert client is not None
         assert provider == "anthropic"
 
+    def test_exclude_providers_skips_main_in_favor_of_aggregator(self, monkeypatch):
+        """A provider in ``exclude_providers`` is skipped so auto-detect lands
+        on a vision-capable aggregator instead of the excluded main provider.
+
+        Mirrors the Z.AI Coding-plan case: zai's vision model (glm-5v-turbo)
+        is not licensed, so the retry re-resolves with zai excluded and must
+        pick an aggregator (OpenRouter) rather than returning zai again.
+
+        The provider-resolution primitives are stubbed so this exercises only
+        the ``exclude_providers`` branching — not real credential/pool
+        resolution, which carries cross-test cached state and is flaky here.
+        """
+        _fresh_modules()
+        import agent.auxiliary_client as ac
+
+        class _FakeClient:
+            def __init__(self, label):
+                self.base_url = f"https://{label}.example/v1"
+
+        zai_client = _FakeClient("zai")
+        or_client = _FakeClient("openrouter")
+
+        # Force the auto path: main provider = zai, no config/credential reads.
+        monkeypatch.setattr(
+            ac, "_resolve_task_provider_model",
+            lambda *a, **k: ("auto", "", "", "", "chat_completions"))
+        monkeypatch.setattr(ac, "_read_main_provider", lambda: "zai")
+        monkeypatch.setattr(ac, "_read_main_model", lambda: "glm-5.1")
+        # Main-provider vision attempt resolves to a zai client.
+        monkeypatch.setattr(
+            ac, "resolve_provider_client",
+            lambda provider, model=None, **k: (zai_client, model) if provider == "zai" else (None, None))
+        # Aggregator chain offers an OpenRouter vision backend.
+        monkeypatch.setattr(
+            ac, "_resolve_strict_vision_backend",
+            lambda candidate, *a, **k: (or_client, "openrouter-vision") if candidate == "openrouter" else (None, None))
+
+        # Without exclusion, auto-detect picks the main provider (zai).
+        provider_default, client_default, _ = ac.resolve_vision_provider_client(provider="auto")
+        assert client_default is zai_client
+        assert provider_default == "zai"
+
+        # Excluding zai must skip it and fall through to the aggregator chain.
+        provider_excl, client_excl, _ = ac.resolve_vision_provider_client(
+            provider="auto", exclude_providers=frozenset({"zai"})
+        )
+        assert client_excl is or_client
+        assert provider_excl == "openrouter"
+
     def test_unknown_capability_does_not_block(self, isolated_home, monkeypatch):
         """When models.dev has no entry, fall back to permissive (attempt the call).
 


### PR DESCRIPTION
## What changed and why
When the main provider has a dedicated vision model in `_PROVIDER_VISION_MODELS` (e.g. `zai → glm-5v-turbo`) but the account's plan isn't licensed for that model, sending an image **hard-fails** instead of falling through to a configured vision aggregator.

Concrete repro: a Z.AI **GLM Coding / Lite** plan. Vision auto-detect picks `glm-5v-turbo`; the plan can't access it, so the call returns:
```
openai.RateLimitError: Error code: 429 - {'error': {'code': '1311', 'message': '当前订阅套餐暂未开放GLM-5V-Turbo权限'}}
```
(`1311` ≈ "this model is not yet open on your subscription plan"). `glm-5.1` chat on the same plan works fine — only the vision model is unavailable.

### Root cause
The `1311` failure is a 429, which would normally trigger provider fallback — but a guard meant to respect *explicitly chosen* providers blocks it:

1. **Vision auto-detect resolves to a concrete provider.** `provider: auto` is resolved to `zai` before the call, so `resolved_provider == "zai"` → `is_auto` is `False`.
2. **The call fails with `1311` (HTTP 429).** `_is_rate_limit_error()` flags it → `should_fallback` is `True`.
3. **The fallback gate rejects it.** The gate is `should_fallback and (is_auto or is_capacity_error)`. Rate-limit errors only fall back when `is_auto` is `True`; `1311` is not an `is_capacity_error` (those are payment/connection only).
4. So the gate is `True and (False or False)` → **`False`**, and `call_llm` / `async_call_llm` re-raise.

**Net:** an entitlement error (model not in the plan) looks like a plain rate-limit on a now-concrete provider, so vision hard-fails even when OpenRouter / Nous vision aggregators are configured.

### Fix
- **`_is_zai_model_not_entitled(exc, provider)`** — matches Z.AI's **structured error code `1311`** (`exc.code` / parsed `exc.body`, the same body `_summarize_api_error` reads), scoped to the **normalized** provider identity: `zai` and its documented aliases (`glm`/`z-ai`/`z.ai`/`zhipu`), including `main`-routes that resolve to Z.AI. Code-based, not substring-scanning — so it can't misfire on an auth/quota error or another vendor reusing `1311`. **User-defined endpoints never match**: `custom`/`custom:<name>` labels, alias labels shadowed by a same-named `custom_providers` entry, and (enforced at the reroute decision) any route with a configured `base_url` — an image payload is never routed away from an explicitly pinned endpoint.
- **`resolve_vision_provider_client(..., exclude_providers=…)`** — re-resolves vision while skipping the provider whose vision model just failed. Under exclusion, a config-pinned `auxiliary.vision.model` is treated as belonging to the failed route: every candidate (main-provider shortcut and aggregator chain alike) uses its **own known-good default** instead of a pin the surviving provider would 404 on.
- **`call_llm` / `async_call_llm`** — on a vision `1311`, **re-enter with `provider="auto"` and zai excluded** (decision in one shared helper, `_zai_vision_reroute_exclusions`, so the sync/async branches can't drift). Re-entry means the rerouted attempt gets the full normal machinery: transient-transport retry, unsupported-parameter strips, Nous portal tags, Anthropic-wire image conversion, and the generic fallback chain. The reroute runs as the **first branch of the `except` handler**, and the credential-pool guard keys on **`pool_provider`** (the pool actually rotated) — so an unentitled *model* can never rotate or exhaust a healthy Z.AI pool, even on auto/alias routes. If no aggregator exists, the handler falls through to the generic chain (the configured `fallback_chain` is still consulted) and the original `1311` is what ultimately re-raises.

Scoped deliberately to the one confirmed case (Z.AI `1311`) rather than a speculative cross-provider abstraction — easy to generalize when another provider's code is confirmed. Two adjacent behaviors deliberately unchanged: `1311` skips pool rotation even for hypothetical mixed-entitlement multi-account pools (rotation marks healthy keys exhausted — the worse failure), and the no-aggregator fall-through matches main's existing generic-chain behavior for vision 429s.

### Addresses review feedback
- **Ordering vs. credential-pool recovery.** The vision-entitlement reroute is the first branch in the `except` handler, ahead of the pool-recovery block — and the guard keys on the pool actually rotated, so auto-routed and alias-configured Z.AI clients are covered, not just the literal `zai` label.
- **Call-path coverage.** Sync + async end-to-end tests (`TestZaiVisionEntitlementFallback`) drive `call_llm` / `async_call_llm` and assert aggregator completion with `_recover_provider_pool` never called — plus dedicated tests for alias normalization, custom-entry shadowing, base_url-pin no-reroute, probe/re-entry divergence, parameter-strip recovery on the rerouted attempt, the auto-route pool guard, fallback_chain fall-through, and pin-vs-default on both resolver paths.

## How to test
Automated:
```
pytest tests/agent/test_auxiliary_client.py tests/agent/test_vision_routing_31179.py -v
```
- `TestIsZaiModelNotEntitled` — structured-code match via `exc.body`/`exc.code`; normalized-identity scoping (aliases match; another provider's `1311`, `custom:*` routes, and custom-entry-shadowed aliases don't); a different Z.AI code (e.g. 1305 overload) and a message-only error are **not** matched (no substring scanning); and the `1311` error is **not** classified as a payment error (so the provider isn't marked unhealthy).
- Resolver tests — exclusion skips the main provider (including alias-configured, e.g. `glm`) in favor of the aggregator, and a config-pinned vision model is **not** leaked onto the reroute target on either resolver path (aggregator loop and main-provider shortcut).
- `TestZaiVisionEntitlementFallback` — end-to-end on both call paths: a `1311` on the Z.AI vision client reroutes to the aggregator and returns its response with `_recover_provider_pool` never called; the rerouted attempt gets normal recovery (parameter-strip retry test); a base_url-pinned route never reroutes; probe/re-entry divergence still surfaces the original `1311`; no-aggregator falls through to the configured `fallback_chain`; and the pool guard holds on the auto route (sync + async), where the route label is `"auto"` but the pool is `zai`.

Manual repro (before fix): on a Z.AI GLM Coding/Lite plan with `model.provider: zai` and an OpenRouter or Nous key configured, send an image → previously raised the `1311` error with no analysis; with the fix, vision falls through to the aggregator and succeeds.

## Platforms tested
- Automated suite on macOS (local). Pure-Python change, no platform-specific code.
- Original `1311` failure observed on a Linux deployment running a Z.AI GLM Coding plan; structured extraction verified against a real `openai.RateLimitError`.

## Related issues
No existing issue/PR was found for the Z.AI `1311` / coding-plan vision case (searched open + closed). Adjacent but distinct from the open provider-health-check / fallback PRs (this is specifically about a *model* being unentitled while the provider stays healthy, scoped to the vision aggregator fallthrough).
