### PR TITLE
fix(cli): clear TUI input buffer before dispatching inline /steer

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9626,6 +9626,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         except Exception:
             return False
 
+    def _dispatch_inline_steer(self, buffer, text: str) -> None:
+        """Dispatch a mid-run ``/steer`` and guarantee the input field is cleared.
+
+        The input field is reset **before** ``process_command()`` runs.  The
+        steer dispatch path can re-enter the prompt_toolkit event loop (a print
+        routed through ``run_in_terminal``, or a modal that snapshots+restores
+        the in-progress draft) or raise before control returns to the Enter
+        handler.  Clearing afterwards would be skipped in those cases, leaving
+        the submitted prompt in the buffer where the next Enter / turn-handoff
+        re-submits it (issue #34569).  Resetting first makes the TUI's
+        input-state contract — "what's in the box hasn't been sent" — hold
+        unconditionally, regardless of how ``process_command`` behaves.
+        """
+        if buffer is not None:
+            buffer.reset(append_to_history=True)
+        self.process_command(text)
+
     def _output_console(self):
         """Use prompt_toolkit-safe Rich rendering once the TUI is live."""
         if getattr(self, "_app", None):
@@ -15222,8 +15239,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # post-run next-turn message — defeating mid-run injection.
                 # agent.steer() is thread-safe (holds _pending_steer_lock).
                 if self._should_handle_steer_command_inline(text, has_images=has_images):
-                    self.process_command(text)
-                    event.app.current_buffer.reset(append_to_history=True)
+                    self._dispatch_inline_steer(event.app.current_buffer, text)
                     # Force a repaint after clearing the buffer.  /steer is
                     # dispatched mid-run while the agent streams output through
                     # patch_stdout; process_command() never invalidates the

--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/tests/cli/test_cli_steer_busy_path.py
+++ b/tests/cli/test_cli_steer_busy_path.py
@@ -140,6 +140,87 @@ class TestSteerBusyPathDispatch:
         cli._pending_input.put.assert_called_once_with("would-be-next-turn")
 
 
+class _FakeBuffer:
+    """Minimal stand-in for a prompt_toolkit buffer.
+
+    Records reset() calls and the buffer text at the moment of each reset so a
+    test can assert ordering relative to the steer dispatch.
+    """
+
+    def __init__(self, text: str = ""):
+        self.text = text
+        self.reset_calls: list[str] = []
+        self.append_to_history_flags: list[bool] = []
+
+    def reset(self, append_to_history: bool = False):
+        # Capture what was in the buffer at reset time, then clear it.
+        self.reset_calls.append(self.text)
+        self.append_to_history_flags.append(append_to_history)
+        self.text = ""
+
+
+class TestInlineSteerBufferClear:
+    """Regression tests for issue #34569.
+
+    The submitted ``/steer <prompt>`` must never linger in the TUI input
+    buffer, where the next Enter / turn-handoff could re-submit it.  The
+    Enter handler routes the inline-steer case through
+    ``_dispatch_inline_steer``, which must reset the buffer BEFORE running
+    ``process_command`` so the clear is not skipped if the dispatch re-enters
+    the event loop or raises.
+    """
+
+    def test_buffer_cleared_before_dispatch(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        cli.agent = MagicMock()
+        cli.agent.steer = MagicMock(return_value=True)
+
+        buf = _FakeBuffer("/steer focus on errors")
+        observed = {}
+
+        real_process = cli.process_command
+
+        def _spy_process(cmd):
+            # At dispatch time the buffer must already be empty.
+            observed["text_at_dispatch"] = buf.text
+            return real_process(cmd)
+
+        with patch.object(cli, "process_command", side_effect=_spy_process):
+            cli._dispatch_inline_steer(buf, "/steer focus on errors")
+
+        # Buffer reset happened, captured the submitted text, and appended to history.
+        assert buf.reset_calls == ["/steer focus on errors"]
+        assert buf.append_to_history_flags == [True]
+        # Reset happened strictly before process_command ran.
+        assert observed["text_at_dispatch"] == ""
+        # And the steer still reached the agent.
+        cli.agent.steer.assert_called_once_with("focus on errors")
+        # Final buffer state is empty — nothing left to accidentally re-submit.
+        assert buf.text == ""
+
+    def test_buffer_cleared_even_if_dispatch_raises(self):
+        """If process_command raises, the buffer must STILL be clear.
+
+        This is the core of #34569: a post-dispatch reset would be skipped on
+        an exception, leaving the prompt in the box.  Reset-first guarantees
+        the input-state contract holds regardless.
+        """
+        cli = _make_cli()
+        cli._agent_running = True
+
+        buf = _FakeBuffer("/steer do the thing")
+
+        with patch.object(cli, "process_command", side_effect=RuntimeError("boom")):
+            try:
+                cli._dispatch_inline_steer(buf, "/steer do the thing")
+            except RuntimeError:
+                pass  # exception is allowed to propagate; the buffer must still be clear
+
+        assert buf.reset_calls == ["/steer do the thing"]
+        assert buf.text == ""
+
+
 if __name__ == "__main__":  # pragma: no cover
     import pytest
 


### PR DESCRIPTION
## Summary

- Clear the TUI input field **before** dispatching an inline `/steer`, so the submitted prompt can never linger in the buffer.
- Fixes the workflow hazard where a steered prompt could be accidentally re-submitted on the next Enter or turn-handoff.

## Motivation

Closes #34569.

When `/steer <prompt>` is submitted while the agent is working, the Enter handler dispatched the command and reset the input buffer **afterward**. If `process_command()` re-entered the prompt_toolkit event loop (a print routed through `run_in_terminal`, or a modal that snapshots+restores the in-progress draft) or raised before returning, the post-dispatch `reset()` was skipped — leaving the submitted prompt sitting in the input field. The next Enter (or the auto-resume / next-turn handoff) could then re-send it, which is the opposite of `/steer`'s mid-run-injection purpose.

The fix routes the inline-steer case through a small `_dispatch_inline_steer()` helper that resets the buffer **before** running `process_command()`. This makes the TUI's input-state contract — *"what's in the box hasn't been sent"* — hold unconditionally, regardless of how `process_command` behaves. As a bonus, because the buffer is now empty before any modal opens, the modal draft snapshot/restore path (`_capture_modal_input_snapshot` / `_restore_modal_input_snapshot`) can no longer resurrect the submitted steer text.

This matches the existing post-submit clear contract that normal prompts already get, and addresses the issue's hypothesis #3 (race between async steer consumption and the synchronous buffer clear).

## Verification

- `python3 -m pytest tests/cli/test_cli_steer_busy_path.py` — 9 passed (7 existing + 2 new)
- New tests:
  - `test_buffer_cleared_before_dispatch` — asserts the buffer is empty at the moment `process_command` runs, the submitted text was appended to history, the steer still reaches `agent.steer()`, and the final buffer is empty.
  - `test_buffer_cleared_even_if_dispatch_raises` — asserts the buffer is still cleared when `process_command` raises (the exact case a post-dispatch reset would miss).
- Did NOT change: steer semantics, the idle-path / queue / interrupt fallbacks, or the detector gate — only the ordering of the buffer reset relative to dispatch on the inline path.

## Notes

The change is a single small refactor: the inline-steer block in the Enter handler now calls `self._dispatch_inline_steer(buffer, text)`, which does `buffer.reset(append_to_history=True)` then `process_command(text)`.
