### PR TITLE
feat(agent): add tool_repetition guardrail for repeated mutating calls

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -345,6 +345,27 @@ class ToolCallGuardrailController:
                     self._halt_decision = decision
                     return decision
 
+        if self._is_mutating(tool_name):
+            record = self._tool_repetition.get(signature)
+            if record is not None:
+                _result_hash, repeat_count = record
+                if repeat_count >= self.config.tool_repetition_block_after:
+                    decision = ToolGuardrailDecision(
+                        action="block",
+                        code="tool_repetition_block",
+                        message=(
+                            f"Blocked {tool_name}: this call repeated the same arguments and "
+                            f"returned the same result {repeat_count} times without making "
+                            "progress. Stop repeating it unchanged; change the arguments or "
+                            "approach, or report the blocker."
+                        ),
+                        tool_name=tool_name,
+                        count=repeat_count,
+                        signature=signature,
+                    )
+                    self._halt_decision = decision
+                    return decision
+
         return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
     def after_call(
@@ -364,6 +385,7 @@ class ToolCallGuardrailController:
             exact_count = self._exact_failure_counts.get(signature, 0) + 1
             self._exact_failure_counts[signature] = exact_count
             self._no_progress.pop(signature, None)
+            self._tool_repetition.pop(signature, None)
 
             same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
             self._same_tool_failure_counts[tool_name] = same_count
@@ -414,6 +436,8 @@ class ToolCallGuardrailController:
 
         if not self._is_idempotent(tool_name):
             self._no_progress.pop(signature, None)
+            if self._is_mutating(tool_name):
+                return self._track_tool_repetition(tool_name, signature, result)
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
         result_hash = _result_hash(result)

--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)


### PR DESCRIPTION
## Summary

- Adds a dedicated `tool_repetition` guardrail axis that catches *mutating* tool calls which "succeed" but never make progress (e.g. `browser_navigate` to a 404 URL).
- Counts identical tool signature (name + canonical args) **and** identical result repetitions for tools in `MUTATING_TOOL_NAMES`; warns past the threshold and, when `hard_stop_enabled`, blocks the next identical call.

## Motivation

Closes #34610.

`tool_loop_guardrails` previously tracked only three axes:

- `exact_failure_*` / `same_tool_failure_*` — error-classified failures
- `idempotent_no_progress_*` — same-result loops for **read-only** tools

Mutating tools are explicitly excluded from the idempotent `no_progress` check, so a mutating call that returns a *non-error* payload but never progresses (the canonical case: `browser_navigate` to a consistently-404 page) was never counted on any axis. It could loop until `max_iterations` was exhausted, burning tokens silently.

This adds a fourth axis, `tool_repetition`, scoped to mutating tools, paralleling the existing idempotent `no_progress` logic but keyed on "same tool + same args + same result" rather than error classification — exactly as the issue proposes.

## Behavior

- On a successful mutating call, the controller records `(result_hash, repeat_count)` per `ToolCallSignature`.
- `warnings_enabled` + `repeat_count >= warn_after.tool_repetition` → `warn` (never blocks execution).
- `hard_stop_enabled` + `repeat_count >= hard_stop_after.tool_repetition` → `before_call` returns `block` on the next identical call.
- A **changed result** for the same signature counts as progress and restarts the streak.
- A **failure** clears the streak (routes back through the failure axes).
- **Read-only tools are unchanged** — they keep using `idempotent_no_progress`.
- **Unknown tools** (neither idempotent nor mutating) remain untracked.

## Config

New thresholds (defaults `5` / `8`), wired into `DEFAULT_CONFIG`:

```yaml
tool_loop_guardrails:
  warn_after:
    tool_repetition: 5
  hard_stop_after:
    tool_repetition: 8
```

## Changes

- `agent/tool_guardrails.py`: `tool_repetition_warn_after` / `tool_repetition_block_after` config fields + `from_mapping` parsing; per-turn `_tool_repetition` state; `before_call` block guard; `_track_tool_repetition` + `_is_mutating` helpers; failure/changed-result reset.
- `hermes_cli/config.py`: `DEFAULT_CONFIG` documents the new `tool_repetition` thresholds.
- `tests/agent/test_tool_guardrails.py`: 8 new tests.

## Verification

- `python3 -m pytest tests/agent/test_tool_guardrails.py` — **22 passed** (8 new + 14 existing).
- `python3 -m pytest tests/run_agent/test_agent_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py` — **44 passed** (runtime integration intact).
- `python3 -m py_compile agent/tool_guardrails.py hermes_cli/config.py` — clean.

New tests cover: default thresholds, config parsing, warn-only-by-default for mutating repetition, hard-stop block on next repeat, streak reset on changed result, streak reset on failure, read-only tools still routed to `idempotent_no_progress`, unknown tools untracked, and `reset_for_turn` clearing the new state.

Did **not** change the existing axes or the idempotent/mutating tool classification — the new axis is additive and inert unless a mutating tool repeats identically.

## Differential value

#33761 (`feat(guardrails): add per-tool thresholds`) is adjacent but distinct: it adds per-tool *overrides* and lowers defaults on the **existing three** axes. It does **not** add a `tool_repetition` dimension for successful-but-no-progress mutating calls, which is the specific gap #34610 describes. The two are complementary and non-conflicting.
