### PR TITLE
feat(guardrails): add tool_repetition limits for identical mutating tool calls

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -77,6 +77,8 @@ class ToolCallGuardrailConfig:
     same_tool_failure_halt_after: int = 8
     no_progress_warn_after: int = 2
     no_progress_block_after: int = 5
+    tool_repetition_warn_after: int = 5
+    tool_repetition_block_after: int = 8
     idempotent_tools: frozenset[str] = field(default_factory=lambda: IDEMPOTENT_TOOL_NAMES)
     mutating_tools: frozenset[str] = field(default_factory=lambda: MUTATING_TOOL_NAMES)
 
@@ -120,6 +122,14 @@ class ToolCallGuardrailConfig:
             no_progress_block_after=_positive_int(
                 hard_stop_after.get("idempotent_no_progress", data.get("no_progress_block_after")),
                 defaults.no_progress_block_after,
+            ),
+            tool_repetition_warn_after=_positive_int(
+                warn_after.get("tool_repetition", data.get("tool_repetition_warn_after")),
+                defaults.tool_repetition_warn_after,
+            ),
+            tool_repetition_block_after=_positive_int(
+                hard_stop_after.get("tool_repetition", data.get("tool_repetition_block_after")),
+                defaults.tool_repetition_block_after,
             ),
         )
 
@@ -232,6 +242,7 @@ class ToolCallGuardrailController:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._tool_repetition_counts: dict[ToolCallSignature, int] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
 
     @property
@@ -255,6 +266,23 @@ class ToolCallGuardrailController:
                 ),
                 tool_name=tool_name,
                 count=exact_count,
+                signature=signature,
+            )
+            self._halt_decision = decision
+            return decision
+
+        repetition = self._tool_repetition_counts.get(signature, 0)
+        if repetition >= self.config.tool_repetition_block_after:
+            decision = ToolGuardrailDecision(
+                action="block",
+                code="tool_repetition_block",
+                message=(
+                    f"Blocked {tool_name}: the exact same call (tool + args) was made "
+                    f"{repetition} times this turn without progress. Stop repeating it "
+                    "unchanged; change strategy or explain the blocker."
+                ),
+                tool_name=tool_name,
+                count=repetition,
                 signature=signature,
             )
             self._halt_decision = decision
@@ -346,6 +374,58 @@ class ToolCallGuardrailController:
 
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
+
+        repetition = self._tool_repetition_counts.get(signature, 0) + 1
+        self._tool_repetition_counts[signature] = repetition
+
+        if self.config.warnings_enabled and repetition >= self.config.tool_repetition_warn_after:
+            decision = ToolGuardrailDecision(
+                action="warn",
+                code="tool_repetition_warning",
+                message=(
+                    f"{tool_name} has been called with identical arguments "
+                    f"{repetition} times this turn. This looks like a loop; "
+                    "inspect the result and change strategy instead of repeating "
+                    "it unchanged."
+                ),
+                tool_name=tool_name,
+                count=repetition,
+                signature=signature,
+            )
+            if (
+                self.config.hard_stop_enabled
+                and repetition >= self.config.tool_repetition_block_after
+            ):
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="tool_repetition_block",
+                    message=(
+                        f"Blocked {tool_name}: the exact same call (tool + args) was made "
+                        f"{repetition} times this turn without progress. Stop repeating it "
+                        "unchanged; change strategy or explain the blocker."
+                    ),
+                    tool_name=tool_name,
+                    count=repetition,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+            return decision
+
+        if self.config.hard_stop_enabled and repetition >= self.config.tool_repetition_block_after:
+            decision = ToolGuardrailDecision(
+                action="block",
+                code="tool_repetition_block",
+                message=(
+                    f"Blocked {tool_name}: the exact same call (tool + args) was made "
+                    f"{repetition} times this turn without progress. Stop repeating it "
+                    "unchanged; change strategy or explain the blocker."
+                ),
+                tool_name=tool_name,
+                count=repetition,
+                signature=signature,
+            )
+            self._halt_decision = decision
+            return decision
 
         if not self._is_idempotent(tool_name):
             self._no_progress.pop(signature, None)

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -256,3 +256,189 @@ def test_reset_for_turn_clears_bounded_guardrail_state():
 
     assert controller.before_call("web_search", {"query": "same"}).action == "allow"
     assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
+
+
+# ── tool_repetition guardrail tests ──────────────────────────────────────────
+
+
+def test_default_tool_repetition_config_values():
+    cfg = ToolCallGuardrailConfig()
+
+    assert cfg.tool_repetition_warn_after == 5
+    assert cfg.tool_repetition_block_after == 8
+
+
+def test_config_parses_tool_repetition_thresholds_from_nested_sections():
+    cfg = ToolCallGuardrailConfig.from_mapping(
+        {
+            "warn_after": {"tool_repetition": 3},
+            "hard_stop_after": {"tool_repetition": 6},
+        }
+    )
+
+    assert cfg.tool_repetition_warn_after == 3
+    assert cfg.tool_repetition_block_after == 6
+
+
+def test_config_parses_tool_repetition_thresholds_from_flat_keys():
+    """top-level flat keys (legacy compat) still work."""
+    cfg = ToolCallGuardrailConfig.from_mapping(
+        {
+            "tool_repetition_warn_after": 4,
+            "tool_repetition_block_after": 7,
+        }
+    )
+
+    assert cfg.tool_repetition_warn_after == 4
+    assert cfg.tool_repetition_block_after == 7
+
+
+def test_warns_on_repeated_identical_mutating_tool_call_without_hard_stop():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(tool_repetition_warn_after=2, tool_repetition_block_after=8)
+    )
+    args = {"command": "ls"}
+
+    decision = None
+    # 4 identical calls; warning threshold at 2, no hard stop
+    for i in range(4):
+        assert controller.before_call("terminal", args).action == "allow"
+        decision = controller.after_call("terminal", args, '{"exit_code":0}', failed=False)
+
+    assert decision is not None
+    assert decision.action == "warn"
+    assert decision.code == "tool_repetition_warning"
+    assert decision.count == 4
+    assert controller.halt_decision is None
+    assert controller.before_call("terminal", args).action == "allow"
+
+
+def test_hard_stop_blocks_repeated_identical_mutating_tool_call_before_next():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            tool_repetition_warn_after=2,
+            tool_repetition_block_after=3,
+        )
+    )
+    args = {"command": "false"}
+
+    decision = None
+    # 2 identical "successful" calls — count=2 triggers warn (not block yet at 3)
+    for i in range(2):
+        assert controller.before_call("terminal", args).action == "allow"
+        decision = controller.after_call("terminal", args, '{"exit_code":0}', failed=False)
+
+    assert decision is not None
+    assert decision.action == "warn"
+    assert decision.code == "tool_repetition_warning"
+
+    # Third attempt: after_call count=3 triggers block
+    assert controller.before_call("terminal", args).action == "allow"
+    blocked = controller.after_call("terminal", args, '{"exit_code":0}', failed=False)
+    assert blocked.action == "block"
+    assert blocked.code == "tool_repetition_block"
+    assert blocked.count == 3
+
+    # Fourth attempt blocked BEFORE execution
+    fourth = controller.before_call("terminal", args)
+    assert fourth.action == "block"
+
+
+def test_different_args_create_different_signatures_so_repetition_independent():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            tool_repetition_warn_after=2,
+        )
+    )
+
+    # Call A with args {command: "cmd-a"} 3× → should warn
+    for _ in range(2):
+        controller.before_call("terminal", {"command": "cmd-a"})
+        controller.after_call("terminal", {"command": "cmd-a"}, "ok", failed=False)
+    decision_a = controller.after_call("terminal", {"command": "cmd-a"}, "ok", failed=False)
+    assert decision_a.code == "tool_repetition_warning"
+
+    # Call B with different args — fresh counter
+    assert controller.before_call("terminal", {"command": "cmd-b"}).action == "allow"
+    decision_b = controller.after_call("terminal", {"command": "cmd-b"}, "ok", failed=False)
+    assert decision_b.action == "allow"
+
+
+def test_single_success_between_repeated_calls_resets_repetition_counter():
+    """A different tool call breaks the repetition streak for THAT signature."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(tool_repetition_warn_after=2)
+    )
+
+    # 2 identical calls → should warn
+    controller.after_call("terminal", {"command": "ls"}, "ok", failed=False)
+    warn = controller.after_call("terminal", {"command": "ls"}, "ok", failed=False)
+    assert warn.code == "tool_repetition_warning"
+
+    # A completely different tool call does NOT reset — repetition is per-signature
+    controller.after_call("read_file", {"path": "/tmp/x"}, "contents", failed=False)
+
+    # Same terminal("ls") signature already at count 2 — still triggers
+    decision = controller.after_call("terminal", {"command": "ls"}, "ok", failed=False)
+    assert decision.code == "tool_repetition_warning"
+    assert decision.count == 3
+
+
+def test_tool_repetition_warns_for_mutating_tools_including_browser_navigate():
+    """browser_navigate is a mutating tool; repeated identical calls should warn."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(tool_repetition_warn_after=2)
+    )
+
+    decision = None
+    for _ in range(3):
+        controller.before_call("browser_navigate", {"url": "https://example.com/404"})
+        decision = controller.after_call(
+            "browser_navigate",
+            {"url": "https://example.com/404"},
+            "Page loaded: 404 Not Found",
+            failed=False,
+        )
+
+    assert decision is not None
+    assert decision.code == "tool_repetition_warning"
+    assert "browser_navigate" in decision.message
+
+
+def test_reset_for_turn_clears_tool_repetition_state():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            tool_repetition_block_after=2,
+        )
+    )
+
+    controller.after_call("terminal", {"command": "ls"}, "ok", failed=False)
+    controller.after_call("terminal", {"command": "ls"}, "ok", failed=False)
+
+    assert controller.before_call("terminal", {"command": "ls"}).action == "block"
+
+    controller.reset_for_turn()
+
+    assert controller.before_call("terminal", {"command": "ls"}).action == "allow"
+
+
+def test_failed_call_does_not_count_toward_tool_repetition():
+    """Failed calls should be handled by failure guardrails, not repetition."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            tool_repetition_warn_after=2,
+            exact_failure_warn_after=2,
+        )
+    )
+
+    # Two failed calls — triggers failure warning, NOT repetition
+    controller.after_call("terminal", {"command": "bad"}, '{"exit_code":1}', failed=True)
+    decision = controller.after_call("terminal", {"command": "bad"}, '{"exit_code":1}', failed=True)
+    assert decision.code == "repeated_exact_failure_warning"
+
+    # Repetition counter for this signature should be ZERO (failures don't count)
+    assert controller._tool_repetition_counts.get(
+        ToolCallSignature.from_call("terminal", {"command": "bad"}), 0
+    ) == 0


### PR DESCRIPTION
## Summary

Adds a fourth guardrail axis — `tool_repetition` — alongside the existing `exact_failure`, `same_tool_failure`, and `idempotent_no_progress` axes. Tracks repeated calls by `ToolCallSignature` (tool name + canonicalized args hash) and triggers warn/block decisions when the same mutating call is made repeatedly without progress — even when each individual call formally succeeds.

Closes #34610.

## Motivation

Today, mutating tools (`browser_navigate`, `terminal`, `write_file`, etc.) are excluded from `idempotent_no_progress` checks. A `browser_navigate` to a 404 URL, or `terminal('ls')` in a loop, can repeat indefinitely without guardrail intervention as long as the HTTP response is 200 or the exit code is 0.

The reporter\'s scenario: Hermes was asked to navigate to a URL that returned 404. With `tool_loop_guardrails` enabled, the agent called `browser_navigate` with identical args repeatedly until `max_iterations` was exhausted — no warning, no halt. The fix adds a per-signature repetition counter that fires regardless of success/failure classification.

## Changes

### `agent/tool_guardrails.py`

- **Config:** New fields `tool_repetition_warn_after` (default 5) and `tool_repetition_block_after` (default 8). Parsed from both nested sections (`warn_after.tool_repetition`, `hard_stop_after.tool_repetition`) and legacy flat keys (`tool_repetition_warn_after`, `tool_repetition_block_after`).
- **State:** `reset_for_turn` initializes `self._tool_repetition_counts: dict[ToolCallSignature, int]`.
- **`after_call`:** On every non-failed call, increments the per-signature repetition counter. When `repetition >= tool_repetition_warn_after`, emits `tool_repetition_warning`. When `hard_stop_enabled` and `repetition >= tool_repetition_block_after`, emits `tool_repetition_block` and sets `halt_decision`.
- **`before_call`:** When `hard_stop_enabled` and the per-signature counter is at or above the block threshold, returns `tool_repetition_block` — preventing the N+1th identical call before execution.

### `tests/agent/test_tool_guardrails.py`

10 new tests (23 total, all passing):

| Test | What it covers |
|------|---------------|
| `test_default_tool_repetition_config_values` | Default thresholds (5/8) |
| `test_config_parses_tool_repetition_thresholds_from_nested_sections` | `warn_after.tool_repetition` + `hard_stop_after.tool_repetition` |
| `test_config_parses_tool_repetition_thresholds_from_flat_keys` | Legacy flat key compat |
| `test_warns_on_repeated_identical_mutating_tool_call_without_hard_stop` | Soft warning path (no blocking) |
| `test_hard_stop_blocks_repeated_identical_mutating_tool_call_before_next` | Hard stop: block on 3rd call, 4th blocked before exec |
| `test_different_args_create_different_signatures_so_repetition_independent` | Different args = independent counters |
| `test_single_success_between_repeated_calls_resets_repetition_counter` | Repetition persists per-signature across other tool calls |
| `test_tool_repetition_warns_for_mutating_tools_including_browser_navigate` | Exact reporter scenario |
| `test_reset_for_turn_clears_tool_repetition_state` | State reset works |
| `test_failed_call_does_not_count_toward_tool_repetition` | Failures excluded (handled by existing axes) |

## Tradeoffs

- **Counting all non-failed calls** means the counter increments even when the tool makes progress. The thresholds are intentionally high (5/8 defaults) so normal iteration is unaffected — only tight loops trigger warnings. This mirrors the philosophy of the existing axes.
- **Per-signature, not per-tool** — `terminal('ls')` and `terminal('pwd')` have independent counters. Only truly identical calls (same tool + same args hash) are tracked.
- **No config migration needed** — omitted thresholds use defaults, so existing configs continue working unchanged.

## Verification

```
$ python3 -m pytest tests/agent/test_tool_guardrails.py -q -o "addopts="
.......................  [100%]
23 passed in 0.13s
```