### PR TITLE
feat(mcp): 转发 MCP 被动通知并补齐会话重连恢复

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -410,6 +410,29 @@ class MemoryManager:
                     provider.name, e,
                 )
 
+    def sync_passive_event_all(
+        self,
+        content: str,
+        *,
+        session_id: str = "",
+        source_label: str = "",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Sync an out-of-band observed event to all providers."""
+        for provider in self._providers:
+            try:
+                provider.sync_passive_event(
+                    content,
+                    session_id=session_id,
+                    source_label=source_label,
+                    metadata=metadata,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Memory provider '%s' sync_passive_event failed: %s",
+                    provider.name, e,
+                )
+
     # -- Tools ---------------------------------------------------------------
 
     def get_all_tool_schemas(self) -> List[Dict[str, Any]]:

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -26,6 +26,7 @@ Optional hooks (override to opt in):
   on_session_end(messages)               — end-of-session extraction
   on_session_switch(new_session_id, **kwargs) — mid-process session_id rotation
   on_pre_compress(messages) -> str       — extract before context compression
+    sync_passive_event(content, **kwargs)  — persist out-of-band observed events
   on_memory_write(action, target, content, metadata=None) — mirror built-in memory writes
   on_delegation(task, result, **kwargs)  — parent-side observation of subagent work
 """
@@ -129,6 +130,28 @@ class MemoryProvider(ABC):
         completed turn, including any assistant tool calls and tool results.
         Providers that do not need raw turn context can ignore it.
         """
+
+    def sync_passive_event(
+        self,
+        content: str,
+        *,
+        session_id: str = "",
+        source_label: str = "",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Persist an out-of-band observed event.
+
+        Default behavior adapts the passive event into a synthetic turn so
+        existing providers (Mem0, Hindsight, Honcho, etc.) ingest it without
+        needing provider-specific changes. Providers that support a more
+        structured event model can override this hook.
+        """
+        if not content:
+            return
+        note = "Hermes observed a passive event."
+        if source_label:
+            note = f"Hermes observed a passive event from {source_label}."
+        self.sync_turn(note, content, session_id=session_id)
 
     @abstractmethod
     def get_tool_schemas(self) -> List[Dict[str, Any]]:

--- a/gateway/mcp_passthrough.py
+++ b/gateway/mcp_passthrough.py
@@ -1,0 +1,401 @@
+"""Gateway delivery helpers for MCP custom notification passthrough."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from gateway.config import HomeChannel, Platform, load_gateway_config
+from gateway.session import SessionSource
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_RETRY_ATTEMPTS = 3
+
+
+def _truncate_log_text(text: Any, max_chars: int = 240) -> str:
+    """Return a single-line truncated string for log payload previews."""
+    rendered = str(text or "").replace("\n", "\\n")
+    if len(rendered) <= max_chars:
+        return rendered
+    return rendered[: max_chars - 3] + "..."
+
+
+def build_mcp_passthrough_transcript_content(server_name: str, payload_json: str) -> str:
+    """Build the assistant transcript entry stored for future replay."""
+    return f"[MCP passthrough from {server_name}] {payload_json}"
+
+
+def _get_live_runner() -> Any | None:
+    try:
+        from gateway.run import _gateway_runner_ref
+
+        return _gateway_runner_ref()
+    except Exception:
+        return None
+
+
+def _resolve_home(platform: Platform, runner: Any | None) -> tuple[Any, Any | None, HomeChannel | None]:
+    config = runner.config if runner is not None else load_gateway_config()
+    return config, config.platforms.get(platform), config.get_home_channel(platform)
+
+
+def _resolve_live_runner_target_entries(runner: Any, platform: Platform, home: HomeChannel) -> list[Any]:
+    thread_id = str(home.thread_id) if home.thread_id else None
+    matches: list[Any] = []
+    for entry in runner.session_store.list_sessions():
+        origin = getattr(entry, "origin", None)
+        entry_platform = getattr(origin, "platform", None) or getattr(entry, "platform", None)
+        entry_chat_id = str(getattr(origin, "chat_id", "") or "")
+        entry_thread_id = getattr(origin, "thread_id", None)
+        if entry_platform != platform:
+            continue
+        if entry_chat_id != str(home.chat_id):
+            continue
+        if str(entry_thread_id or "") != str(thread_id or ""):
+            continue
+        matches.append(entry)
+    if not matches:
+        matches = [runner.session_store.get_or_create_session(_default_home_source(platform, home))]
+
+    deduped: list[Any] = []
+    seen_session_ids: set[str] = set()
+    for entry in matches:
+        session_id = getattr(entry, "session_id", None)
+        if not session_id or session_id in seen_session_ids:
+            continue
+        seen_session_ids.add(session_id)
+        deduped.append(entry)
+    return deduped
+
+
+def _default_home_source(platform: Platform, home: HomeChannel) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        chat_id=str(home.chat_id),
+        chat_name=home.name,
+        chat_type="group" if home.thread_id else "dm",
+        thread_id=str(home.thread_id) if home.thread_id else None,
+    )
+
+
+def _persist_to_live_runner_sessions(
+    runner: Any,
+    platform: Platform,
+    home: HomeChannel,
+    server_name: str,
+    payload_json: str,
+) -> int:
+    message = {
+        "role": "assistant",
+        "content": build_mcp_passthrough_transcript_content(server_name, payload_json),
+    }
+    entries = _resolve_live_runner_target_entries(runner, platform, home)
+
+    written = 0
+    for entry in entries:
+        session_id = getattr(entry, "session_id", None)
+        session_key = getattr(entry, "session_key", None)
+        if not session_id:
+            continue
+        runner.session_store.append_to_transcript(session_id, message)
+        if session_key:
+            runner.session_store.update_session(session_key)
+        written += 1
+    return written
+
+
+def _build_memory_manager_for_entry(entry: Any, platform: Platform) -> Any | None:
+    try:
+        from agent.memory_manager import MemoryManager
+        from hermes_cli.config import load_config
+        from hermes_constants import get_hermes_home
+        from plugins.memory import load_memory_provider
+
+        config = load_config() or {}
+        mem_cfg = config.get("memory") or {}
+        provider_name = str(mem_cfg.get("provider") or "").strip()
+        if not provider_name:
+            return None
+
+        provider = load_memory_provider(provider_name)
+        if provider is None or not provider.is_available():
+            return None
+
+        manager = MemoryManager()
+        manager.add_provider(provider)
+        if not manager.providers:
+            return None
+
+        origin = getattr(entry, "origin", None)
+        init_kwargs = {
+            "platform": platform.value,
+            "hermes_home": str(get_hermes_home()),
+            "agent_context": "primary",
+        }
+        if origin is not None:
+            if getattr(origin, "user_id", None):
+                init_kwargs["user_id"] = origin.user_id
+            if getattr(origin, "user_id_alt", None):
+                init_kwargs["user_id_alt"] = origin.user_id_alt
+            if getattr(origin, "user_name", None):
+                init_kwargs["user_name"] = origin.user_name
+            if getattr(origin, "chat_id", None):
+                init_kwargs["chat_id"] = origin.chat_id
+            if getattr(origin, "chat_name", None):
+                init_kwargs["chat_name"] = origin.chat_name
+            if getattr(origin, "chat_type", None):
+                init_kwargs["chat_type"] = origin.chat_type
+            if getattr(origin, "thread_id", None):
+                init_kwargs["thread_id"] = origin.thread_id
+        session_key = getattr(entry, "session_key", None)
+        if session_key:
+            init_kwargs["gateway_session_key"] = session_key
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+
+            init_kwargs["agent_identity"] = get_active_profile_name()
+            init_kwargs["agent_workspace"] = "hermes"
+        except Exception:
+            pass
+
+        session_id = str(getattr(entry, "session_id", "") or "").strip()
+        if not session_id:
+            return None
+        manager.initialize_all(session_id=session_id, **init_kwargs)
+        return manager
+    except Exception:
+        logger.exception(
+            "MCP passthrough: failed to initialize memory provider for %s",
+            platform.value,
+        )
+        return None
+
+
+def _sync_entries_to_memory(entries: list[Any], platform: Platform, server_name: str, payload_json: str) -> int:
+    synced = 0
+    for entry in entries:
+        session_id = str(getattr(entry, "session_id", "") or "").strip()
+        if not session_id:
+            continue
+        manager = _build_memory_manager_for_entry(entry, platform)
+        if manager is None:
+            continue
+        try:
+            manager.sync_passive_event_all(
+                payload_json,
+                session_id=session_id,
+                source_label=f"mcp:{server_name}",
+                metadata={
+                    "kind": "mcp_passthrough",
+                    "server_name": server_name,
+                    "platform": platform.value,
+                },
+            )
+            synced += 1
+        finally:
+            manager.shutdown_all()
+    return synced
+
+
+def _persist_without_live_runner(
+    platform: Platform,
+    home: HomeChannel,
+    server_name: str,
+    payload_json: str,
+) -> int:
+    from gateway.mirror import mirror_to_session
+
+    mirrored = mirror_to_session(
+        platform=platform.value,
+        chat_id=str(home.chat_id),
+        message_text=build_mcp_passthrough_transcript_content(server_name, payload_json),
+        source_label=f"mcp:{server_name}",
+        thread_id=str(home.thread_id) if home.thread_id else None,
+    )
+    return 1 if mirrored else 0
+
+
+async def _deliver_once(
+    platform: Platform,
+    pconfig: Any | None,
+    home: HomeChannel,
+    payload_json: str,
+    runner: Any | None,
+) -> tuple[bool, str | None]:
+    thread_id = str(home.thread_id) if home.thread_id else None
+    if runner is not None:
+        adapter = runner.adapters.get(platform)
+        if adapter is not None:
+            try:
+                metadata = {"thread_id": thread_id} if thread_id else None
+                result = await adapter.send(
+                    chat_id=str(home.chat_id),
+                    content=payload_json,
+                    metadata=metadata,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                return False, str(exc)
+            if result.success:
+                return True, None
+            return False, result.error or "adapter send failed"
+
+    if pconfig is None:
+        return False, "platform is not configured in gateway config"
+
+    from tools.send_message_tool import _send_to_platform
+
+    result = await _send_to_platform(
+        platform,
+        pconfig,
+        str(home.chat_id),
+        payload_json,
+        thread_id=thread_id,
+        media_files=[],
+        force_document=False,
+    )
+    if result.get("success"):
+        return True, None
+    return False, result.get("error") or "delivery failed"
+
+
+async def forward_mcp_passthrough_notification(
+    *,
+    server_name: str,
+    payload_json: str,
+    targets: list[str],
+    retry_attempts: int = _DEFAULT_RETRY_ATTEMPTS,
+) -> None:
+    """Forward an MCP custom notification to configured gateway home channels."""
+    if not targets:
+        return
+
+    runner = _get_live_runner()
+    logger.info(
+        "MCP server '%s': dispatching passthrough payload to targets=%s live_runner=%s payload_bytes=%d payload_preview=%s",
+        server_name,
+        ",".join(targets),
+        bool(runner),
+        len(payload_json.encode("utf-8")),
+        _truncate_log_text(payload_json),
+    )
+    for target in targets:
+        try:
+            platform = Platform(target)
+        except Exception:
+            logger.warning(
+                "MCP server '%s': unknown passthrough target '%s'",
+                server_name,
+                target,
+            )
+            continue
+
+        _config, pconfig, home = _resolve_home(platform, runner)
+        if home is None or not home.chat_id:
+            logger.warning(
+                "MCP server '%s': passthrough target '%s' has no home channel configured",
+                server_name,
+                platform.value,
+            )
+            continue
+
+        adapter = runner.adapters.get(platform) if runner is not None else None
+        delivery_path = "live_adapter" if adapter is not None else "send_message_tool"
+        logger.info(
+            "MCP server '%s': resolved passthrough target=%s chat_id=%s thread_id=%s path=%s",
+            server_name,
+            platform.value,
+            home.chat_id,
+            home.thread_id or "-",
+            delivery_path,
+        )
+
+        delivered = False
+        last_error: str | None = None
+        attempts = max(1, retry_attempts)
+        for attempt in range(1, attempts + 1):
+            logger.info(
+                "MCP server '%s': passthrough delivery attempt %d/%d to %s",
+                server_name,
+                attempt,
+                attempts,
+                platform.value,
+            )
+            ok, error = await _deliver_once(platform, pconfig, home, payload_json, runner)
+            if ok:
+                delivered = True
+                logger.info(
+                    "MCP server '%s': passthrough delivered to %s on attempt %d/%d",
+                    server_name,
+                    platform.value,
+                    attempt,
+                    attempts,
+                )
+                break
+            last_error = error or "delivery failed"
+            if attempt < attempts:
+                logger.warning(
+                    "MCP server '%s': passthrough to %s failed (attempt %d/%d), retrying: %s",
+                    server_name,
+                    platform.value,
+                    attempt,
+                    attempts,
+                    last_error,
+                )
+                await asyncio.sleep(min(2 ** (attempt - 1), 2.0))
+
+        if not delivered:
+            logger.warning(
+                "MCP server '%s': passthrough to %s failed after %d attempts: %s",
+                server_name,
+                platform.value,
+                attempts,
+                last_error or "delivery failed",
+            )
+            continue
+
+        memory_synced = 0
+        if runner is not None:
+            memory_entries = _resolve_live_runner_target_entries(runner, platform, home)
+            persisted = _persist_to_live_runner_sessions(
+                runner,
+                platform,
+                home,
+                server_name,
+                payload_json,
+            )
+            memory_synced = _sync_entries_to_memory(
+                memory_entries,
+                platform,
+                server_name,
+                payload_json,
+            )
+        else:
+            persisted = _persist_without_live_runner(
+                platform,
+                home,
+                server_name,
+                payload_json,
+            )
+        logger.info(
+            "MCP server '%s': passthrough target=%s persisted=%d memory_synced=%d",
+            server_name,
+            platform.value,
+            persisted,
+            memory_synced,
+        )
+        if persisted == 0:
+            logger.warning(
+                "MCP server '%s': delivered passthrough to %s but no matching session transcript was updated",
+                server_name,
+                platform.value,
+            )
+        if runner is not None and memory_synced == 0:
+            logger.warning(
+                "MCP server '%s': delivered passthrough to %s but no memory provider session was synced",
+                server_name,
+                platform.value,
+            )

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -118,6 +118,7 @@ class TestMemoryProviderABC:
         p.on_memory_write("add", "memory", "test")
         p.queue_prefetch("query")
         p.sync_turn("user", "assistant")
+        p.sync_passive_event("observed", source_label="mcp:test")
         p.shutdown()
 
 
@@ -277,6 +278,32 @@ class TestMemoryManager:
         mgr.sync_all("user", "assistant")
         # p1 failed but p2 still synced
         assert p2.synced_turns == [("user", "assistant")]
+
+    def test_sync_passive_event_all_uses_provider_hook(self):
+        mgr = MemoryManager()
+        p1 = FakeMemoryProvider("builtin")
+        p2 = FakeMemoryProvider("external")
+        mgr.add_provider(p1)
+        mgr.add_provider(p2)
+
+        mgr.sync_passive_event_all(
+            '{"event": "ping"}',
+            session_id="sess-1",
+            source_label="mcp:notif_srv",
+        )
+
+        assert p1.synced_turns == [
+            (
+                "Hermes observed a passive event from mcp:notif_srv.",
+                '{"event": "ping"}',
+            )
+        ]
+        assert p2.synced_turns == [
+            (
+                "Hermes observed a passive event from mcp:notif_srv.",
+                '{"event": "ping"}',
+            )
+        ]
 
     # -- Tool routing -------------------------------------------------------
 

--- a/tests/e2e/test_mcp_passthrough.py
+++ b/tests/e2e/test_mcp_passthrough.py
@@ -1,0 +1,74 @@
+"""End-to-end coverage for MCP passthrough delivery into gateway replay history."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import hermes_state
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.mcp_passthrough import forward_mcp_passthrough_notification
+from gateway.run import _build_gateway_agent_history
+from gateway.session import SessionSource, SessionStore
+
+
+@pytest.mark.asyncio
+async def test_mcp_passthrough_is_replayed_in_future_gateway_history(tmp_path, monkeypatch):
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="e2e-token",
+                home_channel=HomeChannel(
+                    platform=Platform.TELEGRAM,
+                    chat_id="home-chat",
+                    name="Ops Home",
+                ),
+            )
+        },
+        group_sessions_per_user=False,
+    )
+    session_store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+    entry = session_store.get_or_create_session(
+        SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="home-chat",
+            chat_type="dm",
+            user_id="home-chat",
+            user_name="Ops Home",
+        )
+    )
+    adapter = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg-1"))
+    )
+    runner = SimpleNamespace(
+        config=config,
+        adapters={Platform.TELEGRAM: adapter},
+        session_store=session_store,
+    )
+
+    with patch("gateway.mcp_passthrough._get_live_runner", return_value=runner):
+        await forward_mcp_passthrough_notification(
+            server_name="notif_srv",
+            payload_json='{"level": "warn", "text": "hello"}',
+            targets=["telegram"],
+        )
+
+    adapter.send.assert_awaited_once_with(
+        chat_id="home-chat",
+        content='{"level": "warn", "text": "hello"}',
+        metadata=None,
+    )
+
+    history = session_store.load_transcript(entry.session_id)
+    assert history[-1]["role"] == "assistant"
+    assert history[-1]["content"] == '[MCP passthrough from notif_srv] {"level": "warn", "text": "hello"}'
+
+    agent_history, observed_context = _build_gateway_agent_history(history)
+    assert observed_context is None
+    assert agent_history[-1] == {
+        "role": "assistant",
+        "content": '[MCP passthrough from notif_srv] {"level": "warn", "text": "hello"}',
+    }

--- a/tests/tools/test_mcp_passthrough.py
+++ b/tests/tools/test_mcp_passthrough.py
@@ -1,0 +1,335 @@
+"""Unit tests for MCP passthrough interception and gateway delivery."""
+
+import json
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.memory_provider import MemoryProvider
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.mcp_passthrough import forward_mcp_passthrough_notification
+from gateway.session import SessionSource
+from tools.mcp_tool import MCPServerTask, _PassthroughInterceptingReadStream
+
+
+class _FakeReadStream:
+    def __init__(self, messages):
+        self._messages = list(messages)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+    async def aclose(self):
+        return None
+
+    def __aiter__(self):
+        return self._iter_messages()
+
+    async def _iter_messages(self):
+        for message in self._messages:
+            yield message
+
+
+class _RecordingMemoryProvider(MemoryProvider):
+    def __init__(self):
+        self.initialized = []
+        self.events = []
+        self.shutdown_called = False
+
+    @property
+    def name(self) -> str:
+        return "recording"
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self.initialized.append((session_id, kwargs))
+
+    def get_tool_schemas(self):
+        return []
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        self.events.append((user_content, assistant_content, session_id))
+
+    def sync_passive_event(
+        self,
+        content: str,
+        *,
+        session_id: str = "",
+        source_label: str = "",
+        metadata=None,
+    ) -> None:
+        self.events.append((content, session_id, source_label, dict(metadata or {})))
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+@pytest.mark.asyncio
+async def test_handle_passthrough_notification_prefers_markdown_field(caplog):
+    server = MCPServerTask("notif_srv")
+    server._passthrough_targets = ["wecom"]
+    message = SimpleNamespace(
+        message=SimpleNamespace(
+            root=SimpleNamespace(
+                method="notifications/message",
+                params={
+                    "type": "alert",
+                    "markdown": "# 告警研判主动推送\n\n- 告警 ID: 181953",
+                    "summary": "ignored",
+                },
+            )
+        )
+    )
+
+    with caplog.at_level(logging.INFO):
+        with patch(
+            "gateway.mcp_passthrough.forward_mcp_passthrough_notification",
+            new=AsyncMock(),
+        ) as forward:
+            handled = await server._handle_passthrough_notification(message)
+
+    assert handled is True
+    forward.assert_awaited_once_with(
+        server_name="notif_srv",
+        payload_json="# 告警研判主动推送\n\n- 告警 ID: 181953",
+        targets=["wecom"],
+    )
+    assert "payload_source=markdown" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_passthrough_notification_falls_back_to_raw_json_without_markdown():
+    server = MCPServerTask("notif_srv")
+    server._passthrough_targets = ["wecom"]
+    message = SimpleNamespace(
+        message=SimpleNamespace(
+            root=SimpleNamespace(
+                method="notifications/message",
+                params={"text": "hello", "count": 2},
+            )
+        )
+    )
+
+    with patch(
+        "gateway.mcp_passthrough.forward_mcp_passthrough_notification",
+        new=AsyncMock(),
+    ) as forward:
+        handled = await server._handle_passthrough_notification(message)
+
+    assert handled is True
+    forward.assert_awaited_once_with(
+        server_name="notif_srv",
+        payload_json='{"text": "hello", "count": 2}',
+        targets=["wecom"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_passthrough_notification_logs_custom_method_mismatch(caplog):
+    server = MCPServerTask("notif_srv")
+    server._passthrough_targets = ["wecom"]
+    message = SimpleNamespace(
+        message=SimpleNamespace(
+            root=SimpleNamespace(
+                method="notifications/alert",
+                params={"text": "hello"},
+            )
+        )
+    )
+
+    with caplog.at_level(logging.INFO):
+        handled = await server._handle_passthrough_notification(message)
+
+    assert handled is False
+    assert "received notification 'notifications/alert' but passthrough only forwards 'notifications/message'" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_passthrough_notification_logs_missing_params(caplog):
+    server = MCPServerTask("notif_srv")
+    server._passthrough_targets = ["wecom"]
+    message = SimpleNamespace(
+        message=SimpleNamespace(
+            root=SimpleNamespace(
+                method="notifications/message",
+            )
+        )
+    )
+
+    with caplog.at_level(logging.WARNING):
+        handled = await server._handle_passthrough_notification(message)
+
+    assert handled is True
+    assert "received notifications/message without params; not forwarding" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_intercepting_read_stream_swallows_handled_notifications():
+    passthrough_message = SimpleNamespace(
+        message=SimpleNamespace(
+            root=SimpleNamespace(method="notifications/message", params={"event": "alert"})
+        )
+    )
+    normal_message = SimpleNamespace(message=SimpleNamespace(root=SimpleNamespace(method="notifications/tools/list_changed")))
+    handler = AsyncMock(side_effect=[True, False])
+    stream = _PassthroughInterceptingReadStream(
+        _FakeReadStream([passthrough_message, normal_message]),
+        handler,
+        "notif_srv",
+    )
+
+    seen = []
+    async for item in stream:
+        seen.append(item)
+
+    assert seen == [normal_message]
+    assert handler.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_forward_passthrough_retries_then_persists_to_live_sessions(caplog):
+    home = HomeChannel(platform=Platform.WECOM, chat_id="home-chat", name="Ops")
+    config = GatewayConfig(
+        platforms={
+            Platform.WECOM: PlatformConfig(enabled=True, home_channel=home),
+        }
+    )
+    session_entry = SimpleNamespace(
+        session_id="sess-1",
+        session_key="agent:main:wecom:dm:home-chat",
+        origin=SessionSource(
+            platform=Platform.WECOM,
+            chat_id="home-chat",
+            chat_type="dm",
+            user_id="home-chat",
+            user_name="Ops",
+        ),
+        platform=Platform.WECOM,
+    )
+    adapter = SimpleNamespace(
+        send=AsyncMock(
+            side_effect=[
+                SimpleNamespace(success=False, error="first failure"),
+                SimpleNamespace(success=False, error="second failure"),
+                SimpleNamespace(success=True, message_id="msg-1"),
+            ]
+        )
+    )
+    session_store = SimpleNamespace(
+        list_sessions=MagicMock(return_value=[session_entry]),
+        append_to_transcript=MagicMock(),
+        update_session=MagicMock(),
+        get_or_create_session=MagicMock(return_value=session_entry),
+    )
+    runner = SimpleNamespace(
+        config=config,
+        adapters={Platform.WECOM: adapter},
+        session_store=session_store,
+    )
+
+    with caplog.at_level(logging.INFO):
+        with patch("gateway.mcp_passthrough._get_live_runner", return_value=runner), patch(
+            "gateway.mcp_passthrough.asyncio.sleep",
+            new=AsyncMock(),
+        ) as sleep_mock:
+            await forward_mcp_passthrough_notification(
+                server_name="notif_srv",
+                payload_json='{"event": "ping"}',
+                targets=["wecom"],
+            )
+
+    assert adapter.send.await_count == 3
+    assert sleep_mock.await_count == 2
+    session_store.append_to_transcript.assert_called_once_with(
+        "sess-1",
+        {
+            "role": "assistant",
+            "content": '[MCP passthrough from notif_srv] {"event": "ping"}',
+        },
+    )
+    session_store.update_session.assert_called_once_with("agent:main:wecom:dm:home-chat")
+    assert "passthrough delivered to wecom on attempt 3/3" in caplog.text
+    assert "passthrough target=wecom persisted=1 memory_synced=0" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_forward_passthrough_syncs_active_memory_provider_for_target_session():
+    home = HomeChannel(platform=Platform.WECOM, chat_id="home-chat", name="Ops")
+    config = GatewayConfig(
+        platforms={
+            Platform.WECOM: PlatformConfig(enabled=True, home_channel=home),
+        }
+    )
+    session_entry = SimpleNamespace(
+        session_id="sess-1",
+        session_key="agent:main:wecom:dm:home-chat",
+        origin=SessionSource(
+            platform=Platform.WECOM,
+            chat_id="home-chat",
+            chat_type="dm",
+            user_id="user-1",
+            user_name="Ops User",
+        ),
+        platform=Platform.WECOM,
+    )
+    adapter = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg-1"))
+    )
+    session_store = SimpleNamespace(
+        list_sessions=MagicMock(return_value=[session_entry]),
+        append_to_transcript=MagicMock(),
+        update_session=MagicMock(),
+        get_or_create_session=MagicMock(return_value=session_entry),
+    )
+    runner = SimpleNamespace(
+        config=config,
+        adapters={Platform.WECOM: adapter},
+        session_store=session_store,
+    )
+    provider = _RecordingMemoryProvider()
+
+    with patch("gateway.mcp_passthrough._get_live_runner", return_value=runner), patch(
+        "hermes_cli.config.load_config",
+        return_value={"memory": {"provider": "recording"}},
+    ), patch(
+        "plugins.memory.load_memory_provider",
+        return_value=provider,
+    ), patch(
+        "hermes_constants.get_hermes_home",
+        return_value="/tmp/hermes-home",
+    ), patch(
+        "hermes_cli.profiles.get_active_profile_name",
+        return_value="coder",
+    ):
+        await forward_mcp_passthrough_notification(
+            server_name="notif_srv",
+            payload_json=json.dumps({"event": "ping"}, ensure_ascii=False),
+            targets=["wecom"],
+        )
+
+    assert provider.initialized[0][0] == "sess-1"
+    init_kwargs = provider.initialized[0][1]
+    assert init_kwargs["platform"] == "wecom"
+    assert init_kwargs["user_id"] == "user-1"
+    assert init_kwargs["chat_id"] == "home-chat"
+    assert init_kwargs["gateway_session_key"] == "agent:main:wecom:dm:home-chat"
+    assert provider.events == [
+        (
+            '{"event": "ping"}',
+            "sess-1",
+            "mcp:notif_srv",
+            {
+                "kind": "mcp_passthrough",
+                "server_name": "notif_srv",
+                "platform": "wecom",
+            },
+        )
+    ]
+    assert provider.shutdown_called is True

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1577,6 +1577,64 @@ class TestHTTPConfig:
 class TestReconnection:
     """Tests for automatic reconnection behavior in MCPServerTask.run()."""
 
+    @pytest.mark.asyncio
+    async def test_streamable_http_get_reconnect_exhaustion_raises(self):
+        """GET push-stream exhaustion must bubble so Hermes rebuilds the session."""
+        from tools.mcp_tool import _install_streamable_http_transport_patch
+
+        class DummyTransport:
+            def __init__(self):
+                self.session_id = "sess-1"
+                self.url = "https://example.com/mcp"
+
+            def _prepare_headers(self):
+                return {}
+
+            async def _handle_sse_event(self, sse, read_stream_writer):
+                return None
+
+            async def handle_get_stream(self, client, read_stream_writer):
+                raise AssertionError("patch not installed")
+
+        class DummyEventSource:
+            def __init__(self):
+                self.response = SimpleNamespace(
+                    raise_for_status=MagicMock(side_effect=RuntimeError("boom"))
+                )
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def aiter_sse(self):
+                if False:
+                    yield None
+
+        fake_module = SimpleNamespace(
+            StreamableHTTPTransport=DummyTransport,
+            aconnect_sse=lambda *args, **kwargs: DummyEventSource(),
+            LAST_EVENT_ID="last-event-id",
+            DEFAULT_RECONNECTION_DELAY_MS=10,
+            MAX_RECONNECTION_ATTEMPTS=2,
+            logger=MagicMock(),
+        )
+
+        _install_streamable_http_transport_patch(fake_module)
+        transport = fake_module.StreamableHTTPTransport()
+
+        with patch("tools.mcp_tool.asyncio.sleep", new=AsyncMock()) as sleep_mock:
+            with pytest.raises(
+                RuntimeError,
+                match=r"GET stream reconnection exhausted after 2/2 attempts: boom",
+            ):
+                await transport.handle_get_stream(MagicMock(), MagicMock())
+
+        assert fake_module.logger.warning.call_count == 1
+        fake_module.logger.error.assert_called_once()
+        assert sleep_mock.await_count == 1
+
     def test_reconnect_on_disconnect(self):
         """After initial success, a connection drop triggers reconnection."""
         from tools.mcp_tool import MCPServerTask

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -30,6 +30,7 @@ Example config::
         headers:
           Authorization: "Bearer sk-..."
         timeout: 180
+                passthrough: [wecom, weixin]
       searxng:
         url: "http://localhost:8000/sse"
         transport: sse       # use SSE transport instead of Streamable HTTP
@@ -176,6 +177,8 @@ _MCP_HTTP_AVAILABLE = False
 _MCP_SAMPLING_TYPES = False
 _MCP_NOTIFICATION_TYPES = False
 _MCP_MESSAGE_HANDLER_SUPPORTED = False
+_MCP_NEW_HTTP = False
+_MCP_STREAMABLE_HTTP_MODULE: Any | None = None
 # Conservative fallback for SDK builds that don't export LATEST_PROTOCOL_VERSION.
 # Streamable HTTP was introduced by 2025-03-26, so this remains valid for the
 # HTTP transport path even on older-but-supported SDK versions.
@@ -185,6 +188,7 @@ try:
     from mcp.client.stdio import stdio_client
     _MCP_AVAILABLE = True
     try:
+        import mcp.client.streamable_http as _MCP_STREAMABLE_HTTP_MODULE
         from mcp.client.streamable_http import streamablehttp_client
         _MCP_HTTP_AVAILABLE = True
     except ImportError:
@@ -235,6 +239,129 @@ except ImportError:
     logger.debug("mcp package not installed -- MCP tool support disabled")
 
 
+def _install_streamable_http_transport_patch(module: Any | None) -> None:
+    """Patch SDK GET-stream reconnect exhaustion into a hard transport failure.
+
+    The upstream SDK retries GET stream reconnection a small number of times
+    and then returns quietly. That leaves Hermes in a degraded state where
+    POST-based MCP RPCs can still work but passive server-push notifications
+    are permanently lost. Patch the transport so reconnect exhaustion raises,
+    letting Hermes' outer MCP reconnect loop rebuild the full HTTP session.
+    """
+    if module is None or getattr(module, "_hermes_get_stream_patch_installed", False):
+        return
+
+    transport_cls = getattr(module, "StreamableHTTPTransport", None)
+    aconnect_sse = getattr(module, "aconnect_sse", None)
+    if transport_cls is None or aconnect_sse is None:
+        return
+
+    original_handle_get_stream = getattr(transport_cls, "handle_get_stream", None)
+    if original_handle_get_stream is None or getattr(
+        original_handle_get_stream,
+        "_hermes_get_stream_patch",
+        False,
+    ):
+        return
+
+    async def _patched_handle_get_stream(self, client, read_stream_writer) -> None:
+        last_event_id: str | None = None
+        retry_interval_ms: int | None = None
+        attempt = 0
+        connected_once = False
+        max_attempts = max(
+            1,
+            int(getattr(module, "MAX_RECONNECTION_ATTEMPTS", 2) or 2),
+        )
+        default_delay_ms = int(
+            getattr(module, "DEFAULT_RECONNECTION_DELAY_MS", 1000) or 1000
+        )
+        last_event_id_header = str(
+            getattr(module, "LAST_EVENT_ID", "last-event-id")
+        )
+
+        while True:
+            try:
+                if not self.session_id:
+                    return
+
+                headers = self._prepare_headers()
+                if last_event_id:
+                    headers[last_event_id_header] = last_event_id
+
+                async with aconnect_sse(
+                    client,
+                    "GET",
+                    self.url,
+                    headers=headers,
+                ) as event_source:
+                    event_source.response.raise_for_status()
+                    if connected_once:
+                        module.logger.info("GET stream reconnected successfully")
+                    else:
+                        module.logger.debug("GET SSE connection established")
+                    connected_once = True
+                    attempt = 0
+
+                    async for sse in event_source.aiter_sse():
+                        if sse.id:
+                            last_event_id = sse.id  # pragma: no cover
+                        if sse.retry is not None:
+                            retry_interval_ms = sse.retry  # pragma: no cover
+
+                        await self._handle_sse_event(sse, read_stream_writer)
+
+                delay_ms = (
+                    retry_interval_ms
+                    if retry_interval_ms is not None
+                    else default_delay_ms
+                )
+                module.logger.info(
+                    "GET stream disconnected, reconnecting in %dms...",
+                    delay_ms,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                delay_ms = (
+                    retry_interval_ms
+                    if retry_interval_ms is not None
+                    else default_delay_ms
+                )
+                attempt += 1
+                if attempt >= max_attempts:
+                    module.logger.error(
+                        "GET stream reconnection exhausted after %d/%d attempts; "
+                        "forcing full MCP session reconnect: %s",
+                        attempt,
+                        max_attempts,
+                        exc,
+                    )
+                    raise RuntimeError(
+                        "GET stream reconnection exhausted after "
+                        f"{attempt}/{max_attempts} attempts: {exc}"
+                    ) from exc
+                module.logger.warning(
+                    "GET stream disconnected, reconnecting in %dms "
+                    "(attempt %d/%d): %s",
+                    delay_ms,
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+
+            await asyncio.sleep(delay_ms / 1000.0)
+
+    _patched_handle_get_stream._hermes_get_stream_patch = True
+    _patched_handle_get_stream._hermes_original = original_handle_get_stream
+    transport_cls.handle_get_stream = _patched_handle_get_stream
+    module._hermes_get_stream_patch_installed = True
+
+
+if _MCP_HTTP_AVAILABLE:
+    _install_streamable_http_transport_patch(_MCP_STREAMABLE_HTTP_MODULE)
+
+
 def _check_message_handler_support() -> bool:
     """Check if ClientSession accepts ``message_handler`` kwarg.
 
@@ -262,6 +389,15 @@ _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
 _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
 _MAX_BACKOFF_SECONDS = 60
+_MCP_PASSTHROUGH_METHOD = "notifications/message"
+_MCP_QUIET_NOTIFICATION_METHODS = frozenset({
+    "notifications/tools/list_changed",
+    "notifications/prompts/list_changed",
+    "notifications/resources/list_changed",
+    "notifications/progress",
+    "notifications/cancelled",
+    "notifications/initialized",
+})
 
 # Environment variables that are safe to pass to stdio subprocesses
 _SAFE_ENV_KEYS = frozenset({
@@ -287,6 +423,194 @@ _CREDENTIAL_PATTERN = re.compile(
 # Supports any non-} characters in the variable name (hyphens, dots, etc.)
 # so providers like MY-VAR or my.var work correctly.
 _ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+def _json_default(value: Any) -> Any:
+    """Best-effort JSON serializer for MCP notification params."""
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json", exclude_none=False)
+    if hasattr(value, "dict"):
+        return value.dict()
+    if isinstance(value, set):
+        return list(value)
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def _jsonify_passthrough_params(params: Any) -> str:
+    """Serialize MCP notification params without interpreting their shape."""
+    if hasattr(params, "model_dump"):
+        params = params.model_dump(mode="json", exclude_none=False)
+    elif hasattr(params, "dict"):
+        params = params.dict()
+    return json.dumps(params, ensure_ascii=False, default=_json_default)
+
+
+def _extract_passthrough_markdown(params: Any) -> str | None:
+    """Extract ``params.markdown`` when alert pushes provide a Markdown payload."""
+    normalized = params
+    if hasattr(normalized, "model_dump"):
+        normalized = normalized.model_dump(mode="json", exclude_none=False)
+    elif hasattr(normalized, "dict"):
+        normalized = normalized.dict()
+
+    markdown = None
+    if isinstance(normalized, dict):
+        markdown = normalized.get("markdown")
+    elif hasattr(normalized, "markdown"):
+        markdown = getattr(normalized, "markdown")
+
+    return markdown if isinstance(markdown, str) else None
+
+
+def _build_passthrough_payload_text(params: Any) -> tuple[str, str]:
+    """Build passthrough text, preferring ``markdown`` over raw JSON."""
+    markdown = _extract_passthrough_markdown(params)
+    if markdown is not None:
+        return markdown, "markdown"
+    return _jsonify_passthrough_params(params), "json"
+
+
+def _truncate_log_text(text: Any, max_chars: int = 240) -> str:
+    """Return a single-line truncated string for structured log fields."""
+    rendered = str(text or "").replace("\n", "\\n")
+    if len(rendered) <= max_chars:
+        return rendered
+    return rendered[: max_chars - 3] + "..."
+
+
+def _get_raw_mcp_message_root(message: Any) -> Any | None:
+    """Extract the JSON-RPC root object from a transport message."""
+    if isinstance(message, dict):
+        wrapped = message.get("message")
+        if isinstance(wrapped, dict) and "root" in wrapped:
+            return wrapped.get("root")
+        return message.get("root")
+
+    wrapped = getattr(message, "message", None)
+    if wrapped is not None and hasattr(wrapped, "root"):
+        return wrapped.root
+    if hasattr(message, "root"):
+        return message.root
+    return None
+
+
+def _get_raw_mcp_message_method(message: Any) -> str | None:
+    """Return the JSON-RPC method string when the transport item is a notification."""
+    root = _get_raw_mcp_message_root(message)
+    if isinstance(root, dict):
+        method = root.get("method")
+    else:
+        method = getattr(root, "method", None)
+    if isinstance(method, str) and method:
+        return method
+    return None
+
+
+def _get_raw_mcp_message_params(message: Any) -> tuple[bool, Any]:
+    """Return whether ``params`` exists on the raw transport message and its value."""
+    root = _get_raw_mcp_message_root(message)
+    if isinstance(root, dict):
+        return ("params" in root, root.get("params"))
+    if root is None:
+        return False, None
+    if hasattr(root, "params"):
+        return True, getattr(root, "params")
+    return False, None
+
+
+def _summarize_raw_mcp_message(message: Any) -> str:
+    """Build a compact summary for passthrough diagnostics."""
+    root = _get_raw_mcp_message_root(message)
+    method = _get_raw_mcp_message_method(message)
+    has_params, _params = _get_raw_mcp_message_params(message)
+    root_type = type(root).__name__ if root is not None else type(message).__name__
+    try:
+        if hasattr(root, "model_dump"):
+            preview_obj = root.model_dump(mode="json", exclude_none=False)
+        elif hasattr(root, "dict"):
+            preview_obj = root.dict()
+        else:
+            preview_obj = root
+        preview = _truncate_log_text(
+            json.dumps(preview_obj, ensure_ascii=False, default=_json_default)
+        )
+    except Exception as exc:
+        preview = f"<unserializable {root_type}: {exc}>"
+    return (
+        f"root_type={root_type} method={method!r} "
+        f"has_params={has_params} preview={preview}"
+    )
+
+
+def _extract_passthrough_params(message: Any) -> Any | None:
+    """Return params for raw ``notifications/message`` events."""
+    if _get_raw_mcp_message_method(message) != _MCP_PASSTHROUGH_METHOD:
+        return None
+    has_params, params = _get_raw_mcp_message_params(message)
+    if not has_params:
+        return None
+    return params
+
+
+def _normalize_passthrough_targets(value: Any, label: str) -> list[str]:
+    """Normalize ``mcp_servers.<name>.passthrough`` to a list of targets."""
+    if value in (None, [], ()): 
+        return []
+    if not isinstance(value, (list, tuple, set)):
+        logger.warning(
+            "MCP config %s must be a list of gateway platforms; ignoring %r",
+            label,
+            value,
+        )
+        return []
+
+    targets: list[str] = []
+    for item in value:
+        target = str(item or "").strip().lower()
+        if not target:
+            continue
+        targets.append(target)
+    return targets
+
+
+class _PassthroughInterceptingReadStream:
+    """Transparent read-stream wrapper that swallows custom passthrough notifications."""
+
+    def __init__(self, read_stream: Any, handler, server_name: str):
+        self._read_stream = read_stream
+        self._handler = handler
+        self._server_name = server_name
+
+    async def __aenter__(self):
+        await self._read_stream.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return await self._read_stream.__aexit__(exc_type, exc_val, exc_tb)
+
+    async def aclose(self):
+        if hasattr(self._read_stream, "aclose"):
+            await self._read_stream.aclose()
+
+    def __aiter__(self):
+        return self._iter_messages()
+
+    async def _iter_messages(self):
+        async for message in self._read_stream:
+            try:
+                if await self._handler(message):
+                    continue
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception(
+                    "MCP server '%s': passthrough intercept failed",
+                    self._server_name,
+                )
+            yield message
+
+    def __getattr__(self, name: str):
+        return getattr(self._read_stream, name)
 
 
 # ---------------------------------------------------------------------------
@@ -1108,7 +1432,7 @@ class MCPServerTask:
         "_task", "_ready", "_shutdown_event", "_reconnect_event",
         "_tools", "_error", "_config",
         "_sampling", "_registered_tool_names", "_auth_type", "_refresh_lock",
-        "_rpc_lock", "_pending_refresh_tasks",
+        "_rpc_lock", "_pending_refresh_tasks", "_passthrough_targets",
         "initialize_result",
     )
 
@@ -1146,6 +1470,7 @@ class MCPServerTask:
         # ``.capabilities.prompts``) instead of assuming every ``ClientSession``
         # method attribute corresponds to a supported server method. See #18051.
         self.initialize_result: Optional[Any] = None
+        self._passthrough_targets: list[str] = []
 
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
@@ -1211,6 +1536,97 @@ class MCPServerTask:
             except Exception:
                 logger.exception("Error in MCP message handler for '%s'", self.name)
         return _handler
+
+    async def _handle_passthrough_notification(self, message: Any) -> bool:
+        """Handle raw custom notifications before the SDK validates them."""
+        method = _get_raw_mcp_message_method(message)
+        if method != _MCP_PASSTHROUGH_METHOD:
+            if self._passthrough_targets and method and method.startswith("notifications/"):
+                log_level = (
+                    logging.DEBUG
+                    if method in _MCP_QUIET_NOTIFICATION_METHODS
+                    else logging.INFO
+                )
+                logger.log(
+                    log_level,
+                    "MCP server '%s': received notification '%s' but passthrough only forwards '%s'. %s",
+                    self.name,
+                    method,
+                    _MCP_PASSTHROUGH_METHOD,
+                    _summarize_raw_mcp_message(message),
+                )
+            return False
+
+        has_params, params = _get_raw_mcp_message_params(message)
+        if not has_params:
+            logger.warning(
+                "MCP server '%s': received %s without params; not forwarding. %s",
+                self.name,
+                _MCP_PASSTHROUGH_METHOD,
+                _summarize_raw_mcp_message(message),
+            )
+            return True
+
+        if not self._passthrough_targets:
+            logger.warning(
+                "MCP server '%s': received %s but no passthrough targets are configured. %s",
+                self.name,
+                _MCP_PASSTHROUGH_METHOD,
+                _summarize_raw_mcp_message(message),
+            )
+            return True
+
+        try:
+            payload_text, payload_source = _build_passthrough_payload_text(params)
+        except Exception:
+            logger.exception(
+                "MCP server '%s': failed to serialize %s payload. %s",
+                self.name,
+                _MCP_PASSTHROUGH_METHOD,
+                _summarize_raw_mcp_message(message),
+            )
+            return True
+
+        logger.info(
+            "MCP server '%s': received %s for passthrough targets=%s payload_source=%s payload_bytes=%d payload_preview=%s",
+            self.name,
+            _MCP_PASSTHROUGH_METHOD,
+            ",".join(self._passthrough_targets),
+            payload_source,
+            len(payload_text.encode("utf-8")),
+            _truncate_log_text(payload_text),
+        )
+        try:
+            from gateway.mcp_passthrough import forward_mcp_passthrough_notification
+
+            await forward_mcp_passthrough_notification(
+                server_name=self.name,
+                payload_json=payload_text,
+                targets=self._passthrough_targets,
+            )
+            logger.info(
+                "MCP server '%s': completed passthrough forwarding for %s to targets=%s",
+                self.name,
+                _MCP_PASSTHROUGH_METHOD,
+                ",".join(self._passthrough_targets),
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception(
+                "MCP server '%s': failed to forward %s",
+                self.name,
+                _MCP_PASSTHROUGH_METHOD,
+            )
+        return True
+
+    def _wrap_read_stream(self, read_stream: Any) -> Any:
+        """Wrap the raw MCP read stream so custom notifications can be intercepted."""
+        return _PassthroughInterceptingReadStream(
+            read_stream,
+            self._handle_passthrough_notification,
+            self.name,
+        )
 
     async def _refresh_tools(self):
         """Re-fetch tools from the server and update the registry.
@@ -1392,6 +1808,7 @@ class MCPServerTask:
                 read_stream,
                 write_stream,
             ):
+                intercepted_read_stream = self._wrap_read_stream(read_stream)
                 # Capture the newly spawned subprocess PID for force-kill cleanup.
                 new_pids = _snapshot_child_pids() - pids_before
                 if new_pids:
@@ -1399,7 +1816,7 @@ class MCPServerTask:
                         for _pid in new_pids:
                             _stdio_pids[_pid] = self.name
                 async with ClientSession(
-                    read_stream, write_stream, **sampling_kwargs
+                    intercepted_read_stream, write_stream, **sampling_kwargs
                 ) as session:
                     self.initialize_result = await session.initialize()
                     self.session = session
@@ -1530,8 +1947,9 @@ class MCPServerTask:
 
                 _sse_kwargs["httpx_client_factory"] = _mcp_http_client_factory
             async with sse_client(**_sse_kwargs) as (read_stream, write_stream):
+                intercepted_read_stream = self._wrap_read_stream(read_stream)
                 async with ClientSession(
-                    read_stream, write_stream, **sampling_kwargs
+                    intercepted_read_stream, write_stream, **sampling_kwargs
                 ) as session:
                     self.initialize_result = await session.initialize()
                     self.session = session
@@ -1581,7 +1999,8 @@ class MCPServerTask:
                 async with streamable_http_client(url, http_client=http_client) as (
                     read_stream, write_stream, _get_session_id,
                 ):
-                    async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+                    intercepted_read_stream = self._wrap_read_stream(read_stream)
+                    async with ClientSession(intercepted_read_stream, write_stream, **sampling_kwargs) as session:
                         self.initialize_result = await session.initialize()
                         self.session = session
                         await self._discover_tools()
@@ -1604,7 +2023,8 @@ class MCPServerTask:
             async with streamablehttp_client(url, **_http_kwargs) as (
                 read_stream, write_stream, _get_session_id,
             ):
-                async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+                intercepted_read_stream = self._wrap_read_stream(read_stream)
+                async with ClientSession(intercepted_read_stream, write_stream, **sampling_kwargs) as session:
                     self.initialize_result = await session.initialize()
                     self.session = session
                     await self._discover_tools()
@@ -1637,6 +2057,17 @@ class MCPServerTask:
         self._config = config
         self.tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
         self._auth_type = (config.get("auth") or "").lower().strip()
+        self._passthrough_targets = _normalize_passthrough_targets(
+            config.get("passthrough"),
+            f"mcp_servers.{self.name}.passthrough",
+        )
+        if self._passthrough_targets:
+            logger.info(
+                "MCP server '%s': passthrough enabled for targets=%s (method=%s)",
+                self.name,
+                ",".join(self._passthrough_targets),
+                _MCP_PASSTHROUGH_METHOD,
+            )
 
         # Set up sampling handler if enabled and SDK types are available
         sampling_config = config.get("sampling", {})


### PR DESCRIPTION
- 为 MCP 增加 notifications/message 被动通知拦截与 passthrough 转发能力
- 新增 gateway 侧转发与持久化逻辑，将推送内容写入 home channel 对应会话历史
- 为 memory provider 增加 sync_passive_event 钩子，并支持 MemoryManager 广播同步被动事件
- 在有活动会话时同步写入 memory provider，保留被动通知上下文
- 修复 streamable HTTP GET 流在重连耗尽后静默失效的问题，改为抛错触发完整 MCP 会话重建
- 补充单测与 e2e 测试，覆盖通知转发、memory 同步和重连耗尽场景 使用说明，config.yaml添加：
mcp_servers:
  notif_srv: url: "https://example.com/mcp" headers: Authorization: "Bearer sk-xxx" passthrough: [wecom]

gateway:
  platforms: wecom: enabled: true home_channel: platform: wecom chat_id: "ops-room" name: "Ops Room"

MCP服务端发送：
{
  "jsonrpc": "2.0", "method": "notifications/message", "params": { "markdown": "推送透传信息" } }

## What does this PR do?

本 PR 为 MCP (Model Context Protocol) 集成增加了对 notifications/message 被动通知的拦截与透传能力，并完善了相关的网关转发、记忆同步和连接健壮性逻辑。

核心目标：让 Hermes Agent 不仅能主动调用 MCP 工具，还能作为一个 MCP 客户端，被动接收并处理来自 MCP 服务端的实时推送消息，将其同步到即时通讯（IM）频道和长期记忆中。

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- MCP 客户端层: 为 mcp_client 增加 notifications/message 被动通知的拦截能力，支持按配置的 passthrough 列表（如 wecom）将通知转发至指定平台。

- Gateway 层: 新增转发与持久化逻辑。在接收到转发通知后，gateway 会根据配置将 Markdown 内容推送到对应平台的 home_channel（如企业微信群），并将其写入该频道对应的会话历史。

- Memory Provider 层: 为 memory provider 增加 sync_passive_event 钩子，并支持 MemoryManager 广播同步被动事件。当存在与 home_channel 的活动会话时，同步将通知上下文写入 memory，以保留被动通知的历史。

- 连接管理修复: 修复了 Streamable HTTP GET 流在重连次数耗尽后静默失效的 bug。现在，当重连失败时会正确地抛出异常，从而触发上层进行完整的 MCP 会话重建，避免通知接收静默中断。

- 测试: 补充了单元测试与端到端 (e2e) 测试，完整覆盖了通知转发、memory 同步以及重连耗尽后会话重建的场景。


## How to Test
1. 配置环境: 在 config.yaml 中添加 MCP 服务端和 Gateway 配置：
```json
mcp_servers:
  notif_srv:
    url: "https://example.com/mcp"
    headers:
      Authorization: "Bearer sk-xxx"
    passthrough: [wecom]

gateway:
  platforms:
    wecom:
      enabled: true
      home_channel:
        platform: wecom
        chat_id: "ops-room"
        name: "Ops Room"
```
2. 启动 Hermes Agent: 确保 Agent 正常启动并连接到MCP服务器与gateway。

3. 模拟服务端推送: 使用脚本或测试工具模拟 MCP 服务端发送 JSON-RPC 通知：

```json
{
  "jsonrpc": "2.0",
  "method": "notifications/message",
  "params": {
    "markdown": "【告警】CPU 使用率超过 90%"
  }
}
```
验证结果:

1. 检查配置的企业微信 Ops Room 群聊，应收到内容为 【告警】CPU 使用率超过 90% 的消息。

2. 查看 Agent 的会话历史，该消息应被记录在与 Ops Room 的对话中。

3. 查询 Memory Provider（如 vector store），应能检索到这条告警通知的上下文。

4. 重连测试: 中断 MCP 服务端连接，待客户端重连次数耗尽后，确认 Agent 日志中抛出明确错误并触发 MCP 会话重建，不再静默失效。

