### PR TITLE
docs(credential-pools): document immediate rotation on usage-limit 429

### DIFF
--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -22,8 +22,11 @@ Your request
   → Pick key from pool (round_robin / least_used / fill_first / random)
   → Send to provider
   → 429 rate limit?
-      → Retry same key once (transient blip)
-      → Second 429 → rotate to next pool key
+      → Plan/usage limit reached (e.g. ChatGPT/Codex "usage limit reached")?
+          → Rotate to next pool key immediately (no retry — the cap won't clear on retry)
+      → Generic / transient 429?
+          → Retry same key once (transient blip)
+          → Second 429 → rotate to next pool key
       → All keys exhausted → fallback_model (different provider)
   → 402 billing error?
       → Immediately rotate to next pool key (24h cooldown)

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/credential-pools.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/credential-pools.md
@@ -18,8 +18,11 @@ Your request
   → Pick key from pool (round_robin / least_used / fill_first / random)
   → Send to provider
   → 429 rate limit?
-      → Retry same key once (transient blip)
-      → Second 429 → rotate to next pool key
+      → Plan/usage limit reached (e.g. ChatGPT/Codex "usage limit reached")?
+          → Rotate to next pool key immediately (no retry — the cap won't clear on retry)
+      → Generic / transient 429?
+          → Retry same key once (transient blip)
+          → Second 429 → rotate to next pool key
       → All keys exhausted → fallback_model (different provider)
   → 402 billing error?
       → Immediately rotate to next pool key (24h cooldown)


### PR DESCRIPTION
## Summary
The credential-pool rotation docs now match the code: a 429 carrying a usage-limit reason rotates to the next pool key immediately, rather than retrying the same key first.

The flowchart in `credential-pools.md` only described the generic 429 path ("retry once, rotate on the second 429"). But ChatGPT/Codex plan-limit 429s carry a `usage_limit_reached` reason, and the recovery path (`recover_with_credential_pool` in `agent/agent_runtime_helpers.py`) rotates on the **first** such hit — retrying is pointless since a usage cap won't clear on retry. The docs underspecified this, leading users to expect a retry-then-rotate when they actually get immediate rotation.

## Changes
- `website/docs/user-guide/features/credential-pools.md`: split the 429 branch in the "How It Works" flowchart into the usage-limit (immediate rotate) case and the generic/transient (retry-once-then-rotate) case.
- `website/i18n/zh-Hans/.../credential-pools.md`: same flowchart update (kept in sync).

## Validation
Docs-only change. The documented behavior matches the tested code path (`test_recover_with_pool_rotates_usage_limit_429_immediately`).
