### PR TITLE
feat: add platform context to log session tags

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -396,9 +396,10 @@ def run_conversation(
     except Exception:
         pass
 
-    # Tag all log records on this thread with the session ID so
-    # ``hermes logs --session <id>`` can filter a single conversation.
-    set_session_context(agent.session_id)
+    # Tag all log records on this thread with the session ID and platform so
+    # ``hermes logs --session <id>`` can filter a single conversation and
+    # the platform origin is visible at a glance.
+    set_session_context(agent.session_id, platform=getattr(agent, "platform", None))
 
     # Bind the skill write-origin ContextVar for this thread so tool
     # handlers (e.g. skill_manage create) can tell whether they are

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -18,9 +18,11 @@ Component separation:
     agent.log remains the catch-all (everything goes there).
 
 Session context:
-    Call ``set_session_context(session_id)`` at the start of a conversation
-    and ``clear_session_context()`` when done.  All log lines emitted on
-    that thread will include ``[session_id]`` for filtering/correlation.
+    Call ``set_session_context(session_id, platform=None)`` at the start of a
+    conversation and ``clear_session_context()`` when done.  All log lines
+    emitted on that thread will include ``[session_id]`` (or
+    ``[platform|session_id]`` when a platform is provided) for
+    filtering/correlation.
 """
 
 import logging
@@ -69,18 +71,22 @@ _NOISY_LOGGERS = (
 # Public session context API
 # ---------------------------------------------------------------------------
 
-def set_session_context(session_id: str) -> None:
-    """Set the session ID for the current thread.
+def set_session_context(session_id: str, platform: Optional[str] = None) -> None:
+    """Set the session ID and optional platform for the current thread.
 
     All subsequent log records on this thread will include ``[session_id]``
-    in the formatted output.  Call at the start of ``run_conversation()``.
+    (or ``[platform|session_id]`` when platform is provided) in the formatted
+    output.  Call at the start of ``run_conversation()``.
     """
     _session_context.session_id = session_id
+    if platform:
+        _session_context.platform = platform
 
 
 def clear_session_context() -> None:
-    """Clear the session ID for the current thread."""
+    """Clear the session ID and platform for the current thread."""
     _session_context.session_id = None
+    _session_context.platform = None
 
 
 # ---------------------------------------------------------------------------
@@ -107,7 +113,12 @@ def _install_session_record_factory() -> None:
     def _session_record_factory(*args, **kwargs):
         record = current_factory(*args, **kwargs)
         sid = getattr(_session_context, "session_id", None)
-        record.session_tag = f" [{sid}]" if sid else ""  # type: ignore[attr-defined]
+        platform = getattr(_session_context, "platform", None)
+        if sid:
+            tag = f" [{platform}|{sid}]" if platform else f" [{sid}]"
+        else:
+            tag = ""
+        record.session_tag = tag  # type: ignore[attr-defined]
         return record
 
     _session_record_factory._hermes_session_injector = True  # type: ignore[attr-defined]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -699,7 +699,7 @@ def _set_session_context(session_key: str) -> list:
     try:
         from gateway.session_context import set_session_vars
 
-        return set_session_vars(session_key=session_key)
+        return set_session_vars(platform="tui", session_key=session_key)
     except Exception:
         return []
 


### PR DESCRIPTION
## Summary

Log lines now show the platform origin alongside the session ID, making it easy to tell at a glance which interface generated a given log line.

Before: `2026-05-29 09:49:43 INFO [a61d7e] run_agent: Starting conversation`
After:  `2026-05-29 09:49:43 INFO [cli|a61d7e] run_agent: Starting conversation` (CLI)
        `2026-05-29 09:49:43 INFO [tui|a61d7e] run_agent: Starting conversation` (dashboard/TUI)
        `2026-05-29 09:49:43 INFO [google_chat|a61d7e] run_agent: Starting conversation` (Google Chat)

## Changes

- **hermes_logging.py**: `set_session_context()` now accepts an optional `platform` parameter. The record factory produces `[platform|session_id]` when a platform is set, falling back to `[session_id]` when it isn't (backward-compatible).
- **agent/conversation_loop.py**: passes `agent.platform` through to `set_session_context()` so every conversation turn is tagged with its origin.
- **tui_gateway/server.py**: `_set_session_context()` now passes `platform="tui"` to `set_session_vars()` — this was a gap where TUI/dashboard sessions lacked platform context.

## Backward Compatibility

Existing behavior is preserved: when no platform is set, the log format remains `[session_id]`. All 55 existing logging tests continue to pass without modification.

## Test Plan

- [x] `python -m pytest tests/test_hermes_logging.py -q` — 55 passed
- [x] Format verified: `[platform|id]` when platform set, `[id]` when not
- [x] `clear_session_context()` clears both fields correctly
