### PR TITLE
fix(telegram): strip raw markdown in MarkdownV2 fallback paths

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -181,6 +181,8 @@ def _strip_mdv2(text: str) -> str:
     """
     # Remove escape backslashes before special characters
     cleaned = re.sub(r'\\([_*\[\]()~`>#\+\-=|{}.!\\])', r'\1', text)
+    # Remove raw **bold** markers (unconverted standard markdown)
+    cleaned = re.sub(r'\*\*(.+?)\*\*', r'\1', cleaned)
     # Remove MarkdownV2 bold markers that format_message converted from **bold**
     cleaned = re.sub(r'\*([^*]+)\*', r'\1', cleaned)
     # Remove MarkdownV2 italic markers that format_message converted from *italic*
@@ -2144,6 +2146,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 return SendResult(success=True, message_id=message_id)
 
+            formatted = None
             formatted = self.format_message(content)
             try:
                 await self._bot.edit_message_text(
@@ -2156,11 +2159,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 # "Message is not modified" is a no-op, not an error
                 if "not modified" in str(fmt_err).lower():
                     return SendResult(success=True, message_id=message_id)
-                # Fallback: retry without markdown formatting
+                # Fallback: strip markdown formatting and retry as plain text
+                if "parse" in str(fmt_err).lower() or "markdown" in str(fmt_err).lower():
+                    logger.warning("[%s] MarkdownV2 parse failed in edit_message, falling back to plain text: %s", self.name, fmt_err)
+                plain_content = _strip_mdv2(content)
                 await self._bot.edit_message_text(
                     chat_id=int(chat_id),
                     message_id=int(message_id),
-                    text=content,
+                    text=plain_content,
+                    parse_mode=None,
                 )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -2193,10 +2200,15 @@ class TelegramAdapter(BasePlatformAdapter):
                     return SendResult(success=False, error=f"flood_control:{wait}")
                 await asyncio.sleep(wait)
                 try:
+                    # Prefer the already-formatted MarkdownV2 text; fall back
+                    # to plain-text stripping if formatting was never reached.
+                    retry_text = formatted if formatted is not None else _strip_mdv2(content)
+                    retry_parse = ParseMode.MARKDOWN_V2 if formatted is not None else None
                     await self._bot.edit_message_text(
                         chat_id=int(chat_id),
                         message_id=int(message_id),
-                        text=content,
+                        text=retry_text,
+                        parse_mode=retry_parse,
                     )
                     return SendResult(success=True, message_id=message_id)
                 except Exception as retry_err:

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -835,7 +835,8 @@ class TestEditMessageStreamingSafety:
         assert second_call == {
             "chat_id": 123,
             "message_id": 456,
-            "text": "final **bold**",
+            "text": "final bold",
+            "parse_mode": None,
         }
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem
When Telegram rejects MarkdownV2 in edit_message (e.g. during streaming
finalization of multi-chunk responses), the fallback sends raw content
with literal **bold** markers and no parse_mode. Users see raw markdown
syntax instead of formatted or plain text.

## Fix
- _strip_mdv2(): strip raw **bold** (unconverted) before *bold* (converted)
- edit_message fallback: use _strip_mdv2(content) + parse_mode=None
- flood control retry: use already-formatted text or _strip_mdv2 fallback

Reproduced with long streamed responses split into chunks where the
second chunk (with inline buttons) triggered a MarkdownV2 parse error.
