### PR TITLE
feat(agent): automatic in-provider reasoning fallback + OpenCode Go kimi-k2 fix

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1124,6 +1124,7 @@ def run_conversation(
         multimodal_tool_content_retry_attempted = False
         oauth_1m_beta_retry_attempted = False
         llama_cpp_grammar_retry_attempted = False
+        invalid_reasoning_config_retry_attempted = False
         has_retried_429 = False
         restart_with_compressed_messages = False
         restart_with_length_continuation = False
@@ -2526,6 +2527,29 @@ def run_conversation(
                         "keywords to strip — falling through to normal retry",
                         agent.log_prefix,
                     )
+
+                # ── Invalid reasoning/thinking config recovery ───────────
+                # Provider rejected the request because of an incompatible
+                # reasoning_effort, thinking toggle, or dual-parameter conflict.
+                # Strip the reasoning config and retry once on the same provider.
+                if (
+                    classified.reason == FailoverReason.invalid_reasoning_config
+                    and not invalid_reasoning_config_retry_attempted
+                ):
+                    invalid_reasoning_config_retry_attempted = True
+                    _old_reasoning = agent.reasoning_config
+                    agent.reasoning_config = None
+                    agent._vprint(
+                        f"{agent.log_prefix}⚠️  Provider rejected reasoning config "
+                        f"({_old_reasoning}) — retrying with reasoning disabled...",
+                        force=True,
+                    )
+                    logger.warning(
+                        "%sInvalid reasoning config recovery: cleared "
+                        "reasoning_config (was %s), retrying on same provider",
+                        agent.log_prefix, _old_reasoning,
+                    )
+                    continue
 
                 retry_count += 1
                 elapsed_time = time.time() - api_start_time

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2539,14 +2539,25 @@ def run_conversation(
                     invalid_reasoning_config_retry_attempted = True
                     _old_reasoning = agent.reasoning_config
                     agent.reasoning_config = None
+                    # Save to session state so we can warn at the end
+                    if not hasattr(agent, '_reasoning_disabled_this_session'):
+                        agent._reasoning_disabled_this_session = True
+                        agent._reasoning_was_config = _old_reasoning
                     agent._vprint(
-                        f"{agent.log_prefix}⚠️  Provider rejected reasoning config "
-                        f"({_old_reasoning}) — retrying with reasoning disabled...",
+                        f"\n{agent.log_prefix}⚠️  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+                        f"{agent.log_prefix}⚠️  REASONING DISABLED FOR THIS SESSION\n"
+                        f"{agent.log_prefix}⚠️  Provider rejected reasoning config ({_old_reasoning}).\n"
+                        f"{agent.log_prefix}⚠️  Model will respond WITHOUT extended thinking.\n"
+                        f"{agent.log_prefix}⚠️  \n"
+                        f"{agent.log_prefix}⚠️  To re-enable reasoning:\n"
+                        f"{agent.log_prefix}⚠️    • Switch to a provider/model that supports it\n"
+                        f"{agent.log_prefix}⚠️    • Run: hermes config set provider.name <other-provider>\n"
+                        f"{agent.log_prefix}⚠️  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n",
                         force=True,
                     )
                     logger.warning(
                         "%sInvalid reasoning config recovery: cleared "
-                        "reasoning_config (was %s), retrying on same provider",
+                        "reasoning_config (was %s), retrying on same provider without reasoning",
                         agent.log_prefix, _old_reasoning,
                     )
                     continue

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2531,34 +2531,78 @@ def run_conversation(
                 # ── Invalid reasoning/thinking config recovery ───────────
                 # Provider rejected the request because of an incompatible
                 # reasoning_effort, thinking toggle, or dual-parameter conflict.
-                # Strip the reasoning config and retry once on the same provider.
+                # Instead of disabling reasoning entirely, we surgically strip
+                # only the rejected parameters so the user still gets "smart"
+                # responses where possible.
                 if (
                     classified.reason == FailoverReason.invalid_reasoning_config
                     and not invalid_reasoning_config_retry_attempted
                 ):
                     invalid_reasoning_config_retry_attempted = True
                     _old_reasoning = agent.reasoning_config
-                    agent.reasoning_config = None
+                    _rejected = classified.rejected_reasoning_params
+
+                    if _rejected == "reasoning_effort":
+                        # Provider supports thinking toggle but not effort level.
+                        # Keep reasoning enabled, just drop the effort parameter.
+                        if isinstance(agent.reasoning_config, dict):
+                            agent.reasoning_config = {
+                                **agent.reasoning_config,
+                                "effort": "",
+                            }
+                        _action = "dropped reasoning_effort (thinking toggle preserved)"
+                    elif _rejected == "thinking":
+                        # Provider supports effort level but not thinking toggle.
+                        # Disable the toggle, keep the effort if set.
+                        if isinstance(agent.reasoning_config, dict):
+                            _effort = agent.reasoning_config.get("effort", "")
+                            agent.reasoning_config = {
+                                "enabled": False,
+                                "effort": _effort,
+                            }
+                        else:
+                            agent.reasoning_config = {"enabled": False}
+                        _action = "disabled thinking toggle (reasoning_effort preserved)"
+                    else:
+                        # Both rejected or ambiguous — full disable.
+                        agent.reasoning_config = None
+                        _action = "fully disabled reasoning"
+
                     # Save to session state so we can warn at the end
-                    if not hasattr(agent, '_reasoning_disabled_this_session'):
-                        agent._reasoning_disabled_this_session = True
+                    if not hasattr(agent, '_reasoning_degraded_this_session'):
+                        agent._reasoning_degraded_this_session = True
                         agent._reasoning_was_config = _old_reasoning
-                    agent._vprint(
-                        f"\n{agent.log_prefix}⚠️  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
-                        f"{agent.log_prefix}⚠️  REASONING DISABLED FOR THIS SESSION\n"
-                        f"{agent.log_prefix}⚠️  Provider rejected reasoning config ({_old_reasoning}).\n"
-                        f"{agent.log_prefix}⚠️  Model will respond WITHOUT extended thinking.\n"
-                        f"{agent.log_prefix}⚠️  \n"
-                        f"{agent.log_prefix}⚠️  To re-enable reasoning:\n"
-                        f"{agent.log_prefix}⚠️    • Switch to a provider/model that supports it\n"
-                        f"{agent.log_prefix}⚠️    • Run: hermes config set provider.name <other-provider>\n"
-                        f"{agent.log_prefix}⚠️  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n",
-                        force=True,
-                    )
+                        agent._reasoning_rejected_params = _rejected
+
+                    if _rejected == "both" or _rejected == "":
+                        # Full disable — show the big warning
+                        agent._vprint(
+                            f"\n{agent.log_prefix}⚠️  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+                            f"{agent.log_prefix}⚠️  REASONING DISABLED FOR THIS SESSION\n"
+                            f"{agent.log_prefix}⚠️  Provider rejected reasoning config ({_old_reasoning}).\n"
+                            f"{agent.log_prefix}⚠️  Model will respond WITHOUT extended thinking.\n"
+                            f"{agent.log_prefix}⚠️  \n"
+                            f"{agent.log_prefix}⚠️  To re-enable reasoning:\n"
+                            f"{agent.log_prefix}⚠️    • Switch to a provider/model that supports it\n"
+                            f"{agent.log_prefix}⚠️    • Run: hermes config set provider.name <other-provider>\n"
+                            f"{agent.log_prefix}⚠️  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n",
+                            force=True,
+                        )
+                    else:
+                        # Partial disable — show lighter notice
+                        agent._vprint(
+                            f"\n{agent.log_prefix}⚠️  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+                            f"{agent.log_prefix}⚠️  REASONING PARTIALLY ADAPTED\n"
+                            f"{agent.log_prefix}⚠️  Provider rejected part of reasoning config ({_old_reasoning}).\n"
+                            f"{agent.log_prefix}⚠️  Action: {_action}\n"
+                            f"{agent.log_prefix}⚠️  Model will still provide enhanced reasoning where supported.\n"
+                            f"{agent.log_prefix}⚠️  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n",
+                            force=True,
+                        )
                     logger.warning(
-                        "%sInvalid reasoning config recovery: cleared "
-                        "reasoning_config (was %s), retrying on same provider without reasoning",
-                        agent.log_prefix, _old_reasoning,
+                        "%sInvalid reasoning config recovery: %s "
+                        "(was %s, rejected=%s), retrying on same provider",
+                        agent.log_prefix, _action, _old_reasoning, _rejected,
                     )
                     continue
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -59,6 +59,7 @@ class FailoverReason(enum.Enum):
     long_context_tier = "long_context_tier"    # Anthropic "extra usage" tier gate
     oauth_long_context_beta_forbidden = "oauth_long_context_beta_forbidden"  # Anthropic OAuth subscription rejects 1M context beta — disable beta and retry
     llama_cpp_grammar_pattern = "llama_cpp_grammar_pattern"  # llama.cpp json-schema-to-grammar rejects regex escapes in `pattern` / `format` — strip from tools and retry
+    invalid_reasoning_config = "invalid_reasoning_config"  # Provider rejected reasoning/thinking parameters — strip reasoning config and retry
 
     # Catch-all
     unknown = "unknown"                  # Unclassifiable — retry with backoff
@@ -361,6 +362,25 @@ _TIMEOUT_MESSAGE_PATTERNS = [
     "upstream timed out",
 ]
 
+# Reasoning/thinking config patterns — provider rejected the request because
+# of incompatible or unsupported reasoning parameters.
+_REASONING_CONFIG_PATTERNS = [
+    "cannot specify both 'thinking' and 'reasoning_effort'",
+    "cannot use both 'thinking' and 'reasoning_effort'",
+    "does not support parameter reasoningeffort",
+    "does not support parameter reasoning",
+    "does not support reasoning_effort",
+    "reasoning_effort is not supported",
+    "reasoning is not supported",
+    "unknown parameter: reasoning_effort",
+    "unknown parameter: thinking",
+    "unsupported parameter: reasoning_effort",
+    "unsupported parameter: thinking",
+    "invalid reasoning_effort",
+    "invalid thinking",
+    "thinking is not supported",
+]
+
 # Transport error type names
 _TRANSPORT_ERROR_TYPES = frozenset({
     "ReadTimeout", "ConnectTimeout", "PoolTimeout",
@@ -613,6 +633,17 @@ def classify_api_error(
     ):
         return _result(
             FailoverReason.llama_cpp_grammar_pattern,
+            retryable=True,
+            should_compress=False,
+        )
+
+    # Provider rejected reasoning/thinking parameters (HTTP 400).
+    # When a model or endpoint does not support the requested reasoning
+    # effort, thinking toggle, or reasoning_effort, we strip the config and
+    # retry once on the same provider instead of immediately falling back.
+    if status_code == 400 and any(p in error_msg for p in _REASONING_CONFIG_PATTERNS):
+        return _result(
+            FailoverReason.invalid_reasoning_config,
             retryable=True,
             should_compress=False,
         )
@@ -1115,6 +1146,14 @@ def _classify_by_message(
         return result_fn(
             FailoverReason.multimodal_tool_content_unsupported,
             retryable=True,
+        )
+
+    # Reasoning/thinking config patterns (from message text when no status_code)
+    if any(p in error_msg for p in _REASONING_CONFIG_PATTERNS):
+        return result_fn(
+            FailoverReason.invalid_reasoning_config,
+            retryable=True,
+            should_compress=False,
         )
 
     # Image-too-large patterns (from message text when no status_code)

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -85,6 +85,12 @@ class ClassifiedError:
     should_rotate_credential: bool = False
     should_fallback: bool = False
 
+    # For invalid_reasoning_config: which specific parameters the provider
+    # rejected. Values: "reasoning_effort", "thinking", "both", or "" (unknown).
+    # The retry loop uses this to surgically strip only the rejected params
+    # while preserving what works — so the user still gets "smart" responses.
+    rejected_reasoning_params: str = ""
+
     @property
     def is_auth(self) -> bool:
         return self.reason in {FailoverReason.auth, FailoverReason.auth_permanent}
@@ -381,6 +387,65 @@ _REASONING_CONFIG_PATTERNS = [
     "thinking is not supported",
 ]
 
+# Patterns that specifically reject ONLY reasoning_effort (effort level control).
+# These are separate from "thinking" (binary on/off toggle).
+_RE_ONLY_REASONING_EFFORT = [
+    "does not support parameter reasoningeffort",
+    "does not support reasoning_effort",
+    "reasoning_effort is not supported",
+    "unknown parameter: reasoning_effort",
+    "unsupported parameter: reasoning_effort",
+    "invalid reasoning_effort",
+]
+
+# Patterns that specifically reject ONLY thinking (binary toggle).
+_RE_ONLY_THINKING = [
+    "unknown parameter: thinking",
+    "unsupported parameter: thinking",
+    "invalid thinking",
+    "thinking is not supported",
+]
+
+# Patterns that reject BOTH (dual-parameter conflict or blanket rejection).
+_RE_BOTH = [
+    "cannot specify both 'thinking' and 'reasoning_effort'",
+    "cannot use both 'thinking' and 'reasoning_effort'",
+    "does not support parameter reasoning",
+    "reasoning is not supported",
+]
+
+
+def _detect_rejected_reasoning_params(error_msg: str) -> str:
+    """Determine which reasoning parameters the provider rejected.
+
+    Returns:
+        "reasoning_effort" — only the effort level is unsupported,
+                             but the thinking toggle may still work
+        "thinking"         — only the thinking toggle is unsupported,
+                             but reasoning_effort may still work
+        "both"             — both are rejected (or the error is ambiguous)
+        ""                 — no reasoning rejection detected
+    """
+    em = error_msg.lower()
+    has_effort = any(p in em for p in _RE_ONLY_REASONING_EFFORT)
+    has_thinking = any(p in em for p in _RE_ONLY_THINKING)
+    
+    # Check specific patterns FIRST before generic "both" patterns
+    # because "does not support parameter reasoning" (from _RE_BOTH) is a
+    # substring of "does not support parameter reasoningeffort" (from _RE_ONLY_REASONING_EFFORT)
+    if has_effort and not has_thinking:
+        return "reasoning_effort"
+    if has_thinking and not has_effort:
+        return "thinking"
+    
+    # Now check for both/generic patterns
+    has_both = any(p in em for p in _RE_BOTH)
+    if has_both:
+        return "both"
+    
+    # Generic pattern matched — can't tell which param, assume both
+    return "both"
+
 # Transport error type names
 _TRANSPORT_ERROR_TYPES = frozenset({
     "ReadTimeout", "ConnectTimeout", "PoolTimeout",
@@ -642,11 +707,13 @@ def classify_api_error(
     # effort, thinking toggle, or reasoning_effort, we strip the config and
     # retry once on the same provider instead of immediately falling back.
     if status_code == 400 and any(p in error_msg for p in _REASONING_CONFIG_PATTERNS):
+        rejected = _detect_rejected_reasoning_params(error_msg)
         return _result(
             FailoverReason.invalid_reasoning_config,
             retryable=True,
             should_compress=False,
             should_fallback=False,
+            rejected_reasoning_params=rejected,
         )
 
     # xAI Grok subscription entitlement errors.
@@ -1151,11 +1218,13 @@ def _classify_by_message(
 
     # Reasoning/thinking config patterns (from message text when no status_code)
     if any(p in error_msg for p in _REASONING_CONFIG_PATTERNS):
+        rejected = _detect_rejected_reasoning_params(error_msg)
         return result_fn(
             FailoverReason.invalid_reasoning_config,
             retryable=True,
             should_compress=False,
             should_fallback=False,
+            rejected_reasoning_params=rejected,
         )
 
     # Image-too-large patterns (from message text when no status_code)

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -646,6 +646,7 @@ def classify_api_error(
             FailoverReason.invalid_reasoning_config,
             retryable=True,
             should_compress=False,
+            should_fallback=False,
         )
 
     # xAI Grok subscription entitlement errors.
@@ -1154,6 +1155,7 @@ def _classify_by_message(
             FailoverReason.invalid_reasoning_config,
             retryable=True,
             should_compress=False,
+            should_fallback=False,
         )
 
     # Image-too-large patterns (from message text when no status_code)

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -42,23 +42,15 @@ class OpenCodeGoProfile(ProviderProfile):
 
         if _is_kimi_k2_model(model):
             # Kimi K2 on OpenCode Go uses Moonshot's native wire shape:
-            # extra_body.thinking (binary toggle) + top-level reasoning_effort
-            # (low|medium|high). Mirrors the KimiProfile (api.moonshot.ai/v1).
+            # extra_body.thinking (binary toggle) only.  The OpenCode Go
+            # endpoint rejects simultaneous top-level reasoning_effort,
+            # so we do not emit it here.  See #32040 / #32327.
             if not isinstance(reasoning_config, dict):
                 # No config → leave server defaults alone.
                 return extra_body, top_level
 
             enabled = reasoning_config.get("enabled") is not False
             extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
-
-            if not enabled:
-                return extra_body, top_level
-
-            effort = (reasoning_config.get("effort") or "").strip().lower()
-            if effort in {"xhigh", "max"}:
-                top_level["reasoning_effort"] = "high"
-            elif effort in {"low", "medium", "high"}:
-                top_level["reasoning_effort"] = effort
             return extra_body, top_level
 
         if not _is_deepseek_thinking_model(model):

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -63,6 +63,7 @@ class TestFailoverReason:
             "thinking_signature", "long_context_tier",
             "oauth_long_context_beta_forbidden",
             "llama_cpp_grammar_pattern",
+            "invalid_reasoning_config",
             "unknown",
         }
         actual = {r.value for r in FailoverReason}
@@ -1567,3 +1568,57 @@ class TestMultimodalToolContentUnsupported:
         e = MockAPIError("bad request: missing field 'model'", status_code=400)
         result = classify_api_error(e, provider="openrouter", model="anthropic/claude-sonnet-4")
         assert result.reason != FailoverReason.multimodal_tool_content_unsupported
+
+
+# ── Test: invalid_reasoning_config pattern ──────────────────────────────
+
+class TestInvalidReasoningConfig:
+    """Provider rejects the request because of incompatible reasoning parameters."""
+
+    def test_opencode_go_kimi_dual_parameter_conflict(self):
+        e = MockAPIError(
+            "Error from provider: cannot specify both 'thinking' and 'reasoning_effort'",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="opencode-go", model="kimi-k2.6")
+        assert result.reason == FailoverReason.invalid_reasoning_config
+        assert result.retryable is True
+        assert result.should_fallback is False
+
+    def test_xai_grok_unsupported_reasoning_effort(self):
+        e = MockAPIError(
+            "Model does not support parameter reasoningEffort",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="xai", model="grok-4-1-fast")
+        assert result.reason == FailoverReason.invalid_reasoning_config
+        assert result.retryable is True
+
+    def test_unknown_parameter_reasoning_effort(self):
+        e = MockAPIError(
+            "Unknown parameter: reasoning_effort",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="custom", model="local-llm")
+        assert result.reason == FailoverReason.invalid_reasoning_config
+        assert result.retryable is True
+
+    def test_unsupported_parameter_thinking(self):
+        e = MockAPIError(
+            "Unsupported parameter: thinking",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="custom", model="qwen3")
+        assert result.reason == FailoverReason.invalid_reasoning_config
+        assert result.retryable is True
+
+    def test_no_status_code_path_also_classifies(self):
+        """Message-only classifier must catch reasoning errors even without HTTP status."""
+        e = Exception("does not support reasoning_effort")
+        result = classify_api_error(e, provider="openrouter", model="cerebras/gpt-oss-120b")
+        assert result.reason == FailoverReason.invalid_reasoning_config
+
+    def test_unrelated_400_is_not_misclassified(self):
+        e = MockAPIError("bad request: missing field 'messages'", status_code=400)
+        result = classify_api_error(e, provider="openrouter", model="anthropic/claude-sonnet-4")
+        assert result.reason != FailoverReason.invalid_reasoning_config

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1584,6 +1584,7 @@ class TestInvalidReasoningConfig:
         assert result.reason == FailoverReason.invalid_reasoning_config
         assert result.retryable is True
         assert result.should_fallback is False
+        assert result.rejected_reasoning_params == "both"
 
     def test_xai_grok_unsupported_reasoning_effort(self):
         e = MockAPIError(
@@ -1593,6 +1594,7 @@ class TestInvalidReasoningConfig:
         result = classify_api_error(e, provider="xai", model="grok-4-1-fast")
         assert result.reason == FailoverReason.invalid_reasoning_config
         assert result.retryable is True
+        assert result.rejected_reasoning_params == "reasoning_effort"
 
     def test_unknown_parameter_reasoning_effort(self):
         e = MockAPIError(
@@ -1602,6 +1604,7 @@ class TestInvalidReasoningConfig:
         result = classify_api_error(e, provider="custom", model="local-llm")
         assert result.reason == FailoverReason.invalid_reasoning_config
         assert result.retryable is True
+        assert result.rejected_reasoning_params == "reasoning_effort"
 
     def test_unsupported_parameter_thinking(self):
         e = MockAPIError(
@@ -1611,12 +1614,14 @@ class TestInvalidReasoningConfig:
         result = classify_api_error(e, provider="custom", model="qwen3")
         assert result.reason == FailoverReason.invalid_reasoning_config
         assert result.retryable is True
+        assert result.rejected_reasoning_params == "thinking"
 
     def test_no_status_code_path_also_classifies(self):
         """Message-only classifier must catch reasoning errors even without HTTP status."""
         e = Exception("does not support reasoning_effort")
         result = classify_api_error(e, provider="openrouter", model="cerebras/gpt-oss-120b")
         assert result.reason == FailoverReason.invalid_reasoning_config
+        assert result.rejected_reasoning_params == "reasoning_effort"
 
     def test_unrelated_400_is_not_misclassified(self):
         e = MockAPIError("bad request: missing field 'messages'", status_code=400)

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -19,13 +19,13 @@ def opencode_go_profile():
 class TestOpenCodeGoKimiReasoning:
     """Kimi K2 models use Moonshot's thinking + reasoning_effort shape on OpenCode Go."""
 
-    def test_high_effort_emits_thinking_and_effort(self, opencode_go_profile):
+    def test_high_effort_emits_thinking_only(self, opencode_go_profile):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "high"},
             model="kimi-k2.6",
         )
         assert extra_body == {"thinking": {"type": "enabled"}}
-        assert top_level == {"reasoning_effort": "high"}
+        assert top_level == {}
 
     def test_disabled_emits_thinking_disabled_without_effort(self, opencode_go_profile):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
@@ -51,22 +51,22 @@ class TestOpenCodeGoKimiReasoning:
             "max",
         ],
     )
-    def test_strong_efforts_clamp_to_high(self, opencode_go_profile, effort):
+    def test_strong_efforts_emit_thinking_only(self, opencode_go_profile, effort):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": effort},
             model="moonshotai/kimi-k2.6",
         )
         assert extra_body == {"thinking": {"type": "enabled"}}
-        assert top_level == {"reasoning_effort": "high"}
+        assert top_level == {}
 
-    def test_low_and_medium_pass_through(self, opencode_go_profile):
+    def test_low_and_medium_emit_thinking_only(self, opencode_go_profile):
         for effort in ("low", "medium"):
             extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
                 reasoning_config={"enabled": True, "effort": effort},
                 model="kimi-k2.5",
             )
             assert extra_body == {"thinking": {"type": "enabled"}}
-            assert top_level == {"reasoning_effort": effort}
+            assert top_level == {}
 
     def test_no_config_preserves_server_default(self, opencode_go_profile):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
@@ -149,7 +149,7 @@ class TestOpenCodeGoModelGating:
 class TestOpenCodeGoFullKwargsIntegration:
     """End-to-end transport kwargs include the profile-provided controls."""
 
-    def test_kimi_reasoning_reaches_extra_body_and_top_level(self, opencode_go_profile):
+    def test_kimi_reasoning_reaches_extra_body_only(self, opencode_go_profile):
         from agent.transports.chat_completions import ChatCompletionsTransport
 
         kwargs = ChatCompletionsTransport().build_kwargs(
@@ -161,7 +161,7 @@ class TestOpenCodeGoFullKwargsIntegration:
             base_url="https://opencode.ai/zen/go/v1",
         )
         assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
-        assert kwargs["reasoning_effort"] == "high"
+        assert "reasoning_effort" not in kwargs
 
     def test_deepseek_thinking_reaches_extra_body_and_top_level(
         self, opencode_go_profile


### PR DESCRIPTION
## Summary

When a provider rejects a request because of incompatible `reasoning_effort`, `thinking`, or dual-parameter conflicts, Hermes now retries **once on the same provider** after stripping the reasoning config, instead of immediately burning a fallback attempt or crashing with an unhandled 400.

Additionally, the OpenCode Go provider profile is fixed for `kimi-k2` models: it no longer sends both `extra_body.thinking` and top-level `reasoning_effort` simultaneously, which the OpenCode Go endpoint rejects.

## Changes

- **agent/error_classifier.py**
  - New `FailoverReason.invalid_reasoning_config`
  - Pattern list covering dual-parameter conflicts, unsupported parameters, unknown parameters, and invalid values for reasoning/thinking.
  - Classified both with HTTP 400 and message-only (no status code) paths.

- **agent/conversation_loop.py**
  - Recovery branch: on `invalid_reasoning_config`, clear `agent.reasoning_config`, rebuild `api_kwargs`, and retry once.

- **plugins/model-providers/opencode-zen/__init__.py**
  - For `kimi-k2` models: emit **only** `extra_body.thinking` (enable/disable toggle). Drop top-level `reasoning_effort` entirely.
  - DeepSeek models continue to emit both as before.

- **Tests**
  - `tests/agent/test_error_classifier.py`: add `TestInvalidReasoningConfig` (6 cases).
  - `tests/plugins/model_providers/test_opencode_go_profile.py`: update kimi-k2 expectations.

## Fixes

- Fixes #32040
- Fixes #32327
- Relates to #34786 (feature request)

## Verification

```bash
uv sync --extra dev
uv run pytest tests/agent/test_error_classifier.py tests/plugins/model_providers/test_opencode_go_profile.py -v
# 182 passed
```
