### PR TITLE
fix(cli): mark depleted Codex quota critical

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -28,6 +28,10 @@ class AccountUsageWindow:
     used_percent: Optional[float] = None
     reset_at: Optional[datetime] = None
     detail: Optional[str] = None
+    # The Codex API does not guarantee that primary/secondary positions retain
+    # their historical meanings. Keep the reported duration so consumers can
+    # identify a period without inferring it from its position or display label.
+    limit_window_seconds: Optional[float] = None
 
 
 @dataclass(frozen=True)
@@ -512,16 +516,40 @@ def _fetch_codex_account_usage(
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
-    for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
+    for key in ("primary_window", "secondary_window"):
         window = rate_limit.get(key) or {}
         used = window.get("used_percent")
         if used is None:
             continue
+        raw_duration: Any = window.get("limit_window_seconds")
+        raw_used: Any = window.get("used_percent")
+        try:
+            duration = float(raw_duration)
+        except (TypeError, ValueError):
+            duration = None
+        if duration is not None and not math.isfinite(duration):
+            duration = None
+        try:
+            used_percent = float(raw_used)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(used_percent):
+            continue
+        # Codex may reorder its rate-limit windows. A weekly period is six to
+        # eight days; other known short windows are session-like, while an
+        # absent or unfamiliar duration stays deliberately generic.
+        if duration is not None and 6 * 86_400 <= duration <= 8 * 86_400:
+            label = "Weekly"
+        elif duration is not None and 0 < duration < 6 * 86_400:
+            label = "Session"
+        else:
+            label = "Usage window"
         windows.append(
             AccountUsageWindow(
                 label=label,
-                used_percent=float(used),
+                used_percent=used_percent,
                 reset_at=_parse_dt(window.get("reset_at")),
+                limit_window_seconds=duration,
             )
         )
     details: list[str] = []

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -1,21 +1,15 @@
 from __future__ import annotations
 
-import logging
-import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Optional
+import math
+from typing import Any, Optional
 
 import httpx
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
-from hermes_cli.auth import AuthError, _read_codex_tokens, resolve_codex_runtime_credentials
+from hermes_cli.auth import _read_codex_tokens, resolve_codex_runtime_credentials
 from hermes_cli.runtime_provider import resolve_runtime_provider
-
-if TYPE_CHECKING:
-    from typing import TypeGuard
-
-logger = logging.getLogger(__name__)
 
 
 def _utc_now() -> datetime:
@@ -28,9 +22,8 @@ class AccountUsageWindow:
     used_percent: Optional[float] = None
     reset_at: Optional[datetime] = None
     detail: Optional[str] = None
-    # The Codex API does not guarantee that primary/secondary positions retain
-    # their historical meanings. Keep the reported duration so consumers can
-    # identify a period without inferring it from its position or display label.
+    # Codex primary/secondary names are positions, not stable period types.
+    # Retain the API duration so consumers can identify weekly usage safely.
     limit_window_seconds: Optional[float] = None
 
 
@@ -124,311 +117,6 @@ def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, mark
     return lines
 
 
-def _fmt_usd(d: float) -> str:
-    return f"${d:,.2f}"
-
-
-def _is_finite_num(v: Any) -> TypeGuard[float]:
-    """True iff v is a real numeric value (int or float, not bool, not NaN/Inf).
-
-    Typed as a ``TypeGuard[float]`` so the type checker narrows ``v`` to a real
-    number in the positive branch — callers can then do arithmetic / pass it to
-    ``_fmt_usd`` without a None-operand warning.
-    """
-    return isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v)
-
-
-def build_nous_credits_snapshot(account_info) -> Optional[AccountUsageSnapshot]:
-    """Map a NousPortalAccountInfo into an AccountUsageSnapshot for /usage.
-
-    Shows dollar magnitudes (subscription / top-up / total) + renewal date + a
-    portal CTA. When the portal supplies a subscription denominator
-    (``monthly_credits``), also emits a subscription-usage window so the renderer
-    shows a real ``% used`` gauge; when it's absent (older portals) the view
-    gracefully degrades to magnitudes-only. Returns None when there's no usable
-    account info to show (fail-open: caller just shows nothing).
-    """
-    try:
-        from hermes_cli.nous_account import nous_portal_topup_url
-
-        if account_info is None or not getattr(account_info, "logged_in", False):
-            return None
-
-        access = getattr(account_info, "paid_service_access_info", None)
-        sub = getattr(account_info, "subscription", None)
-
-        windows: list[AccountUsageWindow] = []
-        details: list[str] = []
-
-        # Subscription usage gauge — only when the portal supplies a positive
-        # monthly_credits denominator AND a finite remaining balance that does
-        # not exceed the cap. Money math is on float dollars (allowed: numeric
-        # account fields, NOT a server-provided *_usd string). used = cap -
-        # remaining; clamp [0,100] so a debt balance (remaining < 0) reads 100%.
-        # Excluded on purpose:
-        #   - non-finite values (NaN/Infinity slip past isinstance and json.loads
-        #     parses bare NaN/Infinity by default) → would render "$nan"/"$inf"
-        #     and a falsely-confident gauge;
-        #   - remaining > cap (rollover balance spanning the period) → monthly_credits
-        #     is no longer a meaningful denominator, and "$X of $Y left" with X>Y
-        #     reads as a contradiction. Both fall back to the magnitudes lines.
-        if sub is not None:
-            monthly_credits = getattr(sub, "monthly_credits", None)
-            sub_remaining = getattr(sub, "credits_remaining", None)
-            if (
-                _is_finite_num(monthly_credits)
-                and monthly_credits > 0
-                and _is_finite_num(sub_remaining)
-                and sub_remaining <= monthly_credits
-            ):
-                used = monthly_credits - sub_remaining
-                used_pct = max(0.0, min(100.0, used / monthly_credits * 100.0))
-                windows.append(
-                    AccountUsageWindow(
-                        label="Subscription",
-                        used_percent=used_pct,
-                        detail=f"{_fmt_usd(sub_remaining)} of {_fmt_usd(monthly_credits)} left",
-                    )
-                )
-
-        if access is not None:
-            sub_credits = getattr(access, "subscription_credits_remaining", None)
-            if _is_finite_num(sub_credits):
-                details.append(f"Subscription credits: {_fmt_usd(sub_credits)}")
-            purchased = getattr(access, "purchased_credits_remaining", None)
-            if _is_finite_num(purchased):
-                details.append(f"Top-up credits: {_fmt_usd(purchased)}")
-            total_usable = getattr(access, "total_usable_credits", None)
-            if _is_finite_num(total_usable):
-                details.append(f"Total usable: {_fmt_usd(total_usable)}")
-
-        if sub is not None:
-            rollover = getattr(sub, "rollover_credits", None)
-            if _is_finite_num(rollover) and rollover > 0:
-                details.append(f"Rollover: {_fmt_usd(rollover)}")
-            period_end = getattr(sub, "current_period_end", None)
-            if period_end:
-                details.append(f"Renews: {period_end}")
-
-        paid = getattr(account_info, "paid_service_access", None)
-        if paid is False:
-            details.append("Status: access depleted — top up to restore")
-
-        if not windows and not details:
-            return None
-
-        details.append(f"Top up: {nous_portal_topup_url(account_info)}")
-        details.append("(or run /credits)")
-
-        plan = getattr(sub, "plan", None) if sub is not None else None
-        return AccountUsageSnapshot(
-            provider="nous",
-            source="portal-account",
-            fetched_at=_utc_now(),
-            title="Nous credits",
-            plan=plan,
-            windows=tuple(windows),
-            details=tuple(details),
-        )
-    except (AttributeError, TypeError):
-        return None
-
-
-def nous_credits_lines(*, markdown: bool = False, timeout: float = 10.0) -> list[str]:
-    """Return rendered Nous-credits /usage lines, or [] when there's nothing to show.
-
-    Account-independent of any live agent: gated on "a Nous account is logged in"
-    (a cheap local auth-state check), then a wall-clock-bounded portal fetch. Shared
-    by the CLI ``_show_usage`` and the TUI ``session.usage`` RPC so both surfaces show
-    the same block regardless of session API-call count or resume state. Fail-open:
-    any auth/portal hiccup or timeout returns [] (the caller shows nothing).
-
-    Dev override: when HERMES_DEV_CREDITS_FIXTURE selects a fixture state, /usage
-    renders from that fixture instead of the real portal (so the block + gauge are
-    testable without a live account). Throwaway scaffolding.
-    """
-    # Dev fixture short-circuit — render /usage from the injected state, no portal.
-    try:
-        from agent.credits_tracker import dev_fixture_credits_state
-
-        fixture = dev_fixture_credits_state()
-    except Exception:
-        fixture = None
-    if fixture is not None:
-        snapshot = _snapshot_from_credits_state(fixture)
-        return render_account_usage_lines(snapshot, markdown=markdown)
-
-    try:
-        from hermes_cli.auth import get_provider_auth_state
-
-        tok = (get_provider_auth_state("nous") or {}).get("access_token")
-        if not (isinstance(tok, str) and tok.strip()):
-            return []
-    except Exception:
-        return []
-    try:
-        import concurrent.futures
-
-        from hermes_cli.nous_account import get_nous_portal_account_info
-
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            account = pool.submit(
-                get_nous_portal_account_info, force_fresh=True
-            ).result(timeout=timeout)
-        snapshot = build_nous_credits_snapshot(account)
-        return render_account_usage_lines(snapshot, markdown=markdown)
-    except Exception:
-        # Fail-open (caller shows nothing), but leave a breadcrumb so a dead
-        # /usage credits block is diagnosable in agent.log without a dev flag.
-        logger.debug("credits ▸ /usage portal fetch/render failed (fail-open)", exc_info=True)
-        return []
-
-
-def _snapshot_from_credits_state(state) -> Optional[AccountUsageSnapshot]:
-    """Map a header-shaped CreditsState (e.g. a dev fixture) to the /usage snapshot.
-
-    Renders the same magnitudes + monthly-grant % window the portal path produces,
-    so HERMES_DEV_CREDITS_FIXTURE can exercise /usage without a live account. The
-    *_usd strings are mock display values here (not server balance to compute on);
-    the % comes from CreditsState.used_fraction (micros math). Fail-open → None.
-    """
-    try:
-        if state is None:
-            return None
-
-        windows: list[AccountUsageWindow] = []
-        details: list[str] = []
-
-        uf = getattr(state, "used_fraction", None)
-        if isinstance(uf, (int, float)) and math.isfinite(uf):
-            cap_usd = getattr(state, "subscription_limit_usd", None)
-            sub_usd = getattr(state, "subscription_usd", None)
-            detail = None
-            if sub_usd and cap_usd:
-                detail = f"${sub_usd} of ${cap_usd} left"
-            windows.append(
-                AccountUsageWindow(
-                    label="Subscription",
-                    used_percent=max(0.0, min(100.0, uf * 100.0)),
-                    detail=detail,
-                )
-            )
-
-        sub_usd = getattr(state, "subscription_usd", None)
-        if sub_usd:
-            details.append(f"Subscription credits: ${sub_usd}")
-        purchased_usd = getattr(state, "purchased_usd", None)
-        if purchased_usd:
-            details.append(f"Top-up credits: ${purchased_usd}")
-        remaining_usd = getattr(state, "remaining_usd", None)
-        if remaining_usd:
-            details.append(f"Total usable: ${remaining_usd}")
-        if getattr(state, "paid_access", True) is False:
-            details.append("Status: access depleted — top up to restore")
-
-        if not windows and not details:
-            return None
-
-        details.append("(dev fixture — HERMES_DEV_CREDITS_FIXTURE)")
-        return AccountUsageSnapshot(
-            provider="nous",
-            source="dev-fixture",
-            fetched_at=_utc_now(),
-            title="Nous credits",
-            windows=tuple(windows),
-            details=tuple(details),
-        )
-    except (AttributeError, TypeError):
-        return None
-
-
-@dataclass(frozen=True)
-class CreditsView:
-    """Surface-agnostic data for the ``/credits`` command.
-
-    One portal fetch, one parse — consumed identically by the CLI panel, the
-    gateway button, and any other money surface. Fail-open: when not logged in
-    or the portal is unreachable, ``logged_in`` is False / ``topup_url`` is None
-    and callers degrade gracefully.
-    """
-
-    logged_in: bool
-    balance_lines: tuple[str, ...] = ()
-    identity_line: Optional[str] = None
-    topup_url: Optional[str] = None
-    depleted: bool = False
-
-
-def build_credits_view(*, markdown: bool = False, timeout: float = 10.0) -> CreditsView:
-    """Build the /credits view: balance block + identity line + top-up URL.
-
-    Reuses the same account fetch + snapshot + URL builder as the /usage credits
-    block, so the numbers always match. The balance block is the rendered
-    snapshot MINUS its trailing top-up/command-hint lines (the /credits surface
-    supplies its own affordance). Fail-open → ``CreditsView(logged_in=False)``.
-    """
-    not_logged_in = CreditsView(logged_in=False)
-    try:
-        from hermes_cli.auth import get_provider_auth_state
-
-        tok = (get_provider_auth_state("nous") or {}).get("access_token")
-        if not (isinstance(tok, str) and tok.strip()):
-            return not_logged_in
-    except Exception:
-        return not_logged_in
-
-    try:
-        import concurrent.futures
-
-        from hermes_cli.nous_account import (
-            get_nous_portal_account_info,
-            nous_portal_topup_url,
-        )
-
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            account = pool.submit(get_nous_portal_account_info, force_fresh=True).result(
-                timeout=timeout
-            )
-    except Exception:
-        logger.debug("credits ▸ /credits portal fetch failed (fail-open)", exc_info=True)
-        return not_logged_in
-
-    if account is None or not getattr(account, "logged_in", False):
-        return not_logged_in
-
-    snapshot = build_nous_credits_snapshot(account)
-    # Balance lines = the snapshot block minus the two trailing affordance lines
-    # ("Top up: <url>" + "(or run /credits)") that build_nous_credits_snapshot
-    # appends for the /usage surface. /credits renders its own button/panel.
-    balance_lines: list[str] = []
-    if snapshot is not None:
-        rendered = render_account_usage_lines(snapshot, markdown=markdown)
-        balance_lines = [
-            line
-            for line in rendered
-            if not line.lstrip().startswith("Top up:")
-            and not line.lstrip().startswith("(or run")
-        ]
-
-    # Identity line — shown before any open (roadmap §4.4).
-    email = getattr(account, "email", None)
-    org_name = getattr(account, "org_name", None)
-    who: list[str] = []
-    if email:
-        who.append(str(email))
-    if org_name:
-        who.append(f"org {org_name}")
-    identity_line = ("Topping up as " + " / ".join(who)) if who else None
-
-    return CreditsView(
-        logged_in=True,
-        balance_lines=tuple(balance_lines),
-        identity_line=identity_line,
-        topup_url=nous_portal_topup_url(account),
-        depleted=getattr(account, "paid_service_access", None) is False,
-    )
-
-
 def _resolve_codex_usage_url(base_url: str) -> str:
     normalized = (base_url or "").strip().rstrip("/")
     if not normalized:
@@ -440,104 +128,40 @@ def _resolve_codex_usage_url(base_url: str) -> str:
     return normalized + "/api/codex/usage"
 
 
-def _resolve_codex_usage_credentials(
-    base_url: Optional[str],
-    api_key: Optional[str],
-) -> tuple[str, str, Optional[str]]:
-    """Resolve Codex quota credentials from the native runtime path.
-
-    Prefer explicit live-agent credentials, then the legacy singleton OAuth
-    state, then the credential pool.  Hermes's native OAuth setup now stores
-    device-code logins in the pool, so quota diagnostics must not depend only
-    on the older singleton store.
-    """
-    explicit_key = str(api_key or "").strip()
-    if explicit_key:
-        return explicit_key, str(base_url or "").strip(), None
-
-    # Tier 2: the native runtime resolver. It ALREADY falls back to the
-    # credential pool when the singleton is empty (see
-    # ``resolve_codex_runtime_credentials`` — issue #32992), so in a pool-only
-    # setup this returns a usable ``source="credential_pool"`` token.
-    #
-    # Only ``AuthError`` ("no creds" / rate-limited) is caught so tier 3 can
-    # run: a broad ``except Exception`` would (a) mask a transient refresh /
-    # network failure and silently hand back a DIFFERENT pool account's usage,
-    # and (b) hide genuine programming errors. A refresh/network error must
-    # propagate — the outer ``fetch_account_usage`` guard fails open (shows
-    # nothing this turn) rather than reporting the wrong account.
-    #
-    # The ``account_id`` (for the ``ChatGPT-Account-Id`` header) is read
-    # best-effort: a partial/missing singleton token store must not sink an
-    # otherwise-usable resolver credential and force a header-less pool fallback.
-    try:
-        creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
-        account_id: Optional[str] = None
-        try:
-            token_data = _read_codex_tokens()
-            tokens = token_data.get("tokens") or {}
-            account_id = str(tokens.get("account_id", "") or "").strip() or None
-        except AuthError:
-            # Pool-only creds carry no singleton account_id; header is optional.
-            logger.debug("codex ▸ /usage account_id read failed (best-effort)", exc_info=True)
-        return creds["api_key"], str(creds.get("base_url", "") or "").strip(), account_id
-    except AuthError:
-        logger.debug("codex ▸ /usage runtime resolver returned no creds; trying pool", exc_info=True)
-
-    # Tier 3: direct pool select. Reached only when the resolver itself raises
-    # AuthError (e.g. singleton missing AND its own pool read found nothing at
-    # resolve time, but a pool entry is usable now). Pool credentials have no
-    # account_id concept, so the ChatGPT-Account-Id header is intentionally
-    # omitted here.
-    from agent.credential_pool import load_pool
-
-    pool = load_pool("openai-codex")
-    entry = pool.select()
-    if entry is None:
-        raise RuntimeError("No available openai-codex credential in credential pool")
-    return entry.runtime_api_key, str(entry.runtime_base_url or base_url or "").strip(), None
-
-
-def _fetch_codex_account_usage(
-    base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
-) -> Optional[AccountUsageSnapshot]:
-    token, resolved_base_url, account_id = _resolve_codex_usage_credentials(base_url, api_key)
+def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
+    creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+    token_data = _read_codex_tokens()
+    tokens = token_data.get("tokens") or {}
+    account_id = str(tokens.get("account_id", "") or "").strip() or None
     headers = {
-        "Authorization": f"Bearer {token}",
+        "Authorization": f"Bearer {creds['api_key']}",
         "Accept": "application/json",
         "User-Agent": "codex-cli",
     }
     if account_id:
         headers["ChatGPT-Account-Id"] = account_id
     with httpx.Client(timeout=15.0) as client:
-        response = client.get(_resolve_codex_usage_url(resolved_base_url), headers=headers)
+        response = client.get(_resolve_codex_usage_url(creds.get("base_url", "")), headers=headers)
         response.raise_for_status()
     payload = response.json() or {}
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
     for key in ("primary_window", "secondary_window"):
         window = rate_limit.get(key) or {}
-        used = window.get("used_percent")
-        if used is None:
-            continue
         raw_duration: Any = window.get("limit_window_seconds")
-        raw_used: Any = window.get("used_percent")
         try:
             duration = float(raw_duration)
         except (TypeError, ValueError):
             duration = None
         if duration is not None and not math.isfinite(duration):
             duration = None
+        raw_used: Any = window.get("used_percent")
         try:
             used_percent = float(raw_used)
         except (TypeError, ValueError):
             continue
         if not math.isfinite(used_percent):
             continue
-        # Codex may reorder its rate-limit windows. A weekly period is six to
-        # eight days; other known short windows are session-like, while an
-        # absent or unfamiliar duration stays deliberately generic.
         if duration is not None and 6 * 86_400 <= duration <= 8 * 86_400:
             label = "Weekly"
         elif duration is not None and 0 < duration < 6 * 86_400:
@@ -714,7 +338,7 @@ def fetch_account_usage(
         return None
     try:
         if normalized == "openai-codex":
-            return _fetch_codex_account_usage(base_url=base_url, api_key=api_key)
+            return _fetch_codex_account_usage()
         if normalized == "anthropic":
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":

--- a/cli.py
+++ b/cli.py
@@ -4124,6 +4124,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Status bar visibility (toggled via /statusbar)
         self._status_bar_visible = True
+        # Codex account usage is fetched off the prompt_toolkit render path.
+        # Keep the cache scoped to its provider so a fallback cannot display a
+        # stale quota badge for a different account.
+        self._account_limits_lock = threading.Lock()
+        self._account_limits_label: str | None = None
+        self._account_limits_style = "class:status-bar-good"
+        self._account_limits_provider: str | None = None
+        self._account_limits_checked_at = 0.0
+        self._account_limits_refreshing = False
         # When True, the input separator rules and the dynamic status bar are
         # hidden until the next user input. Set by _recover_after_resize() so a
         # SIGWINCH cannot stamp a freshly-drawn status bar on top of one that
@@ -4490,6 +4499,99 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return "class:status-bar-warn"
         return "class:status-bar-dim"
 
+    @staticmethod
+    def _format_account_limits_badge(snapshot: Any) -> str:
+        """Format Codex session and weekly quota remaining for the status bar."""
+        parts: list[str] = []
+        for window in getattr(snapshot, "windows", ()) or ():
+            used = getattr(window, "used_percent", None)
+            if used is None:
+                continue
+            label = str(getattr(window, "label", "") or "").strip().lower()
+            if "week" in label:
+                prefix = "W"
+            elif "session" in label or "current" in label:
+                prefix = "S"
+            else:
+                continue
+            try:
+                remaining = max(0, min(100, round(100 - float(used))))
+            except (TypeError, ValueError):
+                continue
+            parts.append(f"{prefix}{remaining}%")
+        return f"Acct {' '.join(parts[:2])}" if parts else ""
+
+    @staticmethod
+    def _account_limits_badge_style(label: str) -> str:
+        """Mark an exhausted Codex session or weekly quota as critical."""
+        if re.search(r"(?<!\w)[SW]0%(?!\d)", label or ""):
+            return "class:status-bar-critical"
+        return "class:status-bar-good"
+
+    def _maybe_refresh_account_limits_badge(self, agent: Any) -> str:
+        """Return a cached Codex badge and refresh stale data asynchronously.
+
+        This method deliberately only schedules work; ``fetch_account_usage``
+        runs in the daemon worker, never while prompt_toolkit renders.
+        Successful values live for five minutes. Failed or unavailable requests
+        retain a same-provider value but are retried after thirty seconds.
+        """
+        provider = str(getattr(agent, "provider", None) or getattr(self, "provider", None) or "").strip().lower()
+        if not hasattr(self, "_account_limits_lock"):
+            return ""
+        if provider != "openai-codex":
+            # Do not let a model/provider fallback retain a Codex account badge.
+            with self._account_limits_lock:
+                self._account_limits_label = None
+                self._account_limits_style = "class:status-bar-good"
+                self._account_limits_provider = None
+                self._account_limits_checked_at = 0.0
+            return ""
+
+        now = time.monotonic()
+        with self._account_limits_lock:
+            cached = self._account_limits_label or ""
+            stale = self._account_limits_provider != provider or now - self._account_limits_checked_at > 300
+            if not stale or self._account_limits_refreshing:
+                return cached if self._account_limits_provider == provider else ""
+            self._account_limits_refreshing = True
+
+        base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
+        api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
+
+        def _worker() -> None:
+            label = ""
+            try:
+                from agent.account_usage import fetch_account_usage
+
+                snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
+                label = self._format_account_limits_badge(snapshot) if snapshot else ""
+            except Exception:
+                pass
+            finally:
+                with self._account_limits_lock:
+                    if label:
+                        self._account_limits_label = label
+                        self._account_limits_style = self._account_limits_badge_style(label)
+                        self._account_limits_provider = provider
+                        self._account_limits_checked_at = time.monotonic()
+                    elif self._account_limits_provider != provider:
+                        self._account_limits_label = None
+                        self._account_limits_style = "class:status-bar-good"
+                        self._account_limits_provider = provider
+                    if not label:
+                        # Retain a same-provider cache across transient failures,
+                        # but retry unavailable/error responses after 30 seconds.
+                        self._account_limits_checked_at = time.monotonic() - 270
+                    self._account_limits_refreshing = False
+                try:
+                    self._invalidate(min_interval=0.0)
+                except Exception:
+                    pass
+
+        threading.Thread(target=_worker, name="hermes-account-limits", daemon=True).start()
+        return cached if self._account_limits_provider == provider else ""
+
     def _build_context_bar(self, percent_used: Optional[int], width: int = 10) -> str:
         safe_percent = max(0, min(100, percent_used or 0))
         filled = round((safe_percent / 100) * width)
@@ -4588,6 +4690,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             "active_background_tasks": 0,
             "active_background_processes": 0,
             "active_background_subagents": 0,
+            "account_limits": "",
+            "account_limits_style": "class:status-bar-good",
         }
 
         # Count live /background tasks. The dict entry is removed in the
@@ -4630,6 +4734,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         snapshot["session_completion_tokens"] = getattr(agent, "session_completion_tokens", 0) or 0
         snapshot["session_total_tokens"] = getattr(agent, "session_total_tokens", 0) or 0
         snapshot["session_api_calls"] = getattr(agent, "session_api_calls", 0) or 0
+        account_limits = self._maybe_refresh_account_limits_badge(agent)
+        snapshot["account_limits"] = account_limits
+        if account_limits:
+            # Derive the style from this render's label so a freshly depleted
+            # cache entry cannot inherit the preceding green style for one tick.
+            snapshot["account_limits_style"] = self._account_limits_badge_style(account_limits)
 
         compressor = getattr(agent, "context_compressor", None)
         if compressor:
@@ -5078,6 +5188,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 return self._trim_status_bar_text(text, width)
             if width < 76:
                 parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                account_limits = snapshot.get("account_limits")
+                if account_limits:
+                    parts.append(account_limits)
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -5104,6 +5217,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             compressions = snapshot.get("compressions", 0)
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            account_limits = snapshot.get("account_limits")
+            if account_limits:
+                parts.append(account_limits)
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -5167,6 +5283,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]
+                    account_limits = snapshot.get("account_limits")
+                    if account_limits:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append((snapshot.get("account_limits_style", "class:status-bar-good"), account_limits))
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -5210,6 +5330,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
                     ]
+                    account_limits = snapshot.get("account_limits")
+                    if account_limits:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append((snapshot.get("account_limits_style", "class:status-bar-good"), account_limits))
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -5245,7 +5369,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if total_width > width:
                 plain_text = "".join(text for _, text in frags)
                 trimmed = self._trim_status_bar_text(plain_text, width)
-                return [("class:status-bar", trimmed)]
+                overflow_style = "class:status-bar"
+                if snapshot.get("account_limits") and snapshot.get("account_limits_style") == "class:status-bar-critical":
+                    # Preserve a depleted quota warning when styled fragments
+                    # must collapse into one narrow-terminal fragment.
+                    overflow_style = "class:status-bar-critical"
+                return [(overflow_style, trimmed)]
             return frags
         except Exception:
             return [("class:status-bar", f" {self._build_status_bar_text()} ")]

--- a/cli.py
+++ b/cli.py
@@ -53,15 +53,13 @@ os.environ["HERMES_QUIET"] = "1"  # Our own modules
 import yaml
 
 from hermes_cli.fallback_config import get_fallback_chain
-from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
-from hermes_cli.cli_commands_mixin import CLICommandsMixin
 
 # prompt_toolkit for fixed input area TUI
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.styles import Style as PTStyle
 from prompt_toolkit.patch_stdout import patch_stdout
 from prompt_toolkit.application import Application
-from prompt_toolkit.layout import Layout, HSplit, Window, FormattedTextControl, ConditionalContainer, WindowAlign
+from prompt_toolkit.layout import Layout, HSplit, Window, FormattedTextControl, ConditionalContainer
 from prompt_toolkit.layout.processors import Processor, Transformation, PasswordProcessor, ConditionalProcessor
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.layout.dimension import Dimension
@@ -77,15 +75,10 @@ except (ImportError, AttributeError):
     _STEADY_CURSOR = None
 
 try:
-    from hermes_cli.pt_input_extras import (
-        install_ctrl_enter_alias,
-        install_ignored_terminal_sequences,
-        install_shift_enter_alias,
-    )
+    from hermes_cli.pt_input_extras import install_shift_enter_alias, install_ctrl_enter_alias
     install_shift_enter_alias()
     install_ctrl_enter_alias()
-    install_ignored_terminal_sequences()
-    del install_shift_enter_alias, install_ctrl_enter_alias, install_ignored_terminal_sequences
+    del install_shift_enter_alias, install_ctrl_enter_alias
 except Exception:
     pass
 import threading
@@ -176,7 +169,7 @@ from hermes_cli.browser_connect import (
     try_launch_chrome_debug,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
-from utils import base_url_host_matches, fast_safe_load
+from utils import base_url_host_matches, is_truthy_value
 
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
@@ -316,34 +309,11 @@ def _load_prefill_messages(file_path: str) -> List[Dict[str, Any]]:
         return []
 
 
-def _resolve_prefill_messages_file(config: Dict[str, Any]) -> str:
-    """Resolve the prefill file path from env/config.
-
-    ``prefill_messages_file`` at the top level is the canonical config key.
-    ``agent.prefill_messages_file`` remains a legacy fallback for older CLI and
-    godmode-generated configs.
-    """
-    env_path = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "").strip()
-    if env_path:
-        return env_path
-    top_level = str(config.get("prefill_messages_file", "") or "").strip()
-    if top_level:
-        return top_level
-    agent_cfg = config.get("agent", {})
-    if isinstance(agent_cfg, dict):
-        return str(agent_cfg.get("prefill_messages_file", "") or "").strip()
-    return ""
-
-
-def _parse_reasoning_config(effort) -> dict | None:
-    """Parse a reasoning effort level into an OpenRouter reasoning config dict.
-
-    Accepts the raw config value (string or YAML boolean — ``false``/``off``
-    parse as thinking disabled, see parse_reasoning_effort).
-    """
+def _parse_reasoning_config(effort: str) -> dict | None:
+    """Parse a reasoning effort level into an OpenRouter reasoning config dict."""
     from hermes_constants import parse_reasoning_effort
     result = parse_reasoning_effort(effort)
-    if effort and str(effort).strip() and result is None:
+    if effort and effort.strip() and result is None:
         logger.warning("Unknown reasoning_effort '%s', using default (medium)", effort)
     return result
 
@@ -399,7 +369,7 @@ def load_cli_config() -> Dict[str, Any]:
         "terminal": {
             "env_type": "local",
             "cwd": ".",  # "." is resolved to os.getcwd() at runtime
-            "home_mode": "auto",
+            "timeout": 60,
             "lifetime_seconds": 300,
             "docker_image": "nikolaik/python-nodejs:python3.11-nodejs20",
             "docker_forward_env": [],
@@ -413,10 +383,6 @@ def load_cli_config() -> Dict[str, Any]:
             "inactivity_timeout": 120,  # Auto-cleanup inactive browser sessions after 2 min
             "record_sessions": False,  # Auto-record browser sessions as WebM videos
             "engine": "auto",  # Browser engine: auto (Chrome), lightpanda, chrome
-            "camofox": {
-                "rewrite_loopback_urls": False,
-                "loopback_host_alias": "host.docker.internal",
-            },
         },
         "compression": {
             "enabled": True,      # Auto-compress when approaching context limit
@@ -456,17 +422,11 @@ def load_cli_config() -> Dict[str, Any]:
             "resume_max_assistant_chars": 200,
             "resume_max_assistant_lines": 3,
             "resume_skip_tool_only": True,
-            # Live reasoning display default ON — keep in sync with
-            # hermes_cli/config.py DEFAULT_CONFIG (display.show_reasoning).
-            "show_reasoning": True,
-            "reasoning_full": False,
+            "show_reasoning": False,
             "streaming": True,
             "busy_input_mode": "interrupt",
             "persistent_output": True,
             "persistent_output_max_lines": 200,
-            # Print a one-line summary of resolved modal prompts (approval /
-            # clarify) into scrollback so the decision survives the repaint.
-            "persist_prompts": True,
 
             "skin": "default",
         },
@@ -517,7 +477,7 @@ def load_cli_config() -> Dict[str, Any]:
             with open(config_path, "r", encoding="utf-8") as f:
                 from hermes_cli.config import _normalize_root_model_keys
 
-                file_config = _normalize_root_model_keys(fast_safe_load(f) or {})
+                file_config = _normalize_root_model_keys(yaml.safe_load(f) or {})
             
             _file_has_terminal_config = "terminal" in file_config
 
@@ -544,8 +504,6 @@ def load_cli_config() -> Dict[str, Any]:
                 if key == "model":
                     continue  # Already handled above
                 if key in file_config:
-                    if isinstance(defaults[key], dict) and file_config[key] is None:
-                        continue
                     if isinstance(defaults[key], dict) and isinstance(file_config[key], dict):
                         defaults[key].update(file_config[key])
                     else:
@@ -571,18 +529,6 @@ def load_cli_config() -> Dict[str, Any]:
     # Expand ${ENV_VAR} references in config values before bridging to env vars.
     from hermes_cli.config import _expand_env_vars
     defaults = _expand_env_vars(defaults)
-
-    # Managed scope: overlay administrator-pinned values LAST so they win over
-    # the user's config here too. cli.py builds its config independently of
-    # hermes_cli.config._load_config_impl (which has its own managed merge), so
-    # without this the entire interactive CLI/TUI surface — skin, display prefs,
-    # etc. read from CLI_CONFIG — would silently ignore managed scope while
-    # `hermes config`/`doctor`/guards (which use load_config) honor it. The
-    # shared helper mirrors _load_config_impl (env-only expansion, root-model
-    # normalization, leaf-merge) and is fail-open.
-    from hermes_cli import managed_scope
-
-    defaults = managed_scope.apply_managed_overlay(defaults)
 
     # Apply terminal config to environment variables (so terminal_tool picks them up)
     terminal_config = defaults.get("terminal", {})
@@ -611,7 +557,6 @@ def load_cli_config() -> Dict[str, Any]:
         "env_type": "TERMINAL_ENV",
         "cwd": "TERMINAL_CWD",
         "timeout": "TERMINAL_TIMEOUT",
-        "home_mode": "TERMINAL_HOME_MODE",
         "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
         "docker_image": "TERMINAL_DOCKER_IMAGE",
         "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
@@ -630,12 +575,8 @@ def load_cli_config() -> Dict[str, Any]:
         "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
         "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
         "docker_env": "TERMINAL_DOCKER_ENV",
-        "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
-        "docker_network": "TERMINAL_DOCKER_NETWORK",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
-        "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
-        "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
         "sandbox_dir": "TERMINAL_SANDBOX_DIR",
         # Persistent shell (non-local backends)
         "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
@@ -761,14 +702,6 @@ try:
 except Exception:
     pass
 
-# Initialize friendly tool labels from config (default on)
-try:
-    from agent.display import set_friendly_tool_labels
-    _ftl = CLI_CONFIG.get("display", {}).get("friendly_tool_labels", True)
-    set_friendly_tool_labels(bool(_ftl))
-except Exception:
-    pass
-
 # Neuter AsyncHttpxClientWrapper.__del__ before any AsyncOpenAI clients are
 # created.  The SDK's __del__ schedules aclose() on asyncio.get_running_loop()
 # which, during CLI idle time, finds prompt_toolkit's event loop and tries to
@@ -844,10 +777,8 @@ def AIAgent(*args, **kwargs):
 
 
 def get_tool_definitions(*args, **kwargs):
-    from hermes_cli.mcp_startup import wait_for_mcp_discovery
     from model_tools import get_tool_definitions as _get_tool_definitions
 
-    wait_for_mcp_discovery()
     return _get_tool_definitions(*args, **kwargs)
 
 
@@ -926,24 +857,9 @@ def _cleanup_all_browsers(*args, **kwargs):
 
 # Guard to prevent cleanup from running multiple times on exit
 _cleanup_done = False
-# One-shot CLI finalization runs before process cleanup so plugins can observe
-# the session boundary while the agent is still attached. If a signal lands in
-# that narrow window, atexit cleanup must not emit that session finalize again.
-_single_query_finalize_attempted_session_ids: set[str | None] = set()
 # Weak reference to the active AIAgent for memory provider shutdown at exit
 _active_agent_ref = None
 _deferred_agent_startup_done = False
-# Set True once the TUI's prompt_toolkit app starts (which enables focus
-# reporting + mouse tracking). Gates the on-exit terminal reset so non-TUI
-# one-shot CLI runs — which also register _run_cleanup via atexit — don't emit
-# escape codes for modes they never enabled (#36823).
-_tui_input_modes_active = False
-
-
-def _mark_tui_input_modes_active() -> None:
-    """Record that the TUI app started, so _run_cleanup resets input modes."""
-    global _tui_input_modes_active
-    _tui_input_modes_active = True
 
 
 def _prepare_deferred_agent_startup() -> None:
@@ -970,12 +886,9 @@ def _prepare_deferred_agent_startup() -> None:
             exc_info=True,
         )
     try:
-        from hermes_cli.mcp_startup import start_background_mcp_discovery
+        from tools.mcp_tool import discover_mcp_tools
 
-        start_background_mcp_discovery(
-            logger=logger,
-            thread_name="termux-cli-mcp-discovery",
-        )
+        discover_mcp_tools()
     except Exception:
         logger.debug(
             "MCP tool discovery failed at deferred CLI startup",
@@ -992,96 +905,15 @@ def _prepare_deferred_agent_startup() -> None:
             exc_info=True,
         )
 
-def _arm_exit_watchdog(timeout_s: float | None = None) -> None:
-    """Guarantee the process actually exits once shutdown has begun.
-
-    Two hang classes have kept "dead" CLI processes alive for minutes:
-
-      1. A cleanup step wedged on network I/O (memory provider
-         ``on_session_end``, MCP teardown, remote terminal cleanup).
-      2. Interpreter teardown blocked joining non-daemon threads —
-         stdlib ``ThreadPoolExecutor`` workers are joined unconditionally
-         by ``concurrent.futures``' atexit hook even after
-         ``shutdown(wait=False)``, so one tool thread wedged on a socket
-         held the process open forever (#27563 class).
-
-    The shared daemon pool (``tools.daemon_pool``) removes the main cause
-    of (2); this watchdog is the backstop for both. It arms a daemon
-    timer when ``_run_cleanup`` starts; if the process is still alive
-    after ``timeout_s`` it flushes logging/stdio and calls ``os._exit(0)``.
-    Daemon threads keep running through ``Py_FinalizeEx``'s thread joins,
-    so the timer fires even when the main thread is stuck in teardown.
-
-    Tune with ``HERMES_EXIT_WATCHDOG_S`` (seconds); ``0`` disables.
-    """
-    if timeout_s is None:
-        try:
-            timeout_s = float(os.getenv("HERMES_EXIT_WATCHDOG_S", "30"))
-        except (TypeError, ValueError):
-            timeout_s = 30.0
-    if timeout_s <= 0:
-        return
-    # Never arm under pytest: tests invoke _run_cleanup() directly and a
-    # 30s-delayed os._exit(0) would silently kill the test worker.
-    if os.environ.get("PYTEST_CURRENT_TEST"):
-        return
-
-    def _watchdog():
-        time.sleep(timeout_s)
-        # Still alive — cleanup or interpreter teardown is wedged.
-        try:
-            logger.warning(
-                "Exit watchdog fired after %.0fs — forcing process exit "
-                "(a cleanup step or non-daemon thread is wedged).",
-                timeout_s,
-            )
-        except Exception:
-            pass
-        try:
-            import logging as _lg
-            _lg.shutdown()
-        except Exception:
-            pass
-        for _stream in (sys.stdout, sys.stderr):
-            try:
-                _stream.flush()
-            except Exception:
-                pass
-        os._exit(0)
-
-    try:
-        threading.Thread(
-            target=_watchdog, daemon=True, name="exit-watchdog"
-        ).start()
-    except Exception:
-        pass  # best-effort — never block shutdown on watchdog setup
-
-
-def _run_cleanup(*, notify_session_finalize: bool = True):
+def _run_cleanup():
     """Run resource cleanup exactly once."""
     global _cleanup_done
     if _cleanup_done:
         return
     _cleanup_done = True
 
-    # Bound total shutdown time: if cleanup (or the interpreter's
-    # thread-join teardown after it) wedges, force-exit instead of
-    # leaving a zombie CLI holding the terminal for minutes.
-    _arm_exit_watchdog()
-
-    # Reset terminal input modes first, before the slower resource teardown
-    # below (MCP / browser / memory shutdown can take seconds). On Ctrl+C the
-    # user's terminal becomes usable immediately, and a later step raising
-    # can't skip the reset (#36823). No-op unless the TUI actually ran.
-    _reset_terminal_input_modes_on_exit()
-
     try:
         _cleanup_all_terminals()
-    except Exception:
-        pass
-    try:
-        from tools.async_delegation import interrupt_all as _interrupt_async_delegations
-        _interrupt_async_delegations(reason="CLI shutdown")
     except Exception:
         pass
     try:
@@ -1091,7 +923,7 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
     try:
         from tools.mcp_tool import shutdown_mcp_servers
         shutdown_mcp_servers()
-    except BaseException:
+    except Exception:
         pass
     # Close cached auxiliary LLM clients (sync + async) so that
     # AsyncHttpxClientWrapper.__del__ doesn't fire on a closed event loop
@@ -1103,29 +935,13 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
         pass
     # Shut down memory provider (on_session_end + shutdown_all) at actual
     # session boundary — NOT per-turn inside run_conversation().
-    if notify_session_finalize:
-        cleanup_session_id = _active_agent_ref.session_id if _active_agent_ref else None
-        if _should_emit_cleanup_session_finalize(cleanup_session_id):
-            _notify_session_finalize(
-                session_id=cleanup_session_id,
-                platform="cli",
-                reason="shutdown",
-            )
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _invoke_hook("on_session_finalize", session_id=_active_agent_ref.session_id if _active_agent_ref else None, platform="cli")
+    except Exception:
+        pass
     try:
         if _active_agent_ref and hasattr(_active_agent_ref, 'shutdown_memory_provider'):
-            # A /new shortly before exit leaves its end→switch boundary task
-            # (old-session extraction, LLM-bound) queued on the memory
-            # manager's serialized worker. shutdown_all()'s drain only waits
-            # ~5s and cancels queued tasks, so give pending work a bounded
-            # head start via the manager's own barrier — otherwise a
-            # "/new then quit" silently drops the old session's extraction.
-            # The 30s exit watchdog remains the hard backstop.
-            _mm = getattr(_active_agent_ref, '_memory_manager', None)
-            if _mm is not None and hasattr(_mm, 'flush_pending'):
-                try:
-                    _mm.flush_pending(timeout=10)
-                except Exception:
-                    pass
             # Forward the agent's own transcript so memory providers'
             # ``on_session_end`` hooks see the real conversation instead of
             # an empty list (#15165). ``_session_messages`` is set on
@@ -1134,149 +950,9 @@ def _run_cleanup(*, notify_session_finalize: bool = True):
             # partially-initialised agents where the attribute is missing.
             _session_msgs = getattr(_active_agent_ref, '_session_messages', None)
             if isinstance(_session_msgs, list):
-                logger.info(
-                    "CLI cleanup calling memory shutdown for session %s with %d message(s)",
-                    getattr(_active_agent_ref, "session_id", None) or "<unknown>",
-                    len(_session_msgs),
-                )
                 _active_agent_ref.shutdown_memory_provider(_session_msgs)
             else:
-                logger.info(
-                    "CLI cleanup calling memory shutdown for session %s without session message list",
-                    getattr(_active_agent_ref, "session_id", None) or "<unknown>",
-                )
                 _active_agent_ref.shutdown_memory_provider()
-    except Exception as e:
-        logger.warning("CLI cleanup memory shutdown failed: %s", e, exc_info=True)
-
-
-def _should_emit_cleanup_session_finalize(session_id: str | None) -> bool:
-    if not _single_query_finalize_attempted_session_ids:
-        return True
-    if session_id is None:
-        return False
-    return session_id not in _single_query_finalize_attempted_session_ids
-
-
-def _notify_session_finalize(
-    *,
-    session_id: str | None,
-    platform: str = "cli",
-    reason: str = "shutdown",
-) -> None:
-    try:
-        from hermes_cli.plugins import invoke_hook as _invoke_hook
-        _invoke_hook(
-            "on_session_finalize",
-            session_id=session_id,
-            platform=platform,
-            reason=reason,
-        )
-    except Exception:
-        pass
-
-
-def _emit_interrupted_session_end(cli, *, reason: str = "keyboard_interrupt") -> None:
-    """Best-effort on_session_end hook for interrupted non-interactive runs."""
-    agent = getattr(cli, "agent", None)
-    if agent is None:
-        return
-
-    try:
-        agent.interrupt(reason.replace("_", " "))
-    except Exception:
-        pass
-
-    session_id = getattr(agent, "session_id", None) or getattr(cli, "session_id", None)
-    if session_id:
-        try:
-            cli.session_id = session_id
-        except Exception:
-            pass
-
-    try:
-        from hermes_cli.plugins import invoke_hook as _invoke_hook
-        _invoke_hook(
-            "on_session_end",
-            session_id=session_id,
-            task_id=getattr(agent, "_current_task_id", "") or "",
-            turn_id=getattr(agent, "_current_turn_id", "") or "",
-            api_request_id=getattr(agent, "_current_api_request_id", "") or "",
-            completed=False,
-            interrupted=True,
-            model=getattr(agent, "model", None),
-            platform=getattr(agent, "platform", None) or "cli",
-            reason=reason,
-        )
-    except Exception:
-        pass
-
-
-def _notify_single_query_session_finalize(cli, *, reason: str = "shutdown") -> None:
-    agent = getattr(cli, "agent", None)
-    session_id = getattr(agent, "session_id", None) or getattr(cli, "session_id", None)
-    if session_id in _single_query_finalize_attempted_session_ids:
-        return
-
-    try:
-        _notify_session_finalize(
-            session_id=session_id,
-            platform=getattr(agent, "platform", None) or "cli",
-            reason=reason,
-        )
-    finally:
-        _single_query_finalize_attempted_session_ids.add(session_id)
-
-
-def _finalize_single_query(cli) -> None:
-    """Close one-shot CLI resources before releasing the active session lease."""
-    try:
-        _notify_single_query_session_finalize(cli)
-        _run_cleanup(notify_session_finalize=False)
-    finally:
-        cli._release_active_session()
-
-
-def _reset_terminal_input_modes_on_exit() -> None:
-    """Best-effort: disable focus reporting + mouse tracking on TUI exit so they
-    don't leak into the next shell session sharing the tab.
-
-    prompt_toolkit restores these on a clean teardown, but Ctrl+C, SIGTERM /
-    SIGHUP and crashes can bypass its unwind, leaving the modes enabled. The
-    terminal then emits raw ``ESC[I`` / ``ESC[O`` focus events and fragmented
-    SGR mouse reports as visible text in whatever runs next in the same tab
-    (#36823). Called from ``_run_cleanup`` (atexit-registered + invoked on the
-    normal / EOF / interrupt exit paths) this covers normal quit, Ctrl+C and
-    SIGTERM/SIGHUP. ``kill -9`` is uncatchable, and the kanban worker's
-    ``os._exit(0)`` path bypasses ``atexit``; neither runs this — but both are
-    non-TTY / non-TUI, so there is nothing to reset there.
-
-    Gated on ``_tui_input_modes_active`` so one-shot non-TUI CLI runs (which
-    share ``_run_cleanup`` via ``atexit``) never emit these codes. Writes to the
-    controlling terminal directly: by exit, prompt_toolkit's own output is torn
-    down, so ``sys.stdout`` is the real fd; falls back to ``/dev/tty`` when
-    stdout is redirected away from the terminal.
-    """
-    global _tui_input_modes_active
-    if not _tui_input_modes_active:
-        return
-    # About to disable the modes — clear the flag so a re-armed _run_cleanup (or
-    # a long-lived process that reuses it) doesn't re-emit them.
-    _tui_input_modes_active = False
-    # Prefer stdout when it's the terminal; otherwise the TUI may have driven
-    # /dev/tty while stdout was redirected — reset there instead of nowhere.
-    try:
-        stream = sys.stdout
-        if stream is not None and stream.isatty():
-            stream.write(_TERMINAL_INPUT_MODE_RESET_SEQ)
-            stream.flush()
-            return
-    except Exception:
-        pass
-    try:
-        with open("/dev/tty", "w", encoding="ascii") as tty:
-            tty.write(_TERMINAL_INPUT_MODE_RESET_SEQ)
-            tty.flush()
     except Exception:
         pass
 
@@ -1348,91 +1024,11 @@ def _path_is_within_root(path: Path, root: Path) -> bool:
         return False
 
 
-def _resolve_worktree_base(repo_root: str) -> tuple:
-    """Resolve the freshest base ref to branch a new worktree from.
-
-    The standalone clone's ``HEAD`` can lag the remote by hundreds of commits
-    (the ``~/.hermes/hermes-agent`` clone is updated only by ``hermes update``,
-    not on every session). Branching a worktree from that stale ``HEAD`` roots
-    every new branch on an old base — so the PR diff GitHub computes against
-    current ``main`` balloons with unrelated changes, and the agent has to
-    discover the staleness via the pre-push gate and rebase. Branching from the
-    freshly-fetched remote tip instead means the worktree starts current.
-
-    Strategy (each step falls back to the next on failure):
-      1. If the current branch tracks an upstream, fetch and use that upstream
-         ref — so a deliberate feature-branch worktree tracks its own remote,
-         not the default branch.
-      2. Else fetch the remote's default branch (``origin/HEAD`` → e.g.
-         ``origin/main``) and use it.
-      3. Else fall back to ``HEAD`` (offline, no remote, or detached) — the
-         old behavior, never worse than before.
-
-    Returns ``(base_ref, label)`` where *base_ref* is a git revision suitable
-    for ``git worktree add ... <base_ref>`` and *label* is a short
-    human-readable description for the session banner.
-    """
-    import subprocess
-
-    def _git(args, timeout=20):
-        return subprocess.run(
-            ["git", *args],
-            capture_output=True, text=True, timeout=timeout, cwd=repo_root,
-        )
-
-    # 1. Current branch's upstream, if it tracks one.
-    try:
-        up = _git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"])
-        if up.returncode == 0:
-            upstream = up.stdout.strip()  # e.g. "origin/main"
-            if upstream and "/" in upstream:
-                remote = upstream.split("/", 1)[0]
-                # Fetch just that branch; fail-soft if offline.
-                _git(["fetch", remote, upstream.split("/", 1)[1]], timeout=30)
-                return upstream, f"{upstream} (fetched)"
-    except Exception as e:
-        logger.debug("worktree base: upstream resolution failed: %s", e)
-
-    # 2. Remote default branch (origin/HEAD).
-    try:
-        # Resolve the remote's default branch symref.
-        head_ref = _git(["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"])
-        default_ref = ""
-        if head_ref.returncode == 0:
-            default_ref = head_ref.stdout.strip().replace("refs/remotes/", "", 1)
-        if not default_ref:
-            # origin/HEAD not set locally; ask the remote.
-            show = _git(["remote", "show", "origin"], timeout=30)
-            for line in show.stdout.splitlines():
-                line = line.strip()
-                if line.startswith("HEAD branch:"):
-                    _branch = line.split(":", 1)[1].strip()
-                    # A remote with no default branch reports "(unknown)";
-                    # don't construct a bogus "origin/(unknown)" ref from it.
-                    if _branch and _branch != "(unknown)":
-                        default_ref = "origin/" + _branch
-                    break
-        if default_ref and "/" in default_ref:
-            remote, branch = default_ref.split("/", 1)
-            _git(["fetch", remote, branch], timeout=30)
-            return default_ref, f"{default_ref} (fetched)"
-    except Exception as e:
-        logger.debug("worktree base: default-branch resolution failed: %s", e)
-
-    # 3. Fall back to local HEAD (offline / no remote / detached).
-    return "HEAD", "HEAD (local — could not reach remote)"
-
-
-def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[Dict[str, str]]:
+def _setup_worktree(repo_root: str = None) -> Optional[Dict[str, str]]:
     """Create an isolated git worktree for this CLI session.
 
     Returns a dict with worktree metadata on success, None on failure.
     The dict contains: path, branch, repo_root.
-
-    When *sync_base* is True (default), the worktree branches from the
-    freshly-fetched remote tip rather than the (possibly stale) local ``HEAD``
-    — see ``_resolve_worktree_base``. Set ``worktree_sync: false`` in config to
-    branch from local ``HEAD`` (the pre-#10760-followup behavior).
     """
     import subprocess
 
@@ -1464,37 +1060,15 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[D
     except Exception as e:
         logger.debug("Could not update .gitignore: %s", e)
 
-    # Resolve the base ref. By default branch from the freshly-fetched remote
-    # tip so the worktree starts current with the project, not from the
-    # (possibly stale) local HEAD of the standalone clone (#10760 follow-up).
-    if sync_base:
-        base_ref, base_label = _resolve_worktree_base(repo_root)
-    else:
-        base_ref, base_label = "HEAD", "HEAD (local — worktree_sync disabled)"
-
     # Create the worktree
     try:
         result = subprocess.run(
-            ["git", "worktree", "add", str(wt_path), "-b", branch_name, base_ref],
+            ["git", "worktree", "add", str(wt_path), "-b", branch_name, "HEAD"],
             capture_output=True, text=True, timeout=30, cwd=repo_root,
         )
         if result.returncode != 0:
-            # If branching from the resolved remote ref failed for any reason
-            # (e.g. a partial fetch left the ref unusable), retry from local
-            # HEAD so worktree creation never hard-fails on a sync hiccup.
-            if base_ref != "HEAD":
-                logger.warning(
-                    "worktree add from %s failed (%s); retrying from local HEAD",
-                    base_ref, result.stderr.strip(),
-                )
-                base_ref, base_label = "HEAD", "HEAD (fallback — remote base failed)"
-                result = subprocess.run(
-                    ["git", "worktree", "add", str(wt_path), "-b", branch_name, base_ref],
-                    capture_output=True, text=True, timeout=30, cwd=repo_root,
-                )
-            if result.returncode != 0:
-                print(f"\033[31m✗ Failed to create worktree: {result.stderr.strip()}\033[0m")
-                return None
+            print(f"\033[31m✗ Failed to create worktree: {result.stderr.strip()}\033[0m")
+            return None
     except Exception as e:
         print(f"\033[31m✗ Failed to create worktree: {e}\033[0m")
         return None
@@ -1566,27 +1140,14 @@ def _setup_worktree(repo_root: str = None, sync_base: bool = True) -> Optional[D
         except Exception as e:
             logger.debug("Error copying .worktreeinclude entries: %s", e)
 
-    # Lock the worktree so other processes (and `git worktree remove`) can see
-    # it is actively in use.  Fail-soft: a lock failure never blocks the session.
-    try:
-        subprocess.run(
-            ["git", "worktree", "lock", "--reason", f"hermes pid={os.getpid()}", str(wt_path)],
-            capture_output=True, text=True, timeout=10, cwd=repo_root,
-        )
-        logger.debug("Worktree locked: %s (pid=%s)", wt_path, os.getpid())
-    except Exception as e:
-        logger.debug("git worktree lock failed (non-fatal): %s", e)
-
     info = {
         "path": str(wt_path),
         "branch": branch_name,
         "repo_root": repo_root,
-        "base": base_ref,
     }
 
     print(f"\033[32m✓ Worktree created:\033[0m {wt_path}")
     print(f"  Branch: {branch_name}")
-    print(f"  Base:   {base_label}")
 
     return info
 
@@ -1622,89 +1183,6 @@ def _worktree_has_unpushed_commits(worktree_path: str, timeout: int = 10) -> boo
         return True
 
 
-def _worktree_is_dirty(worktree_path: str, timeout: int = 10) -> bool:
-    """Return whether a worktree has uncommitted changes (staged, unstaged, or
-    untracked).
-
-    Fails SAFE: on any error returns True so callers do not delete a worktree
-    whose state they cannot determine.
-    """
-    import subprocess
-
-    try:
-        result = subprocess.run(
-            ["git", "status", "--porcelain"],
-            capture_output=True, text=True, timeout=timeout, cwd=worktree_path,
-        )
-        if result.returncode != 0:
-            return True
-        return bool(result.stdout.strip())
-    except Exception:
-        return True
-
-
-def _worktree_lock_is_live(repo_root: str, worktree_path: str, timeout: int = 10):
-    """Classify a worktree's git lock as live, dead, or absent.
-
-    ``hermes -w`` locks each worktree with reason ``hermes pid=<pid>`` so a
-    concurrent hermes process' startup prune leaves an in-use worktree alone.
-    But a *crashed* session leaves the lock behind forever, and
-    ``git worktree remove --force`` (single ``-f``) refuses to remove a locked
-    worktree — so dead-locked worktrees accumulate indefinitely. This lets the
-    pruner tell the two apart:
-
-    - ``"live"``  — locked and the owning pid is still running (skip it).
-    - ``"dead"``  — locked but the owning pid is gone, or the reason isn't a
-                    parseable hermes lock (safe to unlock + reap).
-    - ``None``    — not locked at all.
-
-    Fails SAFE toward ``"live"``: if git can't be queried at all we cannot
-    prove the worktree is safe to touch, so we report it as live.
-    """
-    import re
-    import subprocess
-
-    try:
-        result = subprocess.run(
-            ["git", "worktree", "list", "--porcelain"],
-            capture_output=True, text=True, timeout=timeout, cwd=repo_root,
-        )
-        if result.returncode != 0:
-            return "live"
-    except Exception:
-        return "live"
-
-    target = Path(worktree_path).resolve()
-    current: Optional[Path] = None
-    for line in result.stdout.splitlines():
-        if line.startswith("worktree "):
-            try:
-                current = Path(line[len("worktree "):].strip()).resolve()
-            except Exception:
-                current = None
-        elif line == "locked" or line.startswith("locked "):
-            if current != target:
-                continue
-            reason = line[len("locked"):].strip()
-            m = re.search(r"hermes pid=(\d+)", reason)
-            if not m:
-                # Locked by something we don't recognize as a hermes session
-                # (or lock reason unavailable). Treat as dead — a foreign lock
-                # on a hermes -w worktree is almost certainly a leftover, and
-                # the age/dirty/unpushed gates already ran before we got here.
-                return "dead"
-            pid = int(m.group(1))
-            if pid == os.getpid():
-                return "live"
-            try:
-                from gateway.status import _pid_exists
-                return "live" if _pid_exists(pid) else "dead"
-            except Exception:
-                # Can't determine liveness — fail safe toward keeping it.
-                return "live"
-    return None
-
-
 def _cleanup_worktree(info: Dict[str, str] = None) -> None:
     """Remove a worktree and its branch on exit.
 
@@ -1737,16 +1215,6 @@ def _cleanup_worktree(info: Dict[str, str] = None) -> None:
 
     # Remove worktree (even if working tree is dirty — uncommitted
     # changes without unpushed commits are just artifacts)
-    # Unlock first so `git worktree remove` isn't blocked by the lock we
-    # placed at creation time.  Fail-soft — never block cleanup.
-    try:
-        subprocess.run(
-            ["git", "worktree", "unlock", wt_path],
-            capture_output=True, text=True, timeout=10, cwd=repo_root,
-        )
-    except Exception as e:
-        logger.debug("git worktree unlock failed (non-fatal): %s", e)
-
     try:
         subprocess.run(
             ["git", "worktree", "remove", wt_path, "--force"],
@@ -1849,22 +1317,10 @@ def _run_checkpoint_auto_maintenance() -> None:
 def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
     """Remove stale worktrees and orphaned branches on startup.
 
-    Age-based tiers (aggressive cleanup keeps ``.worktrees/`` from growing
-    unbounded):
+    Age-based tiers:
     - Under max_age_hours (24h): skip — session may still be active.
     - 24h–72h: remove if no unpushed commits.
     - Over 72h: force remove regardless (nothing should sit this long).
-
-    Lock handling (orthogonal to age): ``hermes -w`` locks each worktree with
-    reason ``hermes pid=<pid>`` so a concurrent hermes process leaves an in-use
-    worktree alone. A *live*-locked worktree is skipped at any age; a
-    *dead*-locked one (owning pid gone — a crashed session) is unlocked first
-    so ``git worktree remove --force`` can actually reap it, otherwise those
-    leftovers accumulate forever (``remove --force`` refuses a locked tree).
-
-    Branch deletion is gated on ``git worktree remove`` succeeding, so a failed
-    removal never orphans the branch (which would drop easy reachability of any
-    commits still in the worktree).
 
     Also prunes orphaned ``hermes/*`` and ``pr-*`` local branches that
     have no corresponding worktree.
@@ -1893,37 +1349,12 @@ def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
         except Exception:
             continue
 
-        force = mtime <= hard_cutoff  # Over 72h — reap aggressively
+        force = mtime <= hard_cutoff  # Over 72h — force remove
 
-        # Never delete real work, regardless of age. Unpushed commits and
-        # uncommitted changes may be a crashed session's in-flight work; the
-        # >72h tier reaps only abandoned *clean, fully-pushed* worktrees (the
-        # scratch trees that actually cause .worktrees/ bloat).
-        if _worktree_has_unpushed_commits(str(entry), timeout=5):
-            continue  # Has unpushed commits or can't check — skip
         if not force:
-            # 24h–72h tier is conservative: unpushed check above is enough.
-            pass
-        elif _worktree_is_dirty(str(entry), timeout=5):
-            continue  # >72h but dirty — preserve uncommitted work
-
-        # Respect git-native session locks. A lock owned by a still-running
-        # hermes process means the worktree is actively in use — never touch
-        # it. A lock whose owning pid is gone is a crashed session's leftover:
-        # unlock it so `git worktree remove --force` (single -f) can reap it,
-        # otherwise dead-locked worktrees pile up indefinitely.
-        lock_state = _worktree_lock_is_live(repo_root, str(entry), timeout=5)
-        if lock_state == "live":
-            logger.debug("Skipping live-locked worktree: %s", entry.name)
-            continue
-        if lock_state == "dead":
-            try:
-                subprocess.run(
-                    ["git", "worktree", "unlock", str(entry)],
-                    capture_output=True, text=True, timeout=10, cwd=repo_root,
-                )
-            except Exception as e:
-                logger.debug("Failed to unlock dead worktree %s: %s", entry.name, e)
+            # 24h–72h tier: only remove if no unpushed commits
+            if _worktree_has_unpushed_commits(str(entry), timeout=5):
+                continue  # Has unpushed commits or can't check — skip
 
         # Safe to remove
         try:
@@ -1933,18 +1364,10 @@ def _prune_stale_worktrees(repo_root: str, max_age_hours: int = 24) -> None:
             )
             branch = branch_result.stdout.strip()
 
-            remove_result = subprocess.run(
+            subprocess.run(
                 ["git", "worktree", "remove", str(entry), "--force"],
                 capture_output=True, text=True, timeout=15, cwd=repo_root,
             )
-            if remove_result.returncode != 0:
-                # Removal failed — keep the branch so any commits stay
-                # reachable rather than orphaning it.
-                logger.debug(
-                    "Failed to remove worktree %s: %s",
-                    entry.name, remove_result.stderr.strip(),
-                )
-                continue
             if branch:
                 subprocess.run(
                     ["git", "branch", "-D", branch],
@@ -2104,16 +1527,8 @@ def _query_osc11_background() -> str | None:
     Most modern terminals reply with \x1b]11;rgb:RRRR/GGGG/BBBB\x1b\\
     within a few ms.  We wait up to 100ms total before giving up.
     Returns "#RRGGBB" or None on timeout / non-tty.
-
-    Skipped over SSH: the round-trip routinely exceeds our 100ms budget, so a
-    late reply lands after prompt_toolkit has grabbed the tty — its payload
-    leaks in as typed text and the BEL terminator reads as Ctrl+G (open
-    editor), trapping the user in a stray editor. Remote sessions fall back to
-    COLORFGBG / env hints / the dark default instead.
     """
     if not sys.stdin.isatty() or not sys.stdout.isatty():
-        return None
-    if any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")):
         return None
     try:
         import termios
@@ -2162,11 +1577,8 @@ def _query_osc11_background() -> str | None:
         r, g, b = norm(m.group(1)), norm(m.group(2)), norm(m.group(3))
         return f"#{r:02X}{g:02X}{b:02X}"
     finally:
-        # TCSAFLUSH discards any unread input as it restores the original
-        # attributes — scrubs a slow/partial OSC 11 reply out of the tty
-        # buffer before prompt_toolkit can read it as keystrokes.
         try:
-            termios.tcsetattr(fd, termios.TCSAFLUSH, old)
+            termios.tcsetattr(fd, termios.TCSANOW, old)
         except Exception:
             pass
 
@@ -2359,24 +1771,6 @@ _ACCENT = _SkinAwareAnsi("response_border", "#FFD700", bold=True)
 # Terminal.app modes.  Hardcoded skin colors like #B8860B
 # (dark goldenrod) become invisible against light cream backgrounds.
 _DIM = "\x1b[2;3m"
-
-
-def _b(s: str) -> str:
-    """Bold if stdout is a real TTY; plain text otherwise (slash-worker safe)."""
-    import sys as _sys
-    try:
-        return f"\x1b[1m{s}\x1b[0m" if _sys.stdout.isatty() else str(s)
-    except Exception:
-        return str(s)
-
-
-def _d(s: str) -> str:
-    """Dim-italic if stdout is a real TTY; plain text otherwise."""
-    import sys as _sys
-    try:
-        return f"\x1b[2;3m{s}\x1b[0m" if _sys.stdout.isatty() else str(s)
-    except Exception:
-        return str(s)
 
 
 def _accent_hex() -> str:
@@ -2694,61 +2088,6 @@ def _cprint(text: str):
             _pt_print(_PT_ANSI(text))
         except Exception:
             pass
-
-
-def _prepend_note_to_message(message, note: str):
-    """Prepend a one-shot system-style note to a user message.
-
-    ``message`` is normally a plain string, but when the user attaches an image
-    to a vision-capable model it becomes a list of OpenAI-style content parts
-    (text + ``image_url`` blocks). Naively doing ``note + "\\n\\n" + message``
-    then raises ``TypeError: can only concatenate str (not "list") to str`` —
-    e.g. running ``/model ...`` (which queues a model-switch note) and then
-    sending a pasted image in the same turn.
-
-    Returns the message with ``note`` prepended:
-      * ``str``  → ``f"{note}\\n\\n{message}"`` (just ``note`` when empty)
-      * ``list`` → note folded into the first text part, or inserted as a new
-        leading ``{"type": "text"}`` part when there is no text part.
-    Unknown shapes are returned unchanged (fail-open).
-    """
-    note = str(note or "").strip()
-    if not note:
-        return message
-    if isinstance(message, str):
-        return f"{note}\n\n{message}" if message else note
-    if isinstance(message, list):
-        parts = list(message)
-        for i, part in enumerate(parts):
-            if isinstance(part, dict) and part.get("type") == "text":
-                merged = dict(part)
-                text = merged.get("text", "")
-                merged["text"] = f"{note}\n\n{text}" if text else note
-                parts[i] = merged
-                return parts
-        # No text part (image-only) — insert the note as a leading text block.
-        return [{"type": "text", "text": note}, *parts]
-    return message
-
-
-def _cli_visible_print(text: str = "") -> None:
-    """Print normally unless prompt_toolkit owns the live terminal.
-
-    Bare ``print()`` output is swallowed by ``patch_stdout`` while an
-    interactive ``Application`` is running, so ``/sessions`` and ``/history``
-    would render nothing. Route through ``_cprint`` (prompt_toolkit-native)
-    in that case, and fall back to ``print`` otherwise.
-    """
-    try:
-        from prompt_toolkit.application import get_app_or_none
-        app = get_app_or_none()
-    except Exception:
-        app = None
-
-    if app is not None and getattr(app, "_is_running", False):
-        _cprint(text)
-    else:
-        print(text)
 
 
 # ---------------------------------------------------------------------------
@@ -3137,9 +2476,8 @@ _TERMINAL_INPUT_MODE_RESET_SEQ = (
 def _preserve_ctrl_enter_newline() -> bool:
     """Detect environments where Ctrl+Enter must produce a newline, not submit.
 
-    Windows Terminal, WSL, SSH sessions, Ghostty, and some modern terminals
-    deliver Ctrl+Enter/Ctrl+J as bare LF (c-j). On those terminals c-j must
-    NOT be bound to submit;
+    Native Windows, WSL, SSH sessions, and Windows Terminal all send Ctrl+Enter
+    as bare LF (c-j). On those terminals c-j must NOT be bound to submit;
     binding it to submit makes Ctrl+Enter (intended as 'newline like Alt+Enter')
     submit instead. Local POSIX TTYs that deliver Enter as LF (docker exec,
     some thin PTYs without SSH) still need c-j bound to submit, so we keep
@@ -3152,12 +2490,6 @@ def _preserve_ctrl_enter_newline() -> bool:
     if any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")):
         return True
     if os.environ.get("WT_SESSION"):
-        return True
-    if os.environ.get("GHOSTTY_RESOURCES_DIR") or os.environ.get("GHOSTTY_BIN_DIR"):
-        return True
-    if os.environ.get("TERM", "").lower() == "xterm-ghostty":
-        return True
-    if os.environ.get("TERM_PROGRAM", "").lower() == "ghostty":
         return True
     if "microsoft" in os.environ.get("WSL_DISTRO_NAME", "").lower():
         return True
@@ -3179,7 +2511,7 @@ def _bind_prompt_submit_keys(kb, handler) -> None:
     some thin PTYs (docker exec, certain SSH flavors) deliver Enter as LF
     instead of CR — without this, Enter appears dead on those terminals.
 
-    Exception: on Windows, WSL, SSH sessions, Windows Terminal, and Ghostty,
+    Exception: on Windows, WSL, SSH sessions, and Windows Terminal,
     c-j is the wire encoding of Ctrl+Enter (a distinct keystroke from
     plain Enter / c-m). We leave c-j unbound there so the c-j newline
     handler registered separately can fire — giving the user an
@@ -3197,77 +2529,6 @@ def _disable_prompt_toolkit_cpr_warning(app) -> None:
         app.renderer.cpr_not_supported_callback = None
     except Exception:
         pass
-
-
-def _terminal_may_leak_cpr() -> bool:
-    """Detect terminals where CPR (ESC[6n) replies are likely to leak.
-
-    The CPR leak in #13870 is environment-specific: it shows up over SSH +
-    cloudflared/mux tunnels and slow PTYs, where the terminal's
-    ``ESC[<row>;<col>R`` reply round-trips slowly enough to race past the input
-    parser and land in the display as raw ``20;1R`` text (and the pending-CPR
-    future can stall the renderer, freezing the prompt). On a local terminal the
-    reply returns instantly and cleanly, so CPR works fine and there is nothing
-    to fix — we leave prompt_toolkit's default behavior untouched there.
-
-    We only suppress CPR on a remote/tunneled link (SSH env vars) or when the
-    user has explicitly opted out via prompt_toolkit's own ``PROMPT_TOOLKIT_NO_CPR``
-    escape hatch. Keeping this narrow (not the broader WSL/Ghostty/Windows set
-    that ``_preserve_ctrl_enter_newline`` keys on) means the only behavior change
-    lands exactly where the bug reproduces.
-    """
-    if os.environ.get("PROMPT_TOOLKIT_NO_CPR", "") == "1":
-        return True
-    if any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")):
-        return True
-    return False
-
-
-def _build_cpr_disabled_output(stdout):
-    """Build a Vt100_Output that never sends Cursor Position Report queries.
-
-    prompt_toolkit's renderer sends ``ESC[6n`` (Device Status Report) to learn
-    the cursor row before painting in non-fullscreen mode; the terminal replies
-    ``ESC[<row>;<col>R``. Over SSH + cloudflared/mux tunnels and some slow PTYs
-    these replies race past the input parser and land in the display as raw text
-    like ``20;1R21;1R``, and the pending-CPR future can stall the renderer so the
-    prompt appears frozen after the agent's final answer (see #13870).
-
-    Constructing the output with ``enable_cpr=False`` makes the renderer mark CPR
-    ``NOT_SUPPORTED`` up front, so ``ESC[6n`` is never sent and no CPR response
-    can leak. This is the root-cause counterpart to the input-side scrubbing in
-    ``_strip_leaked_terminal_responses`` — that cleans leaks after the fact; this
-    stops them at the source. The UI is otherwise identical (prompt_toolkit uses
-    its heuristic available-height fallback, which it already relies on whenever a
-    terminal doesn't answer CPR).
-
-    This is only invoked on terminals flagged by ``_terminal_may_leak_cpr()`` —
-    CPR is a layout hint, not a speed optimization, and it works fine locally, so
-    we leave the upstream default in place on local terminals and only suppress it
-    where the leak actually reproduces.
-
-    Note: ``Vt100_Output.from_pty()`` does NOT expose ``enable_cpr`` in
-    prompt_toolkit 3.x, so we reproduce its ``get_size`` setup and call the
-    constructor directly. Returns ``None`` on any failure so the caller falls back
-    to prompt_toolkit's default output (CPR enabled, but input-side scrubbing
-    still protects against leaks).
-    """
-    try:
-        import io as _io
-        from prompt_toolkit.output.vt100 import Vt100_Output, _get_size
-        from prompt_toolkit.data_structures import Size
-
-        def _get_term_size():
-            rows = columns = None
-            try:
-                rows, columns = _get_size(stdout.fileno())
-            except (OSError, _io.UnsupportedOperation, AttributeError, ValueError):
-                pass
-            return Size(rows=rows or 24, columns=columns or 80)
-
-        return Vt100_Output(stdout, _get_term_size, enable_cpr=False)
-    except Exception:
-        return None
 
 
 def _strip_leaked_terminal_responses_with_meta(text: str) -> tuple[str, bool]:
@@ -3319,53 +2580,6 @@ def _strip_leaked_terminal_responses(text: str) -> str:
     return cleaned
 
 
-def _estimate_tui_input_height(
-    lines: list[str] | tuple[str, ...],
-    prompt_text: str,
-    terminal_columns: int,
-    *,
-    max_height: int = 8,
-) -> int:
-    """Estimate classic prompt_toolkit input rows using live terminal cells.
-
-    The TextArea prompt is injected with prompt_toolkit's BeforeInput
-    processor, which means it consumes cells only on logical line 0. After a
-    narrow resize, that first row can leave only one input cell beside an icon
-    prompt such as ``⚔ ``, while continuation rows use the full terminal width.
-    Never substitute a fake wide fallback here: under- or over-allocating the
-    TextArea height leaves stale prompt/input cells visible at the bottom of the
-    terminal.
-    """
-    try:
-        from prompt_toolkit.utils import get_cwidth
-    except Exception:
-        get_cwidth = lambda value: len(value or "")  # type: ignore[assignment]
-
-    try:
-        columns = int(terminal_columns or 0)
-    except (TypeError, ValueError):
-        columns = 0
-
-    columns = max(1, columns)
-    prompt_width = max(0, get_cwidth(prompt_text or ""))
-
-    visual_lines = 0
-    for index, line in enumerate(lines or [""]):
-        # prompt_toolkit's TextArea injects ``prompt`` via BeforeInput, which
-        # applies only to logical line 0. Wrapped continuation rows, and later
-        # logical lines, use the full terminal width. Count the display cells
-        # after that same transformation rather than subtracting the prompt from
-        # every wrapped row.
-        line_width = get_cwidth(line or "")
-        display_width = line_width + (prompt_width if index == 0 else 0)
-        if display_width <= 0:
-            visual_lines += 1
-        else:
-            visual_lines += max(1, -(-display_width // columns))
-
-    return min(max(visual_lines, 1), max(1, int(max_height or 1)))
-
-
 def _collect_query_images(query: str | None, image_arg: str | None = None) -> tuple[str, list[Path]]:
     """Collect local image attachments for single-query CLI flows."""
     message = query or ""
@@ -3396,12 +2610,6 @@ def _collect_query_images(query: str | None, image_arg: str | None = None) -> tu
     return message, deduped
 
 
-# Strip OSC escape sequences (e.g. OSC-8 hyperlinks) that prompt_toolkit's
-# ANSI parser can't handle — it strips \x1b but passes the payload through
-# as literal text, garbling the TUI output.
-_OSC_ESCAPE_RE = re.compile(r"\x1b\][\s\S]*?(?:\x07|\x1b\\)")
-
-
 class ChatConsole:
     """Rich Console adapter for prompt_toolkit's patch_stdout context.
 
@@ -3428,10 +2636,6 @@ class ChatConsole:
         self._inner.width = shutil.get_terminal_size((80, 24)).columns
         self._inner.print(*args, **kwargs)
         output = self._buffer.getvalue()
-        # Strip OSC escape sequences (e.g. OSC-8 hyperlinks) before
-        # routing through prompt_toolkit's ANSI parser, which only
-        # handles CSI/SGR and passes OSC payload through as literal text.
-        output = _OSC_ESCAPE_RE.sub("", output)
         for line in output.rstrip("\n").split("\n"):
             _cprint(line)
 
@@ -3675,7 +2879,7 @@ def save_config_value(key_path: str, value: any) -> bool:
 # HermesCLI Class
 # ============================================================================
 
-class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
+class HermesCLI:
     """
     Interactive CLI for the Hermes Agent.
     
@@ -3726,10 +2930,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         # show_reasoning: display model thinking/reasoning before the response
-        self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", True)
-        # reasoning_full: when reasoning display is on, print the post-response
-        # recap box uncollapsed instead of clamping to the first 10 lines.
-        self.reasoning_full = CLI_CONFIG["display"].get("reasoning_full", False)
+        self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", False)
         _configure_output_history(
             enabled=CLI_CONFIG["display"].get("persistent_output", True),
             max_lines=CLI_CONFIG["display"].get("persistent_output_max_lines", 200),
@@ -3754,9 +2955,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         
         # streaming: stream tokens to the terminal as they arrive (display.streaming in config.yaml)
         self.streaming_enabled = CLI_CONFIG["display"].get("streaming", False)
-        # show_timestamps: prefix user and assistant labels with timestamps
+        # show_timestamps: prefix user and assistant labels with [HH:MM]
         self.show_timestamps = CLI_CONFIG["display"].get("timestamps", False)
-        self.timestamp_format = CLI_CONFIG["display"].get("timestamp_format", "%H:%M")
         self.final_response_markdown = str(
             CLI_CONFIG["display"].get("final_response_markdown", "strip")
         ).strip().lower() or "strip"
@@ -3805,18 +3005,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         _config_model = (_model_config.get("default") or _model_config.get("model") or "") if isinstance(_model_config, dict) else (_model_config or "")
         _DEFAULT_CONFIG_MODEL = ""
         self.model = model or _config_model or _DEFAULT_CONFIG_MODEL
-        # Read max_tokens from config (env var override: HERMES_MAX_TOKENS)
-        _env_mt = os.environ.get("HERMES_MAX_TOKENS")
-        if _env_mt:
-            try:
-                self.max_tokens = int(_env_mt)
-            except (ValueError, TypeError):
-                self.max_tokens = None
-        elif isinstance(_model_config, dict):
-            _mt = _model_config.get("max_tokens")
-            self.max_tokens = _mt if isinstance(_mt, int) else None
-        else:
-            self.max_tokens = None
         # Auto-detect model from local server if still on default
         if self.model == _DEFAULT_CONFIG_MODEL:
             _base_url = (_model_config.get("base_url") or "") if isinstance(_model_config, dict) else ""
@@ -3914,7 +3102,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         
         # Ephemeral prefill messages (few-shot priming, never persisted)
         self.prefill_messages = _load_prefill_messages(
-            _resolve_prefill_messages_file(CLI_CONFIG)
+            CLI_CONFIG["agent"].get("prefill_messages_file", "")
         )
         
         # Reasoning config (OpenRouter reasoning effort level)
@@ -3972,39 +3160,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # frozen when the agent thread completes, displayed in the status bar.
         self._prompt_start_time: Optional[float] = None  # time.time() when turn started
         self._prompt_duration: float = 0.0  # frozen duration of last completed turn
-        self._last_turn_finished_at: Optional[float] = None  # time.time() when the last agent loop finished
         # Initialize SQLite session store early so /title works before first message
         self._session_db = None
-        self._session_db_unavailable = False
         try:
             from hermes_state import SessionDB
             self._session_db = SessionDB()
         except Exception as e:
-            # #41386: a failed session store means the transcript is NOT
-            # persisted to state.db — the live chat looks healthy but resume
-            # later shows a truncated/empty session. A buried log line is not
-            # enough; surface it prominently so the user knows persistence is
-            # off for this run and can fix the store before relying on resume.
-            self._session_db_unavailable = True
             logger.warning("Failed to initialize SessionDB — session will NOT be indexed for search: %s", e)
-            try:
-                # Console is imported at module scope; do NOT re-import it here.
-                # A function-local `import` would make `Console` a local name for
-                # the whole __init__ body and break the earlier `self.console =
-                # Console()` with UnboundLocalError.
-                Console(stderr=True).print(
-                    "[bold yellow]⚠ Session store unavailable[/bold yellow] — "
-                    "this conversation will [bold]NOT be saved[/bold] to disk and "
-                    "cannot be resumed later. Searching past sessions is also disabled.\n"
-                    f"  Reason: {e}\n"
-                    "  Fix the state.db store (e.g. `hermes update` to rebuild the venv) to restore persistence."
-                )
-            except Exception:
-                # Never let the warning path itself break startup.
-                print(
-                    "WARNING: Session store unavailable — this conversation will NOT be "
-                    f"saved to disk and cannot be resumed later. Reason: {e}"
-                )
 
         # Opportunistic state.db maintenance — runs at most once per
         # min_interval_hours, tracked via state_meta in state.db itself so
@@ -4069,16 +3231,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._slash_confirm_state = None
         self._slash_confirm_deadline = 0
         self._model_picker_state = None
-        # Armed when a bare `/resume` prints the recent-sessions list so the
-        # very next bare numeric input (e.g. `3`) resolves to that session.
-        # Holds the exact list used for index resolution; one-shot (cleared on
-        # the next submitted input, whether it's the selection or anything
-        # else). See #34584.
-        self._pending_resume_sessions = None
-        # One-shot agent seed set by a slash handler (e.g. /blueprint <name>)
-        # that wants its output run as the next agent turn. Consumed and cleared
-        # by the interactive loop immediately after process_command() returns.
-        self._pending_agent_seed = None
         self._secret_state = None
         self._secret_deadline = 0
         self._spinner_text: str = ""  # thinking spinner text for TUI
@@ -4087,30 +3239,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._last_scrollback_tool: str = ""  # last tool name printed to scrollback (for "new" dedup)
         self._command_running = False
         self._command_status = ""
-        # Petdex mascot (opt-in via display.pet). The base CLI mirrors the TUI's
-        # PetPane: a half-block sprite above the prompt that reacts to agent
-        # activity. Lazily resolved; an invalidate timer drives the animation.
-        self._pet_renderer = None  # agent.pet.render.PetRenderer | None
-        self._pet_slug: str = ""
-        self._pet_enabled: bool = False
-        self._pet_cols: int = 18
-        self._pet_scale: float = 0.7
-        self._pet_frames_cache: dict = {}  # state -> list[grid]
-        self._pet_frame_idx: int = 0
-        self._pet_lock = threading.Lock()
-        self._pet_cfg_checked: float = 0.0
-        self._pet_anim_running: bool = False
-        self._pet_anim_thread = None
-        # Transient reaction beats (wave/jump/failed) + steady reasoning flag.
-        self._pet_event: str = ""
-        self._pet_event_until: float = 0.0
-        self._pet_reasoning: bool = False
-        self._pet_turn_error: bool = False
         self._attached_images: list[Path] = []
         self._image_counter = 0
         self.preloaded_skills: list[str] = []
         self._startup_skills_line_shown = False
-        self._active_session_lease = None
 
         # Voice mode state (also reinitialized inside run() for interactive TUI).
         self._voice_lock = threading.Lock()
@@ -4125,14 +3257,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Status bar visibility (toggled via /statusbar)
         self._status_bar_visible = True
-        # Codex account usage is fetched off the prompt_toolkit render path.
-        # Keep the cache scoped to its provider so a fallback cannot display a
-        # stale quota badge for a different account.
+        # Usage is refreshed asynchronously, so prompt_toolkit rendering never
+        # performs network I/O. This cache exists only for this CLI session.
         self._account_limits_lock = threading.Lock()
-        self._account_limits_label: str | None = None
+        self._account_limits_label = None
+        self._account_limits_used_percent = None
         self._account_limits_style = "class:status-bar-good"
-        self._account_limits_used_percent: float | None = None
-        self._account_limits_provider: str | None = None
+        self._account_limits_provider = None
         self._account_limits_checked_at = 0.0
         self._account_limits_refreshing = False
         # When True, the input separator rules and the dynamic status bar are
@@ -4144,100 +3275,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._resize_recovery_lock = threading.Lock()
         self._resize_recovery_timer = None
         self._resize_recovery_pending = False
-        # Debounced timer that clears the post-resize suppression once the
-        # terminal reflow settles, so the status bar returns during idle
-        # without waiting for the next submitted input.
-        self._status_bar_unsuppress_timer = None
-        # Last terminal width seen by the resize handler. Used to distinguish a
-        # width change (column reflow → possible ghost chrome, needs a viewport
-        # clear) from a rows-only change (no reflow). None until the first
-        # resize fires.
-        self._last_resize_width = None
 
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
 
-    def _claim_active_session(self, surface: str = "cli", *, stderr: bool = False) -> bool:
-        """Claim a global active-session slot for this CLI process."""
-        if self._active_session_lease is not None:
-            return True
-        try:
-            from hermes_cli.active_sessions import try_acquire_active_session
-
-            lease, message = try_acquire_active_session(
-                session_id=self.session_id,
-                surface=surface,
-                config=self.config,
-            )
-        except Exception as exc:
-            logger.warning("Failed to claim active session slot: %s", exc)
-            return True
-        if message:
-            if stderr:
-                print(message, file=sys.stderr)
-            else:
-                self._console_print(f"[bold red]{message}[/]")
-            return False
-        self._active_session_lease = lease
-        try:
-            atexit.register(self._release_active_session)
-        except Exception:
-            pass
-        return True
-
-    def _release_active_session(self) -> None:
-        lease = getattr(self, "_active_session_lease", None)
-        if lease is None:
-            return
-        try:
-            lease.release()
-        except Exception:
-            logger.debug("Failed to release active session slot", exc_info=True)
-        finally:
-            self._active_session_lease = None
-
     def _invalidate(self, min_interval: float = 0.25) -> None:
-        """Throttled UI repaint for high-frequency background updates.
-
-        Use this for spinner frames, streaming token flushes, and other
-        repaints that can fire many times per second — the throttle prevents
-        terminal blinking on slow/SSH connections, and the resize-recovery
-        guard avoids stamping footer/status-bar chrome into scrollback while a
-        SIGWINCH reflow is in flight.
-
-        Do NOT use this for user-blocking modal prompts (approval / clarify /
-        sudo). Those are rare, one-shot, user-blocking events that must paint
-        immediately; route them through ``self._app.invalidate()`` directly, the
-        same way the modal key-binding handlers already do. Sending a modal's
-        entry paint through this throttle lets an unrelated background repaint
-        within the 250ms window — or an in-flight resize — silently drop it, so
-        the prompt never renders and times out unseen (#41098).
-        """
+        """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
         if getattr(self, "_resize_recovery_pending", False):
             return
         now = time.monotonic()
-        if hasattr(self, "_app") and self._app and (now - getattr(self, "_last_invalidate", 0.0)) >= min_interval:
+        if hasattr(self, "_app") and self._app and (now - self._last_invalidate) >= min_interval:
             self._last_invalidate = now
             self._app.invalidate()
-
-    def _paint_now(self) -> None:
-        """Immediate, unthrottled repaint for user-blocking modal prompts.
-
-        Background-thread callbacks (approval / clarify / sudo) set their modal
-        state then call this to make the panel visible at once. It deliberately
-        bypasses the ``_invalidate`` throttle and resize-recovery guard — a
-        modal the user is actively waiting on must never be dropped — mirroring
-        the direct ``event.app.invalidate()`` the modal key-binding handlers
-        already use. See ``_invalidate`` for why the throttle must not gate
-        these paints (#41098).
-        """
-        app = getattr(self, "_app", None)
-        if app is not None:
-            try:
-                app.invalidate()
-            except Exception:
-                pass
 
     def _force_full_redraw(self) -> None:
         """Force a clean full-screen repaint of the prompt_toolkit UI.
@@ -4263,32 +3313,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             app.invalidate()
         except Exception:
             pass
-
-    def _recover_terminal_after_interrupt(self) -> None:
-        """Recover the terminal after an interrupted agent turn (#33271).
-
-        When the user interrupts a running turn by typing a new message,
-        prompt_toolkit may have an in-flight ``CSI 6n`` cursor-position query
-        whose reply (``ESC[<row>;<col>R``) arrives on stdin after the input
-        parser has torn down. The reply then leaks as literal text
-        (``^[[19;1R``) and the VT100 parser can stall in a partial-escape
-        state, accepting no further keystrokes — the terminal appears frozen.
-
-        Two steps recover a sane state:
-          1. ``flush_stdin()`` drains stray escape bytes from the OS input
-             buffer (``termios.tcflush(TCIFLUSH)``; no-op on non-TTY).
-          2. ``_force_full_redraw()`` drops prompt_toolkit's cached
-             screen/cursor state and forces a clean repaint.
-
-        Both steps are independently safe and self-guard, so a failure of one
-        never prevents the other.
-        """
-        try:
-            from hermes_cli.curses_ui import flush_stdin
-            flush_stdin()
-        except Exception:
-            pass
-        self._force_full_redraw()
 
     def _clear_prompt_toolkit_screen(self, app, *, rebuild_scrollback: bool = False) -> None:
         """Clear the terminal and reset prompt_toolkit renderer state."""
@@ -4321,120 +3345,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         startup UI and ``_replay_output_history`` cannot reconstruct it
         (the banner was never added to ``_OUTPUT_HISTORY``).
 
-        Let prompt_toolkit's own resize path run with its renderer cursor
-        cache intact. Its Application._on_resize() starts with
-        renderer.erase(leave_alternate_screen=False), which needs the cached
-        cursor position to move back to the live prompt origin before
-        erase_down(). Resetting the renderer before that erase loses the
-        origin and can leave stale prompt glyphs after a narrow resize.
+        Instead we just reset prompt_toolkit's renderer cache so the next
+        incremental redraw starts from a clean slate, then let
+        ``original_on_resize`` recalculate layout for the new size.
 
         We also flag ``_status_bar_suppressed_after_resize`` so the dynamic
-        status bar and input separator rules stay hidden while the terminal
-        reflow settles.  On column shrink the terminal reflows already-rendered
-        status bar rows into scrollback before prompt_toolkit can erase them;
-        drawing a fresh full-width bar immediately makes the old and new
-        versions look duplicated (#19280, #22976).
-
-        Suppression alone is not enough on a WIDTH change.  prompt_toolkit's
-        ``renderer.erase()`` does ``cursor_up(_cursor_pos.y)`` + ``erase_down()``
-        using the ``_cursor_pos.y`` cached from the LAST render at the OLD
-        width (renderer.py).  When the column count shrinks, the terminal
-        reflows each already-painted full-width chrome row into 2+ physical
-        rows, so the cached ``y`` undershoots: ``cursor_up`` does not climb
-        past the reflowed rows and ``erase_down`` leaves the stale bar stranded
-        ABOVE the live origin.  The next paint then stacks a fresh bar below it
-        — the duplicated-status-bar report (two bars, two elapsed readings).
-        Suppression hides the *new* bar but never erases the already-reflowed
-        *old* one, so the ghost survives the whole suppression window.
-
-        Fix: on a width change, wipe the visible viewport with ``erase_screen``
-        (CSI 2J) BEFORE delegating to prompt_toolkit's resize, then let its
-        repaint redraw from a clean origin.  This is banner-safe: 2J clears
-        only the visible screen, NOT scrollback history (that is CSI 3J, which
-        we do not send here — ``rebuild_scrollback=False``), so the startup
-        banner that scrolled into history is preserved and
-        ``_replay_output_history`` is not needed.  Row-count-only changes skip
-        the clear (no reflow, so no ghost) to avoid an unnecessary repaint.
-
-        The suppression is transient: a short follow-up timer clears it and
-        repaints once the reflow has settled, so the bar returns on its own
-        during idle.  Previously the flag was only cleared on the next
-        *submitted* user input, so a resize/reflow (tmux pane change, SSH
-        window restore, font zoom) followed by idle left the status bar hidden
-        indefinitely even while the refresh clock kept ticking (the dynamic
-        chrome rendered at height 0 on every repaint).  The next-submit clear
-        at the input loop remains as a fast path.
+        status bar and input separator rules stay hidden until the next user
+        input.  On column shrink the terminal reflows already-rendered status
+        bar rows into scrollback before prompt_toolkit can erase them; drawing
+        a fresh full-width bar immediately makes the old and new versions
+        look duplicated (#19280, #22976).  Clearing the suppression on the
+        next prompt restores the bar cleanly.
         """
         self._status_bar_suppressed_after_resize = True
-        # On a WIDTH change the terminal has already reflowed the old full-width
-        # chrome into extra physical rows that prompt_toolkit's stale-cursor
-        # erase (cursor_up(_cursor_pos.y) cached at the OLD width) will not
-        # reach, leaving a duplicated status bar stranded above the live origin.
-        # Ctrl+L / /redraw clears it cleanly, so route the resize path through
-        # the SAME recovery: wipe the visible viewport (banner-safe — CSI 2J
-        # only, never CSI 3J) and replay the transcript so nothing is lost.
-        # Row-count-only changes skip this (no reflow → no ghost) to avoid an
-        # unnecessary full repaint.
         try:
-            new_width = self._get_tui_terminal_width()
+            app.renderer.reset(leave_alternate_screen=False)
         except Exception:
-            new_width = None
-        prev_width = getattr(self, "_last_resize_width", None)
-        # First resize of the session has no prior width to compare against;
-        # treat it as a change so an initial maximize/restore is covered too.
-        width_changed = new_width is not None and new_width != prev_width
-        if width_changed:
-            try:
-                self._clear_prompt_toolkit_screen(app, rebuild_scrollback=False)
-                _replay_output_history()
-            except Exception:
-                pass
-        if new_width is not None:
-            self._last_resize_width = new_width
+            pass
+        try:
+            app.invalidate()
+        except Exception:
+            pass
         original_on_resize()
-        self._schedule_status_bar_unsuppress(app)
-
-    def _schedule_status_bar_unsuppress(self, app, delay: float = 0.35) -> None:
-        """Clear the post-resize status-bar suppression after the reflow settles.
-
-        Debounced: a fresh resize cancels the pending unsuppress and restarts
-        the timer, so a resize storm only repaints the bar once it stops.
-        """
-        try:
-            old_timer = getattr(self, "_status_bar_unsuppress_timer", None)
-            if old_timer is not None:
-                try:
-                    old_timer.cancel()
-                except Exception:
-                    pass
-
-            def _clear():
-                self._status_bar_suppressed_after_resize = False
-                try:
-                    app.invalidate()
-                except Exception:
-                    pass
-
-            def _fire():
-                try:
-                    loop = getattr(app, "loop", None)
-                except Exception:
-                    loop = None
-                if loop is not None:
-                    try:
-                        loop.call_soon_threadsafe(_clear)
-                        return
-                    except Exception:
-                        pass
-                _clear()
-
-            timer = threading.Timer(delay, _fire)
-            timer.daemon = True
-            self._status_bar_unsuppress_timer = timer
-            timer.start()
-        except Exception:
-            # Fail open: never leave the bar stuck hidden.
-            self._status_bar_suppressed_after_resize = False
 
     def _schedule_resize_recovery(self, app, original_on_resize, delay: float = 0.12) -> None:
         """Debounce resize redraws so footer chrome is not stamped into scrollback."""
@@ -4502,8 +3434,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         return "class:status-bar-dim"
 
     @staticmethod
-    def _weekly_account_usage_percent(snapshot: Any) -> float | None:
-        """Return the finite raw usage for a duration-verified weekly window."""
+    def _weekly_account_limits_used_percent(snapshot: Any) -> Optional[float]:
+        """Return the raw finite percentage for the duration-detected weekly quota."""
         for window in getattr(snapshot, "windows", ()) or ():
             try:
                 raw_duration: Any = getattr(window, "limit_window_seconds", None)
@@ -4512,81 +3444,53 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 used = float(raw_used)
             except (TypeError, ValueError):
                 continue
-            if math.isfinite(duration) and math.isfinite(used) and 6 * 86_400 <= duration <= 8 * 86_400:
-                return used
+            if not (math.isfinite(duration) and math.isfinite(used)):
+                continue
+            if not 6 * 86_400 <= duration <= 8 * 86_400:
+                continue
+            return used
         return None
 
     @classmethod
-    def _format_account_limits_badge(
-        cls, snapshot: Any, *, available_width: int | None = None, ascii_fallback: bool = False
-    ) -> str:
-        """Format only the duration-detected Codex weekly quota for the status bar.
-
-        The API's primary/secondary names are positions, not period types. The
-        formatter therefore uses the retained duration and never a label to find
-        the weekly window. ``available_width`` gives deterministic full, compact
-        (no-space), and percent-only forms; the default remains full.
-        """
-        used = cls._weekly_account_usage_percent(snapshot)
+    def _format_account_limits_badge(cls, snapshot: Any) -> str:
+        """Format only the duration-detected Codex weekly quota for the footer."""
+        used = cls._weekly_account_limits_used_percent(snapshot)
         if used is None:
             return ""
         displayed_used = max(0, min(100, round(used)))
-        percent = f"W{displayed_used}%{'+' if used > 100 else ''}"
-        filled = round(displayed_used / 10)
-        on, off = ("#", "-") if ascii_fallback else ("█", "░")
-        gauge = f"[{on * filled}{off * (10 - filled)}]"
-        full = f"{percent} {gauge}"
-        compact = f"{percent}{gauge}"
-        if available_width is None or available_width >= len(full):
-            return full
-        if available_width >= len(compact):
-            return compact
-        if available_width >= len(percent):
-            return percent
-        return ""
+        gauge = f"[{'█' * round(displayed_used / 10)}{'░' * (10 - round(displayed_used / 10))}]"
+        return f"W{displayed_used}%{'+' if used > 100 else ''} {gauge}"
 
     @staticmethod
-    def _account_limits_badge_style(label: str, used_percent: float | None = None) -> str:
-        """Return weekly pressure style, using raw usage when it is available."""
-        if used_percent is None:
-            match = re.search(r"(?<!\w)W(\d+)%([+])?(?!\w)", label or "")
-            if not match:
-                return "class:status-bar-good"
-            used_percent = float(match.group(1))
-            overflow = bool(match.group(2))
-        else:
-            overflow = used_percent > 100
-        if not math.isfinite(used_percent):
+    def _account_limits_badge_style(used_percent: Any) -> str:
+        """Return the weekly usage-pressure style from the raw percentage."""
+        try:
+            used = float(used_percent)
+        except (TypeError, ValueError):
             return "class:status-bar-good"
-        if overflow or used_percent >= 95:
+        if not math.isfinite(used):
+            return "class:status-bar-good"
+        if used >= 95:
             return "class:status-bar-critical"
-        if used_percent >= 90:
+        if used >= 90:
             return "class:status-bar-bad"
-        if used_percent >= 80:
+        if used >= 80:
             return "class:status-bar-warn"
         return "class:status-bar-good"
 
     def _maybe_refresh_account_limits_badge(self, agent: Any) -> str:
-        """Return a cached Codex badge and refresh stale data asynchronously.
-
-        This method deliberately only schedules work; ``fetch_account_usage``
-        runs in the daemon worker, never while prompt_toolkit renders.
-        Successful values live for five minutes. Failed or unavailable requests
-        retain a same-provider value but are retried after thirty seconds.
-        """
+        """Return cached Codex weekly usage and asynchronously refresh stale data."""
         provider = str(getattr(agent, "provider", None) or getattr(self, "provider", None) or "").strip().lower()
         if not hasattr(self, "_account_limits_lock"):
             return ""
         if provider != "openai-codex":
-            # Do not let a model/provider fallback retain a Codex account badge.
             with self._account_limits_lock:
                 self._account_limits_label = None
-                self._account_limits_style = "class:status-bar-good"
                 self._account_limits_used_percent = None
+                self._account_limits_style = "class:status-bar-good"
                 self._account_limits_provider = None
                 self._account_limits_checked_at = 0.0
             return ""
-
         now = time.monotonic()
         with self._account_limits_lock:
             cached = self._account_limits_label or ""
@@ -4594,36 +3498,34 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if not stale or self._account_limits_refreshing:
                 return cached if self._account_limits_provider == provider else ""
             self._account_limits_refreshing = True
-
         base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
         api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
 
         def _worker() -> None:
             label = ""
-            weekly_used_percent: float | None = None
+            used_percent = None
             try:
                 from agent.account_usage import fetch_account_usage
-
                 snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
-                weekly_used_percent = self._weekly_account_usage_percent(snapshot) if snapshot else None
-                label = self._format_account_limits_badge(snapshot) if snapshot else ""
+                if snapshot:
+                    used_percent = self._weekly_account_limits_used_percent(snapshot)
+                    label = self._format_account_limits_badge(snapshot)
             except Exception:
                 pass
             finally:
                 with self._account_limits_lock:
                     if label:
                         self._account_limits_label = label
-                        self._account_limits_used_percent = weekly_used_percent
-                        self._account_limits_style = self._account_limits_badge_style(label, weekly_used_percent)
+                        self._account_limits_used_percent = used_percent
+                        self._account_limits_style = self._account_limits_badge_style(used_percent)
                         self._account_limits_provider = provider
                         self._account_limits_checked_at = time.monotonic()
                     elif self._account_limits_provider != provider:
                         self._account_limits_label = None
+                        self._account_limits_used_percent = None
                         self._account_limits_style = "class:status-bar-good"
                         self._account_limits_provider = provider
                     if not label:
-                        # Retain a same-provider cache across transient failures,
-                        # but retry unavailable/error responses after 30 seconds.
                         self._account_limits_checked_at = time.monotonic() - 270
                     self._account_limits_refreshing = False
                 try:
@@ -4677,19 +3579,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         emoji = "⏱" if live else "⏲"
         return f"{emoji} {time_str}"
 
-    @staticmethod
-    def _format_idle_since(last_finished_at: Optional[float], turn_live: bool) -> str:
-        """Format time since the last final agent response for the status bar.
-
-        Returns an empty string while a turn is live (the per-prompt elapsed
-        timer covers that case) or before the first turn has completed.
-        Compact read-out: ``✓ 42s`` / ``✓ 3m`` / ``✓ 1h 12m``.
-        """
-        if turn_live or last_finished_at is None:
-            return ""
-        idle = max(0.0, time.time() - last_finished_at)
-        return f"✓ {format_duration_compact(idle)}"
-
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         # Prefer the agent's model name — it updates on fallback.
         # self.model reflects the originally configured model and never
@@ -4713,10 +3602,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 getattr(self, "_prompt_duration", 0.0),
                 live=getattr(self, "_prompt_start_time", None) is not None,
             ),
-            "idle_since": self._format_idle_since(
-                getattr(self, "_last_turn_finished_at", None),
-                turn_live=getattr(self, "_prompt_start_time", None) is not None,
-            ),
             "context_tokens": 0,
             "context_length": None,
             "context_percent": None,
@@ -4731,7 +3616,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             "compressions": 0,
             "active_background_tasks": 0,
             "active_background_processes": 0,
-            "active_background_subagents": 0,
             "account_limits": "",
             "account_limits_style": "class:status-bar-good",
         }
@@ -4754,17 +3638,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         except Exception:
             pass
 
-        # Count live background/async subagents (delegate_task batches and
-        # background single delegations tracked by tools.async_delegation).
-        # active_count() iterates an in-memory records dict under a lock —
-        # cheap and only counts records still in the "running" state.
-        try:
-            from tools.async_delegation import active_count as _async_active_count
-            snapshot["active_background_subagents"] = _async_active_count()
-        except Exception:
-            pass
-
-
         if not agent:
             return snapshot
 
@@ -4779,25 +3652,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         account_limits = self._maybe_refresh_account_limits_badge(agent)
         snapshot["account_limits"] = account_limits
         if account_limits:
-            # Use the current cached raw value when present so fractional usage
-            # crosses thresholds at 80/90/95 before display rounding occurs.
             snapshot["account_limits_style"] = self._account_limits_badge_style(
-                account_limits, getattr(self, "_account_limits_used_percent", None)
+                getattr(self, "_account_limits_used_percent", None)
             )
 
         compressor = getattr(agent, "context_compressor", None)
         if compressor:
-            # last_prompt_tokens is parked at the -1 sentinel right after a
-            # compression, until the next real API call reports a prompt count
-            # (awaiting_real_usage_after_compression). The status bar must not
-            # render that sentinel verbatim — it produced "-1/200K" / "-1%".
-            # Clamp it to 0 so the one transitional turn reads as empty context.
             context_tokens = getattr(compressor, "last_prompt_tokens", 0) or 0
-            if context_tokens < 0:
-                context_tokens = 0
             context_length = getattr(compressor, "context_length", 0) or 0
-            if context_length < 0:
-                context_length = 0
             snapshot["context_tokens"] = context_tokens
             snapshot["context_length"] = context_length or None
             snapshot["compressions"] = getattr(compressor, "compression_count", 0) or 0
@@ -4942,224 +3804,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return f"  {txt}  ({elapsed_str})"
         return f"  {txt}"
 
-    # ── Petdex mascot (base-CLI pet pane) ───────────────────────────────
-    #
-    # Parity with the TUI: a half-block sprite rendered as a prompt_toolkit
-    # window above the prompt, reacting to agent state and animated by a timer
-    # that calls ``app.invalidate()``. Half-blocks only — the crisp Kitty image
-    # protocol can't coexist with prompt_toolkit's patch_stdout output layer
-    # (raw image escapes get swallowed/mangled), so we use truecolor styled
-    # text, which prompt_toolkit renders natively in any 24-bit terminal.
-
-    _PET_FRAME_INTERVAL = 0.16
-    _PET_CFG_INTERVAL = 2.5
-
-    def _pet_resolve_config(self) -> None:
-        """(Re)resolve the active pet from config — picks up live enable/disable/
-
-        switch made via ``/pet`` or ``hermes pets`` without a restart, mirroring
-        the TUI's steady poll. Cheap and fail-open: any problem disables the pet.
-        """
-        try:
-            from agent.pet import constants, store
-            from agent.pet.render import PetRenderer
-            from hermes_cli.config import load_config
-
-            cfg = load_config()
-            display = cfg.get("display", {}) if isinstance(cfg.get("display"), dict) else {}
-            pet_cfg = display.get("pet", {}) if isinstance(display.get("pet"), dict) else {}
-
-            enabled = bool(pet_cfg.get("enabled"))
-            slug = str(pet_cfg.get("slug", "") or "")
-            scale = float(pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE)
-            cols = constants.resolve_cols(scale, pet_cfg.get("unicode_cols", 0))
-
-            if not enabled:
-                with self._pet_lock:
-                    self._pet_enabled = False
-                    self._pet_renderer = None
-                    self._pet_frames_cache.clear()
-                return
-
-            pet = store.resolve_active_pet(slug)
-            if pet is None or not pet.exists:
-                with self._pet_lock:
-                    self._pet_enabled = False
-                    self._pet_renderer = None
-                    self._pet_frames_cache.clear()
-                return
-
-            with self._pet_lock:
-                # Rebuild only when the resolved pet or geometry changes.
-                if (
-                    self._pet_renderer is None
-                    or self._pet_slug != pet.slug
-                    or self._pet_cols != cols
-                    or self._pet_scale != scale
-                ):
-                    self._pet_renderer = PetRenderer(
-                        str(pet.spritesheet), mode="unicode", scale=scale, unicode_cols=cols
-                    )
-                    self._pet_slug = pet.slug
-                    self._pet_cols = cols
-                    self._pet_scale = scale
-                    self._pet_frames_cache.clear()
-                    self._pet_frame_idx = 0
-                self._pet_enabled = True
-        except Exception:
-            with self._pet_lock:
-                self._pet_enabled = False
-                self._pet_renderer = None
-
-    def _pet_flash(self, state: str, secs: float = 1.6) -> None:
-        """Briefly force a transient reaction (wave/jump/failed) before resting."""
-        self._pet_event = state
-        self._pet_event_until = time.monotonic() + secs
-
-    def _on_reaction(self, kind: str) -> None:
-        """User affection (ily / <3 / good bot), core-detected — the pet's share
-        of the vibe signal that plays hearts on the TUI/desktop. Flash a celebrate."""
-        if kind == "vibe":
-            self._pet_flash("jump")
-
-    def _pet_react_turn_end(self) -> None:
-        """Flash the end-of-turn beat: failed on error, jump on a finished plan, else wave."""
-        if not self._pet_enabled:
-            return
-        from agent.pet.state import todos_all_done
-
-        if self._pet_turn_error:
-            self._pet_flash("failed")
-            return
-        try:
-            store = getattr(self.agent, "_todo_store", None)
-            done = todos_all_done(store.read()) if store else False
-        except Exception:
-            done = False
-        self._pet_flash("jump" if done else "wave")
-
-    def _derive_pet_state(self) -> str:
-        """Map current CLI activity to a pet animation state.
-
-        A transient reaction beat (wave/jump/failed) wins while it's live;
-        otherwise the steady state comes from the shared
-        :func:`agent.pet.state.derive_pet_state` so the CLI can't drift from the
-        TUI/desktop priority order.
-        """
-        if self._pet_event and time.monotonic() < self._pet_event_until:
-            return self._pet_event
-        self._pet_event = ""
-        from agent.pet.state import derive_pet_state
-
-        # A live blocking modal (approval / clarify / sudo / secret / slash
-        # confirm) means the agent is paused on the user → the `waiting` pose,
-        # which outranks the in-flight signals in derive_pet_state.
-        awaiting_input = bool(
-            self._approval_state
-            or self._clarify_state
-            or self._sudo_state
-            or self._secret_state
-            or getattr(self, "_slash_confirm_state", None)
-        )
-
-        return derive_pet_state(
-            awaiting_input=awaiting_input,
-            busy=getattr(self, "_agent_running", False),
-            reasoning=self._pet_reasoning,
-        ).value
-
-    def _pet_frames_for(self, state: str) -> list:
-        """Return (and cache) the half-block grids for one state."""
-        cached = self._pet_frames_cache.get(state)
-        if cached is not None:
-            return cached
-        renderer = self._pet_renderer
-        if renderer is None:
-            return []
-        try:
-            count = renderer.frame_count(state) or 1
-            grids = [renderer.cells(state, i, cols=self._pet_cols) for i in range(count)]
-        except Exception:
-            grids = []
-        self._pet_frames_cache[state] = grids
-        return grids
-
-    def _pet_fragments(self):
-        """Return prompt_toolkit FormattedText for the current pet frame, or []."""
-        with self._pet_lock:
-            if not self._pet_enabled or self._pet_renderer is None:
-                return []
-            state = self._derive_pet_state()
-            grids = self._pet_frames_for(state)
-            if not grids:
-                return []
-            grid = grids[self._pet_frame_idx % len(grids)]
-
-        frags = []
-        for y, row in enumerate(grid):
-            if y:
-                frags.append(("", "\n"))
-            for top, bottom in row:
-                tr, tg, tb, ta = top
-                br, bg, bb, ba = bottom
-                top_op = ta >= 32
-                bot_op = ba >= 32
-                if not top_op and not bot_op:
-                    frags.append(("", " "))
-                elif top_op and bot_op:
-                    frags.append((f"fg:#{tr:02x}{tg:02x}{tb:02x} bg:#{br:02x}{bg:02x}{bb:02x}", "▀"))
-                elif top_op:
-                    # Upper half only — leave the lower half the terminal's bg
-                    # instead of painting it black (cleaner on light themes).
-                    frags.append((f"fg:#{tr:02x}{tg:02x}{tb:02x}", "▀"))
-                else:
-                    frags.append((f"fg:#{br:02x}{bg:02x}{bb:02x}", "▄"))
-        return frags
-
-    def _pet_widget_height(self) -> int:
-        """Visible rows for the pet window — 0 collapses it when no pet shows."""
-        with self._pet_lock:
-            if not self._pet_enabled or self._pet_renderer is None:
-                return 0
-            grids = self._pet_frames_for(self._derive_pet_state())
-            if not grids or not grids[0]:
-                return 0
-            return len(grids[0])
-
-    def _pet_anim_loop(self) -> None:
-        """Advance the frame + invalidate on a timer while a pet is enabled."""
-        while self._pet_anim_running:
-            time.sleep(self._PET_FRAME_INTERVAL)
-            now = time.monotonic()
-            if now - self._pet_cfg_checked >= self._PET_CFG_INTERVAL:
-                self._pet_cfg_checked = now
-                self._pet_resolve_config()
-            if not self._pet_enabled:
-                continue
-            with self._pet_lock:
-                self._pet_frame_idx += 1
-            app = getattr(self, "_app", None)
-            if app is not None:
-                try:
-                    app.invalidate()
-                except Exception:
-                    pass
-
-    def _pet_start_anim(self) -> None:
-        if self._pet_anim_running:
-            return
-        self._pet_resolve_config()
-        self._pet_anim_running = True
-        self._pet_anim_thread = threading.Thread(target=self._pet_anim_loop, daemon=True)
-        self._pet_anim_thread.start()
-
-    def _pet_stop_anim(self) -> None:
-        self._pet_anim_running = False
-        thread = self._pet_anim_thread
-        if thread is not None:
-            thread.join(timeout=0.3)
-        self._pet_anim_thread = None
-
     def _voice_record_key_label(self) -> str:
         """Return the configured voice push-to-talk key formatted for UI.
 
@@ -5224,7 +3868,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
 
-            yolo_active = self._is_session_yolo_active()
+            yolo_active = bool(os.getenv("HERMES_YOLO_MODE"))
             if width < 52:
                 text = f"⚕ {snapshot['model_short']} · {duration_label}"
                 if yolo_active:
@@ -5244,9 +3888,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 bg_proc_count = snapshot.get("active_background_processes", 0)
                 if bg_proc_count:
                     parts.append(f"⚙ {bg_proc_count}")
-                bg_subagent_count = snapshot.get("active_background_subagents", 0)
-                if bg_subagent_count:
-                    parts.append(f"⛓ {bg_subagent_count}")
                 parts.append(duration_label)
                 if yolo_active:
                     parts.append("⚠ YOLO")
@@ -5272,16 +3913,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             bg_proc_count = snapshot.get("active_background_processes", 0)
             if bg_proc_count:
                 parts.append(f"⚙ {bg_proc_count}")
-            bg_subagent_count = snapshot.get("active_background_subagents", 0)
-            if bg_subagent_count:
-                parts.append(f"⛓ {bg_subagent_count}")
             parts.append(duration_label)
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
                 parts.append(prompt_elapsed)
-            idle_since = snapshot.get("idle_since")
-            if idle_since:
-                parts.append(idle_since)
             if yolo_active:
                 parts.append("⚠ YOLO")
             return self._trim_status_bar_text(" │ ".join(parts), width)
@@ -5300,7 +3935,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # line and produce duplicated status bar rows over long sessions.
             width = self._get_tui_terminal_width()
             duration_label = snapshot["duration"]
-            yolo_active = self._is_session_yolo_active()
+            yolo_active = bool(os.getenv("HERMES_YOLO_MODE"))
 
             if width < 52:
                 frags = [
@@ -5320,7 +3955,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
                     bg_proc_count = snapshot.get("active_background_processes", 0)
-                    bg_subagent_count = snapshot.get("active_background_subagents", 0)
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
@@ -5330,7 +3964,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     account_limits = snapshot.get("account_limits")
                     if account_limits:
                         frags.append(("class:status-bar-dim", " · "))
-                        frags.append((snapshot.get("account_limits_style", "class:status-bar-good"), account_limits))
+                        frags.append((snapshot["account_limits_style"], account_limits))
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -5340,9 +3974,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if bg_proc_count:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append(("class:status-bar-strong", f"⚙ {bg_proc_count}"))
-                    if bg_subagent_count:
-                        frags.append(("class:status-bar-dim", " · "))
-                        frags.append(("class:status-bar-strong", f"⛓ {bg_subagent_count}"))
                     frags.extend([
                         ("class:status-bar-dim", " · "),
                         ("class:status-bar-dim", duration_label),
@@ -5363,7 +3994,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
                     bg_proc_count = snapshot.get("active_background_processes", 0)
-                    bg_subagent_count = snapshot.get("active_background_subagents", 0)
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
@@ -5377,7 +4007,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     account_limits = snapshot.get("account_limits")
                     if account_limits:
                         frags.append(("class:status-bar-dim", " │ "))
-                        frags.append((snapshot.get("account_limits_style", "class:status-bar-good"), account_limits))
+                        frags.append((snapshot["account_limits_style"], account_limits))
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -5387,9 +4017,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if bg_proc_count:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-strong", f"⚙ {bg_proc_count}"))
-                    if bg_subagent_count:
-                        frags.append(("class:status-bar-dim", " │ "))
-                        frags.append(("class:status-bar-strong", f"⛓ {bg_subagent_count}"))
                     frags.extend([
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", duration_label),
@@ -5399,11 +4026,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if prompt_elapsed:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-dim", prompt_elapsed))
-                    # Position 8: idle time since the last final agent response
-                    idle_since = snapshot.get("idle_since")
-                    if idle_since:
-                        frags.append(("class:status-bar-dim", " │ "))
-                        frags.append(("class:status-bar-dim", idle_since))
                     if yolo_active:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-yolo", "⚠ YOLO"))
@@ -5413,12 +4035,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if total_width > width:
                 plain_text = "".join(text for _, text in frags)
                 trimmed = self._trim_status_bar_text(plain_text, width)
-                overflow_style = "class:status-bar"
-                if snapshot.get("account_limits") and snapshot.get("account_limits_style") == "class:status-bar-critical":
-                    # Preserve a depleted quota warning when styled fragments
-                    # must collapse into one narrow-terminal fragment.
-                    overflow_style = "class:status-bar-critical"
-                return [(overflow_style, trimmed)]
+                return [("class:status-bar", trimmed)]
             return frags
         except Exception:
             return [("class:status-bar", f" {self._build_status_bar_text()} ")]
@@ -5534,52 +4151,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._tool_start_time = 0.0  # clear tool timer when switching to thinking
         self._invalidate()
 
-    def _on_notice(self, notice) -> None:
-        """Queue an out-of-band AgentNotice for rendering at the next clean boundary.
-
-        Notices fire from inside the agent turn (cold-start seed during _init_agent,
-        per-turn _capture_credits after the API call) — printing immediately races the
-        streaming response and the line gets buried behind the prompt (see _cprint's
-        bg-thread caveat). So we QUEUE here and flush in _flush_credit_notices(), called
-        right after run_conversation returns. Fail-soft: never break the turn.
-        """
-        try:
-            text = getattr(notice, "text", "") or ""
-            if not text:
-                return
-            level = getattr(notice, "level", "info") or "info"
-            if not hasattr(self, "_pending_credit_notices"):
-                self._pending_credit_notices = []
-            self._pending_credit_notices.append((level, text))
-        except Exception:
-            pass
-
-    def _flush_credit_notices(self) -> None:
-        """Print any queued credit notices as level-colored lines. Called at turn end
-        (after run_conversation) where _cprint paints cleanly above the prompt."""
-        try:
-            pending = getattr(self, "_pending_credit_notices", None)
-            if not pending:
-                return
-            self._pending_credit_notices = []
-            for level, text in pending:
-                color = {
-                    "error": "\033[31m",
-                    "warn": "\033[33m",
-                    "success": "\033[32m",
-                    "info": _DIM,
-                }.get(level, _DIM)
-                _cprint(f"  {color}{text}{_RST}")
-        except Exception:
-            pass
-
-    def _on_notice_clear(self, key: str) -> None:
-        """Notice cleared. The REPL prints lines (no persistent slot to wipe), so
-        this drops any still-queued notice with that key is not tracked by key here;
-        it's a no-op for rendering — kept so the agent's clear callback is bound
-        symmetrically with the show callback (and so future REPL UIs can hook it)."""
-        return
-
     # ── Streaming display ────────────────────────────────────────────────
 
     def _current_reasoning_callback(self):
@@ -5677,7 +4248,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
     def _format_submitted_user_message_preview(self, user_input: str) -> str:
         """Format the submitted user-message scrollback preview."""
         ts_suffix = (
-            f" [dim]{datetime.now().strftime(getattr(self, 'timestamp_format', '%H:%M'))}[/]"
+            f" [dim]{datetime.now().strftime('%H:%M')}[/]"
             if getattr(self, "show_timestamps", False) else ""
         )
         lines = user_input.split("\n")
@@ -5843,14 +4414,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._stream_last_was_newline = True  # start of stream = boundary
 
         if not getattr(self, "_in_reasoning_block", False):
-            # Case-insensitive matching against a lowercased view so
-            # mixed-case tag variants (<Think>, <THINKING>, …) are caught.
-            prefilt_lower = self._stream_prefilt.lower()
             for tag in _OPEN_TAGS:
-                tag_lower = tag.lower()
                 search_start = 0
                 while True:
-                    idx = prefilt_lower.find(tag_lower, search_start)
+                    idx = self._stream_prefilt.find(tag, search_start)
                     if idx == -1:
                         break
                     # Check if this is a block boundary position
@@ -5890,12 +4457,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
             # Could also be a partial open tag at the end — hold it back
             if not getattr(self, "_in_reasoning_block", False):
-                # Check for partial tag match at the end (case-insensitive)
+                # Check for partial tag match at the end
                 safe = self._stream_prefilt
                 for tag in _OPEN_TAGS:
-                    tag_lower = tag.lower()
                     for i in range(1, len(tag)):
-                        if prefilt_lower.endswith(tag_lower[:i]):
+                        if self._stream_prefilt.endswith(tag[:i]):
                             safe = self._stream_prefilt[:-i]
                             break
                 if safe:
@@ -5908,9 +4474,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # Keep accumulating _stream_prefilt because close tags can arrive
         # split across multiple tokens (e.g. "</REASONING_SCRATCH" + "PAD>...").
         if getattr(self, "_in_reasoning_block", False):
-            prefilt_lower = self._stream_prefilt.lower()
             for tag in _CLOSE_TAGS:
-                idx = prefilt_lower.find(tag.lower())
+                idx = self._stream_prefilt.find(tag)
                 if idx != -1:
                     self._in_reasoning_block = False
                     # When show_reasoning is on, route inner content to
@@ -5978,7 +4543,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             except (ValueError, IndexError):
                 self._stream_text_ansi = ""
             if self.show_timestamps:
-                label = f"{label} {datetime.now().strftime(getattr(self, 'timestamp_format', '%H:%M'))}"
+                label = f"{label} {datetime.now().strftime('%H:%M')}"
             w = self._scrollback_box_width()
             fill = w - 2 - HermesCLI._status_bar_display_width(label)
             _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
@@ -6032,33 +4597,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if self.final_response_markdown == "strip":
                 line = _strip_markdown_syntax(line)
             _emit_one(line)
-
-        # Force-flush long partial lines so a response that opens with a
-        # long paragraph paints as tokens arrive instead of staying blank
-        # until the first newline (TTFT perception fix — the reasoning box
-        # has done this at 80 chars since day one; the response box never
-        # did). Wrap at the terminal's visible width so we only ever emit
-        # text that would have line-broken at that point anyway; the
-        # remainder stays buffered as the logical line's continuation.
-        # Table-shaped partials are exempt — they need the whole block for
-        # realignment (see the table side-buffer above).
-        if (
-            self._stream_buf
-            and not self._in_stream_table
-            and not self._stream_buf.lstrip().startswith("|")
-        ):
-            wrap_w = max(40, _terminal_width_for_streaming())
-            while len(self._stream_buf) >= wrap_w:
-                cut = self._stream_buf.rfind(" ", 0, wrap_w)
-                if cut <= 0:
-                    cut = wrap_w  # single unbreakable run — hard wrap
-                chunk, self._stream_buf = (
-                    self._stream_buf[:cut],
-                    self._stream_buf[cut:].lstrip(" "),
-                )
-                if self.final_response_markdown == "strip":
-                    chunk = _strip_markdown_syntax(chunk)
-                _emit_one(chunk)
 
     def _flush_stream(self) -> None:
         """Emit any remaining partial line from the stream buffer and close the box."""
@@ -6193,87 +4731,203 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # Set skip flag (again) so the text-change event fired when the
             # editor closes does not re-collapse the returned content.
             self._skip_paste_collapse = True
-            # Open the editor, then submit the saved draft on a clean exit —
-            # matching the TUI's Ctrl+G (openEditor), which sends the buffer
-            # instead of requiring a second Enter. Submission in this CLI is
-            # driven by the custom `enter` keybinding, NOT the buffer's
-            # accept_handler, so validate_and_handle can't route through it;
-            # chain a done-callback on the returned Task that re-uses the
-            # real submit pipeline via _submit_editor_buffer().
-            task = target_buffer.open_in_editor(validate_and_handle=False)
-            if task is not None and hasattr(task, "add_done_callback"):
-                task.add_done_callback(
-                    lambda _t, b=target_buffer: self._submit_editor_buffer(b)
-                )
+            target_buffer.open_in_editor(validate_and_handle=False)
             return True
         except Exception as exc:
             _cprint(f"{_DIM}Failed to open external editor: {exc}{_RST}")
             return False
 
-    def _submit_editor_buffer(self, buffer) -> None:
-        """Submit the draft an external editor left in ``buffer``.
-
-        Invoked from the Ctrl+G done-callback so saving the editor sends the
-        prompt (TUI parity) instead of leaving it sitting in the input area.
-        Mirrors the idle/queue branches of the `enter` keybinding handler:
-        an empty save is ignored (never submits a blank turn), a slash command
-        is dispatched, otherwise the text is routed through the same input
-        queues the normal Enter path uses. Runs on the prompt_toolkit event
-        loop via the Task callback, so it must be cheap and non-blocking.
+    def _ensure_runtime_credentials(self) -> bool:
         """
+        Ensure runtime credentials are resolved before agent use.
+        Re-resolves provider credentials so key rotation and token refresh
+        are picked up without restarting the CLI.
+        Returns True if credentials are ready, False on auth failure.
+        """
+        from hermes_cli.runtime_provider import (
+            resolve_runtime_provider,
+            format_runtime_provider_error,
+        )
+
+        _primary_exc = None
+        runtime = None
         try:
-            text = (getattr(buffer, "text", "") or "").strip()
-        except Exception:
-            return
-        if not text:
-            # Editor saved empty / was cleared — match the TUI, which drops
-            # an empty draft instead of submitting a blank turn.
-            return
+            runtime = resolve_runtime_provider(
+                requested=self.requested_provider,
+                explicit_api_key=self._explicit_api_key,
+                explicit_base_url=self._explicit_base_url,
+            )
+        except Exception as exc:
+            _primary_exc = exc
 
-        app = getattr(self, "_app", None)
+        # Primary provider auth failed — try fallback providers before giving up.
+        if runtime is None and _primary_exc is not None:
+            from hermes_cli.auth import AuthError
+            if isinstance(_primary_exc, AuthError):
+                _fb_chain = self._fallback_model if isinstance(self._fallback_model, list) else []
+                for _fb in _fb_chain:
+                    _fb_provider = (_fb.get("provider") or "").strip().lower()
+                    _fb_model = (_fb.get("model") or "").strip()
+                    if not _fb_provider or not _fb_model:
+                        continue
+                    try:
+                        runtime = resolve_runtime_provider(requested=_fb_provider)
+                        logger.warning(
+                            "Primary provider auth failed (%s). Falling through to fallback: %s/%s",
+                            _primary_exc, _fb_provider, _fb_model,
+                        )
+                        _cprint(f"⚠️  Primary auth failed — switching to fallback: {_fb_provider} / {_fb_model}")
+                        self.requested_provider = _fb_provider
+                        self.model = _fb_model
+                        _primary_exc = None
+                        break
+                    except Exception:
+                        continue
 
-        # Slash commands: dispatch directly, same as the Enter handler's
-        # _looks_like_slash_command branch.
-        if _looks_like_slash_command(text):
+        if runtime is None:
+            message = format_runtime_provider_error(_primary_exc) if _primary_exc else "Provider resolution failed."
+            ChatConsole().print(f"[bold red]{message}[/]")
+            return False
+
+        api_key = runtime.get("api_key")
+        base_url = runtime.get("base_url")
+        resolved_provider = runtime.get("provider", "openrouter")
+        resolved_api_mode = runtime.get("api_mode", self.api_mode)
+        resolved_acp_command = runtime.get("command")
+        resolved_acp_args = list(runtime.get("args") or [])
+        resolved_credential_pool = runtime.get("credential_pool")
+        # A callable api_key is a bearer-token provider (Azure Foundry
+        # Entra ID — ``azure_identity_adapter.build_token_provider``).
+        # The OpenAI SDK accepts ``Callable[[], str]`` for ``api_key`` and
+        # invokes it before every request. Skip the string-only validation
+        # and placeholder substitution for callables.
+        _is_callable_provider = callable(api_key) and not isinstance(api_key, str)
+        if not _is_callable_provider and (not isinstance(api_key, str) or not api_key):
+            # Custom / local endpoints (llama.cpp, ollama, vLLM, etc.) often
+            # don't require authentication.  When a base_url IS configured but
+            # no API key was found, use a placeholder so the OpenAI SDK
+            # doesn't reject the request and local servers just ignore it.
+            _source = runtime.get("source", "")
+            _has_custom_base = isinstance(base_url, str) and base_url and "openrouter.ai" not in base_url
+            if _has_custom_base:
+                api_key = "no-key-required"
+                logger.debug(
+                    "No API key for custom endpoint %s (source=%s), "
+                    "using placeholder — local servers typically ignore auth",
+                    base_url, _source,
+                )
+            else:
+                print("\n⚠️  Provider resolver returned an empty API key. "
+                      "Set OPENROUTER_API_KEY or run: hermes setup")
+                return False
+        if not isinstance(base_url, str) or not base_url:
+            print("\n⚠️  Provider resolver returned an empty base URL. "
+                  "Check your provider config or run: hermes setup")
+            return False
+
+        credentials_changed = api_key != self.api_key or base_url != self.base_url
+        routing_changed = (
+            resolved_provider != self.provider
+            or resolved_api_mode != self.api_mode
+            or resolved_acp_command != self.acp_command
+            or resolved_acp_args != self.acp_args
+        )
+        self.provider = resolved_provider
+        self.api_mode = resolved_api_mode
+        self.acp_command = resolved_acp_command
+        self.acp_args = resolved_acp_args
+        self._credential_pool = resolved_credential_pool
+        self._provider_source = runtime.get("source")
+        self.api_key = api_key
+        self.base_url = base_url
+
+        # When a custom_provider entry carries an explicit `model` field,
+        # use it as the effective model name.  Without this, running
+        # `hermes chat --model <provider-name>` sends the provider name
+        # (e.g. "my-provider") as the model string to the API instead of
+        # the configured model (e.g. "qwen3.6-plus"), causing 400 errors.
+        runtime_model = runtime.get("model")
+        if runtime_model and isinstance(runtime_model, str):
+            # Only use runtime model if: model is unset, or model equals provider name
+            should_use_runtime_model = (
+                not self.model or  # No model configured yet
+                self.model == self.provider or  # Model is the provider slug
+                self.model == runtime.get("name")  # Model matches provider display name
+            )
+            if should_use_runtime_model:
+                self.model = runtime_model
+
+        # If model is still empty (e.g. user ran `hermes auth add openai-codex`
+        # without `hermes model`), fall back to the provider's first catalog
+        # model so the API call doesn't fail with "model must be non-empty".
+        if not self.model and resolved_provider:
             try:
-                if not self.process_command(text):
-                    self._should_exit = True
-                    if app is not None and app.is_running:
-                        app.exit()
-            except Exception as exc:
-                _cprint(f"  {_DIM}Command failed: {exc}{_RST}")
-            finally:
-                self._reset_input_buffer(buffer)
-                if app is not None:
-                    app.invalidate()
-            return
-
-        # Regular prompt: route through the same queues the Enter handler uses.
-        if self._agent_running:
-            # Agent busy → honour the configured busy-input behaviour by
-            # queueing for the next turn (the safe default; interrupt/steer
-            # remain reachable via the normal Enter path).
-            self._interrupt_queue.put(text) if self.busy_input_mode == "interrupt" else self._pending_input.put(text)
-            preview = text[:80] + ("..." if len(text) > 80 else "")
-            _cprint(f"  Queued for the next turn: {preview}")
-        else:
-            self._pending_input.put(text)
-
-        self._reset_input_buffer(buffer)
-        if app is not None:
-            app.invalidate()
-
-    def _reset_input_buffer(self, buffer) -> None:
-        """Clear an input buffer after a programmatic submit (best-effort)."""
-        try:
-            buffer.reset(append_to_history=True)
-        except Exception:
-            try:
-                buffer.text = ""
+                from hermes_cli.models import get_default_model_for_provider
+                _default = get_default_model_for_provider(resolved_provider)
+                if _default:
+                    self.model = _default
+                    logger.info(
+                        "No model configured — defaulting to %s for provider %s",
+                        _default, resolved_provider,
+                    )
             except Exception:
                 pass
 
+        # Normalize model for the resolved provider (e.g. swap non-Codex
+        # models when provider is openai-codex).  Fixes #651.
+        model_changed = self._normalize_model_for_provider(resolved_provider)
 
+        # AIAgent/OpenAI client holds auth at init time, so rebuild if key,
+        # routing, or the effective model changed.
+        if (credentials_changed or routing_changed or model_changed) and self.agent is not None:
+            self.agent = None
+            self._active_agent_route_signature = None
+
+        return True
+
+    def _resolve_turn_agent_config(self, user_message: str) -> dict:
+        """Build the effective model/runtime config for a single user turn.
+
+        Always uses the session's primary model/provider.  If the user has
+        toggled `/fast` on and the current model supports Priority
+        Processing / Anthropic fast mode, attach `request_overrides` so the
+        API call is marked accordingly.
+        """
+        from hermes_cli.models import resolve_fast_mode_overrides
+
+        runtime = {
+            "api_key": self.api_key,
+            "base_url": self.base_url,
+            "provider": self.provider,
+            "api_mode": self.api_mode,
+            "command": self.acp_command,
+            "args": list(self.acp_args or []),
+            "credential_pool": getattr(self, "_credential_pool", None),
+        }
+        route = {
+            "model": self.model,
+            "runtime": runtime,
+            "signature": (
+                self.model,
+                runtime["provider"],
+                runtime["base_url"],
+                runtime["api_mode"],
+                runtime["command"],
+                tuple(runtime["args"]),
+            ),
+        }
+
+        service_tier = getattr(self, "service_tier", None)
+        if not service_tier:
+            route["request_overrides"] = None
+            return route
+
+        try:
+            overrides = resolve_fast_mode_overrides(route["model"])
+        except Exception:
+            overrides = None
+        route["request_overrides"] = overrides
+        return route
 
     def _install_tool_callbacks(self) -> None:
         """Install tool callbacks that need the live prompt UI."""
@@ -6310,6 +4964,203 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         except Exception:
             pass
 
+    def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, request_overrides: dict | None = None) -> bool:
+        """
+        Initialize the agent on first use.
+        When resuming a session, restores conversation history from SQLite.
+        
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        if self.agent is not None:
+            return True
+
+        _prepare_deferred_agent_startup()
+        self._install_tool_callbacks()
+        self._ensure_tirith_security()
+
+        if not self._ensure_runtime_credentials():
+            return False
+
+        # Initialize SQLite session store for CLI sessions (if not already done in __init__)
+        if self._session_db is None:
+            try:
+                from hermes_state import SessionDB
+                self._session_db = SessionDB()
+            except Exception as e:
+                logger.warning("SQLite session store not available — session will NOT be indexed: %s", e)
+        
+        # If resuming, validate the session exists and load its history.
+        # _preload_resumed_session() may have already loaded it (called from
+        # run() for immediate display).  In that case, conversation_history
+        # is non-empty and we skip the DB round-trip.
+        if self._resumed and self._session_db and not self.conversation_history:
+            session_meta = self._session_db.get_session(self.session_id)
+            # In quiet mode (`hermes chat -Q` / --quiet, surfaced via
+            # tool_progress_mode == "off"), resume status lines go to stderr
+            # so stdout stays machine-readable for automation wrappers that
+            # do `$(hermes chat -Q --resume <id> -q "...")`. Without this,
+            # the resume banner pollutes captured stdout. See #11793.
+            _quiet_mode = getattr(self, "tool_progress_mode", "full") == "off"
+            if not session_meta:
+                if _quiet_mode:
+                    print(f"Session not found: {self.session_id}", file=sys.stderr)
+                    print(
+                        "Use a session ID from a previous CLI run (hermes sessions list).",
+                        file=sys.stderr,
+                    )
+                else:
+                    _cprint(f"\033[1;31mSession not found: {self.session_id}{_RST}")
+                    _cprint(f"{_DIM}Use a session ID from a previous CLI run (hermes sessions list).{_RST}")
+                return False
+            # If the requested session is the (empty) head of a compression
+            # chain, walk to the descendant that actually holds the messages.
+            # See #15000 and SessionDB.resolve_resume_session_id.
+            try:
+                resolved_id = self._session_db.resolve_resume_session_id(self.session_id)
+            except Exception:
+                resolved_id = self.session_id
+            if resolved_id and resolved_id != self.session_id:
+                ChatConsole().print(
+                    f"[{_DIM}]Session {_escape(self.session_id)} was compressed into "
+                    f"{_escape(resolved_id)}; resuming the descendant with your "
+                    f"transcript.[/]"
+                )
+                self.session_id = resolved_id
+                resolved_meta = self._session_db.get_session(self.session_id)
+                if resolved_meta:
+                    session_meta = resolved_meta
+            restored = self._session_db.get_messages_as_conversation(self.session_id)
+            if restored:
+                restored = [m for m in restored if m.get("role") != "session_meta"]
+                self.conversation_history = restored
+                msg_count = len([m for m in restored if m.get("role") == "user"])
+                title_part = ""
+                if session_meta.get("title"):
+                    title_part = f" \"{session_meta['title']}\""
+                if _quiet_mode:
+                    print(
+                        f"↻ Resumed session {self.session_id}{title_part} "
+                        f"({msg_count} user message{'s' if msg_count != 1 else ''}, "
+                        f"{len(restored)} total messages)",
+                        file=sys.stderr,
+                    )
+                else:
+                    ChatConsole().print(
+                        f"[bold {_accent_hex()}]↻ Resumed session[/] "
+                        f"[bold]{_escape(self.session_id)}[/]"
+                        f"[bold {_accent_hex()}]{_escape(title_part)}[/] "
+                        f"({msg_count} user message{'s' if msg_count != 1 else ''}, {len(restored)} total messages)"
+                    )
+            else:
+                if _quiet_mode:
+                    print(
+                        f"Session {self.session_id} found but has no messages. Starting fresh.",
+                        file=sys.stderr,
+                    )
+                else:
+                    ChatConsole().print(
+                        f"[bold {_accent_hex()}]Session {_escape(self.session_id)} found but has no messages. Starting fresh.[/]"
+                    )
+            # Re-open the session (clear ended_at so it's active again)
+            try:
+                self._session_db._conn.execute(
+                    "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
+                    (self.session_id,),
+                )
+                self._session_db._conn.commit()
+            except Exception:
+                pass
+        
+        try:
+            runtime = runtime_override or {
+                "api_key": self.api_key,
+                "base_url": self.base_url,
+                "provider": self.provider,
+                "api_mode": self.api_mode,
+                "command": self.acp_command,
+                "args": list(self.acp_args or []),
+                "credential_pool": getattr(self, "_credential_pool", None),
+            }
+            effective_model = model_override or self.model
+            self.agent = AIAgent(
+                model=effective_model,
+                api_key=runtime.get("api_key"),
+                base_url=runtime.get("base_url"),
+                provider=runtime.get("provider"),
+                api_mode=runtime.get("api_mode"),
+                acp_command=runtime.get("command"),
+                acp_args=runtime.get("args"),
+                credential_pool=runtime.get("credential_pool"),
+                max_iterations=self.max_turns,
+                enabled_toolsets=self.enabled_toolsets,
+                disabled_toolsets=self.disabled_toolsets,
+                verbose_logging=self.verbose,
+                quiet_mode=not self.verbose,
+                ephemeral_system_prompt=self.system_prompt if self.system_prompt else None,
+                prefill_messages=self.prefill_messages or None,
+                reasoning_config=self.reasoning_config,
+                service_tier=self.service_tier,
+                request_overrides=request_overrides,
+                providers_allowed=self._providers_only,
+                providers_ignored=self._providers_ignore,
+                providers_order=self._providers_order,
+                provider_sort=self._provider_sort,
+                provider_require_parameters=self._provider_require_params,
+                provider_data_collection=self._provider_data_collection,
+                openrouter_min_coding_score=self._openrouter_min_coding_score,
+                session_id=self.session_id,
+                platform="cli",
+                session_db=self._session_db,
+                clarify_callback=self._clarify_callback,
+                reasoning_callback=self._current_reasoning_callback(),
+
+                fallback_model=self._fallback_model,
+                thinking_callback=self._on_thinking,
+                checkpoints_enabled=self.checkpoints_enabled,
+                checkpoint_max_snapshots=self.checkpoint_max_snapshots,
+                checkpoint_max_total_size_mb=self.checkpoint_max_total_size_mb,
+                checkpoint_max_file_size_mb=self.checkpoint_max_file_size_mb,
+                pass_session_id=self.pass_session_id,
+                skip_context_files=self.ignore_rules,
+                skip_memory=self.ignore_rules,
+                tool_progress_callback=self._on_tool_progress,
+                tool_start_callback=self._on_tool_start if self._inline_diffs_enabled else None,
+                tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
+                stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
+                tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
+            )
+            # Store reference for atexit memory provider shutdown
+            global _active_agent_ref
+            _active_agent_ref = self.agent
+            # Route agent status output through prompt_toolkit so ANSI escape
+            # sequences aren't garbled by patch_stdout's StdoutProxy (#2262).
+            self.agent._print_fn = _cprint
+            self._active_agent_route_signature = (
+                effective_model,
+                runtime.get("provider"),
+                runtime.get("base_url"),
+                runtime.get("api_mode"),
+                runtime.get("command"),
+                tuple(runtime.get("args") or ()),
+            )
+
+            # Force-create DB row on /title intent, then apply title.
+            if self._pending_title and self._session_db and self.agent:
+                try:
+                    self.agent._ensure_db_session()
+                    if self.agent._session_db_created:
+                        self._session_db.set_session_title(self.session_id, self._pending_title)
+                        _cprint(f"  Session title applied: {self._pending_title}")
+                        self._pending_title = None
+                    # else: row creation failed transiently — keep _pending_title for retry
+                except (ValueError, Exception) as e:
+                    _cprint(f"  Could not apply pending title: {e}")
+                    # Keep _pending_title so it can be retried after row creation succeeds
+            return True
+        except Exception as e:
+            ChatConsole().print(f"[bold red]Failed to initialize agent: {e}[/]")
+            return False
     
     def _show_security_advisories(self):
         """Show a startup banner if any unacked security advisories match.
@@ -6367,7 +5218,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 enabled_toolsets=self.enabled_toolsets,
                 session_id=self.session_id,
                 context_length=ctx_len,
-                provider=self.provider,
             )
         
         # Tool discovery is intentionally deferred on the Termux bare prompt
@@ -6421,60 +5271,249 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         self._console_print()
 
-    def _restore_session_cwd(self, session_meta: dict, *, quiet: bool = False) -> None:
-        """Relaunch a resumed session in the directory it was started from.
+    def _preload_resumed_session(self) -> bool:
+        """Load a resumed session's history from the DB early (before first chat).
 
-        Idempotent and safe to call from every resume path. When the stored
-        ``cwd`` differs from the current process directory, we both
-        ``os.chdir()`` (so the process and any ``os.getcwd()`` fallback agree)
-        and retarget ``TERMINAL_CWD`` (so the terminal tool, code-exec tool,
-        and relative-path resolution all land in the same place — the local
-        terminal backend snapshots cwd on first use, which happens after this).
+        Called from run() so the conversation history is available for display
+        before the user sends their first message.  Sets
+        ``self.conversation_history`` and prints the one-liner status.  Returns
+        True if history was loaded, False otherwise.
 
-        No-ops when: the session recorded no cwd (gateway/remote/older
-        sessions), the directory no longer exists, or we're already there.
-        A missing directory degrades to a single dim warning rather than a
-        crash — repos get moved and deleted.
+        The corresponding block in ``_init_agent()`` checks whether history is
+        already populated and skips the DB round-trip.
         """
-        recorded = (session_meta or {}).get("cwd")
-        if not recorded:
-            return
-        recorded = os.path.expanduser(str(recorded))
+        if not self._resumed or not self._session_db:
+            return False
+
+        session_meta = self._session_db.get_session(self.session_id)
+        if not session_meta:
+            self._console_print(
+                f"[bold red]Session not found: {self.session_id}[/]"
+            )
+            self._console_print(
+                "[dim]Use a session ID from a previous CLI run "
+                "(hermes sessions list).[/]"
+            )
+            return False
+
+        # If the requested session is the (empty) head of a compression chain,
+        # walk to the descendant that actually holds the messages. See #15000.
         try:
-            current = os.getcwd()
-        except OSError:
-            current = None
-        if current and os.path.realpath(recorded) == os.path.realpath(current):
-            return  # Already where the session lived — nothing to announce.
+            resolved_id = self._session_db.resolve_resume_session_id(self.session_id)
+        except Exception:
+            resolved_id = self.session_id
+        if resolved_id and resolved_id != self.session_id:
+            self._console_print(
+                f"[dim]Session {self.session_id} was compressed into "
+                f"{resolved_id}; resuming the descendant with your transcript.[/]"
+            )
+            self.session_id = resolved_id
+            resolved_meta = self._session_db.get_session(self.session_id)
+            if resolved_meta:
+                session_meta = resolved_meta
 
-        if not os.path.isdir(recorded):
-            msg = f"⚠ Session's working directory is gone: {recorded} — staying in {current or '.'}"
-            if quiet:
-                print(msg, file=sys.stderr)
-            else:
-                self._console_print(f"[dim]{_escape(msg)}[/dim]")
-            return
-
-        try:
-            os.chdir(recorded)
-        except OSError as e:
-            msg = f"⚠ Could not enter session's working directory {recorded}: {e}"
-            if quiet:
-                print(msg, file=sys.stderr)
-            else:
-                self._console_print(f"[dim]{_escape(msg)}[/dim]")
-            return
-
-        # Retarget the terminal/code-exec tools to match the process cwd.
-        os.environ["TERMINAL_CWD"] = recorded
-
-        msg = f"↻ Working directory: {recorded}"
-        if quiet:
-            print(msg, file=sys.stderr)
+        restored = self._session_db.get_messages_as_conversation(self.session_id)
+        if restored:
+            restored = [m for m in restored if m.get("role") != "session_meta"]
+            self.conversation_history = restored
+            msg_count = len([m for m in restored if m.get("role") == "user"])
+            title_part = ""
+            if session_meta.get("title"):
+                title_part = f' "{session_meta["title"]}"'
+            accent_color = _accent_hex()
+            self._console_print(
+                f"[{accent_color}]↻ Resumed session [bold]{self.session_id}[/bold]"
+                f"{title_part} "
+                f"({msg_count} user message{'s' if msg_count != 1 else ''}, "
+                f"{len(restored)} total messages)[/]"
+            )
         else:
-            self._console_print(f"[dim]{_escape(msg)}[/dim]")
+            accent_color = _accent_hex()
+            self._console_print(
+                f"[{accent_color}]Session {self.session_id} found but has no "
+                f"messages. Starting fresh.[/]"
+            )
+            return False
 
+        # Re-open the session (clear ended_at so it's active again)
+        try:
+            self._session_db._conn.execute(
+                "UPDATE sessions SET ended_at = NULL, end_reason = NULL "
+                "WHERE id = ?",
+                (self.session_id,),
+            )
+            self._session_db._conn.commit()
+        except Exception:
+            pass
 
+        return True
+
+    def _display_resumed_history(self):
+        """Render a compact recap of previous conversation messages.
+
+        Uses Rich markup with dim/muted styling so the recap is visually
+        distinct from the active conversation.  Caps the display at the
+        last ``MAX_DISPLAY_EXCHANGES`` user/assistant exchanges and shows
+        an indicator for earlier hidden messages.
+        """
+        if not self.conversation_history:
+            return
+
+        # Check config: resume_display setting
+        if self.resume_display == "minimal":
+            return
+
+        # Read limits from config (with hardcoded defaults)
+        _disp = CLI_CONFIG.get("display", {})
+        MAX_DISPLAY_EXCHANGES = int(_disp.get("resume_exchanges", 10))
+        MAX_USER_LEN = int(_disp.get("resume_max_user_chars", 300))
+        MAX_ASST_LEN = int(_disp.get("resume_max_assistant_chars", 200))
+        MAX_ASST_LINES = int(_disp.get("resume_max_assistant_lines", 3))
+        SKIP_TOOL_ONLY = _disp.get("resume_skip_tool_only", True)
+
+        # Collect displayable entries (skip system, tool-result messages)
+        entries = []  # list of (role, display_text)
+        _last_asst_idx = None       # index of last assistant entry
+        _last_asst_full = None      # un-truncated display text for last assistant
+        for msg in self.conversation_history:
+            role = msg.get("role", "")
+            content = msg.get("content")
+            tool_calls = msg.get("tool_calls") or []
+
+            if role == "system":
+                continue
+            if role == "tool":
+                continue
+
+            if role == "user":
+                text = "" if content is None else str(content)
+                # Handle multimodal content (list of dicts)
+                if isinstance(content, list):
+                    parts = []
+                    for part in content:
+                        if isinstance(part, dict) and part.get("type") == "text":
+                            parts.append(part.get("text", ""))
+                        elif isinstance(part, dict) and part.get("type") == "image_url":
+                            parts.append("[image]")
+                    text = " ".join(parts)
+                if len(text) > MAX_USER_LEN:
+                    text = text[:MAX_USER_LEN] + "..."
+                entries.append(("user", text))
+
+            elif role == "assistant":
+                text = "" if content is None else str(content)
+                text = _strip_reasoning_tags(text)
+                parts = []
+                full_parts = []  # un-truncated version
+                if text:
+                    full_parts.append(text)
+                    lines = text.splitlines()
+                    if len(lines) > MAX_ASST_LINES:
+                        text = "\n".join(lines[:MAX_ASST_LINES]) + " ..."
+                    if len(text) > MAX_ASST_LEN:
+                        text = text[:MAX_ASST_LEN] + "..."
+                    parts.append(text)
+                if tool_calls:
+                    tc_count = len(tool_calls)
+                    # Extract tool names
+                    names = []
+                    for tc in tool_calls:
+                        fn = tc.get("function", {})
+                        name = fn.get("name", "unknown") if isinstance(fn, dict) else "unknown"
+                        if name not in names:
+                            names.append(name)
+                    names_str = ", ".join(names[:4])
+                    if len(names) > 4:
+                        names_str += ", ..."
+                    noun = "call" if tc_count == 1 else "calls"
+                    tc_summary = f"[{tc_count} tool {noun}: {names_str}]"
+                    parts.append(tc_summary)
+                    full_parts.append(tc_summary)
+                if not parts:
+                    # Skip pure-reasoning messages that have no visible output
+                    continue
+                # Skip tool-call-only entries when SKIP_TOOL_ONLY is enabled
+                has_text = bool(text)
+                if SKIP_TOOL_ONLY and not has_text and tool_calls:
+                    continue
+                entries.append(("assistant", " ".join(parts)))
+                _last_asst_idx = len(entries) - 1
+                _last_asst_full = " ".join(full_parts)
+
+        if not entries:
+            return
+
+        # Determine if we need to truncate
+        skipped = 0
+        if len(entries) > MAX_DISPLAY_EXCHANGES * 2:
+            skipped = len(entries) - MAX_DISPLAY_EXCHANGES * 2
+            entries = entries[skipped:]
+
+        # Replace last assistant entry with full (un-truncated) text
+        # so the user can see where they left off without wasting tokens.
+        if _last_asst_idx is not None and _last_asst_full:
+            adj_idx = _last_asst_idx - skipped
+            if 0 <= adj_idx < len(entries):
+                entries[adj_idx] = ("assistant_last", _last_asst_full)
+
+        # Build the display using Rich
+        from rich.panel import Panel
+        from rich.text import Text
+
+        try:
+            from hermes_cli.skin_engine import get_active_skin
+            _skin = get_active_skin()
+            _history_text_c = _skin.get_color("banner_text", "#FFF8DC")
+            _session_label_c = _skin.get_color("session_label", "#DAA520")
+            _session_border_c = _skin.get_color("session_border", "#8B8682")
+            _assistant_label_c = _skin.get_color("ui_ok", "#8FBC8F")
+        except Exception:
+            _history_text_c = "#FFF8DC"
+            _session_label_c = "#DAA520"
+            _session_border_c = "#8B8682"
+            _assistant_label_c = "#8FBC8F"
+
+        lines = Text()
+        if skipped:
+            lines.append(
+                f"  ... {skipped} earlier messages ...\n\n",
+                style="dim italic",
+            )
+
+        for i, (role, text) in enumerate(entries):
+            if role == "user":
+                lines.append("  ● You: ", style=f"dim bold {_session_label_c}")
+                # Show first line inline, indent rest
+                msg_lines = text.splitlines()
+                lines.append(msg_lines[0] + "\n", style="dim")
+                for ml in msg_lines[1:]:
+                    lines.append(f"         {ml}\n", style="dim")
+            elif role == "assistant_last":
+                # Last assistant response shown in full, non-dim
+                lines.append("  ◆ Hermes: ", style=f"bold {_assistant_label_c}")
+                msg_lines = text.splitlines()
+                lines.append(msg_lines[0] + "\n", style="")
+                for ml in msg_lines[1:]:
+                    lines.append(f"            {ml}\n", style="")
+            else:
+                lines.append("  ◆ Hermes: ", style=f"dim bold {_assistant_label_c}")
+                msg_lines = text.splitlines()
+                lines.append(msg_lines[0] + "\n", style="dim")
+                for ml in msg_lines[1:]:
+                    lines.append(f"            {ml}\n", style="dim")
+            if i < len(entries) - 1:
+                lines.append("")  # small gap
+
+        panel = Panel(
+            lines,
+            title=f"[dim {_session_label_c}]Previous Conversation[/]",
+            border_style=f"dim {_session_border_c}",
+            padding=(0, 1),
+            style=_history_text_c,
+        )
+        _record_output_history_entry(lambda: self._render_resume_history_panel_lines(panel))
+        with _suspend_output_history():
+            self._console_print(panel)
 
     def _render_resume_history_panel_lines(self, panel) -> list[str]:
         """Render the resume panel at the current terminal width for resize replay."""
@@ -6512,6 +5551,99 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._image_counter -= 1
         return False
 
+    def _handle_rollback_command(self, command: str):
+        """Handle /rollback — list, diff, or restore filesystem checkpoints.
+
+        Syntax:
+            /rollback                 — list checkpoints
+            /rollback <N>             — restore checkpoint N (also undoes last chat turn)
+            /rollback diff <N>        — preview changes since checkpoint N
+            /rollback <N> <file>      — restore a single file from checkpoint N
+        """
+        from tools.checkpoint_manager import format_checkpoint_list
+
+        if not hasattr(self, 'agent') or not self.agent:
+            print("  No active agent session.")
+            return
+
+        mgr = self.agent._checkpoint_mgr
+        if not mgr.enabled:
+            print("  Checkpoints are not enabled.")
+            print("  Enable with: hermes --checkpoints")
+            print("  Or in config.yaml: checkpoints: { enabled: true }")
+            return
+
+        cwd = os.getenv("TERMINAL_CWD", os.getcwd())
+        parts = command.split()
+        args = parts[1:] if len(parts) > 1 else []
+
+        if not args:
+            # List checkpoints
+            checkpoints = mgr.list_checkpoints(cwd)
+            print(format_checkpoint_list(checkpoints, cwd))
+            return
+
+        # Handle /rollback diff <N>
+        if args[0].lower() == "diff":
+            if len(args) < 2:
+                print("  Usage: /rollback diff <N>")
+                return
+            checkpoints = mgr.list_checkpoints(cwd)
+            if not checkpoints:
+                print(f"  No checkpoints found for {cwd}")
+                return
+            target_hash = self._resolve_checkpoint_ref(args[1], checkpoints)
+            if not target_hash:
+                return
+            result = mgr.diff(cwd, target_hash)
+            if result["success"]:
+                stat = result.get("stat", "")
+                diff = result.get("diff", "")
+                if not stat and not diff:
+                    print("  No changes since this checkpoint.")
+                else:
+                    if stat:
+                        print(f"\n{stat}")
+                    if diff:
+                        # Limit diff output to avoid terminal flood
+                        diff_lines = diff.splitlines()
+                        if len(diff_lines) > 80:
+                            print("\n".join(diff_lines[:80]))
+                            print(f"\n  ... ({len(diff_lines) - 80} more lines, showing first 80)")
+                        else:
+                            print(f"\n{diff}")
+            else:
+                print(f"  ❌ {result['error']}")
+            return
+
+        # Resolve checkpoint reference (number or hash)
+        checkpoints = mgr.list_checkpoints(cwd)
+        if not checkpoints:
+            print(f"  No checkpoints found for {cwd}")
+            return
+
+        target_hash = self._resolve_checkpoint_ref(args[0], checkpoints)
+        if not target_hash:
+            return
+
+        # Check for file-level restore: /rollback <N> <file>
+        file_path = args[1] if len(args) > 1 else None
+
+        result = mgr.restore(cwd, target_hash, file_path=file_path)
+        if result["success"]:
+            if file_path:
+                print(f"  ✅ Restored {file_path} from checkpoint {result['restored_to']}: {result['reason']}")
+            else:
+                print(f"  ✅ Restored to checkpoint {result['restored_to']}: {result['reason']}")
+            print("  A pre-rollback snapshot was saved automatically.")
+
+            # Also undo the last conversation turn so the agent's context
+            # matches the restored filesystem state
+            if self.conversation_history:
+                self.undo_last()
+                print("  Chat turn undone to match restored file state.")
+        else:
+            print(f"  ❌ {result['error']}")
 
     def _resolve_checkpoint_ref(self, ref: str, checkpoints: list) -> str | None:
         """Resolve a checkpoint number or hash to a full commit hash."""
@@ -6526,9 +5658,156 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # Treat as a git hash
             return ref
 
+    def _handle_snapshot_command(self, command: str):
+        """Handle /snapshot — lightweight state snapshots for Hermes config/state.
 
+        Syntax:
+            /snapshot                  — list recent snapshots
+            /snapshot create [label]   — create a snapshot
+            /snapshot restore <id>     — restore state from snapshot
+            /snapshot prune [N]        — prune to N snapshots (default 20)
+        """
+        from hermes_cli.backup import (
+            create_quick_snapshot, list_quick_snapshots,
+            restore_quick_snapshot, prune_quick_snapshots,
+        )
+        from hermes_constants import display_hermes_home
 
+        parts = command.split()
+        subcmd = parts[1].lower() if len(parts) > 1 else "list"
 
+        if subcmd in {"list", "ls"}:
+            snaps = list_quick_snapshots()
+            if not snaps:
+                print("  No state snapshots yet.")
+                print("  Create one: /snapshot create [label]")
+                return
+            print(f"  State snapshots ({display_hermes_home()}/state-snapshots/):\n")
+            print(f"  {'#':>3}  {'ID':<35} {'Files':>5} {'Size':>10} {'Label'}")
+            print(f"  {'─'*3}  {'─'*35} {'─'*5} {'─'*10} {'─'*20}")
+            for i, s in enumerate(snaps, 1):
+                size = s.get("total_size", 0)
+                if size < 1024:
+                    size_str = f"{size} B"
+                elif size < 1024 * 1024:
+                    size_str = f"{size / 1024:.0f} KB"
+                else:
+                    size_str = f"{size / 1024 / 1024:.1f} MB"
+                label = s.get("label") or ""
+                print(f"  {i:3}  {s['id']:<35} {s.get('file_count', 0):>5} {size_str:>10} {label}")
+
+        elif subcmd == "create":
+            label = " ".join(parts[2:]) if len(parts) > 2 else None
+            snap_id = create_quick_snapshot(label=label)
+            if snap_id:
+                print(f"  Snapshot created: {snap_id}")
+            else:
+                print("  No state files found to snapshot.")
+
+        elif subcmd in {"restore", "rewind"}:
+            if len(parts) < 3:
+                print("  Usage: /snapshot restore <snapshot-id>")
+                # Show hint with most recent snapshot
+                snaps = list_quick_snapshots(limit=1)
+                if snaps:
+                    print(f"  Most recent: {snaps[0]['id']}")
+                return
+            snap_id = parts[2]
+            # Allow restore by number (1-indexed)
+            try:
+                idx = int(snap_id)
+                snaps = list_quick_snapshots()
+                if 1 <= idx <= len(snaps):
+                    snap_id = snaps[idx - 1]["id"]
+                else:
+                    print(f"  Invalid snapshot number. Use 1-{len(snaps)}.")
+                    return
+            except ValueError:
+                pass
+            if restore_quick_snapshot(snap_id):
+                print(f"  Restored state from: {snap_id}")
+                print("  Restart recommended for state.db changes to take effect.")
+            else:
+                print(f"  Snapshot not found: {snap_id}")
+
+        elif subcmd == "prune":
+            keep = 20
+            if len(parts) > 2:
+                try:
+                    keep = int(parts[2])
+                except ValueError:
+                    print("  Usage: /snapshot prune [keep-count]")
+                    return
+            deleted = prune_quick_snapshots(keep=keep)
+            print(f"  Pruned {deleted} old snapshot(s) (keeping {keep}).")
+
+        else:
+            print(f"  Unknown subcommand: {subcmd}")
+            print("  Usage: /snapshot [list|create [label]|restore <id>|prune [N]]")
+
+    def _handle_stop_command(self):
+        """Handle /stop — kill all running background processes.
+
+        Inspired by OpenAI Codex's separation of interrupt (stop current turn)
+        from /stop (clean up background processes). See openai/codex#14602.
+        """
+        from tools.process_registry import process_registry
+
+        processes = process_registry.list_sessions()
+        running = [p for p in processes if p.get("status") == "running"]
+
+        if not running:
+            print("  No running background processes.")
+            return
+
+        print(f"  Stopping {len(running)} background process(es)...")
+        killed = process_registry.kill_all()
+        print(f"  ✅ Stopped {killed} process(es).")
+
+    def _handle_agents_command(self):
+        """Handle /agents — show background processes and agent status."""
+        from tools.process_registry import format_uptime_short, process_registry
+
+        processes = process_registry.list_sessions()
+        running = [p for p in processes if p.get("status") == "running"]
+        finished = [p for p in processes if p.get("status") != "running"]
+
+        _cprint(f"  Running processes: {len(running)}")
+        for p in running:
+            cmd = p.get("command", "")[:80]
+            up = format_uptime_short(p.get("uptime_seconds", 0))
+            _cprint(f"    {p.get('session_id', '?')} · {up} · {cmd}")
+
+        if finished:
+            _cprint(f"  Recently finished: {len(finished)}")
+
+        agent_running = getattr(self, "_agent_running", False)
+        _cprint(f"  Agent: {'running' if agent_running else 'idle'}")
+
+    def _handle_paste_command(self):
+        """Handle /paste — explicitly check clipboard for an image.
+
+        This is the reliable fallback for terminals where BracketedPaste
+        doesn't fire for image-only clipboard content (e.g., VSCode terminal,
+        Windows Terminal with WSL2).
+        """
+        if _is_termux_environment():
+            _cprint(
+                f"  {_DIM}Clipboard image paste is not available on Termux — "
+                f"use /image <path> or paste a local image path like "
+                f"{_termux_example_image_path()}{_RST}"
+            )
+            return
+
+        from hermes_cli.clipboard import has_clipboard_image
+        if has_clipboard_image():
+            if self._try_attach_clipboard_image():
+                n = len(self._attached_images)
+                _cprint(f"  📎 Image #{n} attached from clipboard")
+            else:
+                _cprint(f"  {_DIM}(>_<) Clipboard has an image but extraction failed{_RST}")
+        else:
+            _cprint(f"  {_DIM}(._.) No image found in clipboard{_RST}")
 
     def _write_osc52_clipboard(self, text: str) -> None:
         """Copy *text* to terminal clipboard via OSC 52."""
@@ -6578,7 +5857,67 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 f"If this repeats, run /new or restart this tab.{_RST}"
             )
 
+    def _handle_copy_command(self, cmd_original: str) -> None:
+        """Handle /copy [number] — copy assistant output to clipboard."""
+        parts = cmd_original.split(maxsplit=1)
+        arg = parts[1].strip() if len(parts) > 1 else ""
 
+        assistant = [m for m in self.conversation_history if m.get("role") == "assistant"]
+        if not assistant:
+            _cprint("  Nothing to copy yet.")
+            return
+
+        if arg:
+            try:
+                idx = int(arg) - 1
+            except ValueError:
+                _cprint("  Usage: /copy [number]")
+                return
+            if idx < 0 or idx >= len(assistant):
+                _cprint(f"  Invalid response number. Use 1-{len(assistant)}.")
+                return
+        else:
+            idx = len(assistant) - 1
+            while idx >= 0 and not _assistant_copy_text(assistant[idx].get("content")):
+                idx -= 1
+            if idx < 0:
+                _cprint("  Nothing to copy in assistant responses yet.")
+                return
+
+        text = _assistant_copy_text(assistant[idx].get("content"))
+        if not text:
+            _cprint("  Nothing to copy in that assistant response.")
+            return
+
+        try:
+            self._write_osc52_clipboard(text)
+            _cprint(f"  Copied assistant response #{idx + 1} to clipboard")
+        except Exception as e:
+            _cprint(f"  Clipboard copy failed: {e}")
+
+    def _handle_image_command(self, cmd_original: str):
+        """Handle /image <path> — attach a local image file for the next prompt."""
+        raw_args = (cmd_original.split(None, 1)[1].strip() if " " in cmd_original else "")
+        if not raw_args:
+            hint = _termux_example_image_path() if _is_termux_environment() else "/path/to/image.png"
+            _cprint(f"  {_DIM}Usage: /image <path>  e.g. /image {hint}{_RST}")
+            return
+
+        path_token, _remainder = _split_path_input(raw_args)
+        image_path = _resolve_attachment_path(path_token)
+        if image_path is None:
+            _cprint(f"  {_DIM}(>_<) File not found: {path_token}{_RST}")
+            return
+        if image_path.suffix.lower() not in _IMAGE_EXTENSIONS:
+            _cprint(f"  {_DIM}(._.) Not a supported image file: {image_path.name}{_RST}")
+            return
+
+        self._attached_images.append(image_path)
+        _cprint(f"  📎 Attached image: {image_path.name}")
+        if _remainder:
+            _cprint(f"  {_DIM}Now type your prompt (or use --image in single-query mode): {_remainder}{_RST}")
+        elif _is_termux_environment():
+            _cprint(f"  {_DIM}Tip: type your next message, or run hermes chat -q --image {_termux_example_image_path(image_path.name)} \"What do you see?\"{_RST}")
 
     def _preprocess_images_with_vision(self, text: str, images: list, *, announce: bool = True) -> str:
         """Analyze attached images via the vision tool and return enriched text.
@@ -6763,6 +6102,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             f"Tokens: {total_tokens:,}",
             f"Agent Running: {'Yes' if is_running else 'No'}",
         ])
+
+        # Session recap — pure local compute summary of recent activity
+        # (turn counts, tools used, files touched, last ask, last reply).
+        # No LLM call, no prompt-cache impact. Inspired by Claude Code
+        # 2.1.114's /recap.
+        try:
+            from hermes_cli.session_recap import build_recap
+            recap = build_recap(
+                self.conversation_history or [],
+                session_title=title or None,
+                session_id=self.session_id,
+                platform="cli",
+            )
+            if recap:
+                lines.extend(["", recap])
+        except Exception as exc:  # defensive — don't let /status fail
+            logger.debug("build_recap failed in /status: %s", exc)
+
         self._console_print("\n".join(lines), highlight=False, markup=False)
     
     def _fast_command_available(self) -> bool:
@@ -6822,15 +6179,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     f"{_escape(desc)} [dim]({skill_count} skills)[/]"
                 )
 
-        quick_commands = self.config.get("quick_commands", {})
-        if quick_commands:
-            _cprint(f"\n  ⚡ {_BOLD}Quick Commands{_RST} ({len(quick_commands)} configured):")
-            for name, qcmd in sorted(quick_commands.items()):
-                desc = qcmd.get("description", qcmd.get("type", ""))
-                ChatConsole().print(
-                    f"    [bold {_accent_hex()}]{('/' + name):<22}[/] [dim]-[/] {_escape(desc)}"
-                )
-
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
         _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
         _cprint(f"  {_DIM}Draft editor: Ctrl+G (Alt+G in VSCode/Cursor){_RST}")
@@ -6881,6 +6229,84 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         print(f"  Total: {len(tools)} tools  ヽ(^o^)ノ")
         print()
 
+    def _handle_tools_command(self, cmd: str):
+        """Handle /tools [list|disable|enable] slash commands.
+
+        /tools (no args) shows the tool list.
+        /tools list shows enabled/disabled status per toolset.
+        /tools disable/enable saves the change to config and resets
+        the session so the new tool set takes effect cleanly (no
+        prompt-cache breakage mid-conversation).
+        """
+        import shlex
+        from argparse import Namespace
+        from contextlib import redirect_stdout
+        from io import StringIO
+        from hermes_cli.tools_config import tools_disable_enable_command
+
+        def _run_capture(ns: Namespace) -> None:
+            """Run tools_disable_enable_command, routing its ANSI-colored
+            print() output through _cprint when inside the interactive TUI
+            so escapes aren't mangled by patch_stdout's StdoutProxy into
+            garbled '?[32m...?[0m' text.
+
+            Outside the TUI (standalone mode, tests), call straight through
+            so real stdout / pytest capture works as expected.
+            """
+            # Standalone/tests, run as usual
+            if getattr(self, "_app", None) is None:
+                tools_disable_enable_command(ns)
+                return
+
+            # Buffer reports isatty()=True so color() in hermes_cli/colors.py
+            # still emits ANSI escapes. StringIO.isatty() is False, which
+            # would otherwise strip all colors before we re-render them.
+            class _TTYBuf(StringIO):
+                def isatty(self) -> bool:
+                    return True
+
+            buf = _TTYBuf()
+            with redirect_stdout(buf):
+                tools_disable_enable_command(ns)
+            for line in buf.getvalue().splitlines():
+                _cprint(line)
+
+        try:
+            parts = shlex.split(cmd)
+        except ValueError:
+            parts = cmd.split()
+
+        subcommand = parts[1] if len(parts) > 1 else ""
+        if subcommand not in {"list", "disable", "enable"}:
+            self.show_tools()
+            return
+
+        if subcommand == "list":
+            _run_capture(Namespace(tools_action="list", platform="cli"))
+            return
+
+        names = parts[2:]
+        if not names:
+            print(f"(._.) Usage: /tools {subcommand} <name> [name ...]")
+            print(f"  Built-in toolset:  /tools {subcommand} web")
+            print(f"  MCP tool:          /tools {subcommand} github:create_issue")
+            return
+
+        # Apply the change directly — the user typing the command is implicit
+        # consent.  Do NOT use input() here; it hangs inside prompt_toolkit's
+        # TUI event loop (known pitfall).
+        verb = "Disabling" if subcommand == "disable" else "Enabling"
+        label = ", ".join(names)
+        _cprint(f"{_ACCENT}{verb} {label}...{_RST}")
+
+        _run_capture(Namespace(tools_action=subcommand, names=names, platform="cli"))
+
+        # Reset session so the new tool config is picked up from a clean state
+        from hermes_cli.tools_config import _get_platform_tools
+        from hermes_cli.config import load_config
+        self.enabled_toolsets = _get_platform_tools(load_config(), "cli")
+        self.new_session()
+        _cprint(f"{_DIM}Session reset. New tool configuration is active.{_RST}")
 
     def show_toolsets(self):
         """Display available toolsets with kawaii ASCII art."""
@@ -6913,6 +6339,18 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         print("  Example: python cli.py --toolsets web,terminal")
         print()
     
+    def _handle_profile_command(self):
+        """Display active profile name and home directory."""
+        from hermes_constants import display_hermes_home
+        from hermes_cli.profiles import get_active_profile_name
+
+        display = display_hermes_home()
+        profile_name = get_active_profile_name()
+
+        print()
+        print(f"  Profile: {profile_name}")
+        print(f"  Home:    {display}")
+        print()
 
     def show_config(self):
         """Display current configuration with kawaii ASCII art."""
@@ -6977,19 +6415,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if not self._session_db:
             return []
         try:
-            from hermes_cli.session_listing import query_session_listing
-
-            return query_session_listing(
-                self._session_db,
+            sessions = self._session_db.list_sessions_rich(
                 source="cli",
-                current_session_id=self.session_id,
-                include_all_sources=False,
-                include_unnamed=True,
-                limit=limit,
                 exclude_sources=["tool"],
+                limit=limit,
             )
         except Exception:
             return []
+        return [s for s in sessions if s.get("id") != self.session_id]
 
     def _show_recent_sessions(self, *, reason: str = "history", limit: int = 10) -> bool:
         """Render recent sessions inline from the active chat TUI.
@@ -7002,51 +6435,35 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         from hermes_cli.main import _relative_time
 
-        _cli_visible_print()
+        print()
         if reason == "history":
-            _cli_visible_print("(._.) No messages in the current chat yet — here are recent sessions you can resume:")
+            print("(._.) No messages in the current chat yet — here are recent sessions you can resume:")
         else:
-            _cli_visible_print("  Recent sessions:")
-        _cli_visible_print()
-        _cli_visible_print(f"  {'#':<3} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-        _cli_visible_print(f"  {'─' * 3} {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
+            print("  Recent sessions:")
+        print()
+        print(f"  {'#':<3} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
+        print(f"  {'─' * 3} {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
         for idx, session in enumerate(sessions, start=1):
             title = session.get("title") or "—"
             preview = (session.get("preview") or "")[:38]
             last_active = _relative_time(session.get("last_active"))
-            _cli_visible_print(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
-        _cli_visible_print()
-        _cli_visible_print("  Use /resume <number>, /resume <session id>, or /resume <session title> to continue.")
-        _cli_visible_print("  Example: /resume 2")
-        _cli_visible_print()
+            print(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
+        print()
+        print("  Use /resume <number>, /resume <session id>, or /resume <session title> to continue.")
+        print("  Example: /resume 2")
+        print()
         return True
 
     def show_history(self):
         """Display conversation history."""
         if not self.conversation_history:
             if not self._show_recent_sessions(reason="history"):
-                _cli_visible_print("(._.) No conversation history yet.")
+                print("(._.) No conversation history yet.")
             return
 
         preview_limit = 400
         visible_index = 0
         hidden_tool_messages = 0
-        show_ts = bool(getattr(self, "show_timestamps", False))
-
-        def _ts_suffix(message: dict) -> str:
-            # Messages restored from SessionDB carry a unix `timestamp`; live
-            # unsaved turns may not. Only annotate when both the toggle is on
-            # and the turn actually has a stored time — never fabricate one.
-            if not show_ts:
-                return ""
-            ts = message.get("timestamp")
-            if not ts:
-                return ""
-            try:
-                from datetime import datetime
-                return f"  [{datetime.fromtimestamp(float(ts)).strftime(getattr(self, 'timestamp_format', '%H:%M'))}]"
-            except (ValueError, OSError, TypeError):
-                return ""
 
         def flush_tool_summary():
             nonlocal hidden_tool_messages
@@ -7054,14 +6471,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 return
 
             noun = "message" if hidden_tool_messages == 1 else "messages"
-            _cli_visible_print("\n  [Tools]")
-            _cli_visible_print(f"    ({hidden_tool_messages} tool {noun} hidden)")
+            print("\n  [Tools]")
+            print(f"    ({hidden_tool_messages} tool {noun} hidden)")
             hidden_tool_messages = 0
 
-        _cli_visible_print()
-        _cli_visible_print("+" + "-" * 50 + "+")
-        _cli_visible_print("|" + " " * 12 + "(^_^) Conversation History" + " " * 11 + "|")
-        _cli_visible_print("+" + "-" * 50 + "+")
+        print()
+        print("+" + "-" * 50 + "+")
+        print("|" + " " * 12 + "(^_^) Conversation History" + " " * 11 + "|")
+        print("+" + "-" * 50 + "+")
 
         for msg in self.conversation_history:
             role = msg.get("role", "unknown")
@@ -7080,13 +6497,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             content_text = "" if content is None else str(content)
 
             if role == "user":
-                _cli_visible_print(f"\n  [You #{visible_index}]{_ts_suffix(msg)}")
-                _cli_visible_print(
+                print(f"\n  [You #{visible_index}]")
+                print(
                     f"    {content_text[:preview_limit]}{'...' if len(content_text) > preview_limit else ''}"
                 )
                 continue
 
-            _cli_visible_print(f"\n  [Hermes #{visible_index}]{_ts_suffix(msg)}")
+            print(f"\n  [Hermes #{visible_index}]")
             tool_calls = msg.get("tool_calls") or []
             if content_text:
                 preview = content_text[:preview_limit]
@@ -7099,10 +6516,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             else:
                 preview = "(no text response)"
                 suffix = ""
-            _cli_visible_print(f"    {preview}{suffix}")
+            print(f"    {preview}{suffix}")
 
         flush_tool_summary()
-        _cli_visible_print()
+        print()
     
     def _notify_session_boundary(self, event_type: str) -> None:
         """Fire a session-boundary plugin hook (on_session_finalize or on_session_reset).
@@ -7116,123 +6533,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 event_type,
                 session_id=self.agent.session_id if self.agent else None,
                 platform=getattr(self, "platform", None) or "cli",
-                reason="new_session" if event_type == "on_session_reset" else "session_boundary",
             )
         except Exception:
             pass
 
-    def _discard_session_if_empty(self, session_id: Optional[str]) -> bool:
-        """Drop a just-ended session row when it never gained content.
-
-        Starting the CLI and immediately quitting (or rotating with /new,
-        /clear) used to leave an empty untitled row behind that clutters
-        ``/resume`` and ``hermes sessions list``. Delegates the
-        check-and-delete to ``SessionDB.delete_session_if_empty``, which
-        only removes rows with no messages, no title, and no child
-        sessions. Ported from google-gemini/gemini-cli#27770.
-        """
-        if not self._session_db or not session_id:
-            return False
-        # In-memory transcript is authoritative: if this CLI object holds
-        # conversation messages (flushed to the DB or not), the session is
-        # not empty. Protects against pruning a real conversation whose DB
-        # flush failed or hasn't happened yet.
-        if getattr(self, "conversation_history", None):
-            return False
-        try:
-            from hermes_constants import get_hermes_home as _ghh
-            return self._session_db.delete_session_if_empty(
-                session_id, sessions_dir=_ghh() / "sessions"
-            )
-        except Exception:
-            logger.debug(
-                "Could not prune empty session %s", session_id, exc_info=True
-            )
-            return False
-
-    def _launch_session_boundary_memory_flush(
-        self,
-        history_snapshot: list,
-        *,
-        session_id: Optional[str] = None,
-    ) -> Optional[list]:
-        """Stage old-session memory extraction so /new stays responsive.
-
-        The context-engine ``on_session_end`` boundary is delivered
-        synchronously here: it is cheap (local state clear, no LLM call) and
-        ordering-sensitive — it must land before ``reset_session_state()``
-        rebinds the engine to the new session.
-
-        The memory-provider half (LLM-bound extraction, seconds) is NOT run
-        here. The returned snapshot is handed by ``new_session()`` to
-        ``MemoryManager.commit_session_boundary_async`` as a single
-        end→switch task on the manager's serialized background worker, so
-        extraction can never race the provider rebinding (providers key off
-        internal ``_session_id`` state — a late ``on_session_end`` after
-        ``on_session_switch`` would misattribute the old transcript to the
-        new session).
-
-        Returns the history snapshot to queue, or ``None`` when there is
-        nothing to extract (no agent / empty history / no memory manager).
-        """
-        agent = getattr(self, "agent", None)
-        if not agent or not history_snapshot:
-            return None
-
-        engine = getattr(agent, "context_compressor", None)
-        if engine is not None and hasattr(engine, "on_session_end"):
-            try:
-                engine.on_session_end(session_id or "", history_snapshot)
-            except Exception:
-                logger.debug(
-                    "Context engine on_session_end failed at /new boundary",
-                    exc_info=True,
-                )
-
-        # No provider extraction to queue when no memory manager is
-        # configured — new_session() falls back to the inline switch path.
-        if getattr(agent, "_memory_manager", None) is None:
-            return None
-        return history_snapshot
-
     def new_session(self, silent=False, title=None):
         """Start a fresh session with a new session ID and cleared agent state."""
-        old_session_id = self.session_id
-        _boundary_snapshot = None
         if self.agent and self.conversation_history:
-            # Deliver the context-engine boundary synchronously and get back
-            # the history snapshot for the deferred provider extraction —
-            # queued below (after rotation) so /new never blocks on the
-            # LLM-bound extraction call.
-            _boundary_snapshot = self._launch_session_boundary_memory_flush(
-                list(self.conversation_history),
-                session_id=old_session_id,
-            )
+            # Trigger memory extraction on the old session before session_id rotates.
+            self.agent.commit_memory_session(self.conversation_history)
             self._notify_session_boundary("on_session_finalize")
         elif self.agent:
             # First session or empty history — still finalize the old session
             self._notify_session_boundary("on_session_finalize")
 
+        old_session_id = self.session_id
         if self._session_db and old_session_id:
-            # Flush any un-persisted messages from the current turn to the
-            # old session *before* rotating.  /new can be called mid-turn
-            # when _flush_messages_to_session_db() has not yet run — without
-            # this, messages generated during the current turn are silently
-            # lost on session rotation (#47202).
-            if self.agent:
-                try:
-                    self.agent._flush_messages_to_session_db(
-                        self.conversation_history
-                    )
-                except Exception:
-                    pass  # best-effort
             try:
                 self._session_db.end_session(old_session_id, "new_session")
             except Exception:
                 pass
-            # Don't let immediately-rotated empty sessions pile up in
-            # /resume and `hermes sessions list` (gemini-cli#27770 port).
-            self._discard_session_if_empty(old_session_id)
 
         self.session_start = datetime.now()
         timestamp_str = self.session_start.strftime("%Y%m%d_%H%M%S")
@@ -7300,29 +6620,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # per-session state (_session_turns, _turn_counter, _document_id).
             # Fires BEFORE the plugin on_session_reset hook (shell hooks only
             # see the new id; Python providers see the transition). See #6672.
-            #
-            # When the old session has history, end-of-session extraction
-            # (LLM-bound, seconds) and this switch are queued as ONE task on
-            # the memory manager's serialized worker — end strictly before
-            # switch, without blocking /new (#16454). With no history there
-            # is nothing to extract; switch inline as before.
             try:
                 _mm = getattr(self.agent, "_memory_manager", None)
                 if _mm is not None:
-                    if _boundary_snapshot:
-                        _mm.commit_session_boundary_async(
-                            _boundary_snapshot,
-                            new_session_id=self.session_id,
-                            parent_session_id=old_session_id or "",
-                            reason="new_session",
-                        )
-                    else:
-                        _mm.on_session_switch(
-                            self.session_id,
-                            parent_session_id=old_session_id or "",
-                            reset=True,
-                            reason="new_session",
-                        )
+                    _mm.on_session_switch(
+                        self.session_id,
+                        parent_session_id=old_session_id or "",
+                        reset=True,
+                        reason="new_session",
+                    )
             except Exception:
                 pass
             self._notify_session_boundary("on_session_reset")
@@ -7333,46 +6639,454 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             else:
                 print("(^_^)v New session started!")
 
+    def _handle_handoff_command(self, cmd_original: str) -> bool:
+        """Handle ``/handoff <platform>`` — transfer this CLI session to a gateway platform.
 
-    def _consume_pending_resume_selection(self, text: str) -> bool:
-        """Resolve a bare numeric reply that follows a bare ``/resume`` prompt.
+        Flow:
+          1. Validate platform name + the gateway has a home channel for it.
+          2. Reject if the agent is currently running (the in-flight turn
+             would race with the gateway's switch_session).
+          3. Write ``handoff_state='pending'`` on this session row.
+          4. Block-poll ``state.db`` for terminal state (timeout 60s).
+          5. On ``completed`` → print resume hint and signal CLI exit by
+             returning False (the caller honors that like ``/quit``).
+          6. On ``failed`` / timeout → print error and return True so the
+             user keeps their CLI session.
 
-        After ``/resume`` (no args) prints the recent-sessions list it arms
-        ``self._pending_resume_sessions``. The next submitted input is given
-        one chance to be a bare session number (``3``); if so we resume that
-        session here. Anything else (another command, free text, blank) simply
-        disarms the prompt and is handled normally by the caller.
-
-        Returns True if the input was consumed as a resume selection (caller
-        must not treat it as chat); False otherwise. The pending state is
-        always one-shot: it is cleared on the first submitted input regardless
-        of outcome. See #34584.
+        Returns:
+            False to signal CLI exit, True to keep going.
         """
-        pending = self._pending_resume_sessions
-        if not pending:
-            return False
-        # One-shot: disarm now so a non-matching input can't leave the prompt
-        # armed and hijack a later number the user meant as chat.
-        self._pending_resume_sessions = None
+        from hermes_state import format_session_db_unavailable
 
-        if not isinstance(text, str):
-            return False
-        stripped = text.strip()
-        # Only a pure number selects; let "/resume 3", titles, or any other
-        # text fall through to normal handling.
-        if not stripped.isdigit():
-            return False
-
-        index = int(stripped)
-        if index < 1 or index > len(pending):
-            _cprint(f"  Resume index {index} is out of range.")
-            _cprint("  Use /resume with no arguments to see available sessions.")
+        parts = cmd_original.split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            _cprint("  Usage: /handoff <platform>")
+            _cprint("  Hands the current session off to that platform's home channel.")
+            _cprint("  The CLI session ends here; resume it later with /resume.")
             return True
 
-        self._handle_resume_command(f"/resume {index}")
+        platform_name = parts[1].strip().lower()
+
+        # Validate platform name + home channel via the live gateway config.
+        try:
+            from gateway.config import load_gateway_config, Platform
+        except Exception as exc:  # pragma: no cover — gateway pkg always shipped
+            _cprint(f"  Could not load gateway config: {exc}")
+            return True
+
+        try:
+            platform = Platform(platform_name)
+        except (ValueError, KeyError):
+            _cprint(f"  Unknown platform '{platform_name}'.")
+            return True
+
+        try:
+            gw_config = load_gateway_config()
+        except Exception as exc:
+            _cprint(f"  Could not load gateway config: {exc}")
+            return True
+
+        pcfg = gw_config.platforms.get(platform)
+        if not pcfg or not pcfg.enabled:
+            _cprint(f"  Platform '{platform_name}' is not configured/enabled in the gateway.")
+            return True
+
+        home = gw_config.get_home_channel(platform)
+        if not home or not home.chat_id:
+            _cprint(f"  No home channel configured for {platform_name}.")
+            _cprint(f"  Set one with /sethome on the destination chat first.")
+            return True
+
+        # Refuse mid-turn: an in-flight agent run would race with the
+        # gateway's switch_session and the synthetic turn dispatch.
+        if getattr(self, "_agent_running", False):
+            _cprint("  Agent is busy. Wait for the current turn to finish, then retry /handoff.")
+            return True
+
+        # Make sure we have a SessionDB handle.
+        if not self._session_db:
+            try:
+                from hermes_state import SessionDB
+                self._session_db = SessionDB()
+            except Exception:
+                pass
+        if not self._session_db:
+            _cprint(f"  {format_session_db_unavailable()}")
+            return True
+
+        # Make sure the session row exists in state.db. Most CLI sessions
+        # are written via _flush_messages_to_session_db on the first turn
+        # already, but if the user tries to hand off an empty session we
+        # still want a row to mark.
+        try:
+            row = self._session_db.get_session(self.session_id)
+            if not row:
+                # Nothing has flushed yet. Create a stub so the gateway has
+                # something to switch_session onto. Inserting via title-set
+                # is the simplest path because set_session_title's INSERT OR
+                # IGNORE creates the row.
+                placeholder_title = f"handoff-{self.session_id[:8]}"
+                self._session_db.set_session_title(self.session_id, placeholder_title)
+        except Exception as exc:
+            _cprint(f"  Could not ensure session row in state.db: {exc}")
+            return True
+
+        # Display title for messaging.
+        session_title = ""
+        try:
+            row = self._session_db.get_session(self.session_id)
+            if row:
+                session_title = row.get("title") or ""
+        except Exception:
+            pass
+        if not session_title:
+            session_title = self.session_id[:8]
+
+        # Mark pending — gateway watcher will pick this up.
+        ok = self._session_db.request_handoff(self.session_id, platform_name)
+        if not ok:
+            _cprint("  Session is already in flight for handoff. Wait for it to settle, then retry.")
+            return True
+
+        _cprint(f"  Queued handoff of '{session_title}' → {platform_name} (home: {home.name}).")
+        _cprint(f"  Waiting for the gateway to pick it up...")
+
+        # Poll-block on terminal state. Tick every 0.5s; bail at ~60s.
+        import time as _time
+        deadline = _time.time() + 60.0
+        last_state = "pending"
+        while _time.time() < deadline:
+            try:
+                state_row = self._session_db.get_handoff_state(self.session_id)
+            except Exception:
+                state_row = None
+            current = (state_row or {}).get("state") or "pending"
+            if current != last_state:
+                if current == "running":
+                    _cprint("  Gateway picked it up; transferring...")
+                last_state = current
+            if current == "completed":
+                _cprint("")
+                _cprint(f"  ↻ Handoff complete. The session is now active on {platform_name}.")
+                _cprint(f"  Resume it on this CLI later with: /resume {session_title}")
+                _cprint("")
+                # End the CLI cleanly — same exit semantics as /quit.
+                self._should_exit = True
+                return False
+            if current == "failed":
+                err = (state_row or {}).get("error") or "unknown error"
+                _cprint(f"  Handoff failed: {err}")
+                _cprint("  Your CLI session is intact. Try /handoff again, or /resume on the platform manually.")
+                return True
+            _time.sleep(0.5)
+
+        # Timed out. Clear the pending flag so the user can retry.
+        try:
+            self._session_db.fail_handoff(self.session_id, "timed out waiting for gateway")
+        except Exception:
+            pass
+        _cprint("  Timed out waiting for the gateway. Is `hermes gateway` running?")
+        _cprint("  Your CLI session is intact.")
         return True
 
+    def _handle_resume_command(self, cmd_original: str) -> None:
+        """Handle /resume <session_id_or_title> — switch to a previous session mid-conversation."""
+        parts = cmd_original.split(None, 1)
+        target = parts[1].strip() if len(parts) > 1 else ""
 
+        # Strip common outer brackets/quotes users may type literally from the
+        # usage hint (e.g. ``/resume <abc123>`` or ``/resume [abc123]``).  The
+        # `/resume` help text shows angle brackets as a placeholder and a few
+        # users copy them through verbatim.  Stripping them keeps the lookup
+        # working without changing the help string.
+        if len(target) >= 2 and (
+            (target[0] == "<" and target[-1] == ">")
+            or (target[0] == "[" and target[-1] == "]")
+            or (target[0] == '"' and target[-1] == '"')
+            or (target[0] == "'" and target[-1] == "'")
+        ):
+            target = target[1:-1].strip()
+
+        if not target:
+            _cprint("  Usage: /resume <number|session_id_or_title>")
+            if self._show_recent_sessions(reason="resume"):
+                return
+            _cprint("  Tip:   Use /history or `hermes sessions list` to find sessions.")
+            return
+
+        if not self._session_db:
+            from hermes_state import format_session_db_unavailable
+            _cprint(f"  {format_session_db_unavailable()}")
+            return
+
+        # Resolve numbered selection, title, or ID
+        if target.isdigit():
+            sessions = self._list_recent_sessions(limit=10)
+            index = int(target)
+            if index < 1 or index > len(sessions):
+                _cprint(f"  Resume index {index} is out of range.")
+                _cprint("  Use /resume with no arguments to see available sessions.")
+                return
+            selected = sessions[index - 1]
+            target_id = selected["id"]
+        else:
+            from hermes_cli.main import _resolve_session_by_name_or_id
+            resolved = _resolve_session_by_name_or_id(target)
+            target_id = resolved or target
+
+        session_meta = self._session_db.get_session(target_id)
+        if not session_meta:
+            _cprint(f"  Session not found: {target}")
+            _cprint("  Use /history or `hermes sessions list` to see available sessions.")
+            return
+
+        # If the target is the empty head of a compression chain, redirect to
+        # the descendant that actually holds the transcript. See #15000.
+        try:
+            resolved_id = self._session_db.resolve_resume_session_id(target_id)
+        except Exception:
+            resolved_id = target_id
+        if resolved_id and resolved_id != target_id:
+            _cprint(
+                f"  Session {target_id} was compressed into {resolved_id}; "
+                f"resuming the descendant with your transcript."
+            )
+            target_id = resolved_id
+            resolved_meta = self._session_db.get_session(target_id)
+            if resolved_meta:
+                session_meta = resolved_meta
+
+        if target_id == self.session_id:
+            _cprint("  Already on that session.")
+            return
+
+        old_session_id = self.session_id
+        # End current session
+        try:
+            self._session_db.end_session(self.session_id, "resumed_other")
+        except Exception:
+            pass
+
+        # Switch to the target session
+        self.session_id = target_id
+        self._resumed = True
+        self._pending_title = None
+        _sync_process_session_id(target_id)
+
+        # Load conversation history (strip transcript-only metadata entries)
+        restored = self._session_db.get_messages_as_conversation(target_id)
+        restored = [m for m in (restored or []) if m.get("role") != "session_meta"]
+        self.conversation_history = restored
+
+        # Re-open the target session so it's not marked as ended
+        try:
+            self._session_db.reopen_session(target_id)
+        except Exception:
+            pass
+
+        # Sync the agent if already initialised
+        if self.agent:
+            self.agent.session_id = target_id
+            self.agent.reset_session_state()
+            if hasattr(self.agent, "_last_flushed_db_idx"):
+                self.agent._last_flushed_db_idx = len(self.conversation_history)
+            if hasattr(self.agent, "_todo_store"):
+                try:
+                    from tools.todo_tool import TodoStore
+                    self.agent._todo_store = TodoStore()
+                except Exception:
+                    pass
+            if hasattr(self.agent, "_invalidate_system_prompt"):
+                self.agent._invalidate_system_prompt()
+
+            # Notify memory providers that session_id rotated to a resumed
+            # session. reset=False — the provider's accumulated state is
+            # still valid; it just needs to target the new session_id for
+            # subsequent writes. See #6672.
+            try:
+                _mm = getattr(self.agent, "_memory_manager", None)
+                if _mm is not None:
+                    _mm.on_session_switch(
+                        target_id,
+                        parent_session_id=old_session_id or "",
+                        reset=False,
+                        reason="resume",
+                    )
+            except Exception:
+                pass
+
+        title_part = f" \"{session_meta['title']}\"" if session_meta.get("title") else ""
+        msg_count = len([m for m in self.conversation_history if m.get("role") == "user"])
+        if self.conversation_history:
+            _cprint(
+                f"  ↻ Resumed session {target_id}{title_part}"
+                f" ({msg_count} user message{'s' if msg_count != 1 else ''},"
+                f" {len(self.conversation_history)} total)"
+            )
+            self._display_resumed_history()
+        else:
+            _cprint(f"  ↻ Resumed session {target_id}{title_part} — no messages, starting fresh.")
+
+    def _handle_sessions_command(self, cmd_original: str) -> None:
+        """Handle /sessions [list|<id_or_title>] — browse or resume previous sessions.
+
+        Without arguments, prints the same recent-sessions table that /resume
+        shows when called without a target, and tells the user how to resume.
+        With an explicit subcommand or target, delegates to the resume flow so
+        ``/sessions <id>`` and ``/resume <id>`` behave identically.
+
+        The TUI ships an interactive picker overlay for this command; the
+        classic CLI prints an inline list because there is no equivalent
+        overlay primitive here. Without this handler the canonical name
+        ``sessions`` falls through ``process_command``'s elif chain and
+        prints ``Unknown command: sessions`` even though the command is
+        registered in the central COMMAND_REGISTRY.
+        """
+        parts = cmd_original.split(None, 1)
+        arg = parts[1].strip() if len(parts) > 1 else ""
+        sub = arg.lower()
+
+        # Bare /sessions or /sessions list — show recent sessions inline.
+        if not arg or sub in {"list", "ls", "browse"}:
+            if not self._session_db:
+                from hermes_state import format_session_db_unavailable
+                _cprint(f"  {format_session_db_unavailable()}")
+                return
+            if not self._show_recent_sessions(reason="sessions"):
+                _cprint("  (._.) No previous sessions yet.")
+            return
+
+        # /sessions <id_or_title> behaves the same as /resume <id_or_title>.
+        self._handle_resume_command(f"/resume {arg}")
+
+    def _handle_branch_command(self, cmd_original: str) -> None:
+        """Handle /branch [name] — fork the current session into a new independent copy.
+
+        Copies the full conversation history to a new session so the user can
+        explore a different approach without losing the original session state.
+        Inspired by Claude Code's /branch command.
+        """
+        if not self.conversation_history:
+            _cprint("  No conversation to branch — send a message first.")
+            return
+
+        if not self._session_db:
+            from hermes_state import format_session_db_unavailable
+            _cprint(f"  {format_session_db_unavailable()}")
+            return
+
+        parts = cmd_original.split(None, 1)
+        branch_name = parts[1].strip() if len(parts) > 1 else ""
+
+        # Generate the new session ID
+        now = datetime.now()
+        timestamp_str = now.strftime("%Y%m%d_%H%M%S")
+        short_uuid = uuid.uuid4().hex[:6]
+        new_session_id = f"{timestamp_str}_{short_uuid}"
+
+        # Determine branch title
+        if branch_name:
+            branch_title = branch_name
+        else:
+            # Auto-generate from the current session title
+            current_title = None
+            if self._session_db:
+                current_title = self._session_db.get_session_title(self.session_id)
+            base = current_title or "branch"
+            branch_title = self._session_db.get_next_title_in_lineage(base)
+
+        # Save the current session's state before branching
+        parent_session_id = self.session_id
+
+        # End the old session
+        try:
+            self._session_db.end_session(self.session_id, "branched")
+        except Exception:
+            pass
+
+        # Create the new session with parent link
+        try:
+            self._session_db.create_session(
+                session_id=new_session_id,
+                source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                model=self.model,
+                model_config={
+                    "max_iterations": self.max_turns,
+                    "reasoning_config": self.reasoning_config,
+                },
+                parent_session_id=parent_session_id,
+            )
+        except Exception as e:
+            _cprint(f"  Failed to create branch session: {e}")
+            return
+
+        # Copy conversation history to the new session
+        for msg in self.conversation_history:
+            try:
+                self._session_db.append_message(
+                    session_id=new_session_id,
+                    role=msg.get("role", "user"),
+                    content=msg.get("content"),
+                    tool_name=msg.get("tool_name") or msg.get("name"),
+                    tool_calls=msg.get("tool_calls"),
+                    tool_call_id=msg.get("tool_call_id"),
+                    reasoning=msg.get("reasoning"),
+                )
+            except Exception:
+                pass  # Best-effort copy
+
+        # Set title on the branch
+        try:
+            self._session_db.set_session_title(new_session_id, branch_title)
+        except Exception:
+            pass
+
+        # Switch to the new session
+        self.session_id = new_session_id
+        self.session_start = now
+        self._pending_title = None
+        self._resumed = True  # Prevents auto-title generation
+        _sync_process_session_id(new_session_id)
+
+        # Sync the agent
+        if self.agent:
+            self.agent.session_id = new_session_id
+            self.agent.session_start = now
+            self.agent.reset_session_state()
+            if hasattr(self.agent, "_last_flushed_db_idx"):
+                self.agent._last_flushed_db_idx = len(self.conversation_history)
+            if hasattr(self.agent, "_todo_store"):
+                try:
+                    from tools.todo_tool import TodoStore
+                    self.agent._todo_store = TodoStore()
+                except Exception:
+                    pass
+            if hasattr(self.agent, "_invalidate_system_prompt"):
+                self.agent._invalidate_system_prompt()
+
+            # Notify memory providers that session_id forked to a new branch.
+            # reset=False — the branched session carries the transcript
+            # forward, so provider state tracks the lineage. parent_session_id
+            # links the branch back to the original. See #6672.
+            try:
+                _mm = getattr(self.agent, "_memory_manager", None)
+                if _mm is not None:
+                    _mm.on_session_switch(
+                        new_session_id,
+                        parent_session_id=parent_session_id or "",
+                        reset=False,
+                        reason="branch",
+                    )
+            except Exception:
+                pass
+
+        msg_count = len([m for m in self.conversation_history if m.get("role") == "user"])
+        _cprint(
+            f"  ⑂ Branched session \"{branch_title}\""
+            f" ({msg_count} user message{'s' if msg_count != 1 else ''})"
+        )
+        _cprint(f"  Original session: {parent_session_id}")
+        _cprint(f"  Branch session:   {new_session_id}")
 
     def save_conversation(self):
         """Save the current conversation to a JSON snapshot under ~/.hermes/sessions/saved/.
@@ -7438,156 +7152,37 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         print(f"(^_^)b Retrying: \"{last_message[:60]}{'...' if len(last_message) > 60 else ''}\"")
         return last_message
     
-    def undo_last(self, n: int = 1, prefill: bool = True):
-        """Back up N user turns: truncate history, soft-delete on disk, prefill.
-
-        Walks backwards N user messages and discards everything from the
-        Nth-from-last user message onward (its assistant response, tool
-        calls, etc.). ``n`` defaults to 1 (the last exchange); ``/undo 3``
-        backs up three user turns. If ``n`` exceeds the number of user
-        turns, it backs up to the oldest one.
-
-        Beyond the in-memory ``conversation_history`` slice, this also:
-          • soft-deletes the truncated rows in SessionDB (``active=0``) so
-            they're hidden from re-prompts and search but kept for audit;
-          • notifies memory providers via ``on_session_switch(rewound=True)``;
-          • mirrors /branch's agent surgery (system-prompt invalidation +
-            flush-index reset);
-          • when ``prefill`` is set and an input buffer is available,
-            pre-fills the composer with the backed-up message text so it
-            can be edited and resubmitted.
-
-        ``prefill=False`` is used by callers that drive the undo
-        programmatically (e.g. checkpoint rollback) and don't want to
-        touch the user's input buffer.
+    def undo_last(self):
+        """Remove the last user/assistant exchange from conversation history.
+        
+        Walks backwards and removes all messages from the last user message
+        onward (including assistant responses, tool calls, etc.).
         """
         if not self.conversation_history:
             print("(._.) No messages to undo.")
             return
-
-        if n < 1:
-            n = 1
-
-        # Walk backwards collecting the indices of the last N user messages.
-        user_indices = []
+        
+        # Walk backwards to find the last user message
+        last_user_idx = None
         for i in range(len(self.conversation_history) - 1, -1, -1):
             if self.conversation_history[i].get("role") == "user":
-                user_indices.append(i)
-                if len(user_indices) >= n:
-                    break
-
-        if not user_indices:
+                last_user_idx = i
+                break
+        
+        if last_user_idx is None:
             print("(._.) No user message found to undo.")
             return
-
-        # The oldest of the collected user messages is our truncation point.
-        cut_idx = user_indices[-1]
-        turns_undone = len(user_indices)
-
-        removed_count = len(self.conversation_history) - cut_idx
-        removed_msg = self.conversation_history[cut_idx].get("content", "")
-        removed_text = self._undo_content_to_text(removed_msg)
-
-        # Truncate the in-memory history to before that user message.
-        self.conversation_history = self.conversation_history[:cut_idx]
-
-        # Soft-delete the truncated rows on disk so re-prompts and search
-        # see the clean transcript while the rows survive for audit.
-        rewound_rows = 0
-        if self._session_db is not None and self.session_id:
-            try:
-                recents = self._session_db.list_recent_user_messages(
-                    self.session_id, limit=max(turns_undone, 10)
-                )
-                if recents:
-                    target_idx = min(turns_undone - 1, len(recents) - 1)
-                    target_id = recents[target_idx]["id"]
-                    result = self._session_db.rewind_to_message(
-                        self.session_id, target_id
-                    )
-                    rewound_rows = result.get("rewound_count", 0)
-                    # Prefer the DB's decoded target text for the prefill —
-                    # it's the canonical persisted copy.
-                    db_text = self._undo_content_to_text(
-                        (result.get("target_message") or {}).get("content")
-                    )
-                    if db_text:
-                        removed_text = db_text
-            except ValueError as e:
-                # Non-user target / cross-session — keep the in-memory undo
-                # but skip the soft-delete; surface a debug-level note.
-                logger.debug("undo: soft-delete skipped: %s", e)
-            except Exception as e:
-                logger.debug("undo: soft-delete failed: %s", e)
-
-        # Agent surgery: invalidate the system-prompt cache and reset the
-        # flush index so the next turn re-flushes from the truncated head.
-        if self.agent is not None:
-            if hasattr(self.agent, "_invalidate_system_prompt"):
-                try:
-                    self.agent._invalidate_system_prompt()
-                except Exception:
-                    pass
-            if hasattr(self.agent, "_last_flushed_db_idx"):
-                try:
-                    self.agent._last_flushed_db_idx = len(self.conversation_history)
-                except Exception:
-                    pass
-            # Notify memory providers — same hook /branch fires, with the
-            # rewound flag so per-turn document caches invalidate (#6672, #21910).
-            try:
-                _mm = getattr(self.agent, "_memory_manager", None)
-                if _mm is not None and self.session_id:
-                    _mm.on_session_switch(
-                        self.session_id,
-                        parent_session_id="",
-                        reset=False,
-                        rewound=True,
-                    )
-            except Exception:
-                pass
-
-        turn_word = "turn" if turns_undone == 1 else "turns"
-        msg_count = rewound_rows or removed_count
-        print(
-            f"(^_^)b Undid {turns_undone} {turn_word} ({msg_count} message(s)). "
-            f"Backed up to: \"{removed_text[:60]}{'...' if len(removed_text) > 60 else ''}\""
-        )
+        
+        # Count how many messages we're removing
+        removed_count = len(self.conversation_history) - last_user_idx
+        removed_msg = self.conversation_history[last_user_idx].get("content", "")
+        
+        # Truncate history to before the last user message
+        self.conversation_history = self.conversation_history[:last_user_idx]
+        
+        print(f"(^_^)b Undid {removed_count} message(s). Removed: \"{removed_msg[:60]}{'...' if len(removed_msg) > 60 else ''}\"")
         remaining = len(self.conversation_history)
         print(f"  {remaining} message(s) remaining in history.")
-
-        # Pre-fill the composer with the backed-up message so the user can
-        # edit and resubmit (Claude-Code-style). Editable, not auto-sent.
-        if prefill and removed_text:
-            self._prefill_input_buffer(removed_text)
-
-    @staticmethod
-    def _undo_content_to_text(content) -> str:
-        """Flatten message content (str or content-part list) to plain text."""
-        if isinstance(content, str):
-            return content
-        if isinstance(content, list):
-            parts = [
-                p.get("text", "")
-                for p in content
-                if isinstance(p, dict) and p.get("type") == "text"
-            ]
-            return "\n".join(t for t in parts if t)
-        return ""
-
-    def _prefill_input_buffer(self, text: str) -> None:
-        """Place ``text`` in the active prompt_toolkit buffer, editable."""
-        app = getattr(self, "_app", None)
-        if app is None:
-            return
-        try:
-            buf = app.current_buffer
-            buf.text = text
-            if hasattr(buf, "cursor_position"):
-                buf.cursor_position = len(text)
-            app.invalidate()
-        except Exception as e:
-            logger.debug("undo: prefill buffer failed: %s", e)
     
     def _run_curses_picker(self, title: str, items: list[str], default_index: int = 0) -> int | None:
         """Run curses_single_select via run_in_terminal so prompt_toolkit handles terminal ownership cleanly."""
@@ -7641,17 +7236,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         in_main_thread = threading.current_thread() is threading.main_thread()
 
-        # Slash-worker guard (#23185 / billing auto-reload hang): when a
-        # prompt_toolkit app is running but we're on a non-main thread (the
-        # process_loop / TUI slash-worker daemon thread), stdin is owned by the
-        # event loop / JSON-RPC pipe.  A bare input() there blocks forever until
-        # the worker's 45s timeout fires.  We cannot safely prompt off the main
-        # thread, so cancel cleanly (None) instead of hanging — mirrors the
-        # _stdin_fallback discipline in _prompt_text_input_modal.
-        if self._app and not in_main_thread:
-            self._invalidate()
-            return None
-
         if self._app and in_main_thread:
             from prompt_toolkit.application import run_in_terminal
             was_visible = self._status_bar_visible
@@ -7691,20 +7275,27 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         choices visible and lets the normal Enter key binding submit the typed
         or highlighted choice.
 
-        **Platform note (Windows — issue #33961):**
-        Earlier code bypassed the modal on ``sys.platform == "win32"`` and fell
-        back to a raw ``input()`` prompt.  When the confirm was triggered from the
-        ``process_loop`` daemon thread (the normal case) that ``input()`` ran off
-        the main thread and deadlocked against prompt_toolkit's stdin ownership —
-        the user saw a frozen cursor and Ctrl-C was swallowed (bare ``/reset``
-        froze; ``/reset now`` worked only because it skips the prompt entirely).
+        **Platform note (Windows dead-lock — issue #30768):**
+        The queue-based modal relies on prompt_toolkit key bindings receiving
+        keyboard events and calling ``_submit_slash_confirm_response``.  On
+        Windows (PowerShell / Windows Terminal) the prompt_toolkit input
+        channel can become unresponsive when the modal is entered from the
+        ``process_loop`` daemon thread, causing a dead-lock: the user sees the
+        confirmation panel but keystrokes never reach the key bindings and the
+        ``response_queue.get()`` blocks until the 120-second timeout expires.
 
-        Native Windows now uses the same path as Linux/macOS: the modal is set up
-        on ``self._app.loop`` via ``call_soon_threadsafe`` and answered by the
-        normal prompt_toolkit key bindings (the same input channel that already
-        handles ordinary typing on Windows).  The raw ``input()`` fallback is kept
-        only for the genuinely safe cases: no running app (unit tests /
-        non-interactive), no resolvable event loop, or a scheduling failure.
+        To avoid this, we fall back to ``_prompt_text_input`` (a simple
+        ``input()``-based prompt) when any of these conditions hold:
+
+        * ``sys.platform == "win32"`` — native Windows console (ConPTY /
+          win32_input) does not support the modal reliably.
+        * ``self._app`` is not set — unit tests / non-interactive contexts.
+
+        On non-Windows platforms the modal itself is still safe from the
+        ``process_loop`` daemon thread as long as the main-thread event loop
+        owns the prompt_toolkit buffer mutations.  When we are off the main
+        thread, schedule the modal snapshot / restore work on ``self._app.loop``
+        via ``call_soon_threadsafe`` and keep the queue-based response path.
         """
         import threading
         import time as _time
@@ -7717,25 +7308,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if not getattr(self, "_app", None):
             return self._prompt_text_input("Choice [1/2/3]: ")
 
+        # On Windows the prompt_toolkit input channel can deadlock when the
+        # modal is entered from the process_loop daemon thread — keystrokes
+        # never reach the key bindings, so response_queue.get() blocks for
+        # the full timeout (issue #30768).  Fall back to the simpler
+        # stdin-based prompt which works reliably on Windows.
+        if sys.platform == "win32":
+            return self._prompt_text_input("Choice [1/2/3]: ")
+
         try:
             app_loop = self._app.loop
         except Exception:
             app_loop = None
 
         in_main_thread = threading.current_thread() is threading.main_thread()
-
-        def _stdin_fallback() -> str | None:
-            # On native Windows a raw input() from a non-main thread deadlocks
-            # against prompt_toolkit's stdin ownership (#33961).  With an app
-            # running we cannot safely prompt off the main thread, so cancel
-            # cleanly (None) rather than hang the terminal.
-            if sys.platform == "win32" and not in_main_thread:
-                self._invalidate()
-                return None
-            return self._prompt_text_input("Choice [1/2/3]: ")
-
         if not in_main_thread and app_loop is None:
-            return _stdin_fallback()
+            return self._prompt_text_input("Choice [1/2/3]: ")
 
         response_queue = queue.Queue()
 
@@ -7776,7 +7364,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return ready.wait(timeout=5)
 
         if not _run_on_app_loop(_setup_modal):
-            return _stdin_fallback()
+            return self._prompt_text_input("Choice [1/2/3]: ")
 
         _last_countdown_refresh = _time.monotonic()
         try:
@@ -7936,47 +7524,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         }
         self._invalidate(min_interval=0.0)
 
-    def _confirm_expensive_model_switch(self, result) -> bool:
-        """Ask for explicit confirmation before applying costly model switches."""
-        if not getattr(result, "success", False):
-            return True
-        try:
-            from hermes_cli.model_cost_guard import expensive_model_warning
-
-            warning = expensive_model_warning(
-                result.new_model,
-                provider=result.target_provider,
-                base_url=result.base_url or self.base_url or "",
-                api_key=result.api_key or self.api_key or "",
-                model_info=result.model_info,
-            )
-        except Exception:
-            warning = None
-        if warning is None:
-            return True
-
-        choices = [
-            ("once", "Switch anyway", "Use this model for the current Hermes session."),
-            ("cancel", "Cancel", "Keep the current model."),
-        ]
-        raw = self._prompt_text_input_modal(
-            title="!!! Expensive Model Warning !!!",
-            detail=warning.message,
-            choices=choices,
-            timeout=120,
-        )
-        choice = self._normalize_slash_confirm_choice(raw, choices)
-        return choice == "once"
-
-    def _confirm_and_apply_model_switch_result(self, result, persist_global: bool) -> None:
-        try:
-            if result.success and not self._confirm_expensive_model_switch(result):
-                _cprint("  Model switch cancelled.")
-                return
-            self._apply_model_switch_result(result, persist_global)
-        except Exception as exc:
-            _cprint(f"  ✗ Model selection failed: {exc}")
-
     def _close_model_picker(self) -> None:
         self._model_picker_state = None
         self._restore_modal_input_snapshot()
@@ -8015,35 +7562,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             _cprint(f"  ✗ {result.error_message}")
             return
 
-        if self.agent is not None:
-            try:
-                from hermes_cli.context_switch_guard import merge_preflight_compression_warning
-
-                merge_preflight_compression_warning(
-                    result,
-                    agent=self.agent,
-                    messages=list(self.conversation_history or []),
-                    config_context_length=getattr(self.agent, "_config_context_length", None),
-                )
-            except Exception as exc:
-                logger.debug("preflight-compression switch warning failed: %s", exc)
-
         old_model = self.model
-        # Snapshot the CLI-level credential/runtime fields BEFORE mutating them
-        # so a failed in-place agent swap can roll the whole CLI back to the old
-        # working model.  Otherwise the broken credentials staged below leak into
-        # the next turn's resolution even though the agent itself rolled back
-        # (#50163).
-        _cli_snapshot = {
-            "model": self.model,
-            "provider": self.provider,
-            "requested_provider": self.requested_provider,
-            "_explicit_api_key": getattr(self, "_explicit_api_key", None),
-            "_explicit_base_url": getattr(self, "_explicit_base_url", None),
-            "api_key": self.api_key,
-            "base_url": self.base_url,
-            "api_mode": self.api_mode,
-        }
         self.model = result.new_model
         self.provider = result.target_provider
         self.requested_provider = result.target_provider
@@ -8069,17 +7588,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     api_mode=result.api_mode,
                 )
             except Exception as exc:
-                # The agent rolled itself back to the old working model/client.
-                # Roll the CLI's own staged fields back too and abort the rest
-                # of the commit (note + success print) so a failed switch is a
-                # no-op rather than a dead session (#50163).
-                for _k, _v in _cli_snapshot.items():
-                    setattr(self, _k, _v)
-                _cprint(
-                    f"  ⚠ Model switch to {result.new_model} failed ({exc}); "
-                    f"staying on {old_model}."
-                )
-                return
+                _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")
 
         self._pending_model_switch_note = (
             f"[Note: model was just switched from {old_model} to {result.new_model} "
@@ -8104,7 +7613,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 api_key=result.api_key or self.api_key or "",
                 model_info=mi,
                 config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None,
-                custom_providers=getattr(self.agent, "_custom_providers", None) if self.agent else None,
             )
             if ctx:
                 _cprint(f"    Context: {ctx:,} tokens")
@@ -8113,6 +7621,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if mi:
             if mi.max_output:
                 _cprint(f"    Max output: {mi.max_output:,} tokens")
+            if mi.has_cost_data():
+                _cprint(f"    Cost: {mi.format_cost()}")
             _cprint(f"    Capabilities: {mi.format_capabilities()}")
 
         cache_enabled = (
@@ -8190,66 +7700,29 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     custom_providers=state.get("custom_provs"),
                 )
                 self._close_model_picker()
-                if getattr(self, "_app", None):
-                    threading.Thread(
-                        target=self._confirm_and_apply_model_switch_result,
-                        args=(result, persist_global),
-                        daemon=True,
-                    ).start()
-                else:
-                    self._confirm_and_apply_model_switch_result(result, persist_global)
+                self._apply_model_switch_result(result, persist_global)
                 return
             self._close_model_picker()
 
     def _handle_model_switch(self, cmd_original: str):
-        """Handle /model command — switch model.
+        """Handle /model command — switch model for this session.
 
         Supports:
           /model                              — show current model + usage hints
-          /model <name>                       — switch model (persists by default)
-          /model <name> --session             — switch for this session only
-          /model <name> --global              — switch and persist (explicit)
+          /model <name>                       — switch for this session only
+          /model <name> --global              — switch and persist to config.yaml
           /model <name> --provider <provider> — switch provider + model
           /model --provider <provider>        — switch to provider, auto-detect model
-
-        Persistence defaults to on (``model.persist_switch_by_default`` in
-        config.yaml, default True). Use ``--session`` for a one-off switch.
         """
-        from hermes_cli.model_switch import (
-            switch_model,
-            parse_model_flags,
-            resolve_persist_behavior,
-        )
+        from hermes_cli.model_switch import switch_model, parse_model_flags
         from hermes_cli.providers import get_label
 
         # Parse args from the original command
         parts = cmd_original.split(None, 1)  # split off '/model'
         raw_args = parts[1].strip() if len(parts) > 1 else ""
 
-        # Parse --provider, --global, --session, and --refresh flags
-        (
-            model_input,
-            explicit_provider,
-            is_global_flag,
-            force_refresh,
-            is_session,
-        ) = parse_model_flags(raw_args)
-        # Resolve the effective persistence once: --session overrides the
-        # config-gated default, --global forces persist, otherwise defer to
-        # model.persist_switch_by_default (defaults to True so /model survives
-        # across sessions).
-        persist_global = resolve_persist_behavior(is_global_flag, is_session)
-
-        # --refresh: wipe the on-disk picker cache before building the
-        # provider list. Forces a live re-fetch of every authed provider's
-        # /v1/models endpoint on this open.
-        if force_refresh:
-            try:
-                from hermes_cli.models import clear_provider_models_cache
-                clear_provider_models_cache()
-                _cprint("  Cleared model picker cache. Refreshing...")
-            except Exception:
-                pass
+        # Parse --provider and --global flags
+        model_input, explicit_provider, persist_global = parse_model_flags(raw_args)
 
         # Single inventory context — replaces the inline config-slice the
         # dashboard / TUI used to duplicate. Overlay live session state
@@ -8279,17 +7752,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             try:
                 if ctx is None:
                     raise RuntimeError("inventory context unavailable")
-                providers = build_models_payload(ctx)["providers"]
+                providers = build_models_payload(ctx, max_models=50)["providers"]
             except Exception:
                 providers = []
 
             if not providers:
                 _cprint("  No authenticated providers found.")
                 _cprint("")
-                _cprint("  /model <name>                        switch model (persists)")
-                _cprint("  /model <name> --session              switch for this session only")
+                _cprint("  /model <name>                        switch model")
                 _cprint("  /model --provider <slug>             switch provider")
-                _cprint("  /model --refresh                     re-fetch live model lists")
                 return
 
             self._open_model_picker(
@@ -8318,39 +7789,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             _cprint(f"  ✗ {result.error_message}")
             return
 
-        if self.agent is not None:
-            try:
-                from hermes_cli.context_switch_guard import merge_preflight_compression_warning
-
-                merge_preflight_compression_warning(
-                    result,
-                    agent=self.agent,
-                    messages=list(self.conversation_history or []),
-                    config_context_length=getattr(self.agent, "_config_context_length", None),
-                )
-            except Exception as exc:
-                logger.debug("preflight-compression switch warning failed: %s", exc)
-
-        if not self._confirm_expensive_model_switch(result):
-            _cprint("  Model switch cancelled.")
-            return
-
         # Apply to CLI state.
         # Update requested_provider so _ensure_runtime_credentials() doesn't
         # overwrite the switch on the next turn (it re-resolves from this).
         old_model = self.model
-        # Snapshot CLI-level fields before mutation so a failed in-place swap
-        # rolls the whole CLI back to the old working model (#50163).
-        _cli_snapshot = {
-            "model": self.model,
-            "provider": self.provider,
-            "requested_provider": self.requested_provider,
-            "_explicit_api_key": getattr(self, "_explicit_api_key", None),
-            "_explicit_base_url": getattr(self, "_explicit_base_url", None),
-            "api_key": self.api_key,
-            "base_url": self.base_url,
-            "api_mode": self.api_mode,
-        }
         self.model = result.new_model
         self.provider = result.target_provider
         self.requested_provider = result.target_provider
@@ -8377,15 +7819,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     api_mode=result.api_mode,
                 )
             except Exception as exc:
-                # Agent rolled itself back; roll the CLI back too and abort so a
-                # failed switch is a no-op rather than a dead session (#50163).
-                for _k, _v in _cli_snapshot.items():
-                    setattr(self, _k, _v)
-                _cprint(
-                    f"  ⚠ Model switch to {result.new_model} failed ({exc}); "
-                    f"staying on {old_model}."
-                )
-                return
+                _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")
 
         # Store a note to prepend to the next user message so the model
         # knows a switch occurred (avoids injecting system messages mid-history
@@ -8413,13 +7847,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             api_key=result.api_key or self.api_key or "",
             model_info=mi,
             config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None,
-            custom_providers=getattr(self.agent, "_custom_providers", None) if self.agent else None,
         )
         if ctx:
             _cprint(f"    Context: {ctx:,} tokens")
         if mi:
             if mi.max_output:
                 _cprint(f"    Max output: {mi.max_output:,} tokens")
+            if mi.has_cost_data():
+                _cprint(f"    Cost: {mi.format_cost()}")
             _cprint(f"    Capabilities: {mi.format_capabilities()}")
 
         # Cache notice
@@ -8439,7 +7874,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
-            _cprint("    Saved to config.yaml")
+            _cprint("    Saved to config.yaml (--global)")
         else:
             _cprint("    (session only — add --global to persist)")
 
@@ -8541,10 +7976,389 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return "\n".join(p for p in parts if p)
         return str(value)
 
+    def _handle_gquota_command(self, cmd_original: str) -> None:
+        """Show Google Gemini Code Assist quota usage for the current OAuth account."""
+        try:
+            from agent.google_oauth import get_valid_access_token, GoogleOAuthError, load_credentials
+            from agent.google_code_assist import retrieve_user_quota, CodeAssistError
+        except ImportError as exc:
+            self._console_print(f"  [red]Gemini modules unavailable: {exc}[/]")
+            return
 
+        try:
+            access_token = get_valid_access_token()
+        except GoogleOAuthError as exc:
+            self._console_print(f"  [yellow]{exc}[/]")
+            self._console_print("  Run [bold]/model[/] and pick 'Google Gemini (OAuth)' to sign in.")
+            return
+
+        creds = load_credentials()
+        project_id = (creds.project_id if creds else "") or ""
+
+        try:
+            buckets = retrieve_user_quota(access_token, project_id=project_id)
+        except CodeAssistError as exc:
+            self._console_print(f"  [red]Quota lookup failed:[/] {exc}")
+            return
+
+        if not buckets:
+            self._console_print("  [dim]No quota buckets reported (account may be on legacy/unmetered tier).[/]")
+            return
+
+        # Sort for stable display, group by model
+        buckets.sort(key=lambda b: (b.model_id, b.token_type))
+        self._console_print()
+        self._console_print(f"  [bold]Gemini Code Assist quota[/]  (project: {project_id or '(auto / free-tier)'})")
+        self._console_print()
+        for b in buckets:
+            pct = max(0.0, min(1.0, b.remaining_fraction))
+            width = 20
+            filled = int(round(pct * width))
+            bar = "▓" * filled + "░" * (width - filled)
+            pct_str = f"{int(pct * 100):3d}%"
+            header = b.model_id
+            if b.token_type:
+                header += f" [{b.token_type}]"
+            self._console_print(f"    {header:40s}  {bar}  {pct_str}")
+        self._console_print()
+
+    def _handle_personality_command(self, cmd: str):
+        """Handle the /personality command to set predefined personalities."""
+        parts = cmd.split(maxsplit=1)
+        
+        if len(parts) > 1:
+            # Set personality
+            personality_name = parts[1].strip().lower()
+            
+            if personality_name in {"none", "default", "neutral"}:
+                self.system_prompt = ""
+                self.agent = None  # Force re-init
+                if save_config_value("agent.system_prompt", ""):
+                    print("(^_^)b Personality cleared (saved to config)")
+                else:
+                    print("(^_^) Personality cleared (session only)")
+                print("  No personality overlay — using base agent behavior.")
+            elif personality_name in self.personalities:
+                self.system_prompt = self._resolve_personality_prompt(self.personalities[personality_name])
+                self.agent = None  # Force re-init
+                if save_config_value("agent.system_prompt", self.system_prompt):
+                    print(f"(^_^)b Personality set to '{personality_name}' (saved to config)")
+                else:
+                    print(f"(^_^) Personality set to '{personality_name}' (session only)")
+                print(f"  \"{self.system_prompt[:60]}{'...' if len(self.system_prompt) > 60 else ''}\"")
+            else:
+                print(f"(._.) Unknown personality: {personality_name}")
+                print(f"  Available: none, {', '.join(self.personalities.keys())}")
+        else:
+            # Show available personalities
+            print()
+            print("+" + "-" * 50 + "+")
+            print("|" + " " * 12 + "(^o^)/ Personalities" + " " * 15 + "|")
+            print("+" + "-" * 50 + "+")
+            print()
+            print(f"  {'none':<12} - (no personality overlay)")
+            for name, prompt in self.personalities.items():
+                if isinstance(prompt, dict):
+                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                else:
+                    preview = str(prompt)[:50]
+                print(f"  {name:<12} - {preview}")
+            print()
+            print("  Usage: /personality <name>")
+            print()
     
+    def _handle_cron_command(self, cmd: str):
+        """Handle the /cron command to manage scheduled tasks."""
+        import shlex
+        from tools.cronjob_tools import cronjob as cronjob_tool
 
+        def _cron_api(**kwargs):
+            return json.loads(cronjob_tool(**kwargs))
 
+        def _normalize_skills(values):
+            normalized = []
+            for value in values:
+                text = str(value or "").strip()
+                if text and text not in normalized:
+                    normalized.append(text)
+            return normalized
+
+        def _parse_flags(tokens):
+            opts = {
+                "name": None,
+                "deliver": None,
+                "repeat": None,
+                "skills": [],
+                "add_skills": [],
+                "remove_skills": [],
+                "clear_skills": False,
+                "all": False,
+                "prompt": None,
+                "schedule": None,
+                "positionals": [],
+            }
+            i = 0
+            while i < len(tokens):
+                token = tokens[i]
+                if token == "--name" and i + 1 < len(tokens):
+                    opts["name"] = tokens[i + 1]
+                    i += 2
+                elif token == "--deliver" and i + 1 < len(tokens):
+                    opts["deliver"] = tokens[i + 1]
+                    i += 2
+                elif token == "--repeat" and i + 1 < len(tokens):
+                    try:
+                        opts["repeat"] = int(tokens[i + 1])
+                    except ValueError:
+                        print("(._.) --repeat must be an integer")
+                        return None
+                    i += 2
+                elif token == "--skill" and i + 1 < len(tokens):
+                    opts["skills"].append(tokens[i + 1])
+                    i += 2
+                elif token == "--add-skill" and i + 1 < len(tokens):
+                    opts["add_skills"].append(tokens[i + 1])
+                    i += 2
+                elif token == "--remove-skill" and i + 1 < len(tokens):
+                    opts["remove_skills"].append(tokens[i + 1])
+                    i += 2
+                elif token == "--clear-skills":
+                    opts["clear_skills"] = True
+                    i += 1
+                elif token == "--all":
+                    opts["all"] = True
+                    i += 1
+                elif token == "--prompt" and i + 1 < len(tokens):
+                    opts["prompt"] = tokens[i + 1]
+                    i += 2
+                elif token == "--schedule" and i + 1 < len(tokens):
+                    opts["schedule"] = tokens[i + 1]
+                    i += 2
+                else:
+                    opts["positionals"].append(token)
+                    i += 1
+            return opts
+
+        tokens = shlex.split(cmd)
+
+        if len(tokens) == 1:
+            print()
+            print("+" + "-" * 68 + "+")
+            print("|" + " " * 22 + "(^_^) Scheduled Tasks" + " " * 23 + "|")
+            print("+" + "-" * 68 + "+")
+            print()
+            print("  Commands:")
+            print("    /cron list")
+            print('    /cron add "every 2h" "Check server status" [--skill blogwatcher]')
+            print('    /cron edit <job_id> --schedule "every 4h" --prompt "New task"')
+            print("    /cron edit <job_id> --skill blogwatcher --skill maps")
+            print("    /cron edit <job_id> --remove-skill blogwatcher")
+            print("    /cron edit <job_id> --clear-skills")
+            print("    /cron pause <job_id>")
+            print("    /cron resume <job_id>")
+            print("    /cron run <job_id>")
+            print("    /cron remove <job_id>")
+            print()
+            result = _cron_api(action="list")
+            jobs = result.get("jobs", []) if result.get("success") else []
+            if jobs:
+                print("  Current Jobs:")
+                print("  " + "-" * 63)
+                for job in jobs:
+                    repeat_str = job.get("repeat", "?")
+                    print(f"    {job['job_id'][:12]:<12} | {job['schedule']:<15} | {repeat_str:<8}")
+                    if job.get("skills"):
+                        print(f"      Skills: {', '.join(job['skills'])}")
+                    print(f"      {job.get('prompt_preview', '')}")
+                    if job.get("next_run_at"):
+                        print(f"      Next: {job['next_run_at']}")
+                    print()
+            else:
+                print("  No scheduled jobs. Use '/cron add' to create one.")
+            print()
+            return
+
+        subcommand = tokens[1].lower()
+        opts = _parse_flags(tokens[2:])
+        if opts is None:
+            return
+
+        if subcommand == "list":
+            result = _cron_api(action="list", include_disabled=opts["all"])
+            jobs = result.get("jobs", []) if result.get("success") else []
+            if not jobs:
+                print("(._.) No scheduled jobs.")
+                return
+
+            print()
+            print("Scheduled Jobs:")
+            print("-" * 80)
+            for job in jobs:
+                print(f"  ID: {job['job_id']}")
+                print(f"  Name: {job['name']}")
+                print(f"  State: {job.get('state', '?')}")
+                print(f"  Schedule: {job['schedule']} ({job.get('repeat', '?')})")
+                print(f"  Next run: {job.get('next_run_at', 'N/A')}")
+                if job.get("skills"):
+                    print(f"  Skills: {', '.join(job['skills'])}")
+                print(f"  Prompt: {job.get('prompt_preview', '')}")
+                if job.get("last_run_at"):
+                    print(f"  Last run: {job['last_run_at']} ({job.get('last_status', '?')})")
+                print()
+            return
+
+        if subcommand in {"add", "create"}:
+            positionals = opts["positionals"]
+            if not positionals:
+                print("(._.) Usage: /cron add <schedule> <prompt>")
+                return
+            schedule = opts["schedule"] or positionals[0]
+            prompt = opts["prompt"] or " ".join(positionals[1:])
+            skills = _normalize_skills(opts["skills"])
+            if not prompt and not skills:
+                print("(._.) Please provide a prompt or at least one skill")
+                return
+            result = _cron_api(
+                action="create",
+                schedule=schedule,
+                prompt=prompt or None,
+                name=opts["name"],
+                deliver=opts["deliver"],
+                repeat=opts["repeat"],
+                skills=skills or None,
+            )
+            if result.get("success"):
+                print(f"(^_^)b Created job: {result['job_id']}")
+                print(f"  Schedule: {result['schedule']}")
+                if result.get("skills"):
+                    print(f"  Skills: {', '.join(result['skills'])}")
+                print(f"  Next run: {result['next_run_at']}")
+            else:
+                print(f"(x_x) Failed to create job: {result.get('error')}")
+            return
+
+        if subcommand == "edit":
+            positionals = opts["positionals"]
+            if not positionals:
+                print("(._.) Usage: /cron edit <job_id> [--schedule ...] [--prompt ...] [--skill ...]")
+                return
+            job_id = positionals[0]
+            existing = get_job(job_id)
+            if not existing:
+                print(f"(._.) Job not found: {job_id}")
+                return
+
+            final_skills = None
+            replacement_skills = _normalize_skills(opts["skills"])
+            add_skills = _normalize_skills(opts["add_skills"])
+            remove_skills = set(_normalize_skills(opts["remove_skills"]))
+            existing_skills = list(existing.get("skills") or ([] if not existing.get("skill") else [existing.get("skill")]))
+            if opts["clear_skills"]:
+                final_skills = []
+            elif replacement_skills:
+                final_skills = replacement_skills
+            elif add_skills or remove_skills:
+                final_skills = [skill for skill in existing_skills if skill not in remove_skills]
+                for skill in add_skills:
+                    if skill not in final_skills:
+                        final_skills.append(skill)
+
+            result = _cron_api(
+                action="update",
+                job_id=job_id,
+                schedule=opts["schedule"],
+                prompt=opts["prompt"],
+                name=opts["name"],
+                deliver=opts["deliver"],
+                repeat=opts["repeat"],
+                skills=final_skills,
+            )
+            if result.get("success"):
+                job = result["job"]
+                print(f"(^_^)b Updated job: {job['job_id']}")
+                print(f"  Schedule: {job['schedule']}")
+                if job.get("skills"):
+                    print(f"  Skills: {', '.join(job['skills'])}")
+                else:
+                    print("  Skills: none")
+            else:
+                print(f"(x_x) Failed to update job: {result.get('error')}")
+            return
+
+        if subcommand in {"pause", "resume", "run", "remove", "rm", "delete"}:
+            positionals = opts["positionals"]
+            if not positionals:
+                print(f"(._.) Usage: /cron {subcommand} <job_id>")
+                return
+            job_id = positionals[0]
+            action = "remove" if subcommand in {"remove", "rm", "delete"} else subcommand
+            result = _cron_api(action=action, job_id=job_id, reason="paused from /cron" if action == "pause" else None)
+            if not result.get("success"):
+                print(f"(x_x) Failed to {action} job: {result.get('error')}")
+                return
+            if action == "pause":
+                print(f"(^_^)b Paused job: {result['job']['name']} ({job_id})")
+            elif action == "resume":
+                print(f"(^_^)b Resumed job: {result['job']['name']} ({job_id})")
+                print(f"  Next run: {result['job'].get('next_run_at')}")
+            elif action == "run":
+                print(f"(^_^)b Triggered job: {result['job']['name']} ({job_id})")
+                print("  It will run on the next scheduler tick.")
+            else:
+                removed = result.get("removed_job", {})
+                print(f"(^_^)b Removed job: {removed.get('name', job_id)} ({job_id})")
+            return
+
+        print(f"(._.) Unknown cron command: {subcommand}")
+        print("  Available: list, add, edit, pause, resume, run, remove")
+
+    def _handle_curator_command(self, cmd: str):
+        """Handle /curator slash command.
+
+        Delegates to hermes_cli.curator so the CLI and the `hermes curator`
+        subcommand share the same handler set.
+        """
+        import shlex
+
+        tokens = shlex.split(cmd)[1:] if cmd else []
+        if not tokens:
+            tokens = ["status"]
+
+        try:
+            from hermes_cli.curator import cli_main
+            cli_main(tokens)
+        except SystemExit:
+            # argparse calls sys.exit() on --help or errors; swallow so we
+            # don't kill the interactive session.
+            pass
+        except Exception as exc:
+            print(f"(._.) curator: {exc}")
+
+    def _handle_kanban_command(self, cmd: str):
+        """Handle the /kanban command — delegate to the shared kanban CLI.
+
+        The string form passed here is the user's full ``/kanban ...``
+        including the leading slash; we strip it and hand the remainder
+        to ``kanban.run_slash`` which returns a single formatted string.
+        """
+        from hermes_cli.kanban import run_slash
+
+        rest = cmd.strip()
+        if rest.startswith("/"):
+            rest = rest.lstrip("/")
+        if rest.startswith("kanban"):
+            rest = rest[len("kanban"):].lstrip()
+        try:
+            output = run_slash(rest)
+        except Exception as exc:  # pragma: no cover - defensive
+            output = f"(._.) kanban error: {exc}"
+        if output:
+            print(output)
+
+    def _handle_skills_command(self, cmd: str):
+        """Handle /skills slash command — delegates to hermes_cli.skills_hub."""
+        from hermes_cli.skills_hub import handle_skills_slash
+        handle_skills_slash(cmd, ChatConsole())
 
     def _show_gateway_status(self):
         """Show status of the gateway and connected messaging platforms."""
@@ -8623,14 +8437,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         _base_word = cmd_lower.split()[0].lstrip("/")
         _cmd_def = _resolve_cmd(_base_word)
         canonical = _cmd_def.name if _cmd_def else _base_word
-
-        # A bare `/resume` prompt is one-shot: any command other than the
-        # resume/sessions handlers (which manage the pending state themselves)
-        # disarms it so a later number isn't swallowed as a stale selection.
-        # See #34584.
-        if canonical not in {"resume", "sessions"}:
-            self._pending_resume_sessions = None
-
+        
         if canonical in {"quit", "exit"}:
             # Parse --delete flag: /exit --delete also removes the current
             # session's transcripts + SQLite history. Ported from
@@ -8666,7 +8473,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 "The current conversation history will be discarded.",
                 cmd_original=cmd_original,
             ) is None:
-                return True  # confirmation cancelled — command handled, keep REPL alive
+                return
             self.new_session(silent=True)
             _clear_output_history()
             # Clear terminal screen.  Inside the TUI, Rich's console.clear()
@@ -8703,7 +8510,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         enabled_toolsets=self.enabled_toolsets,
                         session_id=self.session_id,
                         context_length=ctx_len,
-                        provider=self.provider,
                     )
                 _cprint("  ✨ (◕‿◕)✨ Fresh start! Screen cleared and conversation reset.\n")
                 # Show a random tip on new session
@@ -8801,7 +8607,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 "The current conversation history will be discarded.",
                 cmd_original=cmd_original,
             ) is None:
-                return True  # confirmation cancelled — command handled, keep REPL alive
+                return
             self.new_session(title=title)
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
@@ -8811,56 +8617,31 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._handle_model_switch(cmd_original)
         elif canonical == "codex-runtime":
             self._handle_codex_runtime(cmd_original)
+        elif canonical == "gquota":
+            self._handle_gquota_command(cmd_original)
 
         elif canonical == "personality":
             # Use original case (handler lowercases the personality name itself)
             self._handle_personality_command(cmd_original)
-        elif canonical == "pet":
-            self._handle_pet_command(cmd_original)
-
-        elif canonical == "hatch":
-            self._handle_hatch_command(cmd_original)
         elif canonical == "retry":
             retry_msg = self.retry_last()
             if retry_msg and hasattr(self, '_pending_input'):
                 # Re-queue the message so process_loop sends it to the agent
                 self._pending_input.put(retry_msg)
-        elif canonical == "prompt":
-            self._handle_prompt_compose_command(cmd_original)
         elif canonical == "undo":
-            # Parse optional turn count: "/undo" → 1, "/undo 3" → 3.
-            _undo_n = 1
-            _undo_parts = cmd_original.split()
-            if len(_undo_parts) > 1:
-                try:
-                    _undo_n = int(_undo_parts[1])
-                except ValueError:
-                    print(f"(._.) Invalid count {_undo_parts[1]!r} — use /undo or /undo N.")
-                    return
-                if _undo_n < 1:
-                    _undo_n = 1
-            _undo_desc = (
-                "This removes the last user/assistant exchange from history."
-                if _undo_n == 1
-                else f"This removes the last {_undo_n} user turns from history."
-            )
             if self._confirm_destructive_slash(
                 "undo",
-                _undo_desc,
+                "This removes the last user/assistant exchange from history.",
                 cmd_original=cmd_original,
             ) is None:
-                return True  # confirmation cancelled — command handled, keep REPL alive
-            self.undo_last(_undo_n)
+                return
+            self.undo_last()
         elif canonical == "branch":
             self._handle_branch_command(cmd_original)
         elif canonical == "save":
             self.save_conversation()
         elif canonical == "cron":
             self._handle_cron_command(cmd_original)
-        elif canonical == "suggestions":
-            self._handle_suggestions_command(cmd_original)
-        elif canonical == "blueprint":
-            self._handle_blueprint_command(cmd_original)
         elif canonical == "curator":
             self._handle_curator_command(cmd_original)
         elif canonical == "kanban":
@@ -8868,10 +8649,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         elif canonical == "skills":
             with self._busy_command(self._slow_command_status(cmd_original)):
                 self._handle_skills_command(cmd_original)
-        elif canonical == "learn":
-            self._handle_learn_command(cmd_original)
-        elif canonical == "memory":
-            self._handle_memory_command(cmd_original)
         elif canonical == "platforms":
             self._show_gateway_status()
         elif canonical == "status":
@@ -8880,8 +8657,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._status_bar_visible = not self._status_bar_visible
             state = "visible" if self._status_bar_visible else "hidden"
             self._console_print(f"  Status bar {state}")
-        elif canonical == "timestamps":
-            self._handle_timestamps_command(cmd_original)
         elif canonical == "verbose":
             self._toggle_verbose()
         elif canonical == "footer":
@@ -8896,23 +8671,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._manual_compress(cmd_original)
         elif canonical == "usage":
             self._show_usage()
-        elif canonical == "credits":
-            self._show_credits()
-        elif canonical == "billing":
-            self._show_billing(cmd_original)
         elif canonical == "insights":
             self._show_insights(cmd_original)
         elif canonical == "copy":
             self._handle_copy_command(cmd_original)
         elif canonical == "debug":
-            self._handle_debug_command(cmd_original)
+            self._handle_debug_command()
         elif canonical == "update":
             if self._handle_update_command():
                 return False
-        elif canonical == "version":
-            from hermes_cli.main import _print_version_info
-
-            _print_version_info(check_updates=True)
         elif canonical == "paste":
             self._handle_paste_command()
         elif canonical == "image":
@@ -8935,66 +8702,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._handle_browser_command(cmd_original)
         elif canonical == "plugins":
             try:
-                # Discover from disk (bundled + user), matching `hermes plugins
-                # list` — so installed-but-not-enabled plugins are visible here
-                # too. The plugin manager only knows about *loaded* plugins, so
-                # using it alone made freshly-installed, not-yet-enabled plugins
-                # look like "nothing installed".
-                from hermes_cli.plugins_cmd import (
-                    _discover_all_plugins,
-                    _get_disabled_set,
-                    _get_enabled_set,
-                    _plugin_status,
-                )
-
-                entries = _discover_all_plugins()
-                enabled = _get_enabled_set()
-                disabled = _get_disabled_set()
-
-                # `/plugins` is a quick glance — default to user-installed
-                # plugins (what the user actually added). Bundled provider/
-                # platform plugins are summarized on one line; the full
-                # catalog lives behind `hermes plugins list`.
-                user_entries = [e for e in entries if e[3] != "bundled"]
-                bundled_count = len(entries) - len(user_entries)
-
-                if not user_entries:
-                    print("No user plugins installed.")
-                    print("  Install one: hermes plugins install owner/repo")
-                    print(f"  Or drop a plugin directory into {display_hermes_home()}/plugins/")
-                    if bundled_count:
-                        print(f"  ({bundled_count} bundled plugins available — see: hermes plugins list)")
+                from hermes_cli.plugins import get_plugin_manager
+                mgr = get_plugin_manager()
+                plugins = mgr.list_plugins()
+                if not plugins:
+                    print("No plugins installed.")
+                    print(f"Drop plugin directories into {display_hermes_home()}/plugins/ to get started.")
                 else:
-                    # Loaded-plugin details (tools/hooks/commands counts, errors)
-                    # keyed by name, when available.
-                    loaded: dict = {}
-                    try:
-                        from hermes_cli.plugins import get_plugin_manager
-                        for p in get_plugin_manager().list_plugins():
-                            loaded[p["name"]] = p
-                    except Exception:
-                        loaded = {}
-
-                    print(f"User plugins ({len(user_entries)}):")
-                    for name, version, _desc, source, _dir, key in sorted(user_entries):
-                        state = _plugin_status(name, enabled, disabled, key=key)
-                        glyph = {"enabled": "✓", "disabled": "✗"}.get(state, "○")
-                        ver = f" v{version}" if version else ""
-                        info = loaded.get(name) or {}
-                        bits = []
-                        if info.get("tools"):
-                            bits.append(f"{info['tools']} tools")
-                        if info.get("hooks"):
-                            bits.append(f"{info['hooks']} hooks")
-                        if info.get("commands"):
-                            bits.append(f"{info['commands']} commands")
-                        detail = f" ({', '.join(bits)})" if bits else ""
-                        label = "" if state == "enabled" else f" [{state}]"
-                        error = f" — {info['error']}" if info.get("error") else ""
-                        print(f"  {glyph} {name}{ver}{label}{detail}{error}")
-                    if bundled_count:
-                        print(f"  (+{bundled_count} bundled — see: hermes plugins list)")
-                    print("  Enable/disable: hermes plugins enable/disable <name>")
+                    print(f"Plugins ({len(plugins)}):")
+                    for p in plugins:
+                        status = "✓" if p["enabled"] else "✗"
+                        version = f" v{p['version']}" if p["version"] else ""
+                        tools = f"{p['tools']} tools" if p["tools"] else ""
+                        hooks = f"{p['hooks']} hooks" if p["hooks"] else ""
+                        commands = f"{p['commands']} commands" if p.get("commands") else ""
+                        parts = [x for x in [tools, hooks, commands] if x]
+                        detail = f" ({', '.join(parts)})" if parts else ""
+                        error = f" — {p['error']}" if p["error"] else ""
+                        print(f"  {status} {p['name']}{version}{detail}{error}")
             except Exception as e:
                 print(f"Plugin system error: {e}")
         elif canonical == "rollback":
@@ -9005,8 +8730,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._handle_stop_command()
         elif canonical == "agents":
             self._handle_agents_command()
-        elif canonical == "journey":
-            self._handle_journey_command(cmd_original)
         elif canonical == "background":
             self._handle_background_command(cmd_original)
         elif canonical == "queue":
@@ -9047,42 +8770,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 _cprint(f"  No agent running; queued as next turn: {payload[:80]}{'...' if len(payload) > 80 else ''}")
         elif canonical == "goal":
             self._handle_goal_command(cmd_original)
-        elif canonical == "moa":
-            # /moa is one-shot sugar only: run a single prompt through the
-            # default MoA preset, then restore the prior model. To *switch* to a
-            # MoA preset for the session, pick it from the model picker (MoA
-            # presets surface as a virtual "Mixture of Agents" provider).
-            from hermes_cli.moa_config import (
-                moa_usage,
-                normalize_moa_config,
-            )
-
-            parts = cmd_original.split(None, 1)
-            payload = parts[1].strip() if len(parts) > 1 else ""
-            if not payload:
-                _cprint(f"  {moa_usage()}")
-                return True
-            moa_cfg = self.config.get("moa") if isinstance(self.config, dict) else {}
-            normalized = normalize_moa_config(moa_cfg)
-            preset = normalized["default_preset"]
-            self._pending_moa_restore_model = {
-                "requested_provider": getattr(self, "requested_provider", None),
-                "provider": getattr(self, "provider", None),
-                "model": getattr(self, "model", None),
-                "api_key": getattr(self, "api_key", None),
-                "base_url": getattr(self, "base_url", None),
-                "api_mode": getattr(self, "api_mode", None),
-            }
-            self.requested_provider = "moa"
-            self.provider = "moa"
-            self.model = preset
-            self.api_key = "moa-virtual-provider"
-            self.base_url = "moa://local"
-            self.api_mode = "chat_completions"
-            self.agent = None
-            self._pending_moa_disable_after_turn = True
-            self._pending_agent_seed = payload
-            _cprint(f"  MoA one-shot queued with preset {preset}; previous model will be restored after this turn.")
         elif canonical == "subgoal":
             self._handle_subgoal_command(cmd_original)
         elif canonical == "skin":
@@ -9106,19 +8793,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         try:
                             # shell=True is intentional: quick_commands are user-defined
                             # shell snippets from config.yaml — not agent/LLM controlled.
-                            # Sanitize env to prevent credential leakage —
-                            # quick commands run in the CLI process which
-                            # has all API keys in os.environ.
-                            from tools.environments.local import _sanitize_subprocess_env
-                            sanitized_env = _sanitize_subprocess_env(os.environ.copy())
                             result = subprocess.run(
                                 exec_cmd, shell=True, capture_output=True,
-                                text=True, timeout=30, env=sanitized_env
+                                text=True, timeout=30
                             )
                             output = result.stdout.strip() or result.stderr.strip()
                             if output:
-                                from agent.redact import redact_sensitive_text
-                                output = redact_sensitive_text(output)
                                 self._console_print(_rich_text_from_ansi(output))
                             else:
                                 self._console_print("[dim]Command returned no output[/]")
@@ -9182,39 +8862,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     )
             # Check for skill slash commands (/gif-search, /axolotl, etc.)
             elif base_cmd in skill_commands:
-                rest = cmd_original[len(base_cmd):].strip()
-                # Stacked slash-skill invocations: `/skill-a /skill-b do XYZ`
-                # loads every leading skill (up to 5), not just the first.
-                # Inspired by Claude Code v2.1.199.
-                from agent.skill_commands import (
-                    build_stacked_skill_invocation_message,
-                    split_stacked_skill_commands,
-                )
-                extra_keys, user_instruction = split_stacked_skill_commands(rest)
-                if extra_keys:
-                    stacked_result = build_stacked_skill_invocation_message(
-                        [base_cmd, *extra_keys],
-                        user_instruction,
-                        task_id=self.session_id,
-                    )
-                    if stacked_result:
-                        msg, loaded_names, missing = stacked_result
-                        print(
-                            f"\n⚡ Loading {len(loaded_names)} stacked skills: "
-                            f"{', '.join(loaded_names)}"
-                        )
-                        if missing:
-                            ChatConsole().print(
-                                f"[yellow]Skipped missing skills: {', '.join(missing)}[/]"
-                            )
-                        if hasattr(self, '_pending_input'):
-                            self._pending_input.put(msg)
-                    else:
-                        ChatConsole().print(
-                            f"[bold red]Failed to load stacked skills for {base_cmd}[/]"
-                        )
-                    return True
-                user_instruction = rest
+                user_instruction = cmd_original[len(base_cmd):].strip()
                 msg = build_skill_invocation_message(
                     base_cmd, user_instruction, task_id=self.session_id
                 )
@@ -9268,6 +8916,158 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         
         return True
     
+    def _handle_background_command(self, cmd: str):
+        """Handle /background <prompt> — run a prompt in a separate background session.
+
+        Spawns a new AIAgent in a background thread with its own session.
+        When it completes, prints the result to the CLI without modifying
+        the active session's conversation history.
+        """
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            _cprint("  Usage: /background <prompt>")
+            _cprint("  Example: /background Summarize the top HN stories today")
+            _cprint("  The task runs in a separate session and results display here when done.")
+            return
+
+        prompt = parts[1].strip()
+        self._background_task_counter += 1
+        task_num = self._background_task_counter
+        task_id = f"bg_{datetime.now().strftime('%H%M%S')}_{uuid.uuid4().hex[:6]}"
+
+        # Make sure we have valid credentials
+        if not self._ensure_runtime_credentials():
+            _cprint("  (>_<) Cannot start background task: no valid credentials.")
+            return
+
+        _cprint(f"  🔄 Background task #{task_num} started: \"{prompt[:60]}{'...' if len(prompt) > 60 else ''}\"")
+        _cprint(f"  Task ID: {task_id}")
+        _cprint("  You can continue chatting — results will appear when done.\n")
+
+        turn_route = self._resolve_turn_agent_config(prompt)
+
+        def run_background():
+            set_sudo_password_callback(self._sudo_password_callback)
+            set_approval_callback(self._approval_callback)
+            try:
+                set_secret_capture_callback(self._secret_capture_callback)
+            except Exception:
+                pass
+            try:
+                bg_agent = AIAgent(
+                    model=turn_route["model"],
+                    api_key=turn_route["runtime"].get("api_key"),
+                    base_url=turn_route["runtime"].get("base_url"),
+                    provider=turn_route["runtime"].get("provider"),
+                    api_mode=turn_route["runtime"].get("api_mode"),
+                    acp_command=turn_route["runtime"].get("command"),
+                    acp_args=turn_route["runtime"].get("args"),
+                    max_iterations=self.max_turns,
+                    enabled_toolsets=self.enabled_toolsets,
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    session_id=task_id,
+                    platform="cli",
+                    session_db=self._session_db,
+                    reasoning_config=self.reasoning_config,
+                    service_tier=self.service_tier,
+                    request_overrides=turn_route.get("request_overrides"),
+                    providers_allowed=self._providers_only,
+                    providers_ignored=self._providers_ignore,
+                    providers_order=self._providers_order,
+                    provider_sort=self._provider_sort,
+                    provider_require_parameters=self._provider_require_params,
+                    provider_data_collection=self._provider_data_collection,
+                    openrouter_min_coding_score=self._openrouter_min_coding_score,
+                    fallback_model=self._fallback_model,
+                )
+                # Silence raw spinner; route thinking through TUI widget when no foreground agent is active.
+                bg_agent._print_fn = lambda *_a, **_kw: None
+
+                def _bg_thinking(text: str) -> None:
+                    # Concurrent bg tasks may race on _spinner_text; acceptable for best-effort UI.
+                    if not self._agent_running:
+                        self._spinner_text = text
+                        if self._app:
+                            self._app.invalidate()
+
+                bg_agent.thinking_callback = _bg_thinking
+
+                result = bg_agent.run_conversation(
+                    user_message=prompt,
+                    task_id=task_id,
+                )
+
+                response = result.get("final_response", "") if result else ""
+                if not response and result and result.get("error"):
+                    response = f"Error: {result['error']}"
+
+                # Display result in the CLI (thread-safe via patch_stdout).
+                # Force a TUI refresh first so spinner/status bar don't overlap
+                # with the output (fixes #2718).
+                if self._app:
+                    self._app.invalidate()
+                    time.sleep(0.05)  # brief pause for refresh
+                print()
+                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                _cprint(f"  ✅ Background task #{task_num} complete")
+                _cprint(f"  Prompt: \"{prompt[:60]}{'...' if len(prompt) > 60 else ''}\"")
+                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                if response:
+                    try:
+                        from hermes_cli.skin_engine import get_active_skin
+                        _skin = get_active_skin()
+                        label = _skin.get_branding("response_label", "⚕ Hermes")
+                        _resp_color = _maybe_remap_for_light_mode(_skin.get_color("response_border", "#CD7F32"))
+                        _resp_text = _maybe_remap_for_light_mode(_skin.get_color("banner_text", "#FFF8DC"))
+                    except Exception:
+                        label = "⚕ Hermes"
+                        _resp_color = "#CD7F32"
+                        _resp_text = "#FFF8DC"
+
+                    _chat_console = ChatConsole()
+                    _chat_console.print(Panel(
+                        _render_final_assistant_content(response, mode=self.final_response_markdown),
+                        title=f"[{_resp_color} bold]{label} (background #{task_num})[/]",
+                        title_align="left",
+                        border_style=_resp_color,
+                        style=_resp_text,
+                        box=rich_box.HORIZONTALS,
+                        padding=(1, 4),
+                        width=self._scrollback_box_width(),
+                    ))
+                else:
+                    _cprint("  (No response generated)")
+
+                # Play bell if enabled
+                if self.bell_on_complete:
+                    sys.stdout.write("\a")
+                    sys.stdout.flush()
+
+            except Exception as e:
+                # Same TUI refresh pattern as success path (#2718)
+                if self._app:
+                    self._app.invalidate()
+                    time.sleep(0.05)
+                print()
+                _cprint(f"  ❌ Background task #{task_num} failed: {e}")
+            finally:
+                try:
+                    set_sudo_password_callback(None)
+                    set_approval_callback(None)
+                    set_secret_capture_callback(None)
+                except Exception:
+                    pass
+                self._background_tasks.pop(task_id, None)
+                # Clear spinner only if no foreground agent owns it
+                if not self._agent_running:
+                    self._spinner_text = ""
+                if self._app:
+                    self._invalidate(min_interval=0)
+
+        thread = threading.Thread(target=run_background, daemon=True, name=f"bg-task-{task_id}")
+        self._background_tasks[task_id] = thread
+        thread.start()
 
     @staticmethod
     def _try_launch_chrome_debug(port: int, system: str) -> bool:
@@ -9280,7 +9080,247 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         """
         return try_launch_chrome_debug(port, system)
 
+    def _handle_bundles_command(self, cmd: str) -> None:
+        """In-session ``/bundles`` — show installed skill bundles.
 
+        Mirrors ``hermes bundles list`` but renders inside the running
+        CLI so users can discover what's available without dropping out
+        of their session. Bundles are loaded via ``/<bundle-name>``.
+        """
+        try:
+            from agent.skill_bundles import list_bundles, _bundles_dir
+        except Exception as exc:
+            _cprint(f"\033[1;31mBundle subsystem unavailable: {exc}{_RST}")
+            return
+
+        bundles = list_bundles()
+        if not bundles:
+            _cprint("  No skill bundles installed.")
+            _cprint(
+                f"  {_DIM}Create one with: hermes bundles create "
+                f"<name> --skill <s1> --skill <s2>{_RST}"
+            )
+            _cprint(f"  {_DIM}Directory: {_bundles_dir()}{_RST}")
+            return
+
+        _cprint(f"\n  ▣ {_BOLD}Skill Bundles{_RST} ({len(bundles)} installed):")
+        for info in bundles:
+            skill_count = len(info.get("skills", []))
+            desc = info.get("description") or f"Load {skill_count} skills"
+            ChatConsole().print(
+                f"    [bold {_accent_hex()}]/{info['slug']:<20}[/] "
+                f"[dim]-[/] {_escape(desc)} [dim]({skill_count} skills)[/]"
+            )
+            for s in info.get("skills", []):
+                ChatConsole().print(f"        [dim]· {_escape(s)}[/]")
+        _cprint(
+            f"\n  {_DIM}Invoke a bundle with /<slug>. "
+            f"Manage with `hermes bundles`.{_RST}"
+        )
+
+    def _handle_browser_command(self, cmd: str):
+        """Handle /browser connect|disconnect|status — manage live Chromium-family CDP connection."""
+        import platform as _plat
+
+        parts = cmd.strip().split(None, 1)
+        sub = parts[1].lower().strip() if len(parts) > 1 else "status"
+
+        _DEFAULT_CDP = DEFAULT_BROWSER_CDP_URL
+        current = os.environ.get("BROWSER_CDP_URL", "").strip()
+
+        if sub.startswith("connect"):
+            # Optionally accept a custom CDP URL: /browser connect ws://host:port
+            connect_parts = cmd.strip().split(None, 2)  # ["/browser", "connect", "ws://..."]
+            cdp_url = connect_parts[2].strip() if len(connect_parts) > 2 else _DEFAULT_CDP
+            parsed_cdp = urlparse(cdp_url if "://" in cdp_url else f"http://{cdp_url}")
+            if parsed_cdp.scheme not in {"http", "https", "ws", "wss"}:
+                print()
+                print(
+                    f"   ⚠ Unsupported browser url scheme: {parsed_cdp.scheme or '(missing)'} "
+                    "(expected one of: http, https, ws, wss)"
+                )
+                print()
+                return
+            try:
+                _port = parsed_cdp.port or (443 if parsed_cdp.scheme in {"https", "wss"} else 80)
+            except ValueError:
+                print()
+                print(f"   ⚠ Invalid port in browser url: {cdp_url}")
+                print()
+                return
+            if not parsed_cdp.hostname:
+                print()
+                print(f"   ⚠ Missing host in browser url: {cdp_url}")
+                print()
+                return
+            _host = parsed_cdp.hostname
+            if parsed_cdp.path.startswith("/devtools/browser/"):
+                cdp_url = parsed_cdp.geturl()
+            else:
+                cdp_url = parsed_cdp._replace(
+                    path="",
+                    params="",
+                    query="",
+                    fragment="",
+                ).geturl()
+
+            # Clear any existing browser sessions so the next tool call uses the new backend
+            try:
+                from tools.browser_tool import cleanup_all_browsers
+                cleanup_all_browsers()
+            except Exception:
+                pass
+
+            print()
+
+            # Check if a Chromium-family browser is already serving CDP on the debug port
+            _already_open = is_browser_debug_ready(cdp_url, timeout=1.0)
+
+            if _already_open:
+                print(f"   ✓ Chromium-family browser is already listening on port {_port}")
+            elif cdp_url == _DEFAULT_CDP:
+                # Try to auto-launch a Chromium-family browser with remote debugging
+                print("   Chromium-family browser isn't running with remote debugging — attempting to launch...")
+                _launched = self._try_launch_chrome_debug(_port, _plat.system())
+                if _launched:
+                    # Wait for the DevTools discovery endpoint to come up
+                    for _wait in range(10):
+                        if is_browser_debug_ready(cdp_url, timeout=1.0):
+                            _already_open = True
+                            break
+                        time.sleep(0.5)
+                    if _already_open:
+                        print(f"   ✓ Chromium-family browser launched and listening on port {_port}")
+                    else:
+                        print(f"   ⚠ Browser launched but port {_port} isn't responding yet")
+                        print("     Try again in a few seconds — the debug instance may still be starting")
+                else:
+                    print("   ⚠ Could not auto-launch a Chromium-family browser")
+                    sys_name = _plat.system()
+                    chrome_cmd = manual_chrome_debug_command(_port, sys_name)
+                    if chrome_cmd:
+                        print(f"     Launch a Chromium-family browser manually:")
+                        print(f"     {chrome_cmd}")
+                    else:
+                        print("     No supported Chromium-family browser executable found in this environment")
+            else:
+                print(f"   ⚠ Port {_port} is not reachable at {cdp_url}")
+
+            if not _already_open:
+                print()
+                print("Browser not connected — start a Chromium-family browser with remote debugging and retry /browser connect")
+                print()
+                return
+
+            os.environ["BROWSER_CDP_URL"] = cdp_url
+            # Eagerly start the CDP supervisor so pending_dialogs + frame_tree
+            # show up in the next browser_snapshot.  No-op if already started.
+            try:
+                from tools.browser_tool import _ensure_cdp_supervisor  # type: ignore[import-not-found]
+                _ensure_cdp_supervisor("default")
+            except Exception:
+                pass
+            print()
+            print("🌐 Browser connected to live Chromium-family browser via CDP")
+            print(f"   Endpoint: {cdp_url}")
+            print()
+
+            # Inject context message so the model knows this slash command
+            # intentionally makes the dev/debug CDP browser available for use.
+            if hasattr(self, '_pending_input'):
+                self._pending_input.put(
+                    "[System note: The user invoked /browser connect and connected your browser tools to "
+                    "a Chromium-family dev/debug browser via Chrome DevTools Protocol. "
+                    "Your browser_navigate, browser_snapshot, browser_click, and other browser tools now "
+                    "control that CDP browser. The command itself is a signal that using browser tools for "
+                    "their current browser-related request is expected; do not wait for separate permission "
+                    "just because CDP is connected. This is typically a Hermes-managed isolated debug "
+                    "profile, not the user's main everyday browser. It is still user-visible and may contain "
+                    "pages, logged-in sessions, or cookies in that debug profile, so avoid destructive actions, "
+                    "closing tabs, or navigating away unless the user's task calls for it.]"
+                )
+
+        elif sub == "disconnect":
+            if current:
+                os.environ.pop("BROWSER_CDP_URL", None)
+                try:
+                    from tools.browser_tool import cleanup_all_browsers, _stop_cdp_supervisor
+                    _stop_cdp_supervisor("default")
+                    cleanup_all_browsers()
+                except Exception:
+                    pass
+                print()
+                print("🌐 Browser disconnected from live Chromium-family browser")
+                print("   Browser tools reverted to default mode (local headless or cloud provider)")
+                print()
+
+                if hasattr(self, '_pending_input'):
+                    self._pending_input.put(
+                        "[System note: The user has disconnected the browser tools from their live Chromium-family browser. "
+                        "Browser tools are back to default mode (headless local browser or cloud provider).]"
+                    )
+            else:
+                print()
+                print("Browser is not connected to a live Chromium-family browser (already using default mode)")
+                print()
+
+        elif sub == "status":
+            print()
+            if current:
+                print("🌐 Browser: connected to live Chromium-family browser via CDP")
+                print(f"   Endpoint: {current}")
+
+                _port = 9222
+                try:
+                    _port = int(current.rsplit(":", 1)[-1].split("/")[0])
+                except (ValueError, IndexError):
+                    pass
+                try:
+                    import socket
+                    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    s.settimeout(1)
+                    s.connect(("127.0.0.1", _port))
+                    s.close()
+                    print("   Status: ✓ reachable")
+                except (OSError, Exception):
+                    print("   Status: ⚠ not reachable (browser may not be running)")
+            else:
+                try:
+                    from tools.browser_tool import _get_cloud_provider
+                    provider = _get_cloud_provider()
+                except Exception:
+                    provider = None
+
+                if provider is not None:
+                    print(f"🌐 Browser: {provider.provider_name()} (cloud)")
+                else:
+                    # Show engine info for local mode
+                    try:
+                        from tools.browser_tool import _get_browser_engine
+                        engine = _get_browser_engine()
+                    except Exception:
+                        engine = "auto"
+                    if engine == "lightpanda":
+                        print("🌐 Browser: local Lightpanda (agent-browser --engine lightpanda)")
+                        print("   ⚡ Lightpanda: faster navigation, no screenshot support")
+                        print("   Automatic Chromium fallback for screenshots and failed commands")
+                    elif engine == "chrome":
+                        print("🌐 Browser: local headless Chromium (agent-browser --engine chrome)")
+                    else:
+                        print("🌐 Browser: local headless Chromium (agent-browser)")
+            print()
+            print("   /browser connect      — connect to your live Chromium-family browser")
+            print("   /browser disconnect   — revert to default")
+            print()
+
+        else:
+            print()
+            print("Usage: /browser connect|disconnect|status")
+            print()
+            print("   connect      Connect browser tools to your live Chromium-family browser session")
+            print("   disconnect   Revert to default browser backend")
+            print("   status       Show current browser mode")
+            print()
 
     # ────────────────────────────────────────────────────────────────
     # /goal — persistent cross-turn goals (Ralph-style loop)
@@ -9318,32 +9358,146 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._goal_manager = mgr
         return mgr
 
+    def _handle_goal_command(self, cmd: str) -> None:
+        """Dispatch /goal subcommands: set / status / pause / resume / clear."""
+        parts = (cmd or "").strip().split(None, 1)
+        arg = parts[1].strip() if len(parts) > 1 else ""
 
+        mgr = self._get_goal_manager()
+        if mgr is None:
+            _cprint(f"  {_DIM}Goals unavailable (no active session).{_RST}")
+            return
 
-    def _drain_interrupt_queue_to_pending_input(self) -> None:
-        """Move stray messages from ``_interrupt_queue`` into ``_pending_input``.
+        lower = arg.lower()
 
-        While the agent is running, user input is routed into
-        ``_interrupt_queue`` (see the architecture comment near
-        ``_route_user_input_when_busy``). The explicit-interrupt path at the
-        top of ``process_loop`` only drains that queue when
-        ``busy_input_mode == "interrupt"`` AND a ``pending_message`` was
-        acknowledged. If the agent's turn finishes naturally (no interrupt),
-        any messages typed during the turn stay stuck in ``_interrupt_queue``
-        forever. Subsequent ``Enter`` presses re-route to the same blocked
-        queue and the CLI appears to hang.
+        # Bare /goal or /goal status → show current state
+        if not arg or lower == "status":
+            _cprint(f"  {mgr.status_line()}")
+            return
 
-        Called once at the end of every turn from ``process_loop``'s ``finally``
-        block. Catches and swallows ``Exception`` because the drain must never
-        break the main loop. (#20271)
-        """
+        if lower == "pause":
+            state = mgr.pause(reason="user-paused")
+            if state is None:
+                _cprint(f"  {_DIM}No goal set.{_RST}")
+            else:
+                _cprint(f"  ⏸ Goal paused: {state.goal}")
+            return
+
+        if lower == "resume":
+            state = mgr.resume()
+            if state is None:
+                _cprint(f"  {_DIM}No goal to resume.{_RST}")
+            else:
+                _cprint(f"  ▶ Goal resumed: {state.goal}")
+                _cprint(
+                    f"  {_DIM}Send any message (or press Enter on an empty prompt "
+                    f"is a no-op; type 'continue' to kick it off).{_RST}"
+                )
+            return
+
+        if lower in {"clear", "stop", "done"}:
+            had = mgr.has_goal()
+            mgr.clear()
+            if had:
+                _cprint("  ✓ Goal cleared.")
+            else:
+                _cprint(f"  {_DIM}No active goal.{_RST}")
+            return
+
+        # Otherwise treat the arg as the goal text.
         try:
-            while not self._interrupt_queue.empty():
-                stray = self._interrupt_queue.get_nowait()
-                if stray:
-                    self._pending_input.put(stray)
+            state = mgr.set(arg)
+        except ValueError as exc:
+            _cprint(f"  Invalid goal: {exc}")
+            return
+
+        _cprint(f"  ⊙ Goal set ({state.max_turns}-turn budget): {state.goal}")
+        _cprint(
+            f"  {_DIM}After each turn, a judge model will check if the goal is done. "
+            f"Hermes keeps working until it is, you pause/clear it, or the budget is "
+            f"exhausted. Use /goal status, /goal pause, /goal resume, /goal clear.{_RST}"
+        )
+        # Kick the loop off immediately so the user doesn't have to send a
+        # separate message after setting the goal.
+        try:
+            self._pending_input.put(state.goal)
         except Exception:
-            pass  # Non-fatal — never break the main loop
+            pass
+
+    def _handle_subgoal_command(self, cmd: str) -> None:
+        """Dispatch /subgoal subcommands.
+
+        Forms:
+          /subgoal                              show current subgoals
+          /subgoal <text>                       append a criterion
+          /subgoal remove <n>                   drop subgoal n (1-based)
+          /subgoal clear                        wipe all subgoals
+
+        Subgoals are extra criteria the user adds mid-loop. They get
+        appended to both the judge prompt (verdict must consider them)
+        and the continuation prompt (agent sees them) on the next turn
+        boundary. No special kick — the running turn finishes, the next
+        judge call includes them.
+        """
+        parts = (cmd or "").strip().split(None, 2)
+        arg = " ".join(parts[1:]).strip() if len(parts) > 1 else ""
+
+        mgr = self._get_goal_manager()
+        if mgr is None:
+            _cprint(f"  {_DIM}Goals unavailable (no active session).{_RST}")
+            return
+
+        if not mgr.has_goal():
+            _cprint(f"  {_DIM}No active goal. Set one with /goal <text>.{_RST}")
+            return
+
+        # No args → list current subgoals.
+        if not arg:
+            _cprint(f"  {mgr.status_line()}")
+            _cprint(f"  {mgr.render_subgoals()}")
+            return
+
+        tokens = arg.split(None, 1)
+        verb = tokens[0].lower()
+        rest = tokens[1].strip() if len(tokens) > 1 else ""
+
+        if verb == "remove":
+            if not rest:
+                _cprint("  Usage: /subgoal remove <n>")
+                return
+            try:
+                idx = int(rest.split()[0])
+            except ValueError:
+                _cprint("  /subgoal remove: <n> must be an integer (1-based index).")
+                return
+            try:
+                removed = mgr.remove_subgoal(idx)
+            except (IndexError, RuntimeError) as exc:
+                _cprint(f"  /subgoal remove: {exc}")
+                return
+            _cprint(f"  ✓ Removed subgoal {idx}: {removed}")
+            return
+
+        if verb == "clear":
+            try:
+                prev = mgr.clear_subgoals()
+            except RuntimeError as exc:
+                _cprint(f"  /subgoal clear: {exc}")
+                return
+            if prev:
+                _cprint(f"  ✓ Cleared {prev} subgoal{'s' if prev != 1 else ''}.")
+            else:
+                _cprint(f"  {_DIM}No subgoals to clear.{_RST}")
+            return
+
+        # Otherwise — append the whole arg as a new subgoal.
+        try:
+            text = mgr.add_subgoal(arg)
+        except (ValueError, RuntimeError) as exc:
+            _cprint(f"  /subgoal: {exc}")
+            return
+        idx = len(mgr.state.subgoals) if mgr.state else 0
+        _cprint(f"  ✓ Added subgoal {idx}: {text}")
 
     def _maybe_continue_goal_after_turn(self) -> None:
         """Hook run after every CLI turn. Judges + maybe re-queues.
@@ -9448,17 +9602,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if not last_response.strip():
             return
 
-        try:
-            from hermes_cli.goals import gather_background_processes as _gather_bg
-            _bg_procs = _gather_bg()
-        except Exception:
-            _bg_procs = None
-
-        decision = mgr.evaluate_after_turn(
-            last_response,
-            user_initiated=True,
-            background_processes=_bg_procs,
-        )
+        decision = mgr.evaluate_after_turn(last_response, user_initiated=True)
         msg = decision.get("message") or ""
         if msg:
             _cprint(f"  {msg}")
@@ -9471,7 +9615,99 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 except Exception as exc:
                     logging.debug("goal continuation enqueue failed: %s", exc)
 
+    def _handle_skin_command(self, cmd: str):
+        """Handle /skin [name] — show or change the display skin."""
+        try:
+            from hermes_cli.skin_engine import list_skins, set_active_skin, get_active_skin_name
+        except ImportError:
+            print("Skin engine not available.")
+            return
 
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            # Show current skin and list available
+            current = get_active_skin_name()
+            skins = list_skins()
+            print(f"\n  Current skin: {current}")
+            print("  Available skins:")
+            for s in skins:
+                marker = " ●" if s["name"] == current else "  "
+                source = f" ({s['source']})" if s["source"] == "user" else ""
+                print(f"   {marker} {s['name']}{source} — {s['description']}")
+            print("\n  Usage: /skin <name>")
+            print(f"  Custom skins: drop a YAML file in {display_hermes_home()}/skins/\n")
+            return
+
+        new_skin = parts[1].strip().lower()
+        available = {s["name"] for s in list_skins()}
+        if new_skin not in available:
+            print(f"  Unknown skin: {new_skin}")
+            print(f"  Available: {', '.join(sorted(available))}")
+            return
+
+        set_active_skin(new_skin)
+        _ACCENT.reset()  # Re-resolve ANSI color for the new skin
+        # _DIM is now a fixed dim+italic ANSI escape (terminal-default fg)
+        # so it doesn't need re-resolving on skin switch.
+        if save_config_value("display.skin", new_skin):
+            print(f"  Skin set to: {new_skin} (saved)")
+        else:
+            print(f"  Skin set to: {new_skin}")
+        print("  Note: banner colors will update on next session start.")
+        if self._apply_tui_skin_style():
+            print("  Prompt + TUI colors updated.")
+
+    def _handle_footer_command(self, cmd_original: str) -> None:
+        """Toggle or inspect ``display.runtime_footer.enabled`` from the CLI.
+
+        Usage:
+            /footer           → toggle
+            /footer on|off    → explicit
+            /footer status    → show current state
+        """
+        from hermes_cli.config import load_config
+        from hermes_cli.colors import Colors as _Colors
+
+        # Parse arg
+        arg = ""
+        try:
+            parts = (cmd_original or "").strip().split(None, 1)
+            if len(parts) > 1:
+                arg = parts[1].strip().lower()
+        except Exception:
+            arg = ""
+
+        cfg = load_config() or {}
+        footer_cfg = ((cfg.get("display") or {}).get("runtime_footer") or {})
+        current = bool(footer_cfg.get("enabled", False))
+        fields = footer_cfg.get("fields") or ["model", "context_pct", "cwd"]
+
+        if arg in {"status", "?"}:
+            state = "ON" if current else "OFF"
+            _cprint(
+                f"  {_Colors.BOLD}Runtime footer:{_Colors.RESET} {state}\n"
+                f"  Fields: {', '.join(fields)}"
+            )
+            return
+
+        if arg in {"on", "enable", "true", "1"}:
+            new_state = True
+        elif arg in {"off", "disable", "false", "0"}:
+            new_state = False
+        elif arg == "":
+            new_state = not current
+        else:
+            _cprint("  Usage: /footer [on|off|status]")
+            return
+
+        if save_config_value("display.runtime_footer.enabled", new_state):
+            state = (
+                f"{_Colors.GREEN}ON{_Colors.RESET}" if new_state
+                else f"{_Colors.DIM}OFF{_Colors.RESET}"
+            )
+            _cprint(f"  Runtime footer: {state}")
+        else:
+            _cprint("  Failed to save runtime_footer setting to config.yaml")
 
     def _toggle_verbose(self):
         """Cycle tool progress mode: off → new → all → verbose → off.
@@ -9492,10 +9728,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         if self.agent:
             self.agent.reasoning_callback = self._current_reasoning_callback()
-            # Keep the live agent's tool_progress_mode in sync so the
-            # tool_executor rendering path reflects the new mode this turn,
-            # without waiting for an agent rebuild.
-            self.agent.tool_progress_mode = self.tool_progress_mode
 
         # Use raw ANSI codes via _cprint so the output is routed through
         # prompt_toolkit's renderer.  self.console.print() with Rich markup
@@ -9510,99 +9742,170 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         }
         _cprint(labels.get(self.tool_progress_mode, ""))
 
-    def _transfer_session_yolo(self, old_session_id: str, new_session_id: str) -> None:
-        """Move YOLO bypass state from an old session key to a new one.
-
-        Called whenever ``self.session_id`` is reassigned mid-run — ``/branch``
-        forks into a new session, and auto-compression rotates the agent's
-        session id into a fresh continuation session. Without this transfer
-        the user's ``/yolo ON`` toggle would silently revert on the very next
-        turn (the same UX failure mode that motivated this entire fix), since
-        ``_session_yolo`` is keyed by session id.
-
-        Mirrors ``tui_gateway/server.py`` (~line 1297-1305) which performs the
-        same transfer for the TUI's session-rename path. No-op when YOLO
-        wasn't enabled or when the ids match.
-        """
-        if not old_session_id or not new_session_id or old_session_id == new_session_id:
-            return
-        try:
-            from tools.approval import (
-                disable_session_yolo,
-                enable_session_yolo,
-                is_session_yolo_enabled,
-            )
-        except Exception:
-            return
-        if is_session_yolo_enabled(old_session_id):
-            enable_session_yolo(new_session_id)
-            disable_session_yolo(old_session_id)
-
-    def _is_session_yolo_active(self) -> bool:
-        """Whether YOLO bypass is currently enabled for this CLI session.
-
-        Reads from ``tools.approval._session_yolo`` (the same set that
-        ``enable_session_yolo`` / ``disable_session_yolo`` write to) so the
-        status bar reflects the actual bypass state instead of a stale env
-        var. Also honors the process-start ``--yolo`` flag, which freezes
-        ``HERMES_YOLO_MODE`` into ``_YOLO_MODE_FROZEN`` before tool imports
-        happen.
-        """
-        try:
-            from tools.approval import (
-                _YOLO_MODE_FROZEN,
-                is_session_yolo_enabled,
-            )
-        except Exception:
-            return False
-        if _YOLO_MODE_FROZEN:
-            return True
-        # Use ``getattr`` so test fixtures that build a CLI via ``__new__``
-        # (skipping ``__init__``) don't trip an AttributeError here; the
-        # status-bar builders swallow exceptions silently but lose every
-        # field after the failure.
-        session_key = getattr(self, "session_id", None) or "default"
-        return is_session_yolo_enabled(session_key)
-
     def _toggle_yolo(self):
-        """Toggle YOLO mode — skip all dangerous command approval prompts.
-
-        Per-session toggle that mirrors the gateway and TUI ``/yolo`` handlers
-        (see ``gateway/run.py:_handle_yolo_command`` and
-        ``tui_gateway/server.py`` key=="yolo"). We deliberately do NOT mutate
-        ``HERMES_YOLO_MODE`` here — that env var is read once at module import
-        time into ``tools.approval._YOLO_MODE_FROZEN`` to keep prompt-injected
-        skills from flipping the bypass mid-session, so setting it after CLI
-        startup is a silent no-op. Routing through ``enable_session_yolo`` /
-        ``disable_session_yolo`` gives the same auditable, per-session bypass
-        the other surfaces have. ``run_conversation`` binds
-        ``self.session_id`` as the active approval session key via
-        ``set_current_session_key`` so the bypass takes effect on the very
-        next dangerous command in this run.
-        """
+        """Toggle YOLO mode — skip all dangerous command approval prompts."""
+        import os
         from hermes_cli.colors import Colors as _Colors
-        from tools.approval import (
-            disable_session_yolo,
-            enable_session_yolo,
-            is_session_yolo_enabled,
-        )
 
-        session_key = self.session_id or "default"
-        if is_session_yolo_enabled(session_key):
-            disable_session_yolo(session_key)
+        current = is_truthy_value(os.environ.get("HERMES_YOLO_MODE"))
+        if current:
+            os.environ.pop("HERMES_YOLO_MODE", None)
             _cprint(
                 f"  ⚠ YOLO mode {_Colors.BOLD}{_Colors.RED}OFF{_Colors.RESET}"
                 " — dangerous commands will require approval."
             )
         else:
-            enable_session_yolo(session_key)
+            os.environ["HERMES_YOLO_MODE"] = "1"
             _cprint(
                 f"  ⚡ YOLO mode {_Colors.BOLD}{_Colors.GREEN}ON{_Colors.RESET}"
                 " — all commands auto-approved. Use with caution."
             )
 
+    def _handle_reasoning_command(self, cmd: str):
+        """Handle /reasoning — manage effort level and display toggle.
 
+        Usage:
+            /reasoning              Show current effort level and display state
+            /reasoning <level>      Set reasoning effort (none, minimal, low, medium, high, xhigh)
+            /reasoning show|on      Show model thinking/reasoning in output
+            /reasoning hide|off     Hide model thinking/reasoning from output
+        """
+        parts = cmd.strip().split(maxsplit=1)
 
+        if len(parts) < 2:
+            # Show current state
+            rc = self.reasoning_config
+            if rc is None:
+                level = "medium (default)"
+            elif rc.get("enabled") is False:
+                level = "none (disabled)"
+            else:
+                level = rc.get("effort", "medium")
+            display_state = "on ✓" if self.show_reasoning else "off"
+            _cprint(f"  {_ACCENT}Reasoning effort:  {level}{_RST}")
+            _cprint(f"  {_ACCENT}Reasoning display: {display_state}{_RST}")
+            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide>{_RST}")
+            return
+
+        arg = parts[1].strip().lower()
+
+        # Display toggle
+        if arg in {"show", "on"}:
+            self.show_reasoning = True
+            if self.agent:
+                self.agent.reasoning_callback = self._current_reasoning_callback()
+            save_config_value("display.show_reasoning", True)
+            _cprint(f"  {_ACCENT}✓ Reasoning display: ON (saved){_RST}")
+            _cprint(f"  {_DIM}  Model thinking will be shown during and after each response.{_RST}")
+            return
+        if arg in {"hide", "off"}:
+            self.show_reasoning = False
+            if self.agent:
+                self.agent.reasoning_callback = self._current_reasoning_callback()
+            save_config_value("display.show_reasoning", False)
+            _cprint(f"  {_ACCENT}✓ Reasoning display: OFF (saved){_RST}")
+            return
+
+        # Effort level change
+        parsed = _parse_reasoning_config(arg)
+        if parsed is None:
+            _cprint(f"  {_DIM}(._.) Unknown argument: {arg}{_RST}")
+            _cprint(f"  {_DIM}Valid levels: none, minimal, low, medium, high, xhigh{_RST}")
+            _cprint(f"  {_DIM}Display:      show, hide{_RST}")
+            return
+
+        self.reasoning_config = parsed
+        self.agent = None  # Force agent re-init with new reasoning config
+
+        if save_config_value("agent.reasoning_effort", arg):
+            _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (saved to config){_RST}")
+        else:
+            _cprint(f"  {_ACCENT}✓ Reasoning effort set to '{arg}' (session only){_RST}")
+
+    def _handle_busy_command(self, cmd: str):
+        """Handle /busy — control what Enter does while Hermes is working.
+
+        Usage:
+            /busy               Show current busy input mode
+            /busy status        Show current busy input mode
+            /busy queue         Queue input for the next turn instead of interrupting
+            /busy steer         Inject Enter mid-run via /steer (after next tool call)
+            /busy interrupt     Interrupt the current run on Enter (default)
+        """
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or parts[1].strip().lower() == "status":
+            _cprint(f"  {_ACCENT}Busy input mode: {self.busy_input_mode}{_RST}")
+            if self.busy_input_mode == "queue":
+                _behavior = "queues for next turn"
+            elif self.busy_input_mode == "steer":
+                _behavior = "steers into current run (after next tool call)"
+            else:
+                _behavior = "interrupts current run"
+            _cprint(f"  {_DIM}Enter while busy: {_behavior}{_RST}")
+            _cprint(f"  {_DIM}Usage: /busy [queue|steer|interrupt|status]{_RST}")
+            return
+
+        arg = parts[1].strip().lower()
+        if arg not in {"queue", "interrupt", "steer"}:
+            _cprint(f"  {_DIM}(._.) Unknown argument: {arg}{_RST}")
+            _cprint(f"  {_DIM}Usage: /busy [queue|steer|interrupt|status]{_RST}")
+            return
+
+        self.busy_input_mode = arg
+        if save_config_value("display.busy_input_mode", arg):
+            if arg == "queue":
+                behavior = "Enter will queue follow-up input while Hermes is busy."
+            elif arg == "steer":
+                behavior = "Enter will steer your message into the current run (after the next tool call)."
+            else:
+                behavior = "Enter will interrupt the current run while Hermes is busy."
+            _cprint(f"  {_ACCENT}✓ Busy input mode set to '{arg}' (saved to config){_RST}")
+            _cprint(f"  {_DIM}{behavior}{_RST}")
+        else:
+            _cprint(f"  {_ACCENT}✓ Busy input mode set to '{arg}' (session only){_RST}")
+
+    def _handle_fast_command(self, cmd: str):
+        """Handle /fast — toggle fast mode (OpenAI Priority Processing / Anthropic Fast Mode)."""
+        if not self._fast_command_available():
+            _cprint("  (._.) /fast is only available for models that support fast mode (OpenAI Priority Processing or Anthropic Fast Mode).")
+            return
+
+        # Determine the branding for the current model
+        try:
+            from hermes_cli.models import _is_anthropic_fast_model
+            agent = getattr(self, "agent", None)
+            model = getattr(agent, "model", None) or getattr(self, "model", None)
+            feature_name = "Anthropic Fast Mode" if _is_anthropic_fast_model(model) else "Priority Processing"
+        except Exception:
+            feature_name = "Fast mode"
+
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or parts[1].strip().lower() == "status":
+            status = "fast" if self.service_tier == "priority" else "normal"
+            _cprint(f"  {_ACCENT}{feature_name}: {status}{_RST}")
+            _cprint(f"  {_DIM}Usage: /fast [normal|fast|status]{_RST}")
+            return
+
+        arg = parts[1].strip().lower()
+
+        if arg in {"fast", "on"}:
+            self.service_tier = "priority"
+            saved_value = "fast"
+            label = "FAST"
+        elif arg in {"normal", "off"}:
+            self.service_tier = None
+            saved_value = "normal"
+            label = "NORMAL"
+        else:
+            _cprint(f"  {_DIM}(._.) Unknown argument: {arg}{_RST}")
+            _cprint(f"  {_DIM}Usage: /fast [normal|fast|status]{_RST}")
+            return
+
+        self.agent = None  # Force agent re-init with new service-tier config
+        if save_config_value("agent.service_tier", saved_value):
+            _cprint(f"  {_ACCENT}✓ {feature_name} set to {label} (saved to config){_RST}")
+        else:
+            _cprint(f"  {_ACCENT}✓ {feature_name} set to {label} (session only){_RST}")
 
     def _on_reasoning(self, reasoning_text: str):
         """Callback for intermediate reasoning display during tool-call loops."""
@@ -9614,20 +9917,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
     def _manual_compress(self, cmd_original: str = ""):
         """Manually trigger context compression on the current conversation.
 
-        Two modes:
-
-        * ``/compress [<focus>]`` — compress the *whole* history. An
-          optional focus topic guides the summariser to preserve
-          information related to *focus* while being more aggressive
-          about discarding everything else.  Inspired by Claude Code's
-          ``/compact <focus>`` feature.
-        * ``/compress here [N]`` — boundary-aware compression. Summarize
-          everything *except* the most recent ``N`` exchanges (default
-          2), which are preserved verbatim. Inspired by Claude Code's
-          Rewind "Summarize up to here" action (v2.1.139, May 2026,
-          https://code.claude.com/docs/en/whats-new/2026-w20). Lets the
-          user pick the compression boundary instead of leaving it to
-          the automatic token-budget heuristic.
+        Accepts an optional focus topic: ``/compress <focus>`` guides the
+        summariser to preserve information related to *focus* while being
+        more aggressive about discarding everything else.  Inspired by
+        Claude Code's ``/compact <focus>`` feature.
         """
         if not self.conversation_history or len(self.conversation_history) < 4:
             print("(._.) Not enough conversation to compress (need at least 4 messages).")
@@ -9641,56 +9934,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             print("(._.) Compression is disabled in config.")
             return
 
-        from hermes_cli.partial_compress import (
-            extract_compress_flags,
-            parse_partial_compress_args,
-            rejoin_compressed_head_and_tail,
-            split_history_for_partial_compress,
-            summarize_compress_preview,
-        )
-
-        # Args after the command word (e.g. "/compress here 3" -> "here 3").
-        raw_args = ""
+        # Extract optional focus topic from the command (e.g. "/compress database schema")
+        focus_topic = ""
         if cmd_original:
-            _parts = cmd_original.strip().split(None, 1)
-            if len(_parts) > 1:
-                raw_args = _parts[1].strip()
-
-        # Strip --preview/--dry-run/--aggressive before positional parsing
-        # so the flags coexist with 'here [N]' / focus-topic forms.
-        raw_args, preview, aggressive = extract_compress_flags(raw_args)
-        partial, keep_last, focus_topic = parse_partial_compress_args(raw_args)
-        focus_topic = focus_topic or ""
-
-        if aggressive:
-            # LLM-free hard truncation is not supported: it would need its
-            # own transcript-persistence path outside the guarded
-            # _compress_context rotation machinery. Surface that instead of
-            # silently mis-parsing the flag as a focus topic.
-            print("(._.) --aggressive is not supported; use '/compress here [N]' "
-                  "to keep only recent exchanges, or /undo to drop turns.")
-            if not preview:
-                return
-
-        if preview:
-            from agent.model_metadata import estimate_request_tokens_rough
-            _sys_prompt = getattr(self.agent, "_cached_system_prompt", "") or ""
-            _tools = getattr(self.agent, "tools", None) or None
-            approx_tokens = estimate_request_tokens_rough(
-                self.conversation_history,
-                system_prompt=_sys_prompt,
-                tools=_tools,
-            )
-            report = summarize_compress_preview(
-                self.conversation_history,
-                partial,
-                keep_last,
-                focus_topic or None,
-                approx_tokens,
-            )
-            for line in report["lines"]:
-                print(f"🗜️  {line}")
-            return
+            parts = cmd_original.strip().split(None, 1)
+            if len(parts) > 1:
+                focus_topic = parts[1].strip()
 
         original_count = len(self.conversation_history)
         with self._busy_command("Compressing context..."):
@@ -9698,22 +9947,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 from agent.model_metadata import estimate_request_tokens_rough
                 from agent.manual_compression_feedback import summarize_manual_compression
                 original_history = list(self.conversation_history)
-
-                # Boundary-aware split: only the head is summarized; the
-                # most recent `keep_last` exchanges ride along verbatim.
-                tail: list = []
-                head = original_history
-                if partial:
-                    head, tail = split_history_for_partial_compress(
-                        original_history, keep_last
-                    )
-                    if not tail:
-                        # Split degenerated (everything would be kept, or
-                        # no head left to compress). Fall back to full
-                        # compression so the user still gets an action.
-                        partial = False
-                        head = original_history
-
                 # Include system prompt + tool schemas in the estimate —
                 # a transcript-only number understates real request pressure
                 # and can even appear to grow after compression because a
@@ -9725,11 +9958,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     system_prompt=_sys_prompt,
                     tools=_tools,
                 )
-                if partial:
-                    print(f"🗜️  Summarizing up to here: compressing {len(head)} of "
-                          f"{original_count} messages (~{approx_tokens:,} tokens), "
-                          f"keeping last {keep_last} exchange(s) verbatim...")
-                elif focus_topic:
+                if focus_topic:
                     print(f"🗜️  Compressing {original_count} messages (~{approx_tokens:,} tokens), "
                           f"focus: \"{focus_topic}\"...")
                 else:
@@ -9742,21 +9971,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 # which already contain the agent identity — resulting in the
                 # identity block appearing twice (issue #15281).
                 compressed, _ = self.agent._compress_context(
-                    head,
+                    original_history,
                     None,
                     approx_tokens=approx_tokens,
                     focus_topic=focus_topic or None,
                     force=True,
                 )
-                # Re-append the verbatim tail after the compressed head.
-                # The split guarantees `tail` begins on a user turn, so the
-                # compressed-head -> tail boundary is normally valid
-                # (the head's compressed output ends on assistant/tool).
-                # rejoin_compressed_head_and_tail() additionally guards the
-                # seam against any illegal user->user / assistant->assistant
-                # adjacency, defending provider role-alternation rules.
-                if partial and tail:
-                    compressed = rejoin_compressed_head_and_tail(compressed, tail)
                 self.conversation_history = compressed
                 # _compress_context ends the old session and creates a new child
                 # session on the agent (run_agent.py::_compress_context). Sync the
@@ -9794,27 +10014,77 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             except Exception as e:
                 print(f"  ❌ Compression failed: {e}")
 
+    def _handle_debug_command(self):
+        """Handle /debug — upload debug report + logs and print paste URLs."""
+        from hermes_cli.debug import run_debug_share
+        from types import SimpleNamespace
 
+        args = SimpleNamespace(lines=200, expire=7, local=False)
+        run_debug_share(args)
+
+    def _handle_update_command(self) -> bool:
+        """Handle /update — update Hermes Agent to the latest version.
+
+        In the classic CLI this exits the session and relaunches as
+        ``hermes update`` so the user sees update output directly and gets
+        the new version on next launch.
+
+        Returns ``True`` when the update was confirmed (caller should trigger
+        app exit so the relaunch is deferred to the main thread after
+        prompt_toolkit cleans up terminal modes).  Returns ``False`` / falsy
+        when cancelled.
+        """
+        from hermes_cli.config import is_managed, format_managed_message
+
+        if is_managed():
+            print(f"  ✗ {format_managed_message('update Hermes Agent')}")
+            return False
+
+        # Use the prompt_toolkit-native modal so the confirmation panel
+        # renders properly above the composer and avoids raw input() races
+        # with the prompt_toolkit event loop (same pattern as
+        # _confirm_destructive_slash).
+        choices = [
+            ("once", "Update Now", "exit the current session and update Hermes Agent"),
+            ("cancel", "Cancel", "keep the current session"),
+        ]
+        raw = self._prompt_text_input_modal(
+            title="⚕  Update Hermes Agent",
+            detail="This will exit the current session and run `hermes update`.",
+            choices=choices,
+        )
+        if raw is None:
+            print("  🟡 /update cancelled.")
+            return False
+        choice = self._normalize_slash_confirm_choice(raw, choices)
+        if choice != "once":
+            print("  🟡 /update cancelled.")
+            return False
+
+        print()
+        print("  ⚕ Launching update...")
+        print()
+
+        # Store the relaunch args so run() can exec them from the main thread
+        # after prompt_toolkit exits and restores terminal modes.  Calling
+        # relaunch() directly here (from the process_loop daemon thread) would
+        # skip terminal cleanup on POSIX (execvp replaces the process mid-TUI)
+        # and only exit the worker thread on Windows (subprocess.run +
+        # sys.exit inside a non-main thread does not exit the process).
+        self._pending_relaunch = ["update"]
+        return True
 
     def _show_usage(self):
-        """Rate limits + session token usage (when a live agent exists) + Nous credits.
-
-        The Nous credits block is agent-independent (a portal fetch), so it runs even
-        with no live agent — important for the TUI, where /usage runs in a slash-worker
-        subprocess that resumes the session WITHOUT building an agent (self.agent is None),
-        which would otherwise early-return before any credits showed.
-        """
+        """Show rate limits (if available) and session token usage."""
         if not self.agent:
-            if not self._print_nous_credits_block():
-                print("(._.) No active agent -- send a message first.")
+            print("(._.) No active agent -- send a message first.")
             return
 
         agent = self.agent
         calls = agent.session_api_calls
 
         if calls == 0:
-            if not self._print_nous_credits_block():
-                print("(._.) No API calls made yet in this session.")
+            print("(._.) No API calls made yet in this session.")
             return
 
         # ── Rate limits (shown first when available) ────────────────
@@ -9828,24 +10098,39 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # ── Session token usage ─────────────────────────────────────
         input_tokens = getattr(agent, "session_input_tokens", 0) or 0
         output_tokens = getattr(agent, "session_output_tokens", 0) or 0
+        cache_read_tokens = getattr(agent, "session_cache_read_tokens", 0) or 0
+        cache_write_tokens = getattr(agent, "session_cache_write_tokens", 0) or 0
         reasoning_tokens = getattr(agent, "session_reasoning_tokens", 0) or 0
         prompt = agent.session_prompt_tokens
         completion = agent.session_completion_tokens
         total = agent.session_total_tokens
 
         compressor = agent.context_compressor
-        last_prompt = compressor.last_prompt_tokens if compressor.last_prompt_tokens > 0 else 0
+        last_prompt = compressor.last_prompt_tokens
         ctx_len = compressor.context_length
         pct = min(100, (last_prompt / ctx_len * 100)) if ctx_len else 0
         compressions = compressor.compression_count
 
         msg_count = len(self.conversation_history)
+        cost_result = estimate_usage_cost(
+            agent.model,
+            CanonicalUsage(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+            ),
+            provider=getattr(agent, "provider", None),
+            base_url=getattr(agent, "base_url", None),
+        )
         elapsed = format_duration_compact((datetime.now() - self.session_start).total_seconds())
 
         print("  📊 Session Token Usage")
         print(f"  {'─' * 40}")
         print(f"  Model:                     {agent.model}")
         print(f"  Input tokens:              {input_tokens:>10,}")
+        print(f"  Cache read tokens:         {cache_read_tokens:>10,}")
+        print(f"  Cache write tokens:        {cache_write_tokens:>10,}")
         print(f"  Output tokens:             {output_tokens:>10,}")
         if reasoning_tokens:
             print(f"  ↳ Reasoning (subset):      {reasoning_tokens:>10,}")
@@ -9854,10 +10139,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         print(f"  Total tokens:              {total:>10,}")
         print(f"  API calls:                 {calls:>10,}")
         print(f"  Session duration:          {elapsed:>10}")
+        print(f"  Cost status:              {cost_result.status:>10}")
+        print(f"  Cost source:              {cost_result.source:>10}")
+        if cost_result.amount_usd is not None:
+            prefix = "~" if cost_result.status == "estimated" else ""
+            print(f"  Total cost:              {prefix}${float(cost_result.amount_usd):>10.4f}")
+        elif cost_result.status == "included":
+            print(f"  Total cost:              {'included':>10}")
+        else:
+            print(f"  Total cost:              {'n/a':>10}")
         print(f"  {'─' * 40}")
         print(f"  Current context:  {last_prompt:,} / {ctx_len:,} ({pct:.0f}%)")
         print(f"  Messages:         {msg_count}")
         print(f"  Compressions:     {compressions}")
+        if cost_result.status == "unknown":
+            print(f"  Note:             Pricing unknown for {agent.model}")
 
         # Account limits -- fetched off-thread with a hard timeout so slow
         # provider APIs don't hang the prompt.
@@ -9882,10 +10178,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             for line in account_lines:
                 print(line)
 
-        # Nous credits magnitudes + monthly-grant gauge (agent-independent — also
-        # runs at the no-agent / no-calls early-returns above). See the helper.
-        self._print_nous_credits_block()
-
         if self.verbose:
             logging.getLogger().setLevel(logging.DEBUG)
             for noisy in ('openai', 'openai._base_client', 'httpx', 'httpcore', 'asyncio', 'hpack', 'grpc', 'modal'):
@@ -9899,730 +10191,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # into stream-retry events, credential rotations, etc.
             # Console quietness is enforced by hermes_logging not
             # installing a console StreamHandler in non-verbose mode.
-
-    def _print_nous_credits_block(self) -> bool:
-        """Print the Nous credits magnitudes + monthly-grant gauge when a Nous account
-        is logged in. Returns True if it printed anything.
-
-        Delegates to the shared ``agent.account_usage.nous_credits_lines`` helper —
-        the single source for the /usage credits block across CLI, gateway, and TUI.
-        It's agent-independent (a portal fetch gated on "a Nous account is logged in",
-        NOT the inference-provider string), so /usage shows the block even in the TUI
-        slash-worker subprocess that resumes WITHOUT a live agent. Fail-open and
-        wall-clock-bounded inside the helper; also honors HERMES_DEV_CREDITS_FIXTURE
-        for offline testing — same behavior as every other surface.
-        """
-        from agent.account_usage import nous_credits_lines
-
-        lines = nous_credits_lines()
-        if not lines:
-            return False
-        print()
-        for line in lines:
-            print(f"  {line}")
-        return True
-
-    def _show_credits(self):
-        """`/credits` — focused Nous credit balance + top-up handoff.
-
-        Interactive CLI: balance block + identity line + a 3-button panel
-        (Open top-up / Copy link / Cancel). Non-interactive contexts — the TUI
-        slash-worker subprocess and any place without a live prompt_toolkit app
-        (``self._app is None``) — render a text variant (balance + tappable
-        top-up URL), because the modal would try to read the RPC stdin and crash
-        the worker. The terminal never confirms or polls payment (billing phase
-        2a). Fail-open: a portal hiccup or logged-out account degrades to a clear
-        message, never a crash.
-        """
-        from agent.account_usage import build_credits_view
-
-        view = build_credits_view()
-
-        if not view.logged_in:
-            print()
-            _cprint(f"  💳 {_d('Not logged into Nous Portal.')}")
-            print("  Run `hermes portal` to log in, then /credits.")
-            return
-
-        print()
-        print("  💳 Nous credits")
-        print(f"  {'─' * 41}")
-        for line in view.balance_lines:
-            # Drop the helper's own "📈 Nous credits" header — we print our own.
-            if line.lstrip().startswith("📈"):
-                continue
-            print(f"  {line}")
-        print(f"  {'─' * 41}")
-        if view.identity_line:
-            print(f"  {view.identity_line}")
-
-        if not view.topup_url:
-            return
-
-        # Non-interactive (TUI slash-worker, piped, no live app): the
-        # prompt_toolkit modal can't run here — it would read the worker's
-        # JSON-RPC stdin and crash the command. Render the text variant: the
-        # tappable URL IS the affordance, same as the messaging surfaces.
-        if not getattr(self, "_app", None):
-            print()
-            print(f"  Top up: {view.topup_url}")
-            print("  Complete your top-up in the browser — credits will appear in /credits shortly.")
-            return
-
-        choices = [
-            ("open", "Open top-up in browser", "launch the portal billing page"),
-            ("copy", "Copy link", "copy the top-up URL to your clipboard"),
-            ("cancel", "Cancel", "do nothing"),
-        ]
-        raw = self._prompt_text_input_modal(
-            title="💳 Add credits?",
-            detail=f"Top-up page:\n{view.topup_url}",
-            choices=choices,
-        )
-        choice = self._normalize_slash_confirm_choice(raw, choices)
-
-        if choice == "open":
-            opened = False
-            try:
-                import webbrowser
-
-                opened = webbrowser.open(view.topup_url)
-            except Exception:
-                opened = False
-            if not opened:
-                print(f"  Open this URL to top up: {view.topup_url}")
-            print()
-            print("  Complete your top-up in the browser — credits will appear in /credits shortly.")
-        elif choice == "copy":
-            try:
-                self._write_osc52_clipboard(view.topup_url)
-                print(f"  📋 Copied: {view.topup_url}")
-            except Exception:
-                print(f"  Top-up URL: {view.topup_url}")
-        else:
-            print("  🟡 Cancelled. No credits added.")
-
-    # ------------------------------------------------------------------
-    # /billing — Phase 2b terminal billing (CLI surface, all 5 screens)
-    # ------------------------------------------------------------------
-
-    def _show_billing(self, command: str = "/billing"):
-        """`/billing` — terminal billing for Nous (one interactive modal).
-
-        ZERO sub-commands: any argument is ignored. Bare ``/billing`` always
-        opens the Overview (Screen 1), whose numbered menu is the *only* way to
-        reach the Buy / Auto-reload / Monthly-limit sub-screens. (Per the unified
-        UX spec §0.4 — ``/billing buy`` etc. are gone; we don't error on a stray
-        arg, we just open the menu.)
-
-        Interactive CLI uses the prompt_toolkit modal; non-interactive contexts
-        (TUI slash-worker / no live app) render text + the portal deep-link, never
-        prompting (the URL is the affordance), same discipline as ``_show_credits``.
-        All money is Decimal end-to-end; the terminal never collects card details.
-        """
-        from agent.billing_view import build_billing_state
-
-        state = build_billing_state()
-        if not state.logged_in:
-            print()
-            if state.error:
-                _msg = f"Couldn't load billing: {state.error}"
-                _cprint(f"  💳 {_d(_msg)}")
-            else:
-                _cprint(f"  💳 {_d('Not logged into Nous Portal.')}")
-                print("  Run `hermes portal` to log in, then /billing.")
-            return
-
-        # Any sub-arg is intentionally ignored — always open the menu.
-        self._billing_overview(state)
-
-    def _billing_portal_hint(self, state, *, reason: str = "") -> None:
-        """Print a portal deep-link line (the funnel for portal-only actions)."""
-        url = getattr(state, "portal_url", None)
-        if not url:
-            return
-        if reason:
-            print(f"  {reason}")
-        print(f"  Manage on portal: {url}")
-
-    def _billing_overview(self, state):
-        """Screen 1 — overview: balance, spend bar, role-gated action menu."""
-        from agent.billing_view import format_money
-
-        print()
-        _cprint(f"  💳 {_b('Usage credits')}")
-        print(f"  {'─' * 41}")
-
-        cap = state.monthly_cap
-        if cap is not None and cap.limit_usd is not None:
-            spent = format_money(cap.spent_this_month_usd)
-            limit = format_money(cap.limit_usd)
-            ceiling = " (default ceiling)" if cap.is_default_ceiling else ""
-            bar, pct = self._billing_spend_bar(
-                cap.spent_this_month_usd, cap.limit_usd
-            )
-            print(f"  {spent} of {limit} used{ceiling}   {bar} {pct}%")
-
-        print(f"  Balance: {format_money(state.balance_usd)}")
-
-        ar = state.auto_reload
-        if ar is not None:
-            if ar.enabled:
-                print(
-                    f"  Auto-reload: on — below {format_money(ar.threshold_usd)} "
-                    f"→ reload to {format_money(ar.reload_to_usd)}"
-                )
-            else:
-                print("  Auto-reload: off")
-
-        if state.org_name:
-            role = (state.role or "").title()
-            _org_line = f"Org: {state.org_name}{f' · {role}' if role else ''}"
-            _cprint(f"  {_d(_org_line)}")
-        print(f"  {'─' * 41}")
-
-        # Action gating: admin + kill-switch for charge/auto-reload; everyone gets portal.
-        if not state.is_admin:
-            _cprint(f"  {_d('Billing actions require an org admin/owner.')}")
-            self._billing_portal_hint(state)
-            return
-        if not state.cli_billing_enabled:
-            _cprint(f"  {_d('Terminal billing is turned off for this org.')}")
-            self._billing_portal_hint(state, reason="Enable it on the portal to buy credits here.")
-            return
-
-        # Optimistic funnel: no card on file → a charge will 403 no_payment_method.
-        # Surface that up front (with the portal link) but DON'T hide Buy — /state.card
-        # can't fully prove CLI-chargeability, so we advise rather than gate.
-        if state.card is None:
-            _cprint(
-                f"  {_d('No saved card for terminal charges yet — set one up on the portal first.')}"
-            )
-            self._billing_portal_hint(state)
-
-        # Non-interactive (slash-worker / no live app): no modal, no sub-command
-        # advertising — just the portal funnel (the URL is the affordance).
-        if not getattr(self, "_app", None):
-            self._billing_portal_hint(state)
-            return
-
-        choices = [
-            ("buy", "Buy credits", "purchase a one-time credit top-up"),
-            ("auto", "Adjust auto-reload", "configure automatic top-ups"),
-            ("limit", "Adjust monthly limit", "show the monthly spend cap (read-only)"),
-            ("portal", "Manage on portal", "open the billing page in your browser"),
-            ("cancel", "Cancel", "do nothing"),
-        ]
-        # The overview summary is already printed above; the modal only needs to
-        # present the action menu — repeating the title/balance reads as a dupe.
-        raw = self._prompt_text_input_modal(
-            title="💳 Choose an action", detail="",
-            choices=choices,
-        )
-        choice = self._normalize_slash_confirm_choice(raw, choices)
-        if choice == "buy":
-            self._billing_buy_flow(state)
-        elif choice == "auto":
-            self._billing_auto_reload_flow(state)
-        elif choice == "limit":
-            self._billing_limit_screen(state)
-        elif choice == "portal":
-            self._billing_open_portal(state)
-        else:
-            print("  🟡 Cancelled.")
-
-    def _billing_spend_bar(self, spent, limit, *, cells: int = 10):
-        """Render a 10-cell `█`/`░` spend bar + integer percent from spent/limit.
-
-        Returns ``(bar, pct)`` where ``bar`` is like ``[████░░░░░░]`` and ``pct``
-        is the spent/limit percentage clamped to 0..100. Box-drawing glyphs are
-        not SGR codes, so this is leak-safe even without ``_b()``/``_d()``.
-        """
-        from decimal import Decimal
-
-        try:
-            s = Decimal(str(spent)) if spent is not None else Decimal("0")
-            l = Decimal(str(limit)) if limit is not None else Decimal("0")
-        except Exception:
-            s, l = Decimal("0"), Decimal("0")
-        if l <= 0:
-            pct = 0
-        else:
-            pct = int((s / l) * 100)
-        pct = max(0, min(100, pct))
-        filled = int(round(pct / 100 * cells))
-        filled = max(0, min(cells, filled))
-        bar = ("█" * filled) + ("░" * (cells - filled))
-        return bar, pct
-
-    def _billing_open_portal(self, state):
-        url = getattr(state, "portal_url", None)
-        if not url:
-            print("  No portal URL available.")
-            return
-        opened = False
-        try:
-            import webbrowser
-
-            opened = webbrowser.open(url)
-        except Exception:
-            opened = False
-        if not opened:
-            print(f"  Open this URL: {url}")
-        print("  Complete billing changes in the browser.")
-
-    def _billing_require_admin(self, state) -> bool:
-        """Guard charge/auto-reload entry points; print + return False if blocked."""
-        if not state.is_admin:
-            print()
-            _cprint(f"  💳 {_d('Billing actions require an org admin/owner.')}")
-            self._billing_portal_hint(state)
-            return False
-        if not state.cli_billing_enabled:
-            print()
-            _cprint(f"  💳 {_d('Terminal billing is turned off for this org.')}")
-            self._billing_portal_hint(state, reason="Enable it on the portal first.")
-            return False
-        return True
-
-    def _billing_buy_flow(self, state):
-        """Screen 2 (preset select) → Screen 3 (confirm + charge + poll)."""
-        from agent.billing_view import format_money, validate_charge_amount
-
-        if not self._billing_require_admin(state):
-            return
-
-        # Screen 3 — preset selection.
-        if not getattr(self, "_app", None):
-            presets = ", ".join(format_money(p) for p in state.charge_presets)
-            print()
-            _cprint(f"  💳 {_b('Buy usage credits')}")
-            print(f"  Presets: {presets}")
-            print("  Run this in the interactive CLI to complete a purchase.")
-            self._billing_portal_hint(state)
-            return
-
-        preset_choices = []
-        for p in state.charge_presets:
-            preset_choices.append((str(p), format_money(p), "one-time credit purchase"))
-        preset_choices.append(("custom", "Custom amount…", "enter your own amount"))
-        preset_choices.append(("cancel", "Cancel", "do nothing"))
-
-        card = state.card
-        detail = f"Payment: {card.masked}" if card else "No saved card on file"
-        raw = self._prompt_text_input_modal(
-            title="💳 Buy usage credits", detail=detail, choices=preset_choices,
-        )
-        choice = self._normalize_slash_confirm_choice(raw, preset_choices)
-        if not choice or choice == "cancel":
-            print("  🟡 Cancelled. No credits added.")
-            return
-
-        from decimal import Decimal
-
-        if choice == "custom":
-            entered = self._prompt_text_input("  Amount (USD): ")
-            if entered is None:
-                # None = cancelled (e.g. slash-worker can't prompt off-thread).
-                print("  🟡 Cancelled. No credits added.")
-                return
-            v = validate_charge_amount(
-                entered or "", min_usd=state.min_usd, max_usd=state.max_usd
-            )
-            if not v.ok:
-                print(f"  🔴 {v.error}")
-                return
-            amount = v.amount
-        else:
-            try:
-                amount = Decimal(choice)
-            except Exception:
-                print("  🔴 Invalid selection.")
-                return
-
-        self._billing_confirm_and_charge(state, amount)
-
-    def _billing_confirm_and_charge(self, state, amount):
-        """Screen 3 — confirm total + consent, charge, then poll to settlement."""
-        from agent.billing_view import format_money, new_idempotency_key
-
-        card = state.card
-        print()
-        _cprint(f"  💳 {_b('Confirm purchase')}")
-        print(f"  {'─' * 41}")
-        print(f"  Total: {format_money(amount)}")
-        if card:
-            print(f"  Payment: {card.masked}")
-        print(f"  {'─' * 41}")
-        _consent = (
-            "By confirming, you allow Nous Research to charge your card."
-        )
-        _cprint(f"  {_d(_consent)}")
-
-        confirm_choices = [
-            ("pay", f"Pay {format_money(amount)} now", "submit the charge"),
-            ("cancel", "Go back", "do not charge"),
-        ]
-        if not getattr(self, "_app", None):
-            print("  Run in the interactive CLI to confirm a purchase.")
-            return
-        raw = self._prompt_text_input_modal(
-            title=f"💳 Pay {format_money(amount)}?",
-            detail=(card.masked if card else "no saved card"),
-            choices=confirm_choices,
-        )
-        choice = self._normalize_slash_confirm_choice(raw, confirm_choices)
-        if choice != "pay":
-            print("  🟡 Cancelled. No credits added.")
-            return
-
-        # Submit the charge with a fresh idempotency key (reused on retry).
-        from hermes_cli.nous_billing import (
-            BillingError,
-            BillingScopeRequired,
-            post_charge,
-        )
-
-        key = new_idempotency_key()
-        try:
-            result = post_charge(amount_usd=amount, idempotency_key=key)
-        except BillingScopeRequired:
-            self._billing_handle_scope_required(state)
-            return
-        except BillingError as exc:
-            self._billing_render_charge_error(state, exc)
-            return
-
-        charge_id = result.get("chargeId")
-        if not charge_id:
-            print("  🔴 No charge id returned; please check the portal.")
-            return
-        _cprint(f"  {_d('Charge submitted — confirming settlement…')}")
-        self._billing_poll_charge(state, charge_id, amount)
-
-    def _billing_poll_charge(self, state, charge_id, amount):
-        """Poll loop: 2s interval, 5-min cap, cancellable. settled = ledger truth."""
-        import time as _time
-
-        from agent.billing_view import format_money
-        from hermes_cli.nous_billing import (
-            BillingError,
-            BillingRateLimited,
-            get_charge_status,
-        )
-
-        deadline = _time.time() + 300  # 5-minute cap
-        interval = 2.0
-        while _time.time() < deadline:
-            try:
-                status = get_charge_status(charge_id)
-            except BillingRateLimited as exc:
-                # Retry-after, NOT a failure — back off and keep polling.
-                wait = exc.retry_after or 5
-                _time.sleep(min(wait, 30))
-                continue
-            except BillingError as exc:
-                print(f"  🔴 Could not check the charge: {exc}")
-                return
-
-            state_str = status.get("status")
-            if state_str == "settled":
-                amt = status.get("amountUsd")
-                from agent.billing_view import parse_money
-
-                shown = format_money(parse_money(amt)) if amt else format_money(amount)
-                print(f"  ✅ {shown} in credits added.")
-                return
-            if state_str == "failed":
-                self._billing_render_charge_failed(state, status.get("reason"))
-                return
-            # pending → wait and poll again
-            _time.sleep(interval)
-
-        # Past the cap with no terminal state = timeout (not an error).
-        print("  🟡 Still processing after 5 minutes — this is a timeout, not a "
-              "failure. Check /billing or the portal shortly.")
-        self._billing_portal_hint(state)
-
-    def _billing_render_charge_failed(self, state, reason):
-        """Branch the poll `failed` reasons to the right copy + portal funnel."""
-        reason = (reason or "").strip()
-        if reason == "authentication_required":
-            print("  🔴 Your bank requires verification (3DS). Complete it on the "
-                  "portal to finish this purchase.")
-        elif reason == "payment_method_expired":
-            print("  🔴 Your card has expired. Update it on the portal.")
-        elif reason == "card_declined":
-            print("  🔴 Your card was declined. Try another card on the portal.")
-        else:
-            print(f"  🔴 The charge didn't go through ({reason or 'processing_error'}).")
-        self._billing_portal_hint(state)
-
-    def _billing_render_charge_error(self, state, exc):
-        """Render a typed BillingError at submit time (pre-poll)."""
-        from hermes_cli.nous_billing import BillingRateLimited
-
-        code = getattr(exc, "error", None)
-        portal_url = getattr(exc, "portal_url", None) or getattr(state, "portal_url", None)
-        if code == "no_payment_method":
-            print("  💳 No saved card for terminal charges yet. Set one up on the "
-                  "portal (one-time credit buys don't save a reusable card).")
-        elif code == "cli_billing_disabled":
-            print("  🔴 Terminal billing is turned off for this org — an admin must enable it on the portal.")
-        elif code == "monthly_cap_exceeded":
-            remaining = (getattr(exc, "payload", {}) or {}).get("remainingUsd")
-            if remaining is not None:
-                print(f"  🔴 Monthly spend cap reached — ${remaining} headroom left.")
-            else:
-                print("  🔴 Monthly spend cap reached.")
-        elif isinstance(exc, BillingRateLimited):
-            wait = getattr(exc, "retry_after", None)
-            mins = f" (try again in ~{max(1, round(wait / 60))} min)" if wait else ""
-            print(f"  🟡 Too many charges right now{mins}. This isn't a payment failure.")
-        else:
-            print(f"  🔴 {exc}")
-        if portal_url:
-            print(f"  Portal: {portal_url}")
-
-    def _billing_handle_scope_required(self, state):
-        """403 insufficient_scope → lazy step-up re-auth (plan D-A)."""
-        print()
-        print("  💳 Terminal billing needs an extra permission (billing:manage).")
-        _scope_msg = (
-            "An org admin/owner must tick \"Allow terminal billing\" during "
-            "login."
-        )
-        _cprint(f"  {_d(_scope_msg)}")
-        if not getattr(self, "_app", None):
-            print("  Run `hermes portal` and approve terminal billing, then retry.")
-            return
-        confirm_choices = [
-            ("yes", "Re-authorize now", "open the portal to grant billing access"),
-            ("no", "Not now", "cancel"),
-        ]
-        raw = self._prompt_text_input_modal(
-            title="💳 Grant terminal billing access?",
-            detail="Opens the portal device-authorization page.",
-            choices=confirm_choices,
-        )
-        choice = self._normalize_slash_confirm_choice(raw, confirm_choices)
-        if choice != "yes":
-            print("  🟡 Cancelled.")
-            return
-        try:
-            from hermes_cli.auth import step_up_nous_billing_scope
-
-            granted = step_up_nous_billing_scope(open_browser=True)
-        except Exception as exc:
-            print(f"  🔴 Re-authorization failed: {exc}")
-            return
-        if granted:
-            print("  ✅ Billing permission granted.")
-            # Step-up only grants the billing:manage TOKEN scope; the ORG
-            # kill-switch (cli_billing_enabled) is a separate gate. Re-fetch
-            # /state so we don't over-promise when a charge would still hit
-            # cli_billing_disabled.
-            from agent.billing_view import build_billing_state
-
-            fresh = build_billing_state()
-            if fresh.logged_in and fresh.cli_billing_enabled:
-                print("  Run /billing buy again to continue.")
-            else:
-                print("  🟡 Permission granted, but terminal billing is still turned "
-                      "off for this org. Enable it in the portal, then run /billing again.")
-                self._billing_portal_hint(fresh)
-        else:
-            print("  🟡 Terminal billing was not granted (an admin must tick the box).")
-
-    def _billing_auto_reload_flow(self, state):
-        """Screen 4 — auto-reload config: threshold + reload-to → PATCH.
-
-        Prefills the current values from ``state.auto_reload``. Validates both
-        amounts (2dp, within bounds, ``reload_to > threshold``). When auto-reload
-        is already on, offers a "Turn off" path (PATCH ``enabled:false``).
-        """
-        from agent.billing_view import format_money, validate_charge_amount
-
-        if not self._billing_require_admin(state):
-            return
-
-        card = state.card
-        ar = state.auto_reload
-        currently_on = bool(ar and ar.enabled)
-
-        print()
-        _cprint(f"  💳 {_b('Auto-reload')}")
-        print(f"  {'─' * 41}")
-        _cprint(f"  {_d('Automatically buy more credits when your balance is low.')}")
-        if card:
-            print(f"  Card on file: {card.masked}")
-        else:
-            print("  No saved card — set one up on the portal first.")
-            self._billing_portal_hint(state)
-            return
-        if currently_on:
-            print(
-                f"  Currently: below {format_money(ar.threshold_usd)} → "
-                f"reload to {format_money(ar.reload_to_usd)}"
-            )
-
-        if not getattr(self, "_app", None):
-            print("  Run in the interactive CLI to configure auto-reload.")
-            self._billing_portal_hint(state)
-            return
-
-        # When already enabled, let the user turn it off without re-entering values.
-        if currently_on:
-            top_choices = [
-                ("edit", "Edit thresholds", "change when / how much to reload"),
-                ("off", "Turn off", "disable auto-reload"),
-                ("cancel", "Cancel", "do nothing"),
-            ]
-            raw = self._prompt_text_input_modal(
-                title="💳 Auto-reload",
-                detail=(
-                    f"On — below {format_money(ar.threshold_usd)} → "
-                    f"reload to {format_money(ar.reload_to_usd)}"
-                ),
-                choices=top_choices,
-            )
-            top = self._normalize_slash_confirm_choice(raw, top_choices)
-            if top == "off":
-                self._billing_auto_reload_disable(state)
-                return
-            if top != "edit":
-                print("  🟡 Cancelled.")
-                return
-
-        # Field 1 — threshold (prefilled when editing an existing config).
-        cur_thr = format_money(ar.threshold_usd) if currently_on else None
-        thr_prompt = "  When balance falls below (USD)"
-        thr_prompt += f" [{cur_thr}]: " if cur_thr else ": "
-        threshold_raw = self._prompt_text_input(thr_prompt)
-        if threshold_raw is None:
-            # None = cancelled (e.g. slash-worker can't prompt off-thread).
-            print("  🟡 Cancelled.")
-            return
-        if not (threshold_raw or "").strip() and currently_on:
-            threshold_amt = ar.threshold_usd  # keep current value on empty input
-        else:
-            tv = validate_charge_amount(
-                threshold_raw or "", min_usd=state.min_usd, max_usd=state.max_usd
-            )
-            if not tv.ok or tv.amount is None:
-                print(f"  🔴 {tv.error}")
-                return
-            threshold_amt = tv.amount
-
-        # Field 2 — reload-to (prefilled when editing an existing config).
-        cur_rel = format_money(ar.reload_to_usd) if currently_on else None
-        rel_prompt = "  Reload balance to (USD)"
-        rel_prompt += f" [{cur_rel}]: " if cur_rel else ": "
-        reload_raw = self._prompt_text_input(rel_prompt)
-        if reload_raw is None:
-            print("  🟡 Cancelled.")
-            return
-        if not (reload_raw or "").strip() and currently_on:
-            reload_amt = ar.reload_to_usd  # keep current value on empty input
-        else:
-            rv = validate_charge_amount(
-                reload_raw or "", min_usd=state.min_usd, max_usd=state.max_usd
-            )
-            if not rv.ok or rv.amount is None:
-                print(f"  🔴 {rv.error}")
-                return
-            reload_amt = rv.amount
-
-        if reload_amt is None or threshold_amt is None or reload_amt <= threshold_amt:
-            print("  🔴 Reload-to amount must be greater than the threshold.")
-            return
-
-        print()
-        _ar_consent = (
-            f"By confirming, you authorize Nous Research to charge {card.masked} "
-            f"whenever your balance reaches {format_money(threshold_amt)}. "
-            f"Turn off any time here or on the portal."
-        )
-        _cprint(f"  {_d(_ar_consent)}")
-        confirm_choices = [
-            ("agree", "Agree and turn on", "enable auto-reload"),
-            ("cancel", "Cancel", "do nothing"),
-        ]
-        raw = self._prompt_text_input_modal(
-            title="💳 Turn on auto-reload?",
-            detail=f"Below {format_money(threshold_amt)} → reload to {format_money(reload_amt)}",
-            choices=confirm_choices,
-        )
-        choice = self._normalize_slash_confirm_choice(raw, confirm_choices)
-        if choice != "agree":
-            print("  🟡 Cancelled.")
-            return
-
-        from hermes_cli.nous_billing import (
-            BillingError,
-            BillingScopeRequired,
-            patch_auto_top_up,
-        )
-
-        try:
-            patch_auto_top_up(
-                enabled=True, threshold=float(threshold_amt), top_up_amount=float(reload_amt)
-            )
-        except BillingScopeRequired:
-            self._billing_handle_scope_required(state)
-            return
-        except BillingError as exc:
-            self._billing_render_charge_error(state, exc)
-            return
-        print(f"  ✅ Auto-reload on: below {format_money(threshold_amt)} → "
-              f"reload to {format_money(reload_amt)}.")
-
-    def _billing_auto_reload_disable(self, state):
-        """Turn off auto-reload (PATCH ``enabled:false``).
-
-        The endpoint requires ``threshold``/``topUpAmount`` in the body even when
-        disabling, so we echo back the current values (falling back to 0).
-        """
-        from hermes_cli.nous_billing import (
-            BillingError,
-            BillingScopeRequired,
-            patch_auto_top_up,
-        )
-
-        ar = state.auto_reload
-        thr = float(ar.threshold_usd) if ar and ar.threshold_usd is not None else 0.0
-        rel = float(ar.reload_to_usd) if ar and ar.reload_to_usd is not None else 0.0
-        try:
-            patch_auto_top_up(enabled=False, threshold=thr, top_up_amount=rel)
-        except BillingScopeRequired:
-            self._billing_handle_scope_required(state)
-            return
-        except BillingError as exc:
-            self._billing_render_charge_error(state, exc)
-            return
-        print("  ✅ Auto-reload turned off.")
-
-    def _billing_limit_screen(self, state):
-        """Screen 5 — monthly spend limit (read-only; cap is portal-only)."""
-        from agent.billing_view import format_money
-
-        print()
-        _cprint(f"  💳 {_b('Monthly spend limit')}")
-        print(f"  {'─' * 41}")
-        cap = state.monthly_cap
-        if cap is None or cap.limit_usd is None:
-            _cprint(f"  {_d('No monthly cap visible (managed on the portal).')}")
-        else:
-            spent = format_money(cap.spent_this_month_usd)
-            limit = format_money(cap.limit_usd)
-            ceiling = " (default ceiling)" if cap.is_default_ceiling else ""
-            print(f"  {spent} of {limit} used this month{ceiling}")
-        _limit_note = (
-            "The monthly limit is set on the portal — the terminal shows "
-            "it read-only."
-        )
-        _cprint(f"  {_d(_limit_note)}")
-        self._billing_portal_hint(state)
 
     def _show_insights(self, command: str = "/insights"):
         """Show usage insights and analytics from session history."""
@@ -10712,17 +10280,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             target=self._reload_mcp, daemon=True
         )
         _reload_thread.start()
-        # Do NOT join here — process_loop calls this from its idle branch, so a
-        # blocking join would freeze input consumption for up to 30s (and a hung
-        # MCP server could block far longer). The reload runs purely in the
-        # background daemon thread, which reports its own progress/completion
-        # status via print() inside _reload_mcp().
+        _reload_thread.join(timeout=30)
+        if _reload_thread.is_alive():
+            print("  ⚠️  MCP reload timed out (30s). Some servers may not have reconnected.")
 
     # Inline-skip tokens that bypass the destructive-slash confirmation modal.
-    # A general escape hatch for non-interactive use (scripting/automation) and
-    # for the degraded path where the modal can't be marshaled onto the app loop
-    # — lets users self-serve without flipping approvals.destructive_slash_confirm
-    # in config. (Native Windows now drives the modal normally — see #33961.)
+    # Matches the escape-hatch pattern users on broken modal platforms
+    # (currently native Windows PowerShell — issue #30768) need to self-serve
+    # without having to flip approvals.destructive_slash_confirm in config.
     _DESTRUCTIVE_SKIP_TOKENS = frozenset({"now", "--yes", "-y"})
 
     @classmethod
@@ -10780,9 +10345,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         Inline-skip: if ``cmd_original`` contains ``now``, ``--yes``, or
         ``-y`` as an argument (e.g. ``/reset now``, ``/new --yes My title``),
         the modal is bypassed and ``"once"`` is returned immediately. This is
-        an escape hatch for non-interactive use and for the degraded path where
-        the modal can't be marshaled onto the app loop (native Windows itself now
-        drives the modal normally — see #33961). Callers are responsible
+        an escape hatch for platforms where the prompt_toolkit modal hangs
+        (issue #30768 — native Windows PowerShell). Callers are responsible
         for stripping the skip tokens from any remaining argument parsing
         (see :meth:`_split_destructive_skip`).
 
@@ -10951,35 +10515,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             else:
                 print(f"  🔧 {len(new_tools)} tool(s) available from {len(connected_servers)} server(s)")
 
-            # Refresh the agent's tool list so the model can call new tools.
-            # Route through the shared helper so this CLI /reload-mcp path stays
-            # in lockstep with the TUI RPC / gateway reload / late-binding paths
-            # (name-diff, thread-safe, and — critically — additive-preserving so
-            # memory-provider and context-engine tools survive the rebuild).
+            # Refresh the agent's tool list so the model can call new tools
             if self.agent is not None:
-                from tools.mcp_tool import refresh_agent_mcp_tools
-                # Explicit reload: pick up MCP servers the user ENABLED in config
-                # this session. self.enabled_toolsets was resolved once at
-                # startup; merge in any now-connected server names (unless the
-                # user pinned `all`/`*`, which already includes everything) so a
-                # freshly-added server isn't filtered out. Mirrors startup, where
-                # MCP server names are part of enabled_toolsets (see __init__).
-                enabled_override = None
-                et = self.enabled_toolsets
-                if et and "all" not in et and "*" not in et:
-                    merged = list(et)
-                    for _name in sorted(connected_servers):
-                        if _name not in merged:
-                            merged.append(_name)
-                    enabled_override = merged
-                refresh_agent_mcp_tools(
-                    self.agent,
-                    enabled_override=enabled_override,
+                self.agent.tools = get_tool_definitions(
+                    enabled_toolsets=self.agent.enabled_toolsets
+                    if hasattr(self.agent, "enabled_toolsets") else None,
                     quiet_mode=True,
                 )
-                # Keep the CLI's own list in sync with what the agent now uses.
-                if enabled_override is not None:
-                    self.enabled_toolsets = enabled_override
+                self.agent.valid_tool_names = {
+                    tool["function"]["name"] for tool in self.agent.tools
+                } if self.agent.tools else set()
 
             # Inject a message at the END of conversation history so the
             # model knows tools changed.  Appended after all existing
@@ -11131,57 +10676,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         stacked line to scrollback on tool.completed so users can see the
         full history of tool calls (not just the current one in the spinner).
         """
-        # MoA reference-model outputs: render each reference's answer as a
-        # labelled thinking-style block BEFORE the aggregator acts, so the user
-        # sees the mixture-of-agents process instead of a silent pause. These
-        # are display-only events emitted by the MoA facade (agent_init relay);
-        # they never enter message history.
-        if event_type == "moa.reference":
-            label = function_name or "reference"
-            text = preview or ""
-            idx = kwargs.get("moa_index")
-            count = kwargs.get("moa_count")
-            header = f"Reference {idx}/{count} — {label}" if idx and count else f"Reference — {label}"
-            try:
-                self._flush_reasoning_preview(force=True)
-            except Exception:
-                pass
-            _cprint(f"  {_DIM}┊ ◇ {header}{_RST}")
-            try:
-                self._emit_reasoning_preview(text)
-            except Exception:
-                # Fallback: print the raw text dimmed if the preview helper fails.
-                if text.strip():
-                    _cprint(f"  {_DIM}{text.strip()}{_RST}")
-            self._invalidate()
-            return
-        if event_type == "moa.aggregating":
-            agg = function_name or ""
-            self._spinner_text = f"◆ aggregating ({agg})" if agg else "◆ aggregating"
-            self._invalidate()
-            return
-
-        # Feed the pet: tools mean "running" (not reasoning); a failed tool
-        # latches the turn so it ends on a sulk.
-        if event_type == "tool.started":
-            self._pet_reasoning = False
-        elif event_type == "tool.completed" and kwargs.get("is_error"):
-            self._pet_turn_error = True
-        elif event_type and event_type.startswith("reasoning"):
-            self._pet_reasoning = True
-
         if event_type == "tool.completed":
             self._tool_start_time = 0.0
-            # Print stacked scrollback line for "new" / "all" / "verbose" modes.
-            # "verbose" was previously omitted here, so non-streaming model
-            # calls (MoA aggregator, copilot-acp) rendered each tool only into
-            # the transient spinner line — which overwrites itself, so no
-            # scrollable tool history accumulated. Streaming models hid the bug
-            # because _on_tool_gen_start commits a "preparing" line per tool;
-            # non-streaming calls never emit that, leaving verbose mode with no
-            # committed line at all. "verbose" is strictly more than "all", so
-            # it must commit at least the same line.
-            if function_name and self.tool_progress_mode in {"new", "all", "verbose"}:
+            # Print stacked scrollback line for "all" / "new" modes
+            if function_name and self.tool_progress_mode in {"all", "new"}:
                 duration = kwargs.get("duration", 0.0)
                 is_error = kwargs.get("is_error", False)
                 # Pop stored args from tool.started for this function
@@ -11258,21 +10756,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
     def _on_tool_complete(self, tool_call_id: str, function_name: str, function_args: dict, function_result: str):
         """Render file edits with inline diff after write-capable tools complete."""
-        # A top-level delegate_task dispatches in the background and re-enters as
-        # a fresh turn when done. Say so once — no spinner, nothing to poll — so
-        # the idle prompt doesn't read as "nothing happened" (⛓ tracks the work).
-        if function_name == "delegate_task":
-            try:
-                parsed = json.loads(function_result) if isinstance(function_result, str) else (function_result or {})
-            except Exception:
-                parsed = {}
-            if isinstance(parsed, dict) and parsed.get("status") == "dispatched" and parsed.get("mode") == "background":
-                n = parsed.get("count") or 1
-                noun, tail = ("task", "it finishes") if n == 1 else (f"{n} tasks", "they finish")
-                try:
-                    _cprint(f"\033[2m\u21a9 Background {noun} running — I'll resume when {tail}. Keep chatting.\033[0m")
-                except Exception:
-                    pass
         snapshot = self._pending_edit_snapshots.pop(tool_call_id, None)
         try:
             from agent.display import render_edit_diff_with_delta
@@ -11319,8 +10802,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if not reqs.get("stt_available", reqs.get("stt_key_set")):
             raise RuntimeError(
                 "Voice mode requires an STT provider for transcription.\n"
-                "Option 1: uv pip install faster-whisper  "
-                "(free, local; `pip install faster-whisper` also works if pip is on PATH)\n"
+                "Option 1: pip install faster-whisper  (free, local)\n"
                 "Option 2: Set GROQ_API_KEY (free tier)\n"
                 "Option 3: Set VOICE_TOOLS_OPENAI_KEY (paid)"
             )
@@ -11344,16 +10826,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         except Exception:
             pass
 
-        # Recorder creation can fail (no input device, PortAudio init error).
-        # Reset the flag on failure or _voice_recording stays True forever and
-        # every future voice start is silently skipped by the guard above.
         if self._voice_recorder is None:
-            try:
-                self._voice_recorder = create_audio_recorder()
-            except Exception:
-                with self._voice_lock:
-                    self._voice_recording = False
-                raise
+            self._voice_recorder = create_audio_recorder()
 
         # Apply config-driven silence params (numeric-guarded so YAML
         # scalar corruption doesn't break recording start-up).
@@ -11587,6 +11061,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         finally:
             self._voice_tts_done.set()
 
+    def _handle_voice_command(self, command: str):
+        """Handle /voice [on|off|tts|status] command."""
+        parts = command.strip().split(maxsplit=1)
+        subcommand = parts[1].lower().strip() if len(parts) > 1 else ""
+
+        if subcommand == "on":
+            self._enable_voice_mode()
+        elif subcommand == "off":
+            self._disable_voice_mode()
+        elif subcommand == "tts":
+            self._toggle_voice_tts()
+        elif subcommand == "status":
+            self._show_voice_status()
+        elif subcommand == "":
+            # Toggle
+            if self._voice_mode:
+                self._disable_voice_mode()
+            else:
+                self._enable_voice_mode()
+        else:
+            _cprint(f"Unknown voice subcommand: {subcommand}")
+            _cprint("Usage: /voice [on|off|tts|status]")
 
     def _voice_beeps_enabled(self) -> bool:
         """Return whether CLI voice mode should play record start/stop beeps."""
@@ -11727,25 +11223,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         for line in reqs["details"].split("\n"):
             _cprint(f"    {line}")
 
-    def _persist_prompt_summary(self, icon: str, label: str, detail: str, outcome: str) -> None:
-        """Print a one-line scrollback summary of a resolved modal prompt.
-
-        Modal panels (approval / clarify) live in the prompt_toolkit layout and
-        vanish on the next repaint, so the question and the decision leave no
-        trace in the terminal scrollback. When display.persist_prompts is on
-        (default), emit a dim single line after the prompt resolves so the
-        decision survives in chat history.
-        """
-        if not CLI_CONFIG.get("display", {}).get("persist_prompts", True):
-            return
-        detail = " ".join(detail.split())
-        if len(detail) > 120:
-            detail = detail[:119] + "…"
-        outcome = " ".join(outcome.split())
-        if len(outcome) > 120:
-            outcome = outcome[:119] + "…"
-        _cprint(f"\n{_DIM}{icon} {label}: {detail} → {outcome}{_RST}")
-
     def _clarify_callback(self, question, choices):
         """
         Platform callback for the clarify tool. Called from the agent thread.
@@ -11771,36 +11248,42 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # Open-ended questions skip straight to freetext input
         self._clarify_freetext = is_open_ended
 
-        # Trigger an immediate prompt_toolkit repaint from this (non-main)
-        # thread. Modal prompts must paint at once and must not be gated by the
-        # _invalidate throttle / resize guard — see _paint_now / _invalidate (#41098).
-        self._paint_now()
+        # Trigger prompt_toolkit repaint from this (non-main) thread
+        self._invalidate()
 
-        # Poll for the user's response. The countdown in the hint line updates
-        # on each repaint; refresh it once a second so the timer stays visible
-        # while we wait. Selection changes (↑/↓) trigger instant repaints via
-        # the key bindings.
+        # Poll for the user's response.  The countdown in the hint line
+        # updates on each invalidate — but frequent repaints cause visible
+        # flicker in some terminals (Kitty, ghostty).  We only refresh the
+        # countdown every 5 s; selection changes (↑/↓) trigger instant
+        # Poll for the user's response.  The countdown in the hint line
+        # updates on each invalidate — but frequent repaints cause visible
+        # flicker in some terminals (Kitty, ghostty).  We only refresh the
+        # countdown every 5 s; selection changes (↑/↓) trigger instant
+        # repaints via the key bindings.
         _last_countdown_refresh = _time.monotonic()
         while True:
             try:
                 result = response_queue.get(timeout=1)
                 self._clarify_deadline = 0
-                self._persist_prompt_summary("?", "Clarify", question, str(result))
                 return result
             except queue.Empty:
                 remaining = self._clarify_deadline - _time.monotonic()
                 if remaining <= 0:
                     break
+                # Only repaint every 5 s for the countdown — avoids flicker
                 now = _time.monotonic()
-                if now - _last_countdown_refresh >= 1.0:
+                if now - _last_countdown_refresh >= 5.0:
                     _last_countdown_refresh = now
-                    self._paint_now()
+                    self._invalidate()
+                if now - _last_countdown_refresh >= 5.0:
+                    _last_countdown_refresh = now
+                    self._invalidate()
 
         # Timed out — tear down the UI and let the agent decide
         self._clarify_state = None
         self._clarify_freetext = False
         self._clarify_deadline = 0
-        self._paint_now()
+        self._invalidate()
         _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
         return (
             "The user did not provide a response within the time limit. "
@@ -11826,9 +11309,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         }
         self._sudo_deadline = _time.monotonic() + timeout
 
-        # Modal prompt — paint immediately, bypassing the throttle/resize guard
-        # so the prompt can't be dropped and time out unseen (#41098).
-        self._paint_now()
+        self._invalidate()
 
         while True:
             try:
@@ -11836,7 +11317,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 self._sudo_state = None
                 self._sudo_deadline = 0
                 self._restore_modal_input_snapshot()
-                self._paint_now()
+                self._invalidate()
                 if result:
                     _cprint(f"\n{_DIM}  ✓ Password received (cached for session){_RST}")
                 else:
@@ -11846,25 +11327,23 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 remaining = self._sudo_deadline - _time.monotonic()
                 if remaining <= 0:
                     break
-                self._paint_now()
+                self._invalidate()
 
         self._sudo_state = None
         self._sudo_deadline = 0
         self._restore_modal_input_snapshot()
-        self._paint_now()
+        self._invalidate()
         _cprint(f"\n{_DIM}  ⏱ Timeout — continuing without sudo{_RST}")
         return ""
 
     def _approval_callback(self, command: str, description: str,
-                           *, allow_permanent: bool = True,
-                           smart_denied: bool = False) -> str:
+                           *, allow_permanent: bool = True) -> str:
         """
         Prompt for dangerous command approval through the prompt_toolkit UI.
 
         Called from the agent thread. Shows a selection UI similar to clarify
-        with choices: once / session / always / deny. Smart DENY owner
-        overrides show only once / deny. When allow_permanent is False for
-        another reason (for example tirith), only 'always' is hidden.
+        with choices: once / session / always / deny. When allow_permanent
+        is False (tirith warnings present), the 'always' option is hidden.
         Long commands also get a 'view' option so the full command can be
         expanded before deciding.
 
@@ -11881,22 +11360,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._approval_state = {
                 "command": command,
                 "description": description,
-                "choices": self._approval_choices(
-                    command,
-                    allow_permanent=allow_permanent,
-                    smart_denied=smart_denied,
-                ),
+                "choices": self._approval_choices(command, allow_permanent=allow_permanent),
                 "selected": 0,
                 "response_queue": response_queue,
             }
             self._approval_deadline = _time.monotonic() + timeout
 
-            # Modal prompt — paint immediately, bypassing the throttle/resize
-            # guard. A throttled paint here can be silently dropped (250ms
-            # window collision or in-flight resize), leaving the panel unseen so
-            # the command is denied on timeout without the user ever seeing it
-            # (#41098). The countdown refreshes below paint the same way.
-            self._paint_now()
+            self._invalidate()
 
             _last_countdown_refresh = _time.monotonic()
             while True:
@@ -11904,40 +11374,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     result = response_queue.get(timeout=1)
                     self._approval_state = None
                     self._approval_deadline = 0
-                    self._paint_now()
-                    _outcome_labels = {
-                        "once": "allowed once",
-                        "session": "allowed for session",
-                        "always": "added to allowlist",
-                        "deny": "denied",
-                    }
-                    self._persist_prompt_summary(
-                        "⚠", "Approval", command,
-                        _outcome_labels.get(result, str(result)),
-                    )
+                    self._invalidate()
                     return result
                 except queue.Empty:
                     remaining = self._approval_deadline - _time.monotonic()
                     if remaining <= 0:
                         break
                     now = _time.monotonic()
-                    if now - _last_countdown_refresh >= 1.0:
+                    if now - _last_countdown_refresh >= 5.0:
                         _last_countdown_refresh = now
-                        self._paint_now()
+                        self._invalidate()
 
             self._approval_state = None
             self._approval_deadline = 0
-            self._paint_now()
+            self._invalidate()
             _cprint(f"\n{_DIM}  ⏱ Timeout — denying command{_RST}")
             return "deny"
 
-    def _approval_choices(self, command: str, *, allow_permanent: bool = True,
-                          smart_denied: bool = False) -> list[str]:
+    def _approval_choices(self, command: str, *, allow_permanent: bool = True) -> list[str]:
         """Return approval choices for a dangerous command prompt."""
-        if smart_denied:
-            choices = ["once", "deny"]
-        else:
-            choices = ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
+        choices = ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
         if len(command) > 70:
             choices.append("view")
         return choices
@@ -12035,7 +11491,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         show_full = state.get("show_full", False)
 
         title = "⚠️  Dangerous Command"
-        cmd_display = command
+        cmd_display = command if show_full or len(command) <= 70 else command[:70] + '...'
         choice_labels = {
             "once": "Allow once",
             "session": "Allow for this session",
@@ -12059,11 +11515,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Pre-wrap the mandatory content — command + choices must always render.
         cmd_wrapped = _wrap_panel_text(cmd_display, inner_text_width)
-        if not show_full and "view" in choices and len(cmd_wrapped) > 4:
-            cmd_wrapped = cmd_wrapped[:3] + _wrap_panel_text(
-                "… (choose Show full command)",
-                inner_text_width,
-            )
 
         # (choice_index, wrapped_line) so we can re-apply selected styling below
         choice_wrapped: list[tuple[int, str]] = []
@@ -12113,10 +11564,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         max_cmd_rows = max(1, available - chrome_rows - len(choice_wrapped))
         if len(cmd_wrapped) > max_cmd_rows:
             keep = max(1, max_cmd_rows - 1) if max_cmd_rows > 1 else 1
-            cmd_wrapped = cmd_wrapped[:keep] + _wrap_panel_text(
-                "… (command truncated — use /logs or /debug for full text)",
-                inner_text_width,
-            )
+            cmd_wrapped = cmd_wrapped[:keep] + ["… (command truncated — use /logs or /debug for full text)"]
 
         # Allocate any remaining rows to description. The extra -1 in full mode
         # accounts for the blank separator between choices and description.
@@ -12191,60 +11639,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         except Exception:
             pass
 
-    def _clear_active_overlays_for_interrupt(self) -> None:
-        """Drain and clear every input-blocking overlay left by an interrupted agent.
-
-        approval/clarify/sudo/secret prompts each block a worker thread on a
-        ``response_queue.get()``.  When the agent is interrupted the worker
-        thread is torn down, but the overlay's state dict stays set — leaving
-        the CLI input gated (``read_only`` condition + keypress filter) with no
-        thread servicing the prompt.  The result is a frozen terminal until the
-        prompt's own timeout expires.  Push a terminal value onto each queue so
-        any still-blocked thread unblocks cleanly, then nil the state out and
-        restore the user's pre-modal draft (#14026).
-
-        Safe default per prompt: approval -> "deny", clarify/sudo/secret ->
-        cancel (None / empty).  Each step is wrapped so a dead queue can't
-        prevent clearing the others.
-        """
-        if self._approval_state:
-            try:
-                self._approval_state["response_queue"].put("deny")
-            except Exception:
-                pass
-            self._approval_state = None
-        if self._clarify_state:
-            try:
-                self._clarify_state["response_queue"].put(
-                    "The user cancelled. Use your best judgement to proceed."
-                )
-            except Exception:
-                pass
-            self._clarify_state = None
-            self._clarify_freetext = False
-        if self._sudo_state:
-            try:
-                self._sudo_state["response_queue"].put("")
-            except Exception:
-                pass
-            self._sudo_state = None
-            self._sudo_deadline = 0
-            self._restore_modal_input_snapshot()
-        if self._secret_state:
-            try:
-                self._cancel_secret_capture()
-            except Exception:
-                self._secret_state = None
-
     def _submit_secret_response(self, value: str) -> None:
         if not self._secret_state:
             return
         self._secret_state["response_queue"].put(value)
         self._secret_state = None
         self._secret_deadline = 0
-        # Modal teardown — paint directly so the secret panel clears at once and
-        # isn't held by the _invalidate throttle/resize guard (#41098).
-        self._paint_now()
+        self._invalidate()
 
     def _cancel_secret_capture(self) -> None:
         self._submit_secret_response("")
@@ -12450,7 +11851,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         w = self._scrollback_box_width(getattr(self.console, "width", 80))
                         label = " ⚕ Hermes "
                         if self.show_timestamps:
-                            label = f"{label}{datetime.now().strftime(getattr(self, 'timestamp_format', '%H:%M'))} "
+                            label = f"{label}{datetime.now().strftime('%H:%M')} "
                         fill = w - 2 - HermesCLI._status_bar_display_width(label)
                         _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
                     _cprint(f"{_STREAM_PAD}{sentence.rstrip()}")
@@ -12490,44 +11891,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     set_secret_capture_callback(self._secret_capture_callback)
                 except Exception:
                     pass
-                # Bind this turn's approval session key into the contextvar so
-                # ``tools.approval.is_current_session_yolo_enabled()`` resolves
-                # against the same key that ``/yolo`` toggles under (see
-                # ``_toggle_yolo`` → ``enable_session_yolo(self.session_id)``).
-                # Mirrors ``tui_gateway/server.py`` and ``gateway/run.py`` which
-                # bind the same contextvar before invoking the agent.
-                try:
-                    from tools.approval import (
-                        reset_current_session_key,
-                        set_current_session_key,
-                    )
-                    _approval_session_token = set_current_session_key(
-                        self.session_id or "default"
-                    )
-                except Exception:
-                    reset_current_session_key = None  # type: ignore[assignment]
-                    _approval_session_token = None
                 agent_message = _voice_prefix + message if _voice_prefix else message
-                # Prepend pending notes via _prepend_note_to_message, which
-                # handles both plain-string and multimodal content-parts list
-                # messages. Naive ``note + "\n\n" + agent_message`` crashed with
-                # TypeError when an image was attached (agent_message is a list)
-                # and a /model or /reload-skills note was queued for the turn.
+                # Prepend pending model switch note so the model knows about the switch
                 _msn = getattr(self, '_pending_model_switch_note', None)
                 if _msn:
-                    agent_message = _prepend_note_to_message(agent_message, _msn)
+                    agent_message = _msn + "\n\n" + agent_message
                     self._pending_model_switch_note = None
                 # Prepend pending /reload-skills note so the model sees which
                 # skills were added/removed before handling this turn. Same
                 # one-shot queue pattern as the model-switch note above.
                 _srn = getattr(self, '_pending_skills_reload_note', None)
                 if _srn:
-                    agent_message = _prepend_note_to_message(agent_message, _srn)
+                    agent_message = _srn + "\n\n" + agent_message
                     self._pending_skills_reload_note = None
-                _moa_cfg = getattr(self, "_pending_moa_config", None)
-                self._pending_moa_config = None
-                if _moa_cfg is None:
-                    _moa_cfg = None
                 try:
                     result = self.agent.run_conversation(
                         user_message=agent_message,
@@ -12535,16 +11911,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         stream_callback=stream_callback,
                         task_id=self.session_id,
                         persist_user_message=message if _voice_prefix else None,
-                        moa_config=_moa_cfg,
                     )
-                    if getattr(self, "_pending_moa_disable_after_turn", False):
-                        _restore = getattr(self, "_pending_moa_restore_model", None) or {}
-                        for _key, _value in _restore.items():
-                            if _value is not None:
-                                setattr(self, _key, _value)
-                        self.agent = None
-                        self._pending_moa_restore_model = None
-                        self._pending_moa_disable_after_turn = False
                 except Exception as exc:
                     logging.error("run_conversation raised: %s", exc, exc_info=True)
                     _summary = getattr(self.agent, '_summarize_api_error', lambda e: str(e)[:300])(exc)
@@ -12557,11 +11924,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         "error": _summary,
                     }
                 finally:
-                    # Surface any credit notices queued during the turn (cold-start
-                    # seed / per-turn capture) now that the response is done — printing
-                    # at this boundary paints cleanly above the prompt instead of being
-                    # buried behind the streaming output.
-                    self._flush_credit_notices()
                     # Clear thread-local callbacks so a reused thread doesn't
                     # hold stale references to a disposed CLI instance.
                     try:
@@ -12570,15 +11932,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         set_secret_capture_callback(None)
                     except Exception:
                         pass
-                    # Release the per-turn approval session key. ``_session_yolo``
-                    # state itself is preserved across turns (so /yolo persists
-                    # for the whole CLI run); we just unbind the contextvar so a
-                    # reused thread doesn't see stale identity on its next run.
-                    if _approval_session_token is not None and reset_current_session_key is not None:
-                        try:
-                            reset_current_session_key(_approval_session_token)
-                        except Exception:
-                            pass
 
             # Start agent in background thread (daemon so it cannot keep the
             # process alive when the user closes the terminal tab — SIGHUP
@@ -12604,27 +11957,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         if interrupt_msg:
                             # If clarify is active, the Enter handler routes
                             # input directly; this queue shouldn't have anything.
-                            # But if it does (race condition), don't interrupt —
-                            # and don't drop the message either: park it in
-                            # _pending_input so it runs as the next turn.
+                            # But if it does (race condition), don't interrupt.
                             if self._clarify_state or self._clarify_freetext:
-                                try:
-                                    self._pending_input.put(interrupt_msg)
-                                except Exception:
-                                    pass
-                                interrupt_msg = None
                                 continue
                             print("\n⚡ New message detected, interrupting...")
                             # Signal TTS to stop on interrupt
                             if stop_event is not None:
                                 stop_event.set()
                             self.agent.interrupt(interrupt_msg)
-                            # Clear any active overlay states the interrupted agent
-                            # left behind.  approval/clarify/sudo/secret prompts gate
-                            # input (read_only condition + keypress filter) until
-                            # explicitly reset — without this the CLI freezes after
-                            # an interrupt until the prompt's own timeout expires (#14026).
-                            self._clear_active_overlays_for_interrupt()
                             # Debug: log to file (stdout may be devnull from redirect_stdout)
                             try:
                                 _dbg = _hermes_home / "interrupt_debug.log"
@@ -12681,9 +12021,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if self._prompt_start_time is not None:
                 self._prompt_duration = max(0.0, time.time() - self._prompt_start_time)
                 self._prompt_start_time = None
-            # Record when this agent loop finished so the status bar can show
-            # idle time since the last final response.
-            self._last_turn_finished_at = time.time()
 
             # Proactively clean up async clients whose event loop is dead.
             # The agent thread may have created AsyncOpenAI clients bound
@@ -12725,7 +12062,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 and getattr(self.agent, "session_id", None)
                 and self.agent.session_id != self.session_id
             ):
-                self._transfer_session_yolo(self.session_id, self.agent.session_id)
                 self.session_id = self.agent.session_id
                 self._pending_title = None
 
@@ -12784,33 +12120,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 # Add indicator that we were interrupted
                 if response and pending_message:
                     response = response + "\n\n---\n_[Interrupted - processing new message]_"
-            elif interrupt_msg:
-                # We fired agent.interrupt(interrupt_msg) but the turn result
-                # doesn't acknowledge it. Two ways this happens, both racy:
-                #   1. The agent thread had already passed its last interrupt
-                #      check (or finished) when the interrupt landed — the turn
-                #      completed normally and finalize_turn() never saw the flag.
-                #   2. The 10s post-interrupt wait above expired and we
-                #      abandoned the daemon thread; `result` is still None.
-                # In both cases the user's message must NOT be dropped —
-                # re-queue it as the next turn (#interrupt-vacuumed-into-void).
-                pending_message = interrupt_msg
-                # If the interrupt landed after finalize_turn()'s
-                # clear_interrupt(), the stale flag would instantly abort the
-                # NEXT turn at its first loop check. Clear it now that we've
-                # claimed the message — but ONLY if the agent thread actually
-                # exited. If it's still alive (abandoned after the 10s wait),
-                # the flag is what makes the wedged tool eventually unwind;
-                # clearing it would un-signal that thread.
-                try:
-                    if (
-                        not agent_thread.is_alive()
-                        and self.agent
-                        and getattr(self.agent, "_interrupt_requested", False)
-                    ):
-                        self.agent.clear_interrupt()
-                except Exception:
-                    pass
 
             response_previewed = result.get("response_previewed", False) if result else False
 
@@ -12829,12 +12138,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     r_fill = w - 2 - len(r_label)
                     r_top = f"{_DIM}┌─{r_label}{'─' * max(r_fill - 1, 0)}┐{_RST}"
                     r_bot = f"{_DIM}└{'─' * (w - 2)}┘{_RST}"
-                    # Collapse long reasoning to the first 10 lines unless the
-                    # user opted into full display via /reasoning full.
+                    # Collapse long reasoning: show first 10 lines
                     lines = reasoning.strip().splitlines()
-                    if len(lines) > 10 and not getattr(self, "reasoning_full", False):
+                    if len(lines) > 10:
                         display_reasoning = "\n".join(lines[:10])
-                        display_reasoning += f"\n{_DIM}  ... ({len(lines) - 10} more lines — /reasoning full to show){_RST}"
+                        display_reasoning += f"\n{_DIM}  ... ({len(lines) - 10} more lines){_RST}"
                     else:
                         display_reasoning = reasoning.strip()
                     _cprint(f"\n{r_top}\n{_DIM}{display_reasoning}{_RST}\n{r_bot}")
@@ -12950,91 +12258,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if tts_thread is not None and tts_thread.is_alive():
                 tts_thread.join(timeout=5)
     
-    def _clear_terminal_on_exit(self):
-        """Clear screen + scrollback so nothing is stranded above the exit summary.
-
-        Called from ``_print_exit_summary`` after ``app.run()`` has returned and
-        prompt_toolkit has torn down its renderer + restored terminal modes —
-        so a direct write to the real stdout fd is safe (the StdoutProxy /
-        patch_stdout layer is gone by now).
-
-        Sequence: ``ESC[3J`` (erase scrollback) + ``ESC[2J`` (erase visible
-        screen) + ``ESC[H`` (cursor home). Modern terminals on Linux, macOS and
-        Windows (Terminal / conhost with VT processing, which prompt_toolkit
-        already enables) all honor these. Best-effort: skip silently when
-        stdout isn't a real console, and fall back to the platform ``clear`` /
-        ``cls`` command if the escape write fails.
-        """
-        try:
-            stream = sys.stdout
-            if stream is None or not stream.isatty():
-                return
-        except Exception:
-            return
-        try:
-            stream.write("\033[3J\033[2J\033[H")
-            stream.flush()
-            return
-        except Exception:
-            pass
-        # Fallback: shell clear command (rarely needed — escapes work on every
-        # VT-capable terminal, but this covers exotic stdout wrappers).
-        try:
-            os.system("cls" if os.name == "nt" else "clear")
-        except Exception:
-            pass
-
-    def _persist_active_session_before_close(self):
-        """Best-effort SQLite/JSON flush before the CLI marks a session closed.
-
-        ``run_conversation()`` normally persists at turn boundaries, but a
-        terminal close/SIGHUP/SIGTERM can unwind the prompt_toolkit app while
-        the agent thread still holds the current turn only in memory.  Flush the
-        agent's live ``_session_messages`` before ``end_session()`` so resume,
-        session_search, and state.db do not lose the interrupted turn.
-        """
-        agent = getattr(self, "agent", None)
-        if not agent or not hasattr(agent, "_persist_session"):
-            return
-
-        messages = getattr(agent, "_session_messages", None)
-        if not isinstance(messages, list):
-            messages = getattr(self, "conversation_history", None)
-        if not isinstance(messages, list) or not messages:
-            return
-
-        conversation_history = getattr(self, "conversation_history", None)
-        if not isinstance(conversation_history, list):
-            conversation_history = messages
-
-        try:
-            agent._persist_session(messages, conversation_history)
-            if getattr(agent, "session_id", None):
-                self.session_id = agent.session_id
-        except (Exception, KeyboardInterrupt) as e:
-            logger.debug("Could not persist active CLI session before close: %s", e)
-
-    def _print_exit_summary(self, clear_screen: bool = True):
-        """Print session resume info on exit, similar to Claude Code.
-
-        Args:
-            clear_screen: When True (default), clear the terminal screen and
-                scrollback before printing the summary. This is appropriate for
-                interactive TUI teardown (#38252). Single-query (-q) mode should
-                pass False to preserve the printed answer (#53009).
-        """
-        if clear_screen:
-            # Clear the screen + scrollback before printing the summary so the
-            # live bottom chrome (status bar, input box, separator rules) and the
-            # rest of the session transcript don't get stranded above the exit
-            # summary (#38252). By this point app.run() has returned and
-            # prompt_toolkit has restored terminal modes, so writing raw escapes
-            # to stdout is safe. ESC[3J clears scrollback, ESC[2J clears the
-            # visible screen, ESC[H homes the cursor — so the summary prints at a
-            # clean top-left. Falls back to the platform clear command if stdout
-            # isn't a TTY-capable stream. Honors NO_COLOR/dumb terminals by
-            # skipping silently when there's no real console.
-            self._clear_terminal_on_exit()
+    def _print_exit_summary(self):
+        """Print session resume info on exit, similar to Claude Code."""
         print()
         msg_count = len(self.conversation_history)
         if msg_count > 0:
@@ -13300,7 +12525,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 spinner_widget,
                 spacer,
                 *self._get_extra_tui_widgets(),
-                getattr(self, "_pet_widget", None),
                 status_bar,
                 input_rule_top,
                 image_bar,
@@ -13313,9 +12537,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
     def run(self):
         """Run the interactive CLI loop with persistent input at bottom."""
-        if not self._claim_active_session("cli"):
-            return
-
         # Detect light/dark terminal mode now (before pt grabs the tty).
         # Caches the result so subsequent _hex_to_ansi / style calls
         # don't risk re-querying mid-render.
@@ -13353,39 +12574,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             _welcome_text = "Welcome to Hermes Agent! Type your message or /help for commands."
             _welcome_color = "#FFF8DC"
         self._console_print(f"[{_welcome_color}]{_welcome_text}[/]")
-
-        # Warm the /model picker's provider-models cache off-thread during this
-        # idle window (banner shown, user about to type). The no-args picker
-        # otherwise blocks ~1-2s on serial /v1/models fetches the first time
-        # it's opened in a session. Fire-and-forget, guarded once-per-process.
-        try:
-            from hermes_cli.model_switch import prewarm_picker_cache_async
-            prewarm_picker_cache_async()
-        except Exception:
-            pass
-
-        # Pre-import the agent runtime off-thread during the same idle window.
-        # The first turn otherwise pays ~1.5s of module imports on the
-        # time-to-first-token critical path: `import run_agent` (~0.9s,
-        # deferred by the lazy AIAgent wrapper above) plus the OpenAI SDK
-        # (~0.6s, deferred until client construction). Python's import lock
-        # makes this safe: if the user submits before the warm finishes, the
-        # main thread simply blocks on the remaining import work instead of
-        # redoing it. Skipped when agent startup is explicitly deferred
-        # (Termux) — that path defers heavy work on purpose.
-        if os.environ.get("HERMES_DEFER_AGENT_STARTUP") != "1":
-            def _prewarm_agent_runtime() -> None:
-                try:
-                    import run_agent  # noqa: F401  (imports model_tools + tool registry)
-                    import openai  # noqa: F401
-                except Exception:
-                    logger.debug("agent runtime pre-import failed", exc_info=True)
-
-            threading.Thread(
-                target=_prewarm_agent_runtime,
-                name="agent-runtime-prewarm",
-                daemon=True,
-            ).start()
 
         # Redaction opt-out warning (#17691): ON by default, loud when off.
         # The redactor snapshots its state at import time so any toggle now
@@ -13538,21 +12726,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         
         # Key bindings for the input area
         kb = KeyBindings()
-
-        from prompt_toolkit.keys import Keys as _IgnoreKeys
-
-        @kb.add(_IgnoreKeys.Ignore, eager=True)
-        def handle_ignored_terminal_sequence(event):
-            """Consume parser-level ignored terminal sequences before self-insert.
-
-            install_ignored_terminal_sequences() in hermes_cli.pt_input_extras
-            registers focus reports (CSI I / CSI O) as Keys.Ignore at the
-            VT100 parser level. Without this no-op binding the default
-            self-insert path would still fire and the bytes would land in
-            the buffer.
-            """
-            return None
-
+        
         def handle_enter(event):
             """Handle Enter key - submit input.
             
@@ -13605,13 +12779,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # --- /model picker modal ---
             if self._model_picker_state:
                 try:
-                    # Picker selections persist by default (same default as
-                    # /model <name>); honour model.persist_switch_by_default.
-                    from hermes_cli.model_switch import resolve_persist_behavior
-
-                    self._handle_model_picker_selection(
-                        persist_global=resolve_persist_behavior(False, False)
-                    )
+                    self._handle_model_picker_selection()
                 except Exception as _exc:
                     _cprint(f"  ✗ Model selection failed: {_exc}")
                     self._close_model_picker()
@@ -13657,13 +12825,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         if event.app.is_running:
                             event.app.exit()
                     event.app.current_buffer.reset(append_to_history=True)
-                    # Force a repaint: process_command() prints through
-                    # patch_stdout (scrolls output above the prompt) and never
-                    # invalidates the app, so the just-cleared input area can
-                    # keep showing the submitted text until some unrelated
-                    # redraw fires. Every other early-return branch in this
-                    # handler invalidates after reset — match them.
-                    event.app.invalidate()
                     return
 
                 # Handle /steer while the agent is running immediately on the
@@ -13675,13 +12836,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 if self._should_handle_steer_command_inline(text, has_images=has_images):
                     self.process_command(text)
                     event.app.current_buffer.reset(append_to_history=True)
-                    # Force a repaint after clearing the buffer.  /steer is
-                    # dispatched mid-run while the agent streams output through
-                    # patch_stdout; process_command() never invalidates the
-                    # app, so without this the submitted "/steer <text>" can
-                    # linger in the input area (looking unsent) and invite an
-                    # accidental re-submit. See issue #34569.
-                    event.app.invalidate()
                     return
 
                 # Snapshot and clear attached images
@@ -14010,42 +13164,50 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 event.app.invalidate()
                 return
 
-            # Cancel slash confirmation prompt (foreground UI, not an
-            # agent-blocking overlay — cancel and stop here).
+            # Cancel sudo prompt
+            if self._sudo_state:
+                self._sudo_state["response_queue"].put("")
+                self._sudo_state = None
+                event.app.invalidate()
+                return
+
+            # Cancel secret prompt
+            if self._secret_state:
+                self._cancel_secret_capture()
+                event.app.current_buffer.reset()
+                event.app.invalidate()
+                return
+
+            # Cancel approval prompt (deny)
+            if self._approval_state:
+                self._approval_state["response_queue"].put("deny")
+                self._approval_state = None
+                event.app.invalidate()
+                return
+
+            # Cancel slash confirmation prompt
             if self._slash_confirm_state:
                 self._submit_slash_confirm_response("cancel")
                 event.app.current_buffer.reset()
                 event.app.invalidate()
                 return
 
-            # Cancel /model picker (foreground UI — cancel and stop here).
+            # Cancel /model picker
             if self._model_picker_state:
                 self._close_model_picker()
                 event.app.current_buffer.reset()
                 event.app.invalidate()
                 return
 
-            # Clear all agent-blocking overlays (approval/clarify/sudo/secret)
-            # in one shot.  We do NOT return after clearing — we fall through so
-            # that if the agent is also running we fire the interrupt on the same
-            # Ctrl+C press.  This fixes the case where a stale/orphaned overlay
-            # (left behind by a previous interrupt) consumes the press without
-            # ever reaching the agent-interrupt branch, leaving the chat frozen
-            # (#14026).
-            _overlay_cleared = bool(
-                self._sudo_state
-                or self._secret_state
-                or self._approval_state
-                or self._clarify_state
-            )
-            if _overlay_cleared:
-                self._clear_active_overlays_for_interrupt()
+            # Cancel clarify prompt
+            if self._clarify_state:
+                self._clarify_state["response_queue"].put(
+                    "The user cancelled. Use your best judgement to proceed."
+                )
+                self._clarify_state = None
+                self._clarify_freetext = False
                 event.app.current_buffer.reset()
                 event.app.invalidate()
-
-            # If we only cleared overlays and the agent is NOT running, stop here
-            # (don't fall through to the interrupt/exit path).
-            if _overlay_cleared and not (self._agent_running and self.agent):
                 return
 
             if self._agent_running and self.agent:
@@ -14102,35 +13264,50 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 event.app.invalidate()
                 return
 
-            # Cancel slash confirmation prompt (foreground UI — cancel and stop).
+            # Cancel sudo prompt
+            if self._sudo_state:
+                self._sudo_state["response_queue"].put("")
+                self._sudo_state = None
+                event.app.invalidate()
+                return
+
+            # Cancel secret prompt
+            if self._secret_state:
+                self._cancel_secret_capture()
+                event.app.current_buffer.reset()
+                event.app.invalidate()
+                return
+
+            # Cancel approval prompt (deny)
+            if self._approval_state:
+                self._approval_state["response_queue"].put("deny")
+                self._approval_state = None
+                event.app.invalidate()
+                return
+
+            # Cancel slash confirmation prompt
             if self._slash_confirm_state:
                 self._submit_slash_confirm_response("cancel")
                 event.app.current_buffer.reset()
                 event.app.invalidate()
                 return
 
-            # Cancel /model picker (foreground UI — cancel and stop).
+            # Cancel /model picker
             if self._model_picker_state:
                 self._close_model_picker()
                 event.app.current_buffer.reset()
                 event.app.invalidate()
                 return
 
-            # Clear all agent-blocking overlays in one shot, then fall through to
-            # the agent-interrupt branch so a single Ctrl+Q both clears a stale
-            # overlay and interrupts a still-running agent (#14026).
-            _overlay_cleared = bool(
-                self._sudo_state
-                or self._secret_state
-                or self._approval_state
-                or self._clarify_state
-            )
-            if _overlay_cleared:
-                self._clear_active_overlays_for_interrupt()
+            # Cancel clarify prompt
+            if self._clarify_state:
+                self._clarify_state["response_queue"].put(
+                    "The user cancelled. Use your best judgement to proceed."
+                )
+                self._clarify_state = None
+                self._clarify_freetext = False
                 event.app.current_buffer.reset()
                 event.app.invalidate()
-
-            if _overlay_cleared and not (self._agent_running and self.agent):
                 return
 
             if self._agent_running and self.agent:
@@ -14406,7 +13583,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Create the input area with multiline (Alt+Enter), autocomplete, and paste handling
         from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
-        from prompt_toolkit.completion import ThreadedCompleter
 
 
         _completer = SlashCommandCompleter(
@@ -14422,13 +13598,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             wrap_lines=True,
             read_only=Condition(lambda: bool(cli_ref._command_running)),
             history=FileHistory(str(self._history_file)),
-            # complete_while_typing fires the completer on every keystroke. The
-            # completer does blocking work — fuzzy @-file indexing shells out to
-            # rg/fd (up to a 2s timeout) and path completion hits os.listdir/stat
-            # — so running it inline would stall the render loop on each key (very
-            # noticeable on WSL2/slow filesystems). ThreadedCompleter moves it off
-            # the UI event loop, keeping typing responsive.
-            completer=ThreadedCompleter(_completer),
+            completer=_completer,
             complete_while_typing=True,
             auto_suggest=SlashCommandAutoSuggest(
                 history_suggest=AutoSuggestFromHistory(),
@@ -14446,17 +13616,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         def _input_height():
             try:
                 from prompt_toolkit.application import get_app
+                from prompt_toolkit.utils import get_cwidth
 
                 doc = input_area.buffer.document
+                prompt_width = max(2, get_cwidth(self._get_tui_prompt_text()))
                 try:
-                    terminal_columns = get_app().output.get_size().columns
+                    available_width = get_app().output.get_size().columns - prompt_width
                 except Exception:
-                    terminal_columns = shutil.get_terminal_size((80, 24)).columns
-                return _estimate_tui_input_height(
-                    doc.lines,
-                    self._get_tui_prompt_text(),
-                    terminal_columns,
-                )
+                    available_width = shutil.get_terminal_size((80, 24)).columns - prompt_width
+                if available_width < 10:
+                    available_width = 40
+                visual_lines = 0
+                for line in doc.lines:
+                    # Each logical line takes at least 1 visual row; long lines wrap.
+                    # Use prompt_toolkit's cell width so CJK wide characters count as 2.
+                    line_width = get_cwidth(line)
+                    if line_width <= 0:
+                        visual_lines += 1
+                    else:
+                        visual_lines += max(1, -(-line_width // available_width))  # ceil division
+                return min(max(visual_lines, 1), 8)
             except Exception:
                 return 1
 
@@ -14655,16 +13834,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             wrap_lines=True,
         )
 
-        # Petdex mascot — right-aligned half-block sprite above the prompt,
-        # mirroring the TUI's PetPane. Collapses to height 0 when no pet is
-        # enabled, so it's a no-op for everyone else. The _pet_anim_loop thread
-        # advances frames + invalidates; align=RIGHT pins it to the edge.
-        self._pet_widget = Window(
-            content=FormattedTextControl(self._pet_fragments),
-            height=self._pet_widget_height,
-            align=WindowAlign.RIGHT,
-        )
-
         spacer = Window(
             content=FormattedTextControl(get_hint_text),
             height=get_hint_height,
@@ -14800,12 +13969,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             reserved_below = 6
 
             available = max(0, term_rows - reserved_below)
-            # The compact decision must reserve room for at least one question
-            # row on top of the choices, otherwise full chrome (3 blank
-            # separators) gets kept when there is no room for it and the panel
-            # overflows the viewport — HSplit then clips the panel's tail,
-            # silently dropping the choices (the reported bug).
-            mandatory_full = chrome_full + 1 + len(choice_wrapped) + len(other_wrapped)
+            mandatory_full = chrome_full + len(choice_wrapped) + len(other_wrapped)
 
             use_compact_chrome = mandatory_full > available
             chrome_rows = chrome_tight if use_compact_chrome else chrome_full
@@ -14813,24 +13977,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             max_question_rows = max(1, available - chrome_rows - len(choice_wrapped) - len(other_wrapped))
             max_question_rows = min(max_question_rows, 12)  # soft cap on huge terminals
 
-            # When the choices alone (plus compact chrome) already exceed the
-            # viewport, drop the question entirely — the choices are the only
-            # thing the user must see to make a selection. Without this the
-            # question would still claim its 1-row floor above and push the
-            # tail of the choices off-screen (HSplit clips the overflow).
-            choices_overflow = chrome_rows + len(choice_wrapped) + len(other_wrapped) >= available
-            if choices_overflow:
-                max_question_rows = 0
-
             question_wrapped = _wrap_panel_text(question, inner_text_width)
-            if max_question_rows <= 0:
-                question_wrapped = []
-            elif len(question_wrapped) > max_question_rows:
-                # The truncation marker is itself a row, so it must count
-                # against the budget. With a 1-row budget there is no room for
-                # both a question line and the marker — show the marker alone
-                # so the rendered question never exceeds max_question_rows.
-                keep = max(0, max_question_rows - 1)
+            if len(question_wrapped) > max_question_rows:
+                keep = max(1, max_question_rows - 1)
                 question_wrapped = question_wrapped[:keep] + ["… (question truncated)"]
 
             lines = []
@@ -15200,24 +14349,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             'voice-status-recording': 'bg:#1a1a2e #FF4444 bold',
         }
         style = PTStyle.from_dict(self._build_tui_style_dict())
-
-        # Disable CPR (Cursor Position Report) at the source so prompt_toolkit
-        # never sends ESC[6n cursor-position queries — but only on terminals
-        # where the reply is likely to leak. Over SSH/cloudflared tunnels and
-        # slow PTYs the CPR replies (ESC[<row>;<col>R) leak into the display as
-        # raw "20;1R21;1R" text and can stall the renderer's pending-CPR future,
-        # freezing the prompt after the agent's final answer (#13870). CPR is a
-        # layout hint, not a speed optimization, and it works fine locally, so we
-        # leave prompt_toolkit's default untouched on local terminals and only
-        # suppress it where the bug reproduces. None (local, or build failure)
-        # falls back to the default output; the input-side scrubbing in
-        # _strip_leaked_terminal_responses still guards against any leaks.
-        _cpr_disabled_output = (
-            _build_cpr_disabled_output(sys.stdout)
-            if _terminal_may_leak_cpr()
-            else None
-        )
-
+        
         # Create the application
         app = Application(
             layout=layout,
@@ -15225,25 +14357,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             style=style,
             full_screen=False,
             mouse_support=False,
-            **({"output": _cpr_disabled_output} if _cpr_disabled_output is not None else {}),
-            # Read from display.cli_refresh_interval (default 0 = disabled).
-            # When non-zero, prompt_toolkit redraws the UI on this cadence
-            # during idle, keeping wall-clock status-bar read-outs ticking.
-            # Set to 0 to suppress background redraws entirely — avoids
-            # fighting terminal auto-scroll in non-fullscreen mode (Xshell,
-            # iTerm2, Windows Terminal). See #48309.
-            refresh_interval=float(CLI_CONFIG.get("display", {}).get("cli_refresh_interval", 0)),
-            # Erase the live bottom chrome (status bar, input box, separator
-            # rules) on exit instead of freezing a final copy into scrollback.
-            # Without this, prompt_toolkit's render_as_done teardown repaints
-            # the chrome one last time and leaves it stranded above the exit
-            # summary — so a dead status bar + empty prompt sit between the
-            # conversation transcript and the "Resume this session" block, and
-            # stack with the next session's UI on resume (#38252). The actual
-            # conversation transcript is printed through patch_stdout into
-            # normal scrollback and is unaffected; only the managed chrome is
-            # erased. Applies to every exit path (/exit, /quit, EOF, Ctrl+C).
-            erase_when_done=True,
             **({'cursor': _STEADY_CURSOR} if _STEADY_CURSOR is not None else {}),
         )
         _disable_prompt_toolkit_cpr_warning(app)
@@ -15359,17 +14472,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                             # and watch pattern matches) while agent is idle.
                             try:
                                 from tools.process_registry import process_registry
-                                from tools.approval import get_current_session_key
-                                _drain_sk = get_current_session_key(default="")
-                                for _evt, _synth in process_registry.drain_notifications(session_key=_drain_sk):
-                                    from tools.async_delegation import (
-                                        claim_event_delivery, complete_event_delivery,
-                                    )
-                                    _claim = claim_event_delivery(_evt, "cli-idle")
-                                    if _claim is None:
-                                        continue
+                                for _evt, _synth in process_registry.drain_notifications():
                                     self._pending_input.put(_synth)
-                                    complete_event_delivery(_evt, _claim)
                             except Exception:
                                 pass
                         continue
@@ -15409,17 +14513,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                                 + (f"\n{_remainder}" if _remainder else "")
                             )
 
-                    # A bare number right after a bare `/resume` prompt selects
-                    # that session (see #34584). Checked before chat routing so
-                    # the digit isn't sent to the agent as a message.
-                    if (
-                        not _file_drop
-                        and self._pending_resume_sessions
-                        and isinstance(user_input, str)
-                        and self._consume_pending_resume_selection(user_input)
-                    ):
-                        continue
-
                     if not _file_drop and isinstance(user_input, str) and _looks_like_slash_command(user_input):
                         _cprint(f"\n⚙️  {user_input}")
                         try:
@@ -15435,17 +14528,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                             # session. Without this guard a KeyboardInterrupt unwinds
                             # to the outer prompt_toolkit loop and the session dies.
                             _cprint("\n[dim]Command interrupted.[/dim]")
-                            continue
-                        # A slash handler may set a one-shot pending seed (e.g.
-                        # /blueprint <name>) to be run as the next agent turn.
-                        # If present, fall through to the chat path with the seed
-                        # as the user message instead of looping back to idle.
-                        _seed = getattr(self, "_pending_agent_seed", None)
-                        if _seed:
-                            self._pending_agent_seed = None
-                            user_input = _seed
-                        else:
-                            continue
+                        continue
                     
                     # Expand paste references back to full content
                     _paste_ref_re = re.compile(r'\[Pasted text #\d+: \d+ lines \u2192 (.+?)\]')
@@ -15462,8 +14545,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
                     # Regular chat - run agent
                     self._agent_running = True
-                    self._pet_turn_error = False
-                    self._pet_reasoning = False
                     app.invalidate()  # Refresh status line
 
                     try:
@@ -15474,30 +14555,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         self._tool_start_time = 0.0
                         self._pending_tool_info.clear()
                         self._last_scrollback_tool = ""
-                        self._pet_reasoning = False
-                        self._pet_react_turn_end()
 
                         app.invalidate()  # Refresh status line
-
-                        # Post-turn terminal recovery (#33271): after an
-                        # interrupt the prompt_toolkit renderer may have
-                        # drifted from the physical terminal state — CSI 6n
-                        # cursor position reports can leak as literal text
-                        # (^[[19;1R), and the VT100 input parser can stall in
-                        # a partial-escape state, accepting no further
-                        # keystrokes.  Drain stray escape bytes from the OS
-                        # input buffer and force a clean renderer redraw.
-                        if self._last_turn_interrupted:
-                            self._recover_terminal_after_interrupt()
-
-                        # Re-queue any messages that arrived in _interrupt_queue
-                        # while the agent was running and were never claimed by
-                        # the explicit interrupt path. See
-                        # _drain_interrupt_queue_to_pending_input for the full
-                        # rationale. Regression of #17666 / #18760 — the drain
-                        # block from the original PR #17939 was deferred as
-                        # "worth its own review" and never re-landed (#20271).
-                        self._drain_interrupt_queue_to_pending_input()
 
                         # Goal continuation: if a standing goal is active, ask
                         # the judge whether the turn satisfied it. If not, and
@@ -15531,14 +14590,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         try:
                             from tools.process_registry import process_registry
                             for _evt, _synth in process_registry.drain_notifications():
-                                from tools.async_delegation import (
-                                    claim_event_delivery, complete_event_delivery,
-                                )
-                                _claim = claim_event_delivery(_evt, "cli-post-turn")
-                                if _claim is None:
-                                    continue
                                 self._pending_input.put(_synth)
-                                complete_event_delivery(_evt, _claim)
                         except Exception:
                             pass  # Non-fatal — don't break the main loop
 
@@ -15732,11 +14784,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     pass  # No running loop -- nothing to patch
                 except Exception:
                     pass
-                # The app enables focus reporting + mouse tracking; record that
-                # so _run_cleanup resets them on exit (#36823).
-                _mark_tui_input_modes_active()
-                # Drive the petdex mascot animation (no-op when no pet enabled).
-                self._pet_start_anim()
                 app.run()
         except (EOFError, KeyboardInterrupt, BrokenPipeError):
             pass
@@ -15763,16 +14810,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 raise
         finally:
             self._should_exit = True
-            self._pet_stop_anim()
-            # Immediate feedback: prompt_toolkit has just torn down the input
-            # box + status bar, so without a line here the terminal sits
-            # silent for the whole cleanup window (session flush, memory
-            # shutdown, MCP/browser/terminal teardown) and the exit looks
-            # hung. Print before any potentially-slow step.
-            try:
-                print(f"{_DIM}Shutting down… (finalizing session){_RST}", flush=True)
-            except Exception:
-                pass
             # Interrupt the agent immediately so its daemon thread stops making
             # API calls and exits promptly (agent_thread is daemon, so the
             # process will exit once the main thread finishes, but interrupting
@@ -15799,27 +14836,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             set_sudo_password_callback(None)
             set_approval_callback(None)
             set_secret_capture_callback(None)
-            # Flush any in-memory turn transcript before marking the session
-            # closed.  On SIGHUP/SIGTERM/window close the agent thread may not
-            # reach its normal run_conversation() persistence path before the
-            # daemon thread is reaped.
-            self._persist_active_session_before_close()
-
             # Close session in SQLite
             if hasattr(self, '_session_db') and self._session_db and self.agent:
                 try:
                     self._session_db.end_session(self.agent.session_id, "cli_close")
                 except (Exception, KeyboardInterrupt) as e:
                     logger.debug("Could not close session in DB: %s", e)
-                # Started-and-immediately-quit sessions never gained content;
-                # drop the empty row so /resume and `hermes sessions list`
-                # stay clean (gemini-cli#27770 port). No-op for resumed or
-                # titled sessions and anything with messages or children.
-                if not getattr(self, '_delete_session_on_exit', False):
-                    try:
-                        self._discard_session_if_empty(self.agent.session_id)
-                    except (Exception, KeyboardInterrupt) as e:
-                        logger.debug("Could not prune empty session: %s", e)
                 # /exit --delete: also remove the current session's transcripts
                 # and SQLite history. Ported from google-gemini/gemini-cli#19332.
                 if getattr(self, '_delete_session_on_exit', False):
@@ -15847,13 +14869,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         interrupted=True,
                         model=getattr(self.agent, 'model', None),
                         platform=getattr(self.agent, 'platform', None) or "cli",
-                        reason="shutdown",
                     )
                 except Exception:
                     pass
             _run_cleanup()
             self._print_exit_summary()
-            self._release_active_session()
 
         # Deferred relaunch: /update sets _pending_relaunch so the exec
         # happens here — after prompt_toolkit has exited and fully restored
@@ -15868,96 +14888,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 # ============================================================================
 # Main Entry Point
 # ============================================================================
-
-def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
-    """Drive a kanban goal_mode worker through the Ralph-style goal loop.
-
-    Called from the quiet single-query path AFTER the worker's first turn,
-    only when ``HERMES_KANBAN_GOAL_MODE`` is set (dispatcher-spawned
-    goal_mode card). Wires the worker's ``run_conversation`` and the kanban
-    DB into ``goals.run_kanban_goal_loop``. All errors are swallowed by the
-    caller — a broken goal loop must never wedge a worker, the dispatcher's
-    claim TTL / crash detection is the backstop.
-    """
-    import os as _os
-
-    task_id = (_os.environ.get("HERMES_KANBAN_TASK") or "").strip()
-    if not task_id:
-        return
-
-    from hermes_cli import kanban_db as _kb
-    from hermes_cli.goals import run_kanban_goal_loop as _run_loop, DEFAULT_MAX_TURNS as _DEF_TURNS
-
-    # Resolve goal text from the card (title + body = the acceptance
-    # criteria the judge evaluates against).
-    conn = _kb.connect()
-    try:
-        task = _kb.get_task(conn, task_id)
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
-    if task is None:
-        return
-
-    goal_parts = [task.title or ""]
-    if task.body:
-        goal_parts.append(task.body)
-    goal_text = "\n\n".join(p for p in goal_parts if p).strip()
-    if not goal_text:
-        return
-
-    max_turns = task.goal_max_turns or _DEF_TURNS
-
-    def _run_turn(prompt: str) -> str:
-        result = cli.agent.run_conversation(
-            user_message=prompt,
-            conversation_history=cli.conversation_history,
-        )
-        # Keep session_id in sync if mid-run compression rotated it.
-        if (
-            getattr(cli.agent, "session_id", None)
-            and cli.agent.session_id != cli.session_id
-        ):
-            cli.session_id = cli.agent.session_id
-        resp = result.get("final_response", "") if isinstance(result, dict) else str(result)
-        if resp:
-            print(resp)
-        return resp or ""
-
-    def _task_status() -> "str | None":
-        c = _kb.connect()
-        try:
-            t = _kb.get_task(c, task_id)
-            return t.status if t is not None else None
-        finally:
-            try:
-                c.close()
-            except Exception:
-                pass
-
-    def _block(reason: str) -> None:
-        c = _kb.connect()
-        try:
-            _kb.block_task(c, task_id, reason=reason)
-        finally:
-            try:
-                c.close()
-            except Exception:
-                pass
-
-    _run_loop(
-        task_id=task_id,
-        goal_text=goal_text,
-        run_turn=_run_turn,
-        task_status_fn=_task_status,
-        block_fn=_block,
-        max_turns=max_turns,
-        first_response=first_response or "",
-        log=lambda m: logger.info("%s", m),
-    )
-
 
 def main(
     query: str = None,
@@ -16052,11 +14982,7 @@ def main(
             _repo = _git_repo_root()
             if _repo:
                 _prune_stale_worktrees(_repo)
-            # Branch the worktree from the freshly-fetched remote tip by
-            # default so it starts current with the project. Opt out with
-            # worktree_sync: false to branch from local HEAD instead.
-            _sync_base = CLI_CONFIG.get("worktree_sync", True)
-            wt_info = _setup_worktree(sync_base=_sync_base)
+            wt_info = _setup_worktree()
             if wt_info:
                 _active_worktree = wt_info
                 os.environ["TERMINAL_CWD"] = wt_info["path"]
@@ -16086,21 +15012,9 @@ def main(
                 else:
                     toolsets_list.append(str(t))
     else:
-        # Coding posture (base Hermes): with no explicit --toolsets, collapse
-        # to the coding toolset (+ enabled MCP servers) when sitting in a code
-        # workspace. See agent/coding_context.py.
-        _coding = None
-        try:
-            from agent.coding_context import coding_selection
-            _coding = coding_selection(platform="cli", config=CLI_CONFIG)
-        except Exception:
-            _coding = None
-        if _coding is not None:
-            toolsets_list = _coding
-        else:
-            # Use the shared resolver so MCP servers are included at runtime
-            from hermes_cli.tools_config import _get_platform_tools
-            toolsets_list = sorted(_get_platform_tools(CLI_CONFIG, "cli"))
+        # Use the shared resolver so MCP servers are included at runtime
+        from hermes_cli.tools_config import _get_platform_tools
+        toolsets_list = sorted(_get_platform_tools(CLI_CONFIG, "cli"))
     
     parsed_skills = _parse_skills_argument(skills)
 
@@ -16127,21 +15041,7 @@ def main(
         )
         if missing_skills:
             missing_display = ", ".join(missing_skills)
-            # If at least one skill loaded, degrade gracefully: skip the
-            # unknown ones and continue. A typo'd skill name should not crash
-            # the worker (which auto-blocks the Kanban task after retries).
-            # Only when EVERY requested skill is missing do we hard-fail, so a
-            # fully-misconfigured worker fails loudly instead of running blind.
-            if loaded_skills:
-                logger.warning(
-                    "Unknown skill(s) requested, skipping: %s. "
-                    "Continuing with: %s. "
-                    "List available skills with `hermes skills list`.",
-                    missing_display,
-                    ", ".join(loaded_skills),
-                )
-            else:
-                raise ValueError(f"Unknown skill(s): {missing_display}")
+            raise ValueError(f"Unknown skill(s): {missing_display}")
         if skills_prompt:
             cli.system_prompt = "\n\n".join(
                 part for part in (cli.system_prompt, skills_prompt) if part
@@ -16202,43 +15102,9 @@ def main(
                     time.sleep(_grace)
         except Exception:
             pass  # never block signal handling
-        # Kanban worker exit path (#28181): SIGTERM hits a dispatcher-spawned
-        # worker that's likely in a non-daemon thread waiting on a child
-        # subprocess in _wait_for_process. Raising KeyboardInterrupt only
-        # unwinds the main thread; the worker thread keeps running, the
-        # process gets reparented to init, and the dispatcher's _pid_alive
-        # check returns True forever — task stuck in 'running' indefinitely.
-        # Skip the controlled-unwind dance and call os._exit(0) so the kernel
-        # reclaims the PID immediately and detect_crashed_workers can reclaim
-        # the stale claim on the next tick. Flush logging + stdout/stderr
-        # first so the final debug trace isn't lost; SIGALRM deadman guards
-        # the flush against any rare blocking-I/O case (the reporter measured
-        # flush in <1ms; the alarm is a failsafe, not the common path).
-        if os.environ.get("HERMES_KANBAN_TASK"):
-            try:
-                import signal as _sig_mod
-                if hasattr(_sig_mod, "SIGALRM"):
-                    # Cancel any pre-existing alarm to avoid colliding with
-                    # caller-installed timers.
-                    _sig_mod.signal(_sig_mod.SIGALRM, lambda *_: os._exit(0))
-                    _sig_mod.alarm(2)
-            except Exception:
-                pass
-            try:
-                import logging as _lg
-                _lg.shutdown()
-            except Exception:
-                pass
-            for _stream in (sys.stdout, sys.stderr):
-                try:
-                    _stream.flush()
-                except Exception:
-                    pass
-            os._exit(0)
         raise KeyboardInterrupt()
     try:
         import signal as _signal
-        _signal.signal(_signal.SIGINT, _signal_handler_q)
         _signal.signal(_signal.SIGTERM, _signal_handler_q)
         if hasattr(_signal, "SIGHUP"):
             _signal.signal(_signal.SIGHUP, _signal_handler_q)
@@ -16247,224 +15113,132 @@ def main(
     
     # Handle single query mode
     if query or image:
-        if not cli._claim_active_session("cli", stderr=bool(quiet)):
-            sys.exit(1)
-        try:
-            query, single_query_images = _collect_query_images(query, image)
-            # Kanban workers spawn with ``hermes chat -q "work kanban task <id>"``;
-            # the actual task description lives in the task body. Mirror the
-            # gateway/CLI behaviour for inbound images by scanning the body for
-            # local image paths and http(s) image URLs and attaching them to the
-            # worker's first turn. Without this, users who paste a screenshot
-            # path or URL into a kanban task body never get it routed to the
-            # model's vision input.
-            single_query_image_urls: list[str] = []
-            _kanban_task_id = os.environ.get("HERMES_KANBAN_TASK", "").strip()
-            if _kanban_task_id:
-                try:
-                    from hermes_cli import kanban_db as _kb
-                    from agent.image_routing import extract_image_refs as _extract_refs
-
-                    _conn = _kb.connect()
+        query, single_query_images = _collect_query_images(query, image)
+        if quiet:
+            # Quiet mode: suppress banner, spinner, tool previews.
+            # Only print the final response and parseable session info.
+            cli.tool_progress_mode = "off"
+            if cli._ensure_runtime_credentials():
+                effective_query: Any = query
+                if single_query_images:
+                    # Honour the same image-routing decision used by the
+                    # interactive path. With a vision-capable model (incl.
+                    # custom-provider models declared via
+                    # `model.supports_vision: true`), attach images natively
+                    # as image_url content parts. Otherwise fall back to the
+                    # text-pipeline (vision_analyze pre-description).
+                    _img_mode = "text"
+                    _build_parts = None
                     try:
-                        _task = _kb.get_task(_conn, _kanban_task_id)
-                    finally:
-                        try:
-                            _conn.close()
-                        except Exception:
-                            pass
-                    _body = getattr(_task, "body", "") if _task is not None else ""
-                    if _body:
-                        _kb_paths, _kb_urls = _extract_refs(_body)
-                        if _kb_paths:
-                            # Dedupe against any --image the user already passed.
-                            _seen = {str(p) for p in single_query_images}
-                            for _p in _kb_paths:
-                                if _p not in _seen:
-                                    _seen.add(_p)
-                                    single_query_images.append(Path(_p))
-                        if _kb_urls:
-                            single_query_image_urls.extend(_kb_urls)
-                except Exception as _exc:
-                    # Best-effort enrichment; never block worker startup on it.
-                    logger.debug("kanban image-ref extraction failed: %s", _exc)
-            if quiet:
-                # Quiet mode: suppress banner, spinner, tool previews.
-                # Only print the final response and parseable session info.
-                cli.tool_progress_mode = "off"
-                if cli._ensure_runtime_credentials():
-                    effective_query: Any = query
-                    if single_query_images or single_query_image_urls:
-                        # Honour the same image-routing decision used by the
-                        # interactive path. With a vision-capable model (incl.
-                        # custom-provider models declared via
-                        # `model.supports_vision: true`), attach images natively
-                        # as image_url content parts. Otherwise fall back to the
-                        # text-pipeline (vision_analyze pre-description).
+                        from agent.image_routing import (
+                            build_native_content_parts as _build_parts,  # noqa: F811
+                        )
+                        from agent.image_routing import decide_image_input_mode
+                        from hermes_cli.config import load_config
+
+                        _img_mode = decide_image_input_mode(
+                            (cli.provider or "").strip(),
+                            (cli.model or "").strip(),
+                            load_config(),
+                        )
+                    except Exception:
                         _img_mode = "text"
-                        _build_parts = None
+
+                    if _img_mode == "native" and _build_parts is not None:
                         try:
-                            from agent.image_routing import (
-                                build_native_content_parts as _build_parts,  # noqa: F811
+                            _parts, _skipped = _build_parts(
+                                query if isinstance(query, str) else "",
+                                [str(p) for p in single_query_images],
                             )
-                            from agent.image_routing import decide_image_input_mode
-                            from hermes_cli.config import load_config
-
-                            _img_mode = decide_image_input_mode(
-                                (cli.provider or "").strip(),
-                                (cli.model or "").strip(),
-                                load_config(),
-                            )
-                        except Exception:
-                            _img_mode = "text"
-
-                        if _img_mode == "native" and _build_parts is not None:
-                            try:
-                                _parts, _skipped = _build_parts(
-                                    query if isinstance(query, str) else "",
-                                    [str(p) for p in single_query_images],
-                                    image_urls=list(single_query_image_urls) or None,
+                            if any(p.get("type") == "image_url" for p in _parts):
+                                effective_query = _parts
+                            else:
+                                # All images unreadable — text fallback.
+                                effective_query = cli._preprocess_images_with_vision(
+                                    query, single_query_images, announce=False,
                                 )
-                                if any(p.get("type") == "image_url" for p in _parts):
-                                    effective_query = _parts
-                                else:
-                                    # All images unreadable — text fallback.
-                                    # ``_preprocess_images_with_vision`` only knows
-                                    # about local files; URLs would be lost there,
-                                    # so keep the original query text intact when
-                                    # only URLs were supplied.
-                                    if single_query_images:
-                                        effective_query = cli._preprocess_images_with_vision(
-                                            query, single_query_images, announce=False,
-                                        )
-                            except Exception:
-                                if single_query_images:
-                                    effective_query = cli._preprocess_images_with_vision(
-                                        query, single_query_images, announce=False,
-                                    )
-                        elif single_query_images:
+                        except Exception:
                             effective_query = cli._preprocess_images_with_vision(
-                                query,
-                                single_query_images,
-                                announce=False,
+                                query, single_query_images, announce=False,
                             )
-                    turn_route = cli._resolve_turn_agent_config(effective_query)
-                    if turn_route["signature"] != cli._active_agent_route_signature:
-                        cli.agent = None
-                    if cli._init_agent(
-                        model_override=turn_route["model"],
-                        runtime_override=turn_route["runtime"],
-                        request_overrides=turn_route.get("request_overrides"),
+                    else:
+                        effective_query = cli._preprocess_images_with_vision(
+                            query,
+                            single_query_images,
+                            announce=False,
+                        )
+                turn_route = cli._resolve_turn_agent_config(effective_query)
+                if turn_route["signature"] != cli._active_agent_route_signature:
+                    cli.agent = None
+                if cli._init_agent(
+                    model_override=turn_route["model"],
+                    runtime_override=turn_route["runtime"],
+                    request_overrides=turn_route.get("request_overrides"),
+                ):
+                    cli.agent.quiet_mode = True
+                    cli.agent.suppress_status_output = True
+                    # Suppress streaming display callbacks so stdout stays
+                    # machine-readable (no styled "Hermes" box, no tool-gen
+                    # status lines).  The response is printed once below.
+                    cli.agent.stream_delta_callback = None
+                    cli.agent.tool_gen_callback = None
+                    result = cli.agent.run_conversation(
+                        user_message=effective_query,
+                        conversation_history=cli.conversation_history,
+                    )
+                    # Sync session_id if mid-run compression created a
+                    # continuation session. The exit line below reports
+                    # session_id to stderr for automation wrappers; without
+                    # this sync it would point at the ended parent.
+                    if (
+                        getattr(cli.agent, "session_id", None)
+                        and cli.agent.session_id != cli.session_id
                     ):
-                        cli.agent.quiet_mode = True
-                        cli.agent.suppress_status_output = True
-                        # Suppress streaming display callbacks so stdout stays
-                        # machine-readable (no styled "Hermes" box, no tool-gen
-                        # status lines).  The response is printed once below.
-                        cli.agent.stream_delta_callback = None
-                        cli.agent.tool_gen_callback = None
-                        try:
-                            result = cli.agent.run_conversation(
-                                user_message=effective_query,
-                                conversation_history=cli.conversation_history,
-                            )
-                        except KeyboardInterrupt:
-                            _emit_interrupted_session_end(cli, reason="keyboard_interrupt")
-                            print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
-                            sys.exit(130)
-                        # Sync session_id if mid-run compression created a
-                        # continuation session. The exit line below reports
-                        # session_id to stderr for automation wrappers; without
-                        # this sync it would point at the ended parent.
-                        if (
-                            getattr(cli.agent, "session_id", None)
-                            and cli.agent.session_id != cli.session_id
-                        ):
-                            cli.session_id = cli.agent.session_id
-                        response = result.get("final_response", "") if isinstance(result, dict) else str(result)
-                        # Surface backend errors that produced no visible output
-                        # (e.g. invalid model slug → provider 4xx). Mirrors the
-                        # interactive CLI path. Write to stderr so piped stdout
-                        # stays clean for automation wrappers.
-                        if (
-                            not response
-                            and isinstance(result, dict)
-                            and result.get("error")
-                            and (result.get("failed") or result.get("partial"))
-                        ):
-                            print(f"Error: {result['error']}", file=sys.stderr)
-                        elif response:
-                            print(response)
-
-                        # Kanban goal-loop mode: a worker spawned for a
-                        # goal_mode card keeps working in THIS session until an
-                        # auxiliary judge agrees the card is done, the worker
-                        # terminates the task itself, or the turn budget runs
-                        # out (→ sticky block). Gated on the env vars the
-                        # dispatcher sets in `_default_spawn`; a no-op for every
-                        # normal worker and every non-kanban `-q` run.
-                        if os.environ.get("HERMES_KANBAN_GOAL_MODE") == "1":
-                            try:
-                                _run_kanban_goal_loop_q(cli, response)
-                            except Exception as _goal_exc:
-                                logger.debug("kanban goal loop failed: %s", _goal_exc)
-
-                        # Session ID goes to stderr so piped stdout is clean.
-                        print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
-
-                        # Ensure proper exit code for automation wrappers.
-                        #
-                        # Kanban workers get a special case: when the run failed
-                        # purely because the provider rate-limited / exhausted
-                        # quota (not because the task itself is broken), exit with
-                        # the EX_TEMPFAIL sentinel instead of the generic 1. The
-                        # dispatcher's reap classifier maps that code to a
-                        # ``rate_limited`` exit and releases the task back to
-                        # ``ready`` WITHOUT incrementing the failure counter, so a
-                        # 5-hour quota window can't trip the circuit breaker and
-                        # permanently block the card. Non-kanban runs keep the
-                        # plain 0/1 contract automation wrappers expect.
-                        _exit_code = 0
-                        if isinstance(result, dict) and result.get("failed"):
-                            _exit_code = 1
-                            if os.environ.get("HERMES_KANBAN_TASK") and result.get(
-                                "failure_reason"
-                            ) in ("rate_limit", "billing"):
-                                try:
-                                    from hermes_cli.kanban_db import (
-                                        KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE,
-                                    )
-                                    _exit_code = _RL_CODE
-                                except Exception:
-                                    _exit_code = 1
-                        sys.exit(_exit_code)
-
-                # Exit with error code if credentials or agent init fails
-                sys.exit(1)
-            else:
-                # Single-query mode (`hermes chat -q "…"`): skip the welcome
-                # banner. Building the banner takes ~420 ms on cold start —
-                # ~200 ms of that is the version-update check, the rest is
-                # toolset / skill enumeration and Rich panel rendering. None
-                # of that is useful for a one-shot query: the user already
-                # picked the prompt, doesn't need a toolset reference, and
-                # gets the session ID + resume hint from
-                # ``_print_exit_summary()`` after the response prints.
-                #
-                # The fully-quiet ``-Q`` / ``--quiet`` machine-readable path
-                # above was already banner-free; this brings the human-
-                # facing single-query path in line so all non-interactive
-                # invocations are fast.
-                _query_label = query or ("[image attached]" if single_query_images else "")
-                if _query_label:
-                    cli.console.print(f"[bold blue]Query:[/] {_query_label}")
-                # Surface security advisories before the agent runs — short
-                # banner, doesn't depend on the welcome banner being shown.
-                cli._show_security_advisories()
-                cli.chat(query, images=single_query_images or None)
-                cli._print_exit_summary(clear_screen=False)
-        finally:
-            _finalize_single_query(cli)
+                        cli.session_id = cli.agent.session_id
+                    response = result.get("final_response", "") if isinstance(result, dict) else str(result)
+                    # Surface backend errors that produced no visible output
+                    # (e.g. invalid model slug → provider 4xx). Mirrors the
+                    # interactive CLI path. Write to stderr so piped stdout
+                    # stays clean for automation wrappers.
+                    if (
+                        not response
+                        and isinstance(result, dict)
+                        and result.get("error")
+                        and (result.get("failed") or result.get("partial"))
+                    ):
+                        print(f"Error: {result['error']}", file=sys.stderr)
+                    elif response:
+                        print(response)
+                    # Session ID goes to stderr so piped stdout is clean.
+                    print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
+                    
+                    # Ensure proper exit code for automation wrappers
+                    sys.exit(1 if isinstance(result, dict) and result.get("failed") else 0)
+            
+            # Exit with error code if credentials or agent init fails
+            sys.exit(1)
+        else:
+            # Single-query mode (`hermes chat -q "…"`): skip the welcome
+            # banner. Building the banner takes ~420 ms on cold start —
+            # ~200 ms of that is the version-update check, the rest is
+            # toolset / skill enumeration and Rich panel rendering. None
+            # of that is useful for a one-shot query: the user already
+            # picked the prompt, doesn't need a toolset reference, and
+            # gets the session ID + resume hint from
+            # ``_print_exit_summary()`` after the response prints.
+            #
+            # The fully-quiet ``-Q`` / ``--quiet`` machine-readable path
+            # above was already banner-free; this brings the human-
+            # facing single-query path in line so all non-interactive
+            # invocations are fast.
+            _query_label = query or ("[image attached]" if single_query_images else "")
+            if _query_label:
+                cli.console.print(f"[bold blue]Query:[/] {_query_label}")
+            # Surface security advisories before the agent runs — short
+            # banner, doesn't depend on the welcome banner being shown.
+            cli._show_security_advisories()
+            cli.chat(query, images=single_query_images or None)
+            cli._print_exit_summary()
         return
     
     # Run interactive mode

--- a/cli.py
+++ b/cli.py
@@ -24,6 +24,7 @@ except ModuleNotFoundError:
     pass
 
 import logging
+import math
 import os
 import shutil
 import sys
@@ -4130,6 +4131,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._account_limits_lock = threading.Lock()
         self._account_limits_label: str | None = None
         self._account_limits_style = "class:status-bar-good"
+        self._account_limits_used_percent: float | None = None
         self._account_limits_provider: str | None = None
         self._account_limits_checked_at = 0.0
         self._account_limits_refreshing = False
@@ -4500,32 +4502,68 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         return "class:status-bar-dim"
 
     @staticmethod
-    def _format_account_limits_badge(snapshot: Any) -> str:
-        """Format Codex session and weekly quota remaining for the status bar."""
-        parts: list[str] = []
+    def _weekly_account_usage_percent(snapshot: Any) -> float | None:
+        """Return the finite raw usage for a duration-verified weekly window."""
         for window in getattr(snapshot, "windows", ()) or ():
-            used = getattr(window, "used_percent", None)
-            if used is None:
-                continue
-            label = str(getattr(window, "label", "") or "").strip().lower()
-            if "week" in label:
-                prefix = "W"
-            elif "session" in label or "current" in label:
-                prefix = "S"
-            else:
-                continue
             try:
-                remaining = max(0, min(100, round(100 - float(used))))
+                raw_duration: Any = getattr(window, "limit_window_seconds", None)
+                raw_used: Any = getattr(window, "used_percent", None)
+                duration = float(raw_duration)
+                used = float(raw_used)
             except (TypeError, ValueError):
                 continue
-            parts.append(f"{prefix}{remaining}%")
-        return f"Acct {' '.join(parts[:2])}" if parts else ""
+            if math.isfinite(duration) and math.isfinite(used) and 6 * 86_400 <= duration <= 8 * 86_400:
+                return used
+        return None
+
+    @classmethod
+    def _format_account_limits_badge(
+        cls, snapshot: Any, *, available_width: int | None = None, ascii_fallback: bool = False
+    ) -> str:
+        """Format only the duration-detected Codex weekly quota for the status bar.
+
+        The API's primary/secondary names are positions, not period types. The
+        formatter therefore uses the retained duration and never a label to find
+        the weekly window. ``available_width`` gives deterministic full, compact
+        (no-space), and percent-only forms; the default remains full.
+        """
+        used = cls._weekly_account_usage_percent(snapshot)
+        if used is None:
+            return ""
+        displayed_used = max(0, min(100, round(used)))
+        percent = f"W{displayed_used}%{'+' if used > 100 else ''}"
+        filled = round(displayed_used / 10)
+        on, off = ("#", "-") if ascii_fallback else ("█", "░")
+        gauge = f"[{on * filled}{off * (10 - filled)}]"
+        full = f"{percent} {gauge}"
+        compact = f"{percent}{gauge}"
+        if available_width is None or available_width >= len(full):
+            return full
+        if available_width >= len(compact):
+            return compact
+        if available_width >= len(percent):
+            return percent
+        return ""
 
     @staticmethod
-    def _account_limits_badge_style(label: str) -> str:
-        """Mark an exhausted Codex session or weekly quota as critical."""
-        if re.search(r"(?<!\w)[SW]0%(?!\d)", label or ""):
+    def _account_limits_badge_style(label: str, used_percent: float | None = None) -> str:
+        """Return weekly pressure style, using raw usage when it is available."""
+        if used_percent is None:
+            match = re.search(r"(?<!\w)W(\d+)%([+])?(?!\w)", label or "")
+            if not match:
+                return "class:status-bar-good"
+            used_percent = float(match.group(1))
+            overflow = bool(match.group(2))
+        else:
+            overflow = used_percent > 100
+        if not math.isfinite(used_percent):
+            return "class:status-bar-good"
+        if overflow or used_percent >= 95:
             return "class:status-bar-critical"
+        if used_percent >= 90:
+            return "class:status-bar-bad"
+        if used_percent >= 80:
+            return "class:status-bar-warn"
         return "class:status-bar-good"
 
     def _maybe_refresh_account_limits_badge(self, agent: Any) -> str:
@@ -4544,6 +4582,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             with self._account_limits_lock:
                 self._account_limits_label = None
                 self._account_limits_style = "class:status-bar-good"
+                self._account_limits_used_percent = None
                 self._account_limits_provider = None
                 self._account_limits_checked_at = 0.0
             return ""
@@ -4561,10 +4600,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         def _worker() -> None:
             label = ""
+            weekly_used_percent: float | None = None
             try:
                 from agent.account_usage import fetch_account_usage
 
                 snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
+                weekly_used_percent = self._weekly_account_usage_percent(snapshot) if snapshot else None
                 label = self._format_account_limits_badge(snapshot) if snapshot else ""
             except Exception:
                 pass
@@ -4572,7 +4613,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 with self._account_limits_lock:
                     if label:
                         self._account_limits_label = label
-                        self._account_limits_style = self._account_limits_badge_style(label)
+                        self._account_limits_used_percent = weekly_used_percent
+                        self._account_limits_style = self._account_limits_badge_style(label, weekly_used_percent)
                         self._account_limits_provider = provider
                         self._account_limits_checked_at = time.monotonic()
                     elif self._account_limits_provider != provider:
@@ -4737,9 +4779,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         account_limits = self._maybe_refresh_account_limits_badge(agent)
         snapshot["account_limits"] = account_limits
         if account_limits:
-            # Derive the style from this render's label so a freshly depleted
-            # cache entry cannot inherit the preceding green style for one tick.
-            snapshot["account_limits_style"] = self._account_limits_badge_style(account_limits)
+            # Use the current cached raw value when present so fractional usage
+            # crosses thresholds at 80/90/95 before display rounding occurs.
+            snapshot["account_limits_style"] = self._account_limits_badge_style(
+                account_limits, getattr(self, "_account_limits_used_percent", None)
+            )
 
         compressor = getattr(agent, "context_compressor", None)
         if compressor:

--- a/tests/cli/test_account_limits_status_bar.py
+++ b/tests/cli/test_account_limits_status_bar.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from types import SimpleNamespace
 
 import cli as cli_mod
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
 from cli import HermesCLI
 
 
@@ -43,25 +44,89 @@ def _shell() -> HermesCLI:
     return shell
 
 
-def test_account_limits_badge_marks_depleted_session_or_weekly_critical() -> None:
-    assert HermesCLI._account_limits_badge_style("Acct S0% W42%") == "class:status-bar-critical"
-    assert HermesCLI._account_limits_badge_style("Acct S42% W0%") == "class:status-bar-critical"
-    assert HermesCLI._account_limits_badge_style("Acct S42% W99%") == "class:status-bar-good"
+def test_account_limits_badge_styles_follow_weekly_used_thresholds() -> None:
+    expected = {
+        79: "class:status-bar-good",
+        80: "class:status-bar-warn",
+        89: "class:status-bar-warn",
+        90: "class:status-bar-bad",
+        94: "class:status-bar-bad",
+        95: "class:status-bar-critical",
+        100: "class:status-bar-critical",
+        110: "class:status-bar-critical",
+    }
+    for used, style in expected.items():
+        suffix = "+" if used > 100 else ""
+        assert HermesCLI._account_limits_badge_style(f"W{min(used, 100)}%{suffix}") == style
+
+
+def test_account_limits_badge_style_uses_raw_fractional_usage_before_display_rounding() -> None:
+    assert HermesCLI._account_limits_badge_style("W80%", 79.6) == "class:status-bar-good"
+    assert HermesCLI._account_limits_badge_style("W90%", 89.6) == "class:status-bar-warn"
+    assert HermesCLI._account_limits_badge_style("W95%", 94.6) == "class:status-bar-bad"
+    assert HermesCLI._account_limits_badge_style("W95%", 95.0) == "class:status-bar-critical"
+
+
+def test_badge_uses_only_duration_detected_weekly_window_and_supports_widths() -> None:
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(),
+        windows=(
+            AccountUsageWindow("Session", 99, limit_window_seconds=18_000),
+            AccountUsageWindow("Usage window", 31, limit_window_seconds=604_800),
+        ),
+    )
+
+    assert HermesCLI._format_account_limits_badge(snapshot) == "W31% [███░░░░░░░]"
+    assert HermesCLI._format_account_limits_badge(snapshot, available_width=16) == "W31%[███░░░░░░░]"
+    assert HermesCLI._format_account_limits_badge(snapshot, available_width=4) == "W31%"
+    assert HermesCLI._format_account_limits_badge(snapshot, available_width=3) == ""
+    assert HermesCLI._format_account_limits_badge(snapshot, ascii_fallback=True) == "W31% [###-------]"
+
+
+def test_badge_ignores_missing_invalid_and_nonweekly_windows_and_marks_overflow() -> None:
+    assert HermesCLI._format_account_limits_badge(
+        AccountUsageSnapshot(
+            provider="openai-codex", source="usage_api", fetched_at=datetime.now(),
+            windows=(AccountUsageWindow("Weekly", 50),),
+        )
+    ) == ""
+    assert HermesCLI._format_account_limits_badge(
+        AccountUsageSnapshot(
+            provider="openai-codex", source="usage_api", fetched_at=datetime.now(),
+            windows=(AccountUsageWindow("Weekly", 50, limit_window_seconds=18_000),),
+        )
+    ) == ""
+    assert HermesCLI._format_account_limits_badge(
+        AccountUsageSnapshot(
+            provider="openai-codex", source="usage_api", fetched_at=datetime.now(),
+            windows=(AccountUsageWindow("Weekly", "bad", limit_window_seconds=604_800),),
+        )
+    ) == ""
+    overflow = HermesCLI._format_account_limits_badge(
+        AccountUsageSnapshot(
+            provider="openai-codex", source="usage_api", fetched_at=datetime.now(),
+            windows=(AccountUsageWindow("Weekly", 110, limit_window_seconds=604_800),),
+        )
+    )
+    assert overflow == "W100%+ [██████████]"
+    assert HermesCLI._account_limits_badge_style(overflow) == "class:status-bar-critical"
 
 
 def test_status_bar_snapshot_styles_current_depleted_label(monkeypatch) -> None:
     shell = _shell()
-    monkeypatch.setattr(shell, "_maybe_refresh_account_limits_badge", lambda agent: "Acct S0% W42%")
+    monkeypatch.setattr(shell, "_maybe_refresh_account_limits_badge", lambda agent: "W100% [██████████]")
 
     snapshot = shell._get_status_bar_snapshot()
 
-    assert snapshot["account_limits"] == "Acct S0% W42%"
+    assert snapshot["account_limits"] == "W100% [██████████]"
     assert snapshot["account_limits_style"] == "class:status-bar-critical"
 
 
 def test_non_codex_provider_clears_cached_codex_badge_without_starting_worker(monkeypatch) -> None:
     shell = _shell()
-    shell._account_limits_label = "Acct S0% W42%"
+    shell._account_limits_label = "W42% [████░░░░░░░]"
     shell._account_limits_provider = "openai-codex"
     assert shell.agent is not None
     shell.agent.provider = "anthropic"
@@ -106,7 +171,7 @@ def test_stale_codex_badge_schedules_worker_without_fetching_in_render(monkeypat
 
 def test_failed_refresh_keeps_cached_badge_and_retries_soon(monkeypatch) -> None:
     shell = _shell()
-    shell._account_limits_label = "Acct S42% W99%"
+    shell._account_limits_label = "W42% [████░░░░░░░]"
     shell._account_limits_provider = "openai-codex"
     shell._account_limits_checked_at = time.monotonic() - 301
     monkeypatch.setattr(shell, "_invalidate", lambda **kwargs: None)
@@ -121,8 +186,8 @@ def test_failed_refresh_keeps_cached_badge_and_retries_soon(monkeypatch) -> None
     monkeypatch.setattr(cli_mod.threading, "Thread", ImmediateThread)
     monkeypatch.setitem(__import__("sys").modules, "agent.account_usage", SimpleNamespace(fetch_account_usage=lambda **kwargs: None))
 
-    assert shell._maybe_refresh_account_limits_badge(shell.agent) == "Acct S42% W99%"
-    assert shell._account_limits_label == "Acct S42% W99%"
+    assert shell._maybe_refresh_account_limits_badge(shell.agent) == "W42% [████░░░░░░░]"
+    assert shell._account_limits_label == "W42% [████░░░░░░░]"
     assert shell._account_limits_checked_at < time.monotonic() - 269
 
 
@@ -139,7 +204,7 @@ def test_overflow_keeps_depleted_badge_critical(monkeypatch) -> None:
             "context_percent": 12,
             "context_length": 200_000,
             "context_tokens": 24_000,
-            "account_limits": "Acct S0% W42%",
+            "account_limits": "W100% [██████████]",
             "account_limits_style": "class:status-bar-critical",
             "compressions": 0,
             "active_background_tasks": 0,
@@ -155,4 +220,4 @@ def test_overflow_keeps_depleted_badge_critical(monkeypatch) -> None:
 
     assert len(fragments) == 1
     assert fragments[0][0] == "class:status-bar-critical"
-    assert "Acct S0%" in fragments[0][1]
+    assert "W100%" in fragments[0][1]

--- a/tests/cli/test_account_limits_status_bar.py
+++ b/tests/cli/test_account_limits_status_bar.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime
+from types import SimpleNamespace
+
+import cli as cli_mod
+from cli import HermesCLI
+
+
+def _shell() -> HermesCLI:
+    shell = HermesCLI.__new__(HermesCLI)
+    shell.model = "openai-codex/gpt-5.5-codex"
+    shell.provider = "openai-codex"
+    shell.base_url = None
+    shell.api_key = None
+    shell.session_start = datetime.now()
+    shell._prompt_start_time = None
+    shell._prompt_duration = 0.0
+    shell._background_tasks = {}
+    shell._account_limits_lock = threading.Lock()
+    shell._account_limits_label = None
+    shell._account_limits_style = "class:status-bar-good"
+    shell._account_limits_provider = None
+    shell._account_limits_checked_at = 0.0
+    shell._account_limits_refreshing = False
+    shell.agent = SimpleNamespace(
+        model=shell.model,
+        provider="openai-codex",
+        base_url=None,
+        api_key=None,
+        session_input_tokens=0,
+        session_output_tokens=0,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_prompt_tokens=0,
+        session_completion_tokens=0,
+        session_total_tokens=0,
+        session_api_calls=0,
+        context_compressor=None,
+    )
+    return shell
+
+
+def test_account_limits_badge_marks_depleted_session_or_weekly_critical() -> None:
+    assert HermesCLI._account_limits_badge_style("Acct S0% W42%") == "class:status-bar-critical"
+    assert HermesCLI._account_limits_badge_style("Acct S42% W0%") == "class:status-bar-critical"
+    assert HermesCLI._account_limits_badge_style("Acct S42% W99%") == "class:status-bar-good"
+
+
+def test_status_bar_snapshot_styles_current_depleted_label(monkeypatch) -> None:
+    shell = _shell()
+    monkeypatch.setattr(shell, "_maybe_refresh_account_limits_badge", lambda agent: "Acct S0% W42%")
+
+    snapshot = shell._get_status_bar_snapshot()
+
+    assert snapshot["account_limits"] == "Acct S0% W42%"
+    assert snapshot["account_limits_style"] == "class:status-bar-critical"
+
+
+def test_non_codex_provider_clears_cached_codex_badge_without_starting_worker(monkeypatch) -> None:
+    shell = _shell()
+    shell._account_limits_label = "Acct S0% W42%"
+    shell._account_limits_provider = "openai-codex"
+    assert shell.agent is not None
+    shell.agent.provider = "anthropic"
+    started = False
+
+    class ThreadMustNotStart:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            nonlocal started
+            started = True
+
+    monkeypatch.setattr(cli_mod.threading, "Thread", ThreadMustNotStart)
+
+    assert shell._maybe_refresh_account_limits_badge(shell.agent) == ""
+    assert shell._account_limits_label is None
+    assert shell._account_limits_provider is None
+    assert started is False
+
+
+def test_stale_codex_badge_schedules_worker_without_fetching_in_render(monkeypatch) -> None:
+    shell = _shell()
+    started = []
+
+    class DeferredThread:
+        def __init__(self, *, target, name, daemon):
+            self.target = target
+            self.name = name
+            self.daemon = daemon
+
+        def start(self):
+            started.append(self)
+
+    monkeypatch.setattr(cli_mod.threading, "Thread", DeferredThread)
+
+    assert shell._maybe_refresh_account_limits_badge(shell.agent) == ""
+    assert len(started) == 1
+    assert started[0].name == "hermes-account-limits"
+    assert shell._account_limits_refreshing is True
+
+
+def test_failed_refresh_keeps_cached_badge_and_retries_soon(monkeypatch) -> None:
+    shell = _shell()
+    shell._account_limits_label = "Acct S42% W99%"
+    shell._account_limits_provider = "openai-codex"
+    shell._account_limits_checked_at = time.monotonic() - 301
+    monkeypatch.setattr(shell, "_invalidate", lambda **kwargs: None)
+
+    class ImmediateThread:
+        def __init__(self, *, target, name, daemon):
+            self.target = target
+
+        def start(self):
+            self.target()
+
+    monkeypatch.setattr(cli_mod.threading, "Thread", ImmediateThread)
+    monkeypatch.setitem(__import__("sys").modules, "agent.account_usage", SimpleNamespace(fetch_account_usage=lambda **kwargs: None))
+
+    assert shell._maybe_refresh_account_limits_badge(shell.agent) == "Acct S42% W99%"
+    assert shell._account_limits_label == "Acct S42% W99%"
+    assert shell._account_limits_checked_at < time.monotonic() - 269
+
+
+def test_overflow_keeps_depleted_badge_critical(monkeypatch) -> None:
+    shell = _shell()
+    shell._status_bar_visible = True
+    shell._model_picker_state = None
+    monkeypatch.setattr(shell, "_get_tui_terminal_width", lambda: 76)
+    monkeypatch.setattr(
+        shell,
+        "_get_status_bar_snapshot",
+        lambda: {
+            "model_short": "gpt-5.5-codex",
+            "context_percent": 12,
+            "context_length": 200_000,
+            "context_tokens": 24_000,
+            "account_limits": "Acct S0% W42%",
+            "account_limits_style": "class:status-bar-critical",
+            "compressions": 0,
+            "active_background_tasks": 0,
+            "active_background_processes": 0,
+            "active_background_subagents": 0,
+            "duration": "123m",
+            "prompt_elapsed": "⏲ 99s",
+            "idle_since": "",
+        },
+    )
+
+    fragments = shell._get_status_bar_fragments()
+
+    assert len(fragments) == 1
+    assert fragments[0][0] == "class:status-bar-critical"
+    assert "Acct S0%" in fragments[0][1]

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -92,6 +92,9 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert snapshot.windows[0].label == "Session"
     assert snapshot.windows[0].used_percent == 15.0
     assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
+    assert snapshot.windows[0].limit_window_seconds == 18_000.0
+    assert snapshot.windows[1].label == "Weekly"
+    assert snapshot.windows[1].limit_window_seconds == 604_800.0
     assert "Credits balance: $12.50" in snapshot.details
 
 
@@ -201,3 +204,48 @@ def test_fetch_account_usage_openrouter_omits_quota_window_when_key_has_no_limit
     assert snapshot.windows == ()
     assert "Credits balance: $74.50" in snapshot.details
     assert "API key usage: $25.50 total • $1.25 today • $4.50 this week • $18.00 this month" in snapshot.details
+
+
+def test_codex_windows_are_classified_by_duration_not_position(monkeypatch):
+    payload = {
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 31,
+                "reset_at": 1_900_000_000,
+                "limit_window_seconds": 604_800,
+            },
+        }
+    }
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: {"api_key": "token", "base_url": "https://example.test"},
+    )
+    monkeypatch.setattr("agent.account_usage._read_codex_tokens", lambda: {"tokens": {}})
+    monkeypatch.setattr("agent.account_usage.httpx.Client", lambda timeout=15.0: _Client(payload))
+
+    snapshot = fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert [window.label for window in snapshot.windows] == ["Weekly"]
+    assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
+
+
+def test_codex_missing_or_unfamiliar_window_duration_is_generic(monkeypatch):
+    payload = {
+        "rate_limit": {
+            "primary_window": {"used_percent": 10, "reset_at": 1_900_000_000, "limit_window_seconds": 43_200},
+            "secondary_window": {"used_percent": 20, "reset_at": 1_900_500_000},
+        }
+    }
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: {"api_key": "token", "base_url": "https://example.test"},
+    )
+    monkeypatch.setattr("agent.account_usage._read_codex_tokens", lambda: {"tokens": {}})
+    monkeypatch.setattr("agent.account_usage.httpx.Client", lambda timeout=15.0: _Client(payload))
+
+    snapshot = fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert [window.label for window in snapshot.windows] == ["Session", "Usage window"]
+    assert snapshot.windows[1].reset_at == datetime.fromtimestamp(1_900_500_000, tz=timezone.utc)


### PR DESCRIPTION
## Summary
- Add a compact account quota badge to the classic CLI status bar.
- Mark the badge critical/red when Codex session or weekly quota is depleted (`S0%` or `W0%`).
- Keep the critical style in compact/overflow status bar rendering.

## Test Plan
- `/usr/local/lib/hermes-agent/venv/bin/python3 -m pytest tests/hermes_cli/test_account_limits_status_bar.py tests/cli/test_cli_status_bar.py -q`

## Privacy / scope
This PR intentionally contains only the generic Hermes CLI quota/status-bar changes. Private Ops Center/outbox/dashboard work is excluded.
