### PR TITLE
fix(discord): inject thread starter context

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3725,6 +3725,125 @@ class DiscordAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("DISCORD_HISTORY_BACKFILL", "true").lower() in {"true", "1", "yes"}
 
+    def _discord_thread_context_messages(self) -> int:
+        """Return number of prior Discord thread messages to inject.
+
+        Thread context is separate from channel history backfill: Discord does
+        not include the thread starter message in inbound thread events, so a
+        short follow-up like "can you do this?" can otherwise reach the agent
+        without the message the thread was created from.
+        """
+        configured = self.config.extra.get("thread_context_messages")
+        if configured is None:
+            configured = os.getenv("DISCORD_THREAD_CONTEXT_MESSAGES", "5")
+        try:
+            value = int(configured)
+        except (TypeError, ValueError):
+            value = 5
+        return max(0, min(value, 20))
+
+    def _discord_thread_context_max_chars(self) -> int:
+        """Return maximum character budget for injected thread context."""
+        configured = self.config.extra.get("thread_context_max_chars")
+        if configured is None:
+            configured = os.getenv("DISCORD_THREAD_CONTEXT_MAX_CHARS", "4000")
+        try:
+            value = int(configured)
+        except (TypeError, ValueError):
+            value = 4000
+        return max(500, min(value, 20000))
+
+    @staticmethod
+    def _discord_message_author_name(message: Any) -> str:
+        author = getattr(message, "author", None)
+        return str(
+            getattr(author, "display_name", None)
+            or getattr(author, "name", None)
+            or getattr(author, "id", None)
+            or "unknown"
+        )
+
+    @staticmethod
+    def _discord_message_text(message: Any) -> str:
+        text = (getattr(message, "clean_content", None) or getattr(message, "content", None) or "").strip()
+        if text:
+            return text
+        attachments = getattr(message, "attachments", None) or []
+        if attachments:
+            names = [getattr(att, "filename", None) for att in attachments]
+            names = [name for name in names if name]
+            return f"[attachments: {', '.join(names)}]" if names else "[attachments]"
+        return ""
+
+    async def _build_thread_context_injection(self, thread: Any, current_message: Any) -> Optional[str]:
+        """Fetch a bounded Discord thread starter/history block for context.
+
+        Discord thread events include the new message and thread metadata, but
+        not the starter message/body.  Fetch only the starter plus a small
+        thread-local history snapshot; never scan the parent channel here.
+        """
+        context_message_limit = self._discord_thread_context_messages()
+        if context_message_limit <= 0:
+            return None
+
+        max_chars = self._discord_thread_context_max_chars()
+        current_id = str(getattr(current_message, "id", "") or "")
+        seen_ids = {current_id} if current_id else set()
+        entries: list[tuple[str, str, str]] = []
+
+        def add(label: str, msg: Any) -> None:
+            msg_id = str(getattr(msg, "id", "") or "")
+            if msg_id and msg_id in seen_ids:
+                return
+            if msg_id:
+                seen_ids.add(msg_id)
+            text = self._discord_message_text(msg)
+            if not text:
+                return
+            entries.append((label, self._discord_message_author_name(msg), text))
+
+        starter = getattr(thread, "starter_message", None)
+        if starter:
+            add("starter", starter)
+        else:
+            parent = getattr(thread, "parent", None)
+            fetch_message: Any = getattr(parent, "fetch_message", None)
+            thread_id = getattr(thread, "id", None)
+            if callable(fetch_message) and thread_id is not None:
+                try:
+                    add("starter", await fetch_message(thread_id))
+                except Exception as e:
+                    logger.debug("[%s] Could not fetch Discord thread starter: %s", self.name, e)
+
+        history: Any = getattr(thread, "history", None)
+        if callable(history):
+            try:
+                message_entries = 0
+                history_iter: Any = history(limit=context_message_limit + 1, before=current_message, oldest_first=True)
+                async for msg in history_iter:
+                    before_count = len(entries)
+                    add("message", msg)
+                    if len(entries) > before_count and entries[-1][0] == "message":
+                        message_entries += 1
+                    if message_entries >= context_message_limit:
+                        break
+            except Exception as e:
+                logger.debug("[%s] Could not fetch Discord thread history: %s", self.name, e)
+
+        if not entries:
+            return None
+
+        title = getattr(thread, "name", None) or getattr(thread, "id", "thread")
+        lines = ["[Discord thread context]", f"Thread: {title}"]
+        for label, author, text in entries:
+            prefix = "starter" if label == "starter" else "message"
+            lines.append(f"[{prefix}] {author}: {text}")
+
+        block = "\n".join(lines)
+        if len(block) > max_chars:
+            block = block[: max_chars - 15].rstrip() + "\n[truncated]"
+        return block
+
     def _discord_history_backfill_limit(self) -> int:
         """Return the max number of messages to scan backwards for context.
 
@@ -4830,10 +4949,15 @@ class DiscordAdapter(BasePlatformAdapter):
                 if _backfill_text:
                     _channel_context = _backfill_text
 
+        if is_thread and msg_type != MessageType.COMMAND and auto_threaded_channel is None:
+            thread_context = await self._build_thread_context_injection(effective_channel, message)
+            if thread_context:
+                event_text = f"{thread_context}\n\n{event_text}" if event_text else thread_context
+
         # Defense-in-depth: prevent empty user messages from entering session
-        # (can happen when user sends @mention-only with no other text).
-        # When channel_context is present, a bare mention means "catch me up"
-        # — the context IS the message, so skip the placeholder.
+        # (can happen when user sends @mention-only with no text).
+        # When channel_context or thread_context is present, a bare mention means
+        # "catch me up" — the context IS the message, so skip the placeholder.
         if (not event_text or not event_text.strip()) and not _channel_context:
             event_text = "(The user sent a message with no text content)"
 

--- a/tests/gateway/test_discord_thread_context.py
+++ b/tests/gateway/test_discord_thread_context.py
@@ -1,0 +1,210 @@
+"""Tests for Discord thread starter/body context injection."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import sys
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    """Install a mock discord module when discord.py isn't available."""
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.MessageType = SimpleNamespace(default="default", reply="reply")
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+class FakeTextChannel:
+    def __init__(self, channel_id: int = 1, name: str = "general", guild_name: str = "Hermes Server", messages=None):
+        self.id = channel_id
+        self.name = name
+        self.guild = SimpleNamespace(id=10, name=guild_name)
+        self.topic = None
+        self._messages = {str(getattr(message, "id", "")): message for message in (messages or [])}
+
+    async def fetch_message(self, message_id):
+        return self._messages[str(message_id)]
+
+    def history(self, *, limit, before, after=None, oldest_first=None):
+        async def _iter():
+            return
+            yield
+
+        return _iter()
+
+
+class FakeThread:
+    def __init__(self, channel_id: int = 2, name: str = "email alert", parent=None, history_messages=None, starter_message=None):
+        self.id = channel_id
+        self.name = name
+        self.parent = parent
+        self.parent_id = getattr(parent, "id", None)
+        self.guild = getattr(parent, "guild", None) or SimpleNamespace(id=10, name="Hermes Server")
+        self.topic = None
+        self.starter_message = starter_message
+        self._history_messages = list(history_messages or [])
+
+    def history(self, *, limit=100, before=None, after=None, oldest_first=None):
+        async def _iter():
+            messages = self._history_messages[:limit]
+            if oldest_first is False:
+                messages = list(reversed(messages))
+            for message in messages:
+                yield message
+
+        return _iter()
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+    monkeypatch.setattr(discord_platform.discord, "DMChannel", type("FakeDMChannel", (), {}), raising=False)
+    monkeypatch.setattr(discord_platform.discord, "MessageType", SimpleNamespace(default="default", reply="reply"), raising=False)
+    for var in (
+        "DISCORD_REQUIRE_MENTION",
+        "DISCORD_THREAD_REQUIRE_MENTION",
+        "DISCORD_FREE_RESPONSE_CHANNELS",
+        "DISCORD_AUTO_THREAD",
+        "DISCORD_NO_THREAD_CHANNELS",
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_IGNORED_CHANNELS",
+        "DISCORD_HISTORY_BACKFILL",
+        "DISCORD_THREAD_CONTEXT_MESSAGES",
+        "DISCORD_THREAD_CONTEXT_MAX_CHARS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = DiscordAdapter(config)
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+    adapter._text_batch_delay_seconds = 0
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def fake_message(message_id: int, content: str, *, author_name: str = "User", channel=None, msg_type="default", attachments=None):
+    return SimpleNamespace(
+        id=message_id,
+        content=content,
+        clean_content=content,
+        mentions=[],
+        attachments=list(attachments or []),
+        message_snapshots=[],
+        reference=None,
+        created_at=datetime.now(timezone.utc),
+        channel=channel,
+        author=SimpleNamespace(id=message_id + 1000, display_name=author_name, name=author_name),
+        guild=getattr(channel, "guild", None),
+        type=msg_type,
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_thread_context_uses_starter_message(adapter):
+    starter = fake_message(200, "# 고로켓 이메일 알림\n요약: TLS 인증서 확인 필요", author_name="Hermes")
+    prior = fake_message(201, "이건 배포 환경 확인 필요", author_name="Doo")
+    thread = FakeThread(channel_id=200, name="고로켓 이메일 알림", starter_message=starter, history_messages=[starter, prior])
+    current = fake_message(202, "이거 무슨 내용이야?", channel=thread, author_name="Doo")
+
+    context = await adapter._build_thread_context_injection(thread, current)
+
+    assert context is not None
+    assert context.startswith("[Discord thread context]")
+    assert "Thread: 고로켓 이메일 알림" in context
+    assert "[starter] Hermes: # 고로켓 이메일 알림" in context
+    assert "TLS 인증서 확인 필요" in context
+    assert "[message] Doo: 이건 배포 환경 확인 필요" in context
+    assert "이거 무슨 내용이야?" not in context
+
+
+@pytest.mark.asyncio
+async def test_build_thread_context_fetches_parent_starter_fallback(adapter):
+    starter = fake_message(300, "Parent channel starter content", author_name="Hermes")
+    parent = FakeTextChannel(channel_id=100, messages=[starter])
+    thread = FakeThread(channel_id=300, name="fallback-thread", parent=parent, starter_message=None)
+    current = fake_message(301, "follow-up", channel=thread)
+
+    context = await adapter._build_thread_context_injection(thread, current)
+
+    assert context is not None
+    assert "[starter] Hermes: Parent channel starter content" in context
+
+
+@pytest.mark.asyncio
+async def test_handle_message_injects_thread_context_for_non_command(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_HISTORY_BACKFILL", "false")
+    starter = fake_message(400, "Cron alert body", author_name="Hermes")
+    thread = FakeThread(channel_id=400, name="alert-thread", starter_message=starter, history_messages=[starter])
+    message = fake_message(401, "이거 처리해줘", channel=thread, author_name="Doo")
+    adapter._threads.mark(str(thread.id))
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text.startswith("[Discord thread context]")
+    assert "[starter] Hermes: Cron alert body" in event.text
+    assert event.text.endswith("이거 처리해줘")
+
+
+@pytest.mark.asyncio
+async def test_handle_message_skips_thread_context_for_commands(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_HISTORY_BACKFILL", "false")
+    starter = fake_message(500, "Do not inject into command", author_name="Hermes")
+    thread = FakeThread(channel_id=500, name="command-thread", starter_message=starter, history_messages=[starter])
+    message = fake_message(501, "/status", channel=thread, author_name="Doo")
+    adapter._threads.mark(str(thread.id))
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "/status"
+
+
+@pytest.mark.asyncio
+async def test_thread_context_can_be_disabled(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_THREAD_CONTEXT_MESSAGES", "0")
+    starter = fake_message(600, "Hidden starter", author_name="Hermes")
+    thread = FakeThread(channel_id=600, name="disabled-thread", starter_message=starter, history_messages=[starter])
+    current = fake_message(601, "follow-up", channel=thread)
+
+    context = await adapter._build_thread_context_injection(thread, current)
+
+    assert context is None


### PR DESCRIPTION
## Summary
- inject a bounded Discord thread context block into non-command thread messages
- include the thread starter message via `Thread.starter_message` or `parent.fetch_message(thread.id)` fallback
- include a small thread-local history snapshot, capped by message count and chars, without scanning parent channel history

## Why
Discord inbound thread events include the new message and thread metadata, but not the message the thread was created from. For threads created from Hermes/cron messages, follow-ups like “handle this” reach the agent without the parent/starter content.

This is narrower than session rebind semantics in #31550: it does not switch active sessions or change `create_thread` tool behavior. It only makes inbound Discord thread replies carry the bounded starter/thread context the user can see in the UI.

Supersedes #20825 against the current plugin adapter structure.
Related: #31467, #33666, #33827.

## Controls / safety
- skips slash/command messages so `/status`, `/stop`, etc. parse unchanged
- skips newly auto-created threads to avoid duplicating the triggering message
- reads only thread-local starter/history; does not scan parent channel history
- defaults are bounded and configurable:
  - `discord.thread_context_messages` / `DISCORD_THREAD_CONTEXT_MESSAGES` (default 5, max 20, 0 disables)
  - `discord.thread_context_max_chars` / `DISCORD_THREAD_CONTEXT_MAX_CHARS` (default 4000, max 20000)

## Test Plan
- `python -m pytest tests/gateway/test_discord_thread_context.py tests/gateway/test_discord_free_response.py tests/gateway/test_discord_thread_persistence.py tests/gateway/test_discord_slash_commands.py -q -o 'addopts='`
- `python -m py_compile plugins/platforms/discord/adapter.py tests/gateway/test_discord_thread_context.py`
- `git diff --check`
