### PR TITLE
fix(docker): skip unnecessary boot chown when volume ownership already matches remapped UID

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -120,9 +120,7 @@ done
 # mkdir -p block below seeds. Keep them in sync if the seed list changes.
 actual_hermes_uid=$(id -u hermes)
 needs_chown=false
-if [ -n "${HERMES_UID:-}" ] && [ "$HERMES_UID" != "10000" ]; then
-    needs_chown=true
-elif [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
+if [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
     needs_chown=true
 fi
 if [ "$needs_chown" = true ]; then


### PR DESCRIPTION
## What does this PR do?

### Bug Description

When `HERMES_UID`/`PUID` is set to a non-default value, `stage2-hook.sh` runs `chown -R` on all Hermes-managed subdirectories on **every** container start, even though the volume was already chowned to the correct UID on the first boot. On slow storage (SD card, NAS) with large data directories (~38K files), this adds 20+ minutes to every `docker restart`.

### Root Cause

The `needs_chown` condition at line 123 checks `$HERMES_UID != "10000"` — a hardcoded constant — instead of comparing actual filesystem ownership against the hermes user's current UID. Since the usermod block above has already remapped `id -u hermes` to `$HERMES_UID`, `actual_hermes_uid` already reflects the correct target. The hardcoded `"10000"` check always evaluates to `true` whenever `HERMES_UID` is set to any non-default value, causing the full `chown -R` cycle on every boot regardless of actual filesystem state.

### Fix

Remove the two redundant lines and keep only the `stat`-based ownership check:

```diff
 actual_hermes_uid=$(id -u hermes)
 needs_chown=false
-if [ -n "${HERMES_UID:-}" ] && [ "$HERMES_UID" != "10000" ]; then
-    needs_chown=true
-elif [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
+if [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
     needs_chown=true
 fi
```

The original `elif` branch already correctly checks actual ownership. The first branch (`HERMES_UID != "10000"`) was a heuristic that guessed "user set PUID → files probably don't match". The `stat` call answers the real question directly: "do the files actually need fixing?" — making the heuristic both redundant and harmful.

## Related Issue

Fixes #35025 

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Remove the two redundant lines and keep only the `stat`-based ownership check

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run the container with `PUID` set to a non-10000 value, e.g. `-e PUID=1000 -e PGID=1000`
2. First boot: let chown complete (may be slow on first run)
3. `docker restart <container>`
4. Verify: `docker logs <container>` shows **no** `[stage2] Fixing ownership of /opt/data` line
5. Verify: container reaches ready state in seconds, not minutes

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform:  Raspberry Pi 4B (aarch64, Debian trixie, Docker overlay2)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or **N/A**
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or **N/A**
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or **N/A**
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or **N/A**
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or **N/A**


