### PR TITLE
fix(kanban): stop false-positive crash storm on Windows in detect_crashed_workers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4896,6 +4896,15 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     returning 0 without a terminal transition just loops forever.
     """
     crashed: list[str] = []
+    # On Windows the recorded worker_pid is the distlib console-script
+    # launcher shim (hermes.exe / the venv python launcher), which exits
+    # within seconds of spawning the real worker python child. _pid_alive()
+    # then reports the worker dead while it is still running orphaned, so
+    # PID-based crash detection produces a respawn storm. Fall back to
+    # claim-TTL reclamation (release_stale_claims) on Windows instead. Same
+    # launcher-shim-PID phenomenon as ``hermes update`` on Windows (#29341).
+    if os.name == "nt":
+        return crashed
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
     # write_txn so can't nest). ``protocol_violation`` flags the

--- a/tests/hermes_cli/test_kanban_windows_pid_crash.py
+++ b/tests/hermes_cli/test_kanban_windows_pid_crash.py
@@ -1,0 +1,132 @@
+"""PR1 — detect_crashed_workers must short-circuit on Windows.
+
+On Windows the recorded ``worker_pid`` is the distlib console-script launcher
+shim, which exits within seconds of spawning the real (orphaned) worker child.
+PID-liveness then reports a live worker dead and the dispatcher reclaims +
+respawns it every tick — a respawn storm where ``spawned=N crashed=N`` repeats
+for the same tasks and nothing progresses. The fix returns ``[]`` early when
+``os.name == 'nt'`` and lets claim-TTL reclamation handle genuine crashes;
+POSIX behavior is unchanged.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB.
+
+    Mirrors the fixture in test_kanban_db.py so the crash-detection tests build
+    their conn/DB the same way the rest of the kanban suite does.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _seed_running_task_with_dead_pid(conn, monkeypatch):
+    """Create a ``running`` task whose recorded worker_pid looks dead.
+
+    Mirrors the setup the existing detect_crashed_workers tests use: a running
+    task with a claim_lock, started long enough ago to be past the crash grace
+    period, and ``_pid_alive`` stubbed False so PID-based detection *would*
+    reclaim it on POSIX.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    # Push "now" well past the default crash grace window so the grace guard
+    # never suppresses reclaim — we want to isolate the os.name gate.
+    now = 5_000_000.0
+    monkeypatch.setattr(_kb.time, "time", lambda: now)
+
+    host = _kb._claimer_id().split(":", 1)[0]
+    tid = kb.create_task(conn, title="windows pid task", assignee="a")
+    conn.execute(
+        "UPDATE tasks SET status='running', worker_pid=?, "
+        "claim_lock=?, started_at=? WHERE id=?",
+        (99999, f"{host}:w", int(now) - 3600, tid),
+    )
+    conn.commit()
+    return tid
+
+
+def test_detect_crashed_workers_noop_on_windows(kanban_home, monkeypatch):
+    """On Windows the launcher-shim PID is not a reliable liveness signal, so
+    PID-based crash detection is skipped entirely and the running task is left
+    in place (claim-TTL reclamation handles genuine crashes)."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb.os, "name", "nt")
+
+    with kb.connect() as conn:
+        tid = _seed_running_task_with_dead_pid(conn, monkeypatch)
+
+        # Guard short-circuits: nothing reclaimed despite the dead PID.
+        assert kb.detect_crashed_workers(conn) == []
+
+        # Task is still 'running' — NOT bounced back to 'ready' (that would be
+        # the respawn-storm bug). Reclaim is deferred to claim-TTL.
+        assert kb.get_task(conn, tid).status == "running"
+
+
+def test_detect_crashed_workers_guard_skips_liveness_on_windows(
+    kanban_home, monkeypatch,
+):
+    """On Windows the guard returns before any PID-liveness probe, so
+    ``_pid_alive`` is never consulted for the running task. This is the
+    behavioral signature of the early return: PID-based detection is fully
+    bypassed (claim-TTL reclaims genuine crashes instead)."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb.os, "name", "nt")
+
+    probed: list[int] = []
+    with kb.connect() as conn:
+        _seed_running_task_with_dead_pid(conn, monkeypatch)
+        monkeypatch.setattr(_kb, "_pid_alive", lambda pid: probed.append(pid))
+
+        assert kb.detect_crashed_workers(conn) == []
+
+    assert probed == [], "Windows guard must short-circuit before _pid_alive"
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "Cannot simulate POSIX path semantics on a Windows host — forcing "
+        "os.name='posix' makes pathlib instantiate PosixPath, which Python "
+        "refuses to construct on Windows. The reclaim path is exercised on "
+        "POSIX CI by the existing detect_crashed_workers_* tests; this control "
+        "runs there to confirm the os.name=='nt' guard is the only suppressor."
+    ),
+)
+def test_detect_crashed_workers_reclaims_when_not_windows(
+    kanban_home, monkeypatch,
+):
+    """Control (POSIX runner only): the same dead-PID running task that the
+    Windows guard leaves alone IS reclaimed when ``os.name != 'nt'`` — the
+    early return is the sole reason for the Windows no-op, and POSIX behavior is
+    unchanged by the patch."""
+    import hermes_cli.kanban_db as _kb
+
+    # On a POSIX host os.name is already 'posix'; assert that to be explicit.
+    assert _kb.os.name != "nt"
+
+    with kb.connect() as conn:
+        tid = _seed_running_task_with_dead_pid(conn, monkeypatch)
+
+        crashed = kb.detect_crashed_workers(conn)
+
+        assert tid in crashed
+        assert kb.get_task(conn, tid).status == "ready"


### PR DESCRIPTION
## Problem

On Windows the kanban dispatcher repeatedly marks live workers as "crashed" and
respawns them — a respawn storm where each tick logs `spawned=N crashed=N` for
the same tasks and no task ever completes.

## Root cause

`detect_crashed_workers` reclaims `running` tasks whose recorded `worker_pid` is
not alive. `worker_pid` comes from `subprocess.Popen(...).pid` in
`_default_spawn`. On Windows that PID is the distlib console-script launcher
shim (`hermes.exe` / the venv python launcher), which spawns the real worker
python child and exits within seconds. `_pid_alive(worker_pid)` then returns
False while the real worker runs orphaned, so the task is marked crashed and
respawned every tick.

The existing launch-window grace period and `_classify_worker_exit` don't help:
the launcher PID is permanently dead after spawn, and `reap_worker_zombies()`
(which feeds the reap registry) is a no-op on Windows, so classification returns
"unknown" and the task is still marked crashed.

Same launcher-shim-PID phenomenon as `hermes update` on Windows (#29341),
surfacing here in the dispatcher's liveness check.

## Fix

Skip PID-based crash detection on Windows and fall back to claim-TTL
reclamation (`release_stale_claims`), which does not depend on a meaningful
parent/child PID relationship. POSIX behavior is unchanged. Trade-off: a
genuinely crashed Windows worker is reclaimed after the claim TTL instead of
immediately — strictly better than respawning live workers every tick.

A follow-up could capture the real worker PID (worker-written pidfile or
in-worker `os.getpid()` overwrite) to restore immediate Windows crash
reclamation; this guard is the minimal, validated fix in the meantime.

## Test plan

- Windows: dispatcher loop now reports `crashed=0`; workers complete and tasks
  reach review/done (previously `spawned=N crashed=N` every tick).
- POSIX: unchanged — guard only short-circuits when `os.name == "nt"`.
- Adds `tests/hermes_cli/test_kanban_windows_pid_crash.py` (passes on Linux CI).
