### PR TITLE
fix(api-server): keep chat completions SSE OpenAI-compatible

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1799,62 +1799,15 @@ class APIServerAdapter(BasePlatformAdapter):
                 if delta is not None:
                     _stream_q.put(delta)
 
-            # Track which tool_call_ids we've emitted a "running" lifecycle
-            # event for, so a "completed" event without a matching "running"
-            # (e.g. internal/filtered tools) is silently dropped instead of
-            # producing an orphaned event clients can't correlate.
-            _started_tool_call_ids: set[str] = set()
-
-            def _on_tool_start(tool_call_id, function_name, function_args):
-                """Emit ``hermes.tool.progress`` with ``status: running``.
-
-                Replaces the old ``tool_progress_callback("tool.started",
-                ...)`` emit so SSE consumers receive a single event per
-                tool start, carrying both the legacy ``tool``/``emoji``/
-                ``label`` payload (for #6972 frontends) and the new
-                ``toolCallId``/``status`` correlation fields (#16588).
-
-                Skips tools whose names start with ``_`` so internal
-                events (``_thinking``, …) stay off the wire — matching
-                the prior ``_on_tool_progress`` filter exactly.
-                """
-                if not tool_call_id or function_name.startswith("_"):
-                    return
-                _started_tool_call_ids.add(tool_call_id)
-                from agent.display import build_tool_preview, get_tool_emoji
-                label = build_tool_preview(function_name, function_args) or function_name
-                _stream_q.put(("__tool_progress__", {
-                    "tool": function_name,
-                    "emoji": get_tool_emoji(function_name),
-                    "label": label,
-                    "toolCallId": tool_call_id,
-                    "status": "running",
-                }))
-
-            def _on_tool_complete(tool_call_id, function_name, function_args, function_result):
-                """Emit the matching ``status: completed`` event.
-
-                Dropped if the start was filtered (internal tool, missing
-                id, or never seen) so clients never get an orphaned
-                ``completed`` they can't correlate to a prior ``running``.
-                """
-                if not tool_call_id or tool_call_id not in _started_tool_call_ids:
-                    return
-                _started_tool_call_ids.discard(tool_call_id)
-                _stream_q.put(("__tool_progress__", {
-                    "tool": function_name,
-                    "toolCallId": tool_call_id,
-                    "status": "completed",
-                }))
-
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.
             #
-            # ``tool_progress_callback`` is intentionally not wired here:
-            # it would duplicate every emit because ``run_agent`` fires it
-            # side-by-side with ``tool_start_callback``/``tool_complete_callback``.
-            # The structured callbacks are strictly richer (they carry the
-            # tool_call id), so they own the chat-completions SSE channel.
+            # Do NOT wire tool lifecycle/progress callbacks into the
+            # OpenAI-compatible Chat Completions stream.  Strict clients parse
+            # every ``data:`` frame as a ``chat.completion.chunk``; custom
+            # Hermes payloads such as ``event: hermes.tool.progress`` break
+            # their schema validation.  Tool progress belongs on Hermes-native
+            # streams and the Responses stream, not /v1/chat/completions.
             agent_ref = [None]
             agent_task = asyncio.ensure_future(self._run_agent(
                 user_message=user_message,
@@ -1862,8 +1815,6 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
-                tool_start_callback=_on_tool_start,
-                tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
             ))
@@ -2034,25 +1985,22 @@ class APIServerAdapter(BasePlatformAdapter):
             async def _emit(item):
                 """Write a single queue item to the SSE stream.
 
-                Plain strings are sent as normal ``delta.content`` chunks.
-                Tagged tuples ``("__tool_progress__", payload)`` are sent
-                as a custom ``event: hermes.tool.progress`` SSE event so
-                frontends can display them without storing the markers in
-                conversation history.  See #6972 for the original event,
-                #16588 for the ``toolCallId``/``status`` lifecycle fields.
+                Only OpenAI ``chat.completion.chunk`` frames are written so
+                strict clients that parse every ``data:`` payload as a Chat
+                Completions chunk never encounter a custom Hermes frame.  Tool
+                lifecycle callbacks are not wired into this endpoint (see
+                ``_handle_chat_completions``); should an internal tagged tuple
+                ever reach this queue it is dropped rather than serialized as a
+                custom ``event: hermes.tool.progress`` frame.
                 """
-                if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
-                    event_data = json.dumps(item[1])
-                    await response.write(
-                        f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
-                    )
-                else:
-                    content_chunk = {
-                        "id": completion_id, "object": "chat.completion.chunk",
-                        "created": created, "model": model,
-                        "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
-                    }
-                    await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+                if isinstance(item, tuple):
+                    return time.monotonic()
+                content_chunk = {
+                    "id": completion_id, "object": "chat.completion.chunk",
+                    "created": created, "model": model,
+                    "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
+                }
+                await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
                 return time.monotonic()
 
             # Stream content chunks as they arrive from the agent

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1061,18 +1061,27 @@ class TestChatCompletionsEndpoint:
                 assert " about it..." in body
 
     @pytest.mark.asyncio
-    async def test_stream_includes_tool_progress(self, adapter):
-        """tool_start_callback fires → progress appears as custom SSE event, not in delta.content."""
-        import asyncio
+    async def test_stream_suppresses_tool_progress_for_openai_chat_completions(self, adapter):
+        """Regression: /v1/chat/completions must stay OpenAI-compatible.
 
+        Strict OpenAI clients validate every ``data:`` frame as a
+        ``chat.completion.chunk``.  The mocked agent drives the tool
+        lifecycle callbacks if they are wired; the endpoint must not wire
+        them, so no ``event: hermes.tool.progress`` frame is emitted and
+        every streamed ``data:`` payload stays a Chat Completions chunk.
+        """
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             async def _mock_run_agent(**kwargs):
                 cb = kwargs.get("stream_delta_callback")
+                # If the endpoint ever (re)wired these, the agent would push
+                # custom tool-progress frames onto the OpenAI SSE stream.
                 ts_cb = kwargs.get("tool_start_callback")
-                # Simulate the structured tool start the gateway now consumes.
+                tc_cb = kwargs.get("tool_complete_callback")
                 if ts_cb:
                     ts_cb("call_terminal_1", "terminal", {"command": "ls -la"})
+                if tc_cb:
+                    tc_cb("call_terminal_1", "terminal", {"command": "ls -la"}, "ok")
                 if cb:
                     await asyncio.sleep(0.05)
                     cb("Here are the files.")
@@ -1092,46 +1101,39 @@ class TestChatCompletionsEndpoint:
                 )
                 assert resp.status == 200
                 body = await resp.text()
-                assert "[DONE]" in body
-                # Tool progress must appear as a custom SSE event, not in
-                # delta.content — prevents model from learning to imitate
-                # markers instead of calling tools (#6972).
-                assert "event: hermes.tool.progress" in body
-                assert '"tool": "terminal"' in body
-                # ``label`` is now derived by ``build_tool_preview`` from the
-                # tool args rather than passed by the caller, so we assert
-                # only that *some* label exists rather than a literal value.
-                assert '"label":' in body
-                # The progress marker must NOT appear inside any
-                # chat.completion.chunk delta.content field.
-                import json as _json
-                for line in body.splitlines():
-                    if line.startswith("data: ") and line.strip() != "data: [DONE]":
-                        try:
-                            chunk = _json.loads(line[len("data: "):])
-                        except _json.JSONDecodeError:
-                            continue
-                        if chunk.get("object") == "chat.completion.chunk":
-                            for choice in chunk.get("choices", []):
-                                content = choice.get("delta", {}).get("content", "")
-                                # Tool emoji markers must never leak into content
-                                assert "ls -la" not in content or content == "Here are the files."
-                # Final content must also be present
-                assert "Here are the files." in body
+
+            assert "[DONE]" in body
+            assert "Here are the files." in body
+            # No custom Hermes SSE event may appear on this endpoint.
+            assert "event: hermes.tool.progress" not in body
+            assert "event:" not in body
+            # Every non-[DONE] data frame must be a valid chat.completion.chunk.
+            for line in body.splitlines():
+                if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+                    continue
+                chunk = json.loads(line[len("data: "):])
+                assert chunk["object"] == "chat.completion.chunk"
+                assert "choices" in chunk
 
     @pytest.mark.asyncio
-    async def test_stream_tool_progress_skips_internal_events(self, adapter):
-        """Internal tool calls (name starting with ``_``) are not streamed."""
-        import asyncio
-
+    async def test_stream_does_not_expose_tool_progress_or_internal_events(self, adapter):
+        """No tool metadata (names, args, call ids, status) or internal-tool
+        state may leak into the chat completions stream, neither as a custom
+        SSE event nor inside any ``delta.content`` chunk."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             async def _mock_run_agent(**kwargs):
                 cb = kwargs.get("stream_delta_callback")
                 ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                # A normal tool plus an internal (_-prefixed) tool: if the
+                # endpoint wired these, the tool args and internal state
+                # would surface on the wire.
                 if ts_cb:
                     ts_cb("call_internal_1", "_thinking", {"text": "some internal state"})
                     ts_cb("call_search_1", "web_search", {"query": "Python docs"})
+                if tc_cb:
+                    tc_cb("call_search_1", "web_search", {"query": "Python docs"}, "ok")
                 if cb:
                     await asyncio.sleep(0.05)
                     cb("Found it.")
@@ -1151,52 +1153,37 @@ class TestChatCompletionsEndpoint:
                 )
                 assert resp.status == 200
                 body = await resp.text()
-                # Internal _thinking event should NOT appear anywhere
-                assert "some internal state" not in body
-                assert "call_internal_1" not in body
-                # Real tool progress should appear as custom SSE event
-                assert "event: hermes.tool.progress" in body
-                assert '"tool": "web_search"' in body
-                # Label is derived from the args dict by build_tool_preview;
-                # asserting on the structural fact (label exists, call id
-                # is correlated) rather than a literal preview string keeps
-                # the test robust against preview-formatter tweaks.
-                assert '"label":' in body
-                assert '"toolCallId": "call_search_1"' in body
+
+            assert "Found it." in body
+            assert "[DONE]" in body
+            for leaked in (
+                "event: hermes.tool.progress",
+                "some internal state",
+                "call_internal_1",
+                "call_search_1",
+                "web_search",
+                "_thinking",
+                "toolCallId",
+                '"status"',
+            ):
+                assert leaked not in body, leaked
 
     @pytest.mark.asyncio
-    async def test_stream_emits_tool_lifecycle_with_call_id(self, adapter):
-        """Regression for #16588.
+    async def test_stream_does_not_wire_tool_lifecycle_callbacks_for_chat_completions(self, adapter):
+        """The endpoint must invoke ``_run_agent`` with delta streaming only.
 
-        ``/v1/chat/completions`` streaming previously emitted only a
-        ``tool.started``-style ``hermes.tool.progress`` event; clients
-        rendering tool lifecycle UI had no way to mark a tool as finished
-        because no matching ``status: completed`` event was emitted, and
-        no ``toolCallId`` was carried for correlation.
-
-        The fix adds ``tool_start_callback`` / ``tool_complete_callback``
-        to the chat completions agent invocation and writes both halves
-        of the lifecycle pair on the same ``event: hermes.tool.progress``
-        SSE line, with stable ``toolCallId`` and ``status``.
+        Wiring ``tool_start_callback`` / ``tool_complete_callback`` (or
+        ``tool_progress_callback``) would queue custom Hermes frames that
+        break strict OpenAI clients, so they must stay unset on this path.
         """
-        import asyncio
-        import json as _json
+        captured = {}
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             async def _mock_run_agent(**kwargs):
+                captured.update(kwargs)
                 cb = kwargs.get("stream_delta_callback")
-                ts_cb = kwargs.get("tool_start_callback")
-                tc_cb = kwargs.get("tool_complete_callback")
-                # The structured callbacks own the chat-completions SSE
-                # channel now; ``tool_progress_callback`` is intentionally
-                # not wired so each tool start emits exactly one event.
-                if ts_cb:
-                    ts_cb("call_terminal_1", "terminal", {"command": "ls -la"})
-                if tc_cb:
-                    tc_cb("call_terminal_1", "terminal", {"command": "ls -la"}, "ok")
                 if cb:
-                    await asyncio.sleep(0.05)
                     cb("done.")
                 return (
                     {"final_response": "done.", "messages": [], "api_calls": 1},
@@ -1213,61 +1200,36 @@ class TestChatCompletionsEndpoint:
                     },
                 )
                 assert resp.status == 200
-                body = await resp.text()
+                await resp.text()
 
-            # Walk the SSE body and collect *(status, toolCallId)* pairs
-            # per event so the assertions verify per-event correlation —
-            # an event missing ``toolCallId`` would not pass even if a
-            # different event happens to carry the right id.
-            pairs: list[tuple[str | None, str | None]] = []
-            lines = body.splitlines()
-            for i, line in enumerate(lines):
-                if line.strip() != "event: hermes.tool.progress":
-                    continue
-                for follow in lines[i + 1: i + 4]:
-                    if follow.startswith("data: "):
-                        try:
-                            payload = _json.loads(follow[len("data: "):])
-                        except _json.JSONDecodeError:
-                            break
-                        pairs.append((payload.get("status"), payload.get("toolCallId")))
-                        break
-
-            # Each tool start must emit exactly one event (no duplicate
-            # legacy + new emit), and each lifecycle pair must carry the
-            # same toolCallId on every event — not just somewhere in the
-            # aggregate.
-            assert len(pairs) == 2, f"expected 2 events (running+completed), got {pairs}"
-            assert pairs[0] == ("running", "call_terminal_1"), pairs
-            assert pairs[1] == ("completed", "call_terminal_1"), pairs
+        assert captured.get("stream_delta_callback") is not None
+        assert captured.get("tool_start_callback") is None
+        assert captured.get("tool_complete_callback") is None
+        assert captured.get("tool_progress_callback") is None
 
     @pytest.mark.asyncio
-    async def test_stream_tool_lifecycle_skips_internal_and_orphan_completes(self, adapter):
-        """Internal tools (``_thinking``-style) and ``completed`` events
-        without a prior matching ``running`` must produce no lifecycle
-        events on the wire — otherwise clients would see orphaned
-        ``status: completed`` updates they cannot correlate."""
-        import asyncio
-
+    async def test_stream_drops_accidental_tagged_queue_items_for_chat_completions(self, adapter):
+        """Defense in depth: if an internal tagged tuple (such as a
+        ``("__tool_progress__", payload)`` marker) ever reaches the chat
+        completions SSE queue, the writer must drop it rather than
+        serialize a custom ``event: hermes.tool.progress`` frame."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             async def _mock_run_agent(**kwargs):
                 cb = kwargs.get("stream_delta_callback")
-                ts_cb = kwargs.get("tool_start_callback")
-                tc_cb = kwargs.get("tool_complete_callback")
-                # Internal tool — must be filtered.
-                if ts_cb:
-                    ts_cb("call_internal_1", "_thinking", {})
-                if tc_cb:
-                    tc_cb("call_internal_1", "_thinking", {}, "")
-                # Completion without start — orphan, must be dropped.
-                if tc_cb:
-                    tc_cb("call_orphan_1", "web_search", {}, "ok")
                 if cb:
+                    cb("before ")
+                    # Simulate a stray tagged tuple landing on the queue.
+                    cb(("__tool_progress__", {
+                        "tool": "terminal",
+                        "toolCallId": "call_leak_1",
+                        "status": "running",
+                        "label": "secret_tool_marker",
+                    }))
                     await asyncio.sleep(0.05)
-                    cb("ok.")
+                    cb("after")
                 return (
-                    {"final_response": "ok.", "messages": [], "api_calls": 1},
+                    {"final_response": "before after", "messages": [], "api_calls": 1},
                     {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
                 )
 
@@ -1283,12 +1245,19 @@ class TestChatCompletionsEndpoint:
                 assert resp.status == 200
                 body = await resp.text()
 
-            # Neither the internal call_id nor the orphan call_id should
-            # surface as a lifecycle payload on the wire.
-            assert "call_internal_1" not in body
-            assert "call_orphan_1" not in body
-            assert '"status": "running"' not in body
-            assert '"status": "completed"' not in body
+            # The stray marker must not be serialized in any form.
+            assert "event: hermes.tool.progress" not in body
+            assert "__tool_progress__" not in body
+            assert "secret_tool_marker" not in body
+            assert "call_leak_1" not in body
+            # Normal text deltas still stream through as valid chunks.
+            assert "before " in body
+            assert "after" in body
+            for line in body.splitlines():
+                if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+                    continue
+                chunk = json.loads(line[len("data: "):])
+                assert chunk["object"] == "chat.completion.chunk"
 
     @pytest.mark.asyncio
     async def test_no_user_message_returns_400(self, adapter):


### PR DESCRIPTION
## What does this PR do?

Strict OpenAI-compatible clients validate every `data:` frame from
`/v1/chat/completions?stream=true` as an OpenAI `chat.completion.chunk`.
Hermes was also emitting custom tool-progress frames on that same stream:

```sse
event: hermes.tool.progress
data: {"tool":"skill_view","emoji":"...","label":"meeting-processor","toolCallId":"call_...","status":"running"}
```

Clients that ignore the SSE `event:` name and parse every `data:` payload as a
Chat Completions chunk fail schema validation, because the payload has no
`choices` array and is not `object: "chat.completion.chunk"`:

```text
Type validation failed: Value: {"tool":"skill_view",...,"status":"running"}.
Error message: [{"code":"invalid_union", ... "path":["choices"], "message":"Invalid input" ...}]
```

This change makes the OpenAI-compatible endpoint emit **only**
`chat.completion.chunk` data frames plus `[DONE]`. Tool progress remains
available on Hermes-native streams and on the Responses (`/v1/responses`)
stream, which are not bound by the strict Chat Completions schema.

This effectively unwires, on `/v1/chat/completions` only, the tool-progress
lifecycle added in #17505 (#16588). That lifecycle signal belongs on the
Responses stream / Hermes-native streams, both of which are left intact.

## Related Issue

No public issue filed; reproduced with a strict OpenAI client (Open WebUI /
Vercel AI SDK style) pointed at the streaming Chat Completions endpoint.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`
  - `_handle_chat_completions` (streaming branch): stop wiring
    `tool_start_callback` / `tool_complete_callback` into the chat-completions
    agent run; remove the now-unused `_on_tool_start` / `_on_tool_complete`
    helpers and `_started_tool_call_ids` tracking. Added a comment explaining
    why tool progress must not be wired into this endpoint.
  - `_write_sse_chat_completion._emit`: only write `chat.completion.chunk`
    frames; defensively drop any internal tagged tuple instead of serializing
    it as a custom `event: hermes.tool.progress` SSE event.
- `tests/gateway/test_api_server.py`
  - Replaced the chat-completions tool-progress tests with regression tests.

The Responses endpoint (`/v1/responses`) and its `tool_start_callback` /
`tool_complete_callback` wiring are intentionally untouched — tool lifecycle
there uses a separate `__tool_started__` / `__tool_completed__` channel
rendered by `_write_sse_responses`.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_api_server.py` (or
   `pytest tests/gateway/test_api_server.py -q`) — `156 passed`.
2. The four new regression tests fail on `main` and pass with this change:
   - `test_stream_suppresses_tool_progress_for_openai_chat_completions`
   - `test_stream_does_not_expose_tool_progress_or_internal_events`
   - `test_stream_does_not_wire_tool_lifecycle_callbacks_for_chat_completions`
   - `test_stream_drops_accidental_tagged_queue_items_for_chat_completions`
3. Manual: point a strict OpenAI client at `/v1/chat/completions?stream=true`,
   trigger a tool run, and confirm no schema-validation error and no custom
   SSE frames on the stream.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(api-server): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/gateway/test_api_server.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.2), Python 3.11

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing config/docs change)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure SSE serialization logic)
- [x] Tool descriptions/schemas — N/A
