### PR TITLE
fix(signal): support spoiler markdown + correct PLATFORM_HINTS dialect

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -481,7 +481,13 @@ PLATFORM_HINTS = {
     ),
     "signal": (
         "You are on a text messaging communication platform, Signal. "
-        "Please do not use markdown as it does not render. "
+        "Standard markdown is automatically converted to Signal's native "
+        "text styles. Supported: **bold**, *italic*, ~~strikethrough~~, "
+        "||spoiler||, `inline code`, ```code blocks```, and ## headers "
+        "(rendered as bold). Signal has NO link syntax — [text](url) "
+        "renders as literal text, so include URLs directly. No underline. "
+        "No table syntax — prefer bullet lists or labeled key: value pairs "
+        "over pipe tables. "
         "You can send media files natively: to deliver a file to the user, "
         "include MEDIA:/absolute/path/to/file in your response. Images "
         "(.png, .jpg, .webp) appear as photos, audio as attachments, and other "

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -824,9 +824,7 @@ class SignalAdapter(BasePlatformAdapter):
         Positions are measured in **UTF-16 code units** (not Python code
         points) because that's what the Signal protocol uses.
 
-        Supported styles: BOLD, ITALIC, STRIKETHROUGH, MONOSPACE.
-        (Signal's SPOILER style is not currently mapped — no standard
-        markdown syntax for it; would need ``||spoiler||`` parsing.)
+        Supported styles: BOLD, ITALIC, STRIKETHROUGH, MONOSPACE, SPOILER.
 
         Returns ``(plain_text, styles_list)`` where *styles_list* may be
         empty if there's nothing to format.
@@ -881,6 +879,7 @@ class SignalAdapter(BasePlatformAdapter):
             (re.compile(r"\*\*(.+?)\*\*", re.DOTALL), "BOLD"),
             (re.compile(r"__(.+?)__", re.DOTALL), "BOLD"),
             (re.compile(r"~~(.+?)~~", re.DOTALL), "STRIKETHROUGH"),
+            (re.compile(r"\|\|(.+?)\|\|", re.DOTALL), "SPOILER"),
             (re.compile(r"`(.+?)`"), "MONOSPACE"),
             (re.compile(r"(?<!\*)\*(?!\*| )(.+?)(?<!\*)\*(?!\*)"), "ITALIC"),
             (re.compile(r"(?<!\w)_(?!_)(.+?)(?<!_)_(?!\w)"), "ITALIC"),

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -785,6 +785,7 @@ class TestPromptBuilderConstants:
         assert "whatsapp" in PLATFORM_HINTS
         assert "telegram" in PLATFORM_HINTS
         assert "discord" in PLATFORM_HINTS
+        assert "signal" in PLATFORM_HINTS
         assert "cron" in PLATFORM_HINTS
         assert "cli" in PLATFORM_HINTS
         assert "api_server" in PLATFORM_HINTS
@@ -832,6 +833,32 @@ class TestPromptBuilderConstants:
         assert "MEDIA:" in hint
         assert "Markdown" in hint
         assert "absolute" in hint
+
+    def test_platform_hints_signal_lists_supported_styles(self):
+        # signal-cli's textStyles wire format supports BOLD, ITALIC,
+        # STRIKETHROUGH, MONOSPACE, and SPOILER (see TextStyle.java in
+        # AsamK/signal-cli). _markdown_to_signal converts standard
+        # markdown syntax to these styles, so the hint must advertise
+        # the supported set rather than telling the model to avoid
+        # markdown entirely.
+        hint = PLATFORM_HINTS["signal"]
+        assert "Signal" in hint
+        assert "MEDIA:" in hint
+        assert "**bold**" in hint
+        assert "*italic*" in hint
+        assert "~~strikethrough~~" in hint
+        assert "||spoiler||" in hint
+        assert "`inline code`" in hint
+
+    def test_platform_hints_signal_no_stale_no_markdown_claim(self):
+        # Regression guard: the prior hint said "Please do not use
+        # markdown as it does not render", but _markdown_to_signal
+        # always ran on outbound text, so markdown DID render — the
+        # hint just made the model emit literal asterisks. Make sure
+        # we don't reintroduce a blanket "no markdown" claim.
+        hint = PLATFORM_HINTS["signal"].lower()
+        assert "do not use markdown" not in hint
+        assert "does not render" not in hint
 
 
 # =========================================================================

--- a/tests/gateway/test_signal_format.py
+++ b/tests/gateway/test_signal_format.py
@@ -102,6 +102,51 @@ class TestMarkdownToSignalBasic:
         assert text == ""
         assert styles == []
 
+    def test_spoiler_double_pipe(self):
+        text, styles = _m2s("hello ||world||")
+        assert text == "hello world"
+        assert len(styles) == 1
+        assert styles[0].endswith(":SPOILER")
+
+    def test_spoiler_offset_correct(self):
+        text, styles = _m2s("||hidden||")
+        assert text == "hidden"
+        assert styles == ["0:6:SPOILER"]
+
+    def test_spoiler_inside_sentence(self):
+        text, styles = _m2s("the answer is ||42||.")
+        assert text == "the answer is 42."
+        spoilers = _find_style(styles, "SPOILER")
+        assert len(spoilers) == 1
+        # 14 UTF-16 code units before "42" ("the answer is "), spoiler length 2
+        assert spoilers[0] == "14:2:SPOILER"
+
+    def test_spoiler_multi_word(self):
+        text, styles = _m2s("||two words||")
+        assert text == "two words"
+        spoilers = _find_style(styles, "SPOILER")
+        assert spoilers == ["0:9:SPOILER"]
+
+    def test_spoiler_multiple_in_one_message(self):
+        text, styles = _m2s("||a|| and ||b||")
+        assert text == "a and b"
+        spoilers = _find_style(styles, "SPOILER")
+        assert len(spoilers) == 2
+
+    def test_single_pipe_not_spoiler(self):
+        # Pipe tables and math notation must not trip the spoiler pattern.
+        text, styles = _m2s("5 | 3 | 2")
+        assert text == "5 | 3 | 2"
+        assert _find_style(styles, "SPOILER") == []
+
+    def test_spoiler_with_other_styles(self):
+        text, styles = _m2s("**bold** ||hidden|| `code`")
+        assert text == "bold hidden code"
+        types = _style_types(styles)
+        assert "BOLD" in types
+        assert "SPOILER" in types
+        assert "MONOSPACE" in types
+
 
 # ===========================================================================
 # Italic false-positive regressions


### PR DESCRIPTION
## What does this PR do?

Closes the explicit TODO in `_markdown_to_signal`'s docstring ("Signal's SPOILER
style is not currently mapped — no standard markdown syntax for it; would need
``||spoiler||`` parsing.") by adding the missing pattern, and replaces the stale
`PLATFORM_HINTS["signal"]` text ("Please do not use markdown as it does not
render") with an accurate description of what `_markdown_to_signal` actually
supports.

**Before this PR:**
- `||x||` in agent output passes through as literal `||x||`, even though
  signal-cli's wire format supports SPOILER.
- The platform hint tells the model not to emit markdown, but
  `_markdown_to_signal` always ran on outbound text. The hint's only effect was
  the model emitting literal asterisks (e.g. `\*bold\*`) or wrong marker counts
  (e.g. `*x*` for bold-not-italic).

**After this PR:**
- `||x||` renders as a SPOILER bodyRange on a real Signal client.
- The platform hint accurately lists what's supported (`**bold**`, `*italic*`,
  `~~strikethrough~~`, `||spoiler||`, `` `inline code` ``,
  ` ```code blocks``` `, `## headers`) and what isn't (link syntax, underline,
  table syntax).

## Related Issue

(none filed; this closes the explicit `||spoiler||` TODO at `gateway/platforms/signal.py:828-829`)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/signal.py`: Add `(re.compile(r"\|\|(.+?)\|\|", re.DOTALL), "SPOILER")` to `_markdown_to_signal`'s `_PATTERNS` list immediately after STRIKETHROUGH (so it wins position-ties over MONOSPACE/ITALIC per the existing earlier-pattern precedence). Update docstring to list SPOILER as supported.
- `agent/prompt_builder.py`: Replace `PLATFORM_HINTS["signal"]`'s "Please do not use markdown" line with the actually-supported dialect — modeled on the existing `"telegram"` hint. Calls out unsupported things explicitly so the model doesn't waste tokens on them.
- `tests/gateway/test_signal_format.py`: 7 new test cases covering SPOILER conversion (basic, offset correctness, multi-word, multiple-in-one, single-pipe-not-confused, combined-with-other-styles).
- `tests/agent/test_prompt_builder.py`: 1 added assertion to `test_platform_hints_known_platforms` (signal in dict), 2 new tests (positive assertions + regression guard against the stale claim).

## How to Test

```
pytest tests/gateway/test_signal_format.py tests/agent/test_prompt_builder.py \
       tests/gateway/test_signal.py tests/gateway/test_signal_rate_limit.py \
       -q -o 'addopts='
# 314 passed
```

Manual verification (requires a running signal-cli daemon and a real Signal receiver):
1. Send `||spoiler text||` from the agent. The receiver's Signal client renders it as tap-to-reveal.
2. Send `` **bold** *italic* ~~strike~~ ||hidden|| `code` ``; all five render in their respective styles.

## Verification

SPOILER is part of signal-cli's public textStyle API — see
[`TextStyle.java`](https://github.com/AsamK/signal-cli/blob/master/lib/src/main/java/org/asamk/signal/manager/api/TextStyle.java)
(enum values `BOLD, ITALIC, SPOILER, STRIKETHROUGH, MONOSPACE`) and
[`man/signal-cli.1.adoc`](https://github.com/AsamK/signal-cli/blob/master/man/signal-cli.1.adoc)
(`--text-style "start:length:STYLE"` where STYLE is one of those five).
The bodyRange wire format `"0:6:SPOILER"` matches the `start:length:STYLE` shape
`_markdown_to_signal` already emits for the four existing styles, so no other
wire-level changes are required.

The `||spoiler||` markdown syntax matches the convention already documented in
`PLATFORM_HINTS["telegram"]`, so the model doesn't have to learn a new syntax
per platform.

Verified end-to-end on a production Signal deployment.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant pytest scope and all 314 tests pass
- [x] I've added tests for my changes (9 new: 7 SPOILER + 2 hint)
- [x] I've tested on my platform: Linux (Debian 13 trixie, Python 3.13.5), signal-cli 0.14.4.1

### Documentation & Housekeeping
- [x] `_markdown_to_signal` docstring updated to list SPOILER as supported
- [x] `cli-config.yaml.example` — N/A (no config changes)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — signal-cli runs on Linux/macOS/Windows; conversion is pure Python regex, no platform-specific paths
- [x] Tool descriptions/schemas — N/A

### Authorship
Drafted with AI assistance; reviewed, tested, and verified end-to-end on a production Signal deployment by Vinay Bikkina (@vb3). Issues with this PR are mine, not the tool's.
