### PR TITLE
fix(packaging): add setuptools to dev extra so packaging test collects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "ty==0.0.21", "ruff==0.15.10"]
+dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "ty==0.0.21", "ruff==0.15.10", "setuptools>=61.0,<83"]
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.3", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.27.0", "slack-sdk==3.40.1", "aiohttp==3.13.3"]

--- a/uv.lock
+++ b/uv.lock
@@ -1638,6 +1638,7 @@ all = [
     { name = "pytest-timeout" },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
     { name = "ruff" },
+    { name = "setuptools" },
     { name = "simple-term-menu" },
     { name = "ty" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1668,6 +1669,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
     { name = "ruff" },
+    { name = "setuptools" },
     { name = "ty" },
 ]
 dingtalk = [
@@ -1877,6 +1879,7 @@ requires-dist = [
     { name = "rich", specifier = "==14.3.3" },
     { name = "ruamel-yaml", specifier = "==0.18.17" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.10" },
+    { name = "setuptools", marker = "extra == 'dev'", specifier = ">=61.0,<83" },
     { name = "simple-term-menu", marker = "extra == 'cli'", specifier = "==1.6.6" },
     { name = "slack-bolt", marker = "extra == 'messaging'", specifier = "==1.27.0" },
     { name = "slack-bolt", marker = "extra == 'slack'", specifier = "==1.27.0" },


### PR DESCRIPTION
## Summary

`tests/test_packaging_metadata.py` (added in #34811) now collects in CI instead of erroring out.

The test imports `from setuptools import find_packages` at module level. `setuptools` is declared only under `[build-system].requires`, not as a runtime/test dependency — so CI's uv-managed test venv (`uv pip install -e ".[all,dev]"`) doesn't have it, and the module fails at collection with `ModuleNotFoundError: No module named 'setuptools'`. This shows up as a red `test (slice 4/6)` shard on every PR branched off main since #34811 landed, even though all 4026 tests pass.

## Changes

- `pyproject.toml`: add `setuptools>=61.0` to the `dev` extra (matching the `[build-system]` pin), so the wheel-packaging regression test keeps running in CI rather than being skipped or erroring.
- `uv.lock`: regenerated (setuptools was already a transitive entry; just adds it to the `all`/`dev` extra references).

## Validation

```
$ python3 -m pytest tests/test_packaging_metadata.py -q
4 passed in 0.10s
```

Before: `ERROR collecting tests/test_packaging_metadata.py` → `ModuleNotFoundError: No module named 'setuptools'` → shard 4 red.
