### PR TITLE
fix(slack): don't memoize _mentioned_threads for bot-source @-mentions

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2001,7 +2001,15 @@ class SlackAdapter(BasePlatformAdapter):
             # Skipped in strict mode: strict_mention=true bots must be
             # re-mentioned every turn, so remembering the thread would
             # defeat the feature (and re-enable agent-to-agent ack loops).
-            if event_thread_ts and not self._slack_strict_mention():
+            #
+            # Also skipped when the @-mention came from another bot: a sibling
+            # bot's one-shot question (e.g. "@dev please check this") should be
+            # processed, but the thread MUST NOT then be memoized as "always
+            # answer", or both bots' subsequent courtesy replies (Standing by,
+            # Idle, busy-acks) will bypass SLACK_ALLOW_BOTS=mentions and feed
+            # an infinite acknowledgment loop that drains tokens.
+            from_bot = bool(event.get("bot_id")) or event.get("subtype") == "bot_message"
+            if event_thread_ts and not self._slack_strict_mention() and not from_bot:
                 self._mentioned_threads.add(event_thread_ts)
                 if len(self._mentioned_threads) > self._MENTIONED_THREADS_MAX:
                     to_remove = list(self._mentioned_threads)[:self._MENTIONED_THREADS_MAX // 2]

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -562,6 +562,85 @@ def test_mention_outside_strict_mode_still_registers_thread():
 
 
 # ---------------------------------------------------------------------------
+# Regression: bot-sourced @-mentions must NOT register the thread, otherwise
+# sibling-bot ack loops bypass SLACK_ALLOW_BOTS=mentions on every follow-up.
+# ---------------------------------------------------------------------------
+
+def test_bot_sourced_mention_does_not_register_thread():
+    """A one-shot @-mention from another bot (e.g. sibling agent asking a
+    question) is fine to process, but the thread MUST NOT be memoized — or
+    every subsequent bot reply in that thread bypasses the mentions filter
+    and feeds an infinite ack loop.
+    """
+    adapter = _make_adapter(strict_mention=False)
+    adapter._bot_user_id = "U_BOT"
+    adapter._mentioned_threads = set()
+    adapter._MENTIONED_THREADS_MAX = 5000
+
+    thread_ts = "1700000000.100200"
+    event_thread_ts = thread_ts
+
+    # Simulated Slack event: sibling bot @-mentions us
+    event = {"bot_id": "B_SIBLING", "text": "<@U_BOT> can you check this?"}
+    text = event["text"]
+    is_mentioned = f"<@{adapter._bot_user_id}>" in text
+    assert is_mentioned
+
+    from_bot = bool(event.get("bot_id")) or event.get("subtype") == "bot_message"
+    if event_thread_ts and not adapter._slack_strict_mention() and not from_bot:
+        adapter._mentioned_threads.add(event_thread_ts)
+
+    assert thread_ts not in adapter._mentioned_threads
+
+
+def test_bot_message_subtype_mention_does_not_register_thread():
+    """Same as above for the subtype=bot_message variant (legacy webhooks)."""
+    adapter = _make_adapter(strict_mention=False)
+    adapter._bot_user_id = "U_BOT"
+    adapter._mentioned_threads = set()
+    adapter._MENTIONED_THREADS_MAX = 5000
+
+    thread_ts = "1700000000.100200"
+    event_thread_ts = thread_ts
+
+    event = {"subtype": "bot_message", "text": "<@U_BOT> ping"}
+    text = event["text"]
+    is_mentioned = f"<@{adapter._bot_user_id}>" in text
+    assert is_mentioned
+
+    from_bot = bool(event.get("bot_id")) or event.get("subtype") == "bot_message"
+    if event_thread_ts and not adapter._slack_strict_mention() and not from_bot:
+        adapter._mentioned_threads.add(event_thread_ts)
+
+    assert thread_ts not in adapter._mentioned_threads
+
+
+def test_human_mention_still_registers_thread_under_new_guard():
+    """Sanity: with the new bot-source guard in place, human @-mentions
+    continue to register the thread for follow-up auto-trigger (the whole
+    point of _mentioned_threads — humans don't want to @-mention every turn).
+    """
+    adapter = _make_adapter(strict_mention=False)
+    adapter._bot_user_id = "U_BOT"
+    adapter._mentioned_threads = set()
+    adapter._MENTIONED_THREADS_MAX = 5000
+
+    thread_ts = "1700000000.100200"
+    event_thread_ts = thread_ts
+
+    event = {"user": "U_HUMAN", "text": "<@U_BOT> hi"}
+    text = event["text"]
+    is_mentioned = f"<@{adapter._bot_user_id}>" in text
+    assert is_mentioned
+
+    from_bot = bool(event.get("bot_id")) or event.get("subtype") == "bot_message"
+    if event_thread_ts and not adapter._slack_strict_mention() and not from_bot:
+        adapter._mentioned_threads.add(event_thread_ts)
+
+    assert thread_ts in adapter._mentioned_threads
+
+
+# ---------------------------------------------------------------------------
 # Tests: _slack_allowed_channels
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Two sibling bots active in the same Slack thread @-mentioning each other (legitimate cross-agent question, e.g. wiki agent asking dev agent to check the code) enter an infinite courtesy/acknowledgment loop. Each bot's `Standing by.` / `(Idle.)` / 👍 / busy-ack reply triggers the other's busy handler, which sends another reply, which triggers the first bot, etc. Tokens drain silently until a human kills the containers.

Observed live with two agents on v0.12.0 — ~30 round-trips before I noticed and stopped them. Repro is reliable: any thread where both bots have been @-mentioned at least once.

## Root cause

`gateway/platforms/slack.py` (currently line ~2004) adds the thread's `thread_ts` to `self._mentioned_threads` once any @-mention happens. From then on, every subsequent message in that thread bypasses the `SLACK_ALLOW_BOTS=mentions` filter (via the `in_mentioned_thread` short-circuit a few hundred lines earlier in `_handle_slack_message`). Sibling-bot courtesy replies are bot messages, so they should be filtered — but the cache lets them through.

The existing code comment already calls this out as the motivation for `SLACK_STRICT_MENTION`:

> Skipped in strict mode: strict_mention=true bots must be re-mentioned every turn, so remembering the thread would defeat the feature (and re-enable agent-to-agent ack loops).

…but strict mode penalises **human** users too (they must @-mention every turn), so it's rarely enabled in real deployments.

## Fix

Only register the thread in `_mentioned_threads` when the @-mention came from a **non-bot** sender. Bot-to-bot @-mentions are still processed as one-shot (a sibling bot's `@dev please check this` legitimately runs once), but they no longer leave the thread permanently subscribed. Humans keep their convenient single-mention UX.

```python
from_bot = bool(event.get("bot_id")) or event.get("subtype") == "bot_message"
if event_thread_ts and not self._slack_strict_mention() and not from_bot:
    self._mentioned_threads.add(event_thread_ts)
    ...
```

## Tests

3 new regression tests in `tests/gateway/test_slack_mention.py` mirroring the existing `_mentioned_threads` test style:

- `test_bot_sourced_mention_does_not_register_thread` — bot @-mention via `bot_id` does NOT add to `_mentioned_threads`
- `test_bot_message_subtype_mention_does_not_register_thread` — same for `subtype=bot_message` (legacy webhook path)
- `test_human_mention_still_registers_thread_under_new_guard` — sanity: human @-mention behavior unchanged

Full test file passes (58/58). No other tests touched.

## Compatibility

Pure behaviour subset for bot-sourced mentions. Human-sourced mentions and the existing strict-mention behaviour are unchanged. Anyone currently relying on bot-to-bot persistent threads should switch to either explicit re-@-mentioning per turn or `free_response_channels`.