### PR TITLE
ci(nix): fold package+devShell builds into flake check

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -37,23 +37,16 @@ jobs:
 
       - name: Check flake
         id: flake
-        if: runner.os == 'Linux'
         continue-on-error: true
         run: nix flake check --print-build-logs
 
-      - name: Build package
-        id: build
-        if: runner.os == 'Linux'
-        continue-on-error: true
-        run: nix build --print-build-logs
-
-      # When the real Nix build fails, run a targeted diagnostic to see if
+      # When the flake check fails, run a targeted diagnostic to see if
       # the failure is specifically a stale npm lockfile hash in one of the
       # known npm subpackages (tui / web).  This avoids surfacing a generic
       # "build failed" message when the fix is a single known command.
       - name: Diagnose npm lockfile hashes
         id: hash_check
-        if: (steps.flake.outcome == 'failure' || steps.build.outcome == 'failure') && runner.os == 'Linux'
+        if: steps.flake.outcome == 'failure' && runner.os == 'Linux'
         continue-on-error: true
         env:
           LINK_SHA: ${{ steps.sha.outputs.full }}
@@ -88,30 +81,25 @@ jobs:
             - Or [run the Nix Lockfile Fix workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/nix-lockfile-fix.yml) manually (pass PR `#${{ github.event.pull_request.number }}`)
             - Or locally: `nix run .#fix-lockfiles` and commit the diff
 
-      # Clear the sticky comment when either the build passed outright (no
+      # Clear the sticky comment when either the flake check passed outright (no
       # hash check needed) or the hash check explicitly returned stale=false
-      # (build failed for a non-hash reason).
+      # (check failed for a non-hash reason).
       - name: Clear sticky PR comment (resolved)
         if: |
           github.event_name == 'pull_request' &&
-          runner.os == 'Linux' &&
           (steps.hash_check.outputs.stale == 'false' ||
-           (steps.flake.outcome == 'success' && steps.build.outcome == 'success'))
+           steps.flake.outcome == 'success')
         uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728  # v2.9.1
         with:
           header: nix-lockfile-check
           delete: true
 
-      - name: Final fail if build or flake failed
-        if: steps.flake.outcome == 'failure' || steps.build.outcome == 'failure'
+      - name: Final fail if flake check failed
+        if: steps.flake.outcome == 'failure'
         run: |
           if [ "${{ steps.hash_check.outputs.stale }}" == "true" ]; then
             echo "::error::Nix build failed due to stale npm lockfile hash. Run: nix run .#fix-lockfiles"
           else
-            echo "::error::Nix build/flake check failed. See logs above."
+            echo "::error::Nix flake check failed. See logs above."
           fi
           exit 1
-
-      - name: Evaluate flake (macOS)
-        if: runner.os == 'macOS'
-        run: nix flake show --json > /dev/null

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -58,6 +58,22 @@ json.dump(sorted(leaf_paths(DEFAULT_CONFIG)), sys.stdout, indent=2)
             echo "ok" > $out/result
           ''
         );
+
+        # Verify the default package builds successfully (cross-platform).
+        # On Linux the runtime checks below already depend on the package,
+        # but this ensures darwin builders also build it during flake check.
+        build-package = pkgs.runCommand "hermes-build-package" { } ''
+          echo "PASS: package built at ${hermes-agent}"
+          mkdir -p $out
+          echo "ok" > $out/result
+        '';
+
+        # Verify the devShell builds successfully (cross-platform).
+        build-devshell = pkgs.runCommand "hermes-build-devshell" { } ''
+          echo "PASS: devShell built at ${self'.devShells.default}"
+          mkdir -p $out
+          echo "ok" > $out/result
+        '';
       } // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
         # Verify binaries exist and are executable
         package-contents = pkgs.runCommand "hermes-package-contents" { } ''


### PR DESCRIPTION
## What does this PR do?

Folds the `nix build` step into `nix flake check` by adding two cross-platform check derivations — `build-package` and `build-devshell` — so a single `nix flake check` verifies the package and devShell build on **every** platform (including darwin, which previously only did eval-only checks).

This eliminates the redundant separate `nix build` step in CI and gives macOS real build coverage instead of just `nix flake show --json`.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `nix/checks.nix` — Added `build-package` and `build-devshell` check derivations (cross-platform, outside the `isLinux` guard). Each is a trivial `runCommand` that depends on the package/devShell store path, forcing Nix to build them as part of `nix flake check`.
- `.github/workflows/nix.yml` — Removed the separate `Build package` step, removed the macOS-only eval step (`nix flake show --json`), removed the `if: runner.os == 'Linux'` guard from the `Check flake` step, and simplified all failure conditions to reference only `steps.flake.outcome`.

## How to Test

1. `nix flake show --json | jq '.checks.x86_64-linux | keys'` — should include `build-package` and `build-devshell`
2. `nix flake show --json | jq '.checks.aarch64-darwin | keys'` — should include `build-package` and `build-devshell` (plus `cross-eval`, but NOT the linux-only runtime checks)
3. `nix build .#checks.x86_64-linux.build-package --no-link` — should build the hermes-agent package and pass
4. `nix build .#checks.x86_64-linux.build-devshell --no-link` — should build the devShell and pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — or N/A (Nix/CI changes only)
- [ ] I've added tests for my changes — or N/A (the checks themselves ARE the tests)
- [x] I've tested on my platform: NixOS

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — or N/A
- [ ] I've updated `cli-config.yaml.example` — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — darwin now gets real build coverage instead of eval-only
- [ ] I've updated tool descriptions/schemas — or N/A

## Screenshots / Logs

```
$ nix flake show --json | jq '.checks.x86_64-linux | keys'
[
  "build-devshell",
  "build-package",
  "bundled-plugins",
  "bundled-skills",
  "bundled-tui",
  "cli-commands",
  "config-roundtrip",
  "cross-eval",
  "entry-points-sync",
  "extra-dependency-groups",
  "extra-python-packages",
  "hermes-node",
  "managed-guard",
  "messaging-variant",
  "package-contents"
]

$ nix flake show --json | jq '.checks.aarch64-darwin | keys'
[
  "build-devshell",
  "build-package",
  "cross-eval"
]

$ nix build .#checks.x86_64-linux.build-package --no-link --print-build-logs 2>&1 | tail -3
hermes-agent> stripping (with command strip and flags -S -p) in  /nix/store/.../bin
building '/nix/store/...-hermes-build-package.drv'...
hermes-build-package> PASS: package built at /nix/store/...-hermes-agent-0.15.1
```
