### PR TITLE
feat: add body composition brief helper

### DIFF
--- a/docs/plans/body-composition-brief.md
+++ b/docs/plans/body-composition-brief.md
@@ -1,0 +1,51 @@
+# Body Composition Brief Helper Implementation Plan
+
+> **For Hermes:** Implement directly with strict TDD in this worktree.
+
+**Goal:** Add a local-first script that turns Joe's body-composition logs into a concise Traditional Chinese morning brief or exact `[SILENT]` when there is nothing actionable.
+
+**Architecture:** Create a standalone Python script under `scripts/` with pure parsing/scoring/rendering functions and a small CLI wrapper. Keep inputs local JSON/YAML/CSV, avoid network or private-data expansion, and make output deterministic for cron usage.
+
+**Tech Stack:** Python standard library, optional PyYAML when installed, pytest tests under `tests/scripts/`.
+
+---
+
+### Task 1: Define expected parsing and silence behavior
+
+**Objective:** Tests lock in JSON/YAML/CSV loading and `[SILENT]` output for empty inputs.
+
+**Files:**
+- Create: `tests/scripts/test_body_composition_brief.py`
+- Create later: `scripts/body_composition_brief.py`
+
+**Steps:**
+1. Write failing tests for loading JSON records and empty exact `[SILENT]` rendering.
+2. Run focused tests and verify failure because the script does not exist.
+3. Implement minimal parser and renderer to pass.
+
+### Task 2: Add trend/status behavior
+
+**Objective:** Tests verify latest weight/body-fat summary and simple direction calculations.
+
+**Files:**
+- Modify: `tests/scripts/test_body_composition_brief.py`
+- Modify: `scripts/body_composition_brief.py`
+
+**Steps:**
+1. Add failing tests for latest metric selection, body-fat target distance, and trend labels.
+2. Run focused tests and verify failures.
+3. Implement minimal summarization logic.
+
+### Task 3: Add Joe-style Traditional Chinese report and CLI
+
+**Objective:** CLI prints TL;DR, facts, hypotheses, and measurable next actions without sending anything.
+
+**Files:**
+- Modify: `tests/scripts/test_body_composition_brief.py`
+- Modify: `scripts/body_composition_brief.py`
+
+**Steps:**
+1. Add failing tests for rendered headings and CLI smoke behavior.
+2. Run focused tests and verify failures.
+3. Implement CLI args: `--input`, `--days`, `--silent-if-empty`.
+4. Verify focused tests and script smoke checks.

--- a/scripts/body_composition_brief.py
+++ b/scripts/body_composition_brief.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Generate a local-first body-composition brief for Joe.
+
+Inputs stay local: JSON/YAML arrays, JSON objects with a ``records`` key, or CSV.
+The script prints Traditional Chinese markdown suitable for cron delivery, or exact
+``[SILENT]`` when there is nothing actionable and suppression is requested.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+SILENT = "[SILENT]"
+TARGET_BODY_FAT_MIN = 18.0
+TARGET_BODY_FAT_MAX = 20.0
+
+
+@dataclass(frozen=True)
+class BodyRecord:
+    date: date
+    weight_kg: float | None = None
+    body_fat_pct: float | None = None
+    waist_cm: float | None = None
+    note: str = ""
+
+
+def _parse_date(value: Any) -> date:
+    if isinstance(value, date):
+        return value
+    if value is None:
+        raise ValueError("record is missing date")
+    return date.fromisoformat(str(value)[:10])
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    return float(value)
+
+
+def _normalise_record(raw: dict[str, Any]) -> BodyRecord:
+    return BodyRecord(
+        date=_parse_date(raw.get("date") or raw.get("logged_at")),
+        weight_kg=_to_float(raw.get("weight_kg") or raw.get("weight")),
+        body_fat_pct=_to_float(raw.get("body_fat_pct") or raw.get("body_fat") or raw.get("bf_pct")),
+        waist_cm=_to_float(raw.get("waist_cm") or raw.get("waist")),
+        note=str(raw.get("note") or raw.get("notes") or ""),
+    )
+
+
+def _load_yaml(path: Path) -> Any:
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:  # pragma: no cover - exercised only without PyYAML
+        raise RuntimeError("YAML input requires PyYAML; use JSON/CSV or install pyyaml") from exc
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _load_raw(path: Path) -> Any:
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        with path.open(newline="", encoding="utf-8") as handle:
+            return list(csv.DictReader(handle))
+    if suffix in {".yaml", ".yml"}:
+        return _load_yaml(path)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_records(path: str | Path) -> list[BodyRecord]:
+    """Load body records from JSON/YAML/CSV and sort oldest to newest."""
+    raw = _load_raw(Path(path))
+    if raw is None:
+        return []
+    if isinstance(raw, dict):
+        raw = raw.get("records", [])
+    if not isinstance(raw, list):
+        raise ValueError("body-composition input must be a list or an object with records")
+    return sorted((_normalise_record(item) for item in raw), key=lambda item: item.date)
+
+
+def filter_records(records: Iterable[BodyRecord], days: int | None) -> list[BodyRecord]:
+    ordered = sorted(records, key=lambda item: item.date)
+    if not ordered or not days:
+        return ordered
+    cutoff = ordered[-1].date - timedelta(days=days - 1)
+    return [record for record in ordered if record.date >= cutoff]
+
+
+def _fmt_delta(value: float | None, unit: str) -> str:
+    if value is None:
+        return "資料不足"
+    sign = "+" if value > 0 else ""
+    return f"{sign}{value:.1f}{unit}"
+
+
+def _latest_with(records: Sequence[BodyRecord], attr: str) -> BodyRecord | None:
+    for record in reversed(records):
+        if getattr(record, attr) is not None:
+            return record
+    return None
+
+
+def summarise(records: Sequence[BodyRecord]) -> dict[str, Any]:
+    ordered = sorted(records, key=lambda item: item.date)
+    latest = ordered[-1] if ordered else None
+    latest_weight = _latest_with(ordered, "weight_kg")
+    latest_body_fat = _latest_with(ordered, "body_fat_pct")
+    first_weight = next((item for item in ordered if item.weight_kg is not None), None)
+    first_body_fat = next((item for item in ordered if item.body_fat_pct is not None), None)
+
+    weight_delta = None
+    if (
+        first_weight
+        and latest_weight
+        and first_weight != latest_weight
+        and first_weight.weight_kg is not None
+        and latest_weight.weight_kg is not None
+    ):
+        weight_delta = round(latest_weight.weight_kg - first_weight.weight_kg, 1)
+
+    body_fat_delta = None
+    if (
+        first_body_fat
+        and latest_body_fat
+        and first_body_fat != latest_body_fat
+        and first_body_fat.body_fat_pct is not None
+        and latest_body_fat.body_fat_pct is not None
+    ):
+        body_fat_delta = round(latest_body_fat.body_fat_pct - first_body_fat.body_fat_pct, 1)
+
+    target_gap = None
+    if latest_body_fat and latest_body_fat.body_fat_pct is not None:
+        target_gap = round(max(0.0, latest_body_fat.body_fat_pct - TARGET_BODY_FAT_MAX), 1)
+
+    return {
+        "latest": latest,
+        "latest_weight": latest_weight,
+        "latest_body_fat": latest_body_fat,
+        "weight_delta": weight_delta,
+        "body_fat_delta": body_fat_delta,
+        "target_gap": target_gap,
+        "count": len(ordered),
+    }
+
+
+def render_brief(records: Sequence[BodyRecord], *, silent_if_empty: bool = False, days: int | None = None) -> str:
+    scoped = filter_records(records, days)
+    if not scoped:
+        return SILENT if silent_if_empty else "## TL;DR\n- 沒有可用的身體組成紀錄。"
+
+    summary = summarise(scoped)
+    latest = summary["latest"]
+    latest_weight = summary["latest_weight"]
+    latest_body_fat = summary["latest_body_fat"]
+    target_gap = summary["target_gap"]
+
+    weight_text = "無體重資料" if latest_weight is None else f"{latest_weight.weight_kg:.1f}kg"
+    body_fat_text = "無體脂資料" if latest_body_fat is None else f"{latest_body_fat.body_fat_pct:.1f}%"
+    gap_text = "資料不足" if target_gap is None else f"距離 20% 還差 {target_gap:.1f} 個百分點"
+
+    direction = "資料不足"
+    if summary["body_fat_delta"] is not None:
+        direction = "下降中" if summary["body_fat_delta"] < 0 else "上升中" if summary["body_fat_delta"] > 0 else "持平"
+
+    lines = [
+        "## TL;DR",
+        f"- 最新紀錄（{latest.date.isoformat()}）：{weight_text}，體脂 {body_fat_text}；{gap_text}。",
+        f"- 期間趨勢：體重 {_fmt_delta(summary['weight_delta'], 'kg')}，體脂 {_fmt_delta(summary['body_fat_delta'], 'pct')}（{direction}）。",
+        "",
+        "## Fact / verified",
+        f"- 本次讀取 {summary['count']} 筆本地紀錄；未連接任何新資料源、未傳送訊息。",
+        f"- Joe 的目標區間：體脂 {TARGET_BODY_FAT_MIN:.0f}–{TARGET_BODY_FAT_MAX:.0f}%。",
+        "",
+        "## Hypothesis",
+        "- 如果體脂趨勢連續兩週沒有下降，問題更可能是飲食紀錄/週末熱量，而不是訓練不足。",
+        "",
+        "## Action for Joe",
+        "- 今天只做一件可衡量的事：記錄體重、體脂/腰圍、蛋白質是否達標（是/否）。",
+        "- 若已有 7 天以上資料：用週平均看趨勢，不要被單日水分波動騙走。",
+    ]
+    return "\n".join(lines)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate a Traditional Chinese body-composition brief.")
+    parser.add_argument("--input", required=True, help="Path to JSON/YAML/CSV body-composition records")
+    parser.add_argument("--days", type=int, default=14, help="Only consider the most recent N-day window")
+    parser.add_argument("--silent-if-empty", action="store_true", help="Print exact [SILENT] when no records exist")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    records = load_records(args.input)
+    print(render_brief(records, silent_if_empty=args.silent_if_empty, days=args.days))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/scripts/test_body_composition_brief.py
+++ b/tests/scripts/test_body_composition_brief.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "body_composition_brief.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("body_composition_brief", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_records_from_json_file(tmp_path):
+    module = load_module()
+    source = tmp_path / "body.json"
+    source.write_text(
+        '[{"date":"2026-05-20","weight_kg":82.4,"body_fat_pct":24.0}]',
+        encoding="utf-8",
+    )
+
+    records = module.load_records(source)
+
+    assert len(records) == 1
+    assert records[0].date.isoformat() == "2026-05-20"
+    assert records[0].weight_kg == 82.4
+    assert records[0].body_fat_pct == 24.0
+
+
+def test_render_empty_records_can_suppress_delivery():
+    module = load_module()
+
+    assert module.render_brief([], silent_if_empty=True) == "[SILENT]"
+
+
+def test_summarise_reports_latest_metrics_and_target_gap():
+    module = load_module()
+    records = [
+        module.BodyRecord(date=module.date(2026, 5, 1), weight_kg=83.0, body_fat_pct=24.5),
+        module.BodyRecord(date=module.date(2026, 5, 8), weight_kg=82.0, body_fat_pct=23.8),
+        module.BodyRecord(date=module.date(2026, 5, 15), weight_kg=81.8, body_fat_pct=23.1),
+    ]
+
+    summary = module.summarise(records)
+
+    assert summary["latest"].date.isoformat() == "2026-05-15"
+    assert summary["latest_weight"].weight_kg == 81.8
+    assert summary["latest_body_fat"].body_fat_pct == 23.1
+    assert summary["weight_delta"] == -1.2
+    assert summary["body_fat_delta"] == -1.4
+    assert summary["target_gap"] == 3.1
+
+
+def test_render_brief_uses_traditional_chinese_sections_and_actions():
+    module = load_module()
+    records = [
+        module.BodyRecord(date=module.date(2026, 5, 1), weight_kg=83.0, body_fat_pct=24.5),
+        module.BodyRecord(date=module.date(2026, 5, 15), weight_kg=81.8, body_fat_pct=23.1),
+    ]
+
+    brief = module.render_brief(records, days=30)
+
+    assert "## TL;DR" in brief
+    assert "## Fact / verified" in brief
+    assert "## Hypothesis" in brief
+    assert "## Action for Joe" in brief
+    assert "最新紀錄（2026-05-15）：81.8kg，體脂 23.1%" in brief
+    assert "距離 20% 還差 3.1 個百分點" in brief
+    assert "體重 -1.2kg，體脂 -1.4pct（下降中）" in brief
+
+
+def test_cli_prints_brief_from_csv(tmp_path, capsys):
+    module = load_module()
+    source = tmp_path / "body.csv"
+    source.write_text(
+        "date,weight_kg,body_fat_pct\n2026-05-01,83.0,24.5\n2026-05-15,81.8,23.1\n",
+        encoding="utf-8",
+    )
+
+    exit_code = module.main(["--input", str(source), "--days", "30"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "## TL;DR" in captured.out
+    assert "81.8kg" in captured.out
+    assert "未連接任何新資料源、未傳送訊息" in captured.out


### PR DESCRIPTION
## Summary
- Add a local-first `scripts/body_composition_brief.py` helper for Joe-style body-composition morning briefs.
- Support JSON/YAML/CSV inputs, deterministic trend/target-gap summaries, Traditional Chinese report sections, and exact `[SILENT]` output for empty cron runs.
- Include a small implementation plan under `docs/plans/` and focused parser/render/CLI tests.

## Why this helps Joe
- Gives Joe a low-friction health/body-composition check-in loop without connecting new private data sources or sending messages.
- Keeps output measurable: latest weight/body fat, target gap to 20%, trend, and one actionable next step.

## Test Plan
- [x] `python -m pytest tests/scripts/test_body_composition_brief.py -q -o 'addopts='`
- [x] `python -m py_compile scripts/body_composition_brief.py tests/scripts/test_body_composition_brief.py`
- [x] Smoke: `python scripts/body_composition_brief.py --input .hermes/tmp-body-sample.json --days 30`
- [x] Smoke: `python scripts/body_composition_brief.py --input .hermes/tmp-body-empty.json --silent-if-empty`

Note: `scripts/run_tests.sh tests/scripts/test_body_composition_brief.py` could not start because the local dev environment is missing the pytest-timeout plugin options (`--timeout`, `--timeout-method`). Used the documented direct-pytest fallback with `-o 'addopts='` for this focused check.
