### PR TITLE
Add mj41 MCP server to optional catalog

### DIFF
--- a/optional-mcps/mj41/manifest.yaml
+++ b/optional-mcps/mj41/manifest.yaml
@@ -1,0 +1,51 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: mj41
+description: >
+  Real-time copper pricing (COMEX spot, scrap, industrial), blockchain
+  investigation, and AI news wire. 11 tools spanning ZJ Industries copper
+  oracles on Base L2, Richard Tracy wallet forensics, and The First Signal
+  news platform.
+source: https://github.com/mj41Fantastican/mj41-mcp
+
+# npx-based stdio server — no clone or local install needed.
+transport:
+  type: stdio
+  command: "npx"
+  args:
+    - "-y"
+    - "mj41-mcp@1.2.1"
+
+auth:
+  type: none
+
+tools:
+  default_enabled:
+    - get_copper_price
+    - get_all_copper_prices
+    - get_oracle_status
+    - get_eth_price
+    - get_latest_news
+    - get_news_by_beat
+    - get_story
+    - investigate_wallet
+    - submit_story_idea
+    - about_mj41
+
+post_install: |
+  All tools work immediately with no API keys or configuration.
+
+  Copper oracles read live on-chain data from Base mainnet:
+    - Class A: COMEX spot copper (auto-updated every 15 min during market hours)
+    - Class B: Scrap copper (COMEX-derived, dual-discount bands)
+    - Class C: Industrial copper (ZJ Industries pricing)
+
+  Richard Tracy investigates any Ethereum/Base wallet address and returns
+  a full forensic case report.
+
+  The First Signal delivers AI-generated news across 16 beats with full
+  article retrieval.
+
+  More info: https://github.com/mj41Fantastican/mj41-mcp


### PR DESCRIPTION
## Summary
- Adds `optional-mcps/mj41/manifest.yaml` — 11 tools, zero-config `npx` install, no API keys
- **Copper Oracles:** Live on-chain COMEX spot, scrap, and industrial copper pricing from Base L2 (ZJ Industries)
- **Richard Tracy:** Blockchain wallet investigation — full forensic case reports for any ETH/Base address
- **The First Signal:** AI news wire with 16 beats, article retrieval, and story submission

## Details
- **npm:** [mj41-mcp@1.2.1](https://www.npmjs.com/package/mj41-mcp)
- **Repo:** [mj41Fantastican/mj41-mcp](https://github.com/mj41Fantastican/mj41-mcp)
- **Transport:** stdio via `npx -y mj41-mcp@1.2.1`
- **Auth:** none — all tools work immediately
- **Tools (11):** `get_copper_price`, `get_all_copper_prices`, `get_oracle_status`, `get_eth_price`, `get_latest_news`, `get_news_by_beat`, `get_story`, `investigate_wallet`, `submit_story_idea`, `about_mj41`

## Test plan
- [x] `npx mj41-mcp` starts clean on stdio
- [x] All 11 tools smoke-tested (Session #78 — 11/11 passed)
- [x] Published to npm as v1.2.1
- [ ] Verify Hermes `mcp install` picks up manifest correctly