### PR TITLE
feat(image_gen): add Gemini edit backend

### DIFF
--- a/plugins/image_gen/gemini/__init__.py
+++ b/plugins/image_gen/gemini/__init__.py
@@ -1,0 +1,380 @@
+"""Google Gemini image generation backend.
+
+Supports Gemini native image generation/editing via the Google AI Studio
+``generateContent`` API. Input/reference images are sent as inlineData parts,
+so the provider actually receives the pixels instead of relying on chat vision
+context. Psychic remote APIs remain sadly unsupported.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import mimetypes
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote
+
+import requests
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_b64_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "gemini-2.5-flash-image": {
+        "display": "Gemini 2.5 Flash Image",
+        "speed": "fast",
+        "strengths": "Low-cost image generation, edits, multi-reference composition",
+        "price": "Google AI Studio pricing",
+    },
+    "gemini-3.1-flash-image-preview": {
+        "display": "Gemini 3.1 Flash Image Preview",
+        "speed": "fast",
+        "strengths": "Newer preview image model; supports imageConfig controls",
+        "price": "Google AI Studio pricing",
+    },
+    "gemini-3-pro-image-preview": {
+        "display": "Gemini 3 Pro Image Preview",
+        "speed": "slower",
+        "strengths": "Higher-end preview image generation/editing",
+        "price": "Google AI Studio pricing",
+    },
+}
+
+DEFAULT_MODEL = "gemini-2.5-flash-image"
+_ENDPOINT = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
+_MAX_INPUT_BYTES = 20 * 1024 * 1024
+
+_GEMINI_ASPECT_RATIOS = {
+    "landscape": "16:9",
+    "square": "1:1",
+    "portrait": "9:16",
+}
+
+_MIME_EXTENSIONS = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/webp": "webp",
+    "image/gif": "gif",
+}
+
+
+def _get_env_value(*keys: str) -> Optional[str]:
+    """Read an env var, falling back to Hermes' .env loader."""
+    for key in keys:
+        value = os.environ.get(key)
+        if value:
+            return value
+    try:
+        from hermes_cli.config import get_env_value
+
+        for key in keys:
+            value = get_env_value(key)
+            if value:
+                return value
+    except Exception as exc:  # pragma: no cover - defensive only
+        logger.debug("Could not read Gemini env value: %s", exc)
+    return None
+
+
+def _load_gemini_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        gemini = section.get("gemini") if isinstance(section, dict) else None
+        return gemini if isinstance(gemini, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen.gemini config: %s", exc)
+        return {}
+
+
+def _resolve_model(explicit: Optional[str] = None) -> Tuple[str, Dict[str, Any]]:
+    candidates = [
+        explicit,
+        os.environ.get("GEMINI_IMAGE_MODEL"),
+        _load_gemini_config().get("model"),
+    ]
+    for candidate in candidates:
+        if isinstance(candidate, str):
+            normalized = candidate.strip().removeprefix("models/")
+            if normalized in _MODELS:
+                return normalized, _MODELS[normalized]
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _mime_from_path(path: Path) -> str:
+    guessed, _ = mimetypes.guess_type(str(path))
+    if guessed and guessed.startswith("image/"):
+        return guessed
+    suffix = path.suffix.lower()
+    if suffix in {".jpg", ".jpeg"}:
+        return "image/jpeg"
+    if suffix == ".webp":
+        return "image/webp"
+    if suffix == ".gif":
+        return "image/gif"
+    return "image/png"
+
+
+def _inline_part_from_source(source: str) -> Dict[str, Any]:
+    """Convert a local path, URL, or data URI into a Gemini inlineData part."""
+    if not isinstance(source, str) or not source.strip():
+        raise ValueError("image source must be a non-empty string")
+    value = source.strip()
+
+    if value.startswith("data:"):
+        header, _, payload = value.partition(",")
+        if not payload or ";base64" not in header:
+            raise ValueError("data URI image inputs must be base64-encoded")
+        mime = header[5:].split(";", 1)[0] or "image/png"
+        return {"inlineData": {"mimeType": mime, "data": payload}}
+
+    if value.startswith(("http://", "https://")):
+        response = requests.get(value, timeout=45, stream=True)
+        response.raise_for_status()
+        content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
+        if not content_type.startswith("image/"):
+            raise ValueError(f"URL did not return an image content-type: {content_type or 'unknown'}")
+        chunks: List[bytes] = []
+        total = 0
+        for chunk in response.iter_content(chunk_size=64 * 1024):
+            if not chunk:
+                continue
+            total += len(chunk)
+            if total > _MAX_INPUT_BYTES:
+                raise ValueError("input image exceeds 20MB cap")
+            chunks.append(chunk)
+        data = b"".join(chunks)
+        if not data:
+            raise ValueError("input image URL returned 0 bytes")
+        return {"inlineData": {"mimeType": content_type, "data": base64.b64encode(data).decode("ascii")}}
+
+    path = Path(value).expanduser()
+    if not path.exists() or not path.is_file():
+        raise ValueError(f"input image path does not exist: {value}")
+    data = path.read_bytes()
+    if len(data) > _MAX_INPUT_BYTES:
+        raise ValueError("input image exceeds 20MB cap")
+    return {"inlineData": {"mimeType": _mime_from_path(path), "data": base64.b64encode(data).decode("ascii")}}
+
+
+def _collect_image_sources(kwargs: Dict[str, Any]) -> List[str]:
+    sources: List[str] = []
+    for key in ("input_image", "image_url"):
+        value = kwargs.get(key)
+        if isinstance(value, str) and value.strip():
+            sources.append(value.strip())
+    refs = kwargs.get("reference_images") or kwargs.get("reference_image_urls")
+    if isinstance(refs, str) and refs.strip():
+        sources.append(refs.strip())
+    elif isinstance(refs, list):
+        for item in refs:
+            if isinstance(item, str) and item.strip():
+                sources.append(item.strip())
+    return sources
+
+
+class GeminiImageGenProvider(ImageGenProvider):
+    """Google AI Studio Gemini image generation/editing backend."""
+
+    @property
+    def name(self) -> str:
+        return "gemini"
+
+    @property
+    def display_name(self) -> str:
+        return "Google Gemini"
+
+    def is_available(self) -> bool:
+        return bool(_get_env_value("GEMINI_API_KEY", "GOOGLE_API_KEY"))
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": model_id,
+                "display": meta.get("display", model_id),
+                "speed": meta.get("speed", ""),
+                "strengths": meta.get("strengths", ""),
+                "price": meta.get("price", ""),
+            }
+            for model_id, meta in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Google Gemini Image",
+            "badge": "paid",
+            "tag": "Gemini image generation/editing via Google AI Studio (GEMINI_API_KEY)",
+            "env_vars": [
+                {
+                    "key": "GEMINI_API_KEY",
+                    "prompt": "Google AI Studio / Gemini API key",
+                    "url": "https://aistudio.google.com/app/apikey",
+                },
+            ],
+        }
+
+    def generate(self, prompt: str, aspect_ratio: str = DEFAULT_ASPECT_RATIO, **kwargs: Any) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider="gemini",
+                aspect_ratio=aspect,
+            )
+
+        api_key = _get_env_value("GEMINI_API_KEY", "GOOGLE_API_KEY")
+        if not api_key:
+            return error_response(
+                error="GEMINI_API_KEY or GOOGLE_API_KEY not set. Add the key to ~/.hermes/.env or run `hermes tools`.",
+                error_type="auth_required",
+                provider="gemini",
+                aspect_ratio=aspect,
+            )
+
+        model_id, _meta = _resolve_model(kwargs.get("model") if isinstance(kwargs.get("model"), str) else None)
+        image_sources = _collect_image_sources(kwargs)
+        parts: List[Dict[str, Any]] = [{"text": prompt}]
+        try:
+            for source in image_sources:
+                parts.append(_inline_part_from_source(source))
+        except Exception as exc:
+            return error_response(
+                error=f"Could not prepare input/reference image: {exc}",
+                error_type="invalid_image_input",
+                provider="gemini",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        generation_config: Dict[str, Any] = {
+            "responseModalities": ["TEXT", "IMAGE"],
+            "imageConfig": {"aspectRatio": _GEMINI_ASPECT_RATIOS.get(aspect, "1:1")},
+        }
+        resolution = kwargs.get("resolution") or _load_gemini_config().get("resolution")
+        if isinstance(resolution, str) and resolution.strip():
+            generation_config["imageConfig"]["imageSize"] = resolution.strip()
+
+        payload = {
+            "contents": [{"role": "user", "parts": parts}],
+            "generationConfig": generation_config,
+        }
+        url = _ENDPOINT.format(model=quote(model_id, safe=""))
+
+        try:
+            response = requests.post(
+                url,
+                params={"key": api_key},
+                headers={"Content-Type": "application/json"},
+                json=payload,
+                timeout=180,
+            )
+            if response.status_code == 400 and "imageConfig" in response.text:
+                # Older/preview models can lag the docs. Retry without imageConfig
+                # instead of failing an otherwise valid prompt.
+                payload["generationConfig"] = {"responseModalities": ["TEXT", "IMAGE"]}
+                response = requests.post(
+                    url,
+                    params={"key": api_key},
+                    headers={"Content-Type": "application/json"},
+                    json=payload,
+                    timeout=180,
+                )
+            response.raise_for_status()
+            result = response.json()
+        except requests.Timeout:
+            return error_response(
+                error="Gemini image generation timed out (180s)",
+                error_type="timeout",
+                provider="gemini",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None else 0
+            try:
+                body = exc.response.json() if exc.response is not None else {}
+                message = body.get("error", {}).get("message") or str(body)[:300]
+            except Exception:
+                message = exc.response.text[:300] if exc.response is not None else str(exc)
+            return error_response(
+                error=f"Gemini image generation failed ({status}): {message}",
+                error_type="api_error",
+                provider="gemini",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.ConnectionError as exc:
+            return error_response(
+                error=f"Gemini connection error: {exc}",
+                error_type="connection_error",
+                provider="gemini",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except Exception as exc:
+            return error_response(
+                error=f"Gemini returned an invalid response: {exc}",
+                error_type="invalid_response",
+                provider="gemini",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        output_text: List[str] = []
+        for candidate in result.get("candidates", []):
+            for part in candidate.get("content", {}).get("parts", []):
+                if part.get("text"):
+                    output_text.append(part["text"])
+                inline = part.get("inlineData") or part.get("inline_data")
+                if inline and inline.get("data"):
+                    mime = inline.get("mimeType") or inline.get("mime_type") or "image/png"
+                    extension = _MIME_EXTENSIONS.get(str(mime).lower(), "png")
+                    path = save_b64_image(inline["data"], prefix="gemini", extension=extension)
+                    return success_response(
+                        image=str(path),
+                        model=model_id,
+                        prompt=prompt,
+                        aspect_ratio=aspect,
+                        provider="gemini",
+                        extra={
+                            "mode": "edit" if image_sources else "generate",
+                            "input_images": len(image_sources),
+                            "text": "\n".join(output_text).strip(),
+                        },
+                    )
+
+        return error_response(
+            error="Gemini returned no inline image data",
+            error_type="empty_response",
+            provider="gemini",
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+
+
+def register(ctx):
+    ctx.register_image_gen_provider(GeminiImageGenProvider())

--- a/plugins/image_gen/gemini/plugin.yaml
+++ b/plugins/image_gen/gemini/plugin.yaml
@@ -1,0 +1,7 @@
+name: gemini
+version: 1.0.0
+description: "Google Gemini image generation/editing backend. Supports text-to-image and input/reference image workflows via Google AI Studio."
+author: NousResearch
+kind: backend
+requires_env:
+  - GEMINI_API_KEY

--- a/tests/plugins/image_gen/test_gemini_provider.py
+++ b/tests/plugins/image_gen/test_gemini_provider.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _fake_key(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+
+
+class TestGeminiImageGenProvider:
+    def test_name_and_default_model(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        provider = GeminiImageGenProvider()
+        assert provider.name == "gemini"
+        assert provider.default_model() == "gemini-2.5-flash-image"
+
+    def test_is_available_with_key(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        assert GeminiImageGenProvider().is_available() is True
+
+    def test_is_available_without_key(self, monkeypatch):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        with patch("plugins.image_gen.gemini._get_env_value", return_value=None):
+            assert GeminiImageGenProvider().is_available() is False
+
+    def test_list_models(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        ids = {model["id"] for model in GeminiImageGenProvider().list_models()}
+        assert "gemini-2.5-flash-image" in ids
+        assert "gemini-3.1-flash-image-preview" in ids
+
+    def test_setup_schema_prompts_for_gemini_key(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        schema = GeminiImageGenProvider().get_setup_schema()
+        assert schema["name"] == "Google Gemini Image"
+        assert schema["env_vars"][0]["key"] == "GEMINI_API_KEY"
+
+
+class TestGeminiGenerate:
+    def _mock_success_response(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"text": "done"},
+                            {
+                                "inlineData": {
+                                    "mimeType": "image/png",
+                                    "data": base64.b64encode(b"fake-image").decode("ascii"),
+                                }
+                            },
+                        ]
+                    }
+                }
+            ]
+        }
+        return mock_resp
+
+    def test_successful_text_to_image_payload_and_response(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        with patch("plugins.image_gen.gemini.requests.post", return_value=self._mock_success_response()) as mock_post, \
+             patch("plugins.image_gen.gemini.save_b64_image", return_value="/tmp/gemini.png"):
+            result = GeminiImageGenProvider().generate("a cinematic product photo", aspect_ratio="landscape")
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/gemini.png"
+        assert result["provider"] == "gemini"
+        assert result["model"] == "gemini-2.5-flash-image"
+        assert result["mode"] == "generate"
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["generationConfig"]["responseModalities"] == ["TEXT", "IMAGE"]
+        assert payload["generationConfig"]["imageConfig"]["aspectRatio"] == "16:9"
+        assert payload["contents"][0]["parts"] == [{"text": "a cinematic product photo"}]
+        assert mock_post.call_args.kwargs["params"] == {"key": "test-gemini-key"}
+
+    def test_input_image_is_sent_as_inline_data(self, tmp_path):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        source = tmp_path / "source.png"
+        source.write_bytes(b"source-image")
+
+        with patch("plugins.image_gen.gemini.requests.post", return_value=self._mock_success_response()) as mock_post, \
+             patch("plugins.image_gen.gemini.save_b64_image", return_value="/tmp/gemini-edit.png"):
+            result = GeminiImageGenProvider().generate(
+                "turn this into a clean studio product shot",
+                aspect_ratio="square",
+                input_image=str(source),
+            )
+
+        assert result["success"] is True
+        assert result["mode"] == "edit"
+        assert result["input_images"] == 1
+        parts = mock_post.call_args.kwargs["json"]["contents"][0]["parts"]
+        assert parts[0]["text"].startswith("turn this")
+        assert parts[1]["inlineData"]["mimeType"] == "image/png"
+        assert base64.b64decode(parts[1]["inlineData"]["data"]) == b"source-image"
+
+    def test_invalid_input_image_returns_clear_error(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        result = GeminiImageGenProvider().generate("edit it", input_image="/does/not/exist.png")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_image_input"
+        assert "input image path does not exist" in result["error"]
+
+    def test_missing_key(self, monkeypatch):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        with patch("plugins.image_gen.gemini._get_env_value", return_value=None):
+            result = GeminiImageGenProvider().generate("test")
+        assert result["success"] is False
+        assert result["error_type"] == "auth_required"
+
+
+class TestRegistration:
+    def test_register(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider, register
+
+        mock_ctx = MagicMock()
+        register(mock_ctx)
+        mock_ctx.register_image_gen_provider.assert_called_once()
+        provider = mock_ctx.register_image_gen_provider.call_args[0][0]
+        assert isinstance(provider, GeminiImageGenProvider)
+        assert provider.name == "gemini"

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -363,11 +363,13 @@ class TestAspectRatioNormalization:
 
 class TestRegistryIntegration:
 
-    def test_schema_exposes_only_prompt_and_aspect_ratio_to_agent(self, image_tool):
-        """The agent-facing schema must stay tight — model selection is a
-        user-level config choice, not an agent-level arg."""
+    def test_schema_exposes_generation_and_image_input_args_to_agent(self, image_tool):
+        """The agent-facing schema exposes image inputs, but model/backend
+        selection remains a user-level config choice rather than an agent arg.
+        """
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
-        assert set(props.keys()) == {"prompt", "aspect_ratio"}
+        assert set(props.keys()) == {"prompt", "aspect_ratio", "input_image", "reference_images", "mode"}
+        assert "model" not in props
 
     def test_aspect_ratio_enum_is_three_values(self, image_tool):
         enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["aspect_ratio"]["enum"]

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -15,11 +15,14 @@ def _reset_registry():
 
 
 class _FakeCodexProvider(ImageGenProvider):
+    last_kwargs = None
+
     @property
     def name(self) -> str:
         return "codex"
 
     def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        type(self).last_kwargs = kwargs
         return {
             "success": True,
             "image": "/tmp/codex-test.png",
@@ -51,6 +54,34 @@ class TestPluginDispatch:
         assert payload["provider"] == "codex"
         assert payload["image"] == "/tmp/codex-test.png"
         assert payload["aspect_ratio"] == "square"
+
+    def test_dispatch_forwards_image_input_kwargs(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+        from agent import image_gen_registry as registry_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: codex\n")
+        provider = _FakeCodexProvider()
+        _FakeCodexProvider.last_kwargs = None
+
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "codex")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: provider if name == "codex" else None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider(
+            "turn this into a campaign hero shot",
+            "landscape",
+            input_image="/tmp/source.png",
+            reference_images=["https://example.com/ref.png"],
+            mode="edit",
+        )
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is True
+        assert _FakeCodexProvider.last_kwargs["input_image"] == "/tmp/source.png"
+        assert _FakeCodexProvider.last_kwargs["reference_images"] == ["https://example.com/ref.png"]
+        assert _FakeCodexProvider.last_kwargs["mode"] == "edit"
 
     def test_dispatch_reports_missing_registered_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -887,24 +887,40 @@ from tools.registry import registry, tool_error
 IMAGE_GENERATE_SCHEMA = {
     "name": "image_generate",
     "description": (
-        "Generate high-quality images from text prompts. The underlying "
-        "backend (FAL, OpenAI, etc.) and model are user-configured and not "
-        "selectable by the agent. Returns either a URL or an absolute file "
-        "path in the `image` field; display it with markdown "
-        "![description](url-or-path) and the gateway will deliver it."
+        "Generate or edit high-quality images. The underlying backend "
+        "(FAL, OpenAI, Gemini, etc.) and model are user-configured. When "
+        "`input_image` or `reference_images` are provided, capable providers "
+        "receive the actual image bytes/URLs for editing or reference-guided "
+        "generation. Returns either a URL or an absolute file path in the "
+        "`image` field; display it with markdown ![description](url-or-path) "
+        "and the gateway will deliver it."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "prompt": {
                 "type": "string",
-                "description": "The text prompt describing the desired image. Be detailed and descriptive.",
+                "description": "The text prompt describing the desired image/edit. Be detailed and descriptive.",
             },
             "aspect_ratio": {
                 "type": "string",
                 "enum": list(VALID_ASPECT_RATIOS),
-                "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
+                "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 9:16 tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
+            },
+            "input_image": {
+                "type": "string",
+                "description": "Optional local path, URL, or data URI for an image to edit or use as the primary reference.",
+            },
+            "reference_images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional additional reference image paths, URLs, or data URIs. Requires a provider that supports image inputs.",
+            },
+            "mode": {
+                "type": "string",
+                "enum": ["generate", "edit"],
+                "description": "Optional intent hint. If omitted, providers auto-detect edit/reference mode from image inputs.",
             },
         },
         "required": ["prompt"],
@@ -951,7 +967,7 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, **image_kwargs):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -961,7 +977,8 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
     ``"fal"`` itself, which now resolves to the
     ``plugins/image_gen/fal/`` plugin (the plugin re-enters this module's
     pipeline via ``_it`` indirection so behavior is identical to the
-    direct call, just routed through the registry).
+    direct call, just routed through the registry). Image/reference kwargs are
+    forwarded so capable providers can perform actual edit/reference workflows.
     """
     configured = _read_configured_image_provider()
     if not configured:
@@ -1006,6 +1023,9 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
 
     try:
         kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
+        for key, value in image_kwargs.items():
+            if value not in (None, "", []):
+                kwargs[key] = value
         if configured_model:
             kwargs["model"] = configured_model
         result = provider.generate(**kwargs)
@@ -1035,12 +1055,25 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    image_kwargs = {
+        "input_image": args.get("input_image"),
+        "image_url": args.get("image_url"),
+        "reference_images": args.get("reference_images"),
+        "reference_image_urls": args.get("reference_image_urls"),
+        "mode": args.get("mode"),
+    }
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio, **image_kwargs)
     if dispatched is not None:
         return dispatched
+
+    if any(value not in (None, "", []) for value in image_kwargs.values()):
+        return tool_error(
+            "image inputs require an image_gen provider with edit/reference support; "
+            "set image_gen.provider to 'gemini' or another capable backend"
+        )
 
     return image_generate_tool(
         prompt=prompt,


### PR DESCRIPTION
## Summary
- Add Gemini image generation/edit backend plugin
- Route image generation tool requests through plugin dispatch when Gemini is configured
- Add provider and dispatch tests

## Test Plan
- `python -m pytest -q tests/plugins/image_gen/test_gemini_provider.py tests/tools/test_image_generation.py tests/tools/test_image_generation_plugin_dispatch.py` → 69 passed
- `gitleaks git --redact=100 --log-opts='origin/main..HEAD'` → 0 findings