### PR TITLE
fix(gateway): guard chained .get() against None intermediate values

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1697,8 +1697,8 @@ class HermesACPAgent(acp.Agent):
                 return "No tools available."
             lines = [f"Available tools ({len(tools)}):"]
             for t in tools:
-                name = t.get("function", {}).get("name", "?")
-                desc = t.get("function", {}).get("description", "")
+                name = (t.get("function") or {}).get("name", "?")
+                desc = (t.get("function") or {}).get("description", "")
                 # Truncate long descriptions
                 if len(desc) > 80:
                     desc = desc[:77] + "..."

--- a/gateway/platforms/qqbot/onboard.py
+++ b/gateway/platforms/qqbot/onboard.py
@@ -100,7 +100,7 @@ def _create_bind_task(timeout: float = ONBOARD_API_TIMEOUT) -> Tuple[str, str]:
     if data.get("retcode") != 0:
         raise RuntimeError(data.get("msg", "create_bind_task failed"))
 
-    task_id = data.get("data", {}).get("task_id")
+    task_id = (data.get("data") or {}).get("task_id")
     if not task_id:
         raise RuntimeError("create_bind_task: missing task_id in response")
 

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2431,7 +2431,7 @@ class SlackAdapter(BasePlatformAdapter):
         original_text = ""
         for block in message.get("blocks", []):
             if block.get("type") == "section":
-                original_text = block.get("text", {}).get("text", "")
+                original_text = (block.get("text") or {}).get("text", "")
                 break
 
         updated_blocks = [
@@ -2532,7 +2532,7 @@ class SlackAdapter(BasePlatformAdapter):
         original_text = ""
         for block in message.get("blocks", []):
             if block.get("type") == "section":
-                original_text = block.get("text", {}).get("text", "")
+                original_text = (block.get("text") or {}).get("text", "")
                 break
 
         updated_blocks = [

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -2019,7 +2019,7 @@ class GroupAtGuardMiddleware(InboundMiddleware):
         for elem in msg_body:
             if elem.get("msg_type") != "TIMCustomElem":
                 continue
-            data_str = elem.get("msg_content", {}).get("data", "")
+            data_str = (elem.get("msg_content") or {}).get("data", "")
             if not data_str:
                 continue
             try:
@@ -2038,7 +2038,7 @@ class GroupAtGuardMiddleware(InboundMiddleware):
         for elem in msg_body:
             if elem.get("msg_type") != "TIMCustomElem":
                 continue
-            data_str = elem.get("msg_content", {}).get("data", "")
+            data_str = (elem.get("msg_content") or {}).get("data", "")
             if not data_str:
                 continue
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11626,7 +11626,7 @@ class GatewayRunner:
         has_agent_tts = any(
             msg.get("role") == "assistant"
             and any(
-                tc.get("function", {}).get("name") == "text_to_speech"
+                (tc.get("function") or {}).get("name") == "text_to_speech"
                 for tc in (msg.get("tool_calls") or [])
             )
             for msg in agent_messages

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3357,7 +3357,7 @@ def _(rid, params: dict) -> dict:
                 "error",
                 sid,
                 {
-                    "message": err.get("error", {}).get(
+                    "message": (err.get("error") or {}).get(
                         "message", "agent initialization failed"
                     )
                 },


### PR DESCRIPTION
## Summary

`.get("key", {})` only applies the default `{}` when the key is **absent** from the dict. When the key **exists** with value `None` (null in JSON/API responses), `.get()` returns `None` and the subsequent `.get()` raises `AttributeError`.

This is the same pattern documented in [Pitfall 28](https://github.com/NousResearch/hermes-agent) — `.get(key, default)` vs `.get(key) or default`.

### Fix

Replace `.get("key", {}).get(...)` with `(.get("key") or {}).get(...)` which handles both missing keys AND None values.

### Affected locations (8 instances, 6 files)

| File | Line | Context | Severity |
|------|------|---------|----------|
| `gateway/run.py` | 11629 | tool_call function name for TTS filter | Low-Med |
| `acp_adapter/server.py` | 1700-1701 | tool name/description extraction | Low-Med |
| `gateway/platforms/qqbot/onboard.py` | 103 | API response task_id extraction | Low-Med |
| `gateway/platforms/yuanbao.py` | 2022, 2041 | message content parsing (x2) | Low-Med |
| `gateway/platforms/slack.py` | 2434, 2535 | block text extraction (x2) | Low |
| `tui_gateway/server.py` | 3360 | error message extraction | Low |

### Impact

All instances involve parsing external API responses or tool call structures where null/None values are possible. The crash manifests as `AttributeError: 'NoneType' object has no attribute 'get'`.