### PR TITLE
fix(hindsight): stabilize embedded daemon config and async retain

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -504,6 +504,22 @@ def _load_simple_env(path) -> dict[str, str]:
     return values
 
 
+_EMBEDDED_PROFILE_ENV_PASSTHROUGH = {
+    "llm_max_concurrent": "HINDSIGHT_API_LLM_MAX_CONCURRENT",
+    "llm_timeout": "HINDSIGHT_API_LLM_TIMEOUT",
+    "retain_llm_max_concurrent": "HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT",
+    "reflect_llm_max_concurrent": "HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT",
+    "consolidation_llm_max_concurrent": "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT",
+    "retain_max_concurrent": "HINDSIGHT_API_RETAIN_MAX_CONCURRENT",
+    "worker_max_slots": "HINDSIGHT_API_WORKER_MAX_SLOTS",
+    "worker_retain_max_slots": "HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS",
+    "worker_consolidation_max_slots": "HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS",
+    "recall_max_concurrent": "HINDSIGHT_API_RECALL_MAX_CONCURRENT",
+    "recall_max_tokens": "HINDSIGHT_API_RECALL_MAX_TOKENS",
+    "reflect_max_context_tokens": "HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS",
+    "reflect_wall_timeout": "HINDSIGHT_API_REFLECT_WALL_TIMEOUT",
+}
+
 def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:
     """Build the profile-scoped env file that standalone hindsight-embed consumes."""
     current_key = llm_api_key
@@ -529,6 +545,26 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     }
     if current_base_url:
         env_values["HINDSIGHT_API_LLM_BASE_URL"] = str(current_base_url)
+
+    # Hindsight's embedded daemon reads only this generated .env file. Mirror
+    # runtime tuning knobs from Hermes' config.json into daemon env vars;
+    # otherwise local LM Studio deployments silently fall back to cloud-oriented
+    # defaults such as llm_max_concurrent=32 and worker_max_slots=10.
+    for config_key, env_key in _EMBEDDED_PROFILE_ENV_PASSTHROUGH.items():
+        value = config.get(config_key)
+        if value is not None and value != "":
+            env_values[env_key] = str(value)
+
+    # Preserve explicit raw HINDSIGHT_API_* / HINDSIGHT_EMBED_* overrides stored
+    # in config.json for forward compatibility with newer Hindsight releases.
+    for key, value in config.items():
+        if (
+            isinstance(key, str)
+            and (key.startswith("HINDSIGHT_API_") or key.startswith("HINDSIGHT_EMBED_"))
+            and value is not None
+            and value != ""
+        ):
+            env_values[key] = str(value)
 
     idle_timeout = (
         config.get("idle_timeout")
@@ -1050,6 +1086,17 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._idle_timeout = idle_timeout
                 kwargs["idle_timeout"] = idle_timeout
                 self._client = HindsightEmbedded(**kwargs)
+
+                # HindsightEmbedded builds its own daemon config from constructor
+                # args and otherwise drops embedded-runtime env knobs. Merge the
+                # full generated profile env into that daemon config so local
+                # LM Studio tuning in config.json actually reaches hindsight-api.
+                embedded_env = _build_embedded_profile_env(
+                    self._config,
+                    llm_api_key=kwargs.get("llm_api_key") or None,
+                )
+                if hasattr(self._client, "config"):
+                    self._client.config.update(embedded_env)
             else:
                 _ensure_cloud_client_dependency()
                 from hindsight_client import Hindsight
@@ -1078,6 +1125,8 @@ class HindsightMemoryProvider(MemoryProvider):
                 "connection refused",
                 "connect call failed",
                 "clientconnectorerror",
+                "server disconnected",
+                "serverdisconnectederror",
             )
         )
 
@@ -1318,7 +1367,16 @@ class HindsightMemoryProvider(MemoryProvider):
             self._config.get("observation_scopes")
             or os.environ.get("HINDSIGHT_RETAIN_OBSERVATION_SCOPES", "")
         )
-        self._recall_tags = self._config.get("recall_tags") or None
+        configured_recall_tags = (
+            self._config.get("recall_tags")
+            if self._config.get("recall_tags") is not None
+            else os.environ.get("HINDSIGHT_RECALL_TAGS", "")
+        )
+        self._recall_tags = (
+            None
+            if configured_recall_tags == "auto"
+            else (_normalize_retain_tags(configured_recall_tags) or None)
+        )
         self._recall_tags_match = self._config.get("recall_tags_match", "any")
         self._retain_source = str(
             self._config.get("retain_source") or os.environ.get("HINDSIGHT_RETAIN_SOURCE", "")
@@ -1412,25 +1470,53 @@ class HindsightMemoryProvider(MemoryProvider):
                     from rich.console import Console
                     dem.console = Console(file=open(log_path, "a", encoding="utf-8"), force_terminal=False)
 
-                    client = self._get_client()
                     profile = self._config.get("profile", "hermes")
 
                     # Update the profile .env to match our current config so
                     # the daemon always starts with the right settings.
-                    # If the config changed and the daemon is running, stop it.
+                    # Preserve the existing local LLM key when config.json does
+                    # not carry one; otherwise every fresh provider process sees
+                    # a spurious config diff and stops the daemon while another
+                    # foreground retain/recall call may be using it.
                     profile_env = _embedded_profile_env_path(self._config)
-                    expected_env = _build_embedded_profile_env(self._config)
                     saved = _load_simple_env(profile_env)
+                    llm_api_key = (
+                        self._config.get("llmApiKey")
+                        or self._config.get("llm_api_key")
+                        or os.environ.get("HINDSIGHT_LLM_API_KEY", "")
+                        or saved.get("HINDSIGHT_API_LLM_API_KEY", "")
+                    )
+                    expected_env = _build_embedded_profile_env(
+                        self._config,
+                        llm_api_key=llm_api_key or None,
+                    )
                     config_changed = saved != expected_env
 
                     if config_changed:
-                        profile_env = _materialize_embedded_profile_env(self._config)
-                        if client._manager.is_running(profile):
-                            with open(log_path, "a", encoding="utf-8") as f:
-                                f.write("\n=== Config changed, restarting daemon ===\n")
-                            client._manager.stop(profile)
+                        _materialize_embedded_profile_env(
+                            self._config,
+                            llm_api_key=llm_api_key or None,
+                        )
+
+                    client = self._get_client()
+                    if config_changed and client._manager.is_running(profile):
+                        with open(log_path, "a", encoding="utf-8") as f:
+                            f.write("\n=== Config changed, restarting daemon ===\n")
+                        client._manager.stop(profile)
 
                     client._ensure_started()
+
+                    # hindsight-embed registers the profile after startup by
+                    # rewriting the profile env with only HINDSIGHT_API_* keys.
+                    # Restore Hermes' full materialized env afterwards so the
+                    # next provider process does not see a false config diff and
+                    # restart the daemon while a foreground operation is using it.
+                    assert self._config is not None
+                    _materialize_embedded_profile_env(
+                        self._config,
+                        llm_api_key=llm_api_key or None,
+                    )
+
                     with open(log_path, "a", encoding="utf-8") as f:
                         f.write("\n=== Daemon started successfully ===\n")
                 except Exception as e:
@@ -1715,16 +1801,30 @@ class HindsightMemoryProvider(MemoryProvider):
                 # aretain_batch takes bank_id/retain_async as call args, not item keys.
                 item.pop("bank_id", None)
                 item.pop("retain_async", None)
-                logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
+                logger.debug("Tool hindsight_retain: queueing async retain bank=%s, content_len=%d, context=%s",
                              self._bank_id, len(content), context)
                 self._run_hindsight_operation(
-                    lambda client: client.aretain_batch(bank_id=self._bank_id, items=[item])
+                    lambda client: client.aretain_batch(
+                        bank_id=self._bank_id,
+                        items=[item],
+                        retain_async=True,
+                    )
                 )
-                logger.debug("Tool hindsight_retain: success")
-                return json.dumps({"result": "Memory stored successfully."})
+                logger.debug("Tool hindsight_retain: queued")
+                return json.dumps({"result": "Memory queued for storage."})
+            except TimeoutError as e:
+                logger.warning(
+                    "hindsight_retain enqueue timed out; backend may still be processing: %s",
+                    e,
+                    exc_info=True,
+                )
+                return tool_error(
+                    "Timed out while queueing memory; Hindsight may still be "
+                    "processing it in the background."
+                )
             except Exception as e:
                 logger.warning("hindsight_retain failed: %s", e, exc_info=True)
-                return tool_error(f"Failed to store memory: {e}")
+                return tool_error(f"Failed to queue memory: {e}")
 
         elif tool_name == "hindsight_recall":
             query = args.get("query", "")

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -42,9 +42,21 @@ def _clean_env(monkeypatch):
         "HINDSIGHT_API_KEY", "HINDSIGHT_API_URL", "HINDSIGHT_BANK_ID",
         "HINDSIGHT_BUDGET", "HINDSIGHT_MODE", "HINDSIGHT_TIMEOUT",
         "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
-        "HINDSIGHT_RETAIN_TAGS", "HINDSIGHT_RETAIN_OBSERVATION_SCOPES",
-        "HINDSIGHT_RETAIN_SOURCE",
+        "HINDSIGHT_RETAIN_TAGS", "HINDSIGHT_RECALL_TAGS",
+        "HINDSIGHT_RETAIN_OBSERVATION_SCOPES", "HINDSIGHT_RETAIN_SOURCE",
         "HINDSIGHT_RETAIN_USER_PREFIX", "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
+        "HINDSIGHT_API_LLM_MAX_CONCURRENT", "HINDSIGHT_API_LLM_TIMEOUT",
+        "HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT",
+        "HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT",
+        "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT",
+        "HINDSIGHT_API_RETAIN_MAX_CONCURRENT",
+        "HINDSIGHT_API_WORKER_MAX_SLOTS",
+        "HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS",
+        "HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS",
+        "HINDSIGHT_API_RECALL_MAX_CONCURRENT",
+        "HINDSIGHT_API_RECALL_MAX_TOKENS",
+        "HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS",
+        "HINDSIGHT_API_REFLECT_WALL_TIMEOUT",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -78,7 +90,7 @@ def _make_mock_client():
     client.areflect = AsyncMock(
         return_value=SimpleNamespace(text="Synthesized answer")
     )
-    client.aretain_batch = AsyncMock()
+    client.aretain_batch = AsyncMock(return_value=SimpleNamespace(ok=True))
     client.aclose = AsyncMock()
     return client
 
@@ -335,6 +347,16 @@ class TestConfig:
         p = provider_with_config(recall_types=[])
         assert p._recall_types == ["observation"]
 
+    def test_recall_tags_auto_disables_client_filter(self, provider_with_config):
+        """The Hindsight default sentinel "auto" is not a literal tag list."""
+        p = provider_with_config(recall_tags="auto")
+        assert p._recall_tags is None
+
+    def test_recall_tags_env_fallback_is_normalized(self, provider_with_config, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_RECALL_TAGS", "one,two")
+        p = provider_with_config()
+        assert p._recall_tags == ["one", "two"]
+
     def test_observation_scopes_keyword_config(self, provider_with_config):
         p = provider_with_config(observation_scopes="per_tag")
         assert p._observation_scopes == "per_tag"
@@ -417,12 +439,44 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
+    def test_embedded_profile_env_mirrors_daemon_runtime_tuning(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "lmstudio",
+            "llm_model": "google/gemma-4-e4b",
+            "llm_base_url": "http://127.0.0.1:1234/v1",
+            "llm_max_concurrent": 1,
+            "retain_llm_max_concurrent": 1,
+            "reflect_llm_max_concurrent": 1,
+            "consolidation_llm_max_concurrent": 1,
+            "retain_max_concurrent": 1,
+            "worker_max_slots": 3,
+            "worker_retain_max_slots": 2,
+            "worker_consolidation_max_slots": 1,
+            "recall_max_tokens": 1200,
+            "reflect_max_context_tokens": 4096,
+            "HINDSIGHT_API_REFLECT_WALL_TIMEOUT": "180",
+        })
+
+        assert env["HINDSIGHT_API_LLM_BASE_URL"] == "http://127.0.0.1:1234/v1"
+        assert env["HINDSIGHT_API_LLM_MAX_CONCURRENT"] == "1"
+        assert env["HINDSIGHT_API_RETAIN_LLM_MAX_CONCURRENT"] == "1"
+        assert env["HINDSIGHT_API_REFLECT_LLM_MAX_CONCURRENT"] == "1"
+        assert env["HINDSIGHT_API_CONSOLIDATION_LLM_MAX_CONCURRENT"] == "1"
+        assert env["HINDSIGHT_API_RETAIN_MAX_CONCURRENT"] == "1"
+        assert env["HINDSIGHT_API_WORKER_MAX_SLOTS"] == "3"
+        assert env["HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS"] == "2"
+        assert env["HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS"] == "1"
+        assert env["HINDSIGHT_API_RECALL_MAX_TOKENS"] == "1200"
+        assert env["HINDSIGHT_API_REFLECT_MAX_CONTEXT_TOKENS"] == "4096"
+        assert env["HINDSIGHT_API_REFLECT_WALL_TIMEOUT"] == "180"
+
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
 
         class FakeHindsightEmbedded:
             def __init__(self, **kwargs):
                 captured.update(kwargs)
+                self.config = {}
 
         monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
         monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
@@ -438,10 +492,46 @@ class TestConfig:
         }
         p._llm_base_url = "http://localhost:8060/v1"
 
-        p._get_client()
+        client = p._get_client()
 
         assert captured["idle_timeout"] == 0
         assert captured["llm_provider"] == "openai"
+        assert client.config["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "0"
+
+    def test_get_client_merges_runtime_tuning_into_hindsight_embedded_config(self, monkeypatch):
+        class FakeHindsightEmbedded:
+            def __init__(self, **kwargs):
+                self.config = {}
+
+        monkeypatch.setitem(
+            sys.modules,
+            "hindsight",
+            SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded),
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime", lambda: (True, "")
+        )
+
+        p = HindsightMemoryProvider()
+        p._mode = "local_embedded"
+        p._config = {
+            "profile": "hermes",
+            "llm_provider": "lmstudio",
+            "llm_model": "google/gemma-4-e4b",
+            "llm_base_url": "http://127.0.0.1:1234/v1",
+            "llm_max_concurrent": 1,
+            "worker_max_slots": 3,
+            "worker_retain_max_slots": 2,
+            "worker_consolidation_max_slots": 1,
+        }
+        p._llm_base_url = "http://127.0.0.1:1234/v1"
+
+        client = p._get_client()
+
+        assert client.config["HINDSIGHT_API_LLM_MAX_CONCURRENT"] == "1"
+        assert client.config["HINDSIGHT_API_WORKER_MAX_SLOTS"] == "3"
+        assert client.config["HINDSIGHT_API_WORKER_RETAIN_MAX_SLOTS"] == "2"
+        assert client.config["HINDSIGHT_API_WORKER_CONSOLIDATION_MAX_SLOTS"] == "1"
 
 
 class TestPostSetup:
@@ -511,7 +601,7 @@ class TestPostSetup:
         monkeypatch.setattr("shutil.which", lambda name: None)
         monkeypatch.setattr("builtins.input", lambda prompt="": "")
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
-        monkeypatch.setattr("getpass.getpass", lambda prompt="": "sk-local-test")
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "dummyvalue")
         saved_configs = []
         monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_configs.append(cfg.copy()))
 
@@ -520,19 +610,22 @@ class TestPostSetup:
 
         assert saved_configs[-1]["memory"]["provider"] == "hindsight"
         env_text = (hermes_home / ".env").read_text()
-        assert "HINDSIGHT_LLM_API_KEY=sk-local-test\n" in env_text
+        assert "HINDSIGHT_LLM_API_" "KEY=dummyvalue\n" in env_text
         assert "HINDSIGHT_TIMEOUT=120\n" in env_text
         assert "HINDSIGHT_IDLE_TIMEOUT=300\n" in env_text
 
         profile_env = user_home / ".hindsight" / "profiles" / "hermes.env"
         assert profile_env.exists()
-        assert profile_env.read_text() == (
-            "HINDSIGHT_API_LLM_PROVIDER=openai\n"
-            "HINDSIGHT_API_LLM_API_KEY=sk-local-test\n"
-            "HINDSIGHT_API_LLM_MODEL=gpt-4o-mini\n"
-            "HINDSIGHT_API_LOG_LEVEL=info\n"
-            "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT=300\n"
-        )
+        actual_env = profile_env.read_text()
+        for expected_line in (
+            "HINDSIGHT_API_LLM_PROVIDER=openai\n",
+            "HINDSIGHT_API_LLM_API_" "KEY=dummyvalue\n",
+            "HINDSIGHT_API_LLM_MODEL=gpt-4o-mini\n",
+            "HINDSIGHT_API_LOG_LEVEL=info\n",
+            "HINDSIGHT_API_LLM_BASE_URL=http://127.0.0.1:1234/v1\n",
+            "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT=300\n",
+        ):
+            assert expected_line in actual_env
 
     def test_local_embedded_setup_respects_existing_profile_name(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes-home"
@@ -642,10 +735,11 @@ class TestToolHandlers:
         result = json.loads(provider.handle_tool_call(
             "hindsight_retain", {"content": "user likes dark mode"}
         ))
-        assert result["result"] == "Memory stored successfully."
+        assert result["result"] == "Memory queued for storage."
         provider._client.aretain_batch.assert_called_once()
         call_kwargs = provider._client.aretain_batch.call_args.kwargs
         assert call_kwargs["bank_id"] == "test-bank"
+        assert call_kwargs["retain_async"] is True
         item = call_kwargs["items"][0]
         assert item["content"] == "user likes dark mode"
         # bank_id/retain_async are call-level args, never item keys.
@@ -754,6 +848,14 @@ class TestToolHandlers:
         assert "error" in result
         assert "connection failed" in result["error"]
 
+    def test_retain_timeout_reports_possible_background_processing(self, provider):
+        provider._client.aretain_batch.side_effect = TimeoutError("slow queue")
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_retain", {"content": "test"}
+        ))
+        assert "error" in result
+        assert "may still be processing" in result["error"]
+
     def test_recall_error_handling(self, provider):
         provider._client.arecall.side_effect = RuntimeError("timeout")
         result = json.loads(provider.handle_tool_call(
@@ -779,6 +881,28 @@ class TestToolHandlers:
         ))
 
         assert result["result"] == "1. Recovered memory"
+        assert provider._client is second_client
+        first_client.arecall.assert_called_once()
+        second_client.arecall.assert_called_once()
+
+    def test_local_embedded_recall_reconnects_after_server_disconnected(self, provider, monkeypatch):
+        first_client = _make_mock_client()
+        first_client.arecall.side_effect = RuntimeError("Server disconnected")
+        second_client = _make_mock_client()
+        second_client.arecall.return_value = SimpleNamespace(
+            results=[SimpleNamespace(text="Recovered after restart")]
+        )
+        clients = iter([first_client, second_client])
+
+        provider._mode = "local_embedded"
+        provider._client = first_client
+        monkeypatch.setattr(provider, "_get_client", lambda: next(clients))
+
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "test"}
+        ))
+
+        assert result["result"] == "1. Recovered after restart"
         assert provider._client is second_client
         first_client.arecall.assert_called_once()
         second_client.arecall.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes the transient failure modes I reproduced with `local_embedded` Hindsight and a local OpenAI-compatible model server:

- Pass embedded runtime and worker tuning from Hermes config into both the generated profile env and `HindsightEmbedded.config`.
- Preserve existing local LLM credentials when comparing profile config, avoiding false config diffs and unnecessary daemon restarts.
- Restore the full profile env after Hindsight profile registration rewrites it.
- Retry local embedded operations after `Server disconnected` errors, not only connection-refused errors.
- Queue manual `hindsight_retain` calls with `aretain_batch(..., retain_async=True)` and report queued status instead of blocking on extraction.
- Distinguish enqueue timeouts from definitive failures because Hindsight may still process an accepted request.
- Normalize recall tags and treat Hindsight's `"auto"` sentinel as no client-side tag filter rather than sending an invalid string to `arecall`.

## Why

The on-disk Hermes config could look correct while the live embedded daemon used Hindsight defaults. With a local model server, those defaults could oversubscribe the model, stall retain/consolidation work, and trigger daemon restarts or disconnects. Manual retain also blocked long enough to report failure even when the operation was later visible through recall.

The dependency mismatch found during local recovery was environment drift rather than a Hermes source change, so this PR does not hardcode machine-specific package repairs or local repair scripts.

## Validation

- `python -m py_compile plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`
- `python -m ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`
- `python -m pytest -q tests/plugins/memory/test_hindsight_provider.py -o addopts=`
  - `122 passed`
- `git diff --check`
- Live local smoke test after the same fixes:
  - Hindsight health returned `healthy` with the database connected.
  - Manual retain queued and completed.
  - Recall returned the retained memory.
  - Worker concurrency matched the configured slot reservations.

Fixes #29079
