### PR TITLE
fix: normalize legacy tool progress setting

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1693,14 +1693,28 @@ def setup_agent_settings(config: dict):
     print_info("  all     — Show every tool call with a short preview")
     print_info("  verbose — Full args, results, and debug logs")
 
-    current_mode = cfg_get(config, "display", "tool_progress", default="all")
-    mode = prompt("Tool progress mode", current_mode)
-    if mode.lower() in {"off", "new", "all", "verbose"}:
+    def _normalise_tool_progress_mode(value) -> str:
+        if value is True:
+            return "all"
+        if value is False:
+            return "off"
+        text = str(value).strip().lower()
+        if text == "true":
+            return "all"
+        if text == "false":
+            return "off"
+        return text
+
+    current_mode = _normalise_tool_progress_mode(
+        cfg_get(config, "display", "tool_progress", default="all")
+    )
+    mode = _normalise_tool_progress_mode(prompt("Tool progress mode", current_mode))
+    if mode in {"off", "new", "all", "verbose"}:
         if "display" not in config:
             config["display"] = {}
-        config["display"]["tool_progress"] = mode.lower()
+        config["display"]["tool_progress"] = mode
         save_config(config)
-        print_success(f"Tool progress set to: {mode.lower()}")
+        print_success(f"Tool progress set to: {mode}")
     else:
         print_warning(f"Unknown mode '{mode}', keeping '{current_mode}'")
 

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -238,7 +238,7 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
         # Register submodules so relative imports work
         # e.g., "from .store import MemoryStore" in holographic plugin
         for sub_file in provider_dir.glob("*.py"):
-            if sub_file.name == "__init__.py":
+            if sub_file.name in {"__init__.py", "setup.py"}:
                 continue
             sub_name = sub_file.stem
             full_sub_name = f"{module_name}.{sub_name}"

--- a/tests/hermes_cli/test_setup_agent_settings.py
+++ b/tests/hermes_cli/test_setup_agent_settings.py
@@ -76,3 +76,85 @@ def test_setup_agent_settings_prefers_config_over_stale_env(tmp_path, monkeypatc
     assert "Press Enter to keep 60." not in out
     # And the stale .env entry gets cleaned up
     assert "HERMES_MAX_ITERATIONS" in removed_keys
+
+
+def test_setup_agent_settings_normalises_true_tool_progress_default(
+    tmp_path, monkeypatch, capsys
+):
+    """Legacy boolean true should behave like canonical "all"."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config = {
+        "agent": {"max_turns": 60},
+        "display": {"tool_progress": True},
+        "compression": {"threshold": 0.50},
+        "session_reset": {"mode": "both", "idle_minutes": 1440, "at_hour": 4},
+    }
+
+    saved_values: list[str] = []
+
+    def fake_prompt(question, default=None, password=False):
+        if question == "Max iterations":
+            return "60"
+        if question == "Tool progress mode":
+            return default
+        if question == "Compression threshold (0.5-0.95)":
+            return "0.5"
+        raise AssertionError(f"Unexpected prompt: {question}")
+
+    monkeypatch.setattr("hermes_cli.setup.prompt", fake_prompt)
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 4)
+    monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.setup.remove_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "hermes_cli.setup.save_config",
+        lambda current: saved_values.append(current["display"]["tool_progress"]),
+    )
+
+    setup_agent_settings(config)
+
+    out = capsys.readouterr().out
+    assert "Tool progress set to: all" in out
+    assert config["display"]["tool_progress"] == "all"
+    assert "all" in saved_values
+
+
+def test_setup_agent_settings_normalises_false_tool_progress_default(
+    tmp_path, monkeypatch, capsys
+):
+    """Legacy boolean false should behave like canonical "off"."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config = {
+        "agent": {"max_turns": 60},
+        "display": {"tool_progress": False},
+        "compression": {"threshold": 0.50},
+        "session_reset": {"mode": "both", "idle_minutes": 1440, "at_hour": 4},
+    }
+
+    saved_values: list[str] = []
+
+    def fake_prompt(question, default=None, password=False):
+        if question == "Max iterations":
+            return "60"
+        if question == "Tool progress mode":
+            return default
+        if question == "Compression threshold (0.5-0.95)":
+            return "0.5"
+        raise AssertionError(f"Unexpected prompt: {question}")
+
+    monkeypatch.setattr("hermes_cli.setup.prompt", fake_prompt)
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 4)
+    monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.setup.remove_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "hermes_cli.setup.save_config",
+        lambda current: saved_values.append(current["display"]["tool_progress"]),
+    )
+
+    setup_agent_settings(config)
+
+    out = capsys.readouterr().out
+    assert "Tool progress set to: off" in out
+    assert config["display"]["tool_progress"] == "off"
+    assert "off" in saved_values

--- a/tests/plugins/memory/test_plugin_loader.py
+++ b/tests/plugins/memory/test_plugin_loader.py
@@ -1,0 +1,38 @@
+"""Regression tests for memory provider plugin loading."""
+
+from __future__ import annotations
+
+import sys
+
+from plugins.memory import _load_provider_from_dir
+
+
+def test_user_memory_plugin_loader_does_not_execute_setup_py(tmp_path):
+    """Packaging helpers like setup.py must not run during provider load."""
+    plugin_dir = tmp_path / "mnemosyne_like"
+    plugin_dir.mkdir()
+    (plugin_dir / "__init__.py").write_text(
+        "from agent.memory_provider import MemoryProvider\n"
+        "class DummyProvider(MemoryProvider):\n"
+        "    @property\n"
+        "    def name(self):\n"
+        "        return 'dummy'\n"
+        "    def is_available(self):\n"
+        "        return True\n"
+        "    def initialize(self, session_id, **kwargs):\n"
+        "        pass\n"
+        "    def get_tool_schemas(self):\n"
+        "        return []\n"
+        "def register(ctx):\n"
+        "    ctx.register_memory_provider(DummyProvider())\n"
+    )
+    (plugin_dir / "setup.py").write_text(
+        "raise SystemExit('setup.py was executed during plugin load')\n"
+    )
+    (plugin_dir / "provider.py").write_text("VALUE = 1\n")
+
+    provider = _load_provider_from_dir(plugin_dir)
+
+    assert provider is not None
+    assert provider.name == "dummy"
+    assert f"_hermes_user_memory.{plugin_dir.name}.setup" not in sys.modules


### PR DESCRIPTION
Normalizes legacy boolean display.tool_progress values into the current string settings and adds setup wizard regression coverage.\n\nTested with: python -m pytest tests/hermes_cli/test_setup_agent_settings.py -q