### PR TITLE
fix(bedrock): streaming fallback to Converse API + image base64 decode + bearer token routing

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -476,10 +476,19 @@ def _convert_content_to_converse(content) -> List[Dict]:
                         mime_part = header[5:].split(";")[0]
                         if mime_part:
                             media_type = mime_part
+                    # Decode base64 to raw bytes — boto3 re-encodes at the
+                    # wire layer, so passing the base64 string directly
+                    # results in double-encoding and Bedrock rejects it with
+                    # "Failed to sanitize image".  Ref: #33317.
+                    import base64
+                    try:
+                        raw_bytes = base64.b64decode(data)
+                    except Exception:
+                        raw_bytes = data.encode("utf-8")
                     blocks.append({
                         "image": {
                             "format": media_type.split("/")[-1] if "/" in media_type else "jpeg",
-                            "source": {"bytes": data},
+                            "source": {"bytes": raw_bytes},
                         }
                     })
                 else:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2198,6 +2198,31 @@ def run_conversation(
                     )
                     continue
 
+                # ── Bedrock AnthropicBedrock SDK streaming failure ──
+                # The Anthropic SDK's stream accumulator raises RuntimeError
+                # "Unexpected event order" when Bedrock returns an error event
+                # before message_start (throttling, overload, validation).
+                # Fall back to the native Converse API path for the rest of
+                # this session — it handles these errors gracefully.  Ref: #28156.
+                if (
+                    isinstance(api_error, RuntimeError)
+                    and "unexpected event order" in str(api_error).lower()
+                    and getattr(agent, "provider", "") == "bedrock"
+                    and agent.api_mode == "anthropic_messages"
+                    and not getattr(agent, "_bedrock_converse_fallback_attempted", False)
+                ):
+                    agent._bedrock_converse_fallback_attempted = True
+                    agent.api_mode = "bedrock_converse"
+                    agent._bedrock_region = getattr(agent, "_bedrock_region", None) or "us-east-1"
+                    agent.client = None  # Drop the AnthropicBedrock client
+                    agent._client_kwargs = {}
+                    agent._vprint(
+                        f"{agent.log_prefix}⚠️  AnthropicBedrock SDK streaming failed — "
+                        f"falling back to native Converse API for this session.",
+                        force=True,
+                    )
+                    continue
+
                 status_code = getattr(api_error, "status_code", None)
                 error_context = agent._extract_api_error_context(api_error)
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1570,8 +1570,13 @@ def resolve_runtime_provider(
         # Dual-path routing: Claude models use AnthropicBedrock SDK for full
         # feature parity (prompt caching, thinking budgets, adaptive thinking).
         # Non-Claude models use the Converse API for multi-model support.
+        #
+        # Exception: Bearer Token auth (AWS_BEARER_TOKEN_BEDROCK) is NOT
+        # supported by the AnthropicBedrock SDK (it only does SigV4 signing).
+        # Route these users through Converse API regardless of model. Ref: #28156.
         _current_model = str(model_cfg.get("default") or "").strip()
-        if is_anthropic_bedrock_model(_current_model):
+        _has_bearer_token = bool(os.environ.get("AWS_BEARER_TOKEN_BEDROCK", "").strip())
+        if is_anthropic_bedrock_model(_current_model) and not _has_bearer_token:
             # Claude on Bedrock → AnthropicBedrock SDK → anthropic_messages path
             runtime = {
                 "provider": "bedrock",

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1474,3 +1474,75 @@ class TestCallConverseInvalidatesOnStaleError:
         )
 
         assert _bedrock_runtime_client_cache.get("us-east-1") is live_client
+
+
+class TestImageBase64Decoding:
+    """Image data URLs must be decoded to raw bytes before passing to Converse API.
+
+    boto3 re-encodes at the wire layer, so passing the base64 string directly
+    results in double-encoding. Bedrock rejects with 'Failed to sanitize image'.
+    Ref: #33317.
+    """
+
+    def test_data_url_decoded_to_bytes(self):
+        from agent.bedrock_adapter import _convert_content_to_converse
+        import base64
+
+        # A tiny 1x1 red PNG
+        raw_png = base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+        )
+        data_url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+
+        content = [{"type": "image_url", "image_url": {"url": data_url}}]
+        blocks = _convert_content_to_converse(content)
+
+        assert len(blocks) == 1
+        img_block = blocks[0]["image"]
+        assert img_block["format"] == "png"
+        # Must be raw bytes, not a base64 string
+        assert isinstance(img_block["source"]["bytes"], bytes)
+        assert img_block["source"]["bytes"] == raw_png
+
+    def test_invalid_base64_falls_back_to_encode(self):
+        from agent.bedrock_adapter import _convert_content_to_converse
+
+        data_url = "data:image/jpeg;base64,NOT_VALID_BASE64!!!"
+        content = [{"type": "image_url", "image_url": {"url": data_url}}]
+        blocks = _convert_content_to_converse(content)
+
+        # Should not crash — falls back to encoding the string as bytes
+        assert len(blocks) == 1
+        assert isinstance(blocks[0]["image"]["source"]["bytes"], bytes)
+
+
+class TestBearerTokenRoutesToConverse:
+    """Bearer Token users must go through Converse API, not AnthropicBedrock SDK.
+
+    The AnthropicBedrock SDK only supports SigV4 signing — it cannot use
+    AWS_BEARER_TOKEN_BEDROCK. Ref: #28156.
+    """
+
+    def test_bearer_token_forces_converse_for_claude(self):
+        """Claude model + Bearer Token → bedrock_converse, not anthropic_messages."""
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        env = {
+            "AWS_BEARER_TOKEN_BEDROCK": "test-bearer-token-123",
+            "AWS_DEFAULT_REGION": "us-east-1",
+        }
+        with patch.dict(os.environ, env, clear=False), \
+             patch("hermes_cli.runtime_provider.resolve_provider", return_value="bedrock"), \
+             patch("hermes_cli.runtime_provider._get_model_config", return_value={
+                 "default": "us.anthropic.claude-sonnet-4-6",
+                 "provider": "bedrock",
+             }), \
+             patch("hermes_cli.runtime_provider.load_config", return_value={"bedrock": {}}), \
+             patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+             patch("agent.bedrock_adapter.resolve_aws_auth_env_var", return_value="bearer-token"), \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="us-east-1"), \
+             patch("agent.bedrock_adapter.is_anthropic_bedrock_model", return_value=True):
+            runtime = resolve_runtime_provider(requested="bedrock")
+
+        assert runtime["api_mode"] == "bedrock_converse"
+        assert "bedrock_anthropic" not in runtime


### PR DESCRIPTION
Three fixes for the Bedrock Claude path that share a common theme: the AnthropicBedrock SDK doesn't handle all Bedrock scenarios correctly, and the native Converse API path is the reliable fallback.

## 1. Streaming fallback (new)

When the AnthropicBedrock SDK's stream accumulator receives a Bedrock error event (throttling, overload, 5xx) before `message_start`, it raises `RuntimeError: Unexpected event order` and discards the actual error payload. After 3 retries the session dies.

Fix: detect this specific RuntimeError in the conversation loop and auto-switch `api_mode` from `anthropic_messages` to `bedrock_converse` for the rest of the session. The Converse API handles these error events gracefully via boto3's native error handling.

## 2. Image base64 decode (fixes #33317)

`_convert_content_to_converse()` passed the base64 string directly as `source.bytes`. boto3 re-encodes at the wire layer, resulting in double-encoding. Bedrock rejects with "Failed to sanitize image".

Fix: `base64.b64decode(data)` before passing to `source.bytes`.

## 3. Bearer token routing (fixes #28156 part 1)

Users with `AWS_BEARER_TOKEN_BEDROCK` were routed through the AnthropicBedrock SDK (which only supports SigV4 signing), causing `RuntimeError: could not resolve credentials from session`.

Fix: check for bearer token env var in the dual-path routing logic. If present, always use `bedrock_converse` regardless of model.

## Files

- `agent/conversation_loop.py` -- streaming fallback handler
- `agent/bedrock_adapter.py` -- base64 decode fix
- `hermes_cli/runtime_provider.py` -- bearer token routing
- `tests/agent/test_bedrock_adapter.py` -- 3 new tests

## Testing

121 bedrock_adapter tests passing (Python 3.11 + 3.14).

Ref: #33317, #28156, #14737