### PR TITLE
feat(cli): add semantic color palette for consistent CLI design system

### DIFF
--- a/hermes_cli/cli_output.py
+++ b/hermes_cli/cli_output.py
@@ -5,7 +5,7 @@ functions previously duplicated across setup.py, tools_config.py,
 mcp_config.py, and memory_setup.py.
 """
 
-from hermes_cli.colors import Colors, color
+from hermes_cli.colors import Palette, semantic
 from hermes_cli.secret_prompt import masked_secret_prompt
 
 
@@ -13,28 +13,32 @@ from hermes_cli.secret_prompt import masked_secret_prompt
 
 
 def print_info(text: str) -> None:
-    """Print a dim informational message."""
-    print(color(f"  {text}", Colors.DIM))
+    """Print a dim informational message (Palette.INFO)."""
+    print(semantic(f"  {text}", Palette.INFO))
 
 
 def print_success(text: str) -> None:
-    """Print a green success message with ✓ prefix."""
-    print(color(f"✓ {text}", Colors.GREEN))
+    """Print a success message with ✓ prefix (Palette.SUCCESS)."""
+    print(semantic(f"✓ {text}", Palette.SUCCESS))
 
 
 def print_warning(text: str) -> None:
-    """Print a yellow warning message with ⚠ prefix."""
-    print(color(f"⚠ {text}", Colors.YELLOW))
+    """Print a warning message with ⚠ prefix (Palette.WARNING)."""
+    print(semantic(f"⚠ {text}", Palette.WARNING))
 
 
 def print_error(text: str) -> None:
-    """Print a red error message with ✗ prefix."""
-    print(color(f"✗ {text}", Colors.RED))
+    """Print an error message with ✗ prefix (Palette.ERROR)."""
+    print(semantic(f"✗ {text}", Palette.ERROR))
 
 
 def print_header(text: str) -> None:
-    """Print a bold yellow header."""
-    print(color(f"\n  {text}", Colors.YELLOW))
+    """Print a section header in the design-system heading style.
+
+    Uses :data:`Palette.HEADING` (cyan + bold) so section titles read
+    consistently across the CLI instead of varying per call site.
+    """
+    print(semantic(f"\n  {text}", Palette.HEADING))
 
 
 # ─── Input Prompts ────────────────────────────────────────────────────────────
@@ -54,7 +58,7 @@ def prompt(
     Returns empty string on Ctrl-C or EOF.
     """
     suffix = f" [{default}]" if default else ""
-    display = color(f"  {question}{suffix}: ", Colors.YELLOW)
+    display = semantic(f"  {question}{suffix}: ", Palette.PROMPT)
 
     try:
         if password:

--- a/hermes_cli/colors.py
+++ b/hermes_cli/colors.py
@@ -31,8 +31,61 @@ class Colors:
     CYAN = "\033[36m"
 
 
+class Palette:
+    """Semantic color roles for the Hermes CLI design system.
+
+    Centralizes *which raw color means what* so callers express intent
+    ("this is a success message") instead of hand-picking ``Colors.GREEN``
+    in one place and ``Colors.CYAN`` in another for the same role. This is
+    the single source of truth for the CLI's visual identity; raw
+    :class:`Colors` codes remain available for one-off needs and for
+    backwards compatibility.
+
+    Roles map to ANSI escape sequences (the same strings exposed by
+    :class:`Colors`). Pass them to :func:`color` exactly like the raw codes::
+
+        print(color("saved", Palette.SUCCESS))
+        print(color("section title", *Palette.HEADING))
+
+    ``HEADING`` and ``EMPHASIS`` are tuples because they combine two codes
+    (a base color plus ``BOLD``); :func:`color` already accepts any number
+    of codes, and :func:`semantic` unpacks tuples for you.
+    """
+
+    SUCCESS = (Colors.GREEN,)
+    WARNING = (Colors.YELLOW,)
+    ERROR = (Colors.RED,)
+    INFO = (Colors.DIM,)
+    MUTED = (Colors.DIM,)
+    HEADING = (Colors.CYAN, Colors.BOLD)
+    EMPHASIS = (Colors.BOLD,)
+    PROMPT = (Colors.YELLOW,)
+
+
 def color(text: str, *codes) -> str:
-    """Apply color codes to text (only when color output is appropriate)."""
+    """Apply color codes to text (only when color output is appropriate).
+
+    ``codes`` may be raw :class:`Colors` strings, a :class:`Palette` role
+    tuple, or a mix; nested tuples/lists are flattened so callers can write
+    either ``color(t, Colors.GREEN)`` or ``color(t, Palette.SUCCESS)``.
+    """
+    flat: list[str] = []
+    for c in codes:
+        if isinstance(c, (tuple, list)):
+            flat.extend(c)
+        else:
+            flat.append(c)
     if not should_use_color():
         return text
-    return "".join(codes) + text + Colors.RESET
+    return "".join(flat) + text + Colors.RESET
+
+
+def semantic(text: str, role) -> str:
+    """Color ``text`` using a semantic :class:`Palette` role.
+
+    Thin wrapper over :func:`color` that reads at call sites as intent::
+
+        semantic("✓ done", Palette.SUCCESS)
+        semantic("Section", Palette.HEADING)
+    """
+    return color(text, role)

--- a/tests/hermes_cli/test_cli_output.py
+++ b/tests/hermes_cli/test_cli_output.py
@@ -1,4 +1,40 @@
-from hermes_cli import cli_output
+from hermes_cli import cli_output, colors
+from hermes_cli.colors import Colors
+
+
+def _force_color(monkeypatch, enabled=True):
+    monkeypatch.setattr(colors, "should_use_color", lambda: enabled)
+
+
+def test_print_helpers_use_semantic_palette(monkeypatch, capsys):
+    """Each helper renders its semantic role's color + prefix."""
+    _force_color(monkeypatch, True)
+
+    cli_output.print_success("saved")
+    cli_output.print_warning("careful")
+    cli_output.print_error("boom")
+    out = capsys.readouterr().out
+
+    assert Colors.GREEN in out and "✓ saved" in out
+    assert Colors.YELLOW in out and "⚠ careful" in out
+    assert Colors.RED in out and "✗ boom" in out
+
+
+def test_header_uses_design_system_heading_style(monkeypatch, capsys):
+    """Headers render in the cyan+bold design-system heading style.
+
+    Regression guard for issue #34566: section headers previously used a
+    one-off yellow here while config.py/cron.py used cyan, producing the
+    inconsistent visual hierarchy the issue calls out.
+    """
+    _force_color(monkeypatch, True)
+
+    cli_output.print_header("Section")
+    out = capsys.readouterr().out
+
+    assert Colors.CYAN in out
+    assert Colors.BOLD in out
+    assert "Section" in out
 
 
 def test_password_prompt_uses_masked_secret_prompt(monkeypatch):

--- a/tests/hermes_cli/test_colors_palette.py
+++ b/tests/hermes_cli/test_colors_palette.py
@@ -1,0 +1,89 @@
+"""Tests for the semantic color design-system primitives in hermes_cli.colors.
+
+Covers the Palette semantic roles, the color() flattening of role tuples,
+and the semantic() convenience wrapper. These are the design-system
+foundation requested in issue #34566 (standardize CLI color usage so the
+same semantic role renders consistently everywhere).
+"""
+
+from hermes_cli import colors
+from hermes_cli.colors import Colors, Palette, color, semantic
+
+
+def _force_color(monkeypatch, enabled: bool = True) -> None:
+    """Make should_use_color() deterministic regardless of the test TTY."""
+    monkeypatch.setattr(colors, "should_use_color", lambda: enabled)
+
+
+def test_color_flattens_palette_role_tuple(monkeypatch):
+    """A Palette role (a tuple of codes) wraps text just like raw codes."""
+    _force_color(monkeypatch, True)
+
+    out = color("ok", Palette.SUCCESS)
+
+    assert out.startswith(Colors.GREEN)
+    assert out.endswith(Colors.RESET)
+    assert "ok" in out
+    # The literal tuple must not leak into the output.
+    assert "(" not in out
+
+
+def test_color_accepts_mixed_raw_and_role(monkeypatch):
+    """color() flattens a mix of raw codes and a role tuple in order."""
+    _force_color(monkeypatch, True)
+
+    out = color("hi", Colors.BOLD, Palette.WARNING)
+
+    assert out == Colors.BOLD + Colors.YELLOW + "hi" + Colors.RESET
+
+
+def test_color_disabled_returns_plain_text(monkeypatch):
+    """With color disabled (NO_COLOR / not a TTY), text is returned bare."""
+    _force_color(monkeypatch, False)
+
+    assert color("plain", Palette.ERROR) == "plain"
+    assert semantic("plain", Palette.HEADING) == "plain"
+
+
+def test_semantic_matches_color(monkeypatch):
+    """semantic() is a thin, equivalent wrapper over color()."""
+    _force_color(monkeypatch, True)
+
+    assert semantic("x", Palette.INFO) == color("x", Palette.INFO)
+
+
+def test_heading_role_is_multi_code(monkeypatch):
+    """HEADING combines cyan + bold so titles read consistently."""
+    _force_color(monkeypatch, True)
+
+    out = semantic("Section", Palette.HEADING)
+
+    assert Colors.CYAN in out
+    assert Colors.BOLD in out
+    assert out.endswith(Colors.RESET)
+
+
+def test_every_palette_role_is_a_tuple_of_known_codes():
+    """Guardrail: each semantic role is a tuple of real ANSI code strings.
+
+    Prevents a future edit from assigning a bare string (which color()
+    would still accept but which breaks the role-tuple contract used by
+    callers that splat with ``*Palette.ROLE``).
+    """
+    known = {
+        getattr(Colors, name)
+        for name in dir(Colors)
+        if not name.startswith("_")
+    }
+    roles = [
+        n for n in dir(Palette) if not n.startswith("_")
+    ]
+    assert roles, "Palette must define at least one semantic role"
+    for name in roles:
+        value = getattr(Palette, name)
+        assert isinstance(value, tuple), f"Palette.{name} must be a tuple"
+        assert value, f"Palette.{name} must not be empty"
+        for code in value:
+            assert code in known, (
+                f"Palette.{name} references unknown ANSI code {code!r}"
+            )


### PR DESCRIPTION
## Summary

- Adds a semantic color **`Palette`** (SUCCESS / WARNING / ERROR / INFO / MUTED / HEADING / EMPHASIS / PROMPT) to `hermes_cli.colors` as the single source of truth for CLI color usage, plus a `semantic()` helper.
- Refactors the shared `cli_output` print helpers to express *intent* via the palette instead of hand-picking raw ANSI codes, and unifies section headers on the design-system heading style.

## Motivation

Closes #34566.

The issue asks for "a formal design system with standardized colors" and calls out that "color usage is inconsistent in some areas" with weak visual hierarchy. That's literally true in the CLI today: dozens of call sites hand-pick `Colors.GREEN` / `Colors.RED` / `Colors.YELLOW` / `Colors.CYAN` for the *same* semantic roles, with no shared vocabulary. A concrete symptom — `cli_output.print_header()` rendered section titles in **yellow**, while `config.py` and `cron.py` render their section headers in **cyan**, so the same conceptual element looks different depending on which command you ran.

This PR lays the bounded, first-party foundation the issue's "Scope: Medium (few files, < 300 lines)" / "CLI improvement" classification asks for: a centralized semantic palette so callers say *what a message means* and the design system decides *how it looks*. Raw `Colors` codes are untouched and remain available, so this is fully backwards compatible — no existing call site changes behavior except the header color, which now matches the rest of the CLI.

## Verification

- `python3 -m pytest tests/hermes_cli/test_colors_palette.py tests/hermes_cli/test_cli_output.py tests/hermes_cli/test_curses_color_compat.py -q` — **16 passed**
- New `test_colors_palette.py`: palette role flattening, mixed raw+role codes, NO_COLOR disable path, multi-code HEADING, and a guardrail that every role is a tuple of real ANSI codes.
- Extended `test_cli_output.py`: helpers route through the semantic palette; header now renders in the cyan+bold heading style (regression guard for the inconsistency above).
- `color()` now flattens role tuples, so both `color(t, Colors.GREEN)` and `color(t, Palette.SUCCESS)` work — existing callers are unaffected.

## Notes / scope

- Intentionally **does not** touch logos, motion design, or web/desktop assets from the broader issue — those are maintainer-owned product decisions. This PR ships the one concrete, testable CLI primitive the design-system goal depends on.
- Pre-ship checklist: 9/10 (the single warning is the `print(...)` calls inside `cli_output.py`, which are the output functions themselves, not debug statements).
