### PR TITLE
fix(packaging): include hermes_cli subpackages in wheel build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,7 @@ plugins = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## What does this PR do?

`pyproject.toml` `packages.find.include` listed `hermes_cli` but not `hermes_cli.*`. Subpackages (`dashboard_auth`, `proxy`, `proxy.adapters`) were silently excluded from built wheels. Local dev worked fine (source tree imports) but anyone installing via pip, Homebrew, or Docker got `ModuleNotFoundError` at runtime.

## Related Issue

Fixes #34701, Fixes #27664

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `pyproject.toml`: Added `"hermes_cli.*"` to `[tool.setuptools.packages.find]` include list

## How to Test

1. Run: `python -c "from setuptools import find_packages; pkgs = find_packages(include=['hermes_cli', 'hermes_cli.*']); print([p for p in pkgs if p.startswith('hermes_cli')])"`
2. Confirm `hermes_cli.dashboard_auth`, `hermes_cli.proxy`, `hermes_cli.proxy.adapters` appear
3. Build wheel: `python -m build --wheel` and verify subpackages are included

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix