### PR TITLE
fix(api-server): require auth for runs continuation

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3585,6 +3585,22 @@ class APIServerAdapter(BasePlatformAdapter):
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")
 
+        # Server-side response chaining exposes stored conversation state, so
+        # it is only allowed when API key auth is configured. Open servers can
+        # still accept explicit conversation_history from the caller.
+        if previous_response_id and not self._api_key:
+            logger.warning(
+                "Runs continuation rejected: no API key configured. "
+                "Set API_SERVER_KEY to enable previous_response_id."
+            )
+            return web.json_response(
+                _openai_error(
+                    "Runs continuation requires API key authentication. "
+                    "Configure API_SERVER_KEY to enable previous_response_id."
+                ),
+                status=403,
+            )
+
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
         conversation_history: List[Dict[str, str]] = []

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "cryptoworlldz@gmail.com": "worlldz",
     "metalclaudbot@gmail.com": "HashClawAI",
     "tonybear55665566@gmail.com": "TonyPepeBear",
     "kaspersniels@gmail.com": "nielskaspers",

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2392,6 +2392,41 @@ class TestEndpointAuth:
             assert resp.status == 401
 
     @pytest.mark.asyncio
+    async def test_runs_previous_response_id_rejected_without_api_key(self, adapter):
+        """Runs API should not allow server-side response chaining on an open server."""
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "status": "completed"},
+                "conversation_history": [{"role": "user", "content": "secret prior turn"}],
+                "session_id": "api-session-123",
+            },
+        )
+
+        class _FakeAgent:
+            def __init__(self):
+                self.session_prompt_tokens = 0
+                self.session_completion_tokens = 0
+                self.session_total_tokens = 0
+
+            def run_conversation(self, **kwargs):
+                return {"final_response": "ok", "messages": []}
+
+        app = _create_app(adapter)
+        app.router.add_post("/v1/runs", adapter._handle_runs)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=_FakeAgent()):
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "model": "test",
+                        "input": "follow up",
+                        "previous_response_id": "resp_prev",
+                    },
+                )
+            assert resp.status == 403
+
+    @pytest.mark.asyncio
     async def test_models_requires_auth(self, auth_adapter):
         app = _create_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:


### PR DESCRIPTION
Fixes #34969

`POST /v1/runs` was still accepting `previous_response_id` even when `API_SERVER_KEY` was unset.

That meant an open API server could attach a new run to stored server-side response history without API key protection.

This patch requires API key auth for Runs API continuation through `previous_response_id`, while leaving explicit client-supplied `conversation_history` unchanged.

Validation:
`uv run --extra dev --extra messaging pytest tests/gateway/test_api_server.py -q -k 'runs_previous_response_id_rejected_without_api_key or responses_requires_auth'`

Result:
`2 passed, 155 deselected in 3.49s`