### PR TITLE
Don't eager-install camofox in bootstrap installers

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -179,7 +179,7 @@ function Install-AgentBrowser {
     $npmLog = [System.IO.Path]::GetTempFileName()
     $prevEAP = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
-    & $npm install -g --prefix $prefixDir --silent --ignore-scripts "agent-browser@^0.26.0" "@askjo/camofox-browser@^1.5.2" 2>&1 | Tee-Object -FilePath $npmLog | Out-Null
+    & $npm install -g --prefix $prefixDir --silent --ignore-scripts "agent-browser@^0.26.0" 2>&1 | Tee-Object -FilePath $npmLog | Out-Null
     $npmExit = $LASTEXITCODE
     $ErrorActionPreference = $prevEAP
     if ($npmExit -ne 0) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1935,7 +1935,6 @@ ensure_browser() {
     log_file="$(mktemp)"
     if ! "$npm_bin" install -g --prefix "$HERMES_HOME/node" --silent --ignore-scripts \
         "agent-browser@^0.26.0" \
-        "@askjo/camofox-browser@^1.5.2" \
         >"$log_file" 2>&1; then
         log_error "npm install failed:"
         cat "$log_file" >&2

--- a/tests/test_package_json_lazy_deps.py
+++ b/tests/test_package_json_lazy_deps.py
@@ -1,4 +1,4 @@
-"""Invariants for what is eager vs lazy in the root ``package.json``.
+"""Invariants for what is eager vs lazy in Node dependency installs.
 
 The root ``package.json`` is installed by ``hermes update`` on every user,
 including users who never opted into a given browser backend. Anything
@@ -23,9 +23,9 @@ The contract:
   "camofox"`` when the user actually selects Camofox.
 
 If a future PR re-adds Camofox (or any other binary-postinstall package)
-to root ``dependencies``, this test fails — read the lazy-install
-guidance in the ``hermes-agent-dev`` skill before changing the
-expectations.
+to root ``dependencies`` or the bootstrap installers, this test fails -- read
+the lazy-install guidance in the ``hermes-agent-dev`` skill before changing
+the expectations.
 """
 
 from __future__ import annotations
@@ -83,3 +83,14 @@ def test_root_lockfile_has_no_camofox_entries() -> None:
         "package-lock.json still references camoufox-js (transitive of "
         "@askjo/camofox-browser). Regenerate the lockfile."
     )
+
+
+def test_installers_do_not_eager_install_camofox() -> None:
+    """Bootstrap installers must preserve the same lazy Camofox contract."""
+    for rel_path in ("scripts/install.sh", "scripts/install.ps1"):
+        text = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+        assert "@askjo/camofox-browser" not in text, (
+            f"{rel_path} eagerly installs @askjo/camofox-browser. Camofox "
+            "must stay opt-in via the post_setup handler in "
+            "hermes_cli/tools_config.py."
+        )


### PR DESCRIPTION
`install.sh` / `install.ps1` eagerly installed `@askjo/camofox-browser`, violating the lazy-install contract documented in `test_package_json_lazy_deps` (Camofox should be opt-in via the `post_setup` handler). Drops it from both installers and extends the lazy-deps test to cover the bootstrap scripts.