### PR TITLE
fix: surface active-pr respawn guards

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2163,6 +2163,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
             ],
+            "respawn_guarded": [
+                {"task_id": tid, "reason": reason}
+                for (tid, reason) in res.respawn_guarded
+            ],
             "auto_assigned_default": res.auto_assigned_default,
         }, indent=2))
         return 0
@@ -2201,6 +2205,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
         )
+    if res.respawn_guarded:
+        guarded = ", ".join(
+            f"{tid} ({reason})" for tid, reason in res.respawn_guarded
+        )
+        print(f"Respawn-guarded: {guarded}")
     return 0
 
 

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -208,6 +208,22 @@ def _latest_clean_event_ts(events: Iterable[Any]) -> int:
     return latest
 
 
+def _latest_respawn_guard(events: Iterable[Any]) -> tuple[str, int]:
+    """Return ``(reason, created_at)`` for the latest respawn_guarded event."""
+    latest_reason = ""
+    latest_ts = 0
+    for ev in events:
+        if _event_kind(ev) != "respawn_guarded":
+            continue
+        ts = _event_ts(ev)
+        if ts < latest_ts:
+            continue
+        payload = _parse_payload(ev)
+        latest_reason = str(payload.get("reason") or "").strip()
+        latest_ts = ts
+    return latest_reason, latest_ts
+
+
 # Standard always-available actions. Every diagnostic can offer these as
 # fallbacks regardless of kind — they're the two baseline recovery
 # primitives the kernel supports.
@@ -913,6 +929,13 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
         # double-flag the same condition.
         return []
 
+    guard_reason, guard_ts = _latest_respawn_guard(events)
+    guard_window = int(cfg.get("active_pr_guard_window_seconds", 24 * 60 * 60))
+    if guard_reason == "active_pr" and guard_ts and now - guard_ts <= guard_window:
+        # A task with an active PR guard is blocked by review workflow, not
+        # an unknown missing worker. A more specific rule below owns it.
+        return []
+
     # Find the most recent event that put this task into ready.
     # ``created`` covers tasks born ready; ``promoted`` covers parent-
     # done auto-promotion; ``reclaimed`` covers TTL/crash recovery;
@@ -991,6 +1014,54 @@ def _rule_stranded_in_ready(task, events, runs, now, cfg) -> list[Diagnostic]:
     )]
 
 
+def _rule_active_pr_respawn_guarded(task, events, runs, now, cfg) -> list[Diagnostic]:
+    """Ready task cannot spawn because the respawn guard found an active PR."""
+    if _task_field(task, "status") != "ready":
+        return []
+    if _task_field(task, "claim_lock"):
+        return []
+    assignee = (_task_field(task, "assignee") or "").strip()
+    if not assignee:
+        return []
+    reason, guard_ts = _latest_respawn_guard(events)
+    guard_window = int(cfg.get("active_pr_guard_window_seconds", 24 * 60 * 60))
+    if reason != "active_pr" or not guard_ts or now - guard_ts > guard_window:
+        return []
+
+    return [Diagnostic(
+        kind="active_pr_respawn_guarded",
+        severity="warning",
+        title="Ready task is blocked by active PR respawn guard",
+        detail=(
+            "The dispatcher is intentionally not spawning this ready task "
+            "because a recent comment contains a GitHub PR URL. Confirm a "
+            "downstream review task exists and is progressing; if not, "
+            "block this implementation task with an exact review/unblock "
+            "question instead of leaving it silently ready."
+        ),
+        actions=[
+            DiagnosticAction(
+                kind="cli_hint",
+                label="Inspect recent respawn guard events",
+                payload={"command": "hermes kanban tail"},
+            ),
+            DiagnosticAction(
+                kind="comment",
+                label="Add review-task or unblock context",
+                payload={},
+            ),
+        ],
+        first_seen_at=guard_ts,
+        last_seen_at=guard_ts,
+        count=1,
+        data={
+            "reason": reason,
+            "assignee": assignee,
+            "guarded_at": guard_ts,
+        },
+    )]
+
+
 # Registry — order matters: rules higher on the list render first when
 # severity ties. Add new rules here.
 _RULES: list[RuleFn] = [
@@ -1001,6 +1072,7 @@ _RULES: list[RuleFn] = [
     _rule_repeated_crashes,
     _rule_stuck_in_blocked,
     _rule_block_unblock_cycling,
+    _rule_active_pr_respawn_guarded,
     _rule_stranded_in_ready,
 ]
 
@@ -1015,6 +1087,7 @@ DIAGNOSTIC_KINDS = (
     "repeated_crashes",
     "stuck_in_blocked",
     "block_unblock_cycling",
+    "active_pr_respawn_guarded",
     "stranded_in_ready",
 )
 
@@ -1027,6 +1100,7 @@ DEFAULT_CONFIG = {
     "spawn_failure_threshold": 2,
     "crash_threshold": 2,
     "blocked_stale_hours": 24,
+    "active_pr_guard_window_seconds": 24 * 60 * 60,
     # Stranded-task threshold. 30 min by default — below that, the
     # signal is dominated by tasks that are about to be claimed on the
     # next dispatcher tick (default 60s) and would just be noise.

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -173,6 +173,43 @@ def test_run_slash_dispatch_dry_run_counts(kanban_home):
     assert "Spawned:" in out
 
 
+def test_run_slash_dispatch_dry_run_surfaces_respawn_guarded_active_pr(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="impl with pr", assignee="alice")
+        kb.add_comment(
+            conn,
+            tid,
+            "worker",
+            "review-required handoff: https://github.com/NousResearch/hermes-agent/pull/123",
+        )
+
+    out = kc.run_slash("dispatch --dry-run --json")
+    payload = json.loads(out)
+
+    assert payload["spawned"] == []
+    assert {"task_id": tid, "reason": "active_pr"} in payload["respawn_guarded"]
+
+
+def test_run_slash_dispatch_plain_surfaces_respawn_guarded_active_pr(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="impl with pr", assignee="alice")
+        kb.add_comment(
+            conn,
+            tid,
+            "worker",
+            "PR ready: https://github.com/NousResearch/hermes-agent/pull/456",
+        )
+
+    out = kc.run_slash("dispatch --dry-run")
+
+    assert "Respawn-guarded:" in out
+    assert f"{tid} (active_pr)" in out
+
+
 def test_run_slash_context_output_format(kanban_home):
     out = kc.run_slash("create 'tech spec' --assignee alice --body 'write an RFC'")
     import re

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -466,6 +466,24 @@ def test_stranded_in_ready_fires_when_age_exceeds_threshold():
     assert stranded[0].data["assignee"] == "demo"
 
 
+def test_active_pr_respawn_guard_diagnostic_overrides_generic_stranded_ready():
+    now = 100_000
+    task = _task(status="ready", assignee="demo", claim_lock=None)
+    events = [
+        _event("created", ts=now - 2 * 3600),
+        _event("respawn_guarded", ts=now - 60, reason="active_pr"),
+    ]
+
+    diags = kd.compute_task_diagnostics(task, events, [], now=now)
+
+    assert [d.kind for d in diags] == ["active_pr_respawn_guarded"]
+    diag = diags[0]
+    assert diag.severity == "warning"
+    assert "review task" in diag.detail
+    assert diag.data["reason"] == "active_pr"
+    assert diag.data["assignee"] == "demo"
+
+
 def test_stranded_in_ready_silent_below_threshold():
     """A ready task only 10 min old should NOT fire."""
     now = 100_000


### PR DESCRIPTION
## Summary
- include active PR respawn-guarded tasks in kanban dispatch dry-run JSON/plain output
- add a dedicated active_pr_respawn_guarded diagnostic so ready tasks blocked by review workflow are explicit instead of generic stranded-ready/no-spawn
- add regressions for dispatch output and diagnostic precedence

## Test Plan
- python -m pytest tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_diagnostics.py -q -o 'addopts='
- python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py -q -o 'addopts='