### PR TITLE
fix(deps): declare setuptools in dev extra for packaging tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "ty==0.0.21", "ruff==0.15.10"]
+dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "ty==0.0.21", "ruff==0.15.10", "setuptools==82.0.1"]
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.3", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.27.0", "slack-sdk==3.40.1", "aiohttp==3.13.3"]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,7 +1,14 @@
 from pathlib import Path
 import tomllib
 
-from setuptools import find_packages
+import pytest
+
+# setuptools is declared in the [dev] extra and is the build backend, but
+# guard the import so a runner without it skips these packaging checks
+# instead of erroring out collection for the whole shard (it used to be
+# picked up ambiently from the CI image; newer ubuntu-latest images don't
+# ship it in the test venv).
+find_packages = pytest.importorskip("setuptools", exc_type=ImportError).find_packages
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/uv.lock
+++ b/uv.lock
@@ -1638,6 +1638,7 @@ all = [
     { name = "pytest-timeout" },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
     { name = "ruff" },
+    { name = "setuptools" },
     { name = "simple-term-menu" },
     { name = "ty" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1668,6 +1669,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
     { name = "ruff" },
+    { name = "setuptools" },
     { name = "ty" },
 ]
 dingtalk = [
@@ -1877,6 +1879,7 @@ requires-dist = [
     { name = "rich", specifier = "==14.3.3" },
     { name = "ruamel-yaml", specifier = "==0.18.17" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.10" },
+    { name = "setuptools", marker = "extra == 'dev'", specifier = "==82.0.1" },
     { name = "simple-term-menu", marker = "extra == 'cli'", specifier = "==1.6.6" },
     { name = "slack-bolt", marker = "extra == 'messaging'", specifier = "==1.27.0" },
     { name = "slack-bolt", marker = "extra == 'slack'", specifier = "==1.27.0" },


### PR DESCRIPTION
## Summary
Packaging tests stop breaking CI. `tests/test_packaging_metadata.py` does `from setuptools import find_packages` at module scope to validate package discovery against the live tree. setuptools used to be present ambiently in the GitHub runner image; recent `ubuntu-latest` images no longer ship it in the test venv, so the `test (4)` shard fails at collection with `ModuleNotFoundError: No module named 'setuptools'` on every PR — even though the 4996-test run itself is green.

Two fixes, belt-and-suspenders:

## Changes
- `pyproject.toml`: add `setuptools==82.0.1` to the `dev` optional-dependencies so `.[all,dev]` installs it explicitly instead of relying on the runner environment.
- `tests/test_packaging_metadata.py`: guard the module-level setuptools import with `pytest.importorskip("setuptools", exc_type=ImportError)` — if setuptools is ever absent again, these checks SKIP instead of erroring out collection for the whole shard.

## Validation
| scenario | before | after |
|---|---|---|
| `test (4)` collection, no ambient setuptools | `ModuleNotFoundError` (shard fails) | setuptools installed via `[dev]`; if still absent → 1 skipped, no error |
| setuptools present (normal) | 4 pass | 4 pass |

Pre-existing breakage surfaced on PR #34839's CI; fixed standalone here.
