### PR TITLE
fix(gateway): suppress compaction lifecycle chatter

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -319,6 +319,18 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     return text
 
 
+def _gateway_status_allowed(event_type: str, progress_mode: str) -> bool:
+    """Return whether a status callback should be delivered to chat.
+
+    ``lifecycle`` statuses are progress chatter, including context compaction
+    notices. Honour ``display.platforms.<platform>.tool_progress: off`` for
+    those, while still letting warnings through.
+    """
+    if str(event_type or "").strip().lower() != "lifecycle":
+        return True
+    return str(progress_mode or "all").strip().lower() != "off"
+
+
 async def _send_or_update_status_coro(adapter, chat_id, status_key, content, metadata):
     """Route a status message through adapter.send_or_update_status when supported.
 
@@ -9636,6 +9648,18 @@ class GatewayRunner:
             new_entry = self.session_store.get_or_create_session(source, force_new=True)
             header = self._telegram_topic_new_header(source) or t("gateway.reset.header_new")
 
+        # Topic-mode Telegram DMs have a durable thread -> session binding.
+        # /new replaces the session attached to the current topic, so update
+        # that binding immediately. Otherwise the next message in the topic
+        # sees the stale binding and switch_session() resurrects the old,
+        # huge transcript, which can trigger context compaction on a supposedly
+        # fresh session.
+        if new_entry and self._is_telegram_topic_lane(source):
+            try:
+                self._record_telegram_topic_binding(source, new_entry)
+            except Exception:
+                logger.debug("Failed to update Telegram topic binding after /new", exc_info=True)
+
         # Set session title if provided with /new <title>
         _title_arg = event.get_command_args().strip()
         _title_note = ""
@@ -16744,6 +16768,15 @@ class GatewayRunner:
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
+                return
+            if not _gateway_status_allowed(event_type, progress_mode):
+                logger.debug(
+                    "status_callback suppressed by tool_progress=%s for %s/%s: %s",
+                    progress_mode,
+                    source.platform.value if source.platform else "unknown",
+                    event_type,
+                    _redact_gateway_user_facing_secrets(str(message or ""))[:160],
+                )
                 return
             prepared_message = _prepare_gateway_status_message(
                 source.platform,

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -2,6 +2,7 @@
 
 from gateway.config import Platform
 from gateway.run import (
+    _gateway_status_allowed,
     _prepare_gateway_status_message,
     _sanitize_gateway_final_response,
 )
@@ -29,6 +30,13 @@ def test_non_telegram_status_is_unchanged():
 
     assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", message) == message
     assert _prepare_gateway_status_message("local", "lifecycle", message) == message
+
+
+def test_lifecycle_status_honours_tool_progress_off_but_keeps_warnings():
+    """Context compaction lifecycle bubbles should obey per-platform quiet mode."""
+    assert _gateway_status_allowed("lifecycle", "off") is False
+    assert _gateway_status_allowed("lifecycle", "new") is True
+    assert _gateway_status_allowed("warn", "off") is True
 
 
 def test_telegram_status_sanitizes_raw_provider_security_errors():

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -277,6 +277,67 @@ class TestResetCommandWithTitle:
         assert "Custom Name" in str(result)
 
     @pytest.mark.asyncio
+    async def test_reset_command_updates_telegram_topic_binding(self):
+        """/new in a Telegram topic lane rebinds the topic to the new session."""
+        from datetime import datetime
+
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionEntry, SessionSource, build_session_key
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+        )
+        runner.adapters = {Platform.TELEGRAM: MagicMock(send=AsyncMock())}
+        runner._voice_mode = {}
+        runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+        runner._session_model_overrides = {}
+        runner._pending_model_notes = {}
+        runner._background_tasks = set()
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+            thread_id="10947",
+        )
+        session_key = build_session_key(source)
+        new_session_entry = SessionEntry(
+            session_key=session_key,
+            session_id="sess-new",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+        )
+        runner.session_store = MagicMock()
+        runner.session_store.get_or_create_session.return_value = new_session_entry
+        runner.session_store.reset_session.return_value = new_session_entry
+        runner.session_store._entries = {session_key: new_session_entry}
+        runner.session_store._generate_session_key.return_value = session_key
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._session_db = MagicMock()
+        runner._session_db.is_telegram_topic_mode_enabled.return_value = True
+        runner._agent_cache = {}
+        runner._agent_cache_lock = None
+        runner._is_user_authorized = lambda _source: True
+        runner._format_session_info = lambda: ""
+
+        event = MessageEvent(text="/new", source=source)
+        await runner._handle_reset_command(event)
+
+        runner._session_db.bind_telegram_topic.assert_called_with(
+            chat_id="67890",
+            thread_id="10947",
+            user_id="12345",
+            session_key=session_key,
+            session_id="sess-new",
+        )
+
+    @pytest.mark.asyncio
     async def test_reset_command_duplicate_title_surfaces_warning(self):
         """/new <title> with an already-in-use title returns a warning in the reply."""
         from datetime import datetime

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -671,6 +671,28 @@ def test_status_callback_accepts_single_message_argument():
     )
 
 
+def test_status_callback_suppresses_lifecycle_when_tool_progress_off(monkeypatch):
+    monkeypatch.setitem(server._sessions, "sid", {"tool_progress_mode": "off"})
+    with patch("tui_gateway.server._emit") as emit:
+        cb = server._agent_cbs("sid")["status_callback"]
+        cb("lifecycle", "🗜️ Compacting context — summarizing earlier conversation so I can continue...")
+
+    emit.assert_not_called()
+
+
+def test_status_callback_keeps_warnings_when_tool_progress_off(monkeypatch):
+    monkeypatch.setitem(server._sessions, "sid", {"tool_progress_mode": "off"})
+    with patch("tui_gateway.server._emit") as emit:
+        cb = server._agent_cbs("sid")["status_callback"]
+        cb("warn", "compression failed")
+
+    emit.assert_called_once_with(
+        "status.update",
+        "sid",
+        {"kind": "warn", "text": "compression failed"},
+    )
+
+
 def test_resolve_model_uses_inference_model_env(monkeypatch):
     monkeypatch.delenv("HERMES_MODEL", raising=False)
     monkeypatch.setenv("HERMES_INFERENCE_MODEL", " anthropic/claude-sonnet-4.6\n")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -394,10 +394,16 @@ def _status_update(sid: str, kind: str, text: str | None = None):
     body = (text if text is not None else kind).strip()
     if not body:
         return
+    event_kind = kind if text is not None else "status"
+    # Lifecycle statuses are progress chatter, including context compaction
+    # notices. Honour display.tool_progress=off for embedded/TUI consumers too,
+    # while still allowing warn/error style statuses through.
+    if str(event_kind or "").strip().lower() == "lifecycle" and not _tool_progress_enabled(sid):
+        return
     _emit(
         "status.update",
         sid,
-        {"kind": kind if text is not None else "status", "text": body},
+        {"kind": event_kind, "text": body},
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Suppresses noisy context-compaction lifecycle chatter in gateway/chat surfaces when tool progress is disabled, while still allowing warnings through.

It fixes two related paths:

- Messaging gateway status callbacks now honour `display.platforms.<platform>.tool_progress: off` for lifecycle events such as `🗜️ Compacting context...`.
- TUI/embedded gateway status callbacks now suppress lifecycle status updates when the session has `tool_progress_mode: off`.

It also fixes Telegram topic-mode `/new` rebinding so a topic is attached to the new session immediately, instead of being able to resurrect the previous huge transcript via a stale durable topic binding.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Adds lifecycle-status filtering for messaging gateway status callbacks.
  - Keeps warning statuses visible even when progress is off.
  - Rebinds Telegram topic lanes after `/new` so the next message cannot switch back to the old session.
- `tui_gateway/server.py`
  - Suppresses lifecycle `status.update` events when session tool progress is off.
- `tests/gateway/test_telegram_noise_filter.py`
  - Covers lifecycle suppression and warning passthrough.
- `tests/gateway/test_title_command.py`
  - Covers Telegram topic rebinding after `/new`.
- `tests/test_tui_gateway_server.py`
  - Covers TUI/embedded lifecycle suppression and warning passthrough.

## How to Test

1. Set Discord/Joke or another gateway platform to `tool_progress: off`.
2. Trigger a large-context turn that would normally emit context-compaction lifecycle statuses.
3. Verify compaction lifecycle messages are not posted to chat, but warning statuses still are.
4. In Telegram topic mode, run `/new` in a topic and verify subsequent messages stay on the new session.

Local verification run:

```text
pytest tests/gateway/test_telegram_noise_filter.py tests/gateway/test_title_command.py tests/test_tui_gateway_server.py -q
210 passed in 4.56s
```

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

```text
pytest tests/gateway/test_telegram_noise_filter.py tests/gateway/test_title_command.py tests/test_tui_gateway_server.py -q
210 passed in 4.56s
```
