### PR TITLE
docs(code-execution): document HERMES_* env narrowing + passthrough workaround

### DIFF
--- a/website/docs/user-guide/features/code-execution.md
+++ b/website/docs/user-guide/features/code-execution.md
@@ -219,6 +219,62 @@ terminal:
 
 See the [Security guide](/user-guide/security#environment-variable-passthrough) for full details.
 
+### `HERMES_*` variables in the child
+
+The child process receives only a small, fixed set of operational `HERMES_*`
+variables by exact name:
+
+- `HERMES_HOME`
+- `HERMES_PROFILE`
+- `HERMES_CONFIG`
+- `HERMES_ENV`
+
+(plus `HERMES_RPC_DIR` / `HERMES_RPC_SOCKET` / `TZ` / `HOME`, which Hermes
+injects explicitly so the RPC channel works).
+
+:::note Behavior change
+Earlier versions passed **any** variable whose name began with `HERMES_`
+through to the child. That broad prefix was removed for security hardening: it
+could leak `HERMES_*`-named configuration that doesn't match a secret substring
+(for example `HERMES_BASE_URL`, `HERMES_KANBAN_DB`, or a `HERMES_*_WEBHOOK`
+endpoint) into arbitrary sandboxed code.
+
+If an `execute_code` script — or a repo/plugin module it imports at import time
+— relied on a `HERMES_*` variable outside the four operational names above, it
+will now find that variable **unset** in the child. The drop is intentional,
+not a bug.
+:::
+
+**Workaround — opt the variable back in explicitly.** Both routes pass the
+variable through `execute_code` *and* `terminal` children, and neither weakens
+the secret-stripping guarantee (Hermes-managed provider credentials can never
+be re-allowed this way):
+
+1. **Per-machine, in `config.yaml`** — add the exact variable name to the
+   passthrough allowlist:
+
+   ```yaml
+   terminal:
+     env_passthrough:
+       - HERMES_KANBAN_DB
+       - HERMES_BASE_URL
+   ```
+
+2. **Per-skill, in the skill's frontmatter** — declare it so it is registered
+   automatically whenever that skill is loaded:
+
+   ```yaml
+   required_environment_variables:
+     - HERMES_KANBAN_DB
+   ```
+
+**Diagnosing it.** When the child drops one or more non-allowlisted `HERMES_*`
+variables, Hermes emits a one-line `debug` log naming them and pointing at the
+`env_passthrough` escape hatch. Run with debug logging (`hermes logs --level
+DEBUG`, or check `~/.hermes/logs/agent.log`) and look for
+`execute_code: dropped N non-allowlisted HERMES_* var(s)` if a script behaves
+as though a `HERMES_*` variable is missing.
+
 Hermes always writes the script and the auto-generated `hermes_tools.py` RPC stub into a temp staging directory that is cleaned up after execution. In `strict` mode the script also *runs* there; in `project` mode it runs in the session's working directory (the staging directory stays on `PYTHONPATH` so imports still resolve). The child process runs in its own process group so it can be cleanly killed on timeout or interruption.
 
 ## execute_code vs terminal


### PR DESCRIPTION
## Why

The execute_code sandbox-child env scrub (landed in `108397726`, hardening for #27303) deliberately removed the broad `HERMES_` prefix passthrough, keeping only an operational 4-var allowlist:

```
HERMES_HOME, HERMES_PROFILE, HERMES_CONFIG, HERMES_ENV
```

This is correct hardening — the broad prefix leaked `HERMES_*`-named config that lacks a secret substring (`HERMES_BASE_URL`, `HERMES_KANBAN_DB`, `HERMES_*_WEBHOOK`) into arbitrary sandboxed code. But it's a **silent behavior change**: a script (or a repo/plugin module it imports at import time) that read a non-secret `HERMES_*` var outside those four now finds it unset in the child, with no doc explaining why.

## What this adds

A `### HERMES_* variables in the child` subsection in the code-execution docs covering:

- The exact 4-var operational allowlist + the explicitly-injected RPC vars
- A `:::note Behavior change` callout explaining the drop is intentional
- The **workaround**, both routes:
  - `terminal.env_passthrough` in `config.yaml` (per-machine)
  - `required_environment_variables` in skill frontmatter (per-skill)
- How to **diagnose** it: the existing `debug` log line (`execute_code: dropped N non-allowlisted HERMES_* var(s)`) and how to surface it via `hermes logs --level DEBUG`

Neither workaround weakens the secret-stripping guarantee — Hermes-managed provider credentials can never be re-allowed through `env_passthrough` (GHSA-rhgp-j443-p4rf).

Docs-only. No code change.