### PR TITLE
Fix gateway cron delivery framing and self-management guard

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -650,12 +650,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     if wrap_response:
         task_name = job.get("name", job["id"])
         job_id = job.get("id", "")
+        body = str(content or "").strip()
         delivery_content = (
-            f"Cronjob Response: {task_name}\n"
-            f"(job_id: {job_id})\n"
-            f"-------------\n\n"
-            f"{content}\n\n"
-            f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+            "⏰ **Cronjob Response**\n\n"
+            f"{body}\n\n"
+            "---\n"
+            f"**Cron job:** `{task_name}`\n"
+            f"**Job ID:** `{job_id}`"
         )
     else:
         delivery_content = content

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -522,11 +522,11 @@ class TestDeliverResultWrapping:
 
         send_mock.assert_called_once()
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
-        assert "Cronjob Response: daily-report" in sent_content
-        assert "(job_id: test-job)" in sent_content
-        assert "-------------" in sent_content
+        assert "⏰ **Cronjob Response**" in sent_content
         assert "Here is today's summary." in sent_content
-        assert "To stop or manage this job" in sent_content
+        assert sent_content.rstrip().endswith("**Job ID:** `test-job`")
+        assert "**Cron job:** `daily-report`" in sent_content
+        assert sent_content.index("Here is today's summary.") < sent_content.index("**Cron job:** `daily-report`")
 
     def test_delivery_uses_job_id_when_no_name(self):
         """When a job has no name, the wrapper should fall back to job id."""
@@ -547,7 +547,8 @@ class TestDeliverResultWrapping:
             _deliver_result(job, "Output.")
 
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
-        assert "Cronjob Response: abc-123" in sent_content
+        assert "**Cron job:** `abc-123`" in sent_content
+        assert sent_content.rstrip().endswith("**Job ID:** `abc-123`")
 
     def test_delivery_skips_wrapping_when_config_disabled(self):
         """When cron.wrap_response is false, deliver raw content without header/footer."""

--- a/tests/tools/test_gateway_self_protection.py
+++ b/tests/tools/test_gateway_self_protection.py
@@ -1,0 +1,97 @@
+import importlib
+
+
+def _approval(monkeypatch):
+    from tools import approval
+
+    # Keep each test isolated from context/env state that previous gateway tests
+    # may have bound in the process.
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    return approval
+
+
+def test_gateway_session_blocks_delayed_gateway_start(monkeypatch):
+    approval = _approval(monkeypatch)
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+
+    result = approval.check_all_command_guards(
+        "sleep 30; /Users/dobby/.hermes/hermes-agent/venv/bin/hermes gateway start",
+        "local",
+    )
+
+    assert result["approved"] is False
+    assert result["pattern_key"] == "gateway_self_mutation"
+    assert "gateway self-protection" in result["message"]
+    assert "Do not retry" in result["message"]
+
+
+def test_gateway_session_allows_gateway_status(monkeypatch):
+    approval = _approval(monkeypatch)
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+
+    result = approval.check_all_command_guards("hermes gateway status", "local")
+
+    assert result["approved"] is True
+
+
+def test_cron_session_blocks_launchd_gateway_mutation(monkeypatch):
+    approval = _approval(monkeypatch)
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+
+    result = approval.check_all_command_guards(
+        "launchctl bootout gui/501/ai.hermes.gateway; launchctl bootstrap gui/501 ~/Library/LaunchAgents/ai.hermes.gateway.plist",
+        "local",
+    )
+
+    assert result["approved"] is False
+    assert result["pattern_key"] == "gateway_self_mutation"
+
+
+def test_cli_context_does_not_block_gateway_restart_guard(monkeypatch):
+    approval = _approval(monkeypatch)
+
+    result = approval.check_all_command_guards("hermes gateway restart", "local")
+
+    # Non-interactive CLI/local behavior remains unchanged; the self-protection
+    # guard is scoped only to gateway-hosted runtimes.
+    assert result["approved"] is True
+
+
+def test_gateway_session_blocks_hermes_update(monkeypatch):
+    approval = _approval(monkeypatch)
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+
+    result = approval.check_all_command_guards("hermes update", "local")
+
+    assert result["approved"] is False
+    assert result["pattern_key"] == "gateway_self_mutation"
+
+
+def test_execute_code_blocks_subprocess_list_gateway_restart(monkeypatch):
+    approval = _approval(monkeypatch)
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+
+    result = approval.check_execute_code_guard(
+        "import subprocess\nsubprocess.run(['hermes', 'gateway', 'restart'])\n",
+        "local",
+    )
+
+    assert result["approved"] is False
+    assert result["pattern_key"] == "gateway_self_mutation"
+
+
+def test_execute_code_blocks_os_system_gateway_restart(monkeypatch):
+    approval = _approval(monkeypatch)
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+
+    result = approval.check_execute_code_guard(
+        "import os\nos.system('hermes gateway restart')\n",
+        "local",
+    )
+
+    assert result["approved"] is False
+    assert result["pattern_key"] == "gateway_self_mutation"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -119,6 +119,20 @@ def _is_gateway_approval_context() -> bool:
         return True
     return bool(_get_session_platform())
 
+
+def _is_gateway_hosted_runtime_context() -> bool:
+    """True when command execution is running inside the gateway daemon.
+
+    This is broader than ``_is_gateway_approval_context()``: cron jobs clear
+    ``HERMES_SESSION_PLATFORM`` on purpose so they do not ask absent users for
+    approval, but they still execute inside the long-lived gateway process.
+    Commands that manipulate the gateway service itself can therefore kill the
+    daemon from both user sessions and cron jobs.
+    """
+    if env_var_enabled("HERMES_CRON_SESSION"):
+        return True
+    return _is_gateway_approval_context()
+
 # Sensitive write targets that should trigger approval even when referenced
 # via shell expansions like $HOME or $HERMES_HOME.
 _SSH_SENSITIVE_PATH = r'(?:~|\$home|\$\{home\})/\.ssh(?:/|$)'
@@ -250,6 +264,108 @@ HARDLINE_PATTERNS_COMPILED = [
 _SUDO_STDIN_RE = re.compile(
     r'(?:^|[;&|`\n]|&&|\|\||\$\()\s*sudo\s+-S\b',
     re.IGNORECASE)
+
+
+# Gateway self-management commands are safe from a normal terminal, but are a
+# self-kill footgun when launched by an agent turn that is itself hosted by the
+# gateway daemon.  The real incident this protects: a Discord-origin turn
+# spawned ``sleep 30; hermes gateway start`` in the background after finishing a
+# Hermes update.  ``gateway start`` refreshed the launchd service and sent
+# SIGTERM to the running gateway, but because the service definition was stale
+# the daemon did not come back.  Treat these as a hard runtime guard (not a
+# normal approval prompt) while the caller is gateway-hosted.
+_GATEWAY_SELF_MUTATION_PATTERNS = [
+    (
+        # hermes gateway start|stop|restart|install|uninstall|run, including
+        # absolute venv-bin paths and wrapper commands handled by _CMDPOS.
+        _CMDPOS + r'(?:\S*/)?hermes\s+gateway\s+'
+        r'(?:start|stop|restart|install|uninstall|run)\b',
+        "Hermes gateway service self-management from inside a gateway-hosted session",
+    ),
+    (
+        # python -m hermes_cli.main gateway run --replace / start / restart …
+        _CMDPOS + r'(?:\S*/)?python(?:3(?:\.\d+)?)?\s+(?:-[^\s]+\s+)*-m\s+'
+        r'hermes_cli\.main\s+gateway\s+'
+        r'(?:start|stop|restart|install|uninstall|run)\b',
+        "Hermes gateway module self-management from inside a gateway-hosted session",
+    ),
+    (
+        # execute_code / Python subprocess list form:
+        # subprocess.run(['hermes', 'gateway', 'restart'])
+        r'["\'](?:\S*/)?hermes["\']\s*,\s*["\']gateway["\']\s*,\s*'
+        r'["\'](?:start|stop|restart|install|uninstall|run)["\']',
+        "Hermes gateway subprocess self-management from inside a gateway-hosted session",
+    ),
+    (
+        # execute_code / Python shell-string form:
+        # os.system('hermes gateway restart')
+        r'["\'](?:\S*/)?hermes\s+gateway\s+'
+        r'(?:start|stop|restart|install|uninstall|run)\b',
+        "Hermes gateway shell-string self-management from inside a gateway-hosted session",
+    ),
+    (
+        # launchd service refresh/bootout/kickstart against the Hermes gateway.
+        r'\blaunchctl\s+(?:bootout|bootstrap|kickstart|enable|disable|unload|load)\b'
+        r'[^\n;]*(?:ai\.hermes\.gateway|hermes.*gateway)',
+        "launchd mutation of the Hermes gateway service from inside the gateway",
+    ),
+    (
+        # Linux service-manager equivalents.
+        r'\bsystemctl\b[^\n;]*\b(?:stop|restart|reload|disable|mask)\b'
+        r'[^\n;]*(?:hermes-gateway|ai\.hermes\.gateway|hermes.*gateway)',
+        "systemd mutation of the Hermes gateway service from inside the gateway",
+    ),
+    (
+        # Direct process-targeting by name.  Generic kill <pid> is handled by
+        # normal dangerous-command approval; these name-based variants reveal
+        # intent to kill the gateway specifically.
+        r'\b(?:pkill|killall)\b[^\n;]*(?:hermes.*gateway|gateway.*hermes|ai\.hermes\.gateway)',
+        "directly killing Hermes gateway processes from inside the gateway",
+    ),
+    (
+        # Updating Hermes from inside the gateway can replace code/service
+        # files out from under the process and often ends by restarting the
+        # gateway.  Do it from CLI or through the gateway's explicit update
+        # command path, not from an agent-issued terminal subprocess.
+        _CMDPOS + r'(?:\S*/)?hermes\s+update\b',
+        "Hermes self-update from inside a gateway-hosted session",
+    ),
+]
+_GATEWAY_SELF_MUTATION_PATTERNS_COMPILED = [
+    (re.compile(pattern, _RE_FLAGS), description)
+    for pattern, description in _GATEWAY_SELF_MUTATION_PATTERNS
+]
+
+
+def _check_gateway_self_mutation_guard(command: str) -> tuple:
+    """Block commands that can kill/restart the hosting gateway daemon."""
+    if not _is_gateway_hosted_runtime_context():
+        return (False, None)
+    normalized = _normalize_command_for_detection(command).lower()
+    for pattern_re, description in _GATEWAY_SELF_MUTATION_PATTERNS_COMPILED:
+        if pattern_re.search(normalized):
+            return (True, description)
+    return (False, None)
+
+
+def _gateway_self_mutation_block_result(description: str) -> dict:
+    return {
+        "approved": False,
+        "hardline": True,
+        "message": (
+            f"BLOCKED (gateway self-protection): {description}. "
+            "This command is running from inside the Hermes gateway daemon and "
+            "could terminate the messaging gateway before the user sees the "
+            "result. Do not retry through terminal/execute_code/background "
+            "processes. Use the gateway's explicit /restart or /update command "
+            "path, or run the service-management command from a separate local "
+            "CLI/SSH terminal after reporting the plan."
+        ),
+        "pattern_key": "gateway_self_mutation",
+        "description": description,
+        "outcome": "blocked",
+        "user_consent": False,
+    }
 
 
 def _check_sudo_stdin_guard(command: str) -> tuple:
@@ -1191,6 +1307,12 @@ def check_all_command_guards(command: str, env_type: str,
                        sudo_guess_desc, command[:200])
         return _sudo_stdin_block_result(sudo_guess_desc)
 
+    is_gateway_self_mutation, gateway_self_mutation_desc = _check_gateway_self_mutation_guard(command)
+    if is_gateway_self_mutation:
+        logger.warning("Gateway self-protection block: %s (command: %s)",
+                       gateway_self_mutation_desc, command[:200])
+        return _gateway_self_mutation_block_result(gateway_self_mutation_desc)
+
     # --yolo or approvals.mode=off: bypass all approval prompts.
     # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.
     approval_mode = _get_approval_mode()
@@ -1481,6 +1603,13 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
     # in check_all_command_guards / check_dangerous_command.
     if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
         return {"approved": True, "message": None}
+
+    # Gateway-hosted hardline self-protection applies before yolo/mode=off.
+    is_gateway_self_mutation, gateway_self_mutation_desc = _check_gateway_self_mutation_guard(code)
+    if is_gateway_self_mutation:
+        logger.warning("Gateway self-protection block in execute_code: %s",
+                       gateway_self_mutation_desc)
+        return _gateway_self_mutation_block_result(gateway_self_mutation_desc)
 
     # --yolo or approvals.mode=off: bypass (session- or process-scoped).
     approval_mode = _get_approval_mode()


### PR DESCRIPTION
## Summary
- improve gateway-delivered cron job response framing so message body appears first and job metadata is a compact footer
- add a gateway-hosted self-protection guard that blocks terminal/execute_code attempts to restart, update, or kill the hosting Hermes gateway
- cover cron delivery wrapping and gateway self-protection cases with targeted tests

## Tests
- `python3 -m pytest tests/cron/test_scheduler.py::TestDeliverResultWrapping tests/tools/test_gateway_self_protection.py -q -o 'addopts='`
