### PR TITLE
fix(codex): honor app-server runtime for direct credentials

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1365,9 +1365,14 @@ def resolve_runtime_provider(
     if provider == "openai-codex":
         try:
             creds = resolve_codex_runtime_credentials()
+            api_mode = _maybe_apply_codex_app_server_runtime(
+                provider="openai-codex",
+                api_mode="codex_responses",
+                model_cfg=model_cfg,
+            )
             return {
                 "provider": "openai-codex",
-                "api_mode": "codex_responses",
+                "api_mode": api_mode,
                 "base_url": creds.get("base_url", "").rstrip("/"),
                 "api_key": creds.get("api_key", ""),
                 "source": creds.get("source", "hermes-auth-store"),

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -150,6 +150,41 @@ def test_resolve_runtime_provider_codex(monkeypatch):
     assert resolved["requested_provider"] == "openai-codex"
 
 
+def test_resolve_runtime_provider_codex_app_server_without_pool(monkeypatch):
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("P", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openai-codex",
+            "default": "gpt-5.5",
+            "openai_runtime": "codex_app_server",
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_codex_runtime_credentials",
+        lambda: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "codex-token",
+            "source": "codex-auth-json",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="openai-codex")
+
+    assert resolved["provider"] == "openai-codex"
+    assert resolved["api_mode"] == "codex_app_server"
+    assert resolved["api_key"] == "codex-token"
+    assert resolved.get("credential_pool") is None
+
+
 def test_resolve_runtime_provider_qwen_oauth(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "qwen-oauth")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- honor `model.openai_runtime: codex_app_server` when `openai-codex` resolves through the direct Codex auth store path
- keep the existing default `codex_responses` behavior unless the app-server runtime is explicitly requested
- add a regression test for the no-credential-pool `openai-codex` path

## Why
The credential-pool branch already applies `_maybe_apply_codex_app_server_runtime`, but the direct Codex auth-store branch hard-coded `api_mode = "codex_responses"`. That means a user can configure `model.openai_runtime: codex_app_server` and still silently get the legacy responses runtime whenever no credential pool is present.

This is especially visible for Codex App plugin workflows that require the app-server runtime.

## Test plan
- `python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py::test_resolve_runtime_provider_codex_app_server_without_pool tests/hermes_cli/test_runtime_provider_resolution.py::test_resolve_runtime_provider_codex -q -o 'addopts='`

Result: `2 passed in 0.17s`

Note: running the full `tests/hermes_cli/test_runtime_provider_resolution.py` file in my local installed environment currently exposes two unrelated Qwen OAuth/env-dependent failures; the focused Codex regression tests above pass.
