### PR TITLE
fix(gateway): restart through launchd supervision

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10202,6 +10202,33 @@ class GatewayRunner:
             "  /platform resume <name> — re-queue a paused platform"
         )
 
+    def _running_under_launchd_service(self) -> bool:
+        """Return True when this gateway PID is supervised by launchd."""
+        if sys.platform != "darwin":
+            return False
+        try:
+            import subprocess
+            from hermes_cli.gateway import get_launchd_label
+
+            label = get_launchd_label()
+            result = subprocess.run(
+                ["launchctl", "list", label],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except Exception:
+            return False
+        if result.returncode != 0:
+            return False
+        current_pid = os.getpid()
+        output = result.stdout or ""
+        if re.search(rf'"PID"\s*=\s*{current_pid}\b', output):
+            return True
+        if re.search(rf"^{current_pid}\s+", output, flags=re.MULTILINE):
+            return True
+        return False
+
     async def _handle_restart_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /restart command - drain active work, then restart the gateway."""
         # Defensive idempotency check: if the previous gateway process
@@ -10274,7 +10301,12 @@ class GatewayRunner:
         # us.  The detached subprocess approach (setsid + bash) doesn't work
         # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
         # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        _service_manager = os.environ.get("HERMES_GATEWAY_SERVICE_MANAGER", "").strip().lower()
+        _under_service = (
+            bool(os.environ.get("INVOCATION_ID"))
+            or _service_manager in {"systemd", "launchd"}
+            or self._running_under_launchd_service()
+        )
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
         if _under_service or _in_container:
             self.request_restart(detached=False, via_service=True)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -969,6 +969,29 @@ def _probe_launchd_service_running() -> bool:
     return result.returncode == 0
 
 
+def _ensure_launchd_service_loaded() -> bool:
+    """Ensure the macOS launchd job is loaded before self-signalling restarts.
+
+    A gateway-hosted restart is only safe if launchd is actively supervising
+    the current job. If the plist exists but the job was booted out/unloaded,
+    sending SIGUSR1 to the gateway makes it exit with the planned-restart code
+    and nothing is left to bring it back. Bootstrap first so launchd owns the
+    relaunch instead of relying on a fragile detached helper that can be killed
+    with the old gateway process.
+    """
+    plist_path = get_launchd_plist_path()
+    if not plist_path.exists():
+        return False
+    if _probe_launchd_service_running():
+        return True
+    subprocess.run(
+        ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+        check=True,
+        timeout=30,
+    )
+    return True
+
+
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
     """Return a unified view of gateway liveness for the current profile."""
     gateway_pids = tuple(find_gateway_pids())
@@ -2902,6 +2925,8 @@ def generate_launchd_plist() -> str:
         <string>{venv_dir}</string>
         <key>HERMES_HOME</key>
         <string>{hermes_home}</string>
+        <key>HERMES_GATEWAY_SERVICE_MANAGER</key>
+        <string>launchd</string>
     </dict>
     
     <key>RunAtLoad</key>
@@ -3090,10 +3115,13 @@ def launchd_restart():
 
     try:
         pid = get_running_pid()
-        if pid is not None and _request_gateway_self_restart(pid):
-            print("✓ Service restart requested")
-            return
-        if pid is not None:
+        if pid is not None and _ensure_launchd_service_loaded():
+            print(f"⏳ Launchd service restarting gracefully (PID {pid})...")
+            if _graceful_restart_via_sigusr1(pid, drain_timeout + 5):
+                print("✓ Service restart requested")
+                return
+            print(f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart")
+        elif pid is not None:
             try:
                 terminate_pid(pid, force=False)
             except (ProcessLookupError, PermissionError, OSError):

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3118,9 +3118,14 @@ def launchd_restart():
         if pid is not None and _ensure_launchd_service_loaded():
             print(f"⏳ Launchd service restarting gracefully (PID {pid})...")
             if _graceful_restart_via_sigusr1(pid, drain_timeout + 5):
-                print("✓ Service restart requested")
-                return
-            print(f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart")
+                # On this macOS/launchd combination, KeepAlive can leave the
+                # job loaded but not running after the gateway exits with
+                # EX_TEMPFAIL (75). Do not return after the graceful drain;
+                # explicitly kickstart the loaded job so restart is
+                # deterministic instead of relying on launchd's semaphore.
+                print("↻ Graceful drain complete; kickstarting launchd job")
+            else:
+                print(f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart")
         elif pid is not None:
             try:
                 terminate_pid(pid, force=False)

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -84,13 +84,60 @@ async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monk
 
 
 @pytest.mark.asyncio
-async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypatch):
-    """Without systemd, /restart uses the detached subprocess approach."""
+async def test_restart_command_uses_service_restart_under_launchd(tmp_path, monkeypatch):
+    """Under launchd, /restart must use the supervisor instead of a fragile detached helper."""
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.setenv("HERMES_GATEWAY_SERVICE_MANAGER", "launchd")
 
     runner, _adapter = make_restart_runner()
     runner.request_restart = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_service_restart_when_launchd_owns_pid(tmp_path, monkeypatch):
+    """Existing launchd installs without the new env marker still restart through launchd."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_SERVICE_MANAGER", raising=False)
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    runner._running_under_launchd_service = MagicMock(return_value=True)
+
+    source = make_restart_source(chat_id="42")
+    event = MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+    await runner._handle_restart_command(event)
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_command_uses_detached_without_service_manager(tmp_path, monkeypatch):
+    """Without a service manager, /restart uses the detached subprocess approach."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("HERMES_GATEWAY_SERVICE_MANAGER", raising=False)
+
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    runner._running_under_launchd_service = MagicMock(return_value=False)
 
     source = make_restart_source(chat_id="42")
     event = MessageEvent(

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -310,6 +310,42 @@ def test_gateway_restart_on_windows_without_service_uses_detached_backend(monkey
     assert calls == ["restart"]
 
 
+def test_generate_launchd_plist_marks_launchd_service_manager():
+    plist = gateway.generate_launchd_plist()
+
+    assert "<key>HERMES_GATEWAY_SERVICE_MANAGER</key>" in plist
+    assert "<string>launchd</string>" in plist
+
+
+def test_launchd_restart_bootstraps_unloaded_job_before_self_signal(monkeypatch, tmp_path):
+    plist_path = tmp_path / "ai.hermes.gateway.plist"
+    plist_path.write_text("<plist></plist>", encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr(gateway, "refresh_launchd_plist_if_needed", lambda: False)
+    monkeypatch.setattr(gateway, "get_launchd_plist_path", lambda: plist_path)
+    monkeypatch.setattr(gateway, "_probe_launchd_service_running", lambda: False)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 4242)
+    monkeypatch.setattr(gateway, "_get_restart_drain_timeout", lambda: 30.0)
+    monkeypatch.setattr(
+        gateway,
+        "_graceful_restart_via_sigusr1",
+        lambda pid, timeout: calls.append(("sigusr1_restart", pid, timeout)) or True,
+    )
+
+    def fake_run(cmd, **kwargs):
+        calls.append(("run", cmd, kwargs))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    gateway.launchd_restart()
+
+    assert calls[0][0] == "run"
+    assert calls[0][1][:2] == ["launchctl", "bootstrap"]
+    assert calls[1] == ("sigusr1_restart", 4242, 35.0)
+
+
 def test_gateway_restart_on_windows_preserves_failure_fallback(monkeypatch):
     """If the Windows backend cannot launch, keep the existing fallback."""
     import hermes_cli.gateway_windows as gateway_windows

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -344,6 +344,8 @@ def test_launchd_restart_bootstraps_unloaded_job_before_self_signal(monkeypatch,
     assert calls[0][0] == "run"
     assert calls[0][1][:2] == ["launchctl", "bootstrap"]
     assert calls[1] == ("sigusr1_restart", 4242, 35.0)
+    assert calls[2][0] == "run"
+    assert calls[2][1] == ["launchctl", "kickstart", "-k", "gui/501/ai.hermes.gateway"]
 
 
 def test_gateway_restart_on_windows_preserves_failure_fallback(monkeypatch):


### PR DESCRIPTION
## Summary
- Restart the macOS gateway through launchd supervision instead of ad-hoc process replacement
- Add a kickstart path after graceful restart so launchd-backed gateways come back reliably
- Cover restart notification and CLI gateway behavior with tests

## Test Plan
- `python -m pytest -q tests/gateway/test_restart_notification.py tests/hermes_cli/test_gateway.py` → 62 passed
- `gitleaks git --redact=100 --log-opts='origin/main..HEAD'` → 0 findings