### PR TITLE
fix(gateway): background task completions should auto-deliver bare local files

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12053,6 +12053,8 @@ class GatewayRunner:
                 from gateway.platforms.base import BasePlatformAdapter
                 media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
                 images, text_content = adapter.extract_images(response)
+                local_files, text_content = adapter.extract_local_files(text_content)
+                local_files = BasePlatformAdapter.filter_local_delivery_paths(local_files)
 
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
                 header = f'✅ Background task complete\nPrompt: "{preview}"\n\n'
@@ -12088,6 +12090,16 @@ class GatewayRunner:
                         await adapter.send_document(
                             chat_id=source.chat_id,
                             file_path=media_path,
+                            metadata=_thread_metadata,
+                        )
+                    except Exception:
+                        pass
+
+                for file_path in (local_files or []):
+                    try:
+                        await adapter.send_document(
+                            chat_id=source.chat_id,
+                            file_path=file_path,
                             metadata=_thread_metadata,
                         )
                     except Exception:

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -237,6 +237,7 @@ class TestRunBackgroundTask:
         mock_adapter.send = AsyncMock()
         mock_adapter.extract_media = MagicMock(return_value=([], "Hello from background!"))
         mock_adapter.extract_images = MagicMock(return_value=([], "Hello from background!"))
+        mock_adapter.extract_local_files = MagicMock(return_value=([], "Hello from background!"))
         runner.adapters[Platform.TELEGRAM] = mock_adapter
 
         source = SessionSource(
@@ -268,6 +269,63 @@ class TestRunBackgroundTask:
         mock_agent_instance.close.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_background_task_auto_delivers_bare_local_files(self, tmp_path, monkeypatch):
+        """Background completions should deliver bare local file paths as attachments."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.send_document = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], f"Saved the report to {tmp_path / 'report.md'}"))
+        mock_adapter.extract_images = MagicMock(return_value=([], f"Saved the report to {tmp_path / 'report.md'}"))
+        mock_adapter.extract_local_files = MagicMock(
+            return_value=([str(tmp_path / "report.md")], "Saved the report to")
+        )
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        report_path = tmp_path / "report.md"
+        report_path.write_text("# report\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "0")
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        mock_result = {
+            "final_response": f"Saved the report to {report_path}",
+            "messages": [],
+        }
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            with patch(
+                "gateway.platforms.base.BasePlatformAdapter.filter_local_delivery_paths",
+                return_value=[str(report_path)],
+            ):
+                await runner._run_background_task("write the report", source, "bg_test")
+
+        mock_adapter.send.assert_called_once()
+        content = mock_adapter.send.call_args.kwargs["content"]
+        assert "Background task complete" in content
+        assert str(report_path) not in content
+        mock_adapter.extract_local_files.assert_called_once_with(
+            f"Saved the report to {report_path}"
+        )
+        mock_adapter.send_document.assert_awaited_once_with(
+            chat_id="67890",
+            file_path=str(report_path),
+            metadata=None,
+        )
+
+    @pytest.mark.asyncio
     async def test_telegram_dm_topic_completion_preserves_reply_anchor_metadata(self, monkeypatch):
         """Background completion metadata must let Telegram send thread id plus reply id."""
         from gateway import run as gateway_run
@@ -294,6 +352,7 @@ class TestRunBackgroundTask:
         mock_adapter.send = AsyncMock()
         mock_adapter.extract_media = MagicMock(return_value=([], "done"))
         mock_adapter.extract_images = MagicMock(return_value=([], "done"))
+        mock_adapter.extract_local_files = MagicMock(return_value=([], "done"))
         runner.adapters[Platform.TELEGRAM] = mock_adapter
 
         source = SessionSource(


### PR DESCRIPTION
## Summary

This PR fixes a parity gap in background task completions: bare local file paths in background responses are now auto-delivered as attachments, matching the existing foreground and post-streaming delivery behavior.

The fix extends the background completion extraction chain to include `extract_local_files(...)` after `extract_media(...)` and `extract_images(...)`, and adds a regression test covering bare local file auto-delivery.

Inspired by commit 781604ce4 (`fix(gateway): unify MEDIA: extraction extension set + close the unknown-ext black hole`), which established the shared media-extraction parity expectation across sibling delivery paths.

## Testing

Passed:
- `tests/gateway/test_background_command.py` — `22 passed`
- `tests/gateway/test_extract_local_files.py` — `44 passed`

Additional adjacent coverage run:
- `tests/gateway/test_tts_media_routing.py tests/gateway/test_platform_base.py` — `10 failed, 114 passed, 3 skipped`

Notes on the additional failures:
- The failures were in existing media-routing and path-validation coverage outside this change.
- They do not point to the background bare-local-file fix introduced in this PR.

## Why

Before this change, background completions only processed explicit `MEDIA:` tags and extracted image references. If a background task returned a bare local file path such as `/tmp/report.md`, the file was not delivered as an attachment even though sibling response paths already supported that behavior.

This change restores consistent attachment delivery across those response flows.