### PR TITLE
fix(gateway): bind session context for auto tts

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3756,9 +3756,26 @@ class BasePlatformAdapter(ABC):
                             speech_text = self.prepare_tts_text(text_content)
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
-                            tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
+                            from gateway.session_context import clear_session_vars, set_session_vars
+
+                            source_platform = getattr(event.source, "platform", None)
+                            source_platform = getattr(source_platform, "value", source_platform)
+                            tts_context_tokens = set_session_vars(
+                                platform=str(source_platform or self.platform.value or ""),
+                                chat_id=str(getattr(event.source, "chat_id", "") or ""),
+                                chat_name=str(getattr(event.source, "chat_name", "") or ""),
+                                thread_id=str(getattr(event.source, "thread_id", "") or ""),
+                                user_id=str(getattr(event.source, "user_id", "") or ""),
+                                user_name=str(getattr(event.source, "user_name", "") or ""),
+                                session_key=session_key,
+                                message_id=str(getattr(event, "message_id", "") or ""),
                             )
+                            try:
+                                tts_result_str = await asyncio.to_thread(
+                                    text_to_speech_tool, text=speech_text
+                                )
+                            finally:
+                                clear_session_vars(tts_context_tokens)
                             tts_data = _json.loads(tts_result_str)
                             _tts_path = tts_data.get("file_path")
                     except Exception as tts_err:

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -121,6 +121,71 @@ async def test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_
     adapter.send_document.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_auto_tts_rebinds_gateway_session_context_for_tts_tool(tmp_path, monkeypatch):
+    """Auto-TTS runs after the message handler has returned.
+
+    The handler path may clear gateway session contextvars before the base
+    adapter calls ``text_to_speech_tool``.  The auto-TTS call must re-bind the
+    current event context so Telegram replies generate voice-compatible audio
+    instead of falling back to contextless MP3 output.
+    """
+    from gateway.session_context import (
+        _UNSET,
+        _VAR_MAP,
+        clear_session_vars,
+        get_session_env,
+        set_session_vars,
+    )
+
+    captured_context = {}
+    adapter = _MediaRoutingAdapter()
+    adapter._auto_tts_enabled_chats.add("chat-1")
+    event = _event()
+    event.message_type = MessageType.VOICE
+    session_key = build_session_key(event.source)
+    audio_file = tmp_path / "auto-tts.ogg"
+
+    async def _handler(_event):
+        tokens = set_session_vars(
+            platform="telegram",
+            chat_id=_event.source.chat_id,
+            user_id=getattr(_event.source, "user_id", "") or "",
+            session_key=session_key,
+            message_id=getattr(_event, "message_id", "") or "",
+        )
+        clear_session_vars(tokens)
+        return "spoken reply"
+
+    def _fake_tts_tool(*, text, **_kwargs):
+        captured_context["platform"] = get_session_env("HERMES_SESSION_PLATFORM", "")
+        captured_context["chat_id"] = get_session_env("HERMES_SESSION_CHAT_ID", "")
+        captured_context["session_key"] = get_session_env("HERMES_SESSION_KEY", "")
+        captured_context["message_id"] = get_session_env("HERMES_SESSION_MESSAGE_ID", "")
+        audio_file.write_bytes(b"ogg")
+        return '{"success": true, "file_path": "' + str(audio_file) + '"}'
+
+    adapter._message_handler = AsyncMock(side_effect=_handler)
+    adapter.send_voice = AsyncMock(return_value=SendResult(success=True, message_id="voice"))
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="text"))
+    monkeypatch.setattr("tools.tts_tool.check_tts_requirements", lambda: True)
+    monkeypatch.setattr("tools.tts_tool.text_to_speech_tool", _fake_tts_tool)
+
+    try:
+        await adapter._process_message_background(event, session_key)
+    finally:
+        for var in _VAR_MAP.values():
+            var.set(_UNSET)
+
+    assert captured_context == {
+        "platform": "telegram",
+        "chat_id": "chat-1",
+        "session_key": session_key,
+        "message_id": "msg-1",
+    }
+    adapter.send_voice.assert_awaited_once()
+
+
 def _fake_runner(thread_meta):
     """Build a fake GatewayRunner-like object with the helper methods needed by
     _deliver_media_from_response."""


### PR DESCRIPTION
## What does this PR do?

Fixes Telegram gateway auto-TTS delivery so voice replies are sent with the correct Telegram session context and arrive as native voice bubbles instead of MP3/audio attachments.

The gateway auto-TTS path calls `text_to_speech_tool()` from the platform send pipeline, outside the normal agent tool-call context. The TTS tool chooses Telegram Opus/OGG output based on gateway session context, but that context was not reliably bound for this out-of-band path. This PR temporarily rebinds the current gateway event context while calling TTS, then restores the previous context afterward.

This keeps the fix scoped to the auto-TTS call, preserves any prior context, and covers more than just the platform string: platform, chat ID, session key, and message ID are all available to the TTS tool during the call.

## Related Issue

No issue filed.

Related existing PRs found during duplicate check:

- #31937 — overlaps on Telegram auto-TTS platform context, but does not add this regression test coverage and appears to focus on platform-only context plus broader auto-TTS behavior.
- #20878 / #20882 — earlier related attempts around Telegram OGG/Opus output.

This PR is intentionally minimal: one gateway context-binding fix plus a regression test.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`
  - Rebinds gateway session context around the auto-TTS `text_to_speech_tool()` call.
  - Restores the previous context in `finally` so the binding cannot leak past the TTS send scope.
- `tests/gateway/test_tts_media_routing.py`
  - Adds regression coverage proving auto-TTS receives:
    - `platform: telegram`
    - event `chat_id`
    - gateway `session_key`
    - event `message_id`
  - Verifies the Telegram auto-TTS delivery path sends voice rather than an MP3/audio attachment.

## How to Test

1. Enable Telegram gateway voice auto-TTS.
2. Send a Telegram voice message to the bot.
3. Confirm the reply arrives as a native Telegram voice bubble, not an MP3/audio attachment.
4. Run the regression tests listed below.

Test evidence from this branch:

```text
$ python -m pytest tests/gateway/test_tts_media_routing.py tests/tools/test_voice_mode.py tests/tools/test_tts_plugin_dispatch.py tests/tools/test_tts_path_traversal.py -q
114 passed in 7.08s
```

Full-suite preflight:

```text
$ scripts/run_tests.sh
26911 passed, 3 failed
```

The full-suite failures were outside this change area:

- `tests/hermes_cli/test_cmd_update.py::TestCmdUpdateBranchFallback::test_update_refreshes_repo_and_tui_node_dependencies`
- `tests/tools/test_browser_hardening.py::TestFindAgentBrowserCache::test_not_found_cached_raises_on_subsequent`
- `tests/tools/test_browser_homebrew_paths.py::TestFindAgentBrowser::test_raises_when_not_found`

The two browser failures timed out while attempting to install/download Chromium via `agent-browser`; the update-command failure asserted unrelated web dashboard build helper behavior. None touch `gateway/platforms/base.py` or TTS media routing.

Live verification:

- Tested on Telegram after restarting `hermes-gateway.service`.
- Telegram reply arrived as a voice message, not an MP3/audio attachment.
- Fresh live-path cache evidence showed `.ogg` output present (`audio_9bb55ddcaceb.ogg`), with an MP3 intermediate only.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu Linux 6.17.0-29-generic

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Live Telegram verification passed: the reply is delivered as a native voice message rather than an MP3/audio attachment.
