### PR TITLE
feat: add optional ds4-manager skill for DS4 Dwarfstar Dashboard

### DIFF
--- a/optional-skills/devops/ds4-manager/SKILL.md
+++ b/optional-skills/devops/ds4-manager/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: ds4-manager
+description: "Manage the DS4 Dwarfstar Dashboard — REST API, MCP tools, benchmark suites, config browser, updater, and launchd integration for DS4 inference engine. Triggers: ds4-dashboard, dwarfstar, ds4-manager, ds4 dashboard, ds4 telemetry"
+version: 1.0.0
+author: shagghiesuperstar
+license: MIT
+platforms: [macos]
+metadata:
+  hermes:
+    tags: [ds4, dashboard, inference, devops, macos, launchd]
+    related_skills: [ds4-system-health, ds4-deepseek-tui-opencode-local-coding]
+---
+
+# DS4 Dwarfstar Dashboard Manager
+
+Manage the DS4 Dwarfstar Dashboard — a FastAPI dashboard running on port 8765 that provides REST + MCP dual transport for DS4 inference engine telemetry, config management, benchmark execution, and binary updates.
+
+## When to Use
+
+- User asks to check DS4 status, metrics, KV cache, GPU/CPU temps
+- User wants to browse or change DS4 config options via the dashboard
+- User wants to run a benchmark suite and compare results
+- User wants to check for or apply a DS4 binary update
+- User wants to restart DS4 after config changes (launchd integration)
+- User asks about the config schema browser or MCP tools
+
+## Prerequisites
+
+- DS4 server running on port 8001 (or configured port)
+- DS4 Dashboard running on port 8765 (`dashboard.py`)
+- DS4 binary at `~/ds4/ds4-server` and model at `~/ds4/ds4flash.gguf` (or env overrides)
+- Python 3.9+ venv in the dashboard directory
+
+## Setup
+
+### Clone and start the dashboard
+
+```bash
+cd ~/ds4-dashboard
+source .venv/bin/activate
+python dashboard.py
+# Starts on http://127.0.0.1:8765
+```
+
+### Launchd integration
+
+A launchd plist (`com.ds4.dashboard.plist`) can manage the dashboard process and restart DS4 after config changes. See `scripts/start.sh` and the launchd section below.
+
+## REST API Endpoints
+
+All endpoints are at `http://127.0.0.1:8765`.
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/` | GET | Static frontend (index.html) |
+| `/api/status` | GET | Full DS4 status: uptime, model, port, config snapshot, system metrics, KV cache |
+| `/api/metrics` | GET | Live telemetry subset: telemetry, KV cache, system metrics |
+| `/api/config` | GET | Current config snapshot (defaults + overrides) |
+| `/api/config-schema` | GET | All discoverable DS4 CLI options with types, defaults, choices |
+| `/api/config` | PATCH | Apply a config override (`{"key": "...", "value": ...}`) |
+| `/api/config/{key}` | DELETE | Remove a specific config override |
+| `/api/config-overrides` | GET | List current active overrides only |
+| `/api/benchmarks` | GET | Available benchmark suites + last results |
+| `/api/benchmarks/run` | POST | Run a benchmark suite (`suite_id`, `iterations`, `compare_label`) |
+| `/api/benchmarks/results` | GET | Last benchmark results |
+| `/api/update/check` | GET | Check GitHub for latest DS4 release |
+| `/api/update` | POST | Apply a DS4 binary update from GitHub |
+| `/api/mcp/manifest` | GET | Full MCP tool + resource manifest |
+| `/api/mcp/tools/{tool_name}` | POST | Call an MCP tool by name |
+| `/api/mcp/resources` | GET | List available MCP resources |
+| `/api/mcp/resources/read` | GET | Read an MCP resource by URI (`?uri=...`) |
+| `/mcp` | POST | MCP JSON-RPC endpoint (full protocol) |
+| `/mcp/sse` | GET | SSE stream of telemetry events (2s interval) |
+
+## MCP Tools (JSON-RPC)
+
+Available via `/mcp` (POST) or `/api/mcp/tools/{tool_name}`.
+
+| Tool | Input | Returns |
+| --- | --- | --- |
+| `get_status` | {} | Full status: uptime, model, port, config, system, KV cache |
+| `get_metrics` | {} | Live telemetry, KV cache, GPU/CPU/temps |
+| `get_config` | {} | Current config snapshot (defaults + overrides) |
+| `set_config` | `key`, `value` | Apply override, returns updated config |
+| `get_schema` | {} | All discoverable DS4 CLI options |
+| `run_benchmark` | `suite_id`, `iterations`, `compare_label` | Run a suite, optionally compare with previous |
+| `update_ds4` | `apply`, `asset_url`, `sha256` | Check or apply a DS4 binary update |
+
+## MCP Resources (JSON-RPC)
+
+Available via `/mcp` (POST) with `resources/list` or `resources/read`.
+
+| Resource URI | Description |
+| --- | --- |
+| `ds4://status` | Full DS4 status snapshot |
+| `ds4://metrics` | Live telemetry metrics |
+| `ds4://config` | Current config snapshot |
+| `ds4://config-schema` | Config schema browser |
+| `ds4://benchmarks` | Available suites + last results |
+| `ds4://benchmarks/last` | Last benchmark results only |
+
+## Benchmark Suites
+
+The dashboard defines benchmark suites for measuring DS4 performance:
+
+| Suite ID | Description | Default Iterations |
+| --- | --- | --- |
+| `quick_smoke` | Single completion, low latency | 1 |
+| `token_throughput` | Token generation throughput test | 3 |
+| `latency_p90` | Latency distribution (P50/P90/P99) | 5 |
+| `kv_cache_stress` | Large-context KV cache throughput | 3 |
+| `mtp_sweep` | Compare MTP modes (off/1/2/4) | 3 |
+| `batch_size_sweep` | Throughput vs batch size | 3 |
+| `context_len_sweep` | Throughput vs context length | 3 |
+
+### Compare mode
+
+Pass `compare_label` when running a benchmark to label the result. The dashboard stores previous results and returns a `compare` field with both old and new for side-by-side diffing.
+
+## Config Schema Browser
+
+The dashboard auto-discovers DS4 CLI options by:
+1. Parsing `--help` output for flag definitions
+2. Reading telemetry `/telem` for active config values
+3. Applying dashboard defaults from environment variables
+
+Access via `GET /api/config-schema?refresh=true` to force re-discovery.
+
+Each config option shows:
+- `type`: string/integer/float/boolean/choice
+- `default`: dashboard default value
+- `current`: active value (from telemetry or override)
+- `desc`: description from `--help`
+- `source`: "dashboard", "telemetry", or "cli"
+- `flag`: CLI flag (e.g. `--model`, `--ctx-size`)
+- `choices`: enum choices for choice-type options
+
+### Setting config overrides
+
+```bash
+# Set a config value
+curl -X PATCH http://127.0.0.1:8765/api/config \
+  -H 'Content-Type: application/json' \
+  -d '{"key": "context_window", "value": 65536}'
+
+# Remove an override (reverts to default)
+curl -X DELETE http://127.0.0.1:8765/api/config/context_window
+```
+
+**After config changes, restart DS4 with the launchd integration** (see launchd section below).
+
+## Launchd Integration
+
+The DS4 dashboard can be managed via launchd for automatic restart after config changes.
+
+### Plist: `~/Library/LaunchAgents/com.ds4.dashboard.plist`
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ds4.dashboard</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/m4mbp/ds4-dashboard/scripts/start.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>/Users/m4mbp/ds4-dashboard</string>
+    <key>StandardOutPath</key>
+    <string>/tmp/ds4-dashboard.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/ds4-dashboard-err.log</string>
+</dict>
+</plist>
+```
+
+### Restarting DS4 after config changes
+
+```bash
+# After setting config overrides, restart DS4
+# The dashboard scripts/restart-ds4.sh handles this
+scripts/restart-ds4.sh
+# Or via launchd:
+launchctl kickstart gui/$(id -u)/com.ds4.server
+```
+
+## Verification
+
+```bash
+# Check dashboard is running
+curl -s http://127.0.0.1:8765/api/status | jq .
+
+# Check metrics
+curl -s http://127.0.0.1:8765/api/metrics | jq .
+
+# List available config options
+curl -s http://127.0.0.1:8765/api/config-schema | jq .
+
+# Run quick smoke benchmark
+curl -X POST http://127.0.0.1:8765/api/benchmarks/run \
+  -H 'Content-Type: application/json' \
+  -d '{"suite_id": "quick_smoke", "iterations": 1}'
+```
+
+## Troubleshooting
+
+- **Dashboard won't start**: ensure `.venv/bin/activate` exists and dependencies are installed (`pip install -r requirements.txt`)
+- **Status shows "stopped"**: DS4 server is not running — start DS4 via launchd or `ds4-server`
+- **Config schema empty**: ensure DS4 binary path is correct and `--help` parsing works
+- **Benchmarks fail**: check DS4 is running and accepting completions on the configured port
+- **Update fails**: verify GitHub repo access and binary path write permissions

--- a/optional-skills/devops/ds4-manager/references/api-docs.md
+++ b/optional-skills/devops/ds4-manager/references/api-docs.md
@@ -1,0 +1,334 @@
+# DS4 Dwarfstar Dashboard — API Reference
+
+## REST Endpoints
+
+### GET /api/status
+Full DS4 status, config, and system metrics.
+
+**Response:**
+```json
+{
+  "state": "running",
+  "running": true,
+  "port": 8001,
+  "model": "DeepSeek-V4-Flash-MTP-Q4K-Q8_0-F32",
+  "pid": 12345,
+  "uptime_seconds": 3600,
+  "checked_at": "2025-06-01T12:00:00Z",
+  "telemetry": {
+    "kv_cache": {
+      "used_slots": 4096,
+      "total_slots": 131072,
+      "context_utilization_pct": 3.125
+    },
+    "generation": {
+      "tokens_per_second": 42.5,
+      "last_generation_ms": 1234
+    }
+  },
+  "config": {
+    "binary": "/Users/m4mbp/ds4/ds4-server",
+    "primary_port": 8001,
+    "model": "/Users/m4mbp/ds4/ds4flash.gguf",
+    "mtp": "/Users/m4mbp/ds4/gguf/DeepSeek-V4-Flash-MTP-Q4K-Q8_0-F32.gguf",
+    "context_window": 131072,
+    "kv_disk_cache": "/tmp/ds4-kv",
+    "kv_cache_budget_mib": 51200,
+    "metal_shader_dir": "/Users/m4mbp/ds4/metal"
+  },
+  "system": {
+    "cpu": {"user_pct": 12.5, "system_pct": 3.2, "idle_pct": 84.3},
+    "gpu": {"gpu_pct": 65.0, "cpu_pct": 15.0, "memory_pct": 45.0, "temp_c": 72.0},
+    "memory": {"active": 32768, "wired": 16384, "pressure": "ok", "pressure_pct": 65.0},
+    "process": {"pid": 12345, "cpu_pct": 42.0, "memory_mib": 2048},
+    "smc_temp_c": 68.0
+  },
+  "kv_cache": {
+    "path": "/tmp/ds4-kv",
+    "budget_mib": 51200,
+    "budget_bytes": 53687091200,
+    "disk_used_bytes": 8589934592,
+    "disk_fill_percent": 16.0,
+    "used_slots": 4096,
+    "total_slots": 131072,
+    "context_utilization_pct": 3.125
+  }
+}
+```
+
+### GET /api/metrics
+Live telemetry subset.
+
+**Response:** Same as `/api/status` but filtered to `checked_at`, `state`, `running`, `port`, `telemetry`, `kv_cache`, `system`.
+
+### GET /api/config
+Current config snapshot (defaults + active overrides).
+
+**Response:**
+```json
+{
+  "binary": "/Users/m4mbp/ds4/ds4-server",
+  "primary_port": 8001,
+  "model": "/Users/m4mbp/ds4/ds4flash.gguf",
+  "mtp": "/Users/m4mbp/ds4/gguf/DeepSeek-V4-Flash-MTP-Q4K-Q8_0-F32.gguf",
+  "context_window": 131072,
+  "kv_disk_cache": "/tmp/ds4-kv",
+  "kv_cache_budget_mib": 51200,
+  "metal_shader_dir": "/Users/m4mbp/ds4/metal",
+  "overrides": {
+    "context_window": 65536
+  }
+}
+```
+
+### GET /api/config-schema?refresh=true
+All discoverable DS4 CLI options.
+
+**Response:**
+```json
+{
+  "context_window": {
+    "type": "integer",
+    "default": 131072,
+    "current": 131072,
+    "desc": "Number of tokens to process in context",
+    "source": "dashboard",
+    "flag": "--ctx-size"
+  },
+  "model": {
+    "type": "string",
+    "default": "/Users/m4mbp/ds4/ds4flash.gguf",
+    "current": "/Users/m4mbp/ds4/ds4flash.gguf",
+    "desc": "Path to model file",
+    "source": "dashboard",
+    "flag": "--model"
+  },
+  "port": {
+    "type": "integer",
+    "default": 8001,
+    "current": 8001,
+    "desc": "Server port",
+    "source": "dashboard",
+    "flag": "--port"
+  },
+  "mtp": {
+    "type": "choice",
+    "default": "MTP model path",
+    "current": "MTP model path",
+    "desc": "MTP mode: off, 1, 2, 4",
+    "source": "dashboard",
+    "flag": "--mtp",
+    "choices": ["off", "1", "2", "4"]
+  }
+}
+```
+
+### PATCH /api/config
+Apply a config override.
+
+**Request:**
+```json
+{"key": "context_window", "value": 65536}
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "updated": true,
+  "config": {
+    "binary": "/Users/m4mbp/ds4/ds4-server",
+    "context_window": 65536,
+    "overrides": {
+      "context_window": 65536
+    }
+  }
+}
+```
+
+### DELETE /api/config/{key}
+Remove a config override (reverts to default).
+
+**Response:**
+```json
+{"ok": true, "removed": true, "config": {...}}
+```
+
+### GET /api/config-overrides
+List active overrides only.
+
+**Response:**
+```json
+{"overrides": {"context_window": 65536}}
+```
+
+### GET /api/benchmarks
+Available suites and last results.
+
+**Response:**
+```json
+{
+  "suites": [
+    {"id": "quick_smoke", "description": "Single completion, low latency", "default_iterations": 1},
+    {"id": "token_throughput", "description": "Token generation throughput test", "default_iterations": 3},
+    {"id": "latency_p90", "description": "Latency distribution (P50/P90/P99)", "default_iterations": 5},
+    {"id": "kv_cache_stress", "description": "Large-context KV cache throughput", "default_iterations": 3},
+    {"id": "mtp_sweep", "description": "Compare MTP modes (off/1/2/4)", "default_iterations": 3},
+    {"id": "batch_size_sweep", "description": "Throughput vs batch size", "default_iterations": 3},
+    {"id": "context_len_sweep", "description": "Throughput vs context length", "default_iterations": 3}
+  ],
+  "last_results": null
+}
+```
+
+### POST /api/benchmarks/run
+Execute a benchmark suite.
+
+**Request:**
+```json
+{"suite_id": "quick_smoke", "iterations": 1, "compare_label": "baseline-20250601"}
+```
+
+**Response (single run):**
+```json
+{
+  "suite_id": "quick_smoke",
+  "iterations": 1,
+  "completed_at": "2025-06-01T12:00:00Z",
+  "metrics": {
+    "latency_ms": 1234.5,
+    "tokens_generated": 100,
+    "tokens_per_second": 42.5,
+    "context_window": 131072
+  }
+}
+```
+
+**Response (compare mode — with `compare_label`):**
+```json
+{
+  "suite_id": "quick_smoke",
+  "iterations": 1,
+  "compare_label": "baseline-20250601",
+  "completed_at": "2025-06-01T12:00:00Z",
+  "metrics": {
+    "latency_ms": 1234.5,
+    "tokens_generated": 100,
+    "tokens_per_second": 42.5
+  },
+  "compare": {
+    "baseline": {
+      "label": "baseline-20250601",
+      "latency_ms": 1200.0,
+      "tokens_per_second": 40.0
+    },
+    "current": {
+      "label": "current",
+      "latency_ms": 1234.5,
+      "tokens_per_second": 42.5
+    },
+    "diff": {
+      "latency_ms": "+34.5 (+2.9%)",
+      "tokens_per_second": "+2.5 (+6.2%)"
+    }
+  }
+}
+```
+
+### GET /api/benchmarks/results
+Last benchmark results.
+
+**Response:**
+```json
+{"results": {...}}
+```
+
+### GET /api/update/check
+Check GitHub for latest DS4 release.
+
+**Response:**
+```json
+{
+  "latest_version": "v1.2.3",
+  "published_at": "2025-06-01T10:00:00Z",
+  "current_version": "v1.2.2",
+  "update_available": true,
+  "asset_url": "https://github.com/antirez/ds4/releases/download/v1.2.3/ds4-server-macos-universal.zip",
+  "asset_sha256": "abc123..."
+}
+```
+
+### POST /api/update
+Apply a DS4 binary update.
+
+**Request:**
+```json
+{"apply": true, "asset_url": "...", "sha256": "abc123..."}
+```
+
+**Response:**
+```json
+{
+  "applied": true,
+  "previous_path": "/Users/m4mbp/ds4/ds4-server",
+  "backup_path": "/Users/m4mbp/ds4/ds4-server.bak",
+  "restart_required": true
+}
+```
+
+### GET /api/mcp/manifest
+Full MCP tool + resource manifest.
+
+**Response:**
+```json
+{
+  "tools": [
+    {"name": "get_status", "description": "...", "inputSchema": {...}},
+    {"name": "get_metrics", "description": "...", "inputSchema": {...}},
+    {"name": "set_config", "description": "...", "inputSchema": {...}},
+    {"name": "get_config", "description": "...", "inputSchema": {...}},
+    {"name": "get_schema", "description": "...", "inputSchema": {...}},
+    {"name": "run_benchmark", "description": "...", "inputSchema": {...}},
+    {"name": "update_ds4", "description": "...", "inputSchema": {...}}
+  ],
+  "resources": [
+    {"uri": "ds4://status", "description": "...", "mimeType": "application/json"},
+    {"uri": "ds4://metrics", "description": "...", "mimeType": "application/json"},
+    {"uri": "ds4://config", "description": "...", "mimeType": "application/json"},
+    {"uri": "ds4://config-schema", "description": "...", "mimeType": "application/json"},
+    {"uri": "ds4://benchmarks", "description": "...", "mimeType": "application/json"},
+    {"uri": "ds4://benchmarks/last", "description": "...", "mimeType": "application/json"}
+  ]
+}
+```
+
+### POST /mcp (JSON-RPC)
+Full MCP protocol endpoint.
+
+**Request (tools/list):**
+```json
+{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+```
+
+**Response:**
+```json
+{"jsonrpc": "2.0", "id": 1, "result": {"tools": [...]}}
+```
+
+**Request (tools/call):**
+```json
+{"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "get_status", "arguments": {}}}
+```
+
+**Response:**
+```json
+{"jsonrpc": "2.0", "id": 2, "result": {"content": [{"type": "text", "text": "..."}], "structuredContent": {...}}}
+```
+
+### GET /mcp/sse (SSE streaming)
+Server-sent events stream of telemetry at 2s intervals.
+
+```text
+event: telemetry
+data: {"checked_at":"...","state":"running","telemetry":{...}}
+```

--- a/optional-skills/devops/ds4-manager/references/architecture.md
+++ b/optional-skills/devops/ds4-manager/references/architecture.md
@@ -1,0 +1,187 @@
+# DS4 Dwarfstar Dashboard — Architecture
+
+## System Overview
+
+```
+┌──────────────────────────────────────────────────────┐
+│                  macOS Host (TrinityMBPM5)           │
+│                                                      │
+│  ┌──────────────┐    ┌───────────────────────────┐   │
+│  │   DS4 Server │    │   DS4 Dwarfstar Dashboard │   │
+│  │   port 8001  │    │   port 8765               │   │
+│  │              │    │                           │   │
+│  │  /telem      │◄──│  bridge/engine_client.py  │   │
+│  │  /metrics    │    │  (telemetry polling)      │   │
+│  │  /v1/chat/   │    │                           │   │
+│  │  completions │◄──│  benchmarks/runner.py     │   │
+│  │              │    │  (benchmark execution)    │   │
+│  └──────────────┘    └───────────────────────────┘   │
+│         ▲                                            │
+│         │ launchd (com.ds4.server)                   │
+│         │                                            │
+│  ┌──────┴──────────────────────────────────────┐     │
+│  │  DS4 Config Manager (bridge/config_manager) │     │
+│  │                                            │     │
+│  │  - Parses --help for CLI options            │     │
+│  │  - Reads /telem for active values           │     │
+│  │  - Applies env-based defaults               │     │
+│  │  - Stores overrides (in-memory)             │     │
+│  └────────────────────────────────────────────┘     │
+│                                                      │
+│  ┌──────────────────────────────────────────────┐   │
+│  │  MCP Server (mcp/server.py)                 │   │
+│  │  Dual transport:                             │   │
+│  │  - JSON-RPC endpoint (/mcp POST)            │   │
+│  │  - SSE streaming (/mcp/sse GET)             │   │
+│  │  - REST wrappers (/api/mcp/*)               │   │
+│  │  Tools: get_status, get_metrics, set_config,│   │
+│  │         get_config, run_benchmark,           │   │
+│  │         update_ds4, get_schema               │   │
+│  │  Resources: ds4://status, ds4://metrics,    │   │
+│  │         ds4://config, ds4://config-schema,   │   │
+│  │         ds4://benchmarks, ds4://benchmarks/  │   │
+│  └──────────────────────────────────────────────┘   │
+│                                                      │
+│  ┌──────────────────────────────────────────────┐   │
+│  │  Frontend (static/)                           │   │
+│  │  - index.html (Dwarfstar cyberpunk theme)    │   │
+│  │  - dashboard.js (SPA, fetches all endpoints) │   │
+│  │  - style.css (dark theme, white dwarf SVG)   │   │
+│  └──────────────────────────────────────────────┘   │
+│                                                      │
+│  ┌──────────────────────────────────────────────┐   │
+│  │  Updater (updater/updater.py)                │   │
+│  │  - Checks GitHub releases for DS4 binary     │   │
+│  │  - Downloads + verifies SHA256               │   │
+│  │  - Replaces binary, triggers restart         │   │
+│  └──────────────────────────────────────────────┘   │
+│                                                      │
+│  ┌──────────────────────────────────────────────┐   │
+│  │  System Metrics (bridge/system_metrics.py)   │   │
+│  │  - GPU utilization (MPS/iStats)              │   │
+│  │  - CPU load (psutil)                         │   │
+│  │  - Temperature sensors (macOS SMC)           │   │
+│  │  - Memory pressure (vm_stat)                 │   │
+│  │  - Disk KV cache usage                       │   │
+│  └──────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────┘
+```
+
+## Data Flow
+
+### Status Polling
+```
+Browser / Agent
+    │
+    ▼
+GET /api/status
+    │
+    ▼
+dashboard.py
+    ├─► engine_client.get_status()  →  GET http://127.0.0.1:8001/telem
+    ├─► config_manager.get_config()  →  merge defaults + overrides
+    └─► system_metrics.get_metrics() →  psutil + SMC + KV cache stat
+    │
+    ▼
+JSON response: {state, uptime, model, port, config, system, kv_cache}
+```
+
+### Config Schema Discovery
+```
+GET /api/config-schema?refresh=true
+    │
+    ▼
+config_manager.get_schema(force_refresh=true)
+    ├─► subprocess: ds4-server --help  →  parse flags
+    ├─► GET /telem  →  read active values
+    └─► merge dashboard defaults
+    │
+    ▼
+JSON response: {key: {type, default, current, desc, source, flag, choices}}
+```
+
+### Config Override
+```
+PATCH /api/config  {"key": "context_window", "value": 65536}
+    │
+    ▼
+config_manager.set_override(key, value)
+    │
+    ▼
+Stored in memory (_overrides dict)
+get_config() now merges defaults + overrides
+    │
+    ▼
+Return: {ok, updated, config}
+```
+
+### Benchmark Execution
+```
+POST /api/benchmarks/run  {"suite_id": "quick_smoke", "iterations": 1}
+    │
+    ▼
+benchmark_runner.run_suite("quick_smoke")
+    ├─► engine_client.completion(...)  →  POST /v1/chat/completions
+    ├─► measure tokens, latency, throughput
+    └─► store result with compare_label (if provided)
+    │
+    ▼
+JSON response: {suite_id, iterations, metrics, compare?}
+```
+
+### MCP Dual Transport
+```
+Transport 1: JSON-RPC over POST
+POST /mcp  {"jsonrpc": "2.0", "method": "tools/call", "params": {"name": "get_status"}}
+
+Transport 2: REST wrappers
+POST /api/mcp/tools/get_status
+
+Transport 3: SSE streaming
+GET /mcp/sse  →  event: telemetry  data: {...}  (every 2s)
+```
+
+## Component Dependencies
+
+```
+dashboard.py
+  ├── benchmarks/runner.py
+  │     └── bridge/engine_client.py (completions)
+  ├── bridge/config_manager.py
+  │     ├── subprocess (ds4-server --help)
+  │     └── bridge/engine_client.py (/telem)
+  ├── bridge/engine_client.py
+  │     └── httpx (async HTTP to DS4)
+  ├── bridge/system_metrics.py
+  │     ├── psutil (CPU/memory)
+  │     └── subprocess (iStats GPU temps, SMC)
+  ├── mcp/server.py
+  │     ├── mcp/tools.py (tool registry)
+  │     └── mcp/resources.py (resource registry)
+  ├── updater/updater.py
+  │     └── httpx (GitHub API)
+  └── static/ (frontend assets)
+```
+
+## Ports
+
+| Port | Service | Protocol |
+| --- | --- | --- |
+| 8001 | DS4 Server | HTTP (OpenAI API + telemetry) |
+| 8765 | DS4 Dashboard | HTTP (REST + MCP + static) |
+| 7777 | DS4 Telemetry | HTTP (internal, /telem endpoint) |
+
+## Key Environment Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `DS4_HOME` | `~/ds4` | DS4 installation directory |
+| `DS4_BINARY` | `$DS4_HOME/ds4-server` | DS4 server binary path |
+| `DS4_MODEL` | `$DS4_HOME/ds4flash.gguf` | Model path |
+| `DS4_MTP` | `$DS4_HOME/gguf/...MTP...gguf` | MTP model path |
+| `DS4_METAL_DIR` | `$DS4_HOME/metal` | Metal shader directory |
+| `DS4_KV_CACHE` | `/tmp/ds4-kv` | KV disk cache path |
+| `DS4_PRIMARY_PORT` | `8001` | DS4 server port |
+| `DS4_CONTEXT_WINDOW` | `131072` | Context window size |
+| `DS4_KV_CACHE_BUDGET_MIB` | `51200` | KV cache budget (50 GiB) |
+| `DS4_GITHUB_REPO` | `antirez/ds4` | GitHub repo for updates |

--- a/optional-skills/devops/ds4-manager/references/setup-guide.md
+++ b/optional-skills/devops/ds4-manager/references/setup-guide.md
@@ -1,0 +1,110 @@
+# DS4 Dwarfstar Dashboard — Setup Guide
+
+## Step 1: Clone the Repository
+
+```bash
+git clone git@github.com:shagghiesuperstar/ds4-dashboard.git ~/ds4-dashboard
+cd ~/ds4-dashboard
+```
+
+## Step 2: Create Python Virtual Environment
+
+```bash
+python3.9 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+**requirements.txt** installs: fastapi, uvicorn, httpx, pydantic, psutil, starlette, websockets.
+
+## Step 3: Ensure DS4 Server is Running
+
+DS4 must be running on port 8001 for the dashboard to collect telemetry.
+
+```bash
+# Verify DS4 status
+curl -s http://127.0.0.1:8001/telem | jq .
+```
+
+If DS4 is not running, start it:
+
+```bash
+# Via launchd (if configured)
+launchctl kickstart gui/$(id -u)/com.ds4.server
+
+# Or directly
+~/ds4/ds4-server --model ~/ds4/ds4flash.gguf --port 8001 --ctx-size 131072
+```
+
+## Step 4: Start the Dashboard
+
+### Direct (foreground)
+```bash
+cd ~/ds4-dashboard
+source .venv/bin/activate
+python dashboard.py
+# → http://127.0.0.1:8765
+```
+
+### Via launchd (background, auto-restart)
+```bash
+cp com.ds4.dashboard.plist ~/Library/LaunchAgents/
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.ds4.dashboard.plist
+```
+
+Or use the `scripts/start.sh` wrapper:
+```bash
+cd ~/ds4-dashboard
+chmod +x scripts/start.sh
+scripts/start.sh
+```
+
+## Step 5: Verify Everything
+
+```bash
+# Check dashboard status
+curl -s http://127.0.0.1:8765/api/status | jq .
+
+# Expected: state=stopped or running, config populated, system metrics present
+```
+
+Full verification script: `scripts/verify.sh`
+
+```bash
+cd ~/ds4-dashboard
+chmod +x scripts/verify.sh
+scripts/verify.sh
+```
+
+## Step 6: Open the Frontend
+
+Open `http://127.0.0.1:8765` in a browser. The Dwarfstar dashboard shows:
+- Live status bar (DS4 state, uptime, model, port)
+- KV cache usage bar
+- Telemetry metrics (tokens/s, context utilization)
+- System metrics (GPU, CPU, temps, memory pressure)
+- Config browser (all DS4 CLI options with current values)
+- Benchmark runner (select suite, run, compare results)
+- Update checker (GitHub release status)
+
+## Quick Config Change Example
+
+```bash
+# Set context window to 64K
+curl -X PATCH http://127.0.0.1:8765/api/config \
+  -H 'Content-Type: application/json' \
+  -d '{"key": "context_window", "value": 65536}'
+
+# Verify the change
+curl -s http://127.0.0.1:8765/api/config | jq '.context_window'
+
+# Restart DS4 for the change to take effect
+scripts/restart-ds4.sh
+```
+
+## Troubleshooting Setup
+
+- **`.venv` not found**: run `python3.9 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt`
+- **Dashboard starts but status is empty**: DS4 is not running — start DS4 first
+- **Port 8765 already in use**: kill existing process: `kill $(lsof -ti:8765)`
+- **Benchmarks fail**: verify DS4 accepts completions: `curl -s http://127.0.0.1:8001/v1/chat/completions`

--- a/optional-skills/devops/ds4-manager/scripts/restart-ds4.sh
+++ b/optional-skills/devops/ds4-manager/scripts/restart-ds4.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# DS4 Restart Helper
+# Restarts the DS4 inference engine after dashboard config changes
+# Supports both direct and launchd-managed DS4
+
+set -euo pipefail
+
+DS4_BINARY="${DS4_BINARY:-/Users/m4mbp/ds4/ds4-server}"
+DS4_LAUNCHD_LABEL="com.ds4.server"
+
+echo "DS4 Restart Helper"
+echo "=================="
+
+# Check if launchd-managed
+if launchctl list | grep -q "$DS4_LAUNCHD_LABEL"; then
+    echo "DS4 is launchd-managed — restarting via launchctl..."
+    launchctl kickstart "gui/$(id -u)/$DS4_LAUNCHD_LABEL"
+    echo "Done. Verify: curl -s http://127.0.0.1:8001/telem | jq .state"
+    exit 0
+fi
+
+# Direct restart
+PID=$(lsof -ti:8001 2>/dev/null || true)
+if [ -n "$PID" ]; then
+    echo "Killing DS4 on port 8001 (PID $PID)..."
+    kill "$PID" 2>/dev/null || true
+    sleep 2
+fi
+
+echo "Starting DS4..."
+exec "$DS4_BINARY" \
+    --model "$DS4_MODEL" \
+    --port 8001 \
+    --ctx-size "${DS4_CONTEXT_WINDOW:-131072}" \
+    --mtp-path "$DS4_MTP" \
+    --kv-cache-path "$DS4_KV_CACHE" \
+    --cache-capacity "$DS4_KV_CACHE_BUDGET_MIB" \
+    "$@"

--- a/optional-skills/devops/ds4-manager/scripts/start.sh
+++ b/optional-skills/devops/ds4-manager/scripts/start.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# DS4 Dwarfstar Dashboard — launchd wrapper
+# Starts dashboard.py with the correct venv and working directory
+
+set -euo pipefail
+
+DASHBOARD_DIR="/Users/m4mbp/ds4-dashboard"
+VENV="$DASHBOARD_DIR/.venv"
+PORT="${DS4_DASHBOARD_PORT:-8765}"
+
+cd "$DASHBOARD_DIR"
+
+if [ ! -d "$VENV" ]; then
+    echo "ERROR: Virtual environment not found at $VENV" >&2
+    echo "Run: cd $DASHBOARD_DIR && python3.9 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt" >&2
+    exit 1
+fi
+
+source "$VENV/bin/activate"
+
+exec python dashboard.py \
+    --port "$PORT" \
+    2>&1

--- a/optional-skills/devops/ds4-manager/scripts/verify.sh
+++ b/optional-skills/devops/ds4-manager/scripts/verify.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# DS4 Dwarfstar Dashboard — full verification script
+# Tests all REST endpoints and reports status
+
+set -euo pipefail
+
+BASE="http://127.0.0.1:8765"
+PASS=0
+FAIL=0
+
+check() {
+    local name="$1"
+    local url="$2"
+    local method="${3:-GET}"
+    local data="${4:-}"
+
+    if [ "$method" = "GET" ]; then
+        resp=$(curl -s -o /tmp/ds4-check.json -w "%{http_code}" "$url" 2>/dev/null)
+    else
+        resp=$(curl -s -X "$method" -o /tmp/ds4-check.json -w "%{http_code}" \
+            -H 'Content-Type: application/json' -d "$data" "$url" 2>/dev/null)
+    fi
+
+    if [ "$resp" = "200" ] || [ "$resp" = "404" ]; then
+        echo "  ✓ $name ($resp)"
+        PASS=$((PASS + 1))
+    else
+        echo "  ✗ $name ($resp)"
+        cat /tmp/ds4-check.json 2>/dev/null | head -c 200
+        echo ""
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "DS4 Dwarfstar Dashboard — Verification"
+echo "========================================"
+echo ""
+
+# Core endpoints
+check "GET /api/status" "$BASE/api/status"
+check "GET /api/metrics" "$BASE/api/metrics"
+check "GET /api/config" "$BASE/api/config"
+check "GET /api/config-schema" "$BASE/api/config-schema"
+check "GET /api/config-overrides" "$BASE/api/config-overrides"
+check "GET /api/benchmarks" "$BASE/api/benchmarks"
+
+# MCP endpoints
+check "GET /api/mcp/manifest" "$BASE/api/mcp/manifest"
+check "GET /api/mcp/resources" "$BASE/api/mcp/resources"
+check "GET /api/mcp/resources/read?uri=ds4://status" "$BASE/api/mcp/resources/read?uri=ds4://status"
+
+# POST endpoints
+check "POST /api/benchmarks/run" "$BASE/api/benchmarks/run" POST '{"suite_id":"quick_smoke","iterations":1}'
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Description

Adds an optional Hermes skill for managing the DS4 Dwarfstar Dashboard — a FastAPI dashboard that provides REST + MCP dual transport for DS4 inference engine telemetry, config management, benchmark execution, and binary updates.

## Files

- `optional-skills/devops/ds4-manager/SKILL.md` — Main skill definition with API docs, MCP tools/resources, benchmark workflows, launchd integration
- `references/` — API docs, architecture docs, setup guide
- `scripts/` — Restart, start, and verify scripts

## Related

- DS4 Dwarfstar Dashboard repo: https://github.com/shagghiesuperstar/ds4-dashboard
- This skill is the Hermes-side companion that teaches the agent how to interact with the dashboards REST/MCP endpoints.