### PR TITLE
fix: restore Codex usage window reporting

### DIFF
--- a/agent/rate_limit_tracker.py
+++ b/agent/rate_limit_tracker.py
@@ -1,9 +1,9 @@
 """Rate limit tracking for inference API responses.
 
-Captures x-ratelimit-* headers from provider responses and provides
+Captures x-ratelimit-* and x-codex-* headers from provider responses and provides
 formatted display for the /usage slash command.  Currently supports
 the Nous Portal header format (also used by OpenRouter and OpenAI-compatible
-APIs that follow the same convention).
+APIs that follow the same convention) and OpenAI Codex percent-window headers.
 
 Header schema (12 headers total):
     x-ratelimit-limit-requests          RPM cap
@@ -59,8 +59,12 @@ class RateLimitState:
 
     requests_min: RateLimitBucket = field(default_factory=RateLimitBucket)
     requests_hour: RateLimitBucket = field(default_factory=RateLimitBucket)
+    requests_5h: RateLimitBucket = field(default_factory=RateLimitBucket)
+    requests_week: RateLimitBucket = field(default_factory=RateLimitBucket)
     tokens_min: RateLimitBucket = field(default_factory=RateLimitBucket)
     tokens_hour: RateLimitBucket = field(default_factory=RateLimitBucket)
+    tokens_5h: RateLimitBucket = field(default_factory=RateLimitBucket)
+    tokens_week: RateLimitBucket = field(default_factory=RateLimitBucket)
     captured_at: float = 0.0  # when the headers were captured
     provider: str = ""
 
@@ -89,11 +93,26 @@ def _safe_float(value: Any, default: float = 0.0) -> float:
         return default
 
 
+def _codex_percent_bucket(prefix: str, window_minutes: int, lowered: Mapping[str, str], now: float) -> RateLimitBucket:
+    percent_key = f"x-codex-{prefix}-used-percent"
+    window_key = f"x-codex-{prefix}-window-minutes"
+    if percent_key not in lowered or _safe_int(lowered.get(window_key)) != window_minutes:
+        return RateLimitBucket(captured_at=now)
+
+    used_percent = max(0, min(100, _safe_int(lowered.get(percent_key))))
+    return RateLimitBucket(
+        limit=100,
+        remaining=100 - used_percent,
+        reset_seconds=_safe_float(lowered.get(f"x-codex-{prefix}-reset-after-seconds")),
+        captured_at=now,
+    )
+
+
 def parse_rate_limit_headers(
     headers: Mapping[str, str],
     provider: str = "",
 ) -> Optional[RateLimitState]:
-    """Parse x-ratelimit-* headers into a RateLimitState.
+    """Parse x-ratelimit-* and x-codex-* headers into a RateLimitState.
 
     Returns None if no rate limit headers are present.
     """
@@ -101,8 +120,8 @@ def parse_rate_limit_headers(
     # capitalises headers (HTTP header names are case-insensitive per RFC 7230).
     lowered = {k.lower(): v for k, v in headers.items()}
 
-    # Quick check: at least one rate limit header must exist
-    has_any = any(k.startswith("x-ratelimit-") for k in lowered)
+    # Quick check: at least one supported rate-limit header must exist.
+    has_any = any(k.startswith("x-ratelimit-") or k.startswith("x-codex-") for k in lowered)
     if not has_any:
         return None
 
@@ -119,14 +138,40 @@ def parse_rate_limit_headers(
             captured_at=now,
         )
 
-    return RateLimitState(
+    def _bucket_any(resource: str, suffixes: tuple[str, ...]) -> RateLimitBucket:
+        for suffix in suffixes:
+            tag = f"{resource}{suffix}"
+            if any(
+                f"x-ratelimit-{field}-{tag}" in lowered
+                for field in ("limit", "remaining", "reset")
+            ):
+                return _bucket(resource, suffix)
+        return RateLimitBucket(captured_at=now)
+
+    five_hour_suffixes = ("-5h", "-5hr", "-5hour", "-5hours")
+    week_suffixes = ("-1w", "-7d", "-week", "-weekly")
+
+    state = RateLimitState(
         requests_min=_bucket("requests"),
         requests_hour=_bucket("requests", "-1h"),
+        requests_5h=_bucket_any("requests", five_hour_suffixes),
+        requests_week=_bucket_any("requests", week_suffixes),
         tokens_min=_bucket("tokens"),
         tokens_hour=_bucket("tokens", "-1h"),
+        tokens_5h=_bucket_any("tokens", five_hour_suffixes),
+        tokens_week=_bucket_any("tokens", week_suffixes),
         captured_at=now,
         provider=provider,
     )
+
+    codex_primary = _codex_percent_bucket("primary", 300, lowered, now)
+    if codex_primary.limit > 0:
+        state.requests_5h = codex_primary
+    codex_secondary = _codex_percent_bucket("secondary", 10080, lowered, now)
+    if codex_secondary.limit > 0:
+        state.requests_week = codex_secondary
+
+    return state
 
 
 # ── Formatting ──────────────────────────────────────────────────────────
@@ -199,18 +244,32 @@ def format_rate_limit_display(state: RateLimitState) -> str:
         "",
         _bucket_line("Requests/min", state.requests_min),
         _bucket_line("Requests/hr", state.requests_hour),
+    ]
+    if state.requests_5h.limit > 0:
+        lines.append(_bucket_line("Requests/5h", state.requests_5h))
+    if state.requests_week.limit > 0:
+        lines.append(_bucket_line("Requests/week", state.requests_week))
+    lines.extend([
         "",
         _bucket_line("Tokens/min", state.tokens_min),
         _bucket_line("Tokens/hr", state.tokens_hour),
-    ]
+    ])
+    if state.tokens_5h.limit > 0:
+        lines.append(_bucket_line("Tokens/5h", state.tokens_5h))
+    if state.tokens_week.limit > 0:
+        lines.append(_bucket_line("Tokens/week", state.tokens_week))
 
     # Add warnings if any bucket is getting hot
     warnings = []
     for label, bucket in [
         ("requests/min", state.requests_min),
         ("requests/hr", state.requests_hour),
+        ("requests/5h", state.requests_5h),
+        ("requests/week", state.requests_week),
         ("tokens/min", state.tokens_min),
         ("tokens/hr", state.tokens_hour),
+        ("tokens/5h", state.tokens_5h),
+        ("tokens/week", state.tokens_week),
     ]:
         if bucket.limit > 0 and bucket.usage_pct >= 80:
             reset = _fmt_seconds(bucket.remaining_seconds_now)
@@ -232,6 +291,10 @@ def format_rate_limit_compact(state: RateLimitState) -> str:
     tm = state.tokens_min
     rh = state.requests_hour
     th = state.tokens_hour
+    r5h = state.requests_5h
+    t5h = state.tokens_5h
+    rw = state.requests_week
+    tw = state.tokens_week
 
     parts = []
     if rm.limit > 0:
@@ -242,5 +305,13 @@ def format_rate_limit_compact(state: RateLimitState) -> str:
         parts.append(f"TPM: {_fmt_count(tm.remaining)}/{_fmt_count(tm.limit)}")
     if th.limit > 0:
         parts.append(f"TPH: {_fmt_count(th.remaining)}/{_fmt_count(th.limit)} (resets {_fmt_seconds(th.remaining_seconds_now)})")
+    if r5h.limit > 0:
+        parts.append(f"R5H: {_fmt_count(r5h.remaining)}/{_fmt_count(r5h.limit)} (resets {_fmt_seconds(r5h.remaining_seconds_now)})")
+    if t5h.limit > 0:
+        parts.append(f"T5H: {_fmt_count(t5h.remaining)}/{_fmt_count(t5h.limit)} (resets {_fmt_seconds(t5h.remaining_seconds_now)})")
+    if rw.limit > 0:
+        parts.append(f"RW: {_fmt_count(rw.remaining)}/{_fmt_count(rw.limit)} (resets {_fmt_seconds(rw.remaining_seconds_now)})")
+    if tw.limit > 0:
+        parts.append(f"TW: {_fmt_count(tw.remaining)}/{_fmt_count(tw.limit)} (resets {_fmt_seconds(tw.remaining_seconds_now)})")
 
     return " | ".join(parts)

--- a/cli.py
+++ b/cli.py
@@ -3438,6 +3438,57 @@ class HermesCLI:
             return "class:status-bar-warn"
         return "class:status-bar-good"
 
+    def _status_bar_limit_style(self, percent_used: Optional[int]) -> str:
+        return self._status_bar_context_style(percent_used)
+
+    @staticmethod
+    def _format_provider_limit_reset(bucket: Any) -> str:
+        """Return a compact reset countdown for a provider-limit bucket."""
+        reset_seconds = float(getattr(bucket, "remaining_seconds_now", 0.0) or 0.0)
+        if reset_seconds <= 0:
+            return ""
+        return format_duration_compact(reset_seconds).replace(" ", "")
+
+    @staticmethod
+    def _provider_limit_indicator(label: str, *buckets: Any) -> Optional[Dict[str, Any]]:
+        best_bucket = None
+        best_pct = -1.0
+        for bucket in buckets:
+            if getattr(bucket, "limit", 0) <= 0:
+                continue
+            pct = float(getattr(bucket, "usage_pct", 0.0) or 0.0)
+            if pct > best_pct:
+                best_bucket = bucket
+                best_pct = pct
+        if best_bucket is None:
+            return None
+        percent = max(0, min(100, round(best_pct)))
+        reset = HermesCLI._format_provider_limit_reset(best_bucket)
+        label_text = f"{label} {percent}%"
+        if reset:
+            label_text += f" ↻{reset}"
+        return {"label": label_text, "percent": percent, "reset": reset}
+
+    def _build_provider_limit_indicators(self, rate_limit_state: Any) -> List[Dict[str, Any]]:
+        if not rate_limit_state or not getattr(rate_limit_state, "has_data", False):
+            return []
+        indicators = []
+        five_hour = self._provider_limit_indicator(
+            "5h",
+            getattr(rate_limit_state, "requests_5h", None),
+            getattr(rate_limit_state, "tokens_5h", None),
+        )
+        week = self._provider_limit_indicator(
+            "W",
+            getattr(rate_limit_state, "requests_week", None),
+            getattr(rate_limit_state, "tokens_week", None),
+        )
+        if five_hour:
+            indicators.append(five_hour)
+        if week:
+            indicators.append(week)
+        return indicators
+
     @staticmethod
     def _compression_count_style(count: int) -> str:
         """Return a style class reflecting context compression pressure."""
@@ -3525,6 +3576,7 @@ class HermesCLI:
             "session_total_tokens": 0,
             "session_api_calls": 0,
             "compressions": 0,
+            "provider_limit_indicators": [],
             "active_background_tasks": 0,
             "active_background_processes": 0,
         }
@@ -3568,6 +3620,15 @@ class HermesCLI:
             snapshot["compressions"] = getattr(compressor, "compression_count", 0) or 0
             if context_length:
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
+
+        get_rate_limit_state = getattr(agent, "get_rate_limit_state", None)
+        if callable(get_rate_limit_state):
+            try:
+                snapshot["provider_limit_indicators"] = self._build_provider_limit_indicators(
+                    get_rate_limit_state()
+                )
+            except Exception:
+                snapshot["provider_limit_indicators"] = []
 
         return snapshot
 
@@ -3779,6 +3840,10 @@ class HermesCLI:
                 return self._trim_status_bar_text(text, width)
             if width < 76:
                 parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                provider_limits = snapshot.get("provider_limit_indicators", [])
+                if provider_limits:
+                    hottest = max(provider_limits, key=lambda item: item.get("percent", 0))
+                    parts.append(hottest["label"])
                 compressions = snapshot.get("compressions", 0)
                 if compressions:
                     parts.append(f"🗜️ {compressions}")
@@ -3801,7 +3866,9 @@ class HermesCLI:
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
+            provider_limits = snapshot.get("provider_limit_indicators", [])
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts.extend(item["label"] for item in provider_limits)
             if compressions:
                 parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
@@ -3852,12 +3919,17 @@ class HermesCLI:
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
                     bg_proc_count = snapshot.get("active_background_processes", 0)
+                    provider_limits = snapshot.get("provider_limit_indicators", [])
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]
+                    if provider_limits:
+                        hottest = max(provider_limits, key=lambda item: item.get("percent", 0))
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append((self._status_bar_limit_style(hottest.get("percent")), hottest["label"]))
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -3887,6 +3959,7 @@ class HermesCLI:
                     compressions = snapshot.get("compressions", 0)
                     bg_count = snapshot.get("active_background_tasks", 0)
                     bg_proc_count = snapshot.get("active_background_processes", 0)
+                    provider_limits = snapshot.get("provider_limit_indicators", [])
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
@@ -3897,6 +3970,10 @@ class HermesCLI:
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
                     ]
+                    if provider_limits:
+                        for item in provider_limits:
+                            frags.append(("class:status-bar-dim", " │ "))
+                            frags.append((self._status_bar_limit_style(item.get("percent")), item["label"]))
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))

--- a/tests/agent/test_rate_limit_tracker.py
+++ b/tests/agent/test_rate_limit_tracker.py
@@ -31,6 +31,15 @@ NOUS_HEADERS = {
     "x-ratelimit-reset-tokens-1h": "3490.0",
 }
 
+CODEX_HEADERS = {
+    "x-codex-primary-used-percent": "16",
+    "x-codex-primary-window-minutes": "300",
+    "x-codex-primary-reset-after-seconds": "8222",
+    "x-codex-secondary-used-percent": "5",
+    "x-codex-secondary-window-minutes": "10080",
+    "x-codex-secondary-reset-after-seconds": "520389",
+}
+
 
 class TestParseHeaders:
     def test_basic_parsing(self):
@@ -52,6 +61,45 @@ class TestParseHeaders:
         assert state.tokens_hour.limit == 336000000
         assert state.tokens_hour.remaining == 335999000
         assert state.tokens_hour.reset_seconds == 3490.0
+
+    def test_openai_codex_percent_headers_populate_five_hour_and_weekly_requests(self):
+        state = parse_rate_limit_headers(CODEX_HEADERS, provider="openai-codex")
+
+        assert state is not None
+        assert state.provider == "openai-codex"
+        assert state.has_data
+        assert state.requests_5h.limit == 100
+        assert state.requests_5h.remaining == 84
+        assert state.requests_5h.reset_seconds == 8222
+        assert state.requests_5h.usage_pct == pytest.approx(16.0)
+        assert state.requests_week.limit == 100
+        assert state.requests_week.remaining == 95
+        assert state.requests_week.reset_seconds == 520389
+        assert state.requests_week.usage_pct == pytest.approx(5.0)
+
+    def test_openai_codex_percent_headers_do_not_populate_unrecognized_windows(self):
+        headers = {
+            **CODEX_HEADERS,
+            "x-codex-primary-window-minutes": "60",
+            "x-codex-secondary-window-minutes": "1440",
+        }
+
+        state = parse_rate_limit_headers(headers)
+
+        assert state is not None
+        assert state.has_data
+        assert state.requests_5h.limit == 0
+        assert state.requests_week.limit == 0
+
+    def test_x_ratelimit_parsing_still_populates_existing_buckets(self):
+        state = parse_rate_limit_headers(NOUS_HEADERS, provider="nous")
+
+        assert state is not None
+        assert state.has_data
+        assert state.requests_min.usage_pct == pytest.approx(0.625)
+        assert state.requests_hour.usage_pct == pytest.approx(0.02976190476190476)
+        assert state.tokens_min.usage_pct == pytest.approx(0.00625)
+        assert state.tokens_hour.usage_pct == pytest.approx(0.00029761904761904765)
 
     def test_no_headers(self):
         state = parse_rate_limit_headers({})
@@ -76,6 +124,40 @@ class TestParseHeaders:
         }
         state = parse_rate_limit_headers(headers)
         assert state is None
+
+    def test_parses_five_hour_and_weekly_aliases(self):
+        headers = {
+            "x-ratelimit-limit-requests-5h": "100",
+            "x-ratelimit-remaining-requests-5h": "20",
+            "x-ratelimit-reset-requests-5h": "1200",
+            "x-ratelimit-limit-tokens-weekly": "1000",
+            "x-ratelimit-remaining-tokens-weekly": "650",
+        }
+
+        state = parse_rate_limit_headers(headers)
+
+        assert state is not None
+        assert state.requests_5h.limit == 100
+        assert state.requests_5h.remaining == 20
+        assert state.requests_5h.reset_seconds == 1200
+        assert state.tokens_week.limit == 1000
+        assert state.tokens_week.remaining == 650
+
+    def test_parses_alternate_five_hour_and_weekly_suffixes(self):
+        headers = {
+            "x-ratelimit-limit-tokens-5hours": "500",
+            "x-ratelimit-remaining-tokens-5hours": "100",
+            "x-ratelimit-limit-requests-7d": "70",
+            "x-ratelimit-remaining-requests-7d": "35",
+        }
+
+        state = parse_rate_limit_headers(headers)
+
+        assert state is not None
+        assert state.tokens_5h.limit == 500
+        assert state.tokens_5h.remaining == 100
+        assert state.requests_week.limit == 70
+        assert state.requests_week.remaining == 35
 
     def test_malformed_values(self):
         headers = {
@@ -152,6 +234,7 @@ class TestFormatting:
 
     def test_format_display_with_data(self):
         state = parse_rate_limit_headers(NOUS_HEADERS, provider="nous")
+        assert state is not None
         result = format_rate_limit_display(state)
         assert "Nous" in result
         assert "Requests/min" in result
@@ -160,22 +243,50 @@ class TestFormatting:
         assert "Tokens/hr" in result
         assert "resets in" in result
 
+    def test_format_display_includes_five_hour_and_weekly_windows(self):
+        state = parse_rate_limit_headers(
+            {
+                "x-ratelimit-limit-requests-5h": "100",
+                "x-ratelimit-remaining-requests-5h": "20",
+                "x-ratelimit-reset-requests-5h": "1200",
+                "x-ratelimit-limit-tokens-weekly": "1000",
+                "x-ratelimit-remaining-tokens-weekly": "650",
+                "x-ratelimit-reset-tokens-weekly": "520389",
+            },
+            provider="openai-codex",
+        )
+        assert state is not None
+        result = format_rate_limit_display(state)
+        assert "Requests/5h" in result
+        assert "Tokens/week" in result
+        assert "resets in" in result
+
     def test_format_display_warning_on_high_usage(self):
         headers = {
             **NOUS_HEADERS,
             "x-ratelimit-remaining-requests": "50",  # 750/800 used = 93.75%
         }
         state = parse_rate_limit_headers(headers)
+        assert state is not None
         result = format_rate_limit_display(state)
         assert "⚠" in result
 
     def test_format_compact(self):
         state = parse_rate_limit_headers(NOUS_HEADERS, provider="nous")
+        assert state is not None
         result = format_rate_limit_compact(state)
         assert "RPM:" in result
         assert "RPH:" in result
         assert "TPM:" in result
         assert "TPH:" in result
+        assert "resets" in result
+
+    def test_format_compact_includes_codex_five_hour_and_weekly_resets(self):
+        state = parse_rate_limit_headers(CODEX_HEADERS, provider="openai-codex")
+        assert state is not None
+        result = format_rate_limit_compact(state)
+        assert "R5H: 84/100" in result
+        assert "RW: 95/100" in result
         assert "resets" in result
 
     def test_format_compact_no_data(self):

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from agent.rate_limit_tracker import RateLimitBucket, RateLimitState, parse_rate_limit_headers
 from cli import HermesCLI
 
 
@@ -29,6 +30,7 @@ def _attach_agent(
     context_tokens: int,
     context_length: int,
     compressions: int = 0,
+    rate_limit_state: RateLimitState | None = None,
 ):
     cli_obj.agent = SimpleNamespace(
         model=cli_obj.model,
@@ -42,7 +44,7 @@ def _attach_agent(
         session_completion_tokens=completion_tokens,
         session_total_tokens=total_tokens,
         session_api_calls=api_calls,
-        get_rate_limit_state=lambda: None,
+        get_rate_limit_state=lambda: rate_limit_state,
         context_compressor=SimpleNamespace(
             last_prompt_tokens=context_tokens,
             context_length=context_length,
@@ -166,6 +168,122 @@ class TestCLIStatusBar:
              patch("shutil.get_terminal_size") as mock_shutil:
             assert _input_height() == 2
         mock_shutil.assert_not_called()
+
+    def test_build_status_bar_text_no_limit_indicators_without_data(self):
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "5h" not in text
+        assert "W " not in text
+
+    def test_build_status_bar_text_includes_provider_limits_when_present(self):
+        now = time.time()
+        rate_limits = RateLimitState(
+            requests_5h=RateLimitBucket(limit=100, remaining=20, reset_seconds=8222, captured_at=now),
+            tokens_week=RateLimitBucket(limit=200, remaining=130, reset_seconds=520389, captured_at=now),
+            captured_at=now,
+        )
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            rate_limit_state=rate_limits,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "5h 80% ↻2h17m" in text
+        assert "W 35% ↻6.0d" in text
+
+    def test_build_status_bar_text_renders_openai_codex_percent_headers(self):
+        rate_limits = parse_rate_limit_headers(
+            {
+                "x-codex-primary-used-percent": "16",
+                "x-codex-primary-window-minutes": "300",
+                "x-codex-primary-reset-after-seconds": "8222",
+                "x-codex-secondary-used-percent": "5",
+                "x-codex-secondary-window-minutes": "10080",
+                "x-codex-secondary-reset-after-seconds": "520389",
+            },
+            provider="openai-codex",
+        )
+        assert rate_limits is not None
+        cli_obj = _attach_agent(
+            _make_cli(model="openai-codex/gpt-5.5"),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            rate_limit_state=rate_limits,
+        )
+
+        text = cli_obj._build_status_bar_text(width=120)
+
+        assert "5h 16% ↻2h17m" in text
+        assert "W 5% ↻6.0d" in text
+
+    def test_build_status_bar_text_omits_provider_limits_on_narrow_terminal(self):
+        rate_limits = RateLimitState(
+            requests_5h=RateLimitBucket(limit=100, remaining=20, captured_at=time.time()),
+            tokens_week=RateLimitBucket(limit=200, remaining=130, captured_at=time.time()),
+            captured_at=time.time(),
+        )
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            rate_limit_state=rate_limits,
+        )
+
+        text = cli_obj._build_status_bar_text(width=50)
+
+        assert "5h" not in text
+        assert "W " not in text
+
+    def test_provider_limit_fragments_use_threshold_styles(self):
+        now = time.time()
+        rate_limits = RateLimitState(
+            requests_5h=RateLimitBucket(limit=100, remaining=5, reset_seconds=4000, captured_at=now),
+            tokens_week=RateLimitBucket(limit=200, remaining=80, reset_seconds=90000, captured_at=now),
+            captured_at=now,
+        )
+        cli_obj = _attach_agent(
+            _make_cli(),
+            prompt_tokens=10_230,
+            completion_tokens=2_220,
+            total_tokens=12_450,
+            api_calls=7,
+            context_tokens=12_450,
+            context_length=200_000,
+            rate_limit_state=rate_limits,
+        )
+        cli_obj._status_bar_visible = True
+
+        with patch.object(cli_obj, "_get_tui_terminal_width", return_value=120):
+            frags = cli_obj._get_status_bar_fragments()
+
+        frag_styles = {text: style for style, text in frags}
+        assert frag_styles["5h 95% ↻1h6m"] == "class:status-bar-critical"
+        assert frag_styles["W 60% ↻1.0d"] == "class:status-bar-warn"
 
     def test_build_status_bar_text_no_cost_in_status_bar(self):
         cli_obj = _attach_agent(


### PR DESCRIPTION
## Summary
- Parse OpenAI Codex 5-hour and weekly usage window headers
- Show 5h/weekly usage and reset times in /usage again
- Restore CLI statusbar indicators for provider usage windows
- Add regression tests for Codex percent headers and x-ratelimit aliases

## Test Plan
- `venv/bin/python -m pytest tests/agent/test_rate_limit_tracker.py tests/cli/test_cli_status_bar.py -q`
- `venv/bin/ruff check agent/rate_limit_tracker.py cli.py tests/agent/test_rate_limit_tracker.py tests/cli/test_cli_status_bar.py`
- `git diff --check`