### PR TITLE
fix(streaming): abort wedged Anthropic stream in stale-stream detector

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2570,16 +2570,32 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 f"context: ~{_est_ctx:,} tokens). "
                 f"Reconnecting..."
             )
+            # Abort the hung connection so the inner retry loop can open a
+            # fresh one.  This MUST branch on api_mode: in anthropic_messages
+            # mode the live request is owned by ``agent._anthropic_client``
+            # (via messages.stream()), NOT the OpenAI request-client holder.
+            # Calling only the OpenAI cleanup here (the historical behaviour)
+            # was a no-op for Anthropic, so a wedged Anthropic stream was
+            # never killed — the worker thread stayed blocked in recv()
+            # indefinitely, the poll loop spun resetting its own timer, and
+            # the turn never ended (queued inbound messages were never read).
+            # Mirror the interrupt handler below, which already branches.
             try:
-                _close_request_client_once("stale_stream_kill")
+                if agent.api_mode == "anthropic_messages":
+                    agent._anthropic_client.close()
+                    agent._rebuild_anthropic_client()
+                else:
+                    _close_request_client_once("stale_stream_kill")
             except Exception:
                 pass
             # Rebuild the primary client too — its connection pool
             # may hold dead sockets from the same provider outage.
-            try:
-                agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
-            except Exception:
-                pass
+            # (OpenAI-wire only; Anthropic was rebuilt above.)
+            if agent.api_mode != "anthropic_messages":
+                try:
+                    agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
+                except Exception:
+                    pass
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
             last_chunk_time["t"] = time.time()

--- a/tests/agent/test_anthropic_stale_stream.py
+++ b/tests/agent/test_anthropic_stale_stream.py
@@ -1,0 +1,144 @@
+"""Regression test for the Anthropic stale-stream abort path.
+
+Root cause (fixed in fix/anthropic-stale-stream-abort):
+The streaming poll loop's stale-stream detector
+(``agent/chat_completion_helpers.py::interruptible_streaming_api_call``)
+only ever called the OpenAI-wire cleanup helpers
+(``_close_request_client_once`` / ``_replace_primary_openai_client``).
+In ``anthropic_messages`` mode the live request is owned by
+``agent._anthropic_client`` via ``messages.stream()`` — those OpenAI
+helpers are no-ops for it.  So when an Anthropic stream wedged (provider
+accepts the connection, then delivers no chunks — the classic
+"Overloaded"/500 outage), the detector fired but killed nothing: the
+worker thread stayed blocked in recv() indefinitely, the turn never
+ended, and queued inbound gateway messages were never read.
+
+The fix branches on ``api_mode`` in the stale-kill block, mirroring the
+interrupt handler a few lines below it:
+    if api_mode == "anthropic_messages":
+        agent._anthropic_client.close(); agent._rebuild_anthropic_client()
+    else:
+        _close_request_client_once(...) ; _replace_primary_openai_client(...)
+
+This test drives a deliberately-hung Anthropic stream against a tiny
+stale timeout and asserts the Anthropic abort path runs.  Against the
+pre-fix code it hangs/fails because close() is never called.
+"""
+import os
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names):
+    return [
+        {
+            "type": "function",
+            "function": {"name": n, "description": n, "parameters": {"type": "object", "properties": {}}},
+        }
+        for n in names
+    ]
+
+
+@pytest.fixture()
+def anthropic_agent():
+    """AIAgent pinned to anthropic_messages mode with mocked clients."""
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://api.anthropic.com",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    a.api_mode = "anthropic_messages"
+    a.reasoning_config = None
+    # Silence the noisy recovery/diagnostic helpers so the test focuses on
+    # the abort branch.  Credential refresh is a no-op here.
+    a._try_refresh_anthropic_client_credentials = MagicMock()
+    a._emit_stream_drop = MagicMock()
+    a._log_stream_retry = MagicMock()
+    a._buffer_status = MagicMock()
+    a._stream_diag_init = MagicMock(return_value={})
+    a._stream_diag_capture_response = MagicMock()
+    a._touch_activity = MagicMock()
+    # Track the OpenAI-wire pool cleanup — it must NOT be called in
+    # anthropic mode (proves we took the Anthropic branch, not the old
+    # no-op OpenAI path).
+    a._replace_primary_openai_client = MagicMock()
+    return a
+
+
+def test_stale_anthropic_stream_is_aborted_and_client_rebuilt(anthropic_agent, monkeypatch):
+    agent = anthropic_agent
+
+    # Tiny stale timeout so the detector fires within the test.
+    monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "0.5")
+    # No retries — once aborted, surface the error and return immediately.
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+    close_event = threading.Event()
+    close_calls = {"n": 0}
+    rebuild_calls = {"n": 0}
+
+    class HungStream:
+        """Anthropic stream that delivers no events until the connection
+        is aborted via client.close() — simulating a wedged provider."""
+
+        response = None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            # Block as if waiting on recv(); unblock only when the
+            # stale-stream kill calls close(), then raise as a dropped
+            # connection would.
+            if close_event.wait(timeout=10):
+                raise ConnectionError("aborted by stale-stream kill")
+            raise AssertionError("stream was never aborted — stale detector did not fire")
+
+        def get_final_message(self):  # pragma: no cover - should never reach
+            raise AssertionError("should not reach get_final_message on a hung stream")
+
+    mock_client = MagicMock()
+    mock_client.messages.stream.return_value = HungStream()
+
+    def _on_close():
+        close_calls["n"] += 1
+        close_event.set()
+
+    mock_client.close.side_effect = _on_close
+    agent._anthropic_client = mock_client
+
+    def _rebuild():
+        rebuild_calls["n"] += 1
+
+    agent._rebuild_anthropic_client = MagicMock(side_effect=_rebuild)
+
+    # The hung stream is aborted -> ConnectionError -> retries disabled ->
+    # the error propagates out.  We only care that the abort path ran.
+    with pytest.raises(Exception):
+        agent._interruptible_streaming_api_call({"messages": [], "model": "claude-opus-4-8"})
+
+    assert close_calls["n"] >= 1, "stale detector must close the wedged Anthropic client"
+    assert rebuild_calls["n"] >= 1, "stale detector must rebuild the Anthropic client after abort"
+    assert agent._replace_primary_openai_client.call_count == 0, (
+        "OpenAI-wire pool cleanup must NOT run in anthropic_messages mode "
+        "(would be a no-op for the live Anthropic request and signals the "
+        "wrong branch was taken)"
+    )


### PR DESCRIPTION
## Summary

Fixes a real, observed production hang: an **alive-but-wedged gateway** in `anthropic_messages` mode. When an outbound Anthropic API call hangs (provider accepts the connection then delivers no chunks — e.g. an `Overloaded`/`500` outage), the streaming stale-stream detector fires but **kills nothing**, so the worker thread stays blocked in `recv()` indefinitely, the agent turn never ends, and queued inbound messages are never read. The bot looks dead and ignores follow-ups (including "stop").

## Root cause

In `agent/chat_completion_helpers.py::interruptible_streaming_api_call`, the stale-stream detector's kill block only calls the **OpenAI-wire** cleanup helpers:

```python
_close_request_client_once("stale_stream_kill")          # no-op in anthropic mode
agent._replace_primary_openai_client(...)                # no-op in anthropic mode
```

In `anthropic_messages` mode the live request is owned by `agent._anthropic_client` via `messages.stream()`, so those helpers are no-ops for it. The connection is never aborted — the detector just re-fires `"Stream stale … Killing connection"` on every poll forever.

Note the **interrupt** handler a few lines below in the same loop already branches correctly on `api_mode` (`agent._anthropic_client.close()` + `agent._rebuild_anthropic_client()`). The stale path simply never got the same treatment. `_rebuild_anthropic_client`'s own docstring even says it's for use "after an interrupt **or stale call**" — the stale wiring was missing.

## Fix

Branch the stale-kill block on `api_mode`, mirroring the existing interrupt handler:

- `anthropic_messages` → `agent._anthropic_client.close()` + `agent._rebuild_anthropic_client()`
- everything else → the existing OpenAI-wire cleanup (`_close_request_client_once` + `_replace_primary_openai_client`)

One focused change. No behavior change for OpenAI-wire providers.

## Test

Adds `tests/agent/test_anthropic_stale_stream.py` — drives a deliberately-hung Anthropic stream against a tiny stale timeout and asserts the abort path runs (`close()` + rebuild called; the OpenAI pool-cleanup *not* called, proving the correct branch is taken).

- **Against the old code the test fails**, and the captured logs show the bug verbatim: `"Stream stale … Killing connection"` firing repeatedly with no recovery.
- **Against the fix it passes.**
- Adjacent streaming + Anthropic suites: `pytest -k "stream or nthropic"` → **39 passed, 0 regressions.**

## Diagnostic tell for anyone hitting this

Repeated `"Stream stale for Ns — no chunks received. Killing connection."` WARNINGs in a profile's `logs/agent.log` with no recovery == this bug.
