### PR TITLE
fix(agent): route structured-reasoning empties to prefill, not nudge

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4861,10 +4861,25 @@ def run_conversation(
                             re.IGNORECASE,
                         )
                     )
+                    # Detect structured reasoning emitted via API fields
+                    # (OpenRouter `reasoning` / `reasoning_details`, or the
+                    # streaming-accumulated `reasoning_content`).  Thinking
+                    # models like qwen3-vl-8b-thinking return reasoning here
+                    # with empty content after tool calls — that's the model
+                    # still working, not a genuine empty response.  Compute
+                    # this BEFORE the nudge guard so those turns route to the
+                    # prefill branch below instead of wasting an LLM round-trip
+                    # on a nudge.
+                    _has_structured = bool(
+                        getattr(assistant_message, "reasoning", None)
+                        or getattr(assistant_message, "reasoning_content", None)
+                        or getattr(assistant_message, "reasoning_details", None)
+                        or _has_inline_thinking
+                    )
                     if (
                         _prior_was_tool
                         and not getattr(agent, "_post_tool_empty_retried", False)
-                        and not _has_inline_thinking  # thinking model still working — let prefill handle
+                        and not _has_structured  # thinking model still working — let prefill handle
                     ):
                         agent._post_tool_empty_retried = True
                         # Clear stale narration so it doesn't resurface
@@ -4908,12 +4923,8 @@ def run_conversation(
                     # Inspired by clawdbot's "incomplete-text" recovery.
                     # Also covers Qwen3/Ollama in-content <think> blocks
                     # (detected above as _has_inline_thinking).
-                    _has_structured = bool(
-                        getattr(assistant_message, "reasoning", None)
-                        or getattr(assistant_message, "reasoning_content", None)
-                        or getattr(assistant_message, "reasoning_details", None)
-                        or _has_inline_thinking
-                    )
+                    # _has_structured was computed above the nudge guard so
+                    # both branches share the same definition.
                     if _has_structured and agent._thinking_prefill_retries < 2:
                         agent._thinking_prefill_retries += 1
                         logger.info(


### PR DESCRIPTION
## Summary
Thinking models that emit reasoning via structured API fields (OpenRouter `reasoning`/`reasoning_details`, e.g. `qwen3-vl-8b-thinking`) no longer waste an LLM round-trip on a spurious post-tool "empty response" nudge.

Root cause: the post-tool empty-response **nudge** branch fired before the **prefill** branch, and its guard only checked `_has_inline_thinking` (`<think>` tags in content) — not the structured reasoning fields these models populate. Every tool-using turn hit the nudge (~3-5s, ~400 tokens, a `⚠️` warning) before self-recovering.

## Changes
- `agent/conversation_loop.py`: hoist `_has_structured` above the nudge guard; widen the guard `not _has_inline_thinking` → `not _has_structured`. Remove the now-duplicate computation below.

## Validation
| scenario | before | after |
|---|---|---|
| structured reasoning (reasoning / reasoning_content / reasoning_details), empty, post-tool | NUDGE | PREFILL |
| no reasoning, empty, post-tool | NUDGE | NUDGE (preserved) |
| inline `<think>`, post-tool | PREFILL | PREFILL (preserved) |

Nudge and prefill are now disjoint on `_has_structured`; the empty-retry branch's existing `_prefill_exhausted` guard already handles always-reasoning models (mimo-v2-pro etc.) falling through after prefill is spent.

Closes #34655. Reported by @sawtdakhili.