### PR TITLE
fix(supermemory): read API key from .env via get_env_value()

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -18,6 +18,18 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
+
+
+def _get_env(key: str, default: str = "") -> str:
+    """Read env var from Hermes .env file first, then os.environ."""
+    try:
+        from hermes_cli.config import get_env_value
+        val = (get_env_value(key) or "").strip()
+        if val:
+            return val
+    except Exception:
+        pass
+    return os.environ.get(key, default)
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
@@ -452,7 +464,7 @@ class SupermemoryMemoryProvider(MemoryProvider):
         return "supermemory"
 
     def is_available(self) -> bool:
-        api_key = os.environ.get("SUPERMEMORY_API_KEY", "")
+        api_key = _get_env("SUPERMEMORY_API_KEY", "")
         if not api_key:
             return False
         try:
@@ -483,11 +495,11 @@ class SupermemoryMemoryProvider(MemoryProvider):
         self._session_id = session_id
         self._turn_count = 0
         self._config = _load_supermemory_config(self._hermes_home)
-        self._api_key = os.environ.get("SUPERMEMORY_API_KEY", "")
+        self._api_key = _get_env("SUPERMEMORY_API_KEY", "")
 
         # Resolve container tag: env var > config > default.
         # Supports {identity} template for profile-scoped containers.
-        env_tag = os.environ.get("SUPERMEMORY_CONTAINER_TAG", "").strip()
+        env_tag = _get_env("SUPERMEMORY_CONTAINER_TAG", "").strip()
         raw_tag = env_tag or self._config["container_tag"]
         identity = kwargs.get("agent_identity", "default")
         self._container_tag = _sanitize_tag(raw_tag.replace("{identity}", identity))


### PR DESCRIPTION
## Problem

The supermemory plugin's `is_available()` and `activate()` methods use `os.environ.get("SUPERMEMORY_API_KEY")` to find the API key. However, Hermes stores API keys in `~/.hermes/.env` and reads them via `hermes_cli.config.get_env_value()`.

When the bridge runs as a worker process (default for Web UI sessions), `_profile_env()` skips loading `.env` into `os.environ`:

```python
def _profile_env(profile):
    if _worker_profile():
        yield        # skips .env loading
        return
```

This causes `is_available()` to return `False` and the 4 supermemory tools to never register.

## Fix

Add a `_get_env()` helper that reads from Hermes's `.env` file first, then falls back to `os.environ`:

```python
def _get_env(key: str, default: str = "") -> str:
    try:
        from hermes_cli.config import get_env_value
        val = (get_env_value(key) or "").strip()
        if val:
            return val
    except Exception:
        pass
    return os.environ.get(key, default)
```

Replace 3 occurrences of `os.environ.get()` with `_get_env()`:
- `is_available()` 
- `activate()` - API key
- `activate()` - container tag

## Testing

Verified plugin reports `available: True` even when `SUPERMEMORY_API_KEY` is not in `os.environ` but is present in `~/.hermes/.env`.
