### PR TITLE
fix(hermes_cli): add URL validation to azure_detect to prevent SSRF

### DIFF
--- a/hermes_cli/azure_detect.py
+++ b/hermes_cli/azure_detect.py
@@ -46,6 +46,8 @@ from urllib import request as urllib_request
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 
+from tools.url_safety import is_safe_url
+
 logger = logging.getLogger(__name__)
 
 
@@ -319,6 +321,13 @@ def detect(base_url: str,
         result.hostname = (parsed.hostname or "").lower()
     except Exception:
         result.hostname = ""
+
+    # Block private/internal/loopback IPs and non-https schemes before
+    # making any outbound requests (SSRF-002).
+    if not is_safe_url(base_url):
+        logger.warning("azure_detect: unsafe URL rejected: %s", base_url)
+        result.reason = "URL blocked — must use https and may not target private/internal addresses"
+        return result
 
     # 1. Path sniff.  Azure Foundry exposes Anthropic-style deployments
     #    under a dedicated ``/anthropic`` path.

--- a/tests/hermes_cli/test_azure_detect.py
+++ b/tests/hermes_cli/test_azure_detect.py
@@ -88,7 +88,8 @@ def test_extract_model_ids_bad_shape_returns_empty():
 
 def test_detect_anthropic_path_wins_without_http():
     """URL path sniff short-circuits — no HTTP call happens."""
-    with patch.object(azure_detect, "_http_get_json") as fake_get, \
+    with patch.object(azure_detect, "is_safe_url", return_value=True), \
+         patch.object(azure_detect, "_http_get_json") as fake_get, \
          patch.object(azure_detect, "_probe_anthropic_messages") as fake_probe:
         result = azure_detect.detect(
             "https://foo.services.ai.azure.com/anthropic", "key-abc",
@@ -106,7 +107,8 @@ def test_detect_openai_models_probe_success():
         assert "key-abc" == api_key
         return 200, json.loads(_openai_models_body("gpt-5.4", "claude-opus-4-6"))
 
-    with patch.object(azure_detect, "_http_get_json", side_effect=_fake_get):
+    with patch.object(azure_detect, "is_safe_url", return_value=True), \
+         patch.object(azure_detect, "_http_get_json", side_effect=_fake_get):
         result = azure_detect.detect(
             "https://my.openai.azure.com/openai/v1", "key-abc",
         )
@@ -121,7 +123,8 @@ def test_detect_openai_models_probe_empty_list_still_counts():
     def _fake_get(url, api_key, timeout=6.0, **kwargs):
         return 200, {"object": "list", "data": []}
 
-    with patch.object(azure_detect, "_http_get_json", side_effect=_fake_get):
+    with patch.object(azure_detect, "is_safe_url", return_value=True), \
+         patch.object(azure_detect, "_http_get_json", side_effect=_fake_get):
         result = azure_detect.detect(
             "https://my.openai.azure.com/openai/v1", "key-abc",
         )
@@ -135,7 +138,8 @@ def test_detect_falls_back_to_anthropic_probe():
     def _fake_get(url, api_key, timeout=6.0, **kwargs):
         return 401, None  # /models forbidden
 
-    with patch.object(azure_detect, "_http_get_json", side_effect=_fake_get), \
+    with patch.object(azure_detect, "is_safe_url", return_value=True), \
+         patch.object(azure_detect, "_http_get_json", side_effect=_fake_get), \
          patch.object(azure_detect, "_probe_anthropic_messages", return_value=True):
         result = azure_detect.detect(
             "https://my.services.ai.azure.com/v1", "key-abc",
@@ -146,7 +150,8 @@ def test_detect_falls_back_to_anthropic_probe():
 
 def test_detect_all_probes_fail_returns_none():
     """Every probe fails → api_mode is None and caller falls back to manual."""
-    with patch.object(azure_detect, "_http_get_json", return_value=(500, None)), \
+    with patch.object(azure_detect, "is_safe_url", return_value=True), \
+         patch.object(azure_detect, "_http_get_json", return_value=(500, None)), \
          patch.object(azure_detect, "_probe_anthropic_messages", return_value=False):
         result = azure_detect.detect(
             "https://some-private.example.com/", "key-abc",
@@ -154,6 +159,20 @@ def test_detect_all_probes_fail_returns_none():
     assert result.api_mode is None
     assert result.models == []
     assert "manual" in result.reason.lower()
+
+
+def test_detect_unsafe_url_rejected_without_http():
+    """SSRF guard: unsafe URL is rejected and no HTTP call is made."""
+    with patch.object(azure_detect, "is_safe_url", return_value=False), \
+         patch.object(azure_detect, "_http_get_json") as fake_get, \
+         patch.object(azure_detect, "_probe_anthropic_messages") as fake_probe:
+        result = azure_detect.detect(
+            "http://10.0.0.1/v1", "key-abc",
+        )
+    assert result.api_mode is None
+    assert "blocked" in result.reason.lower()
+    fake_get.assert_not_called()
+    fake_probe.assert_not_called()
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary\n\nFixes SSRF-002: The  function in the Azure setup wizard accepted arbitrary URLs and sent the user's API key to them with no validation, enabling SSRF attacks and credential exfiltration.\n\n---\n\n## Pain Before\n\n in  accepted an unvalidated  parameter and immediately began making HTTP GET/POST probes — including requests that sent the user's Azure API key — to whatever address they provided. There was no scheme enforcement, no block on private/internal/loopback IPs, and no guard against cloud metadata endpoints ().\n\nAn attacker who could influence the URL submitted to the wizard could:\n- Probe internal network resources\n- Exfiltrate the user's API key by redirecting to an attacker-controlled server\n- Scan internal infrastructure via the HTTP probes\n\n---\n\n## What Was Fixed\n\nAdded URL validation at the top of  using the existing  guard from . The function now rejects non-HTTPS URLs and blocks loopback, private, and internal IP ranges before making any outbound requests.\n\nOn a blocked URL, it logs a warning, sets an informative  on the , and returns early — the probing logic is never reached.\n\n---\n\n## Changes\n\n**File:** \n\n- Added  import\n- Added 7-line validation block at the start of \n- No changes to the probing logic itself\n\n