### PR TITLE
fix(agent): remove logging.basicConfig() from library __init__ methods

### DIFF
--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -195,11 +195,6 @@ class MiniSWERunner:
         self.cwd = cwd
         
         # Setup logging
-        logging.basicConfig(
-            level=logging.DEBUG if verbose else logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
         
         # Initialize LLM client via centralized provider router.

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -352,11 +352,6 @@ class TrajectoryCompressor:
         # Initialize OpenRouter client
         self._init_summarizer()
         
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
     
     def _init_tokenizer(self):


### PR DESCRIPTION
## Summary

`logging.basicConfig()` configures the **root logger**. When called from library code inside `__init__`, it hijacks the host application's logging configuration — overriding format, level, and handlers.

`basicConfig()` is a no-op after the first call, but if these classes are instantiated before the main app configures logging, they steal the root logger config.

### Affected locations

| File | Line | Class |
|------|------|-------|
| `mini_swe_runner.py` | 198 | `MiniSWERunner.__init__` |
| `trajectory_compressor.py` | 355 | `TrajectoryCompressor.__init__` |

### Fix

Remove `logging.basicConfig(...)` from both `__init__` methods. Keep only `self.logger = logging.getLogger(__name__)` — the entry point (`cli.py`, `gateway`) is responsible for root logger configuration.

### Same pattern

This is the same bug fixed in PR #29330 (3 files: `trajectory_compressor.py`, `mini_swe_runner.py`). These 2 instances survived that pass — possibly re-introduced or missed.