### PR TITLE
fix(cli): prevent SIGABRT after successful one-shot runs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -65,6 +65,23 @@ import os
 import sys
 
 
+def _exit_after_oneshot(rc: object) -> None:
+    """Terminate a one-shot process without running fragile finalizers.
+
+    ``hermes -z`` / ``hermes chat -q`` are subprocess-style entry points: once
+    the answer has printed and stdout/stderr are flushed, there is no useful
+    interactive state left for Python teardown to preserve. Using ``os._exit``
+    here avoids late native-extension finalizer crashes being misreported as a
+    failed one-shot run.
+    """
+    try:
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except Exception:
+        pass
+    os._exit(rc if isinstance(rc, int) else 0)
+
+
 # Mouse-tracking residue suppression — runs BEFORE every other import on the
 # TUI hot path so the terminal stops emitting SGR/X10 mouse reports while the
 # Python launcher is still doing imports (≈100–300ms in cooked + echo mode,
@@ -11202,14 +11219,13 @@ def _try_termux_fast_cli_launch() -> bool:
         _prepare_agent_startup(args)
         from hermes_cli.oneshot import run_oneshot
 
-        sys.exit(
-            run_oneshot(
-                args.oneshot,
-                model=getattr(args, "model", None),
-                provider=getattr(args, "provider", None),
-                toolsets=getattr(args, "toolsets", None),
-            )
+        rc = run_oneshot(
+            args.oneshot,
+            model=getattr(args, "model", None),
+            provider=getattr(args, "provider", None),
+            toolsets=getattr(args, "toolsets", None),
         )
+        _exit_after_oneshot(rc)
 
     if (args.resume or args.continue_last) and args.command is None:
         args.command = "chat"
@@ -14307,14 +14323,13 @@ Examples:
     if getattr(args, "oneshot", None):
         from hermes_cli.oneshot import run_oneshot
 
-        sys.exit(
-            run_oneshot(
-                args.oneshot,
-                model=getattr(args, "model", None),
-                provider=getattr(args, "provider", None),
-                toolsets=getattr(args, "toolsets", None),
-            )
+        rc = run_oneshot(
+            args.oneshot,
+            model=getattr(args, "model", None),
+            provider=getattr(args, "provider", None),
+            toolsets=getattr(args, "toolsets", None),
         )
+        _exit_after_oneshot(rc)
 
     # Handle top-level --resume / --continue as shortcut to chat
     if (args.resume or args.continue_last) and args.command is None:

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -368,6 +368,11 @@ def test_termux_fast_cli_launch_oneshot_uses_light_parser(monkeypatch, main_mod)
             or 17
         ),
     )
+    monkeypatch.setattr(
+        main_mod,
+        "_exit_after_oneshot",
+        lambda rc: (_ for _ in ()).throw(SystemExit(rc)),
+    )
 
     with pytest.raises(SystemExit) as exc:
         main_mod._try_termux_fast_cli_launch()
@@ -607,6 +612,17 @@ def test_main_top_level_oneshot_accepts_toolsets(monkeypatch, main_mod):
             or 0
         ),
     )
+    monkeypatch.setattr(
+        main_mod,
+        "_exit_after_oneshot",
+        lambda rc: (_ for _ in ()).throw(SystemExit(rc)),
+    )
+
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, _chat_parser = build_top_level_parser()
+    args = parser.parse_args(["-z", "hello", "--toolsets", "web,terminal"])
+    assert args.oneshot == "hello"
 
     with pytest.raises(SystemExit) as exc:
         main_mod.main()


### PR DESCRIPTION
## Summary
- route one-shot exits through a helper that flushes stdio and terminates with `os._exit`
- avoid Python interpreter teardown/finalizer crashes surfacing as `SIGABRT` / exit 134 after a successful one-shot response
- patch CLI tests to monkeypatch the one-shot exit helper instead of letting pytest be terminated

## Rationale
One-shot mode has two phases: the agent work phase and interpreter teardown. The bug is in teardown: a command can print the correct final answer and then abort while Python finalizers/native daemon threads unwind. Automation then sees exit 134 and treats a semantically successful run as failed.

For `hermes -z` / one-shot subprocess use, after stdout/stderr are flushed there is no interactive state left to preserve, so bypassing finalizers is the safest contract.

## Verification
- `python -m pytest tests/hermes_cli/test_tui_resume_flow.py -q -o 'addopts='` → `41 passed`
- `hermes -p maya -z 'Reply exactly: ok'` → exit `0`, output `ok`
- `hermes -p maya chat -Q -q 'Reply exactly: ok'` → exit `0`, output `ok`
- `hermes -p maya chat -Q -t web -q 'Use web search for github.com and reply with only the domain github.com'` → exit `0`, output `github.com`

Implemented-by: Sprout
Hermes-profile: sprout