### PR TITLE
feat(gateway): opt-in per-platform model via platform_models (#34612)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2655,7 +2655,8 @@ class APIServerAdapter(BasePlatformAdapter):
             runtime_kwargs = _resolve_runtime_agent_kwargs()
         except RuntimeError as exc:
             raise _ProviderAuthResolutionError(str(exc)) from exc
-        model = _resolve_gateway_model()
+        user_config = _load_gateway_config()
+        model = _resolve_gateway_model(user_config, platform="api_server")
 
         # When the primary provider's auth fails (expired token / 429 quota
         # cap), _resolve_runtime_agent_kwargs() falls through to the fallback

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3306,14 +3306,35 @@ def _load_gateway_runtime_config() -> dict:
     return expanded if isinstance(expanded, dict) else {}
 
 
-def _resolve_gateway_model(config: dict | None = None) -> str:
+def _resolve_gateway_model(config: dict | None = None, platform: str | None = None) -> str:
     """Read model from config.yaml — single source of truth.
 
     Without this, temporary AIAgent instances (e.g. /compress) fall
     back to the hardcoded default which fails when the active provider is
     openai-codex.
+
+    Per-platform override (opt-in): when ``platform`` is supplied AND
+    ``platform_models.<platform>`` is set in config.yaml, that model wins
+    over the global ``model.default``. This lets a single platform (e.g.
+    the HTTP API server) run a cheaper/faster model than every other
+    platform. Callers that omit ``platform`` — every existing call site —
+    are unchanged.
+
+    Override shape: bare string, or ``{default|model: name}``. Provider and
+    credentials still come from the global runtime config, so a platform
+    override must name a model that works with the active provider.
     """
     cfg = config if config is not None else _load_gateway_config()
+    if platform:
+        platform_models = cfg.get("platform_models")
+        if isinstance(platform_models, dict):
+            override = platform_models.get(platform)
+            if isinstance(override, str) and override.strip():
+                return override.strip()
+            if isinstance(override, dict):
+                name = override.get("default") or override.get("model") or ""
+                if isinstance(name, str) and name.strip():
+                    return name.strip()
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, str):
         return model_cfg

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -194,7 +194,7 @@ class TestAdapterInit:
                 "api_mode": "codex_responses",
             },
         )
-        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "gpt-5.5")
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda *a, **k: "gpt-5.5")
         monkeypatch.setattr(
             "gateway.run._load_gateway_config",
             lambda: {
@@ -2465,7 +2465,7 @@ def _patch_create_agent_runtime(monkeypatch, captured: dict, fake_agent_cls):
             "api_mode": "chat_completions",
         },
     )
-    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "global/model")
+    monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda *a, **k: "global/model")
     monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
     monkeypatch.setattr(
         "gateway.run.GatewayRunner._load_reasoning_config", staticmethod(lambda model="": {})
@@ -2818,7 +2818,7 @@ class TestCreateAgentModelRecovery:
             lambda: {"provider": "openai-codex", "base_url": "https://example.test/v1",
                      "api_mode": "codex_responses"},
         )
-        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "")
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda *a, **k: "")
         monkeypatch.setattr(
             "hermes_cli.models.get_default_model_for_provider",
             lambda provider: "gpt-5.5-codex" if provider == "openai-codex" else None,
@@ -2851,14 +2851,14 @@ class TestCreateAgentModelRecovery:
 
         # Turn 1: model resolves fine — populates the last-known-good cache
         # (keyed on gateway_session_key).
-        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "minimax/minimax-m3")
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda *a, **k: "minimax/minimax-m3")
         adapter._create_agent(session_id="api-session", gateway_session_key="stable-chan-1")
         assert captured[0]["model"] == "minimax/minimax-m3"
         assert adapter._last_resolved_model["stable-chan-1"] == "minimax/minimax-m3"
 
         # Turn 2: transient empty resolution, no provider catalog default —
         # must recover the model from turn 1, not build model="".
-        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "")
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda *a, **k: "")
         monkeypatch.setattr(
             "gateway.run._resolve_runtime_agent_kwargs",
             lambda: {"provider": None, "base_url": None, "api_mode": None},

--- a/tests/test_empty_model_fallback.py
+++ b/tests/test_empty_model_fallback.py
@@ -130,3 +130,85 @@ class TestResolveGatewayModel:
     def test_string_model_config(self):
         from gateway.run import _resolve_gateway_model
         assert _resolve_gateway_model({"model": "my-model"}) == "my-model"
+
+
+class TestResolveGatewayModelPlatformOverride:
+    """Opt-in per-platform override via platform_models.<platform>."""
+
+    BASE = {
+        "model": {"default": "claude-opus-4-8"},
+        "platform_models": {
+            "api_server": {"default": "claude-sonnet-4-6"},
+        },
+    }
+
+    def test_no_platform_arg_returns_global_default(self):
+        """Existing call sites omit platform= and are byte-for-byte unaffected."""
+        from gateway.run import _resolve_gateway_model
+        assert _resolve_gateway_model(self.BASE) == "claude-opus-4-8"
+
+    def test_matching_platform_uses_override(self):
+        from gateway.run import _resolve_gateway_model
+        assert (
+            _resolve_gateway_model(self.BASE, platform="api_server")
+            == "claude-sonnet-4-6"
+        )
+
+    def test_non_matching_platform_falls_back_to_global(self):
+        from gateway.run import _resolve_gateway_model
+        assert (
+            _resolve_gateway_model(self.BASE, platform="telegram")
+            == "claude-opus-4-8"
+        )
+
+    def test_bare_string_override(self):
+        from gateway.run import _resolve_gateway_model
+        cfg = {
+            "model": {"default": "claude-opus-4-8"},
+            "platform_models": {"api_server": "claude-sonnet-4-6"},
+        }
+        assert (
+            _resolve_gateway_model(cfg, platform="api_server")
+            == "claude-sonnet-4-6"
+        )
+
+    def test_dict_override_model_key(self):
+        from gateway.run import _resolve_gateway_model
+        cfg = {
+            "model": {"default": "claude-opus-4-8"},
+            "platform_models": {"api_server": {"model": "claude-sonnet-4-6"}},
+        }
+        assert (
+            _resolve_gateway_model(cfg, platform="api_server")
+            == "claude-sonnet-4-6"
+        )
+
+    def test_missing_platform_models_section_falls_back(self):
+        from gateway.run import _resolve_gateway_model
+        cfg = {"model": {"default": "claude-opus-4-8"}}
+        assert (
+            _resolve_gateway_model(cfg, platform="api_server")
+            == "claude-opus-4-8"
+        )
+
+    def test_empty_override_value_falls_back(self):
+        from gateway.run import _resolve_gateway_model
+        cfg = {
+            "model": {"default": "claude-opus-4-8"},
+            "platform_models": {"api_server": {"default": ""}},
+        }
+        assert (
+            _resolve_gateway_model(cfg, platform="api_server")
+            == "claude-opus-4-8"
+        )
+
+    def test_malformed_platform_models_falls_back(self):
+        from gateway.run import _resolve_gateway_model
+        cfg = {
+            "model": {"default": "claude-opus-4-8"},
+            "platform_models": ["not", "a", "dict"],
+        }
+        assert (
+            _resolve_gateway_model(cfg, platform="api_server")
+            == "claude-opus-4-8"
+        )

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -868,3 +868,21 @@ If your issue isn't covered here:
 1. **Search existing issues:** [GitHub Issues](https://github.com/NousResearch/hermes-agent/issues)
 2. **Ask the community:** [Nous Research Discord](https://discord.gg/nousresearch)
 3. **File a bug report:** Include your OS, Python version (`python3 --version`), Hermes version (`hermes --version`), and the full error message
+
+
+### Running the API server on a different model than the rest of the gateway
+
+**Scenario:** You want the HTTP API server (`gateway/platforms/api_server.py`) to answer on a cheaper/faster model (e.g. Sonnet) while CLI, Discord, and Telegram stay on your premium default (e.g. Opus).
+
+**Solution: `platform_models` override (opt-in).** Add a `platform_models` section to `config.yaml`:
+
+```yaml
+model:
+  default: claude-opus-4-8
+platform_models:
+  api_server:
+    default: claude-sonnet-4-6   # or a bare string: api_server: claude-sonnet-4-6
+```
+
+Only the named platform is affected; every other platform continues to use `model.default`. Provider and credentials still come from the global runtime config, so the override must name a model compatible with the active provider.
+


### PR DESCRIPTION
## Summary

- Adds an **opt-in** `platform` parameter to `_resolve_gateway_model()` so a single gateway platform can run a different default model.
- Wires the HTTP API server (`api_server._create_agent`) to opt in via `platform_models.api_server`, letting operators run it on a cheaper/faster model than CLI/Discord/Telegram.

## Motivation

Closes #34612.

`gateway/platforms/api_server.py::APIServerAdapter._create_agent` resolved its model with a bare `_resolve_gateway_model()`, which only ever reads `model.default` / `model.model`. There was no platform dimension, so every gateway platform that builds a temporary agent shared one model — no supported knob to put, say, the API server on Sonnet while everything else stays on Opus.

This implements the issue author's proposed design faithfully: `platform_models.<platform>` (additive, optional) wins over the global default **only** when a caller passes `platform=`. The override accepts a bare model string or a `{default|model}` mapping. Provider/credentials still come from the global runtime config, so the override must name a model compatible with the active provider.

Config shape:

```yaml
model:
  default: claude-opus-4-8
platform_models:
  api_server:
    default: claude-sonnet-4-6   # or a bare string: api_server: claude-sonnet-4-6
```

## Verification

- `python3 -m pytest tests/test_empty_model_fallback.py` — 20 passed (12 existing + 8 new in `TestResolveGatewayModelPlatformOverride`: opt-in isolation, matching/non-matching platform, bare-string + dict shapes, empty/missing/malformed `platform_models`).
- `python3 -m pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_toolset.py` — 168 passed.
- `python3 -m pytest tests/gateway/test_{fast_command,compress_command,discord_channel_prompts,session_info,compress_plugin_engine,compress_focus}.py` — 31 passed. Confirms the other `_resolve_gateway_model()` consumers (compress/fast/discord/session_info) are unaffected.
- **Backwards compat:** every existing call site omits `platform=` and is byte-for-byte unchanged. One existing monkeypatch in `tests/gateway/test_api_server.py` was widened from `lambda:` to `lambda *a, **k:` to accept the new optional arg.

> Note (matches the issue's heads-up): the `tests/gateway/test_api_server.py` suite leaks file descriptors via aiohttp test apps and can hit `OSError: [Errno 24] Too many open files` under a low `ulimit -n`. `ulimit -n 4096` makes it green; unrelated to this change.

## Differential value (related open PRs)

Two older PRs propose per-platform model routing but neither closes #34612:

- **#11439** (@Wang-tianhao, Apr 17, 0 reviews) — uses `platforms.<platform>.extra.{model,provider,...}` and threads provider/credentials through the **session-creation** path (`_resolve_session_agent_runtime`). It adds a `platform` param to `_resolve_gateway_model()` too, but **does not update the `api_server._create_agent` call site**, which still calls `_resolve_gateway_model()` with no args — so the API server gap in #34612 remains open under that PR.
- **#15660** (@GeorgeXu, Apr 25) — adds `platform_models` for IM platforms in `_create_agent_for_session()`, also not the api_server temporary-agent path.

This PR is intentionally minimal and surgical to the issue's scope: it adds the opt-in dimension and wires only the API server. If the maintainers prefer the broader provider-aware design, the cleaner consolidation is to land #11439 **and** add the one-line api_server opt-in from here. Happy to rebase onto whichever direction is chosen.
