### PR TITLE
docs(cli): document 'hermes sessions optimize' subcommand (#34596)

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1218,6 +1218,7 @@ Subcommands:
 | `export <output> [--session-id ID]` | Export sessions to JSONL. |
 | `delete <session-id>` | Delete one session. |
 | `prune` | Delete old sessions. |
+| `optimize` | Reclaim disk space: merge FTS5 segments + VACUUM (no data change). |
 | `stats` | Show session-store statistics. |
 | `rename <session-id> <title>` | Set or change a session title. |
 


### PR DESCRIPTION
#34596 added a `hermes sessions optimize` subcommand (`hermes_cli/main.py`: `sessions_subparsers.add_parser("optimize", help="Reclaim disk space: merge FTS5 segments + VACUUM (no data change)")` → `db.vacuum()` which merges FTS5 segments then VACUUMs). The `hermes sessions` subcommands table in the CLI reference still lists `list`/`browse`/`export`/`delete`/`prune`/`stats`/`rename` but not `optimize`.

Adds the missing row (description verbatim from the subparser help string). Pure docs.
