### PR TITLE
fix(cli): clarify panel clips choices off-screen on short terminals

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13979,7 +13979,12 @@ class HermesCLI:
             reserved_below = 6
 
             available = max(0, term_rows - reserved_below)
-            mandatory_full = chrome_full + len(choice_wrapped) + len(other_wrapped)
+            # The compact decision must reserve room for at least one question
+            # row on top of the choices, otherwise full chrome (3 blank
+            # separators) gets kept when there is no room for it and the panel
+            # overflows the viewport — HSplit then clips the panel's tail,
+            # silently dropping the choices (the reported bug).
+            mandatory_full = chrome_full + 1 + len(choice_wrapped) + len(other_wrapped)
 
             use_compact_chrome = mandatory_full > available
             chrome_rows = chrome_tight if use_compact_chrome else chrome_full
@@ -13987,9 +13992,24 @@ class HermesCLI:
             max_question_rows = max(1, available - chrome_rows - len(choice_wrapped) - len(other_wrapped))
             max_question_rows = min(max_question_rows, 12)  # soft cap on huge terminals
 
+            # When the choices alone (plus compact chrome) already exceed the
+            # viewport, drop the question entirely — the choices are the only
+            # thing the user must see to make a selection. Without this the
+            # question would still claim its 1-row floor above and push the
+            # tail of the choices off-screen (HSplit clips the overflow).
+            choices_overflow = chrome_rows + len(choice_wrapped) + len(other_wrapped) >= available
+            if choices_overflow:
+                max_question_rows = 0
+
             question_wrapped = _wrap_panel_text(question, inner_text_width)
-            if len(question_wrapped) > max_question_rows:
-                keep = max(1, max_question_rows - 1)
+            if max_question_rows <= 0:
+                question_wrapped = []
+            elif len(question_wrapped) > max_question_rows:
+                # The truncation marker is itself a row, so it must count
+                # against the budget. With a 1-row budget there is no room for
+                # both a question line and the marker — show the marker alone
+                # so the rendered question never exceeds max_question_rows.
+                keep = max(0, max_question_rows - 1)
                 question_wrapped = question_wrapped[:keep] + ["… (question truncated)"]
 
             lines = []

--- a/website/docs/user-guide/features/code-execution.md
+++ b/website/docs/user-guide/features/code-execution.md
@@ -219,6 +219,62 @@ terminal:
 
 See the [Security guide](/user-guide/security#environment-variable-passthrough) for full details.
 
+### `HERMES_*` variables in the child
+
+The child process receives only a small, fixed set of operational `HERMES_*`
+variables by exact name:
+
+- `HERMES_HOME`
+- `HERMES_PROFILE`
+- `HERMES_CONFIG`
+- `HERMES_ENV`
+
+(plus `HERMES_RPC_DIR` / `HERMES_RPC_SOCKET` / `TZ` / `HOME`, which Hermes
+injects explicitly so the RPC channel works).
+
+:::note Behavior change
+Earlier versions passed **any** variable whose name began with `HERMES_`
+through to the child. That broad prefix was removed for security hardening: it
+could leak `HERMES_*`-named configuration that doesn't match a secret substring
+(for example `HERMES_BASE_URL`, `HERMES_KANBAN_DB`, or a `HERMES_*_WEBHOOK`
+endpoint) into arbitrary sandboxed code.
+
+If an `execute_code` script — or a repo/plugin module it imports at import time
+— relied on a `HERMES_*` variable outside the four operational names above, it
+will now find that variable **unset** in the child. The drop is intentional,
+not a bug.
+:::
+
+**Workaround — opt the variable back in explicitly.** Both routes pass the
+variable through `execute_code` *and* `terminal` children, and neither weakens
+the secret-stripping guarantee (Hermes-managed provider credentials can never
+be re-allowed this way):
+
+1. **Per-machine, in `config.yaml`** — add the exact variable name to the
+   passthrough allowlist:
+
+   ```yaml
+   terminal:
+     env_passthrough:
+       - HERMES_KANBAN_DB
+       - HERMES_BASE_URL
+   ```
+
+2. **Per-skill, in the skill's frontmatter** — declare it so it is registered
+   automatically whenever that skill is loaded:
+
+   ```yaml
+   required_environment_variables:
+     - HERMES_KANBAN_DB
+   ```
+
+**Diagnosing it.** When the child drops one or more non-allowlisted `HERMES_*`
+variables, Hermes emits a one-line `debug` log naming them and pointing at the
+`env_passthrough` escape hatch. Run with debug logging (`hermes logs --level
+DEBUG`, or check `~/.hermes/logs/agent.log`) and look for
+`execute_code: dropped N non-allowlisted HERMES_* var(s)` if a script behaves
+as though a `HERMES_*` variable is missing.
+
 Hermes always writes the script and the auto-generated `hermes_tools.py` RPC stub into a temp staging directory that is cleaned up after execution. In `strict` mode the script also *runs* there; in `project` mode it runs in the session's working directory (the staging directory stays on `PYTHONPATH` so imports still resolve). The child process runs in its own process group so it can be cleanly killed on timeout or interruption.
 
 ## execute_code vs terminal


### PR DESCRIPTION
## Summary
The clarify multiple-choice panel now renders all options within the viewport on short terminals — previously the choices at the bottom of the panel were clipped off-screen, making them invisible/unselectable (#34645).

Root cause: the clarify panel is a height-less `Window(FormattedTextControl, wrap_lines=True)` inside a non-full-screen `HSplit`. When its content exceeds the terminal height, prompt_toolkit distributes height per child and clips the panel's tail — exactly where the choices live. The row-budgeting that should prevent this had two accounting bugs.

## Changes
- `cli.py` `_get_clarify_display`:
  - Reserve one question row in the compact-chrome decision so the blank separators collapse when there's no room (previously `mandatory_full` ignored the question entirely and kept full chrome).
  - Count the `… (question truncated)` marker against the question's row budget (previously it rendered an extra row at a 1-row budget).
  - Drop the question entirely when the choices alone already exceed the viewport — the choices are the must-see content for making a selection.

The approval panel (`_get_approval_display_fragments`) already renders its long content (description) last and budgets it explicitly, so it does not have this bug and is untouched.

Note: the issue is titled "TUI" but the debug dump shows the reporter is on the classic prompt_toolkit CLI (`platform: CLI (hermes_cli)`). The Ink TUI's `prompts.tsx` is unaffected.

## Validation
| Terminal | Before | After |
|---|---|---|
| ≥16 rows, multi-line question | choices clipped off-screen | all options render, 0 overflow |
| 12 rows, 4 choices | silent tail clip | chrome collapsed + question dropped, all choices present |

Verified end-to-end with a real prompt_toolkit `write_to_screen` render at 16×80: the full panel (title + question + 4 choices + Other + borders) fits the viewport and the content below stays intact, with every option visible. Reproduced the original clip first (12-row panel into 10-row viewport drops the last 7 rows).

Fixes #34645



## Infographic

![clarify-panel-choices-clip-fix](https://v3b.fal.media/files/b/0a9c30fe/q4MWn9bftI4zzk9smHTRS_SGq1Pbao.png)
