### PR TITLE
Resolve Codex CLI from Hermes-managed node bin on minimal PATH

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 import queue
+import shutil
 import subprocess
 import threading
 import time
@@ -28,6 +29,35 @@ from typing import Any, Optional
 # Default minimum codex version we test against. The PR sets this from the
 # `codex --version` parsed at install time; bumping is a one-line change here.
 MIN_CODEX_VERSION = (0, 125, 0)
+
+
+def resolve_codex_binary(codex_bin: str = "codex", env: Optional[dict[str, str]] = None) -> str:
+    """Resolve the Codex CLI, including Hermes' managed Node install.
+
+    Gateway and cron processes often run with a minimal PATH that omits
+    ``~/.hermes/node/bin`` even though Hermes installed Codex there. Keep
+    explicit paths untouched, then try PATH, then Hermes' managed location.
+    """
+    if os.path.isabs(codex_bin) or os.sep in codex_bin:
+        return codex_bin
+
+    search_env = env or os.environ
+    found = shutil.which(codex_bin, path=search_env.get("PATH"))
+    if found:
+        return found
+
+    candidates: list[str] = []
+    hermes_home = (search_env.get("HERMES_HOME") or "").strip()
+    home = (search_env.get("HOME") or "").strip()
+    if hermes_home:
+        candidates.append(os.path.join(hermes_home, "node", "bin", codex_bin))
+    if home:
+        candidates.append(os.path.join(home, ".hermes", "node", "bin", codex_bin))
+
+    for candidate in candidates:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return codex_bin
 
 
 @dataclass
@@ -110,7 +140,7 @@ class CodexAppServerClient:
                 ]
             )
 
-        cmd = [codex_bin, "app-server"] + app_server_args
+        cmd = [resolve_codex_binary(codex_bin, spawn_env), "app-server"] + app_server_args
         # Codex emits tracing to stderr; default WARN keeps it quiet for users.
         spawn_env.setdefault("RUST_LOG", "warn")
 
@@ -374,7 +404,7 @@ def check_codex_binary(
     Returns (ok, message). Used by setup wizard and runtime startup."""
     try:
         proc = subprocess.run(
-            [codex_bin, "--version"],
+            [resolve_codex_binary(codex_bin), "--version"],
             capture_output=True,
             text=True,
             timeout=10,

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -112,6 +112,7 @@ class TestCodexAppServerModule:
 
         assert codex_app_server.MIN_CODEX_VERSION >= (0, 1, 0)
         assert callable(codex_app_server.parse_codex_version)
+        assert callable(codex_app_server.resolve_codex_binary)
         assert callable(codex_app_server.check_codex_binary)
 
     def test_parse_codex_version_valid(self) -> None:
@@ -134,6 +135,24 @@ class TestCodexAppServerModule:
         ok, msg = check_codex_binary(codex_bin="/nonexistent/codex/binary/path")
         assert ok is False
         assert "not found" in msg.lower() or "no such" in msg.lower()
+
+    def test_resolve_codex_binary_keeps_explicit_path(self) -> None:
+        from agent.transports.codex_app_server import resolve_codex_binary
+
+        assert resolve_codex_binary("/custom/codex", env={}) == "/custom/codex"
+
+    def test_resolve_codex_binary_uses_hermes_managed_node_bin(self, tmp_path) -> None:
+        from agent.transports.codex_app_server import resolve_codex_binary
+
+        hermes_home = tmp_path / ".hermes"
+        codex = hermes_home / "node" / "bin" / "codex"
+        codex.parent.mkdir(parents=True)
+        codex.write_text("#!/usr/bin/env node\n")
+        codex.chmod(0o755)
+
+        env = {"PATH": "", "HERMES_HOME": str(hermes_home), "HOME": str(tmp_path / "home")}
+
+        assert resolve_codex_binary("codex", env=env) == str(codex)
 
     def test_codex_error_class_is_runtimeerror(self) -> None:
         from agent.transports.codex_app_server import CodexAppServerError
@@ -276,6 +295,7 @@ class TestSpawnEnvIsolation:
                 pass
 
         monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setenv("PATH", "")
         monkeypatch.setenv("HOME", "/users/alice")
         monkeypatch.setenv("HERMES_HOME", "/users/alice/.hermes/profiles/backend-worker")
         monkeypatch.setenv("HERMES_KANBAN_TASK", "t_smoke")


### PR DESCRIPTION
Gateway and cron processes often run with a minimal `PATH` that omits `~/.hermes/node/bin`, so `codex` (installed there by Hermes) isn't found even though it exists.

Adds `resolve_codex_binary()`: honors explicit paths, then `PATH` lookup, then falls back to `$HERMES_HOME/node/bin` and `~/.hermes/node/bin`. Used at app-server spawn and version check. Includes tests.