### PR TITLE
fix: remove duplicate vendor prefix key in model_normalize

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -60,7 +60,6 @@ _VENDOR_PREFIXES: dict[str, str] = {
     "nemotron": "nvidia",
     "llama": "meta-llama",
     "step": "stepfun",
-    "trinity": "arcee-ai",
 }
 
 # Providers whose APIs consume vendor/model slugs.


### PR DESCRIPTION
## Summary

Remove a duplicate dictionary key in `_VENDOR_PREFIXES` (`hermes_cli/model_normalize.py`).

The key `"trinity"` → `"arcee-ai"` appeared twice (lines 59 and 63). Python silently drops the first occurrence, so the second entry is dead code.

## Changes

- Removed the duplicate `"trinity": "arcee-ai"` entry on line 63

## Verification

- `python3 -m py_compile hermes_cli/model_normalize.py` — passes
- `ruff check --select F601` — no more duplicate key warnings
- 121 related tests pass (`test_model_normalize.py`, `test_arcee_trinity_overrides.py`, `test_arcee_provider.py`)

## Impact

No functional change — both entries had the same value (`"arcee-ai"`), so the duplicate was purely dead code.