### PR TITLE
fix(dashboard): honour suffix-match in dashboard.hidden_plugins

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4389,11 +4389,24 @@ async def get_dashboard_plugins():
     # Read user's hidden plugins list from config.
     config = load_config()
     hidden: list = cfg_get(config, "dashboard", "hidden_plugins", default=[]) or []
+
+    # The /plugins UI Hide-from-sidebar button POSTs the agent-plugin path
+    # (e.g. "image_gen/openai") into dashboard.hidden_plugins, while
+    # dashboard manifests carry their own short ``name`` field ("openai").
+    # A literal in-list check misses the suffix match, so toggling Hide for
+    # any category-namespaced plugin had no visible effect. Treat trailing-
+    # segment matches as hits too.
+    def _is_hidden(plugin_name: str) -> bool:
+        if plugin_name in hidden:
+            return True
+        suffix = "/" + plugin_name
+        return any(isinstance(h, str) and h.endswith(suffix) for h in hidden)
+
     # Strip internal fields before sending to frontend and filter out hidden.
     return [
         {k: v for k, v in p.items() if not k.startswith("_")}
         for p in plugins
-        if p["name"] not in hidden
+        if not _is_hidden(p["name"])
     ]
 
 


### PR DESCRIPTION
## Summary

The `/plugins` UI "Hide from sidebar" button POSTs the **agent-plugin path** (e.g. `image_gen/openai` or `platforms/teams`) into `dashboard.hidden_plugins`, but `_get_dashboard_plugins` returns manifests using only the **dashboard short name** (`openai`, `teams`). The literal `if p["name"] not in hidden` check in `get_dashboard_plugins` never matched — toggling Hide for any **category-namespaced** plugin had no visible effect; the tab reappeared in the sidebar on reload.

## Fix

Treat trailing-segment matches as hits too: a hidden entry `"<category>/<name>"` should hide the dashboard plugin named `"<name>"`.

* Backwards compatible — bare-name hidden entries continue to match unchanged.
* Only the `/`-prefixed suffix is checked, so `foo` will never accidentally match a hidden entry like `barfoo`.
* `Show in sidebar` continues to work via the same endpoint by removing the entry.

## Reproduction

1. Install any category-namespaced plugin that ships a dashboard manifest. Examples in the repo:
   - `plugins/image_gen/openai/` (bundled, but lacks dashboard/ — invariant still holds for any third-party `image_gen/<name>/dashboard/manifest.json`)
   - `plugins/observability/langfuse/` (same)
   - Any third-party `plugins/<category>/<name>/dashboard/manifest.json` plugin pulled via `hermes plugins install`.

2. Open `http://127.0.0.1:9119/plugins` in the dashboard, click **Hide from sidebar** on the row.

3. Inspect `~/.hermes/config.yaml` — `dashboard.hidden_plugins` now contains `<category>/<name>`.

4. Reload the dashboard — the plugin tab still appears in the sidebar (bug).

After this patch, step 4 hides the tab as expected.

## Test plan

- [x] Manually verified with a third-party `model-providers/openrouter_custom` plugin: Hide → tab disappears from sidebar after reload. Show → tab reappears.
- [x] Verified bare-name plugins (e.g. `kanban`, `hermes-achievements`) are unaffected — the literal-membership path still matches.
- [x] Confirmed no accidental substring matches: `dashboard.hidden_plugins: ["xfoo"]` does NOT hide a plugin named `foo` (suffix requires the leading `/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)