### PR TITLE
docs(config): sync stale defaults in cli-config.yaml.example (restart_drain_timeout, streaming)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -578,7 +578,7 @@ agent:
   # The gateway stops accepting new work, waits for in-flight agents to
   # finish, then interrupts anything still running after this timeout.
   # 0 = no drain, interrupt immediately.
-  # restart_drain_timeout: 60
+  # restart_drain_timeout: 180
 
   # Max app-level retry attempts for API errors (connection drops, provider
   # timeouts, 5xx, etc.) before the agent surfaces the failure. Lower this
@@ -1002,9 +1002,9 @@ display:
   # Stream tokens to the terminal as they arrive instead of waiting for the
   # full response. The response box opens on first token and text appears
   # line-by-line. Tool calls are still captured silently.
-  #   true:  Stream tokens as they arrive (default)
-  #   false: Wait for the full response before rendering
-  streaming: true
+  #   true:  Stream tokens as they arrive
+  #   false: Wait for the full response before rendering (default)
+  streaming: false
 
   # Show [HH:MM] timestamps on user input and assistant response labels.
   # timestamps: false


### PR DESCRIPTION
## What & why

Two values in `cli-config.yaml.example` drifted from the actual code defaults after the defaults were changed without updating the example, so the template now misstates current behavior.

### 1. `agent.restart_drain_timeout`: `60` → `180`
The runtime default (`DEFAULT_CONFIG["agent"]["restart_drain_timeout"]`, consumed via `gateway/restart.py` `DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT` / `parse_restart_drain_timeout`) was raised from 60 to 180 in #18761, which explicitly rejected 60 as too short ("a 60s budget routinely interrupted legitimate work on `/restart`"). The commented illustration line still showed `60`. The sibling commented defaults in the same block all match their code defaults (`gateway_timeout: 1800`, `gateway_timeout_warning: 900`, `api_max_retries: 3`), so these lines are meant to show the default — and uncommenting the stale `60` re-applies the value #18761 fixed.

### 2. `display.streaming`: example presented `true` as the default
Streaming was made opt-in / disabled by default ("ship streaming disabled by default — opt-in via config"). Both `DEFAULT_CONFIG["display"]["streaming"]` and `cli.py`'s `CLI_CONFIG["display"].get("streaming", False)` default to `False`, but the example set `streaming: true` and annotated `true` as "(default)". Every other toggle in the `display:` block shows its default as the active uncommented value; streaming was the lone stale entry. Corrected the active value to `false` and moved the `(default)` marker accordingly.

## How to test
Documentation/example-only change to `cli-config.yaml.example` (a copy-this template; not imported at runtime or by the test suite). Verified each stated default against `hermes_cli/config.py` (`DEFAULT_CONFIG`), `gateway/restart.py`, and `cli.py`.

## Platforms
N/A — example/comment text only, no code or behavior change.