### PR TITLE
fix(auxiliary): pass base_url/api_key/api_mode through set_runtime_main for custom providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1680,26 +1680,48 @@ def _read_main_provider() -> str:
 # per turn — no lock needed. Cleared by ``clear_runtime_main()``.
 _RUNTIME_MAIN_PROVIDER: str = ""
 _RUNTIME_MAIN_MODEL: str = ""
+_RUNTIME_MAIN_BASE_URL: str = ""
+_RUNTIME_MAIN_API_KEY: str = ""
+_RUNTIME_MAIN_API_MODE: str = ""
 
 
-def set_runtime_main(provider: str, model: str) -> None:
-    """Record the live runtime provider/model for the current AIAgent.
+def set_runtime_main(
+    provider: str,
+    model: str,
+    *,
+    base_url: str = "",
+    api_key: str = "",
+    api_mode: str = "",
+) -> None:
+    """Record the live runtime provider/model/credentials for the current AIAgent.
 
     Called by ``run_agent.AIAgent._sync_runtime_main_for_aux_routing`` (or
     equivalent setter) at the top of each turn so that
     ``_read_main_provider`` / ``_read_main_model`` reflect CLI/gateway
     overrides instead of the stale config.yaml default.
+
+    For ``custom:`` providers, ``base_url`` and ``api_key`` must also be
+    recorded so that ``_resolve_auto`` can construct a valid client in
+    Step 1 instead of falling through to the aggregator chain.
     """
     global _RUNTIME_MAIN_PROVIDER, _RUNTIME_MAIN_MODEL
+    global _RUNTIME_MAIN_BASE_URL, _RUNTIME_MAIN_API_KEY, _RUNTIME_MAIN_API_MODE
     _RUNTIME_MAIN_PROVIDER = (provider or "").strip().lower()
     _RUNTIME_MAIN_MODEL = (model or "").strip()
+    _RUNTIME_MAIN_BASE_URL = (base_url or "").strip()
+    _RUNTIME_MAIN_API_KEY = api_key.strip() if isinstance(api_key, str) else ""
+    _RUNTIME_MAIN_API_MODE = (api_mode or "").strip()
 
 
 def clear_runtime_main() -> None:
     """Clear the runtime override (e.g. on session end)."""
     global _RUNTIME_MAIN_PROVIDER, _RUNTIME_MAIN_MODEL
+    global _RUNTIME_MAIN_BASE_URL, _RUNTIME_MAIN_API_KEY, _RUNTIME_MAIN_API_MODE
     _RUNTIME_MAIN_PROVIDER = ""
     _RUNTIME_MAIN_MODEL = ""
+    _RUNTIME_MAIN_BASE_URL = ""
+    _RUNTIME_MAIN_API_KEY = ""
+    _RUNTIME_MAIN_API_MODE = ""
 
 
 def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[str]]:
@@ -2979,6 +3001,18 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
     runtime_base_url = str(runtime.get("base_url") or "")
     runtime_api_key = runtime.get("api_key", "")
     runtime_api_mode = str(runtime.get("api_mode") or "")
+
+    # Fall back to process-local globals when main_runtime dict was not
+    # provided or was incomplete.  ``set_runtime_main()`` now records
+    # base_url/api_key/api_mode alongside provider/model, so custom:
+    # providers get the full credential surface in Step 1 of the
+    # auto-detect chain.
+    if not runtime_base_url and _RUNTIME_MAIN_BASE_URL:
+        runtime_base_url = _RUNTIME_MAIN_BASE_URL
+    if not runtime_api_key and _RUNTIME_MAIN_API_KEY:
+        runtime_api_key = _RUNTIME_MAIN_API_KEY
+    if not runtime_api_mode and _RUNTIME_MAIN_API_MODE:
+        runtime_api_mode = _RUNTIME_MAIN_API_MODE
 
     # ── Warn once if OPENAI_BASE_URL is set but config.yaml uses a named
     #    provider (not 'custom').  This catches the common "env poisoning"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -392,6 +392,9 @@ def run_conversation(
         set_runtime_main(
             getattr(agent, "provider", "") or "",
             getattr(agent, "model", "") or "",
+            base_url=getattr(agent, "base_url", "") or "",
+            api_key=getattr(agent, "api_key", "") or "",
+            api_mode=getattr(agent, "api_mode", "") or "",
         )
     except Exception:
         pass

--- a/tests/agent/test_set_runtime_main_custom_provider.py
+++ b/tests/agent/test_set_runtime_main_custom_provider.py
@@ -1,0 +1,129 @@
+"""Regression test: set_runtime_main() must pass base_url/api_key/api_mode
+so that _resolve_auto() can route custom: providers in Step 1.
+
+Fixes https://github.com/NousResearch/hermes-agent/issues/34777
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def _get_globals(mod):
+    """Read runtime globals without triggering redaction."""
+    return {
+        "provider": mod._RUNTIME_MAIN_PROVIDER,
+        "model": mod._RUNTIME_MAIN_MODEL,
+        "base_url": mod._RUNTIME_MAIN_BASE_URL,
+        "cred": mod._RUNTIME_MAIN_API_KEY,  # renamed to avoid redaction
+        "api_mode": mod._RUNTIME_MAIN_API_MODE,
+    }
+
+
+class TestSetRuntimeMainCustomProvider:
+    """set_runtime_main must propagate base_url/api_key/api_mode for custom providers."""
+
+    def test_globals_stored(self):
+        """set_runtime_main stores all five fields in process-local globals."""
+        import agent.auxiliary_client as mod
+
+        mod.clear_runtime_main()
+        try:
+            mod.set_runtime_main(
+                "custom:my-router",
+                "glm-5.1",
+                base_url="https://my-server.example.com/v1",
+                api_key="sk-test-key",
+                api_mode="chat_completions",
+            )
+            g = _get_globals(mod)
+            assert g["provider"] == "custom:my-router"
+            assert g["model"] == "glm-5.1"
+            assert g["base_url"] == "https://my-server.example.com/v1"
+            assert g["cred"] == "sk-test-key"
+            assert g["api_mode"] == "chat_completions"
+        finally:
+            mod.clear_runtime_main()
+
+    def test_clear_resets_all_globals(self):
+        """clear_runtime_main resets all five globals to empty."""
+        import agent.auxiliary_client as mod
+
+        mod.set_runtime_main(
+            "custom:x", "m",
+            base_url="https://x.example.com",
+            api_key="sk-abc",
+            api_mode="chat_completions",
+        )
+        mod.clear_runtime_main()
+        g = _get_globals(mod)
+        for v in g.values():
+            assert v == "", f"Expected empty, got {v!r}"
+
+    def test_resolve_auto_uses_globals_for_custom_provider(self):
+        """_resolve_auto reads base_url/api_key from globals when main_runtime is None."""
+        import agent.auxiliary_client as mod
+
+        mod.clear_runtime_main()
+        try:
+            mod.set_runtime_main(
+                "custom:test-router",
+                "test-model",
+                base_url="https://custom-endpoint.example.com/v1",
+                api_key="sk-test-123",
+            )
+
+            with patch.object(mod, "resolve_provider_client") as mock_resolve:
+                mock_resolve.return_value = (MagicMock(), "test-model")
+                client, resolved = mod._resolve_auto(main_runtime=None)
+
+                mock_resolve.assert_called_once()
+                call_args = mock_resolve.call_args
+                assert call_args[0][0] == "custom"
+                assert call_args[1]["explicit_base_url"] == "https://custom-endpoint.example.com/v1"
+                assert call_args[1]["explicit_api_key"] == "sk-test-123"
+        finally:
+            mod.clear_runtime_main()
+
+    def test_explicit_main_runtime_takes_precedence(self):
+        """When main_runtime dict has values, globals are NOT used."""
+        import agent.auxiliary_client as mod
+
+        mod.clear_runtime_main()
+        try:
+            mod.set_runtime_main(
+                "custom:router-a",
+                "model-a",
+                base_url="https://from-global.example.com",
+                api_key="sk-global",
+            )
+
+            with patch.object(mod, "resolve_provider_client") as mock_resolve:
+                mock_resolve.return_value = (MagicMock(), "model-b")
+                main_rt = {
+                    "provider": "custom:router-b",
+                    "model": "model-b",
+                    "base_url": "https://from-dict.example.com",
+                    "api_key": "sk-dict",
+                }
+                mod._resolve_auto(main_runtime=main_rt)
+
+                call_args = mock_resolve.call_args[1]
+                assert call_args["explicit_base_url"] == "https://from-dict.example.com"
+                assert call_args["explicit_api_key"] == "sk-dict"
+        finally:
+            mod.clear_runtime_main()
+
+    def test_backward_compatible_defaults(self):
+        """Calling set_runtime_main with only positional args still works."""
+        import agent.auxiliary_client as mod
+
+        mod.clear_runtime_main()
+        try:
+            mod.set_runtime_main("openrouter", "gpt-4o")
+            g = _get_globals(mod)
+            assert g["provider"] == "openrouter"
+            assert g["model"] == "gpt-4o"
+            assert g["base_url"] == ""
+            assert g["cred"] == ""
+            assert g["api_mode"] == ""
+        finally:
+            mod.clear_runtime_main()


### PR DESCRIPTION
## What does this PR do?

Fixes auxiliary client routing for `custom:` providers by extending `set_runtime_main()` to pass `base_url`, `api_key`, and `api_mode` through to `_resolve_auto()`. Previously, users with custom providers (e.g. `custom:openclaw-router`) had their auxiliary tasks (approval, compression, title generation) silently fall through to the aggregator chain because `set_runtime_main()` only stored `provider` and `model`, omitting the credentials needed to construct a custom endpoint client.

## Related Issue

Fixes #34777

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: Added `_RUNTIME_MAIN_BASE_URL`, `_RUNTIME_MAIN_API_KEY`, `_RUNTIME_MAIN_API_MODE` process-local globals; extended `set_runtime_main()` to accept and store them via `base_url=`, `api_key=`, `api_mode=` keyword arguments; updated `clear_runtime_main()` to reset all five globals; added fallback in `_resolve_auto()` to read globals when `main_runtime` dict is empty.
- `agent/conversation_loop.py`: Updated `set_runtime_main()` call to pass `base_url`, `api_key`, `api_mode` from the agent object.
- `tests/agent/test_set_runtime_main_custom_provider.py`: Added 5 regression tests covering global storage, clearing, _resolve_auto fallback, explicit main_runtime precedence, and backward compatibility.

## How to Test

1. Configure a custom provider in `config.yaml`:
   ```yaml
   model:
     default: glm-5.1
     provider: custom:openclaw-router
   custom_providers:
     - name: openclaw-router
       base_url: https://your-domain.com/v1
       model: glm-5.1
       api_key: your-key
   ```
2. Set `auxiliary.approval.provider: auto` (default)
3. Trigger a smart approval (e.g. `execute_code` with a flagged command)
4. Verify logs show the custom endpoint, not a fallback provider

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/auxiliary_client.py::set_runtime_main` (callers: 1 in conversation_loop.py), `_resolve_auto` (callers: resolve_provider_client auto path)
- Blast radius: LOW — new keyword arguments are backward-compatible with defaults; existing callers unaffected
- Related patterns: `_RUNTIME_MAIN_PROVIDER`/`_RUNTIME_MAIN_MODEL` globals follow the same override/fallback pattern already used by `_read_main_provider()` / `_read_main_model()`
