### PR TITLE
fix(agent): strip reasoning_content echo for providers that reject it (Cerebras)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1923,6 +1923,19 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
     if source_msg.get("role") != "assistant":
         return
 
+    # 0. Some providers REJECT reasoning_content when it is replayed in
+    # assistant history. Cerebras returns reasoning_content on turn 1 but
+    # fails the next request with HTTP 400 ("messages.N.assistant.
+    # reasoning_content ... is unsupported" / wrong_api_format). This is the
+    # exact inverse of the DeepSeek / Kimi / MiMo thinking-mode echo
+    # requirement handled by the branches below — there the field must be
+    # present, here it must be stripped from the outgoing API copy. Strip it
+    # (and never promote 'reasoning' into it) so multi-turn tool use survives.
+    # Refs #34716.
+    if agent._rejects_reasoning_content_echo():
+        api_msg.pop("reasoning_content", None)
+        return
+
     # 1. Explicit reasoning_content already set — preserve it verbatim
     # (includes DeepSeek/Kimi's own space-placeholder written at creation
     # time, and any valid reasoning content from the same provider).

--- a/run_agent.py
+++ b/run_agent.py
@@ -4126,6 +4126,37 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "xiaomimimo.com")
         )
 
+    def _rejects_reasoning_content_echo(self) -> bool:
+        """Return True when the active provider REJECTS replayed reasoning_content.
+
+        Cerebras emits ``reasoning_content`` on a turn-1 response but rejects
+        it when that assistant message is echoed back in history on the next
+        turn, failing with HTTP 400 (``messages.N.assistant.reasoning_content
+        ... is unsupported`` / ``wrong_api_format``). This is the exact inverse
+        of the DeepSeek / Kimi / MiMo thinking-mode requirement enforced by
+        ``_needs_thinking_reasoning_pad()``: there the field must be present on
+        every replay; here it must be stripped from the outgoing API copy.
+        Refs #34716.
+
+        Detection is host/provider-driven (not model-name-driven), mirroring
+        the thinking-pad predicates: aggregators that re-export the same model
+        names speak their own protocol, so we only strip when the request
+        actually targets a Cerebras endpoint. Result cached on the AIAgent
+        instance keyed by (provider, model, base_url); the key comparison
+        self-invalidates whenever ``switch_model()`` / ``_try_activate_fallback()``
+        change any of those.
+        """
+        key = (self.provider, self.model, getattr(self, "_base_url_lower", self.base_url))
+        cached = getattr(self, "_rejects_echo_cache", None)
+        if cached is not None and cached[0] == key:
+            return cached[1]
+        result = (
+            (self.provider or "").lower() == "cerebras"
+            or base_url_host_matches(self.base_url, "cerebras.ai")
+        )
+        self._rejects_echo_cache = (key, result)
+        return result
+
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
         """Forwarder — see ``agent.agent_runtime_helpers.copy_reasoning_content_for_api``."""
         from agent.agent_runtime_helpers import copy_reasoning_content_for_api

--- a/tests/run_agent/test_cerebras_reasoning_content_strip.py
+++ b/tests/run_agent/test_cerebras_reasoning_content_strip.py
@@ -1,0 +1,161 @@
+"""Regression test: Cerebras reasoning_content echo rejection (#34716).
+
+Cerebras (``api.cerebras.ai``) emits ``reasoning_content`` on a turn-1 response
+but REJECTS that field when it is echoed back in assistant message history on
+the next turn::
+
+    HTTP 400: messages.2.assistant.reasoning_content:
+    property 'messages.2.assistant.reasoning_content' is unsupported
+    code: wrong_api_format
+
+This is the exact inverse of the DeepSeek / Kimi / MiMo thinking-mode
+requirement (where ``reasoning_content`` MUST be replayed). Before this fix the
+first branch of ``copy_reasoning_content_for_api`` forwarded any non-empty
+``reasoning_content`` string verbatim, so the second message always 400'd and
+multi-turn tool use was impossible on Cerebras.
+
+The fix adds ``_rejects_reasoning_content_echo()`` (the inverse of
+``_needs_thinking_reasoning_pad()``) and strips ``reasoning_content`` from the
+outgoing API copy for providers that reject it.
+"""
+
+from __future__ import annotations
+
+from run_agent import AIAgent
+
+
+def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    return agent
+
+
+class TestRejectsReasoningContentEcho:
+    """_rejects_reasoning_content_echo() recognises Cerebras by provider and host."""
+
+    def test_provider_cerebras(self) -> None:
+        agent = _make_agent(provider="cerebras", model="gpt-oss-120b")
+        assert agent._rejects_reasoning_content_echo() is True
+
+    def test_provider_case_insensitive(self) -> None:
+        agent = _make_agent(provider="Cerebras", model="zai-glm-4.7")
+        assert agent._rejects_reasoning_content_echo() is True
+
+    def test_base_url_host_custom_provider(self) -> None:
+        # The issue's configuration: provider='custom', base_url at Cerebras.
+        agent = _make_agent(
+            provider="custom",
+            model="gpt-oss-120b",
+            base_url="https://api.cerebras.ai/v1",
+        )
+        assert agent._rejects_reasoning_content_echo() is True
+
+    def test_base_url_bare_domain(self) -> None:
+        agent = _make_agent(provider="custom", base_url="https://cerebras.ai/v1")
+        assert agent._rejects_reasoning_content_echo() is True
+
+    def test_substring_false_positive_rejected(self) -> None:
+        # A host that merely contains "cerebras.ai" in its path must NOT match.
+        agent = _make_agent(
+            provider="custom",
+            model="gpt-oss-120b",
+            base_url="https://evil.com/cerebras.ai/v1",
+        )
+        assert agent._rejects_reasoning_content_echo() is False
+
+    def test_non_cerebras_provider(self) -> None:
+        agent = _make_agent(
+            provider="openrouter",
+            model="deepseek/deepseek-v4-pro",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert agent._rejects_reasoning_content_echo() is False
+
+    def test_empty_everything(self) -> None:
+        agent = _make_agent()
+        assert agent._rejects_reasoning_content_echo() is False
+
+    def test_result_is_cached(self) -> None:
+        agent = _make_agent(provider="cerebras", model="gpt-oss-120b")
+        assert agent._rejects_reasoning_content_echo() is True
+        # Cache is keyed by (provider, model, base_url); a stale True cache must
+        # not survive a provider change away from Cerebras.
+        agent.provider = "openrouter"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        assert agent._rejects_reasoning_content_echo() is False
+
+
+class TestCopyReasoningContentStripsForCerebras:
+    """copy_reasoning_content_for_api strips reasoning_content for Cerebras."""
+
+    def test_explicit_reasoning_content_stripped(self) -> None:
+        """The turn-2 failure: a stored reasoning_content string is NOT echoed."""
+        agent = _make_agent(
+            provider="custom",
+            model="gpt-oss-120b",
+            base_url="https://api.cerebras.ai/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "Casablanca is 22C and sunny.",
+            "reasoning_content": "Okay, the user asked about the weather...",
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_tool_call_turn_reasoning_content_stripped(self) -> None:
+        """Reproduces the issue exactly: an assistant tool-call turn carrying
+        reasoning_content must ship to Cerebras without it."""
+        agent = _make_agent(
+            provider="cerebras",
+            model="zai-glm-4.7",
+            base_url="https://api.cerebras.ai/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "I should call the weather tool.",
+            "tool_calls": [{"id": "call_1", "function": {"name": "web_search"}}],
+        }
+        api_msg = {"reasoning_content": "I should call the weather tool."}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_reasoning_field_not_promoted_for_cerebras(self) -> None:
+        """The 'reasoning' field must NOT be promoted into reasoning_content."""
+        agent = _make_agent(
+            provider="custom",
+            model="gpt-oss-120b",
+            base_url="https://api.cerebras.ai/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning": "chain of thought from a prior provider",
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_non_cerebras_preserves_reasoning_content(self) -> None:
+        """Regression guard: providers that don't reject the echo keep it."""
+        agent = _make_agent(
+            provider="openrouter",
+            model="deepseek/deepseek-v4-pro",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "answer",
+            "reasoning_content": "<think>real chain of thought</think>",
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == "<think>real chain of thought</think>"


### PR DESCRIPTION
## What does this PR do?

Fixes multi-turn tool use on **Cerebras** models (`gpt-oss-120b`, `zai-glm-4.7`). Cerebras returns `reasoning_content` on a turn-1 response but **rejects** that field when it is replayed in assistant history on the next turn:

```
HTTP 400: messages.2.assistant.reasoning_content:
property 'messages.2.assistant.reasoning_content' is unsupported
code: wrong_api_format
```

So the first message works and every subsequent message 400s — the agent is effectively single-turn on Cerebras.

`copy_reasoning_content_for_api()` previously forwarded any non-empty `reasoning_content` string verbatim (branch 1). That is the **exact inverse** of what Cerebras needs, and the exact inverse of the DeepSeek / Kimi / MiMo thinking-mode requirement (PR #33795) where the field *must* be replayed. This PR adds the missing inverse side.

## Related Issue

Fixes #34716

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`run_agent.py`** — add `AIAgent._rejects_reasoning_content_echo()`, the inverse of `_needs_thinking_reasoning_pad()`. Host/provider-driven detection (`provider == "cerebras"` or `*.cerebras.ai` via `base_url_host_matches`), **not** model-name-driven, so aggregators that re-export the same model names are unaffected. Result is cached on the instance keyed by `(provider, model, base_url)` exactly like the thinking-pad predicate, so the key comparison self-invalidates on `switch_model()` / `_try_activate_fallback()`.
- **`agent/agent_runtime_helpers.py`** — add an early guard (branch 0) at the top of `copy_reasoning_content_for_api()`: when the active provider rejects the echo, pop `reasoning_content` from the outgoing API copy and return before any branch can set/promote it. Both call sites (`conversation_loop.py`, `chat_completion_helpers.py`) route through this single helper, so the fix is complete in one place.
- **`tests/run_agent/test_cerebras_reasoning_content_strip.py`** — new regression tests (predicate detection incl. substring false-positive guard + caching invalidation; and the strip behavior incl. the exact turn-2 tool-call scenario from the issue, plus a guard that non-Cerebras providers still preserve `reasoning_content`).

The change is purely additive: behavior for every other provider is byte-for-byte unchanged (the new branch only fires for Cerebras endpoints).

## How to Test

Reproduction (before this PR): configure Cerebras as a custom provider (`base_url: https://api.cerebras.ai/v1`), set model to `gpt-oss-120b` or `zai-glm-4.7`, send a message (works), then send a second message → HTTP 400 `wrong_api_format` on `reasoning_content`. With this PR the field is stripped from replayed history and the conversation continues.

Automated:

```bash
pytest tests/run_agent/test_cerebras_reasoning_content_strip.py \
       tests/run_agent/test_deepseek_reasoning_content_echo.py -q
# 52 passed  (12 new + 40 existing DeepSeek/Kimi/MiMo regression — no behavior change)
```

Broader sweep `pytest tests/run_agent/ -k "reasoning or thinking or fallback or empty or nudge or prefill"`: 337 passed, 2 skipped. (One unrelated test, `TestMemoryNudgeCounterPersistence::test_counters_initialized_in_init`, times out trying to reach a local model server at `localhost:1234` — it fails identically on a clean `main` checkout and is unrelated to this change.)

`ruff check` (the blocking `PLW1514` rule) passes on all changed files.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal provider-quirk handling, no user-facing config)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact — N/A (pure string/dict logic, no platform-specific code)
