### PR TITLE
fix(install): use PSBoundParameters.ContainsKey for -Ensure guard

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2281,7 +2281,7 @@ function Main {
 # structured JSON error frame instead of a bare exception.
 
 try {
-    if ($Ensure -ne "") {
+    if ($PSBoundParameters.ContainsKey('Ensure')) {
         if ($PSBoundParameters.ContainsKey("Stage")) {
             Write-Err "Cannot use -Ensure and -Stage simultaneously"
             exit 1


### PR DESCRIPTION
## What does this PR do?

Fixes the `-Ensure` parameter guard in `install.ps1` so it no longer throws "Cannot use -Ensure and -Stage simultaneously" on PowerShell 5.1 when neither flag is passed. The previous string comparison (`$Ensure -ne ""`) is unreliable across PowerShell versions; `PSBoundParameters.ContainsKey` is the idiomatic way to detect explicit parameter usage.

## Related Issue

Fixes #34821

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.ps1`: Replace `$Ensure -ne ""` with `$PSBoundParameters.ContainsKey('Ensure')` on line 2284 to correctly detect whether `-Ensure` was explicitly passed.

## How to Test

1. On Windows with PowerShell 5.1, run: `powershell -ExecutionPolicy Bypass -Command "iex (irm https://raw.githubusercontent.com/liuhao1024/hermes-agent/fix/install-ps1-ensure-param-binding/scripts/install.ps1)"`
2. Verify the script no longer throws "Cannot use -Ensure and -Stage simultaneously" on bare invocation.
3. Verify that explicitly passing `-Ensure node` still triggers the ensure-mode path.
4. Verify that passing both `-Ensure node -Stage 2` still throws the conflict error.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A: PowerShell installer script, no automated test infrastructure for .ps1
- [x] I've tested on my platform: macOS (code review verified)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — This fix is Windows/PowerShell-specific; no impact on macOS/Linux
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `scripts/install.ps1` line 2284 (`if ($Ensure -ne "")` guard)
- Blast radius: LOW — single condition in installer entry point, no runtime code affected
- Related patterns: `PSBoundParameters.ContainsKey` is already used for `-Stage` check on line 2285; this fix aligns the `-Ensure` check with the same pattern
