### PR TITLE
fix(gateway): deliver markdown media attachments reliably

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2544,7 +2544,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|md|csv|apk|ipa)(?=[\s`"',;:)\]}]|$))[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17186,7 +17186,7 @@ class GatewayRunner:
                             r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                             r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                             r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|apk|ipa))',
+                            r'txt|md|csv|apk|ipa))',
                             re.IGNORECASE
                         )
                         for _match in _TOOL_MEDIA_RE.finditer(_hc):
@@ -17492,7 +17492,7 @@ class GatewayRunner:
                                 r'MEDIA:((?:/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                                 r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                                 r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                                r'txt|csv|apk|ipa))',
+                                r'txt|md|csv|apk|ipa))',
                                 re.IGNORECASE
                             )
                             for match in _TOOL_MEDIA_RE.finditer(content):

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -8,6 +8,7 @@ import pytest
 
 from gateway.platforms.base import (
     BasePlatformAdapter,
+    DOCUMENT_CACHE_DIR,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
     safe_url_for_log,
@@ -270,6 +271,44 @@ class TestExtractMedia:
         assert len(media) == 1
         assert media[0][0] == "/path/to/audio.ogg"
         assert media[0][1] is False  # no voice tag
+
+    def test_media_tag_supports_markdown_file(self):
+        content = "MEDIA:/tmp/ai-news-evaluation-source.md"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/ai-news-evaluation-source.md", False)]
+        assert cleaned == ""
+
+    def test_media_tag_supports_markdown_file_from_document_cache(self, tmp_path, monkeypatch):
+        """Markdown deliverables in Hermes document cache should attach reliably.
+
+        This protects Mahdy's recurring "send me the .md" workflow: explicit
+        MEDIA: tags must extract .md paths and the safety filter must accept
+        the profile-safe document cache root rather than silently dropping the
+        attachment as unsafe.
+        """
+        doc_cache = tmp_path / "cache" / "documents"
+        md_file = doc_cache / "model-development-learning-starter.md"
+        md_file.parent.mkdir(parents=True)
+        md_file.write_text("# Learning file\n", encoding="utf-8")
+        monkeypatch.setattr("gateway.platforms.base.DOCUMENT_CACHE_DIR", doc_cache)
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+            (doc_cache,),
+        )
+        monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "0")
+
+        media, cleaned = BasePlatformAdapter.extract_media(f"MEDIA:{md_file}")
+        assert cleaned == ""
+        assert media == [(str(md_file), False)]
+        assert BasePlatformAdapter.filter_media_delivery_paths(media) == [
+            (str(md_file.resolve()), False)
+        ]
+
+    def test_default_safe_roots_include_document_cache(self):
+        """The modern document cache path is a permanent native-delivery root."""
+        from gateway.platforms import base as base_module
+
+        assert DOCUMENT_CACHE_DIR in base_module.MEDIA_DELIVERY_SAFE_ROOTS
 
     def test_media_with_voice_directive(self):
         content = "[[audio_as_voice]]\nMEDIA:/path/to/voice.ogg"

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -26,6 +26,7 @@ def _reset_signal_scheduler():
     _reset_scheduler()
 
 from gateway.config import Platform
+from gateway.platforms.base import SendResult
 from tools.send_message_tool import (
     _is_telegram_thread_not_found,
     _parse_target_ref,
@@ -2381,6 +2382,75 @@ class TestSendViaAdapterStandaloneFallback:
         assert recorded["chat_id"] == "room/123"
         assert recorded["message"] == "hello cron"
         assert recorded["pconfig"] is pconfig
+
+    @pytest.mark.asyncio
+    async def test_live_adapter_sends_media_files_after_text(self, monkeypatch, tmp_path):
+        """Live gateway adapter path must upload attachments, not only mirror text."""
+        from tools.send_message_tool import _send_via_adapter
+        from gateway.config import Platform
+
+        media_file = tmp_path / "learning.md"
+        media_file.write_text("# Learning\n", encoding="utf-8")
+
+        adapter = SimpleNamespace(
+            send=AsyncMock(return_value=SendResult(success=True, message_id="text-1")),
+            send_image_file=AsyncMock(),
+            send_video=AsyncMock(),
+            send_voice=AsyncMock(),
+            send_audio=AsyncMock(),
+            send_document=AsyncMock(return_value=SendResult(success=True, message_id="doc-1")),
+        )
+        runner = SimpleNamespace(adapters={Platform.TELEGRAM: adapter})
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+        result = await _send_via_adapter(
+            Platform.TELEGRAM,
+            SimpleNamespace(extra={}),
+            "12345",
+            "Fallback ZIP containing the MD file:",
+            media_files=[(str(media_file), False)],
+        )
+
+        assert result == {"success": True, "message_id": "doc-1"}
+        adapter.send.assert_awaited_once()
+        adapter.send_document.assert_awaited_once_with(
+            chat_id="12345",
+            file_path=str(media_file),
+            metadata=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_live_adapter_reports_media_warning_when_upload_fails(self, monkeypatch, tmp_path):
+        """A text success must not hide a failed attachment upload."""
+        from tools.send_message_tool import _send_via_adapter
+        from gateway.config import Platform
+
+        media_file = tmp_path / "learning.md"
+        media_file.write_text("# Learning\n", encoding="utf-8")
+
+        adapter = SimpleNamespace(
+            send=AsyncMock(return_value=SendResult(success=True, message_id="text-1")),
+            send_image_file=AsyncMock(),
+            send_video=AsyncMock(),
+            send_voice=AsyncMock(),
+            send_audio=AsyncMock(),
+            send_document=AsyncMock(return_value=SendResult(success=False, error="upload failed")),
+        )
+        runner = SimpleNamespace(adapters={Platform.TELEGRAM: adapter})
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+        result = await _send_via_adapter(
+            Platform.TELEGRAM,
+            SimpleNamespace(extra={}),
+            "12345",
+            "Here is the file",
+            media_files=[(str(media_file), False)],
+        )
+
+        assert result["success"] is True
+        assert result["message_id"] == "text-1"
+        assert "warnings" in result
+        assert any("upload failed" in warning for warning in result["warnings"])
 
     @pytest.mark.asyncio
     async def test_standalone_sender_fn_kwargs_forwarded(self, monkeypatch):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -502,12 +502,63 @@ async def _send_via_adapter(
             try:
                 metadata = {"thread_id": thread_id} if thread_id else None
                 result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
+                media_warnings = []
+                for media_path, is_voice in media_files or []:
+                    try:
+                        ext = os.path.splitext(str(media_path))[1].lower()
+                        if ext in _IMAGE_EXTS and not force_document:
+                            media_result = await adapter.send_image_file(
+                                chat_id=chat_id,
+                                image_path=media_path,
+                                metadata=metadata,
+                            )
+                        elif ext in _VIDEO_EXTS:
+                            media_result = await adapter.send_video(
+                                chat_id=chat_id,
+                                video_path=media_path,
+                                metadata=metadata,
+                            )
+                        elif ext in _VOICE_EXTS and is_voice:
+                            media_result = await adapter.send_voice(
+                                chat_id=chat_id,
+                                audio_path=media_path,
+                                metadata=metadata,
+                            )
+                        elif ext in _TELEGRAM_SEND_AUDIO_EXTS:
+                            media_result = await adapter.send_audio(
+                                chat_id=chat_id,
+                                audio_path=media_path,
+                                metadata=metadata,
+                            )
+                        else:
+                            media_result = await adapter.send_document(
+                                chat_id=chat_id,
+                                file_path=media_path,
+                                metadata=metadata,
+                            )
+                    except Exception as media_exc:
+                        media_warnings.append(
+                            _sanitize_error_text(f"Failed to send media {media_path}: {media_exc}")
+                        )
+                        continue
+                    if not getattr(media_result, "success", False):
+                        media_warnings.append(
+                            _sanitize_error_text(
+                                f"Failed to send media {media_path}: "
+                                f"{getattr(media_result, 'error', 'unknown error')}"
+                            )
+                        )
+                    elif getattr(media_result, "message_id", None):
+                        result = media_result
             except asyncio.CancelledError:
                 raise
             except Exception as e:
                 return {"error": f"Plugin platform send failed: {e}"}
             if result.success:
-                return {"success": True, "message_id": result.message_id}
+                payload = {"success": True, "message_id": result.message_id}
+                if media_warnings:
+                    payload["warnings"] = media_warnings
+                return payload
             return {"error": f"Adapter send failed: {result.error}"}
 
     platform_name = platform.value if hasattr(platform, "value") else str(platform)


### PR DESCRIPTION
## Summary
- allow explicit `MEDIA:` tags and document-cache files to deliver `.md` attachments
- make live gateway `send_message` adapters upload media instead of only mirroring text
- surface per-file upload warnings so text success does not hide attachment failure

## Test Plan
- `python -m pytest tests/gateway/test_platform_base.py tests/tools/test_send_message_tool.py -q`

This fixes the situation where Telegram showed the text message but silently missed the requested Markdown document.
