### PR TITLE
Preserve retrieval entrypoints during curator consolidation

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -14,7 +14,8 @@ Responsibilities:
 
 Strict invariants:
   - Only touches agent-created skills (see tools/skill_usage.is_agent_created)
-  - Never auto-deletes — only archives. Archive is recoverable.
+  - Stale skills are auto-archived (restorable from ~/.hermes/skills/.archive/)
+  - Consolidation deletes (absorbed_into) remove directories without archive copies
   - Pinned skills bypass all auto-transitions
   - Uses the auxiliary client; never touches the main session's prompt cache
 """
@@ -329,138 +330,106 @@ CURATOR_DRY_RUN_BANNER = (
 
 CURATOR_REVIEW_PROMPT = (
     "You are running as Hermes' background skill CURATOR. This is an "
-    "UMBRELLA-BUILDING consolidation pass, not a passive audit and not a "
-    "duplicate-finder.\n\n"
-    "The goal of the skill collection is a LIBRARY OF CLASS-LEVEL "
-    "INSTRUCTIONS AND EXPERIENTIAL KNOWLEDGE. A collection of hundreds of "
-    "narrow skills where each one captures one session's specific bug is "
-    "a FAILURE of the library — not a feature. An agent searching skills "
-    "matches on descriptions, not on exact names; one broad umbrella "
-    "skill with labeled subsections beats five narrow siblings for "
-    "discoverability, not the other way around.\n\n"
-    "The right target shape is CLASS-LEVEL skills with rich SKILL.md "
-    "bodies + `references/`, `templates/`, and `scripts/` subfiles for "
-    "session-specific detail — not one-session-one-skill micro-entries.\n\n"
+    "ENTRYPOINT-PRESERVING curation pass.\n\n"
+    "A curator may consolidate implementation, references, templates, "
+    "scripts, and shared knowledge. It may not consolidate away a "
+    "user-facing retrieval entrypoint unless an equivalent or better "
+    "entrypoint is created, retained, and verified.\n\n"
+    "Primary success metric: future successful invocation by users/agents, "
+    "not taxonomy neatness.\n\n"
     "Hard rules — do not violate:\n"
-    "1. DO NOT touch bundled or hub-installed skills. The candidate list "
-    "below is already filtered to agent-created skills only.\n"
-    "2. DO NOT delete any skill. Archiving (moving the skill's directory "
-    "into ~/.hermes/skills/.archive/) is the maximum destructive action. "
-    "Archives are recoverable; deletion is not.\n"
-    "3. DO NOT touch skills shown as pinned=yes. Skip them entirely.\n"
-    "4. DO NOT use usage counters as a reason to skip consolidation. The "
-    "counters are new and often mostly zero. Judge overlap on CONTENT, "
-    "not on use_count. 'use=0' is not evidence a skill is valuable; it's "
-    "absence of evidence either way.\n"
-    "5. DO NOT reject consolidation on the grounds that 'each skill has "
-    "a distinct trigger'. Pairwise distinctness is the wrong bar. The "
-    "right bar is: 'would a human maintainer write this as N separate "
-    "skills, or as one skill with N labeled subsections?' When the "
-    "answer is the latter, merge.\n\n"
-    "How to work — not optional:\n"
-    "1. Scan the full candidate list. Identify PREFIX CLUSTERS (skills "
-    "sharing a first word or domain keyword). Examples you are likely "
-    "to find: hermes-config-*, hermes-dashboard-*, gateway-*, codex-*, "
-    "ollama-*, anthropic-*, gemini-*, mcp-*, salvage-*, pr-*, "
-    "competitor-*, python-*, security-*, etc. Expect 10-25 clusters.\n"
-    "2. For each cluster with 2+ members, do NOT ask 'are these pairs "
-    "overlapping?' — ask 'what is the UMBRELLA CLASS these skills all "
-    "serve? Would a maintainer name that class and write one skill for "
-    "it?' If yes, pick (or create) the umbrella and absorb the siblings "
-    "into it.\n"
-    "3. Three ways to consolidate — use the right one per cluster:\n"
-    "   a. MERGE INTO EXISTING UMBRELLA — one skill in the cluster is "
-    "already broad enough to be the umbrella (example: `pr-triage-"
-    "salvage` for the PR review cluster). Patch it to add a labeled "
-    "section for each sibling's unique insight, then archive the "
-    "siblings.\n"
-    "   b. CREATE A NEW UMBRELLA SKILL.md — no existing member is broad "
-    "enough. Use skill_manage action=create to write a new class-level "
-    "skill whose SKILL.md covers the shared workflow and has short "
-    "labeled subsections. Archive the now-absorbed narrow siblings.\n"
-    "   c. DEMOTE TO REFERENCES/TEMPLATES/SCRIPTS — a sibling has "
-    "narrow-but-valuable session-specific content. Move it into the "
-    "umbrella's appropriate support directory:\n"
-    "      • `references/<topic>.md` for session-specific detail OR "
-    "condensed knowledge banks (quoted research, API docs excerpts, "
-    "domain notes, provider quirks, reproduction recipes)\n"
-    "      • `templates/<name>.<ext>` for starter files meant to be "
-    "copied and modified\n"
-    "      • `scripts/<name>.<ext>` for statically re-runnable actions "
-    "(verification scripts, fixture generators, probes)\n"
-    "      Then archive the old sibling. Use `terminal` with `mkdir -p "
-    "~/.hermes/skills/<umbrella>/references/ && mv ... <umbrella>/"
-    "references/<topic>.md` (or templates/ / scripts/).\n\n"
-    "Package integrity — not optional:\n"
-    "Before demoting or archiving a skill, inspect it as a COMPLETE "
-    "directory package, not just SKILL.md. A skill root may include "
-    "`references/`, `templates/`, `scripts/`, and `assets/`; `skill_view` "
-    "discovers those relative to the skill root. A reference markdown file "
-    "inside another skill is NOT a new skill root and does not get its own "
-    "linked-file discovery.\n"
-    "If the source skill has support files OR SKILL.md contains relative "
-    "links such as `references/...`, `templates/...`, `scripts/...`, or "
-    "`assets/...`, DO NOT flatten only SKILL.md into "
-    "`<umbrella>/references/<old>.md`. Choose one safe path instead:\n"
-    "   • keep it as a standalone skill, OR\n"
-    "   • fully merge it by re-homing every needed support file into the "
-    "umbrella's canonical `references/`, `templates/`, `scripts/`, or "
-    "`assets/` directories AND rewrite the destination instructions to "
-    "the new paths, OR\n"
-    "   • archive the entire original skill package unchanged.\n"
-    "Never leave archived/demoted instructions pointing at files that were "
-    "left behind under the old skill directory.\n"
-    "4. Also flag skills whose NAME is too narrow (contains a PR number, "
-    "a feature codename, a specific error string, an 'audit' / "
-    "'diagnosis' / 'salvage' session artifact). These almost always "
-    "belong as a subsection or support file under a class-level umbrella.\n"
-    "5. Iterate. After one consolidation round, scan the remaining set "
-    "and look for the NEXT umbrella opportunity. Don't stop after 3 "
-    "merges.\n\n"
-    "Your toolset:\n"
-    "  - skills_list, skill_view        — read the current landscape\n"
-    "  - skill_manage action=patch      — add sections to the umbrella\n"
-    "  - skill_manage action=create     — create a new umbrella SKILL.md\n"
-    "  - skill_manage action=write_file — add a references/, templates/, "
-    "or scripts/ file under an existing skill (the skill must already "
-    "exist)\n"
-    "  - skill_manage action=delete     — archive a skill. MUST pass "
-    "`absorbed_into=<umbrella>` when you've merged its content into another "
-    "skill, or `absorbed_into=\"\"` when you're truly pruning with no "
-    "forwarding target. This drives cron-job skill-reference migration — "
-    "guessing from your YAML summary after the fact is fragile.\n"
-    "  - terminal                       — mv a sibling into the archive "
-    "OR move its content into a support subfile\n\n"
-    "'keep' is a legitimate decision ONLY when the skill is already a "
-    "class-level umbrella and none of the proposed merges would improve "
-    "discoverability. 'This is narrow but distinct from its siblings' "
-    "is NOT a reason to keep — it's a reason to move it under an "
-    "umbrella as a subsection or support file.\n\n"
-    "Expected output: real umbrella-ification. Process every obvious "
-    "cluster. If you end the pass with fewer than 10 archives, you "
-    "stopped too early — go back and look at the clusters you left "
-    "alone.\n\n"
-    "When done, write a human summary AND a structured machine-readable "
-    "block so downstream tooling can distinguish consolidation from "
-    "pruning. Format EXACTLY:\n\n"
+    "1. Preserve narrow, task-shaped skills by default.\n"
+    "2. Do not touch bundled/hub-installed skills; candidate list is "
+    "agent-created only.\n"
+    "3. Do not touch pinned skills.\n"
+    "4. Prefer soft consolidation over hard deletion.\n"
+    "5. Never delete a skill merely because it shares a prefix, domain, "
+    "or category with others.\n"
+    "6. Never replace a concrete skill only with a vague umbrella.\n"
+    "7. absorbed_into alone is not sufficient proof of safe consolidation.\n"
+    "8. If uncertain, default to retain and annotate.\n\n"
+    "Retrieval surface rules:\n"
+    "Treat all of the following as retrieval surface that must be preserved "
+    "or safely forwarded: old skill names, aliases, trigger phrases, "
+    "example requests, filenames, scripts/templates/reference names, and "
+    "cron refs.\n"
+    "Keep narrow skills as first-class retrieval entrypoints whenever they "
+    "contain useful user-facing search terms.\n"
+    "Create stubs when old names/aliases/triggers/examples are useful for "
+    "future discovery.\n\n"
+    "Umbrella rules:\n"
+    "Broad umbrella names are suspicious unless they are clearly routers, "
+    "indexes, parent categories, or shared implementation packages. "
+    "Umbrellas can organize, but must not erase concrete entrypoints.\n\n"
+    "Classification rules (use these exact concepts):\n"
+    "- exact duplicate\n"
+    "- true prune\n"
+    "- soft consolidation\n"
+    "- hard deletion\n"
+    "- stub retained\n"
+    "- umbrella/index/router created\n\n"
+    "Deletion rules:\n"
+    "Hard deletion is allowed only for: exact duplicates, true prunes, or "
+    "skills replaced by retained stubs that preserve retrieval surface.\n"
+    "Require retrieval-preservation evidence before any deletion.\n"
+    "Block deletion if ANY of these is true:\n"
+    "- unique behavior would be lost\n"
+    "- old retrieval queries would no longer resolve\n"
+    "- replacement is only a broad umbrella\n"
+    "- cron refs would be rewritten to a less concrete skill\n"
+    "- no stub/alias preserves old search terms\n"
+    "Prove exact duplication before deletion.\n\n"
+    "Package integrity rule:\n"
+    "Preserve references/templates/scripts/assets integrity, but do not use "
+    "package cleanup as an excuse to erase retrieval entrypoints.\n\n"
+    "Tool usage notes:\n"
+    "- You may use skills_list/skill_view for analysis.\n"
+    "- You may use skill_manage actions supported by current schema.\n"
+    "- If deletion evidence is insufficient, retain and annotate instead of "
+    "forcing deletion.\n\n"
+    "When done, output a human summary and this REQUIRED structured YAML:\n"
     "## Structured summary (required)\n"
     "```yaml\n"
-    "consolidations:\n"
-    "  - from: <old-skill-name>\n"
-    "    into: <umbrella-skill-name>\n"
-    "    reason: <one short sentence — why merged, not just 'similar'>\n"
-    "prunings:\n"
-    "  - name: <skill-name>\n"
-    "    reason: <one short sentence — why archived with no merge target>\n"
+    "curator_summary:\n"
+    "  retained_entrypoints:\n"
+    "    - name:\n"
+    "      reason:\n"
+    "      preserved_queries:\n"
+    "  stubs_created:\n"
+    "    - name:\n"
+    "      delegates_to:\n"
+    "      preserved_surface:\n"
+    "  umbrellas_created:\n"
+    "    - name:\n"
+    "      purpose:\n"
+    "      child_entrypoints:\n"
+    "  soft_consolidations:\n"
+    "    - shared_parent:\n"
+    "      children:\n"
+    "      reason:\n"
+    "  hard_deletions:\n"
+    "    - name:\n"
+    "      category:\n"
+    "      reason:\n"
+    "      retrieval_preservation_evidence:\n"
+    "        old_queries:\n"
+    "        preserved_by:\n"
+    "        unique_behavior_lost:\n"
+    "        retrieval_preservation_passed:\n"
+    "  prunings:\n"
+    "    - name:\n"
+    "      reason:\n"
+    "      proof_no_unique_retrieval_surface:\n"
+    "  blocked_deletions:\n"
+    "    - name:\n"
+    "      reason:\n"
+    "  retrieval_tests:\n"
+    "    - old_query:\n"
+    "      expected_post_curator_target:\n"
+    "      status:\n"
     "```\n\n"
-    "Every skill you moved to .archive/ MUST appear in exactly one of the "
-    "two lists. If you consolidated X into umbrella Y (patched Y, wrote "
-    "a references file to Y, or created Y with X's content absorbed), X "
-    "goes under `consolidations` with `into: Y`. If you archived X with "
-    "no absorption — truly stale, irrelevant, or obsolete — X goes under "
-    "`prunings`. Leave a list empty (`consolidations: []`) if none. Do "
-    "not omit the block. The block comes AFTER your human-readable "
-    "summary of clusters processed, patches made, and decisions left alone."
+    "Successful curation preserves retrieval quality under realistic future "
+    "queries."
 )
 
 
@@ -1221,19 +1190,24 @@ def _render_report_markdown(p: Dict[str, Any]) -> str:
                  f"**{counts.get('state_transitions', 0)}**")
     lines.append("")
 
-    # Consolidated list — content absorbed into an umbrella. The directory
-    # on disk still lives under ~/.hermes/skills/.archive/ (every removal is
-    # recoverable by design), but the "live" content for these skills
-    # continues to exist inside the destination umbrella.
+    # Consolidated list — content absorbed into an umbrella.
+    # IMPORTANT: consolidation deletes use skill_manage(delete, absorbed_into)
+    # which calls shutil.rmtree; they do NOT create .archive artifacts.
+    # Only stale auto-archive (pre-review step) and manual
+    # `hermes curator archive` create restorable .archive copies.
+    # The "live" content for consolidated skills continues inside the umbrella.
     consolidated = p.get("consolidated") or []
     if consolidated:
         lines.append(f"### Consolidated into umbrella skills ({len(consolidated)})\n")
         lines.append(
             "_These skills were **absorbed into another skill** during this run — "
-            "their content still lives, just under a different name. "
-            "The original directory was moved to `~/.hermes/skills/.archive/` for "
-            "safety and can be restored via `hermes curator restore <name>` if the "
-            "consolidation was wrong._\n"
+            "their content still lives inside the destination umbrella. "
+            "The original directory was **deleted** (via skill_manage delete with absorbed_into). "
+            "No .archive artifact is created for consolidation deletes. "
+            "Only skills that pass through the explicit archive_skill path "
+            "(stale auto-archive in the pre-review step or manual `hermes curator archive`) "
+            "have restorable artifacts under `~/.hermes/skills/.archive/`. "
+            "Restore applies only to those explicitly archived skills._\n"
         )
         SHOW = 50
         for entry in consolidated[:SHOW]:
@@ -1353,8 +1327,9 @@ def _render_report_markdown(p: Dict[str, Any]) -> str:
 
     # Recovery footer
     lines.append("## Recovery\n")
-    lines.append("- Restore an archived skill: `hermes curator restore <name>`")
-    lines.append("- All archives live under `~/.hermes/skills/.archive/` and are recoverable by `mv`")
+    lines.append("- Restore an explicitly archived skill: `hermes curator restore <name>`")
+    lines.append("- Explicitly archived skills live under `~/.hermes/skills/.archive/` and are recoverable by `mv`")
+    lines.append("- Consolidation deletes (absorbed_into) do NOT create .archive artifacts; recovery is only possible if the umbrella still contains the content.")
     lines.append("- See `run.json` in this directory for the full machine-readable record.")
     lines.append("")
 
@@ -1638,6 +1613,24 @@ def _resolve_review_model(cfg: Dict[str, Any]) -> tuple[str, str]:
     return b.provider, b.model
 
 
+_CURATOR_TERMINAL_RISK_TOOLSETS = ["terminal"]
+
+
+def _curator_sandbox_mode_enabled() -> bool:
+    return os.environ.get("HERMES_CURATOR_SANDBOX_MODE") == "1"
+
+
+def _curator_disabled_toolsets() -> List[str]:
+    """Return curator-only toolset restrictions for the current environment.
+
+    In sandbox mode we must prevent curator mutation flows from escaping
+    through shell execution paths.
+    """
+    if _curator_sandbox_mode_enabled():
+        return list(_CURATOR_TERMINAL_RISK_TOOLSETS)
+    return []
+
+
 def _run_llm_review(prompt: str) -> Dict[str, Any]:
     """Spawn an AIAgent fork to run the curator review prompt.
 
@@ -1706,6 +1699,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
     result_meta["provider"] = _resolved_provider or ""
 
     review_agent = None
+    _disabled_toolsets = _curator_disabled_toolsets()
     try:
         review_agent = AIAgent(
             model=_model_name,
@@ -1713,7 +1707,8 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
             api_key=_api_key,
             base_url=_base_url,
             api_mode=_api_mode,
-            # Umbrella-building over a large skill collection is worth a
+            disabled_toolsets=_disabled_toolsets or None,
+
             # high iteration ceiling — the pass typically takes 50-100
             # API calls against hundreds of candidate skills. The
             # single-session review path caps itself at a much smaller

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -17,6 +17,7 @@ import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
 from hermes_constants import get_hermes_home
+from tools.curator_sandbox import get_cron_root, assert_sandbox_write_path
 from typing import Optional, Dict, List, Any, Union
 
 logger = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ except ImportError:
 # =============================================================================
 
 HERMES_DIR = get_hermes_home().resolve()
-CRON_DIR = HERMES_DIR / "cron"
+CRON_DIR = get_cron_root()
 JOBS_FILE = CRON_DIR / "jobs.json"
 
 # In-process lock protecting load_jobs→modify→save_jobs cycles.
@@ -175,6 +176,8 @@ def _secure_file(path: Path):
 
 def ensure_dirs():
     """Ensure cron directories exist with secure permissions."""
+    assert_sandbox_write_path(CRON_DIR, "cron")
+    assert_sandbox_write_path(OUTPUT_DIR, "cron")
     CRON_DIR.mkdir(parents=True, exist_ok=True)
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     _secure_dir(CRON_DIR)

--- a/tools/curator_sandbox.py
+++ b/tools/curator_sandbox.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+
+def is_curator_sandbox_mode() -> bool:
+    return str(os.getenv("HERMES_CURATOR_SANDBOX_MODE", "")).strip() == "1"
+
+
+def get_sandbox_root() -> Path | None:
+    skills = os.getenv("HERMES_SKILLS_ROOT", "").strip()
+    if not skills:
+        return None
+    p = Path(skills).expanduser().resolve()
+    # expected .../.hermes_bg_curator_lab/sandbox/skills
+    return p.parent if p.name == "skills" else p
+
+
+def get_skills_root() -> Path:
+    override = os.getenv("HERMES_SKILLS_ROOT", "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    return (get_hermes_home() / "skills").resolve()
+
+
+def get_usage_path() -> Path:
+    override = os.getenv("HERMES_USAGE_PATH", "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    return get_skills_root() / ".usage.json"
+
+
+def get_cron_root() -> Path:
+    override = os.getenv("HERMES_CRON_ROOT", "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    return (get_hermes_home() / "cron").resolve()
+
+
+def resolve_under(root: Path, candidate: Path) -> Path:
+    return (root / candidate).resolve()
+
+
+def assert_under_root(candidate: Path, allowed_root: Path, operation_label: str) -> Path:
+    c = candidate.resolve()
+    r = allowed_root.resolve()
+    try:
+        c.relative_to(r)
+    except Exception as exc:
+        raise ValueError(
+            f"{operation_label}: path escapes allowed root; candidate={c} allowed_root={r} err={exc}"
+        )
+    return c
+
+
+def assert_sandbox_write_path(candidate: Path, category: str) -> Path:
+    if not is_curator_sandbox_mode():
+        return candidate.resolve()
+
+    if category == "skills":
+        root = get_skills_root()
+    elif category == "usage":
+        root = get_usage_path().parent
+    elif category == "cron":
+        root = get_cron_root()
+    else:
+        root = get_sandbox_root() or candidate.parent
+
+    return assert_under_root(candidate, root, f"sandbox-write[{category}]")

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -40,6 +40,7 @@ import shutil
 import tempfile
 from pathlib import Path
 from hermes_constants import get_hermes_home, display_hermes_home
+from tools.curator_sandbox import get_skills_root, assert_sandbox_write_path
 from typing import Dict, Any, List, Optional, Tuple
 
 from utils import atomic_replace, is_truthy_value
@@ -106,7 +107,7 @@ import yaml
 
 # All skills live in ~/.hermes/skills/ (single source of truth)
 HERMES_HOME = get_hermes_home()
-SKILLS_DIR = HERMES_HOME / "skills"
+SKILLS_DIR = get_skills_root()
 
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
@@ -277,14 +278,24 @@ def _resolve_skill_dir(name: str, category: str = None) -> Path:
 
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     """
-    Find a skill by name across all skill directories.
+    Find a skill by name across skill roots.
 
-    Searches the local skills dir (~/.hermes/skills/) first, then any
-    external dirs configured via skills.external_dirs.  Returns
-    {"path": Path} or None.
+    Search order:
+      1) Active SKILLS_DIR (sandbox-aware via get_skills_root())
+      2) Additional configured skill dirs (agent.skill_utils.get_all_skills_dirs)
+
+    Returns {"path": Path} or None.
     """
     from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
-    for skills_dir in get_all_skills_dirs():
+
+    search_roots: List[Path] = []
+    if SKILLS_DIR not in search_roots:
+        search_roots.append(SKILLS_DIR)
+    for d in get_all_skills_dirs():
+        if d not in search_roots:
+            search_roots.append(d)
+
+    for skills_dir in search_roots:
         if not skills_dir.exists():
             continue
         for skill_md in skills_dir.rglob("SKILL.md"):
@@ -450,6 +461,7 @@ def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -
         content: Content to write
         encoding: Text encoding (default: utf-8)
     """
+    assert_sandbox_write_path(file_path, "skills")
     file_path.parent.mkdir(parents=True, exist_ok=True)
     fd, temp_path = tempfile.mkstemp(
         dir=str(file_path.parent),
@@ -657,18 +669,140 @@ def _patch_skill(
     }
 
 
-def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, Any]:
-    """Delete a skill.
+def _strict_delete_contract_mode() -> bool:
+    """True when retrieval-preservation contract enforcement is required.
+
+    Strict mode currently applies to:
+    - curator sandbox runs (HERMES_CURATOR_SANDBOX_MODE=1), and
+    - background self-improvement review fork calls.
+    """
+    if os.environ.get("HERMES_CURATOR_SANDBOX_MODE") == "1":
+        return True
+    try:
+        from tools.skill_provenance import is_background_review
+        if is_background_review():
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _validate_retrieval_preservation_contract(
+    *,
+    name: str,
+    absorbed_into: Optional[str],
+    retrieval_preservation: Optional[Dict[str, Any]],
+) -> Optional[str]:
+    """Validate strict delete contract for curator/sandbox flows.
+
+    Returns error string on validation failure, else None.
+    """
+    category_allowed = {"exact_duplicate", "true_prune", "replaced_by_stub"}
+
+    if not isinstance(retrieval_preservation, dict):
+        return (
+            "Strict delete mode requires retrieval_preservation object; "
+            "absorbed_into alone is not sufficient."
+        )
+
+    category = retrieval_preservation.get("deletion_category")
+    if category not in category_allowed:
+        return (
+            "retrieval_preservation.deletion_category must be one of: "
+            "exact_duplicate, true_prune, replaced_by_stub."
+        )
+
+    reason = retrieval_preservation.get("reason")
+    if not isinstance(reason, str) or not reason.strip():
+        return "retrieval_preservation.reason is required and must be non-empty."
+
+    unique_behavior_lost = retrieval_preservation.get("unique_behavior_lost")
+    if unique_behavior_lost is True:
+        return "Delete rejected: retrieval_preservation.unique_behavior_lost=true."
+
+    retrieval_passed = retrieval_preservation.get("retrieval_preservation_passed")
+    if retrieval_passed is not True:
+        return "Delete rejected: retrieval_preservation.retrieval_preservation_passed must be true."
+
+    retained_entrypoint = retrieval_preservation.get("retained_entrypoint")
+
+    def _as_nonempty_list(v: Any) -> List[str]:
+        if not isinstance(v, list):
+            return []
+        return [str(x).strip() for x in v if isinstance(x, str) and str(x).strip()]
+
+    aliases_preserved = _as_nonempty_list(retrieval_preservation.get("aliases_preserved"))
+    trigger_phrases_preserved = _as_nonempty_list(retrieval_preservation.get("trigger_phrases_preserved"))
+    example_queries_preserved = _as_nonempty_list(retrieval_preservation.get("example_queries_preserved"))
+
+    absorbed_target = (absorbed_into or "").strip()
+
+    if absorbed_target:
+        # Consolidation path in strict mode.
+        if category == "true_prune":
+            return (
+                "Delete rejected: absorbed_into is non-empty but deletion_category=true_prune. "
+                "Use exact_duplicate/replaced_by_stub for consolidation deletes."
+            )
+
+    else:
+        # Prune path in strict mode.
+        if category != "true_prune":
+            return (
+                "Delete rejected: absorbed_into is empty in strict mode; "
+                "deletion_category must be true_prune for prune deletes."
+            )
+
+    if category == "replaced_by_stub":
+        if not isinstance(retained_entrypoint, str) or not retained_entrypoint.strip():
+            return (
+                "Delete rejected: replaced_by_stub requires "
+                "retrieval_preservation.retained_entrypoint."
+            )
+        target_name = retained_entrypoint.strip()
+        if target_name == name:
+            return "Delete rejected: retained_entrypoint cannot equal deleted skill name."
+        if not _find_skill(target_name):
+            return (
+                "Delete rejected: retrieval_preservation.retained_entrypoint "
+                f"'{target_name}' does not exist."
+            )
+        if not (aliases_preserved or trigger_phrases_preserved or example_queries_preserved):
+            return (
+                "Delete rejected: replaced_by_stub requires at least one preserved retrieval-surface list "
+                "(aliases_preserved, trigger_phrases_preserved, example_queries_preserved)."
+            )
+
+    if category == "exact_duplicate":
+        if not example_queries_preserved:
+            return "Delete rejected: exact_duplicate requires non-empty example_queries_preserved."
+
+    if category == "true_prune":
+        # Enforced already via non-empty reason + true preservation_passed.
+        # Keep strict non-empty reason semantics explicit in message contract.
+        if not reason.strip():
+            return "Delete rejected: true_prune requires non-empty reason."
+
+    return None
+
+
+def _delete_skill(
+    name: str,
+    absorbed_into: Optional[str] = None,
+    retrieval_preservation: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Delete a skill with optional strict retrieval-preservation contract.
 
     ``absorbed_into`` declares intent:
-      - ``None`` / missing  → caller didn't declare (legacy / non-curator path);
-        accepted for backward compat but logs a warning because the curator
-        classification pipeline can't tell consolidation from pruning without it.
-      - ``""`` (empty)      → explicit "truly pruned, no forwarding target".
-      - ``"<skill-name>"``  → content was absorbed into that umbrella; the
-        target must exist on disk. Validated here so the model can't claim an
-        umbrella that doesn't exist.
+      - ``None`` / missing  → caller didn't declare (legacy path outside strict mode).
+      - ``""`` (empty)      → explicit prune with no forwarding target.
+      - ``"<skill-name>"``  → content absorbed into target; target must exist.
+
+    In strict mode (curator sandbox or background-review origin),
+    ``retrieval_preservation`` is required and ``absorbed_into`` alone is not
+    sufficient proof of safe deletion.
     """
+
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": _skill_not_found_error(name)}
@@ -695,13 +829,25 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
                 ),
             }
 
+    strict_mode = _strict_delete_contract_mode()
+    if strict_mode:
+        contract_error = _validate_retrieval_preservation_contract(
+            name=name,
+            absorbed_into=absorbed_into,
+            retrieval_preservation=retrieval_preservation,
+        )
+        if contract_error:
+            return {"success": False, "error": contract_error}
+
     skill_dir = existing["path"]
     skills_root = _containing_skills_root(skill_dir)
+    assert_sandbox_write_path(skill_dir, "skills")
     shutil.rmtree(skill_dir)
 
     # Clean up empty category directories (don't remove the skills root itself)
     parent = skill_dir.parent
     if parent != skills_root and parent.exists() and not any(parent.iterdir()):
+        assert_sandbox_write_path(parent, "skills")
         parent.rmdir()
 
     message = f"Skill '{name}' deleted."
@@ -824,12 +970,14 @@ def skill_manage(
     new_string: str = None,
     replace_all: bool = False,
     absorbed_into: str = None,
+    retrieval_preservation: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Manage user-created skills. Dispatches to the appropriate action handler.
 
     Returns JSON string with results.
     """
+
     if action == "create":
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
@@ -848,7 +996,11 @@ def skill_manage(
         result = _patch_skill(name, old_string, new_string, file_path, replace_all)
 
     elif action == "delete":
-        result = _delete_skill(name, absorbed_into=absorbed_into)
+        result = _delete_skill(
+            name,
+            absorbed_into=absorbed_into,
+            retrieval_preservation=retrieval_preservation,
+        )
 
     elif action == "write_file":
         if not file_path:
@@ -914,12 +1066,20 @@ SKILL_MANAGE_SCHEMA = {
         "(cron jobs that reference the old skill name, etc.) get updated "
         "correctly. The target you name in `absorbed_into` must already "
         "exist — create/patch the umbrella first, then delete.\n\n"
+        "In strict curator/sandbox delete mode, absorbed_into alone is NOT "
+        "sufficient for consolidation deletes. You must also provide "
+        "retrieval_preservation evidence with deletion_category "
+        "(exact_duplicate|true_prune|replaced_by_stub), "
+        "retrieval_preservation_passed=true, unique_behavior_lost=false, and "
+        "a non-empty reason. Unsafe consolidation deletes are rejected.\n\n"
+
         "Create when: complex task succeeded (5+ calls), errors overcome, "
         "user-corrected approach worked, non-trivial workflow discovered, "
         "or user asks you to remember a procedure.\n"
         "Update when: instructions stale/wrong, OS-specific failures, "
         "missing steps or pitfalls found during use. "
         "If you used a skill and hit issues not covered by it, patch it immediately.\n\n"
+
         "After difficult/iterative tasks, offer to save as a skill. "
         "Skip for simple one-offs. Confirm with user before creating/deleting.\n\n"
         "Good skills: trigger conditions, numbered steps with exact commands, "
@@ -1003,9 +1163,59 @@ SKILL_MANAGE_SCHEMA = {
                     "being pruned with no forwarding target. Omitting the arg "
                     "on delete is supported for backward compatibility but "
                     "downstream tooling (e.g. cron-job skill reference "
-                    "rewriting) will have to guess at intent."
+                    "rewriting) will have to guess at intent. In strict "
+                    "curator/sandbox mode, absorbed_into alone is not "
+                    "sufficient for consolidation deletes."
                 )
             },
+            "retrieval_preservation": {
+                "type": "object",
+                "description": (
+                    "Optional generally, but REQUIRED in strict curator/sandbox delete mode. "
+                    "Use to prove retrieval-preserving deletion safety. "
+                    "For consolidation deletes in strict mode, absorbed_into alone is insufficient. "
+                    "Allowed deletion_category: exact_duplicate | true_prune | replaced_by_stub. "
+                    "Unsafe consolidation deletes are rejected."
+                ),
+                "properties": {
+                    "deletion_category": {
+                        "type": "string",
+                        "enum": ["exact_duplicate", "true_prune", "replaced_by_stub"],
+                        "description": "Why deletion is safe under strict mode."
+                    },
+                    "retained_entrypoint": {
+                        "type": ["string", "null"],
+                        "description": "Required when deletion_category=replaced_by_stub; must exist."
+                    },
+                    "aliases_preserved": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Aliases preserved by retained entrypoint/stub."
+                    },
+                    "trigger_phrases_preserved": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Trigger phrases preserved by retained entrypoint/stub."
+                    },
+                    "example_queries_preserved": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Example user queries still expected to resolve post-delete."
+                    },
+                    "unique_behavior_lost": {
+                        "type": "boolean",
+                        "description": "Must be false in strict mode."
+                    },
+                    "retrieval_preservation_passed": {
+                        "type": "boolean",
+                        "description": "Must be true in strict mode."
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Non-empty explanation of deletion safety/proof."
+                    }
+                }
+            }
         },
         "required": ["action", "name"],
     },
@@ -1029,6 +1239,7 @@ registry.register(
         old_string=args.get("old_string"),
         new_string=args.get("new_string"),
         replace_all=args.get("replace_all", False),
-        absorbed_into=args.get("absorbed_into")),
+        absorbed_into=args.get("absorbed_into"),
+        retrieval_preservation=args.get("retrieval_preservation")),
     emoji="📝",
 )

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -31,9 +31,10 @@ import tempfile
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
+from tools.curator_sandbox import get_skills_root, get_usage_path, assert_sandbox_write_path
 from agent.skill_utils import is_excluded_skill_path
 
 logger = logging.getLogger(__name__)
@@ -57,11 +58,11 @@ _VALID_STATES = {STATE_ACTIVE, STATE_STALE, STATE_ARCHIVED}
 
 
 def _skills_dir() -> Path:
-    return get_hermes_home() / "skills"
+    return get_skills_root()
 
 
 def _usage_file() -> Path:
-    return _skills_dir() / ".usage.json"
+    return get_usage_path()
 
 
 @contextmanager
@@ -344,6 +345,7 @@ def save_usage(data: Dict[str, Dict[str, Any]]) -> None:
     """Write the usage map atomically. Best-effort — errors are logged, not raised."""
     path = _usage_file()
     try:
+        assert_sandbox_write_path(path, "usage")
         path.parent.mkdir(parents=True, exist_ok=True)
         fd, tmp_path = tempfile.mkstemp(
             dir=str(path.parent), prefix=".usage_", suffix=".tmp"

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -70,6 +70,7 @@ import json
 import logging
 
 from hermes_constants import get_hermes_home, display_hermes_home
+from tools.curator_sandbox import get_skills_root
 import os
 import re
 from enum import Enum
@@ -88,7 +89,7 @@ logger = logging.getLogger(__name__)
 # This is the single source of truth -- agent edits, hub installs, and bundled
 # skills all coexist here without polluting the git repo.
 HERMES_HOME = get_hermes_home()
-SKILLS_DIR = HERMES_HOME / "skills"
+SKILLS_DIR = get_skills_root()
 
 # Anthropic-recommended limits for progressive disclosure efficiency
 MAX_NAME_LENGTH = 64
@@ -627,6 +628,49 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Keep every skill listing path ordered the same way."""
     return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
+
+
+def _load_category_description(category_dir: Path) -> Optional[str]:
+    """
+    Load category description from DESCRIPTION.md if it exists.
+
+    Args:
+        category_dir: Path to the category directory
+
+    Returns:
+        Description string or None if not found
+    """
+    desc_file = category_dir / "DESCRIPTION.md"
+    if not desc_file.exists():
+        return None
+
+    try:
+        content = desc_file.read_text(encoding="utf-8")
+        # Parse frontmatter if present
+        frontmatter, body = _parse_frontmatter(content)
+
+        # Prefer frontmatter description, fall back to first non-header line
+        description = frontmatter.get("description", "")
+        if not description:
+            for line in body.strip().split("\n"):
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    description = line
+                    break
+
+        # Truncate to reasonable length
+        if len(description) > MAX_DESCRIPTION_LENGTH:
+            description = description[: MAX_DESCRIPTION_LENGTH - 3] + "..."
+
+        return description if description else None
+    except (UnicodeDecodeError, PermissionError) as e:
+        logger.debug("Failed to read category description %s: %s", desc_file, e)
+        return None
+    except Exception as e:
+        logger.warning(
+            "Error parsing category description %s: %s", desc_file, e, exc_info=True
+        )
+        return None
 
 
 def skills_list(category: str = None, task_id: str = None) -> str:


### PR DESCRIPTION
Summary

Fixes a safety issue where the background curator could consolidate skills in ways that destroy retrieval entrypoints — narrow task-shaped skills being absorbed into broad umbrellas without preserving discoverability.

Problem

The previous curator prompt steered toward aggressive umbrella-building consolidation. This could cause:

* Narrow, task-shaped skills to be archived or deleted without retaining equivalent entrypoints
* absorbed_into to be treated as sufficient proof of safe consolidation
* Archive/restore guarantees to be overclaimed for consolidation deletes

Fix

* Replaces umbrella-first curator steering with an entrypoint-preserving curation policy
* Requires retrieval-preservation evidence for strict curator/sandbox delete flows
* Rejects absorbed_into-only deletion in strict mode
* Adds sandbox-aware routing via HERMES_CURATOR_SANDBOX_MODE, HERMES_SKILLS_ROOT, HERMES_USAGE_PATH, and HERMES_CRON_ROOT
* Disables terminal/process toolsets for sandbox curator runs
* Corrects archive/restore wording so consolidation deletes are not described as recoverable from .archive

Safety / Compatibility

* Sandbox routing helper is a no-op when env overrides are unset
* Strict delete contract activates only in sandbox mode or background self-improvement review context
* Normal non-curator skill management remains compatible

Validation

* python -m py_compile passed on all changed files
* git diff --check passed
* Only six production/tool files are included
* No local lab artifacts are included

Notes for Maintainers

The curator may consolidate implementation, references, templates, scripts, and shared knowledge. It should not consolidate away a user-facing retrieval entrypoint unless an equivalent or better entrypoint is created, retained, and verified.

Sandbox routing is opt-in for isolated testing/evaluation via env vars. Normal live Hermes runs use existing live/default paths. The production safety change is retrieval-preservation enforcement, not requiring a sandbox.
