### PR TITLE
fix: accept OpenAI-compatible provider type alias

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3374,7 +3374,7 @@ def _normalize_custom_provider_entry(
         entry["key_env"] = entry["api_key_env"]
     _KNOWN_KEYS = {
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
-        "api_mode", "transport", "model", "default_model", "models",
+        "api_mode", "transport", "type", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
         "discover_models", "extra_body",
@@ -3440,7 +3440,13 @@ def _normalize_custom_provider_entry(
     if isinstance(key_env, str) and key_env.strip():
         normalized["key_env"] = key_env.strip()
 
+    provider_type = entry.get("type")
     api_mode = entry.get("api_mode") or entry.get("transport")
+    if not api_mode and isinstance(provider_type, str) and provider_type.strip().lower() == "openai":
+        # Accept the common provider schema used by OpenAI-compatible endpoints
+        # (for example Ollama/LiteLLM snippets) without warning.  Treat it as a
+        # lowest-precedence alias so explicit api_mode/transport still wins.
+        api_mode = "chat_completions"
     if isinstance(api_mode, str) and api_mode.strip():
         normalized["api_mode"] = api_mode.strip()
 

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -102,6 +102,41 @@ class TestNormalizeCustomProviderEntry:
         assert result is not None
         assert not any("unknown config keys" in r.message.lower() for r in caplog.records)
 
+    def test_type_openai_alias_sets_chat_completions_without_warning(self, caplog):
+        """type: openai should be accepted as an OpenAI-compatible alias."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "api_key": "***",
+            "type": "openai",
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert result["api_mode"] == "chat_completions"
+        assert not any("unknown config keys" in r.message.lower() for r in caplog.records)
+
+    def test_explicit_api_mode_wins_over_type_openai_alias(self):
+        """type is lowest precedence; explicit api_mode keeps compatibility."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "type": "openai",
+            "api_mode": "anthropic_messages",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert result["api_mode"] == "anthropic_messages"
+
+    def test_explicit_transport_wins_over_type_openai_alias(self):
+        """type is lowest precedence; explicit transport keeps compatibility."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "type": "openai",
+            "transport": "anthropic_messages",
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="test")
+        assert result is not None
+        assert result["api_mode"] == "anthropic_messages"
+
     def test_camel_case_warning_logged(self, caplog):
         """camelCase alias mapping should produce a warning."""
         entry = {


### PR DESCRIPTION
## Summary
- Accept `type: openai` in custom provider config as a lowest-precedence OpenAI-compatible alias.
- Normalize that alias to `api_mode: chat_completions` only when explicit `api_mode` or `transport` is absent.
- Treat `type` as a known provider key so common OpenAI-compatible snippets do not emit unknown-key warnings.

## Test plan
- `python -m pytest tests/hermes_cli/test_provider_config_validation.py -q -o 'addopts='`
- Broader `python -m pytest tests/hermes_cli -q -o 'addopts='` was attempted; it still has unrelated existing environment/auth/platform failures on this macOS checkout, while the focused provider config suite passes.
