### PR TITLE
fix(cli): pin worker TERMINAL_CWD to profile dir in kanban spawn

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6049,6 +6049,18 @@ def _default_spawn(
     from hermes_cli.profiles import resolve_profile_env
     try:
         env["HERMES_HOME"] = resolve_profile_env(profile_arg)
+        # Pin TERMINAL_CWD to the same profile dir as HERMES_HOME.
+        # build_context_files_prompt() locates AGENTS.md (and other
+        # context files) relative to TERMINAL_CWD, not HERMES_HOME.
+        # Without this, the child inherits TERMINAL_CWD from the
+        # dispatching gateway's own env (`env = dict(os.environ)`), so
+        # in a multi-gateway / multi-profile install whichever gateway
+        # wins the claim race determines which AGENTS.md the worker
+        # loads — non-deterministic, and frequently the wrong profile's
+        # rules. Pinning it symmetrically with HERMES_HOME makes
+        # context-file loading deterministic for the task's profile
+        # regardless of which gateway dispatched it.
+        env["TERMINAL_CWD"] = env["HERMES_HOME"]
     except FileNotFoundError:
         # Profile dir doesn't exist — defer resolution to the CLI's
         # _apply_profile_override() via HERMES_PROFILE (set below).

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2128,6 +2128,107 @@ class TestSharedBoardPaths:
         assert env["HERMES_KANBAN_TASK"] == "t_dispatch_env"
         assert env["HERMES_KANBAN_BRANCH"] == "wt/t_dispatch_env"
 
+    def test_dispatcher_spawn_pins_terminal_cwd_to_profile_dir(
+        self, tmp_path, monkeypatch
+    ):
+        # The dispatcher's `_default_spawn` must pin TERMINAL_CWD to the
+        # task's profile dir, symmetrically with HERMES_HOME. Otherwise
+        # the worker inherits the dispatching gateway's TERMINAL_CWD and
+        # build_context_files_prompt() loads the wrong profile's
+        # AGENTS.md under multi-gateway / multi-profile dispatch.
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        # A real on-disk named profile so resolve_profile_env() returns
+        # its dir rather than raising FileNotFoundError.
+        profile_dir = default_home / "profiles" / "coder"
+        profile_dir.mkdir(parents=True)
+        self._set_home(monkeypatch, tmp_path, default_home)
+        # The dispatching gateway's own TERMINAL_CWD — the value the
+        # child would wrongly inherit if the fix were absent.
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path / "dispatcher-cwd"))
+
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                captured["env"] = kwargs.get("env", {})
+                self.pid = 4343
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+
+        task = kb.Task(
+            id="t_terminal_cwd",
+            title="x",
+            body=None,
+            assignee="coder",
+            status="ready",
+            priority=0,
+            created_by=None,
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="worktree",
+            workspace_path=str(tmp_path / "ws"),
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+            branch_name="wt/t_terminal_cwd",
+        )
+        kb._default_spawn(task, str(tmp_path / "ws"))
+
+        env = captured["env"]
+        # TERMINAL_CWD tracks the profile dir, not the dispatcher's cwd.
+        assert env["TERMINAL_CWD"] == str(profile_dir)
+        assert env["TERMINAL_CWD"] == env["HERMES_HOME"]
+        assert env["TERMINAL_CWD"] != str(tmp_path / "dispatcher-cwd")
+
+    def test_dispatcher_spawn_leaves_terminal_cwd_when_profile_missing(
+        self, tmp_path, monkeypatch
+    ):
+        # When the profile dir doesn't exist, resolve_profile_env raises
+        # FileNotFoundError and neither HERMES_HOME nor TERMINAL_CWD is
+        # pinned here (deferred to the CLI's _apply_profile_override).
+        # The child then keeps the inherited TERMINAL_CWD untouched.
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        self._set_home(monkeypatch, tmp_path, default_home)
+        inherited = str(tmp_path / "dispatcher-cwd")
+        monkeypatch.setenv("TERMINAL_CWD", inherited)
+
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                captured["env"] = kwargs.get("env", {})
+                self.pid = 4444
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+
+        task = kb.Task(
+            id="t_terminal_cwd_missing",
+            title="x",
+            body=None,
+            assignee="ghost",  # no on-disk profile dir
+            status="ready",
+            priority=0,
+            created_by=None,
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="worktree",
+            workspace_path=str(tmp_path / "ws"),
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+            branch_name="wt/t_terminal_cwd_missing",
+        )
+        kb._default_spawn(task, str(tmp_path / "ws"))
+
+        env = captured["env"]
+        # Unchanged inherited value (no spurious override on the
+        # FileNotFoundError path).
+        assert env["TERMINAL_CWD"] == inherited
+
 
 # ---------------------------------------------------------------------------
 # latest_summary / latest_summaries — surface task_runs.summary handoffs


### PR DESCRIPTION
## Summary

- `_default_spawn` now pins the worker's `TERMINAL_CWD` to the task's profile dir, symmetrically with the existing `HERMES_HOME` injection.
- Kanban workers load *their own* profile's `AGENTS.md` (and other context files) deterministically, regardless of which gateway wins the claim race.

## Motivation

Closes #34619.

`hermes_cli/kanban_db.py::_default_spawn()` injected `HERMES_HOME` so the worker reads its profile-scoped `config.yaml`, but it never set `TERMINAL_CWD`. The child therefore inherited `TERMINAL_CWD` from the dispatching gateway's own environment (`env = dict(os.environ)`). `build_context_files_prompt()` locates `AGENTS.md` relative to `TERMINAL_CWD` (see `tools/file_tools.py`, `tools/terminal_tool.py`), not `HERMES_HOME` — so in a multi-gateway / multi-profile install, whichever gateway with `kanban.dispatch_in_gateway: true` won the claim race determined which `AGENTS.md` the spawned worker saw. Context-file loading was non-deterministic across the install, and frequently loaded the wrong profile's rules (the reporter observed a worker implementing code despite its profile's `AGENTS.md` carrying a scope-escalation block rule).

The fix mirrors the existing `HERMES_HOME` pattern exactly: on the `resolve_profile_env` success path, pin `TERMINAL_CWD = HERMES_HOME` (the task's profile dir). The `FileNotFoundError` path is left untouched, so the inherited `TERMINAL_CWD` is preserved and resolution defers to the CLI's `_apply_profile_override()` via `HERMES_PROFILE`, matching the pre-existing `HERMES_HOME` behavior there.

This matches how `hermes_cli/main.py` already pins `TERMINAL_CWD` for worktree workspaces — symmetric cwd/home resolution is the established norm.

## Verification

- `python3 -m pytest tests/hermes_cli/test_kanban_db.py -q` — **203 passed**
- New tests:
  - `test_dispatcher_spawn_pins_terminal_cwd_to_profile_dir` — with a real on-disk named profile, asserts `TERMINAL_CWD == profile dir == HERMES_HOME` and that it does **not** equal the dispatching gateway's inherited `TERMINAL_CWD`.
  - `test_dispatcher_spawn_leaves_terminal_cwd_when_profile_missing` — on the `FileNotFoundError` path (no profile dir), the inherited `TERMINAL_CWD` is left untouched (no spurious override).
- Did NOT change: the `FileNotFoundError` branch behavior, or any other env var injection.

One-line behavioral change, two regression tests covering both the success and the missing-profile paths.
