### PR TITLE
fix: keep Windows dashboard port mapping env-driven

### DIFF
--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -32,7 +32,14 @@ services:
     environment:
       - HERMES_UID=10000
       - HERMES_GID=10000
+      - HERMES_DASHBOARD=1
       - HERMES_DASHBOARD_HOST=0.0.0.0
+      - HERMES_DASHBOARD_PORT=${HERMES_DASHBOARD_PORT:-9119}
+      # Windows Docker Desktop maps the container-public bind to host
+      # localhost below. Keep the no-OAuth local compose path explicit:
+      # Docker dashboard insecure mode is opt-in via this env var, never
+      # derived from HERMES_DASHBOARD_HOST.
+      - HERMES_DASHBOARD_INSECURE=1
     ports:
-      - "127.0.0.1:9119:9119"
-    command: ["dashboard", "--host", "0.0.0.0", "--port", "9119", "--no-open", "--insecure"]
+      - "127.0.0.1:${HERMES_DASHBOARD_PORT:-9119}:${HERMES_DASHBOARD_PORT:-9119}"
+    command: ["sleep", "infinity"]

--- a/tests/test_docker_home_override_scripts.py
+++ b/tests/test_docker_home_override_scripts.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DASHBOARD_RUN = REPO_ROOT / "docker" / "s6-rc.d" / "dashboard" / "run"
+WINDOWS_COMPOSE = REPO_ROOT / "docker-compose.windows.yml"
 
 
 def test_dashboard_run_resets_home_before_dropping_privileges() -> None:
@@ -46,3 +47,23 @@ def test_dashboard_run_does_not_derive_insecure_from_bind_host() -> None:
         assert truthy in text, (
             f"HERMES_DASHBOARD_INSECURE should accept truthy value {truthy!r}"
         )
+
+
+def test_windows_compose_uses_dashboard_env_opt_in_for_insecure_mode() -> None:
+    """Windows Docker Desktop needs a container-public bind for port mapping.
+
+    Keep that local-only compose path on the s6 dashboard service so the
+    insecure dashboard mode is still an explicit ``HERMES_DASHBOARD_INSECURE``
+    opt-in, not a hard-coded CLI flag hidden in the command line.
+    """
+    text = WINDOWS_COMPOSE.read_text(encoding="utf-8")
+
+    assert "HERMES_DASHBOARD=1" in text
+    assert "HERMES_DASHBOARD_HOST=0.0.0.0" in text
+    assert "HERMES_DASHBOARD_PORT=${HERMES_DASHBOARD_PORT:-9119}" in text
+    assert "HERMES_DASHBOARD_PORT=9119" not in text
+    assert "HERMES_DASHBOARD_INSECURE=1" in text
+    assert '      - "127.0.0.1:${HERMES_DASHBOARD_PORT:-9119}:${HERMES_DASHBOARD_PORT:-9119}"' in text
+    assert '      - "127.0.0.1:9119:9119"' not in text
+    assert 'command: ["dashboard",' not in text
+    assert '"--insecure"' not in text


### PR DESCRIPTION
## Summary

- Make Windows dashboard compose read `HERMES_DASHBOARD_PORT` with default `9119`.
- Use the same env/default expression for localhost-only host publishing so the service bind port and mapped port cannot diverge.
- Add regression assertions preventing hard-coded dashboard port/env values and preserving the explicit `HERMES_DASHBOARD_INSECURE=1` s6 dashboard path.

## Test Plan

- `uv run --with pytest python -m pytest tests/test_docker_home_override_scripts.py -q -o 'addopts='` → `3 passed in 0.07s`
- Docker Compose config validation was not run locally because this environment has neither the Docker Compose plugin nor standalone `docker-compose` binary.

Refs CORA-51