### PR TITLE
fix: keep explicitly blocked Kanban tasks sticky

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2457,6 +2457,33 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     return bool(row) and row["kind"] == "blocked"
 
 
+def _restore_sticky_block(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: str,
+) -> bool:
+    """Repair runnable/pending tasks that still carry an explicit sticky block.
+
+    Older dispatchers could promote a review-required / operator block
+    back to ``ready``.  A later claim could also demote that corrupted
+    ``ready`` row with unfinished parents to ``todo``.  The event stream
+    still records that the most recent explicit block/unblock transition
+    is ``blocked``; use that durable signal to put the task back in
+    ``blocked`` before it can be promoted, claimed, or respawn-guarded as
+    if it were runnable work.
+    """
+    cur = conn.execute(
+        "UPDATE tasks SET status = 'blocked' "
+        "WHERE id = ? AND status IN ('ready', 'todo')",
+        (task_id,),
+    )
+    if cur.rowcount != 1:
+        return False
+    _append_event(conn, task_id, "blocked_restored", {"reason": reason})
+    return True
+
+
 def recompute_ready(conn: sqlite3.Connection) -> int:
     """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
 
@@ -2467,25 +2494,42 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
     blocked purely by a parent dependency unblocks itself when the
     parent completes), *except* when the most recent block event was a
     worker-initiated ``kanban_block`` — those stay blocked until an
-    explicit ``kanban_unblock`` (#28712).  Without that guard, a
-    ``review-required`` handoff would auto-respawn, the fresh worker
-    would find nothing to do, exit cleanly, get recorded as a protocol
-    violation, and the cycle would repeat indefinitely.
+    explicit ``kanban_unblock`` (#28712).  If an older dispatcher
+    already promoted a sticky block back to ``ready``, the next tick
+    repairs it to ``blocked`` before it can be respawn-guarded or
+    claimed as runnable work.
     """
     promoted = 0
     with write_txn(conn):
-        todo_rows = conn.execute(
-            "SELECT id, status FROM tasks WHERE status IN ('todo', 'blocked')"
+        candidate_rows = conn.execute(
+            "SELECT id, status FROM tasks WHERE status IN ('ready', 'todo', 'blocked')"
         ).fetchall()
-        for row in todo_rows:
+        sticky_ids: set[str] = set()
+        for row in candidate_rows:
             task_id = row["id"]
             cur_status = row["status"]
-            if cur_status == "blocked" and _has_sticky_block(conn, task_id):
+            if _has_sticky_block(conn, task_id):
+                sticky_ids.add(task_id)
                 # Worker / operator asked for human review — do not
                 # silently auto-recover.  ``unblock_task`` is the only
                 # legitimate exit (it emits ``"unblocked"`` which flips
-                # this predicate back).
-                continue
+                # this predicate back).  If older/racy code already moved
+                # the sticky task into a runnable/pending column, repair it
+                # before continuing.
+                if cur_status in ("ready", "todo"):
+                    _restore_sticky_block(
+                        conn,
+                        task_id,
+                        reason="sticky_block_recompute_repair",
+                    )
+
+        todo_rows = [
+            row for row in candidate_rows
+            if row["status"] in ("todo", "blocked") and row["id"] not in sticky_ids
+        ]
+        for row in todo_rows:
+            task_id = row["id"]
+            cur_status = row["status"]
             parents = conn.execute(
                 "SELECT t.status FROM tasks t "
                 "JOIN task_links l ON l.parent_id = t.id "
@@ -2533,6 +2577,22 @@ def claim_task(
     lock = claimer or _claimer_id()
     expires = now + _resolve_claim_ttl_seconds(ttl_seconds)
     with write_txn(conn):
+        # Review-required/operator blocks are branch-local blockers for
+        # this task.  If a previous dispatcher already corrupted one back
+        # to ready, repair it here as the final ready->running guard before
+        # any parent-dependency demotion can move it to a promotable ``todo``.
+        if _has_sticky_block(conn, task_id):
+            if _restore_sticky_block(
+                conn,
+                task_id,
+                reason="sticky_block_claim_rejected",
+            ):
+                _append_event(
+                    conn, task_id, "claim_rejected",
+                    {"reason": "sticky_block"},
+                )
+            return None
+
         # Structural invariant: never transition ready -> running while any
         # parent is not yet 'done'. This is the single enforcement point
         # regardless of which writer (create_task, link_tasks, unblock_task,
@@ -2558,6 +2618,7 @@ def claim_task(
                 {"reason": "parents_not_done"},
             )
             return None
+
         # Defensive: if a prior run somehow leaked (invariant violation from
         # an unknown code path), close it as 'reclaimed' so we don't strand
         # it when the CAS resets the pointer below. No-op when the invariant

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -200,6 +200,125 @@ def test_unblock_clears_sticky_state_and_lets_block_recover(kanban_home: Path) -
 # ---------------------------------------------------------------------------
 
 
+def test_dispatch_repairs_legacy_ready_task_with_sticky_block(kanban_home: Path) -> None:
+    """If an older dispatcher already promoted a review-required block
+    back to ``ready``, the next dispatcher tick must repair the task to
+    ``blocked`` instead of leaving it ready-but-respawn-guarded."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="already corrupted review task")
+        kb.claim_task(conn, tid)
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        kb.block_task(
+            conn,
+            tid,
+            reason="review-required: review the branch",
+            expected_run_id=task.current_run_id,
+        )
+
+        # Reproduce the live corrupt state: a sticky block event exists,
+        # but a buggy promotion flipped the task back to ready afterward.
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'promoted', NULL, ?)",
+            (tid, int(time.time())),
+        )
+        conn.commit()
+        ready_task = kb.get_task(conn, tid)
+        assert ready_task is not None
+        assert ready_task.status == "ready"
+        assert kb._has_sticky_block(conn, tid)
+
+        promoted = kb.recompute_ready(conn)
+
+        assert promoted == 0
+        repaired = kb.get_task(conn, tid)
+        assert repaired is not None
+        assert repaired.status == "blocked"
+
+
+def test_claim_refuses_ready_task_with_sticky_block(kanban_home: Path) -> None:
+    """The ready->running claim boundary is the final defensive gate:
+    review-required sticky blocks are blockers for this task, not new work."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="sticky ready must not claim")
+        kb.claim_task(conn, tid)
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        kb.block_task(
+            conn,
+            tid,
+            reason="review-required: needs approval",
+            expected_run_id=task.current_run_id,
+        )
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+        conn.commit()
+
+        claimed = kb.claim_task(conn, tid)
+
+        assert claimed is None
+        repaired = kb.get_task(conn, tid)
+        assert repaired is not None
+        assert repaired.status == "blocked"
+
+
+def test_recompute_repairs_corrupted_sticky_todo_before_promotion(kanban_home: Path) -> None:
+    """A sticky block that somehow landed in ``todo`` must be repaired
+    before parent-completion promotion can make it runnable again."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        initial = kb.get_task(conn, child)
+        assert initial is not None
+        assert initial.status == "todo"
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'blocked', ?, ?)",
+            (child, '{"reason":"review-required: todo repair"}', int(time.time())),
+        )
+        conn.commit()
+
+        kb.complete_task(conn, parent, result="parent ok")
+        assert kb.recompute_ready(conn) == 0
+
+        repaired = kb.get_task(conn, child)
+        assert repaired is not None
+        assert repaired.status == "blocked"
+
+
+def test_claim_repairs_sticky_ready_before_parent_demote(kanban_home: Path) -> None:
+    """A sticky-ready child with unfinished parents must be restored to
+    blocked, not demoted to ``todo`` and later promoted when parents finish."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+
+        # Reproduce a corrupt intermediate state that should never become
+        # runnable: the child has a sticky review block event but status was
+        # incorrectly moved to ready while its parent is still open.
+        conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (child,))
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'blocked', ?, ?)",
+            (child, '{"reason":"review-required: parent-gated review"}', int(time.time())),
+        )
+        conn.commit()
+
+        claimed = kb.claim_task(conn, child)
+
+        assert claimed is None
+        repaired = kb.get_task(conn, child)
+        assert repaired is not None
+        assert repaired.status == "blocked"
+
+        kb.complete_task(conn, parent, result="parent ok")
+        assert kb.recompute_ready(conn) == 0
+        final = kb.get_task(conn, child)
+        assert final is not None
+        assert final.status == "blocked"
+
+
 def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
     """Reproduces the exact #28712 loop and asserts the dispatcher
     leaves the task blocked instead of cycling.


### PR DESCRIPTION
## Summary
- keep explicitly blocked Kanban tasks sticky until an explicit unblock event
- repair sticky ready/todo rows back to blocked during ready recomputation
- reject sticky-blocked tasks in claim_task before worker spawn
- preserve separate auto-recovery for circuit-breaker/gave-up blocks

## Test plan
- python -m pytest tests/hermes_cli/test_kanban_blocked_sticky.py -q -o 'addopts='
- python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_cli.py -q -o 'addopts='

Supersedes #34578. Accepted by Yunuen in Matrix review.

Blocker status: NOT BLOCKED — PR created for upstream review/merge.