### PR TITLE
docs(cli): document hermes plugins list filter/output flags (#34471)

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1155,7 +1155,7 @@ Unified plugin management — general plugins, memory providers, and context eng
 | `remove <name>` (aliases: `rm`, `uninstall`) | Remove an installed plugin. |
 | `enable <name>` | Enable a disabled plugin. |
 | `disable <name>` | Disable a plugin without removing it. |
-| `list` (alias: `ls`) | List installed plugins with enabled/disabled status. |
+| `list` (alias: `ls`) | List installed plugins with enabled/disabled status. Filter with `--enabled`, `--user`, `--no-bundled`; format with `--plain` (compact text) or `--json` (machine-readable). |
 
 Provider plugin selections are saved to `config.yaml`:
 - `memory.provider` — active memory provider (empty = built-in only)

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1493,7 +1493,7 @@ Unified plugin management — general plugins, memory providers, and context eng
 | `remove <name>` (aliases: `rm`, `uninstall`) | Remove an installed plugin. |
 | `enable <name>` | Enable a disabled plugin. |
 | `disable <name>` | Disable a plugin without removing it. |
-| `list` (alias: `ls`) | List installed plugins with enabled/disabled status. |
+| `list` (alias: `ls`) | List installed plugins with enabled/disabled status. Filter with `--enabled`, `--user`, `--no-bundled`; format with `--plain` (compact text) or `--json` (machine-readable). |
 | `doctor [path-or-id] [--ci]` | Validate a native plugin through the real manifest parser, loader, and registration path. `--ci` exits 1 on errors. |
 | `pack install <path-or-url> [--force]` | Install a plugin pack (`hermes-pack.yaml`) — a declarative set of plugins each pinned to an exact 40-character commit SHA. Shows a mandatory review screen (every plugin, source, pinned ref, declared capabilities), asks one confirmation for the pack contents, then runs ordinary pinned installs. Each plugin's declared capabilities still go through the standard per-plugin consent — a pack never bulk-grants. Partial failures are reported per plugin; exits non-zero when any plugin failed. Interactive only (no `--yes`). |
 | `pack export [--enabled-only] [--name NAME]` | Emit a pack YAML on stdout from the current install: repo + exact SHA of each git-installed plugin plus sanitized non-secret `plugins.entries` config. Local-only plugins (no git provenance) are listed as warning comments, never as installable entries. Secrets, capability grants, and `allow_*` gates are always stripped. |


### PR DESCRIPTION
`#34471` (salvage of #33363) added five user-facing flags to `hermes plugins list` — `--enabled`, `--user`, `--no-bundled` (filters) and `--plain`, `--json` (output formats) — but the CLI reference `list` row still documents none of them.

This documents them inline on the existing row, matching the in-repo convention already used for the `kanban list` row (`Filter with --mine, --assignee, ...`).

Flag descriptions taken verbatim from the argparse help in `hermes_cli/main.py` (#34471):
- `--enabled` — Show only enabled plugins
- `--user` — Show only user-installed plugins (including git plugins)
- `--no-bundled` — Hide bundled plugins
- `--plain` — Print compact plain-text output instead of a Rich table
- `--json` — Print machine-readable JSON

Pure docs, single row. If this has already landed via a separate patch, please feel free to close and mark accordingly.
