### PR TITLE
test: validate Build Lane Discord forum visibility

### DIFF
--- a/hermes_cli/kanban_discord_approvals.py
+++ b/hermes_cli/kanban_discord_approvals.py
@@ -1,0 +1,206 @@
+"""Discord approval-button helpers for human Kanban gates.
+
+This module is intentionally free of discord.py imports so both the gateway
+adapter and small watcher scripts can share the same routing/formatting logic.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from hermes_cli import kanban_db as kb
+
+CUSTOM_ID_PREFIX = "hermes:kanban-approval:"
+APPROVAL_ACTIONS = ("approve", "deny", "needs_changes")
+REVIEW_REQUIRED_RE = re.compile(r"\breview[-_ ]required\b", re.I)
+HUMAN_GATE_RE = re.compile(
+    r"\b(human[-_ ]gate|human[-_ ]approval|approval[-_ ]required|matthew[-_ ]approval|manual[-_ ]approval)\b",
+    re.I,
+)
+
+
+@dataclass(frozen=True)
+class ApprovalRequest:
+    task_id: str
+    title: str
+    reason: str
+    project_context: str
+    what_is_approved: str
+    if_approved: str
+    risk_rollback: str
+    run_context: str = ""
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            return {}
+        return dict(parsed) if isinstance(parsed, Mapping) else {}
+    return {}
+
+
+def parse_payload(raw: Any) -> dict[str, Any]:
+    return _as_dict(raw)
+
+
+def parse_metadata(payload: Mapping[str, Any]) -> dict[str, Any]:
+    return _as_dict(payload.get("metadata"))
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on", "required"}
+
+
+def is_autonomous_review_gate(task: Mapping[str, Any], payload: Mapping[str, Any]) -> bool:
+    metadata = parse_metadata(payload)
+    reason = str(payload.get("reason") or payload.get("summary") or payload.get("error") or "")
+    haystack = "\n".join(
+        str(x or "") for x in (
+            reason,
+            task.get("title"),
+            task.get("body"),
+            metadata.get("gate"),
+            metadata.get("review_gate"),
+        )
+    )
+    return bool(
+        _truthy(payload.get("review_required"))
+        or _truthy(metadata.get("review_required"))
+        or REVIEW_REQUIRED_RE.search(haystack)
+    )
+
+
+def is_human_approval_gate(task: Mapping[str, Any], event_kind: str, payload: Mapping[str, Any]) -> bool:
+    if event_kind != "blocked":
+        return False
+    if is_autonomous_review_gate(task, payload):
+        return False
+    metadata = parse_metadata(payload)
+    reason = str(payload.get("reason") or payload.get("summary") or payload.get("error") or "")
+    explicit = (
+        payload.get("human_approval_required"),
+        payload.get("human_gate"),
+        metadata.get("human_approval_required"),
+        metadata.get("human_gate"),
+        metadata.get("discord_approval_request"),
+    )
+    if any(_truthy(v) for v in explicit):
+        return True
+    return bool(HUMAN_GATE_RE.search(reason))
+
+
+def build_custom_id(task_id: str, action: str) -> str:
+    if action not in APPROVAL_ACTIONS:
+        raise ValueError(f"unsupported Kanban approval action: {action}")
+    return f"{CUSTOM_ID_PREFIX}{task_id}:{action}"
+
+
+def parse_custom_id(custom_id: str) -> Optional[tuple[str, str]]:
+    if not custom_id.startswith(CUSTOM_ID_PREFIX):
+        return None
+    rest = custom_id[len(CUSTOM_ID_PREFIX):]
+    try:
+        task_id, action = rest.rsplit(":", 1)
+    except ValueError:
+        return None
+    if not task_id or action not in APPROVAL_ACTIONS:
+        return None
+    return task_id, action
+
+
+def build_approval_request(task: Mapping[str, Any], payload: Mapping[str, Any], project_context: Optional[Mapping[str, Any]] = None) -> ApprovalRequest:
+    metadata = parse_metadata(payload)
+    reason = str(payload.get("reason") or payload.get("summary") or payload.get("error") or "human approval required").strip()
+    project_context = project_context or {}
+    task_id = str(task.get("id") or payload.get("task_id") or "unknown")
+    title = str(task.get("title") or task_id).strip()
+    project = str(
+        metadata.get("project_title")
+        or project_context.get("project_title")
+        or project_context.get("project_hub_slug")
+        or metadata.get("project")
+        or "not provided"
+    )
+    run_bits = []
+    if payload.get("run_id"):
+        run_bits.append(f"run {payload['run_id']}")
+    if task.get("assignee"):
+        run_bits.append(f"assignee {task['assignee']}")
+    return ApprovalRequest(
+        task_id=task_id,
+        title=title,
+        reason=reason,
+        project_context=project,
+        run_context=", ".join(run_bits),
+        what_is_approved=str(metadata.get("what_is_approved") or payload.get("what_is_approved") or reason),
+        if_approved=str(metadata.get("if_approved") or payload.get("if_approved") or "the task will be unblocked and returned to the Kanban dispatcher"),
+        risk_rollback=str(metadata.get("risk_rollback") or payload.get("risk_rollback") or "Deny/Needs changes leaves durable evidence and keeps the task blocked for follow-up."),
+    )
+
+
+def format_approval_content(req: ApprovalRequest, mentions: str = "") -> str:
+    prefix = f"{mentions}\n" if mentions else ""
+    lines = [
+        f"{prefix}🛂 **Human Kanban approval requested**",
+        f"**Task:** `{req.task_id}` — {req.title}",
+        f"**Project/run:** {req.project_context}{(' | ' + req.run_context) if req.run_context else ''}",
+        f"**Approve:** {req.what_is_approved}",
+        f"**If approved:** {req.if_approved}",
+        f"**Risk / rollback:** {req.risk_rollback}",
+        f"**Source:** {req.reason}",
+    ]
+    return "\n".join(lines)[:1900]
+
+
+def build_message_payload(req: ApprovalRequest, mentions: str = "") -> dict[str, Any]:
+    return {
+        "content": format_approval_content(req, mentions),
+        "components": [{
+            "type": 1,
+            "components": [
+                {"type": 2, "style": 3, "label": "Approve", "custom_id": build_custom_id(req.task_id, "approve")},
+                {"type": 2, "style": 4, "label": "Deny", "custom_id": build_custom_id(req.task_id, "deny")},
+                {"type": 2, "style": 2, "label": "Needs changes", "custom_id": build_custom_id(req.task_id, "needs_changes")},
+            ],
+        }],
+    }
+
+
+def resolve_db_path(raw: Optional[str] = None) -> Path:
+    raw = (raw if raw is not None else os.getenv("KANBAN_DB_PATH") or os.getenv("HERMES_KANBAN_DB") or "").strip()
+    if not raw or raw.lower() == "default":
+        from hermes_constants import get_hermes_home
+        return Path(get_hermes_home()) / "kanban.db"
+    path = Path(raw).expanduser()
+    return path if path.is_absolute() else Path.cwd() / path
+
+
+def apply_approval_decision(task_id: str, action: str, actor: str, *, db_path: Optional[Path] = None) -> str:
+    if action not in APPROVAL_ACTIONS:
+        raise ValueError(f"unsupported Kanban approval action: {action}")
+    author = f"discord:{actor}" if actor else "discord:unknown"
+    with kb.connect_closing(db_path=db_path or resolve_db_path()) as conn:
+        task = conn.execute("SELECT id, status FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        if not task:
+            raise ValueError(f"unknown task {task_id}")
+        label = {"approve": "APPROVED", "deny": "DENIED", "needs_changes": "NEEDS CHANGES"}[action]
+        kb.add_comment(conn, task_id, author, f"{label} via Discord approval button at {int(time.time())}.")
+        if action == "approve":
+            changed = kb.unblock_task(conn, task_id)
+            return "approved_unblocked" if changed else "approved_no_status_change"
+        return f"{action}_recorded"

--- a/hermes_cli/kanban_discord_approvals.py
+++ b/hermes_cli/kanban_discord_approvals.py
@@ -22,6 +22,38 @@ HUMAN_GATE_RE = re.compile(
     r"\b(human[-_ ]gate|human[-_ ]approval|approval[-_ ]required|matthew[-_ ]approval|manual[-_ ]approval)\b",
     re.I,
 )
+SYNOPSIS_FIELD_LIMIT = 220
+SECRET_FIELD_RE = re.compile(
+    r"(?i)\b([\w.-]*(?:api[-_ ]?key|auth[-_ ]?token|access[-_ ]?token|refresh[-_ ]?token|secret|password|passwd|pwd|credential|private[-_ ]?key|token)[\w.-]*)\b\s*([:=])\s*([^\s,;\]\)\}]+|\"[^\"]*\"|'[^']*')"
+)
+SECRET_JSON_RE = re.compile(
+    r"(?i)([\"']?[\w.-]*(?:api[-_ ]?key|auth[-_ ]?token|access[-_ ]?token|refresh[-_ ]?token|secret|password|passwd|pwd|credential|private[-_ ]?key)[\w.-]*[\"']?\s*:\s*)([\"'][^\"']*[\"']|[^\s,}\]]+)"
+)
+SECRET_TOKEN_RE = re.compile(
+    r"(?i)\b(?:sk-[A-Za-z0-9_-]{12,}|xox[baprs]-[A-Za-z0-9-]{12,}|gh[pousr]_[A-Za-z0-9_]{20,}|(?:bearer\s+)[A-Za-z0-9._~+/=-]{16,}|[A-Za-z0-9._~+/=-]{32,})\b"
+)
+EMAIL_RE = re.compile(r"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b")
+
+
+def redact_synopsis_field(value: Any, *, limit: int = SYNOPSIS_FIELD_LIMIT) -> str:
+    """Return a compact, Discord-safe synopsis with obvious secrets redacted."""
+    if value is None:
+        text = ""
+    elif isinstance(value, (dict, list, tuple)):
+        try:
+            text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        except Exception:
+            text = str(value)
+    else:
+        text = str(value)
+    text = " ".join(text.split())
+    text = SECRET_FIELD_RE.sub(lambda m: f"{m.group(1)}{m.group(2)}[redacted]", text)
+    text = SECRET_JSON_RE.sub(lambda m: f"{m.group(1)}[redacted]", text)
+    text = SECRET_TOKEN_RE.sub("[redacted]", text)
+    text = EMAIL_RE.sub("[redacted]", text)
+    if len(text) > limit:
+        return text[: max(0, limit - 12)].rstrip() + " …[truncated]"
+    return text
 
 
 @dataclass(frozen=True)
@@ -128,13 +160,14 @@ def build_approval_request(task: Mapping[str, Any], payload: Mapping[str, Any], 
     reason = str(payload.get("reason") or payload.get("summary") or payload.get("error") or "human approval required").strip()
     project_context = project_context or {}
     task_id = str(task.get("id") or payload.get("task_id") or "unknown")
-    title = str(task.get("title") or task_id).strip()
-    project = str(
+    title = redact_synopsis_field(task.get("title") or task_id, limit=140)
+    project = redact_synopsis_field(
         metadata.get("project_title")
         or project_context.get("project_title")
         or project_context.get("project_hub_slug")
         or metadata.get("project")
-        or "not provided"
+        or "not provided",
+        limit=140,
     )
     run_bits = []
     if payload.get("run_id"):
@@ -144,12 +177,12 @@ def build_approval_request(task: Mapping[str, Any], payload: Mapping[str, Any], 
     return ApprovalRequest(
         task_id=task_id,
         title=title,
-        reason=reason,
+        reason=redact_synopsis_field(reason),
         project_context=project,
         run_context=", ".join(run_bits),
-        what_is_approved=str(metadata.get("what_is_approved") or payload.get("what_is_approved") or reason),
-        if_approved=str(metadata.get("if_approved") or payload.get("if_approved") or "the task will be unblocked and returned to the Kanban dispatcher"),
-        risk_rollback=str(metadata.get("risk_rollback") or payload.get("risk_rollback") or "Deny/Needs changes leaves durable evidence and keeps the task blocked for follow-up."),
+        what_is_approved=redact_synopsis_field(metadata.get("what_is_approved") or payload.get("what_is_approved") or reason),
+        if_approved=redact_synopsis_field(metadata.get("if_approved") or payload.get("if_approved") or "the task will be unblocked and returned to the Kanban dispatcher"),
+        risk_rollback=redact_synopsis_field(metadata.get("risk_rollback") or payload.get("risk_rollback") or "Deny/Needs changes leaves durable evidence and keeps the task blocked for follow-up."),
     )
 
 
@@ -159,10 +192,10 @@ def format_approval_content(req: ApprovalRequest, mentions: str = "") -> str:
         f"{prefix}🛂 **Human Kanban approval requested**",
         f"**Task:** `{req.task_id}` — {req.title}",
         f"**Project/run:** {req.project_context}{(' | ' + req.run_context) if req.run_context else ''}",
-        f"**Approve:** {req.what_is_approved}",
-        f"**If approved:** {req.if_approved}",
-        f"**Risk / rollback:** {req.risk_rollback}",
-        f"**Source:** {req.reason}",
+        f"**Approve:** {redact_synopsis_field(req.what_is_approved)}",
+        f"**If approved:** {redact_synopsis_field(req.if_approved)}",
+        f"**Risk / rollback:** {redact_synopsis_field(req.risk_rollback)}",
+        f"**Source:** {redact_synopsis_field(req.reason)}",
     ]
     return "\n".join(lines)[:1900]
 

--- a/hermes_cli/kanban_project_model.py
+++ b/hermes_cli/kanban_project_model.py
@@ -16,9 +16,11 @@ from typing import Any, Iterable
 
 PROJECT_STATUS = {"idea", "active", "blocked", "review", "done", "archived"}
 PROJECT_BODY_MARKER_RE = re.compile(r"^Project Hub slug:\s*(?P<slug>[a-zA-Z0-9][a-zA-Z0-9_-]{0,100})\s*$", re.M)
+PROJECT_TITLE_BODY_MARKER_RE = re.compile(r"^Project title:\s*(?P<title>.+?)\s*$", re.M)
 THREAD_BODY_MARKER_RE = re.compile(r"^Discord thread id:\s*(?P<thread>[0-9]{6,})\s*$", re.M)
 ROOT_BODY_MARKER_RE = re.compile(r"^Kanban root task id:\s*(?P<root>t_[a-f0-9]+|[A-Za-z0-9_-]+)\s*$", re.M)
 STAGE_BODY_MARKER_RE = re.compile(r"^Kanban stage:\s*(?P<stage>.+?)\s*$", re.M)
+RUN_KEY_BODY_MARKER_RE = re.compile(r"^Run key:\s*(?P<run_key>.+?)\s*$", re.M)
 
 ROUTINE_EVENT_KINDS = {"created", "promoted", "claimed", "spawned", "heartbeat", "unblocked", "archived"}
 THREAD_EVENT_KINDS = {"completed", "blocked", "failed", "crashed", "timed_out", "spawn_failed", "gave_up", "commented"}
@@ -80,6 +82,7 @@ def extract_task_project_metadata(task: dict[str, Any], payload: dict[str, Any] 
         "project_status": ("project_status", "status"),
         "stage_name": ("stage_name", "stage", "stage_id"),
         "execution_wave_id": ("execution_wave_id", "wave_id"),
+        "run_key": ("run_key", "build_lane_run_key"),
         "dsr_visible": ("dsr_visible", "dsr_include"),
     }
     for target, keys in aliases.items():
@@ -89,9 +92,11 @@ def extract_task_project_metadata(task: dict[str, Any], payload: dict[str, Any] 
                 out[target] = value
                 break
     out.setdefault("project_hub_slug", _body_marker(body, PROJECT_BODY_MARKER_RE))
+    out.setdefault("project_title", _body_marker(body, PROJECT_TITLE_BODY_MARKER_RE))
     out.setdefault("discord_thread_id", _body_marker(body, THREAD_BODY_MARKER_RE))
     out.setdefault("kanban_root_task_id", _body_marker(body, ROOT_BODY_MARKER_RE))
     out.setdefault("stage_name", _body_marker(body, STAGE_BODY_MARKER_RE))
+    out.setdefault("run_key", _body_marker(body, RUN_KEY_BODY_MARKER_RE))
     if out.get("project_title") in (None, "") and out.get("project_hub_slug"):
         out["project_title"] = task.get("title") or out.get("project_hub_slug")
     if out.get("kanban_root_task_id") in (None, "") and out.get("project_hub_slug"):
@@ -243,6 +248,56 @@ def should_post_project_thread_event(kind: str, payload: dict[str, Any] | None =
     return False
 
 
+def project_thread_key(project: dict[str, Any]) -> str:
+    """Stable Discord thread-state key for a Project Hub run.
+
+    Project Hub slugs are long-lived; Build Lane can create multiple runs for
+    the same slug. Prefer an explicit run key, then the Kanban root id, so fresh
+    starter-helper runs do not collapse into an older forum thread.
+    """
+    slug = str(project.get("project_hub_slug") or "unknown")
+    run_key = project.get("run_key") or project.get("execution_wave_id")
+    if run_key:
+        return f"{slug}:{run_key}"
+    root = project.get("kanban_root_task_id")
+    if root:
+        return f"{slug}:{root}"
+    return slug
+
+
+
+def format_project_thread_starter(project: dict[str, Any]) -> str:
+    """Return the first Discord forum/thread message for a Project Hub run.
+
+    The starter post is the only parent-channel-visible artifact for Discord
+    forum channels, so keep it compact but structured enough for humans,
+    project-thread consumers, and DSR readers to recover the Project Hub slug,
+    Kanban root, and visibility contract without scraping later worker posts.
+    """
+    title = project.get("project_title") or project.get("project_hub_slug") or "Kanban project"
+    slug = project.get("project_hub_slug") or "unknown"
+    root = project.get("kanban_root_task_id") or "unknown"
+    status = project.get("project_status") or "active"
+    stage = project.get("stage_name") or project.get("stage")
+    run_key = project.get("run_key") or project.get("execution_wave_id")
+    task_ids = project.get("task_ids") or []
+    lines = [
+        f"Project thread: {title}",
+        f"Project Hub: `{slug}`",
+        f"Kanban root: `{root}`",
+        f"Status: `{status}`",
+    ]
+    if stage:
+        lines.append(f"Current stage: `{stage}`")
+    if run_key:
+        lines.append(f"Run key: `{run_key}`")
+    if task_ids:
+        lines.append(f"Tracked tasks: {len(task_ids)}")
+    lines.append("DSR: project-linked updates with `dsr_visible`/`dsr_include` metadata are eligible for daily-status consumers.")
+    return "\n".join(lines)[:1800]
+
+
+
 def format_project_thread_update(task: dict[str, Any], kind: str, payload: dict[str, Any] | None, project: dict[str, Any]) -> str:
     payload = payload or {}
     title = task.get("title") or task.get("id") or "task"
@@ -381,6 +436,11 @@ def dsr_project_activity(con: sqlite3.Connection, start_ts: int, end_ts: int, li
         out.append({
             "project_hub_slug": meta.get("project_hub_slug"),
             "project_title": meta.get("project_title") or task.get("title"),
+            "kanban_root_task_id": meta.get("kanban_root_task_id"),
+            "stage_name": meta.get("stage_name"),
+            "run_key": meta.get("run_key"),
+            "discord_thread_id": meta.get("discord_thread_id"),
+            "dsr_visible": bool(payload_meta.get("dsr_visible") or payload_meta.get("dsr_include")),
             "task_id": task.get("id"),
             "title": task.get("title"),
             "assignee": task.get("assignee"),
@@ -399,6 +459,8 @@ __all__ = [
     "project_metadata_markers",
     "resolve_project_context",
     "should_post_project_thread_event",
+    "project_thread_key",
+    "format_project_thread_starter",
     "format_project_thread_update",
     "project_rows",
     "archive_completed_project_tasks",

--- a/hermes_cli/kanban_project_model.py
+++ b/hermes_cli/kanban_project_model.py
@@ -1,0 +1,406 @@
+"""Project-level helpers for the Hermes Kanban execution model.
+
+Project Hub remains canonical; Kanban tasks carry execution metadata in event
+payloads, run metadata, and lightweight body markers. These helpers are kept
+pure-SQL / JSON so they can be reused by the Discord watcher, dashboard, DSR,
+and janitor without importing gateway code.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import time
+from dataclasses import dataclass, asdict
+from typing import Any, Iterable
+
+PROJECT_STATUS = {"idea", "active", "blocked", "review", "done", "archived"}
+PROJECT_BODY_MARKER_RE = re.compile(r"^Project Hub slug:\s*(?P<slug>[a-zA-Z0-9][a-zA-Z0-9_-]{0,100})\s*$", re.M)
+THREAD_BODY_MARKER_RE = re.compile(r"^Discord thread id:\s*(?P<thread>[0-9]{6,})\s*$", re.M)
+ROOT_BODY_MARKER_RE = re.compile(r"^Kanban root task id:\s*(?P<root>t_[a-f0-9]+|[A-Za-z0-9_-]+)\s*$", re.M)
+STAGE_BODY_MARKER_RE = re.compile(r"^Kanban stage:\s*(?P<stage>.+?)\s*$", re.M)
+
+ROUTINE_EVENT_KINDS = {"created", "promoted", "claimed", "spawned", "heartbeat", "unblocked", "archived"}
+THREAD_EVENT_KINDS = {"completed", "blocked", "failed", "crashed", "timed_out", "spawn_failed", "gave_up", "commented"}
+PROJECT_EVENT_KINDS = {"project_kickoff", "project_stage_started", "project_stage_completed", "project_final_summary", "project_blocked", "project_review"}
+DANGER_EVENT_KINDS = {"blocked", "failed", "crashed", "timed_out", "spawn_failed", "gave_up"}
+
+
+def _json_loads(raw: Any, default: Any = None) -> Any:
+    if raw is None or raw == "":
+        return default
+    if isinstance(raw, (dict, list)):
+        return raw
+    try:
+        return json.loads(raw)
+    except Exception:
+        return default
+
+
+def _meta_from_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
+    if not payload:
+        return {}
+    meta = payload.get("metadata") or payload.get("project") or {}
+    if isinstance(meta, str):
+        meta = _json_loads(meta, {})
+    return meta if isinstance(meta, dict) else {}
+
+
+def _body_marker(body: str | None, regex: re.Pattern[str]) -> str | None:
+    if not body:
+        return None
+    m = regex.search(body)
+    if not m:
+        return None
+    return next(iter(m.groupdict().values())).strip()
+
+
+def extract_task_project_metadata(task: dict[str, Any], payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Return normalized project metadata from task body + event/run payload.
+
+    Supported keys:
+    - project_hub_slug
+    - project_title
+    - discord_thread_id
+    - kanban_root_task_id
+    - project_status
+    - stage_name
+    - execution_wave_id
+    - dsr_visible
+    """
+    body = task.get("body") or ""
+    payload = payload or {}
+    meta = _meta_from_payload(payload).copy()
+    out: dict[str, Any] = {}
+    aliases = {
+        "project_hub_slug": ("project_hub_slug", "project_slug", "hub_slug"),
+        "project_title": ("project_title", "title"),
+        "discord_thread_id": ("discord_thread_id", "thread_id"),
+        "kanban_root_task_id": ("kanban_root_task_id", "root_task_id", "root_id"),
+        "project_status": ("project_status", "status"),
+        "stage_name": ("stage_name", "stage", "stage_id"),
+        "execution_wave_id": ("execution_wave_id", "wave_id"),
+        "dsr_visible": ("dsr_visible", "dsr_include"),
+    }
+    for target, keys in aliases.items():
+        for key in keys:
+            value = meta.get(key) or payload.get(key)
+            if value not in (None, ""):
+                out[target] = value
+                break
+    out.setdefault("project_hub_slug", _body_marker(body, PROJECT_BODY_MARKER_RE))
+    out.setdefault("discord_thread_id", _body_marker(body, THREAD_BODY_MARKER_RE))
+    out.setdefault("kanban_root_task_id", _body_marker(body, ROOT_BODY_MARKER_RE))
+    out.setdefault("stage_name", _body_marker(body, STAGE_BODY_MARKER_RE))
+    if out.get("project_title") in (None, "") and out.get("project_hub_slug"):
+        out["project_title"] = task.get("title") or out.get("project_hub_slug")
+    if out.get("kanban_root_task_id") in (None, "") and out.get("project_hub_slug"):
+        out["kanban_root_task_id"] = task.get("id")
+    status = str(out.get("project_status") or "").strip().lower()
+    if status and status not in PROJECT_STATUS:
+        status = "active"
+    if status:
+        out["project_status"] = status
+    if "dsr_visible" in out:
+        out["dsr_visible"] = bool(out["dsr_visible"])
+    return {k: v for k, v in out.items() if v not in (None, "")}
+
+
+def project_metadata_markers(
+    *,
+    project_hub_slug: str,
+    project_title: str | None = None,
+    discord_thread_id: str | None = None,
+    kanban_root_task_id: str | None = None,
+    stage_name: str | None = None,
+) -> str:
+    lines = ["", "---", "Kanban project metadata:", f"Project Hub slug: {project_hub_slug}"]
+    if project_title:
+        lines.append(f"Project title: {project_title}")
+    if discord_thread_id:
+        lines.append(f"Discord thread id: {discord_thread_id}")
+    if kanban_root_task_id:
+        lines.append(f"Kanban root task id: {kanban_root_task_id}")
+    if stage_name:
+        lines.append(f"Kanban stage: {stage_name}")
+    return "\n".join(lines) + "\n"
+
+
+def task_lookup(con: sqlite3.Connection, task_id: str) -> dict[str, Any]:
+    con.row_factory = sqlite3.Row
+    row = con.execute("SELECT * FROM tasks WHERE id=?", (task_id,)).fetchone()
+    return dict(row) if row else {"id": task_id, "title": task_id, "body": "", "status": "unknown", "assignee": "unknown"}
+
+
+def latest_run_metadata(con: sqlite3.Connection, task_id: str) -> dict[str, Any]:
+    con.row_factory = sqlite3.Row
+    row = con.execute(
+        "SELECT metadata, summary, outcome FROM task_runs WHERE task_id=? ORDER BY COALESCE(ended_at, started_at) DESC, id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if not row:
+        return {}
+    meta = _json_loads(row["metadata"], {}) or {}
+    if not isinstance(meta, dict):
+        meta = {}
+    if row["summary"]:
+        meta.setdefault("latest_summary", row["summary"])
+    if row["outcome"]:
+        meta.setdefault("latest_outcome", row["outcome"])
+    return meta
+
+
+def component_task_ids(con: sqlite3.Connection, task_id: str) -> set[str]:
+    seen = {task_id}
+    q = [task_id]
+    while q:
+        cur = q.pop(0)
+        for row in con.execute("SELECT parent_id, child_id FROM task_links WHERE parent_id=? OR child_id=?", (cur, cur)).fetchall():
+            parent, child = row["parent_id"], row["child_id"]
+            for nxt in (parent, child):
+                if nxt not in seen:
+                    seen.add(nxt)
+                    q.append(nxt)
+    return seen
+
+
+def component_tasks(con: sqlite3.Connection, task_id: str) -> list[dict[str, Any]]:
+    return [task_lookup(con, tid) for tid in sorted(component_task_ids(con, task_id))]
+
+
+def component_root(con: sqlite3.Connection, tasks: list[dict[str, Any]]) -> dict[str, Any]:
+    ids = {t["id"] for t in tasks}
+    if not ids:
+        return {}
+    placeholders = ",".join("?" for _ in ids)
+    rows = con.execute(f"SELECT child_id FROM task_links WHERE child_id IN ({placeholders})", tuple(ids)).fetchall()
+    children = {r["child_id"] for r in rows}
+    roots = [t for t in tasks if t["id"] not in children] or tasks
+    roots.sort(key=lambda t: (-(t.get("priority") or 0), t.get("created_at") or 0, t.get("id") or ""))
+    return roots[0]
+
+
+def resolve_project_context(con: sqlite3.Connection, task_id: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    task = task_lookup(con, task_id)
+    meta = extract_task_project_metadata(task, payload)
+    tasks = component_tasks(con, task_id)
+    root = component_root(con, tasks)
+    if not meta.get("project_hub_slug"):
+        for candidate in [root, *tasks]:
+            candidate_meta = extract_task_project_metadata(candidate, payload if candidate.get("id") == task_id else None)
+            if candidate_meta.get("project_hub_slug"):
+                meta = {**candidate_meta, **meta}
+                break
+    if meta.get("project_hub_slug"):
+        meta.setdefault("kanban_root_task_id", root.get("id") or task_id)
+        meta.setdefault("project_title", root.get("title") or task.get("title") or meta["project_hub_slug"])
+        meta.setdefault("project_status", map_project_status(tasks))
+        meta["task_ids"] = sorted(t["id"] for t in tasks)
+        return meta
+    return {}
+
+
+def map_project_status(tasks: Iterable[dict[str, Any]]) -> str:
+    statuses = {str(t.get("status") or "").lower() for t in tasks}
+    active = statuses - {"archived"}
+    if not active:
+        return "archived"
+    if "blocked" in active:
+        return "blocked"
+    if "review" in active:
+        return "review"
+    if active and active <= {"done"}:
+        return "done"
+    if active & {"ready", "running", "todo", "scheduled", "triage"}:
+        return "active"
+    return "active"
+
+
+def should_post_project_thread_event(kind: str, payload: dict[str, Any] | None = None) -> bool:
+    payload = payload or {}
+    if kind in PROJECT_EVENT_KINDS:
+        return True
+    if kind in ROUTINE_EVENT_KINDS:
+        return False
+    if kind in DANGER_EVENT_KINDS:
+        return True
+    if kind == "completed":
+        meta = _meta_from_payload(payload)
+        # Completion summaries are required for Kanban handoffs, but they are
+        # not automatically Discord-worthy. Project-thread completion posts are
+        # opt-in via explicit user-visible / DSR / final-project metadata so
+        # routine leaf completions do not become thread spam.
+        return bool(
+            meta.get("user_visible_change")
+            or meta.get("dsr_visible")
+            or meta.get("dsr_include")
+            or meta.get("project_final")
+            or meta.get("project_completion")
+        )
+    if kind == "commented":
+        text = str(payload.get("body") or payload.get("comment") or "").lower()
+        return any(word in text for word in ("block", "approval", "review", "done", "complete", "milestone"))
+    return False
+
+
+def format_project_thread_update(task: dict[str, Any], kind: str, payload: dict[str, Any] | None, project: dict[str, Any]) -> str:
+    payload = payload or {}
+    title = task.get("title") or task.get("id") or "task"
+    assignee = task.get("assignee") or "agent"
+    meta = _meta_from_payload(payload)
+    summary = payload.get("summary") or payload.get("result") or meta.get("dsr_summary") or meta.get("latest_summary") or ""
+    stage = project.get("stage_name") or meta.get("stage_name") or meta.get("stage")
+    worker_prefix = f"{assignee}: " if assignee and assignee not in {"worker", "x", "unknown", "unassigned"} else ""
+    if kind == "completed":
+        if meta.get("project_final") or meta.get("project_completion"):
+            return f"✅ Final: {summary or title}"[:1800]
+        lead = "✅ Done"
+        if stage:
+            lead += f" · {stage}"
+        return f"{lead}: {worker_prefix}{title}\n{summary or 'Completed.'}"[:1800]
+    if kind in DANGER_EVENT_KINDS:
+        reason = payload.get("reason") or payload.get("error") or summary or "Needs attention."
+        icon = "⛔" if kind == "blocked" else "⚠️"
+        return f"{icon} {kind.replace('_', ' ').title()}: {title}\n{reason}"[:1800]
+    if kind == "commented":
+        body = payload.get("body") or payload.get("comment") or summary or "Comment added."
+        return f"💬 Update: {title}\n{str(body)[:1200]}"[:1800]
+    if kind in PROJECT_EVENT_KINDS:
+        text = summary or payload.get("message") or title
+        return f"📌 {kind.replace('_', ' ').title()}: {text}"[:1800]
+    return f"• {title}: {summary or kind}"[:1800]
+
+
+def project_rows(con: sqlite3.Connection, include_archived: bool = False) -> list[dict[str, Any]]:
+    con.row_factory = sqlite3.Row
+    rows = con.execute("SELECT * FROM tasks ORDER BY created_at ASC").fetchall()
+    tasks = [dict(r) for r in rows]
+    by_slug: dict[str, dict[str, Any]] = {}
+    for task in tasks:
+        meta = extract_task_project_metadata(task)
+        if not meta.get("project_hub_slug"):
+            continue
+        slug = str(meta["project_hub_slug"])
+        entry = by_slug.setdefault(slug, {
+            "project_hub_slug": slug,
+            "title": meta.get("project_title") or task.get("title") or slug,
+            "project_hub_status": "active",
+            "kanban_root_task_id": meta.get("kanban_root_task_id") or task.get("id"),
+            "discord_thread_id": meta.get("discord_thread_id"),
+            "tasks": [],
+            "active_agents": [],
+            "blockers": [],
+            "latest_update": None,
+            "next_step": None,
+        })
+        entry["tasks"].append(task)
+        if meta.get("discord_thread_id"):
+            entry["discord_thread_id"] = meta["discord_thread_id"]
+        if meta.get("kanban_root_task_id"):
+            entry["kanban_root_task_id"] = meta["kanban_root_task_id"]
+    for slug, entry in list(by_slug.items()):
+        tasks = entry["tasks"]
+        status = map_project_status(tasks)
+        if status == "archived" and not include_archived:
+            del by_slug[slug]
+            continue
+        entry["project_hub_status"] = status
+        active_agents = sorted({t.get("assignee") for t in tasks if t.get("status") in {"ready", "running", "todo", "scheduled", "triage"} and t.get("assignee")})
+        blockers = [t for t in tasks if t.get("status") == "blocked"]
+        entry["active_agents"] = active_agents
+        entry["blockers"] = [{"id": t["id"], "title": t.get("title"), "assignee": t.get("assignee"), "last_failure_error": t.get("last_failure_error")} for t in blockers]
+        latest_task = max(tasks, key=lambda t: max(t.get("completed_at") or 0, t.get("started_at") or 0, t.get("created_at") or 0)) if tasks else None
+        if latest_task:
+            ts = max(latest_task.get("completed_at") or 0, latest_task.get("started_at") or 0, latest_task.get("created_at") or 0)
+            entry["latest_update"] = {"at": ts, "task_id": latest_task.get("id"), "title": latest_task.get("title"), "status": latest_task.get("status")}
+        next_candidates = [t for t in tasks if t.get("status") in {"ready", "running", "todo", "scheduled", "triage", "blocked"}]
+        if next_candidates:
+            next_candidates.sort(key=lambda t: (-(t.get("priority") or 0), t.get("created_at") or 0))
+            entry["next_step"] = next_candidates[0].get("title")
+        entry["counts"] = {s: sum(1 for t in tasks if t.get("status") == s) for s in sorted({t.get("status") for t in tasks})}
+        entry["task_count"] = len(tasks)
+        entry.pop("tasks", None)
+    return sorted(by_slug.values(), key=lambda p: ((p.get("project_hub_status") == "archived"), -(p.get("latest_update") or {}).get("at", 0), p.get("title") or ""))
+
+
+def archive_completed_project_tasks(con: sqlite3.Connection, older_than_seconds: int = 48 * 3600, now_ts: int | None = None, dry_run: bool = False) -> dict[str, Any]:
+    """Silently archive completed project-linked tasks older than retention.
+
+    Adds only `archived` events with `discord_silent=True`; the Discord watcher
+    must ignore archived events regardless.
+    """
+    now_ts = now_ts or int(time.time())
+    cutoff = now_ts - int(older_than_seconds)
+    con.row_factory = sqlite3.Row
+    rows = con.execute("SELECT * FROM tasks WHERE status='done' AND completed_at IS NOT NULL AND completed_at < ?", (cutoff,)).fetchall()
+    candidates = []
+    for row in rows:
+        task = dict(row)
+        if extract_task_project_metadata(task):
+            candidates.append(task)
+    if dry_run:
+        return {"archived": [], "candidates": [t["id"] for t in candidates], "cutoff": cutoff}
+    archived = []
+    with con:
+        for task in candidates:
+            con.execute("UPDATE tasks SET status='archived' WHERE id=? AND status='done'", (task["id"],))
+            con.execute(
+                "INSERT INTO task_events(task_id, run_id, kind, payload, created_at) VALUES (?, NULL, 'archived', ?, ?)",
+                (task["id"], json.dumps({"reason": "project-retention-48h", "discord_silent": True}), now_ts),
+            )
+            archived.append(task["id"])
+    return {"archived": archived, "candidates": [t["id"] for t in candidates], "cutoff": cutoff}
+
+
+def dsr_project_activity(con: sqlite3.Connection, start_ts: int, end_ts: int, limit: int = 20) -> list[dict[str, Any]]:
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        """
+        SELECT t.*, r.summary AS run_summary, r.metadata AS run_metadata, r.outcome AS run_outcome
+        FROM tasks t
+        LEFT JOIN task_runs r ON r.id = (
+            SELECT id FROM task_runs rr WHERE rr.task_id=t.id ORDER BY COALESCE(rr.ended_at, rr.started_at) DESC, rr.id DESC LIMIT 1
+        )
+        WHERE t.completed_at >= ? AND t.completed_at < ?
+        ORDER BY t.completed_at DESC
+        LIMIT ?
+        """,
+        (start_ts, end_ts, limit * 4),
+    ).fetchall()
+    out = []
+    for row in rows:
+        task = dict(row)
+        payload_meta = _json_loads(task.get("run_metadata"), {}) or {}
+        meta = extract_task_project_metadata(task, {"metadata": payload_meta})
+        user_visible = bool(payload_meta.get("user_visible_change") or payload_meta.get("dsr_visible") or payload_meta.get("dsr_include") or payload_meta.get("project_final") or payload_meta.get("project_completion"))
+        if not meta.get("project_hub_slug") and not user_visible:
+            continue
+        if not user_visible and task.get("status") == "done":
+            # DSR should not become a worker attendance sheet.
+            continue
+        out.append({
+            "project_hub_slug": meta.get("project_hub_slug"),
+            "project_title": meta.get("project_title") or task.get("title"),
+            "task_id": task.get("id"),
+            "title": task.get("title"),
+            "assignee": task.get("assignee"),
+            "summary": payload_meta.get("dsr_summary") or task.get("run_summary") or task.get("result") or "completed",
+            "completed_at": task.get("completed_at"),
+            "metadata": payload_meta,
+        })
+        if len(out) >= limit:
+            break
+    return out
+
+
+__all__ = [
+    "PROJECT_STATUS",
+    "extract_task_project_metadata",
+    "project_metadata_markers",
+    "resolve_project_context",
+    "should_post_project_thread_event",
+    "format_project_thread_update",
+    "project_rows",
+    "archive_completed_project_tasks",
+    "dsr_project_activity",
+]

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -759,45 +759,12 @@ class DiscordAdapter(BasePlatformAdapter):
                 so route their custom_id prefix here and leave every other
                 interaction to discord.py's normal command/component machinery.
                 """
-                data = getattr(interaction, "data", None) or {}
-                custom_id = data.get("custom_id") if isinstance(data, dict) else None
-                if not custom_id:
-                    return
                 try:
-                    from hermes_cli.kanban_discord_approvals import (
-                        apply_approval_decision,
-                        parse_custom_id,
-                    )
-                    parsed = parse_custom_id(str(custom_id))
-                    if not parsed:
-                        return
-                    task_id, action = parsed
-                    if not _component_check_auth(
+                    await handle_kanban_approval_interaction(
                         interaction,
                         adapter_self._allowed_user_ids,
                         adapter_self._allowed_role_ids,
-                    ):
-                        await interaction.response.send_message(
-                            "You're not authorized to approve Kanban gates~",
-                            ephemeral=True,
-                        )
-                        return
-                    actor = f"{getattr(interaction.user, 'display_name', '')} ({getattr(interaction.user, 'id', '')})"
-                    result = apply_approval_decision(task_id, action, actor)
-                    label = {
-                        "approve": "Approved",
-                        "deny": "Denied",
-                        "needs_changes": "Needs changes requested",
-                    }[action]
-                    for child in getattr(interaction.message, "components", []) or []:
-                        for item in getattr(child, "children", []) or []:
-                            try:
-                                item.disabled = True
-                            except Exception:
-                                pass
-                    content = (getattr(interaction.message, "content", "") or "")
-                    content = f"{content}\n\n**Decision:** {label} by {getattr(interaction.user, 'display_name', 'unknown')} (`{result}`)"[:1900]
-                    await interaction.response.edit_message(content=content, view=None)
+                    )
                 except Exception as exc:
                     logger.exception("Failed to handle Kanban approval component: %s", exc)
                     try:
@@ -5086,6 +5053,52 @@ def _component_check_auth(
             return True
 
     return False
+
+
+async def handle_kanban_approval_interaction(
+    interaction,
+    allowed_user_ids: Optional[set],
+    allowed_role_ids: Optional[set],
+    *,
+    db_path: Optional[_Path] = None,
+) -> bool:
+    """Handle a persistent Kanban approval component, if the custom_id matches."""
+    data = getattr(interaction, "data", None) or {}
+    custom_id = data.get("custom_id") if isinstance(data, dict) else None
+    if not custom_id:
+        return False
+    from hermes_cli.kanban_discord_approvals import (
+        apply_approval_decision,
+        parse_custom_id,
+    )
+
+    parsed = parse_custom_id(str(custom_id))
+    if not parsed:
+        return False
+    task_id, action = parsed
+    if not _component_check_auth(interaction, allowed_user_ids, allowed_role_ids):
+        await interaction.response.send_message(
+            "You're not authorized to approve Kanban gates~",
+            ephemeral=True,
+        )
+        return True
+    actor = f"{getattr(interaction.user, 'display_name', '')} ({getattr(interaction.user, 'id', '')})"
+    result = apply_approval_decision(task_id, action, actor, db_path=db_path)
+    label = {
+        "approve": "Approved",
+        "deny": "Denied",
+        "needs_changes": "Needs changes requested",
+    }[action]
+    for child in getattr(getattr(interaction, "message", None), "components", []) or []:
+        for item in getattr(child, "children", []) or []:
+            try:
+                item.disabled = True
+            except Exception:
+                pass
+    content = (getattr(getattr(interaction, "message", None), "content", "") or "")
+    content = f"{content}\n\n**Decision:** {label} by {getattr(interaction.user, 'display_name', 'unknown')} (`{result}`)"[:1900]
+    await interaction.response.edit_message(content=content, view=None)
+    return True
 
 
 def _define_discord_view_classes() -> None:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -750,6 +750,64 @@ class DiscordAdapter(BasePlatformAdapter):
                     adapter_self._run_post_connect_initialization()
                 )
 
+            @self._client.listen("on_interaction")
+            async def _kanban_approval_on_interaction(interaction: discord.Interaction):
+                """Handle persistent Kanban approval components posted by watchers.
+
+                The Kanban Discord mirror posts raw Discord components via REST;
+                those buttons are not attached to an in-memory discord.py View,
+                so route their custom_id prefix here and leave every other
+                interaction to discord.py's normal command/component machinery.
+                """
+                data = getattr(interaction, "data", None) or {}
+                custom_id = data.get("custom_id") if isinstance(data, dict) else None
+                if not custom_id:
+                    return
+                try:
+                    from hermes_cli.kanban_discord_approvals import (
+                        apply_approval_decision,
+                        parse_custom_id,
+                    )
+                    parsed = parse_custom_id(str(custom_id))
+                    if not parsed:
+                        return
+                    task_id, action = parsed
+                    if not _component_check_auth(
+                        interaction,
+                        adapter_self._allowed_user_ids,
+                        adapter_self._allowed_role_ids,
+                    ):
+                        await interaction.response.send_message(
+                            "You're not authorized to approve Kanban gates~",
+                            ephemeral=True,
+                        )
+                        return
+                    actor = f"{getattr(interaction.user, 'display_name', '')} ({getattr(interaction.user, 'id', '')})"
+                    result = apply_approval_decision(task_id, action, actor)
+                    label = {
+                        "approve": "Approved",
+                        "deny": "Denied",
+                        "needs_changes": "Needs changes requested",
+                    }[action]
+                    for child in getattr(interaction.message, "components", []) or []:
+                        for item in getattr(child, "children", []) or []:
+                            try:
+                                item.disabled = True
+                            except Exception:
+                                pass
+                    content = (getattr(interaction.message, "content", "") or "")
+                    content = f"{content}\n\n**Decision:** {label} by {getattr(interaction.user, 'display_name', 'unknown')} (`{result}`)"[:1900]
+                    await interaction.response.edit_message(content=content, view=None)
+                except Exception as exc:
+                    logger.exception("Failed to handle Kanban approval component: %s", exc)
+                    try:
+                        await interaction.response.send_message(
+                            f"Failed to record Kanban approval: {exc}",
+                            ephemeral=True,
+                        )
+                    except Exception:
+                        pass
+
             @self._client.event
             async def on_message(message: DiscordMessage):
                 # Block until _resolve_allowed_usernames has swapped

--- a/scripts/kanban_discord_log.py
+++ b/scripts/kanban_discord_log.py
@@ -1,0 +1,815 @@
+#!/usr/bin/env python3
+"""Post Hermes Kanban task events to Discord.
+
+Watches ~/.hermes/kanban.db task_events and posts lifecycle updates. By default,
+connected Kanban task graphs are grouped into project-scoped Discord threads
+instead of a noisy flat #kanban-log stream.
+
+Managed local deployment:
+    install -m 0755 scripts/kanban_discord_log.py ~/.hermes/scripts/kanban_discord_log.py
+
+The checked-in script is the runtime source of truth for the local watcher; the
+copy under ~/.hermes/scripts/ is just the operator-managed deployment target.
+"""
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+from collections import deque
+from pathlib import Path
+
+HERMES_AGENT_ROOT = HOME = Path.home() / ".hermes"
+AGENT_REPO = HERMES_AGENT_ROOT / "hermes-agent"
+if str(AGENT_REPO) not in sys.path:
+    sys.path.insert(0, str(AGENT_REPO))
+
+from hermes_cli import kanban_project_model as kpm  # type: ignore
+from hermes_cli import kanban_discord_approvals as kap  # type: ignore
+
+ENV_PATH = HOME / ".env"
+
+
+def resolve_db_path() -> Path:
+    raw = (os.getenv("KANBAN_DB_PATH") or "").strip()
+    if not raw or raw.lower() == "default":
+        return HOME / "kanban.db"
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        path = HOME / path
+    return path
+
+
+def resolve_state_path() -> Path:
+    raw = (os.getenv("KANBAN_DISCORD_LOG_STATE") or "").strip()
+    if not raw:
+        return HOME / "state" / "kanban_discord_log_state.json"
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        path = HOME / path
+    return path
+
+
+DB_PATH = resolve_db_path()
+STATE_PATH = resolve_state_path()
+CHANNEL_NAME = os.getenv("DISCORD_KANBAN_LOG_CHANNEL_NAME", "kanban-log")
+PROJECT_CHANNEL_NAME = os.getenv("DISCORD_KANBAN_PROJECT_LOG_CHANNEL_NAME", "kanban-project-logs")
+RED_CHANNEL_NAME = os.getenv("DISCORD_RED_KANBAN_LOG_CHANNEL_NAME", "red-kanban-log")
+RED_ASSIGNEES = {
+    "red-antonetta",
+    "red-scribe",
+    "red-recon",
+    "red-labops",
+    "red-reporter",
+    "red-reviewer",
+    "red-exploitdev",
+    "red-toolsmith",
+}
+SYNTHETIC_CREATED_BY = {"weak-handoff-replay", "sparse-handoff-robustness", "threshold-supplement"}
+SYNTHETIC_ROOT_PREFIXES = ("root ",)
+POLL_SECONDS = int(os.getenv("KANBAN_LOG_POLL_SECONDS", "5"))
+THREAD_MODE = os.getenv("KANBAN_DISCORD_THREAD_MODE", "1").lower() not in {"0", "false", "no"}
+THREAD_DEBUG = os.getenv("KANBAN_DISCORD_THREAD_DEBUG", "").lower() in {"1", "true", "yes"}
+NOISE_KINDS = {"claimed", "spawned", "heartbeat"}
+DANGER = {"blocked", "failed", "crashed", "timed_out", "spawn_failed", "gave_up"}
+TERMINAL_STATUSES = {"done", "archived"}
+PROJECT_WORDS = ("project", "orchestrat", "umbrella", "fan-in", "fanout", "fan-out", "milestone", "phase")
+
+
+def load_env(path: Path):
+    if not path.exists():
+        return
+    for line in path.read_text(errors="ignore").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+
+def discord_api(method, endpoint, body=None):
+    token = os.environ["DISCORD_BOT_TOKEN"]
+    cmd = [
+        "curl", "-sS", "-X", method,
+        "-H", f"Authorization: Bot {token}",
+        "-H", "Content-Type: application/json",
+        "-H", "User-Agent: DiscordBot (https://github.com/NousResearch/hermes-agent, 1.0)",
+    ]
+    if body is not None:
+        cmd += ["--data", json.dumps(body)]
+    cmd.append(f"https://discord.com/api/v10{endpoint}")
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=30)
+    if proc.returncode != 0:
+        raise RuntimeError(f"Discord API curl failed for {method} {endpoint}: {proc.stderr.strip()}")
+    raw = proc.stdout.strip()
+    if not raw:
+        return {}
+    data = json.loads(raw)
+    if isinstance(data, dict) and "code" in data and "message" in data and str(data.get("code")) not in ("0",):
+        raise RuntimeError(f"Discord API {method} {endpoint} returned error code {data.get('code')}: {data.get('message')}")
+    return data
+
+
+def post(channel_id, content, dry_run=False, components=None):
+    body = content if isinstance(content, dict) else {"content": content}
+    if components is not None:
+        body["components"] = components
+    text = str(body.get("content") or "")
+    if len(text) > 1900:
+        body["content"] = text[:1850] + "\n…[truncated]"
+    if dry_run:
+        print(f"DRY-RUN post channel={channel_id}:\n{body.get('content', '')}\ncomponents={json.dumps(body.get('components', []), ensure_ascii=False)}\n---")
+        return {"id": f"dry-msg-{int(time.time() * 1000)}", "channel_id": channel_id}
+    return discord_api("POST", f"/channels/{channel_id}/messages", body)
+
+
+_CHANNEL_CACHE = {}
+
+
+def get_channel(channel_id, dry_run=False):
+    if dry_run:
+        return {"id": channel_id, "type": 0, "name": f"dry-{channel_id}"}
+    if channel_id not in _CHANNEL_CACHE:
+        _CHANNEL_CACHE[channel_id] = discord_api("GET", f"/channels/{channel_id}")
+    return _CHANNEL_CACHE[channel_id]
+
+
+def create_thread(parent_channel_id, name, message, dry_run=False, applied_tags=None):
+    parent = get_channel(parent_channel_id, dry_run=dry_run)
+    parent_type = int(parent.get("type", 0) or 0)
+    body = {"name": name[:90], "auto_archive_duration": 10080, "message": {"content": message}}
+    # Text channels need an explicit public-thread type. Forum/media channels
+    # create posts via the same endpoint but reject/ignore the text-thread type;
+    # the created post's thread id is still returned as `id` and can be reused
+    # by the project_threads state map.
+    if parent_type not in {15, 16}:  # GUILD_FORUM / GUILD_MEDIA
+        body["type"] = 11
+    elif applied_tags:
+        body["applied_tags"] = list(applied_tags)
+    if dry_run:
+        thread_id = f"dry-thread-{parent_channel_id}-{abs(hash(name)) % 100000}"
+        surface = "forum-post" if parent_type in {15, 16} else "thread"
+        print(f"DRY-RUN create_{surface} parent={parent_channel_id} name={name}:\n{message}\n---")
+        return {"id": thread_id, "parent_id": parent_channel_id, "name": name}
+    return discord_api("POST", f"/channels/{parent_channel_id}/threads", body)
+
+
+def ensure_channel():
+    return ensure_named_channel(
+        configured=os.getenv("DISCORD_KANBAN_LOG_CHANNEL") or os.getenv("DISCORD_KANBAN_LOG_CHANNEL_ID"),
+        name=CHANNEL_NAME,
+        topic="Hermes Kanban lifecycle log: project thread milestones plus compact one-off events.",
+        required_label="DISCORD_KANBAN_LOG_CHANNEL",
+    )
+
+
+def ensure_red_channel(default_channel_id):
+    configured = os.getenv("DISCORD_RED_KANBAN_LOG_CHANNEL") or os.getenv("DISCORD_RED_KANBAN_LOG_CHANNEL_ID")
+    if not configured:
+        return default_channel_id
+    return ensure_named_channel(
+        configured=configured,
+        name=RED_CHANNEL_NAME,
+        topic="Hermes Red-lane Kanban lifecycle log. Scope-sensitive red project milestones only.",
+        required_label="DISCORD_RED_KANBAN_LOG_CHANNEL",
+    )
+
+
+def ensure_project_channel(default_channel_id):
+    configured = os.getenv("DISCORD_KANBAN_PROJECT_LOG_CHANNEL") or os.getenv("DISCORD_KANBAN_PROJECT_LOG_CHANNEL_ID")
+    if configured:
+        return configured
+    return ensure_named_channel(
+        configured=None,
+        name=PROJECT_CHANNEL_NAME,
+        topic="Project-scoped Hermes Kanban logs. One thread per umbrella project; completion pings happen inside the project thread.",
+        required_label="DISCORD_KANBAN_PROJECT_LOG_CHANNEL",
+    )
+
+
+def ensure_named_channel(configured=None, name=None, topic=None, required_label="DISCORD_KANBAN_LOG_CHANNEL"):
+    if configured:
+        return configured
+    home_channel = os.environ.get("DISCORD_HOME_CHANNEL") or os.environ.get("DISCORD_SYSTEM_CHANNEL")
+    if not home_channel:
+        raise RuntimeError(f"Need DISCORD_HOME_CHANNEL or {required_label} in ~/.hermes/.env")
+    home = discord_api("GET", f"/channels/{home_channel}")
+    guild_id = home.get("guild_id")
+    if not guild_id:
+        raise RuntimeError("Configured Discord home channel is not a guild channel; cannot infer guild")
+    channels = discord_api("GET", f"/guilds/{guild_id}/channels")
+    for ch in channels:
+        if ch.get("name") == name and ch.get("type") in {0, 15, 16}:
+            return ch["id"]
+    created = discord_api("POST", f"/guilds/{guild_id}/channels", {"name": name, "type": 0, "topic": topic})
+    return created["id"]
+
+
+def load_state():
+    if STATE_PATH.exists():
+        try:
+            state = json.loads(STATE_PATH.read_text())
+            state.setdefault("components", {})
+            state.setdefault("task_aliases", {})
+            state.setdefault("red_thread_posts", {})
+            return state
+        except Exception:
+            pass
+    return {"last_event_id": 0, "components": {}, "task_aliases": {}, "red_thread_posts": {}}
+
+
+def save_state(state):
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = STATE_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True))
+    tmp.replace(STATE_PATH)
+
+
+def parse_payload(raw):
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except Exception:
+        return {"raw": raw}
+
+
+def parse_task_metadata(payload):
+    metadata = payload.get("metadata") or {}
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except Exception:
+            metadata = {}
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def extract_thread_id(task, payload):
+    metadata = parse_task_metadata(payload)
+    for key in ("discord_thread_id", "thread_id"):
+        value = metadata.get(key)
+        if value:
+            return str(value)
+    body = task.get("body") or ""
+    import re
+    for pattern in (
+        r"Discord thread id:\s*([0-9]{6,})",
+        r"Discord thread:\s*`?([0-9]{6,})`?",
+    ):
+        m = re.search(pattern, body, flags=re.I)
+        if m:
+            return m.group(1)
+    return None
+
+
+def summarize_findings(metadata):
+    findings = metadata.get("findings") or metadata.get("decisions") or metadata.get("outputs") or []
+    if isinstance(findings, str):
+        findings = [findings]
+    if not isinstance(findings, list):
+        return []
+    out = []
+    for item in findings:
+        text = str(item).strip()
+        if text:
+            out.append(text.rstrip('.'))
+        if len(out) >= 3:
+            break
+    return out
+
+
+def suggest_next_action(task, payload):
+    metadata = parse_task_metadata(payload)
+    for key in ("recommended_next_skill", "next_wave_priority", "follow_on_branch_executed"):
+        value = metadata.get(key)
+        if value:
+            return str(value).strip()
+    summary = payload.get("summary") or payload.get("result") or ""
+    if "queued successor orchestrator" in summary.lower():
+        return "successor orchestrator queued to fan out the next wave"
+    return f"review downstream handoff from `{task.get('id')}` and use it for the next justified branch"
+
+
+def format_red_thread_update(task, ev, payload):
+    metadata = parse_task_metadata(payload)
+    title = (task.get("title") or task.get("id") or "task").strip()
+    assignee = (task.get("assignee") or payload.get("assignee") or "unknown").strip()
+    kind = ev["kind"]
+    lines = [f"🧠 **Worker update:** {title}", f"👤 **Owner:** `{assignee}`"]
+    if kind == "created":
+        parents = payload.get("parents") or []
+        if isinstance(parents, str):
+            parents = [parents]
+        lines.append("🚦 **Stage status:** queued")
+        if parents:
+            lines.append(f"🔗 **Depends on:** {', '.join(str(p) for p in parents[:4])}")
+        lines.append("📌 **Why it exists:** new branch/stage created and waiting to start")
+    elif kind == "claimed":
+        lines.append("▶️ **Stage status:** started")
+        run_id = payload.get("run_id")
+        if run_id:
+            lines.append(f"🆔 **Run id:** `{run_id}`")
+        lines.append("⚙️ **What is happening:** worker claimed the branch and execution is underway")
+    elif kind == "completed":
+        summary = (payload.get("summary") or payload.get("result") or "completed").strip()
+        lines.append("✅ **Stage status:** finished")
+        lines.append(f"📝 **Summary:** {summary}")
+        findings = summarize_findings(metadata)
+        if findings:
+            lines.append("🔍 **Findings:**")
+            for item in findings:
+                lines.append(f"- {item}")
+        lines.append(f"➡️ **Suggested next action:** {suggest_next_action(task, payload)}")
+    elif kind == "blocked":
+        reason = payload.get("reason") or payload.get("summary") or payload.get("error") or "blocked"
+        lines.append("⛔ **Stage status:** blocked")
+        lines.append(f"🚧 **Blocked:** {reason}")
+        lines.append("➡️ **Suggested next action:** resolve the blocker or route the missing reviewer/fan-in step, then resume the workflow")
+    else:
+        return None
+    return "\n".join(lines)[:1800]
+
+
+def inherited_component_thread_id(con, task_id):
+    for linked_task in component_tasks(con, task_id):
+        thread_id = extract_thread_id(linked_task, {})
+        if thread_id:
+            return thread_id
+    return None
+
+
+def maybe_post_red_thread_update(con, state, task, ev, payload, dry_run=False):
+    if ev["kind"] not in {"created", "claimed", "completed", "blocked"}:
+        return
+    if not is_red_task(task):
+        return
+    thread_id = extract_thread_id(task, payload) or inherited_component_thread_id(con, ev["task_id"])
+    if not thread_id:
+        return
+    posted = state.setdefault("red_thread_posts", {})
+    event_key = str(ev["id"])
+    if posted.get(event_key):
+        return
+    body = format_red_thread_update(task, ev, payload)
+    if not body:
+        return
+    post(thread_id, body, dry_run=dry_run)
+    posted[event_key] = {"thread_id": thread_id, "task_id": ev["task_id"], "kind": ev["kind"]}
+
+
+def red_thread_target(con, task, payload, task_id):
+    if not is_red_task(task):
+        return None
+    return extract_thread_id(task, payload) or inherited_component_thread_id(con, task_id)
+
+
+def task_lookup(con, task_id):
+    con.row_factory = sqlite3.Row
+    row = con.execute("select id,title,body,assignee,status,priority,created_at,started_at,completed_at,current_run_id,created_by from tasks where id=?", (task_id,)).fetchone()
+    return dict(row) if row else {"id": task_id, "title": "unknown", "body": "", "assignee": "unknown", "status": "unknown", "created_at": 0, "priority": 0, "created_by": ""}
+
+
+def is_synthetic_test_task(task):
+    created_by = (task.get("created_by") or "").strip()
+    title = (task.get("title") or "").strip().lower()
+    if created_by in SYNTHETIC_CREATED_BY:
+        return True
+    return any(title.startswith(prefix) for prefix in SYNTHETIC_ROOT_PREFIXES)
+
+
+def is_red_task(task):
+    assignee = (task.get("assignee") or "").strip()
+    return assignee in RED_ASSIGNEES or assignee.startswith("red-")
+
+
+def component_task_ids(con, task_id):
+    seen = {task_id}
+    q = deque([task_id])
+    while q:
+        cur = q.popleft()
+        rows = con.execute("select parent_id, child_id from task_links where parent_id=? or child_id=?", (cur, cur)).fetchall()
+        for row in rows:
+            parent_id = row["parent_id"] if isinstance(row, sqlite3.Row) else row[0]
+            child_id = row["child_id"] if isinstance(row, sqlite3.Row) else row[1]
+            for nxt in (parent_id, child_id):
+                if nxt not in seen:
+                    seen.add(nxt)
+                    q.append(nxt)
+    return seen
+
+
+def component_tasks(con, task_id):
+    ids = sorted(component_task_ids(con, task_id))
+    return [task_lookup(con, tid) for tid in ids]
+
+
+def component_root(con, tasks):
+    ids = {t["id"] for t in tasks}
+    child_rows = con.execute("select child_id from task_links where child_id in (%s)" % ",".join("?" for _ in ids), tuple(ids)).fetchall() if ids else []
+    children = {r["child_id"] if isinstance(r, sqlite3.Row) else r[0] for r in child_rows}
+    roots = [t for t in tasks if t["id"] not in children] or tasks
+    roots.sort(key=lambda t: (-(t.get("priority") or 0), t.get("created_at") or 0, t.get("id") or ""))
+    return roots[0]
+
+
+def project_trigger(task, payload, component_size):
+    if kpm.extract_task_project_metadata(task, payload):
+        return True
+    if component_size > 1:
+        return True
+    metadata = payload.get("metadata") or {}
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except Exception:
+            metadata = {}
+    if payload.get("project_completion") or metadata.get("project_completion"):
+        return True
+    haystack = f"{task.get('title') or ''}\n{task.get('body') or ''}".lower()
+    return any(word in haystack for word in PROJECT_WORDS)
+
+
+def thread_title(root, tasks):
+    # New project-thread model: Discord thread name matches the Project Hub
+    # title exactly when project metadata is present. Legacy untagged project
+    # graphs still get a `kanban:` prefix so they remain obviously mechanical.
+    meta = kpm.extract_task_project_metadata(root)
+    title = (meta.get("project_title") or root.get("title") or root.get("id") or "Kanban project").strip()
+    if meta.get("project_hub_slug"):
+        return title[:90]
+    return f"kanban: {title}"[:90]
+
+
+def choose_component_channel(tasks, general_channel_id, red_channel_id):
+    return red_channel_id if any(is_red_task(t) for t in tasks) else general_channel_id
+
+
+def refresh_component_state(con, state, root, tasks, channel_id):
+    root_id = root["id"]
+    comp = state.setdefault("components", {}).setdefault(root_id, {})
+    comp.setdefault("thread_id", None)
+    comp["channel_id"] = channel_id
+    comp["title"] = thread_title(root, tasks)
+    comp["task_ids"] = sorted(t["id"] for t in tasks)
+    comp.setdefault("status", "open")
+    comp.setdefault("completed_ping_sent", False)
+    for tid in comp["task_ids"]:
+        state.setdefault("task_aliases", {})[tid] = root_id
+    return comp
+
+
+def project_terminal_state(tasks):
+    active = [t for t in tasks if t.get("status") != "archived"]
+    if active and all(t.get("status") == "done" for t in active):
+        return "completed"
+    if any(t.get("status") == "blocked" for t in active):
+        return "blocked"
+    if any(t.get("status") in {"failed", "crashed", "timed_out", "spawn_failed"} for t in active):
+        return "failed"
+    return None
+
+
+def explicit_project_completion(payload):
+    metadata = payload.get("metadata") or {}
+    if isinstance(metadata, str):
+        try:
+            metadata = json.loads(metadata)
+        except Exception:
+            metadata = {}
+    return bool(payload.get("project_completion") or metadata.get("project_completion"))
+
+
+def allowed_user_mentions():
+    users = [u.strip() for u in os.environ.get("DISCORD_ALLOWED_USERS", "").replace(",", " ").split() if u.strip()]
+    return " ".join(f"<@{u}>" for u in users)
+
+
+def maybe_post_human_approval(task, ev, payload, target_channel_id, project_ctx=None, dry_run=False):
+    if not kap.is_human_approval_gate(task, ev["kind"], payload):
+        return False
+    req = kap.build_approval_request(task, {**payload, "run_id": ev.get("run_id")}, project_ctx)
+    body = kap.build_message_payload(req, allowed_user_mentions())
+    post(target_channel_id, body, dry_run=dry_run)
+    return True
+
+
+def recent_task_failures(con, task_id):
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        """
+        select outcome, status, error, summary, profile, started_at, ended_at
+        from task_runs
+        where task_id=?
+        order by started_at desc
+        limit 5
+        """,
+        (task_id,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def recovery_suggestions(task, kind, payload, failures):
+    title = (task.get("title") or "").lower()
+    assignee = task.get("assignee") or "unknown"
+    outcomes = [f.get("outcome") or f.get("status") for f in failures if f.get("outcome") or f.get("status")]
+    repeated = len([o for o in outcomes if o in {"crashed", "timed_out", "spawn_failed", "failed", "blocked"}]) >= 2
+    gave_up = kind == "gave_up" or payload.get("trigger_outcome") or payload.get("failures")
+    if not (repeated or gave_up or kind in {"blocked", "spawn_failed"}):
+        return []
+    suggestions = []
+    if kind == "blocked":
+        suggestions.extend([
+            "answer the blocker in-thread, then unblock/requeue the same task",
+            "create a smaller recovery task with the blocked task id in context",
+            "if the blocker is a missing decision/credential, resolve that explicitly before retrying",
+        ])
+    elif "spawn_failed" in outcomes or kind == "spawn_failed":
+        suggestions.extend([
+            f"smoke-test profile `{assignee}` directly (`hermes --profile {assignee} chat -Q -q ...`)",
+            "check profile auth/config/toolsets and missing skill names",
+            "after profile is healthy, reset/requeue the task instead of cloning blindly",
+        ])
+    elif "timed_out" in outcomes:
+        suggestions.extend([
+            "split the work into a smaller recovery task with tighter acceptance criteria",
+            "raise max_runtime_seconds only if progress/heartbeat evidence shows it was genuinely still working",
+            "ask the worker to write partial artifacts early so retries can resume instead of restart",
+        ])
+    elif "crashed" in outcomes or kind == "crashed" or kind == "gave_up":
+        suggestions.extend([
+            f"smoke-test profile `{assignee}` outside Kanban to separate profile crash from task logic",
+            "inspect the latest run/gateway logs for the first traceback or missing dependency",
+            "create a bounded recovery task carrying this task id, prior errors, and any parent handoff",
+        ])
+    else:
+        suggestions.extend([
+            "inspect task comments/runs before retrying",
+            "make a smaller recovery task if the same failure repeats",
+            "route to a more appropriate specialist if the assignee is mismatched",
+        ])
+    if any(word in title for word in ("discord", "gateway", "kanban-log", "watcher")):
+        suggestions.append("for Discord/gateway work, verify env channel ids and send a test message before requeueing")
+    out = []
+    for s in suggestions:
+        if s not in out:
+            out.append(s)
+    return out[:4]
+
+
+def format_event(con, ev, compact=False):
+    task = task_lookup(con, ev["task_id"])
+    payload = parse_payload(ev.get("payload"))
+    kind = ev["kind"]
+    title = task.get("title") or "untitled"
+    assignee = task.get("assignee") or "unassigned"
+    status = task.get("status") or "unknown"
+    failures = recent_task_failures(con, ev["task_id"]) if (kind in DANGER or payload.get("outcome") in DANGER) else []
+    suggestions = recovery_suggestions(task, kind, payload, failures)
+    prefix = "Kanban" if not compact else "•"
+    lines = [
+        f"{prefix} {kind}: {title}",
+        f"task: `{ev['task_id']}` | assignee: `{assignee}` | status: `{status}` | run: `{ev.get('run_id') or '-'}`",
+    ]
+    if kind == "created":
+        parents = payload.get("parents") or []
+        lines.append(f"created for `{payload.get('assignee', assignee)}`; parents: {', '.join(parents) if parents else 'none'}")
+    elif kind == "claimed":
+        lines.append(f"claimed by `{payload.get('lock', 'unknown')}`")
+    elif kind == "spawned":
+        lines.append(f"spawned pid `{payload.get('pid', 'unknown')}`")
+    elif kind == "completed":
+        summary = payload.get("summary") or payload.get("result") or "completed"
+        lines.append(f"summary: {summary}")
+    elif kind == "commented":
+        body = payload.get("body") or payload.get("comment") or payload.get("summary") or "comment added"
+        author = payload.get("author") or "unknown"
+        lines.append(f"comment by `{author}`: {str(body)[:700]}")
+    elif kind == "blocked":
+        reason = payload.get("reason") or payload.get("summary") or payload.get("error") or "blocked"
+        lines.append(f"action needed: {reason}")
+    elif kind in DANGER:
+        lines.append(f"issue: {payload.get('error') or payload.get('reason') or payload.get('outcome') or json.dumps(payload)[:400]}")
+    else:
+        small = {k: v for k, v in payload.items() if k in ("status", "outcome", "summary", "error", "reason")}
+        if small:
+            lines.append("details: " + json.dumps(small, ensure_ascii=False)[:700])
+    if suggestions:
+        lines.append("suggested next moves:")
+        for idx, suggestion in enumerate(suggestions, 1):
+            lines.append(f"{idx}. {suggestion}")
+    return "\n".join(lines)
+
+
+def should_skip_thread_event(kind):
+    return kind in NOISE_KINDS and not THREAD_DEBUG
+
+
+def route_event(con, state, ev, channel_id, project_channel_id, red_channel_id, dry_run=False):
+    task = task_lookup(con, ev["task_id"])
+    if is_synthetic_test_task(task):
+        return "skipped-synthetic-test-task"
+    payload = parse_payload(ev.get("payload"))
+    if ev["kind"] == "archived" or payload.get("discord_silent"):
+        return "skipped-silent-archive"
+    project_ctx = kpm.resolve_project_context(con, ev["task_id"], payload)
+    if project_ctx:
+        thread_key = kpm.project_thread_key(project_ctx)
+        thread_id = project_ctx.get("discord_thread_id") or state.setdefault("project_threads", {}).get(thread_key)
+        if not thread_id:
+            # Discord requires a starter message for public-thread creation.
+            # Keep it minimal; all real progress stays in the thread.
+            thread = create_thread(
+                project_channel_id,
+                str(project_ctx.get("project_title") or task.get("title") or project_ctx["project_hub_slug"]),
+                kpm.format_project_thread_starter(project_ctx),
+                dry_run=dry_run,
+            )
+            thread_id = thread["id"]
+            state.setdefault("project_threads", {})[thread_key] = thread_id
+        if kpm.should_post_project_thread_event(ev["kind"], payload):
+            body = kpm.format_project_thread_update(task, ev["kind"], payload, project_ctx)
+            post(thread_id, body, dry_run=dry_run)
+        if maybe_post_human_approval(task, ev, payload, thread_id, project_ctx, dry_run=dry_run):
+            return "posted-human-approval"
+        return "posted-project-thread" if kpm.should_post_project_thread_event(ev["kind"], payload) else "skipped-project-noise"
+
+    if maybe_post_human_approval(task, ev, payload, channel_id, None, dry_run=dry_run):
+        return "posted-human-approval"
+
+    maybe_post_red_thread_update(con, state, task, ev, payload, dry_run=dry_run)
+    if red_thread_target(con, task, payload, ev["task_id"]):
+        return "posted-red-thread"
+    tasks = component_tasks(con, ev["task_id"])
+    root = component_root(con, tasks)
+    target_channel_id = choose_component_channel(tasks, channel_id, red_channel_id)
+    is_project_event = THREAD_MODE and project_trigger(root if root else task, payload, len(tasks))
+    if not is_project_event:
+        if ev["kind"] in NOISE_KINDS and not THREAD_DEBUG:
+            return "skipped-flat-noise"
+        post(target_channel_id, format_event(con, ev), dry_run=dry_run)
+        return "posted-flat"
+
+    if target_channel_id == channel_id:
+        target_channel_id = project_channel_id
+
+    comp = refresh_component_state(con, state, root, tasks, target_channel_id)
+    if not comp.get("thread_id"):
+        intro = f"Kanban project opened: {comp['title']}\nroot: `{root['id']}` | tasks: {len(comp['task_ids'])} | lane: {'red' if target_channel_id == red_channel_id and red_channel_id != channel_id else 'general'}"
+        thread = create_thread(target_channel_id, comp["title"], intro, dry_run=dry_run)
+        comp["thread_id"] = thread["id"]
+        # No parent-channel announcements. The parent channel is not a progress
+        # feed; the thread itself is the live room.
+
+    if not should_skip_thread_event(ev["kind"]):
+        post(comp["thread_id"], format_event(con, ev, compact=True), dry_run=dry_run)
+
+    terminal = None
+    if ev["kind"] == "completed":
+        terminal = "completed" if explicit_project_completion(payload) else project_terminal_state(tasks)
+    elif ev["kind"] == "blocked":
+        terminal = "blocked"
+    elif ev["kind"] in DANGER:
+        terminal = "failed"
+    if terminal and comp.get("status") != terminal:
+        comp["status"] = terminal
+        parent_msg = f"Kanban project {terminal}: {comp['title']} | root `{root['id']}` | tasks: {len(comp['task_ids'])}"
+        if terminal in {"blocked", "failed"}:
+            post(comp["thread_id"], parent_msg, dry_run=dry_run)
+        if terminal == "completed" and not comp.get("completed_ping_sent"):
+            thread_msg = f"✅ Final: {comp['title']}"
+            post(comp["thread_id"], thread_msg, dry_run=dry_run)
+            comp["completed_ping_sent"] = True
+    return "posted-thread"
+
+
+def run_once(state, channel_id, project_channel_id, red_channel_id, dry_run=False, limit=50):
+    con = sqlite3.connect(DB_PATH)
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        "select id, task_id, run_id, kind, payload, created_at from task_events where id > ? order by id asc limit ?",
+        (int(state.get("last_event_id", 0)), limit),
+    ).fetchall()
+    for row in rows:
+        ev = dict(row)
+        try:
+            route_event(con, state, ev, channel_id, project_channel_id, red_channel_id, dry_run=dry_run)
+        except Exception as e:
+            print(f"post failed for event {ev['id']}: {e}", file=sys.stderr, flush=True)
+        state["last_event_id"] = ev["id"]
+        if not dry_run:
+            save_state(state)
+    return len(rows)
+
+
+def initialize_state(state, channel_id, dry_run=False):
+    con = sqlite3.connect(DB_PATH)
+    con.row_factory = sqlite3.Row
+    if not state.get("last_event_id"):
+        max_id = con.execute("select coalesce(max(id),0) from task_events").fetchone()[0]
+        state["last_event_id"] = max_id
+        if not dry_run:
+            save_state(state)
+        post(channel_id, f"Kanban log online. Watching `{DB_PATH}` from event id `{max_id}`. Project graphs will use Discord threads; one-off tasks remain compact.", dry_run=dry_run)
+
+
+def build_smoke_db(path):
+    con = sqlite3.connect(path)
+    con.executescript(
+        """
+        create table tasks (id text primary key, title text not null, body text, assignee text, status text not null, priority integer default 0, created_by text, created_at integer not null, started_at integer, completed_at integer, workspace_kind text default 'scratch', workspace_path text, claim_lock text, claim_expires integer, tenant text, result text, idempotency_key text, spawn_failures integer default 0, worker_pid integer, last_spawn_error text, max_runtime_seconds integer, last_heartbeat_at integer, current_run_id integer, workflow_template_id text, current_step_key text, skills text, consecutive_failures integer default 0, last_failure_error text, max_retries integer);
+        create table task_links (parent_id text not null, child_id text not null, primary key (parent_id, child_id));
+        create table task_events (id integer primary key, task_id text not null, run_id integer, kind text not null, payload text, created_at integer not null);
+        create table task_runs (id integer primary key, task_id text not null, profile text, step_key text, status text not null, claim_lock text, claim_expires integer, worker_pid integer, max_runtime_seconds integer, last_heartbeat_at integer, started_at integer not null, ended_at integer, outcome text, summary text, metadata text, error text);
+        """
+    )
+    rows = [
+        ("p1", "Demo umbrella project", "orchestration project", "antonetta", "done", 10, 1),
+        ("c1", "Demo worker", "", "forge", "done", 0, 2),
+        ("c2", "Demo red worker", "Discord thread id: 777777", "red-recon", "done", 0, 3),
+        ("r1", "Standalone red thread task", "Discord thread id: 888888", "red-antonetta", "blocked", 0, 4),
+        ("one", "Small one-off", "", "forge", "done", 0, 5),
+        ("rev", "Autonomous review gate", "", "forge", "blocked", 0, 6),
+        ("hum", "Human approval gate", "", "forge", "blocked", 0, 7),
+    ]
+    con.executemany("insert into tasks (id,title,body,assignee,status,priority,created_at) values (?,?,?,?,?,?,?)", rows)
+    con.executemany("insert into task_links (parent_id, child_id) values (?,?)", [("p1", "c1"), ("p1", "c2")])
+    events = [
+        (1, "p1", None, "created", json.dumps({"assignee": "antonetta", "parents": []}), 1),
+        (2, "c1", 7, "spawned", json.dumps({"pid": 123}), 2),
+        (3, "c1", 7, "completed", json.dumps({"summary": "worker done"}), 3),
+        (4, "c2", 8, "created", json.dumps({"assignee": "red-recon", "parents": ["p1"]}), 4),
+        (5, "c2", 8, "claimed", json.dumps({"run_id": 8}), 5),
+        (6, "c2", 8, "completed", json.dumps({"summary": "red worker done", "metadata": {"findings": ["validated Discord lifecycle formatting"]}}), 6),
+        (7, "r1", 9, "created", json.dumps({"assignee": "red-antonetta", "parents": []}), 7),
+        (8, "r1", 9, "claimed", json.dumps({"run_id": 9}), 8),
+        (9, "r1", 9, "blocked", json.dumps({"reason": "need reviewer signoff"}), 9),
+        (10, "p1", 10, "completed", json.dumps({"summary": "project done", "metadata": {"project_completion": True}}), 10),
+        (11, "one", 11, "completed", json.dumps({"summary": "one-off done"}), 11),
+        (12, "rev", 12, "blocked", json.dumps({"reason": "review-required: implementation handoff", "metadata": {"review_required": True}}), 12),
+        (13, "hum", 13, "blocked", json.dumps({"reason": "human-gate: approve live decision", "metadata": {"human_approval_required": True, "what_is_approved": "continuing past the human gate", "if_approved": "the task unblocks", "risk_rollback": "deny keeps it blocked"}}), 13),
+    ]
+    con.executemany("insert into task_events (id, task_id, run_id, kind, payload, created_at) values (?,?,?,?,?,?)", events)
+    con.commit()
+    con.close()
+
+
+def smoke_test():
+    global DB_PATH, STATE_PATH
+    old_db, old_state = DB_PATH, STATE_PATH
+    with tempfile.TemporaryDirectory() as td:
+        DB_PATH = Path(td) / "kanban.db"
+        STATE_PATH = Path(td) / "state.json"
+        build_smoke_db(DB_PATH)
+        os.environ["DISCORD_ALLOWED_USERS"] = "12345"
+        state = {"last_event_id": 0, "components": {}, "task_aliases": {}}
+        count = run_once(state, "general-channel", "project-channel", "red-channel", dry_run=True, limit=20)
+        comp = state["components"].get("p1")
+        assert count == 13, count
+        assert comp and comp["thread_id"], state
+        assert comp["channel_id"] == "red-channel", comp
+        assert comp["completed_ping_sent"] is True, comp
+        assert state["task_aliases"]["c1"] == "p1", state
+        assert "one" not in state["task_aliases"], state
+        assert "r1" not in state["task_aliases"], state
+        red_posts = sorted(item["kind"] for item in state["red_thread_posts"].values())
+        assert red_posts == ["blocked", "claimed", "claimed", "completed", "created", "created"], red_posts
+    DB_PATH, STATE_PATH = old_db, old_state
+    print("smoke-test ok: grouping, red routing, terminal detection, and mention policy passed")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Mirror Hermes Kanban events to Discord with project-thread grouping.")
+    parser.add_argument("--dry-run", action="store_true", help="print intended Discord writes instead of sending them")
+    parser.add_argument("--once", action="store_true", help="process available events once and exit")
+    parser.add_argument("--smoke-test", action="store_true", help="run deterministic local smoke test without Discord")
+    args = parser.parse_args()
+    if args.smoke_test:
+        smoke_test()
+        return
+
+    load_env(ENV_PATH)
+    if not args.dry_run and not os.environ.get("DISCORD_BOT_TOKEN"):
+        raise RuntimeError("Missing DISCORD_BOT_TOKEN")
+    channel_id = os.getenv("DISCORD_KANBAN_LOG_CHANNEL") or os.getenv("DISCORD_KANBAN_LOG_CHANNEL_ID") or ("dry-general" if args.dry_run else ensure_channel())
+    project_channel_id = os.getenv("DISCORD_KANBAN_PROJECT_LOG_CHANNEL") or os.getenv("DISCORD_KANBAN_PROJECT_LOG_CHANNEL_ID") or ("dry-project" if args.dry_run else ensure_project_channel(channel_id))
+    red_channel_id = os.getenv("DISCORD_RED_KANBAN_LOG_CHANNEL") or os.getenv("DISCORD_RED_KANBAN_LOG_CHANNEL_ID") or channel_id
+    if not args.dry_run:
+        channel_id = ensure_channel()
+        red_channel_id = ensure_red_channel(channel_id)
+    state = load_state()
+    initialize_state(state, channel_id, dry_run=args.dry_run)
+
+    if args.once:
+        run_once(state, channel_id, project_channel_id, red_channel_id, dry_run=args.dry_run)
+        return
+
+    while True:
+        run_once(state, channel_id, project_channel_id, red_channel_id, dry_run=args.dry_run)
+        time.sleep(POLL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/gateway/test_discord_kanban_approval_interactions.py
+++ b/tests/gateway/test_discord_kanban_approval_interactions.py
@@ -1,0 +1,126 @@
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_discord_approvals import build_custom_id
+from plugins.platforms.discord.adapter import handle_kanban_approval_interaction
+
+
+class ResponseRecorder:
+    def __init__(self):
+        self.sent = []
+        self.edits = []
+
+    async def send_message(self, content, **kwargs):
+        self.sent.append({"content": content, **kwargs})
+
+    async def edit_message(self, **kwargs):
+        self.edits.append(kwargs)
+
+
+def _interaction(action, *, task_id="t_gate", user_id="111", display_name="Matthew", role_ids=(), content="approval prompt"):
+    button = SimpleNamespace(disabled=False)
+    return SimpleNamespace(
+        data={"custom_id": build_custom_id(task_id, action)},
+        user=SimpleNamespace(
+            id=user_id,
+            display_name=display_name,
+            roles=[SimpleNamespace(id=role_id) for role_id in role_ids],
+        ),
+        message=SimpleNamespace(
+            content=content,
+            components=[SimpleNamespace(children=[button])],
+        ),
+        response=ResponseRecorder(),
+        _button=button,
+    )
+
+
+@pytest.fixture
+def gate_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    with kb.connect_closing(db_path=db_path) as conn:
+        task_id = kb.create_task(conn, title="Human gate", assignee="forge", body="", initial_status="blocked")
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    return db_path, task_id
+
+
+@pytest.mark.asyncio
+async def test_kanban_approval_interaction_allowed_user_approves_and_disables_buttons(gate_db):
+    db_path, task_id = gate_db
+    interaction = _interaction("approve", task_id=task_id, user_id="111", display_name="Matthew")
+
+    handled = await handle_kanban_approval_interaction(interaction, {"111"}, set())
+
+    assert handled is True
+    assert interaction.response.sent == []
+    assert interaction.response.edits
+    assert interaction.response.edits[0]["view"] is None
+    assert "Approved by Matthew" in interaction.response.edits[0]["content"]
+    assert interaction._button.disabled is True
+    with kb.connect_closing(db_path=db_path) as conn:
+        assert conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()["status"] == "ready"
+        comments = kb.list_comments(conn, task_id)
+    assert comments[0].author == "discord:Matthew (111)"
+    assert "APPROVED via Discord approval button" in comments[0].body
+
+
+@pytest.mark.asyncio
+async def test_kanban_approval_interaction_allowed_role_can_deny(gate_db):
+    db_path, task_id = gate_db
+    interaction = _interaction("deny", task_id=task_id, user_id="222", display_name="Reviewer", role_ids=[42])
+
+    handled = await handle_kanban_approval_interaction(interaction, set(), {42})
+
+    assert handled is True
+    assert "Denied by Reviewer" in interaction.response.edits[0]["content"]
+    assert interaction._button.disabled is True
+    with kb.connect_closing(db_path=db_path) as conn:
+        assert conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()["status"] == "blocked"
+        comments = kb.list_comments(conn, task_id)
+    assert "DENIED via Discord approval button" in comments[0].body
+
+
+@pytest.mark.asyncio
+async def test_kanban_approval_interaction_unauthorized_user_gets_ephemeral_error(gate_db):
+    db_path, task_id = gate_db
+    interaction = _interaction("approve", task_id=task_id, user_id="999", display_name="Intruder")
+
+    handled = await handle_kanban_approval_interaction(interaction, {"111"}, {42})
+
+    assert handled is True
+    assert interaction.response.edits == []
+    assert interaction.response.sent == [{"content": "You're not authorized to approve Kanban gates~", "ephemeral": True}]
+    assert interaction._button.disabled is False
+    with kb.connect_closing(db_path=db_path) as conn:
+        assert conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()["status"] == "blocked"
+        assert kb.list_comments(conn, task_id) == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("action", "expected_label", "expected_comment", "expected_status"),
+    [
+        ("approve", "Approved", "APPROVED", "ready"),
+        ("deny", "Denied", "DENIED", "blocked"),
+        ("needs_changes", "Needs changes requested", "NEEDS CHANGES", "blocked"),
+    ],
+)
+async def test_kanban_approval_interaction_records_all_decision_outcomes(tmp_path, monkeypatch, action, expected_label, expected_comment, expected_status):
+    db_path = tmp_path / f"{action}.db"
+    with kb.connect_closing(db_path=db_path) as conn:
+        task_id = kb.create_task(conn, title="Human gate", assignee="forge", body="", initial_status="blocked")
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    interaction = _interaction(action, task_id=task_id, user_id="111", display_name="Matthew")
+
+    handled = await handle_kanban_approval_interaction(interaction, {"111"}, set())
+
+    assert handled is True
+    assert expected_label in interaction.response.edits[0]["content"]
+    assert interaction.response.sent == []
+    assert interaction._button.disabled is True
+    with kb.connect_closing(db_path=db_path) as conn:
+        assert conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()["status"] == expected_status
+        comments = kb.list_comments(conn, task_id)
+    assert expected_comment in comments[0].body

--- a/tests/hermes_cli/test_kanban_discord_approvals.py
+++ b/tests/hermes_cli/test_kanban_discord_approvals.py
@@ -1,0 +1,73 @@
+import json
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_discord_approvals as kap
+
+
+def test_autonomous_review_required_block_is_not_human_ping():
+    task = {"id": "t_review", "title": "Implement feature", "body": "", "assignee": "forge"}
+    payload = {"reason": "review-required: implementation complete", "metadata": {"review_required": True}}
+
+    assert kap.is_autonomous_review_gate(task, payload) is True
+    assert kap.is_human_approval_gate(task, "blocked", payload) is False
+
+
+def test_human_gate_approval_prompt_contains_required_context_and_buttons():
+    task = {"id": "t_gate", "title": "Ship production config", "assignee": "forge"}
+    payload = {
+        "reason": "human-gate: approve production-facing config change",
+        "metadata": {
+            "human_approval_required": True,
+            "what_is_approved": "shipping the config to the shared repo",
+            "if_approved": "Forge will unblock the Kanban task and continue the lane",
+            "risk_rollback": "Rollback is reverting the config commit before merge.",
+        },
+    }
+
+    assert kap.is_human_approval_gate(task, "blocked", payload) is True
+    req = kap.build_approval_request(task, payload, {"project_title": "Build Lane"})
+    body = kap.build_message_payload(req, "<@123>")
+
+    content = body["content"]
+    assert "<@123>" in content
+    assert "`t_gate`" in content
+    assert "Ship production config" in content
+    assert "Build Lane" in content
+    assert "shipping the config" in content
+    assert "Forge will unblock" in content
+    assert "Rollback is reverting" in content
+    assert "human-gate" in content
+    labels = [c["label"] for c in body["components"][0]["components"]]
+    assert labels == ["Approve", "Deny", "Needs changes"]
+    assert kap.parse_custom_id(body["components"][0]["components"][0]["custom_id"]) == ("t_gate", "approve")
+
+
+def test_approval_decision_comments_and_unblocks(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    with kb.connect_closing(db_path=db_path) as conn:
+        task_id = kb.create_task(conn, title="Human gate", assignee="forge", body="", initial_status="blocked")
+
+    result = kap.apply_approval_decision(task_id, "approve", "Matthew (123)", db_path=db_path)
+
+    assert result == "approved_unblocked"
+    with kb.connect_closing(db_path=db_path) as conn:
+        row = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        assert row["status"] == "ready"
+        comments = kb.list_comments(conn, task_id)
+        assert len(comments) == 1
+        assert comments[0].author == "discord:Matthew (123)"
+        assert "APPROVED via Discord approval button" in comments[0].body
+
+
+def test_needs_changes_records_comment_without_unblocking(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    with kb.connect_closing(db_path=db_path) as conn:
+        task_id = kb.create_task(conn, title="Human gate", assignee="forge", body="", initial_status="blocked")
+
+    result = kap.apply_approval_decision(task_id, "needs_changes", "Matthew (123)", db_path=db_path)
+
+    assert result == "needs_changes_recorded"
+    with kb.connect_closing(db_path=db_path) as conn:
+        row = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        assert row["status"] == "blocked"
+        assert "NEEDS CHANGES" in kb.list_comments(conn, task_id)[0].body

--- a/tests/hermes_cli/test_kanban_discord_approvals.py
+++ b/tests/hermes_cli/test_kanban_discord_approvals.py
@@ -42,6 +42,34 @@ def test_human_gate_approval_prompt_contains_required_context_and_buttons():
     assert kap.parse_custom_id(body["components"][0]["components"][0]["custom_id"]) == ("t_gate", "approve")
 
 
+def test_human_gate_prompt_redacts_secret_looking_reason_and_metadata():
+    task = {"id": "t_gate", "title": "Ship production config", "assignee": "forge"}
+    payload = {
+        "reason": "human-gate: deploy with token=sk-live-secret and email matthew@example.com",
+        "metadata": {
+            "human_approval_required": True,
+            "what_is_approved": "use api_key='abc123secret' for a long approval explanation " + ("with details " * 80),
+            "if_approved": "password: correct-horse-battery-staple; continue deployment",
+            "risk_rollback": "rollback_token=ghp_abcdefghijklmnopqrstuvwxyz123456",
+        },
+    }
+
+    req = kap.build_approval_request(task, payload, {"project_title": "Build Lane"})
+    body = kap.build_message_payload(req)
+    content = body["content"]
+
+    assert "sk-live-secret" not in content
+    assert "matthew@example.com" not in content
+    assert "abc123secret" not in content
+    assert "correct-horse-battery-staple" not in content
+    assert "ghp_abcdefghijklmnopqrstuvwxyz123456" not in content
+    assert "[redacted]" in content
+    assert "…[truncated]" in content
+    for line in content.splitlines():
+        if line.startswith(("**Approve:**", "**If approved:**", "**Risk / rollback:**", "**Source:")):
+            assert len(line) <= 260
+
+
 def test_approval_decision_comments_and_unblocks(tmp_path):
     db_path = tmp_path / "kanban.db"
     with kb.connect_closing(db_path=db_path) as conn:

--- a/tests/hermes_cli/test_kanban_project_model_build_lane.py
+++ b/tests/hermes_cli/test_kanban_project_model_build_lane.py
@@ -1,0 +1,77 @@
+import json
+import sqlite3
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_project_model as kpm
+
+
+def _connect_initialized(tmp_path):
+    db_path = tmp_path / "kanban.db"
+    conn = kb.connect(db_path=db_path)
+    return conn
+
+
+def test_build_lane_starter_graph_has_project_thread_starter_metadata(tmp_path):
+    with _connect_initialized(tmp_path) as conn:
+        root_body = kpm.project_metadata_markers(
+            project_hub_slug="build-implementation-lane",
+            project_title="Run 3: Validate Build Lane forum and DSR visibility",
+            kanban_root_task_id="t_root",
+            stage_name="build-lane-root",
+        )
+        child_body = kpm.project_metadata_markers(
+            project_hub_slug="build-implementation-lane",
+            project_title="Run 3: Validate Build Lane forum and DSR visibility",
+            kanban_root_task_id="t_root",
+            stage_name="config-implementation",
+        ) + "Run key: run-3-forum-dsr-visibility\n"
+        root_id = kb.create_task(conn, title="Build Lane run: Run 3", body=root_body, assignee="antonetta", idempotency_key="root")
+        conn.execute("UPDATE tasks SET id=?, status='done' WHERE id=?", ("t_root", root_id))
+        child_id = kb.create_task(conn, title="Implement config change", body=child_body, assignee="forge", parents=["t_root"], idempotency_key="child")
+
+        project = kpm.resolve_project_context(conn, child_id, {"stage": "config-implementation"})
+        starter = kpm.format_project_thread_starter(project)
+
+    assert project["project_hub_slug"] == "build-implementation-lane"
+    assert project["project_title"] == "Run 3: Validate Build Lane forum and DSR visibility"
+    assert project["kanban_root_task_id"] == "t_root"
+    assert project["run_key"] == "run-3-forum-dsr-visibility"
+    assert kpm.project_thread_key(project) == "build-implementation-lane:run-3-forum-dsr-visibility"
+    assert child_id in project["task_ids"]
+    assert "Project Hub: `build-implementation-lane`" in starter
+    assert "Kanban root: `t_root`" in starter
+    assert "DSR: project-linked updates with `dsr_visible`/`dsr_include` metadata are eligible" in starter
+
+
+def test_dsr_project_activity_exposes_structured_build_lane_metadata(tmp_path):
+    with _connect_initialized(tmp_path) as conn:
+        body = kpm.project_metadata_markers(
+            project_hub_slug="build-implementation-lane",
+            project_title="Run 3: Validate Build Lane forum and DSR visibility",
+            kanban_root_task_id="t_root",
+            stage_name="config-implementation",
+        ) + "Run key: run-3-forum-dsr-visibility\n"
+        task_id = kb.create_task(conn, title="Implement config change", body=body, assignee="forge")
+        metadata = {
+            "dsr_visible": True,
+            "dsr_summary": "Validated Build Lane forum visibility.",
+            "changed_files": ["hermes_cli/kanban_project_model.py"],
+        }
+        conn.execute("UPDATE tasks SET status='done', completed_at=200 WHERE id=?", (task_id,))
+        conn.execute(
+            "INSERT INTO task_runs(task_id, profile, status, started_at, ended_at, outcome, summary, metadata) VALUES (?, 'forge', 'done', 100, 200, 'completed', 'implementation complete', ?)",
+            (task_id, json.dumps(metadata)),
+        )
+
+        rows = kpm.dsr_project_activity(conn, 0, 300)
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["project_hub_slug"] == "build-implementation-lane"
+    assert row["project_title"] == "Run 3: Validate Build Lane forum and DSR visibility"
+    assert row["kanban_root_task_id"] == "t_root"
+    assert row["stage_name"] == "config-implementation"
+    assert row["run_key"] == "run-3-forum-dsr-visibility"
+    assert row["dsr_visible"] is True
+    assert row["summary"] == "Validated Build Lane forum visibility."
+    assert row["metadata"]["changed_files"] == ["hermes_cli/kanban_project_model.py"]

--- a/tests/scripts/test_kanban_discord_log_build_lane.py
+++ b/tests/scripts/test_kanban_discord_log_build_lane.py
@@ -1,0 +1,138 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_project_model as kpm
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "kanban_discord_log.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("kanban_discord_log_under_test", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_lane_body(*, slug, title, root_id, stage, run_key):
+    return (
+        kpm.project_metadata_markers(
+            project_hub_slug=slug,
+            project_title=title,
+            kanban_root_task_id=root_id,
+            stage_name=stage,
+        )
+        + "\nBuild Lane task metadata:\n"
+        + f"Project Hub slug: {slug}\n"
+        + f"Project title: {title}\n"
+        + f"Kanban root task id: {root_id}\n"
+        + f"Kanban stage: {stage}\n"
+        + f"Run key: {run_key}\n"
+    )
+
+
+def test_fresh_build_lane_runs_get_distinct_forum_posts_with_dsr_starter_metadata(tmp_path, monkeypatch):
+    log = _load_script_module()
+    db_path = tmp_path / "kanban.db"
+    state_path = tmp_path / "state.json"
+    monkeypatch.setattr(log, "DB_PATH", db_path)
+    monkeypatch.setattr(log, "STATE_PATH", state_path)
+
+    slug = "build-implementation-lane"
+    title_a = "Run A: Validate Build Lane forum visibility"
+    title_b = "Run B: Validate Build Lane forum visibility"
+    with kb.connect(db_path=db_path) as conn:
+        root_a = kb.create_task(
+            conn,
+            title=f"Build Lane run: {title_a}",
+            body=_build_lane_body(slug=slug, title=title_a, root_id="root-a", stage="build-lane-root", run_key="run-a"),
+            assignee="antonetta",
+            created_by="build-lane-start",
+            idempotency_key="root-a",
+        )
+        root_b = kb.create_task(
+            conn,
+            title=f"Build Lane run: {title_b}",
+            body=_build_lane_body(slug=slug, title=title_b, root_id="root-b", stage="build-lane-root", run_key="run-b"),
+            assignee="antonetta",
+            created_by="build-lane-start",
+            idempotency_key="root-b",
+        )
+        conn.execute("UPDATE tasks SET id=?, status='done' WHERE id=?", ("root-a", root_a))
+        conn.execute("UPDATE tasks SET id=?, status='done' WHERE id=?", ("root-b", root_b))
+        conn.execute(
+            "INSERT INTO task_events(task_id, run_id, kind, payload, created_at) VALUES (?, NULL, 'project_stage_started', ?, 100)",
+            (
+                "root-a",
+                json.dumps(
+                    {
+                        "project_hub_slug": slug,
+                        "project_title": title_a,
+                        "kanban_root_task_id": "root-a",
+                        "stage": "build-lane-root",
+                        "run_key": "run-a",
+                        "summary": "Build Lane Kanban graph initialized.",
+                        "dsr_visible": True,
+                    }
+                ),
+            ),
+        )
+        conn.execute(
+            "INSERT INTO task_events(task_id, run_id, kind, payload, created_at) VALUES (?, NULL, 'project_stage_started', ?, 101)",
+            (
+                "root-b",
+                json.dumps(
+                    {
+                        "project_hub_slug": slug,
+                        "project_title": title_b,
+                        "kanban_root_task_id": "root-b",
+                        "stage": "build-lane-root",
+                        "run_key": "run-b",
+                        "summary": "Build Lane Kanban graph initialized.",
+                        "dsr_visible": True,
+                    }
+                ),
+            ),
+        )
+
+    created_threads = []
+    posted_messages = []
+
+    def fake_create_thread(parent_channel_id, name, message, dry_run=False, applied_tags=None):
+        thread_id = f"thread-{len(created_threads) + 1}"
+        created_threads.append({"parent": parent_channel_id, "name": name, "message": message, "id": thread_id})
+        return {"id": thread_id, "parent_id": parent_channel_id, "name": name}
+
+    def fake_post(channel_id, content, dry_run=False, components=None):
+        posted_messages.append({"channel_id": channel_id, "content": content, "components": components})
+        return {"id": f"msg-{len(posted_messages)}", "channel_id": channel_id}
+
+    monkeypatch.setattr(log, "create_thread", fake_create_thread)
+    monkeypatch.setattr(log, "post", fake_post)
+
+    # Start after create_task's mechanical created events; this mirrors the
+    # watcher already being online when the starter helper emits the explicit
+    # Build Lane project-stage events that should create fresh forum posts.
+    state = {"last_event_id": 2, "components": {}, "task_aliases": {}, "red_thread_posts": {}}
+    processed = log.run_once(state, "general-channel", "kanban-project-runs", "red-channel", limit=20)
+
+    assert processed == 2
+    assert state["project_threads"] == {
+        f"{slug}:run-a": "thread-1",
+        f"{slug}:run-b": "thread-2",
+    }
+    assert [thread["parent"] for thread in created_threads] == ["kanban-project-runs", "kanban-project-runs"]
+    assert [thread["name"] for thread in created_threads] == [title_a, title_b]
+    for thread, run_key, root_id in zip(created_threads, ["run-a", "run-b"], ["root-a", "root-b"]):
+        starter = thread["message"]
+        assert f"Project Hub: `{slug}`" in starter
+        assert f"Kanban root: `{root_id}`" in starter
+        assert f"Run key: `{run_key}`" in starter
+        assert "DSR: project-linked updates with `dsr_visible`/`dsr_include` metadata are eligible" in starter
+    assert any("Project Stage Started: Build Lane Kanban graph initialized." in msg["content"] for msg in posted_messages)


### PR DESCRIPTION
## Summary
- Adds an end-to-end regression test for fresh Build Lane starter-helper runs flowing through the Discord watcher into distinct kanban-project-runs forum posts.
- Verifies starter post metadata includes Project Hub slug, Kanban root, run key, and DSR eligibility text.

## Verification
- python -m pytest tests/scripts/test_kanban_discord_log_build_lane.py tests/hermes_cli/test_kanban_project_model_build_lane.py tests/hermes_cli/test_kanban_discord_approvals.py -o 'addopts=' -q
- python scripts/kanban_discord_log.py --smoke-test
- temp HERMES_KANBAN_DB Build Lane starter helper + kanban_discord_log.py --dry-run --once validation
