### PR TITLE
fix(gateway): respect own-policy group_policy when resolving unauthorized DM fallback

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6802,10 +6802,11 @@ class GatewayRunner:
         2. Explicit global ``unauthorized_dm_behavior`` in config — wins when no per-platform.
         3. When an allowlist (``PLATFORM_ALLOWED_USERS``,
            ``PLATFORM_GROUP_ALLOWED_USERS`` / ``PLATFORM_GROUP_ALLOWED_CHATS``,
-           or ``GATEWAY_ALLOWED_USERS``) is configured, default to ``"ignore"`` —
-           the allowlist signals that the owner has deliberately restricted
-           access; spamming unknown contacts with pairing codes is both noisy
-           and a potential info-leak. (#9337)
+           or ``GATEWAY_ALLOWED_USERS``) or a config-driven own-policy
+           gateway restriction is configured, default to ``"ignore"`` — the
+           operator has deliberately restricted access, so spamming unknown
+           contacts with pairing codes is both noisy and a potential
+           info-leak. (#9337)
         4. No allowlist and no explicit config → ``"pair"`` (open-gateway default).
         """
         config = getattr(self, "config", None)
@@ -6822,10 +6823,11 @@ class GatewayRunner:
             if config.unauthorized_dm_behavior != "pair":  # non-default → explicit override
                 return config.unauthorized_dm_behavior
 
-        # Config-driven dm_policy (WeCom / Weixin / Yuanbao / QQBot). An
-        # allowlist or disabled DM policy means the operator restricted access,
-        # so unauthorized DMs should be dropped silently rather than answered
-        # with a pairing code. An explicit pairing policy opts back into codes.
+        # Config-driven own-policy access control (WeCom / Weixin / Yuanbao /
+        # QQBot). Restrictive DM or group policies mean the operator narrowed
+        # access, so unauthorized DMs should be dropped silently rather than
+        # answered with a pairing code. An explicit pairing policy still opts
+        # back into codes.
         if platform and config and hasattr(config, "platforms"):
             platform_cfg = config.platforms.get(platform)
             extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
@@ -6835,6 +6837,10 @@ class GatewayRunner:
                     return "pair"
                 if dm_policy in {"allowlist", "disabled"}:
                     return "ignore"
+                if self._adapter_enforces_own_access_policy(platform):
+                    group_policy = str(extra.get("group_policy") or "").strip().lower()
+                    if group_policy in {"allowlist", "disabled"}:
+                        return "ignore"
 
         # No explicit override.  Fall back to allowlist-aware default:
         # if any allowlist is configured for this platform, silently drop

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -199,7 +199,7 @@ def test_unknown_adapter_does_not_crash_trust_check(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Layer 3: unauthorized-DM behavior reads config dm_policy
+# Layer 3: unauthorized-DM behavior reads config dm/group policy
 # ---------------------------------------------------------------------------
 
 
@@ -220,6 +220,41 @@ def test_unauthorized_dm_behavior_follows_config_dm_policy(monkeypatch, dm_polic
     runner, _adapter = _make_runner(Platform.WECOM, config, enforces=True)
 
     assert runner._get_unauthorized_dm_behavior(Platform.WECOM) == expected
+
+
+@pytest.mark.parametrize("platform", _OWN_POLICY_PLATFORMS)
+@pytest.mark.parametrize("group_policy", ["allowlist", "disabled"])
+def test_unauthorized_dm_behavior_follows_config_group_policy(monkeypatch, platform, group_policy):
+    """Restrictive own-policy group configs should silence stranger DMs too."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            platform: PlatformConfig(enabled=True, extra={"group_policy": group_policy})
+        }
+    )
+    runner, _adapter = _make_runner(platform, config, enforces=True)
+
+    assert runner._get_unauthorized_dm_behavior(platform) == "ignore"
+
+
+@pytest.mark.parametrize("platform", _OWN_POLICY_PLATFORMS)
+def test_explicit_pair_override_beats_group_policy_default(monkeypatch, platform):
+    """Per-platform pairing overrides the restrictive group-policy default."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            platform: PlatformConfig(
+                enabled=True,
+                extra={
+                    "group_policy": "allowlist",
+                    "unauthorized_dm_behavior": "pair",
+                },
+            )
+        }
+    )
+    runner, _adapter = _make_runner(platform, config, enforces=True)
+
+    assert runner._get_unauthorized_dm_behavior(platform) == "pair"
 
 
 def test_unauthorized_dm_behavior_open_policy_keeps_default(monkeypatch):


### PR DESCRIPTION
## Summary

This brings the config-driven own-policy gateway adapters into parity with the existing allowlist-aware unauthorized-DM fallback.

Before this change, `GatewayRunner._get_unauthorized_dm_behavior()` already defaulted to `ignore` when env-based user/group allowlists were configured, but the config-driven own-policy path only looked at `dm_policy`. That left a gap for WeCom, Weixin, Yuanbao, and QQBot: operators could restrict group access with `group_policy: allowlist` or `group_policy: disabled`, yet unauthorized DMs would still receive pairing codes unless they also set an explicit DM restriction or explicit `unauthorized_dm_behavior`.

This patch treats restrictive `group_policy` values on own-policy adapters the same way as the existing allowlist-aware fallback:
- `group_policy: allowlist` => `ignore`
- `group_policy: disabled` => `ignore`

Explicit overrides still win:
- per-platform `unauthorized_dm_behavior`
- global `unauthorized_dm_behavior`
- `dm_policy: pairing`

## Why this is correct

These adapters already enforce `group_policy` at intake, so a restrictive group config is an operator-declared access restriction, just like the env-based allowlist cases already handled in `_get_unauthorized_dm_behavior()`.

That makes the previous behavior inconsistent and noisy: a stranger DM could still get a pairing code even though the operator had intentionally locked group access down on the same adapter.

## Parity / prior art

This is a parity follow-up to the allowlist-aware unauthorized-DM fallback work from `#9337`.

#9337 taught `_get_unauthorized_dm_behavior()` to default to `ignore` when env-based allowlists were present, to avoid pairing spam / unnecessary info leakage to unauthorized contacts. This PR applies the same principle to the config-driven own-policy sibling path.

Related background: `#34515` established the own-policy adapter contract and gateway trust path for WeCom / Weixin / Yuanbao / QQBot.

## Changes

- Extend `_get_unauthorized_dm_behavior()` to treat restrictive `group_policy` values as `ignore` for adapters that declare `enforces_own_access_policy`.
- Keep explicit `unauthorized_dm_behavior: pair` behavior unchanged.
- Add regression coverage for:
  - WeCom / Weixin / Yuanbao / QQBot with `group_policy in {"allowlist", "disabled"}`
  - explicit per-platform `unauthorized_dm_behavior: pair` overriding the restrictive default

## Tests

Passed:

- `tests/gateway/test_config_driven_access_policy.py`
- `tests/gateway/test_unauthorized_dm_behavior.py`
- `tests/gateway/test_wecom.py`
- `tests/gateway/test_weixin.py`
- `tests/gateway/test_qqbot.py`
- `tests/test_yuanbao_pipeline.py`

Local result:
- `413 passed, 4 warnings`

The warnings are pre-existing QQBot test warnings and are not introduced by this change.