### PR TITLE
fix(agent): parenthesize or-expression in personality preview truncation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7955,7 +7955,7 @@ class HermesCLI:
             print(f"  {'none':<12} - (no personality overlay)")
             for name, prompt in self.personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = str(prompt)[:50]
                 print(f"  {name:<12} - {preview}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10863,7 +10863,7 @@ class GatewayRunner:
             lines.append(t("gateway.personality.none_option"))
             for name, prompt in personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = prompt[:50] + "..." if len(prompt) > 50 else prompt
                 lines.append(t("gateway.personality.item", name=name, preview=preview))

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1586,7 +1586,7 @@ class SlashCommandCompleter(Completer):
             for name, prompt in personalities.items():
                 if name.startswith(sub_lower) and name != sub_lower:
                     if isinstance(prompt, dict):
-                        meta = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                        meta = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                     else:
                         meta = str(prompt)[:50]
                     yield Completion(


### PR DESCRIPTION
## Summary

Python's slice operator `[:N]` binds tighter than `or`, so `x or y[:50]` is parsed as `x or (y[:50])` — only truncating the fallback `y`, not the resolved value.

When a personality has a long `description` but no `system_prompt`, the preview string is returned untruncated, breaking display formatting in personality lists.

### Affected locations (3 files)

| File | Line | Context |
|------|------|--------|
| `gateway/run.py` | 10866 | `/personality` slash command in gateway |
| `cli.py` | 7958 | `/personality` in classic CLI |
| `hermes_cli/commands.py` | 1589 | Personality autocomplete |

### Fix

```python
# Before (only truncates system_prompt fallback):
preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]

# After (truncates the resolved value):
preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
```

### Same pattern

This is the same operator-precedence bug fixed in:
- PR #20050 (original 3 locations)
- PR #32347 (cron job name)
- PR #32450 (error handler detail, 6 more locations)

These 3 personality-preview instances were missed in those earlier passes.