### PR TITLE
docs: improve dogfood QA report template

### DIFF
--- a/skills/dogfood/SKILL.md
+++ b/skills/dogfood/SKILL.md
@@ -29,7 +29,7 @@ The user provides:
 
 ## Workflow
 
-Follow this 5-phase systematic workflow:
+Follow this 6-phase systematic workflow:
 
 ### Phase 1: Plan
 
@@ -61,11 +61,14 @@ For each page or feature in your plan:
    browser_snapshot()
    ```
 
-3. **Check the console** for JavaScript errors:
+3. **Check the console** for JavaScript errors and failed network requests:
    ```
    browser_console(clear=true)
    ```
-   Do this after every navigation and after every significant interaction. Silent JS errors are high-value findings.
+   Do this after every navigation and after every significant interaction. Silent JS errors are high-value findings. Capture two distinct kinds of evidence from the console output and keep them separate when recording an issue:
+   - **Console evidence** — uncaught exceptions, unhandled promise rejections, warnings.
+   - **Network evidence** — failed requests surfaced in the console (4xx/5xx responses, CORS failures, mixed-content blocks). Note the request URL and status code.
+   Copy the exact text verbatim; you will paste it into the issue's evidence fields.
 
 4. **Take an annotated screenshot** to visually assess the page and identify interactive elements:
    ```
@@ -96,17 +99,21 @@ For every issue found:
    ```
    Save the `screenshot_path` from the response — you will reference it in the report.
 
-2. **Record the details**:
+2. **Record the details** — capture every field the report template needs so it can be filled without guessing later:
    - URL where the issue occurs
-   - Steps to reproduce
+   - Steps to reproduce (numbered)
    - Expected behavior
    - Actual behavior
-   - Console errors (if any)
-   - Screenshot path
+   - **Console evidence** — verbatim console errors, or "None observed"
+   - **Network evidence** — failed requests with URL and status code, or "None observed"
+   - Screenshot path (from the `screenshot_path` in the `browser_vision` response)
 
 3. **Classify the issue** using the issue taxonomy (see `references/issue-taxonomy.md`):
-   - Severity: Critical / High / Medium / Low
-   - Category: Functional / Visual / Accessibility / Console / UX / Content
+   - **Severity:** Critical / High / Medium / Low
+   - **Category:** Functional / Visual / Accessibility / Console / UX / Content
+   - **Reproduction confidence:** Confirmed (reproduced 2+ times) / Likely (seen once) / Intermittent (could not reproduce reliably). To reach "Confirmed", re-run the reproduction steps at least once.
+   - **Suggested owner:** Frontend / Backend/API / Design / Content / Infra — the area most likely to own the root cause.
+   - **Next action:** the concrete fix or investigation you recommend.
 
 ### Phase 4: Categorize
 
@@ -114,27 +121,46 @@ For every issue found:
 2. De-duplicate — merge issues that are the same bug manifesting in different places.
 3. Assign final severity and category to each issue.
 4. Sort by severity (Critical first, then High, Medium, Low).
-5. Count issues by severity and category for the executive summary.
+5. Count issues **both** by severity and by category for the breakdown section. The two counts must each sum to the same total.
+6. Distill the three-line executive summary: a one-sentence overall **verdict**, the single most important **headline** finding, and the recommended **next action**.
 
 ### Phase 5: Report
 
 Generate the final report using the template at `templates/dogfood-report-template.md`.
 
-The report must include:
-1. **Executive summary** with total issue count, breakdown by severity, and testing scope
-2. **Per-issue sections** with:
+This report is meant to be readable in messaging platforms, so **use no Markdown tables** — the template expresses everything as labeled fields and bullet lists. The report must include:
+
+1. **Three-line executive summary** — Verdict, Headline, Next action (one sentence each).
+2. **Issue breakdown** — counts by severity and by category, as bullet lists (no tables). Both lists sum to the same total.
+3. **Per-issue blocks** (no tables, sorted Critical → Low), each with:
    - Issue number and title
-   - Severity and category badges
+   - Severity and category
    - URL where observed
-   - Description of the issue
-   - Steps to reproduce
-   - Expected vs actual behavior
-   - Screenshot references (use `MEDIA:<screenshot_path>` for inline images)
-   - Console errors if relevant
-3. **Summary table** of all issues
-4. **Testing notes** — what was tested, what was not, any blockers
+   - Reproduction confidence, suggested owner, and next action
+   - Description, numbered steps to reproduce, expected vs actual behavior
+   - **Evidence — Screenshot** (`MEDIA:<screenshot_path>` for inline images)
+   - **Evidence — Console** (verbatim, or "None observed")
+   - **Evidence — Network** (failed requests with status codes, or "None observed")
+4. **All issues at a glance** — one bullet per issue.
+5. **Coverage matrix** — one bullet per page/feature marked Tested / Partial / Not tested, with flows exercised or reason skipped, plus any blockers.
+6. **Artifact inventory** — the report path and every screenshot with a note on what it shows.
+7. **Final smoke-check checklist** — the verification gate completed in Phase 6.
 
 Save the report to `{output_dir}/report.md`.
+
+### Phase 6: Verify Completeness
+
+Before finalizing, **explicitly verify the report against the smoke-check checklist** at the bottom of the template. Do not deliver the report until every box can be checked:
+
+- Executive summary is exactly three lines (Verdict / Headline / Next action).
+- The severity breakdown and the category breakdown each sum to the same total, and that total matches the number of per-issue blocks.
+- Every issue has severity, category, reproduction confidence, suggested owner, and next action.
+- Every issue has at least one populated evidence field (screenshot, console, or network).
+- Every `MEDIA:` screenshot path points to a file that actually exists in `{output_dir}/screenshots/`.
+- The coverage matrix lists both tested and not-tested areas.
+- The report contains no Markdown tables.
+
+If any check fails, return to the relevant phase, gather the missing evidence or fix the count, and re-verify. Only then deliver the report.
 
 ## Tools Reference
 

--- a/skills/dogfood/references/issue-taxonomy.md
+++ b/skills/dogfood/references/issue-taxonomy.md
@@ -107,3 +107,34 @@ Issues with the text, media, or information on the page.
 - Missing content (empty sections)
 - Broken or dead links to external resources
 - Incorrect or misleading labels
+
+## Reproduction Confidence
+
+Record how reliably each issue can be reproduced. This tells the receiving team
+how much to trust the report and whether the bug needs more investigation before
+a fix.
+
+### Confirmed
+Reproduced the issue 2 or more times by following the documented steps. The
+steps to reproduce are reliable.
+
+### Likely
+Observed the issue once and have clear evidence (screenshot/console), but did not
+re-run the steps to confirm it repeats.
+
+### Intermittent
+Saw the issue but could not reproduce it consistently — it appeared under
+conditions that were not reliably repeatable (e.g. timing, race, flaky network).
+Flag these explicitly so the team knows further investigation is needed.
+
+## Suggested Owner
+
+Suggest which area should pick up the issue, to speed up routing. Pick the
+closest match; when unsure, choose based on where the root cause most likely
+lives, not where the symptom appears.
+
+- **Frontend** — rendering, layout, client-side interaction, visual/UX issues
+- **Backend/API** — failed requests, 4xx/5xx responses, incorrect data returned
+- **Design** — visual inconsistencies, accessibility/contrast, UX patterns
+- **Content** — copy, typos, placeholder text, outdated or missing information
+- **Infra** — CORS, mixed content, TLS, asset/CDN delivery, environment config

--- a/skills/dogfood/templates/dogfood-report-template.md
+++ b/skills/dogfood/templates/dogfood-report-template.md
@@ -5,33 +5,67 @@
 **Scope:** {scope_description}
 **Tester:** Hermes Agent (automated exploratory QA)
 
+> This report is written for messaging platforms: no Markdown tables, short
+> scannable lines, and evidence inline. Keep it that way when filling it in.
+
 ---
 
 ## Executive Summary
 
-| Severity | Count |
-|----------|-------|
-| 🔴 Critical | {critical_count} |
-| 🟠 High | {high_count} |
-| 🟡 Medium | {medium_count} |
-| 🔵 Low | {low_count} |
-| **Total** | **{total_count}** |
+<!--
+Exactly three lines. Keep each to one sentence so it reads cleanly in a chat
+client. Fill all three even when there are zero issues.
+  Line 1 — Verdict: overall health of the app for the tested scope.
+  Line 2 — Headline: the single most important finding (or "no blocking issues").
+  Line 3 — Next action: the one thing the team should do next.
+-->
 
-**Overall Assessment:** {one_sentence_assessment}
+- **Verdict:** {one_line_overall_health_verdict}
+- **Headline:** {one_line_most_important_finding}
+- **Next action:** {one_line_recommended_next_step}
+
+---
+
+## Issue Breakdown
+
+**By severity:**
+- 🔴 Critical: {critical_count}
+- 🟠 High: {high_count}
+- 🟡 Medium: {medium_count}
+- 🔵 Low: {low_count}
+- Total: {total_count}
+
+**By category:**
+- Functional: {functional_count}
+- Visual: {visual_count}
+- Accessibility: {accessibility_count}
+- Console: {console_count}
+- UX: {ux_count}
+- Content: {content_count}
+
+<!-- The two breakdowns must each sum to the same Total. -->
 
 ---
 
 ## Issues
 
-<!-- Repeat this section for each issue found, sorted by severity (Critical first) -->
+<!--
+Repeat the block below once per issue, sorted Critical → High → Medium → Low.
+No tables — use the labeled fields so each issue stays readable in a chat
+thread. Every block must have severity, category, reproduction confidence,
+suggested owner, next action, and at least one populated evidence field.
+-->
 
 ### Issue #{issue_number}: {issue_title}
 
-| Field | Value |
-|-------|-------|
-| **Severity** | {severity} |
-| **Category** | {category} |
-| **URL** | {url_where_found} |
+- **Severity:** {severity}
+- **Category:** {category}
+- **URL:** {url_where_found}
+- **Reproduction confidence:** {confidence}
+  <!-- Confirmed (reproduced 2+ times) / Likely (reproduced once) / Intermittent (could not reproduce reliably). See references/issue-taxonomy.md. -->
+- **Suggested owner:** {owner_area}
+  <!-- e.g. Frontend, Backend/API, Design, Content, Infra. See references/issue-taxonomy.md. -->
+- **Next action:** {recommended_fix_or_investigation}
 
 **Description:**
 {detailed_description_of_the_issue}
@@ -47,37 +81,69 @@
 **Actual Behavior:**
 {what_actually_happens}
 
-**Screenshot:**
+**Evidence — Screenshot:**
 MEDIA:{screenshot_path}
 
-**Console Errors** (if applicable):
+**Evidence — Console:**
 ```
-{console_error_output}
+{console_error_output_or_"None observed"}
+```
+
+**Evidence — Network:**
+```
+{failed_requests_with_status_codes_or_"None observed"}
 ```
 
 ---
 
-<!-- End of per-issue section -->
+<!-- End of per-issue block -->
 
-## Issues Summary Table
+## All Issues at a Glance
 
-| # | Title | Severity | Category | URL |
-|---|-------|----------|----------|-----|
-| {n} | {title} | {severity} | {category} | {url} |
+<!-- One bullet per issue (no table), same order as above. -->
+- #{n} [{severity} / {category}] {title} — {url}
 
-## Testing Coverage
+---
 
-### Pages Tested
-- {list_of_pages_visited}
+## Coverage Matrix
 
-### Features Tested
-- {list_of_features_exercised}
+<!--
+One bullet per page/feature area (this replaces a coverage table). Mark each as
+Tested / Partial / Not tested, then note the flows exercised or the reason it
+was skipped. List both what was covered and what was not.
+-->
 
-### Not Tested / Out of Scope
-- {areas_not_covered_and_why}
+- {area_or_page}: {Tested / Partial / Not tested} — {flows_exercised_or_reason_skipped}
 
-### Blockers
-- {any_issues_that_prevented_testing_certain_areas}
+**Blockers encountered:**
+- {anything_that_prevented_testing_an_area_or_"None"}
+
+---
+
+## Artifact Inventory
+
+<!-- Account for every file produced so reviewers can find the evidence. -->
+
+- Report: {output_dir}/report.md
+- Screenshots ({screenshot_count} total) in {output_dir}/screenshots/:
+  - {screenshot_filename} — {what_it_shows}
+- Other artifacts: {other_files_or_"None"}
+
+---
+
+## Final Smoke-Check Checklist
+
+<!-- Verify every box before sending the report. Do not finalize with any box unchecked. -->
+
+- [ ] Executive summary is exactly three lines (Verdict / Headline / Next action)
+- [ ] Severity breakdown and category breakdown each sum to the same Total
+- [ ] The Total matches the number of per-issue blocks
+- [ ] Every issue has severity, category, reproduction confidence, suggested owner, and next action
+- [ ] Every issue has at least one populated evidence field (screenshot, console, or network)
+- [ ] Console was checked after each navigation and significant interaction
+- [ ] Every `MEDIA:` screenshot path points to a file that exists in the artifacts directory
+- [ ] Coverage matrix lists both tested and not-tested areas
+- [ ] Report contains no Markdown tables (messaging-platform friendly)
 
 ---
 


### PR DESCRIPTION
## Summary
- Make the dogfood QA report template messaging-platform friendly by removing Markdown tables
- Add a three-line executive summary, issue breakdown bullets, coverage matrix, artifact inventory, and final smoke-check checklist
- Extend the dogfood workflow and taxonomy with console/network evidence, reproduction confidence, suggested owner, and next action fields

## Test Plan
- [x] Ran template smoke checks for required sections and no table-like rows
- [x] Ran Python compileall over agent, CLI, tools, gateway, cron, and tests
- [x] Ran git diff --check on modified dogfood files