### PR TITLE
Fix Responses replay with store=false

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -435,9 +435,13 @@ def _chat_messages_to_responses_input(
                             "status": _normalize_responses_message_status(raw_item.get("status")),
                             "content": normalized_content_parts,
                         }
-                        item_id = raw_item.get("id")
-                        if isinstance(item_id, str) and item_id.strip():
-                            replay_item["id"] = item_id.strip()
+                        # Do NOT replay persisted message item ids. Hermes uses
+                        # store=False for Responses calls; sending an `id` makes
+                        # the API try to resolve server-side state that was not
+                        # persisted and it returns 404 (`Item ... not found`).
+                        # The text/phase payload is self-contained enough for
+                        # continuity and prefix-cache hints without relying on
+                        # provider-side item storage.
                         phase = raw_item.get("phase")
                         if isinstance(phase, str) and phase.strip():
                             replay_item["phase"] = phase.strip()
@@ -689,9 +693,11 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                 "status": _normalize_responses_message_status(item.get("status")),
                 "content": normalized_content,
             }
-            item_id = item.get("id")
-            if isinstance(item_id, str) and item_id.strip():
-                normalized_item["id"] = item_id.strip()
+            # Do NOT replay message item ids with store=False. Unlike
+            # function_call ids (local call linkage), Responses message ids are
+            # server-side item references; if the original response was not
+            # stored, replaying them causes 404 `Item ... not found`.
+            # Preserve phase but send a self-contained message payload.
             phase = item.get("phase")
             if isinstance(phase, str) and phase.strip():
                 normalized_item["phase"] = phase.strip()

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -3,8 +3,10 @@ from types import SimpleNamespace
 import pytest
 
 from agent.codex_responses_adapter import (
+    _chat_messages_to_responses_input,
     _format_responses_error,
     _normalize_codex_response,
+    _preflight_codex_input_items,
 )
 
 
@@ -174,3 +176,64 @@ def test_normalize_codex_response_failed_with_message_only():
     )
     with pytest.raises(RuntimeError, match=r"^model error$"):
         _normalize_codex_response(response)
+
+
+def test_chat_messages_to_responses_input_strips_stored_message_item_ids():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "fallback answer",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "id": "msg_not_persisted",
+                    "role": "assistant",
+                    "status": "completed",
+                    "phase": "final",
+                    "content": [
+                        {"type": "output_text", "text": "fallback answer"},
+                    ],
+                }
+            ],
+        },
+        {"role": "user", "content": "next turn"},
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    assert items[0] == {
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "phase": "final",
+        "content": [{"type": "output_text", "text": "fallback answer"}],
+    }
+    assert "id" not in items[0]
+    assert items[1] == {"role": "user", "content": "next turn"}
+
+
+def test_preflight_codex_input_items_strips_message_item_ids_for_store_false():
+    raw_items = [
+        {
+            "type": "message",
+            "id": "msg_not_persisted",
+            "role": "assistant",
+            "status": "completed",
+            "phase": "final",
+            "content": [{"type": "output_text", "text": "hello"}],
+        }
+    ]
+
+    normalized = _preflight_codex_input_items(raw_items)
+
+    assert normalized == [
+        {
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "phase": "final",
+            "content": [{"type": "output_text", "text": "hello"}],
+        }
+    ]
+    assert "id" not in normalized[0]
+


### PR DESCRIPTION
## Summary
- strip stored Responses message item IDs before replaying assistant message items
- keep message text/status/phase self-contained so store=false calls do not try to resolve non-persisted server items
- add regressions for chat-history conversion and preflight normalization

## Test plan
- python -m pytest tests/agent/test_codex_responses_adapter.py tests/run_agent/test_run_agent_codex_responses.py -q

## Linear
- Fixes OTO-664
- Related to OTO-660 and OTO-496