### PR TITLE
fix(tui): surface resumable sessions in /sessions empty state

### DIFF
--- a/ui-tui/src/__tests__/activeSessionSwitcher.test.ts
+++ b/ui-tui/src/__tests__/activeSessionSwitcher.test.ts
@@ -22,6 +22,7 @@ import {
   newSessionRowIndex,
   orchestratorRowClickAction,
   orchestratorVisibleRowIndexes,
+  resumableSessionsHint,
   selectedSessionRowStyle
 } from '../components/activeSessionSwitcher.js'
 
@@ -31,6 +32,16 @@ describe('session orchestrator helpers', () => {
     expect(activeSessionCountLabel(1)).toBe('1 live session')
     expect(activeSessionCountLabel(3)).toBe('3 live sessions')
     expect(activeSessionCountLabel(1)).not.toContain('in this TUI')
+  })
+
+  it('points the empty orchestrator at /resume when resumable sessions exist (#34647)', () => {
+    expect(resumableSessionsHint(null)).toBeNull()
+    expect(resumableSessionsHint(0)).toBeNull()
+    expect(resumableSessionsHint(1)).toBe('1 resumable session saved — use /resume to reopen one')
+    expect(resumableSessionsHint(3)).toBe('3 resumable sessions saved — use /resume to reopen one')
+    // Negative counts can't happen from session.list, but guard against a bad
+    // RPC payload rendering a nonsensical "-1 resumable sessions" line.
+    expect(resumableSessionsHint(-2)).toBeNull()
   })
 
   it('keeps session orchestrator hotkey hints short and contextual', () => {

--- a/ui-tui/src/components/activeSessionSwitcher.tsx
+++ b/ui-tui/src/components/activeSessionSwitcher.tsx
@@ -3,7 +3,12 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
-import type { SessionActiveItem, SessionActiveListResponse, SessionCloseResponse } from '../gatewayTypes.js'
+import type {
+  SessionActiveItem,
+  SessionActiveListResponse,
+  SessionCloseResponse,
+  SessionListResponse
+} from '../gatewayTypes.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
@@ -39,6 +44,20 @@ export const fixedSessionColumnStyle = () => ({ flexShrink: 0 })
 
 export const activeSessionCountLabel = (count: number) =>
   `${count} live ${count === 1 ? 'session' : 'sessions'}`
+
+// The orchestrator switches between *live* in-memory sessions only
+// (``session.activate`` attaches to a process-local agent; it cannot reopen a
+// persisted session). After a TUI restart there are no live siblings, so the
+// overlay would otherwise look empty even when resumable transcripts exist in
+// the DB — users then don't realise ``/resume`` is the way back in (#34647).
+// Surface the DB count from ``session.list`` so the empty state points there.
+export const resumableSessionsHint = (count: null | number): null | string => {
+  if (!count || count <= 0) {
+    return null
+  }
+
+  return `${count} resumable ${count === 1 ? 'session' : 'sessions'} saved — use /resume to reopen one`
+}
 
 export type OrchestratorHintRole = 'hotkey' | 'label' | 'text'
 
@@ -250,6 +269,7 @@ export function ActiveSessionSwitcher({
   const [draftModel, setDraftModel] = useState('')
   const [pickingModel, setPickingModel] = useState(false)
   const [closingId, setClosingId] = useState('')
+  const [resumableCount, setResumableCount] = useState<null | number>(null)
   const initialSelectionAppliedRef = useRef(false)
   const { stdout } = useStdout()
   const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
@@ -303,6 +323,28 @@ export function ActiveSessionSwitcher({
 
     return () => clearInterval(timer)
   }, [load])
+
+  // Fetch the historical session count once. This is the DB-backed list that
+  // ``/resume`` and ``hermes sessions list`` use; it is not part of the live
+  // poll above (no need to re-query the DB every 1.5s) and is best-effort —
+  // a failed lookup just leaves the empty state without the resumable hint.
+  useEffect(() => {
+    let cancelled = false
+
+    gw.request<SessionListResponse>('session.list', {})
+      .then(raw => {
+        const r = asRpcResult<SessionListResponse>(raw)
+
+        if (!cancelled && r) {
+          setResumableCount(r.sessions?.length ?? 0)
+        }
+      })
+      .catch(() => {})
+
+    return () => {
+      cancelled = true
+    }
+  }, [gw])
 
   const submitDraft = useCallback(
     (value: string) => {
@@ -463,6 +505,7 @@ export function ActiveSessionSwitcher({
   const totalRows = items.length + 1
   const offset = windowOffset(totalRows, sel, VISIBLE)
   const visibleRows = orchestratorVisibleRowIndexes(items.length, sel, VISIBLE)
+  const resumableHint = resumableSessionsHint(resumableCount)
 
   return (
     <Box flexDirection="column" width={width}>
@@ -473,7 +516,10 @@ export function ActiveSessionSwitcher({
 
       {err && <Text color={t.color.label}>error: {err}</Text>}
       {!items.length && (
-        <Text color={t.color.muted}>no live sessions — closed TUIs only leave resumable transcripts</Text>
+        <>
+          <Text color={t.color.muted}>no live sessions — closed TUIs only leave resumable transcripts</Text>
+          {resumableHint && <Text color={t.color.label}>{resumableHint}</Text>}
+        </>
       )}
       {offset > 0 && <Text color={t.color.muted}> ↑ {offset} more</Text>}
 


### PR DESCRIPTION
## What does this PR do?

When you run `/sessions` in the TUI after restarting it, the Session Orchestrator overlay shows "no live sessions" even though `hermes sessions list` and `/resume` can both still see the transcripts persisted to the DB. As #34647 documents, this is a design mismatch: `/sessions` is backed by `session.active_list`, which only enumerates *live in-memory* sessions in the current gateway process, while `/resume` and the CLI use `session.list` (the SQLite DB). After a restart there are no live siblings, so the overlay is empty and the user gets no signal that `/resume` is the way back into their previous conversation.

This PR keeps the orchestrator focused on live-session switching (its documented purpose) and fixes the **discoverability** gap: the empty state now reports how many resumable sessions exist in the DB and tells the user to run `/resume`.

**Why Option 2 and not the issue's Option 1 (swap `/sessions` to `session.list`):** `session.activate` — how the orchestrator switches rows — attaches the frontend to an *already-live* in-memory session; it cannot reopen a persisted DB session (that path is `session.resume`, which mints a new live session). The `session.active_list` handler docstring also states explicitly that it is intentionally *not* a historical DB browser. Pointing the overlay's data source at `session.list` would therefore list historical rows that the orchestrator's Enter/activate path cannot open. Surfacing the count and routing users to the existing, correct `/resume` flow fixes the reported pain with no behavior change to the live-switching path. I left `Refs #34647` (not `Fixes`) because a maintainer may still want the larger historical-browser rework tracked separately.

## Related Issue

Refs #34647

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/components/activeSessionSwitcher.tsx`: added a pure `resumableSessionsHint(count)` helper; the component fetches the DB session count once via `session.list` (a best-effort one-shot, kept out of the existing 1.5s live poll), and the empty state now renders the resumable-sessions hint pointing at `/resume`.
- `ui-tui/src/__tests__/activeSessionSwitcher.test.ts`: unit tests for `resumableSessionsHint` covering null/zero (no hint), singular/plural wording, and a negative-count guard.

## How to Test

1. Run `hermes --tui`, start a conversation in a session, then close the TUI.
2. Restart with `hermes --tui` and run `/sessions`.
3. The overlay now shows `no live sessions …` followed by e.g. `1 resumable session saved — use /resume to reopen one`, instead of an empty list with no guidance.
4. Confirm the count matches `hermes sessions list` / the `/resume` picker.
5. Run the unit tests: `cd ui-tui && npx vitest run src/__tests__/activeSessionSwitcher.test.ts` (13 passed locally).

## What platforms tested on

- macOS on darwin-arm64 (local): `npx vitest run src/__tests__/activeSessionSwitcher.test.ts` (13 passed); `tsc --noEmit` clean for the changed files (pre-existing errors in the vendored `packages/hermes-ink` package only); `eslint` introduces no new findings on the changed files.
- Change is TypeScript-only (`ui-tui/`); the Python `pytest` suite and `scripts/check-windows-footguns.py` do not exercise it. No process/path/signal/subprocess code touched, so no cross-platform footgun surface.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tui):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A — TypeScript-only change; verified via `vitest`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (user-facing string only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

<!-- autocontrib:worker-id=issue-new-ab44be1c kind=pr-open -->