### PR TITLE
fix(web): clear WebGL atlas on font change to stop glyph corruption

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -113,6 +113,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
+  // Kept so the metrics-sync path can clear the WebGL glyph atlas after a
+  // font-size change.  The atlas caches rasterized glyphs at the font
+  // metrics that were live when it was built; resizing the font without
+  // clearing it makes WebGL re-blit stale glyph tiles, which renders as
+  // character corruption (see #34617).  null when WebGL is unavailable or
+  // the narrow-host DOM renderer is in use.
+  const webglRef = useRef<WebglAddon | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   // Exposed to the main metrics-sync effect so it can refit the terminal
   // the moment `isActive` flips back to true (display:none → display:flex
@@ -456,8 +463,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     if (useWebgl) {
       try {
         const webgl = new WebglAddon();
-        webgl.onContextLoss(() => webgl.dispose());
+        webgl.onContextLoss(() => {
+          webgl.dispose();
+          webglRef.current = null;
+        });
         term.loadAddon(webgl);
+        webglRef.current = webgl;
       } catch (err) {
         console.warn(
           "[hermes-chat] WebGL renderer unavailable; falling back to default",
@@ -517,6 +528,15 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       }
       if (fontChanged && term.rows > 0) {
         try {
+          // The WebGL renderer caches glyphs in a texture atlas keyed on
+          // the font metrics that were live when each glyph was first
+          // drawn.  After we mutate fontSize/lineHeight above, a bare
+          // refresh() re-blits those stale tiles at the new cell size,
+          // which surfaces as garbled characters even though the buffer
+          // is correct (#34617).  Drop the atlas first so glyphs are
+          // re-rasterized at the current metrics.  No-op for the DOM/
+          // canvas renderer, which has no atlas to clear.
+          webglRef.current?.clearTextureAtlas();
           term.refresh(0, term.rows - 1);
         } catch {
           /* ignore */
@@ -709,6 +729,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       term.dispose();
       termRef.current = null;
       fitRef.current = null;
+      webglRef.current = null;
       if (copyResetRef.current) {
         clearTimeout(copyResetRef.current);
         copyResetRef.current = null;


### PR DESCRIPTION
## Summary

- Clear the xterm.js WebGL texture atlas whenever the dashboard chat
  terminal changes font size, so glyphs re-rasterize at the current cell
  metrics instead of being re-blit from stale cached tiles.
- Fixes the visible character corruption in the embedded chat terminal
  (e.g. `FcDataBoss` rendering as `FcDataBpsst`) while the underlying
  buffer is correct.

## Motivation

Closes #34617.

The WebGL renderer caches rasterized glyphs in a texture atlas keyed on
the font metrics that were live when each glyph was first drawn. After
mount, `syncTerminalMetrics` runs on the authoritative double-rAF fit
(and again on later width-tier changes): it mutates
`term.options.fontSize` / `lineHeight` and then calls `term.refresh()`.
`refresh()` re-blits the **existing** atlas tiles at the new cell size —
it does not rebuild the atlas — so glyphs get smeared/mismapped and read
as corrupted characters, even though the xterm buffer holds the correct
bytes.

This is why the reporter saw the corruption only in the dashboard
(WebGL) and not in a native terminal: the DOM/canvas renderer has no
texture atlas, so the same TUI output renders fine there.

`@xterm/addon-webgl` exposes `clearTextureAtlas()` for exactly this
situation ("Clears the terminal's texture atlas and triggers a redraw").
The component previously kept no reference to the WebGL addon, so it
could never clear it. This change:

- keeps a `webglRef` to the loaded `WebglAddon`
- calls `webglRef.current?.clearTextureAtlas()` right before
  `term.refresh(...)` in the `fontChanged` branch (no-op under the
  DOM/canvas renderer used on narrow hosts, where the ref is null)
- nulls the ref on WebGL context loss and on unmount

## Verification

- Root cause confirmed against the addon's public API
  (`WebglAddon.clearTextureAtlas(): void`).
- Manual repro (before): open `hermes dashboard` → `/chat`, run
  `list todos`; the post-mount font-tier fit triggers `fontChanged`,
  WebGL re-blits the stale atlas → corrupted glyphs. After this change
  the atlas is dropped on that same path and glyphs re-rasterize
  correctly.
- Scope: only the `fontChanged` redraw path is touched; steady-state
  rendering, the narrow-host DOM renderer, input, resize, and clipboard
  paths are unchanged.

## Note on tests

`web/` ships no test runner (no `test` script, no vitest/jest in
`web/package.json`), so there is no existing harness to add a unit test
to without introducing new tooling — out of scope for a focused render
fix. The change is a single targeted call on an already-imported addon
using its documented API; happy to add a renderer test if the
maintainers want a harness stood up.
