### PR TITLE
fix(feishu): approval card clicks rejected when FEISHU_ALLOWED_USERS not set

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2578,8 +2578,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        if not self._is_interactive_operator_authorized(open_id):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -615,6 +615,34 @@ class TestCardActionCallbackResponse:
         assert response.card is None
         mock_submit.assert_not_called()
 
+    def test_allows_approval_click_when_no_allowlist_configured(self, _patch_callback_card_types):
+        # Regression: _allow_group_message (group policy gate) was used instead of
+        # _is_interactive_operator_authorized, causing "Unauthorized approval click"
+        # for any user when FEISHU_ALLOWED_USERS is not set (empty allowlist, default
+        # "allowlist" policy → bool(sender_ids & frozenset()) == False).
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = set()
+        adapter._admins = set()
+        adapter._approval_state[7] = {
+            "session_key": "sess-7",
+            "message_id": "msg-7",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 7},
+            open_id="ou_61e0458ad8668346d79895a84055e758",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None, (
+            "Approval click must not be rejected when FEISHU_ALLOWED_USERS is not configured"
+        )
+
     def test_rejects_approval_click_when_callback_chat_mismatches(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = MagicMock()


### PR DESCRIPTION
## What changed and why

`_handle_approval_card_action` used `_allow_group_message` — the group-policy gate for inbound messages — to authorize Feishu approval card button clicks. With the default `FEISHU_GROUP_POLICY=allowlist` and `FEISHU_ALLOWED_USERS` unset, `_allow_group_message` evaluates to `bool(sender_ids & frozenset()) == False` for **every** user, producing the `[Feishu] Unauthorized approval click` warning on every button press and leaving the agent waiting until it times out.

The companion handler `_handle_update_prompt_card_action` already uses the correct helper `_is_interactive_operator_authorized`, which allows any valid `open_id` when neither an allowlist nor an admin set is configured, and checks membership when either is set. This PR aligns `_handle_approval_card_action` to use the same check.

The unused `sender_id = SimpleNamespace(...)` construction (only needed for `_allow_group_message`) is removed alongside.

## How to test

1. `pytest tests/gateway/test_feishu_approval_buttons.py -q` — 36 tests should pass, including the new regression test `test_allows_approval_click_when_no_allowlist_configured`.
2. Run Hermes with a Feishu gateway that has no `FEISHU_ALLOWED_USERS` env var set; trigger a command requiring approval; confirm the card buttons now resolve the approval instead of producing `Unauthorized approval click` warnings.

## What platforms tested on

- macOS (pytest, unit tests only — no live Feishu tenant)

Fixes #20596

<!-- autocontrib:worker-id=issue-followup-dfa0899f kind=pr-open -->