### PR TITLE
fix(auxiliary): preserve named provider identity when base_url is passed to _resolve_task_provider_model

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4527,7 +4527,12 @@ def _resolve_task_provider_model(
         cfg_provider, cfg_base_url = _expand_direct_api_alias(cfg_provider, cfg_base_url)
 
     if base_url:
-        return "custom", resolved_model, base_url, api_key, resolved_api_mode
+        # Preserve named provider identity so downstream resolve_provider_client
+        # can resolve provider-specific credentials (e.g. XIAOMI_API_KEY).
+        # Without this, any explicit base_url forces provider="custom" which
+        # only checks OPENAI_API_KEY, causing 401 for non-OpenAI providers.
+        resolved_provider = provider if provider and provider not in ("", "auto") else "custom"
+        return resolved_provider, resolved_model, base_url, api_key, resolved_api_mode
     if provider:
         return provider, resolved_model, base_url, api_key, resolved_api_mode
 

--- a/tests/agent/test_vision_resolved_args.py
+++ b/tests/agent/test_vision_resolved_args.py
@@ -62,3 +62,45 @@ def test_vision_base_url_override_keeps_explicit_provider():
     assert model == "glm-4v"
     assert mock_resolve.call_args.args[0] == "zai"
     assert mock_resolve.call_args.kwargs["explicit_base_url"] == "https://open.bigmodel.cn/api/paas/v4"
+
+
+def test_resolve_task_provider_preserves_named_provider_with_base_url():
+    """_resolve_task_provider_model must not replace a named provider with 'custom'
+    when base_url is passed as an argument.  Otherwise downstream
+    resolve_provider_client('custom', ...) only checks OPENAI_API_KEY and
+    falls back to 'no-key-required', causing 401 for non-OpenAI providers.
+
+    Regression test for: auxiliary vision with provider=xiaomi + base_url
+    returning api_key='no-key-required' instead of resolving XIAOMI_API_KEY.
+    """
+    from agent.auxiliary_client import _resolve_task_provider_model
+
+    provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+        task=None,
+        provider="xiaomi",
+        model="mimo-v2-omni",
+        base_url="https://token-plan-ams.xiaomimimo.com/v1",
+        api_key=None,
+    )
+
+    # Provider must be preserved as "xiaomi", NOT rewritten to "custom"
+    assert provider == "xiaomi"
+    assert model == "mimo-v2-omni"
+    assert base_url == "https://token-plan-ams.xiaomimimo.com/v1"
+    # api_key is None here — resolve_provider_client will look up XIAOMI_API_KEY
+
+
+def test_resolve_task_provider_base_url_without_named_provider_defaults_to_custom():
+    """When base_url is passed without a named provider, 'custom' is correct."""
+    from agent.auxiliary_client import _resolve_task_provider_model
+
+    provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+        task=None,
+        provider=None,
+        model="gpt-4o",
+        base_url="http://localhost:8080/v1",
+        api_key=None,
+    )
+
+    assert provider == "custom"
+    assert base_url == "http://localhost:8080/v1"


### PR DESCRIPTION
## What does this PR do?

When `_resolve_task_provider_model()` receives a `base_url` argument (from the resolved config), it currently returns `provider="custom"` unconditionally. This discards the named provider identity (e.g. "xiaomi"), so downstream `resolve_provider_client("custom", ...)` only checks `OPENAI_API_KEY` and falls back to the placeholder `"no-key-required"`.

This causes 401 errors for any non-OpenAI provider that has a custom `base_url` in the auxiliary config (e.g. Xiaomi MiMo with `tp-` keys on `token-plan-ams` endpoint, ZAI on `open.bigmodel.cn`, etc.).

The fix preserves the named provider when one is explicitly set, matching the behavior of the config path (line ~4539) which already does this correctly.

## Related Issue

Fixes #34651

(Also related: #16389, #33333)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: In `_resolve_task_provider_model()`, when `base_url` is set and `provider` is a named (non-auto, non-empty) provider, return the provider name instead of `"custom"`. Falls back to `"custom"` when no provider is specified (preserving existing behavior for direct custom endpoints).
- `tests/agent/test_vision_resolved_args.py`: Added 2 regression tests:
  - `test_resolve_task_provider_preserves_named_provider_with_base_url` — verifies provider="xiaomi" is preserved with a custom base_url
  - `test_resolve_task_provider_base_url_without_named_provider_defaults_to_custom` — verifies provider=None still returns "custom"

## How to Test

1. Configure auxiliary vision with a named provider + custom base_url:
```yaml
auxiliary:
  vision:
    provider: xiaomi
    model: mimo-v2-omni
    base_url: https://token-plan-ams.xiaomimimo.com/v1
```
2. Set the provider's API key in `.env` (e.g. `XIAOMI_API_KEY=*** 3. Call `vision_analyze` — should succeed instead of 401
4. Run tests: `pytest tests/agent/test_vision_resolved_args.py tests/agent/test_auxiliary_client.py -q`

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run pytest and all tests pass (205 passed)
- [x] I've added tests for my changes