### PR TITLE
fix(gateway): sandbox file:// URLs and add SSRF guard in WeCom platform

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1415,6 +1415,14 @@ class WeComAdapter(BasePlatformAdapter):
     ) -> SendResult:
         del metadata
 
+        # SSRF protection: validate URL before passing to _send_media_source
+        if self._looks_like_url(image_url):
+            from tools.url_safety import is_safe_url
+
+            if not is_safe_url(image_url):
+                logger.warning("[%s] Blocked unsafe image URL (SSRF): %s", self.name, image_url[:80])
+                return SendResult(success=False, error=f"Blocked unsafe URL (SSRF protection): {image_url[:80]}")
+
         result = await self._send_media_source(
             chat_id=chat_id,
             media_source=image_url,

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1132,6 +1132,15 @@ class WeComAdapter(BasePlatformAdapter):
 
         if not local_path.is_absolute():
             local_path = (Path.cwd() / local_path).resolve()
+        else:
+            local_path = local_path.resolve()
+
+        # Security: enforce root-directory containment to prevent path traversal
+        # via file:// URLs (e.g. file:///etc/passwd) or symlink tricks
+        try:
+            local_path.relative_to(Path.home())
+        except ValueError:
+            raise ValueError(f"Access denied: path escapes allowed sandbox: {local_path}")
 
         if not local_path.exists() or not local_path.is_file():
             raise FileNotFoundError(f"Media file not found: {local_path}")


### PR DESCRIPTION
## Summary\n\nFixes two vulnerabilities in the WeCom platform:\n\n- **PATH-001**:  accepted  URLs and passed the decoded path directly to  without root-directory containment check, allowing arbitrary file read from the server filesystem\n- **SSRF-003**:  passed user-controlled  to  without SSRF validation at the entry point\n\n---\n\n## Changes\n\n**File:** \n\n1.  (~line 1128): Added root-directory containment check after  + , verifies the resolved path is under an allowed base before reading\n\n2.  (~line 1399): Added  check before calling , blocking dangerous URLs (internal/cloud metadata endpoints) at the entry point\n\nBoth fixes use the existing security utilities already present in the codebase ( sandbox and  from )