### PR TITLE
fix: isolate Discord bot messages from agent context

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6609,15 +6609,15 @@ class GatewayRunner:
             return True
 
         if getattr(source, "is_bot", False):
-            # Discord direct trigger isolation is defense-in-depth: the
-            # Discord adapter should already drop bot/webhook messages, but
-            # reject any bot-auth source that reaches the shared gateway layer
-            # so DISCORD_ALLOW_BOTS cannot reopen the loop gate.
-            if source.platform == Platform.DISCORD:
-                return False
             allow_bots_var = platform_allow_bots_map.get(source.platform)
             if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
                 return True
+            # Discord bot/webhook sources are rejected by default as
+            # defense-in-depth: the Discord adapter should already drop them,
+            # and DISCORD_ALLOW_BOTS must be explicit before bot-to-bot
+            # workflows bypass the human allowlist.
+            if source.platform == Platform.DISCORD:
+                return False
 
         # Check pairing store (always checked, regardless of allowlists)
         platform_name = source.platform.value if source.platform else ""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6609,6 +6609,12 @@ class GatewayRunner:
             return True
 
         if getattr(source, "is_bot", False):
+            # Discord direct trigger isolation is defense-in-depth: the
+            # Discord adapter should already drop bot/webhook messages, but
+            # reject any bot-auth source that reaches the shared gateway layer
+            # so DISCORD_ALLOW_BOTS cannot reopen the loop gate.
+            if source.platform == Platform.DISCORD:
+                return False
             allow_bots_var = platform_allow_bots_map.get(source.platform)
             if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in {"mentions", "all"}:
                 return True

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4871,10 +4871,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 or getattr(message.reference, "resolved", None)
             )
             ref_author = getattr(ref_msg, "author", None)
-            if not getattr(ref_author, "bot", False):
+            # Fail closed for unresolved references: without the resolved/cached
+            # target we cannot know whether the reply target was bot-authored,
+            # so do not preserve an ID that a later layer could resolve into
+            # bot-authored reply context.
+            if ref_msg is not None and not getattr(ref_author, "bot", False):
                 reply_to_id = str(message.reference.message_id)
-                if ref_msg is not None:
-                    reply_to_text = getattr(ref_msg, "content", None) or None
+                reply_to_text = getattr(ref_msg, "content", None) or None
 
         event = MessageEvent(
             text=event_text,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -774,36 +774,25 @@ class DiscordAdapter(BasePlatformAdapter):
                 if message.type not in {discord.MessageType.default, discord.MessageType.reply}:
                     return
 
-                # Bot message filtering (DISCORD_ALLOW_BOTS):
-                #   "none"     — ignore all other bots (default)
-                #   "mentions" — accept bot messages only when they @mention us
-                #   "all"      — accept all bot messages
-                # Must run BEFORE the user allowlist check so that bots
-                # permitted by DISCORD_ALLOW_BOTS are not rejected for
-                # not being in DISCORD_ALLOWED_USERS (fixes #4466).
+                # Direct trigger isolation: never let another bot/webhook start
+                # an agent turn. Use getattr(..., False) so partial user objects
+                # fail closed instead of bypassing the gate.
                 if getattr(message.author, "bot", False):
-                    allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
-                    if allow_bots == "none":
-                        return
-                    elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
-                            return
-                    # "all" falls through; bot is permitted — skip the
-                    # human-user allowlist below (bots aren't in it).
-                else:
-                    # Non-bot: enforce the configured user/role allowlists.
-                    # Pass guild + is_dm so role checks are scoped to the
-                    # originating guild (prevents cross-guild DM bypass, see
-                    # _is_allowed_user docstring).
-                    _msg_guild = getattr(message, "guild", None)
-                    _is_dm = isinstance(message.channel, discord.DMChannel) or _msg_guild is None
-                    if not self._is_allowed_user(
-                        str(message.author.id),
-                        message.author,
-                        guild=_msg_guild,
-                        is_dm=_is_dm,
-                    ):
-                        return
+                    return
+
+                # Non-bot: enforce the configured user/role allowlists.
+                # Pass guild + is_dm so role checks are scoped to the
+                # originating guild (prevents cross-guild DM bypass, see
+                # _is_allowed_user docstring).
+                _msg_guild = getattr(message, "guild", None)
+                _is_dm = isinstance(message.channel, discord.DMChannel) or _msg_guild is None
+                if not self._is_allowed_user(
+                    str(message.author.id),
+                    message.author,
+                    guild=_msg_guild,
+                    is_dm=_is_dm,
+                ):
+                    return
                 
                 # Multi-agent filtering: if the message mentions specific bots
                 # but NOT this bot, the sender is talking to another agent —
@@ -3760,7 +3749,6 @@ class DiscordAdapter(BasePlatformAdapter):
 
             [Recent channel messages]
             [Alice] some message
-            [Bob [bot]] another message
 
         Returns an empty string if no context is available.
         """
@@ -3768,9 +3756,10 @@ class DiscordAdapter(BasePlatformAdapter):
         if limit <= 0:
             return ""
 
-        # Determine which bot messages to include in context
-        allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
-        include_other_bots = allow_bots_raw != "none"
+        # Layer 2: history-context isolation. Never include bot/webhook
+        # messages in the prompt backfill, even when DISCORD_ALLOW_BOTS was
+        # previously configured. This prevents bot-loop/status text from
+        # leaking into the model's message array.
 
         # Use the in-memory cache to narrow the fetch window on hot paths.
         # If we know our last message ID in this channel, pass it as `after`
@@ -3813,10 +3802,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 if msg.type not in {discord.MessageType.default, discord.MessageType.reply}:
                     continue
 
-                # Respect DISCORD_ALLOW_BOTS for other bots.
-                # For history context, "mentions" is treated as "all" — we are
-                # deciding what context to show, not whether to respond.
-                if getattr(msg.author, "bot", False) and not include_other_bots:
+                # Layer 2: filter bots out of historical context before it
+                # is passed to the model, independent of trigger policy.
+                if getattr(msg.author, "bot", False):
                     continue
 
                 content = getattr(msg, "clean_content", msg.content) or ""
@@ -4846,9 +4834,19 @@ class DiscordAdapter(BasePlatformAdapter):
         reply_to_id = None
         reply_to_text = None
         if message.reference:
-            reply_to_id = str(message.reference.message_id)
-            if message.reference.resolved:
-                reply_to_text = getattr(message.reference.resolved, "content", None) or None
+            # Layer 3: reply-context isolation. Discord replies can carry a
+            # cached/resolved target message; if that target was authored by a
+            # bot, strip the reference entirely so bot text cannot be injected
+            # later as `[Replying to: ...]` context.
+            ref_msg = (
+                getattr(message.reference, "cached_message", None)
+                or getattr(message.reference, "resolved", None)
+            )
+            ref_author = getattr(ref_msg, "author", None)
+            if not getattr(ref_author, "bot", False):
+                reply_to_id = str(message.reference.message_id)
+                if ref_msg is not None:
+                    reply_to_text = getattr(ref_msg, "content", None) or None
 
         event = MessageEvent(
             text=event_text,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -135,6 +135,29 @@ def check_discord_requirements() -> bool:
     return True
 
 
+def _discord_allow_bots_mode() -> str:
+    """Return the explicit Discord bot-to-bot trigger policy.
+
+    Safe default is ``none``: bot/webhook-authored Discord messages cannot
+    start agent turns. Operators who intentionally run controlled bot-to-bot
+    workflows may opt in with ``DISCORD_ALLOW_BOTS=mentions`` (only when this
+    bot is @mentioned) or ``DISCORD_ALLOW_BOTS=all``.
+    """
+    mode = os.getenv("DISCORD_ALLOW_BOTS", "none").strip().lower()
+    return mode if mode in {"none", "mentions", "all"} else "none"
+
+
+def _discord_bot_message_allowed(message: Any, self_user: Any) -> bool:
+    """Whether a non-self Discord bot/webhook message may pass the trigger gate."""
+    mode = _discord_allow_bots_mode()
+    if mode == "none":
+        return False
+    if mode == "all":
+        return True
+    mentions = getattr(message, "mentions", None) or []
+    return self_user is not None and self_user in mentions
+
+
 def _build_allowed_mentions():
     """Build Discord ``AllowedMentions`` with safe defaults, overridable via env.
 
@@ -774,19 +797,24 @@ class DiscordAdapter(BasePlatformAdapter):
                 if message.type not in {discord.MessageType.default, discord.MessageType.reply}:
                     return
 
-                # Direct trigger isolation: never let another bot/webhook start
-                # an agent turn. Use getattr(..., False) so partial user objects
-                # fail closed instead of bypassing the gate.
-                if getattr(message.author, "bot", False):
-                    return
+                # Direct trigger isolation: safe default drops bot/webhook
+                # messages so peer bots cannot start acknowledgement loops.
+                # Preserve explicit, operator-controlled bot-to-bot workflows
+                # via DISCORD_ALLOW_BOTS=mentions/all.
+                _author_is_bot = getattr(message.author, "bot", False)
+                if _author_is_bot:
+                    if not _discord_bot_message_allowed(message, getattr(self._client, "user", None)):
+                        return
 
-                # Non-bot: enforce the configured user/role allowlists.
+                # Enforce the configured user/role allowlists for human
+                # senders. Bot/webhook senders that reached this point were
+                # already explicitly admitted by DISCORD_ALLOW_BOTS above.
                 # Pass guild + is_dm so role checks are scoped to the
                 # originating guild (prevents cross-guild DM bypass, see
                 # _is_allowed_user docstring).
                 _msg_guild = getattr(message, "guild", None)
                 _is_dm = isinstance(message.channel, discord.DMChannel) or _msg_guild is None
-                if not self._is_allowed_user(
+                if not _author_is_bot and not self._is_allowed_user(
                     str(message.author.id),
                     message.author,
                     guild=_msg_guild,

--- a/tests/gateway/test_discord_bot_auth_bypass.py
+++ b/tests/gateway/test_discord_bot_auth_bypass.py
@@ -1,9 +1,9 @@
 """Regression guards for Discord bot isolation and auth behavior.
 
-Discord bot/webhook messages must not be allowed to start agent turns, even
-when legacy DISCORD_ALLOW_BOTS values are present. The adapter drops bot
-messages at the direct trigger gate, and the shared gateway auth layer also
-rejects Discord bot sources as defense-in-depth.
+Discord bot/webhook messages must not start agent turns by default. Operators
+can explicitly enable controlled bot-to-bot workflows with DISCORD_ALLOW_BOTS
+(`mentions` or `all`); the adapter gate still decides whether a particular
+Discord message is eligible before this shared auth layer sees it.
 """
 
 import os
@@ -33,7 +33,8 @@ def _isolate_discord_env(monkeypatch):
 
 
 # -----------------------------------------------------------------------------
-# Gate 2: _is_user_authorized rejects Discord bots even if legacy allow_bots set
+# Gate 2: _is_user_authorized rejects Discord bots by default but preserves
+# explicit DISCORD_ALLOW_BOTS controlled bot-to-bot mode.
 # -----------------------------------------------------------------------------
 
 
@@ -74,11 +75,11 @@ def _make_discord_human_source(user_id: str = "100200300"):
     )
 
 
-def test_discord_bot_not_authorized_when_allow_bots_mentions(monkeypatch):
-    """DISCORD_ALLOW_BOTS=mentions must not authorize a Discord bot sender.
+def test_discord_bot_authorized_when_allow_bots_mentions(monkeypatch):
+    """DISCORD_ALLOW_BOTS=mentions preserves explicit bot-to-bot mode.
 
-    This prevents a webhook/peer bot that mentions Hermes from starting an
-    agent turn and re-opening bot acknowledgement loops.
+    The adapter message gate decides whether the bot message mentioned Hermes;
+    once such a message reaches shared auth, the bot source is authorized.
     """
     runner = _make_bare_runner()
 
@@ -86,18 +87,18 @@ def test_discord_bot_not_authorized_when_allow_bots_mentions(monkeypatch):
     monkeypatch.setenv("DISCORD_ALLOWED_USERS", "100200300")  # human-only allowlist
 
     source = _make_discord_bot_source(bot_id="999888777")
-    assert runner._is_user_authorized(source) is False
+    assert runner._is_user_authorized(source) is True
 
 
-def test_discord_bot_not_authorized_when_allow_bots_all(monkeypatch):
-    """DISCORD_ALLOW_BOTS=all must not authorize a Discord bot sender."""
+def test_discord_bot_authorized_when_allow_bots_all(monkeypatch):
+    """DISCORD_ALLOW_BOTS=all preserves explicit controlled bot-to-bot mode."""
     runner = _make_bare_runner()
 
     monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
     monkeypatch.setenv("DISCORD_ALLOWED_USERS", "100200300")
 
     source = _make_discord_bot_source()
-    assert runner._is_user_authorized(source) is False
+    assert runner._is_user_authorized(source) is True
 
 
 def test_discord_bot_NOT_authorized_when_allow_bots_none(monkeypatch):

--- a/tests/gateway/test_discord_bot_auth_bypass.py
+++ b/tests/gateway/test_discord_bot_auth_bypass.py
@@ -1,16 +1,9 @@
-"""Regression guard for #4466: DISCORD_ALLOW_BOTS works without DISCORD_ALLOWED_USERS.
+"""Regression guards for Discord bot isolation and auth behavior.
 
-The bug had two sequential gates both rejecting bot messages:
-
-  Gate 1 — `on_message` in gateway/platforms/discord.py ran the user-allowlist
-  check BEFORE the bot filter, so bot senders were dropped with a warning
-  before the DISCORD_ALLOW_BOTS policy was ever evaluated.
-
-  Gate 2 — `_is_user_authorized` in gateway/run.py rejected bots at the
-  gateway level even if they somehow reached that layer.
-
-These tests assert both gates now pass a bot message through when
-DISCORD_ALLOW_BOTS permits it AND no user allowlist entry exists.
+Discord bot/webhook messages must not be allowed to start agent turns, even
+when legacy DISCORD_ALLOW_BOTS values are present. The adapter drops bot
+messages at the direct trigger gate, and the shared gateway auth layer also
+rejects Discord bot sources as defense-in-depth.
 """
 
 import os
@@ -40,7 +33,7 @@ def _isolate_discord_env(monkeypatch):
 
 
 # -----------------------------------------------------------------------------
-# Gate 2: _is_user_authorized bypasses allowlist for permitted bots
+# Gate 2: _is_user_authorized rejects Discord bots even if legacy allow_bots set
 # -----------------------------------------------------------------------------
 
 
@@ -81,14 +74,11 @@ def _make_discord_human_source(user_id: str = "100200300"):
     )
 
 
-def test_discord_bot_authorized_when_allow_bots_mentions(monkeypatch):
-    """DISCORD_ALLOW_BOTS=mentions must authorize a bot sender even when
-    DISCORD_ALLOWED_USERS is set and the bot's ID is NOT in it.
+def test_discord_bot_not_authorized_when_allow_bots_mentions(monkeypatch):
+    """DISCORD_ALLOW_BOTS=mentions must not authorize a Discord bot sender.
 
-    This is the exact scenario from #4466 — a Cloudflare Worker webhook
-    posts Notion events to Discord, the Hermes bot gets @mentioned, and
-    the webhook's bot ID is not (and shouldn't be) on the human
-    allowlist.
+    This prevents a webhook/peer bot that mentions Hermes from starting an
+    agent turn and re-opening bot acknowledgement loops.
     """
     runner = _make_bare_runner()
 
@@ -96,18 +86,18 @@ def test_discord_bot_authorized_when_allow_bots_mentions(monkeypatch):
     monkeypatch.setenv("DISCORD_ALLOWED_USERS", "100200300")  # human-only allowlist
 
     source = _make_discord_bot_source(bot_id="999888777")
-    assert runner._is_user_authorized(source) is True
+    assert runner._is_user_authorized(source) is False
 
 
-def test_discord_bot_authorized_when_allow_bots_all(monkeypatch):
-    """DISCORD_ALLOW_BOTS=all is a superset of =mentions — should also bypass."""
+def test_discord_bot_not_authorized_when_allow_bots_all(monkeypatch):
+    """DISCORD_ALLOW_BOTS=all must not authorize a Discord bot sender."""
     runner = _make_bare_runner()
 
     monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
     monkeypatch.setenv("DISCORD_ALLOWED_USERS", "100200300")
 
     source = _make_discord_bot_source()
-    assert runner._is_user_authorized(source) is True
+    assert runner._is_user_authorized(source) is False
 
 
 def test_discord_bot_NOT_authorized_when_allow_bots_none(monkeypatch):

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -3,7 +3,9 @@
 import asyncio
 import os
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
+
+from plugins.platforms.discord.adapter import _discord_bot_message_allowed
 
 
 def _make_author(*, bot: bool = False, is_self: bool = False):
@@ -43,16 +45,17 @@ class TestDiscordBotFilter(unittest.TestCase):
 
     def _run_filter(self, message, allow_bots="none", client_user=None):
         """Simulate the on_message trigger gate."""
-        # Replicate the exact trigger isolation from DiscordAdapter.on_message:
-        # own messages are ignored, and all other bot/webhook messages are
-        # ignored regardless of DISCORD_ALLOW_BOTS.
-        if message.author == client_user:
-            return False
+        # Replicate the trigger isolation from DiscordAdapter.on_message:
+        # own messages are ignored, and other bot/webhook messages are
+        # accepted only when DISCORD_ALLOW_BOTS explicitly opts in.
+        with patch.dict(os.environ, {"DISCORD_ALLOW_BOTS": allow_bots}, clear=False):
+            if message.author == client_user:
+                return False
 
-        if getattr(message.author, "bot", False):
-            return False
+            if getattr(message.author, "bot", False):
+                return _discord_bot_message_allowed(message, client_user)
 
-        return True  # human message accepted by this direct gate
+            return True  # human message accepted by this direct gate
 
     def test_own_messages_always_ignored(self):
         """Bot's own messages are always ignored regardless of allow_bots."""
@@ -74,11 +77,11 @@ class TestDiscordBotFilter(unittest.TestCase):
         msg = _make_message(author=bot)
         self.assertFalse(self._run_filter(msg, "none"))
 
-    def test_allow_bots_all_still_rejects_direct_bot_triggers(self):
-        """Direct bot triggers are rejected even if legacy allow_bots=all is set."""
+    def test_allow_bots_all_accepts_controlled_bot_triggers(self):
+        """DISCORD_ALLOW_BOTS=all explicitly enables controlled bot-to-bot turns."""
         bot = _make_author(bot=True)
         msg = _make_message(author=bot)
-        self.assertFalse(self._run_filter(msg, "all"))
+        self.assertTrue(self._run_filter(msg, "all"))
 
     def test_allow_bots_mentions_rejects_without_mention(self):
         """With allow_bots=mentions, bot messages without @mention are rejected."""
@@ -87,24 +90,25 @@ class TestDiscordBotFilter(unittest.TestCase):
         msg = _make_message(author=bot, mentions=[])
         self.assertFalse(self._run_filter(msg, "mentions", our_user))
 
-    def test_allow_bots_mentions_rejects_with_mention(self):
-        """Direct bot triggers are rejected even if they @mention this bot."""
+    def test_allow_bots_mentions_accepts_with_mention(self):
+        """DISCORD_ALLOW_BOTS=mentions allows bot messages that @mention this bot."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, mentions=[our_user])
-        self.assertFalse(self._run_filter(msg, "mentions", our_user))
+        self.assertTrue(self._run_filter(msg, "mentions", our_user))
 
     def test_default_is_none(self):
         """Default behavior (no env var) should be 'none'."""
         default = os.getenv("DISCORD_ALLOW_BOTS", "none")
         self.assertEqual(default, "none")
 
-    def test_allow_bots_case_does_not_change_direct_bot_isolation(self):
-        """Direct bot isolation ignores legacy allow_bots casing/values."""
+    def test_allow_bots_case_preserves_explicit_controlled_mode(self):
+        """Legacy DISCORD_ALLOW_BOTS values are case-insensitive."""
+        our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
-        msg = _make_message(author=bot)
-        self.assertFalse(self._run_filter(msg, "ALL"))
-        self.assertFalse(self._run_filter(msg, "All"))
+        msg = _make_message(author=bot, mentions=[our_user])
+        self.assertTrue(self._run_filter(msg, "ALL"))
+        self.assertTrue(self._run_filter(msg, "All"))
         self.assertFalse(self._run_filter(msg, "NONE"))
         self.assertFalse(self._run_filter(msg, "None"))
 

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -1,4 +1,4 @@
-"""Tests for Discord bot message filtering (DISCORD_ALLOW_BOTS)."""
+"""Tests for Discord direct bot-trigger isolation."""
 
 import asyncio
 import os
@@ -39,24 +39,20 @@ def _make_message(*, author=None, content="hello", mentions=None, is_dm=False):
 
 
 class TestDiscordBotFilter(unittest.TestCase):
-    """Test the DISCORD_ALLOW_BOTS filtering logic."""
+    """Test direct bot-trigger isolation."""
 
     def _run_filter(self, message, allow_bots="none", client_user=None):
-        """Simulate the on_message filter logic and return whether message was accepted."""
-        # Replicate the exact filter logic from discord.py on_message
+        """Simulate the on_message trigger gate."""
+        # Replicate the exact trigger isolation from DiscordAdapter.on_message:
+        # own messages are ignored, and all other bot/webhook messages are
+        # ignored regardless of DISCORD_ALLOW_BOTS.
         if message.author == client_user:
-            return False  # own messages always ignored
+            return False
 
         if getattr(message.author, "bot", False):
-            allow = allow_bots.lower().strip()
-            if allow == "none":
-                return False
-            elif allow == "mentions":
-                if not client_user or client_user not in message.mentions:
-                    return False
-            # "all" falls through
-        
-        return True  # message accepted
+            return False
+
+        return True  # human message accepted by this direct gate
 
     def test_own_messages_always_ignored(self):
         """Bot's own messages are always ignored regardless of allow_bots."""
@@ -78,11 +74,11 @@ class TestDiscordBotFilter(unittest.TestCase):
         msg = _make_message(author=bot)
         self.assertFalse(self._run_filter(msg, "none"))
 
-    def test_allow_bots_all_accepts_bots(self):
-        """With allow_bots=all, all bot messages are accepted."""
+    def test_allow_bots_all_still_rejects_direct_bot_triggers(self):
+        """Direct bot triggers are rejected even if legacy allow_bots=all is set."""
         bot = _make_author(bot=True)
         msg = _make_message(author=bot)
-        self.assertTrue(self._run_filter(msg, "all"))
+        self.assertFalse(self._run_filter(msg, "all"))
 
     def test_allow_bots_mentions_rejects_without_mention(self):
         """With allow_bots=mentions, bot messages without @mention are rejected."""
@@ -91,24 +87,24 @@ class TestDiscordBotFilter(unittest.TestCase):
         msg = _make_message(author=bot, mentions=[])
         self.assertFalse(self._run_filter(msg, "mentions", our_user))
 
-    def test_allow_bots_mentions_accepts_with_mention(self):
-        """With allow_bots=mentions, bot messages with @mention are accepted."""
+    def test_allow_bots_mentions_rejects_with_mention(self):
+        """Direct bot triggers are rejected even if they @mention this bot."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, mentions=[our_user])
-        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+        self.assertFalse(self._run_filter(msg, "mentions", our_user))
 
     def test_default_is_none(self):
         """Default behavior (no env var) should be 'none'."""
         default = os.getenv("DISCORD_ALLOW_BOTS", "none")
         self.assertEqual(default, "none")
 
-    def test_case_insensitive(self):
-        """Allow_bots value should be case-insensitive."""
+    def test_allow_bots_case_does_not_change_direct_bot_isolation(self):
+        """Direct bot isolation ignores legacy allow_bots casing/values."""
         bot = _make_author(bot=True)
         msg = _make_message(author=bot)
-        self.assertTrue(self._run_filter(msg, "ALL"))
-        self.assertTrue(self._run_filter(msg, "All"))
+        self.assertFalse(self._run_filter(msg, "ALL"))
+        self.assertFalse(self._run_filter(msg, "All"))
         self.assertFalse(self._run_filter(msg, "NONE"))
         self.assertFalse(self._run_filter(msg, "None"))
 

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -659,11 +659,7 @@ async def test_fetch_channel_context_stops_at_self_message_and_reverses_to_chron
 
     result = await adapter._fetch_channel_context(channel, before=make_message(channel=channel, content="trigger"))
 
-    assert result == (
-        "[Recent channel messages]\n"
-        "[Gemini [bot]] latest bot note\n"
-        "[Alice] latest human note"
-    )
+    assert result == "[Recent channel messages]\n[Alice] latest human note"
 
 
 @pytest.mark.asyncio
@@ -757,7 +753,7 @@ async def test_fetch_channel_context_cache_uses_latest_window_when_after_set(ada
 
     result = await adapter._fetch_channel_context(channel, before=trigger)
 
-    assert "[Codex [bot]] final analysis" in result
+    assert "[Codex [bot]] final analysis" not in (result or "")
     assert "[Alice] latest follow-up" in result
     assert "old tool trace 1" not in result
     assert "old tool trace 2" not in result

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -349,14 +349,26 @@ class TestReplyToText:
         assert event.reply_to_text is None
 
     @pytest.mark.asyncio
-    async def test_reference_without_resolved(self, reply_text_adapter):
+    async def test_reference_without_resolved_fails_closed(self, reply_text_adapter):
         ref = SimpleNamespace(message_id=555, resolved=None)
         message = _make_message(reference=ref)
 
         await reply_text_adapter._handle_message(message)
 
         event = reply_text_adapter.handle_message.await_args.args[0]
-        assert event.reply_to_message_id == "555"
+        assert event.reply_to_message_id is None
+        assert event.reply_to_text is None
+
+    @pytest.mark.asyncio
+    async def test_unresolved_reference_does_not_preserve_id_for_later_bot_text_injection(self, reply_text_adapter):
+        """Unresolved replies must not leave an ID for later bot-context lookup."""
+        ref = SimpleNamespace(message_id=777, resolved=None, cached_message=None)
+        message = _make_message(reference=ref)
+
+        await reply_text_adapter._handle_message(message)
+
+        event = reply_text_adapter.handle_message.await_args.args[0]
+        assert event.reply_to_message_id is None
         assert event.reply_to_text is None
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -397,6 +397,20 @@ class TestReplyToText:
         assert event.reply_to_message_id == "555"
         assert event.reply_to_text is None
 
+    @pytest.mark.asyncio
+    async def test_reference_to_bot_message_strips_reply_context(self, reply_text_adapter):
+        """Replies to bot messages must not leak bot text into reply_to_text."""
+        bot_author = SimpleNamespace(id=123, display_name="OtherBot", name="OtherBot", bot=True)
+        resolved_msg = SimpleNamespace(content="bot status text", author=bot_author)
+        ref = SimpleNamespace(message_id=555, resolved=resolved_msg, cached_message=resolved_msg)
+        message = _make_message(reference=ref)
+
+        await reply_text_adapter._handle_message(message)
+
+        event = reply_text_adapter.handle_message.await_args.args[0]
+        assert event.reply_to_message_id is None
+        assert event.reply_to_text is None
+
 
 class TestYamlConfigLoading:
     """Tests for reply_to_mode loaded from config.yaml discord section."""


### PR DESCRIPTION
## Summary

- Keeps Discord bot/webhook-authored messages ignored by default to prevent bot acknowledgement loops.
- Preserves explicit controlled bot-to-bot workflows via `DISCORD_ALLOW_BOTS=mentions` / `DISCORD_ALLOW_BOTS=all`.
- Keeps bot-authored recent-history context excluded even when bot direct-trigger opt-in is enabled.
- Fails closed for unresolved Discord reply references so no later layer can resolve an unknown target into bot-authored reply context.

## Safety notes for maintainers

1. `DISCORD_ALLOW_BOTS` controls **direct bot-trigger eligibility only**. It decides whether a bot/webhook-authored Discord message is allowed to start a new agent turn at the direct `on_message` gate.
2. Bot-authored recent-history context remains excluded even when `DISCORD_ALLOW_BOTS` is set to `mentions` or `all`; opt-in bot triggering does not reintroduce bot-authored context backfill.
3. `DISCORD_ALLOW_BOTS=all` is high-trust/diagnostic and should be used sparingly. `DISCORD_ALLOW_BOTS=mentions` is preferred for controlled bot-to-bot coordination.
4. Human allowlists still apply to humans only. Peer bots/webhooks are controlled by `DISCORD_ALLOW_BOTS`, not by `DISCORD_ALLOWED_USERS` / `DISCORD_ALLOWED_ROLES`.

## Test plan

```bash
python -m pytest   tests/gateway/test_discord_bot_filter.py   tests/gateway/test_discord_bot_auth_bypass.py   tests/gateway/test_discord_free_response.py   tests/gateway/test_discord_reply_mode.py   -q
```

Result: `88 passed`.

## Merge policy

Do not auto-merge. This PR is ready for maintainer review.
