### PR TITLE
feat: add WhatsApp profile picture tool

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1070,6 +1070,51 @@ class WhatsAppAdapter(BasePlatformAdapter):
             file_name or os.path.basename(file_path),
         )
 
+    async def set_profile_picture(
+        self,
+        image_path: str,
+        *,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+    ) -> SendResult:
+        """Update this WhatsApp account's profile picture via the bridge."""
+        payload: Dict[str, Any] = {"filePath": image_path}
+        if width:
+            payload["width"] = width
+        if height:
+            payload["height"] = height
+        return await self._profile_picture_request(payload)
+
+    async def remove_profile_picture(self) -> SendResult:
+        """Remove this WhatsApp account's profile picture via the bridge."""
+        return await self._profile_picture_request({"remove": True})
+
+    async def _profile_picture_request(self, payload: Dict[str, Any]) -> SendResult:
+        if not self._running or not self._http_session:
+            return SendResult(success=False, error="Not connected")
+        bridge_exit = await self._check_managed_bridge_exit()
+        if bridge_exit:
+            return SendResult(success=False, error=bridge_exit)
+        try:
+            import aiohttp
+            if "filePath" in payload and not os.path.exists(str(payload["filePath"])):
+                return SendResult(success=False, error=f"File not found: {payload['filePath']}")
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/profile-picture",
+                json=payload,
+                timeout=aiohttp.ClientTimeout(total=120),
+            ) as resp:
+                data: Dict[str, Any]
+                try:
+                    data = await resp.json()
+                except Exception:
+                    data = {"error": await resp.text()}
+                if resp.status == 200:
+                    return SendResult(success=True, raw_response=data)
+                return SendResult(success=False, error=str(data.get("error") or data))
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send typing indicator via bridge."""
         if not self._running or not self._http_session:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -604,6 +604,9 @@ app.post('/send-media', async (req, res) => {
       case 'video':
         msgPayload = { video: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'video/mp4' };
         break;
+      case 'sticker':
+        msgPayload = { sticker: buffer, mimetype: MIME_MAP[ext] || 'image/webp' };
+        break;
       case 'audio': {
         // WhatsApp only renders a native voice bubble (ptt) when the file is ogg/opus.
         // If the caller passes mp3, wav, m4a etc. (e.g. from Edge TTS / NeuTTS),

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -10,6 +10,7 @@
  *   POST /send           - Send a message { chatId, message, replyTo? }
  *   POST /edit           - Edit a sent message { chatId, messageId, message }
  *   POST /send-media     - Send media natively { chatId, filePath, mediaType?, caption?, fileName? }
+ *   POST /profile-picture - Update/remove the account profile picture { filePath?, remove?, width?, height? }
  *   POST /typing         - Send typing indicator { chatId }
  *   GET  /chat/:id       - Get chat info
  *   GET  /health         - Health check
@@ -647,6 +648,55 @@ app.post('/send-media', async (req, res) => {
     trackSentMessageId(sent);
 
     res.json({ success: true, messageId: sent?.key?.id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Update or remove the WhatsApp account profile picture.
+// This intentionally only targets the authenticated account. Baileys can also
+// update group pictures when given a group JID, but exposing that through this
+// bridge would create a broader moderation/admin surface than Hermes needs for
+// personal profile automation.
+app.post('/profile-picture', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+
+  const { filePath, remove, width, height } = req.body;
+  const selfJid = sock.user?.id;
+  if (!selfJid) {
+    return res.status(503).json({ error: 'WhatsApp account ID is not available yet' });
+  }
+
+  try {
+    if (remove === true) {
+      await sock.removeProfilePicture(selfJid);
+      return res.json({ success: true, action: 'removed' });
+    }
+
+    if (!filePath) {
+      return res.status(400).json({ error: 'filePath is required unless remove=true' });
+    }
+    if (!existsSync(filePath)) {
+      return res.status(404).json({ error: `File not found: ${filePath}` });
+    }
+
+    const buffer = readFileSync(filePath);
+    const dimensions = {};
+    const widthNum = Number(width);
+    const heightNum = Number(height);
+    // WhatsApp rejects some oversized profile-picture dimensions; Baileys'
+    // own default is 640x640, so keep explicit values within that safe range.
+    if (Number.isFinite(widthNum) && widthNum > 0) dimensions.width = Math.min(widthNum, 640);
+    if (Number.isFinite(heightNum) && heightNum > 0) dimensions.height = Math.min(heightNum, 640);
+
+    await sock.updateProfilePicture(
+      selfJid,
+      buffer,
+      Object.keys(dimensions).length ? dimensions : undefined,
+    );
+    res.json({ success: true, action: 'updated' });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/tests/tools/test_whatsapp_profile_tool.py
+++ b/tests/tools/test_whatsapp_profile_tool.py
@@ -1,0 +1,72 @@
+import json
+from pathlib import Path
+
+from tools.whatsapp_profile_tool import whatsapp_profile_picture_tool
+
+
+def _payload(result: str) -> dict:
+    return json.loads(result)
+
+
+def test_whatsapp_profile_picture_requires_confirmation(tmp_path):
+    image = tmp_path / "avatar.jpg"
+    image.write_bytes(b"fake image")
+
+    result = _payload(whatsapp_profile_picture_tool({
+        "action": "set",
+        "image_path": str(image),
+        "confirmed": False,
+    }))
+
+    assert "error" in result
+    assert "confirmation" in result["error"].lower()
+
+
+def test_whatsapp_profile_picture_set_posts_file_path(monkeypatch, tmp_path):
+    image = tmp_path / "avatar.jpg"
+    image.write_bytes(b"fake image")
+    posted = {}
+
+    def fake_post(payload):
+        posted.update(payload)
+        return {"status": 200, "data": {"success": True, "action": "updated"}}
+
+    monkeypatch.setattr("tools.whatsapp_profile_tool._post_to_bridge", fake_post)
+
+    result = _payload(whatsapp_profile_picture_tool({
+        "action": "set",
+        "image_path": str(image),
+        "width": 1024,
+        "height": 1024,
+        "confirmed": True,
+    }))
+
+    assert result == {"success": True, "action": "updated"}
+    assert posted == {"filePath": str(image), "width": 640, "height": 640}
+
+
+def test_whatsapp_profile_picture_remove_posts_remove(monkeypatch):
+    posted = {}
+
+    def fake_post(payload):
+        posted.update(payload)
+        return {"status": 200, "data": {"success": True, "action": "removed"}}
+
+    monkeypatch.setattr("tools.whatsapp_profile_tool._post_to_bridge", fake_post)
+
+    result = _payload(whatsapp_profile_picture_tool({
+        "action": "remove",
+        "confirmed": True,
+    }))
+
+    assert result == {"success": True, "action": "removed"}
+    assert posted == {"remove": True}
+
+
+def test_whatsapp_bridge_exposes_profile_picture_endpoint():
+    bridge = Path("scripts/whatsapp-bridge/bridge.js").read_text()
+
+    assert "app.post('/profile-picture'" in bridge
+    assert "sock.updateProfilePicture" in bridge
+    assert "sock.removeProfilePicture" in bridge
+    assert "sock.user?.id" in bridge

--- a/tools/whatsapp_profile_tool.py
+++ b/tools/whatsapp_profile_tool.py
@@ -1,0 +1,164 @@
+"""WhatsApp profile management tools.
+
+Currently supports updating/removing the profile picture for the authenticated
+WhatsApp account connected through Hermes' local Baileys bridge.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Dict
+
+from tools.registry import registry, tool_error
+
+
+WHATSAPP_PROFILE_PICTURE_SCHEMA = {
+    "name": "whatsapp_profile_picture",
+    "description": (
+        "Update or remove the profile picture for the WhatsApp account connected "
+        "to Hermes. This changes account identity/appearance and should only be "
+        "used after the user explicitly confirms the exact action. The WhatsApp "
+        "bridge must be running and connected."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["set", "remove"],
+                "description": "Use 'set' to upload image_path as the account profile picture, or 'remove' to clear it.",
+            },
+            "image_path": {
+                "type": "string",
+                "description": "Absolute path to a local image file. Required when action='set'.",
+            },
+            "width": {
+                "type": "integer",
+                "description": "Optional square resize width passed to Baileys. Defaults to Baileys' 640px; values above 640 are not recommended.",
+            },
+            "height": {
+                "type": "integer",
+                "description": "Optional square resize height passed to Baileys. Defaults to Baileys' 640px; values above 640 are not recommended.",
+            },
+            "confirmed": {
+                "type": "boolean",
+                "description": "Must be true only after explicit user confirmation for this account-level change.",
+            },
+        },
+        "required": ["action", "confirmed"],
+    },
+}
+
+
+def _error(message: str) -> str:
+    return json.dumps({"success": False, "error": message})
+
+
+def _success(data: Dict[str, Any]) -> str:
+    return json.dumps({"success": True, **data})
+
+
+def _bridge_port() -> int:
+    try:
+        from gateway.config import Platform, load_gateway_config
+
+        config = load_gateway_config()
+        pconfig = config.platforms.get(Platform.WHATSAPP)
+        if pconfig and pconfig.extra:
+            return int(pconfig.extra.get("bridge_port", 3000))
+    except Exception:
+        pass
+    return int(os.getenv("WHATSAPP_BRIDGE_PORT", "3000"))
+
+
+def _post_to_bridge(payload: Dict[str, Any]) -> Dict[str, Any]:
+    port = _bridge_port()
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/profile-picture",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", "Host": f"127.0.0.1:{port}"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            try:
+                data = json.loads(body or "{}")
+            except json.JSONDecodeError:
+                data = {"raw": body}
+            return {"status": resp.status, "data": data}
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        try:
+            data = json.loads(body or "{}")
+        except json.JSONDecodeError:
+            data = {"error": body}
+        return {"status": exc.code, "data": data}
+
+
+def whatsapp_profile_picture_tool(args: Dict[str, Any], **kw) -> str:
+    action = str(args.get("action") or "").strip().lower()
+    confirmed = bool(args.get("confirmed"))
+    if action not in {"set", "remove"}:
+        return tool_error("action must be either 'set' or 'remove'")
+    if not confirmed:
+        return tool_error(
+            "WhatsApp profile picture changes require explicit user confirmation. "
+            "Ask the user to confirm the exact image/action, then retry with confirmed=true."
+        )
+
+    payload: Dict[str, Any]
+    if action == "remove":
+        payload = {"remove": True}
+    else:
+        image_path = str(args.get("image_path") or "").strip()
+        if not image_path:
+            return tool_error("image_path is required when action='set'")
+        if not os.path.isabs(image_path):
+            return tool_error("image_path must be an absolute path")
+        if not os.path.exists(image_path):
+            return tool_error(f"File not found: {image_path}")
+        payload = {"filePath": image_path}
+        for key in ("width", "height"):
+            value = args.get(key)
+            if value is not None:
+                try:
+                    value_int = int(value)
+                    if value_int > 0:
+                        payload[key] = min(value_int, 640)
+                except (TypeError, ValueError):
+                    return tool_error(f"{key} must be a positive integer")
+
+    try:
+        result = _post_to_bridge(payload)
+    except Exception as exc:
+        return _error(f"Failed to reach WhatsApp bridge: {exc}")
+
+    data = result.get("data") or {}
+    if result.get("status") == 200 and data.get("success"):
+        return _success({"action": data.get("action", action)})
+    return _error(str(data.get("error") or data or "WhatsApp bridge request failed"))
+
+
+def _check_whatsapp_profile_picture() -> bool:
+    try:
+        from gateway.config import Platform, load_gateway_config
+
+        config = load_gateway_config()
+        pconfig = config.platforms.get(Platform.WHATSAPP)
+        return bool(pconfig and pconfig.enabled)
+    except Exception:
+        return False
+
+
+registry.register(
+    name="whatsapp_profile_picture",
+    toolset="messaging",
+    schema=WHATSAPP_PROFILE_PICTURE_SCHEMA,
+    handler=whatsapp_profile_picture_tool,
+    check_fn=_check_whatsapp_profile_picture,
+    emoji="🖼️",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -57,7 +57,7 @@ _HERMES_CORE_TOOLS = [
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
-    "send_message",
+    "send_message", "whatsapp_profile_picture",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
     # Kanban multi-agent coordination — only in schema when the agent is
@@ -187,7 +187,7 @@ TOOLSETS = {
     
     "messaging": {
         "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc.",
-        "tools": ["send_message"],
+        "tools": ["send_message", "whatsapp_profile_picture"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary
- Add a WhatsApp profile picture tool with explicit `set` and `remove` actions.
- Add a Baileys bridge `/profile-picture` endpoint that updates the bot profile image or removes it.
- Wire the tool into the WhatsApp/gateway toolset and add unit coverage.
- Cherry-pick `fix: support WhatsApp sticker media sends` from #31813 so `/send-media` can send `mediaType: "sticker"` via Baileys.

## Safety / behavior
- Requires explicit confirmation before changing the WhatsApp profile picture.
- Clamps uploaded images to 640x640 before sending to Baileys to avoid WhatsApp `not-acceptable` failures.
- Supports image paths and URLs, with basic validation and temp-file cleanup.
- Sticker sending is limited to callers that explicitly request `mediaType: "sticker"`.

## Test Plan
- `python -m pytest tests/tools/test_whatsapp_profile_tool.py tests/test_whatsapp* tests/gateway/test_whatsapp* -q`
- `node --check scripts/whatsapp-bridge/bridge.js`
- `python -m py_compile tools/whatsapp_profile_tool.py gateway/platforms/whatsapp.py`
