### PR TITLE
fix(optional-skills): add HMAC integrity check before pickle.loads in show_snapshot

### DIFF
--- a/optional-skills/research/darwinian-evolver/scripts/show_snapshot.py
+++ b/optional-skills/research/darwinian-evolver/scripts/show_snapshot.py
@@ -11,9 +11,16 @@ target a different attribute (e.g. `regex_pattern`, `sql_query`, `code_block`).
 from __future__ import annotations
 
 import argparse
+import base64
+import hashlib
+import hmac
+import os
 import pickle
 import sys
 from pathlib import Path
+
+
+HERMES_SNAPSHOT_SECRET = "HERMES_SNAPSHOT_SECRET"
 
 
 def main() -> int:
@@ -45,6 +52,41 @@ def main() -> int:
             "code from the snapshot file. Only proceed if you created/control this "
             "file, then re-run with --i-trust-this-file.\n"
             f"  file: {args.snapshot}"
+        )
+
+    # Verify HMAC integrity before unpickling
+    secret = os.environ.get(HERMES_SNAPSHOT_SECRET)
+    if secret:
+        raw_bytes = args.snapshot.read_bytes()
+        try:
+            outer = pickle.loads(raw_bytes)
+            if isinstance(outer, dict) and "population_snapshot" in outer:
+                expected_hmac = outer.get("hmac")
+                if expected_hmac:
+                    computed = hmac.new(
+                        secret.encode(),
+                        outer["population_snapshot"],
+                        hashlib.sha256,
+                    ).hexdigest()
+                    if not hmac.compare_digest(computed, expected_hmac):
+                        sys.exit(
+                            f"HMAC verification failed for {args.snapshot} — "
+                            "snapshot may have been tampered with or corrupted."
+                        )
+                else:
+                    sys.exit(
+                        f"snapshot {args.snapshot} is missing HMAC signature "
+                        "(HERMES_SNAPSHOT_SECRET is set but snapshot has no hmac field)"
+                    )
+            else:
+                sys.exit(f"snapshot {args.snapshot} is not a valid darwinian-evolver snapshot")
+        except Exception as e:
+            sys.exit(f"failed to verify HMAC for {args.snapshot}: {e}")
+    else:
+        print(
+            f"WARNING: HERMES_SNAPSHOT_SECRET is not set — skipping HMAC verification "
+            f"for {args.snapshot}. Set the environment variable to enable integrity checks.",
+            file=sys.stderr,
         )
 
     print(

--- a/optional-skills/research/darwinian-evolver/scripts/show_snapshot.py
+++ b/optional-skills/research/darwinian-evolver/scripts/show_snapshot.py
@@ -11,7 +11,6 @@ target a different attribute (e.g. `regex_pattern`, `sql_query`, `code_block`).
 from __future__ import annotations
 
 import argparse
-import base64
 import hashlib
 import hmac
 import os
@@ -54,34 +53,29 @@ def main() -> int:
             f"  file: {args.snapshot}"
         )
 
-    # Verify HMAC integrity before unpickling
+    # Verify HMAC integrity before unpickling. The HMAC must live in a sidecar
+    # file (e.g. `iteration_N.pkl.hmac`) so we can verify the raw bytes WITHOUT
+    # unpickling them first. pickle.loads() executes arbitrary code, so the
+    # integrity check MUST happen on the file bytes, not on values extracted
+    # post-unpickle.
     secret = os.environ.get(HERMES_SNAPSHOT_SECRET)
     if secret:
+        hmac_path = args.snapshot.with_suffix(args.snapshot.suffix + ".hmac")
+        if not hmac_path.exists():
+            sys.exit(
+                f"HMAC sidecar not found: {hmac_path}. The snapshot must be "
+                "accompanied by an HMAC file written by the producer."
+            )
         raw_bytes = args.snapshot.read_bytes()
-        try:
-            outer = pickle.loads(raw_bytes)
-            if isinstance(outer, dict) and "population_snapshot" in outer:
-                expected_hmac = outer.get("hmac")
-                if expected_hmac:
-                    computed = hmac.new(
-                        secret.encode(),
-                        outer["population_snapshot"],
-                        hashlib.sha256,
-                    ).hexdigest()
-                    if not hmac.compare_digest(computed, expected_hmac):
-                        sys.exit(
-                            f"HMAC verification failed for {args.snapshot} — "
-                            "snapshot may have been tampered with or corrupted."
-                        )
-                else:
-                    sys.exit(
-                        f"snapshot {args.snapshot} is missing HMAC signature "
-                        "(HERMES_SNAPSHOT_SECRET is set but snapshot has no hmac field)"
-                    )
-            else:
-                sys.exit(f"snapshot {args.snapshot} is not a valid darwinian-evolver snapshot")
-        except Exception as e:
-            sys.exit(f"failed to verify HMAC for {args.snapshot}: {e}")
+        expected_hmac = hmac_path.read_text().strip()
+        computed = hmac.new(
+            secret.encode(), raw_bytes, hashlib.sha256
+        ).hexdigest()
+        if not hmac.compare_digest(computed, expected_hmac):
+            sys.exit(
+                f"HMAC verification failed for {args.snapshot} — "
+                "snapshot may have been tampered with or corrupted."
+            )
     else:
         print(
             f"WARNING: HERMES_SNAPSHOT_SECRET is not set — skipping HMAC verification "


### PR DESCRIPTION
## Summary\n\nAdds HMAC-SHA256 integrity verification before calling `pickle.loads()` on untrusted snapshot files in `optional-skills/research/darwinian-evolver/scripts/show_snapshot.py`.\n\n## Changes\n\n- When `HERMES_SNAPSHOT_SECRET` env var is set: verifies the snapshot's HMAC signature before unpickling. Rejects the file if the HMAC is missing or doesn't match.\n- When `HERMES_SNAPSHOT_SECRET` is not set: emits a warning to stderr that integrity verification is skipped.\n\n## Security Fix (PICKLE-001)\n\nWithout HMAC verification, a MITM or compromised output directory could swap a benign snapshot for a malicious one. The new integrity check gates `pickle.loads()` behind a cryptographic HMAC computed with a shared secret.\n\n## Test Plan\n\n1. Run without `HERMES_SNAPSHOT_SECRET` set — should emit a warning but still run.\n2. Set `HERMES_SNAPSHOT_SECRET` and run on a snapshot with an invalid HMAC — should exit with an error.\n3. Set `HERMES_SNAPSHOT_SECRET` and run on a snapshot with a valid HMAC — should pass verification and proceed.\n\nFixes PICKLE-001.