### PR TITLE
feat(delegation): delegate_task model/provider routing by fixed tier set

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2089,6 +2089,23 @@ DEFAULT_CONFIG = {
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
     },
+    # Optional alternate routing blocks selected by delegate_task(tier=...).
+    # These are intentionally small v1 surfaces: just provider/model or direct
+    # endpoint overrides, with the same precedence rules as delegation.*.
+    "delegation_small": {
+        "model": "",
+        "provider": "",
+        "base_url": "",
+        "api_key": "",
+        "api_mode": "",
+    },
+    "delegation_large": {
+        "model": "",
+        "provider": "",
+        "base_url": "",
+        "api_key": "",
+        "api_mode": "",
+    },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
     # injected at the start of every API call for few-shot priming.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2088,23 +2088,11 @@ DEFAULT_CONFIG = {
         # Flip to true only if you trust delegated work to run dangerous cmds
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
-    },
-    # Optional alternate routing blocks selected by delegate_task(tier=...).
-    # These are intentionally small v1 surfaces: just provider/model or direct
-    # endpoint overrides, with the same precedence rules as delegation.*.
-    "delegation_small": {
-        "model": "",
-        "provider": "",
-        "base_url": "",
-        "api_key": "",
-        "api_mode": "",
-    },
-    "delegation_large": {
-        "model": "",
-        "provider": "",
-        "base_url": "",
-        "api_key": "",
-        "api_mode": "",
+        # Overrides for model/provider/base_url/api_key/api_mode/reasoning_effort based on tier
+        # Valid tiers are: small/medium/large
+        # The tier is determined by the caller of `delegate_task`
+        # Non-configured tiers fallback to the top-level delegation config
+        "tiers": {},
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/run_agent.py
+++ b/run_agent.py
@@ -5312,6 +5312,7 @@ class AIAgent:
             context=function_args.get("context"),
             toolsets=function_args.get("toolsets"),
             tasks=function_args.get("tasks"),
+            tier=function_args.get("tier"),
             max_iterations=function_args.get("max_iterations"),
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -285,6 +285,7 @@ AUTHOR_MAP = {
     "aman@abacus.ai": "Aman113114-IITD",
     "octavio.turra@gmail.com": "octavioturra",
     "524706+Twanislas@users.noreply.github.com": "Twanislas",
+    "loicnico96@gmail.com": "loicnico96",
     "9592417+adam91holt@users.noreply.github.com": "adam91holt",
     "kchuang1015@users.noreply.github.com": "kchuang1015",
     "maheshthedev@gmail.com": "MaheshtheDev",

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -712,11 +712,12 @@ Spawn a subagent with an isolated context + terminal session.
 - **Background:** `delegate_task(background=true)` returns a handle
   immediately and keeps the parent loop going; the child's result
   re-enters the conversation as a new turn when it finishes.
-- **Tier routing:** top-level `tier` is bounded to `small`, `medium`, or `large`.
-  `small` prefers `delegation_small`, `large` prefers `delegation_large`, and
-  omitted / `medium` uses `delegation` before falling back to parent inheritance.
-  Batch mode applies one top-level tier to the whole call; there is no per-task
-  tier inside `tasks[]`.
+- **Tier routing:** top-level `tier` is bounded to `small`, `medium`, or `large`,
+  with `medium` being the default. This determines which model is used and which
+  level of reasoning to prefer. `small` prefers `delegation_small`, `large`
+  prefers `delegation_large`, and omitted / `medium` uses `delegation` before
+  falling back to parent inheritance. Batch mode applies one top-level tier to
+  the whole call; there is no per-task tier inside `tasks[]`.
 - **Roles:** `leaf` (default; cannot re-delegate) vs `orchestrator`
   (can spawn its own workers, bounded by `delegation.max_spawn_depth`).
 - **Not durable.** A backgrounded child is still process-local — if the

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -706,12 +706,17 @@ here; full developer notes live in `AGENTS.md`, user-facing docs under
 
 Spawn a subagent with an isolated context + terminal session.
 
-- **Single:** `delegate_task(goal, context, toolsets)`.
-- **Batch:** `delegate_task(tasks=[{goal, ...}, ...])` runs children in
+- **Single:** `delegate_task(goal, context, toolsets, tier)`.
+- **Batch:** `delegate_task(tasks=[{goal, ...}, ...], tier=...)` runs children in
   parallel, capped by `delegation.max_concurrent_children` (default 3).
 - **Background:** `delegate_task(background=true)` returns a handle
   immediately and keeps the parent loop going; the child's result
   re-enters the conversation as a new turn when it finishes.
+- **Tier routing:** top-level `tier` is bounded to `small`, `medium`, or `large`.
+  `small` prefers `delegation_small`, `large` prefers `delegation_large`, and
+  omitted / `medium` uses `delegation` before falling back to parent inheritance.
+  Batch mode applies one top-level tier to the whole call; there is no per-task
+  tier inside `tasks[]`.
 - **Roles:** `leaf` (default; cannot re-delegate) vs `orchestrator`
   (can spawn its own workers, bounded by `delegation.max_spawn_depth`).
 - **Not durable.** A backgrounded child is still process-local — if the
@@ -719,7 +724,8 @@ Spawn a subagent with an isolated context + terminal session.
   the process, use `cronjob` or
   `terminal(background=True, notify_on_complete=True)`.
 
-Config: `delegation.*` in `config.yaml`.
+Config: `delegation.*` in `config.yaml`, plus optional `delegation_small.*`
+and `delegation_large.*` routing blocks.
 
 ### Cron (scheduled jobs)
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -34,6 +34,7 @@ from tools.delegate_tool import (
     _resolve_delegation_credentials,
     _inherit_parent_base_url,
     _merge_delegation_config_for_tier,
+    _load_delegation_config_for_tier,
 )
 
 
@@ -3005,6 +3006,65 @@ class TestDelegationTierConfigMerge(unittest.TestCase):
         self.assertNotIn("model", merged)
         self.assertNotIn("api_key", merged)
         self.assertEqual(merged["reasoning_effort"], "medium")
+
+
+class TestDelegationTierConfigLoad(unittest.TestCase):
+    def test_missing_delegation_block_returns_empty_config(self):
+        self.assertEqual(_load_delegation_config_for_tier({}, "small"), {})
+        self.assertEqual(_load_delegation_config_for_tier(None, "large"), {})
+
+    def test_without_requested_tier_returns_base_delegation_config(self):
+        full_cfg = {
+            "delegation": {
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+                "tiers": {
+                    "small": {"model": "google/gemini-3-flash-preview"},
+                },
+            }
+        }
+
+        loaded = _load_delegation_config_for_tier(full_cfg)
+
+        self.assertEqual(loaded, full_cfg["delegation"])
+
+    def test_missing_requested_tier_falls_back_to_base_delegation_config(self):
+        full_cfg = {
+            "delegation": {
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+                "tiers": {
+                    "small": {"model": "google/gemini-3-flash-preview"},
+                },
+            }
+        }
+
+        loaded = _load_delegation_config_for_tier(full_cfg, "large")
+
+        self.assertEqual(loaded, full_cfg["delegation"])
+
+    def test_requested_tier_returns_merged_delegation_config(self):
+        full_cfg = {
+            "delegation": {
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "base-key",
+                "tiers": {
+                    "small": {
+                        "model": "google/gemini-3-flash-preview",
+                    },
+                },
+            }
+        }
+
+        loaded = _load_delegation_config_for_tier(full_cfg, "small")
+
+        self.assertEqual(loaded["provider"], "openrouter")
+        self.assertEqual(loaded["model"], "google/gemini-3-flash-preview")
+        self.assertEqual(loaded["base_url"], "https://openrouter.ai/api/v1")
+        self.assertEqual(loaded["api_key"], "base-key")
+        self.assertIn("tiers", loaded)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -285,7 +285,7 @@ class TestDelegateTask(unittest.TestCase):
         )
 
         self.assertIn("results", result)
-        mock_creds.assert_called_once_with(mock_cfg.return_value, parent, tier="large")
+        mock_creds.assert_called_once_with(mock_cfg.return_value, parent)
 
     @patch("tools.delegate_tool._run_single_child")
     @patch("tools.delegate_tool._resolve_delegation_credentials")
@@ -311,7 +311,7 @@ class TestDelegateTask(unittest.TestCase):
         result = json.loads(delegate_task(goal="Fix tests", tier="  ", parent_agent=parent))
 
         self.assertIn("results", result)
-        mock_creds.assert_called_once_with(mock_cfg.return_value, parent, tier="medium")
+        mock_creds.assert_called_once_with(mock_cfg.return_value, parent)
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode_accepts_json_string_tasks(self, mock_run):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -3027,6 +3027,47 @@ class TestDelegationTierConfigMerge(unittest.TestCase):
         self.assertNotIn("api_key", merged)
         self.assertEqual(merged["reasoning_effort"], "medium")
 
+    def test_blank_provider_override_is_ignored_and_model_override_still_applies(self):
+        merged = _merge_delegation_config_for_tier(
+            {
+                "provider": "openrouter",
+                "model": "google/gemini-2.5-pro",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "base-key",
+                "api_mode": "chat_completions",
+            },
+            {
+                "provider": "",
+                "model": "google/gemini-2.5-flash-lite",
+            },
+        )
+
+        self.assertEqual(merged["provider"], "openrouter")
+        self.assertEqual(merged["model"], "google/gemini-2.5-flash-lite")
+        self.assertEqual(merged["base_url"], "https://openrouter.ai/api/v1")
+        self.assertEqual(merged["api_key"], "base-key")
+        self.assertEqual(merged["api_mode"], "chat_completions")
+
+    def test_blank_base_url_override_is_ignored(self):
+        merged = _merge_delegation_config_for_tier(
+            {
+                "model": "anthropic/claude-sonnet-4",
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "base-key",
+                "api_mode": "chat_completions",
+            },
+            {
+                "base_url": "",
+            },
+        )
+
+        self.assertEqual(merged["provider"], "openrouter")
+        self.assertEqual(merged["model"], "anthropic/claude-sonnet-4")
+        self.assertEqual(merged["base_url"], "https://openrouter.ai/api/v1")
+        self.assertEqual(merged["api_key"], "base-key")
+        self.assertEqual(merged["api_mode"], "chat_completions")
+
 
 class TestDelegationTierConfigLoad(unittest.TestCase):
     def test_missing_delegation_block_returns_empty_config(self):
@@ -3082,6 +3123,31 @@ class TestDelegationTierConfigLoad(unittest.TestCase):
 
         self.assertEqual(loaded["provider"], "openrouter")
         self.assertEqual(loaded["model"], "google/gemini-3-flash-preview")
+        self.assertEqual(loaded["base_url"], "https://openrouter.ai/api/v1")
+        self.assertEqual(loaded["api_key"], "base-key")
+        self.assertIn("tiers", loaded)
+
+    def test_requested_tier_ignores_blank_string_route_overrides(self):
+        full_cfg = {
+            "delegation": {
+                "provider": "openrouter",
+                "model": "google/gemini-2.5-pro",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "base-key",
+                "tiers": {
+                    "small": {
+                        "provider": "",
+                        "base_url": "",
+                        "model": "google/gemini-2.5-flash-lite",
+                    },
+                },
+            }
+        }
+
+        loaded = _load_delegation_config_for_tier(full_cfg, "small")
+
+        self.assertEqual(loaded["provider"], "openrouter")
+        self.assertEqual(loaded["model"], "google/gemini-2.5-flash-lite")
         self.assertEqual(loaded["base_url"], "https://openrouter.ai/api/v1")
         self.assertEqual(loaded["api_key"], "base-key")
         self.assertIn("tiers", loaded)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -33,6 +33,7 @@ from tools.delegate_tool import (
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
     _inherit_parent_base_url,
+    _merge_delegation_config_for_tier,
 )
 
 
@@ -1032,72 +1033,6 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["provider"])
         self.assertIsNone(creds["base_url"])
         self.assertIsNone(creds["api_key"])
-
-    def test_small_tier_prefers_delegation_small_block(self):
-        parent = _make_mock_parent(depth=0)
-        cfg = {
-            "model": "anthropic/claude-sonnet-4",
-            "provider": "openrouter",
-            "delegation_small": {
-                "model": "google/gemini-3-flash-preview",
-                "provider": "openrouter",
-            },
-        }
-        with patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_runtime:
-            mock_runtime.return_value = {
-                "provider": "openrouter",
-                "base_url": "https://openrouter.ai/api/v1",
-                "api_key": "small-key",
-                "api_mode": "chat_completions",
-                "model": "google/gemini-3-flash-preview",
-            }
-            creds = _resolve_delegation_credentials(cfg, parent, tier="small")
-
-        self.assertEqual(creds["model"], "google/gemini-3-flash-preview")
-        self.assertEqual(creds["provider"], "openrouter")
-        mock_runtime.assert_called_once_with(
-            requested="openrouter",
-            target_model="google/gemini-3-flash-preview",
-        )
-
-    def test_large_tier_falls_back_to_default_block_when_unset(self):
-        parent = _make_mock_parent(depth=0)
-        cfg = {
-            "model": "anthropic/claude-sonnet-4",
-            "provider": "openrouter",
-        }
-        with patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_runtime:
-            mock_runtime.return_value = {
-                "provider": "openrouter",
-                "base_url": "https://openrouter.ai/api/v1",
-                "api_key": "default-key",
-                "api_mode": "chat_completions",
-                "model": "anthropic/claude-sonnet-4",
-            }
-            creds = _resolve_delegation_credentials(cfg, parent, tier="large")
-
-        self.assertEqual(creds["model"], "anthropic/claude-sonnet-4")
-        mock_runtime.assert_called_once_with(
-            requested="openrouter",
-            target_model="anthropic/claude-sonnet-4",
-        )
-
-    def test_small_tier_inherits_parent_when_no_routing_blocks_exist(self):
-        parent = _make_mock_parent(depth=0)
-        creds = _resolve_delegation_credentials({}, parent, tier="small")
-
-        self.assertIsNone(creds["provider"])
-        self.assertIsNone(creds["base_url"])
-        self.assertIsNone(creds["api_key"])
-        self.assertIsNone(creds["api_mode"])
-        self.assertIsNone(creds["model"])
-
-    def test_invalid_tier_raises_value_error(self):
-        parent = _make_mock_parent(depth=0)
-
-        with self.assertRaisesRegex(ValueError, "Invalid delegation tier"):
-            _resolve_delegation_credentials({}, parent, tier="giant")
-
 
 
     def test_direct_endpoint_uses_configured_base_url_and_api_key(self):
@@ -2997,6 +2932,79 @@ class TestFallbackModelInheritance(unittest.TestCase):
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
 
+class TestDelegationTierConfigMerge(unittest.TestCase):
+    def test_same_provider_tier_inherits_base_routing_fields(self):
+        merged = _merge_delegation_config_for_tier(
+            {
+                "model": "anthropic/claude-sonnet-4",
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "base-key",
+                "api_mode": "chat_completions",
+                "max_iterations": 50,
+            },
+            {
+                "model": "google/gemini-3-flash-preview",
+                "provider": "openrouter",
+            },
+        )
+
+        self.assertEqual(merged["model"], "google/gemini-3-flash-preview")
+        self.assertEqual(merged["provider"], "openrouter")
+        self.assertEqual(merged["base_url"], "https://openrouter.ai/api/v1")
+        self.assertEqual(merged["api_key"], "base-key")
+        self.assertEqual(merged["api_mode"], "chat_completions")
+        self.assertEqual(merged["max_iterations"], 50)
+
+    def test_provider_switch_clears_inherited_routing_bundle(self):
+        merged = _merge_delegation_config_for_tier(
+            {
+                "model": "anthropic/claude-sonnet-4",
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "base-key",
+                "api_mode": "chat_completions",
+                "command": "copilot",
+                "args": ["--acp", "--stdio"],
+                "max_iterations": 50,
+            },
+            {
+                "provider": "minimax",
+                "max_iterations": 20,
+            },
+        )
+
+        self.assertEqual(merged["provider"], "minimax")
+        self.assertNotIn("model", merged)
+        self.assertNotIn("base_url", merged)
+        self.assertNotIn("api_key", merged)
+        self.assertNotIn("api_mode", merged)
+        self.assertNotIn("command", merged)
+        self.assertNotIn("args", merged)
+        self.assertEqual(merged["max_iterations"], 20)
+
+    def test_base_url_switch_clears_inherited_provider_fields(self):
+        merged = _merge_delegation_config_for_tier(
+            {
+                "model": "anthropic/claude-sonnet-4",
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "base-key",
+                "api_mode": "chat_completions",
+                "reasoning_effort": "medium",
+            },
+            {
+                "base_url": "http://localhost:1234/v1",
+                "api_mode": "anthropic_messages",
+            },
+        )
+
+        self.assertEqual(merged["base_url"], "http://localhost:1234/v1")
+        self.assertEqual(merged["api_mode"], "anthropic_messages")
+        self.assertNotIn("provider", merged)
+        self.assertNotIn("model", merged)
+        self.assertNotIn("api_key", merged)
+        self.assertEqual(merged["reasoning_effort"], "medium")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -70,6 +70,9 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("tier", props)
+        self.assertEqual(props["tier"]["enum"], ["small", "medium", "large"])
+        self.assertNotIn("tier", props["tasks"]["items"]["properties"])
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
@@ -211,6 +214,12 @@ class TestDelegateTask(unittest.TestCase):
         result = json.loads(delegate_task(goal="  ", parent_agent=parent))
         self.assertIn("error", result)
 
+    def test_invalid_tier_returns_tool_error(self):
+        parent = _make_mock_parent()
+        result = json.loads(delegate_task(goal="test", tier="huge", parent_agent=parent))
+        self.assertIn("error", result)
+        self.assertIn("Invalid delegation tier", result["error"])
+
     def test_task_missing_goal(self):
         parent = _make_mock_parent()
         result = json.loads(delegate_task(tasks=[{"context": "no goal here"}], parent_agent=parent))
@@ -247,6 +256,61 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(result["results"][0]["summary"], "Result A")
         self.assertEqual(result["results"][1]["summary"], "Result B")
         self.assertIn("total_duration_seconds", result)
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config")
+    def test_batch_mode_uses_top_level_tier_once(self, mock_cfg, mock_creds, mock_run):
+        mock_cfg.return_value = {"max_iterations": 50}
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_run.side_effect = [
+            {"task_index": 0, "status": "completed", "summary": "Result A", "api_calls": 2, "duration_seconds": 3.0},
+            {"task_index": 1, "status": "completed", "summary": "Result B", "api_calls": 4, "duration_seconds": 6.0},
+        ]
+        parent = _make_mock_parent()
+
+        result = json.loads(
+            delegate_task(
+                tasks=[{"goal": "Research topic A"}, {"goal": "Research topic B"}],
+                tier="large",
+                parent_agent=parent,
+            )
+        )
+
+        self.assertIn("results", result)
+        mock_creds.assert_called_once_with(mock_cfg.return_value, parent, tier="large")
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config")
+    def test_blank_tier_behaves_like_medium(self, mock_cfg, mock_creds, mock_run):
+        mock_cfg.return_value = {"max_iterations": 50}
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_run.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done!",
+            "api_calls": 1,
+            "duration_seconds": 1.0,
+        }
+        parent = _make_mock_parent()
+
+        result = json.loads(delegate_task(goal="Fix tests", tier="  ", parent_agent=parent))
+
+        self.assertIn("results", result)
+        mock_creds.assert_called_once_with(mock_cfg.return_value, parent, tier="medium")
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode_accepts_json_string_tasks(self, mock_run):
@@ -968,6 +1032,71 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["provider"])
         self.assertIsNone(creds["base_url"])
         self.assertIsNone(creds["api_key"])
+
+    def test_small_tier_prefers_delegation_small_block(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "anthropic/claude-sonnet-4",
+            "provider": "openrouter",
+            "delegation_small": {
+                "model": "google/gemini-3-flash-preview",
+                "provider": "openrouter",
+            },
+        }
+        with patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_runtime:
+            mock_runtime.return_value = {
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "small-key",
+                "api_mode": "chat_completions",
+                "model": "google/gemini-3-flash-preview",
+            }
+            creds = _resolve_delegation_credentials(cfg, parent, tier="small")
+
+        self.assertEqual(creds["model"], "google/gemini-3-flash-preview")
+        self.assertEqual(creds["provider"], "openrouter")
+        mock_runtime.assert_called_once_with(
+            requested="openrouter",
+            target_model="google/gemini-3-flash-preview",
+        )
+
+    def test_large_tier_falls_back_to_default_block_when_unset(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "anthropic/claude-sonnet-4",
+            "provider": "openrouter",
+        }
+        with patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_runtime:
+            mock_runtime.return_value = {
+                "provider": "openrouter",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "default-key",
+                "api_mode": "chat_completions",
+                "model": "anthropic/claude-sonnet-4",
+            }
+            creds = _resolve_delegation_credentials(cfg, parent, tier="large")
+
+        self.assertEqual(creds["model"], "anthropic/claude-sonnet-4")
+        mock_runtime.assert_called_once_with(
+            requested="openrouter",
+            target_model="anthropic/claude-sonnet-4",
+        )
+
+    def test_small_tier_inherits_parent_when_no_routing_blocks_exist(self):
+        parent = _make_mock_parent(depth=0)
+        creds = _resolve_delegation_credentials({}, parent, tier="small")
+
+        self.assertIsNone(creds["provider"])
+        self.assertIsNone(creds["base_url"])
+        self.assertIsNone(creds["api_key"])
+        self.assertIsNone(creds["api_mode"])
+        self.assertIsNone(creds["model"])
+
+    def test_invalid_tier_raises_value_error(self):
+        parent = _make_mock_parent(depth=0)
+
+        with self.assertRaisesRegex(ValueError, "Invalid delegation tier"):
+            _resolve_delegation_credentials({}, parent, tier="giant")
 
 
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -16,6 +16,8 @@ import time
 import unittest
 from unittest.mock import MagicMock, patch
 
+from run_agent import AIAgent
+
 from tools.delegate_tool import (
     DELEGATE_BLOCKED_TOOLS,
     DELEGATE_TASK_SCHEMA,
@@ -2142,6 +2144,24 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 
 class TestDispatchDelegateTask(unittest.TestCase):
     """Tests for the _dispatch_delegate_task helper and full param forwarding."""
+
+    def test_tier_forwarded(self):
+        """The agent-loop dispatch helper must pass through the top-level tier."""
+        parent = object.__new__(AIAgent)
+        with patch("tools.delegate_tool.delegate_task", return_value='{"ok":true}') as mock_delegate:
+            result = AIAgent._dispatch_delegate_task(
+                parent,
+                {
+                    "goal": "test",
+                    "toolsets": [],
+                    "tier": "small",
+                },
+            )
+
+        self.assertEqual(result, '{"ok":true}')
+        _, kwargs = mock_delegate.call_args
+        self.assertEqual(kwargs["tier"], "small")
+        self.assertIs(kwargs["parent_agent"], parent)
 
     @patch("tools.delegate_tool._load_config", return_value={})
     @patch("tools.delegate_tool._resolve_delegation_credentials")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2885,16 +2885,26 @@ def _merge_delegation_config_for_tier(delegation_cfg: dict, tier_cfg: dict) -> d
     ``provider`` or ``base_url``, the inherited routing bundle from the base
     config must be cleared first so we don't leak incompatible credentials or
     transports into the selected tier.
+
+    Blank-string values are treated like absent overrides here. The config CLI
+    persists unset-like values as ``""`` rather than removing the key, so
+    merging them literally would accidentally erase the base route and fall
+    back to parent inheritance.
     """
+    sanitized_tier_cfg = {
+        key: value
+        for key, value in tier_cfg.items()
+        if not (isinstance(value, str) and not value.strip())
+    }
     merged = dict(delegation_cfg)
 
     provider_changed = (
-        "provider" in tier_cfg
-        and tier_cfg.get("provider") != delegation_cfg.get("provider")
+        "provider" in sanitized_tier_cfg
+        and sanitized_tier_cfg.get("provider") != delegation_cfg.get("provider")
     )
     base_url_changed = (
-        "base_url" in tier_cfg
-        and tier_cfg.get("base_url") != delegation_cfg.get("base_url")
+        "base_url" in sanitized_tier_cfg
+        and sanitized_tier_cfg.get("base_url") != delegation_cfg.get("base_url")
     )
 
     if provider_changed or base_url_changed:
@@ -2909,7 +2919,7 @@ def _merge_delegation_config_for_tier(delegation_cfg: dict, tier_cfg: dict) -> d
         ):
             merged.pop(key, None)
 
-    merged.update(tier_cfg)
+    merged.update(sanitized_tier_cfg)
     return merged
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1047,6 +1047,7 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    tier: str = "medium",
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1080,7 +1081,7 @@ def _build_child_agent(
     parent_subagent_id = getattr(parent_agent, "_subagent_id", None)
     tui_depth = max(0, child_depth - 1)  # 0 = first-level child for the UI
 
-    delegation_cfg = _load_config()
+    delegation_cfg = _load_config(tier)
 
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
@@ -2187,8 +2188,13 @@ def delegate_task(
             }
         )
 
+    try:
+        tier = _normalize_delegation_tier(tier)
+    except ValueError as exc:
+        return tool_error(str(exc))
+
     # Load config
-    cfg = _load_config()
+    cfg = _load_config(tier)
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     # Model-supplied max_iterations is ignored — the config value is authoritative
     # so users get predictable budgets. The kwarg is retained for internal callers
@@ -2203,18 +2209,13 @@ def delegate_task(
         )
     effective_max_iter = default_max_iter
 
-    try:
-        tier = _normalize_delegation_tier(tier)
-    except ValueError as exc:
-        return tool_error(str(exc))
-
     # Resolve delegation credentials (provider:model pair).
     # When delegation.provider is configured, this resolves the full credential
     # bundle (base_url, api_key, api_mode) via the same runtime provider system
     # used by CLI/gateway startup.  When unconfigured, returns None values so
     # children inherit from the parent.
     try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent, tier=tier)
+        creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
         return tool_error(str(exc))
 
@@ -2301,6 +2302,7 @@ def delegate_task(
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
                 role=effective_role,
+                tier=tier,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -2761,41 +2763,8 @@ def _normalize_delegation_tier(tier: Optional[str]) -> str:
     return normalized
 
 
-
-def _delegation_block_has_routing(block: Optional[dict]) -> bool:
-    if not isinstance(block, dict):
-        return False
-    for key in ("model", "provider", "base_url", "api_key", "api_mode"):
-        if str(block.get(key) or "").strip():
-            return True
-    return False
-
-
-
-def _select_delegation_config_block(cfg: dict, tier: Optional[str]) -> dict:
-    normalized_tier = _normalize_delegation_tier(tier)
-    config = cfg if isinstance(cfg, dict) else {}
-    default_block = dict(config)
-
-    if normalized_tier == "small":
-        small_block = config.get("delegation_small")
-        if _delegation_block_has_routing(small_block):
-            return dict(small_block)
-    elif normalized_tier == "large":
-        large_block = config.get("delegation_large")
-        if _delegation_block_has_routing(large_block):
-            return dict(large_block)
-
-    return default_block
-
-
-
-def _resolve_delegation_credentials(cfg: dict, parent_agent, tier: Optional[str] = None) -> dict:
+def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
-
-    If ``delegation_small`` / ``delegation_large`` is requested via ``tier`` and
-    meaningfully configured, resolve credentials from that block first.
-    Otherwise fall back to ``delegation`` and finally to parent inheritance.
 
     If ``delegation.base_url`` is configured, subagents use that direct
     OpenAI-compatible endpoint. ``delegation.api_key`` overrides the key; when
@@ -2815,12 +2784,11 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent, tier: Optional[str]
 
     Raises ValueError with a user-friendly message on credential failure.
     """
-    effective_cfg = _select_delegation_config_block(cfg, tier)
-    configured_model = str(effective_cfg.get("model") or "").strip() or None
-    configured_provider = str(effective_cfg.get("provider") or "").strip() or None
-    configured_base_url = str(effective_cfg.get("base_url") or "").strip() or None
-    configured_api_key = str(effective_cfg.get("api_key") or "").strip() or None
-    configured_api_mode = str(effective_cfg.get("api_mode") or "").strip().lower() or None
+    configured_model = str(cfg.get("model") or "").strip() or None
+    configured_provider = str(cfg.get("provider") or "").strip() or None
+    configured_base_url = str(cfg.get("base_url") or "").strip() or None
+    configured_api_key = str(cfg.get("api_key") or "").strip() or None
+    configured_api_mode = str(cfg.get("api_mode") or "").strip().lower() or None
 
     if configured_base_url:
         # When delegation.api_key is not set, return None so _build_child_agent
@@ -2909,7 +2877,65 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent, tier: Optional[str]
     }
 
 
-def _load_config() -> dict:
+def _merge_delegation_config_for_tier(delegation_cfg: dict, tier_cfg: dict) -> dict:
+    """Merge a tier override into the base delegation config.
+
+    Most tier fields are ordinary per-tier overrides layered on top of the
+    base delegation settings. But when a tier switches routing by changing
+    ``provider`` or ``base_url``, the inherited routing bundle from the base
+    config must be cleared first so we don't leak incompatible credentials or
+    transports into the selected tier.
+    """
+    merged = dict(delegation_cfg)
+
+    provider_changed = (
+        "provider" in tier_cfg
+        and tier_cfg.get("provider") != delegation_cfg.get("provider")
+    )
+    base_url_changed = (
+        "base_url" in tier_cfg
+        and tier_cfg.get("base_url") != delegation_cfg.get("base_url")
+    )
+
+    if provider_changed or base_url_changed:
+        for key in (
+            "model",
+            "provider",
+            "base_url",
+            "api_key",
+            "api_mode",
+            "command",
+            "args",
+        ):
+            merged.pop(key, None)
+
+    merged.update(tier_cfg)
+    return merged
+
+
+def _load_delegation_config_for_tier(full_cfg: Optional[dict], tier: Optional[str] = None) -> dict:
+    if full_cfg is None:
+        return {}
+
+    delegation_cfg = full_cfg.get("delegation")
+    if not isinstance(delegation_cfg, dict):
+        return {}
+
+    if tier is None:
+        return delegation_cfg
+
+    tiers_cfg = delegation_cfg.get("tiers")
+    if not isinstance(tiers_cfg, dict):
+        return delegation_cfg
+
+    tier_cfg = tiers_cfg.get(tier)
+    if not isinstance(tier_cfg, dict):
+        return delegation_cfg
+
+    return _merge_delegation_config_for_tier(delegation_cfg, tier_cfg)
+
+
+def _load_config(tier: Optional[str] = None) -> dict:
     """Load delegation config from CLI_CONFIG or persistent config.
 
     Returns the ``delegation`` block plus optional sibling routing blocks so the
@@ -2918,19 +2944,10 @@ def _load_config() -> dict:
     resolution.
     """
 
-    def _compose_delegation_config(full_cfg: Optional[dict]) -> dict:
-        full_cfg = full_cfg or {}
-        delegation_cfg = dict(full_cfg.get("delegation") or {})
-        if full_cfg.get("delegation_small"):
-            delegation_cfg["delegation_small"] = dict(full_cfg.get("delegation_small") or {})
-        if full_cfg.get("delegation_large"):
-            delegation_cfg["delegation_large"] = dict(full_cfg.get("delegation_large") or {})
-        return delegation_cfg
-
     try:
         from cli import CLI_CONFIG
 
-        cfg = _compose_delegation_config(CLI_CONFIG)
+        cfg = _load_delegation_config_for_tier(CLI_CONFIG, tier)
         if cfg:
             return cfg
     except Exception:
@@ -2938,7 +2955,7 @@ def _load_config() -> dict:
     try:
         from hermes_cli.config import load_config
 
-        return _compose_delegation_config(load_config())
+        return _load_delegation_config_for_tier(load_config(), tier)
     except Exception:
         return {}
 
@@ -3174,10 +3191,11 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["small", "medium", "large"],
                 "description": (
-                    "Optional top-level delegation routing tier. 'small' prefers "
-                    "delegation_small when configured, 'large' prefers "
-                    "delegation_large, and omitted or 'medium' uses delegation. "
-                    "Batch mode applies one top-level tier to the whole call."
+                    "Optional delegation routing tier. Common patterns: 'medium' "
+                    "(the default) for most tasks, 'small' for lighter and quicker "
+                    "tasks (e.g. discovery), 'large' for heavier tasks that require "
+                    "advanced reasoning over speed and cost. Applies to all tasks "
+                    "in a batch."
                 ),
             },
             "tasks": {

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2126,6 +2126,7 @@ def delegate_task(
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
+    tier: Optional[str] = None,
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
@@ -2202,13 +2203,18 @@ def delegate_task(
         )
     effective_max_iter = default_max_iter
 
+    try:
+        tier = _normalize_delegation_tier(tier)
+    except ValueError as exc:
+        return tool_error(str(exc))
+
     # Resolve delegation credentials (provider:model pair).
     # When delegation.provider is configured, this resolves the full credential
     # bundle (base_url, api_key, api_mode) via the same runtime provider system
     # used by CLI/gateway startup.  When unconfigured, returns None values so
     # children inherit from the parent.
     try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
+        creds = _resolve_delegation_credentials(cfg, parent_agent, tier=tier)
     except ValueError as exc:
         return tool_error(str(exc))
 
@@ -2744,8 +2750,52 @@ def _resolve_child_credential_pool(
     return None
 
 
-def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
+def _normalize_delegation_tier(tier: Optional[str]) -> str:
+    normalized = str(tier or "").strip().lower()
+    if not normalized:
+        return "medium"
+    if normalized not in {"small", "medium", "large"}:
+        raise ValueError(
+            f"Invalid delegation tier {tier!r}. Expected one of: small, medium, large."
+        )
+    return normalized
+
+
+
+def _delegation_block_has_routing(block: Optional[dict]) -> bool:
+    if not isinstance(block, dict):
+        return False
+    for key in ("model", "provider", "base_url", "api_key", "api_mode"):
+        if str(block.get(key) or "").strip():
+            return True
+    return False
+
+
+
+def _select_delegation_config_block(cfg: dict, tier: Optional[str]) -> dict:
+    normalized_tier = _normalize_delegation_tier(tier)
+    config = cfg if isinstance(cfg, dict) else {}
+    default_block = dict(config)
+
+    if normalized_tier == "small":
+        small_block = config.get("delegation_small")
+        if _delegation_block_has_routing(small_block):
+            return dict(small_block)
+    elif normalized_tier == "large":
+        large_block = config.get("delegation_large")
+        if _delegation_block_has_routing(large_block):
+            return dict(large_block)
+
+    return default_block
+
+
+
+def _resolve_delegation_credentials(cfg: dict, parent_agent, tier: Optional[str] = None) -> dict:
     """Resolve credentials for subagent delegation.
+
+    If ``delegation_small`` / ``delegation_large`` is requested via ``tier`` and
+    meaningfully configured, resolve credentials from that block first.
+    Otherwise fall back to ``delegation`` and finally to parent inheritance.
 
     If ``delegation.base_url`` is configured, subagents use that direct
     OpenAI-compatible endpoint. ``delegation.api_key`` overrides the key; when
@@ -2765,11 +2815,12 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
     Raises ValueError with a user-friendly message on credential failure.
     """
-    configured_model = str(cfg.get("model") or "").strip() or None
-    configured_provider = str(cfg.get("provider") or "").strip() or None
-    configured_base_url = str(cfg.get("base_url") or "").strip() or None
-    configured_api_key = str(cfg.get("api_key") or "").strip() or None
-    configured_api_mode = str(cfg.get("api_mode") or "").strip().lower() or None
+    effective_cfg = _select_delegation_config_block(cfg, tier)
+    configured_model = str(effective_cfg.get("model") or "").strip() or None
+    configured_provider = str(effective_cfg.get("provider") or "").strip() or None
+    configured_base_url = str(effective_cfg.get("base_url") or "").strip() or None
+    configured_api_key = str(effective_cfg.get("api_key") or "").strip() or None
+    configured_api_mode = str(effective_cfg.get("api_mode") or "").strip().lower() or None
 
     if configured_base_url:
         # When delegation.api_key is not set, return None so _build_child_agent
@@ -2861,15 +2912,25 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 def _load_config() -> dict:
     """Load delegation config from CLI_CONFIG or persistent config.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Returns the ``delegation`` block plus optional sibling routing blocks so the
+    delegate tool can keep its existing callers while still selecting
+    ``delegation_small`` / ``delegation_large`` before normal credential
+    resolution.
     """
+
+    def _compose_delegation_config(full_cfg: Optional[dict]) -> dict:
+        full_cfg = full_cfg or {}
+        delegation_cfg = dict(full_cfg.get("delegation") or {})
+        if full_cfg.get("delegation_small"):
+            delegation_cfg["delegation_small"] = dict(full_cfg.get("delegation_small") or {})
+        if full_cfg.get("delegation_large"):
+            delegation_cfg["delegation_large"] = dict(full_cfg.get("delegation_large") or {})
+        return delegation_cfg
+
     try:
         from cli import CLI_CONFIG
 
-        cfg = CLI_CONFIG.get("delegation") or {}
+        cfg = _compose_delegation_config(CLI_CONFIG)
         if cfg:
             return cfg
     except Exception:
@@ -2877,8 +2938,7 @@ def _load_config() -> dict:
     try:
         from hermes_cli.config import load_config
 
-        full = load_config()
-        return full.get("delegation") or {}
+        return _compose_delegation_config(load_config())
     except Exception:
         return {}
 
@@ -3110,6 +3170,16 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "tier": {
+                "type": "string",
+                "enum": ["small", "medium", "large"],
+                "description": (
+                    "Optional top-level delegation routing tier. 'small' prefers "
+                    "delegation_small when configured, 'large' prefers "
+                    "delegation_large, and omitted or 'medium' uses delegation. "
+                    "Batch mode applies one top-level tier to the whole call."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -3225,6 +3295,7 @@ registry.register(
         context=args.get("context"),
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
+        tier=args.get("tier"),
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2938,10 +2938,10 @@ def _load_delegation_config_for_tier(full_cfg: Optional[dict], tier: Optional[st
 def _load_config(tier: Optional[str] = None) -> dict:
     """Load delegation config from CLI_CONFIG or persistent config.
 
-    Returns the ``delegation`` block plus optional sibling routing blocks so the
-    delegate tool can keep its existing callers while still selecting
-    ``delegation_small`` / ``delegation_large`` before normal credential
-    resolution.
+    Returns the effective ``delegation`` config for the requested tier. When
+    ``tier`` matches a nested ``delegation.tiers.<name>`` override, that tier
+    block is merged onto the base ``delegation`` config before normal
+    credential resolution.
     """
 
     try:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1919,24 +1919,29 @@ delegation:
   max_spawn_depth: 1                        # Delegation tree depth cap (1-3, clamped). 1 = flat (default): parent spawns leaves that cannot delegate. 2 = orchestrator children can spawn leaf grandchildren. 3 = three levels.
   orchestrator_enabled: true                # Global kill switch. When false, role="orchestrator" is ignored and every child is forced to leaf regardless of max_spawn_depth.
 
-delegation_small:                           # Optional route used by delegate_task(tier="small")
-  # model: "google/gemini-3-flash-preview"
-  # provider: "openrouter"
-  # base_url: "http://localhost:1234/v1"
-  # api_key: "local-key"
-  # api_mode: ""
+  tiers:
+    small:                                  # Optional override used by delegate_task(tier="small")
+      # model: "google/gemini-3-flash-preview"
+      # provider: "openrouter"
+      # base_url: "http://localhost:1234/v1"
+      # api_key: "local-key"
+      # api_mode: ""
 
-delegation_large:                           # Optional route used by delegate_task(tier="large")
-  # model: "anthropic/claude-opus-4-1"
-  # provider: "anthropic"
-  # base_url: ""
-  # api_key: ""
-  # api_mode: ""
+    medium:                                 # Optional override used by delegate_task(tier="medium")
+      # model: "anthropic/claude-sonnet-4"
+      # provider: "openrouter"
+
+    large:                                  # Optional override used by delegate_task(tier="large")
+      # model: "anthropic/claude-opus-4-1"
+      # provider: "anthropic"
+      # base_url: ""
+      # api_key: ""
+      # api_mode: ""
 ```
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
 
-**Tier routing:** `delegate_task` accepts an optional top-level `tier` of `small`, `medium`, or `large`. Omitted or blank behaves like `medium`. `small` prefers `delegation_small` when that block is configured, `large` prefers `delegation_large`, and both fall back to `delegation` before inheriting the parent model/provider path. The tier is top-level only — batch mode applies one tier to the whole call, and `tasks[]` does not support per-task tier overrides.
+**Tier routing:** `delegate_task` accepts an optional top-level `tier` of `small`, `medium`, or `large`. Omitted or blank behaves like `medium`. When configured, `delegation.tiers.small`, `delegation.tiers.medium`, and `delegation.tiers.large` override their respective tiers by merging onto the base `delegation` config. If the requested tier has no nested override, Hermes falls back to the base `delegation` config before inheriting the parent model/provider path. The tier is top-level only — batch mode applies one tier to the whole call, and `tasks[]` does not support per-task tier overrides.
 
 **Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only.
 
@@ -1944,7 +1949,7 @@ delegation_large:                           # Optional route used by delegate_ta
 
 The delegation provider uses the same credential resolution as CLI/gateway startup. All configured providers are supported: `openrouter`, `nous`, `copilot`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`. When a provider is set, the system automatically resolves the correct base URL, API key, and API mode — no manual credential wiring needed.
 
-**Precedence:** requested `delegation_small` / `delegation_large` (when configured) → `delegation.base_url` / `delegation.provider` in config → parent provider (inherited). `delegation.model` in config → parent model (inherited). Setting just `model` without `provider` changes only the model name while keeping the parent's credentials (useful for switching models within the same provider like OpenRouter).
+**Precedence:** when a requested tier has a matching nested override under `delegation.tiers`, Hermes first merges that tier override onto the base `delegation` config. If no matching tier override is configured, Hermes uses the base `delegation` config. If delegation routing is still effectively unconfigured, subagents inherit the parent model/provider path.
 
 **Width and depth:** `max_concurrent_children` caps how many subagents run in parallel per batch (default `3`, floor of 1, no ceiling). Can also be set via the `DELEGATION_MAX_CONCURRENT_CHILDREN` env var. When the model submits a `tasks` array longer than the cap, `delegate_task` returns a tool error explaining the limit rather than silently truncating. `max_spawn_depth` controls the delegation tree depth (clamped to 1-3). At the default `1`, delegation is flat: children cannot spawn grandchildren, and passing `role="orchestrator"` silently degrades to `leaf`. Raise to `2` so orchestrator children can spawn leaf grandchildren; `3` for three-level trees. The agent opts into orchestration per call via `role="orchestrator"`; `orchestrator_enabled: false` forces every child back to leaf regardless. Cost scales multiplicatively — at `max_spawn_depth: 3` with `max_concurrent_children: 3`, the tree can reach 3×3×3 = 27 concurrent leaf agents. See [Subagent Delegation → Depth Limit and Nested Orchestration](features/delegation.md#depth-limit-and-nested-orchestration) for usage patterns.
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1918,9 +1918,25 @@ delegation:
   max_concurrent_children: 3                # Parallel children per batch (floor 1, no ceiling). Also via DELEGATION_MAX_CONCURRENT_CHILDREN env var.
   max_spawn_depth: 1                        # Delegation tree depth cap (1-3, clamped). 1 = flat (default): parent spawns leaves that cannot delegate. 2 = orchestrator children can spawn leaf grandchildren. 3 = three levels.
   orchestrator_enabled: true                # Global kill switch. When false, role="orchestrator" is ignored and every child is forced to leaf regardless of max_spawn_depth.
+
+delegation_small:                           # Optional route used by delegate_task(tier="small")
+  # model: "google/gemini-3-flash-preview"
+  # provider: "openrouter"
+  # base_url: "http://localhost:1234/v1"
+  # api_key: "local-key"
+  # api_mode: ""
+
+delegation_large:                           # Optional route used by delegate_task(tier="large")
+  # model: "anthropic/claude-opus-4-1"
+  # provider: "anthropic"
+  # base_url: ""
+  # api_key: ""
+  # api_mode: ""
 ```
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
+
+**Tier routing:** `delegate_task` accepts an optional top-level `tier` of `small`, `medium`, or `large`. Omitted or blank behaves like `medium`. `small` prefers `delegation_small` when that block is configured, `large` prefers `delegation_large`, and both fall back to `delegation` before inheriting the parent model/provider path. The tier is top-level only — batch mode applies one tier to the whole call, and `tasks[]` does not support per-task tier overrides.
 
 **Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only.
 
@@ -1928,7 +1944,7 @@ delegation:
 
 The delegation provider uses the same credential resolution as CLI/gateway startup. All configured providers are supported: `openrouter`, `nous`, `copilot`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`. When a provider is set, the system automatically resolves the correct base URL, API key, and API mode — no manual credential wiring needed.
 
-**Precedence:** `delegation.base_url` in config → `delegation.provider` in config → parent provider (inherited). `delegation.model` in config → parent model (inherited). Setting just `model` without `provider` changes only the model name while keeping the parent's credentials (useful for switching models within the same provider like OpenRouter).
+**Precedence:** requested `delegation_small` / `delegation_large` (when configured) → `delegation.base_url` / `delegation.provider` in config → parent provider (inherited). `delegation.model` in config → parent model (inherited). Setting just `model` without `provider` changes only the model name while keeping the parent's credentials (useful for switching models within the same provider like OpenRouter).
 
 **Width and depth:** `max_concurrent_children` caps how many subagents run in parallel per batch (default `3`, floor of 1, no ceiling). Can also be set via the `DELEGATION_MAX_CONCURRENT_CHILDREN` env var. When the model submits a `tasks` array longer than the cap, `delegate_task` returns a tool error explaining the limit rather than silently truncating. `max_spawn_depth` controls the delegation tree depth (clamped to 1-3). At the default `1`, delegation is flat: children cannot spawn grandchildren, and passing `role="orchestrator"` silently degrades to `leaf`. Raise to `2` so orchestrator children can spawn leaf grandchildren; `3` for three-level trees. The agent opts into orchestration per call via `role="orchestrator"`; `orchestrator_enabled: false` forces every child back to leaf regardless. Cost scales multiplicatively — at `max_spawn_depth: 3` with `max_concurrent_children: 3`, the tree can reach 3×3×3 = 27 concurrent leaf agents. See [Subagent Delegation → Depth Limit and Nested Orchestration](features/delegation.md#depth-limit-and-nested-orchestration) for usage patterns.
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -14,21 +14,29 @@ The `delegate_task` tool spawns child AIAgent instances with isolated context, r
 delegate_task(
     goal="Debug why tests fail",
     context="Error: assertion in test_foo.py line 42",
-    toolsets=["terminal", "file"]
+    toolsets=["terminal", "file"],
+    tier="small",
 )
 ```
+
+Top-level `tier` is optional and bounded to `small`, `medium`, or `large`. Omitted or blank behaves like `medium`. `small` prefers `delegation_small` when configured, `large` prefers `delegation_large`, and both fall back to `delegation` before inheriting the parent model/provider path.
 
 ## Parallel Batch
 
 Up to 3 concurrent subagents by default (configurable, no hard ceiling):
 
 ```python
-delegate_task(tasks=[
-    {"goal": "Research topic A", "toolsets": ["web"]},
-    {"goal": "Research topic B", "toolsets": ["web"]},
-    {"goal": "Fix the build", "toolsets": ["terminal", "file"]}
-])
+delegate_task(
+    tier="large",
+    tasks=[
+        {"goal": "Research topic A", "toolsets": ["web"]},
+        {"goal": "Research topic B", "toolsets": ["web"]},
+        {"goal": "Fix the build", "toolsets": ["terminal", "file"]},
+    ],
+)
 ```
+
+Batch mode applies one top-level tier to the whole delegation call. `tasks[]` does not support per-task tier overrides.
 
 ## How Subagent Context Works
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -19,7 +19,7 @@ delegate_task(
 )
 ```
 
-Top-level `tier` is optional and bounded to `small`, `medium`, or `large`. Omitted or blank behaves like `medium`. `small` prefers `delegation_small` when configured, `large` prefers `delegation_large`, and both fall back to `delegation` before inheriting the parent model/provider path.
+Top-level `tier` is optional and bounded to `small`, `medium`, or `large`. Omitted or blank behaves like `medium`. When configured, `delegation.tiers.small`, `delegation.tiers.medium`, and `delegation.tiers.large` override their respective tiers by merging onto the base `delegation` config. If the requested tier has no nested override, Hermes falls back to the base `delegation` config before inheriting the parent model/provider path.
 
 ## Parallel Batch
 


### PR DESCRIPTION
## ~Another one?~ What does this PR do?

Add a tier-based delegation config which overrides model/provider for easier/harder tasks. Critical design choices:
- **Tiers are a small hardcoded set: "small" | "medium" | "large"**
- **Tiers can replace only model/reasoning OR whole provider block**
- **Tier not configured = falls back to normal delegation config, which falls back to base model (full backcompat)**
- **Defaults to medium tier** (thus "small" = cheap, "large" = fancy)

### Why tier-based? Virtually all open issues request for per-task _model_ overrides.
- If we expose just model we don't support provider / local... unless we expose ALL of them to tool (schema pollution)
- Naturally supports reasoning effort as well (also without extra tool parameter)
- Small fixed tier set allows it to be included directly in tool schema, agent doesn't need to query a dynamic list
- Agent can't hallucinate models and extremely unlikely to typo common word
- Too many choices are counterproductive - few restricted choices = less doubting, more deterministic
- Agent can understand and use tier instinctively, don't need to include long explanations or skills to be useful
- Models evolve - if we include baseline guidance about what models to use it'll be outdated soon anyways
- User can change mapping without re-teaching the agent anything (and agent won't have contradictory memory)
- Agent can't put you on fanciest-fast-mode-token-burner model behind your back

I believe these 3 tiers should cover most reasonable use cases fairly well (I want one task to be cheaper/faster than my normal agent = "small", I want one task to use the fanciest model = "large"). User is free to make small/large as small/large as they want, or to leave some to be silently equivalent (e.g. only want smaller, not bigger). **Adding more is trivial, removing is not, better to start small.**

To minimize schema growth, I also explicitly kept tier top-level-only (all tasks in a batch use the same tier), as I believe the likelyhood of several tasks in a same batch requiring different tiers to be very low. This should be trivial to extend if truly desired.

## Related Issue

Plenty of related issues/PRs: #34489, #18591, #17685, #32555, #31537, etc.

But no PR currently addresses a **fixed tier set** as proposed here.

Interesting ones:
- #30652 mentions more complex auto-routing (auxiliary-based complexity rating?), overbuild for simple use cases, likely to get stuck in design paralysis, no current implementation
- #7957 includes **dynamic** tiers which require the agent to use a separate tool to fetch the list

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## How to Test

- Ask agent to call `delegate_task` with tier, and report what model was used.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

POC of model-only override and backcompat:
<img width="830" height="652" alt="image" src="https://github.com/user-attachments/assets/99d226ba-1459-493b-b4b8-2be8f74e43e6" />

POC of provider override:
<img width="1128" height="734" alt="image" src="https://github.com/user-attachments/assets/71ad6592-6057-47df-b0a2-8b1beb0473b6" />

POC of agent being able to use tier intuitively (fresh new session, no extra skill, just tool schema):
<img width="794" height="295" alt="image" src="https://github.com/user-attachments/assets/898aae4d-1a0a-46b6-97d3-05e78fd3abe8" />