### PR TITLE
fix(delegate): cap external research tool calls

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -51,6 +51,89 @@ logger = logging.getLogger(__name__)
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
 _MAX_TOOL_WORKERS = 8
 
+_DELEGATE_LIVE_RESEARCH_TOOL_COUNTS_ATTR = "_delegate_live_research_tool_counts"
+_DELEGATE_LIVE_RESEARCH_TOOL_LIMITS = {
+    "web_search": 1,
+    "x_search": 1,
+    "web_extract": 0,
+    "web_crawl": 0,
+}
+_DELEGATE_MCP_LIVE_RESEARCH_LIMITS = {
+    "search": 1,
+    "extract": 0,
+    "crawl": 0,
+    "scrape": 0,
+}
+
+
+def _is_delegate_agent(agent) -> bool:
+    """Return True for subagents spawned by delegate_task."""
+    try:
+        return int(getattr(agent, "_delegate_depth", 0) or 0) > 0
+    except Exception:
+        return False
+
+
+def _delegate_live_research_budget(tool_name: str) -> tuple[str, int] | None:
+    normalized = (tool_name or "").replace("__", "_")
+    if normalized in _DELEGATE_LIVE_RESEARCH_TOOL_LIMITS:
+        return normalized, _DELEGATE_LIVE_RESEARCH_TOOL_LIMITS[normalized]
+
+    if not normalized.startswith("mcp_"):
+        return None
+
+    for suffix, limit in _DELEGATE_MCP_LIVE_RESEARCH_LIMITS.items():
+        if normalized.endswith(f"_{suffix}"):
+            return f"mcp_{suffix}", limit
+    return None
+
+
+def _delegate_external_tool_guardrail(agent, tool_name: str) -> ToolGuardrailDecision | None:
+    """Enforce live-research tool budgets for delegated agents before dispatch."""
+    if not _is_delegate_agent(agent):
+        return None
+
+    budget = _delegate_live_research_budget(tool_name)
+    if budget is None:
+        return None
+
+    key, limit = budget
+    if limit <= 0:
+        return ToolGuardrailDecision(
+            action="block",
+            code="delegate_live_research_tool_block",
+            message=(
+                f"Blocked {tool_name}: delegated agents may not call live extraction "
+                "or crawl tools by default. The parent agent must pre-fetch live "
+                "evidence or explicitly widen the delegation runtime policy."
+            ),
+            tool_name=tool_name,
+            count=1,
+        )
+
+    counts = getattr(agent, _DELEGATE_LIVE_RESEARCH_TOOL_COUNTS_ATTR, None)
+    if not isinstance(counts, dict):
+        counts = {}
+        setattr(agent, _DELEGATE_LIVE_RESEARCH_TOOL_COUNTS_ATTR, counts)
+
+    count = int(counts.get(key, 0) or 0) + 1
+    counts[key] = count
+    if count <= limit:
+        return None
+
+    return ToolGuardrailDecision(
+        action="block",
+        code="delegate_live_research_tool_budget",
+        message=(
+            f"Blocked {tool_name}: delegated agents may call live search tools in "
+            f"this category at most {limit} time per delegation. Use the earlier "
+            "result, ask the parent agent to pre-fetch more evidence, or finish "
+            "with the evidence already available."
+        ),
+        tool_name=tool_name,
+        count=count,
+    )
+
 
 def _ra():
     """Lazy reference to ``run_agent`` so patches like ``run_agent._set_interrupt`` work."""
@@ -219,7 +302,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             if block_message is not None:
                 block_result = json.dumps({"error": block_message}, ensure_ascii=False)
             else:
-                guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
+                guardrail_decision = _delegate_external_tool_guardrail(agent, function_name)
+                if guardrail_decision is None:
+                    guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
                 if not guardrail_decision.allows_execution:
                     block_result = agent._guardrail_block_result(guardrail_decision)
                     blocked_by_guardrail = True
@@ -595,7 +680,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         _guardrail_block_decision: ToolGuardrailDecision | None = None
         if _block_msg is None:
-            guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
+            guardrail_decision = _delegate_external_tool_guardrail(agent, function_name)
+            if guardrail_decision is None:
+                guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
             if not guardrail_decision.allows_execution:
                 _guardrail_block_decision = guardrail_decision
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -4210,6 +4210,13 @@ class AIAgent:
 
     def _toolguard_controlled_halt_response(self, decision: ToolGuardrailDecision) -> str:
         tool = decision.tool_name or "a tool"
+        if decision.code in {"delegate_live_research_tool_budget", "delegate_live_research_tool_block"}:
+            return (
+                f"I stopped {tool} because it hit the delegation runtime guardrail "
+                f"({decision.code}). The parent agent should pre-fetch live research "
+                "evidence, or the delegate should finish using the evidence already "
+                "available instead of opening more live-research paths."
+            )
         return (
             f"I stopped retrying {tool} because it hit the tool-call guardrail "
             f"({decision.code}) after {decision.count} repeated non-progressing "

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -238,6 +238,139 @@ def test_plugin_pre_tool_block_wins_without_counting_as_toolguard_block():
     assert agent._tool_guardrails.before_call("web_search", args).action == "allow"
 
 
+def test_delegate_live_research_budget_blocks_second_mcp_search_before_execution():
+    agent = _make_agent("mcp_research_web_search", "mcp__research__web_search")
+    agent._delegate_depth = 1
+    args = {"query": "Hermes releases"}
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"ok": True})) as mock_hfc:
+        first = SimpleNamespace(
+            content="",
+            tool_calls=[_mock_tool_call("mcp_research_web_search", json.dumps(args), "c-search-1")],
+        )
+        second = SimpleNamespace(
+            content="",
+            tool_calls=[_mock_tool_call("mcp__research__web_search", json.dumps(args), "c-search-2")],
+        )
+        agent._execute_tool_calls_sequential(first, messages, "task-1")
+        agent._execute_tool_calls_sequential(second, messages, "task-1")
+
+    mock_hfc.assert_called_once()
+    assert [m["tool_call_id"] for m in messages] == ["c-search-1", "c-search-2"]
+    assert json.loads(messages[0]["content"]) == {"ok": True}
+    assert "delegate_live_research_tool_budget" in messages[1]["content"]
+    assert "at most 1 time per delegation" in messages[1]["content"]
+    assert agent._tool_guardrail_halt_decision is not None
+    assert agent._tool_guardrail_halt_decision.code == "delegate_live_research_tool_budget"
+
+
+def test_delegate_live_research_budget_applies_to_native_web_search():
+    agent = _make_agent("web_search")
+    agent._delegate_depth = 1
+    args = {"query": "Hermes releases"}
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"ok": True})) as mock_hfc:
+        first = SimpleNamespace(
+            content="",
+            tool_calls=[_mock_tool_call("web_search", json.dumps(args), "c-web-search-1")],
+        )
+        second = SimpleNamespace(
+            content="",
+            tool_calls=[_mock_tool_call("web_search", json.dumps(args), "c-web-search-2")],
+        )
+        agent._execute_tool_calls_sequential(first, messages, "task-1")
+        agent._execute_tool_calls_sequential(second, messages, "task-1")
+
+    mock_hfc.assert_called_once()
+    assert [m["tool_call_id"] for m in messages] == ["c-web-search-1", "c-web-search-2"]
+    assert json.loads(messages[0]["content"]) == {"ok": True}
+    assert "delegate_live_research_tool_budget" in messages[1]["content"]
+
+
+def test_delegate_live_research_budget_does_not_block_non_live_mcp_search_helpers():
+    agent = _make_agent("mcp_filesystem_search_files")
+    agent._delegate_depth = 1
+    args = {"path": ".", "pattern": "*.py"}
+    messages = []
+
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"ok": True})) as mock_hfc:
+        first = SimpleNamespace(
+            content="",
+            tool_calls=[_mock_tool_call("mcp_filesystem_search_files", json.dumps(args), "c-file-search-1")],
+        )
+        second = SimpleNamespace(
+            content="",
+            tool_calls=[_mock_tool_call("mcp_filesystem_search_files", json.dumps(args), "c-file-search-2")],
+        )
+        agent._execute_tool_calls_sequential(first, messages, "task-1")
+        agent._execute_tool_calls_sequential(second, messages, "task-1")
+
+    assert mock_hfc.call_count == 2
+    assert all("delegate_live_research_tool_" not in m["content"] for m in messages)
+    assert agent._tool_guardrail_halt_decision is None
+
+
+def test_delegate_live_research_blocks_native_extract_before_execution_but_parent_is_not():
+    args = {"urls": ["https://example.com"]}
+
+    delegate = _make_agent("web_extract")
+    delegate._delegate_depth = 1
+    delegate_msg = SimpleNamespace(
+        content="",
+        tool_calls=[_mock_tool_call("web_extract", json.dumps(args), "c-web-delegate")],
+    )
+    delegate_messages = []
+    with patch("run_agent.handle_function_call", return_value="SHOULD_NOT_RUN") as mock_hfc:
+        delegate._execute_tool_calls_sequential(delegate_msg, delegate_messages, "task-1")
+
+    mock_hfc.assert_not_called()
+    assert "delegate_live_research_tool_block" in delegate_messages[0]["content"]
+    assert "live extraction" in delegate_messages[0]["content"]
+
+    parent = _make_agent("web_extract")
+    parent._delegate_depth = 0
+    parent_msg = SimpleNamespace(
+        content="",
+        tool_calls=[_mock_tool_call("web_extract", json.dumps(args), "c-web-parent")],
+    )
+    parent_messages = []
+    with patch("run_agent.handle_function_call", return_value=json.dumps({"ok": "parent"})) as mock_hfc:
+        parent._execute_tool_calls_sequential(parent_msg, parent_messages, "task-1")
+
+    mock_hfc.assert_called_once()
+    assert json.loads(parent_messages[0]["content"]) == {"ok": "parent"}
+    assert parent._tool_guardrail_halt_decision is None
+
+
+def test_delegate_live_research_budget_blocks_duplicate_concurrent_mcp_searches_in_same_batch():
+    agent = _make_agent("mcp_research_web_search")
+    agent._delegate_depth = 1
+    args = {"query": "Hermes releases"}
+    calls = [
+        _mock_tool_call("mcp_research_web_search", json.dumps(args), "c-search-1"),
+        _mock_tool_call("mcp_research_web_search", json.dumps(args), "c-search-2"),
+    ]
+    msg = SimpleNamespace(content="", tool_calls=calls)
+    messages = []
+    executed = []
+
+    def fake_handle(name, call_args, task_id, **kwargs):
+        executed.append((name, call_args, kwargs["tool_call_id"]))
+        return json.dumps({"ok": kwargs["tool_call_id"]})
+
+    with patch("run_agent.handle_function_call", side_effect=fake_handle):
+        agent._execute_tool_calls_concurrent(msg, messages, "task-1")
+
+    assert executed == [("mcp_research_web_search", args, "c-search-1")]
+    assert [m["tool_call_id"] for m in messages] == ["c-search-1", "c-search-2"]
+    assert json.loads(messages[0]["content"]) == {"ok": "c-search-1"}
+    assert "delegate_live_research_tool_budget" in messages[1]["content"]
+    assert agent._tool_guardrail_halt_decision is not None
+    assert agent._tool_guardrail_halt_decision.code == "delegate_live_research_tool_budget"
+
+
 def test_default_run_conversation_warns_without_guardrail_halt():
     agent = _make_agent("web_search", max_iterations=10)
     same_args = {"query": "same"}


### PR DESCRIPTION
## What does this PR do?

Adds runtime enforcement for delegated agents so live-research tools cannot be used without bounds. Prompt guidance can be ignored by a delegated model, so the budget needs to live in the shared tool dispatch path instead of relying only on instructions.

This keeps parent agents unaffected: the parent can still pre-fetch live evidence normally, while delegates receive a synthetic tool result and controlled guardrail halt when they exceed the delegation budget.

## Related Issue

No issue. Raised from delegated-agent runtime testing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/tool_executor.py`: adds a delegate-only live-research guardrail before dispatch.
- `agent/tool_executor.py`: caps delegated native search tools such as `web_search` / `x_search` to 1 call per delegation.
- `agent/tool_executor.py`: caps delegated MCP live-search tools by generic `_search` suffix matching, without depending on a specific MCP server name.
- `agent/tool_executor.py`: blocks delegated live extraction/crawl/scrape tools by default so the parent must pre-fetch evidence or explicitly widen policy later.
- `run_agent.py`: adds a clearer controlled-halt message for delegation runtime guardrails.
- `tests/run_agent/test_tool_call_guardrail_runtime.py`: covers sequential, concurrent, parent-vs-delegate, native web, generic MCP, and non-live MCP behavior.

## How to Test

1. `scripts/run_tests.sh tests/run_agent/test_tool_call_guardrail_runtime.py`
2. `venv/bin/python scripts/check-windows-footguns.py agent/tool_executor.py run_agent.py tests/run_agent/test_tool_call_guardrail_runtime.py`
3. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test run:

```text
[100.0% |    14/14 | ✓14 | ✗ 0] ✓ tests/run_agent/test_tool_call_guardrail_runtime.py (14✓, 6.4s)
```

Compatibility check:

```text
✓ No Windows footguns found (3 file(s) scanned).
```
