### PR TITLE
fix: make dashboard loopback bind configurable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1242,6 +1242,14 @@ DEFAULT_CONFIG = {
 
     # Web dashboard settings
     "dashboard": {
+        # Local bind defaults for ``hermes dashboard``. CLI flags win over
+        # environment variables, which win over config.yaml:
+        #   HERMES_DASHBOARD_HOST=127.0.0.1
+        #   HERMES_DASHBOARD_PORT=9119
+        # Keep the default loopback-only; binding publicly without an auth gate
+        # requires an explicit ``hermes dashboard --insecure`` opt-in.
+        "host": "127.0.0.1",
+        "port": 9119,
         "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"
         # Hide the token/cost analytics surfaces (Analytics page, token bars and
         # cost figures on the Models page) by default.  The numbers shown there

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10818,6 +10818,108 @@ def _render_distribution_plan(plan) -> None:
         )
 
 
+_DASHBOARD_DEFAULT_HOST = "127.0.0.1"
+_DASHBOARD_DEFAULT_PORT = 9119
+
+
+def _parse_dashboard_port(value, *, source: str) -> int:
+    """Parse and validate dashboard bind ports from config/env/CLI."""
+    try:
+        port = int(value)
+    except (TypeError, ValueError):
+        raise SystemExit(f"Invalid dashboard port from {source}: {value!r}")
+    if not 1 <= port <= 65535:
+        raise SystemExit(
+            f"Invalid dashboard port from {source}: {port} (expected 1-65535)"
+        )
+    return port
+
+
+def _resolve_dashboard_bind(args) -> tuple[str, int]:
+    """Resolve the dashboard bind address with explicit precedence.
+
+    Precedence is intentionally predictable for automation:
+      1. ``hermes dashboard --host/--port``
+      2. ``HERMES_DASHBOARD_HOST`` / ``HERMES_DASHBOARD_PORT``
+      3. ``dashboard.host`` / ``dashboard.port`` in config.yaml
+      4. built-in loopback fallback (127.0.0.1:9119)
+    """
+    config_host = _DASHBOARD_DEFAULT_HOST
+    config_port = _DASHBOARD_DEFAULT_PORT
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        cfg = load_config()
+        config_host = cfg_get(cfg, "dashboard", "host", default=_DASHBOARD_DEFAULT_HOST)
+        config_port = cfg_get(cfg, "dashboard", "port", default=_DASHBOARD_DEFAULT_PORT)
+    except Exception:
+        # Dashboard startup should still have deterministic loopback defaults
+        # if config loading fails; the rest of startup will surface config
+        # errors where they are actionable.
+        pass
+
+    host = config_host or _DASHBOARD_DEFAULT_HOST
+    port_value = config_port if config_port not in (None, "") else _DASHBOARD_DEFAULT_PORT
+
+    env_host = os.environ.get("HERMES_DASHBOARD_HOST")
+    if env_host is not None and env_host.strip():
+        host = env_host.strip()
+
+    env_port = os.environ.get("HERMES_DASHBOARD_PORT")
+    if env_port is not None and env_port.strip():
+        port_value = env_port.strip()
+
+    cli_host = getattr(args, "host", None)
+    if cli_host is not None and str(cli_host).strip():
+        host = str(cli_host).strip()
+
+    cli_port = getattr(args, "port", None)
+    if cli_port is not None:
+        port_value = cli_port
+
+    host = str(host).strip()
+    if not host:
+        raise SystemExit("Invalid dashboard host: empty value")
+    port = _parse_dashboard_port(port_value, source="CLI/env/config")
+    return host, port
+
+
+def _extract_dashboard_url_from_cmdline(cmdline: str) -> str | None:
+    """Best-effort URL extraction for ``hermes dashboard --status``."""
+    if not cmdline:
+        return None
+    try:
+        import shlex
+
+        tokens = shlex.split(cmdline)
+    except ValueError:
+        tokens = cmdline.split()
+
+    host: str | None = None
+    port: str | None = None
+    for i, tok in enumerate(tokens):
+        if tok == "--host" and i + 1 < len(tokens):
+            host = tokens[i + 1]
+        elif tok.startswith("--host="):
+            host = tok.split("=", 1)[1]
+        elif tok == "--port" and i + 1 < len(tokens):
+            port = tokens[i + 1]
+        elif tok.startswith("--port="):
+            port = tok.split("=", 1)[1]
+
+    if host is None or port is None:
+        ns = type("_DashboardStatusArgs", (), {"host": host, "port": port})()
+        try:
+            resolved_host, resolved_port = _resolve_dashboard_bind(ns)
+        except SystemExit:
+            resolved_host = host or _DASHBOARD_DEFAULT_HOST
+            resolved_port = port or _DASHBOARD_DEFAULT_PORT
+    else:
+        resolved_host = host
+        resolved_port = port
+    return f"http://{resolved_host}:{resolved_port}"
+
+
 def _report_dashboard_status() -> int:
     """Print ``hermes dashboard`` PIDs and return the count.
 
@@ -10849,7 +10951,11 @@ def _report_dashboard_status() -> int:
         except (OSError, ValueError):
             pass
         if cmdline:
-            print(f"    PID {pid}: {cmdline}")
+            url = _extract_dashboard_url_from_cmdline(cmdline)
+            if url:
+                print(f"    PID {pid}: {cmdline}\n      URL: {url}")
+            else:
+                print(f"    PID {pid}: {cmdline}")
         else:
             print(f"    PID {pid}")
     return len(pids)
@@ -10927,9 +11033,10 @@ def cmd_dashboard(args):
     from hermes_cli.web_server import start_server
 
     embedded_chat = args.tui or os.environ.get("HERMES_DASHBOARD_TUI") == "1"
+    host, port = _resolve_dashboard_bind(args)
     start_server(
-        host=args.host,
-        port=args.port,
+        host=host,
+        port=port,
         open_browser=not args.no_open,
         allow_public=getattr(args, "insecure", False),
         embedded_chat=embedded_chat,
@@ -14097,10 +14204,21 @@ Examples:
         description="Launch the Hermes Agent web dashboard for managing config, API keys, and sessions",
     )
     dashboard_parser.add_argument(
-        "--port", type=int, default=9119, help="Port (default 9119)"
+        "--port",
+        type=int,
+        default=None,
+        help=(
+            "Port (default: dashboard.port config or "
+            "HERMES_DASHBOARD_PORT, falling back to 9119)"
+        ),
     )
     dashboard_parser.add_argument(
-        "--host", default="127.0.0.1", help="Host (default 127.0.0.1)"
+        "--host",
+        default=None,
+        help=(
+            "Host (default: dashboard.host config or "
+            "HERMES_DASHBOARD_HOST, falling back to 127.0.0.1)"
+        ),
     )
     dashboard_parser.add_argument(
         "--no-open", action="store_true", help="Don't open browser automatically"

--- a/tests/hermes_cli/test_dashboard_lifecycle_flags.py
+++ b/tests/hermes_cli/test_dashboard_lifecycle_flags.py
@@ -15,7 +15,11 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from hermes_cli.main import cmd_dashboard
+from hermes_cli.main import (
+    _extract_dashboard_url_from_cmdline,
+    _resolve_dashboard_bind,
+    cmd_dashboard,
+)
 
 
 def _ns(**kw):
@@ -66,6 +70,47 @@ class TestDashboardStatus:
              pytest.raises(SystemExit) as exc:
             cmd_dashboard(_ns(status=True))
         assert exc.value.code == 0
+
+    def test_status_url_from_cmdline_flags(self):
+        url = _extract_dashboard_url_from_cmdline(
+            "python -m hermes_cli.main dashboard --host 127.0.0.1 --port 9120 --no-open"
+        )
+        assert url == "http://127.0.0.1:9120"
+
+
+class TestDashboardBindResolution:
+    def test_cli_flags_win_over_env_and_config(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DASHBOARD_HOST", "localhost")
+        monkeypatch.setenv("HERMES_DASHBOARD_PORT", "9120")
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"dashboard": {"host": "127.0.0.1", "port": 9119}},
+        ):
+            assert _resolve_dashboard_bind(_ns(host="::1", port=9121)) == ("::1", 9121)
+
+    def test_env_wins_over_config_when_cli_omitted(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DASHBOARD_HOST", "localhost")
+        monkeypatch.setenv("HERMES_DASHBOARD_PORT", "9120")
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"dashboard": {"host": "127.0.0.1", "port": 9119}},
+        ):
+            assert _resolve_dashboard_bind(_ns(host=None, port=None)) == ("localhost", 9120)
+
+    def test_config_used_for_stable_default_when_cli_and_env_omitted(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DASHBOARD_HOST", raising=False)
+        monkeypatch.delenv("HERMES_DASHBOARD_PORT", raising=False)
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"dashboard": {"host": "127.0.0.1", "port": 9122}},
+        ):
+            assert _resolve_dashboard_bind(_ns(host=None, port=None)) == ("127.0.0.1", 9122)
+
+    def test_invalid_port_fails_before_server_start(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DASHBOARD_PORT", "not-a-port")
+        with pytest.raises(SystemExit) as exc:
+            _resolve_dashboard_bind(_ns(host=None, port=None))
+        assert "Invalid dashboard port" in str(exc.value)
 
 
 class TestDashboardStop:

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -20,12 +20,14 @@ hermes dashboard
 
 This starts a local web server and opens `http://127.0.0.1:9119` in your browser. The dashboard runs entirely on your machine — no data leaves localhost.
 
+The loopback URL is stable across restarts by default. For local automations, point health checks at `http://127.0.0.1:9119/api/status`.
+
 ### Options
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--port` | `9119` | Port to run the web server on |
-| `--host` | `127.0.0.1` | Bind address |
+| `--port` | `dashboard.port`, `HERMES_DASHBOARD_PORT`, then `9119` | Port to run the web server on |
+| `--host` | `dashboard.host`, `HERMES_DASHBOARD_HOST`, then `127.0.0.1` | Bind address |
 | `--no-open` | — | Don't auto-open the browser |
 | `--insecure` | off | Allow binding to non-localhost hosts (**DANGEROUS** — exposes API keys on the network; pair with a firewall and strong auth) |
 | `--tui` | off | Expose the in-browser Chat tab (embedded `hermes --tui` via PTY/WebSocket). Alternatively set `HERMES_DASHBOARD_TUI=1`. |
@@ -39,6 +41,16 @@ hermes dashboard --host 0.0.0.0
 
 # Start without opening browser
 hermes dashboard --no-open
+
+# Make a different loopback port persistent across restarts
+hermes config set dashboard.port 9120
+hermes dashboard --no-open
+
+# Or override once from the environment
+HERMES_DASHBOARD_PORT=9120 hermes dashboard --no-open
+
+# Show running dashboard processes and their best-effort active URLs
+hermes dashboard --status
 
 # Enable the in-browser Chat tab
 hermes dashboard --tui
@@ -186,7 +198,7 @@ Browse, search, and toggle skills and toolsets. Skills are loaded from `~/.herme
 - **Toolsets** — a separate section shows built-in toolsets (file operations, web browsing, etc.) with their active/inactive status, setup requirements, and list of included tools
 
 :::warning Security
-The web dashboard reads and writes your `.env` file, which contains API keys and secrets. It binds to `127.0.0.1` by default — only accessible from your local machine. If you bind to `0.0.0.0`, anyone on your network can view and modify your credentials. The dashboard has no authentication of its own.
+The web dashboard reads and writes your `.env` file, which contains API keys and secrets. It binds to `127.0.0.1` by default — only accessible from your local machine. If you bind to `0.0.0.0`, anyone on your network may be able to view and modify credentials unless an OAuth/auth gate or external reverse-proxy authentication is in place. Only use `--insecure` on trusted networks with additional controls.
 :::
 
 ## `/reload` Slash Command


### PR DESCRIPTION
## Summary
- add `dashboard.host` / `dashboard.port` defaults plus `HERMES_DASHBOARD_HOST` / `HERMES_DASHBOARD_PORT` overrides for `hermes dashboard`
- keep CLI flags highest precedence and preserve the stable loopback fallback at `127.0.0.1:9119`
- show a best-effort active URL from `hermes dashboard --status`
- document stable loopback health checks and safe public-bind guidance

## Validation
- `python -m pytest tests/hermes_cli/test_dashboard_lifecycle_flags.py -q -o 'addopts='`\n- `python -m compileall -q hermes_cli/main.py hermes_cli/config.py`\n- Manual smoke: `HERMES_WEB_DIST=/tmp/hermes-dashboard-dist HERMES_DASHBOARD_PORT=9127 python -m hermes_cli.main dashboard --no-open`; `GET http://127.0.0.1:9127/api/status` returned HTTP 200\n\nLinear: OPS-1