### PR TITLE
fix(kanban): wire per-task model override through create and worker spawn

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -74,6 +74,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "completed_at": t.completed_at,
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
+        "model_override": t.model_override,
         "max_retries": t.max_retries,
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
@@ -332,6 +333,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "(repeatable). Appended to the built-in "
                                "kanban-worker skill. Example: "
                                "--skill translation --skill github-code-review")
+    p_create.add_argument("-m", "--model", default=None, dest="model_override",
+                          help="Per-task model override for the worker. "
+                               "Use a model name, or provider:model to also "
+                               "override provider when supported by the worker launcher.")
     p_create.add_argument("--max-retries", type=int, default=None,
                           metavar="N",
                           help="Per-task override for the consecutive-failure "
@@ -1337,6 +1342,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             idempotency_key=getattr(args, "idempotency_key", None),
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
+            model_override=getattr(args, "model_override", None),
             max_retries=max_retries,
             initial_status=getattr(args, "initial_status", "running"),
         )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1756,6 +1756,7 @@ def create_task(
     idempotency_key: Optional[str] = None,
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
+    model_override: Optional[str] = None,
     max_retries: Optional[int] = None,
     initial_status: str = "running",
     session_id: Optional[str] = None,
@@ -1784,6 +1785,9 @@ def create_task(
     ``kanban-worker``. Use this to pin a task to a specialist skill
     (e.g. ``skills=["translation"]`` so the worker loads the
     translation skill regardless of the profile's default config).
+
+    ``model_override`` pins the worker invocation to a specific model for
+    this task. ``None`` uses the assignee profile default.
     """
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
@@ -1801,6 +1805,8 @@ def create_task(
         branch_name = str(branch_name).strip() or None
     if branch_name and workspace_kind != "worktree":
         raise ValueError("branch_name is only valid for worktree workspaces")
+    if model_override is not None:
+        model_override = str(model_override).strip() or None
     parents = tuple(p for p in parents if p)
 
     # Normalise + validate skills: strip whitespace, drop empties, dedupe
@@ -1924,8 +1930,8 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, tenant, idempotency_key, max_runtime_seconds,
-                        skills, max_retries, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, model_override, max_retries, session_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -1943,6 +1949,7 @@ def create_task(
                         idempotency_key,
                         int(max_runtime_seconds) if max_runtime_seconds is not None else None,
                         json.dumps(skills_list) if skills_list is not None else None,
+                        model_override,
                         int(max_retries) if max_retries is not None else None,
                         session_id,
                     ),
@@ -1963,6 +1970,7 @@ def create_task(
                         "tenant": tenant,
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
+                        "model_override": model_override,
                     },
                 )
             return task_id
@@ -5993,10 +6001,24 @@ def _default_spawn(
         for sk in task.skills:
             if sk and sk != "kanban-worker":
                 cmd.extend(["--skills", sk])
-    if task.model_override:
-        cmd.extend(["-m", task.model_override])
     cmd.extend([
         "chat",
+    ])
+    if task.model_override:
+        # Support "provider:model" format (e.g. "deepseek:deepseek-v4-pro").
+        # When provider is specified, pass --provider so the CLI resolves
+        # credentials against the correct backend instead of falling back
+        # to the profile's default provider.
+        _mo = task.model_override
+        if ":" in _mo:
+            _prov, _mdl = _mo.split(":", 1)
+            if _prov and _mdl:
+                cmd.extend(["--provider", _prov, "-m", _mdl])
+            else:
+                cmd.extend(["-m", _mo])
+        else:
+            cmd.extend(["-m", _mo])
+    cmd.extend([
         "-q", prompt,
     ])
     # Redirect output to a per-task log under <board-root>/logs/.

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -166,6 +166,19 @@ def test_run_slash_json_output(kanban_home):
     assert payload["status"] == "ready"
 
 
+def test_run_slash_create_with_model_override(kanban_home):
+    out = kc.run_slash(
+        "create 'model task' --assignee alice -m deepseek:deepseek-v4-pro --json"
+    )
+    payload = json.loads(out)
+    assert payload["title"] == "model task"
+    assert payload["model_override"] == "deepseek:deepseek-v4-pro"
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, payload["id"])
+    assert task.model_override == "deepseek:deepseek-v4-pro"
+
+
 def test_run_slash_dispatch_dry_run_counts(kanban_home):
     kc.run_slash("create 'a' --assignee alice")
     kc.run_slash("create 'b' --assignee bob")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -204,6 +204,22 @@ def test_create_task_no_parents_is_ready(kanban_home):
     assert t.workspace_kind == "scratch"
 
 
+def test_create_task_persists_model_override(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="use stronger model",
+            assignee="alice",
+            model_override=" deepseek:deepseek-v4-pro ",
+        )
+        t = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+
+    assert t is not None
+    assert t.model_override == "deepseek:deepseek-v4-pro"
+    assert events[0].payload["model_override"] == "deepseek:deepseek-v4-pro"
+
+
 def test_create_task_with_parent_is_todo_until_parent_done(kanban_home):
     with kb.connect() as conn:
         p = kb.create_task(conn, title="parent")


### PR DESCRIPTION
## What

Wire per-task model override (`model_override`) through the full path:
CLI `kanban create --model` → DB persistence → worker spawn with correct `--provider` and `-m` flags.

## Why

Three independent bugs prevented `hermes kanban create --model <model>` from working:

1. **CLI entry gap**: `kanban.py` did not register `-m/--model` on the create subparser, and `_cmd_create()` did not pass `model_override` to `create_task()`.
2. **DB layer gap**: `create_task()` had no `model_override` parameter, so even direct callers could not set it.
3. **Spawn arg ordering**: `_default_spawn()` placed `-m` before the `chat` subcommand. Argparse subparser defaults (`None`) overrode the top-level value. No `--provider` was passed, so the CLI couldn't resolve the model against the correct backend.

## How to test

```bash
# Create a task with model override
hermes kanban create "test model override" \
  --assignee default \
  -m deepseek:deepseek-v4-pro \
  --body "confirm your model in summary" \
  --json

# Verify model_override in JSON output
# -> should show "model_override": "deepseek:deepseek-v4-pro"

# Wait for worker to spawn, then check the command line:
ps -ef | grep "<task_id>"
# -> should show: hermes ... chat --provider deepseek -m deepseek-v4-pro -q ...
```

## Files changed

| File | Change |
|---|---|
| `hermes_cli/kanban.py` | Register `-m/--model` on create subparser; pass to `create_task()`; expose in JSON output |
| `hermes_cli/kanban_db.py` | Add `model_override` param to `create_task()`; fix spawn arg order; support `provider:model` format |
| `tests/hermes_cli/test_kanban_cli.py` | CLI slash command test for model override |
| `tests/hermes_cli/test_kanban_db.py` | DB-level persistence test for model override |

## Platforms tested

- macOS 26.2 (arm64)
- No cross-platform concerns: changes are in argparse registration, dict serialization, and subprocess arg list construction — all platform-neutral

## Checklist

- [x] `scripts/check-windows-footguns.py` — no footguns found
- [x] `pytest tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_db.py -k model_override` — 2/2 passed
- [x] Manual end-to-end verification: `hermes kanban create -m deepseek:deepseek-v4-pro` -> worker confirmed `Model: deepseek-v4-pro, Provider: deepseek`
