### PR TITLE
fix(docker): boot non-root containers, skip the s6-setuidgid drop when already unprivileged.

### DIFF
--- a/docker/cont-init.d/02-reconcile-profiles
+++ b/docker/cont-init.d/02-reconcile-profiles
@@ -42,5 +42,7 @@ if [ -d /run/service/.s6-svscan ]; then
     done
 fi
 
+# Skip the drop when already non-root.
+[ "$(id -u)" = 0 ] || exec /opt/hermes/.venv/bin/python -m hermes_cli.container_boot
 exec s6-setuidgid hermes /opt/hermes/.venv/bin/python -m hermes_cli.container_boot
 

--- a/docker/main-wrapper.sh
+++ b/docker/main-wrapper.sh
@@ -16,9 +16,10 @@
 #   first arg is an executable    → exec it directly (sleep, bash, sh, …)
 #   first arg is anything else    → exec `hermes <args>` (subcommand passthrough)
 #
-# We drop to the hermes user via `s6-setuidgid` so the supervised
-# workload runs unprivileged (UID 10000 by default).
+# Drop to hermes via s6-setuidgid, but skip it when already non-root.
 set -e
+
+drop() { [ "$(id -u)" = 0 ] && set -- s6-setuidgid hermes "$@"; exec "$@"; }
 
 # HOME comes through with-contenv as /root (the /init context). Override
 # to the hermes user's home before dropping privileges so libraries that
@@ -31,13 +32,13 @@ cd /opt/data
 . /opt/hermes/.venv/bin/activate
 
 if [ $# -eq 0 ]; then
-    exec s6-setuidgid hermes hermes
+    drop hermes
 fi
 
 if command -v "$1" >/dev/null 2>&1; then
     # Bare executable — pass through directly.
-    exec s6-setuidgid hermes "$@"
+    drop "$@"
 fi
 
 # Hermes subcommand pass-through.
-exec s6-setuidgid hermes hermes "$@"
+drop hermes "$@"

--- a/docker/s6-rc.d/dashboard/run
+++ b/docker/s6-rc.d/dashboard/run
@@ -47,6 +47,9 @@ case "${HERMES_DASHBOARD_INSECURE:-}" in
     1|true|TRUE|True|yes|YES|Yes) insecure="--insecure" ;;
 esac
 
+# Skip the drop when already non-root.
+# shellcheck disable=SC2086  # word-splitting of $insecure is intentional
+[ "$(id -u)" = 0 ] || exec hermes dashboard --host "$dash_host" --port "$dash_port" --no-open $insecure
 # shellcheck disable=SC2086  # word-splitting of $insecure is intentional
 exec s6-setuidgid hermes hermes dashboard \
     --host "$dash_host" --port "$dash_port" --no-open $insecure

--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -20,6 +20,9 @@ set -eu
 HERMES_HOME="${HERMES_HOME:-/opt/data}"
 INSTALL_DIR="/opt/hermes"
 
+# Drop to hermes via s6-setuidgid, but skip it when already non-root.
+as_hermes() { [ "$(id -u)" = 0 ] || { "$@"; return; }; s6-setuidgid hermes "$@"; }
+
 # --- Bootstrap HERMES_HOME as root ---
 # Create the directory (and any missing parents) while we still have root
 # privileges so the chown checks below see real metadata and the later
@@ -193,7 +196,7 @@ fi
 # Use direct `mkdir -p` invocation (no `sh -c "..."` wrapper) so the
 # shell isn't a second interpreter — defends against $HERMES_HOME values
 # containing shell metacharacters. PR #30136 review item O2.
-s6-setuidgid hermes mkdir -p \
+as_hermes mkdir -p \
     "$HERMES_HOME/cron" \
     "$HERMES_HOME/sessions" \
     "$HERMES_HOME/logs" \
@@ -210,7 +213,7 @@ s6-setuidgid hermes mkdir -p \
 # the hermes user so ownership matches the file's documented owner.
 # tee is invoked directly via s6-setuidgid (no `sh -c` wrapper) for the
 # same shell-metacharacter safety described above.
-printf 'docker\n' | s6-setuidgid hermes tee "$HERMES_HOME/.install_method" >/dev/null \
+printf 'docker\n' | as_hermes tee "$HERMES_HOME/.install_method" >/dev/null \
     || true
 
 # --- Seed config files (only on first boot) ---
@@ -218,7 +221,7 @@ seed_one() {
     dest=$1
     src=$2
     if [ ! -f "$HERMES_HOME/$dest" ] && [ -f "$INSTALL_DIR/$src" ]; then
-        s6-setuidgid hermes cp "$INSTALL_DIR/$src" "$HERMES_HOME/$dest"
+        as_hermes cp "$INSTALL_DIR/$src" "$HERMES_HOME/$dest"
     fi
 }
 seed_one ".env" ".env.example"
@@ -249,7 +252,7 @@ fi
 # the python binary's own bin-stub already sets up (sys.path is rooted
 # at the venv's site-packages by virtue of running .venv/bin/python).
 if [ -d "$INSTALL_DIR/skills" ]; then
-    s6-setuidgid hermes "$INSTALL_DIR/.venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" \
+    as_hermes "$INSTALL_DIR/.venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" \
         || echo "[stage2] Warning: skills_sync.py failed; continuing"
 fi
 

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -615,11 +615,13 @@ class S6ServiceManager:
         # guard.
         lines.append("export HERMES_S6_SUPERVISED_CHILD=1")
         if profile == "default":
-            lines.append("exec s6-setuidgid hermes hermes gateway run")
+            gateway_cmd = "hermes gateway run"
         else:
-            lines.append(
-                f"exec s6-setuidgid hermes hermes -p {shlex.quote(profile)} gateway run"
-            )
+            gateway_cmd = f"hermes -p {shlex.quote(profile)} gateway run"
+        # Skip the drop when already non-root (setgroups() lacks CAP_SETGID →
+        # s6 boot-loop).
+        lines.append(f'[ "$(id -u)" = 0 ] || exec {gateway_cmd}')
+        lines.append(f"exec s6-setuidgid hermes {gateway_cmd}")
         return "\n".join(lines) + "\n"
 
     @staticmethod
@@ -674,6 +676,8 @@ class S6ServiceManager:
             f'log_dir="$HERMES_HOME/logs/gateways/{prof}"\n'
             f'mkdir -p "$log_dir"\n'
             f'chown -R hermes:hermes "$log_dir" 2>/dev/null || true\n'
+            # Skip the drop when already non-root (CAP_SETGID).
+            f'[ "$(id -u)" = 0 ] || exec s6-log 1 n10 s1000000 T "$log_dir"\n'
             f'exec s6-setuidgid hermes s6-log 1 n10 s1000000 T "$log_dir"\n'
         )
 


### PR DESCRIPTION
## What does this PR do?

Fixes the s6-overlay boot loop that hits any container started as a non-root user.
The container drops privileges to the unprivileged `hermes` user via `s6-setuidgid hermes <cmd>` in every boot script. `s6-setuidgid` calls `setgroups()`, which requires `CAP_SETGID`. A container started **as root** has it; a container started **non-root does not**, so every `s6-setuidgid` invocation dies with:

```
s6-applyuidgid: fatal: unable to set supplementary group list: Operation not permitted
```

The cont-init hooks exit 111 and the supervised services crash-loop, so the container never finishes booting.

The fix guards each privilege drop: if already non-root, run the command directly; only call `s6-setuidgid` when we're root (there's something to drop). This restores the `v0.14` behavior for non-root containers while leaving root containers byte-for-byte unchanged.

## Related Issue

Fixes #34648

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

All changes apply the same guard: `[ "$(id -u)" = 0 ]` → only drop via `s6-setuidgid` when root; otherwise exec directly.

- `docker/main-wrapper.sh`: add a `drop()` helper and route the three CMD exec paths through it.
- `docker/stage2-hook.sh`: add an `as_hermes()` helper; route the four inline drops (mkdir / tee / cp / skills-sync) through it.
- `docker/cont-init.d/02-reconcile-profiles`: guard the `container_boot` drop.
- `docker/s6-rc.d/dashboard/run`: guard the dashboard drop (command/flags unchanged).
- `hermes_cli/service_manager.py`: guard the **generated** per-profile gateway `run` and log `run` scripts (`_render_gateway_run` / `_render_log_run`) — these were the second set of drops, emitted at runtime.

## Security note

This does **not** skip the privilege drop for root containers. The guard only no-ops the drop when the container is **already** running as a non-root user, where `setgroups()` is both impossible (no `CAP_SETGID`) and unnecessary (we're already unprivileged). There is no path where a root process avoids dropping to `hermes`. No privilege escalation, no change to network exposure, and the dashboard's auth (OAuth gate, replay-secret check, `--insecure` default) is untouched. Only the OS user the process runs as changes, and only in the non-root case the operator explicitly opted into.

## How to Test

1. **Reproduce (pre-fix):** `docker run --rm --user 10000:10000 <pre-fix v0.15 image>` → boot loops with `s6-applyuidgid: ... Operation not permitted`.
2. **Non-root (fixed):** same `--user 10000:10000` run → boots clean, no `Operation not permitted`, no cont-init `exited 111`, services start and stay up.
3. **Root (unchanged):** default `docker run` (root) → boots normally and the workload still runs as `hermes` (UID 10000) via `s6-setuidgid`.
4. **Unit tests:** `pytest tests/hermes_cli/test_service_manager.py tests/test_docker_home_override_scripts.py -q` — the generated-script assertions still pass (the `exec s6-setuidgid hermes …` lines are retained as the root branch).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass.
- [ ] I've added tests for my changes
- [x] I've tested on my platform.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (inline comments only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (container-only; root path unchanged, only adds a non-root fallback)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
