### PR TITLE
fix(nix): drop stale 'vercel' extra from #full package

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -43,7 +43,6 @@
             "modal"
             "parallel-web"
             "tts-premium"
-            "vercel"
             "voice"
           ] ++ lib.optionals pkgs.stdenv.isLinux [ "matrix" ];
         };


### PR DESCRIPTION
## Summary

`nix develop` / direnv currently fails to evaluate the flake with:

```
error: Extra/group name 'vercel' does not match either extra or dependency group
```

**Cause:** the `vercel` optional-dependency was removed from `pyproject.toml` in febc4cfec ("remove Vercel AI Gateway and Vercel Sandbox", #33067), but `nix/packages.nix` still lists `"vercel"` in the `full` package's `extraDependencyGroups`. Since the dev shell pulls in every package via `inputsFrom = builtins.attrValues self'.packages` (`nix/devShell.nix`), uv2nix validates `full`'s extras on every shell load and aborts on the now-nonexistent `vercel` extra.

This breaks the dev shell for everyone on the flake (NixOS / `nix develop` / direnv).

**Fix:** remove the dangling `"vercel"` entry. `#full` no longer advertises the removed Vercel integration, and no other `.nix` file references it.

## Test plan
- [ ] `nix eval .#devShells.x86_64-linux.default.name` succeeds (errored before on the `vercel` extra)
- [ ] `nix develop` / direnv loads the dev shell
- [ ] `nix build .#full` evaluates