### PR TITLE
fix: harden gateway pidfile and local STT filtering

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -13,6 +13,7 @@ concurrently under distinct configurations).
 
 import hashlib
 import json
+import logging
 import os
 import signal
 import subprocess
@@ -39,6 +40,7 @@ _gateway_lock_handle = None
 # past the JSON payload so runtime status / PID readers can still read the file
 # while another process holds the mutual-exclusion lock.
 _WINDOWS_LOCK_OFFSET = 1024 * 1024
+logger = logging.getLogger(__name__)
 
 
 def _get_pid_path() -> Path:
@@ -164,12 +166,12 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
     return None
 
 
-def _looks_like_gateway_process(pid: int) -> bool:
-    """Return True when the live PID still looks like the Hermes gateway."""
-    cmdline = _read_process_cmdline(pid)
+def _cmdline_looks_like_gateway(cmdline: str) -> bool:
+    """Return True when a command line looks like a Hermes gateway."""
     if not cmdline:
         return False
-
+    # Normalize Windows backslashes so patterns match cross-platform.
+    cmdline = cmdline.replace("\\", "/")
     patterns = (
         "hermes_cli.main gateway",
         "hermes_cli/main.py gateway",
@@ -178,6 +180,12 @@ def _looks_like_gateway_process(pid: int) -> bool:
         "gateway/run.py",
     )
     return any(pattern in cmdline for pattern in patterns)
+
+
+def _looks_like_gateway_process(pid: int) -> bool:
+    """Return True when the live PID still looks like the Hermes gateway."""
+    cmdline = _read_process_cmdline(pid)
+    return _cmdline_looks_like_gateway(cmdline or "")
 
 
 def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
@@ -191,13 +199,7 @@ def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
 
     # Normalize Windows backslashes so patterns match cross-platform.
     cmdline = " ".join(str(part) for part in argv).replace("\\", "/")
-    patterns = (
-        "hermes_cli.main gateway",
-        "hermes_cli/main.py gateway",
-        "hermes gateway",
-        "gateway/run.py",
-    )
-    return any(pattern in cmdline for pattern in patterns)
+    return _cmdline_looks_like_gateway(cmdline)
 
 
 def _build_pid_record() -> dict:
@@ -283,7 +285,12 @@ def _pid_from_record(record: Optional[dict[str, Any]]) -> Optional[int]:
         return None
 
 
-def _cleanup_invalid_pid_path(pid_path: Path, *, cleanup_stale: bool) -> None:
+def _cleanup_invalid_pid_path(
+    pid_path: Path,
+    *,
+    cleanup_stale: bool,
+    reason: str = "not a live Hermes gateway",
+) -> None:
     """Delete a stale gateway PID file (and its sibling lock metadata).
 
     Called from ``get_running_pid()`` after the runtime lock has already been
@@ -295,12 +302,29 @@ def _cleanup_invalid_pid_path(pid_path: Path, *, cleanup_stale: bool) -> None:
     """
     if not cleanup_stale:
         return
+    lock_path = _get_gateway_lock_path(pid_path)
+    if pid_path.exists() or lock_path.exists():
+        record = _read_pid_record(pid_path)
+        pid = _pid_from_record(record)
+        if pid is not None:
+            logger.warning(
+                "⚠ Stale gateway pidfile detected (PID %s: %s); cleaning up %s",
+                pid,
+                reason,
+                pid_path,
+            )
+        else:
+            logger.warning(
+                "⚠ Stale gateway pidfile detected (%s); cleaning up %s",
+                reason,
+                pid_path,
+            )
     try:
         pid_path.unlink(missing_ok=True)
     except Exception:
         pass
     try:
-        _get_gateway_lock_path(pid_path).unlink(missing_ok=True)
+        lock_path.unlink(missing_ok=True)
     except Exception:
         pass
 
@@ -1010,29 +1034,50 @@ def get_running_pid(
     resolved_lock_path = _get_gateway_lock_path(resolved_pid_path)
     lock_active = is_gateway_runtime_lock_active(resolved_lock_path)
     if not lock_active:
-        _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+        _cleanup_invalid_pid_path(
+            resolved_pid_path,
+            cleanup_stale=cleanup_stale,
+            reason="runtime lock is not held",
+        )
         return None
 
     primary_record = _read_pid_record(resolved_pid_path)
     fallback_record = _read_gateway_lock_record(resolved_lock_path)
 
+    stale_reason = "recorded PID is not a live Hermes gateway"
     for record in (primary_record, fallback_record):
         pid = _pid_from_record(record)
         if pid is None:
             continue
 
         if not _pid_exists(pid):
+            stale_reason = f"PID {pid} is not running"
             continue
 
         recorded_start = record.get("start_time")
         current_start = _get_process_start_time(pid)
         if recorded_start is not None and current_start is not None and current_start != recorded_start:
+            stale_reason = f"PID {pid} start time changed"
             continue
 
-        if _looks_like_gateway_process(pid) or _record_looks_like_gateway(record):
+        cmdline = _read_process_cmdline(pid)
+        if cmdline is not None:
+            if _cmdline_looks_like_gateway(cmdline):
+                return pid
+            stale_reason = f"PID {pid} is not a Hermes gateway process"
+            continue
+
+        # Only trust pidfile metadata when the platform cannot provide a
+        # command line. If we *can* read cmdline and it says "not gateway",
+        # the pidfile is stale even when its own argv claims otherwise.
+        if _record_looks_like_gateway(record):
             return pid
 
-    _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+    _cleanup_invalid_pid_path(
+        resolved_pid_path,
+        cleanup_stale=cleanup_stale,
+        reason=stale_reason,
+    )
     return None
 
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2240,6 +2240,7 @@ StartLimitIntervalSec=0
 Type=simple
 User={username}
 Group={group_name}
+ExecStartPre={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway _cleanup-pidfile
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
 WorkingDirectory={working_dir}
 Environment="HOME={home_dir}"
@@ -2278,6 +2279,7 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
+ExecStartPre={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway _cleanup-pidfile
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
@@ -3353,6 +3355,15 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
         _exit_diag("gateway.exit_nonzero")
         sys.exit(1)
     _exit_diag("gateway.exit_clean")
+
+
+def cleanup_gateway_pidfile() -> None:
+    """Best-effort service preflight: remove stale gateway pidfile metadata."""
+    from gateway.status import get_running_pid
+
+    # get_running_pid() performs the robust stale-pidfile cleanup as a side
+    # effect, while leaving an actual live gateway's pidfile intact.
+    get_running_pid(cleanup_stale=True)
 
 
 # =============================================================================
@@ -5247,6 +5258,10 @@ def _gateway_command_inner(args):
         quiet = getattr(args, 'quiet', False)
         replace = getattr(args, 'replace', False)
         run_gateway(verbose, quiet=quiet, replace=replace)
+        return
+
+    if subcmd == "_cleanup-pidfile":
+        cleanup_gateway_pidfile()
         return
 
     if subcmd == "setup":

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11516,6 +11516,12 @@ def main():
     _add_accept_hooks_flag(gateway_run)
     _add_accept_hooks_flag(gateway_parser)
 
+    gateway_subparsers.add_parser(
+        "_cleanup-pidfile",
+        help=argparse.SUPPRESS,
+        description="Internal systemd preflight for stale gateway pidfiles",
+    )
+
     # gateway start
     gateway_start = gateway_subparsers.add_parser(
         "start", help="Start the installed systemd/launchd background service"

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -52,6 +52,47 @@ class TestGatewayPidState:
         assert status.get_running_pid() is None
         assert not pid_path.exists()
 
+    def test_get_running_pid_cleans_gateway_record_reused_by_non_gateway_pid(self, tmp_path, monkeypatch):
+        """A stale gateway record must not be trusted when cmdline says non-gateway."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        lock_path = tmp_path / "gateway.lock"
+        record = {
+            "pid": 1,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": None,
+        }
+        pid_path.write_text(json.dumps(record))
+        lock_path.write_text(json.dumps(record))
+
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda lock_path=None: True)
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "/sbin/init")
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+        assert not lock_path.exists()
+
+    def test_remove_pid_file_unlinks_own_pidfile(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({"pid": os.getpid(), "kind": "hermes-gateway"}))
+
+        status.remove_pid_file()
+
+        assert not pid_path.exists()
+
+    def test_remove_pid_file_preserves_other_process_pidfile(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({"pid": os.getpid() + 1000, "kind": "hermes-gateway"}))
+
+        status.remove_pid_file()
+
+        assert pid_path.exists()
+
     def test_get_running_pid_cleans_stale_record_from_dead_process(self, tmp_path, monkeypatch):
         # Simulates the aftermath of a crash: the PID file still points at a
         # process that no longer exists. The next gateway startup must be

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -324,6 +324,8 @@ class TestGeneratedSystemdUnits:
         unit = gateway_cli.generate_systemd_unit(system=False)
 
         assert "ExecStart=" in unit
+        assert "ExecStartPre=" in unit
+        assert "gateway _cleanup-pidfile" in unit
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
@@ -379,12 +381,19 @@ class TestGeneratedSystemdUnits:
     def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self, monkeypatch):
         monkeypatch.setattr(
             gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
             "_get_restart_drain_timeout",
             lambda: DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
         )
-        unit = gateway_cli.generate_systemd_unit(system=True)
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
 
         assert "ExecStart=" in unit
+        assert "ExecStartPre=" in unit
+        assert "gateway _cleanup-pidfile" in unit
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
@@ -1308,10 +1317,15 @@ class TestGeneratedUnitIncludesLocalBin:
     def test_system_unit_includes_local_bin_in_path(self, monkeypatch):
         monkeypatch.setattr(
             gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
             "_build_user_local_paths",
             lambda home_path, existing: [str(home_path / ".local" / "bin")],
         )
-        unit = gateway_cli.generate_systemd_unit(system=True)
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
         # System unit uses the resolved home dir from _system_service_identity
         assert "/.local/bin" in unit
 

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -524,6 +524,62 @@ class TestTranscribeLocalExtended:
         assert result["success"] is True
         assert result["transcript"] == "Hello world"
 
+    def test_local_uses_noise_resistant_defaults_for_music_backgrounds(self, tmp_path):
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        seg = MagicMock()
+        seg.text = "real speech"
+        info = MagicMock()
+        info.language = "en"
+        info.duration = 1.0
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([seg], info)
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", return_value=mock_model), \
+             patch("tools.transcription_tools._load_stt_config", return_value={"local": {}}), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_name", None):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(str(audio), "base")
+
+        assert result["success"] is True
+        kwargs = mock_model.transcribe.call_args.kwargs
+        assert kwargs["vad_filter"] is True
+        assert kwargs["condition_on_previous_text"] is False
+        assert kwargs["temperature"] == 0.0
+        assert kwargs["no_speech_threshold"] >= 0.6
+        assert kwargs["hallucination_silence_threshold"] >= 0.5
+
+    def test_local_filters_high_no_speech_low_confidence_segments(self, tmp_path):
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        music_hallucination = MagicMock()
+        music_hallucination.text = "Thank you, boys, for being here. Thank you."
+        music_hallucination.no_speech_prob = 0.96
+        music_hallucination.avg_logprob = -1.25
+        info = MagicMock()
+        info.language = "en"
+        info.duration = 4.0
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([music_hallucination], info)
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", return_value=mock_model), \
+             patch("tools.transcription_tools._load_stt_config", return_value={"local": {}}), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_name", None):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(str(audio), "base")
+
+        assert result["success"] is True
+        assert result["transcript"] == ""
+        assert result.get("filtered") is True
+
     def test_load_time_cuda_lib_failure_falls_back_to_cpu(self, tmp_path):
         """Missing libcublas at load time → reload on CPU, succeed."""
         audio = tmp_path / "test.ogg"

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1051,6 +1051,125 @@ _CUDA_LIB_ERROR_MARKERS = (
     "CUDA driver version is insufficient",
 )
 
+# Conservative local-STT defaults for live voice.  Discord voice often carries
+# music/rhythm from the room; without VAD and segment confidence checks, small
+# local Whisper models are prone to lyric-like hallucinations on that audio.
+DEFAULT_LOCAL_VAD_FILTER = True
+DEFAULT_LOCAL_NO_SPEECH_THRESHOLD = 0.6
+DEFAULT_LOCAL_HALLUCINATION_SILENCE_THRESHOLD = 1.0
+DEFAULT_LOCAL_CONDITION_ON_PREVIOUS_TEXT = False
+DEFAULT_LOCAL_REPETITION_PENALTY = 1.15
+DEFAULT_LOCAL_NO_REPEAT_NGRAM_SIZE = 3
+DEFAULT_LOCAL_SEGMENT_NO_SPEECH_THRESHOLD = 0.85
+DEFAULT_LOCAL_SEGMENT_LOG_PROB_THRESHOLD = -0.5
+
+
+def _get_float_setting(config: dict, key: str, default: float) -> float:
+    try:
+        return float(config.get(key, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _get_int_setting(config: dict, key: str, default: int) -> int:
+    try:
+        return int(config.get(key, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _numeric_segment_attr(segment: object, attr_name: str) -> Optional[float]:
+    value = getattr(segment, attr_name, None)
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _should_filter_local_segment(segment: object, local_cfg: dict) -> bool:
+    """Return True for probable music/no-speech hallucination segments."""
+    text = str(getattr(segment, "text", "") or "").strip()
+    if not text:
+        return True
+
+    no_speech_prob = _numeric_segment_attr(segment, "no_speech_prob")
+    avg_logprob = _numeric_segment_attr(segment, "avg_logprob")
+    no_speech_threshold = _get_float_setting(
+        local_cfg,
+        "segment_no_speech_threshold",
+        DEFAULT_LOCAL_SEGMENT_NO_SPEECH_THRESHOLD,
+    )
+    low_confidence_threshold = _get_float_setting(
+        local_cfg,
+        "segment_log_prob_threshold",
+        DEFAULT_LOCAL_SEGMENT_LOG_PROB_THRESHOLD,
+    )
+
+    if no_speech_prob is not None and no_speech_prob >= no_speech_threshold:
+        if avg_logprob is None or avg_logprob <= low_confidence_threshold:
+            return True
+
+    return False
+
+
+def _collect_local_transcript(segments, local_cfg: dict) -> tuple[str, int]:
+    kept_text = []
+    filtered = 0
+    for segment in segments:
+        if _should_filter_local_segment(segment, local_cfg):
+            filtered += 1
+            continue
+        kept_text.append(str(segment.text).strip())
+    return " ".join(text for text in kept_text if text).strip(), filtered
+
+
+def _local_transcribe_kwargs(local_cfg: dict) -> Dict[str, Any]:
+    vad_filter = is_truthy_value(
+        local_cfg.get("vad_filter", DEFAULT_LOCAL_VAD_FILTER),
+        default=DEFAULT_LOCAL_VAD_FILTER,
+    )
+    kwargs: Dict[str, Any] = {
+        "beam_size": _get_int_setting(local_cfg, "beam_size", 5),
+        "temperature": _get_float_setting(local_cfg, "temperature", 0.0),
+        "condition_on_previous_text": is_truthy_value(
+            local_cfg.get(
+                "condition_on_previous_text",
+                DEFAULT_LOCAL_CONDITION_ON_PREVIOUS_TEXT,
+            ),
+            default=DEFAULT_LOCAL_CONDITION_ON_PREVIOUS_TEXT,
+        ),
+        "vad_filter": vad_filter,
+        "no_speech_threshold": _get_float_setting(
+            local_cfg,
+            "no_speech_threshold",
+            DEFAULT_LOCAL_NO_SPEECH_THRESHOLD,
+        ),
+        "log_prob_threshold": _get_float_setting(local_cfg, "log_prob_threshold", -1.0),
+        "compression_ratio_threshold": _get_float_setting(
+            local_cfg,
+            "compression_ratio_threshold",
+            2.4,
+        ),
+        "hallucination_silence_threshold": _get_float_setting(
+            local_cfg,
+            "hallucination_silence_threshold",
+            DEFAULT_LOCAL_HALLUCINATION_SILENCE_THRESHOLD,
+        ),
+        "repetition_penalty": _get_float_setting(
+            local_cfg,
+            "repetition_penalty",
+            DEFAULT_LOCAL_REPETITION_PENALTY,
+        ),
+        "no_repeat_ngram_size": _get_int_setting(
+            local_cfg,
+            "no_repeat_ngram_size",
+            DEFAULT_LOCAL_NO_REPEAT_NGRAM_SIZE,
+        ),
+    }
+    vad_parameters = local_cfg.get("vad_parameters")
+    if vad_filter and isinstance(vad_parameters, dict):
+        kwargs["vad_parameters"] = vad_parameters
+    return kwargs
+
 
 def _looks_like_cuda_lib_error(exc: BaseException) -> bool:
     """Heuristic: is this exception a missing/broken CUDA runtime library?
@@ -1107,18 +1226,20 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
             _local_model_name = model_name
 
         # Language: config.yaml (stt.local.language) > env var > auto-detect.
+        stt_config = _load_stt_config()
+        local_cfg = stt_config.get("local", {}) if isinstance(stt_config.get("local"), dict) else {}
         _forced_lang = (
-            _load_stt_config().get("local", {}).get("language")
+            local_cfg.get("language")
             or os.getenv(LOCAL_STT_LANGUAGE_ENV)
             or None
         )
-        transcribe_kwargs = {"beam_size": 5}
+        transcribe_kwargs = _local_transcribe_kwargs(local_cfg)
         if _forced_lang:
             transcribe_kwargs["language"] = _forced_lang
 
         try:
             segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
-            transcript = " ".join(segment.text.strip() for segment in segments)
+            transcript, filtered_segments = _collect_local_transcript(segments, local_cfg)
         except Exception as exc:
             # CUDA runtime libs sometimes only fail at dlopen-on-first-use,
             # AFTER the model loaded successfully.  Evict the broken cached
@@ -1138,14 +1259,26 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
             _local_model = WhisperModel(model_name, device="cpu", compute_type="int8")
             _local_model_name = model_name
             segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
-            transcript = " ".join(segment.text.strip() for segment in segments)
+            transcript, filtered_segments = _collect_local_transcript(segments, local_cfg)
+
+        if filtered_segments:
+            logger.info(
+                "Filtered %d low-confidence/no-speech local STT segment(s) from %s",
+                filtered_segments,
+                Path(file_path).name,
+            )
 
         logger.info(
             "Transcribed %s via local whisper (%s, lang=%s, %.1fs audio)",
             Path(file_path).name, model_name, info.language, info.duration,
         )
 
-        return {"success": True, "transcript": transcript, "provider": "local"}
+        return {
+            "success": True,
+            "transcript": transcript,
+            "provider": "local",
+            "filtered": bool(filtered_segments and not transcript),
+        }
 
     except Exception as e:
         logger.error("Local transcription failed: %s", e, exc_info=True)


### PR DESCRIPTION
## Summary
- add a service preflight that removes stale gateway pidfile/lock metadata before systemd/launchd startup
- require live process command-line identity before trusting gateway pid records, including PID-reuse cases
- make local faster-whisper transcription more resistant to no-speech/music hallucinations via VAD/default decode options and segment confidence filtering

## Root cause
- gateway restarts could be blocked by stale pidfile metadata after a dead/reused PID because record argv was trusted even when the live PID cmdline was not a Hermes gateway
- local Whisper could surface hallucinated filler text from high no-speech, low-confidence segments

## Test plan
- pytest tests/gateway/test_status.py tests/hermes_cli/test_gateway_service.py tests/tools/test_transcription_tools.py -q
- git diff --check
- python3 -m py_compile gateway/status.py hermes_cli/gateway.py hermes_cli/main.py tools/transcription_tools.py

Supersedes #34868, which used the same patch but had an unmapped local root author identity.