### PR TITLE
fix(agent): resolve agent cwd from TERMINAL_CWD via one reader (closes #24882, #24969, #27383)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
 from typing import Optional
 
+from agent.runtime_cwd import resolve_agent_cwd
 from agent.skill_utils import (
     extract_skill_conditions,
     extract_skill_description,
@@ -802,7 +803,7 @@ def build_environment_hints() -> str:
 
         host_lines.append(f"User home directory: {os.path.expanduser('~')}")
         try:
-            host_lines.append(f"Current working directory: {os.getcwd()}")
+            host_lines.append(f"Current working directory: {resolve_agent_cwd()}")
         except OSError:
             pass
 

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -25,7 +25,9 @@ def resolve_agent_cwd() -> Path:
 
 
 def resolve_context_cwd() -> Path | None:
-    # None is load-bearing: it signals "skip context-file discovery" so the
-    # gateway install dir's AGENTS.md isn't slurped (see system_prompt.py).
+    # None means "no configured cwd": build_context_files_prompt then falls back
+    # to the launch dir (os.getcwd()) — correct for the local CLI. The gateway
+    # avoids slurping its install dir by setting TERMINAL_CWD (see system_prompt.py).
+    # No getcwd arm here: that fallback is owned by the caller, not this resolver.
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     return Path(raw).expanduser() if raw else None

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -1,0 +1,31 @@
+"""Single source of truth for the agent working directory.
+
+`TERMINAL_CWD` is the runtime carrier for the configured working directory
+(design #19214/#19242: `terminal.cwd` is bridged once to `TERMINAL_CWD` at
+gateway/cron startup). The local-CLI backend deliberately leaves it unset and
+relies on the launch dir. Reading it in one place keeps the system prompt, the
+tool surfaces, and context-file discovery agreeing on where the agent lives.
+
+The #29531 per-session extension point is this function: a future PR adds a
+contextvar arm inside `resolve_agent_cwd` and `.set()`s it at the
+`set_session_vars` seam — by design, not a reopening hazard.
+"""
+
+import os
+from pathlib import Path
+
+
+def resolve_agent_cwd() -> Path:
+    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    if raw:
+        p = Path(raw).expanduser()
+        if p.is_dir():
+            return p
+    return Path(os.getcwd())
+
+
+def resolve_context_cwd() -> Path | None:
+    # None is load-bearing: it signals "skip context-file discovery" so the
+    # gateway install dir's AGENTS.md isn't slurped (see system_prompt.py).
+    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    return Path(raw).expanduser() if raw else None

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -24,7 +24,6 @@ Pure helpers that read the agent's state.  AIAgent keeps thin forwarders.
 from __future__ import annotations
 
 import json
-import os
 from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
@@ -41,6 +40,7 @@ from agent.prompt_builder import (
     TOOL_USE_ENFORCEMENT_GUIDANCE,
     TOOL_USE_ENFORCEMENT_MODELS,
 )
+from agent.runtime_cwd import resolve_context_cwd
 
 
 def _ra():
@@ -288,13 +288,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         context_parts.append(system_message)
 
     if not agent.skip_context_files:
-        # Use TERMINAL_CWD for context file discovery when set (gateway
-        # mode).  The gateway process runs from the hermes-agent install
-        # dir, so os.getcwd() would pick up the repo's AGENTS.md and
-        # other dev files — inflating token usage by ~10k for no benefit.
-        _context_cwd = os.getenv("TERMINAL_CWD") or None
+        # Prefer the configured TERMINAL_CWD (gateway mode). When unset (local
+        # CLI), None lets build_context_files_prompt fall back to the launch
+        # dir — the user's real cwd there, but the install dir for the gateway
+        # daemon, which is why the gateway sets TERMINAL_CWD.
         context_files_prompt = _r.build_context_files_prompt(
-            cwd=_context_cwd, skip_soul=_soul_loaded)
+            cwd=resolve_context_cwd(), skip_soul=_soul_loaded)
         if context_files_prompt:
             context_parts.append(context_files_prompt)
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -3,6 +3,7 @@
 import builtins
 import importlib
 import logging
+import os
 import sys
 
 import pytest
@@ -18,6 +19,7 @@ from agent.prompt_builder import (
     build_skills_system_prompt,
     build_nous_subscription_prompt,
     build_context_files_prompt,
+    build_environment_hints,
     CONTEXT_FILE_MAX_CHARS,
     DEFAULT_AGENT_IDENTITY,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
@@ -1248,3 +1250,25 @@ class TestOpenAIModelExecutionGuidance:
 
 
 
+
+
+class TestBuildEnvironmentHints:
+    """The cwd line must reflect the configured TERMINAL_CWD, not the daemon launch dir.
+
+    Regression for the gateway working-directory cluster (#24882, #24969, #27383, #29265):
+    gateway/cron set TERMINAL_CWD, but build_environment_hints emitted os.getcwd() — telling
+    the model the wrong directory.
+    """
+
+    def test_uses_terminal_cwd_when_set(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        monkeypatch.chdir(os.path.expanduser("~"))
+        assert f"Current working directory: {tmp_path}" in build_environment_hints()
+
+    def test_falls_back_to_launch_dir_when_unset(self, monkeypatch, tmp_path):
+        # The #19242 local-CLI contract: no TERMINAL_CWD → the launch dir.
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.chdir(tmp_path)
+        assert f"Current working directory: {tmp_path}" in build_environment_hints()

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -3,7 +3,6 @@
 import builtins
 import importlib
 import logging
-import os
 import sys
 
 import pytest
@@ -19,7 +18,6 @@ from agent.prompt_builder import (
     build_skills_system_prompt,
     build_nous_subscription_prompt,
     build_context_files_prompt,
-    build_environment_hints,
     CONTEXT_FILE_MAX_CHARS,
     DEFAULT_AGENT_IDENTITY,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
@@ -929,6 +927,29 @@ class TestEnvironmentHints:
         assert "Terminal backend: docker" in result
         assert "inside" in result.lower()
 
+    def test_build_environment_hints_uses_terminal_cwd_over_launch_dir(self, monkeypatch, tmp_path):
+        """THE BUG: gateway/cron set TERMINAL_CWD but the prompt emitted os.getcwd()
+        (the daemon launch dir). Regression for #24882/#24969/#27383/#29265."""
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        configured = tmp_path / "workspace"
+        configured.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(configured))
+        monkeypatch.chdir(tmp_path)
+        _pb._clear_backend_probe_cache()
+        assert f"Current working directory: {configured}" in _pb.build_environment_hints()
+
+    def test_build_environment_hints_falls_back_to_launch_dir(self, monkeypatch, tmp_path):
+        """The #19242 local-CLI contract: no TERMINAL_CWD → the launch dir."""
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.chdir(tmp_path)
+        _pb._clear_backend_probe_cache()
+        assert f"Current working directory: {tmp_path}" in _pb.build_environment_hints()
+
     def test_build_environment_hints_uses_live_probe_when_available(self, monkeypatch):
         """When the probe succeeds, its output must appear in the hint block."""
         import agent.prompt_builder as _pb
@@ -1249,26 +1270,3 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 
 
-
-
-
-class TestBuildEnvironmentHints:
-    """The cwd line must reflect the configured TERMINAL_CWD, not the daemon launch dir.
-
-    Regression for the gateway working-directory cluster (#24882, #24969, #27383, #29265):
-    gateway/cron set TERMINAL_CWD, but build_environment_hints emitted os.getcwd() — telling
-    the model the wrong directory.
-    """
-
-    def test_uses_terminal_cwd_when_set(self, monkeypatch, tmp_path):
-        monkeypatch.delenv("TERMINAL_ENV", raising=False)
-        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
-        monkeypatch.chdir(os.path.expanduser("~"))
-        assert f"Current working directory: {tmp_path}" in build_environment_hints()
-
-    def test_falls_back_to_launch_dir_when_unset(self, monkeypatch, tmp_path):
-        # The #19242 local-CLI contract: no TERMINAL_CWD → the launch dir.
-        monkeypatch.delenv("TERMINAL_ENV", raising=False)
-        monkeypatch.delenv("TERMINAL_CWD", raising=False)
-        monkeypatch.chdir(tmp_path)
-        assert f"Current working directory: {tmp_path}" in build_environment_hints()

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -38,3 +38,14 @@ class TestResolveContextCwd:
         # (don't slurp the gateway install dir's AGENTS.md).
         monkeypatch.delenv("TERMINAL_CWD", raising=False)
         assert resolve_context_cwd() is None
+
+    def test_returns_nonexistent_dir_unguarded(self, monkeypatch, tmp_path):
+        # Deliberate asymmetry vs resolve_agent_cwd: context discovery has no isdir
+        # guard, so a missing dir is returned (not None) — discovery just finds nothing.
+        missing = tmp_path / "gone"
+        monkeypatch.setenv("TERMINAL_CWD", str(missing))
+        assert resolve_context_cwd() == missing
+
+    def test_expands_leading_tilde(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", "~")
+        assert resolve_context_cwd() == Path(os.path.expanduser("~"))

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -34,8 +34,8 @@ class TestResolveContextCwd:
         assert resolve_context_cwd() == tmp_path
 
     def test_returns_none_when_unset(self, monkeypatch):
-        # None is load-bearing: it tells the caller to skip context-file discovery
-        # (don't slurp the gateway install dir's AGENTS.md).
+        # Unset → None; the caller (build_context_files_prompt) then getcwds —
+        # the local-CLI #19242 contract. Discovery still runs; it is NOT skipped.
         monkeypatch.delenv("TERMINAL_CWD", raising=False)
         assert resolve_context_cwd() is None
 

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -1,0 +1,40 @@
+"""Tests for agent/runtime_cwd.py — the single source of truth for the agent working directory."""
+
+import os
+from pathlib import Path
+
+from agent.runtime_cwd import resolve_agent_cwd, resolve_context_cwd
+
+
+class TestResolveAgentCwd:
+    def test_prefers_terminal_cwd_over_getcwd(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        monkeypatch.chdir(os.path.expanduser("~"))
+        assert resolve_agent_cwd() == tmp_path
+
+    def test_falls_back_to_getcwd_when_unset(self, monkeypatch, tmp_path):
+        # The #19242 local-CLI contract: TERMINAL_CWD is unset, so the launch dir wins.
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.chdir(tmp_path)
+        assert resolve_agent_cwd() == tmp_path
+
+    def test_skips_nonexistent_terminal_cwd(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path / "gone"))
+        monkeypatch.chdir(tmp_path)
+        assert resolve_agent_cwd() == tmp_path
+
+    def test_expands_leading_tilde(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", "~")
+        assert resolve_agent_cwd() == Path(os.path.expanduser("~"))
+
+
+class TestResolveContextCwd:
+    def test_returns_dir_when_set(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        assert resolve_context_cwd() == tmp_path
+
+    def test_returns_none_when_unset(self, monkeypatch):
+        # None is load-bearing: it tells the caller to skip context-file discovery
+        # (don't slurp the gateway install dir's AGENTS.md).
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        assert resolve_context_cwd() is None

--- a/tests/agent/test_runtime_cwd.py
+++ b/tests/agent/test_runtime_cwd.py
@@ -3,7 +3,14 @@
 import os
 from pathlib import Path
 
+import pytest
+
+import agent.runtime_cwd as rt
 from agent.runtime_cwd import resolve_agent_cwd, resolve_context_cwd
+
+
+def _raise_oserror(*args, **kwargs):
+    raise OSError("cwd gone")
 
 
 class TestResolveAgentCwd:
@@ -27,6 +34,21 @@ class TestResolveAgentCwd:
         monkeypatch.setenv("TERMINAL_CWD", "~")
         assert resolve_agent_cwd() == Path(os.path.expanduser("~"))
 
+    def test_whitespace_only_terminal_cwd_falls_back_to_getcwd(self, monkeypatch, tmp_path):
+        # "   ".strip() → "" → falsy, so the launch dir wins (not a "   " path).
+        monkeypatch.setenv("TERMINAL_CWD", "   ")
+        monkeypatch.chdir(tmp_path)
+        assert resolve_agent_cwd() == tmp_path
+
+    def test_propagates_oserror_from_getcwd(self, monkeypatch):
+        # The fallback arm calls os.getcwd(), which can raise OSError (deleted cwd).
+        # The resolver must NOT swallow it — build_environment_hints owns the
+        # try/except OSError guard at the call site (prompt_builder.py:805).
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        monkeypatch.setattr(rt.os, "getcwd", _raise_oserror)
+        with pytest.raises(OSError):
+            resolve_agent_cwd()
+
 
 class TestResolveContextCwd:
     def test_returns_dir_when_set(self, monkeypatch, tmp_path):
@@ -49,3 +71,9 @@ class TestResolveContextCwd:
     def test_expands_leading_tilde(self, monkeypatch):
         monkeypatch.setenv("TERMINAL_CWD", "~")
         assert resolve_context_cwd() == Path(os.path.expanduser("~"))
+
+    def test_whitespace_only_terminal_cwd_returns_none(self, monkeypatch):
+        # "   ".strip() → "" → None, so the caller getcwds for discovery rather
+        # than building Path("   ") and resolving garbage under the launch dir.
+        monkeypatch.setenv("TERMINAL_CWD", "   ")
+        assert resolve_context_cwd() is None

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -1,0 +1,57 @@
+"""Tests for agent/system_prompt.py — context-file cwd wiring."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.system_prompt import build_system_prompt_parts
+
+
+def _make_agent(**overrides):
+    base = dict(
+        load_soul_identity=False,
+        skip_context_files=False,
+        valid_tool_names=[],
+        _task_completion_guidance=False,
+        _tool_use_enforcement=False,
+        _environment_probe=False,
+        _kanban_worker_guidance="",
+        _memory_store=None,
+        _memory_manager=None,
+        model="",
+        provider="",
+        platform="",
+        pass_session_id=False,
+        session_id="",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _captured_context_cwd(agent):
+    """The cwd build_system_prompt_parts hands to build_context_files_prompt."""
+    captured = {}
+
+    def fake_context_files(cwd=None, skip_soul=False):
+        captured["cwd"] = cwd
+        return ""
+
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", side_effect=fake_context_files),
+    ):
+        build_system_prompt_parts(agent)
+    return captured["cwd"]
+
+
+class TestContextFileCwd:
+    def test_none_when_terminal_cwd_unset(self, monkeypatch):
+        # Unset → None, so discovery falls back to the launch dir inside
+        # build_context_files_prompt (the local-CLI #19242 contract).
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        assert _captured_context_cwd(_make_agent()) is None
+
+    def test_configured_dir_when_terminal_cwd_set(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        assert _captured_context_cwd(_make_agent()) == tmp_path

--- a/tests/tools/test_gateway_cwd_contract.py
+++ b/tests/tools/test_gateway_cwd_contract.py
@@ -1,0 +1,69 @@
+"""Tool-surface cwd contract tests for gateway workspaces.
+
+These cover the platform-neutral part of #29265: once the gateway has resolved
+``TERMINAL_CWD``, the user-visible tool surfaces should agree on that workspace.
+
+Unlike the system-prompt readers fixed in the gateway-cwd-resolver cluster
+(agent/runtime_cwd.py), these tool sites already read ``TERMINAL_CWD``-first and
+were deliberately left out of scope. This file is a *characterization* guard: it
+pins the already-correct behavior so the supersession of PR #29365 is airtight
+and a future refactor of these sites can't silently regress the contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools import code_execution_tool, file_tools, terminal_tool
+
+
+def test_terminal_env_config_uses_terminal_cwd(monkeypatch, tmp_path):
+    """The terminal tool's default cwd should come from TERMINAL_CWD."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+
+    config = terminal_tool._get_env_config()
+
+    assert config["cwd"] == str(workspace)
+
+
+def test_file_tool_relative_paths_use_terminal_cwd(monkeypatch, tmp_path):
+    """Relative file/search/patch paths resolve under TERMINAL_CWD."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+
+    resolved = file_tools._resolve_path_for_task("notes/today.md", task_id="cwd-contract")
+
+    assert resolved == (workspace / "notes" / "today.md").resolve()
+
+
+def test_execute_code_project_mode_uses_terminal_cwd(monkeypatch, tmp_path):
+    """Project-mode execute_code should run scripts from TERMINAL_CWD."""
+    workspace = tmp_path / "workspace"
+    staging = tmp_path / "staging"
+    workspace.mkdir()
+    staging.mkdir()
+
+    monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+
+    resolved = code_execution_tool._resolve_child_cwd("project", str(staging))
+
+    assert Path(resolved) == workspace
+
+
+def test_execute_code_project_mode_falls_back_when_terminal_cwd_missing(monkeypatch, tmp_path):
+    """Invalid TERMINAL_CWD should not break execute_code project mode startup."""
+    staging = tmp_path / "staging"
+    staging.mkdir()
+
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path / "missing"))
+
+    resolved = code_execution_tool._resolve_child_cwd("project", str(staging))
+
+    assert Path(resolved).is_dir()
+    assert Path(resolved) != tmp_path / "missing"


### PR DESCRIPTION
## Problem

The agent reports — and `cd`s to — the **daemon launch directory** (the hermes-agent install dir) instead of the configured `terminal.cwd` / `TERMINAL_CWD`, so the model ends up working in the wrong place. This bit gateway, cron, and Telegram sessions.

- **Root cause:** `build_environment_hints()` emitted `Current working directory: {os.getcwd()}` (`agent/prompt_builder.py:805`), ignoring `TERMINAL_CWD` entirely.
- **Secondary site:** context-file discovery read `TERMINAL_CWD` ad-hoc (`os.getenv("TERMINAL_CWD") or None`) in `agent/system_prompt.py`, duplicating the cwd-resolution decision so the two prompt tiers could disagree.

This is a reader-only correctness bug — not a config, transport, or service-manager bug.

## Fix

One reader resolver as the single source of truth, with the two prompt-tier read sites routed through it.

- **New `agent/runtime_cwd.py`** centralizes both reads. The docstring records the design lineage (#19214 / #19242: `terminal.cwd` is bridged once to `TERMINAL_CWD` at gateway/cron startup; local-CLI deliberately leaves it unset) and the documented future seam #29531 (per-session `contextvar`) — nothing speculative is pre-built.
- **`agent/prompt_builder.py:806`** — `os.getcwd()` → `resolve_agent_cwd()` for the "Current working directory:" display line. *This is the bug.*
- **`agent/system_prompt.py`** — context-file discovery → `resolve_context_cwd()`; drops the now-dead `import os`.

**Two intentionally asymmetric resolvers:**

| Resolver | Returns | Logic | Why |
|---|---|---|---|
| `resolve_agent_cwd()` | `Path` | strip + `expanduser` + `is_dir()` guard + `os.getcwd()` fallback | A human-facing display line must degrade to the real launch dir, never show a bogus path. |
| `resolve_context_cwd()` | `Path \| None` | strip + `expanduser`, **no** isdir guard, **no** getcwd arm | `None` = unset → the caller (`build_context_files_prompt`) getcwds, so discovery still **runs** (never skipped). A set-but-missing dir is returned as-is → discovery simply finds nothing. The getcwd fallback is owned by the caller here, by the resolver there. |

**Remote backends unchanged:** both fixes sit inside the existing `is_remote_backend` gate (`prompt_builder.py:791`). docker / modal / ssh still suppress the host cwd line and use the live in-backend probe; the probe's cache key (`:694`) intentionally keeps reading `os.getenv`.

**Behavior-preserving:** local-CLI (`TERMINAL_CWD` unset) and remote backends produce output identical to before. The only new behavior is `.strip()` + `expanduser()` — strict improvements (whitespace-only no longer yields a `"   "` path; `~` now expands).

## Design decision: why no gateway re-bridge

The superseded PRs #27488 / #29365 also added a per-turn re-bridge (`_reload_runtime_env_preserving_config_authority` in `gateway/run.py`) that re-reads `terminal.cwd` and re-sets `TERMINAL_CWD` every session. **We deliberately do not adopt it:**

- `TERMINAL_CWD` is set once at gateway/cron startup and is **never deleted** — it persists across `/new`. The re-bridge patches an env loss that does not occur.
- Re-running the bridge re-enters the `.` / `auto` / `cwd` placeholder-clobber zone (refs #10817, #10225).
- The actual "cwd reverts after `/new`" symptom (#27383) was the prompt **reader** re-emitting `os.getcwd()` — fixed here in `resolve_agent_cwd()`, not by rewriting env. This diff contains **no** re-bridge code.

## Linkage

| Ref | Type | Disposition | Why |
|---|---|---|---|
| #24882 | Issue | **Closes** | `terminal.cwd` not injected into the system prompt — fixed at `prompt_builder.py:805`. |
| #24969 | Issue | **Closes** | Cron `--workdir` not reflected in prompt cwd — same read site. |
| #27383 | Issue | **Closes** | Telegram agent wrong working dir — gateway sets `TERMINAL_CWD`, now read correctly. |
| #29265 | Issue | Provenance only (already closed) | The QQBot/Weixin request behind PR #29365; closed, so no auto-close keyword. |
| #24888 | PR | **Supersedes** | Same env-hint fix only; ours is the SSOT superset. |
| #24985 | PR | **Supersedes** | Cron-path variant; subsumed by the single resolver. |
| #27488 | PR | **Supersedes** | Env-hint fix **plus** the session-reset re-bridge we drop. |
| #29365 | PR | **Supersedes** | Gateway-cwd fix **plus** the re-bridge we drop. |
| #11312 | Issue | **Related, not closed** | Service-manager `WorkingDirectory` / `hermes update` env loss — a *different* root cause. |
| #34805 | PR | Related (landed) | Service-unit fix anchoring `WorkingDirectory`; resolves #11312's actual cause, complementary to this PR. |

Closes #24882, closes #24969, closes #27383.

> **Related but out of scope:** #11312 (service-manager environment loss on update) is a distinct root cause and is not addressed here — it is handled separately by the landed service-unit fix #34805.

## Behavior changes & regression analysis

| Aspect | Old | New | Safe? | Test-pinned? |
|---|---|---|---|---|
| Type into `build_context_files_prompt(cwd=)` | `str` / `None` | `Path` / `None` | ✅ callee does `Path(cwd).resolve()`; one prod caller | ✅ `test_system_prompt.py` |
| Whitespace handling | none | `.strip()` | ✅ | ✅ whitespace-only tests (both resolvers) |
| Tilde handling | none | `.expanduser()` | ✅ | ✅ `test_expands_leading_tilde` ×2 |
| `.resolve()` in resolver | n/a | not called (display-only; callee resolves for context) | ✅ intentional | ✅ contract test resolves at call site |
| Local-CLI unset path | getcwd via prompt | identical (agent→getcwd, context→None→callee getcwd) | ✅ #19242 preserved | ✅ fallback tests |
| Remote-backend suppression | TERMINAL_CWD-first | identical | ✅ | ✅ |
| OSError on dead cwd | caught at `:805` | still caught at call site; resolver propagates | ✅ | ✅ `test_propagates_oserror_from_getcwd` |
| `import os` in `system_prompt.py` | present | removed; no orphaned refs | ✅ | grep-verified |

## Scope / out of scope

Deliberately limited to the **2 prompt read sites**. These readers were already `TERMINAL_CWD`-first and are **untouched**: `tools/terminal_tool.py:1039`, `tools/file_tools.py:124`, `agent/tool_executor.py:198/667`, `tools/code_execution_tool.py:1681`, `tools/delegate_tool.py:653`, `agent/agent_init.py:1539`, `gateway/run.py` (the bridge writer), and `prompt_builder.py:694` (remote-probe cache key).

> `tests/tools/test_gateway_cwd_contract.py` is a **characterization fence** over three of those already-correct tool sites (terminal / file / execute_code) — it pins existing behavior to make the #29365 supersession airtight. It is **not** coverage of code changed here.

## Edge cases

- **Whitespace-only `TERMINAL_CWD`** → strip → falsy → agent uses getcwd, context returns `None`.
- **Relative / trailing-slash `TERMINAL_CWD`** → resolver does not `.resolve()`; acceptable because the value is bridged from config and expected absolute.
- **Stale / typo'd `TERMINAL_CWD`** → agent: `is_dir()` fails → getcwd fallback; context: returns the missing dir (no guard) → discovery finds nothing.

## Testing

Touched-area suites pass — **146 passed, 1 skipped**; `ruff` clean on all 7 changed files. Pinned behaviors: whitespace strip · OSError propagation · isdir asymmetry · `None`→getcwd · `~` expansion (both resolvers) · end-to-end hint (set → value, unset → launch dir) · tool-surface contract.

## Infographic

![gateway-reliability-three-fixes](https://v3b.fal.media/files/b/0a9c9d5a/O9pd6WmMTWT83Zv7ZvVta_sMmNoSsQ.png)
