### PR TITLE
fix(tui): suppress macOS MallocStackLogging stderr noise

### DIFF
--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -332,6 +332,11 @@ export class GatewayClient extends EventEmitter {
     const env = { ...process.env }
     const pyPath = env.PYTHONPATH?.trim()
 
+    // Suppress macOS MallocStackLogging warnings in the gateway and all
+    // child Python processes.  Without this, macOS emits noisy stderr lines
+    // that corrupt TUI rendering when Python forks subprocesses.
+    // See: https://github.com/derailed/k9s/issues/2760
+    env.MallocStackLogging = '0'
     env.PYTHONPATH = pyPath ? `${root}${delimiter}${pyPath}` : root
     this.startReadyTimer(python, cwd)
     this.proc = spawn(python, ['-m', 'tui_gateway.entry'], { cwd, env, stdio: ['pipe', 'pipe', 'pipe'] })
@@ -354,6 +359,15 @@ export class GatewayClient extends EventEmitter {
       const line = truncateLine(raw.trim())
 
       if (!line) {
+        return
+      }
+
+      // Drop macOS MallocStackLogging noise — system-level warning that
+      // leaks into stderr when Python forks subprocesses.  Not actionable
+      // and corrupts the TUI layout when it fires in bursts.
+      // See: https://github.com/derailed/k9s/issues/2760
+      if (line.includes('MallocStackLogging')) {
+        this.pushLog(`[filtered] ${line}`)
         return
       }
 


### PR DESCRIPTION
## Problem

macOS emits `MallocStackLogging: can't turn off malloc stack logging because it was not enabled` warnings when Python forks subprocesses. These warnings leak into the TUI via the gateway stderr pipe and corrupt the terminal layout when they fire in bursts (sometimes 20+ lines at once, interleaved with UI elements).

This is a known macOS system-wide issue affecting many TUI apps:
- https://github.com/derailed/k9s/issues/2760
- https://github.com/withfig/fig/issues/2660
- https://forum.posit.co/t/rsession-mallocstacklogging-cant-turn-off-malloc-stack-logging-because-it-was-not-enabled/182771

Triggered by: waking from sleep, lock/unlock, or extended use on macOS Sonoma through Tahoe.

## Fix

Two-pronged approach in `ui-tui/src/gatewayClient.ts`:

1. **Prevention**: Set `MallocStackLogging=0` in the gateway spawn environment so the warning is never emitted in the first place. This propagates to all child Python processes (terminal tool, subagents, etc.).

2. **Defense**: Filter any remaining `MallocStackLogging` lines in the stderr handler. Filtered lines are still logged as `[filtered]` for debugging but never published to the UI, so they can't corrupt the layout.

## Testing

- Verified `MallocStackLogging=0` suppresses the warning in isolation
- TypeScript compiles cleanly (no errors in gatewayClient.ts)
- TUI builds successfully with the change

## Before

```
Python(19669) MallocStackLogging: can't turn off malloc stack logging because it was not enabled.
Python(19673) MallocStackLogging: can't turn off malloc stack logging because it was not enabled.
... (20+ lines corrupting the TUI)
```

## After

Warnings are suppressed at source. Any stragglers are filtered silently.
