### PR TITLE
fix: handle canonical billing access auth errors (NS-415)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -717,6 +717,22 @@ def _resolve_zai_base_url(api_key: str, default_url: str, env_override: str) -> 
 # they must be kept distinct from missing/expired-credential errors.
 CODEX_RATE_LIMITED_CODE = "codex_rate_limited"
 
+BILLING_ACCESS_REQUIRED_CODES = frozenset(
+    {
+        "billing_access_required",
+        # Legacy server code retained during NAS/API rollout.
+        "subscription_required",
+    }
+)
+
+BILLING_ACCESS_EXPIRED_CODES = frozenset(
+    {
+        "billing_access_expired",
+        # Legacy server code retained during NAS/API rollout.
+        "subscription_expired",
+    }
+)
+
 
 class AuthError(RuntimeError):
     """Structured auth error with UX mapping hints."""
@@ -784,17 +800,21 @@ def format_auth_error(error: Exception) -> str:
     if error.relogin_required:
         return f"{error} Run `hermes model` to re-authenticate."
 
-    if error.code == "subscription_required":
+    if error.code in BILLING_ACCESS_REQUIRED_CODES:
         if error.provider == "nous":
             return _format_nous_entitlement_auth_error(error)
-        return "No active paid subscription found. Please purchase/activate a subscription, then retry."
+        return "Billing access is required. Select an eligible org, add credits, or activate billing, then retry."
 
     if error.code == "insufficient_credits":
         if error.provider == "nous":
             return _format_nous_entitlement_auth_error(error)
-        return "Subscription credits are exhausted. Top up/renew credits, then retry."
+        return "Available credits are exhausted. Add credits or update billing, then retry."
 
-    if error.code in {"subscription_expired", "no_usable_credits", "account_missing"}:
+    if error.code in {
+        *BILLING_ACCESS_EXPIRED_CODES,
+        "no_usable_credits",
+        "account_missing",
+    }:
         if error.provider == "nous":
             return _format_nous_entitlement_auth_error(error)
 
@@ -7419,7 +7439,7 @@ def _nous_device_code_login(
             force_refresh=False,
         )
     except AuthError as exc:
-        if exc.code == "subscription_required":
+        if exc.code in BILLING_ACCESS_REQUIRED_CODES:
             portal_url = auth_state.get(
                 "portal_base_url", DEFAULT_NOUS_PORTAL_URL
             ).rstrip("/")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "victor@rocketfueldev.com": "victor-kyriazakos",
     "74339271+SaguaroDev@users.noreply.github.com": "SaguaroDev",
     "subw3@mail2.sysu.edu.cn": "Subway2023",
     "zhipengli@thebrainly.ai": "a1245582339",

--- a/tests/hermes_cli/test_auth_billing_access_messages.py
+++ b/tests/hermes_cli/test_auth_billing_access_messages.py
@@ -1,0 +1,34 @@
+from hermes_cli.auth import AuthError, format_auth_error
+
+
+def test_format_auth_error_handles_canonical_nous_billing_access_code(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.nous_account.get_nous_portal_account_info",
+        lambda force_fresh=True: None,
+    )
+
+    rendered = format_auth_error(
+        AuthError(
+            "billing access required",
+            provider="nous",
+            code="billing_access_required",
+            relogin_required=False,
+        )
+    )
+
+    assert "subscription required" not in rendered.lower()
+    assert "entitlement" in rendered.lower()
+    assert "billing" in rendered.lower()
+
+
+def test_format_auth_error_non_nous_subscription_code_uses_billing_access_copy():
+    rendered = format_auth_error(
+        AuthError(
+            "subscription required",
+            provider="example",
+            code="subscription_required",
+            relogin_required=False,
+        )
+    )
+
+    assert rendered == "Billing access is required. Select an eligible org, add credits, or activate billing, then retry."


### PR DESCRIPTION
## Summary
- Update Hermes CLI auth/billing error handling to understand canonical `billing_access_*` errors.
- Retain legacy handling for `subscription_required` / `subscription_expired` so older services still render useful guidance.
- Reword CLI guidance around billing access / credits instead of mandatory subscription language.
- Add focused CLI regression coverage for the new and legacy messages.

Linear: NS-415
https://linear.app/nousresearch/issue/NS-415/m1devcross-repo-canonicalize-billing-access-errors-before-org-billing

## Test plan
- `python3 -m pytest -o addopts='' tests/hermes_cli/test_auth_billing_access_messages.py`
- Result: 2 passed.
- Branch is clean and rebased/current against upstream `origin/main`.

## Note
The upstream repo grants this GitHub user TRIAGE, not write, so this PR is opened from `victor-kyriazakos:ha-fix-billing-access-copy` into `NousResearch:main`.
