### PR TITLE
fix(discord): keep thread replies mention-free by default

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -842,7 +842,23 @@ class DiscordAdapter(BasePlatformAdapter):
                         _channel_ids = {_channel_id}
                         if _parent_id:
                             _channel_ids.add(_parent_id)
-                        if "*" not in _free_channels and not (_channel_ids & _free_channels):
+
+                        # When thread mention gating is disabled, any thread should
+                        # keep flowing without @mention. The later _handle_message
+                        # mention gate has the same thread exception; mirror it here
+                        # so this early multi-agent filter does not accidentally
+                        # re-require @mention inside threads.
+                        _thread_cls = getattr(discord, "Thread", None)
+                        _in_bot_thread = (
+                            _thread_cls is not None
+                            and isinstance(message.channel, _thread_cls)
+                            and not adapter_self._discord_thread_require_mention()
+                        )
+                        if (
+                            not _in_bot_thread
+                            and "*" not in _free_channels
+                            and not (_channel_ids & _free_channels)
+                        ):
                             return
 
                 await self._handle_message(message)
@@ -4571,7 +4587,6 @@ class DiscordAdapter(BasePlatformAdapter):
             # a thread.
             in_bot_thread = (
                 is_thread
-                and thread_id in self._threads
                 and not self._discord_thread_require_mention()
             )
 

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -448,19 +448,28 @@ async def test_discord_bot_thread_skips_mention_requirement(adapter, monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_discord_unknown_thread_still_requires_mention(adapter, monkeypatch):
-    """Messages in a thread the bot hasn't participated in should still require @mention."""
+async def test_discord_unknown_thread_skips_mention_requirement_by_default(adapter, monkeypatch):
+    """Default thread behavior should not require @mention, even before tracking.
+
+    Discord threads already scope the conversation. Requiring the thread to be
+    present in the persisted participation set makes legitimate replies brittle
+    after restarts or when Discord sends a thread message before local tracking
+    catches up.
+    """
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
     monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
 
-    # Bot has NOT participated in thread 789
+    # Bot has NOT participated in thread 789 yet.
     thread = FakeThread(channel_id=789, name="some thread")
     message = make_message(channel=thread, content="hello from unknown thread")
 
     await adapter._handle_message(message)
 
-    adapter.handle_message.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "hello from unknown thread"
+    assert event.source.chat_type == "thread"
 
 
 @pytest.mark.asyncio
@@ -551,8 +560,8 @@ async def test_discord_free_response_channel_skips_auto_thread(adapter, monkeypa
 
 
 @pytest.mark.asyncio
-async def test_discord_voice_linked_parent_thread_still_requires_mention(adapter, monkeypatch):
-    """Threads under a voice-linked channel should still require @mention."""
+async def test_discord_voice_linked_parent_thread_skips_mention_by_default(adapter, monkeypatch):
+    """Threads under a voice-linked channel follow default thread mention gating."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
 
@@ -564,7 +573,10 @@ async def test_discord_voice_linked_parent_thread_still_requires_mention(adapter
 
     await adapter._handle_message(message)
 
-    adapter.handle_message.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "thread reply without mention"
+    assert event.source.chat_type == "thread"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Allow Discord thread messages to bypass mention gating by default even when the thread was not yet tracked locally
- Mirror that thread exemption in the early multi-agent free-response filter
- Update Discord free-response tests for the new default thread behavior

## Test Plan
- python -m pytest tests/gateway/test_discord_free_response.py -q -o 'addopts='