### PR TITLE
fix(cli): show tool_progress, skin, and show_cost in hermes config display

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5395,6 +5395,10 @@ def show_config():
     print(f"  Personality:  {display.get('personality', 'kawaii')}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
     print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
+    print(f"  Cost:         {'on' if display.get('show_cost', False) else 'off'}")
+    print(f"  Skin:         {display.get('skin', 'default')}")
+    tp = display.get('tool_progress', 'all')
+    print(f"  Tool progress: {tp}")
     ump = display.get('user_message_preview', {}) if isinstance(display.get('user_message_preview', {}), dict) else {}
     ump_first = ump.get('first_lines', 2)
     ump_last = ump.get('last_lines', 2)

--- a/tests/hermes_cli/test_placeholder_usage.py
+++ b/tests/hermes_cli/test_placeholder_usage.py
@@ -46,3 +46,34 @@ def test_setup_summary_marks_placeholders(tmp_path, capsys):
 
     out = capsys.readouterr().out
     assert "hermes config set <key> <value>" in out
+
+def test_show_config_displays_all_display_keys(tmp_path, capsys):
+    """Verify show_config() renders tool_progress, skin, and show_cost."""
+    import yaml
+    from hermes_cli.config import _LOAD_CONFIG_CACHE
+
+    config_dir = tmp_path / ".hermes"
+    config_dir.mkdir()
+    config_file = config_dir / "config.yaml"
+    config_file.write_text(yaml.safe_dump({
+        "display": {
+            "tool_progress": "verbose",
+            "skin": "cyberpunk",
+            "show_cost": True,
+            "show_reasoning": True,
+        }
+    }, sort_keys=False), encoding="utf-8")
+
+    # Clear config cache to ensure fresh load
+    _LOAD_CONFIG_CACHE.clear()
+
+    with patch.dict(os.environ, {"HERMES_HOME": str(config_dir)}):
+        show_config()
+
+    out = capsys.readouterr().out
+    assert "Tool progress:" in out
+    assert "Skin:" in out
+    assert "Cost:" in out
+    # Use non-default values to verify config is actually read
+    assert "verbose" in out
+    assert "cyberpunk" in out


### PR DESCRIPTION
## What does this PR do?

Adds `tool_progress`, `skin`, and `show_cost` display keys to `hermes config show` output. Previously, the Display section only showed personality, reasoning, bell, and user preview — users had to manually inspect `config.yaml` to verify these settings.

## Related Issue

Fixes #34653

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: Add Cost, Skin, and Tool progress lines to the Display section of `show_config()`
- `tests/hermes_cli/test_placeholder_usage.py`: Add `test_show_config_displays_all_display_keys` regression test verifying non-default values are rendered

## How to Test

1. Set custom display values: `hermes config set display.skin cyberpunk && hermes config set display.show_cost true && hermes config set display.tool_progress verbose`
2. Run `hermes config show` and verify the Display section shows the new keys with the correct values
3. Run `pytest tests/hermes_cli/test_placeholder_usage.py -v` to verify the regression test passes

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/config.py:show_config()` (Display section, lines 5391-5401)
- Blast radius: LOW — cosmetic output only, no behavioral change
- Related patterns: `show_config()` already renders terminal/compression/auxiliary sections with `config.get()` — new lines follow the same pattern
