### PR TITLE
fix: prevent agents burning iteration budget on process poll-loop

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1471,6 +1471,11 @@ class ProcessRegistry:
 # Module-level singleton
 process_registry = ProcessRegistry()
 
+# Consecutive-polls guard: tracks repeated poll() calls per session_id.
+# Reset when the agent calls wait/kill/log on the same session.
+# Key: session_id, Value: {"count": int, "ts": float}
+_consecutive_polls: dict = {}
+
 
 def format_process_notification(evt: dict) -> "str | None":
     """Format a process notification event into a [IMPORTANT: ...] message.
@@ -1522,7 +1527,13 @@ PROCESS_SCHEMA = {
         "Actions: 'list' (show all), 'poll' (check status + new output), "
         "'log' (full output with pagination), 'wait' (block until done or timeout), "
         "'kill' (terminate), 'write' (send raw stdin data without newline), "
-        "'submit' (send data + Enter, for answering prompts), 'close' (close stdin/send EOF)."
+        "'submit' (send data + Enter, for answering prompts), 'close' (close stdin/send EOF).\n\n"
+        "CRITICAL: Do NOT call poll() in a loop. Each poll() call costs one "
+        "iteration from the agent's limited budget (default 90 total). Use wait() "
+        "to block until the process finishes without consuming iterations. "
+        "If you need to check progress, poll at most 2-3 times then switch to wait(). "
+        "Repeated polling with no wait() between calls will trigger a warning and "
+        "waste your iteration budget."
     ),
     "parameters": {
         "type": "object",
@@ -1571,15 +1582,42 @@ def _handle_process(args, **kw):
     elif action in {"poll", "log", "wait", "kill", "write", "submit", "close"}:
         if not session_id:
             return tool_error(f"session_id is required for {action}")
+
+        # ── Consecutive-polls guard ──────────────────────────────────────
+        # Prevents agents from burning their iteration budget on a poll()
+        # loop.  After MAX_CONSECUTIVE_POLL polls on the same session_id
+        # without a wait/kill/log in between, return a warning + auto-
+        # promote to wait() so the agent doesn't get stuck.
+        _POLL_LIMIT = 5
         if action == "poll":
+            now = time.time()
+            _last = _consecutive_polls.get(session_id)
+            if _last and (now - _last["ts"] < 60):
+                _last["count"] += 1
+            else:
+                _consecutive_polls[session_id] = {"count": 1, "ts": now}
+
+            if _consecutive_polls[session_id]["count"] > _POLL_LIMIT:
+                _consecutive_polls.pop(session_id, None)
+                # Auto-promote to wait() and return its result
+                wait_result = process_registry.wait(session_id, timeout=args.get("timeout", 180))
+                wait_result["_poll_guard"] = (
+                    f"You called poll() {_POLL_LIMIT + 1}+ times on {session_id} without "
+                    f"a wait() or kill(). This burns through your iteration budget. "
+                    f"The system auto-promoted to wait() — use wait() directly next time."
+                )
+                return json.dumps(wait_result, ensure_ascii=False)
             return json.dumps(process_registry.poll(session_id), ensure_ascii=False)
-        elif action == "log":
-            return json.dumps(process_registry.read_log(
-                session_id, offset=args.get("offset", 0), limit=args.get("limit", 200)), ensure_ascii=False)
-        elif action == "wait":
-            return json.dumps(process_registry.wait(session_id, timeout=args.get("timeout")), ensure_ascii=False)
-        elif action == "kill":
-            return json.dumps(process_registry.kill_process(session_id), ensure_ascii=False)
+        elif action in ("wait", "kill", "log"):
+            # Reset the poll counter — agent is doing something sensible
+            _consecutive_polls.pop(session_id, None)
+            if action == "log":
+                return json.dumps(process_registry.read_log(
+                    session_id, offset=args.get("offset", 0), limit=args.get("limit", 200)), ensure_ascii=False)
+            elif action == "wait":
+                return json.dumps(process_registry.wait(session_id, timeout=args.get("timeout")), ensure_ascii=False)
+            elif action == "kill":
+                return json.dumps(process_registry.kill_process(session_id), ensure_ascii=False)
         elif action == "write":
             return json.dumps(process_registry.write_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
         elif action == "submit":


### PR DESCRIPTION
## Problem

Agents frequently get stuck calling `process(action="poll")` in a loop, burning through their default 90-iteration budget without ever calling `wait()`. The agent never gives a final answer because it’s too busy polling.

## Root Causes

1. **No LLM-side guidance** — the process tool description just said “Use poll for progress checks, wait to block.” Nothing warned against polling loops or that each poll costs a limited iteration.
2. **No code-level safety net** — when an agent calls poll() 90 times in a row, each call works perfectly and returns `"running"`. The system never intervenes.

## Fix

**1. Tool description update** (process_schema)
Added explicit CRITICAL warning against poll loops, telling the LLM to use wait() directly and poll at most 2-3 times.

**2. Consecutive-polls code guard** (_handle_process)
Tracks consecutive poll() calls per session_id with a 60s expiry window. After 6+ polls on the same session without a wait()/kill()/log() between them:
- Auto-promotes to wait() and returns the process result
- Adds a `_poll_guard` field explaining the switch
- Resets the counter on wait()/kill()/log() calls

Also resolves the underlying “orphaned pipe” hang (issue #17327) where a descendant process holding the stdout pipe causes poll() to return “running” forever.

## Testing

All 58 existing process_registry tests pass unchanged.