### PR TITLE
feat: embedder environment-hint hook for the system prompt

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -848,6 +848,27 @@ def build_environment_hints() -> str:
 
     if is_wsl():
         hints.append(WSL_ENVIRONMENT_HINT)
+
+    # Embedder-supplied environment description. Lets a host that wraps Hermes
+    # (e.g. a sandbox runner / managed platform) explain the environment the
+    # agent is running in — proxy, credential handling, mount layout — without
+    # forking the identity slot (SOUL.md). Read once at prompt-build time, so
+    # it's part of the stable, cache-safe system prompt. The env var is the
+    # build-time/embedder mechanism (set in a container ENV); config.yaml
+    # ``agent.environment_hint`` is the user-facing surface. Env var wins.
+    extra = (os.getenv("HERMES_ENVIRONMENT_HINT") or "").strip()
+    if not extra:
+        try:
+            from hermes_cli.config import load_config
+
+            extra = str(
+                (load_config().get("agent", {}) or {}).get("environment_hint", "")
+            ).strip()
+        except Exception as e:
+            logger.debug("Could not read agent.environment_hint from config: %s", e)
+    if extra:
+        hints.append(extra)
+
     return "\n\n".join(hints)
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -683,6 +683,13 @@ DEFAULT_CONFIG = {
         # (docker/modal/ssh — they have their own probe).  Set False to
         # disable entirely.
         "environment_probe": True,
+        # Embedder-supplied environment description appended to the system
+        # prompt's environment-hints block. Lets a host that wraps Hermes
+        # (sandbox runner, managed platform) explain the runtime environment
+        # — proxy, credential handling, mount layout — without editing the
+        # identity slot (SOUL.md). Empty by default. The HERMES_ENVIRONMENT_HINT
+        # env var overrides this (build-time/container mechanism).
+        "environment_hint": "",
         # Staged inactivity warning: send a warning to the user at this
         # threshold before escalating to a full timeout.  The warning fires
         # once per run and does not interrupt the agent.  0 = disable warning.

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -947,6 +947,58 @@ class TestEnvironmentHints:
                 f"info is suppressed in the system prompt"
             )
 
+    def test_environment_hint_from_env_var_is_appended(self, monkeypatch):
+        """HERMES_ENVIRONMENT_HINT lets an embedder describe the runtime env."""
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.setenv("HERMES_ENVIRONMENT_HINT", "Running inside an OpenShell sandbox.")
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Running inside an OpenShell sandbox." in result
+        # The factual host block must still come first.
+        assert result.index("Host:") < result.index("OpenShell")
+
+    def test_environment_hint_env_var_overrides_config(self, monkeypatch):
+        """Env var wins over config.yaml agent.environment_hint."""
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.setenv("HERMES_ENVIRONMENT_HINT", "ENV-WINS")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"agent": {"environment_hint": "CONFIG-VALUE"}},
+        )
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "ENV-WINS" in result
+        assert "CONFIG-VALUE" not in result
+
+    def test_environment_hint_falls_back_to_config(self, monkeypatch):
+        """With no env var, the config.yaml value is used."""
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("HERMES_ENVIRONMENT_HINT", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"agent": {"environment_hint": "CONFIG-VALUE"}},
+        )
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "CONFIG-VALUE" in result
+
+    def test_environment_hint_empty_by_default(self, monkeypatch):
+        """No hint configured anywhere → no embedder text, host block intact."""
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("HERMES_ENVIRONMENT_HINT", raising=False)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"agent": {}})
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Host:" in result
+
 
 # =========================================================================
 # Conditional skill activation

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -93,6 +93,26 @@ class TestProviderEnvBlocklist:
         for var in registry_vars:
             assert var not in result_env, f"{var} leaked into subprocess env"
 
+    def test_aws_sdk_provider_vars_are_stripped(self):
+        """AWS SDK credential-chain vars must not leak to subprocesses."""
+        aws_vars = {
+            "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
+            "AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "AWS_SESSION_TOKEN": "session-token",
+            "AWS_PROFILE": "production",
+            "AWS_SHARED_CREDENTIALS_FILE": "/home/user/.aws/credentials",
+            "AWS_CONFIG_FILE": "/home/user/.aws/config",
+            "AWS_WEB_IDENTITY_TOKEN_FILE": "/var/run/secrets/token",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/123",
+            "AWS_CONTAINER_CREDENTIALS_FULL_URI": "http://169.254.170.2/v2/credentials/123",
+            "AWS_CONTAINER_AUTHORIZATION_TOKEN": "container-token",
+            "AWS_BEARER_TOKEN_BEDROCK": "bedrock-bearer",
+        }
+        result_env = _run_with_env(extra_os_env=aws_vars)
+
+        for var in aws_vars:
+            assert var not in result_env, f"{var} leaked into subprocess env"
+
     def test_non_registry_provider_vars_are_stripped(self):
         """Extra provider vars not in PROVIDER_REGISTRY must also be blocked."""
         extra_provider_vars = {
@@ -212,6 +232,28 @@ class TestBlocklistCoverage:
                     f"Registry base_url_env_var {pconfig.base_url_env_var} "
                     f"(provider={pconfig.id}) missing from blocklist"
                 )
+
+    def test_aws_sdk_provider_vars_are_in_blocklist(self):
+        """auth_type='aws_sdk' providers rely on credential-chain vars, not API keys."""
+        aws_vars = {
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+            "AWS_SECURITY_TOKEN",
+            "AWS_PROFILE",
+            "AWS_DEFAULT_PROFILE",
+            "AWS_SHARED_CREDENTIALS_FILE",
+            "AWS_CONFIG_FILE",
+            "AWS_WEB_IDENTITY_TOKEN_FILE",
+            "AWS_ROLE_ARN",
+            "AWS_ROLE_SESSION_NAME",
+            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+            "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+            "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+            "AWS_BEARER_TOKEN_BEDROCK",
+        }
+        assert aws_vars.issubset(_HERMES_PROVIDER_ENV_BLOCKLIST)
 
     def test_extra_auth_vars_covered(self):
         """Non-registry auth vars (ANTHROPIC_TOKEN, CLAUDE_CODE_OAUTH_TOKEN)

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -93,25 +93,58 @@ class TestProviderEnvBlocklist:
         for var in registry_vars:
             assert var not in result_env, f"{var} leaked into subprocess env"
 
-    def test_aws_sdk_provider_vars_are_stripped(self):
-        """AWS SDK credential-chain vars must not leak to subprocesses."""
-        aws_vars = {
+    def test_bedrock_bearer_token_is_stripped(self):
+        """The Bedrock-specific bearer token is a Hermes inference secret
+        (analogous to OPENAI_API_KEY) and must not leak into subprocesses.
+
+        Regression for #32314: AWS_BEARER_TOKEN_BEDROCK leaked into terminal /
+        execute_code children because the ``bedrock`` ProviderConfig declares
+        ``api_key_env_vars=()`` (auth_type="aws_sdk") and the blocklist builder
+        only consulted that field. The reporter caught it when ``opencode
+        models`` run inside a Hermes terminal enumerated the entire Bedrock
+        catalog off the leaked bearer token.
+        """
+        result_env = _run_with_env(extra_os_env={
+            "AWS_BEARER_TOKEN_BEDROCK": "bedrock-bearer-secret",
+        })
+
+        assert "AWS_BEARER_TOKEN_BEDROCK" not in result_env, (
+            "AWS_BEARER_TOKEN_BEDROCK leaked into subprocess env (see #32314)"
+        )
+
+    def test_general_aws_credential_chain_is_preserved(self):
+        """The GENERAL AWS credential chain must STILL pass through to
+        subprocesses — this is the no-regression guard for #32314.
+
+        Per SECURITY.md §3.2 the local terminal is the user's trusted operator
+        shell. A user running ``aws``/``terraform``/``cdk``/``boto3`` in the
+        agent terminal must keep the same AWS access their own shell has.
+        Stripping these would (a) break every user who does AWS work in the
+        agent terminal — not just Bedrock users, since the registry is iterated
+        unconditionally — and (b) be unrecoverable, because env_passthrough.py
+        refuses to re-allow anything in _HERMES_PROVIDER_ENV_BLOCKLIST
+        (GHSA-rhgp-j443-p4rf). Only the Bedrock inference bearer token is
+        Hermes-managed; the rest belongs to the user.
+        """
+        general_chain = {
             "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
             "AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
             "AWS_SESSION_TOKEN": "session-token",
             "AWS_PROFILE": "production",
+            "AWS_DEFAULT_REGION": "us-east-1",
+            "AWS_REGION": "us-east-1",
             "AWS_SHARED_CREDENTIALS_FILE": "/home/user/.aws/credentials",
             "AWS_CONFIG_FILE": "/home/user/.aws/config",
             "AWS_WEB_IDENTITY_TOKEN_FILE": "/var/run/secrets/token",
-            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/123",
-            "AWS_CONTAINER_CREDENTIALS_FULL_URI": "http://169.254.170.2/v2/credentials/123",
-            "AWS_CONTAINER_AUTHORIZATION_TOKEN": "container-token",
-            "AWS_BEARER_TOKEN_BEDROCK": "bedrock-bearer",
+            "AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/example",
         }
-        result_env = _run_with_env(extra_os_env=aws_vars)
+        result_env = _run_with_env(extra_os_env=general_chain)
 
-        for var in aws_vars:
-            assert var not in result_env, f"{var} leaked into subprocess env"
+        for var, value in general_chain.items():
+            assert result_env.get(var) == value, (
+                f"{var} was stripped from subprocess env — this is a "
+                f"capability regression (see #32314 discussion)"
+            )
 
     def test_non_registry_provider_vars_are_stripped(self):
         """Extra provider vars not in PROVIDER_REGISTRY must also be blocked."""
@@ -233,27 +266,35 @@ class TestBlocklistCoverage:
                     f"(provider={pconfig.id}) missing from blocklist"
                 )
 
-    def test_aws_sdk_provider_vars_are_in_blocklist(self):
-        """auth_type='aws_sdk' providers rely on credential-chain vars, not API keys."""
-        aws_vars = {
+    def test_bedrock_bearer_token_is_in_blocklist(self):
+        """auth_type='aws_sdk' providers contribute their Hermes-managed
+        inference token (the Bedrock bearer) to the blocklist, keyed off
+        auth_type so any future SDK-cred provider is covered automatically."""
+        assert "AWS_BEARER_TOKEN_BEDROCK" in _HERMES_PROVIDER_ENV_BLOCKLIST
+
+    def test_general_aws_chain_not_in_blocklist(self):
+        """The general AWS credential chain must NOT be in the blocklist —
+        no-regression guard for #32314. These belong to the user's trusted
+        operator shell (SECURITY.md §3.2), not to Hermes, and blocklisting
+        them would be unrecoverable via env_passthrough (GHSA-rhgp-j443-p4rf).
+        """
+        general_chain = {
             "AWS_ACCESS_KEY_ID",
             "AWS_SECRET_ACCESS_KEY",
             "AWS_SESSION_TOKEN",
-            "AWS_SECURITY_TOKEN",
             "AWS_PROFILE",
-            "AWS_DEFAULT_PROFILE",
+            "AWS_DEFAULT_REGION",
+            "AWS_REGION",
             "AWS_SHARED_CREDENTIALS_FILE",
             "AWS_CONFIG_FILE",
             "AWS_WEB_IDENTITY_TOKEN_FILE",
             "AWS_ROLE_ARN",
-            "AWS_ROLE_SESSION_NAME",
-            "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
-            "AWS_CONTAINER_CREDENTIALS_FULL_URI",
-            "AWS_CONTAINER_AUTHORIZATION_TOKEN",
-            "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
-            "AWS_BEARER_TOKEN_BEDROCK",
         }
-        assert aws_vars.issubset(_HERMES_PROVIDER_ENV_BLOCKLIST)
+        leaked_block = general_chain & _HERMES_PROVIDER_ENV_BLOCKLIST
+        assert not leaked_block, (
+            f"General AWS chain vars must stay inheritable, but these are "
+            f"blocklisted: {sorted(leaked_block)} (capability regression, #32314)"
+        )
 
     def test_extra_auth_vars_covered(self):
         """Non-registry auth vars (ANTHROPIC_TOKEN, CLAUDE_CODE_OAUTH_TOKEN)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -75,22 +75,24 @@ def _resolve_safe_cwd(cwd: str) -> str:
 # Hermes-internal env vars that should NOT leak into terminal subprocesses.
 _HERMES_PROVIDER_ENV_FORCE_PREFIX = "_HERMES_FORCE_"
 
+# Hermes-managed AWS *inference* credentials for ``auth_type="aws_sdk"``
+# providers (Bedrock).  Scoped DELIBERATELY NARROW: this lists only the
+# Bedrock-specific bearer token, which is a Hermes inference secret exactly
+# analogous to ``OPENAI_API_KEY`` — nobody drives the ``aws``/``terraform``/
+# ``boto3`` toolchain off it, so stripping it from terminal/execute_code
+# subprocesses costs no user capability.
+#
+# The GENERAL AWS credential chain (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+# AWS_SESSION_TOKEN, AWS_PROFILE, and the config/role pointers) is INTENTIONALLY
+# left inheritable.  Per SECURITY.md §3.2 the local terminal is the user's
+# trusted operator shell; the agent having the same general AWS access the
+# user's own shell has is the intended posture, not a leak.  Hard-blocklisting
+# those vars would (a) regress every user who runs aws/terraform/cdk/boto3 in
+# the agent terminal — not just Bedrock users, since the registry is iterated
+# unconditionally — and (b) be unrecoverable, because env_passthrough.py
+# refuses to re-allow anything in this blocklist (GHSA-rhgp-j443-p4rf).  See
+# issue #32314 discussion.
 _AWS_SDK_CREDENTIAL_ENV_VARS = frozenset({
-    "AWS_ACCESS_KEY_ID",
-    "AWS_SECRET_ACCESS_KEY",
-    "AWS_SESSION_TOKEN",
-    "AWS_SECURITY_TOKEN",
-    "AWS_PROFILE",
-    "AWS_DEFAULT_PROFILE",
-    "AWS_SHARED_CREDENTIALS_FILE",
-    "AWS_CONFIG_FILE",
-    "AWS_WEB_IDENTITY_TOKEN_FILE",
-    "AWS_ROLE_ARN",
-    "AWS_ROLE_SESSION_NAME",
-    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
-    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
-    "AWS_CONTAINER_AUTHORIZATION_TOKEN",
-    "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
     "AWS_BEARER_TOKEN_BEDROCK",
 })
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -75,6 +75,25 @@ def _resolve_safe_cwd(cwd: str) -> str:
 # Hermes-internal env vars that should NOT leak into terminal subprocesses.
 _HERMES_PROVIDER_ENV_FORCE_PREFIX = "_HERMES_FORCE_"
 
+_AWS_SDK_CREDENTIAL_ENV_VARS = frozenset({
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_SECURITY_TOKEN",
+    "AWS_PROFILE",
+    "AWS_DEFAULT_PROFILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_CONFIG_FILE",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "AWS_ROLE_ARN",
+    "AWS_ROLE_SESSION_NAME",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+    "AWS_BEARER_TOKEN_BEDROCK",
+})
+
 
 def _build_provider_env_blocklist() -> frozenset:
     """Derive the blocklist from provider, tool, and gateway config."""
@@ -84,6 +103,8 @@ def _build_provider_env_blocklist() -> frozenset:
         from hermes_cli.auth import PROVIDER_REGISTRY
         for pconfig in PROVIDER_REGISTRY.values():
             blocked.update(pconfig.api_key_env_vars)
+            if pconfig.auth_type == "aws_sdk":
+                blocked.update(_AWS_SDK_CREDENTIAL_ENV_VARS)
             if pconfig.base_url_env_var:
                 blocked.add(pconfig.base_url_env_var)
     except ImportError:


### PR DESCRIPTION
## Summary
A host that wraps Hermes can now describe the runtime environment in the system prompt without editing the identity slot (SOUL.md).

Embedders (sandbox runners, managed platforms) were stuffing execution-environment facts — proxy, credential handling, mount layout — into SOUL.md, which is the agent *identity* slot. Those facts belong in the environment-hints block that `build_environment_hints()` already maintains for WSL / docker / remote backends.

## Changes
- `agent/prompt_builder.py`: `build_environment_hints()` appends `HERMES_ENVIRONMENT_HINT` (env var, embedder/container mechanism) or, failing that, `config.yaml` `agent.environment_hint` (user surface). Env var wins. Read once at prompt-build time.
- `hermes_cli/config.py`: new `agent.environment_hint: ""` default (additive, no `_config_version` bump).
- `tests/agent/test_prompt_builder.py`: 4 new tests (env var append, env-over-config precedence, config fallback, empty default).

## Cache safety
The hint is appended to `stable_parts` (`agent/system_prompt.py`, "stable for the lifetime of the process"). It is read once at session start and never mutated mid-conversation — the prompt-caching invariant is preserved.

## Validation
| Configured | Result |
|---|---|
| env var | appended after host block |
| config key only | appended |
| env var + config | env var wins, config ignored |
| neither | host block only, no embedder text |

12/12 environment-hint tests pass (8 existing + 4 new). E2E verified with real imports against an isolated `HERMES_HOME`.

## Infographic

![environment-hint-hook](https://v3b.fal.media/files/b/0a9c24f8/4q1-mMjcTq2INGw7_nrhn_KQoxJshR.png)
