### PR TITLE
fix(gateway): strip echoed restart system notes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -415,6 +415,21 @@ _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
     re.IGNORECASE,
 )
 
+_GATEWAY_INTERNAL_SYSTEM_NOTE_RE = re.compile(
+    r"\[System note:\s*The previous turn was interrupted by\s+"
+    r"a gateway (?:restart|shutdown|interruption);\s*"
+    r"the gateway is now back online\.[\s\S]*?"
+    r"Do NOT re-execute old tool calls\s*[—-]\s*skip any unfinished\s+"
+    r"work from the conversation history\.\]\s*",
+    re.IGNORECASE,
+)
+
+
+def _strip_gateway_internal_system_notes(text: str) -> str:
+    """Remove current gateway recovery notes if a model echoes them."""
+    cleaned = _GATEWAY_INTERNAL_SYSTEM_NOTE_RE.sub("", text)
+    return cleaned.strip() if cleaned != text else text
+
 
 def _looks_like_gateway_provider_error(text: str) -> bool:
     """True when text is infrastructure/provider failure, not normal content.
@@ -454,12 +469,14 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     if _gateway_surface_passes_raw_text(platform):
         return text
 
+    sanitized = _strip_gateway_internal_system_notes(str(text))
+
     # Cancellation metadata, not assistant prose. ACP/TUI already suppress
     # this sentinel; chat surfaces should too (#7921).
-    if str(text).strip().startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX):
+    if sanitized.strip().startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX):
         return ""
 
-    redacted = _redact_gateway_user_facing_secrets(str(text))
+    redacted = _redact_gateway_user_facing_secrets(sanitized)
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -144,6 +144,38 @@ def test_chat_gateways_keep_normal_answers(platform):
     assert _sanitize_gateway_final_response(platform, answer) == answer
 
 
+CURRENT_RESTART_RECOVERY_NOTES = [
+    (
+        "[System note: The previous turn was interrupted by a gateway restart; "
+        "the gateway is now back online. Any restart/shutdown command in the history "
+        "has already run — do NOT re-execute or verify it. Address the user's NEW "
+        "message below FIRST and focus on what the user is asking now. Do NOT "
+        "re-execute old tool calls — skip any unfinished work from the conversation "
+        "history.]"
+    ),
+    (
+        "[System note: The previous turn was interrupted by a gateway restart; "
+        "the gateway is now back online. Any restart/shutdown command in the history "
+        "has already run — do NOT re-execute or verify it. Report to the user that "
+        "the session was restored successfully and ask what they would like to do "
+        "next. Do NOT re-execute old tool calls — skip any unfinished work from the "
+        "conversation history.]"
+    ),
+]
+
+
+@pytest.mark.parametrize("recovery_note", CURRENT_RESTART_RECOVERY_NOTES)
+def test_chat_gateway_strips_current_restart_system_notes(recovery_note):
+    """Fixtures mirror both recovery-note producers in current gateway main."""
+    answer = "Done — the fix is applied."
+    raw = f"{recovery_note}\n\n{answer}"
+
+    sanitized = _sanitize_gateway_final_response(Platform.WHATSAPP, raw)
+
+    assert sanitized == answer
+    assert "System note" not in sanitized
+
+
 @pytest.mark.parametrize("platform", CHAT_PLATFORMS)
 def test_chat_gateways_drop_interrupt_sentinel(platform):
     """The interrupt-while-waiting sentinel is metadata, not a reply (#7921)."""


### PR DESCRIPTION
## What does this PR do?

Prevents gateway restart/resume scaffolding from leaking into user-facing chat replies if the model echoes the synthetic system note.

The resume note is still available to the model during recovery; this only strips it at the final gateway delivery boundary.

## Related Issue

No issue filed. Related area: restart-resume system notes and gateway final-response sanitization.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: strip echoed current gateway restart/shutdown/interruption recovery notes in `_sanitize_gateway_final_response()` before delivery to human-facing chat surfaces.
- `tests/gateway/test_telegram_noise_filter.py`: add WhatsApp regression coverage derived from both current recovery-note producers, ensuring the internal note is removed while preserving the actual assistant reply.

## How to Test

1. Run `python -m pytest tests/gateway/test_telegram_noise_filter.py -q`.
2. Run `python -m pytest tests/gateway/test_telegram_noise_filter.py tests/gateway/test_restart_resume_pending.py -q`.
3. Verify both current `[System note: The previous turn was interrupted by ...]` variants are delivered without the internal note while preserving the assistant reply.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested the rebased change with the full local pytest suite

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no OS-specific code added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Remote-only update verification (no local checkout modified):

```text
- Rebased PR branch directly onto current upstream main.
- Python syntax compilation passed for both modified files.
- Both exact current recovery-note fixtures are stripped.
- Non-note assistant content is preserved.
- GitHub compare: 1 commit ahead, 0 behind; 2 files changed.
- GitHub mergeability: MERGEABLE.
- GitHub Actions: awaiting/absent for the fork PR; no full pytest result claimed here.
```
