### PR TITLE
fix(sessiondb): serialize sqlite state writes

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -16,22 +16,106 @@ Key design decisions:
 
 import json
 import logging
+import os
 import random
 import re
 import sqlite3
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
 
 from agent.memory_manager import sanitize_context
 from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
+try:  # pragma: no cover - Windows fallback exercised by absence of fcntl
+    import fcntl
+except Exception:  # pragma: no cover
+    fcntl = None  # type: ignore[assignment]
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+
+_STATE_DB_WRITE_LOCKS: Dict[str, threading.RLock] = {}
+_STATE_DB_WRITE_LOCKS_GUARD = threading.Lock()
+_STATE_DB_WRITE_LOCK_TIMEOUT_S = 30.0
+
+
+def _state_db_lock_key(db_path: Path) -> str:
+    """Return a stable key for all SessionDB instances targeting one file."""
+    try:
+        return str(Path(db_path).expanduser().resolve(strict=False))
+    except Exception:
+        return str(Path(db_path).expanduser().absolute())
+
+
+def _state_db_process_lock(db_path: Path) -> threading.RLock:
+    """Shared per-process lock keyed by resolved database path."""
+    key = _state_db_lock_key(db_path)
+    with _STATE_DB_WRITE_LOCKS_GUARD:
+        lock = _STATE_DB_WRITE_LOCKS.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _STATE_DB_WRITE_LOCKS[key] = lock
+        return lock
+
+
+def _state_db_write_lock_timeout() -> float:
+    raw = os.getenv("HERMES_STATE_DB_WRITE_LOCK_TIMEOUT", "")
+    if raw:
+        try:
+            return max(1.0, float(raw))
+        except ValueError:
+            pass
+    return _STATE_DB_WRITE_LOCK_TIMEOUT_S
+
+
+@contextmanager
+def _coordinated_state_db_write_lock(db_path: Path):
+    """Serialize state.db writers before they contend for SQLite's WAL lock.
+
+    SQLite WAL still has a single-writer bottleneck. Hermes creates many
+    SessionDB instances inside the gateway/API process and can also have CLI,
+    cron, and worker processes writing the same state.db. Instance-local locks
+    do not coordinate those writers, so they can all hit BEGIN IMMEDIATE at
+    once and surface intermittent ``database is locked`` warnings.
+
+    This outer guard queues writers by resolved DB path: first with a shared
+    process-local RLock, then (when available) with a best-effort filesystem
+    flock so separate processes also serialize before entering SQLite.
+    """
+    process_lock = _state_db_process_lock(db_path)
+    lock_path = Path(_state_db_lock_key(db_path) + ".write.lock")
+    with process_lock:
+        if fcntl is None:
+            yield
+            return
+
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        timeout = _state_db_write_lock_timeout()
+        deadline = time.monotonic() + timeout
+        with open(lock_path, "a", encoding="utf-8") as lock_fd:
+            while True:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except BlockingIOError as exc:
+                    if time.monotonic() >= deadline:
+                        raise sqlite3.OperationalError(
+                            f"state.db write lock timed out after {timeout:.1f}s"
+                        ) from exc
+                    time.sleep(0.05)
+            try:
+                yield
+            finally:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                except OSError:
+                    pass
 
 SCHEMA_VERSION = 14
 
@@ -395,10 +479,15 @@ class SessionDB:
                 isolation_level=None,
             )
             self._conn.row_factory = sqlite3.Row
-            apply_wal_with_fallback(self._conn, db_label="state.db")
-            self._conn.execute("PRAGMA foreign_keys=ON")
 
-            self._init_schema()
+            # WAL negotiation and schema creation/reconciliation can acquire
+            # SQLite write locks during SessionDB() construction. Coordinate
+            # the full startup write path so a burst of gateway/API/cron
+            # instances does not race through PRAGMA journal_mode or DDL.
+            with _coordinated_state_db_write_lock(self.db_path):
+                apply_wal_with_fallback(self._conn, db_label="state.db")
+                self._conn.execute("PRAGMA foreign_keys=ON")
+                self._init_schema()
         except Exception as exc:
             # Capture the cause so /resume and friends can surface WHY the
             # session DB is unavailable instead of a bare "Session database
@@ -433,37 +522,41 @@ class SessionDB:
         Returns whatever *fn* returns.
         """
         last_err: Optional[Exception] = None
-        for attempt in range(self._WRITE_MAX_RETRIES):
-            try:
-                with self._lock:
-                    self._conn.execute("BEGIN IMMEDIATE")
-                    try:
-                        result = fn(self._conn)
-                        self._conn.commit()
-                    except BaseException:
+        with _coordinated_state_db_write_lock(self.db_path):
+            for attempt in range(self._WRITE_MAX_RETRIES):
+                try:
+                    with self._lock:
+                        conn = self._conn
+                        if conn is None:
+                            raise sqlite3.OperationalError("SessionDB connection is closed")
+                        conn.execute("BEGIN IMMEDIATE")
                         try:
-                            self._conn.rollback()
-                        except Exception:
-                            pass
-                        raise
-                # Success — periodic best-effort checkpoint.
-                self._write_count += 1
-                if self._write_count % self._CHECKPOINT_EVERY_N_WRITES == 0:
-                    self._try_wal_checkpoint()
-                return result
-            except sqlite3.OperationalError as exc:
-                err_msg = str(exc).lower()
-                if "locked" in err_msg or "busy" in err_msg:
-                    last_err = exc
-                    if attempt < self._WRITE_MAX_RETRIES - 1:
-                        jitter = random.uniform(
-                            self._WRITE_RETRY_MIN_S,
-                            self._WRITE_RETRY_MAX_S,
-                        )
-                        time.sleep(jitter)
-                        continue
-                # Non-lock error or retries exhausted — propagate.
-                raise
+                            result = fn(conn)
+                            conn.commit()
+                        except BaseException:
+                            try:
+                                conn.rollback()
+                            except Exception:
+                                pass
+                            raise
+                    # Success — periodic best-effort checkpoint.
+                    self._write_count += 1
+                    if self._write_count % self._CHECKPOINT_EVERY_N_WRITES == 0:
+                        self._try_wal_checkpoint()
+                    return result
+                except sqlite3.OperationalError as exc:
+                    err_msg = str(exc).lower()
+                    if "locked" in err_msg or "busy" in err_msg:
+                        last_err = exc
+                        if attempt < self._WRITE_MAX_RETRIES - 1:
+                            jitter = random.uniform(
+                                self._WRITE_RETRY_MIN_S,
+                                self._WRITE_RETRY_MAX_S,
+                            )
+                            time.sleep(jitter)
+                            continue
+                    # Non-lock error or retries exhausted — propagate.
+                    raise
         # Retries exhausted (shouldn't normally reach here).
         raise last_err or sqlite3.OperationalError(
             "database is locked after max retries"
@@ -3313,9 +3406,9 @@ class SessionDB:
 
         VACUUM rewrites the entire DB, so it's expensive (seconds per
         100MB) and cannot run inside a transaction. It also acquires an
-        exclusive lock, so callers must ensure no other writers are
-        active. Safe to call at startup before the gateway/CLI starts
-        serving traffic.
+        exclusive lock; this method coordinates with normal SessionDB writers
+        before running it, but callers should still prefer startup/quiet
+        windows because readers may be delayed.
 
         FTS5 segments are merged first via :meth:`optimize_fts` so the
         subsequent VACUUM reclaims the pages freed by the merge. This is a
@@ -3332,13 +3425,17 @@ class SessionDB:
         except Exception as exc:
             logger.warning("FTS optimize before VACUUM failed: %s", exc)
         # VACUUM cannot be executed inside a transaction.
-        with self._lock:
-            # Best-effort WAL checkpoint first, then VACUUM.
-            try:
-                self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-            except Exception:
-                pass
-            self._conn.execute("VACUUM")
+        with _coordinated_state_db_write_lock(self.db_path):
+            with self._lock:
+                conn = self._conn
+                if conn is None:
+                    raise sqlite3.OperationalError("SessionDB connection is closed")
+                # Best-effort WAL checkpoint first, then VACUUM.
+                try:
+                    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                except Exception:
+                    pass
+                conn.execute("VACUUM")
         return optimized
 
     def maybe_auto_prune_and_vacuum(

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,9 +1,60 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from pathlib import Path
 import time
 import pytest
 
-from hermes_state import SessionDB
+from hermes_state import SessionDB, _state_db_process_lock
+
+
+def _append_messages_in_child_process(args):
+    """ProcessPool helper for state.db cross-process contention tests."""
+    db_path, session_id, worker_id, count = args
+    local = SessionDB(db_path=Path(db_path))
+    try:
+        for i in range(count):
+            local.append_message(
+                session_id,
+                role="user",
+                content=f"worker {worker_id} message {i}",
+            )
+    finally:
+        local.close()
+    return count
+
+
+def _hold_write_transaction_in_child_process(args):
+    """Hold a SessionDB write transaction open from a separate process."""
+    db_path, session_id, marker_path, hold_seconds = args
+    local = SessionDB(db_path=Path(db_path))
+    try:
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET title = title WHERE id = ?",
+                (session_id,),
+            )
+            Path(marker_path).write_text("locked", encoding="utf-8")
+            time.sleep(hold_seconds)
+
+        local._execute_write(_do)
+    finally:
+        local.close()
+    return True
+
+
+def _append_message_with_one_sqlite_attempt(args):
+    """Append from a child process with SQLite retry deliberately minimized."""
+    db_path, session_id = args
+    # This makes the regression deterministic against the old behavior: without
+    # the outer cross-process file lock, this process burns its single SQLite
+    # BEGIN IMMEDIATE attempt while the other process holds the write txn.
+    setattr(SessionDB, "_WRITE_MAX_RETRIES", 1)
+    local = SessionDB(db_path=Path(db_path))
+    try:
+        return local.append_message(session_id, role="user", content="after wait")
+    finally:
+        local.close()
 
 
 @pytest.fixture()
@@ -20,6 +71,117 @@ def db(tmp_path):
 # =========================================================================
 
 class TestSessionLifecycle:
+    def test_sessiondb_instances_share_process_write_lock_for_same_path(self, tmp_path):
+        db_path = tmp_path / "test_state.db"
+        a = db_path
+        b = tmp_path / "." / "test_state.db"
+
+        assert _state_db_process_lock(a) is _state_db_process_lock(b)
+
+    def test_many_sessiondb_instances_write_concurrently_without_lock_errors(self, tmp_path):
+        db_path = tmp_path / "test_state.db"
+        seed = SessionDB(db_path=db_path)
+        seed.create_session(session_id="s1", source="test")
+        seed.close()
+
+        def write_message(i: int) -> None:
+            local = SessionDB(db_path=db_path)
+            try:
+                local.append_message("s1", role="user", content=f"msg {i}")
+            finally:
+                local.close()
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(write_message, range(32)))
+
+        verify = SessionDB(db_path=db_path)
+        try:
+            assert len(verify.get_messages("s1")) == 32
+        finally:
+            verify.close()
+
+    def test_many_processes_write_concurrently_without_lock_errors(self, tmp_path):
+        """SessionDB coordinates independent processes writing one state.db.
+
+        Gateway/API, cron, CLI, and workers are separate processes that can all
+        create their own SessionDB instances for the same database. The
+        regression here exercises the same shape: independent connections in
+        different processes concurrently appending session messages. Every
+        append must land exactly once, without surfacing sqlite busy/locked
+        errors to the caller.
+        """
+        db_path = tmp_path / "test_state.db"
+        session_id = "s1"
+        workers = 6
+        messages_per_worker = 12
+
+        seed = SessionDB(db_path=db_path)
+        try:
+            seed.create_session(session_id=session_id, source="test")
+        finally:
+            seed.close()
+
+        with ProcessPoolExecutor(max_workers=workers) as pool:
+            futures = [
+                pool.submit(
+                    _append_messages_in_child_process,
+                    (str(db_path), session_id, worker_id, messages_per_worker),
+                )
+                for worker_id in range(workers)
+            ]
+            assert sum(f.result(timeout=20) for f in as_completed(futures)) == (
+                workers * messages_per_worker
+            )
+
+        verify = SessionDB(db_path=db_path)
+        try:
+            assert len(verify.get_messages(session_id)) == workers * messages_per_worker
+        finally:
+            verify.close()
+
+    def test_process_writer_waits_on_outer_lock_before_sqlite_busy_timeout(self, tmp_path):
+        """A contending process queues outside SQLite instead of surfacing BUSY.
+
+        This is the production failure mode: two independent Hermes processes
+        target one state.db. Before the outer DB-path lock, process B consumed
+        SQLite's short busy timeout while process A held BEGIN IMMEDIATE, so
+        callers saw ``database is locked`` and dropped session trace writes.
+        """
+        db_path = tmp_path / "test_state.db"
+        marker_path = tmp_path / "holder-started.txt"
+        session_id = "s1"
+
+        seed = SessionDB(db_path=db_path)
+        try:
+            seed.create_session(session_id=session_id, source="test")
+        finally:
+            seed.close()
+
+        with ProcessPoolExecutor(max_workers=2) as pool:
+            holder = pool.submit(
+                _hold_write_transaction_in_child_process,
+                (str(db_path), session_id, str(marker_path), 2.0),
+            )
+            deadline = time.monotonic() + 5.0
+            while not marker_path.exists():
+                assert time.monotonic() < deadline
+                time.sleep(0.02)
+
+            append = pool.submit(
+                _append_message_with_one_sqlite_attempt,
+                (str(db_path), session_id),
+            )
+
+            assert append.result(timeout=10) > 0
+            assert holder.result(timeout=10) is True
+
+        verify = SessionDB(db_path=db_path)
+        try:
+            messages = verify.get_messages(session_id)
+        finally:
+            verify.close()
+        assert [m["content"] for m in messages] == ["after wait"]
+
     def test_create_and_get_session(self, db):
         sid = db.create_session(
             session_id="s1",


### PR DESCRIPTION
## Summary
- Serialize SessionDB/state.db writers by resolved DB path before SQLite BEGIN IMMEDIATE.
- Coordinate WAL/schema initialization and VACUUM/checkpoint maintenance with the same guard.
- Add thread/process regression coverage for concurrent appends and lock-holder contention.

## Test plan
- uv run --extra dev python -m pytest tests/test_hermes_state.py -q -o 'addopts='
- uv run --extra dev python -m pytest tests/run_agent/test_compression_persistence.py tests/gateway/test_compression_session_id_persistence.py -q -o 'addopts='
- uv run --extra dev ruff check hermes_state.py tests/test_hermes_state.py
