### PR TITLE
feat(kanban): make decomposer system prompt configurable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1770,6 +1770,11 @@ DEFAULT_CONFIG = {
         # large bulk-load of triage tasks from spending a burst of aux
         # LLM calls in one tick. Excess tasks defer to the next tick.
         "auto_decompose_per_tick": 3,
+        # Override the decomposer system prompt.  When empty, uses the
+        # built-in task-router prompt.  Set to a custom prompt to change
+        # decomposer behavior (e.g. goal-splitter mode where all children
+        # are routed to the orchestrator profile for pipeline routing).
+        "decompose_system_prompt": "",
         # Stale detection: running tasks that have exceeded this many
         # seconds without a heartbeat (since ``last_heartbeat_at``) are
         # auto-reclaimed to ``ready`` on the next dispatcher tick. The

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -295,6 +295,8 @@ def decompose_task(
     default_assignee = _resolve_default_assignee(cfg)
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
     auto_promote = bool(kanban_cfg.get("auto_promote_children", True))
+    custom_prompt = (kanban_cfg.get("decompose_system_prompt") or "").strip()
+    system_prompt = custom_prompt if custom_prompt else _SYSTEM_PROMPT
     roster, valid_names = _build_roster()
 
     try:
@@ -327,7 +329,7 @@ def decompose_task(
         resp = client.chat.completions.create(
             model=model,
             messages=[
-                {"role": "system", "content": _SYSTEM_PROMPT},
+                {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_msg},
             ],
             temperature=0.3,
@@ -431,6 +433,13 @@ def decompose_task(
             parents = []
         # Clean parent indices: drop non-int and out-of-range.
         clean_parents = [p for p in parents if isinstance(p, int) and 0 <= p < len(raw_tasks) and p != idx]
+        # When a custom decomposer prompt is active (e.g. goal-splitter
+        # mode), hard-override assignee and parents so the LLM cannot
+        # route children to arbitrary profiles or create inter-sibling
+        # dependencies.  The orchestrator (PM) handles all routing.
+        if custom_prompt:
+            chosen = orchestrator
+            clean_parents = []
         children.append({
             "title": title.strip()[:200],
             "body": body.strip(),


### PR DESCRIPTION
## What

Adds a `kanban.decompose_system_prompt` config key that overrides the built-in decomposer prompt. When empty (default), behavior is unchanged.

## Why

The built-in decomposer prompt assigns children to arbitrary profiles based on description matching. Some pipelines need different decomposition strategies — for example, a "goal-splitter" mode where the decomposer breaks big goals into deliverables and routes all children to the orchestrator profile, which then handles pipeline routing.

Making the prompt configurable lets users adapt decomposition to their pipeline without forking Hermes.

## How

Two changes:

1. **`hermes_cli/config.py`** — adds `decompose_system_prompt: ""` to the kanban defaults. Empty string = use built-in prompt (zero behavior change for existing users).

2. **`hermes_cli/kanban_decompose.py`** — reads `kanban.decompose_system_prompt` from config. When set, uses it as the system prompt instead of the hardcoded `_SYSTEM_PROMPT`. Also forces all child assignees to `orchestrator_profile` and clears inter-sibling parent links, since a custom prompt implies the user wants full control over routing.

## Config example

```yaml
kanban:
  decompose_system_prompt: |
    You are a goal splitter. Break the triage task into 2-5 independent
    deliverables. Set ALL assignees to null and ALL parents to [].
    Each body describes WHAT to achieve, not HOW.
    ...
```

## Backwards compatible

- Default is empty string — existing behavior preserved
- No schema changes, no migrations
- Config key ignored by older Hermes versions (harmless unknown key)