### PR TITLE
fix(status): reuse gateway platform status resolver in hermes status

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -89,6 +89,56 @@ def _effective_provider_label() -> str:
 from hermes_constants import is_termux as _is_termux
 
 
+def _messaging_status_ok(status: str) -> bool:
+    """Return whether a messaging-platform status should get a green check.
+
+    Keep this aligned with ``hermes setup gateway`` so both surfaces agree on
+    what counts as meaningful configuration progress.
+    """
+    s = (status or "").strip().lower()
+    return not (
+        s == "not configured"
+        or s.startswith("partially")
+        or s.startswith("plugin disabled")
+    )
+
+
+def _iter_messaging_platform_rows() -> list[tuple[str, str]]:
+    """Return ``[(label, status), ...]`` for messaging platforms.
+
+    Reuse the gateway setup/status helpers so ``hermes status`` stays in sync
+    with plugin ``is_connected`` gates, WhatsApp pairing state, and other
+    platform-specific readiness logic.
+    """
+    from hermes_cli.gateway import _all_platforms, _platform_status
+
+    rows: list[tuple[str, str]] = []
+
+    home_channels = {}
+    try:
+        from gateway.config import load_gateway_config
+
+        gateway_cfg = load_gateway_config()
+        for platform, platform_cfg in getattr(gateway_cfg, "platforms", {}).items():
+            home = getattr(platform_cfg, "home_channel", None)
+            chat_id = getattr(home, "chat_id", None)
+            if chat_id:
+                home_channels[getattr(platform, "value", str(platform))] = str(chat_id)
+    except Exception:
+        home_channels = {}
+
+    for platform in _all_platforms():
+        key = str(platform.get("key") or "")
+        label = str(platform.get("label") or key)
+        status = _platform_status(platform)
+        home_chat_id = home_channels.get(key)
+        if home_chat_id and "home:" not in status:
+            status = f"{status} (home: {home_chat_id})"
+        rows.append((label, status))
+
+    return rows
+
+
 def show_status(args):
     """Show status of all Hermes Agent components."""
     show_all = getattr(args, 'all', False)
@@ -422,50 +472,9 @@ def show_status(args):
     # =========================================================================
     print()
     print(color("◆ Messaging Platforms", Colors.CYAN, Colors.BOLD))
-
-    platforms = {
-        "Telegram": ("TELEGRAM_BOT_TOKEN", "TELEGRAM_HOME_CHANNEL"),
-        "Discord": ("DISCORD_BOT_TOKEN", "DISCORD_HOME_CHANNEL"),
-        "WhatsApp": ("WHATSAPP_ENABLED", None),
-        "Signal": ("SIGNAL_HTTP_URL", "SIGNAL_HOME_CHANNEL"),
-        "Slack": ("SLACK_BOT_TOKEN", None),
-        "Email": ("EMAIL_ADDRESS", "EMAIL_HOME_ADDRESS"),
-        "SMS": ("TWILIO_ACCOUNT_SID", "SMS_HOME_CHANNEL"),
-        "DingTalk": ("DINGTALK_CLIENT_ID", None),
-        "Feishu": ("FEISHU_APP_ID", "FEISHU_HOME_CHANNEL"),
-        "WeCom": ("WECOM_BOT_ID", "WECOM_HOME_CHANNEL"),
-        "WeCom Callback": ("WECOM_CALLBACK_CORP_ID", None),
-        "Weixin": ("WEIXIN_ACCOUNT_ID", "WEIXIN_HOME_CHANNEL"),
-        "BlueBubbles": ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_HOME_CHANNEL"),
-        "QQBot": ("QQ_APP_ID", "QQ_HOME_CHANNEL"),
-        "Yuanbao": ("YUANBAO_APP_ID", "YUANBAO_HOME_CHANNEL"),
-    }
-
-    for name, (token_var, home_var) in platforms.items():
-        token = os.getenv(token_var, "")
-        has_token = bool(token)
-        
-        home_channel = ""
-        if home_var:
-            home_channel = os.getenv(home_var, "")
-        # Back-compat: QQBot home channel was renamed from QQ_HOME_CHANNEL to QQBOT_HOME_CHANNEL
-        if not home_channel and home_var == "QQBOT_HOME_CHANNEL":
-            home_channel = os.getenv("QQ_HOME_CHANNEL", "")
-        
-        status = "configured" if has_token else "not configured"
-        if home_channel:
-            status += f" (home: {home_channel})"
-        
-        print(f"  {name:<12}  {check_mark(has_token)} {status}")
-
-    # Plugin-registered platforms
     try:
-        from gateway.platform_registry import platform_registry
-        for entry in platform_registry.plugin_entries():
-            configured = entry.check_fn()
-            status_str = "configured" if configured else "not configured"
-            label = entry.label
-            print(f"  {label:<12}  {check_mark(configured)} {status_str} (plugin)")
+        for label, status in _iter_messaging_platform_rows():
+            print(f"  {label:<12}  {check_mark(_messaging_status_ok(status))} {status}")
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -3,6 +3,27 @@ from types import SimpleNamespace
 from hermes_cli.status import show_status
 
 
+def _base_status_mocks(monkeypatch, tmp_path):
+    """Patch the non-messaging parts of ``show_status`` to keep tests focused."""
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_minimax_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+    return status_mod, gateway_mod
+
+
 def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
@@ -131,6 +152,57 @@ def test_show_status_reports_nous_inference_key_without_portal_login(monkeypatch
     assert "Nous Portal   ✗ not logged in (Nous inference key configured)" in output
     assert "Inference:  https://inference.example.com/v1" in output
     assert "Nous inference credentials are configured" in output
+
+
+def test_show_status_uses_gateway_plugin_is_connected_over_check_fn(
+    monkeypatch, capsys, tmp_path
+):
+    """Plugin messaging rows must reuse gateway's provider-aware status gate.
+
+    Regression guard for the stale ``entry.check_fn()`` path in status.py:
+    deps-installed-but-unconfigured plugins should remain "not configured"
+    when their ``is_connected`` probe says the user has not provided creds.
+    """
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    _base_status_mocks(monkeypatch, tmp_path)
+
+    entry = PlatformEntry(
+        name="status-check-plugin",
+        label="StatusCheckPlugin",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        is_connected=lambda cfg: False,
+        required_env=["STATUS_CHECK_PLUGIN_TOKEN"],
+        source="plugin",
+    )
+    platform_registry.register(entry)
+    try:
+        show_status(SimpleNamespace(all=False, deep=False))
+    finally:
+        platform_registry.unregister(entry.name)
+
+    output = capsys.readouterr().out
+    assert "StatusCheckPlugin" in output
+    assert "not configured" in output
+
+
+def test_show_status_reports_whatsapp_enabled_not_paired(
+    monkeypatch, capsys, tmp_path
+):
+    """Messaging status should surface the gateway helper's pairing state."""
+    _base_status_mocks(monkeypatch, tmp_path)
+    monkeypatch.setenv("WHATSAPP_ENABLED", "true")
+
+    import hermes_cli.gateway as gateway_mod
+
+    monkeypatch.setattr(gateway_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "WhatsApp" in output
+    assert "enabled, not paired" in output
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Deduplicates messaging platform state tracking by refactoring `hermes status` to reuse the canonical `_all_platforms()` and `_platform_status()` resolver pipelines, enforcing exact feature parity across all CLI dashboard interfaces.

## Why
An architectural parity gap existed within the command terminal routing framework. While the gateway configuration engine and initialization routines (`hermes_cli/setup.py`) accurately queried runtime connection metrics to assess plugin environments, the standalone `hermes status` flow maintained a stale, hardcoded local dictionary alongside unsafe `entry.check_fn()` probes. This produced false-positive readouts—such as flagging a plugin platform as fully "configured" when system dependencies were present but specific credentials were empty, or misrepresenting incomplete WhatsApp pairing states. This fix enforces a single source of truth.

## Parity / Inspiration Reference
This operational alignment directly addresses the identical behavioral invariant established under:
- Commit: 7849a3d73f2d3fcf905cac69eff726160f40956a
- Message: `fix(gateway,discord-plugin): _platform_status must respect is_connected=False, not silently fall back to check_fn`

## Scope of Changes
- **hermes_cli/status.py**: Eliminated the static, duplicate messenger definition block inside `show_status()`, binding the layout formatter straight to core gateway platform utilities.
- **tests/hermes_cli/test_status.py**: Introduced target regression checks validating that plugin combinations yielding active dependencies but unverified sockets correctly register as `not configured` and anchoring strict integration checks.

## Verified Test Suites
Targeted status output sweeps, setup routines, and platform tracking tests completed with absolute success:
- `tests/hermes_cli/test_status.py`
- `tests/hermes_cli/test_setup_irc.py`

```text
Targeted Terminal Surface Sweeps: 27 passed, 0 failed
