### PR TITLE
guard Yuanbao media URL downloads

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -2385,7 +2385,9 @@ class MediaResolveMiddleware(InboundMiddleware):
 
         try:
             file_bytes, content_type = await media_download_url(
-                fetch_url, max_size_mb=adapter.MEDIA_MAX_SIZE_MB,
+                fetch_url,
+                max_size_mb=adapter.MEDIA_MAX_SIZE_MB,
+                allow_trusted_private_hosts=bool(resource_id),
             )
         except Exception as exc:
             logger.warning(

--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -29,6 +29,9 @@ from typing import Optional, Any
 
 import httpx
 
+from gateway.platforms.base import safe_url_for_log
+from tools.url_safety import is_always_blocked_url, is_safe_url
+
 logger = logging.getLogger(__name__)
 
 # ============ 常量 ============
@@ -36,6 +39,16 @@ logger = logging.getLogger(__name__)
 UPLOAD_INFO_PATH = "/api/resource/genUploadInfo"
 DEFAULT_API_DOMAIN = "yuanbao.tencent.com"
 DEFAULT_MAX_SIZE_MB = 50
+
+_TRUSTED_PRIVATE_MEDIA_HOSTS = frozenset({
+    "bot.yuanbao.tencent.com",
+    "hunyuan.tencent.com",
+    "yuanbao.tencent.com",
+})
+_TRUSTED_PRIVATE_MEDIA_SUFFIXES = (
+    ".yuanbao.tencent.com",
+    ".myqcloud.com",
+)
 
 # COS 加速域名后缀（优先使用全球加速）
 COS_USE_ACCELERATE = True
@@ -199,9 +212,55 @@ def _parse_webp_size(buf: bytes) -> Optional[dict[str, int]]:
 
 # ============ URL 下载 ============
 
+def _is_trusted_private_media_host(hostname: str) -> bool:
+    normalized = hostname.strip().lower().rstrip(".")
+    return (
+        normalized in _TRUSTED_PRIVATE_MEDIA_HOSTS
+        or any(normalized.endswith(suffix) for suffix in _TRUSTED_PRIVATE_MEDIA_SUFFIXES)
+    )
+
+
+def _is_safe_download_url(url: str, *, allow_trusted_private_hosts: bool = False) -> bool:
+    if is_safe_url(url):
+        return True
+    if not allow_trusted_private_hosts:
+        return False
+
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except Exception:
+        return False
+
+    hostname = (parsed.hostname or "").strip().lower().rstrip(".")
+    if parsed.scheme.lower() != "https" or not _is_trusted_private_media_host(hostname):
+        return False
+    return not is_always_blocked_url(url)
+
+
+async def _guard_redirect(response, *, allow_trusted_private_hosts: bool) -> None:
+    if response.is_redirect and response.next_request:
+        redirect_url = str(response.next_request.url)
+        if not _is_safe_download_url(
+            redirect_url,
+            allow_trusted_private_hosts=allow_trusted_private_hosts,
+        ):
+            raise ValueError(
+                f"Blocked redirect to private/internal address: {safe_url_for_log(redirect_url)}"
+            )
+
+
+async def _yuanbao_ssrf_redirect_guard(response) -> None:
+    await _guard_redirect(response, allow_trusted_private_hosts=False)
+
+
+async def _trusted_yuanbao_ssrf_redirect_guard(response) -> None:
+    await _guard_redirect(response, allow_trusted_private_hosts=True)
+
+
 async def download_url(
     url: str,
     max_size_mb: int = DEFAULT_MAX_SIZE_MB,
+    allow_trusted_private_hosts: bool = False,
 ) -> tuple[bytes, str]:
     """
     下载 URL 内容，返回 (bytes, content_type)。
@@ -217,8 +276,23 @@ async def download_url(
         ValueError:  内容超过大小限制
         httpx.HTTPError: 网络/HTTP 错误
     """
+    if not _is_safe_download_url(
+        url,
+        allow_trusted_private_hosts=allow_trusted_private_hosts,
+    ):
+        raise ValueError(f"Blocked unsafe URL (SSRF protection): {safe_url_for_log(url)}")
+
     max_bytes = max_size_mb * 1024 * 1024
-    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+    redirect_guard = (
+        _trusted_yuanbao_ssrf_redirect_guard
+        if allow_trusted_private_hosts
+        else _yuanbao_ssrf_redirect_guard
+    )
+    async with httpx.AsyncClient(
+        timeout=30.0,
+        follow_redirects=True,
+        event_hooks={"response": [redirect_guard]},
+    ) as client:
         # 先 HEAD 检查大小
         try:
             head = await client.head(url)

--- a/tests/gateway/test_yuanbao_media.py
+++ b/tests/gateway/test_yuanbao_media.py
@@ -1,0 +1,104 @@
+"""Tests for Yuanbao media download helpers."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.platforms import yuanbao_media
+
+
+class _UnexpectedAsyncClient:
+    def __init__(self, *args, **kwargs):
+        raise AssertionError("network client should not be created for unsafe URLs")
+
+
+@pytest.mark.asyncio
+async def test_download_url_blocks_private_hosts_before_fetch(monkeypatch):
+    monkeypatch.setattr(yuanbao_media.httpx, "AsyncClient", _UnexpectedAsyncClient)
+
+    with pytest.raises(ValueError, match="Blocked unsafe URL"):
+        await yuanbao_media.download_url("http://127.0.0.1/latest/meta-data")
+
+
+@pytest.mark.asyncio
+async def test_download_url_installs_redirect_guard(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(yuanbao_media, "is_safe_url", lambda url: True)
+
+    class FakeHeadResponse:
+        headers = {}
+
+    class FakeStreamResponse:
+        headers = {"content-type": "text/plain"}
+
+        def raise_for_status(self):
+            return None
+
+        async def aiter_bytes(self, chunk_size):
+            yield b"ok"
+
+    class FakeStream:
+        async def __aenter__(self):
+            return FakeStreamResponse()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            captured["event_hooks"] = kwargs.get("event_hooks")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def head(self, url):
+            return FakeHeadResponse()
+
+        def stream(self, method, url):
+            return FakeStream()
+
+    monkeypatch.setattr(yuanbao_media.httpx, "AsyncClient", FakeAsyncClient)
+
+    data, content_type = await yuanbao_media.download_url("https://example.com/file.txt")
+
+    assert data == b"ok"
+    assert content_type == "text/plain"
+    assert captured["event_hooks"] == {
+        "response": [yuanbao_media._yuanbao_ssrf_redirect_guard],
+    }
+
+
+@pytest.mark.asyncio
+async def test_download_url_redirect_guard_blocks_private_redirect(monkeypatch):
+    monkeypatch.setattr(
+        yuanbao_media,
+        "is_safe_url",
+        lambda url: not url.startswith("http://169.254.169.254"),
+    )
+
+    response = SimpleNamespace(
+        is_redirect=True,
+        next_request=SimpleNamespace(url="http://169.254.169.254/latest/meta-data"),
+    )
+
+    with pytest.raises(ValueError, match="Blocked redirect"):
+        await yuanbao_media._yuanbao_ssrf_redirect_guard(response)
+
+
+def test_download_url_trusted_private_hosts_are_opt_in(monkeypatch):
+    monkeypatch.setattr(yuanbao_media, "is_safe_url", lambda url: False)
+    monkeypatch.setattr(yuanbao_media, "is_always_blocked_url", lambda url: False)
+
+    media_url = "https://bucket.cos.accelerate.myqcloud.com/image.png"
+
+    assert yuanbao_media._is_safe_download_url(media_url) is False
+    assert (
+        yuanbao_media._is_safe_download_url(
+            media_url,
+            allow_trusted_private_hosts=True,
+        )
+        is True
+    )


### PR DESCRIPTION
## Summary
- apply URL safety checks before Yuanbao media downloads create an HTTP client
- install a redirect guard for followed media redirects
- keep Yuanbao-resolved resource hosts as an explicit opt-in path for private-IP resolution while preserving metadata endpoint blocking

## Tests
- `.venv/bin/python -m pytest -o addopts='' tests/gateway/test_yuanbao_media.py tests/gateway/platforms/test_yuanbao_recall_db_only.py tests/test_yuanbao_pipeline.py tests/test_yuanbao_markdown.py tests/test_yuanbao_proto.py`