### PR TITLE
feat(cron): mirror cron delivery output to target session for cross-session awareness

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -595,9 +595,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
     # in config.yaml for clean output.
     wrap_response = True
+    mirror_to_session_enabled = False
     try:
         user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
+        cron_cfg = user_cfg.get("cron", {})
+        wrap_response = cron_cfg.get("wrap_response", True)
+        mirror_to_session_enabled = cron_cfg.get("mirror_to_session", False)
     except Exception:
         pass
 
@@ -726,7 +729,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     # Mirror cron output to target session so the main agent
                     # sees it in conversation history on next user message.
-                    mirror_to_session(platform_name, chat_id, content, source_label="cron", thread_id=thread_id)
+                    if mirror_to_session_enabled:
+                        mirror_to_session(platform_name, chat_id, content, source_label="cron", thread_id=thread_id)
                     delivered = True
             except Exception as e:
                 logger.warning(
@@ -763,7 +767,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
             # Mirror cron output to target session so the main agent
             # sees it in conversation history on next user message.
-            mirror_to_session(platform_name, chat_id, content, source_label="cron", thread_id=thread_id)
+            if mirror_to_session_enabled:
+                mirror_to_session(platform_name, chat_id, content, source_label="cron", thread_id=thread_id)
 
     if delivery_errors:
         return "; ".join(delivery_errors)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -589,6 +589,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     from tools.send_message_tool import _send_to_platform
     from gateway.config import load_gateway_config, Platform
+    from gateway.mirror import mirror_to_session
 
     # Optionally wrap the content with a header/footer so the user knows this
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
@@ -723,6 +724,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
+                    # Mirror cron output to target session so the main agent
+                    # sees it in conversation history on next user message.
+                    mirror_to_session(platform_name, chat_id, content, source_label="cron", thread_id=thread_id)
                     delivered = True
             except Exception as e:
                 logger.warning(
@@ -757,6 +761,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 continue
 
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
+            # Mirror cron output to target session so the main agent
+            # sees it in conversation history on next user message.
+            mirror_to_session(platform_name, chat_id, content, source_label="cron", thread_id=thread_id)
 
     if delivery_errors:
         return "; ".join(delivery_errors)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1508,6 +1508,12 @@ DEFAULT_CONFIG = {
         # 1 = serial (pre-v0.9 behaviour).
         # Also overridable via HERMES_CRON_MAX_PARALLEL env var.
         "max_parallel_jobs": None,
+        # Mirror cron delivery output to the target session's SQLite transcript.
+        # When true, the main agent sees cron messages (prefixed with
+        # "[Delivered from cron]") in conversation history on the next user
+        # message, enabling cross-session awareness without manual lookup.
+        # Default: false (no mirror, original behaviour).
+        "mirror_to_session": False,
     },
 
     # Kanban multi-agent coordination — controls the dispatcher loop that


### PR DESCRIPTION
## Summary

When cron jobs autonomously deliver messages to a platform (telegram, discord, etc.), the receiving agent has no awareness that the message was sent — the cron output lives in the delivery channel but not in the agent's session transcript. This means the next time the user talks to the agent, it has no context of what cron just told them.

This is particularly impactful in **persona-driven / SOUL.md scenarios**: when an agent has a defined personality (like Asuka, a custom companion persona), cron-scheduled check-ins, market alerts, and daily briefings are delivered in-character. But when the user follows up on the same platform, the agent starts with a blank conversation — it doesn't know what its own persona just said via cron. The user has to repeat themselves or the agent has to manually call \`session_search\` to piece together context, breaking the natural flow of a persistent personality.

This PR bridges that gap by adding a \`cron.mirror_to_session\` option that mirrors cron delivery output into the target session's SQLite transcript, tagged with \`mirror: true\` and \`mirror_source: "cron"\`. On the user's next message, the agent sees \`[Delivered from cron]\` messages in conversation history — the personality stays continuous without manual lookup.

## Changes

| File | Change |
|---|---|
| \`cron/scheduler.py\` | Import \`mirror_to_session\`; call it after successful delivery in both the live-adapter and no-adapter fallback paths |
| \`hermes_cli/config.py\` | Add \`mirror_to_session: false\` default under \`cron.settings\` section with docstring |
| \`gateway/mirror.py\` | New module — \`mirror_to_session()\` finds the matching gateway session via sessions.json, then writes a delivery-mirror record (role=assistant, mirror=true, mirror_source=cron) to the SQLite session DB |
| \`tests/gateway/test_mirror.py\` | Tests for \`_find_session_id\` (platform matching, thread/user disambiguation, ambiguous-group safety), \`mirror_to_session\` (success, thread-aware, user-aware, missing-session, error), and \`_append_to_sqlite\` (connection lifecycle, error cleanup) |

## How it works

1. User enables \`cron.mirror_to_session: true\` in config.yaml
2. When a cron job fires and successfully delivers to a platform, \`_deliver_result()\` calls \`mirror_to_session()\` with the platform, chat_id, content, and source_label="cron"
3. \`mirror_to_session()\` resolves the session via sessions.json, then persists a mirror message to the SQLite transcript
4. On the user's next message, the prompt builder includes these mirror messages in conversation history — the agent sees them as if it had said them itself

## Config

\`\`\`yaml
cron:
  mirror_to_session: true  # default: false — backward compatible
\`\`\`

## How to test

1. Enable \`cron.mirror_to_session: true\` in \`~/.hermes/config.yaml\`
2. Create a cron job that delivers to your chat: \`/cron create "every 1m" "Say hello from cron"\`
3. Wait for delivery, then send any message — the agent should reference the cron message in context without needing \`session_search\`

## Platforms tested

- macOS 14+ (local development)
- Linux (CI test suite)

## Backward compatibility

Defaults to \`false\` — existing cron behaviour is unchanged. No new dependencies. The mirror function is non-fatal on error (all exceptions caught and logged at DEBUG level).