### PR TITLE
fix(redact): preserve code-like tool output

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -790,6 +790,20 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("No code", result["error"])
 
+    @unittest.skipUnless(check_sandbox_requirements(), "execute_code sandbox unavailable")
+    def test_output_redaction_preserves_code_like_env_names(self):
+        with patch("agent.redact._REDACT_ENABLED", True), \
+             patch("model_tools.handle_function_call",
+                   side_effect=_mock_handle_function_call):
+            result = json.loads(execute_code(
+                'print("MAX_TOKENS=100")',
+                task_id="test-code-output-redaction",
+            ))
+
+        self.assertEqual(result["status"], "success")
+        self.assertIn("MAX_TOKENS=100", result["output"])
+        self.assertNotIn("MAX_TOKENS=***", result["output"])
+
     @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
     def test_none_enabled_tools_uses_all(self):
         """When enabled_tools is None, all sandbox tools should be available."""

--- a/tests/tools/test_terminal_output_transform_hook.py
+++ b/tests/tools/test_terminal_output_transform_hook.py
@@ -130,7 +130,19 @@ def test_terminal_output_transform_still_runs_strip_and_redact(monkeypatch, tmp_
     assert "\x1b" not in result["output"]
     assert secret not in result["output"]
     assert "OPENAI_API_KEY=" in result["output"]
-    assert "***" in result["output"]
+    assert "sk-pro..." in result["output"]
+
+
+def test_terminal_output_redaction_preserves_code_like_env_names(monkeypatch, tmp_path):
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+
+    result, _mock_env = _run_terminal(
+        monkeypatch,
+        tmp_path,
+        output="MAX_TOKENS=100\n",
+    )
+
+    assert result["output"] == "MAX_TOKENS=100"
 
 
 def test_terminal_output_transform_hook_exception_falls_back(monkeypatch, tmp_path):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1025,7 +1025,7 @@ def _execute_remote(
 
     # Redact secrets
     from agent.redact import redact_sensitive_text
-    stdout_text = redact_sensitive_text(stdout_text)
+    stdout_text = redact_sensitive_text(stdout_text, code_file=True)
 
     # Build response
     result: Dict[str, Any] = {
@@ -1426,8 +1426,8 @@ def execute_code(
         # but scripts can still read secrets from disk (e.g. open('~/.hermes/.env')).
         # This ensures leaked secrets never enter the model context.
         from agent.redact import redact_sensitive_text
-        stdout_text = redact_sensitive_text(stdout_text)
-        stderr_text = redact_sensitive_text(stderr_text)
+        stdout_text = redact_sensitive_text(stdout_text, code_file=True)
+        stderr_text = redact_sensitive_text(stderr_text, code_file=True)
 
         # Build response
         result: Dict[str, Any] = {

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2287,7 +2287,7 @@ def terminal_tool(
 
             # Redact secrets from command output (catches env/printenv leaking keys)
             from agent.redact import redact_sensitive_text
-            output = redact_sensitive_text(output.strip()) if output else ""
+            output = redact_sensitive_text(output.strip(), code_file=True) if output else ""
 
             # Interpret non-zero exit codes that aren't real errors
             # (e.g. grep=1 means "no matches", diff=1 means "files differ")


### PR DESCRIPTION
﻿## Summary
- pass `code_file=True` when redacting `execute_code` and `terminal` output so code-like lines such as `MAX_TOKENS=100` are not rewritten as secrets
- keep prefix-based secret masking active for actual leaked tokens
- add regression coverage for both terminal output and execute_code output

## Context
This addresses the remaining code-output corruption reported in #33801. It is related to #33840, but includes behavior tests covering the user-visible regression.

## Tests
- `.\.venv\Scripts\python.exe -m ruff check tools\code_execution_tool.py tools\terminal_tool.py tests\tools\test_code_execution.py tests\tools\test_terminal_output_transform_hook.py`
- `.\.venv\Scripts\python.exe scripts\run_tests_parallel.py tests\tools\test_terminal_output_transform_hook.py tests\tools\test_code_execution.py tests\agent\test_redact.py -- --tb=short --timeout-method=thread -k redaction_preserves_code_like_env_names`
- `.\.venv\Scripts\python.exe -m ruff check .`

Closes #33801
