### PR TITLE
Fix oneshot system prompt handling

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5392,7 +5392,16 @@ def show_config():
     print()
     print(color("◆ Display", Colors.CYAN, Colors.BOLD))
     display = config.get('display', {})
-    print(f"  Personality:  {display.get('personality', 'kawaii')}")
+    if not isinstance(display, dict):
+        display = {}
+    agent_cfg = config.get('agent', {})
+    if not isinstance(agent_cfg, dict):
+        agent_cfg = {}
+    system_prompt = str(agent_cfg.get('system_prompt') or '').strip()
+    personalities = agent_cfg.get('personalities', {})
+    personalities_count = len(personalities) if isinstance(personalities, dict) else 0
+    print(f"  System prompt: {'set' if system_prompt else 'none'}")
+    print(f"  Personalities: {personalities_count} configured")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
     print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
     ump = display.get('user_message_preview', {}) if isinstance(display.get('user_message_preview', {}), dict) else {}

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -17,6 +17,7 @@ Model / provider selection mirrors `hermes chat`:
 
 Env var fallbacks (used when the corresponding arg is not passed):
     - HERMES_INFERENCE_MODEL
+    - HERMES_EPHEMERAL_SYSTEM_PROMPT
 """
 
 from __future__ import annotations
@@ -215,6 +216,20 @@ def _create_session_db_for_oneshot():
         return None
 
 
+def _resolve_ephemeral_system_prompt(cfg: dict) -> str:
+    """Return the configured personality/system prompt overlay for oneshot."""
+    env_prompt = os.getenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "")
+    if env_prompt:
+        return env_prompt
+
+    agent_cfg = cfg.get("agent") if isinstance(cfg, dict) else {}
+    if not isinstance(agent_cfg, dict):
+        return ""
+
+    prompt = agent_cfg.get("system_prompt", "")
+    return prompt if isinstance(prompt, str) else str(prompt or "")
+
+
 def _run_agent(
     prompt: str,
     model: Optional[str] = None,
@@ -304,6 +319,7 @@ def _run_agent(
     # Read the effective fallback chain from profile config so oneshot workers
     # honour the same merge semantics as interactive CLI and gateway sessions.
     _fb = get_fallback_chain(cfg)
+    ephemeral_system_prompt = _resolve_ephemeral_system_prompt(cfg)
 
     agent = AIAgent(
         api_key=runtime.get("api_key"),
@@ -317,6 +333,7 @@ def _run_agent(
         session_db=session_db,
         credential_pool=runtime.get("credential_pool"),
         fallback_model=_fb or None,
+        ephemeral_system_prompt=ephemeral_system_prompt or None,
         # Interactive callbacks are intentionally NOT wired beyond this
         # one.  In oneshot mode there's no user sitting at a terminal:
         #   - clarify  → returns a synthetic "pick a default" instruction

--- a/tests/cli/test_oneshot.py
+++ b/tests/cli/test_oneshot.py
@@ -1,0 +1,71 @@
+"""Regression tests for hermes -z oneshot mode."""
+
+import sys
+from types import SimpleNamespace
+
+
+class _FakeAgent:
+    captured_kwargs = {}
+
+    def __init__(self, **kwargs):
+        type(self).captured_kwargs = kwargs
+        self.suppress_status_output = False
+        self.stream_delta_callback = object()
+        self.tool_gen_callback = object()
+
+    def chat(self, prompt):
+        return f"response to {prompt}"
+
+
+def _patch_oneshot_dependencies(monkeypatch, cfg):
+    import hermes_cli.config as config_mod
+    import hermes_cli.models as models_mod
+    import hermes_cli.oneshot as oneshot_mod
+    import hermes_cli.runtime_provider as runtime_provider_mod
+    import hermes_cli.tools_config as tools_config_mod
+
+    monkeypatch.setattr(config_mod, "load_config", lambda: cfg)
+    monkeypatch.setattr(models_mod, "detect_provider_for_model", lambda model, provider: None)
+    monkeypatch.setattr(
+        runtime_provider_mod,
+        "resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "test-key",
+            "base_url": "https://example.invalid/v1",
+            "provider": "test-provider",
+            "api_mode": "chat",
+            "credential_pool": None,
+        },
+    )
+    monkeypatch.setattr(tools_config_mod, "_get_platform_tools", lambda cfg, platform: set())
+    monkeypatch.setattr(oneshot_mod, "_create_session_db_for_oneshot", lambda: None)
+    monkeypatch.setattr(oneshot_mod, "get_fallback_chain", lambda cfg: [])
+    monkeypatch.setitem(sys.modules, "run_agent", SimpleNamespace(AIAgent=_FakeAgent))
+
+    return oneshot_mod
+
+
+def test_oneshot_passes_configured_system_prompt(monkeypatch):
+    cfg = {
+        "model": {"default": "test-model", "provider": "test-provider"},
+        "agent": {"system_prompt": "You are Alt Brian."},
+    }
+    monkeypatch.delenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", raising=False)
+    oneshot_mod = _patch_oneshot_dependencies(monkeypatch, cfg)
+
+    assert oneshot_mod._run_agent("hello") == "response to hello"
+
+    assert _FakeAgent.captured_kwargs["ephemeral_system_prompt"] == "You are Alt Brian."
+
+
+def test_oneshot_env_system_prompt_overrides_config(monkeypatch):
+    cfg = {
+        "model": {"default": "test-model", "provider": "test-provider"},
+        "agent": {"system_prompt": "Config prompt"},
+    }
+    monkeypatch.setenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "Env prompt")
+    oneshot_mod = _patch_oneshot_dependencies(monkeypatch, cfg)
+
+    oneshot_mod._run_agent("hello")
+
+    assert _FakeAgent.captured_kwargs["ephemeral_system_prompt"] == "Env prompt"

--- a/tests/hermes_cli/test_placeholder_usage.py
+++ b/tests/hermes_cli/test_placeholder_usage.py
@@ -40,6 +40,16 @@ def test_show_config_marks_placeholders(tmp_path, capsys):
     assert "hermes config set <key> <value>" in out
 
 
+def test_show_config_reports_active_system_prompt_not_display_personality(tmp_path, capsys):
+    with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+        show_config()
+
+    out = capsys.readouterr().out
+    assert "System prompt: none" in out
+    assert "Personalities: 0 configured" in out
+    assert "Personality:  kawaii" not in out
+
+
 def test_setup_summary_marks_placeholders(tmp_path, capsys):
     with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
         _print_setup_summary({"tts": {"provider": "edge"}}, tmp_path)


### PR DESCRIPTION
## Summary
- pass the configured agent.system_prompt / HERMES_EPHEMERAL_SYSTEM_PROMPT into hermes -z oneshot agents
- make config show report the active system prompt state instead of the legacy display.personality value
- add focused regression tests for oneshot prompt forwarding and config display output

Fixes #34852

## Tests
- docker run --rm -v "/mnt/user/domains/VS Projects/06_Lab_Sandbox/hermes-agent-upstream:/work" -w /work --entrypoint /opt/hermes/.venv/bin/python nousresearch/hermes-agent:latest -m pytest tests/hermes_cli/test_placeholder_usage.py tests/cli/test_oneshot.py

Result: 7 passed