### PR TITLE
feat(delegate): per-task model/provider overrides (+ fix two latent delegation bugs)

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2792,6 +2792,32 @@ class TestPerTaskOverrideReachesChild(unittest.TestCase):
         self.assertEqual(seen[0]["model"], "task-A-model")
         self.assertIsNone(seen[1]["model"])
 
+    def test_bad_per_task_provider_fails_whole_batch_before_building_children(self):
+        """A per-task provider that can't resolve aborts the whole call with a
+        tool_error in the up-front pre-pass — no children are built, so the
+        batch never half-runs. The valid sibling task must not be spawned."""
+        parent = _make_mock_parent(depth=0)
+
+        def fake_resolve(cfg, _parent):
+            if cfg.get("provider") == "nonexistent":
+                raise ValueError("Cannot resolve delegation provider 'nonexistent'")
+            return {"model": None, "provider": None, "base_url": None,
+                    "api_key": None, "api_mode": None, "base_url_is_explicit": False}
+
+        with patch("tools.delegate_tool._load_config", return_value={}), \
+             patch("tools.delegate_tool._resolve_delegation_credentials",
+                   side_effect=fake_resolve), \
+             patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            result = json.loads(delegate_task(
+                tasks=[{"goal": "ok"}, {"goal": "bad", "provider": "nonexistent"}],
+                parent_agent=parent))
+
+        self.assertIn("error", result)
+        self.assertIn("nonexistent", result["error"])
+        mock_build.assert_not_called()  # pre-pass aborts before construction
+        mock_run.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2686,5 +2686,45 @@ class TestLoadConfig(unittest.TestCase):
                 self.assertEqual(dt._load_config(), {"model": "x"})
 
 
+class TestExplicitEndpointSkipsPool(unittest.TestCase):
+    def test_explicit_base_url_disables_credential_pool(self):
+        """A child built with an explicit override_base_url must not get a pool,
+        so a later lease/swap can't clobber the configured endpoint."""
+        parent = _make_mock_parent(depth=0)
+        # Pretend a pool WOULD resolve if asked.
+        with patch("tools.delegate_tool._resolve_child_credential_pool",
+                   return_value=object()) as mock_pool:
+            child = _build_child_agent(
+                task_index=0,
+                goal="x",
+                context=None,
+                toolsets=None,
+                model="qwen2.5-coder",
+                max_iterations=5,
+                task_count=1,
+                parent_agent=parent,
+                override_provider="custom",
+                override_base_url="http://localhost:1234/v1",
+                override_api_key="local-key",
+                override_api_mode="chat_completions",
+            )
+        self.assertIsNone(getattr(child, "_credential_pool", None))
+        mock_pool.assert_not_called()
+
+    def test_no_override_base_url_still_attaches_pool(self):
+        """Regression: without an explicit endpoint, pool attachment is unchanged."""
+        parent = _make_mock_parent(depth=0)
+        sentinel = object()
+        with patch("tools.delegate_tool._resolve_child_credential_pool",
+                   return_value=sentinel):
+            child = _build_child_agent(
+                task_index=0, goal="x", context=None, toolsets=None,
+                model=None, max_iterations=5, task_count=1, parent_agent=parent,
+                override_provider=None, override_base_url=None,
+                override_api_key=None, override_api_mode=None,
+            )
+        self.assertIs(getattr(child, "_credential_pool", None), sentinel)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2726,5 +2726,73 @@ class TestExplicitEndpointSkipsPool(unittest.TestCase):
         self.assertIs(getattr(child, "_credential_pool", None), sentinel)
 
 
+class TestPerTaskCredentialResolution(unittest.TestCase):
+    def test_no_override_returns_batch_creds_identity(self):
+        from tools.delegate_tool import _resolve_task_credentials
+        parent = _make_mock_parent(depth=0)
+        batch = {"model": "m", "provider": None, "base_url": None,
+                 "api_key": None, "api_mode": None}
+        out = _resolve_task_credentials({"goal": "x"}, {}, batch, parent)
+        self.assertIs(out, batch)  # untouched when no per-task fields
+
+    def test_per_task_model_only_keeps_config_provider(self):
+        from tools.delegate_tool import _resolve_task_credentials
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "cfg-model", "base_url": "http://localhost:1234/v1"}
+        batch = _resolve_delegation_credentials(cfg, parent)
+        out = _resolve_task_credentials({"goal": "x", "model": "task-model"},
+                                        cfg, batch, parent)
+        self.assertEqual(out["model"], "task-model")
+        self.assertEqual(out["base_url"], "http://localhost:1234/v1")  # config endpoint kept
+
+    def test_per_task_provider_redirects_endpoint(self):
+        from tools.delegate_tool import _resolve_task_credentials
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "cfg-model", "base_url": "http://localhost:1234/v1",
+               "api_key": "local-key"}
+        batch = _resolve_delegation_credentials(cfg, parent)
+        # Switching provider per task must drop the config base_url and re-resolve.
+        # Stub the resolver (don't call through — provider resolution needs live
+        # credentials); we only assert on the cfg it receives.
+        with patch("tools.delegate_tool._resolve_delegation_credentials",
+                   return_value={"model": "cfg-model", "provider": "openrouter",
+                                 "base_url": "https://openrouter.ai/api/v1",
+                                 "api_key": "k", "api_mode": "chat_completions"}) as spy:
+            _resolve_task_credentials({"goal": "x", "provider": "openrouter"},
+                                      cfg, batch, parent)
+        passed_cfg = spy.call_args.args[0]
+        self.assertEqual(passed_cfg["provider"], "openrouter")
+        self.assertNotIn("base_url", passed_cfg)  # config endpoint dropped
+        self.assertNotIn("api_key", passed_cfg)
+
+
+class TestPerTaskOverrideReachesChild(unittest.TestCase):
+    def test_per_task_model_threads_into_build_loop(self):
+        """Per-task model must be the model _build_child_agent receives."""
+        parent = _make_mock_parent(depth=0)
+        seen = []
+
+        def _stub_build(**kw):
+            seen.append(kw)
+            return MagicMock()
+
+        with patch("tools.delegate_tool._load_config", return_value={}), \
+             patch("tools.delegate_tool._build_child_agent",
+                   side_effect=_stub_build), \
+             patch("tools.delegate_tool._run_single_child",
+                   return_value={"task_index": 0, "status": "completed",
+                                 "summary": "ok", "api_calls": 1,
+                                 "duration_seconds": 0.1}):
+            delegate_task(
+                tasks=[{"goal": "a", "model": "task-A-model"},
+                       {"goal": "b"}],
+                parent_agent=parent,
+            )
+        self.assertEqual(seen[0]["model"], "task-A-model")
+        # inherit is signaled by None AT THE CALL BOUNDARY (parent-model
+        # fallback happens inside the patched-out _build_child_agent).
+        self.assertIsNone(seen[1]["model"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2687,8 +2687,8 @@ class TestLoadConfig(unittest.TestCase):
 
 class TestExplicitEndpointSkipsPool(unittest.TestCase):
     def test_explicit_base_url_disables_credential_pool(self):
-        """An explicit override_base_url must skip the pool so a later lease/swap
-        can't clobber the configured endpoint."""
+        """A LITERAL config endpoint (override_base_url_explicit) must skip the
+        pool so a later lease/swap can't clobber the configured endpoint."""
         parent = _make_mock_parent(depth=0)
         with patch("tools.delegate_tool._resolve_child_credential_pool",
                    return_value=object()) as mock_pool:
@@ -2696,10 +2696,29 @@ class TestExplicitEndpointSkipsPool(unittest.TestCase):
                 task_index=0, goal="x", context=None, toolsets=None,
                 model="qwen2.5-coder", max_iterations=5, task_count=1, parent_agent=parent,
                 override_provider="custom", override_base_url="http://localhost:1234/v1",
+                override_base_url_explicit=True,
                 override_api_key="local-key", override_api_mode="chat_completions",
             )
         self.assertIsNone(getattr(child, "_credential_pool", None))
         mock_pool.assert_not_called()  # skipped without even resolving a pool
+
+    def test_provider_resolved_base_url_still_attaches_pool(self):
+        """Regression guard for the over-broad skip: a provider-RESOLVED base_url
+        (delegation.provider, base_url_is_explicit=False) must KEEP its pool so
+        delegated providers retain same-provider key rotation. Even with a
+        populated override_base_url, the pool is attached when not explicit."""
+        parent = _make_mock_parent(depth=0)
+        sentinel = object()
+        with patch("tools.delegate_tool._resolve_child_credential_pool", return_value=sentinel):
+            child = _build_child_agent(
+                task_index=0, goal="x", context=None, toolsets=None,
+                model="some-model", max_iterations=5, task_count=1, parent_agent=parent,
+                override_provider="openrouter",
+                override_base_url="https://openrouter.ai/api/v1",
+                override_base_url_explicit=False,
+                override_api_key="or-key", override_api_mode="chat_completions",
+            )
+        self.assertIs(getattr(child, "_credential_pool", None), sentinel)
 
     def test_no_override_base_url_still_attaches_pool(self):
         """Regression: without an explicit endpoint, pool attachment is unchanged."""
@@ -2744,6 +2763,17 @@ class TestPerTaskCredentialResolution(unittest.TestCase):
         self.assertEqual(resolved_cfg["provider"], "openrouter")
         self.assertNotIn("base_url", resolved_cfg)
         self.assertNotIn("api_key", resolved_cfg)
+
+    def test_literal_base_url_is_flagged_explicit(self):
+        """A literal delegation.base_url is tagged base_url_is_explicit so the
+        pool guard skips it; the inherit branch is flagged non-explicit."""
+        parent = _make_mock_parent(depth=0)
+        explicit = _resolve_delegation_credentials(
+            {"base_url": "http://localhost:1234/v1"}, parent
+        )
+        self.assertTrue(explicit["base_url_is_explicit"])
+        inherit = _resolve_delegation_credentials({}, parent)
+        self.assertFalse(inherit["base_url_is_explicit"])
 
 
 class TestPerTaskOverrideReachesChild(unittest.TestCase):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -31,6 +31,9 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _resolve_task_credentials,
+    _load_config,
+    logger,
 )
 
 
@@ -2667,56 +2670,42 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
 
 class TestLoadConfig(unittest.TestCase):
-    def test_persistent_config_failure_logs_warning_and_returns_empty(self):
-        """A raising load_config() must not be silent: warn, then degrade to {}."""
-        import tools.delegate_tool as dt
-        # CLI_CONFIG path absent (gateway/cron) so we fall through to persistent.
-        with patch.dict("sys.modules", {"cli": None}):  # force `from cli import` to fail
-            with patch("hermes_cli.config.load_config", side_effect=RuntimeError("corrupt yaml")):
-                with self.assertLogs(dt.logger, level="WARNING") as logs:
-                    result = dt._load_config()
+    def test_persistent_config_failure_warns_and_degrades_to_empty(self):
+        # cli.CLI_CONFIG absent (gateway/cron) → falls through to the persistent path.
+        with patch.dict("sys.modules", {"cli": None}), \
+             patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")), \
+             self.assertLogs(logger, level="WARNING") as logs:
+            result = _load_config()
         self.assertEqual(result, {})
         self.assertTrue(any("delegation config" in m.lower() for m in logs.output))
 
     def test_persistent_config_success_returns_delegation_block(self):
-        import tools.delegate_tool as dt
-        with patch.dict("sys.modules", {"cli": None}):
-            with patch("hermes_cli.config.load_config",
-                       return_value={"delegation": {"model": "x"}}):
-                self.assertEqual(dt._load_config(), {"model": "x"})
+        with patch.dict("sys.modules", {"cli": None}), \
+             patch("hermes_cli.config.load_config", return_value={"delegation": {"model": "x"}}):
+            self.assertEqual(_load_config(), {"model": "x"})
 
 
 class TestExplicitEndpointSkipsPool(unittest.TestCase):
     def test_explicit_base_url_disables_credential_pool(self):
-        """A child built with an explicit override_base_url must not get a pool,
-        so a later lease/swap can't clobber the configured endpoint."""
+        """An explicit override_base_url must skip the pool so a later lease/swap
+        can't clobber the configured endpoint."""
         parent = _make_mock_parent(depth=0)
-        # Pretend a pool WOULD resolve if asked.
         with patch("tools.delegate_tool._resolve_child_credential_pool",
                    return_value=object()) as mock_pool:
             child = _build_child_agent(
-                task_index=0,
-                goal="x",
-                context=None,
-                toolsets=None,
-                model="qwen2.5-coder",
-                max_iterations=5,
-                task_count=1,
-                parent_agent=parent,
-                override_provider="custom",
-                override_base_url="http://localhost:1234/v1",
-                override_api_key="local-key",
-                override_api_mode="chat_completions",
+                task_index=0, goal="x", context=None, toolsets=None,
+                model="qwen2.5-coder", max_iterations=5, task_count=1, parent_agent=parent,
+                override_provider="custom", override_base_url="http://localhost:1234/v1",
+                override_api_key="local-key", override_api_mode="chat_completions",
             )
         self.assertIsNone(getattr(child, "_credential_pool", None))
-        mock_pool.assert_not_called()
+        mock_pool.assert_not_called()  # skipped without even resolving a pool
 
     def test_no_override_base_url_still_attaches_pool(self):
         """Regression: without an explicit endpoint, pool attachment is unchanged."""
         parent = _make_mock_parent(depth=0)
         sentinel = object()
-        with patch("tools.delegate_tool._resolve_child_credential_pool",
-                   return_value=sentinel):
+        with patch("tools.delegate_tool._resolve_child_credential_pool", return_value=sentinel):
             child = _build_child_agent(
                 task_index=0, goal="x", context=None, toolsets=None,
                 model=None, max_iterations=5, task_count=1, parent_agent=parent,
@@ -2727,70 +2716,50 @@ class TestExplicitEndpointSkipsPool(unittest.TestCase):
 
 
 class TestPerTaskCredentialResolution(unittest.TestCase):
-    def test_no_override_returns_batch_creds_identity(self):
-        from tools.delegate_tool import _resolve_task_credentials
+    def test_no_override_passes_batch_creds_through_without_resolving(self):
         parent = _make_mock_parent(depth=0)
-        batch = {"model": "m", "provider": None, "base_url": None,
-                 "api_key": None, "api_mode": None}
-        out = _resolve_task_credentials({"goal": "x"}, {}, batch, parent)
-        self.assertIs(out, batch)  # untouched when no per-task fields
+        batch = {"model": "m", "provider": None, "base_url": None, "api_key": None, "api_mode": None}
+        with patch("tools.delegate_tool._resolve_delegation_credentials") as resolver:
+            out = _resolve_task_credentials({"goal": "x"}, {}, batch, parent)
+        self.assertIs(out, batch)
+        resolver.assert_not_called()  # no per-task fields → no re-resolution
 
-    def test_per_task_model_only_keeps_config_provider(self):
-        from tools.delegate_tool import _resolve_task_credentials
+    def test_per_task_model_overrides_model_but_keeps_config_endpoint(self):
         parent = _make_mock_parent(depth=0)
         cfg = {"model": "cfg-model", "base_url": "http://localhost:1234/v1"}
         batch = _resolve_delegation_credentials(cfg, parent)
-        out = _resolve_task_credentials({"goal": "x", "model": "task-model"},
-                                        cfg, batch, parent)
+        out = _resolve_task_credentials({"goal": "x", "model": "task-model"}, cfg, batch, parent)
         self.assertEqual(out["model"], "task-model")
-        self.assertEqual(out["base_url"], "http://localhost:1234/v1")  # config endpoint kept
+        self.assertEqual(out["base_url"], "http://localhost:1234/v1")
 
-    def test_per_task_provider_redirects_endpoint(self):
-        from tools.delegate_tool import _resolve_task_credentials
+    def test_per_task_provider_drops_config_endpoint_before_resolving(self):
         parent = _make_mock_parent(depth=0)
-        cfg = {"model": "cfg-model", "base_url": "http://localhost:1234/v1",
-               "api_key": "local-key"}
+        cfg = {"model": "cfg-model", "base_url": "http://localhost:1234/v1", "api_key": "local-key"}
         batch = _resolve_delegation_credentials(cfg, parent)
-        # Switching provider per task must drop the config base_url and re-resolve.
-        # Stub the resolver (don't call through — provider resolution needs live
-        # credentials); we only assert on the cfg it receives.
-        with patch("tools.delegate_tool._resolve_delegation_credentials",
-                   return_value={"model": "cfg-model", "provider": "openrouter",
-                                 "base_url": "https://openrouter.ai/api/v1",
-                                 "api_key": "k", "api_mode": "chat_completions"}) as spy:
-            _resolve_task_credentials({"goal": "x", "provider": "openrouter"},
-                                      cfg, batch, parent)
-        passed_cfg = spy.call_args.args[0]
-        self.assertEqual(passed_cfg["provider"], "openrouter")
-        self.assertNotIn("base_url", passed_cfg)  # config endpoint dropped
-        self.assertNotIn("api_key", passed_cfg)
+        # Stub the resolver — a live provider lookup needs real credentials; the
+        # behavior under test is the cfg this helper hands it.
+        with patch("tools.delegate_tool._resolve_delegation_credentials") as resolver:
+            _resolve_task_credentials({"goal": "x", "provider": "openrouter"}, cfg, batch, parent)
+        resolved_cfg = resolver.call_args.args[0]
+        self.assertEqual(resolved_cfg["provider"], "openrouter")
+        self.assertNotIn("base_url", resolved_cfg)
+        self.assertNotIn("api_key", resolved_cfg)
 
 
 class TestPerTaskOverrideReachesChild(unittest.TestCase):
     def test_per_task_model_threads_into_build_loop(self):
-        """Per-task model must be the model _build_child_agent receives."""
+        """End-to-end: a per-task model reaches _build_child_agent; an absent one
+        stays None (the inherit signal) at the call boundary."""
         parent = _make_mock_parent(depth=0)
         seen = []
-
-        def _stub_build(**kw):
-            seen.append(kw)
-            return MagicMock()
-
         with patch("tools.delegate_tool._load_config", return_value={}), \
              patch("tools.delegate_tool._build_child_agent",
-                   side_effect=_stub_build), \
+                   side_effect=lambda **kw: seen.append(kw) or MagicMock()), \
              patch("tools.delegate_tool._run_single_child",
-                   return_value={"task_index": 0, "status": "completed",
-                                 "summary": "ok", "api_calls": 1,
-                                 "duration_seconds": 0.1}):
-            delegate_task(
-                tasks=[{"goal": "a", "model": "task-A-model"},
-                       {"goal": "b"}],
-                parent_agent=parent,
-            )
+                   return_value={"task_index": 0, "status": "completed", "summary": "ok"}):
+            delegate_task(tasks=[{"goal": "a", "model": "task-A-model"}, {"goal": "b"}],
+                          parent_agent=parent)
         self.assertEqual(seen[0]["model"], "task-A-model")
-        # inherit is signaled by None AT THE CALL BOUNDARY (parent-model
-        # fallback happens inside the patched-out _build_child_agent).
         self.assertIsNone(seen[1]["model"])
 
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2666,5 +2666,25 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIsNone(kwargs["fallback_model"])
 
 
+class TestLoadConfig(unittest.TestCase):
+    def test_persistent_config_failure_logs_warning_and_returns_empty(self):
+        """A raising load_config() must not be silent: warn, then degrade to {}."""
+        import tools.delegate_tool as dt
+        # CLI_CONFIG path absent (gateway/cron) so we fall through to persistent.
+        with patch.dict("sys.modules", {"cli": None}):  # force `from cli import` to fail
+            with patch("hermes_cli.config.load_config", side_effect=RuntimeError("corrupt yaml")):
+                with self.assertLogs(dt.logger, level="WARNING") as logs:
+                    result = dt._load_config()
+        self.assertEqual(result, {})
+        self.assertTrue(any("delegation config" in m.lower() for m in logs.output))
+
+    def test_persistent_config_success_returns_delegation_block(self):
+        import tools.delegate_tool as dt
+        with patch.dict("sys.modules", {"cli": None}):
+            with patch("hermes_cli.config.load_config",
+                       return_value={"delegation": {"model": "x"}}):
+                self.assertEqual(dt._load_config(), {"model": "x"})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2041,6 +2041,17 @@ def delegate_task(
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
 
+    # Resolve per-task credential overrides up front (precedence:
+    # per-task > delegation.* config > parent). Done before child construction
+    # so an invalid per-task provider surfaces a clean tool_error.
+    try:
+        task_creds_list = [
+            _resolve_task_credentials(t, cfg, creds, parent_agent)
+            for t in task_list
+        ]
+    except ValueError as exc:
+        return tool_error(str(exc))
+
     overall_start = time.monotonic()
     results = []
 
@@ -2065,26 +2076,27 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            tc = task_creds_list[i]
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=tc["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=tc["provider"],
+                override_base_url=tc["base_url"],
+                override_api_key=tc["api_key"],
+                override_api_mode=tc["api_mode"],
                 override_acp_command=t.get("acp_command")
                 or acp_command
-                or creds.get("command"),
+                or tc.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (acp_args if acp_args is not None else tc.get("args"))
                 ),
                 role=effective_role,
             )
@@ -2463,6 +2475,33 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     }
 
 
+def _resolve_task_credentials(task: dict, cfg: dict, batch_creds: dict, parent_agent) -> dict:
+    """Resolve per-task model/provider overrides.
+
+    Precedence: per-task field > delegation.* config > parent inherit. Returns
+    ``batch_creds`` unchanged when the task carries no override. A per-task
+    ``provider`` re-derives its own endpoint/credentials through the same
+    resolver used for config-level delegation, so the child does not reuse the
+    config provider's base_url/api_key. Per-task base_url/api_key are not
+    accepted (not in the schema) — only model and provider.
+    """
+    task_model = str(task.get("model") or "").strip() or None
+    task_provider = str(task.get("provider") or "").strip() or None
+    if not task_model and not task_provider:
+        return batch_creds
+    task_cfg = dict(cfg)
+    if task_model:
+        task_cfg["model"] = task_model
+    if task_provider:
+        task_cfg["provider"] = task_provider
+        # A per-task provider switch must re-derive the endpoint; drop any
+        # config-level base_url/api_key/api_mode tied to the previous provider.
+        task_cfg.pop("base_url", None)
+        task_cfg.pop("api_key", None)
+        task_cfg.pop("api_mode", None)
+    return _resolve_delegation_credentials(task_cfg, parent_agent)
+
+
 def _load_config() -> dict:
     """Load delegation config from CLI_CONFIG or persistent config.
 
@@ -2747,6 +2786,26 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "string",
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override (e.g. "
+                                "'google/gemini-3-flash-preview'). Runs this "
+                                "task's child on a different model than the "
+                                "parent. Empty = inherit the parent / "
+                                "delegation-config model."
+                            ),
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Per-task provider override (e.g. 'openrouter'). "
+                                "Must be a provider already configured with "
+                                "credentials; the child re-derives that "
+                                "provider's endpoint and key. Empty = inherit "
+                                "the parent / config provider."
+                            ),
                         },
                     },
                     "required": ["goal"],

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1154,7 +1154,7 @@ def _build_child_agent(
     # EXCEPTION: skip the pool ONLY for a LITERAL config endpoint
     # (delegation.base_url) — there a lease/swap (_swap_credential) would
     # overwrite the configured base_url and silently redirect the child off it.
-    # Fixes #7833 / #20558. A provider-RESOLVED base_url (delegation.provider)
+    # Fixes #7833. A provider-RESOLVED base_url (delegation.provider)
     # is NOT skipped: the pool's entries carry that same provider's endpoint, so
     # a swap is legitimate same-provider key rotation, not an off-endpoint
     # redirect — keeping the pool preserves rotation for delegated providers.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1149,7 +1149,14 @@ def _build_child_agent(
 
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
-    child_pool = _resolve_child_credential_pool(effective_provider, parent_agent)
+    # EXCEPTION: when delegation routes the child to an explicit endpoint
+    # (override_base_url), do NOT attach a pool — a lease/swap (_swap_credential)
+    # would overwrite the configured base_url with the leased entry's, silently
+    # redirecting the child off the intended endpoint. Fixes #7833 / #20558.
+    if override_base_url:
+        child_pool = None
+    else:
+        child_pool = _resolve_child_credential_pool(effective_provider, parent_agent)
     if child_pool is not None:
         child._credential_pool = child_pool
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2477,7 +2477,12 @@ def _load_config() -> dict:
 
         full = load_config()
         return full.get("delegation") or {}
-    except Exception:
+    except Exception as exc:
+        logger.warning(
+            "Failed to load persistent delegation config (%s); delegation.* "
+            "settings will be ignored and subagents will inherit the parent.",
+            exc,
+        )
         return {}
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -879,6 +879,9 @@ def _build_child_agent(
     # Credential overrides from delegation config (provider:model resolution)
     override_provider: Optional[str] = None,
     override_base_url: Optional[str] = None,
+    # True only when override_base_url is a LITERAL config endpoint
+    # (delegation.base_url) — not a provider-resolved one. Gates the pool skip.
+    override_base_url_explicit: bool = False,
     override_api_key: Optional[str] = None,
     override_api_mode: Optional[str] = None,
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
@@ -1148,10 +1151,14 @@ def _build_child_agent(
     child._subagent_goal = goal
 
     # Share a credential pool so subagents can rotate keys on rate limits.
-    # EXCEPTION: skip the pool for an explicit endpoint (override_base_url) — a
-    # lease/swap (_swap_credential) would overwrite the configured base_url and
-    # silently redirect the child off it. Fixes #7833 / #20558.
-    child_pool = None if override_base_url else _resolve_child_credential_pool(effective_provider, parent_agent)
+    # EXCEPTION: skip the pool ONLY for a LITERAL config endpoint
+    # (delegation.base_url) — there a lease/swap (_swap_credential) would
+    # overwrite the configured base_url and silently redirect the child off it.
+    # Fixes #7833 / #20558. A provider-RESOLVED base_url (delegation.provider)
+    # is NOT skipped: the pool's entries carry that same provider's endpoint, so
+    # a swap is legitimate same-provider key rotation, not an off-endpoint
+    # redirect — keeping the pool preserves rotation for delegated providers.
+    child_pool = None if override_base_url_explicit else _resolve_child_credential_pool(effective_provider, parent_agent)
     if child_pool is not None:
         child._credential_pool = child_pool
 
@@ -2083,6 +2090,7 @@ def delegate_task(
                 parent_agent=parent_agent,
                 override_provider=tc["provider"],
                 override_base_url=tc["base_url"],
+                override_base_url_explicit=tc.get("base_url_is_explicit", False),
                 override_api_key=tc["api_key"],
                 override_api_mode=tc["api_mode"],
                 override_acp_command=t.get("acp_command")
@@ -2427,6 +2435,9 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": configured_base_url,
             "api_key": api_key,
             "api_mode": api_mode,
+            # A literal config endpoint: a pool lease/swap would clobber it, so
+            # the child must NOT share a pool. See the guard in _build_child_agent.
+            "base_url_is_explicit": True,
         }
 
     if not configured_provider:
@@ -2437,6 +2448,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": None,
             "api_key": None,
             "api_mode": None,
+            "base_url_is_explicit": False,
         }
 
     # Provider is configured — resolve full credentials
@@ -2467,6 +2479,10 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         "api_mode": runtime.get("api_mode"),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
+        # Provider-resolved endpoint: the pool's entries carry this same
+        # provider's base_url, so a swap is legitimate same-provider key
+        # rotation, not an off-endpoint redirect. Keep the pool.
+        "base_url_is_explicit": False,
     }
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1147,16 +1147,11 @@ def _build_child_agent(
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
 
-    # Share a credential pool with the child when possible so subagents can
-    # rotate credentials on rate limits instead of getting pinned to one key.
-    # EXCEPTION: when delegation routes the child to an explicit endpoint
-    # (override_base_url), do NOT attach a pool — a lease/swap (_swap_credential)
-    # would overwrite the configured base_url with the leased entry's, silently
-    # redirecting the child off the intended endpoint. Fixes #7833 / #20558.
-    if override_base_url:
-        child_pool = None
-    else:
-        child_pool = _resolve_child_credential_pool(effective_provider, parent_agent)
+    # Share a credential pool so subagents can rotate keys on rate limits.
+    # EXCEPTION: skip the pool for an explicit endpoint (override_base_url) — a
+    # lease/swap (_swap_credential) would overwrite the configured base_url and
+    # silently redirect the child off it. Fixes #7833 / #20558.
+    child_pool = None if override_base_url else _resolve_child_credential_pool(effective_provider, parent_agent)
     if child_pool is not None:
         child._credential_pool = child_pool
 
@@ -2494,11 +2489,10 @@ def _resolve_task_credentials(task: dict, cfg: dict, batch_creds: dict, parent_a
         task_cfg["model"] = task_model
     if task_provider:
         task_cfg["provider"] = task_provider
-        # A per-task provider switch must re-derive the endpoint; drop any
+        # A provider switch must re-derive its own endpoint, so drop any
         # config-level base_url/api_key/api_mode tied to the previous provider.
-        task_cfg.pop("base_url", None)
-        task_cfg.pop("api_key", None)
-        task_cfg.pop("api_mode", None)
+        for key in ("base_url", "api_key", "api_mode"):
+            task_cfg.pop(key, None)
     return _resolve_delegation_credentials(task_cfg, parent_agent)
 
 


### PR DESCRIPTION
## Summary

Adds optional **per-task `model`/`provider` overrides** to `delegate_task` (each `tasks[]` entry), with precedence **per-task > `delegation.*` config > parent inherit**. Along the way it fixes two latent bugs that silently made `delegation.*` config inert, so the new feature actually takes effect.

Scope is deliberately tight: the diff touches only `tools/delegate_tool.py` and `tests/tools/test_delegate.py` — no top-level params, no `run_agent.py` dispatch changes. Per-task overrides ride the existing `tasks` forwarding path.

## Problem

Three distinct defects, all in the delegation path:

- **A — silent config swallow.** `_load_config` caught *any* persistent-load failure with a bare `except: return {}`, so a malformed config silently dropped **all** `delegation.*` settings with zero signal — subagents just inherited the parent and nobody knew why.
- **B — credential pool clobbers a pinned endpoint.** A child configured with an explicit `delegation.base_url` was still handed a credential pool. At runtime `_swap_credential` (`run_agent.py:3164/3182/3186`) overwrites `self.base_url` from the leased entry, silently redirecting the child **off** its configured endpoint.
- **Feature gap.** The build loop fed every child the same batch-wide credential bundle and the `tasks[]` schema had no `model`/`provider` field, so subagents could never run on a different model/provider per task.

## Solution

- **A:** keep the graceful degrade (still returns `{}` → parent inherit) but `logger.warning(...)` first so the failure is observable. This is defense-in-depth — the common corrupt-YAML case already surfaces via `_warn_config_parse_failure` in `hermes_cli/config.py`; this catches the residual unexpected-failure path that previously went dark.
- **B:** skip the credential pool **only for a literal config endpoint**. `_resolve_delegation_credentials` now tags its result with `base_url_is_explicit` — `True` only on the literal `delegation.base_url` branch, `False` for a provider-resolved endpoint. `_build_child_agent` gates the skip on a new `override_base_url_explicit` flag. A **provider**-resolved `base_url` (e.g. `delegation.provider: openrouter`) keeps its pool, because that pool's entries carry the same provider's endpoint — a swap there is legitimate same-provider key rotation, not an off-endpoint redirect.
- **Feature:** new `_resolve_task_credentials(task, cfg, batch_creds, parent_agent)` returns the batch bundle unchanged when a task carries no override; otherwise it overlays the per-task `model`/`provider` onto a `dict(cfg)` copy and re-resolves through the existing resolver. A per-task **provider** switch drops `base_url`/`api_key`/`api_mode` from the copy so the new provider re-derives its own endpoint. Resolution runs in an up-front pre-pass (before any child is built), so an invalid per-task provider fails the whole call cleanly with a `tool_error` rather than leaving half-built children. The `tasks.items` schema gains `model` and `provider` string properties.

**Deliberate non-goals:** per-task overrides expose **`model` and `provider` only**. `base_url` and `api_key` are intentionally *not* per-task — an LLM-emitted tool call must not be able to route a subagent to an arbitrary endpoint or inject a key. There is no batch-wide override arg (a shared value is just the same field on each task), no `delegate_task` signature/dispatch change, and `_swap_credential` is untouched.

## Testing

- `tests/tools/test_delegate.py` → **146 passed**.
- `tests/agent/test_credential_pool_routing.py tests/run_agent/test_fallback_credential_isolation.py` → **17 passed** (confirms the guard-narrowing didn't regress pool/isolation behavior).

Coverage: `TestLoadConfig` (Bug A, warn + degrade); `TestExplicitEndpointSkipsPool` — incl. `test_provider_resolved_base_url_still_attaches_pool` and `test_literal_base_url_is_flagged_explicit` — (Bug B + guard, both directions); `TestPerTaskCredentialResolution` (resolver/precedence/endpoint re-derivation); `TestPerTaskOverrideReachesChild` (un-mocked e2e — a per-task `model` actually reaches child construction through the build loop, vs the mocked units that isolate the resolver).

## Reviewer focus

- Pool guard: `tools/delegate_tool.py:1161` (one-line `override_base_url_explicit` gate).
- `_resolve_task_credentials`: `:2489`+ (early by-reference return for no-override tasks — safe, consumers are read-only and `acp_args` is copied at `:1043`; provider switch drops the endpoint).
- Pre-pass: `:2048` (resolves all per-task creds before any child is built → one bad provider fails the batch cleanly).
- Flag origin: `:2440` (`base_url_is_explicit=True` only on the literal config base_url branch).

## Issues & related PRs

Reconciled item-by-item against the full delegation cluster (18 active issues + 2 active PRs, plus stale/closed context). This PR ships **per-task `tasks[].model`/`provider` only** — no top-level `delegate_task(model=…)` argument — which is what splits `Closes` from `Refs` below.

**Closes (reported defect fully resolved):**

Closes #7833 — Bug B: a child pinned to an explicit `delegation.base_url` is no longer rebound to the parent's pool via `_swap_credential`; the pool is skipped for a literal config endpoint.
Closes #17685 — per-task `tasks[].model` is now in the schema and forwarded end-to-end (tested); it is no longer silently ignored.
Closes #18591 — per-task `model` with the exact fallback chain it requests (per-task > `delegation.model` > parent); this issue asks for no top-level arg.
Closes #27294, Closes #27295, Closes #27296 — same explicit-`delegation.base_url` clobber (filed three times); fixed by the pool-skip.
Closes #12440 — the blocking impact (sub-agents stuck on a small-context default) is resolved via the working, tested per-task `model` path plus the now-visible config-load failure. (Caveat: for a config-only `delegation.model` on the *same provider* as the parent with no `base_url`, see the known limitation under #31155; `HERMES_MODEL` env-override is out of scope.)
Closes #15789 — its primary ask is per-task `tasks[].model`/`provider` (the detailed schema it proposes); that surface is delivered and tested. The issue mentions a top-level single-task parameter only in passing, and that surface was intentionally removed upstream (see `fb0f579b1` under Refs), so the substantive request is fully met.

**Refs (related but not fully resolved here):**

Refs #5012, #6306, #10995, #17732, #23467, #32711 — each of these requests a **top-level / per-call** `delegate_task(model=…)` argument. This PR deliberately does **not** add it: the top-level `model` parameter was intentionally removed by the maintainer in `fb0f579b1` ("refactor: remove model parameter from delegate_task function … simplifies the function signature and enforces consistent behavior across task delegation"), which stripped it from the signature, schema, and handler together. Re-introducing it would revert that decision, so these remain `Refs` pending a maintainer call on whether to reverse the refactor. The per-task (`tasks[]`) surface this PR adds is a different, nested surface that does not conflict with that removal, and it satisfies the underlying routing need (a model string per child) for all of these. (#6306 asks `model`-only across three levels; #23467/#32711 are explicitly about the removed top-level parameter.)
Refs #14974 — tracking issue for per-task *endpoint* overrides; per-task `model`/`provider` is delivered, but per-task `base_url`/`api_key`/profile are deliberately not exposed.
Refs #31155 — **known limitation.** config-only `delegation.model` (no `base_url`) where parent and child share the *same provider*: our guard intentionally keeps the pool for a provider-resolved endpoint (to preserve key rotation), so the child can still inherit the parent's pooled model. The root fix is endpoint/model-identity keying in `_resolve_child_credential_pool`, which this PR does not change.
Refs #32671 — Bug A: a silent `_load_config` persistent-load failure is now observable (warns instead of swallowing), but config-read semantics are otherwise unchanged — surfaced, not fully closed.
Refs #26482 — if the reported symptom is the explicit-`delegation.base_url` pool clobber, our pool-skip resolves it. Downgraded from `Closes` to `Refs` because competing PR #26486 (which asserts `Fixes #26482`) attributes this issue to provider **relabeling** — children relabeled `custom`, losing provider identity — fixed in `hermes_cli/gateway.py`, which this PR does not touch. Defer to the maintainer on which mechanism #26482 actually reports.

**Related / competing PRs (overlap — not cleanly superseded; recommend maintainer consolidation):**
- PR #23769 — adds a *top-level* `model` param + per-task. The top-level half **reverts `fb0f579b1`** (the maintainer's deliberate removal of that param); it does not fix Bug A or Bug B. Its claim that `delegation.model` was already plumbed matches our Bug A finding.
- PR #34472 — adds a *top-level* `model` param, passes it through the handler lambda, and overrides `creds['model']` *after* resolution (a post-resolution patch, vs. our up-front single-resolver pre-pass), plus per-task model/provider. Also **reverts `fb0f579b1`**, and likewise fixes neither Bug A nor Bug B. Its premise ("schema advertises a `model` the function ignores") is stale — `fb0f579b1` removed the schema property too, so no schema/impl mismatch exists today.
- PR #26486 — provider-override relabeling for subagents; overlaps Bug B / the provider path (and is the PR that asserts `Fixes #26482` via the gateway relabel path this PR does not touch).
- Stale open PRs attempting the same fixes: #12503 (fixes #12440), #17581, #17718, #18649 (fixes #12440).