### PR TITLE
fix(memory): OR-combine FTS5 tokens so holographic recall actually returns results

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -494,9 +494,21 @@ class FactRetriever:
 
         # Build query - FTS5 rank is negative (lower = better match)
         # We need to join facts_fts with facts to get all columns
+        #
+        # FTS5 MATCH defaults to AND between bare terms, so a natural-language
+        # query ("communication preferences telegram format") would require
+        # every token to appear in a single fact and almost always return
+        # nothing. Auto-recall feeds exactly these multi-word queries, so we
+        # OR-combine the tokens to cast a wide net; the downstream Jaccard +
+        # HRR + trust scoring in search() then ranks the candidates. Each
+        # token is double-quoted so FTS5 treats it as a literal (no operator
+        # injection from punctuation in the query).
+        fts_query = self._build_or_match(query)
+        if not fts_query:
+            return []
         params: list = []
         where_clauses = ["facts_fts MATCH ?"]
-        params.append(query)
+        params.append(fts_query)
 
         if category:
             where_clauses.append("f.category = ?")
@@ -540,6 +552,27 @@ class FactRetriever:
             results.append(fact)
 
         return results
+
+    @staticmethod
+    def _build_or_match(query: str) -> str:
+        """Turn a free-text query into an OR-combined FTS5 MATCH expression.
+
+        FTS5 ANDs bare terms by default. For recall we want a wide net, so we
+        lowercase, strip punctuation, drop FTS5 operator keywords, double-quote
+        each surviving token (literal — prevents operator/syntax injection),
+        and join with OR. Returns "" when no usable tokens remain.
+        """
+        if not query:
+            return ""
+        reserved = {"and", "or", "not", "near"}
+        tokens = []
+        for word in query.lower().split():
+            cleaned = word.strip(".,;:!?\"'()[]{}#@<>*^-+")
+            if cleaned and cleaned not in reserved:
+                tokens.append(cleaned.replace('"', ""))
+        if not tokens:
+            return ""
+        return " OR ".join(f'"{t}"' for t in tokens)
 
     @staticmethod
     def _tokenize(text: str) -> set[str]:

--- a/tests/plugins/memory/test_holographic_or_match.py
+++ b/tests/plugins/memory/test_holographic_or_match.py
@@ -1,0 +1,88 @@
+"""Regression tests for holographic FactRetriever FTS5 OR-match behavior.
+
+Bug: ``_fts_candidates`` passed the raw query straight to FTS5 MATCH, which
+ANDs bare terms by default. Natural-language recall queries (the kind
+auto-recall feeds every turn) therefore required *every* token to appear in a
+single fact and almost always returned nothing — silently disabling recall.
+
+Fix: ``_build_or_match`` lowercases, strips punctuation, drops FTS5 operator
+keywords, double-quotes each token, and OR-joins them so FTS5 casts a wide net;
+the downstream Jaccard + HRR + trust scoring then ranks the candidates.
+"""
+
+import os
+import sys
+
+import pytest
+
+PLUGIN_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "plugins", "memory", "holographic"
+)
+PLUGIN_DIR = os.path.abspath(PLUGIN_DIR)
+if PLUGIN_DIR not in sys.path:
+    sys.path.insert(0, PLUGIN_DIR)
+
+store_mod = pytest.importorskip("store")
+ret_mod = pytest.importorskip("retrieval")
+
+
+def _make_retriever(tmp_path):
+    db = str(tmp_path / "mem.db")
+    st = store_mod.MemoryStore(db)
+    st.add_fact(
+        "Matvii prefers Verdict-Evidence-Next structure and compact Telegram replies.",
+        category="user_pref",
+        tags="communication,format",
+    )
+    st.add_fact(
+        "Matvii's tools: Xcode, VS Code, Claude Code, Hermes, Slack, Jira.",
+        category="tool",
+        tags="tools",
+    )
+    st.add_fact(
+        "Update Hermes via the hermes-fork-update skill, not blind hermes update.",
+        category="tool",
+        tags="hermes,config",
+    )
+    return ret_mod.FactRetriever(st)
+
+
+class TestBuildOrMatch:
+    def test_multiword_joined_with_or(self):
+        out = ret_mod.FactRetriever._build_or_match("communication preferences telegram format")
+        assert " OR " in out
+        assert out.count('"') == 8  # four quoted tokens
+
+    def test_operator_keywords_dropped(self):
+        out = ret_mod.FactRetriever._build_or_match("tools and hermes or vault")
+        assert "and" not in out.lower().replace('"', "").split()
+        assert '"tools"' in out and '"hermes"' in out and '"vault"' in out
+
+    def test_punctuation_stripped_no_injection(self):
+        # A raw query with FTS5 syntax chars must not raise / inject operators.
+        out = ret_mod.FactRetriever._build_or_match('vault* (path) "quote"')
+        assert "*" not in out
+        assert "(" not in out and ")" not in out
+
+    def test_empty_query_returns_empty(self):
+        assert ret_mod.FactRetriever._build_or_match("") == ""
+        assert ret_mod.FactRetriever._build_or_match("   ") == ""
+
+
+class TestRecallSearch:
+    def test_multiword_query_returns_hits(self, tmp_path):
+        r = _make_retriever(tmp_path)
+        res = r.search("communication preferences telegram format", min_trust=0.3, limit=3)
+        assert res, "multi-word recall query must return candidates"
+        assert "Telegram" in res[0]["content"]
+
+    def test_natural_language_question(self, tmp_path):
+        r = _make_retriever(tmp_path)
+        res = r.search("how should I update hermes", min_trust=0.3, limit=3)
+        assert res
+        assert "hermes-fork-update" in res[0]["content"]
+
+    def test_irrelevant_query_returns_nothing(self, tmp_path):
+        r = _make_retriever(tmp_path)
+        res = r.search("totally unrelated quantum banana spaceship", min_trust=0.3, limit=3)
+        assert res == [], "irrelevant query must inject zero context (no bloat)"


### PR DESCRIPTION
## Summary

The holographic memory provider's automatic recall returns **zero results for nearly every real query**, silently disabling the feature.

`FactRetriever._fts_candidates` passes the raw query straight to FTS5 `MATCH`:

```python
where_clauses = ["facts_fts MATCH ?"]
params.append(query)
```

FTS5 ANDs bare terms by default. But both code paths that drive recall feed **natural-language, multi-word** queries:

- `prefetch()` (auto-recall before every turn) — passes the user's message
- `fact_store(action='search')` — passes the agent's free-text query

So `"communication preferences telegram format"` requires *all four* tokens to appear in a single fact — which almost never happens. Recall returns nothing, and the provider's headline feature (automatic context injection) is dead on arrival.

### Proof (pristine `main`, unmodified)

```
search('communication preferences telegram format') -> 0 hits
search('how should I update hermes')                 -> 0 hits
```

Single-word queries work, which is why this slips through casual testing — but real recall is multi-word.

## Fix

Add `_build_or_match()`: lowercase, strip punctuation, drop FTS5 operator keywords (`and`/`or`/`not`/`near`), double-quote each token (literal — prevents operator/syntax injection), and OR-join. FTS5 casts a wide net; the existing Jaccard + HRR + trust scoring in `search()` then ranks the candidates. The scoring layer was always designed to do the ranking — it just never received candidates.

### After

```
search('communication preferences telegram format') -> 2 hits (correct fact ranked #1)
search('how should I update hermes')                 -> 3 hits (correct fact ranked #1)
search('totally unrelated quantum banana spaceship') -> 0 hits  (no bloat on irrelevant turns)
```

Irrelevant queries still inject nothing, so there's no context bloat.

## Test Plan

Adds `tests/plugins/memory/test_holographic_or_match.py` (7 tests, all passing):

- [x] OR-combination of multi-word queries
- [x] operator-keyword filtering (`and`/`or`/`not`/`near`)
- [x] punctuation stripping / FTS5 injection safety
- [x] empty / whitespace-only query handling
- [x] multi-word recall returns correct top-ranked fact
- [x] natural-language question recall
- [x] irrelevant query returns zero hits (no bloat)

```
7 passed in 0.21s
```

Scoped to a single file (`retrieval.py`) + tests. No API or schema changes.
