### PR TITLE
fix(windows): decode schtasks.exe output using system OEM code page

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -108,10 +108,12 @@ def _exec_schtasks(args: list[str]) -> tuple[int, str, str]:
     if schtasks is None:
         return (1, "", "schtasks.exe not found on PATH")
     try:
+        _oem_cp = ctypes.windll.kernel32.GetOEMCP()
         proc = subprocess.run(
             [schtasks, *args],
             capture_output=True,
             text=True,
+            encoding=f"cp{_oem_cp}",
             timeout=_SCHTASKS_TIMEOUT_S,
             # CREATE_NO_WINDOW avoids a flashing console window when the CLI
             # is itself hosted in a TUI. See tools/browser_tool.py for the


### PR DESCRIPTION
## What does this PR do?

On Windows, Hermes automatically enables PYTHONUTF8=1 (via hermes_bootstrap.py) so Python subprocesses use UTF-8 encoding. However, schtasks.exe outputs text in the system's OEM code page (e.g. cp936/GBK on Chinese Windows). When _exec_schtasks(), which is called during hermes gateway restart, runs subprocess.run with text=True, it defaults to UTF-8 decoding and crashes with UnicodeDecodeError on localized output.

Fix by explicitly passing encoding=f"cp{GetOEMCP()}" to subprocess.run() in _exec_schtasks(), so the output is decoded using the system's actual console code page.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- hermes_cli/gateway_windows.py: added encoding=f"cp{GetOEMCP()}" to subprocess.run() in _exec_schtasks()

## How to Test

1. On Chinese Windows, open Hermes Dashboard and click "Restart Gateway"
2. Before: UnicodeDecodeError in gateway-restart.log
3. After: the restart runs without error

## Checklist

- [x] I've tested on my platform: Windows 11
