### PR TITLE
fix(skills): support adaptive prompt catalog

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -9,10 +9,11 @@ import logging
 import os
 import threading
 from collections import OrderedDict
+from datetime import datetime, timezone
 from pathlib import Path
 
-from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
-from typing import Optional
+from hermes_constants import get_config_path, get_hermes_home, get_skills_dir, is_wsl
+from typing import Any, Optional
 
 from agent.skill_utils import (
     extract_skill_conditions,
@@ -22,6 +23,7 @@ from agent.skill_utils import (
     iter_skill_index_files,
     parse_frontmatter,
     skill_matches_platform,
+    yaml_load,
 )
 from utils import atomic_json_write
 
@@ -952,6 +954,247 @@ def _write_skills_snapshot(
         logger.debug("Could not write skills prompt snapshot: %s", e)
 
 
+_DEFAULT_PROMPT_CATALOG_CONFIG: dict[str, Any] = {
+    "mode": "full",
+    "hot_limit": 80,
+    "recent_days": 45,
+    "cold_policy": "category_summary",
+    "always_show": ("hermes-agent",),
+}
+
+
+def _coerce_nonnegative_int(value, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0, parsed)
+
+
+def _normalize_string_tuple(value: Any, default: Any = ()) -> tuple[str, ...]:
+    if value is None:
+        value = default
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, (list, tuple, set)):
+        return tuple(str(v).strip() for v in default if str(v).strip())
+    return tuple(str(v).strip() for v in value if str(v).strip())
+
+
+def _load_skills_prompt_catalog_config() -> dict[str, Any]:
+    """Read the lightweight skills.prompt_catalog config block.
+
+    The default is the historical full catalog. Users can opt into adaptive
+    rendering with::
+
+        skills:
+          prompt_catalog:
+            mode: adaptive
+    """
+    result = dict(_DEFAULT_PROMPT_CATALOG_CONFIG)
+    config_path = get_config_path()
+    if not config_path.exists():
+        return result
+    try:
+        parsed = yaml_load(config_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.debug("Could not read skills prompt catalog config %s: %s", config_path, e)
+        return result
+    if not isinstance(parsed, dict):
+        return result
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return result
+    prompt_cfg = skills_cfg.get("prompt_catalog")
+    if not isinstance(prompt_cfg, dict):
+        return result
+
+    mode = str(prompt_cfg.get("mode", result["mode"])).strip().lower()
+    if mode in {"full", "adaptive"}:
+        result["mode"] = mode
+    result["hot_limit"] = _coerce_nonnegative_int(
+        prompt_cfg.get("hot_limit"), result["hot_limit"]
+    )
+    result["recent_days"] = _coerce_nonnegative_int(
+        prompt_cfg.get("recent_days"), result["recent_days"]
+    )
+    cold_policy = str(prompt_cfg.get("cold_policy", result["cold_policy"])).strip().lower()
+    result["cold_policy"] = (
+        cold_policy if cold_policy in {"category_summary"} else "category_summary"
+    )
+    if "always_show" in prompt_cfg:
+        result["always_show"] = _normalize_string_tuple(prompt_cfg.get("always_show"))
+    else:
+        result["always_show"] = _normalize_string_tuple(result["always_show"])
+    return result
+
+
+def _prompt_catalog_cache_key(config: dict) -> tuple:
+    return (
+        config.get("mode", "full"),
+        int(config.get("hot_limit", 0) or 0),
+        int(config.get("recent_days", 0) or 0),
+        config.get("cold_policy", "category_summary"),
+        tuple(sorted(config.get("always_show") or ())),
+    )
+
+
+def _skills_usage_signature(skills_dir: Path) -> tuple | None:
+    usage_path = skills_dir / ".usage.json"
+    try:
+        stat = usage_path.stat()
+    except OSError:
+        return None
+    return (str(usage_path.resolve()), stat.st_mtime_ns, stat.st_size)
+
+
+def _load_skills_usage(skills_dir: Path) -> dict[str, dict]:
+    usage_path = skills_dir / ".usage.json"
+    if not usage_path.exists():
+        return {}
+    try:
+        data = json.loads(usage_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.debug("Could not read skill usage %s: %s", usage_path, e)
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(k): v for k, v in data.items() if isinstance(v, dict)}
+
+
+def _usage_activity_count(record: dict) -> int:
+    total = 0
+    for key in ("use_count", "view_count", "patch_count"):
+        try:
+            total += int(record.get(key) or 0)
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def _parse_usage_timestamp(value) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _latest_usage_timestamp(record: dict) -> datetime | None:
+    latest = None
+    for key in ("last_used_at", "last_viewed_at", "last_patched_at"):
+        parsed = _parse_usage_timestamp(record.get(key))
+        if parsed and (latest is None or parsed > latest):
+            latest = parsed
+    return latest
+
+
+def _expanded_skill_names_for_adaptive_catalog(
+    skills_by_category: dict[str, list[tuple[str, str]]],
+    skills_dir: Path,
+    catalog_config: dict,
+) -> set[str]:
+    always_show = set(_normalize_string_tuple(catalog_config.get("always_show")))
+    hot_limit = int(catalog_config.get("hot_limit") or 0)
+    if hot_limit <= 0:
+        return always_show
+
+    usage = _load_skills_usage(skills_dir)
+    if not usage:
+        return always_show
+
+    now = datetime.now(timezone.utc)
+    recent_days = int(catalog_config.get("recent_days") or 0)
+    ranked: list[tuple[bool, int, float, str]] = []
+    seen_names: set[str] = set()
+    for rows in skills_by_category.values():
+        for name, _desc in rows:
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+            record = usage.get(name)
+            if not isinstance(record, dict):
+                continue
+            count = _usage_activity_count(record)
+            latest = _latest_usage_timestamp(record)
+            is_recent = False
+            latest_ts = 0.0
+            if latest is not None:
+                latest_ts = latest.timestamp()
+                is_recent = (now - latest).total_seconds() <= recent_days * 86400
+            if count <= 0 and not is_recent:
+                continue
+            ranked.append((is_recent, count, latest_ts, name))
+
+    ranked.sort(reverse=True)
+    hot_names = {name for *_score, name in ranked[:hot_limit]}
+    return always_show | hot_names
+
+
+def _dedupe_sorted_skill_rows(rows: list[tuple[str, str]]) -> list[tuple[str, str]]:
+    seen: set[str] = set()
+    result: list[tuple[str, str]] = []
+    for name, desc in sorted(rows, key=lambda x: x[0]):
+        if name in seen:
+            continue
+        seen.add(name)
+        result.append((name, desc))
+    return result
+
+
+def _skill_is_expanded(category: str, name: str, expanded_names: set[str]) -> bool:
+    return name in expanded_names or f"{category}/{name}" in expanded_names
+
+
+def _render_skill_index_lines(
+    skills_by_category: dict[str, list[tuple[str, str]]],
+    category_descriptions: dict[str, str],
+    skills_dir: Path,
+    catalog_config: dict,
+) -> list[str]:
+    adaptive = catalog_config.get("mode") == "adaptive"
+    expanded_names = (
+        _expanded_skill_names_for_adaptive_catalog(
+            skills_by_category, skills_dir, catalog_config
+        )
+        if adaptive
+        else None
+    )
+
+    index_lines: list[str] = []
+    for category in sorted(skills_by_category.keys()):
+        cat_desc = category_descriptions.get(category, "")
+        if cat_desc:
+            index_lines.append(f"  {category}: {cat_desc}")
+        else:
+            index_lines.append(f"  {category}:")
+
+        folded_count = 0
+        for name, desc in _dedupe_sorted_skill_rows(skills_by_category[category]):
+            if adaptive and expanded_names is not None and not _skill_is_expanded(
+                category, name, expanded_names
+            ):
+                folded_count += 1
+                continue
+            if desc:
+                index_lines.append(f"    - {name}: {desc}")
+            else:
+                index_lines.append(f"    - {name}")
+
+        if adaptive and folded_count:
+            plural = "skill" if folded_count == 1 else "skills"
+            category_arg = json.dumps(category, ensure_ascii=False)
+            index_lines.append(
+                f"    - {folded_count} low-frequency {plural} hidden; "
+                f"use skills_list(category={category_arg}) to inspect."
+            )
+    return index_lines
+
+
 def _build_snapshot_entry(
     skill_file: Path,
     skills_dir: Path,
@@ -1070,6 +1313,12 @@ def build_skills_system_prompt(
         or ""
     )
     disabled = get_disabled_skill_names()
+    catalog_config = _load_skills_prompt_catalog_config()
+    usage_signature = (
+        _skills_usage_signature(skills_dir)
+        if catalog_config.get("mode") == "adaptive"
+        else None
+    )
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
@@ -1077,6 +1326,8 @@ def build_skills_system_prompt(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        _prompt_catalog_cache_key(catalog_config),
+        usage_signature,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1213,23 +1464,19 @@ def build_skills_system_prompt(
     if not skills_by_category:
         result = ""
     else:
-        index_lines = []
-        for category in sorted(skills_by_category.keys()):
-            cat_desc = category_descriptions.get(category, "")
-            if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
-            else:
-                index_lines.append(f"  {category}:")
-            # Deduplicate and sort skills within each category
-            seen = set()
-            for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
-                if name in seen:
-                    continue
-                seen.add(name)
-                if desc:
-                    index_lines.append(f"    - {name}: {desc}")
-                else:
-                    index_lines.append(f"    - {name}")
+        index_lines = _render_skill_index_lines(
+            skills_by_category,
+            category_descriptions,
+            skills_dir,
+            catalog_config,
+        )
+        adaptive_catalog_hint = ""
+        if catalog_config.get("mode") == "adaptive":
+            adaptive_catalog_hint = (
+                "This skill catalog is adaptive: low-frequency skills may be summarized "
+                "by category. If a category looks relevant but no listed skill matches, "
+                "call skills_list(category=\"...\") before deciding no skill applies.\n"
+            )
 
         result = (
             "## Skills (mandatory)\n"
@@ -1243,6 +1490,7 @@ def build_skills_system_prompt(
             "Skills also encode the user's preferred approach, conventions, and quality standards "
             "for tasks like code review, planning, and testing — load them even for tasks you "
             "already know how to do, because the skill defines how it should be done here.\n"
+            + adaptive_catalog_hint +
             "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
             "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
             "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 import builtins
 import importlib
+import json
 import logging
 import sys
 
@@ -264,6 +265,66 @@ class TestBuildSkillsSystemPrompt:
         assert "python-debug" in result
         assert "Debug Python scripts" in result
         assert "available_skills" in result
+
+    def test_adaptive_prompt_catalog_folds_low_activity_skills(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n"
+            "  prompt_catalog:\n"
+            "    mode: adaptive\n"
+            "    hot_limit: 1\n"
+            "    always_show: [keep-me]\n"
+        )
+        tools_dir = tmp_path / "skills" / "tools"
+        for name, desc in {
+            "cold-skill": "Rarely used helper",
+            "hot-skill": "Frequently used helper",
+            "keep-me": "Pinned helper",
+        }.items():
+            skill_dir = tools_dir / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n"
+            )
+        (tmp_path / "skills" / ".usage.json").write_text(
+            json.dumps({"hot-skill": {"view_count": 10}})
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "hot-skill" in result
+        assert "Frequently used helper" in result
+        assert "keep-me" in result
+        assert "Pinned helper" in result
+        assert "cold-skill" not in result
+        assert "1 low-frequency skill hidden" in result
+        assert 'skills_list(category="tools")' in result
+
+    def test_adaptive_prompt_catalog_cache_rebuilds_when_usage_changes(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n"
+            "  prompt_catalog:\n"
+            "    mode: adaptive\n"
+            "    hot_limit: 1\n"
+        )
+        skill_dir = tmp_path / "skills" / "tools" / "becomes-hot"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: becomes-hot\ndescription: Hot after use\n---\n"
+        )
+
+        first = build_skills_system_prompt()
+        assert "becomes-hot" not in first
+        assert "1 low-frequency skill hidden" in first
+
+        (tmp_path / "skills" / ".usage.json").write_text(
+            json.dumps({"becomes-hot": {"use_count": 1}})
+        )
+
+        second = build_skills_system_prompt()
+        assert "becomes-hot" in second
+        assert "Hot after use" in second
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1107,18 +1107,11 @@ Do the legacy thing.
 class TestSkillViewCollisionDetection:
     """Regression tests for skill_view name collision handling.
 
-    When a skill name resolves to multiple paths across the local skills
-    dir and external_dirs, skill_view must refuse to guess. Silent
-    shadowing — where ``/skills`` shows the local version but
-    ``skill_view`` loads the external one — is the bug class this guards
-    against. Reproduces with `skills.external_dirs` registered in
-    config.yaml and a same-name skill nested under a category locally.
-
-    Adapted from a regression suite originally proposed by @polkn in PR
-    #6136 (which used local-first precedence). The collision-refusal
-    behavior preserves the same protection without silently picking a
-    side, and gives the user an actionable hint (use the categorized
-    path) to recover.
+    Prompt construction renders local skills first and skips same-named
+    external skills. skill_view should follow the same precedence so a skill
+    listed in the prompt can be loaded by name. Ambiguity is still surfaced
+    when two candidates have the same precedence, such as two external skill
+    dirs defining the same name.
     """
 
     def _patch_dirs(self, local_dir, external_dirs):
@@ -1131,9 +1124,9 @@ class TestSkillViewCollisionDetection:
             ),
         )
 
-    def test_nested_local_collides_with_top_level_external(self, tmp_path):
-        """The original bug scenario: nested local + top-level external,
-        same name. Now refuses with both paths surfaced."""
+    def test_nested_local_takes_precedence_over_top_level_external(self, tmp_path):
+        """Nested local + top-level external with the same name loads local,
+        matching the prompt catalog's local-first rendering."""
         local_dir = tmp_path / "local"
         external_dir = tmp_path / "external"
         local_dir.mkdir()
@@ -1152,18 +1145,12 @@ class TestSkillViewCollisionDetection:
             raw = skill_view("explore-codebase")
 
         result = json.loads(raw)
-        assert result["success"] is False
-        assert "Ambiguous skill name 'explore-codebase'" in result["error"]
-        assert "matches" in result
-        assert len(result["matches"]) == 2
-        # Both paths surfaced
-        assert any("foundations/runtime" in p for p in result["matches"])
-        assert any("external" in p for p in result["matches"])
-        assert "hint" in result
+        assert result["success"] is True
+        assert "LOCAL VERSION" in result["content"]
+        assert "EXTERNAL VERSION" not in result["content"]
 
-    def test_top_level_local_collides_with_external(self, tmp_path):
-        """Top-level local + top-level external with the same name also
-        refuses — same-name shadowing is ambiguous regardless of nesting."""
+    def test_top_level_local_takes_precedence_over_external(self, tmp_path):
+        """Top-level local + top-level external with the same name loads local."""
         local_dir = tmp_path / "local"
         external_dir = tmp_path / "external"
         local_dir.mkdir()
@@ -1177,13 +1164,43 @@ class TestSkillViewCollisionDetection:
             raw = skill_view("shared-name")
 
         result = json.loads(raw)
-        assert result["success"] is False
-        assert "Ambiguous" in result["error"]
-        assert len(result["matches"]) == 2
+        assert result["success"] is True
+        assert "LOCAL VERSION" in result["content"]
+        assert "EXTERNAL VERSION" not in result["content"]
 
-    def test_collision_resolvable_via_categorized_path(self, tmp_path):
-        """User can recover from a collision by passing the full
-        categorized path — the bare name is ambiguous, the path is not."""
+    def test_categorized_local_takes_precedence_over_same_external_path(self, tmp_path):
+        """The hint to pass a categorized path works even when an external
+        dir has the same category/name layout."""
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+
+        _make_skill(
+            local_dir,
+            "explore-codebase",
+            category="foundations/runtime",
+            body="LOCAL VERSION",
+        )
+        _make_skill(
+            external_dir,
+            "explore-codebase",
+            category="foundations/runtime",
+            body="EXTERNAL VERSION",
+        )
+
+        p1, p2 = self._patch_dirs(local_dir, [external_dir])
+        with p1, p2:
+            raw = skill_view("foundations/runtime/explore-codebase")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "LOCAL VERSION" in result["content"]
+        assert "EXTERNAL VERSION" not in result["content"]
+
+    def test_categorized_path_selects_local_nested_skill(self, tmp_path):
+        """A categorized path selects the intended local nested skill when an
+        external skill has the same bare name elsewhere."""
         local_dir = tmp_path / "local"
         external_dir = tmp_path / "external"
         local_dir.mkdir()

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -914,18 +914,17 @@ def skill_view(
         skill_dir = None
         skill_md = None
 
-        # Collision detection: collect ALL candidates across every dir using
-        # every lookup strategy (direct path, recursive by parent dir name,
-        # legacy flat <name>.md). If more than one matches, refuse and tell
-        # the caller — silent shadowing of a local skill by a same-named
-        # external skill is a real bug class (`/skills` shows one, agent
-        # loaded the other) so we surface it loudly instead of guessing.
+        # Collision handling mirrors prompt_builder: the local skills dir has
+        # precedence over external_dirs, because the system prompt renders the
+        # same way. If multiple candidates remain at the same precedence level
+        # (for example two local categories with the same skill name, or two
+        # external dirs defining the same skill), refuse and surface paths.
         from agent.skill_utils import iter_skill_index_files
 
-        candidates: List[Tuple[Optional[Path], Path]] = []  # (skill_dir, skill_md)
+        candidates: List[Tuple[int, Optional[Path], Path]] = []  # (root_index, skill_dir, skill_md)
         seen_md: set = set()
 
-        def _record(sd: Optional[Path], smd: Path) -> None:
+        def _record(root_index: int, sd: Optional[Path], smd: Path) -> None:
             try:
                 key = smd.resolve()
             except Exception:
@@ -933,16 +932,16 @@ def skill_view(
             if key in seen_md:
                 return
             seen_md.add(key)
-            candidates.append((sd, smd))
+            candidates.append((root_index, sd, smd))
 
-        for search_dir in all_dirs:
+        for root_index, search_dir in enumerate(all_dirs):
             # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
             # at the top of the dir).
             direct_path = search_dir / name
             if direct_path.is_dir() and (direct_path / "SKILL.md").exists():
-                _record(direct_path, direct_path / "SKILL.md")
+                _record(root_index, direct_path, direct_path / "SKILL.md")
             elif direct_path.with_suffix(".md").exists():
-                _record(None, direct_path.with_suffix(".md"))
+                _record(root_index, None, direct_path.with_suffix(".md"))
 
             # Strategy 1b: categorized form for plugin namespace fall-through
             # (e.g., a "myplugin:explore" name with no plugin registered also
@@ -950,33 +949,36 @@ def skill_view(
             if local_category_name:
                 categorized_path = search_dir / local_category_name
                 if categorized_path.is_dir() and (categorized_path / "SKILL.md").exists():
-                    _record(categorized_path, categorized_path / "SKILL.md")
+                    _record(root_index, categorized_path, categorized_path / "SKILL.md")
                 elif categorized_path.with_suffix(".md").exists():
-                    _record(None, categorized_path.with_suffix(".md"))
+                    _record(root_index, None, categorized_path.with_suffix(".md"))
 
             # Strategy 2: recursive by directory name (catches nested skills
             # like "foundations/runtime/explore-codebase" called by bare name).
             for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
                 if found_skill_md.parent.name == name:
-                    _record(found_skill_md.parent, found_skill_md)
+                    _record(root_index, found_skill_md.parent, found_skill_md)
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
             for found_md in search_dir.rglob(f"{name}.md"):
                 if found_md.name != "SKILL.md":
-                    _record(None, found_md)
+                    _record(root_index, None, found_md)
 
-        if len(candidates) > 1:
-            paths = [str(smd) for _, smd in candidates]
+        local_candidates = [(sd, smd) for root_index, sd, smd in candidates if root_index == 0]
+        resolved_candidates = local_candidates or [(sd, smd) for _, sd, smd in candidates]
+
+        if len(resolved_candidates) > 1:
+            paths = [str(smd) for _, smd in resolved_candidates]
             logging.getLogger(__name__).warning(
                 "Skill name collision for '%s': %d candidates — %s",
-                name, len(candidates), "; ".join(paths),
+                name, len(resolved_candidates), "; ".join(paths),
             )
             return json.dumps(
                 {
                     "success": False,
                     "error": (
-                        f"Ambiguous skill name '{name}': {len(candidates)} skills "
-                        "match across your local skills dir and external_dirs. "
+                        f"Ambiguous skill name '{name}': {len(resolved_candidates)} skills "
+                        "match at the same precedence level. "
                         "Refusing to guess — load one explicitly by its categorized path."
                     ),
                     "matches": paths,
@@ -989,8 +991,8 @@ def skill_view(
                 ensure_ascii=False,
             )
 
-        if candidates:
-            skill_dir, skill_md = candidates[0]
+        if resolved_candidates:
+            skill_dir, skill_md = resolved_candidates[0]
 
         if not skill_md or not skill_md.exists():
             available = [s["name"] for s in _sort_skills(_find_all_skills())[:20]]


### PR DESCRIPTION
## Summary
- add an opt-in adaptive skills prompt catalog via `skills.prompt_catalog.mode: adaptive`
- keep frequently/recently used and `always_show` skills expanded while folding low-frequency skills into category-level hints
- make `skill_view` use the same local-first precedence as prompt construction, while still refusing ambiguous same-precedence collisions

## Test Plan
- `python -m pytest tests/agent/test_prompt_builder.py tests/tools/test_skills_tool.py -q`
- `python -m pytest tests/agent/test_prompt_builder.py::TestBuildSkillsSystemPrompt::test_adaptive_prompt_catalog_folds_low_activity_skills tests/agent/test_prompt_builder.py::TestBuildSkillsSystemPrompt::test_adaptive_prompt_catalog_cache_rebuilds_when_usage_changes tests/tools/test_skills_tool.py::TestSkillViewCollisionDetection -q`
- `python -m ruff check agent/prompt_builder.py tools/skills_tool.py tests/agent/test_prompt_builder.py tests/tools/test_skills_tool.py`
- `python -m ty check agent/prompt_builder.py` (passes with an existing unused `type: ignore` warning)

Note: I also tried `python -m pytest -q`; it did not finish within 10 minutes in this environment and showed unrelated failures outside the touched tests before timing out.
