### PR TITLE
fix(cli): complete paths in slash command arguments

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1677,23 +1677,6 @@ class SlashCommandCompleter(Completer):
                     yield from self._personality_completions(sub_text, sub_lower)
                     return
 
-            # Path / @ context completions inside slash-command arguments.
-            # Skill slash commands often take a workspace path as their first
-            # argument (e.g. `/foundation-ai-dev-workflow ../foundation`).
-            # Once input starts with `/`, the normal non-slash path completion
-            # branch above no longer runs, so explicitly reuse it for the
-            # current argument token. Keep the single-token dynamic/static
-            # command completions above first so `/model gpt`, `/skin ...`, and
-            # registered subcommands preserve their existing behavior.
-            ctx_word = self._extract_context_word(sub_text)
-            if ctx_word is not None:
-                yield from self._context_completions(ctx_word)
-                return
-            path_word = self._extract_path_word(sub_text)
-            if path_word is not None:
-                yield from self._path_completions(path_word)
-                return
-
             # Static subcommand completions
             if " " not in sub_text and base_cmd in SUBCOMMANDS and self._command_allowed(base_cmd):
                 for sub in SUBCOMMANDS[base_cmd]:
@@ -1703,6 +1686,24 @@ class SlashCommandCompleter(Completer):
                             start_position=-len(sub_text),
                             display=sub,
                         )
+                return
+
+            # Path / @ context completions inside slash-command arguments.
+            # Skill slash commands often take a workspace path as their first
+            # argument (e.g. `/foundation-ai-dev-workflow ../foundation`).
+            # Once input starts with `/`, the normal non-slash path completion
+            # branch above no longer runs, so explicitly reuse it for the
+            # current argument token. Keep dynamic and static subcommand
+            # completions above first so built-in command arguments preserve
+            # their existing behavior.
+            ctx_word = self._extract_context_word(sub_text)
+            if ctx_word is not None:
+                yield from self._context_completions(ctx_word)
+                return
+            path_word = self._extract_path_word(sub_text)
+            if path_word is not None:
+                yield from self._path_completions(path_word)
+                return
             return
 
         word = text[1:]

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1677,6 +1677,23 @@ class SlashCommandCompleter(Completer):
                     yield from self._personality_completions(sub_text, sub_lower)
                     return
 
+            # Path / @ context completions inside slash-command arguments.
+            # Skill slash commands often take a workspace path as their first
+            # argument (e.g. `/foundation-ai-dev-workflow ../foundation`).
+            # Once input starts with `/`, the normal non-slash path completion
+            # branch above no longer runs, so explicitly reuse it for the
+            # current argument token. Keep the single-token dynamic/static
+            # command completions above first so `/model gpt`, `/skin ...`, and
+            # registered subcommands preserve their existing behavior.
+            ctx_word = self._extract_context_word(sub_text)
+            if ctx_word is not None:
+                yield from self._context_completions(ctx_word)
+                return
+            path_word = self._extract_path_word(sub_text)
+            if path_word is not None:
+                yield from self._path_completions(path_word)
+                return
+
             # Static subcommand completions
             if " " not in sub_text and base_cmd in SUBCOMMANDS and self._command_allowed(base_cmd):
                 for sub in SUBCOMMANDS[base_cmd]:

--- a/tests/hermes_cli/test_at_context_completion_filter.py
+++ b/tests/hermes_cli/test_at_context_completion_filter.py
@@ -140,20 +140,17 @@ def test_slash_skill_argument_completes_at_folder_paths(tmp_path, monkeypatch):
     assert "@folder:../readme.md" not in texts
 
 
-def test_builtin_model_completion_still_takes_precedence(monkeypatch):
-    import hermes_cli.model_switch as ms
-    from hermes_cli.model_switch import DirectAlias
-
-    monkeypatch.setattr(
-        ms,
-        "DIRECT_ALIASES",
-        {"gpt-test": DirectAlias(model="gpt-test-model", provider="openai", base_url="")},
-    )
+def test_static_subcommand_completion_still_takes_precedence(monkeypatch, tmp_path):
+    """Built-in subcommand completions should run before path fallback."""
+    (tmp_path / "onboarding").mkdir()
+    monkeypatch.chdir(tmp_path)
 
     completer = SlashCommandCompleter()
-    text = "/model gpt"
+    text = "/voice o"
 
     completions = list(completer.get_completions(Document(text, cursor_position=len(text)), None))
     texts = [c.text for c in completions]
 
-    assert "gpt-test" in texts
+    assert "on" in texts
+    assert "onboarding/" not in texts
+

--- a/tests/hermes_cli/test_at_context_completion_filter.py
+++ b/tests/hermes_cli/test_at_context_completion_filter.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Iterable
 
+from prompt_toolkit.document import Document
+
 from hermes_cli.commands import SlashCommandCompleter
 
 
@@ -88,3 +90,70 @@ def test_at_file_bare_without_colon_lists_files(tmp_path, monkeypatch):
 
     assert any(t == "@file:readme.md" for t in texts), texts
     assert not any(t == "@file:src/" for t in texts)
+
+
+def test_slash_skill_argument_completes_relative_paths(tmp_path, monkeypatch):
+    """Slash skill arguments should reuse normal path completion.
+
+    Regression coverage for `/foundation-ai-dev-workflow ../foundation`,
+    where the slash-command branch previously returned before path
+    completions could run.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (tmp_path / "foundation").mkdir()
+    (tmp_path / "foundation_dev").mkdir()
+    monkeypatch.chdir(workspace)
+
+    completer = SlashCommandCompleter(
+        skill_commands_provider=lambda: {
+            "foundation-ai-dev-workflow": {"description": "Foundation workflow"}
+        }
+    )
+    text = "/foundation-ai-dev-workflow ../foundation"
+
+    completions = list(completer.get_completions(Document(text, cursor_position=len(text)), None))
+    texts = [c.text for c in completions]
+
+    assert "../foundation/" in texts
+    assert "../foundation_dev/" in texts
+
+
+def test_slash_skill_argument_completes_at_folder_paths(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (tmp_path / "foundation").mkdir()
+    (tmp_path / "readme.md").write_text("x")
+    monkeypatch.chdir(workspace)
+
+    completer = SlashCommandCompleter(
+        skill_commands_provider=lambda: {
+            "foundation-ai-dev-workflow": {"description": "Foundation workflow"}
+        }
+    )
+    text = "/foundation-ai-dev-workflow @folder:../"
+
+    completions = list(completer.get_completions(Document(text, cursor_position=len(text)), None))
+    texts = [c.text for c in completions]
+
+    assert "@folder:../foundation/" in texts
+    assert "@folder:../readme.md" not in texts
+
+
+def test_builtin_model_completion_still_takes_precedence(monkeypatch):
+    import hermes_cli.model_switch as ms
+    from hermes_cli.model_switch import DirectAlias
+
+    monkeypatch.setattr(
+        ms,
+        "DIRECT_ALIASES",
+        {"gpt-test": DirectAlias(model="gpt-test-model", provider="openai", base_url="")},
+    )
+
+    completer = SlashCommandCompleter()
+    text = "/model gpt"
+
+    completions = list(completer.get_completions(Document(text, cursor_position=len(text)), None))
+    texts = [c.text for c in completions]
+
+    assert "gpt-test" in texts


### PR DESCRIPTION
## Summary
- Treat path-like slash command arguments the same as normal prompt text for completion
- Reuse existing `@file:` / `@folder:` context completion inside slash command arguments
- Add regression coverage for slash skill commands such as `/foundation-ai-dev-workflow ../foundation`

## Test Plan
- `uv run python -m py_compile hermes_cli/commands.py tests/hermes_cli/test_at_context_completion_filter.py`
- `uv run --with pytest python -m pytest tests/hermes_cli/test_at_context_completion_filter.py tests/hermes_cli/test_kanban_cli.py::test_kanban_autocomplete_includes_live_subcommands tests/test_tui_gateway_server.py::test_complete_slash_returns_plain_string_fields tests/test_tui_gateway_server.py::test_complete_slash_details_args tests/test_tui_gateway_server.py::test_complete_slash_surfaces_completer_error -q -o 'addopts='`
