### PR TITLE
Enforce update-safe role routing matrix

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -48,6 +48,7 @@ from agent.tool_guardrails import (
     ToolGuardrailDecision,
 )
 from hermes_cli.config import cfg_get
+from hermes_cli.fallback_config import sanitize_fallback_chain
 from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import get_hermes_home
 from utils import base_url_host_matches
@@ -882,15 +883,7 @@ def init_agent(
     # when the primary is exhausted (rate-limit, overload, connection
     # failure).  Supports both legacy single-dict ``fallback_model`` and
     # new list ``fallback_providers`` format.
-    if isinstance(fallback_model, list):
-        agent._fallback_chain = [
-            f for f in fallback_model
-            if isinstance(f, dict) and f.get("provider") and f.get("model")
-        ]
-    elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
-        agent._fallback_chain = [fallback_model]
-    else:
-        agent._fallback_chain = []
+    agent._fallback_chain = sanitize_fallback_chain(fallback_model)
     agent._fallback_index = 0
     agent._fallback_activated = getattr(agent, "_fallback_activated", False)
     # Legacy attribute kept for backward compat (tests, external callers)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1212,6 +1212,23 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 # not only after a later credential-rotation rebuild.
                 agent._replace_primary_openai_client(reason="fallback_timeout_apply")
 
+        try:
+            from hermes_constants import parse_reasoning_effort
+
+            fb_effort = str(fb.get("reasoning_effort") or "").strip()
+            parsed_reasoning = None
+            if fb_effort:
+                parsed_reasoning = parse_reasoning_effort(fb_effort)
+            agent.reasoning_config = parsed_reasoning
+        except Exception as _reasoning_err:
+            agent.reasoning_config = None
+            logger.debug(
+                "Could not apply fallback reasoning_effort for %s/%s: %s",
+                fb_provider,
+                fb_model,
+                _reasoning_err,
+            )
+
         # Re-evaluate prompt caching for the new provider/model
         agent._use_prompt_caching, agent._use_native_cache_layout = (
             agent._anthropic_prompt_cache_policy(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -25,6 +25,7 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
+from hermes_cli.fallback_config import is_opus_48_model
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
@@ -1030,6 +1031,12 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     agent._fallback_index += 1
     fb_provider = (fb.get("provider") or "").strip().lower()
     fb_model = (fb.get("model") or "").strip()
+    if is_opus_48_model(fb_model):
+        logger.warning(
+            "Fallback skip: disallowed Opus 4.8 chain entry %s/%s",
+            fb_provider, fb_model,
+        )
+        return agent._try_activate_fallback()
     if not fb_provider or not fb_model:
         return agent._try_activate_fallback()  # skip invalid, try next
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1545,6 +1545,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             format_runtime_provider_error,
         )
         from hermes_cli.auth import AuthError
+        from hermes_cli.fallback_config import get_fallback_chain
         try:
             # Do not inject HERMES_INFERENCE_PROVIDER here. resolve_runtime_provider()
             # already prefers persisted config over stale shell/env overrides when
@@ -1560,8 +1561,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         except AuthError as auth_exc:
             # Primary provider auth failed — try fallback chain before giving up.
             logger.warning("Job '%s': primary auth failed (%s), trying fallback", job_id, auth_exc)
-            fb = _cfg.get("fallback_providers") or _cfg.get("fallback_model")
-            fb_list = (fb if isinstance(fb, list) else [fb]) if fb else []
+            fb_list = get_fallback_chain(_cfg if isinstance(_cfg, dict) else {})
             runtime = None
             for entry in fb_list:
                 if not isinstance(entry, dict):
@@ -1583,7 +1583,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
             message = format_runtime_provider_error(exc)
             raise RuntimeError(message) from exc
 
-        fallback_model = _cfg.get("fallback_providers") or _cfg.get("fallback_model") or None
+        fallback_model = get_fallback_chain(_cfg if isinstance(_cfg, dict) else {}) or None
         credential_pool = None
         runtime_provider = str(runtime.get("provider") or "").strip().lower()
         if runtime_provider:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -65,6 +65,8 @@ _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+_SHUTDOWN_NOTIFICATION_SEND_TIMEOUT_SECS_DEFAULT = 2.0
+_SHUTDOWN_NOTIFICATION_OVERALL_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
@@ -1681,6 +1683,12 @@ class GatewayRunner:
     _restart_detached: bool = False
     _restart_via_service: bool = False
     _stop_task: Optional[asyncio.Task] = None
+    _shutdown_notification_send_timeout: float = (
+        _SHUTDOWN_NOTIFICATION_SEND_TIMEOUT_SECS_DEFAULT
+    )
+    _shutdown_notification_overall_timeout: float = (
+        _SHUTDOWN_NOTIFICATION_OVERALL_TIMEOUT_SECS_DEFAULT
+    )
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
 
@@ -3436,12 +3444,92 @@ class GatewayRunner:
             except Exception as e:
                 logger.debug("Failed interrupting agent during shutdown: %s", e)
 
+    def _mark_running_sessions_resume_pending(self, reason: str) -> list[str]:
+        """Persist resume markers for every currently running real agent."""
+        marked: list[str] = []
+        for session_key, agent in list(self._running_agents.items()):
+            if agent is _AGENT_PENDING_SENTINEL:
+                continue
+            try:
+                self.session_store.mark_resume_pending(session_key, reason)
+                marked.append(session_key)
+            except Exception as exc:
+                logger.debug(
+                    "mark_resume_pending failed for %s during shutdown: %s",
+                    session_key,
+                    exc,
+                )
+        return marked
+
+    async def _send_shutdown_notification(
+        self,
+        *,
+        adapter: BasePlatformAdapter,
+        platform_str: str,
+        chat_id: str,
+        msg: str,
+        target_label: str,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        timeout = getattr(
+            self,
+            "_shutdown_notification_send_timeout",
+            _SHUTDOWN_NOTIFICATION_SEND_TIMEOUT_SECS_DEFAULT,
+        )
+        try:
+            timeout = float(timeout)
+        except (TypeError, ValueError):
+            timeout = _SHUTDOWN_NOTIFICATION_SEND_TIMEOUT_SECS_DEFAULT
+        timeout = max(timeout, 0.1)
+
+        try:
+            if metadata is not None:
+                send_coro = adapter.send(chat_id, msg, metadata=metadata)
+            else:
+                send_coro = adapter.send(chat_id, msg)
+            result = await asyncio.wait_for(send_coro, timeout=timeout)
+            if result is not None and getattr(result, "success", True) is False:
+                logger.debug(
+                    "Failed to send shutdown notification to %s %s:%s: %s",
+                    target_label,
+                    platform_str,
+                    chat_id,
+                    getattr(result, "error", "send returned success=False"),
+                )
+                return False
+
+            logger.info(
+                "Sent shutdown notification to %s %s:%s",
+                target_label,
+                platform_str,
+                chat_id,
+            )
+            return True
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Shutdown notification to %s %s:%s timed out after %.1fs; continuing shutdown",
+                target_label,
+                platform_str,
+                chat_id,
+                timeout,
+            )
+            return False
+        except Exception as exc:
+            logger.debug(
+                "Failed to send shutdown notification to %s %s:%s: %s",
+                target_label,
+                platform_str,
+                chat_id,
+                exc,
+            )
+            return False
+
     async def _notify_active_sessions_of_shutdown(self) -> None:
         """Send shutdown/restart notifications to active chats and home channels.
 
         Called at the very start of stop() — adapters are still connected so
-        messages can be delivered. Best-effort: individual send failures are
-        logged and swallowed so they never block the shutdown sequence.
+        messages can be delivered. Best-effort: individual send failures and
+        slow network calls are bounded so they never block the shutdown drain.
         """
         active = self._snapshot_running_agents()
 
@@ -3455,6 +3543,38 @@ class GatewayRunner:
         msg = f"⚠️ Gateway {action} — {hint}"
 
         notified: set[tuple[str, str, Optional[str]]] = set()
+        send_jobs: list[asyncio.Future[bool]] = []
+
+        def _schedule_send(
+            *,
+            adapter: BasePlatformAdapter,
+            platform_str: str,
+            chat_id: str,
+            thread_id: Optional[str],
+            target_label: str,
+        ) -> None:
+            dedup_key = (
+                platform_str,
+                str(chat_id),
+                str(thread_id) if thread_id else None,
+            )
+            if dedup_key in notified:
+                return
+            notified.add(dedup_key)
+            metadata = {"thread_id": thread_id} if thread_id else None
+            send_jobs.append(
+                asyncio.create_task(
+                    self._send_shutdown_notification(
+                        adapter=adapter,
+                        platform_str=platform_str,
+                        chat_id=str(chat_id),
+                        msg=msg,
+                        target_label=target_label,
+                        metadata=metadata,
+                    )
+                )
+            )
+
         for session_key in active:
             source = None
             try:
@@ -3486,13 +3606,6 @@ class GatewayRunner:
                 chat_id = _parsed["chat_id"]
                 thread_id = _parsed.get("thread_id")
 
-            # Deduplicate only identical delivery targets. Thread/topic-aware
-            # platforms can share a parent chat while still routing to distinct
-            # destinations via metadata.
-            dedup_key = (platform_str, chat_id, str(thread_id) if thread_id else None)
-            if dedup_key in notified:
-                continue
-
             try:
                 platform = Platform(platform_str)
                 adapter = self.adapters.get(platform)
@@ -3507,28 +3620,16 @@ class GatewayRunner:
                     )
                     continue
 
-                # Include thread_id if present so the message lands in the
-                # correct forum topic / thread.
-                metadata = {"thread_id": thread_id} if thread_id else None
-
-                result = await adapter.send(chat_id, msg, metadata=metadata)
-                if result is not None and getattr(result, "success", True) is False:
-                    logger.debug(
-                        "Failed to send shutdown notification to %s:%s: %s",
-                        platform_str,
-                        chat_id,
-                        getattr(result, "error", "send returned success=False"),
-                    )
-                    continue
-
-                notified.add(dedup_key)
-                logger.info(
-                    "Sent shutdown notification to active chat %s:%s",
-                    platform_str, chat_id,
+                _schedule_send(
+                    adapter=adapter,
+                    platform_str=platform_str,
+                    chat_id=chat_id,
+                    thread_id=thread_id,
+                    target_label="active chat",
                 )
             except Exception as e:
                 logger.debug(
-                    "Failed to send shutdown notification to %s:%s: %s",
+                    "Failed to schedule shutdown notification to %s:%s: %s",
                     platform_str, chat_id, e,
                 )
 
@@ -3550,38 +3651,40 @@ class GatewayRunner:
                 )
                 continue
 
-            dedup_key = (platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None)
-            if dedup_key in notified:
-                continue
+            _schedule_send(
+                adapter=adapter,
+                platform_str=platform.value,
+                chat_id=str(home.chat_id),
+                thread_id=home.thread_id,
+                target_label="home channel",
+            )
 
-            try:
-                metadata = {"thread_id": home.thread_id} if home.thread_id else None
-                if metadata:
-                    result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
-                else:
-                    result = await adapter.send(str(home.chat_id), msg)
-                if result is not None and getattr(result, "success", True) is False:
-                    logger.debug(
-                        "Failed to send shutdown notification to home channel %s:%s: %s",
-                        platform.value,
-                        home.chat_id,
-                        getattr(result, "error", "send returned success=False"),
-                    )
-                    continue
+        if not send_jobs:
+            return
 
-                notified.add(dedup_key)
-                logger.info(
-                    "Sent shutdown notification to home channel %s:%s",
-                    platform.value,
-                    home.chat_id,
-                )
-            except Exception as e:
-                logger.debug(
-                    "Failed to send shutdown notification to home channel %s:%s: %s",
-                    platform.value,
-                    home.chat_id,
-                    e,
-                )
+        overall_timeout = getattr(
+            self,
+            "_shutdown_notification_overall_timeout",
+            _SHUTDOWN_NOTIFICATION_OVERALL_TIMEOUT_SECS_DEFAULT,
+        )
+        try:
+            overall_timeout = float(overall_timeout)
+        except (TypeError, ValueError):
+            overall_timeout = _SHUTDOWN_NOTIFICATION_OVERALL_TIMEOUT_SECS_DEFAULT
+        overall_timeout = max(overall_timeout, 0.1)
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*send_jobs, return_exceptions=True),
+                timeout=overall_timeout,
+            )
+        except asyncio.TimeoutError:
+            for job in send_jobs:
+                if not job.done():
+                    job.cancel()
+            logger.warning(
+                "Shutdown notification fan-out timed out after %.1fs; continuing shutdown",
+                overall_timeout,
+            )
 
     def _finalize_shutdown_agents(self, active_agents: Dict[str, Any]) -> None:
         for agent in active_agents.values():
@@ -6062,6 +6165,22 @@ class GatewayRunner:
             self._running = False
             self._draining = True
 
+            timeout = self._restart_drain_timeout
+            _resume_reason = (
+                "restart_timeout" if self._restart_requested else "shutdown_timeout"
+            )
+
+            # Pre-mark sessions as resume_pending BEFORE the drain wait.
+            # If the process is killed by the service manager during
+            # notifications or drain, the durable marker is already written
+            # so the next gateway boot can recover in-flight sessions
+            # (#27856).  This must happen before any network send; shutdown
+            # notifications are best-effort and can be slow during the exact
+            # outage/restart conditions that cause SIGTERM.
+            _pre_drain_keys = self._mark_running_sessions_resume_pending(
+                _resume_reason
+            )
+
             # Notify all chats with active agents BEFORE draining.
             # Adapters are still connected here, so messages can be sent.
             await self._notify_active_sessions_of_shutdown()
@@ -6069,25 +6188,6 @@ class GatewayRunner:
                 "Shutdown phase: notify_active_sessions done at +%.2fs",
                 _phase_elapsed(),
             )
-
-            timeout = self._restart_drain_timeout
-
-            # Pre-mark sessions as resume_pending BEFORE the drain wait.
-            # If the process is killed by the service manager during the
-            # drain, the durable marker is already written so the next
-            # gateway boot can recover in-flight sessions (#27856).
-            _pre_drain_keys: list[str] = []
-            for _sk, _agent in list(self._running_agents.items()):
-                if _agent is _AGENT_PENDING_SENTINEL:
-                    continue
-                try:
-                    self.session_store.mark_resume_pending(
-                        _sk,
-                        "restart_timeout" if self._restart_requested else "shutdown_timeout",
-                    )
-                    _pre_drain_keys.append(_sk)
-                except Exception as _e:
-                    logger.debug("pre-drain mark_resume_pending failed for %s: %s", _sk, _e)
 
             _drain_started_at = time.monotonic()
             active_agents, timed_out = await self._drain_active_agents(timeout)
@@ -6142,19 +6242,7 @@ class GatewayRunner:
                 # _interrupt_running_agents() does: their agent hasn't
                 # started yet, there's nothing to interrupt, and the
                 # session shouldn't carry a misleading resume flag.
-                _resume_reason = (
-                    "restart_timeout" if self._restart_requested else "shutdown_timeout"
-                )
-                for _sk, _agent in list(self._running_agents.items()):
-                    if _agent is _AGENT_PENDING_SENTINEL:
-                        continue
-                    try:
-                        self.session_store.mark_resume_pending(_sk, _resume_reason)
-                    except Exception as _e:
-                        logger.debug(
-                            "mark_resume_pending failed for %s: %s",
-                            _sk, _e,
-                        )
+                self._mark_running_sessions_resume_pending(_resume_reason)
                 self._interrupt_running_agents(
                     _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
                 )

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -5,6 +5,23 @@ from __future__ import annotations
 from typing import Any
 
 
+_OPUS_48_MARKERS = (
+    "opus-4.8",
+    "opus4.8",
+    "opus_4_8",
+    "opus-4-8",
+    "opus 4.8",
+)
+
+
+def is_opus_48_model(model: Any) -> bool:
+    """Return True when a model slug/name identifies the disallowed Opus 4.8."""
+
+    normalized = str(model or "").strip().lower().replace("_", "-")
+    compact = normalized.replace("-", "").replace(" ", "")
+    return any(marker in normalized for marker in _OPUS_48_MARKERS) or "opus48" in compact
+
+
 def _normalized_base_url(value: Any) -> str:
     if not isinstance(value, str):
         return ""
@@ -40,12 +57,59 @@ def _iter_fallback_entries(raw: Any) -> list[dict[str, Any]]:
     return entries
 
 
-def _entry_identity(entry: dict[str, Any]) -> tuple[str, str, str]:
+def _entry_identity(entry: dict[str, Any]) -> tuple[str, str, str, str]:
     return (
         str(entry.get("provider") or "").strip().lower(),
         str(entry.get("model") or "").strip().lower(),
         _normalized_base_url(entry.get("base_url")).lower(),
+        str(entry.get("reasoning_effort") or "").strip().lower(),
     )
+
+
+def sanitize_fallback_chain(raw: Any) -> list[dict[str, Any]]:
+    """Normalize, de-duplicate, and policy-filter fallback entries.
+
+    Opus 4.8 is not allowed as an active default, runtime fallback, cron
+    fallback, or delegated-child inherited fallback. Keeping the filter here
+    makes stale config safe even when callers pass the legacy single-dict shape.
+    """
+
+    chain: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, str, str]] = set()
+    for entry in _iter_fallback_entries(raw):
+        if is_opus_48_model(entry.get("model")):
+            continue
+        identity = _entry_identity(entry)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        chain.append(entry)
+    return chain
+
+
+def role_fallback_chain(role: str, config: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    """Return the effective fallback chain for a worker role.
+
+    Configured ``role_fallbacks.<role>`` entries win. Builder-like roles get the
+    requested deterministic recovery ladder when no explicit role override is
+    present: MiniMax M2.7 → GPT 5.5 medium → GPT 5.5 xhigh. Reviewer/hardening
+    roles use the ordinary sanitized global fallback chain unless overridden.
+    """
+
+    config = config or {}
+    role_key = str(role or "").strip().lower()
+    role_overrides = config.get("role_fallbacks") or {}
+    if isinstance(role_overrides, dict) and role_key in role_overrides:
+        return sanitize_fallback_chain(role_overrides.get(role_key))
+
+    if role_key in {"builder", "implementer", "worker", "optimizer", "refactor"}:
+        return sanitize_fallback_chain([
+            {"provider": "minimax", "model": "MiniMax-M2.7", "reasoning_effort": "medium"},
+            {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "medium"},
+            {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "xhigh"},
+        ])
+
+    return get_fallback_chain(config)
 
 
 def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
@@ -54,19 +118,12 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     ``fallback_providers`` remains the primary source of truth and keeps its
     order. Legacy ``fallback_model`` entries are appended afterwards unless
     they target the same provider/model/base_url route as an earlier entry.
-    The returned list always contains fresh dict copies.
+    The returned list always contains fresh dict copies and excludes disallowed
+    Opus 4.8 routes.
     """
 
     config = config or {}
-    chain: list[dict[str, Any]] = []
-    seen: set[tuple[str, str, str]] = set()
-
-    for key in ("fallback_providers", "fallback_model"):
-        for entry in _iter_fallback_entries(config.get(key)):
-            identity = _entry_identity(entry)
-            if identity in seen:
-                continue
-            seen.add(identity)
-            chain.append(entry)
-
-    return chain
+    return sanitize_fallback_chain([
+        *(_iter_fallback_entries(config.get("fallback_providers"))),
+        *(_iter_fallback_entries(config.get("fallback_model"))),
+    ])

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -5,6 +5,58 @@ from __future__ import annotations
 from typing import Any
 
 
+_GPT_55_MEDIUM = {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "medium"}
+_GPT_55_XHIGH = {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "xhigh"}
+_MINIMAX_M27_MEDIUM = {"provider": "minimax", "model": "MiniMax-M2.7", "reasoning_effort": "medium"}
+_OPUS_48_XHIGH = {"provider": "anthropic", "model": "claude-opus-4.8", "reasoning_effort": "xhigh"}
+
+_ROLE_ALIASES = {
+    "goal": "orchestrator",
+    "planner": "orchestrator",
+    "architect": "orchestrator",
+    "architecture": "orchestrator",
+    "designer": "orchestrator",
+    "design": "orchestrator",
+    "orchestrator": "orchestrator",
+    "builder": "builder",
+    "implementer": "builder",
+    "worker": "builder",
+    "leaf": "builder",
+    "review": "review",
+    "reviewer": "review",
+    "review_pass": "review",
+    "optimization": "review",
+    "optimization_pass": "review",
+    "optimizer": "review",
+    "refactor": "review",
+    "refactoring": "review",
+    "refactoring_pass": "review",
+    "hardening": "review",
+    "hardening_pass": "review",
+    "hardener": "review",
+    "final": "final_approval",
+    "final_approval": "final_approval",
+    "approval": "final_approval",
+    "synthesis": "final_approval",
+    "final_synthesis": "final_approval",
+    "adversarial": "adversarial_review",
+    "adversarial_review": "adversarial_review",
+    "adverserial": "adversarial_review",
+    "adverserial_review": "adversarial_review",
+    "default": "default",
+    "general": "default",
+}
+
+_DEFAULT_ROLE_ROUTES = {
+    "default": {"primary": _GPT_55_MEDIUM, "fallbacks": []},
+    "orchestrator": {"primary": _OPUS_48_XHIGH, "fallbacks": [_GPT_55_XHIGH]},
+    "builder": {"primary": _MINIMAX_M27_MEDIUM, "fallbacks": [_GPT_55_MEDIUM]},
+    "review": {"primary": _GPT_55_MEDIUM, "fallbacks": [_MINIMAX_M27_MEDIUM]},
+    "final_approval": {"primary": _OPUS_48_XHIGH, "fallbacks": [_GPT_55_XHIGH]},
+    "adversarial_review": {"primary": _GPT_55_XHIGH, "fallbacks": []},
+}
+
+
 _OPUS_48_MARKERS = (
     "opus-4.8",
     "opus4.8",
@@ -87,27 +139,79 @@ def sanitize_fallback_chain(raw: Any) -> list[dict[str, Any]]:
     return chain
 
 
-def role_fallback_chain(role: str, config: dict[str, Any] | None = None) -> list[dict[str, Any]]:
-    """Return the effective fallback chain for a worker role.
+def _role_key(role: str) -> str:
+    return _ROLE_ALIASES.get(str(role or "default").strip().lower(), str(role or "default").strip().lower())
 
-    Configured ``role_fallbacks.<role>`` entries win. Builder-like roles get the
-    requested deterministic recovery ladder when no explicit role override is
-    present: MiniMax M2.7 → GPT 5.5 medium → GPT 5.5 xhigh. Reviewer/hardening
-    roles use the ordinary sanitized global fallback chain unless overridden.
+
+def role_has_route(role: str, config: dict[str, Any] | None = None) -> bool:
+    """Return True when a role has an explicit/default primary or fallback route."""
+
+    config = config or {}
+    raw_key = str(role or "default").strip().lower()
+    key = _role_key(role)
+    routes = config.get("role_routes") or {}
+    if isinstance(routes, dict) and (key in routes or raw_key in routes):
+        return True
+    role_overrides = config.get("role_fallbacks") or {}
+    if isinstance(role_overrides, dict) and (key in role_overrides or raw_key in role_overrides):
+        return True
+    # Unknown roles still receive the built-in default route rather than
+    # mixing an implicit default primary with legacy credential inheritance.
+    return True
+
+
+def role_primary_route(role: str, config: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Return the configured primary model/provider/reasoning route for a role.
+
+    Defaults encode John's approved ladder:
+    general=GPT-5.5 medium; goal/orchestrator/architect/designer=Opus 4.8;
+    builders=MiniMax M2.7; review/optimization/hardening=GPT-5.5 medium;
+    final approval/synthesis=Opus 4.8; adversarial review=GPT-5.5 xhigh.
+    ``role_routes.<role>.primary`` in config may override these defaults.
     """
 
     config = config or {}
-    role_key = str(role or "").strip().lower()
-    role_overrides = config.get("role_fallbacks") or {}
-    if isinstance(role_overrides, dict) and role_key in role_overrides:
-        return sanitize_fallback_chain(role_overrides.get(role_key))
+    key = _role_key(role)
+    routes = config.get("role_routes") or {}
+    if isinstance(routes, dict):
+        override = routes.get(key) or routes.get(str(role or "").strip().lower())
+        if isinstance(override, dict) and isinstance(override.get("primary"), dict):
+            entries = _iter_fallback_entries(override.get("primary"))
+            if entries:
+                return dict(entries[0])
+    default = (_DEFAULT_ROLE_ROUTES.get(key) or _DEFAULT_ROLE_ROUTES["default"])["primary"]
+    return dict(default)
 
-    if role_key in {"builder", "implementer", "worker", "optimizer", "refactor"}:
-        return sanitize_fallback_chain([
-            {"provider": "minimax", "model": "MiniMax-M2.7", "reasoning_effort": "medium"},
-            {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "medium"},
-            {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "xhigh"},
-        ])
+
+def role_fallback_chain(role: str, config: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    """Return the effective fallback chain for a role.
+
+    ``role_routes.<role>.fallbacks`` wins, then legacy ``role_fallbacks.<role>``.
+    Built-in defaults deliberately exclude the primary route: builders start on
+    MiniMax and fail only to GPT-5.5 medium; review/optimization/hardening start
+    on GPT-5.5 medium and fail to MiniMax; Opus roles fail only to GPT-5.5 xhigh.
+    Adversarial review has no non-xhigh fallback by default.
+    """
+
+    config = config or {}
+    key = _role_key(role)
+    routes = config.get("role_routes") or {}
+    if isinstance(routes, dict):
+        override = routes.get(key) or routes.get(str(role or "").strip().lower())
+        if isinstance(override, dict) and "fallbacks" in override:
+            return sanitize_fallback_chain(override.get("fallbacks"))
+
+    raw_key = str(role or "").strip().lower()
+    role_overrides = config.get("role_fallbacks") or {}
+    if isinstance(role_overrides, dict):
+        if key in role_overrides:
+            return sanitize_fallback_chain(role_overrides.get(key))
+        if raw_key in role_overrides:
+            return sanitize_fallback_chain(role_overrides.get(raw_key))
+
+    route = _DEFAULT_ROLE_ROUTES.get(key)
+    if route is not None:
+        return sanitize_fallback_chain(route.get("fallbacks"))
 
     return get_fallback_chain(config)
 

--- a/hermes_cli/model_failover_report.py
+++ b/hermes_cli/model_failover_report.py
@@ -1,0 +1,88 @@
+"""Model-failover traceability report helpers.
+
+These helpers render the final HTML/dashboard sections promised by the model
+failover + Linear traceability goal. They intentionally accept sparse dicts so
+closeout code can produce an honest report even when some evidence is missing.
+"""
+
+from __future__ import annotations
+
+from html import escape
+from typing import Any, Mapping
+
+REQUIRED_TRACEABILITY_SECTIONS = (
+    "Model Routing and Failures",
+    "Attribution Reconciliation",
+    "Helper/Code Reliability",
+    "Opus Usage Audit",
+    "Offline Receipts and Residual Risks",
+)
+
+_SECTION_KEYS = {
+    "Model Routing and Failures": "model_routing_and_failures",
+    "Attribution Reconciliation": "attribution_reconciliation",
+    "Helper/Code Reliability": "helper_code_reliability",
+    "Opus Usage Audit": "opus_usage_audit",
+    "Offline Receipts and Residual Risks": "offline_receipts_and_residual_risks",
+}
+
+_DEFAULTS = {
+    "model_routing_and_failures": "None recorded.",
+    "attribution_reconciliation": "None recorded.",
+    "helper_code_reliability": "None recorded.",
+    "opus_usage_audit": "None recorded.",
+    "offline_receipts_and_residual_risks": "None recorded.",
+}
+
+
+def _coerce_lines(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        lines: list[str] = []
+        for item in value:
+            lines.extend(_coerce_lines(item))
+        return lines
+    if isinstance(value, Mapping):
+        return [f"{key}: {val}" for key, val in value.items()]
+    return [str(value)]
+
+
+def _section_body(value: Any, default: str) -> str:
+    lines = _coerce_lines(value)
+    if not lines:
+        lines = [default]
+    items = "".join(f"<li>{escape(line)}</li>" for line in lines)
+    return f"<ul>{items}</ul>"
+
+
+def render_model_failover_traceability_sections(evidence: Mapping[str, Any] | None = None) -> str:
+    """Return escaped HTML for the five required traceability sections."""
+
+    evidence = evidence or {}
+    chunks: list[str] = []
+    for title in REQUIRED_TRACEABILITY_SECTIONS:
+        key = _SECTION_KEYS[title]
+        value = evidence.get(key, evidence.get(title))
+        chunks.append(f"<section><h2>{escape(title)}</h2>{_section_body(value, _DEFAULTS[key])}</section>")
+    return "\n".join(chunks)
+
+
+def missing_model_failover_traceability_sections(html: str | None) -> list[str]:
+    """Return any required section headings missing from rendered HTML/Markdown."""
+
+    rendered = html or ""
+    return [title for title in REQUIRED_TRACEABILITY_SECTIONS if title not in rendered]
+
+
+def build_model_failover_dashboard_markdown(evidence: Mapping[str, Any] | None = None) -> str:
+    """Return a Linear-dashboard-friendly Markdown traceability summary."""
+
+    evidence = evidence or {}
+    sections: list[str] = ["# Model Failover Traceability Dashboard"]
+    for title in REQUIRED_TRACEABILITY_SECTIONS:
+        key = _SECTION_KEYS[title]
+        lines = _coerce_lines(evidence.get(key, evidence.get(title))) or [_DEFAULTS[key]]
+        sections.append(f"## {title}")
+        sections.extend(f"- {line}" for line in lines)
+    return "\n\n".join(sections) + "\n"

--- a/skills/productivity/linear/scripts/linear_api.py
+++ b/skills/productivity/linear/scripts/linear_api.py
@@ -48,12 +48,92 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import urllib.error
 import urllib.request
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
+_ATTR_RE = re.compile(r"^attr:\s.*$", re.MULTILINE)
+
+
+def _runtime_attr(args: argparse.Namespace, role: str = "builder") -> str:
+    model = (getattr(args, "model", None) or os.getenv("HERMES_MODEL") or "unknown").strip()
+    provider = (getattr(args, "provider", None) or os.getenv("HERMES_PROVIDER") or os.getenv("HERMES_INFERENCE_PROVIDER") or "unknown").strip()
+    effort = (getattr(args, "reasoning_effort", None) or os.getenv("HERMES_REASONING_EFFORT") or "unknown").strip()
+    session_id = (getattr(args, "session_id", None) or os.getenv("HERMES_SESSION_ID") or "unknown").strip()
+    source = "runtime" if model != "unknown" and provider != "unknown" else "manual-unverified"
+    timestamp = datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return f"attr: a=Alfred; r={role}; m={model}; e={effort}; p={provider}; s={session_id}; t={timestamp}; fb=none; src={source}"
+
+
+def _with_attribution(text: str | None, args: argparse.Namespace, role: str = "builder") -> str:
+    body = text or ""
+    body = _ATTR_RE.sub("", body).rstrip()
+    if body:
+        body += "\n"
+    return body + _runtime_attr(args, role=role)
+
 API_URL = "https://api.linear.app/graphql"
+
+
+def _offline_receipt_dir() -> Path:
+    base = os.getenv("LINEAR_OFFLINE_RECEIPT_DIR")
+    if base:
+        return Path(base).expanduser()
+    hermes_home = Path(os.getenv("HERMES_HOME") or Path.home() / ".hermes")
+    return hermes_home / "linear-offline-receipts"
+
+
+def _write_offline_receipt(operation: str, payload: dict[str, Any]) -> Path:
+    directory = _offline_receipt_dir()
+    directory.mkdir(parents=True, exist_ok=True)
+    receipt = {
+        "id": uuid.uuid4().hex,
+        "operation": operation,
+        "createdAt": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "payload": payload,
+    }
+    path = directory / f"{receipt['createdAt'].replace(':', '').replace('-', '')}-{receipt['id']}.json"
+    path.write_text(json.dumps(receipt, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _mutation_with_receipt(operation: str, query: str, variables: dict[str, Any], *, queue_on_failure: bool) -> dict[str, Any]:
+    try:
+        return gql(query, variables)
+    except SystemExit:
+        if not queue_on_failure:
+            raise
+        path = _write_offline_receipt(operation, {"query": query, "variables": variables})
+        return {"offlineReceiptQueued": {"path": str(path), "operation": operation}}
+
+
+def replay_offline_receipts(directory: Path | None = None) -> dict[str, Any]:
+    directory = directory or _offline_receipt_dir()
+    if not directory.exists():
+        return {"replayed": 0, "failed": 0, "remaining": 0, "receipts": []}
+
+    results: list[dict[str, Any]] = []
+    replayed = 0
+    failed = 0
+    for path in sorted(directory.glob("*.json")):
+        receipt = json.loads(path.read_text(encoding="utf-8"))
+        payload = receipt.get("payload") or {}
+        try:
+            data = gql(payload["query"], payload.get("variables") or {})
+        except SystemExit as exc:
+            failed += 1
+            results.append({"path": str(path), "ok": False, "exit_code": exc.code})
+            continue
+        path.unlink()
+        replayed += 1
+        results.append({"path": str(path), "ok": True, "data": data})
+    remaining = len(list(directory.glob("*.json"))) if directory.exists() else 0
+    return {"replayed": replayed, "failed": failed, "remaining": remaining, "receipts": results}
 
 
 def _get_key() -> str:
@@ -224,7 +304,7 @@ def cmd_create_issue(args: argparse.Namespace) -> None:
         sys.exit(1)
     inp: dict[str, Any] = {"title": args.title, "teamId": tid}
     if args.description:
-        inp["description"] = args.description
+        inp["description"] = _with_attribution(args.description, args, role=args.role)
     if args.priority is not None:
         inp["priority"] = args.priority
     if args.parent:
@@ -236,7 +316,8 @@ def cmd_create_issue(args: argparse.Namespace) -> None:
         success issue { id identifier title url }
       }
     }"""
-    emit(gql(q, {"input": inp}).get("issueCreate"))
+    data = _mutation_with_receipt("create-issue", q, {"input": inp}, queue_on_failure=args.queue_offline)
+    emit(data.get("issueCreate") or data.get("offlineReceiptQueued"))
 
 
 def cmd_update_issue(args: argparse.Namespace) -> None:
@@ -244,7 +325,7 @@ def cmd_update_issue(args: argparse.Namespace) -> None:
     if args.title:
         inp["title"] = args.title
     if args.description:
-        inp["description"] = args.description
+        inp["description"] = _with_attribution(args.description, args, role=args.role)
     if args.priority is not None:
         inp["priority"] = args.priority
     if not inp:
@@ -255,7 +336,8 @@ def cmd_update_issue(args: argparse.Namespace) -> None:
         success issue { identifier title url }
       }
     }"""
-    emit(gql(q, {"id": args.identifier, "input": inp}).get("issueUpdate"))
+    data = _mutation_with_receipt("update-issue", q, {"id": args.identifier, "input": inp}, queue_on_failure=args.queue_offline)
+    emit(data.get("issueUpdate") or data.get("offlineReceiptQueued"))
 
 
 def cmd_update_status(args: argparse.Namespace) -> None:
@@ -290,7 +372,9 @@ def cmd_add_comment(args: argparse.Namespace) -> None:
         success comment { id body createdAt }
       }
     }"""
-    emit(gql(q, {"input": {"issueId": args.identifier, "body": args.body}}).get("commentCreate"))
+    body = _with_attribution(args.body, args, role=args.role)
+    data = _mutation_with_receipt("add-comment", q, {"input": {"issueId": args.identifier, "body": body}}, queue_on_failure=args.queue_offline)
+    emit(data.get("commentCreate") or data.get("offlineReceiptQueued"))
 
 
 # ---- Documents ----
@@ -355,6 +439,23 @@ def cmd_raw(args: argparse.Namespace) -> None:
 
 # ---------- Arg parsing ----------
 
+def _add_attribution_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--model", help="Runtime model for compact attr footer")
+    parser.add_argument("--provider", help="Runtime provider for compact attr footer")
+    parser.add_argument("--reasoning-effort", dest="reasoning_effort", help="Runtime reasoning effort for compact attr footer")
+    parser.add_argument("--session-id", dest="session_id", help="Runtime/session id for compact attr footer")
+    parser.add_argument("--role", default="builder", help="Attribution role, e.g. builder/reviewer/verifier")
+
+
+def _add_offline_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--queue-offline", action="store_true", help="Queue mutation receipt instead of failing when Linear is unreachable")
+
+
+def cmd_replay_offline_receipts(args: argparse.Namespace) -> None:
+    directory = Path(args.dir).expanduser() if args.dir else None
+    emit(replay_offline_receipts(directory))
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="linear_api.py", description="Linear GraphQL CLI")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -395,6 +496,8 @@ def build_parser() -> argparse.ArgumentParser:
     ci.add_argument("--label")
     ci.add_argument("--assignee")
     ci.add_argument("--parent")
+    _add_attribution_args(ci)
+    _add_offline_args(ci)
     ci.set_defaults(func=cmd_create_issue)
 
     ui = sub.add_parser("update-issue")
@@ -402,6 +505,8 @@ def build_parser() -> argparse.ArgumentParser:
     ui.add_argument("--title")
     ui.add_argument("--description")
     ui.add_argument("--priority", type=int, choices=[0, 1, 2, 3, 4])
+    _add_attribution_args(ui)
+    _add_offline_args(ui)
     ui.set_defaults(func=cmd_update_issue)
 
     us = sub.add_parser("update-status")
@@ -412,7 +517,13 @@ def build_parser() -> argparse.ArgumentParser:
     ac = sub.add_parser("add-comment")
     ac.add_argument("identifier")
     ac.add_argument("body")
+    _add_attribution_args(ac)
+    _add_offline_args(ac)
     ac.set_defaults(func=cmd_add_comment)
+
+    rr = sub.add_parser("replay-offline-receipts")
+    rr.add_argument("--dir", help="Receipt directory (defaults to $LINEAR_OFFLINE_RECEIPT_DIR or ~/.hermes/linear-offline-receipts)")
+    rr.set_defaults(func=cmd_replay_offline_receipts)
 
     ld = sub.add_parser("list-documents")
     ld.add_argument("--limit", type=int, default=50)

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -286,6 +286,79 @@ async def test_shutdown_notification_send_failure_does_not_block():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_notification_send_timeout_does_not_block():
+    """A wedged platform send must not consume the gateway drain budget."""
+    runner, adapter = make_restart_runner()
+    runner._shutdown_notification_send_timeout = 0.01
+    runner._shutdown_notification_overall_timeout = 0.05
+    send_started = asyncio.Event()
+
+    async def never_returns(*_args, **_kwargs):
+        send_started.set()
+        await asyncio.Event().wait()
+
+    adapter.send = never_returns
+    runner._running_agents["agent:main:telegram:dm:999"] = MagicMock()
+
+    await asyncio.wait_for(runner._notify_active_sessions_of_shutdown(), timeout=0.5)
+
+    assert send_started.is_set()
+
+
+@pytest.mark.asyncio
+async def test_stop_marks_resume_pending_before_shutdown_notifications(monkeypatch):
+    """Resume state is durable before any best-effort network notification."""
+    runner, adapter = make_restart_runner()
+    runner._restart_drain_timeout = 0.0
+    runner._cleanup_agent_resources = MagicMock()
+    runner._increment_restart_failure_counts = MagicMock()
+
+    session_key = "agent:main:telegram:dm:999"
+    running_agent = MagicMock()
+    running_agent.interrupt.side_effect = (
+        lambda _reason: runner._running_agents.clear()
+    )
+    runner._running_agents[session_key] = running_agent
+    order = []
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    def mark_resume_pending(key, reason):
+        order.append(("mark", key, reason))
+
+    async def delayed_send(*_args, **_kwargs):
+        order.append(("send",))
+        send_started.set()
+        await release_send.wait()
+
+    runner.session_store.mark_resume_pending.side_effect = mark_resume_pending
+    adapter.send = delayed_send
+
+    import gateway.status as gateway_status
+    import tools.browser_tool as browser_tool
+    import tools.process_registry as process_registry_mod
+    import tools.terminal_tool as terminal_tool
+    import agent.auxiliary_client as auxiliary_client
+
+    monkeypatch.setattr(gateway_status, "remove_pid_file", lambda: None)
+    monkeypatch.setattr(gateway_status, "release_gateway_runtime_lock", lambda: None)
+    monkeypatch.setattr(gateway_status, "write_runtime_status", lambda *_a, **_k: None)
+    monkeypatch.setattr(process_registry_mod.process_registry, "kill_all", lambda: 0)
+    monkeypatch.setattr(terminal_tool, "cleanup_all_environments", lambda: None)
+    monkeypatch.setattr(browser_tool, "cleanup_all_browsers", lambda: None)
+    monkeypatch.setattr(auxiliary_client, "shutdown_cached_clients", lambda: None)
+
+    task = asyncio.create_task(runner.stop())
+    await asyncio.wait_for(send_started.wait(), timeout=0.5)
+
+    assert order[0] == ("mark", session_key, "shutdown_timeout")
+    assert order[1] == ("send",)
+
+    release_send.set()
+    await asyncio.wait_for(task, timeout=1.0)
+
+
+@pytest.mark.asyncio
 async def test_shutdown_notification_suppressed_when_flag_disabled():
     """Active-session ping is muted when gateway_restart_notification=False on the platform."""
     from gateway.config import Platform

--- a/tests/hermes_cli/test_model_failover_report.py
+++ b/tests/hermes_cli/test_model_failover_report.py
@@ -1,0 +1,40 @@
+from hermes_cli.model_failover_report import (
+    REQUIRED_TRACEABILITY_SECTIONS,
+    build_model_failover_dashboard_markdown,
+    missing_model_failover_traceability_sections,
+    render_model_failover_traceability_sections,
+)
+
+
+def test_model_failover_report_renders_all_required_sections_and_escapes_values():
+    html = render_model_failover_traceability_sections({
+        "model_routing_and_failures": ["MiniMax -> GPT-5.5", "bad <script>"],
+        "attribution_reconciliation": {"runtime": 3, "manual": 1},
+    })
+
+    assert missing_model_failover_traceability_sections(html) == []
+    for section in REQUIRED_TRACEABILITY_SECTIONS:
+        assert section in html
+    assert "bad &lt;script&gt;" in html
+    assert "bad <script>" not in html
+    assert "None recorded." in html
+
+
+def test_model_failover_dashboard_markdown_contains_required_headings_and_defaults():
+    markdown = build_model_failover_dashboard_markdown({
+        "Opus Usage Audit": "No Opus 4.8 fallback routes reachable."
+    })
+
+    for section in REQUIRED_TRACEABILITY_SECTIONS:
+        assert f"## {section}" in markdown
+    assert "No Opus 4.8 fallback routes reachable." in markdown
+    assert "None recorded." in markdown
+
+
+def test_missing_model_failover_traceability_sections_reports_gaps():
+    assert missing_model_failover_traceability_sections("Model Routing and Failures") == [
+        "Attribution Reconciliation",
+        "Helper/Code Reliability",
+        "Opus Usage Audit",
+        "Offline Receipts and Residual Risks",
+    ]

--- a/tests/run_agent/test_model_failover_linear_traceability.py
+++ b/tests/run_agent/test_model_failover_linear_traceability.py
@@ -1,0 +1,194 @@
+from types import ModuleType, SimpleNamespace
+
+from hermes_cli.fallback_config import (
+    get_fallback_chain,
+    is_opus_48_model,
+    role_fallback_chain,
+    sanitize_fallback_chain,
+)
+from agent.chat_completion_helpers import try_activate_fallback
+from skills.productivity.linear.scripts import linear_api
+
+
+def test_sanitize_fallback_chain_filters_opus_48_and_dedupes():
+    raw = [
+        {"provider": "anthropic", "model": "claude-opus-4.8"},
+        {"provider": "minimax", "model": "MiniMax-M2.7"},
+        {"provider": "minimax", "model": "MiniMax-M2.7"},
+        {"provider": "openai-codex", "model": "gpt-5.5", "base_url": "https://example.com/"},
+    ]
+
+    chain = sanitize_fallback_chain(raw)
+
+    assert len(chain) == 2
+    assert all(not is_opus_48_model(entry["model"]) for entry in chain)
+    assert chain[0]["provider"] == "minimax"
+    assert chain[1]["base_url"] == "https://example.com"
+
+
+def test_get_fallback_chain_merges_legacy_and_filters_opus_48():
+    config = {
+        "fallback_providers": [
+            {"provider": "anthropic", "model": "claude-opus-4-8"},
+            {"provider": "minimax", "model": "MiniMax-M2.7"},
+        ],
+        "fallback_model": {"provider": "openai-codex", "model": "gpt-5.5"},
+    }
+
+    assert get_fallback_chain(config) == [
+        {"provider": "minimax", "model": "MiniMax-M2.7"},
+        {"provider": "openai-codex", "model": "gpt-5.5"},
+    ]
+
+
+def test_role_fallback_chain_builder_default_semantics():
+    chain = role_fallback_chain("builder", {})
+
+    assert [(entry["provider"], entry["model"], entry["reasoning_effort"]) for entry in chain] == [
+        ("minimax", "MiniMax-M2.7", "medium"),
+        ("openai-codex", "gpt-5.5", "medium"),
+        ("openai-codex", "gpt-5.5", "xhigh"),
+    ]
+
+
+def test_runtime_fallback_skips_leaked_opus_48(monkeypatch):
+    calls = []
+
+    def fake_resolve_provider_client(provider, model, raw_codex=False, explicit_base_url=None, explicit_api_key=None):
+        calls.append((provider, model))
+        return SimpleNamespace(base_url="https://chatgpt.com/backend-api/codex", api_key="fallback-key"), model
+
+    monkeypatch.setattr("agent.auxiliary_client.resolve_provider_client", fake_resolve_provider_client)
+
+    agent = SimpleNamespace(
+        _fallback_chain=[
+            {"provider": "anthropic", "model": "claude-opus-4.8"},
+            {"provider": "openai-codex", "model": "gpt-5.5"},
+        ],
+        _fallback_index=0,
+        _fallback_activated=False,
+        _primary_runtime={"provider": "anthropic"},
+        _rate_limited_until=0,
+        provider="anthropic",
+        model="claude-sonnet-4.6",
+        base_url="https://api.anthropic.com",
+        api_key="primary",
+        api_mode="anthropic_messages",
+        request_overrides={},
+        _is_azure_openai_url=lambda _url: False,
+        _is_direct_openai_url=lambda _url: False,
+        _provider_model_requires_responses_api=lambda _model, provider=None: False,
+        _anthropic_prompt_cache_policy=lambda **_kwargs: (False, False),
+        _ensure_lmstudio_runtime_loaded=lambda: None,
+        _buffer_status=lambda _message: None,
+        _replace_primary_openai_client=lambda **_kwargs: None,
+        context_compressor=None,
+        _try_activate_fallback=lambda: try_activate_fallback(agent),
+        _abort_request_openai_client=lambda *_args, **_kwargs: None,
+        _close_request_openai_client=lambda *_args, **_kwargs: None,
+    )
+
+    assert try_activate_fallback(agent) is True
+    assert calls == [("openai-codex", "gpt-5.5")]
+    assert agent.provider == "openai-codex"
+    assert agent.model == "gpt-5.5"
+
+
+def test_linear_attribution_replaces_stale_footer(monkeypatch):
+    args = SimpleNamespace(
+        model="gpt-5.5",
+        provider="openai-codex",
+        reasoning_effort="xhigh",
+        session_id="test-session",
+    )
+    monkeypatch.setattr(linear_api, "datetime", SimpleNamespace(
+        now=lambda _tz: SimpleNamespace(
+            replace=lambda microsecond=0: SimpleNamespace(isoformat=lambda: "2026-05-29T00:00:00+00:00")
+        )
+    ))
+
+    stamped = linear_api._with_attribution("Body\nattr: a=old; m=claude-opus-4.8; src=manual-unverified", args, role="reviewer")
+
+    assert stamped.count("attr:") == 1
+    assert "m=gpt-5.5" in stamped
+    assert "p=openai-codex" in stamped
+    assert "r=reviewer" in stamped
+    assert "claude-opus-4.8" not in stamped
+
+
+def test_delegate_child_uses_builder_role_fallback_chain(monkeypatch):
+    import tools.delegate_tool as delegate_tool
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self._active_children = {}
+            self._active_subagents = {}
+            self._delegate_role = None
+
+    fake_run_agent = ModuleType("run_agent")
+    setattr(fake_run_agent, "AIAgent", FakeAgent)
+    monkeypatch.setitem(__import__("sys").modules, "run_agent", fake_run_agent)
+    monkeypatch.setattr(delegate_tool, "_load_config", lambda: {})
+    monkeypatch.setattr(delegate_tool, "_get_max_spawn_depth", lambda: 1)
+    monkeypatch.setattr(delegate_tool, "_get_orchestrator_enabled", lambda: True)
+    monkeypatch.setattr(delegate_tool, "_build_child_progress_callback", lambda *args, **kwargs: None)
+
+    parent = SimpleNamespace(
+        _delegate_depth=0,
+        enabled_toolsets=["terminal"],
+        model="claude-sonnet-4.6",
+        provider="anthropic",
+        base_url="https://api.anthropic.com",
+        api_key="primary",
+        api_mode="anthropic_messages",
+        platform="cli",
+        _fallback_chain=[{"provider": "anthropic", "model": "claude-opus-4.8"}],
+    )
+
+    child = delegate_tool._build_child_agent(
+        task_index=0,
+        goal="build",
+        context=None,
+        toolsets=None,
+        model=None,
+        max_iterations=1,
+        task_count=1,
+        parent_agent=parent,
+    )
+
+    assert child is not None
+    assert captured["fallback_model"] == role_fallback_chain("builder", {})
+
+
+def test_linear_offline_receipt_queue_and_replay(tmp_path, monkeypatch):
+    calls = []
+
+    def failing_once_then_success(query, variables=None):
+        calls.append((query, variables))
+        if len(calls) == 1:
+            raise SystemExit(1)
+        return {"commentCreate": {"success": True}}
+
+    monkeypatch.setenv("LINEAR_OFFLINE_RECEIPT_DIR", str(tmp_path))
+    monkeypatch.setattr(linear_api, "gql", failing_once_then_success)
+
+    queued = linear_api._mutation_with_receipt(
+        "add-comment",
+        "mutation X",
+        {"input": {"issueId": "ALF-1", "body": "Body"}},
+        queue_on_failure=True,
+    )
+    receipts = list(tmp_path.glob("*.json"))
+
+    assert queued["offlineReceiptQueued"]["operation"] == "add-comment"
+    assert len(receipts) == 1
+
+    replay = linear_api.replay_offline_receipts(tmp_path)
+
+    assert replay["replayed"] == 1
+    assert replay["failed"] == 0
+    assert replay["remaining"] == 0
+    assert not list(tmp_path.glob("*.json"))

--- a/tests/run_agent/test_model_failover_linear_traceability.py
+++ b/tests/run_agent/test_model_failover_linear_traceability.py
@@ -4,6 +4,8 @@ from hermes_cli.fallback_config import (
     get_fallback_chain,
     is_opus_48_model,
     role_fallback_chain,
+    role_has_route,
+    role_primary_route,
     sanitize_fallback_chain,
 )
 from agent.chat_completion_helpers import try_activate_fallback
@@ -41,13 +43,87 @@ def test_get_fallback_chain_merges_legacy_and_filters_opus_48():
     ]
 
 
+def test_role_routes_match_approved_matrix():
+    assert role_primary_route("default", {}) == {
+        "provider": "openai-codex",
+        "model": "gpt-5.5",
+        "reasoning_effort": "medium",
+    }
+    assert role_primary_route("architect", {}) == {
+        "provider": "anthropic",
+        "model": "claude-opus-4.8",
+        "reasoning_effort": "xhigh",
+    }
+    assert role_fallback_chain("architect", {}) == [
+        {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "xhigh"},
+    ]
+    assert role_primary_route("builder", {}) == {
+        "provider": "minimax",
+        "model": "MiniMax-M2.7",
+        "reasoning_effort": "medium",
+    }
+    assert role_fallback_chain("builder", {}) == [
+        {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "medium"},
+    ]
+    assert role_primary_route("optimization_pass", {}) == {
+        "provider": "openai-codex",
+        "model": "gpt-5.5",
+        "reasoning_effort": "medium",
+    }
+    assert role_fallback_chain("hardening_pass", {}) == [
+        {"provider": "minimax", "model": "MiniMax-M2.7", "reasoning_effort": "medium"},
+    ]
+    assert role_primary_route("refactoring_pass", {}) == {
+        "provider": "openai-codex",
+        "model": "gpt-5.5",
+        "reasoning_effort": "medium",
+    }
+    assert role_fallback_chain("refactor", {}) == [
+        {"provider": "minimax", "model": "MiniMax-M2.7", "reasoning_effort": "medium"},
+    ]
+    assert role_primary_route("final_synthesis", {}) == {
+        "provider": "anthropic",
+        "model": "claude-opus-4.8",
+        "reasoning_effort": "xhigh",
+    }
+    assert role_fallback_chain("final_synthesis", {}) == [
+        {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "xhigh"},
+    ]
+    assert role_primary_route("adversarial_review", {}) == {
+        "provider": "openai-codex",
+        "model": "gpt-5.5",
+        "reasoning_effort": "xhigh",
+    }
+    assert role_fallback_chain("adversarial_review", {}) == []
+    assert role_has_route("adversarial_review", {}) is True
+
+
+def test_role_fallback_chain_honors_legacy_raw_alias_keys():
+    cfg = {
+        "role_fallbacks": {
+            "implementer": [
+                {"provider": "custom", "model": "custom-builder", "reasoning_effort": "low"}
+            ]
+        }
+    }
+
+    assert role_fallback_chain("implementer", cfg) == [
+        {"provider": "custom", "model": "custom-builder", "reasoning_effort": "low"}
+    ]
+    assert role_has_route("implementer", cfg) is True
+    assert role_has_route("unknown_future_role", {}) is True
+    assert role_primary_route("unknown_future_role", {}) == {
+        "provider": "openai-codex",
+        "model": "gpt-5.5",
+        "reasoning_effort": "medium",
+    }
+
+
 def test_role_fallback_chain_builder_default_semantics():
     chain = role_fallback_chain("builder", {})
 
     assert [(entry["provider"], entry["model"], entry["reasoning_effort"]) for entry in chain] == [
-        ("minimax", "MiniMax-M2.7", "medium"),
         ("openai-codex", "gpt-5.5", "medium"),
-        ("openai-codex", "gpt-5.5", "xhigh"),
     ]
 
 
@@ -63,7 +139,7 @@ def test_runtime_fallback_skips_leaked_opus_48(monkeypatch):
     agent = SimpleNamespace(
         _fallback_chain=[
             {"provider": "anthropic", "model": "claude-opus-4.8"},
-            {"provider": "openai-codex", "model": "gpt-5.5"},
+            {"provider": "openai-codex", "model": "gpt-5.5", "reasoning_effort": "xhigh"},
         ],
         _fallback_index=0,
         _fallback_activated=False,
@@ -92,6 +168,85 @@ def test_runtime_fallback_skips_leaked_opus_48(monkeypatch):
     assert calls == [("openai-codex", "gpt-5.5")]
     assert agent.provider == "openai-codex"
     assert agent.model == "gpt-5.5"
+    assert agent.reasoning_config == {"enabled": True, "effort": "xhigh"}
+
+
+def test_runtime_fallback_without_effort_clears_stale_reasoning(monkeypatch):
+    def fake_resolve_provider_client(provider, model, raw_codex=False, explicit_base_url=None, explicit_api_key=None):
+        return SimpleNamespace(base_url="https://api.minimax.io/anthropic", api_key="fallback-key"), model
+
+    monkeypatch.setattr("agent.auxiliary_client.resolve_provider_client", fake_resolve_provider_client)
+
+    agent = SimpleNamespace(
+        _fallback_chain=[{"provider": "minimax", "model": "MiniMax-M2.7"}],
+        _fallback_index=0,
+        _fallback_activated=False,
+        _primary_runtime={"provider": "openai-codex"},
+        _rate_limited_until=0,
+        provider="openai-codex",
+        model="gpt-5.5",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="primary",
+        api_mode="codex_responses",
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+        request_overrides={},
+        _is_azure_openai_url=lambda _url: False,
+        _is_direct_openai_url=lambda _url: False,
+        _provider_model_requires_responses_api=lambda _model, provider=None: False,
+        _anthropic_prompt_cache_policy=lambda **_kwargs: (False, False),
+        _ensure_lmstudio_runtime_loaded=lambda: None,
+        _buffer_status=lambda _message: None,
+        _replace_primary_openai_client=lambda **_kwargs: None,
+        context_compressor=None,
+        _try_activate_fallback=lambda: try_activate_fallback(agent),
+        _abort_request_openai_client=lambda *_args, **_kwargs: None,
+        _close_request_openai_client=lambda *_args, **_kwargs: None,
+    )
+
+    assert try_activate_fallback(agent) is True
+    assert agent.provider == "minimax"
+    assert agent.model == "MiniMax-M2.7"
+    assert agent.reasoning_config is None
+
+
+def test_runtime_fallback_invalid_effort_clears_stale_reasoning(monkeypatch):
+    def fake_resolve_provider_client(provider, model, raw_codex=False, explicit_base_url=None, explicit_api_key=None):
+        return SimpleNamespace(base_url="https://api.minimax.io/anthropic", api_key="fallback-key"), model
+
+    def raising_parse(_effort):
+        raise ValueError("bad effort")
+
+    monkeypatch.setattr("agent.auxiliary_client.resolve_provider_client", fake_resolve_provider_client)
+    monkeypatch.setattr("hermes_constants.parse_reasoning_effort", raising_parse)
+
+    agent = SimpleNamespace(
+        _fallback_chain=[{"provider": "minimax", "model": "MiniMax-M2.7", "reasoning_effort": "bogus"}],
+        _fallback_index=0,
+        _fallback_activated=False,
+        _primary_runtime={"provider": "openai-codex"},
+        _rate_limited_until=0,
+        provider="openai-codex",
+        model="gpt-5.5",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="primary",
+        api_mode="codex_responses",
+        reasoning_config={"enabled": True, "effort": "xhigh"},
+        request_overrides={},
+        _is_azure_openai_url=lambda _url: False,
+        _is_direct_openai_url=lambda _url: False,
+        _provider_model_requires_responses_api=lambda _model, provider=None: False,
+        _anthropic_prompt_cache_policy=lambda **_kwargs: (False, False),
+        _ensure_lmstudio_runtime_loaded=lambda: None,
+        _buffer_status=lambda _message: None,
+        _replace_primary_openai_client=lambda **_kwargs: None,
+        context_compressor=None,
+        _try_activate_fallback=lambda: try_activate_fallback(agent),
+        _abort_request_openai_client=lambda *_args, **_kwargs: None,
+        _close_request_openai_client=lambda *_args, **_kwargs: None,
+    )
+
+    assert try_activate_fallback(agent) is True
+    assert agent.reasoning_config is None
 
 
 def test_linear_attribution_replaces_stale_footer(monkeypatch):
@@ -136,6 +291,19 @@ def test_delegate_child_uses_builder_role_fallback_chain(monkeypatch):
     monkeypatch.setattr(delegate_tool, "_get_orchestrator_enabled", lambda: True)
     monkeypatch.setattr(delegate_tool, "_build_child_progress_callback", lambda *args, **kwargs: None)
 
+    def fake_resolve_runtime_provider(requested, target_model=None, **_kwargs):
+        return {
+            "provider": requested,
+            "model": target_model,
+            "base_url": f"https://{requested}.example.test",
+            "api_key": f"{requested}-key",
+            "api_mode": "anthropic_messages" if requested in {"anthropic", "minimax"} else "codex_responses",
+        }
+
+    fake_runtime_provider = ModuleType("hermes_cli.runtime_provider")
+    setattr(fake_runtime_provider, "resolve_runtime_provider", fake_resolve_runtime_provider)
+    monkeypatch.setitem(__import__("sys").modules, "hermes_cli.runtime_provider", fake_runtime_provider)
+
     parent = SimpleNamespace(
         _delegate_depth=0,
         enabled_toolsets=["terminal"],
@@ -160,7 +328,220 @@ def test_delegate_child_uses_builder_role_fallback_chain(monkeypatch):
     )
 
     assert child is not None
+    assert captured["model"] == "MiniMax-M2.7"
+    assert captured["provider"] == "minimax"
+    assert captured["base_url"] == "https://minimax.example.test"
     assert captured["fallback_model"] == role_fallback_chain("builder", {})
+    assert captured["reasoning_config"] == {"enabled": True, "effort": "medium"}
+
+
+def test_delegate_role_route_intentionally_overrides_delegation_credentials(monkeypatch):
+    from tools import delegate_tool
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self._active_children = {}
+            self._active_subagents = {}
+            self._delegate_role = None
+
+    fake_run_agent = ModuleType("run_agent")
+    setattr(fake_run_agent, "AIAgent", FakeAgent)
+    monkeypatch.setitem(__import__("sys").modules, "run_agent", fake_run_agent)
+    monkeypatch.setattr(delegate_tool, "_load_config", lambda: {})
+    monkeypatch.setattr(delegate_tool, "_get_max_spawn_depth", lambda: 1)
+    monkeypatch.setattr(delegate_tool, "_get_orchestrator_enabled", lambda: True)
+    monkeypatch.setattr(delegate_tool, "_build_child_progress_callback", lambda *args, **kwargs: None)
+
+    def fake_resolve_runtime_provider(requested, target_model=None, **_kwargs):
+        return {
+            "provider": requested,
+            "model": target_model,
+            "base_url": f"https://{requested}.example.test",
+            "api_key": f"{requested}-key",
+            "api_mode": "anthropic_messages" if requested in {"anthropic", "minimax"} else "codex_responses",
+        }
+
+    fake_runtime_provider = ModuleType("hermes_cli.runtime_provider")
+    setattr(fake_runtime_provider, "resolve_runtime_provider", fake_resolve_runtime_provider)
+    monkeypatch.setitem(__import__("sys").modules, "hermes_cli.runtime_provider", fake_runtime_provider)
+
+    parent = SimpleNamespace(
+        _delegate_depth=0,
+        enabled_toolsets=["terminal"],
+        model="claude-sonnet-4.6",
+        provider="anthropic",
+        base_url="https://api.anthropic.com",
+        api_key="primary",
+        api_mode="anthropic_messages",
+        platform="cli",
+        _fallback_chain=[],
+    )
+
+    delegate_tool._build_child_agent(
+        task_index=0,
+        goal="build",
+        context=None,
+        toolsets=None,
+        model="gpt-5.5",
+        max_iterations=1,
+        task_count=1,
+        parent_agent=parent,
+        override_provider="openai-codex",
+        override_base_url="https://chatgpt.com/backend-api/codex",
+        override_api_key="codex-key",
+        override_api_mode="codex_responses",
+    )
+
+    assert captured["provider"] == "minimax"
+    assert captured["model"] == "MiniMax-M2.7"
+    assert captured["base_url"] == "https://minimax.example.test"
+
+
+def test_delegate_child_uses_approved_fallback_when_primary_role_runtime_incomplete(monkeypatch):
+    from tools import delegate_tool
+
+    captured = {}
+    callback = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self._active_children = {}
+            self._active_subagents = {}
+            self._delegate_role = None
+
+    fake_run_agent = ModuleType("run_agent")
+    setattr(fake_run_agent, "AIAgent", FakeAgent)
+    monkeypatch.setitem(__import__("sys").modules, "run_agent", fake_run_agent)
+    monkeypatch.setattr(delegate_tool, "_load_config", lambda: {})
+    monkeypatch.setattr(delegate_tool, "_get_max_spawn_depth", lambda: 1)
+    monkeypatch.setattr(delegate_tool, "_get_orchestrator_enabled", lambda: True)
+    monkeypatch.setattr(
+        delegate_tool,
+        "_build_child_progress_callback",
+        lambda *args, **kwargs: callback.update(kwargs) or None,
+    )
+
+    def resolve_runtime_provider(requested, target_model=None, **_kwargs):
+        if requested == "minimax":
+            return {
+                "provider": requested,
+                "model": target_model,
+                "base_url": "https://minimax.example.test",
+                "api_mode": "anthropic_messages",
+            }
+        return {
+            "provider": requested,
+            "model": target_model,
+            "base_url": "https://codex.example.test",
+            "api_key": "fallback-codex-key",
+            "api_mode": "codex_responses",
+        }
+
+    fake_runtime_provider = ModuleType("hermes_cli.runtime_provider")
+    setattr(fake_runtime_provider, "resolve_runtime_provider", resolve_runtime_provider)
+    monkeypatch.setitem(__import__("sys").modules, "hermes_cli.runtime_provider", fake_runtime_provider)
+
+    parent = SimpleNamespace(
+        _delegate_depth=0,
+        enabled_toolsets=["terminal"],
+        model="claude-sonnet-4.6",
+        provider="anthropic",
+        base_url="https://api.anthropic.com",
+        api_key="primary",
+        api_mode="anthropic_messages",
+        platform="cli",
+        _fallback_chain=[],
+    )
+
+    child = delegate_tool._build_child_agent(
+        task_index=0,
+        goal="build",
+        context=None,
+        toolsets=None,
+        model="gpt-5.5",
+        max_iterations=1,
+        task_count=1,
+        parent_agent=parent,
+        override_provider="unapproved-provider",
+        override_base_url="https://unapproved.example.test",
+        override_api_key="unapproved-key",
+        override_api_mode="chat_completions",
+    )
+
+    assert child is not None
+    assert captured["model"] == "gpt-5.5"
+    assert captured["provider"] == "openai-codex"
+    assert captured["base_url"] == "https://codex.example.test"
+    assert captured["api_key"] == "fallback-codex-key"
+    assert captured["api_mode"] == "codex_responses"
+    assert captured["fallback_model"] is None
+    assert callback["model"] == "gpt-5.5"
+
+
+def test_delegate_child_preserves_explicit_empty_role_fallback(monkeypatch):
+    from tools import delegate_tool
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self._active_children = {}
+            self._active_subagents = {}
+            self._delegate_role = None
+
+    fake_run_agent = ModuleType("run_agent")
+    setattr(fake_run_agent, "AIAgent", FakeAgent)
+    monkeypatch.setitem(__import__("sys").modules, "run_agent", fake_run_agent)
+    monkeypatch.setattr(delegate_tool, "_load_config", lambda: {"routing_role": "adversarial_review"})
+    monkeypatch.setattr(delegate_tool, "_get_max_spawn_depth", lambda: 1)
+    monkeypatch.setattr(delegate_tool, "_get_orchestrator_enabled", lambda: True)
+    monkeypatch.setattr(delegate_tool, "_build_child_progress_callback", lambda *args, **kwargs: None)
+
+    def fake_resolve_runtime_provider(requested, target_model=None, **_kwargs):
+        return {
+            "provider": requested,
+            "model": target_model,
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "codex-key",
+            "api_mode": "codex_responses",
+        }
+
+    fake_runtime_provider = ModuleType("hermes_cli.runtime_provider")
+    setattr(fake_runtime_provider, "resolve_runtime_provider", fake_resolve_runtime_provider)
+    monkeypatch.setitem(__import__("sys").modules, "hermes_cli.runtime_provider", fake_runtime_provider)
+
+    parent = SimpleNamespace(
+        _delegate_depth=0,
+        enabled_toolsets=["terminal"],
+        model="claude-sonnet-4.6",
+        provider="anthropic",
+        base_url="https://api.anthropic.com",
+        api_key="primary",
+        api_mode="anthropic_messages",
+        platform="cli",
+        _fallback_chain=[{"provider": "minimax", "model": "MiniMax-M2.7"}],
+    )
+
+    child = delegate_tool._build_child_agent(
+        task_index=0,
+        goal="review",
+        context=None,
+        toolsets=None,
+        model=None,
+        max_iterations=1,
+        task_count=1,
+        parent_agent=parent,
+    )
+
+    assert child is not None
+    assert captured["provider"] == "openai-codex"
+    assert captured["model"] == "gpt-5.5"
+    assert captured["fallback_model"] == []
 
 
 def test_linear_offline_receipt_queue_and_replay(tmp_path, monkeypatch):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -31,6 +31,7 @@ from concurrent.futures import (
 from typing import Any, Dict, List, Optional
 
 from toolsets import TOOLSETS
+from hermes_cli.fallback_config import role_fallback_chain, sanitize_fallback_chain
 
 # Sentinel value used by the runtime provider system for providers that are
 # not natively known (named custom providers, third-party aggregators, etc.).
@@ -1076,11 +1077,16 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
-    # Inherit the parent's fallback provider chain so subagents can recover
-    # from rate-limits and credential exhaustion exactly like the top-level
-    # agent does.  _fallback_chain is a list accepted by AIAgent's
-    # fallback_model parameter (which handles both list and dict forms).
-    parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    # Delegated workers are builder-like runtime actors, so prefer the
+    # role-specific failover ladder when configured/available.  This wires the
+    # ALF-99 role ladder into a real child-agent construction path instead of
+    # leaving role_fallback_chain() as unit-tested dead code.  If the role ladder
+    # is intentionally empty, preserve the previous behavior and inherit the
+    # parent's sanitized fallback chain.
+    fallback_role = str(delegation_cfg.get("fallback_role") or "builder").strip().lower()
+    child_fallback = role_fallback_chain(fallback_role, delegation_cfg)
+    parent_fallback = sanitize_fallback_chain(getattr(parent_agent, "_fallback_chain", None))
+    effective_fallback = child_fallback or parent_fallback or None
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -1115,7 +1121,7 @@ def _build_child_agent(
         max_tokens=getattr(parent_agent, "max_tokens", None),
         reasoning_config=child_reasoning,
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
-        fallback_model=parent_fallback,
+        fallback_model=effective_fallback,
         enabled_toolsets=child_toolsets,
         quiet_mode=True,
         ephemeral_system_prompt=child_prompt,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -31,7 +31,12 @@ from concurrent.futures import (
 from typing import Any, Dict, List, Optional
 
 from toolsets import TOOLSETS
-from hermes_cli.fallback_config import role_fallback_chain, sanitize_fallback_chain
+from hermes_cli.fallback_config import (
+    role_fallback_chain,
+    role_has_route,
+    role_primary_route,
+    sanitize_fallback_chain,
+)
 
 # Sentinel value used by the runtime provider system for providers that are
 # not natively known (named custom providers, third-party aggregators, etc.).
@@ -982,55 +987,116 @@ def _build_child_agent(
     if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
         parent_api_key = parent_agent._client_kwargs.get("api_key")
 
-    # Resolve the child's effective model early so it can ride on every event.
-    effective_model_for_cb = model or getattr(parent_agent, "model", None)
-
-    # Build progress callback to relay tool calls to parent display.
-    # Identity kwargs thread the subagent_id through every emitted event so the
-    # TUI can reconstruct the spawn tree and route per-branch controls.
-    child_progress_cb = _build_child_progress_callback(
-        task_index,
-        goal,
-        parent_agent,
-        task_count,
-        subagent_id=subagent_id,
-        parent_id=parent_subagent_id,
-        depth=tui_depth,
-        model=effective_model_for_cb,
-        toolsets=child_toolsets,
+    # Resolve routing role. For nested /goal-style orchestrators, route the child
+    # as an orchestrator (Opus primary). Otherwise delegated children are builders
+    # unless delegation.fallback_role/routing_role says otherwise.
+    routing_role = (
+        "orchestrator"
+        if effective_role == "orchestrator"
+        else str(
+            delegation_cfg.get("routing_role")
+            or delegation_cfg.get("fallback_role")
+            or "builder"
+        ).strip().lower()
     )
+    primary_route = role_primary_route(routing_role, delegation_cfg)
 
     # Each subagent gets its own iteration budget capped at max_iterations
     # (configurable via delegation.max_iterations, default 50).  This means
     # total iterations across parent + subagents can exceed the parent's
     # max_iterations.  The user controls the per-subagent cap in config.yaml.
 
-    child_thinking_cb = None
-    if child_progress_cb:
+    # Resolve effective credentials: role route > delegation config override > parent inherit.
+    # This enforces John's approved matrix: builder children start on MiniMax,
+    # orchestrator children start on Opus 4.8, and each role carries its own
+    # reasoning effort independent of the parent's current model.
+    primary_provider = str(primary_route.get("provider") or "").strip() or None
+    primary_model = str(primary_route.get("model") or "").strip() or None
+    route_provider = primary_provider or override_provider
+    route_model = primary_model or model
 
-        def _child_thinking(text: str) -> None:
-            if not text:
-                return
-            try:
-                child_progress_cb("_thinking", text)
-            except Exception as e:
-                logger.debug("Child thinking callback relay failed: %s", e)
+    # Delegated workers use role-specific primary/fallback ladders. Preserve an
+    # explicitly empty role ladder (for example adversarial_review has no
+    # fallback); inherit the parent chain only when no role route exists.
+    child_fallback = role_fallback_chain(routing_role, delegation_cfg)
+    parent_fallback = sanitize_fallback_chain(getattr(parent_agent, "_fallback_chain", None))
+    role_route_exists = role_has_route(routing_role, delegation_cfg)
+    effective_fallback = child_fallback if role_route_exists else (parent_fallback or None)
 
-        child_thinking_cb = _child_thinking
+    role_runtime = None
+    active_route = primary_route
 
-    # Resolve effective credentials: config override > parent inherit
-    effective_model = model or parent_agent.model
-    effective_provider = override_provider or getattr(parent_agent, "provider", None)
-    effective_base_url = override_base_url or parent_agent.base_url
-    effective_api_key = override_api_key or parent_api_key
+    def _resolve_role_runtime(provider: str | None, target_model: str | None, label: str) -> dict[str, Any] | None:
+        if not provider:
+            return None
+        try:
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+
+            runtime = resolve_runtime_provider(requested=provider, target_model=target_model)
+            if not runtime or not (
+                runtime.get("provider")
+                and runtime.get("base_url")
+                and runtime.get("api_key")
+                and runtime.get("api_mode")
+            ):
+                logger.warning(
+                    "Resolved %s route %s/%s for delegation role %s returned incomplete runtime",
+                    label,
+                    provider,
+                    target_model,
+                    routing_role,
+                )
+                return None
+            return runtime
+        except Exception as exc:
+            logger.warning(
+                "Could not resolve %s route %s/%s for delegation role %s: %s",
+                label,
+                provider,
+                target_model,
+                routing_role,
+                exc,
+            )
+            return None
+
+    role_runtime = _resolve_role_runtime(route_provider, route_model, "primary")
+    if role_runtime is None and role_route_exists:
+        for i, fallback_route in enumerate(child_fallback or []):
+            fallback_provider = str(fallback_route.get("provider") or "").strip() or None
+            fallback_model = str(fallback_route.get("model") or "").strip() or None
+            role_runtime = _resolve_role_runtime(fallback_provider, fallback_model, f"fallback[{i}]")
+            if role_runtime is not None:
+                active_route = fallback_route
+                if role_route_exists:
+                    effective_fallback = child_fallback[i + 1 :] or None
+                break
+        if role_runtime is None:
+            raise RuntimeError(
+                f"Could not resolve any approved runtime for delegation role {routing_role!r}; refusing to use delegation/parent credentials"
+            )
+
+    if role_runtime is not None:
+        effective_model = role_runtime.get("model") or route_model or model or parent_agent.model
+        effective_provider = role_runtime.get("provider") or route_provider or getattr(parent_agent, "provider", None)
+        effective_base_url = str(role_runtime.get("base_url"))
+        effective_api_key = str(role_runtime.get("api_key"))
+    else:
+        # Only non-role-routed legacy delegation may inherit explicit
+        # delegation/parent credentials. Approved role routes fail closed above.
+        effective_model = model or parent_agent.model
+        effective_provider = override_provider or getattr(parent_agent, "provider", None)
+        effective_base_url = override_base_url or parent_agent.base_url
+        effective_api_key = override_api_key or parent_api_key
     # Bug #20558 / PR #20563: api_mode must NOT be inherited when the child uses a
     # different provider than the parent — each provider has its own API surface
     # (e.g. MiniMax uses anthropic_messages, DeepSeek uses chat_completions).
     # Inheriting the parent's mode causes 404 errors when the child routes to the
     # wrong endpoint.  Derive the mode from the target provider when it differs.
     _parent_provider = getattr(parent_agent, "provider", None) or ""
-    if override_api_mode is not None:
+    if override_api_mode is not None and role_runtime is None:
         effective_api_mode = override_api_mode
+    elif role_runtime is not None:
+        effective_api_mode = role_runtime.get("api_mode")
     elif effective_provider != _parent_provider:
         effective_api_mode = None  # force re-derivation from provider's defaults
     else:
@@ -1058,14 +1124,20 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
-    # Resolve reasoning config: delegation override > parent inherit
+    # Resolve reasoning config: role route > delegation override > parent inherit
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning
     try:
-        delegation_effort = str(delegation_cfg.get("reasoning_effort") or "").strip()
-        if delegation_effort:
-            from hermes_constants import parse_reasoning_effort
+        from hermes_constants import parse_reasoning_effort
 
+        route_effort = str(active_route.get("reasoning_effort") or "").strip()
+        if route_effort:
+            parsed = parse_reasoning_effort(route_effort)
+            if parsed is not None:
+                child_reasoning = parsed
+
+        delegation_effort = str(delegation_cfg.get("reasoning_effort") or "").strip()
+        if delegation_effort and not route_effort:
             parsed = parse_reasoning_effort(delegation_effort)
             if parsed is not None:
                 child_reasoning = parsed
@@ -1075,18 +1147,33 @@ def _build_child_agent(
                     delegation_effort,
                 )
     except Exception as exc:
-        logger.debug("Could not load delegation reasoning_effort: %s", exc)
+        logger.debug("Could not load child reasoning_effort: %s", exc)
 
-    # Delegated workers are builder-like runtime actors, so prefer the
-    # role-specific failover ladder when configured/available.  This wires the
-    # ALF-99 role ladder into a real child-agent construction path instead of
-    # leaving role_fallback_chain() as unit-tested dead code.  If the role ladder
-    # is intentionally empty, preserve the previous behavior and inherit the
-    # parent's sanitized fallback chain.
-    fallback_role = str(delegation_cfg.get("fallback_role") or "builder").strip().lower()
-    child_fallback = role_fallback_chain(fallback_role, delegation_cfg)
-    parent_fallback = sanitize_fallback_chain(getattr(parent_agent, "_fallback_chain", None))
-    effective_fallback = child_fallback or parent_fallback or None
+    # Build progress callback after final model/provider resolution so trace
+    # metadata matches the runtime that the child will actually use.
+    child_progress_cb = _build_child_progress_callback(
+        task_index,
+        goal,
+        parent_agent,
+        task_count,
+        subagent_id=subagent_id,
+        parent_id=parent_subagent_id,
+        depth=tui_depth,
+        model=effective_model,
+        toolsets=child_toolsets,
+    )
+    child_thinking_cb = None
+    if child_progress_cb:
+
+        def _child_thinking(text: str) -> None:
+            if not text:
+                return
+            try:
+                child_progress_cb("_thinking", text)
+            except Exception as e:
+                logger.debug("Child thinking callback relay failed: %s", e)
+
+        child_thinking_cb = _child_thinking
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -1110,10 +1197,10 @@ def _build_child_agent(
         # provider is overridden — it's a no-op on any other model.
 
     child = AIAgent(
-        base_url=effective_base_url,
-        api_key=effective_api_key,
-        model=effective_model,
-        provider=effective_provider,
+        base_url=str(effective_base_url or ""),
+        api_key=str(effective_api_key or ""),
+        model=str(effective_model or ""),
+        provider=str(effective_provider or ""),
         api_mode=effective_api_mode,
         acp_command=effective_acp_command,
         acp_args=effective_acp_args,


### PR DESCRIPTION
## Summary
- Encode John's approved Hermes role routing matrix in fallback_config defaults and role route resolution.
- Route delegated children through authoritative role primary/fallback runtimes instead of session-local delegation/parent credentials.
- Apply fallback reasoning_effort on runtime failover and clear stale reasoning on missing/invalid fallback effort.
- Add regression coverage for ALF-99 role ladders, Linear traceability attribution, offline receipts, fallback promotion, and fail-closed credential behavior.

## Verification
- uv run pytest tests/run_agent/test_model_failover_linear_traceability.py tests/run_agent/test_provider_fallback.py -q → 36 passed, 1 warning
- uv run python -m py_compile hermes_cli/fallback_config.py tools/delegate_tool.py agent/chat_completion_helpers.py tests/run_agent/test_model_failover_linear_traceability.py
- Independent Hermes review session 20260529_135932_8af41d passed with no blocking security or logic issues.

## Receipts
- Local diff receipt: /Users/johnchen/Documents/Alfred Reports/Model Failover Linear Traceability/receipts/alf99-routing-update-safe-staged-2026-05-29.diff
- Local review receipt: /Users/johnchen/Documents/Alfred Reports/Model Failover Linear Traceability/receipts/alf99-routing-update-safe-review-2026-05-29.json