### PR TITLE
docs(kanban): document `hermes kanban unblock --reason` flag

### DIFF
--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -618,7 +618,7 @@ hermes kanban comment <id> "<text>" [--author NAME]
 # Bulk verbs — accept multiple ids:
 hermes kanban complete <id>... [--result "..."]
 hermes kanban block <id> "<reason>" [--ids <id>...]
-hermes kanban unblock <id>...
+hermes kanban unblock <id>... [--reason "..."]
 hermes kanban archive <id>...
 
 hermes kanban tail <id>                                # follow a single task's event stream

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/kanban.md
@@ -557,7 +557,7 @@ hermes kanban comment <id> "<text>" [--author NAME]
 # 批量动词 —— 接受多个 id：
 hermes kanban complete <id>... [--result "..."]
 hermes kanban block <id> "<reason>" [--ids <id>...]
-hermes kanban unblock <id>...
+hermes kanban unblock <id>... [--reason "..."]
 hermes kanban archive <id>...
 
 hermes kanban tail <id>                                # 跟踪单个任务的事件流


### PR DESCRIPTION
`#34411` added a `--reason` flag to `hermes kanban unblock` (records an `UNBLOCK: <reason>` comment before unblocking, symmetric with `block`'s reason), but the kanban CLI reference still lists `unblock` with no reason argument:

```
hermes kanban complete <id>... [--result "..."]
hermes kanban block <id> "<reason>" [--ids <id>...]
hermes kanban unblock <id>...          ← omitted the new flag
```

The documented asymmetry actively misleads toward the broken form: a user running `hermes kanban unblock <id> review needed` would have the trailing words parsed as task ids — exactly the footgun `#34411` fixed. This documents `[--reason "..."]` in both the EN reference and the zh-Hans mirror, matching the adjacent `complete ... [--result "..."]` style.

Flag spelling verified against the merged `#34411` diff (`hermes_cli/kanban.py` `p_unblock.add_argument("--reason", ...)`). Pure docs, no code change.

If this has already been picked up via a separate patch, feel free to close and mark accordingly.
