### PR TITLE
fix(gateway): detect launchd for restart service path

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10275,8 +10275,9 @@ class GatewayRunner:
         # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
         # exits when the gateway dies, taking the detached helper with it).
         _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        _under_launchd = bool(os.environ.get("XPC_SERVICE_NAME"))  # launchd sets this
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
-        if _under_service or _in_container:
+        if _under_service or _under_launchd or _in_container:
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -67,6 +67,7 @@ async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monk
     """Under systemd (INVOCATION_ID set), /restart uses via_service=True."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setenv("INVOCATION_ID", "abc123")
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)
@@ -84,10 +85,33 @@ async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monk
 
 
 @pytest.mark.asyncio
-async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypatch):
-    """Without systemd, /restart uses the detached subprocess approach."""
+async def test_restart_command_uses_service_restart_under_launchd(tmp_path, monkeypatch):
+    """Under launchd (XPC_SERVICE_NAME set), /restart uses via_service=True."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_detached_without_service_manager(tmp_path, monkeypatch):
+    """Without systemd or launchd, /restart uses the detached subprocess approach."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)


### PR DESCRIPTION
## Summary
- Detect macOS launchd-managed gateway processes via `XPC_SERVICE_NAME` when handling `/restart`.
- Route launchd-managed gateway restarts through the existing service restart path (`via_service=True`) instead of detached restart.
- Add regression coverage for launchd and tighten the detached-path test to require no service manager env.

## Root cause
On macOS, Hermes Gateway runs under launchd. launchd sets `XPC_SERVICE_NAME`, not systemd's `INVOCATION_ID`. Without recognizing launchd, `/restart` falls through to the detached restart path and can exit cleanly without launchd relaunching the gateway.

## Verification
- `./venv/bin/python -m pytest tests/gateway/test_restart_notification.py -q -o 'addopts='` → 26 passed
- `./venv/bin/python -m py_compile gateway/run.py tests/gateway/test_restart_notification.py`
- `git diff --check`

Related: #29180
