### PR TITLE
docs(contributor): fix stale toolset list, missing skill ref, wrong project-tree paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -702,11 +702,13 @@ Each platform's adapter picks a base toolset (e.g. Telegram uses
 `"messaging"`); `_HERMES_CORE_TOOLS` is the default bundle most
 platforms inherit from.
 
-Current toolset keys: `browser`, `clarify`, `code_execution`, `cronjob`,
-`debugging`, `delegation`, `discord`, `discord_admin`, `feishu_doc`,
-`feishu_drive`, `file`, `homeassistant`, `image_gen`, `kanban`, `memory`,
-`messaging`, `moa`, `rl`, `safe`, `search`, `session_search`, `skills`,
-`spotify`, `terminal`, `todo`, `tts`, `video`, `vision`, `web`, `yuanbao`.
+Current toolset keys: `browser`, `clarify`, `code_execution`,
+`computer_use`, `context_engine`, `cronjob`, `debugging`, `delegation`,
+`discord`, `discord_admin`, `feishu_doc`, `feishu_drive`, `file`,
+`homeassistant`, `image_gen`, `kanban`, `memory`, `messaging`, `moa`,
+`safe`, `search`, `session_search`, `skills`, `spotify`, `terminal`,
+`todo`, `tts`, `video`, `video_gen`, `vision`, `web`, `x_search`,
+`yuanbao`.
 
 Enable/disable per platform via `hermes tools` (the curses UI) or the
 `tools.<platform>.enabled` / `tools.<platform>.disabled` lists in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -688,10 +688,10 @@ violate them.
    `.env.example` versions are usually stale and edits outside the
    skill's own block must be dropped during salvage.
 
-The full salvage / modernization checklist for external skill PRs
-lives in the `hermes-agent-dev` skill at
-`references/new-skill-pr-salvage.md` — load it before polishing
-contributor skill PRs.
+For in-repo skill authoring (frontmatter rules, validator contract,
+where SKILL.md files belong in the source tree), load the
+`hermes-agent-skill-authoring` skill at
+`skills/software-development/hermes-agent-skill-authoring/SKILL.md`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,14 +167,16 @@ hermes-agent/
 │   ├── registry.py               # Central tool registry (schemas, handlers, dispatch)
 │   ├── approval.py               # Dangerous command detection + per-session approval
 │   ├── terminal_tool.py          # Terminal orchestration (sudo, env lifecycle, backends)
-│   ├── file_operations.py        # read_file, write_file, search, patch, etc.
+│   ├── file_tools.py             # read_file, write_file, search, patch, …
+│   │                              # registrations (backed by file_operations.py)
 │   ├── web_tools.py              # web_search, web_extract (Parallel/Firecrawl + Gemini summarization)
 │   ├── vision_tools.py           # Image analysis via multimodal models
 │   ├── delegate_tool.py          # Subagent spawning and parallel task execution
 │   ├── code_execution_tool.py    # Sandboxed Python with RPC tool access
 │   ├── session_search_tool.py    # Search past conversations with FTS5 + anchored windows
 │   ├── cronjob_tools.py          # Scheduled task management
-│   ├── skill_tools.py            # Skill search, load, manage
+│   ├── skills_tool.py            # Agent-facing skill search / load
+│   ├── skill_manager_tool.py     # CRUD over user/in-repo SKILL.md files
 │   └── environments/             # Terminal execution backends
 │       ├── base.py                   # BaseEnvironment ABC
 │       ├── local.py, docker.py, ssh.py, singularity.py, modal.py, daytona.py
@@ -183,8 +185,10 @@ hermes-agent/
 │   ├── run.py                    # GatewayRunner — platform lifecycle, message routing, cron
 │   ├── config.py                 # Platform configuration resolution
 │   ├── session.py                # Session store, context prompts, reset policies
-│   └── platforms/                # Platform adapters
-│       ├── telegram.py, discord_adapter.py, slack.py, whatsapp.py
+│   └── platforms/                # Built-in platform adapters
+│       ├── telegram.py, slack.py, matrix.py, signal.py, feishu.py, …
+│       └── (additional adapters under plugins/platforms/{discord,teams,
+│           irc,line,mattermost,google_chat,ntfy,simplex})
 │
 ├── scripts/                  # Installer and bridge scripts
 │   ├── install.sh                # Linux/macOS installer

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -431,8 +431,8 @@ Enable/disable via `hermes tools` (interactive) or `hermes tools enable/disable 
 | `feishu_doc` | Feishu (Lark) document tools |
 | `feishu_drive` | Feishu (Lark) drive tools |
 | `yuanbao` | Yuanbao integration tools |
-| `rl` | Reinforcement learning tools (off by default) |
 | `moa` | Mixture of Agents (off by default) |
+| `x_search` | X (Twitter) search-only Grok toolset |
 
 Full enumeration lives in `toolsets.py` as the `TOOLSETS` dict; `_HERMES_CORE_TOOLS` is the default bundle most platforms inherit from.
 


### PR DESCRIPTION
## Summary

Three contributor-facing markdown files described code surfaces that have been renamed, removed, or never existed. This PR re-syncs them with the actual repo state.

- **`AGENTS.md` — Toolsets section**: listed an `rl` toolset that is not in `toolsets.py::TOOLSETS`, and omitted four toolsets that ARE there (`computer_use`, `context_engine`, `video_gen`, `x_search`). Re-synced the alphabetical list against `toolsets.py:88-334`.
- **`AGENTS.md` — skill-PR salvage paragraph**: pointed maintainers at a `hermes-agent-dev` skill / `references/new-skill-pr-salvage.md` that does not exist anywhere in the repo (glob returns 0 hits). Re-pointed at the actual in-repo authoring guide at `skills/software-development/hermes-agent-skill-authoring/SKILL.md`.
- **`CONTRIBUTING.md` — project-tree blurb**: referenced `tools/skill_tools.py` (does not exist — actual modules are `skills_tool.py` and `skill_manager_tool.py`) and `gateway/platforms/discord_adapter.py` (Discord moved to `plugins/platforms/discord/`). Also clarified that `tools/file_tools.py` is the agent-facing registration module — `file_operations.py` is the backend it delegates to.
- **`skills/autonomous-ai-agents/hermes-agent/SKILL.md` — toolset table**: documented the same removed `rl` key; replaced with `x_search`.

## Test plan

- [ ] `grep -n "rl" AGENTS.md` returns no toolset-row hit
- [ ] Every toolset listed in `AGENTS.md` exists in `toolsets.py::TOOLSETS`
- [ ] Paths referenced in `CONTRIBUTING.md` project tree all resolve (`tools/skills_tool.py`, `tools/skill_manager_tool.py`, `tools/file_tools.py`, `plugins/platforms/discord/`)
- [ ] `skills/software-development/hermes-agent-skill-authoring/SKILL.md` exists and is the referenced authoring guide

## Note

Split out from #34585 (`fix/docs-audit-sweep`) so this contributor-doc fix can land independently. The other commits in #34585 are unrelated doc sweeps.