### PR TITLE
Remove 'vercel' from nix packages list

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -43,7 +43,6 @@
             "modal"
             "parallel-web"
             "tts-premium"
-            "vercel"
             "voice"
           ] ++ lib.optionals pkgs.stdenv.isLinux [ "matrix" ];
         };


### PR DESCRIPTION
we ripped vercel out earlier, but missed this one :)

## What does this PR do?
nix setup was trying to install the removed `vercel` extra from pyproject.toml. this removes it.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- removed "vercel" from nix/packages.nix
