### PR TITLE
fix(tui): dispatch slash completions on Enter instead of inserting

### DIFF
--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -367,7 +367,17 @@ export function useSubmission(opts: UseSubmissionOptions) {
           const text = value.startsWith('/') && row.text.startsWith('/') ? row.text.slice(1) : row.text
           const next = value.slice(0, composerState.compReplace) + text
 
-          if (next !== value) {
+          // Completion differs from current input in a meaningful way
+          // (not just trailing whitespace from SlashCommandCompleter).
+          if (next !== value && next.trimEnd() !== value) {
+            // For slash commands: dispatch the completed command directly
+            // instead of just inserting it — the user selected it from the
+            // popup, so one Enter should be enough.
+            if (looksLikeSlashCommand(next)) {
+              composerActions.clearIn()
+              return dispatchSubmission([...composerState.inputBuf, next].join('\n'))
+            }
+
             return composerActions.setInput(next)
           }
         }


### PR DESCRIPTION
## Summary

Fixes TUI regression where slash commands required multiple Enter presses to execute. Two changes to the submit handler's completion logic in `useSubmission.ts`:

1. **Trailing-whitespace exact matches**: `SlashCommandCompleter._completion_text()` appends a trailing space to exact-match completions so prompt_toolkit keeps the dropdown visible. The `trimEnd()` check now recognises these as no-ops, so `/help` + Enter submits immediately instead of becoming `/help `.

2. **Partial slash matches dispatch directly**: For completions that differ from input (e.g. `/sta` → `/status`), the completed command is dispatched via `dispatchSubmission()` instead of just inserted into the input field. One Enter is enough.

Non-slash completions (`@file`, `./path`, `~/path`) keep existing `setInput()` behaviour.

## Reproduction

1. `hermes --tui`
2. Type `/sta` → completions show `/status`
3. Press Enter

**Before**: input becomes `/status`, need another Enter to submit
**After**: `/status` executes immediately

## Related

- Fixes #23919
- Supersedes #23939 (broader fix: handles both exact match trailing space AND partial match direct dispatch)
- Regression from 4b0686f (`fix(tui): apply path/@ completion on Enter`)
- Also resolves the `/model` trailing space issue from #13621
