### PR TITLE
docs: add ShopeeAffiliate canonical posting workflow

### DIFF
--- a/docs/blackduckai/finance/accounting-document-sync-workflow.md
+++ b/docs/blackduckai/finance/accounting-document-sync-workflow.md
@@ -1,0 +1,60 @@
+# BlackDuckAi Finance Document Sync Workflow
+
+## Purpose
+
+This note mirrors the non-sensitive Obsidian wiki workflow for BlackDuckAi finance document intake. It documents how Red should keep local archive files, Google Drive, Google Sheets, and review notes aligned without exposing secrets or sensitive identifiers in GitHub.
+
+## Scope
+
+Use this workflow when TOP sends finance/accounting documents such as:
+
+- invoices or receipts
+- payment slips
+- accounting service fees
+- VAT / WHT support documents
+- company compliance documents
+
+## Storage model
+
+1. Preserve the original image/PDF in the local finance archive.
+2. Create a paired `_ocr.txt` text file with extracted visible fields.
+3. Sync both the evidence file and OCR file to the matching Google Drive company/month/category folder after TOP approval.
+4. Update the company Google Sheet:
+   - `Document Inbox` receives one row per source document.
+   - the relevant category tab receives the transaction row, e.g. `Service Fees`.
+5. Update Obsidian/Wiki with only durable, non-sensitive workflow facts.
+
+## KST example pattern
+
+For KST accounting service fee documents:
+
+- Company: KST / KIRA SOLUTION TECH
+- Category: `Service_Fees`
+- Sheet tabs: `Document Inbox`, `Service Fees`
+- Pair invoice/receipt evidence with the transfer slip when the net paid amount matches the invoice after withholding tax.
+- Keep local paths and Drive URLs aligned in the Sheet.
+
+Amount handling example:
+
+```text
+service fee: 13,000 THB
+withholding tax: 3%
+net payment: 12,610 THB
+```
+
+## Safety rules
+
+- Do not commit tax IDs, bank account numbers, slip reference values, tokens, browser session values, or raw credentials.
+- Do not paste full original OCR when it contains sensitive identifiers; summarize visible fields only.
+- Do not share Drive folders externally or send accountant packages without explicit CEO approval.
+- If VAT or tax fields are not clearly visible, leave them blank and mark review required or add an accountant note.
+
+## Verification checklist
+
+- [ ] Local original files exist in the correct company/month/category folder.
+- [ ] OCR sidecar files exist and are readable.
+- [ ] Drive upload returned stable file URLs for every file.
+- [ ] Google Sheet `Document Inbox` rows include matching local paths and Drive URLs.
+- [ ] Category tab includes the canonical transaction row and accountant note.
+- [ ] Obsidian/Wiki note was updated without sensitive identifiers.
+- [ ] GitHub docs mirror only non-sensitive workflow facts.

--- a/docs/blackduckai/workflows/claude-code-oauth.md
+++ b/docs/blackduckai/workflows/claude-code-oauth.md
@@ -36,6 +36,10 @@ claude setup-token
 Set Hermes to use Anthropic + Sonnet:
 
 ```bash
+# TOP local helper: sets model.provider/default and clears stale ANTHROPIC_* env entries.
+python C:/Users/black/AI_Project/scripts/setup/set-claude-code-oauth.py
+
+# Manual equivalent:
 hermes config set model.provider anthropic
 hermes config set model.default claude-sonnet-4-6
 ```

--- a/docs/blackduckai/workflows/claude-code-oauth.md
+++ b/docs/blackduckai/workflows/claude-code-oauth.md
@@ -1,0 +1,75 @@
+# Claude Sonnet via Claude Code OAuth
+
+BlackDuckAi's preferred Claude lane in Hermes uses Claude Code OAuth / Claude Pro-Max credential storage instead of an Anthropic API key.
+
+## Current default-profile config
+
+```yaml
+model:
+  provider: anthropic
+  default: claude-sonnet-4-6
+```
+
+Credential behavior:
+
+- Hermes resolves Anthropic credentials from Claude Code's credential store, e.g. `~/.claude/.credentials.json`.
+- The active Hermes default profile clears `ANTHROPIC_TOKEN` and `ANTHROPIC_API_KEY` so stale API-key values do not shadow Claude Code OAuth.
+- `ANTHROPIC_API_KEY` is legacy/pay-per-token fallback only.
+
+## Setup / repair commands
+
+Install or update Claude Code:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+claude --version
+```
+
+Log in through Claude Code:
+
+```bash
+claude
+# or, if a setup-token flow is needed:
+claude setup-token
+```
+
+Set Hermes to use Anthropic + Sonnet:
+
+```bash
+hermes config set model.provider anthropic
+hermes config set model.default claude-sonnet-4-6
+```
+
+If the profile previously used an API key, clear stale Anthropic env values instead of storing secrets in docs:
+
+```bash
+# Preferred via Hermes internals / model flow:
+hermes model
+# choose Anthropic → existing Claude Code credentials / OAuth → claude-sonnet-4-6
+```
+
+## Verification
+
+```bash
+hermes auth list
+hermes chat --provider anthropic --model claude-sonnet-4-6 -q 'Reply exactly: CLAUDE_OAUTH_OK' --toolsets safe --quiet
+```
+
+Expected:
+
+```text
+anthropic: claude_code oauth
+CLAUDE_OAUTH_OK
+```
+
+## Model/auth matrix for BlackDuckAi
+
+- GPT-5 / orchestration: `openai-codex` via Codex/ChatGPT OAuth; no OpenAI API key required.
+- GPT-Image-2 / ad images: `image_gen.provider: openai-codex`; no OpenAI API key required.
+- Claude Sonnet / executive language, copywriting, QA: `anthropic` via Claude Code OAuth; no Anthropic API key required.
+- Gemini / research and Veo: API-key backed unless Hermes adds OAuth support for that lane.
+- Grok/xAI: API-key backed.
+
+## Safety
+
+Never commit or document credential values: no API keys, OAuth access tokens, refresh tokens, setup tokens, cookies, or page tokens.

--- a/docs/blackduckai/workflows/gpt-image-2-openai-codex.md
+++ b/docs/blackduckai/workflows/gpt-image-2-openai-codex.md
@@ -1,0 +1,51 @@
+# GPT-Image-2 via OpenAI Codex OAuth
+
+BlackDuckAi's current Hermes default for Shopee/Facebook ad images is the `openai-codex` image-generation backend.
+
+## Config
+
+```yaml
+image_gen:
+  provider: openai-codex
+  model: gpt-image-2-high # or gpt-image-2-medium
+  openai-codex:
+    model: gpt-image-2-high # or gpt-image-2-medium
+```
+
+## Auth model
+
+- `openai-codex` uses Hermes Codex/ChatGPT OAuth.
+- It does not require `OPENAI_API_KEY`.
+- Keep the legacy `openai` image backend only as an explicit fallback; that provider uses OpenAI Platform API-key billing and requires `OPENAI_API_KEY`.
+- Do not print OAuth tokens, API keys, cookies, or credential file contents.
+
+## Operational guidance
+
+For Shopee Affiliate Facebook creative workflow:
+
+```text
+facebook-image-prompt-generator
+↓
+image_generate
+↓
+provider: openai-codex
+↓
+model: gpt-image-2-high or gpt-image-2-medium
+↓
+save manifest
+↓
+facebook post after TOP approval
+```
+
+Use `gpt-image-2-high` for final high-value/ad creatives. Use `gpt-image-2-medium` when TOP prioritizes throughput or cost control.
+
+## Verification
+
+Before reporting an image-generation blocker:
+
+1. Check the active provider.
+2. If provider is `openai-codex`, verify Codex/ChatGPT OAuth/provider readiness and model resolution.
+3. If provider is `openai`, verify OpenAI Platform API-key and billing readiness.
+4. If required images are incomplete, stop before real Facebook posting and write a partial manifest.
+
+Do not say `OPENAI_API_KEY` is mandatory for `gpt-image-2` unless the active provider is specifically the legacy `openai` backend.

--- a/docs/blackduckai/workflows/hermes-profile-model-allocation.md
+++ b/docs/blackduckai/workflows/hermes-profile-model-allocation.md
@@ -1,0 +1,137 @@
+# BlackDuckAi Hermes Profile Model Allocation
+
+TOP approved this balanced model allocation on 2026-05-31. It keeps Red as the single Telegram entry point while assigning each specialist profile to the model lane that best matches its role and workload.
+
+## Auth principles
+
+- Claude profiles use Anthropic through Claude Code OAuth / Claude credential store. `ANTHROPIC_TOKEN` and `ANTHROPIC_API_KEY` should stay empty in those profile env files unless TOP explicitly wants legacy API-key billing.
+- GPT chat/tool-heavy profiles use `openai-codex` through Codex/ChatGPT OAuth.
+- GPT-Image-2 image generation uses `image_gen.provider: openai-codex` and does not require `OPENAI_API_KEY`.
+- Gemini remains API-key backed for research and Veo/video lanes.
+- Never commit or document credential values.
+
+## Approved allocation
+
+### default / Red — Chief of Staff
+
+```yaml
+model:
+  provider: anthropic
+  default: claude-sonnet-4-6
+```
+
+Use for executive coordination, Thai nuance, routing, approval control, and risk-aware memos.
+
+### orchestrator / Nexus — CAIO
+
+```yaml
+model:
+  provider: openai-codex
+  default: gpt-5.5
+  base_url: https://chatgpt.com/backend-api/codex
+```
+
+Use for agent ecosystem planning, orchestration, roadmap design, and tool-heavy coordination. Move Nexus to Claude only when TOP explicitly approves a premium Claude lane.
+
+### automation / Operator — COO
+
+```yaml
+model:
+  provider: openai-codex
+  default: gpt-5.5
+  base_url: https://chatgpt.com/backend-api/codex
+```
+
+Use for cron, webhook, SOP, pipeline, and ops automation.
+
+### scribe / Ledger — CFO
+
+```yaml
+model:
+  provider: anthropic
+  default: claude-sonnet-4-6
+```
+
+Use for finance memos, accounting summaries, cashflow/ROI reasoning, and precise Thai executive writing.
+
+### researcher / Magnet — CMO
+
+```yaml
+model:
+  provider: gemini
+  default: gemini-3.1-pro-preview
+  base_url: https://generativelanguage.googleapis.com/v1beta
+```
+
+Use for market research, competitor scans, multimodal synthesis, and trend analysis.
+
+### facebook / Closer — CSO
+
+```yaml
+model:
+  provider: anthropic
+  default: claude-sonnet-4-6
+```
+
+Use for Thai sales copy, Facebook comments/inbox drafts, customer nuance, and conversion-focused replies.
+
+### codexworker / Architect — CTO
+
+```yaml
+model:
+  provider: openai-codex
+  default: gpt-5.5
+  base_url: https://chatgpt.com/backend-api/codex
+```
+
+Use for coding implementation, repo edits, debugging, API/infrastructure work, and tool-heavy development.
+
+### reviewer / Sentinel — QA, Risk & Review
+
+```yaml
+model:
+  provider: anthropic
+  default: claude-sonnet-4-6
+```
+
+Use for QA, risk review, security review, final checks, and decision-quality feedback.
+
+### shopee / Merchant — Shopee Affiliate Specialist
+
+```yaml
+model:
+  provider: openai-codex
+  default: gpt-5.5
+  base_url: https://chatgpt.com/backend-api/codex
+```
+
+Use for product sourcing, affiliate link workflows, Shopee API/tool work, and promotion/mission tracking.
+
+### brandcreative / Studio — Creative & Sales Asset Specialist
+
+```yaml
+model:
+  provider: openai-codex
+  default: gpt-5.5
+  base_url: https://chatgpt.com/backend-api/codex
+
+image_gen:
+  provider: openai-codex
+  model: gpt-image-2-high
+  openai-codex:
+    model: gpt-image-2-high
+```
+
+Use GPT/Codex for creative planning and prompt writing, GPT-Image-2 High via Codex OAuth for images, and Gemini/Veo separately for video rendering.
+
+## Verification checklist
+
+- Parse all edited `config.yaml` files.
+- Confirm `hermes auth list` shows `anthropic -> claude_code oauth` and `openai-codex -> oauth`.
+- Smoke-test one profile per provider lane:
+  - Claude: `CLAUDE_PROFILE_OK`
+  - Codex: `CODEX_PROFILE_OK`
+  - Gemini: `GEMINI_PROFILE_OK`
+- Confirm `openai-codex` image provider resolves `gpt-image-2-high` with high quality.
+- Run a secret-value scan over touched config/docs before committing.
+- Restart gateway or start fresh profile sessions after changing configs.

--- a/docs/blackduckai/workflows/workflow-1-shopeeaffiliate.md
+++ b/docs/blackduckai/workflows/workflow-1-shopeeaffiliate.md
@@ -1,0 +1,83 @@
+# WorkFlow-1-ShopeeAffiliate
+
+Canonical operating workflow for BlackDuckAi Shopee Affiliate Facebook content loops.
+
+## Fixed posting structure
+
+For each selected Shopee Affiliate product, the default publishing structure is fixed:
+
+1. Run Shopee API and Facebook API read-only checks.
+2. Select and verify one product.
+3. Research Facebook Ads Library patterns without copying competitor assets or copy.
+4. Generate the three approved affiliate links:
+   - product link
+   - shop link
+   - Shopee code/deal link
+5. Generate five final ad images with `gpt-image-2` / `gpt-image-2-high` only.
+6. Publish five image posts as a ladder after latest TOP approval:
+   - post 1: image 1
+   - post 2: images 1-2
+   - post 3: images 1-3
+   - post 4: images 1-4
+   - post 5: images 1-5
+7. Under every image post, add:
+   - one link comment containing the three approved affiliate links
+   - five image-only comments with no visible message text or caption
+8. Generate one video/Reel with Veo / Gemini Veo only from the approved image set and TOP's reference/prompt.
+9. Publish the video/Reel after latest TOP approval.
+10. Under the video/Reel, add:
+    - one link comment containing the same three approved affiliate links
+    - five image-only comments with no visible message text or caption
+11. Verify all real Facebook posts/comments by API readback.
+
+## Durable rule from TOP
+
+TOP may revise image direction, content angle, copy direction, voiceover, or video visual direction on each run. Those creative revisions do not change the default posting/comment structure above.
+
+Only skip or change the posting/comment structure when TOP explicitly instructs that exception for the current run.
+
+## Public copy and safety rules
+
+Public captions and comments must not mention:
+
+- AI names, agent names, Red, internal workflow names, or internal system names
+- Sub IDs
+- commission or internal scoring
+- tokens, secrets, credentials, cookies, page tokens, or app secrets
+- unverified price, stock, discount, warranty, medical/legal claims, or official-store claims
+
+Use Thai female admin voice for public copy (`ค่ะ`, `คะ`, `นะคะ`).
+
+## Approval boundaries
+
+Draft/read-only work can proceed as part of the workflow. Real side effects require latest explicit approval from TOP, including:
+
+- publishing Facebook posts/Reels
+- adding Facebook comments
+- deleting or hiding posts/comments
+- sending inbox messages
+- launching ads or spending budget
+- using sensitive customer data
+
+## Required verification
+
+The final run report should include:
+
+- selected product and source verification
+- three affiliate links present
+- five image files present
+- five image posts published and URLs verified
+- image-post link comments posted and link count verified
+- image-post image-only comments: five attachments and zero message text per post
+- Veo video file present
+- video/Reel published and URL verified
+- video/Reel link comment posted and link count verified
+- video/Reel image-only comments: five attachments and zero message text
+- no public Sub ID, commission, AI/internal names, or unverified claims
+
+## Mirrors
+
+This workflow is mirrored in:
+
+- Obsidian: `C:/Users/black/Documents/Obsidian Vault/Wiki/ShopeeAffiliate/WorkFlow-1-ShopeeAffiliate.md`
+- Hermes skill: `workflow-1-shopeeaffiliate`

--- a/docs/blackduckai/workflows/workflow-1-shopeeaffiliate.md
+++ b/docs/blackduckai/workflows/workflow-1-shopeeaffiliate.md
@@ -36,6 +36,8 @@ TOP may revise image direction, content angle, copy direction, voiceover, or vid
 
 Only skip or change the posting/comment structure when TOP explicitly instructs that exception for the current run.
 
+If TOP explicitly asks to split the video/Reel into multiple published Reels for a run, treat that as a run-specific creative/video direction override, not a permanent workflow change. Every published Reel still needs the full under-Reel comment package: one comment with the three approved affiliate links, five image-only comments with no visible message text, and API readback verification for each Reel.
+
 ## Public copy and safety rules
 
 Public captions and comments must not mention:
@@ -73,6 +75,7 @@ The final run report should include:
 - video/Reel published and URL verified
 - video/Reel link comment posted and link count verified
 - video/Reel image-only comments: five attachments and zero message text
+- if multiple Reels were explicitly requested, each Reel independently has the same link-comment and image-only-comment verification
 - no public Sub ID, commission, AI/internal names, or unverified claims
 
 ## Mirrors

--- a/docs/blackduckai/workflows/workflow-1-shopeeaffiliate.md
+++ b/docs/blackduckai/workflows/workflow-1-shopeeaffiliate.md
@@ -2,41 +2,61 @@
 
 Canonical operating workflow for BlackDuckAi Shopee Affiliate Facebook content loops.
 
-## Fixed posting structure
+## Current default posting structure
 
-For each selected Shopee Affiliate product, the default publishing structure is fixed:
+For each selected Shopee Affiliate product/page, the default publishing structure is fixed:
 
 1. Run Shopee API and Facebook API read-only checks.
-2. Select and verify one product.
-3. Research Facebook Ads Library patterns without copying competitor assets or copy.
+2. Select and verify one product per page lane.
+3. Research Facebook Ads Library/trend/source patterns without copying competitor assets or copy.
 4. Generate the three approved affiliate links:
    - product link
    - shop link
    - Shopee code/deal link
-5. Generate five final ad images with `gpt-image-2` / `gpt-image-2-high` only.
-6. Publish five image posts as a ladder after latest TOP approval:
-   - post 1: image 1
-   - post 2: images 1-2
-   - post 3: images 1-3
-   - post 4: images 1-4
-   - post 5: images 1-5
-7. Under every image post, add:
-   - one link comment containing the three approved affiliate links
-   - five image-only comments with no visible message text or caption
-8. Generate one video/Reel with Veo / Gemini Veo only from the approved image set and TOP's reference/prompt.
-9. Publish the video/Reel after latest TOP approval.
-10. Under the video/Reel, add:
-    - one link comment containing the same three approved affiliate links
-    - five image-only comments with no visible message text or caption
-11. Verify all real Facebook posts/comments by API readback.
+5. Generate three final single-post images with `gpt-image-2` only:
+   - Post 1: Main Sales / Hook
+   - Post 2: Use-case / Demo
+   - Post 3: Trust / Detail / CTA
+6. Publish three image posts after latest TOP approval:
+   - post 1: image 1 only
+   - post 2: image 2 only
+   - post 3: image 3 only
+7. Under every image post, add exactly one link comment containing the same three approved affiliate links only. Do not add extra links or image-only comments unless TOP explicitly requests a legacy run.
+8. Verify all real Facebook posts/comments by API readback.
+
+## Image generation default
+
+Use Hermes `image_generate` with the `openai-codex` image backend:
+
+```yaml
+image_gen:
+  provider: openai-codex
+  model: gpt-image-2-high # or gpt-image-2-medium
+  openai-codex:
+    model: gpt-image-2-high # or gpt-image-2-medium
+```
+
+`openai-codex` uses Codex/ChatGPT OAuth and does **not** require `OPENAI_API_KEY`.
+
+Only use the legacy `openai` image backend when TOP explicitly requests OpenAI Platform API-key billing or Codex OAuth is unavailable. The legacy `openai` backend is the one that requires `OPENAI_API_KEY`; do not report API key billing as mandatory when the active provider is `openai-codex`.
+
+## Product filters
+
+Default filters unless TOP explicitly overrides for the current run:
+
+- Price: `>= 1,000 THB`
+- Sales: `>= 200 sold`
+- Commission: `>= 10%`
+- Special commission / Extracomm signal required, e.g. `sellerCommissionRate > 0` from the current Shopee API/source output.
+- One product per page lane; do not duplicate category across the 3-page run unless TOP explicitly allows it.
 
 ## Durable rule from TOP
 
-TOP may revise image direction, content angle, copy direction, voiceover, or video visual direction on each run. Those creative revisions do not change the default posting/comment structure above.
+TOP may revise image direction, content angle, copy direction, voiceover, video visual direction, or product category on each run. Those creative revisions do not change the default posting/comment structure above.
 
 Only skip or change the posting/comment structure when TOP explicitly instructs that exception for the current run.
 
-If TOP explicitly asks to split the video/Reel into multiple published Reels for a run, treat that as a run-specific creative/video direction override, not a permanent workflow change. Every published Reel still needs the full under-Reel comment package: one comment with the three approved affiliate links, five image-only comments with no visible message text, and API readback verification for each Reel.
+Legacy 5-image ladder + Veo/Reel workflow is fallback/legacy only and requires explicit TOP instruction.
 
 ## Public copy and safety rules
 
@@ -67,15 +87,10 @@ The final run report should include:
 
 - selected product and source verification
 - three affiliate links present
-- five image files present
-- five image posts published and URLs verified
-- image-post link comments posted and link count verified
-- image-post image-only comments: five attachments and zero message text per post
-- Veo video file present
-- video/Reel published and URL verified
-- video/Reel link comment posted and link count verified
-- video/Reel image-only comments: five attachments and zero message text
-- if multiple Reels were explicitly requested, each Reel independently has the same link-comment and image-only-comment verification
+- three `gpt-image-2` image files present
+- three image posts published and URLs verified
+- three link comments posted and read back
+- each link comment has exactly product/shop/code links and no extras
 - no public Sub ID, commission, AI/internal names, or unverified claims
 
 ## Mirrors
@@ -83,4 +98,4 @@ The final run report should include:
 This workflow is mirrored in:
 
 - Obsidian: `C:/Users/black/Documents/Obsidian Vault/Wiki/ShopeeAffiliate/WorkFlow-1-ShopeeAffiliate.md`
-- Hermes skill: `workflow-1-shopeeaffiliate`
+- Hermes skill: `affiliate-post-ad-testing-workflow`

--- a/skills/autonomous-ai-agents/claude-code/SKILL.md
+++ b/skills/autonomous-ai-agents/claude-code/SKILL.md
@@ -18,7 +18,7 @@ Delegate coding tasks to [Claude Code](https://code.claude.com/docs/en/cli-refer
 ## Prerequisites
 
 - **Install:** `npm install -g @anthropic-ai/claude-code`
-- **Auth:** run `claude` once to log in (browser OAuth for Pro/Max, or set `ANTHROPIC_API_KEY`)
+- **Auth:** preferred path is browser OAuth: run `claude` once and log in with Claude Pro/Max or an API-capable Claude account. Use `ANTHROPIC_API_KEY` only as explicit API-billing fallback.
 - **Console auth:** `claude auth login --console` for API key billing
 - **SSO auth:** `claude auth login --sso` for Enterprise
 - **Check status:** `claude auth status` (JSON) or `claude auth status --text` (human-readable)
@@ -695,7 +695,7 @@ Use `/context` in interactive mode to see a colored grid of context usage. Key t
 
 | Variable | Effect |
 |----------|--------|
-| `ANTHROPIC_API_KEY` | API key for authentication (alternative to OAuth) |
+| `ANTHROPIC_API_KEY` | Optional API-billing fallback. Leave unset/empty when using Claude Code OAuth so it cannot shadow refreshable credentials. |
 | `CLAUDE_CODE_EFFORT_LEVEL` | Default effort: `low`, `medium`, `high`, `max`, or `auto` |
 | `MAX_THINKING_TOKENS` | Cap thinking tokens (set to `0` to disable thinking entirely) |
 | `MAX_MCP_OUTPUT_TOKENS` | Cap output from MCP servers (default varies; set e.g., `50000`) |

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -374,7 +374,7 @@ Full config reference: https://hermes-agent.nousresearch.com/docs/user-guide/con
 | Provider | Auth | Key env var |
 |----------|------|-------------|
 | OpenRouter | API key | `OPENROUTER_API_KEY` |
-| Anthropic | API key | `ANTHROPIC_API_KEY` |
+| Anthropic | Claude Code OAuth preferred; API key fallback | `claude`/`hermes model` OAuth, fallback `ANTHROPIC_API_KEY` |
 | Nous Portal | OAuth | `hermes auth` |
 | OpenAI Codex | OAuth | `hermes auth` |
 | GitHub Copilot | Token | `COPILOT_GITHUB_TOKEN` |


### PR DESCRIPTION
## Summary
- Adds BlackDuckAi ShopeeAffiliate canonical posting workflow docs.
- Adds BlackDuckAi finance document sync workflow docs.
- Updates ShopeeAffiliate docs for the current 3-post structure.
- Documents `gpt-image-2` via Hermes `openai-codex` image generation backend using Codex/ChatGPT OAuth, without requiring `OPENAI_API_KEY`.
- Documents Claude Sonnet via Claude Code OAuth for the Anthropic lane, without requiring `ANTHROPIC_API_KEY` when Claude Code credentials are available.
- Updates bundled Hermes/Claude Code skills so Claude Code OAuth is the preferred Anthropic path and `ANTHROPIC_API_KEY` is documented only as explicit API-billing fallback.
- Adds BlackDuckAi Hermes profile model-allocation docs covering Red, Nexus, Operator, Ledger, Magnet, Closer, Architect, Sentinel, Merchant, and Studio.

## Verification
- Secret scan over touched docs/skills passed: no access tokens, API-key values, cookies, page tokens, or app secrets.
- Confirmed PR branch pushed successfully.
- Runtime config in TOP's Hermes profile is set to `image_gen.provider: openai-codex` and `gpt-image-2-high`.
- Runtime config in TOP's Hermes profile is set to `model.provider: anthropic` and `claude-sonnet-4-6`; smoke test returned `CLAUDE_OAUTH_OK` via Claude Code OAuth.
- After TOP approval, profile allocation smoke tests passed: Claude lane `CLAUDE_PROFILE_OK`, Codex lane `CODEX_PROFILE_OK`, Gemini lane `GEMINI_PROFILE_OK`; `openai-codex` image provider resolved `gpt-image-2-high` / `quality=high`.

## Notes
- Legacy `openai` image backend remains documented only as explicit fallback; that provider requires OpenAI Platform API-key billing.
- Legacy Anthropic API-key auth remains documented only as explicit fallback; preferred Claude path is Claude Code OAuth / Pro-Max credential store.
- Unrelated untracked local folder `plugins/video_gen/gemini_veo/` was intentionally not committed.
