### PR TITLE
fix(skills): retry transient GitHub rate-limits in skills-index build

### DIFF
--- a/contributors/emails/seraphine@Seraphines-Mac-Studio.local
+++ b/contributors/emails/seraphine@Seraphines-Mac-Studio.local
@@ -1,0 +1,2 @@
+Bartok9
+# Seraphine Mac Studio local email on Bartok9 PR tips (per-PR attribution; Teknium/Daniel 2026-08-01)

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -811,33 +811,35 @@ class GitHubSource(SkillSource):
         headers = self.auth.get_headers()
 
         # Resolve default branch
-        try:
-            resp = httpx.get(
-                f"https://api.github.com/repos/{repo}",
-                headers=headers, timeout=15, follow_redirects=True,
-            )
-            if resp.status_code != 200:
+        resp = self._github_get(
+            f"https://api.github.com/repos/{repo}",
+            headers=headers, timeout=15,
+        )
+        if resp is None or resp.status_code != 200:
+            if resp is not None:
                 self._check_rate_limit_response(resp)
-                return None
+            return None
+        try:
             default_branch = resp.json().get("default_branch", "main")
-        except (httpx.HTTPError, ValueError):
+        except ValueError:
             return None
 
         # Fetch recursive tree
-        try:
-            resp = httpx.get(
-                f"https://api.github.com/repos/{repo}/git/trees/{default_branch}",
-                params={"recursive": "1"},
-                headers=headers, timeout=30, follow_redirects=True,
-            )
-            if resp.status_code != 200:
+        resp = self._github_get(
+            f"https://api.github.com/repos/{repo}/git/trees/{default_branch}",
+            params={"recursive": "1"},
+            headers=headers, timeout=30,
+        )
+        if resp is None or resp.status_code != 200:
+            if resp is not None:
                 self._check_rate_limit_response(resp)
-                return None
+            return None
+        try:
             tree_data = resp.json()
             if tree_data.get("truncated"):
                 logger.debug("Git tree truncated for %s, cannot cache", repo)
                 return None
-        except (httpx.HTTPError, ValueError):
+        except ValueError:
             return None
 
         entries = tree_data.get("tree", [])
@@ -909,6 +911,25 @@ class GitHubSource(SkillSource):
             # Rate-limited: honor the reset header when present, else back off.
             if resp.status_code in (403, 429):
                 remaining = resp.headers.get("X-RateLimit-Remaining", "")
+                # Secondary/abuse rate limit: 403 but primary quota NOT exhausted.
+                # Clears on its own in a few seconds; retry so a transient blip
+                # does not collapse an entire source to zero results.
+                if (
+                    resp.status_code == 403
+                    and remaining not in ("", "0")
+                    and attempt < max_retries - 1
+                ):
+                    wait = backoff
+                    retry_after = resp.headers.get("Retry-After", "")
+                    if retry_after.isdigit():
+                        wait = min(float(retry_after), 30.0)
+                    logger.debug(
+                        "GitHub secondary rate limit on %s, waiting %.1fs (attempt %d/%d)",
+                        url, wait, attempt + 1, max_retries,
+                    )
+                    time.sleep(wait)
+                    backoff = min(backoff * 2, 30.0)
+                    continue
                 is_rl = remaining == "0" or resp.status_code == 429
                 if is_rl and attempt < max_retries - 1:
                     wait = backoff

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -819,33 +819,35 @@ class GitHubSource(SkillSource):
         headers = self.auth.get_headers()
 
         # Resolve default branch
-        try:
-            resp = httpx.get(
-                f"https://api.github.com/repos/{repo}",
-                headers=headers, timeout=15, follow_redirects=True,
-            )
-            if resp.status_code != 200:
+        resp = self._github_get(
+            f"https://api.github.com/repos/{repo}",
+            headers=headers, timeout=15,
+        )
+        if resp is None or resp.status_code != 200:
+            if resp is not None:
                 self._check_rate_limit_response(resp)
-                return None
+            return None
+        try:
             default_branch = resp.json().get("default_branch", "main")
-        except (httpx.HTTPError, ValueError):
+        except ValueError:
             return None
 
         # Fetch recursive tree
-        try:
-            resp = httpx.get(
-                f"https://api.github.com/repos/{repo}/git/trees/{default_branch}",
-                params={"recursive": "1"},
-                headers=headers, timeout=30, follow_redirects=True,
-            )
-            if resp.status_code != 200:
+        resp = self._github_get(
+            f"https://api.github.com/repos/{repo}/git/trees/{default_branch}",
+            params={"recursive": "1"},
+            headers=headers, timeout=30,
+        )
+        if resp is None or resp.status_code != 200:
+            if resp is not None:
                 self._check_rate_limit_response(resp)
-                return None
+            return None
+        try:
             tree_data = resp.json()
             if tree_data.get("truncated"):
                 logger.debug("Git tree truncated for %s, cannot cache", repo)
                 return None
-        except (httpx.HTTPError, ValueError):
+        except ValueError:
             return None
 
         entries = tree_data.get("tree", [])
@@ -917,6 +919,25 @@ class GitHubSource(SkillSource):
             # Rate-limited: honor the reset header when present, else back off.
             if resp.status_code in (403, 429):
                 remaining = resp.headers.get("X-RateLimit-Remaining", "")
+                # Secondary/abuse rate limit: 403 but primary quota NOT exhausted.
+                # Clears on its own in a few seconds; retry so a transient blip
+                # does not collapse an entire source to zero results.
+                if (
+                    resp.status_code == 403
+                    and remaining not in ("", "0")
+                    and attempt < max_retries - 1
+                ):
+                    wait = backoff
+                    retry_after = resp.headers.get("Retry-After", "")
+                    if retry_after.isdigit():
+                        wait = min(float(retry_after), 30.0)
+                    logger.debug(
+                        "GitHub secondary rate limit on %s, waiting %.1fs (attempt %d/%d)",
+                        url, wait, attempt + 1, max_retries,
+                    )
+                    time.sleep(wait)
+                    backoff = min(backoff * 2, 30.0)
+                    continue
                 is_rl = remaining == "0" or resp.status_code == 429
                 if is_rl and attempt < max_retries - 1:
                     wait = backoff


### PR DESCRIPTION
## Summary

- Adds bounded retry-with-backoff for transient GitHub secondary rate-limits in the skills-index GitHub source so a single 403 blip no longer collapses that source to zero.
- User-facing impact: `/docs/skills` is less likely to go stale when GitHub returns a short-lived secondary/abuse limit.

## Motivation

Closes #34634. Related watchdog: #66616.

`GitHubSource._get_repo_tree` used raw `httpx.get` and treated any non-200 as empty. A transient secondary-limit 403 (`X-RateLimit-Remaining` > 0) therefore returned zero GitHub skills and tripped `EXPECTED_FLOORS`.

## Fix

- Route repo + recursive-tree GETs through `_github_get`.
- Retry **only** transient failures: `429`, `5xx`, and `403` with remaining quota (`X-RateLimit-Remaining` not `0`). Primary-quota exhaustion is not retried.

Workflow YAML is **not** changed. A prior `trigger-deploy` retry loop is a real hardening, but it requires the `ci-reviewed` label, which contributors cannot apply. That can land in a maintainer follow-up.

## Verification

- Existing `tests/tools/test_skills_hub.py` coverage for `_github_get` retry behavior.
- `python3 -m py_compile tools/skills_hub.py`