### PR TITLE
Exclude nested references/ dirs from skill index discovery

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -538,8 +538,9 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     matches = []
     for root, dirs, files in os.walk(skills_dir, followlinks=True):
         dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
-        if filename in files:
-            matches.append(Path(root) / filename)
+        root_path = Path(root)
+        if filename in files and "references" not in root_path.relative_to(skills_dir).parts:
+            matches.append(root_path / filename)
     for path in sorted(matches, key=lambda p: str(p.relative_to(skills_dir))):
         yield path
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -276,6 +276,24 @@ class TestBuildSkillsSystemPrompt:
         # "search" should appear only once per category
         assert result.count("- search") == 1
 
+    def test_excludes_nested_reference_skill_indexes(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        normal_skill = tmp_path / "skills" / "tools" / "normal-skill"
+        reference_copy = normal_skill / "references" / "copy"
+        normal_skill.mkdir(parents=True)
+        reference_copy.mkdir(parents=True)
+        (normal_skill / "SKILL.md").write_text(
+            "---\nname: normal-skill\ndescription: Real top-level skill\n---\n"
+        )
+        (reference_copy / "SKILL.md").write_text(
+            "---\nname: reference-copy\ndescription: Nested reference copy\n---\n"
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "normal-skill" in result
+        assert "reference-copy" not in result
+
     def test_excludes_incompatible_platform_skills(self, monkeypatch, tmp_path):
         """Skills with platforms: [macos] should not appear on Linux."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
`iter_skill_index_files` walked into `references/` subdirectories of skills, so a skill that ships a reference copy of another `SKILL.md` registered a phantom duplicate skill. This skips any index file whose path contains a `references` segment.

Adds a regression test (`test_excludes_nested_reference_skill_indexes`).