### PR TITLE
fix(hindsight): flush final append batches reliably

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1447,6 +1447,7 @@ def init_agent(
 
     # Memory provider plugin (external — one at a time, alongside built-in)
     # Reads memory.provider from config to select which plugin to activate.
+    agent._skip_memory_prefetch_after_turn = False
     agent._memory_manager = None
     if not skip_memory:
         try:

--- a/cli.py
+++ b/cli.py
@@ -11553,6 +11553,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         agent = self.agent
         if agent is None:
             return None
+        agent._skip_memory_prefetch_after_turn = getattr(
+            self, "_skip_memory_prefetch_after_turn", False
+        )
 
         # Route image attachments based on the active model's vision capability.
         # "native" → pass pixels as OpenAI-style content parts (adapters
@@ -15586,6 +15589,10 @@ def main(
     if query or image:
         if not cli._claim_active_session("cli", stderr=bool(quiet)):
             sys.exit(1)
+        # A one-shot query has no following turn to consume recalled memory.
+        # Preserve/flush the completed turn, but do not start speculative
+        # prefetch work immediately before deterministic cleanup.
+        cli._skip_memory_prefetch_after_turn = True
         try:
             query, single_query_images = _collect_query_images(query, image)
             # Kanban workers spawn with ``hermes chat -q "work kanban task <id>"``;
@@ -15693,6 +15700,7 @@ def main(
                         runtime_override=turn_route["runtime"],
                         request_overrides=turn_route.get("request_overrides"),
                     ):
+                        cli.agent._skip_memory_prefetch_after_turn = True
                         cli.agent.quiet_mode = True
                         cli.agent.suppress_status_output = True
                         # Suppress streaming display callbacks so stdout stays

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -688,10 +688,14 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_context = "conversation between Hermes Agent and the User"
         self._turn_counter = 0
         self._session_turns: list[str] = []  # accumulates ALL turns for the session
-        # How many turns the last append-mode retain already shipped. Used to
-        # send only the new delta on subsequent retains when the API supports
-        # update_mode='append' (legacy/overwrite path still sends everything).
-        self._last_retained_turn_count = 0
+        # Append-mode work is queued asynchronously. Track reservations and
+        # confirmed writes per local buffer epoch. A stable Hindsight document
+        # can be revisited after /resume or reset in place; generation-scoped
+        # progress prevents the prior epoch's watermark from dropping new turns.
+        self._append_progress_lock = threading.Lock()
+        self._append_epoch = 0
+        self._append_enqueued_turn_counts: Dict[tuple[str, int], int] = {}
+        self._append_retained_turn_counts: Dict[tuple[str, int], int] = {}
 
         # Recall controls
         self._auto_recall = True
@@ -1252,7 +1256,10 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_workspace = str(kwargs.get("agent_workspace") or "").strip()
         self._turn_index = 0
         self._session_turns = []
-        self._last_retained_turn_count = 0
+        with self._append_progress_lock:
+            self._append_epoch = 0
+            self._append_enqueued_turn_counts.clear()
+            self._append_retained_turn_counts.clear()
         self._mode = self._config.get("mode", "cloud")
         # Read timeout from config or env var, fall back to default
         self._timeout = _parse_int_setting(
@@ -1600,6 +1607,184 @@ class HindsightMemoryProvider(MemoryProvider):
             kwargs["observation_scopes"] = self._observation_scopes
         return kwargs
 
+    def _append_progress_key(
+        self, document_id: str, epoch: int | None = None
+    ) -> tuple[str, int]:
+        return (
+            document_id,
+            self._append_epoch if epoch is None else epoch,
+        )
+
+    def _append_enqueued_count(
+        self, document_id: str, epoch: int | None = None
+    ) -> int:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            return self._append_enqueued_turn_counts.get(key, 0)
+
+    def _append_retained_count(
+        self, document_id: str, epoch: int | None = None
+    ) -> int:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            return self._append_retained_turn_counts.get(key, 0)
+
+    def _reserve_append_turns(
+        self, document_id: str, target_count: int, epoch: int | None = None
+    ) -> None:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            self._append_enqueued_turn_counts[key] = max(
+                self._append_enqueued_turn_counts.get(key, 0),
+                target_count,
+            )
+
+    def _confirm_append_turns(
+        self, document_id: str, target_count: int, epoch: int | None = None
+    ) -> None:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            self._append_retained_turn_counts[key] = max(
+                self._append_retained_turn_counts.get(key, 0),
+                target_count,
+            )
+
+    def _release_failed_append_reservation(
+        self,
+        document_id: str,
+        target_count: int,
+        epoch: int | None = None,
+    ) -> None:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            enqueued = self._append_enqueued_turn_counts.get(key, 0)
+            if enqueued <= target_count:
+                retained = self._append_retained_turn_counts.get(key, 0)
+                self._append_enqueued_turn_counts[key] = retained
+
+    def _enqueue_session_retain(
+        self,
+        turns: List[str],
+        *,
+        document_id: str,
+        update_mode: str | None,
+        session_id: str,
+        parent_session_id: str,
+        turn_index: int,
+        reason: str,
+        append_backup: bool = False,
+    ) -> bool:
+        """Queue one serialized session retain and track append durability.
+
+        Append-capable servers need only the delta after the last confirmed
+        write in the current local buffer epoch. Reservations prevent
+        overlapping jobs from duplicating deltas, while confirmation happens
+        only after ``aretain_batch`` succeeds. ``append_backup`` queues a
+        no-op-or-retry job for finalization paths when an earlier append may
+        still be in flight.
+        """
+        if not turns or self._shutting_down.is_set():
+            return False
+
+        target_count = len(turns)
+        append_epoch = 0
+        if update_mode == "append":
+            with self._append_progress_lock:
+                append_epoch = self._append_epoch
+            enqueued_count = self._append_enqueued_count(document_id, append_epoch)
+            retained_count = self._append_retained_count(document_id, append_epoch)
+            if enqueued_count >= target_count:
+                if not append_backup or retained_count >= target_count:
+                    return False
+            self._reserve_append_turns(document_id, target_count, append_epoch)
+
+        lineage_tags: list[str] = []
+        if session_id:
+            lineage_tags.append(f"session:{session_id}")
+        if parent_session_id:
+            lineage_tags.append(f"parent:{parent_session_id}")
+
+        metadata_base = self._build_metadata(
+            message_count=target_count * 2,
+            turn_index=turn_index,
+        )
+        if session_id:
+            metadata_base["session_id"] = session_id
+        else:
+            metadata_base.pop("session_id", None)
+        bank_id = self._bank_id
+        retain_async_flag = self._retain_async
+        retain_context = self._retain_context
+
+        def _do_retain() -> None:
+            if update_mode == "append":
+                start = self._append_retained_count(document_id, append_epoch)
+                turns_to_retain = turns[start:target_count]
+                if not turns_to_retain:
+                    logger.debug(
+                        "Hindsight %s: append already confirmed for doc=%s",
+                        reason,
+                        document_id,
+                    )
+                    return
+            else:
+                turns_to_retain = turns
+
+            content = "[" + ",".join(turns_to_retain) + "]"
+            metadata = dict(metadata_base)
+            metadata["message_count"] = str(len(turns_to_retain) * 2)
+            item = self._build_retain_kwargs(
+                content,
+                context=retain_context,
+                metadata=metadata,
+                tags=lineage_tags or None,
+            )
+            item.pop("bank_id", None)
+            item.pop("retain_async", None)
+            if update_mode is not None:
+                item["update_mode"] = update_mode
+
+            logger.debug(
+                "Hindsight %s: bank=%s, doc=%s, mode=%s, async=%s, num_turns=%d",
+                reason,
+                bank_id,
+                document_id,
+                update_mode,
+                retain_async_flag,
+                len(turns_to_retain),
+            )
+            try:
+                self._run_hindsight_operation(
+                    lambda client: client.aretain_batch(
+                        bank_id=bank_id,
+                        items=[item],
+                        document_id=document_id,
+                        retain_async=retain_async_flag,
+                    )
+                )
+            except Exception:
+                if update_mode == "append":
+                    self._release_failed_append_reservation(
+                        document_id, target_count, append_epoch
+                    )
+                raise
+            if update_mode == "append":
+                self._confirm_append_turns(
+                    document_id, target_count, append_epoch
+                )
+
+        try:
+            self._ensure_writer()
+            self._register_atexit()
+            self._retain_queue.put(_do_retain)
+        except Exception:
+            if update_mode == "append":
+                self._release_failed_append_reservation(
+                    document_id, target_count, append_epoch
+                )
+            raise
+        return True
+
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Enqueue a retain for the current turn. Non-blocking.
 
@@ -1629,71 +1814,15 @@ class HindsightMemoryProvider(MemoryProvider):
             return
 
         document_id, update_mode = self._resolve_retain_target(self._document_id)
-
-        # On append-capable APIs each retain only needs to ship the turns
-        # accumulated since the last retain — the server appends them to the
-        # existing document. On legacy/overwrite APIs we must resend the whole
-        # session because each retain replaces the document.
-        if update_mode == "append":
-            turns_to_retain = self._session_turns[self._last_retained_turn_count:]
-            if not turns_to_retain:
-                logger.debug("sync_turn: skipped append retain; no new turns since last retain")
-                return
-        else:
-            turns_to_retain = list(self._session_turns)
-
-        logger.debug("sync_turn: retaining %d/%d turns, payload %d chars",
-                     len(turns_to_retain), len(self._session_turns),
-                     sum(len(t) for t in turns_to_retain))
-        content = "[" + ",".join(turns_to_retain) + "]"
-
-        lineage_tags: list[str] = []
-        if self._session_id:
-            lineage_tags.append(f"session:{self._session_id}")
-        if self._parent_session_id:
-            lineage_tags.append(f"parent:{self._parent_session_id}")
-
-        # Snapshot the state needed for the retain. The writer may run after
-        # _session_turns / _turn_index are mutated by a later sync_turn().
-        metadata_snapshot = self._build_metadata(
-            message_count=len(turns_to_retain) * 2,
+        self._enqueue_session_retain(
+            list(self._session_turns),
+            document_id=document_id,
+            update_mode=update_mode,
+            session_id=self._session_id,
+            parent_session_id=self._parent_session_id,
             turn_index=self._turn_index,
+            reason="retain",
         )
-        num_turns = len(turns_to_retain)
-        bank_id = self._bank_id
-        retain_async_flag = self._retain_async
-        retain_context = self._retain_context
-
-        def _do_retain() -> None:
-            item = self._build_retain_kwargs(
-                content,
-                context=retain_context,
-                metadata=metadata_snapshot,
-                tags=lineage_tags or None,
-            )
-            item.pop("bank_id", None)
-            item.pop("retain_async", None)
-            if update_mode is not None:
-                item["update_mode"] = update_mode
-            logger.debug("Hindsight retain: bank=%s, doc=%s, mode=%s, async=%s, content_len=%d, num_turns=%d",
-                         bank_id, document_id, update_mode, retain_async_flag, len(content), num_turns)
-            self._run_hindsight_operation(
-                lambda client: client.aretain_batch(
-                    bank_id=bank_id,
-                    items=[item],
-                    document_id=document_id,
-                    retain_async=retain_async_flag,
-                )
-            )
-            logger.debug("Hindsight retain succeeded")
-
-        self._ensure_writer()
-        self._register_atexit()
-        self._retain_queue.put(_do_retain)
-        # Advance the append watermark only after the delta is queued, so a
-        # later retain doesn't re-ship turns we've already handed to the writer.
-        if update_mode == "append":
-            self._last_retained_turn_count = len(self._session_turns)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._memory_mode == "context":
@@ -1773,6 +1902,40 @@ class HindsightMemoryProvider(MemoryProvider):
 
         return tool_error(f"Unknown tool: {tool_name}")
 
+    def on_session_end(self, messages: list, **kwargs) -> None:
+        """Flush turns left below the retain boundary before provider shutdown."""
+        if (
+            not self._auto_retain
+            or self._shutting_down.is_set()
+            or not self._session_turns
+        ):
+            return
+
+        document_id, update_mode = self._resolve_retain_target(self._document_id)
+        # Legacy servers overwrite the whole document at each boundary. An
+        # exact-boundary retain is already queued, so only partial batches need
+        # another overwrite. Append mode also needs a backup job: an exact-
+        # boundary append may still be queued and can fail before shutdown.
+        if (
+            update_mode != "append"
+            and self._turn_counter % self._retain_every_n_turns == 0
+        ):
+            return
+
+        self._enqueue_session_retain(
+            list(self._session_turns),
+            document_id=document_id,
+            update_mode=update_mode,
+            session_id=self._session_id,
+            parent_session_id=self._parent_session_id,
+            turn_index=self._turn_index,
+            reason="flush-on-end",
+            append_backup=update_mode == "append",
+        )
+        self._session_turns = []
+        self._turn_counter = 0
+        self._turn_index = 0
+
     def on_session_switch(
         self,
         new_session_id: str,
@@ -1816,69 +1979,23 @@ class HindsightMemoryProvider(MemoryProvider):
         if not new_id:
             return
 
-        # 1. Flush any buffered turns under the OLD identifiers. Snapshot
-        # everything before mutating self._* so metadata + tags + doc_id
-        # all reference the old session consistently.
+        # 1. Flush buffered turns under the OLD identifiers before mutating
+        # session state. Append mode queues a backup job so an in-flight failed
+        # boundary write is retried in FIFO order without duplicating success.
         if self._session_turns:
-            old_turns = list(self._session_turns)
-            old_session_id = self._session_id
-            old_parent_session_id = self._parent_session_id
-            old_turn_index = self._turn_index
-            old_metadata = self._build_metadata(
-                message_count=len(old_turns) * 2,
-                turn_index=old_turn_index,
-            )
-            old_lineage_tags: list[str] = []
-            if old_session_id:
-                old_lineage_tags.append(f"session:{old_session_id}")
-            if old_parent_session_id:
-                old_lineage_tags.append(f"parent:{old_parent_session_id}")
-            old_content = "[" + ",".join(old_turns) + "]"
-            # Resolve doc_id + update_mode against the OLD session BEFORE
-            # we rotate _session_id, so the flush lands in the old
-            # session's document either way (legacy: per-process unique;
-            # ≥0.5.0: stable session-scoped + append).
             old_document_id, old_update_mode = self._resolve_retain_target(
                 self._document_id
             )
-
-            def _flush():
-                try:
-                    item = self._build_retain_kwargs(
-                        old_content,
-                        context=self._retain_context,
-                        metadata=old_metadata,
-                        tags=old_lineage_tags or None,
-                    )
-                    item.pop("bank_id", None)
-                    item.pop("retain_async", None)
-                    if old_update_mode is not None:
-                        item["update_mode"] = old_update_mode
-                    logger.debug(
-                        "Hindsight flush-on-switch: bank=%s, doc=%s, mode=%s, num_turns=%d",
-                        self._bank_id, old_document_id, old_update_mode, len(old_turns),
-                    )
-                    self._run_hindsight_operation(
-                        lambda client: client.aretain_batch(
-                            bank_id=self._bank_id,
-                            items=[item],
-                            document_id=old_document_id,
-                            retain_async=self._retain_async,
-                        )
-                    )
-                except Exception as e:
-                    logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
-
-            # Route the flush through the same writer queue sync_turn
-            # uses. That serializes it behind any still-queued retains
-            # from the old session (FIFO by document_id), avoids racing
-            # two threads on aretain_batch against the same document, and
-            # keeps shutdown's drain semantics intact. Skip enqueue if
-            # shutdown has already fired — the writer is draining/gone.
-            if not self._shutting_down.is_set():
-                self._ensure_writer()
-                self._register_atexit()
-                self._retain_queue.put(_flush)
+            self._enqueue_session_retain(
+                list(self._session_turns),
+                document_id=old_document_id,
+                update_mode=old_update_mode,
+                session_id=self._session_id,
+                parent_session_id=self._parent_session_id,
+                turn_index=self._turn_index,
+                reason="flush-on-switch",
+                append_backup=old_update_mode == "append",
+            )
 
         # 2. Drain any in-flight prefetch from the old session and drop
         # its cached result so the new session doesn't see stale recall.
@@ -1887,7 +2004,12 @@ class HindsightMemoryProvider(MemoryProvider):
         with self._prefetch_lock:
             self._prefetch_result = ""
 
-        # 3. Now rotate to the new session.
+        # 3. Now rotate to the new session and begin a fresh local append
+        # epoch. Stable Hindsight document IDs may be revisited (A -> B -> A)
+        # or unchanged by an in-place reset, so document ID alone cannot scope
+        # the queued/confirmed watermark for the newly empty local buffer.
+        with self._append_progress_lock:
+            self._append_epoch += 1
         if parent_session_id:
             self._parent_session_id = str(parent_session_id).strip()
         self._session_id = new_id
@@ -1896,7 +2018,6 @@ class HindsightMemoryProvider(MemoryProvider):
         self._session_turns = []
         self._turn_counter = 0
         self._turn_index = 0
-        self._last_retained_turn_count = 0
         logger.debug(
             "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
             self._session_id, self._parent_session_id, reset, self._document_id,

--- a/run_agent.py
+++ b/run_agent.py
@@ -3500,10 +3500,11 @@ class AIAgent:
                 response_text,
                 **sync_kwargs,
             )
-            self._memory_manager.queue_prefetch_all(
-                user_text,
-                session_id=self.session_id or "",
-            )
+            if not getattr(self, "_skip_memory_prefetch_after_turn", False):
+                self._memory_manager.queue_prefetch_all(
+                    user_text,
+                    session_id=self.session_id or "",
+                )
         except Exception:
             pass
 

--- a/tests/agent/test_memory_session_switch.py
+++ b/tests/agent/test_memory_session_switch.py
@@ -215,6 +215,11 @@ def _make_hindsight_provider():
     provider._session_turns = ["turn-1", "turn-2"]
     provider._turn_counter = 2
     provider._turn_index = 2
+    # Append-accounting state normally initialized by the constructor.
+    provider._append_progress_lock = threading.Lock()
+    provider._append_epoch = 0
+    provider._append_enqueued_turn_counts = {}
+    provider._append_retained_turn_counts = {}
     # Attrs read by _build_metadata / _build_retain_kwargs when the
     # buffer-flush path on session switch fires. Empty strings keep the
     # metadata minimal but well-formed.

--- a/tests/cli/test_single_query_session_finalize.py
+++ b/tests/cli/test_single_query_session_finalize.py
@@ -174,7 +174,9 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
             calls.append("advisories")
 
         def chat(self, query, images=None):
-            calls.append(("chat", query, images))
+            calls.append(
+                ("chat", query, images, self._skip_memory_prefetch_after_turn)
+            )
             return "done"
 
         def _print_exit_summary(self, clear_screen=True):
@@ -194,7 +196,7 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
         ("claim", "cli", False),
         "query-label",
         "advisories",
-        ("chat", "hello", None),
+        ("chat", "hello", None, True),
         "summary",
         ("finalize", "single-query-session"),
     ]
@@ -202,10 +204,12 @@ def test_human_single_query_main_finalizes_after_query(monkeypatch):
 
 def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatch):
     calls = []
+    agents = []
 
     import cli as cli_mod
 
     def run_conversation(*, user_message, conversation_history):
+        calls.append(("prefetch-skip", agents[0]._skip_memory_prefetch_after_turn))
         calls.append(("run", user_message, conversation_history))
         return {
             "final_response": "",
@@ -229,6 +233,7 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
                 tool_gen_callback=object(),
                 run_conversation=run_conversation,
             )
+            agents.append(self.agent)
 
         def _claim_active_session(self, surface, *, stderr=False):
             calls.append(("claim", surface, stderr))
@@ -266,5 +271,6 @@ def test_quiet_single_query_main_finalizes_while_preserving_exit_code(monkeypatc
 
     assert exc_info.value.code == 1
     assert ("claim", "cli", True) in calls
+    assert ("prefetch-skip", True) in calls
     assert ("run", "hello", []) in calls
     assert calls[-1] == ("finalize", "quiet-session")

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1180,6 +1180,31 @@ class TestShutdownRace:
         assert client.aretain_batch.call_count == 2
         assert provider._retain_queue.empty()
 
+    def test_session_end_flushes_buffered_partial_retain_batch(self, provider_with_config):
+        """Session finalization must persist a partial retain_every_n buffer."""
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        client = p._client
+        p.sync_turn("last-user", "last-asst")
+        assert p._sync_thread is None
+        client.aretain_batch.assert_not_called()
+
+        p.on_session_end([{"role": "user", "content": "last-user"}])
+        p.shutdown()
+
+        client.aretain_batch.assert_called_once()
+        kw = client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == p._document_id
+        assert kw["retain_async"] is False
+        item = kw["items"][0]
+        content = json.loads(item["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: last-user"
+        assert content[0][1]["content"] == "Assistant: last-asst"
+        assert "session:test-session" in item["tags"]
+        assert item["metadata"]["session_id"] == "test-session"
+        assert item["metadata"]["message_count"] == "2"
+        assert item["metadata"]["turn_index"] == "1"
+
     def test_shutdown_is_idempotent(self, provider):
         provider.sync_turn("a", "b")
         provider.shutdown()
@@ -1376,6 +1401,263 @@ class TestUpdateModeAppendCapability:
         assert kw["document_id"] == "test-session"
         item = kw["items"][0]
         assert item["update_mode"] == "append"
+
+    def test_modern_api_append_retries_failed_boundary_on_next_retain(
+        self, provider_with_config, monkeypatch
+    ):
+        """A failed append retain must not advance confirmed progress."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        p._client.aretain_batch.side_effect = [RuntimeError("network error"), None]
+
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+
+        for idx in range(4, 7):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 2
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        assert item["update_mode"] == "append"
+        content = json.loads(item["content"])
+        assert len(content) == 6
+        assert content[0][0]["content"] == "User: turn1-user"
+        assert content[-1][0]["content"] == "User: turn6-user"
+
+    def test_modern_api_append_failure_during_immediate_drain_rolls_back_reservation(
+        self, provider_with_config, monkeypatch
+    ):
+        """Queued progress must be reserved before an eager writer runs the job."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=1, retain_async=False)
+        p._client.aretain_batch.side_effect = RuntimeError("network error")
+        p._ensure_writer = lambda: None
+
+        class _ImmediateQueue:
+            def put(self, job):
+                try:
+                    job()
+                except RuntimeError:
+                    pass
+
+            def join(self):
+                pass
+
+        p._retain_queue = _ImmediateQueue()
+        p.sync_turn("turn1-user", "turn1-asst")
+
+        assert p._append_enqueued_count("test-session") == 0
+        assert p._append_retained_count("test-session") == 0
+
+    def test_modern_api_session_end_retries_failed_exact_boundary_append(
+        self, provider_with_config, monkeypatch
+    ):
+        """Finalization retries an exact-boundary append that failed earlier."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        p._client.aretain_batch.side_effect = [RuntimeError("network error"), None]
+
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+        assert p._client.aretain_batch.call_count == 1
+
+        p.on_session_end([])
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 2
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        content = json.loads(item["content"])
+        assert len(content) == 3
+        assert content[0][0]["content"] == "User: turn1-user"
+        assert content[-1][0]["content"] == "User: turn3-user"
+
+    def test_modern_api_session_end_retries_in_flight_boundary_failure(
+        self, provider_with_config, monkeypatch
+    ):
+        """Finalization queues a retry behind an append that is still in flight."""
+        import threading
+
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        started = threading.Event()
+        release = threading.Event()
+        attempts = 0
+
+        async def _retain(**kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                started.set()
+                release.wait(timeout=5.0)
+                raise RuntimeError("network error")
+
+        p._client.aretain_batch = AsyncMock(side_effect=_retain)
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        assert started.wait(timeout=5.0)
+
+        p.on_session_end([])
+        release.set()
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 2
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        content = json.loads(item["content"])
+        assert len(content) == 3
+        assert content[0][0]["content"] == "User: turn1-user"
+        assert content[-1][0]["content"] == "User: turn3-user"
+
+    def test_modern_api_session_end_skips_confirmed_exact_boundary(
+        self, provider_with_config, monkeypatch
+    ):
+        """A successful exact-boundary append is not duplicated at finalization."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+        p._client.aretain_batch.reset_mock()
+
+        p.on_session_end([])
+        p._retain_queue.join()
+
+        p._client.aretain_batch.assert_not_called()
+
+    def test_modern_api_session_end_flushes_only_append_remainder(
+        self, provider_with_config, monkeypatch
+    ):
+        """Final partial flush appends only turns not confirmed earlier."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+        p._client.aretain_batch.reset_mock()
+
+        p.sync_turn("turn4-user", "turn4-asst")
+        p.on_session_end([])
+        p._retain_queue.join()
+
+        kw = p._client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == "test-session"
+        item = kw["items"][0]
+        assert item["update_mode"] == "append"
+        content = json.loads(item["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: turn4-user"
+        assert content[0][1]["content"] == "Assistant: turn4-asst"
+        assert "turn1-user" not in item["content"]
+
+    def test_modern_api_session_switch_flushes_only_append_remainder(
+        self, provider_with_config, monkeypatch
+    ):
+        """Session-switch append flush does not duplicate earlier boundaries."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+        p._client.aretain_batch.reset_mock()
+
+        p.sync_turn("turn4-user", "turn4-asst")
+        p.on_session_switch("new-sid", parent_session_id="test-session", reset=True)
+        p._retain_queue.join()
+
+        kw = p._client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == "test-session"
+        item = kw["items"][0]
+        assert item["update_mode"] == "append"
+        content = json.loads(item["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: turn4-user"
+        assert "turn1-user" not in item["content"]
+
+    def test_modern_api_same_id_switch_starts_new_append_epoch(
+        self, provider_with_config, monkeypatch
+    ):
+        """A same-ID buffer reset must not reuse the prior append watermark."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=1, retain_async=False)
+
+        p.sync_turn("before-rewind", "before-asst")
+        p._retain_queue.join()
+        p.on_session_switch("test-session")
+        p.sync_turn("after-rewind", "after-asst")
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 2
+        kw = p._client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == "test-session"
+        content = json.loads(kw["items"][0]["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: after-rewind"
+
+    def test_modern_api_revisited_session_starts_new_append_epoch(
+        self, provider_with_config, monkeypatch
+    ):
+        """Returning A -> B -> A must retain A's new local-buffer epoch."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+
+        p.sync_turn("first-a", "first-a-asst")
+        p.on_session_switch("session-b", parent_session_id="test-session")
+        p.sync_turn("only-b", "only-b-asst")
+        p.on_session_switch("test-session", parent_session_id="session-b")
+        p.sync_turn("second-a", "second-a-asst")
+        p.on_session_end([])
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 3
+        calls = p._client.aretain_batch.call_args_list
+        assert [call.kwargs["document_id"] for call in calls] == [
+            "test-session",
+            "session-b",
+            "test-session",
+        ]
+        content = json.loads(calls[-1].kwargs["items"][0]["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: second-a"
 
     def test_capability_cached_per_url(self, provider, monkeypatch):
         """The /version probe must run at most once per (process, api_url)."""

--- a/tests/run_agent/test_memory_sync_interrupted.py
+++ b/tests/run_agent/test_memory_sync_interrupted.py
@@ -91,6 +91,24 @@ class TestSyncExternalMemoryForTurn:
             session_id="test_session_001",
         )
 
+    def test_completed_turn_can_skip_prefetch_for_one_shot_sessions(self):
+        """One-shot CLI sessions persist the turn without warming a next turn."""
+        agent = _bare_agent()
+        agent._skip_memory_prefetch_after_turn = True
+
+        agent._sync_external_memory_for_turn(
+            original_user_message="What's the weather in Paris?",
+            final_response="It's sunny and 22°C.",
+            interrupted=False,
+        )
+
+        agent._memory_manager.sync_all.assert_called_once_with(
+            "What's the weather in Paris?",
+            "It's sunny and 22°C.",
+            session_id="test_session_001",
+        )
+        agent._memory_manager.queue_prefetch_all.assert_not_called()
+
     def test_completed_turn_syncs_messages_when_present(self):
         agent = _bare_agent()
         messages = [


### PR DESCRIPTION
## What does this PR do?

Rebuilds the still-relevant Hindsight durability fix on current `main`, while preserving the newer one-shot CLI lifecycle (`_finalize_single_query()` → `_run_cleanup()`) that landed upstream after this PR was opened.

The remaining failure modes were:

- `retain_every_n_turns > 1` could leave the final partial batch only in memory because Hindsight had no `on_session_end()` flush.
- Append-mode progress advanced when work was queued rather than when Hindsight accepted it. A failed asynchronous append could therefore cause later turns to omit data that was never persisted.
- Append progress was scoped only by stable Hindsight document ID. Revisiting a session (`A → B → A`) or resetting the local buffer under the same ID could reuse an old watermark and silently drop the new epoch's initial turns.
- Completed one-shot CLI queries still queued recall prefetch even though no next turn could consume it.

This PR addresses those issues without reintroducing the stale parallel CLI finalization helper.

## Related Issues

Fixes #15497
Fixes #15073

Related: #15512 is a narrower provider-side shutdown-guard PR.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✅ Tests

## Changes Made

### `plugins/memory/hindsight/__init__.py`

- Add `on_session_end()` flushing for final partial retain batches.
- Reuse the same flush path when switching sessions, before rotating session identifiers.
- Track append reservations and confirmed writes separately per local buffer epoch, keyed by `(document_id, epoch)`.
- Advance the epoch whenever session-switch handling clears the local turn buffer, including same-ID resets and revisited sessions.
- Build append payloads when the FIFO writer executes:
  - successful earlier writes make backup jobs no-op;
  - failed earlier writes cause the next job to retry the missing suffix;
  - failure rolls a reservation back when no later queued job covers it.
- Keep overwrite-mode behavior compatible with older Hindsight API versions.

### One-shot prefetch suppression

- Initialize `_skip_memory_prefetch_after_turn` in `agent/agent_init.py`.
- Set it for quiet and human-readable one-shot query paths in `cli.py`.
- Honor it after completed turns in `run_agent.py`.
- Preserve current `main`'s existing `_finalize_single_query()` / `_run_cleanup()` lifecycle unchanged.

### Regression coverage

Tests cover:

- final partial-batch session-end flushing;
- append delta behavior across retain boundaries;
- completed and in-flight append failures;
- exact-boundary finalization retry/no-duplicate behavior;
- session-switch remainder flushing;
- same-ID local-buffer resets and `A → B → A` session revisits;
- one-shot prefetch suppression in quiet and human-readable CLI paths.

## Verification

Run after rebasing onto current `origin/main` (`2637aa607`):

```bash
scripts/run_tests.sh \
  tests/agent/test_file_safety_session_state.py \
  tests/agent/test_memory_session_switch.py \
  tests/run_agent/test_memory_sync_interrupted.py \
  tests/plugins/memory/test_hindsight_provider.py \
  tests/cli/test_cli_shutdown_memory_messages.py \
  tests/cli/test_single_query_session_finalize.py -- -q
```

Result: **189 passed, 0 failed**.

Broader memory-provider suite:

```bash
scripts/run_tests.sh tests/plugins/memory -- -q
```

Result: **472 passed, 0 failed**.

Additional checks:

```bash
ruff check agent/agent_init.py cli.py plugins/memory/hindsight/__init__.py run_agent.py \
  tests/agent/test_memory_session_switch.py \
  tests/cli/test_single_query_session_finalize.py \
  tests/plugins/memory/test_hindsight_provider.py \
  tests/run_agent/test_memory_sync_interrupted.py
python -m compileall -q agent/agent_init.py cli.py plugins/memory/hindsight/__init__.py run_agent.py
python scripts/check-windows-footguns.py --all
git diff --check origin/main...HEAD
git merge-tree --write-tree origin/main HEAD
```

Results:

- Ruff: passed
- Compileall: passed
- Windows footgun scan: passed (777 files)
- Diff check: passed
- Merge-tree check: passed

The full repository suite was not completed locally; GitHub's sliced full-suite run is the authoritative broad verification for the pushed commit.

## Checklist

- [x] Rebuilt on current `main` rather than mechanically resolving the obsolete CLI lifecycle
- [x] Conventional commit message
- [x] Only related source and regression-test changes
- [x] Added tests for durability, session-epoch, and one-shot behavior changes
- [x] Tested on Ubuntu 24.04 / Linux 6.8.0
- [ ] Full `tests/` suite completed locally

