### PR TITLE
fix(codex): raise RuntimeError when response.output is None (Cloudflare/non-SSE body)

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -247,6 +247,33 @@ def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta
                             agent._client_log_context(),
                         )
                 final_response = stream.get_final_response()
+                # GUARD: If output is None (not even an empty list), the
+                # backend returned a non-SSE body — most commonly a
+                # Cloudflare challenge page or a gateway error page.
+                # The SDK's response parser silently leaves output=None
+                # in that case, which propagates as 'NoneType' object is
+                # not iterable when _normalize_codex_response iterates it.
+                # Raise a descriptive RuntimeError so the conversation
+                # loop classifies it correctly and falls back to an
+                # alternate provider instead of surfacing a confusing
+                # TypeError to the user.
+                _out = getattr(final_response, "output", None)
+                if _out is None:
+                    # Try to recover text from the streamed parts or
+                    # collected items so we can include a hint in the error.
+                    _hint = ""
+                    if agent._codex_streamed_text_parts:
+                        _hint = (
+                            f" Streamed text before failure: "
+                            f"{repr(''.join(agent._codex_streamed_text_parts)[:120])}"
+                        )
+                    elif collected_output_items:
+                        _hint = f" {len(collected_output_items)} output items were collected before failure."
+                    raise RuntimeError(
+                        f"Codex Responses stream completed but response.output is None — "
+                        f"the backend may have returned a non-SSE body (Cloudflare challenge, "
+                        f"gateway error page, or empty response).{_hint}"
+                    )
                 # PATCH: ChatGPT Codex backend streams valid output items
                 # but get_final_response() can return an empty output list.
                 # Backfill from collected items or synthesize from deltas.


### PR DESCRIPTION
## Summary

When the ChatGPT Codex backend serves a **Cloudflare challenge page** or any non-SSE HTML body (gateway error, temporary block), the OpenAI SDK's stream parser silently leaves `response.output` as `None` rather than raising an exception.

This `None` propagates to `_normalize_codex_response` which tries to iterate `output`, resulting in:

```
TypeError: 'NoneType' object is not iterable
```

The conversation loop classifies `TypeError` as `is_local_validation_error` (a programming bug, **non-retryable**) and immediately triggers the fallback chain. The error message surfaces to users as the cryptic `'NoneType' object is not iterable` with no indication of the real cause.

## Root Cause

Confirmed via `agent.log`: the Codex endpoint `chatgpt.com/backend-api/codex` was serving a Cloudflare JS challenge page when Hermes exceeded the per-IP request rate from the local gateway. The Cloudflare page was being silently swallowed by the SDK's stream parser and exposed downstream as `output=None`.

## Fix

Add a guard in `run_codex_stream` immediately after `stream.get_final_response()` that:
1. Detects `output is None` (distinct from `output == []` which the existing PATCH already handles)
2. Includes any streamed text as a diagnostic hint so the Cloudflare HTML is visible in logs
3. Raises `RuntimeError` instead of `TypeError`

`RuntimeError` is classified as retryable by the conversation loop, giving the retry mechanism a chance to recover before triggering the fallback.

## Before / After

**Before:** `TypeError: 'NoneType' object is not iterable` — classified as non-retryable local bug, misleading, immediately falls back.

**After:** `RuntimeError: Codex Responses stream completed but response.output is None — the backend may have returned a non-SSE body (Cloudflare challenge, gateway error page, or empty response). Streamed text before failure: '<html>...` — classified as retryable, descriptive, includes diagnostic hint.

## Test

```python
# Before fix: raises TypeError
# After fix: raises RuntimeError with descriptive message
response = SimpleNamespace(output=None, status='completed')
_out = getattr(response, 'output', None)
if _out is None:
    raise RuntimeError("Codex Responses stream ... response.output is None")
```

Related: #21444 (gpt-5.5 silent reject pattern on chatgpt.com backend)