### PR TITLE
fix(docker): create s6 envdir before browser path export

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -290,6 +290,9 @@ if [ -z "${AGENT_BROWSER_EXECUTABLE_PATH:-}" ] && \
         # Write to s6's container_environment so with-contenv picks it
         # up for all supervised services (main-hermes, dashboard, etc.).
         # Idempotent: each boot overwrites with the current path.
+        # Some container runtimes / s6-overlay versions do not create the
+        # envdir before cont-init hooks run, so create it defensively.
+        mkdir -p /run/s6/container_environment
         printf '%s' "$browser_bin" > /run/s6/container_environment/AGENT_BROWSER_EXECUTABLE_PATH
     else
         echo "[stage2] Warning: no Chromium binary under $PLAYWRIGHT_BROWSERS_PATH; browser tool may fail"

--- a/tests/tools/test_stage2_hook_puid_pgid.py
+++ b/tests/tools/test_stage2_hook_puid_pgid.py
@@ -84,3 +84,18 @@ def test_hermes_uid_gid_take_precedence_over_aliases(stage2_text: str) -> None:
 def test_no_uid_vars_leaves_values_empty(stage2_text: str) -> None:
     # An empty resolution means the stage2 hook keeps the default hermes user.
     assert _resolve(stage2_text, {}) == ":"
+
+
+def test_stage2_hook_creates_s6_envdir_before_writing_browser_path(stage2_text: str) -> None:
+    """Regression guard for browser-path export on runtimes where the
+    s6 container_environment directory is absent when the cont-init hook runs.
+    """
+    mkdir_line = "mkdir -p /run/s6/container_environment"
+    write_line = (
+        "printf '%s' \"$browser_bin\" > "
+        "/run/s6/container_environment/AGENT_BROWSER_EXECUTABLE_PATH"
+    )
+
+    assert mkdir_line in stage2_text
+    assert write_line in stage2_text
+    assert stage2_text.index(mkdir_line) < stage2_text.index(write_line)


### PR DESCRIPTION
Fix an issue where docker container fails with

```
hermes  | /opt/hermes/docker/stage2-hook.sh: 293: cannot create /run/s6/container_environment/AGENT_BROWSER_EXECUTABLE_PATH: Directory nonexistent
```
## Related Issue

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- docker/stage2-hook.sh

## How to Test

Running docker container shows the bug in logs.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Changed file in docker container and restarted and error is gone.