### PR TITLE
feat: add .epub to SUPPORTED_DOCUMENT_TYPES

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1090,6 +1090,7 @@ def _log_safe_path(path: str) -> str:
 
 SUPPORTED_DOCUMENT_TYPES = {
     ".pdf": "application/pdf",
+    ".epub": "application/epub+zip",
     ".md": "text/markdown",
     ".txt": "text/plain",
     ".csv": "text/csv",


### PR DESCRIPTION
## What does this PR do?

EPUB files (`.epub`) sent via Slack (and other gateway platforms) are silently skipped with no user-facing error or notice. The document handler checks `if ext not in SUPPORTED_DOCUMENT_TYPES: continue` — so the agent receives no indication a file was attached at all.

This adds `.epub` / `application/epub+zip` (the IANA-registered MIME type) to `SUPPORTED_DOCUMENT_TYPES` in `base.py`. No other changes are needed — the existing download-and-cache path handles EPUBs correctly.

## Related Issue

No existing issue — discovered while debugging a self-hosted Slack deployment.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: added `".epub": "application/epub+zip"` to `SUPPORTED_DOCUMENT_TYPES`

## How to Test

1. Send an `.epub` file to Hermes via Slack DM
2. Confirm the agent acknowledges and can read the file
3. Previously: agent silently ignores the attachment with no notice to the user

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Slack API confirms `.epub` files are served with `application/epub+zip` — matching the value added to `SUPPORTED_DOCUMENT_TYPES`:

```json
{"mimetype":"application\/epub+zip","filetype":"epub","name":"Annie Duke - Thinking in Bets.epub"}
```