### PR TITLE
fix(dashboard): chat tab works in gated (OAuth) mode

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -119,8 +119,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const [searchParams, setSearchParams] = useSearchParams();
   // Lazy-init: the missing-token check happens at construction so the effect
   // body doesn't have to setState (React 19's set-state-in-effect rule).
+  // In gated (OAuth) mode the server intentionally omits the session token —
+  // the SPA authenticates the WS via a single-use ticket (buildWsAuthParam),
+  // so a missing token there is expected, not an error.
   const [banner, setBanner] = useState<string | null>(() =>
-    typeof window !== "undefined" && !window.__HERMES_SESSION_TOKEN__
+    typeof window !== "undefined" &&
+    !window.__HERMES_SESSION_TOKEN__ &&
+    !window.__HERMES_AUTH_REQUIRED__
       ? "Session token unavailable. Open this page through `hermes dashboard`, not directly."
       : null,
   );
@@ -273,8 +278,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     if (!host) return;
 
     const token = window.__HERMES_SESSION_TOKEN__;
+    const gated = !!window.__HERMES_AUTH_REQUIRED__;
     // Banner already initialised above; just bail before wiring xterm/WS.
-    if (!token) {
+    // In gated mode the token is absent by design — buildWsAuthParam() mints
+    // a WS ticket instead, so don't bail; let the effect reach that path.
+    if (!token && !gated) {
       return;
     }
 
@@ -876,5 +884,6 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 declare global {
   interface Window {
     __HERMES_SESSION_TOKEN__?: string;
+    __HERMES_AUTH_REQUIRED__?: boolean;
   }
 }


### PR DESCRIPTION
## Summary
The dashboard Chat/TUI tab now renders correctly in gated (OAuth) mode instead of showing a false "Session token unavailable" error.

Root cause: two checks in `ChatPage.tsx` gated purely on `window.__HERMES_SESSION_TOKEN__`, which the server intentionally omits in gated mode (`web_server.py` injects only `__HERMES_AUTH_REQUIRED__=true` there; the SPA is expected to use cookie auth + a single-use WS ticket). `buildWsAuthParam()` in `api.ts` already resolves WS auth correctly for both modes, but the early bail prevented the effect from ever reaching it.

## Changes
- `web/src/pages/ChatPage.tsx`:
  - Banner init: only show the "Session token unavailable" error when there's neither a token **nor** the gated flag.
  - xterm/WS effect: don't bail when the token is absent **and** gated — let the effect fall through to `buildWsAuthParam()`.
  - Add `__HERMES_AUTH_REQUIRED__?: boolean` to the local `Window` global decl (already declared in `api.ts` / `gatewayClient.ts`).

## Validation
| | Gated (OAuth) mode | Loopback / `--insecure` mode |
|---|---|---|
| Before | False "Session token unavailable" banner, terminal never renders | Works |
| After | Banner suppressed; WS opens via ticket → terminal renders | Works (unchanged) |

`web` has no JS unit suite — verified via `npm run build` (tsc -b type-check + vite build): passes clean.

Reported and fix verified by @wbrione on a self-hosted OIDC deployment. Closes #34755.



## Infographic

![dashboard-chat-gated-mode-fix](https://v3b.fal.media/files/b/0a9c30b1/ah4rma48KsdbJvpQaPYw9_0tdnKKuK.png)
