### PR TITLE
feat(mcp): add registry manifest for Hermes server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Hermes Agent ☤
 
+<!-- mcp-name: io.github.nousresearch/hermes-agent -->
+
 <p align="center">
   <a href="https://hermes-agent.nousresearch.com/docs/"><img src="https://img.shields.io/badge/Docs-hermes--agent.nousresearch.com-FFD700?style=for-the-badge" alt="Documentation"></a>
   <a href="https://discord.gg/NousResearch"><img src="https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ dependencies = [
   # (which is a silent killer on Windows — see CONTRIBUTING.md) and
   # `os.killpg` (which doesn't exist on Windows).
   "psutil==7.2.2",
+  # MCP server mode is advertised through the root server.json manifest. Keep
+  # the SDK in the base wheel so registry clients that install plain
+  # `hermes-agent` can actually run `hermes mcp serve`.
+  "mcp==1.26.0",
 ]
 
 [project.optional-dependencies]
@@ -108,7 +112,10 @@ pty = [
   "pywinpty==2.0.15; sys_platform == 'win32'",
 ]
 honcho = ["honcho-ai==2.0.1"]
-mcp = ["mcp==1.26.0"]
+# MCP SDK is a core dependency because root server.json advertises the PyPI
+# package to registry clients. Keep the extra for backwards compatibility with
+# existing install docs and commands such as `pip install hermes-agent[mcp]`.
+mcp = []
 homeassistant = ["aiohttp==3.13.3"]
 sms = ["aiohttp==3.13.3"]
 # Computer use — macOS background desktop control via cua-driver (MCP stdio).
@@ -213,7 +220,10 @@ all = [
 
 [project.scripts]
 hermes = "hermes_cli.main:main"
-hermes-agent = "run_agent:main"
+# Alias the distribution-name executable to the primary CLI so PyPI/MCP
+# registry launchers that infer `hermes-agent` from the package name still
+# dispatch subcommands such as `mcp serve` correctly.
+hermes-agent = "hermes_cli.main:main"
 hermes-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]

--- a/server.json
+++ b/server.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.nousresearch/hermes-agent",
+  "title": "Hermes Agent",
+  "description": "Expose Hermes Agent conversations, messages, channels, and approvals over MCP.",
+  "version": "0.15.1",
+  "websiteUrl": "https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp",
+  "repository": {
+    "url": "https://github.com/NousResearch/hermes-agent",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "hermes-agent",
+      "version": "0.15.1",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_mcp_registry_manifest.py
+++ b/tests/test_mcp_registry_manifest.py
@@ -1,0 +1,61 @@
+"""Regression tests for the MCP Registry server.json manifest."""
+
+import json
+from pathlib import Path
+import tomllib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_pyproject() -> dict:
+    with (ROOT / "pyproject.toml").open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def _load_manifest() -> dict:
+    return json.loads((ROOT / "server.json").read_text(encoding="utf-8"))
+
+
+def test_mcp_registry_manifest_matches_package_version_and_launch_args():
+    manifest = _load_manifest()
+    pyproject = _load_pyproject()
+    version = pyproject["project"]["version"]
+
+    assert manifest["$schema"] == "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+    assert manifest["name"] == "io.github.nousresearch/hermes-agent"
+    assert manifest["version"] == version
+
+    package = manifest["packages"][0]
+    assert package["registryType"] == "pypi"
+    assert package["registryBaseUrl"] == "https://pypi.org"
+    assert package["identifier"] == pyproject["project"]["name"]
+    assert package["version"] == version
+    assert package["runtimeHint"] == "uvx"
+    assert package["transport"] == {"type": "stdio"}
+    assert package["packageArguments"] == [
+        {"type": "positional", "value": "mcp"},
+        {"type": "positional", "value": "serve"},
+    ]
+
+
+def test_pypi_distribution_name_cli_alias_dispatches_main_hermes_cli():
+    """Registry launchers may infer `hermes-agent` from the PyPI package name."""
+
+    scripts = _load_pyproject()["project"]["scripts"]
+    assert scripts["hermes"] == "hermes_cli.main:main"
+    assert scripts["hermes-agent"] == scripts["hermes"]
+
+
+def test_mcp_sdk_available_for_plain_pypi_registry_install():
+    """server.json advertises plain `hermes-agent`, so MCP cannot be extra-only."""
+
+    project = _load_pyproject()["project"]
+    assert "mcp==1.26.0" in project["dependencies"]
+    assert "mcp" in project["optional-dependencies"]
+    assert project["optional-dependencies"]["mcp"] == []
+
+
+def test_readme_contains_mcp_registry_ownership_marker():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert "<!-- mcp-name: io.github.nousresearch/hermes-agent -->" in readme

--- a/uv.lock
+++ b/uv.lock
@@ -1596,6 +1596,7 @@ dependencies = [
     { name = "fire" },
     { name = "httpx", extra = ["socks"] },
     { name = "jinja2" },
+    { name = "mcp" },
     { name = "openai" },
     { name = "prompt-toolkit" },
     { name = "psutil" },
@@ -1703,9 +1704,6 @@ matrix = [
     { name = "markdown" },
     { name = "mautrix", extra = ["encryption"] },
 ]
-mcp = [
-    { name = "mcp" },
-]
 messaging = [
     { name = "aiohttp" },
     { name = "brotlicffi" },
@@ -1736,7 +1734,6 @@ sms = [
 termux = [
     { name = "agent-client-protocol" },
     { name = "honcho-ai" },
-    { name = "mcp" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
     { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
@@ -1750,7 +1747,6 @@ termux-all = [
     { name = "google-auth-httplib2" },
     { name = "google-auth-oauthlib" },
     { name = "honcho-ai" },
-    { name = "mcp" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
     { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
@@ -1837,9 +1833,9 @@ requires-dist = [
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = "==1.5.3" },
     { name = "markdown", marker = "extra == 'matrix'", specifier = "==3.10.2" },
     { name = "mautrix", extras = ["encryption"], marker = "extra == 'matrix'", specifier = "==0.21.0" },
+    { name = "mcp", specifier = "==1.26.0" },
     { name = "mcp", marker = "extra == 'computer-use'", specifier = "==1.26.0" },
     { name = "mcp", marker = "extra == 'dev'", specifier = "==1.26.0" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = "==1.26.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = "==1.3.4" },
     { name = "numpy", marker = "extra == 'voice'", specifier = "==2.4.3" },
     { name = "openai", specifier = "==2.24.0" },

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -644,6 +644,17 @@ hermes mcp serve
 
 This starts a stdio MCP server. The MCP client (not you) manages the process lifecycle.
 
+### MCP Registry metadata
+
+The repository includes a root [`server.json`](https://github.com/NousResearch/hermes-agent/blob/main/server.json) manifest for MCP Registry-compatible clients. It advertises the PyPI package (`hermes-agent`), stdio transport, and the fixed launch arguments `mcp serve` so clients start the server mode instead of plain interactive Hermes.
+
+If your client cannot consume the registry manifest yet, install the MCP extra explicitly and use the manual config below:
+
+```bash
+pip install "hermes-agent[mcp]"
+# or: uv tool install "hermes-agent[mcp]"
+```
+
 ### MCP client configuration
 
 Add Hermes to your MCP client config. For example, in Claude Code's `~/.claude/claude_desktop_config.json`:


### PR DESCRIPTION
## Summary
- Add a root `server.json` manifest for publishing Hermes Agent's `hermes mcp serve` bridge to MCP registries.
- Add the MCP registry ownership marker to the README and document registry/manual fallback install guidance.
- Make registry launches reliable by keeping the MCP SDK available in plain `hermes-agent` installs and aliasing the distribution-name executable to the main Hermes CLI.
- Add regression tests for manifest/package version sync, launch args, CLI aliasing, core MCP dependency, and the README marker.

## Test Plan
- [x] `uv lock --check`
- [x] `python -m pytest tests/test_mcp_registry_manifest.py tests/test_project_metadata.py tests/test_packaging_metadata.py -q -o 'addopts='`
- [x] `mcp-publisher validate`
- [x] JSON Schema validation against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
- [x] `git diff --check`

## Notes
- The manifest uses the official PyPI package identifier (`hermes-agent`) and fixed `packageArguments` (`mcp`, `serve`) so clients start MCP server mode instead of plain interactive Hermes.
- `hermes-agent[mcp]` remains a valid compatibility extra for users/clients following older manual install docs.
