### PR TITLE
fix(plugins): propagate session_id to pre_tool_call hook from all 3 callsites

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1619,6 +1619,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             from hermes_cli.plugins import get_pre_tool_call_block_message
             block_message = get_pre_tool_call_block_message(
                 function_name, function_args, task_id=effective_task_id or "",
+                session_id=agent.session_id or "",
             )
         except Exception:
             pass

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -212,6 +212,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 from hermes_cli.plugins import get_pre_tool_call_block_message
                 block_message = get_pre_tool_call_block_message(
                     function_name, function_args, task_id=effective_task_id or "",
+                    session_id=agent.session_id or "",
                 )
             except Exception:
                 block_message = None
@@ -589,6 +590,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 from hermes_cli.plugins import get_pre_tool_call_block_message
                 _block_msg = get_pre_tool_call_block_message(
                     function_name, function_args, task_id=effective_task_id or "",
+                    session_id=agent.session_id or "",
                 )
             except Exception:
                 pass

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -532,6 +532,38 @@ class TestPreToolCallBlocking:
         )
         assert get_pre_tool_call_block_message("terminal", {}) == "first blocker"
 
+    def test_session_id_forwarded_to_hook(self, monkeypatch):
+        """Verify session_id kwarg reaches the plugin hook (regression test)."""
+        captured_kwargs = {}
+
+        def _capture_hook(hook_name, **kwargs):
+            captured_kwargs.update(kwargs)
+            return []
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            _capture_hook,
+        )
+        get_pre_tool_call_block_message(
+            "terminal", {}, task_id="t1", session_id="sess-42",
+        )
+        assert captured_kwargs.get("session_id") == "sess-42"
+
+    def test_session_id_defaults_to_empty_string(self, monkeypatch):
+        """When session_id is omitted, hook receives empty string default."""
+        captured_kwargs = {}
+
+        def _capture_hook(hook_name, **kwargs):
+            captured_kwargs.update(kwargs)
+            return []
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            _capture_hook,
+        )
+        get_pre_tool_call_block_message("todo", {}, task_id="t1")
+        assert captured_kwargs.get("session_id") == ""
+
 
 class TestThreadToolWhitelist:
     """Tests for the thread-local tool whitelist used by background review forks."""


### PR DESCRIPTION
## What does this PR do?

Propagates `session_id` to the `pre_tool_call` plugin hook from all three callsites in `tool_executor.py` and `agent_runtime_helpers.py`. Previously, `session_id` was accepted by `get_pre_tool_call_block_message()` but never passed by callers, causing plugins that scope by session to silently no-op.

## Related Issue

Fixes #34618

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/tool_executor.py`: Added `session_id=agent.session_id or ""` to both callsites (concurrent path line ~215, sequential path line ~593) of `get_pre_tool_call_block_message()`
- `agent/agent_runtime_helpers.py`: Added `session_id=agent.session_id or ""` to the `invoke_tool()` callsite (line ~1622)
- `tests/hermes_cli/test_plugins.py`: Added 2 regression tests: `test_session_id_forwarded_to_hook` (verifies kwarg reaches hook) and `test_session_id_defaults_to_empty_string` (verifies default behavior preserved)

## How to Test

1. Run `pytest tests/hermes_cli/test_plugins.py -k TestPreToolCallBlock -v` — all 6 tests should pass (4 existing + 2 new)
2. Verify the fix: write a plugin with a `pre_tool_call` hook that checks `session_id`, confirm it receives a non-empty value during agent execution
3. Verify backward compatibility: plugins that don't use `session_id` continue to work unchanged

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_plugins.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `get_pre_tool_call_block_message` (3 callsites in `agent/tool_executor.py` and `agent/agent_runtime_helpers.py`)
- Blast radius: LOW — adds one keyword argument to existing function calls; no behavioral change for plugins that don't use session_id
- Related patterns: `task_id` is already propagated at all callsites; `session_id` follows the same pattern
