### PR TITLE
feat(gateway): opt-in X-Hermes-User-Id header for per-user memory scope

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2,8 +2,8 @@
 OpenAI-compatible API server platform adapter.
 
 Exposes an HTTP server with endpoints:
-- POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id header; opt-in long-term memory scoping via X-Hermes-Session-Key header)
-- POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id; X-Hermes-Session-Key supported)
+- POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id header; opt-in long-term memory scoping via X-Hermes-Session-Key header; opt-in per-user memory scoping via X-Hermes-User-Id header)
+- POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id; X-Hermes-Session-Key + X-Hermes-User-Id supported)
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent and any configured model_routes aliases
@@ -810,7 +810,7 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key, X-Hermes-User-Id, X-Hermes-Session-Key, X-Hermes-Session-Id",
 }
 
 
@@ -1078,9 +1078,25 @@ class _IdempotencyCache:
 _idem_cache = _IdempotencyCache()
 
 
-def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
+def _make_request_fingerprint(
+    body: Dict[str, Any],
+    keys: List[str],
+    *,
+    user_id: Optional[str] = None,
+    gateway_session_key: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> str:
+    """Fingerprint request body keys plus validated memory-scope identity.
+
+    Including ``user_id`` (and optionally session key/id) ensures that an
+    ``Idempotency-Key`` reused across different authenticated end-users cannot
+    reclaim another user's completion/response output.
+    """
     from hashlib import sha256
     subset = {k: body.get(k) for k in keys}
+    subset["__hermes_user_id"] = user_id or ""
+    subset["__hermes_gateway_session_key"] = gateway_session_key or ""
+    subset["__hermes_session_id"] = session_id or ""
     return sha256(repr(subset).encode("utf-8")).hexdigest()
 
 
@@ -1913,6 +1929,59 @@ class APIServerAdapter(BasePlatformAdapter):
         if len(raw) > self._MAX_SESSION_HEADER_LEN:
             return None, web.json_response(
                 {"error": {"message": "Session key too long", "type": "invalid_request_error"}},
+                status=400,
+            )
+
+        return raw, None
+
+    def _parse_user_id_header(
+        self, request: "web.Request"
+    ) -> tuple[Optional[str], Optional["web.Response"]]:
+        """Extract and validate the ``X-Hermes-User-Id`` header.
+
+        The user id is an opt-in, stable end-user identity that scopes
+        long-term memory **per person** (e.g. a Honcho peer) rather than
+        per transcript.  It is independent of ``X-Hermes-Session-Key``
+        (which scopes a chat) and ``X-Hermes-Session-Id`` (short-term
+        transcript): callers may send any, all, or none.
+
+        Returns ``(user_id, None)`` on success (with an empty/absent
+        header yielding ``None``), or ``(None, error_response)`` on
+        validation failure.
+
+        Security: mirrors ``X-Hermes-Session-Key`` exactly.  Accepting a
+        caller-supplied memory scope requires API-key authentication so
+        that an unauthenticated client on a local-only server can't inject
+        itself into another user's long-term memory scope by guessing an id.
+        """
+        raw = request.headers.get("X-Hermes-User-Id", "").strip()
+        if not raw:
+            return None, None
+
+        if not self._api_key:
+            logger.warning(
+                "X-Hermes-User-Id rejected: no API key configured. "
+                "Set API_SERVER_KEY to enable per-user memory scoping."
+            )
+            return None, web.json_response(
+                _openai_error(
+                    "X-Hermes-User-Id requires API key authentication. "
+                    "Configure API_SERVER_KEY to enable this feature."
+                ),
+                status=403,
+            )
+
+        # Reject control characters that could enable header injection on
+        # the echo path.
+        if re.search(r'[\r\n\x00]', raw):
+            return None, web.json_response(
+                {"error": {"message": "Invalid user id", "type": "invalid_request_error"}},
+                status=400,
+            )
+
+        if len(raw) > self._MAX_SESSION_HEADER_LEN:
+            return None, web.json_response(
+                {"error": {"message": "User id too long", "type": "invalid_request_error"}},
                 status=400,
             )
 
@@ -2887,6 +2956,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
+                "user_id_header": "X-Hermes-User-Id",
                 "cors": bool(self._cors_origins),
             },
             "endpoints": {
@@ -3771,6 +3841,13 @@ class APIServerAdapter(BasePlatformAdapter):
         if key_err is not None:
             return key_err
 
+        # Opt-in per-user memory scope via X-Hermes-User-Id (see
+        # _parse_user_id_header).  Threaded to AIAgent(user_id=...) so
+        # long-term memory providers (e.g. Honcho) can scope per end-user.
+        user_id, uid_err = self._parse_user_id_header(request)
+        if uid_err is not None:
+            return uid_err
+
         # Allow caller to continue an existing session by passing X-Hermes-Session-Id.
         # When provided, history is loaded from state.db instead of from the request body.
         #
@@ -3946,6 +4023,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 request, completion_id, model_name, created, _stream_q,
                 agent_task, agent_ref, session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                user_id=user_id,
             )
 
         # Non-streaming: run the agent (with optional Idempotency-Key)
@@ -4006,6 +4084,8 @@ class APIServerAdapter(BasePlatformAdapter):
         }
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
+        if user_id:
+            response_headers["X-Hermes-User-Id"] = user_id
 
         # Hard-fail path: no usable assistant text AND a real failure → 5xx
         # with OpenAI-style error envelope so SDK clients raise instead of
@@ -4067,7 +4147,7 @@ class APIServerAdapter(BasePlatformAdapter):
     async def _write_sse_chat_completion(
         self, request: "web.Request", completion_id: str, model: str,
         created: int, stream_q, agent_task, agent_ref=None, session_id: str = None,
-        gateway_session_key: str = None,
+        gateway_session_key: str = None, user_id: str = None,
     ) -> "web.StreamResponse":
         """Write real streaming SSE from agent's stream_delta_callback queue.
 
@@ -4092,6 +4172,8 @@ class APIServerAdapter(BasePlatformAdapter):
             sse_headers["X-Hermes-Session-Id"] = session_id
         if gateway_session_key:
             sse_headers["X-Hermes-Session-Key"] = gateway_session_key
+        if user_id:
+            sse_headers["X-Hermes-User-Id"] = user_id
         response = web.StreamResponse(status=200, headers=sse_headers)
         await response.prepare(request)
 
@@ -4276,6 +4358,7 @@ class APIServerAdapter(BasePlatformAdapter):
         store: bool,
         session_id: str,
         gateway_session_key: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> "web.StreamResponse":
         """Write an SSE stream for POST /v1/responses (OpenAI Responses API).
 
@@ -4320,6 +4403,8 @@ class APIServerAdapter(BasePlatformAdapter):
             sse_headers["X-Hermes-Session-Id"] = session_id
         if gateway_session_key:
             sse_headers["X-Hermes-Session-Key"] = gateway_session_key
+        if user_id:
+            sse_headers["X-Hermes-User-Id"] = user_id
         response = web.StreamResponse(status=200, headers=sse_headers)
         await response.prepare(request)
 
@@ -4875,6 +4960,10 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        # Opt-in per-user memory scope (see _parse_user_id_header).
+        user_id, uid_err = self._parse_user_id_header(request)
+        if uid_err is not None:
+            return uid_err
 
         # Parse request body
         try:
@@ -5069,6 +5158,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 store=store,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                user_id=user_id,
             )
 
         async def _compute_response():
@@ -6087,6 +6177,10 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        # Opt-in per-user memory scope (see _parse_user_id_header).
+        user_id, uid_err = self._parse_user_id_header(request)
+        if uid_err is not None:
+            return uid_err
 
         # Enforce concurrency limit (shared across all agent-serving
         # endpoints; configurable via gateway.api_server.max_concurrent_runs).
@@ -6468,9 +6562,11 @@ class APIServerAdapter(BasePlatformAdapter):
         if hasattr(task, "add_done_callback"):
             task.add_done_callback(self._background_tasks.discard)
 
-        response_headers = (
-            {"X-Hermes-Session-Key": gateway_session_key} if gateway_session_key else {}
-        )
+        response_headers: Dict[str, str] = {}
+        if gateway_session_key:
+            response_headers["X-Hermes-Session-Key"] = gateway_session_key
+        if user_id:
+            response_headers["X-Hermes-User-Id"] = user_id
         return web.json_response(
             {"run_id": run_id, "status": "started"},
             status=202,

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -499,6 +499,29 @@ X-Hermes-Session-Key: agent:main:webui:dm:user-42
 
 Rules: max 256 chars, control characters (`\r`, `\n`, `\x00`) are rejected, and the value is echoed back on responses (JSON + SSE). `/v1/capabilities` advertises support via `"session_key_header": "X-Hermes-Session-Key"`. Without the key, Honcho's `per-session` strategy produces a different scope per `session_id` — exactly the behavior Hermes had before.
 
+## Per-user memory scoping (`X-Hermes-User-Id`)
+
+When a single Hermes API instance serves multiple end-users (for example multi-tenant Web UIs), pass an **opt-in** `X-Hermes-User-Id` so long-term memory providers (Honcho peers, etc.) can scope state **per person**, independent of the channel key and the rotating transcript id:
+
+```http
+POST /v1/chat/completions HTTP/1.1
+Authorization: Bearer ***
+X-Hermes-User-Id: person-42
+X-Hermes-Session-Key: agent:main:webui:dm:person-42
+X-Hermes-Session-Id: transcript-alpha
+```
+
+Rules (mirrors `X-Hermes-Session-Key`):
+
+- Max 256 characters; control characters (`\r`, `\n`, `\x00`) are rejected (`400`).
+- Only honored when API key auth is configured — accepting a caller-supplied memory scope without auth is a `403`.
+- Echoed on success for chat/completions, responses, runs (202), and session-chat endpoints (including SSE writers).
+- Advertised on `/v1/capabilities` as `"user_id_header": "X-Hermes-User-Id"` / `features.user_id_header`.
+- Browser CORS preflight allows the header when `API_SERVER_CORS_ORIGINS` permits the origin.
+- `Idempotency-Key` fingerprints include the validated `user_id` (plus session key/id) so identical body payloads from different users never share a cached completion.
+
+When the header is absent, `user_id` stays `None` and behavior matches the historical default peer.
+
 ## System Prompt Handling
 
 When a frontend sends a `system` message (Chat Completions) or `instructions` field (Responses API), hermes-agent **layers it on top** of its core system prompt. Your agent keeps all its tools, memory, and skills — the frontend's system prompt adds extra instructions.


### PR DESCRIPTION
## Summary

- Adds an **opt-in** `X-Hermes-User-Id` request header to the HTTP API server, threaded to `AIAgent(user_id=...)`.
- Lets an authenticated front-end scope long-term memory **per end-user** (a Honcho peer) over the HTTP API, on a single Hermes instance serving multiple users.

## Motivation

Closes #34605.

The rest of the stack already consumes `user_id` end-to-end — `run_agent.py` (`AIAgent.__init__(user_id=...)`), `agent/agent_init.py` (`agent._user_id`), and the bundled Honcho provider (`runtime_user_peer_name=kwargs.get("user_id")`). The API server was the **only** entry point that built `AIAgent(...)` without ever setting `user_id`, so every HTTP request collapsed onto the same default memory peer. A session key only separates transcripts of the *same* user; it can't represent a person across sessions. This wires the missing identity through.

The header mirrors the existing `X-Hermes-Session-Key` contract exactly:

- **Auth-gated**: honored only when an API key is configured, else `403` (an unauthenticated client on a local-only server can't inject itself into another user's memory scope).
- **Validated**: control characters rejected (`400`), length bounded to 256 (`400`).
- **Echoed** back on success across `/v1/chat/completions`, `/v1/responses`, `/v1/runs`, and the session-chat endpoints (incl. both SSE writers).
- **Advertised** via `/v1/capabilities` as `features.user_id_header` for client feature-detection.

## Backward compatibility (by design)

When the header is absent, `user_id` stays `None` and behavior is unchanged (current default peer). It is independent of `X-Hermes-Session-Key` (channel) and `X-Hermes-Session-Id` (transcript) — callers may send any, all, or none.

## Verification

- `python3 -m pytest tests/gateway/test_api_server.py -k "SessionKeyHeader or UserIdHeader"` — 18 passed
- `python3 -m pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py tests/gateway/test_session_api.py` — 196 passed
- New `TestUserIdHeader` class (9 tests): passed-and-echoed, coexists with session-key + session-id, absent→`None`, `403` without API key, control-char + oversized rejection, threads into `_create_agent`, `/v1/responses` parity, capabilities advert.
- Did NOT change: existing `X-Hermes-Session-Key` semantics — `user_id` is threaded as a sibling parameter, never coupled to the session key.
