### PR TITLE
fix: persist model switch to session DB to survive compression failures

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1601,6 +1601,22 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         old_model, old_provider, new_model, new_provider,
     )
 
+    # Persist the model switch to session DB so it survives re-initialization
+    # (e.g. compression failure that triggers agent re-init from the session DB).
+    if (
+        hasattr(agent, "_session_db")
+        and agent._session_db
+        and hasattr(agent, "session_id")
+        and agent.session_id
+    ):
+        try:
+            agent._session_db.update_session_model(
+                agent.session_id,
+                agent.model,
+                getattr(agent, "_session_init_model_config", None),
+            )
+        except Exception as e:
+            logger.warning("Failed to persist model switch to session DB: %s", e)
 
 
 def invoke_tool(agent, function_name: str, function_args: dict, effective_task_id: str,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -799,6 +799,29 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def update_session_model(
+        self,
+        session_id: str,
+        model: str,
+        model_config: "Optional[Dict[str, Any]]" = None,
+    ) -> None:
+        """Update the model and model_config fields of an existing session.
+
+        Called after ``switch_model()`` commits successfully so the new model
+        persists across re-initializations (e.g. after compression failure
+        that triggers agent re-init from the session DB).
+        """
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET model = ?, model_config = ? WHERE id = ?",
+                (
+                    model,
+                    json.dumps(model_config) if model_config else None,
+                    session_id,
+                ),
+            )
+        self._execute_write(_do)
+
     # ──────────────────────────────────────────────────────────────────────
     # Compression locks
     # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

After a user runs `/model <alias>`, `switch_model()` correctly updates `agent.model`, `agent.provider`, and related fields in-memory. However, when context compression later triggers and fails (e.g. the aux LLM call raises an exception during `compress_context()`), the exception propagates up and may cause the agent to re-initialize from the session DB — which still holds the **original** model from session creation time.

This fix:

1. **`hermes_state.py`**: Adds `SessionDB.update_session_model()` method that atomically updates the `model` and `model_config` columns of an existing session row.

2. **`agent/agent_runtime_helpers.py`**: After `switch_model()` completes successfully, calls `agent._session_db.update_session_model()` to persist the new model to the session DB, wrapped in a `try/except` with `logger.warning` on failure (non-fatal).

## Root cause
`run_agent.py:483-484` stores `model=self.model` at session creation time (in `_ensure_db_session`). `switch_model()` updates the in-memory agent fields but never writes the new model back to the DB. A subsequent compression failure causing agent re-initialization would read the stale model from the DB.

## Testing
- `git diff --check` passes (no whitespace errors)
- `update_session_model` follows the same `_execute_write` / `_do` pattern as other SessionDB mutations