### PR TITLE
fix(agent): deepcopy agent.tools before llama.cpp grammar-retry sanitization

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2486,8 +2486,11 @@ def run_conversation(
                 ):
                     llama_cpp_grammar_retry_attempted = True
                     try:
+                        import copy as _copy
                         from tools.schema_sanitizer import strip_pattern_and_format
-                        _, _stripped = strip_pattern_and_format(agent.tools)
+                        _tools_copy = _copy.deepcopy(agent.tools)
+                        _, _stripped = strip_pattern_and_format(_tools_copy)
+                        agent.tools = _tools_copy
                     except Exception as _strip_exc:  # pragma: no cover — defensive
                         logger.warning(
                             "%sllama.cpp grammar recovery: strip helper failed: %s",


### PR DESCRIPTION
## Root Cause

`strip_pattern_and_format()` is documented to mutate its input in place:

> *Callers that need to preserve the original should deep-copy first.*
> — `tools/schema_sanitizer.py`

The llama.cpp grammar-retry path in `conversation_loop.py` called it directly
on `agent.tools` without a deep-copy, permanently stripping `pattern`/`format`
keywords from the **shared tool-registry dicts** — not only for the immediate
retry, but for every subsequent API call in the same session.

Affected sessions: any that mix a llama.cpp primary model with cloud-provider
auxiliary tasks (Anthropic, OpenAI, OpenRouter, Gemini), or that switch models
mid-session after a grammar error. Those follow-on calls lose the schema hints
that cloud providers rely on for date/phone/email parameters.

## Missed sibling of #34416

PR #34416 applied the identical deep-copy fix to
`chat_completion_helpers.py` (line 623) and `auxiliary_client.py` (line 708)
after identifying that the xAI sanitizer paths suffered the same permanent
mutation. This call site in `conversation_loop.py` was not included.

## Fix

```python
# before
_, _stripped = strip_pattern_and_format(agent.tools)

# after
_tools_copy = _copy.deepcopy(agent.tools)
_, _stripped = strip_pattern_and_format(_tools_copy)
agent.tools = _tools_copy
```

- Registry dicts are preserved; a future `/reload-mcp` or tool rebuild returns
  full schemas.
- The session-level permanent strip (so subsequent llama.cpp calls don't
  re-trigger the retry) is retained via the explicit `agent.tools = _tools_copy`
  assignment — behaviour is unchanged for pure llama.cpp sessions.
- The exception path is safer: a partial failure in `strip_pattern_and_format`
  no longer leaves `agent.tools` in a partially-mutated state.

## Test plan

- [ ] Start a session with a llama.cpp OAI-compatible server that rejects
  `pattern`/`format` in tool schemas (HTTP 400 grammar error).
- [ ] Confirm the grammar-retry fires and the session continues.
- [ ] Switch to a cloud provider (or trigger an auxiliary task routed to one)
  in the same session — verify the tool schemas sent to the cloud provider
  still contain `pattern`/`format` keywords.
- [ ] Existing `test_run_agent_codex_responses.py` and schema-sanitizer unit
  tests pass unchanged.