### PR TITLE
fix(docker): skip redundant s6 user drop

### DIFF
--- a/docker/cont-init.d/02-reconcile-profiles
+++ b/docker/cont-init.d/02-reconcile-profiles
@@ -24,6 +24,9 @@
 # and swallows the failure).
 set -e
 
+# shellcheck disable=SC1091
+. /opt/hermes/docker/run-as-hermes.sh
+
 # Make the dynamic scandir hermes-writable. The directory itself
 # starts root-owned by s6-overlay.
 chown hermes:hermes /run/service 2>/dev/null || true
@@ -42,5 +45,4 @@ if [ -d /run/service/.s6-svscan ]; then
     done
 fi
 
-exec s6-setuidgid hermes /opt/hermes/.venv/bin/python -m hermes_cli.container_boot
-
+exec_as_hermes /opt/hermes/.venv/bin/python -m hermes_cli.container_boot

--- a/docker/main-wrapper.sh
+++ b/docker/main-wrapper.sh
@@ -16,9 +16,12 @@
 #   first arg is an executable    → exec it directly (sleep, bash, sh, …)
 #   first arg is anything else    → exec `hermes <args>` (subcommand passthrough)
 #
-# We drop to the hermes user via `s6-setuidgid` so the supervised
-# workload runs unprivileged (UID 10000 by default).
+# We drop to the hermes user when needed so the supervised workload runs
+# unprivileged (UID 10000 by default).
 set -e
+
+# shellcheck disable=SC1091
+. /opt/hermes/docker/run-as-hermes.sh
 
 # HOME comes through with-contenv as /root (the /init context). Override
 # to the hermes user's home before dropping privileges so libraries that
@@ -31,13 +34,13 @@ cd /opt/data
 . /opt/hermes/.venv/bin/activate
 
 if [ $# -eq 0 ]; then
-    exec s6-setuidgid hermes hermes
+    exec_as_hermes hermes
 fi
 
 if command -v "$1" >/dev/null 2>&1; then
     # Bare executable — pass through directly.
-    exec s6-setuidgid hermes "$@"
+    exec_as_hermes "$@"
 fi
 
 # Hermes subcommand pass-through.
-exec s6-setuidgid hermes hermes "$@"
+exec_as_hermes hermes "$@"

--- a/docker/run-as-hermes.sh
+++ b/docker/run-as-hermes.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Helpers for running commands as the container's hermes user.
+#
+# s6-setuidgid is only safe when the caller has enough privilege to rebuild
+# the supplementary group list. If Docker already started the container as the
+# hermes UID (for example with compose `user: "10000:10000"` plus group_add),
+# calling s6-setuidgid again fails with "unable to set supplementary group
+# list". In that case the process is already at the target UID, so run the
+# command directly and preserve Docker's injected groups.
+
+_hermes_current_uid() {
+    id -u 2>/dev/null
+}
+
+_hermes_target_uid() {
+    id -u hermes 2>/dev/null
+}
+
+_hermes_already_target_user() {
+    current_uid="$(_hermes_current_uid || true)"
+    target_uid="$(_hermes_target_uid || true)"
+    [ -n "$current_uid" ] && [ -n "$target_uid" ] && [ "$current_uid" = "$target_uid" ]
+}
+
+run_as_hermes() {
+    if _hermes_already_target_user; then
+        "$@"
+    else
+        s6-setuidgid hermes "$@"
+    fi
+}
+
+exec_as_hermes() {
+    if _hermes_already_target_user; then
+        exec "$@"
+    else
+        exec s6-setuidgid hermes "$@"
+    fi
+}

--- a/docker/s6-rc.d/dashboard/run
+++ b/docker/s6-rc.d/dashboard/run
@@ -19,6 +19,9 @@ case "${HERMES_DASHBOARD:-}" in
         ;;
 esac
 
+# shellcheck disable=SC1091
+. /opt/hermes/docker/run-as-hermes.sh
+
 # with-contenv repopulates HOME from /init as /root. Reset it before
 # dropping privileges so HOME-anchored state lands under /opt/data.
 export HOME=/opt/data
@@ -48,5 +51,5 @@ case "${HERMES_DASHBOARD_INSECURE:-}" in
 esac
 
 # shellcheck disable=SC2086  # word-splitting of $insecure is intentional
-exec s6-setuidgid hermes hermes dashboard \
+exec_as_hermes hermes dashboard \
     --host "$dash_host" --port "$dash_port" --no-open $insecure

--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -20,10 +20,13 @@ set -eu
 HERMES_HOME="${HERMES_HOME:-/opt/data}"
 INSTALL_DIR="/opt/hermes"
 
+# shellcheck disable=SC1091
+. "$INSTALL_DIR/docker/run-as-hermes.sh"
+
 # --- Bootstrap HERMES_HOME as root ---
 # Create the directory (and any missing parents) while we still have root
 # privileges so the chown checks below see real metadata and the later
-# `s6-setuidgid hermes mkdir -p` block doesn't EACCES on root-owned
+# hermes-user `mkdir -p` block doesn't EACCES on root-owned
 # ancestors. Without this, custom HERMES_HOME paths whose parents only
 # root can create (e.g. `HERMES_HOME=/home/hermes/.hermes` in a Compose
 # file, or any path under a fresh / not pre-populated by the image)
@@ -187,13 +190,13 @@ if [ -f "$HERMES_HOME/config.yaml" ]; then
 fi
 
 # --- Seed directory structure as hermes user ---
-# Run as hermes via s6-setuidgid so dirs end up owned correctly (matters
-# under rootless Podman where chown back to root would fail).
+# Run as hermes so dirs end up owned correctly (matters under rootless Podman
+# where chown back to root would fail).
 #
 # Use direct `mkdir -p` invocation (no `sh -c "..."` wrapper) so the
 # shell isn't a second interpreter — defends against $HERMES_HOME values
 # containing shell metacharacters. PR #30136 review item O2.
-s6-setuidgid hermes mkdir -p \
+run_as_hermes mkdir -p \
     "$HERMES_HOME/cron" \
     "$HERMES_HOME/sessions" \
     "$HERMES_HOME/logs" \
@@ -208,9 +211,9 @@ s6-setuidgid hermes mkdir -p \
 # --- Install-method stamp (read by detect_install_method() in hermes status) ---
 # Preserved from the tini-era entrypoint (PR #27843). Must be written as
 # the hermes user so ownership matches the file's documented owner.
-# tee is invoked directly via s6-setuidgid (no `sh -c` wrapper) for the
+# tee is invoked directly through run_as_hermes (no `sh -c` wrapper) for the
 # same shell-metacharacter safety described above.
-printf 'docker\n' | s6-setuidgid hermes tee "$HERMES_HOME/.install_method" >/dev/null \
+printf 'docker\n' | run_as_hermes tee "$HERMES_HOME/.install_method" >/dev/null \
     || true
 
 # --- Seed config files (only on first boot) ---
@@ -218,7 +221,7 @@ seed_one() {
     dest=$1
     src=$2
     if [ ! -f "$HERMES_HOME/$dest" ] && [ -f "$INSTALL_DIR/$src" ]; then
-        s6-setuidgid hermes cp "$INSTALL_DIR/$src" "$HERMES_HOME/$dest"
+        run_as_hermes cp "$INSTALL_DIR/$src" "$HERMES_HOME/$dest"
     fi
 }
 seed_one ".env" ".env.example"
@@ -249,7 +252,7 @@ fi
 # the python binary's own bin-stub already sets up (sys.path is rooted
 # at the venv's site-packages by virtue of running .venv/bin/python).
 if [ -d "$INSTALL_DIR/skills" ]; then
-    s6-setuidgid hermes "$INSTALL_DIR/.venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" \
+    run_as_hermes "$INSTALL_DIR/.venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" \
         || echo "[stage2] Warning: skills_sync.py failed; continuing"
 fi
 

--- a/tests/tools/test_docker_run_as_hermes.py
+++ b/tests/tools/test_docker_run_as_hermes.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELPER = REPO_ROOT / "docker" / "run-as-hermes.sh"
+
+
+def _run_shell(script: str, *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["sh", "-eu", "-c", script],
+        cwd=REPO_ROOT,
+        env={"PATH": os.environ.get("PATH", "")} | (env or {}),
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_run_as_hermes_bypasses_s6_when_already_target_uid() -> None:
+    script = f"""
+    . "{HELPER}"
+    id() {{
+        if [ "$1" = "-u" ] && [ "$#" -eq 1 ]; then
+            printf '10000\\n'
+            return 0
+        fi
+        if [ "$1" = "-u" ] && [ "${{2:-}}" = "hermes" ]; then
+            printf '10000\\n'
+            return 0
+        fi
+        return 1
+    }}
+    run_as_hermes printf 'direct\\n'
+    """
+    proc = _run_shell(script)
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == "direct\n"
+
+
+def test_run_as_hermes_uses_s6_when_not_target_uid(tmp_path: Path) -> None:
+    s6 = tmp_path / "s6-setuidgid"
+    s6.write_text("#!/bin/sh\nprintf 's6:%s:%s\\n' \"$1\" \"$2\"\n")
+    s6.chmod(0o755)
+
+    script = f"""
+    . "{HELPER}"
+    id() {{
+        if [ "$1" = "-u" ] && [ "$#" -eq 1 ]; then
+            printf '0\\n'
+            return 0
+        fi
+        if [ "$1" = "-u" ] && [ "${{2:-}}" = "hermes" ]; then
+            printf '10000\\n'
+            return 0
+        fi
+        return 1
+    }}
+    run_as_hermes printf 'dropped\\n'
+    """
+    proc = _run_shell(script, env={"PATH": f"{tmp_path}:{os.environ.get('PATH', '')}"})
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == "s6:hermes:printf\n"
+
+
+@pytest.mark.parametrize(
+    ("path", "helper_call"),
+    [
+        ("docker/stage2-hook.sh", "run_as_hermes"),
+        ("docker/main-wrapper.sh", "exec_as_hermes"),
+        ("docker/s6-rc.d/dashboard/run", "exec_as_hermes"),
+        ("docker/cont-init.d/02-reconcile-profiles", "exec_as_hermes"),
+    ],
+)
+def test_container_scripts_use_hermes_drop_helper(path: str, helper_call: str) -> None:
+    text = (REPO_ROOT / path).read_text()
+
+    assert "run-as-hermes.sh" in text
+    assert helper_call in text


### PR DESCRIPTION
## What does this PR do?

Fixes a Docker image regression where containers started directly as the Hermes UID, for example with Compose `user: "10000:10000"` plus `group_add` for `/var/run/docker.sock`, could hit an s6-overlay restart loop:

`s6-applyuidgid: fatal: unable to set supplementary group list: Operation not permitted`

The Docker scripts now use a shared `run-as-hermes.sh` helper. It keeps the existing `s6-setuidgid hermes` behavior when the process is privileged, but bypasses that extra user/group reset when the current process is already running as the Hermes UID. That preserves Docker-injected supplementary groups and avoids the failing redundant privilege drop.

## Related Issue

Fixes #34648

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `docker/run-as-hermes.sh` with `run_as_hermes` and `exec_as_hermes` helpers.
- Updated `docker/stage2-hook.sh` to use `run_as_hermes` for boot-time Hermes-owned file/directory setup.
- Updated `docker/main-wrapper.sh`, `docker/s6-rc.d/dashboard/run`, and `docker/cont-init.d/02-reconcile-profiles` to use `exec_as_hermes` instead of unconditionally invoking `s6-setuidgid hermes`.
- Added `tests/tools/test_docker_run_as_hermes.py` to cover the already-Hermes UID bypass, the privileged s6 path, and script wiring.

## How to Test

1. Run `git diff --check`.
2. Run `sh -n docker/run-as-hermes.sh docker/stage2-hook.sh docker/main-wrapper.sh docker/s6-rc.d/dashboard/run docker/cont-init.d/02-reconcile-profiles`.
3. Run `uv run --with pytest --with pytest-timeout pytest tests/tools/test_docker_run_as_hermes.py tests/tools/test_stage2_hook_puid_pgid.py -q`.
4. Run `scripts/run_tests.sh tests/tools/test_docker_run_as_hermes.py tests/tools/test_stage2_hook_puid_pgid.py`.
5. For manual container validation, start the image with `user: "10000:10000"`, `group_add` containing the Docker socket GID, and `/var/run/docker.sock:/var/run/docker.sock`; startup should no longer fail with the s6 supplementary-group error.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation run locally:

- `git diff --check` passed
- `sh -n docker/run-as-hermes.sh docker/stage2-hook.sh docker/main-wrapper.sh docker/s6-rc.d/dashboard/run docker/cont-init.d/02-reconcile-profiles` passed
- `uv run --with pytest --with pytest-timeout pytest tests/tools/test_docker_run_as_hermes.py tests/tools/test_stage2_hook_puid_pgid.py -q` -> 10 passed
- `scripts/run_tests.sh tests/tools/test_docker_run_as_hermes.py tests/tools/test_stage2_hook_puid_pgid.py` -> 10 tests passed, 0 failed

Full `pytest tests/ -q` was not run for this PR. Live Docker boot validation was also not run locally because Docker is installed but the daemon is unavailable on this machine: `Cannot connect to the Docker daemon at unix:///Users/danyraihan/.orbstack/run/docker.sock`.
