### PR TITLE
[codex] Pass user task to registry tools

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout
-from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
+from agent.tool_dispatch_helpers import _trajectory_normalize_msg, last_user_task, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import STATUS_EXHAUSTED
 from agent.error_classifier import FailoverReason
@@ -1690,6 +1690,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             function_name, function_args, effective_task_id,
             tool_call_id=tool_call_id,
             session_id=agent.session_id or "",
+            user_task=last_user_task(messages),
             enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
             skip_pre_tool_call_hook=True,
             enabled_toolsets=getattr(agent, "enabled_toolsets", None),

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -87,6 +87,33 @@ def _is_destructive_command(cmd: str) -> bool:
     return False
 
 
+def content_to_text(content: Any) -> str:
+    """Extract text from a chat message content value."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts)
+    return ""
+
+
+def last_user_task(messages: list | None) -> str | None:
+    """Return the latest user message text from a chat transcript."""
+    for msg in reversed(messages or []):
+        if isinstance(msg, dict) and msg.get("role") == "user":
+            text = content_to_text(msg.get("content"))
+            if text:
+                return text
+    return None
+
+
 def _is_mcp_tool_parallel_safe(tool_name: str) -> bool:
     """Check if an MCP tool comes from a server with parallel tool calls enabled.
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -34,6 +34,7 @@ from agent.tool_dispatch_helpers import (
     _is_multimodal_tool_result,
     _multimodal_text_summary,
     _append_subdir_hint_to_multimodal,
+    last_user_task,
     make_tool_result_message,
 )
 from tools.terminal_tool import (
@@ -836,6 +837,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     function_name, function_args, effective_task_id,
                     tool_call_id=tool_call.id,
                     session_id=agent.session_id or "",
+                    user_task=last_user_task(messages),
                     enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
                     skip_pre_tool_call_hook=True,
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),
@@ -858,6 +860,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     function_name, function_args, effective_task_id,
                     tool_call_id=tool_call.id,
                     session_id=agent.session_id or "",
+                    user_task=last_user_task(messages),
                     enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
                     skip_pre_tool_call_hook=True,
                     enabled_toolsets=getattr(agent, "enabled_toolsets", None),

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2426,12 +2426,31 @@ class TestConcurrentToolExecution:
                 "web_search", {"q": "test"}, "task-1",
                 tool_call_id=None,
                 session_id=agent.session_id,
+                user_task=None,
                 enabled_tools=list(agent.valid_tool_names),
                 skip_pre_tool_call_hook=True,
                 enabled_toolsets=agent.enabled_toolsets,
                 disabled_toolsets=agent.disabled_toolsets,
             )
             assert result == "result"
+
+    def test_invoke_tool_passes_last_user_task_to_registry_tools(self, agent):
+        messages = [
+            {"role": "user", "content": "older request"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "what is logged today?"},
+        ]
+
+        with patch("run_agent.handle_function_call", return_value="result") as mock_hfc:
+            result = agent._invoke_tool(
+                "web_search",
+                {"q": "test"},
+                "task-1",
+                messages=messages,
+            )
+
+        assert result == "result"
+        assert mock_hfc.call_args.kwargs["user_task"] == "what is logged today?"
 
     def test_sequential_tool_callbacks_fire_in_order(self, agent):
         tool_call = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="c1")


### PR DESCRIPTION
## Summary

Pass the latest user message through to registry-dispatched tools as `user_task` from both sequential and concurrent tool execution paths.

`model_tools.handle_function_call` already accepts and forwards `user_task` into the tool registry, but the main agent execution paths were not supplying it. That meant registry tools could not see the operator's actual request when validating or correcting model-supplied arguments.

## Motivation

Some registry tools need deterministic context from the current user turn, not just the model-generated tool arguments. A concrete downstream example is a local fitness/trainer tool that resolves relative dates such as "today" in Python and overrides bad model-supplied dates only when the current user request actually says "today" or "current day" and does not include an explicit date.

Without `user_task`, those tools can still receive arguments, but they cannot reliably tell whether an argument came from the user or from model inference. Passing the latest user message lets tool code enforce deterministic validation at the tool boundary instead of relying on prompt compliance.

## Scope

This PR is intentionally narrow:

- It does not change tool schemas or prompt behavior.
- It does not add policy for any specific plugin.
- It only makes the existing `user_task` registry-handler parameter available from the normal agent tool execution paths.

## Changes

- Add `content_to_text()` and `last_user_task()` helpers for transcript-safe user-message extraction.
- Pass `last_user_task(messages)` into sequential registry dispatch in `agent/tool_executor.py`.
- Pass `last_user_task(messages)` into concurrent `_invoke_tool` registry dispatch in `agent/agent_runtime_helpers.py`.
- Update existing registry-dispatch test expectations for the new keyword argument.
- Add regression coverage proving `_invoke_tool` forwards the latest user task, not an older user message.

## Validation

- `python -m py_compile agent/tool_dispatch_helpers.py agent/tool_executor.py agent/agent_runtime_helpers.py tests/run_agent/test_run_agent.py`
- `uv run --extra dev python -m pytest tests/run_agent/test_run_agent.py::TestConcurrentToolExecution::test_invoke_tool_dispatches_to_handle_function_call tests/run_agent/test_run_agent.py::TestConcurrentToolExecution::test_invoke_tool_passes_last_user_task_to_registry_tools`