### PR TITLE
fix(cli): make plugin menus scrollable

### DIFF
--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -203,6 +203,24 @@ def _scroll_for_cursor(
     return max(0, min(scroll_offset, max(0, total_rows - visible_rows)))
 
 
+def _scroll_status_text(
+    cursor_pos: int, scroll_offset: int, visible_rows: int, total_rows: int
+) -> str:
+    """Return compact position and overflow hints for a scrollable list."""
+    if total_rows <= 0:
+        return ""
+
+    cursor_pos = max(0, min(cursor_pos, total_rows - 1))
+    visible_rows = max(1, visible_rows)
+    parts: list[str] = []
+    if scroll_offset > 0:
+        parts.append("↑ more")
+    parts.append(f"{cursor_pos + 1}/{total_rows}")
+    if scroll_offset + visible_rows < total_rows:
+        parts.append("↓ more")
+    return "  ".join(parts)
+
+
 def _handle_active_search_key(
     curses_mod, key: int, search: _SearchState
 ) -> tuple[bool, bool, bool]:
@@ -267,6 +285,10 @@ def flush_stdin() -> None:
 # every menu's key-handling branch identical and free of raw escape-byte logic.
 NAV_UP = "up"
 NAV_DOWN = "down"
+NAV_PAGE_UP = "page_up"
+NAV_PAGE_DOWN = "page_down"
+NAV_HOME = "home"
+NAV_END = "end"
 NAV_SELECT = "select"
 NAV_TOGGLE = "toggle"
 NAV_CANCEL = "cancel"
@@ -304,6 +326,14 @@ def _decode_menu_key(stdscr, key: int) -> str:
         return NAV_UP
     if key in (curses.KEY_DOWN, ord("j")):
         return NAV_DOWN
+    if key in (curses.KEY_PPAGE, ord("b")):
+        return NAV_PAGE_UP
+    if key in (curses.KEY_NPAGE, ord("f")):
+        return NAV_PAGE_DOWN
+    if key == curses.KEY_HOME:
+        return NAV_HOME
+    if key == curses.KEY_END:
+        return NAV_END
     if key in (curses.KEY_ENTER, 10, 13):
         return NAV_SELECT
     if key == ord(" "):
@@ -364,13 +394,11 @@ def _run_curses_menu(
 ):
     """Shared curses single-/multi-select event loop.
 
-    Owns every piece the three public menus used to duplicate verbatim:
-    the non-TTY guard, ``curses.wrapper`` setup (cursor hide + color pairs),
-    the per-frame ``clear``/``getmaxyx``/``refresh`` cycle, scroll-offset math,
-    row iteration, the ``read_menu_key`` dispatch with ``NAV_UP``/``NAV_DOWN``
-    cursor wrap, ``flush_stdin``, and the ``KeyboardInterrupt`` / curses-
-    unavailable fallback. Per-menu behavior is supplied as callbacks so the
-    rendered output stays byte-identical to the old hand-rolled loops.
+    Owns the non-TTY guard, ``curses.wrapper`` setup (cursor hide + color
+    pairs), per-frame rendering, filtered scrolling, extended navigation,
+    position hints, ``flush_stdin``, and the ``KeyboardInterrupt`` / curses-
+    unavailable fallback. Per-menu behavior is supplied as callbacks so
+    checklist, radio-list, and single-select menus share one driver.
 
     Callbacks / params:
         draw_header(stdscr, max_y, max_x) -> int
@@ -469,6 +497,21 @@ def _run_curses_menu(
                         break
                     draw_row(stdscr, y, i, i == cursor, max_x)
 
+                scroll_status = _scroll_status_text(
+                    cursor_pos, scroll_offset, visible_rows, len(filtered)
+                )
+                if scroll_status:
+                    try:
+                        stdscr.addnstr(
+                            max_y - reserve_bottom,
+                            0,
+                            scroll_status,
+                            max_x - 1,
+                            curses.A_DIM,
+                        )
+                    except curses.error:
+                        pass
+
                 if draw_footer is not None:
                     draw_footer(stdscr, max_y, max_x)
 
@@ -510,6 +553,14 @@ def _run_curses_menu(
                     cursor = _move_filtered_cursor(filtered, cursor, cursor_pos, -1)
                 elif action == NAV_DOWN:
                     cursor = _move_filtered_cursor(filtered, cursor, cursor_pos, 1)
+                elif action == NAV_PAGE_UP and filtered:
+                    cursor = filtered[max(0, cursor_pos - visible_rows)]
+                elif action == NAV_PAGE_DOWN and filtered:
+                    cursor = filtered[min(len(filtered) - 1, cursor_pos + visible_rows)]
+                elif action == NAV_HOME and filtered:
+                    cursor = filtered[0]
+                elif action == NAV_END and filtered:
+                    cursor = filtered[-1]
                 elif action in (NAV_SELECT, NAV_TOGGLE, NAV_CANCEL):
                     if action == NAV_SELECT and use_search and not filtered:
                         continue
@@ -561,7 +612,7 @@ def curses_checklist(
             stdscr.addnstr(0, 0, title, max_x - 1, hattr)
             stdscr.addnstr(
                 1, 0,
-                "  ↑↓ navigate  SPACE toggle  ENTER confirm  ESC cancel",
+                "  ↑↓/j/k navigate  PgUp/PgDn page  Home/End jump  SPACE toggle  ENTER confirm  ESC cancel",
                 max_x - 1, curses.A_DIM,
             )
         except curses.error:
@@ -669,9 +720,9 @@ def curses_radiolist(
             if searchable and search is not None and search.active:
                 hint = f"  Search: {search.query}\u258e  BACKSPACE edit  Ctrl+U clear  ESC stop"
             elif searchable:
-                hint = "  \u2191\u2193 navigate  ENTER/SPACE select  / search  ESC cancel"
+                hint = "  \u2191\u2193/j/k navigate  PgUp/PgDn page  Home/End jump  ENTER/SPACE select  / search  ESC cancel"
             else:
-                hint = "  \u2191\u2193 navigate  ENTER/SPACE select  ESC cancel"
+                hint = "  \u2191\u2193/j/k navigate  PgUp/PgDn page  Home/End jump  ENTER/SPACE select  ESC cancel"
             stdscr.addnstr(row, 0, hint, max_x - 1, curses.A_DIM)
             row += 1
         except curses.error:
@@ -768,9 +819,9 @@ def curses_single_select(
             if searchable and search is not None and search.active:
                 hint = f"  Search: {search.query}\u258e  BACKSPACE edit  Ctrl+U clear  ESC stop"
             elif searchable:
-                hint = "  ↑↓ navigate  ENTER confirm  / search  ESC/q cancel"
+                hint = "  ↑↓/j/k navigate  PgUp/PgDn page  Home/End jump  ENTER confirm  / search  ESC/q cancel"
             else:
-                hint = "  ↑↓ navigate  ENTER confirm  ESC/q cancel"
+                hint = "  ↑↓/j/k navigate  PgUp/PgDn page  Home/End jump  ENTER confirm  ESC/q cancel"
             stdscr.addnstr(1, 0, hint, max_x - 1, curses.A_DIM)
         except curses.error:
             pass

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1095,7 +1095,12 @@ def _filter_plugin_entries(entries: list, args: Any, enabled: set, disabled: set
     return filtered
 
 
-def _should_page_plugin_list(args: Any | None, console: Any, entry_count: int) -> bool:
+def _should_page_plugin_list(
+    args: Any | None,
+    console: Any,
+    table: Any,
+    entry_count: int,
+) -> bool:
     """Return whether a long Rich plugin table should open in a pager."""
     if getattr(args, "json", False) or getattr(args, "plain", False):
         return False
@@ -1111,8 +1116,15 @@ def _should_page_plugin_list(args: Any | None, console: Any, entry_count: int) -
     if height <= 0:
         height = shutil.get_terminal_size((80, 24)).lines
 
-    # Account for the table title, borders, header, and the hints below it.
-    return entry_count + 8 > height
+    try:
+        table_height = len(console.render_lines(table, pad=False))
+    except (AttributeError, TypeError, ValueError):
+        # Lightweight test consoles and older Rich versions may not expose
+        # ``render_lines``. Keep a conservative entry-count fallback.
+        table_height = entry_count + 4
+
+    # Two blank lines plus the four standard hints surround the table.
+    return table_height + 6 > height
 
 
 def _print_plugin_table(console: Any, table: Any) -> None:
@@ -1183,7 +1195,7 @@ def cmd_list(args: Any | None = None) -> None:
             status = "[yellow]not enabled[/yellow]"
         table.add_row(name, status, str(version), description, source)
 
-    if _should_page_plugin_list(args, console, len(entries)):
+    if _should_page_plugin_list(args, console, table, len(entries)):
         with console.pager(styles=True):
             _print_plugin_table(console, table)
     else:

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1095,6 +1095,37 @@ def _filter_plugin_entries(entries: list, args: Any, enabled: set, disabled: set
     return filtered
 
 
+def _should_page_plugin_list(args: Any | None, console: Any, entry_count: int) -> bool:
+    """Return whether a long Rich plugin table should open in a pager."""
+    if getattr(args, "json", False) or getattr(args, "plain", False):
+        return False
+    if getattr(args, "no_pager", False):
+        return False
+    if not getattr(console, "is_terminal", False):
+        return False
+
+    try:
+        height = int(getattr(console, "height", 0) or 0)
+    except (TypeError, ValueError):
+        height = 0
+    if height <= 0:
+        height = shutil.get_terminal_size((80, 24)).lines
+
+    # Account for the table title, borders, header, and the hints below it.
+    return entry_count + 8 > height
+
+
+def _print_plugin_table(console: Any, table: Any) -> None:
+    """Render the plugin table and its standard follow-up hints."""
+    console.print()
+    console.print(table)
+    console.print()
+    console.print("[dim]Compact view:[/dim] hermes plugins list --plain --no-bundled")
+    console.print("[dim]Interactive toggle:[/dim] hermes plugins")
+    console.print("[dim]Enable/disable:[/dim] hermes plugins enable/disable <name>")
+    console.print("[dim]Plugins are opt-in by default — only 'enabled' plugins load.[/dim]")
+
+
 def cmd_list(args: Any | None = None) -> None:
     """List all plugins (bundled + user) with enabled/disabled state."""
     from rich.console import Console
@@ -1152,13 +1183,11 @@ def cmd_list(args: Any | None = None) -> None:
             status = "[yellow]not enabled[/yellow]"
         table.add_row(name, status, str(version), description, source)
 
-    console.print()
-    console.print(table)
-    console.print()
-    console.print("[dim]Compact view:[/dim] hermes plugins list --plain --no-bundled")
-    console.print("[dim]Interactive toggle:[/dim] hermes plugins")
-    console.print("[dim]Enable/disable:[/dim] hermes plugins enable/disable <name>")
-    console.print("[dim]Plugins are opt-in by default — only 'enabled' plugins load.[/dim]")
+    if _should_page_plugin_list(args, console, len(entries)):
+        with console.pager(styles=True):
+            _print_plugin_table(console, table)
+    else:
+        _print_plugin_table(console, table)
 
 
 # ---------------------------------------------------------------------------
@@ -1328,6 +1357,64 @@ def _configure_context_engine() -> bool:
 # ---------------------------------------------------------------------------
 
 
+def _build_composite_rows(plugin_labels: list[str], categories: list[tuple]) -> list[dict]:
+    """Build visual rows for the composite menu in display order."""
+    rows: list[dict] = []
+    if plugin_labels:
+        rows.append({"kind": "section", "label": "General Plugins"})
+        for index, label in enumerate(plugin_labels):
+            rows.append(
+                {
+                    "kind": "plugin",
+                    "label": label,
+                    "index": index,
+                    "nav": ("plugin", index),
+                }
+            )
+
+    if categories:
+        if rows:
+            rows.append({"kind": "spacer", "label": ""})
+        rows.append({"kind": "section", "label": "Provider Plugins"})
+        for index, (name, current, _configure) in enumerate(categories):
+            rows.append(
+                {
+                    "kind": "category",
+                    "label": f"{name:<24} ▸ {current}",
+                    "index": index,
+                    "nav": ("category", index),
+                }
+            )
+    return rows
+
+
+def _composite_navigation_rows(rows: list[dict]) -> list[int]:
+    """Return visual row indices that the composite cursor can select."""
+    return [index for index, row in enumerate(rows) if row.get("nav") is not None]
+
+
+def _page_composite_cursor(
+    navigation_rows: list[int], cursor_index: int, visible_rows: int, direction: int
+) -> int:
+    """Move approximately one visual page while landing on a selectable row."""
+    if not navigation_rows:
+        return 0
+
+    cursor_index = max(0, min(cursor_index, len(navigation_rows) - 1))
+    target_row = navigation_rows[cursor_index] + direction * max(1, visible_rows)
+    if direction < 0:
+        candidates = [
+            index for index, row_index in enumerate(navigation_rows)
+            if row_index <= target_row
+        ]
+        return candidates[-1] if candidates else 0
+
+    for index, row_index in enumerate(navigation_rows):
+        if row_index >= target_row:
+            return index
+    return len(navigation_rows) - 1
+
+
 def cmd_toggle() -> None:
     """Interactive composite UI — general plugins + provider plugin categories."""
     from rich.console import Console
@@ -1401,220 +1488,184 @@ def cmd_toggle() -> None:
 
 def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
                       disabled, categories, console):
-    """Custom curses screen with checkboxes + category action rows."""
-    from hermes_cli.curses_ui import flush_stdin
+    """Render plugin and provider items in one visual scroll coordinate space."""
+    from hermes_cli.curses_ui import (
+        _scroll_for_cursor,
+        _scroll_status_text,
+        flush_stdin,
+    )
 
     chosen = set(plugin_selected)
     n_plugins = len(plugin_keys)
-    # Total rows: plugins + separator + categories
-    # separator is not navigable
-    n_categories = len(categories)
-    total_items = n_plugins + n_categories  # navigable items
+    result_holder = {"providers_changed": False}
 
-    result_holder = {"plugins_changed": False, "providers_changed": False}
-
-    def _draw(stdscr):
-        curses.curs_set(0)
+    def _init_screen_colors() -> None:
         if curses.has_colors():
             curses.start_color()
             curses.use_default_colors()
             curses.init_pair(1, curses.COLOR_GREEN, -1)
             curses.init_pair(2, curses.COLOR_YELLOW, -1)
             curses.init_pair(3, curses.COLOR_CYAN, -1)
-            curses.init_pair(4, 8 if curses.COLORS > 8 else curses.COLOR_WHITE, -1)  # dim gray
-        cursor = 0
+
+    def _restore_curses_screen():
+        restored = curses.initscr()
+        curses.noecho()
+        curses.cbreak()
+        restored.keypad(True)
+        _init_screen_colors()
+        curses.curs_set(0)
+        return restored
+
+    def _run_category(category_index: int):
+        curses.endwin()
+        category_name, _current, configure = categories[category_index]
+        changed = configure()
+        if changed:
+            result_holder["providers_changed"] = True
+            current = (
+                (_get_current_memory_provider() or "built-in")
+                if category_index == 0
+                else _get_current_context_engine()
+            )
+            categories[category_index] = (category_name, current, configure)
+        return _restore_curses_screen()
+
+    def _draw(stdscr):
+        curses.curs_set(0)
+        _init_screen_colors()
+        cursor_index = 0
         scroll_offset = 0
 
         while True:
             stdscr.clear()
             max_y, max_x = stdscr.getmaxyx()
+            rows = _build_composite_rows(plugin_labels, categories)
+            navigation_rows = _composite_navigation_rows(rows)
+            total_items = len(navigation_rows)
+            if total_items:
+                cursor_index = max(0, min(cursor_index, total_items - 1))
+                cursor_row = navigation_rows[cursor_index]
+                current_nav = rows[cursor_row]["nav"]
+            else:
+                cursor_row = 0
+                current_nav = None
 
-            # Header
             try:
-                hattr = curses.A_BOLD
+                header_attr = curses.A_BOLD
                 if curses.has_colors():
-                    hattr |= curses.color_pair(2)
-                stdscr.addnstr(0, 0, "Plugins", max_x - 1, hattr)
+                    header_attr |= curses.color_pair(2)
+                stdscr.addnstr(0, 0, "Plugins", max_x - 1, header_attr)
                 stdscr.addnstr(
-                    1, 0,
-                    "  ↑↓/j/k navigate  PgUp/PgDn page  SPACE toggle  ENTER configure/confirm  ESC done",
-                    max_x - 1, curses.A_DIM,
+                    1,
+                    0,
+                    "  ↑↓/j/k navigate  PgUp/PgDn page  Home/End jump  "
+                    "SPACE toggle/configure  ENTER configure/confirm  ESC done",
+                    max_x - 1,
+                    curses.A_DIM,
                 )
             except curses.error:
                 pass
 
-            # Build display rows
-            # Row layout:
-            #   [plugins section header] (not navigable, skipped in scroll math)
-            #   plugin checkboxes (navigable, indices 0..n_plugins-1)
-            #   [separator] (not navigable)
-            #   [categories section header] (not navigable)
-            #   category action rows (navigable, indices n_plugins..total_items-1)
-
-            visible_rows = max_y - 4
-            if cursor < scroll_offset:
-                scroll_offset = cursor
-            elif cursor >= scroll_offset + visible_rows:
-                scroll_offset = cursor - visible_rows + 1
-
-            y = 3  # start drawing after header
-
-            # Determine which items are visible based on scroll
-            # We need to map logical cursor positions to screen rows
-            # accounting for non-navigable separator/headers
-
-
-            # --- General Plugins section ---
-            if n_plugins > 0:
-                # Section header
-                if y < max_y - 1:
+            first_row = 3
+            footer_rows = 1
+            visible_rows = max_y - first_row - footer_rows
+            if visible_rows <= 0:
+                if max_y > 0 and max_x > 1:
                     try:
-                        sattr = curses.A_BOLD
-                        if curses.has_colors():
-                            sattr |= curses.color_pair(2)
-                        stdscr.addnstr(y, 0, "  General Plugins", max_x - 1, sattr)
+                        stdscr.addnstr(
+                            max_y - 1,
+                            0,
+                            "Terminal too small; enlarge window or press q",
+                            max_x - 1,
+                            curses.A_DIM,
+                        )
                     except curses.error:
                         pass
-                    y += 1
+                stdscr.refresh()
+                if stdscr.getch() in {27, ord("q")}:
+                    return
+                continue
 
-                plugin_start = scroll_offset
-                plugin_stop = min(n_plugins, scroll_offset + max(visible_rows, 0))
-                for i in range(plugin_start, plugin_stop):
-                    if y >= max_y - 1:
-                        break
-                    check = "\u2713" if i in chosen else " "
-                    arrow = "\u2192" if i == cursor else " "
-                    line = f" {arrow} [{check}] {plugin_labels[i]}"
-                    attr = curses.A_NORMAL
-                    if i == cursor:
+            scroll_offset = _scroll_for_cursor(
+                scroll_offset, cursor_row, visible_rows, len(rows)
+            )
+            for draw_index, row_index in enumerate(
+                range(scroll_offset, min(len(rows), scroll_offset + visible_rows))
+            ):
+                y = first_row + draw_index
+                row = rows[row_index]
+                kind = row["kind"]
+                line = ""
+                attr = curses.A_NORMAL
+
+                if kind == "section":
+                    line = f"  {row['label']}"
+                    attr = curses.A_BOLD
+                    if curses.has_colors():
+                        attr |= curses.color_pair(2)
+                elif kind == "plugin":
+                    selected = row.get("nav") == current_nav
+                    check = "✓" if row["index"] in chosen else " "
+                    arrow = "→" if selected else " "
+                    line = f" {arrow} [{check}] {row['label']}"
+                    if selected:
                         attr = curses.A_BOLD
                         if curses.has_colors():
                             attr |= curses.color_pair(1)
-                    try:
-                        stdscr.addnstr(y, 0, line, max_x - 1, attr)
-                    except curses.error:
-                        pass
-                    y += 1
-
-            # --- Separator ---
-            if y < max_y - 1:
-                y += 1  # blank line
-
-            # --- Provider Plugins section ---
-            if n_categories > 0 and y < max_y - 1:
-                try:
-                    sattr = curses.A_BOLD
-                    if curses.has_colors():
-                        sattr |= curses.color_pair(2)
-                    stdscr.addnstr(y, 0, "  Provider Plugins", max_x - 1, sattr)
-                except curses.error:
-                    pass
-                y += 1
-
-                for ci, (cat_name, cat_current, _cat_fn) in enumerate(categories):
-                    if y >= max_y - 1:
-                        break
-                    cat_idx = n_plugins + ci
-                    arrow = "\u2192" if cat_idx == cursor else " "
-                    line = f" {arrow}   {cat_name:<24} \u25b8 {cat_current}"
-                    attr = curses.A_NORMAL
-                    if cat_idx == cursor:
+                elif kind == "category":
+                    selected = row.get("nav") == current_nav
+                    arrow = "→" if selected else " "
+                    line = f" {arrow}   {row['label']}"
+                    if selected:
                         attr = curses.A_BOLD
                         if curses.has_colors():
                             attr |= curses.color_pair(3)
-                    try:
-                        stdscr.addnstr(y, 0, line, max_x - 1, attr)
-                    except curses.error:
-                        pass
-                    y += 1
+
+                try:
+                    stdscr.addnstr(y, 0, line, max_x - 1, attr)
+                except curses.error:
+                    pass
+
+            footer = _scroll_status_text(
+                cursor_row, scroll_offset, visible_rows, len(rows)
+            )
+            if footer:
+                try:
+                    stdscr.addnstr(max_y - 1, 0, footer, max_x - 1, curses.A_DIM)
+                except curses.error:
+                    pass
 
             stdscr.refresh()
             key = stdscr.getch()
 
-            if key in {curses.KEY_UP, ord("k")}:
-                if total_items > 0:
-                    cursor = (cursor - 1) % total_items
-            elif key in {curses.KEY_DOWN, ord("j")}:
-                if total_items > 0:
-                    cursor = (cursor + 1) % total_items
-            elif key in {curses.KEY_NPAGE, ord("f")}:
-                if total_items > 0:
-                    cursor = min(total_items - 1, cursor + max(1, max_y - 5))
-            elif key in {curses.KEY_PPAGE, ord("b")}:
-                if total_items > 0:
-                    cursor = max(0, cursor - max(1, max_y - 5))
-            elif key == curses.KEY_HOME:
-                cursor = 0
-            elif key == curses.KEY_END:
-                cursor = max(0, total_items - 1)
-            elif key == ord(" "):
-                if cursor < n_plugins:
-                    # Toggle general plugin
-                    chosen.symmetric_difference_update({cursor})
+            if key in {curses.KEY_UP, ord("k")} and total_items:
+                cursor_index = (cursor_index - 1) % total_items
+            elif key in {curses.KEY_DOWN, ord("j")} and total_items:
+                cursor_index = (cursor_index + 1) % total_items
+            elif key in {curses.KEY_PPAGE, ord("b")} and total_items:
+                cursor_index = _page_composite_cursor(
+                    navigation_rows, cursor_index, visible_rows, -1
+                )
+            elif key in {curses.KEY_NPAGE, ord("f")} and total_items:
+                cursor_index = _page_composite_cursor(
+                    navigation_rows, cursor_index, visible_rows, 1
+                )
+            elif key == curses.KEY_HOME and total_items:
+                cursor_index = 0
+            elif key == curses.KEY_END and total_items:
+                cursor_index = total_items - 1
+            elif key == ord(" ") and total_items:
+                kind, index = current_nav
+                if kind == "plugin":
+                    chosen.symmetric_difference_update({index})
                 else:
-                    # Provider category — launch sub-screen
-                    ci = cursor - n_plugins
-                    if 0 <= ci < n_categories:
-                        curses.endwin()
-                        _cat_name, _cat_cur, cat_fn = categories[ci]
-                        changed = cat_fn()
-                        if changed:
-                            result_holder["providers_changed"] = True
-                            # Refresh current values
-                            categories[ci] = (
-                                _cat_name,
-                                _get_current_memory_provider() or "built-in" if ci == 0
-                                else _get_current_context_engine(),
-                                cat_fn,
-                            )
-                        # Re-enter curses
-                        stdscr = curses.initscr()
-                        curses.noecho()
-                        curses.cbreak()
-                        stdscr.keypad(True)
-                        if curses.has_colors():
-                            curses.start_color()
-                            curses.use_default_colors()
-                            curses.init_pair(1, curses.COLOR_GREEN, -1)
-                            curses.init_pair(2, curses.COLOR_YELLOW, -1)
-                            curses.init_pair(3, curses.COLOR_CYAN, -1)
-                            curses.init_pair(4, 8 if curses.COLORS > 8 else curses.COLOR_WHITE, -1)
-                        curses.curs_set(0)
-            elif key in {curses.KEY_ENTER, 10, 13}:
-                if cursor < n_plugins:
-                    # ENTER on a plugin checkbox — confirm and exit
-                    result_holder["plugins_changed"] = True
+                    stdscr = _run_category(index)
+            elif key in {curses.KEY_ENTER, 10, 13} and total_items:
+                kind, index = current_nav
+                if kind == "plugin":
                     return
-                else:
-                    # ENTER on a category — same as SPACE, launch sub-screen
-                    ci = cursor - n_plugins
-                    if 0 <= ci < n_categories:
-                        curses.endwin()
-                        _cat_name, _cat_cur, cat_fn = categories[ci]
-                        changed = cat_fn()
-                        if changed:
-                            result_holder["providers_changed"] = True
-                            categories[ci] = (
-                                _cat_name,
-                                _get_current_memory_provider() or "built-in" if ci == 0
-                                else _get_current_context_engine(),
-                                cat_fn,
-                            )
-                        stdscr = curses.initscr()
-                        curses.noecho()
-                        curses.cbreak()
-                        stdscr.keypad(True)
-                        if curses.has_colors():
-                            curses.start_color()
-                            curses.use_default_colors()
-                            curses.init_pair(1, curses.COLOR_GREEN, -1)
-                            curses.init_pair(2, curses.COLOR_YELLOW, -1)
-                            curses.init_pair(3, curses.COLOR_CYAN, -1)
-                            curses.init_pair(4, 8 if curses.COLORS > 8 else curses.COLOR_WHITE, -1)
-                        curses.curs_set(0)
+                stdscr = _run_category(index)
             elif key in {27, ord("q")}:
-                # Save plugin changes on exit
-                result_holder["plugins_changed"] = True
                 return
 
     curses.wrapper(_draw)
@@ -1647,7 +1698,7 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
         _save_enabled_set(new_enabled)
         _save_disabled_set(new_disabled)
         console.print(
-            f"\n[green]\u2713[/green] General plugins: {len(new_enabled)} enabled, "
+            f"\n[green]✓[/green] General plugins: {len(new_enabled)} enabled, "
             f"{len(plugin_keys) - len(new_enabled)} disabled."
         )
     elif n_plugins > 0:
@@ -1657,7 +1708,7 @@ def _run_composite_ui(curses, plugin_keys, plugin_labels, plugin_selected,
         new_memory = _get_current_memory_provider() or "built-in"
         new_context = _get_current_context_engine()
         console.print(
-            f"[green]\u2713[/green] Memory provider: [bold]{new_memory}[/bold]  "
+            f"[green]✓[/green] Memory provider: [bold]{new_memory}[/bold]  "
             f"Context engine: [bold]{new_context}[/bold]"
         )
 

--- a/hermes_cli/subcommands/plugins.py
+++ b/hermes_cli/subcommands/plugins.py
@@ -81,6 +81,11 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
         action="store_true",
         help="Print machine-readable JSON",
     )
+    plugins_list.add_argument(
+        "--no-pager",
+        action="store_true",
+        help="Print the Rich table directly even when it is taller than the terminal",
+    )
 
     plugins_enable = plugins_subparsers.add_parser(
         "enable", help="Enable a disabled plugin"

--- a/tests/hermes_cli/test_curses_arrow_keys.py
+++ b/tests/hermes_cli/test_curses_arrow_keys.py
@@ -19,7 +19,11 @@ import curses
 from hermes_cli.curses_ui import (
     NAV_CANCEL,
     NAV_DOWN,
+    NAV_END,
+    NAV_HOME,
     NAV_NONE,
+    NAV_PAGE_DOWN,
+    NAV_PAGE_UP,
     NAV_SELECT,
     NAV_UP,
     read_menu_key,
@@ -63,6 +67,13 @@ def test_raw_ss3_arrow_keys_decode():
 def test_translated_key_constants_still_work():
     assert read_menu_key(FakeStdscr([curses.KEY_DOWN])) == NAV_DOWN
     assert read_menu_key(FakeStdscr([curses.KEY_UP])) == NAV_UP
+
+
+def test_extended_navigation_key_constants_work():
+    assert read_menu_key(FakeStdscr([curses.KEY_PPAGE])) == NAV_PAGE_UP
+    assert read_menu_key(FakeStdscr([curses.KEY_NPAGE])) == NAV_PAGE_DOWN
+    assert read_menu_key(FakeStdscr([curses.KEY_HOME])) == NAV_HOME
+    assert read_menu_key(FakeStdscr([curses.KEY_END])) == NAV_END
 
 
 def test_vim_keys():

--- a/tests/hermes_cli/test_curses_ui.py
+++ b/tests/hermes_cli/test_curses_ui.py
@@ -1,0 +1,37 @@
+"""Tests for shared curses menu scrolling helpers."""
+
+from hermes_cli.curses_ui import _scroll_for_cursor, _scroll_status_text
+
+
+def test_scroll_for_cursor_moves_offset_down_to_keep_cursor_visible():
+    assert _scroll_for_cursor(
+        scroll_offset=0,
+        cursor_pos=7,
+        visible_rows=5,
+        total_rows=20,
+    ) == 3
+
+
+def test_scroll_for_cursor_clamps_offsets_for_tiny_viewport():
+    assert _scroll_for_cursor(
+        scroll_offset=99,
+        cursor_pos=2,
+        visible_rows=-4,
+        total_rows=3,
+    ) == 2
+
+
+def test_scroll_status_text_shows_position_and_more_indicators():
+    assert (
+        _scroll_status_text(
+            cursor_pos=5,
+            scroll_offset=2,
+            visible_rows=4,
+            total_rows=10,
+        )
+        == "↑ more  6/10  ↓ more"
+    )
+
+
+def test_scroll_status_text_empty_is_blank():
+    assert _scroll_status_text(0, 0, 4, 0) == ""

--- a/tests/hermes_cli/test_curses_ui_search.py
+++ b/tests/hermes_cli/test_curses_ui_search.py
@@ -1,3 +1,7 @@
+import sys
+from types import SimpleNamespace
+
+from hermes_cli import curses_ui
 from hermes_cli.curses_ui import (
     _SearchState,
     _filter_indices,
@@ -58,7 +62,11 @@ def test_active_search_allows_navigation_keys_to_reach_menu_loop():
 def test_active_search_consumes_query_editing_and_confirm_keys():
     search = _SearchState(active=True, query="op")
 
-    assert _handle_active_search_key(_FakeCurses, ord("u"), search) == (True, False, True)
+    assert _handle_active_search_key(_FakeCurses, ord("u"), search) == (
+        True,
+        False,
+        True,
+    )
     assert search.query == "opu"
 
     assert _handle_active_search_key(_FakeCurses, _FakeCurses.KEY_ENTER, search) == (
@@ -66,3 +74,82 @@ def test_active_search_consumes_query_editing_and_confirm_keys():
         True,
         False,
     )
+
+
+class _DriverScreen:
+    def __init__(self, keys):
+        self.keys = list(keys)
+
+    def clear(self):
+        pass
+
+    def getmaxyx(self):
+        return 7, 80
+
+    def addnstr(self, *args):
+        pass
+
+    def refresh(self):
+        pass
+
+    def getch(self):
+        return self.keys.pop(0)
+
+    def timeout(self, milliseconds):
+        pass
+
+
+class _DriverCurses:
+    A_NORMAL = 0
+    A_BOLD = 1
+    A_DIM = 2
+    COLOR_GREEN = 2
+    COLOR_YELLOW = 3
+    COLOR_WHITE = 7
+    COLORS = 8
+    KEY_UP = 1001
+    KEY_DOWN = 1002
+    KEY_PPAGE = 1003
+    KEY_NPAGE = 1004
+    KEY_HOME = 1005
+    KEY_END = 1006
+    KEY_ENTER = 1007
+    KEY_BACKSPACE = 1008
+
+    class error(Exception):
+        pass
+
+    def __init__(self, screen):
+        self.screen = screen
+
+    def wrapper(self, draw):
+        draw(self.screen)
+
+    def has_colors(self):
+        return False
+
+    def curs_set(self, visible):
+        pass
+
+
+def test_searchable_driver_pages_through_filtered_original_indices(monkeypatch):
+    screen = _DriverScreen([
+        ord("/"),
+        ord("k"),
+        ord("e"),
+        ord("e"),
+        ord("p"),
+        _DriverCurses.KEY_NPAGE,
+        _DriverCurses.KEY_ENTER,
+    ])
+    curses_mod = _DriverCurses(screen)
+    monkeypatch.setitem(sys.modules, "curses", curses_mod)
+    monkeypatch.setattr(curses_ui.sys, "stdin", SimpleNamespace(isatty=lambda: True))
+
+    selected = curses_ui.curses_radiolist(
+        "Filtered paging",
+        ["aa", "keep-1", "bb", "keep-2", "cc", "keep-3", "dd", "keep-4"],
+        searchable=True,
+    )
+
+    assert selected == 7

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -12,6 +12,7 @@ def _args(**kwargs):
         "no_bundled": False,
         "plain": False,
         "json": False,
+        "no_pager": False,
     }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
@@ -158,3 +159,27 @@ def test_cmd_list_json_output_includes_entrypoint_source(monkeypatch, capsys):
             "source": "entrypoint",
         }
     ]
+
+
+def test_should_page_long_plugin_list_in_tty():
+    console = argparse.Namespace(is_terminal=True, height=10)
+
+    assert plugins_cmd._should_page_plugin_list(_args(), console, entry_count=20)
+
+
+def test_plugin_list_pager_can_be_disabled_or_bypassed_for_streams():
+    tty_console = argparse.Namespace(is_terminal=True, height=10)
+    pipe_console = argparse.Namespace(is_terminal=False, height=10)
+
+    assert not plugins_cmd._should_page_plugin_list(
+        _args(no_pager=True), tty_console, entry_count=20
+    )
+    assert not plugins_cmd._should_page_plugin_list(
+        _args(plain=True), tty_console, entry_count=20
+    )
+    assert not plugins_cmd._should_page_plugin_list(
+        _args(json=True), tty_console, entry_count=20
+    )
+    assert not plugins_cmd._should_page_plugin_list(
+        _args(), pipe_console, entry_count=20
+    )

--- a/tests/hermes_cli/test_plugins_cmd_list.py
+++ b/tests/hermes_cli/test_plugins_cmd_list.py
@@ -2,7 +2,10 @@ import argparse
 import json
 from types import SimpleNamespace
 
+import pytest
+
 from hermes_cli import plugins_cmd
+from hermes_cli.subcommands.plugins import build_plugins_parser
 
 
 def _args(**kwargs):
@@ -164,7 +167,27 @@ def test_cmd_list_json_output_includes_entrypoint_source(monkeypatch, capsys):
 def test_should_page_long_plugin_list_in_tty():
     console = argparse.Namespace(is_terminal=True, height=10)
 
-    assert plugins_cmd._should_page_plugin_list(_args(), console, entry_count=20)
+    assert plugins_cmd._should_page_plugin_list(
+        _args(), console, table=object(), entry_count=20
+    )
+
+
+def test_should_page_wrapped_table_using_rendered_height():
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console(width=30, height=14, force_terminal=True)
+    table = Table(title="Plugins")
+    table.add_column("Name")
+    table.add_column("Description")
+    table.add_row(
+        "demo",
+        "a long description that wraps across several narrow terminal rows",
+    )
+
+    assert plugins_cmd._should_page_plugin_list(
+        _args(), console, table=table, entry_count=1
+    )
 
 
 def test_plugin_list_pager_can_be_disabled_or_bypassed_for_streams():
@@ -172,14 +195,26 @@ def test_plugin_list_pager_can_be_disabled_or_bypassed_for_streams():
     pipe_console = argparse.Namespace(is_terminal=False, height=10)
 
     assert not plugins_cmd._should_page_plugin_list(
-        _args(no_pager=True), tty_console, entry_count=20
+        _args(no_pager=True), tty_console, table=object(), entry_count=20
     )
     assert not plugins_cmd._should_page_plugin_list(
-        _args(plain=True), tty_console, entry_count=20
+        _args(plain=True), tty_console, table=object(), entry_count=20
     )
     assert not plugins_cmd._should_page_plugin_list(
-        _args(json=True), tty_console, entry_count=20
+        _args(json=True), tty_console, table=object(), entry_count=20
     )
     assert not plugins_cmd._should_page_plugin_list(
-        _args(), pipe_console, entry_count=20
+        _args(), pipe_console, table=object(), entry_count=20
     )
+
+
+def test_plugins_list_no_pager_is_owned_by_list_parser():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_plugins_parser(subparsers, cmd_plugins=lambda args: None)
+
+    args = parser.parse_args(["plugins", "list", "--no-pager"])
+    assert args.no_pager is True
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["plugins", "enable", "demo", "--no-pager"])

--- a/tests/hermes_cli/test_plugins_cmd_ui.py
+++ b/tests/hermes_cli/test_plugins_cmd_ui.py
@@ -1,0 +1,122 @@
+"""Tests for the interactive ``hermes plugins`` composite menu."""
+
+from types import SimpleNamespace
+
+from hermes_cli import plugins_cmd
+
+
+class _FakeScreen:
+    def __init__(self, keys, height=8, width=100):
+        self.keys = list(keys)
+        self.height = height
+        self.width = width
+        self.frames = []
+
+    def clear(self):
+        self.frames.append([])
+
+    def getmaxyx(self):
+        return self.height, self.width
+
+    def addnstr(self, row, column, text, width, attr=0):
+        self.frames[-1].append((row, str(text)[:width]))
+
+    def refresh(self):
+        pass
+
+    def getch(self):
+        return self.keys.pop(0)
+
+    def keypad(self, enabled):
+        pass
+
+
+class _FakeCurses:
+    A_NORMAL = 0
+    A_BOLD = 1
+    A_DIM = 2
+    COLOR_GREEN = 2
+    COLOR_YELLOW = 3
+    COLOR_CYAN = 6
+    KEY_UP = 1001
+    KEY_DOWN = 1002
+    KEY_PPAGE = 1003
+    KEY_NPAGE = 1004
+    KEY_HOME = 1005
+    KEY_END = 1006
+    KEY_ENTER = 1007
+
+    class error(Exception):
+        pass
+
+    def __init__(self, screen):
+        self.screen = screen
+
+    def wrapper(self, draw):
+        draw(self.screen)
+
+    def has_colors(self):
+        return False
+
+    def curs_set(self, visible):
+        pass
+
+
+def test_build_composite_rows_uses_one_visual_coordinate_space():
+    categories = [
+        ("Memory Provider", "built-in", lambda: False),
+        ("Context Engine", "compressor", lambda: False),
+    ]
+
+    rows = plugins_cmd._build_composite_rows(
+        plugin_labels=["plugin-a", "plugin-b"],
+        categories=categories,
+    )
+
+    assert [row["kind"] for row in rows] == [
+        "section",
+        "plugin",
+        "plugin",
+        "spacer",
+        "section",
+        "category",
+        "category",
+    ]
+    assert plugins_cmd._composite_navigation_rows(rows) == [1, 2, 5, 6]
+    assert rows[5]["nav"] == ("category", 0)
+
+
+def test_page_navigation_lands_on_selectable_visual_row():
+    navigation_rows = [1, 2, 3, 7, 8]
+
+    assert plugins_cmd._page_composite_cursor(navigation_rows, 0, 4, 1) == 3
+    assert plugins_cmd._page_composite_cursor(navigation_rows, 4, 4, -1) == 2
+
+
+def test_constrained_viewport_renders_selected_provider_category(monkeypatch):
+    screen = _FakeScreen(keys=[_FakeCurses.KEY_END, ord("q")], height=8)
+    curses = _FakeCurses(screen)
+    plugin_keys = [f"group/plugin-{index}" for index in range(6)]
+    categories = [
+        ("Memory Provider", "built-in", lambda: False),
+        ("Context Engine", "compressor", lambda: False),
+    ]
+
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set(plugin_keys))
+    monkeypatch.setattr(plugins_cmd, "_save_enabled_set", lambda value: None)
+    monkeypatch.setattr(plugins_cmd, "_save_disabled_set", lambda value: None)
+
+    plugins_cmd._run_composite_ui(
+        curses,
+        plugin_keys,
+        [f"plugin-{index}" for index in range(6)],
+        set(range(6)),
+        set(),
+        categories,
+        SimpleNamespace(print=lambda *args, **kwargs: None),
+    )
+
+    assert len(screen.frames) == 2
+    rendered = [text for _row, text in screen.frames[-1]]
+    assert any("→   Context Engine" in text for text in rendered)
+    assert any("↑ more" in text for text in rendered)

--- a/tests/hermes_cli/test_plugins_cmd_ui.py
+++ b/tests/hermes_cli/test_plugins_cmd_ui.py
@@ -120,3 +120,30 @@ def test_constrained_viewport_renders_selected_provider_category(monkeypatch):
     rendered = [text for _row, text in screen.frames[-1]]
     assert any("→   Context Engine" in text for text in rendered)
     assert any("↑ more" in text for text in rendered)
+
+
+def test_composite_ui_persists_canonical_nested_plugin_key(monkeypatch):
+    screen = _FakeScreen(keys=[ord(" "), ord("q")])
+    curses = _FakeCurses(screen)
+    saved = {}
+
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: set())
+    monkeypatch.setattr(
+        plugins_cmd, "_save_enabled_set", lambda value: saved.update(enabled=value)
+    )
+    monkeypatch.setattr(
+        plugins_cmd, "_save_disabled_set", lambda value: saved.update(disabled=value)
+    )
+
+    plugins_cmd._run_composite_ui(
+        curses,
+        ["web/firecrawl"],
+        ["web-firecrawl — bundled search"],
+        set(),
+        {"firecrawl"},
+        [],
+        SimpleNamespace(print=lambda *args, **kwargs: None),
+    )
+
+    assert saved["enabled"] == {"web/firecrawl"}
+    assert saved["disabled"] == set()


### PR DESCRIPTION
## What does this PR do?

Fixes scrolling in long plugin menus after rebasing the change onto current `main`.

The composite `hermes plugins` screen now uses one visual-row coordinate space for section headers, spacers, general plugins, and provider categories. This keeps the selected provider row visible in constrained terminal viewports while preserving current canonical `plugin_keys` behavior for nested plugins.

It also extends the existing shared curses menu driver—without replacing its search/filter state—with PgUp/PgDn/Home/End navigation and position/overflow hints. Long Rich plugin tables use a pager in interactive terminals, with `--no-pager` available for direct output.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/plugins_cmd.py`
  - Scroll composite plugin/provider rows in visual coordinates.
  - Preserve canonical `plugin_keys` for nested plugin state.
  - Add automatic pager selection for long Rich plugin tables.
- `hermes_cli/curses_ui.py`
  - Integrate paging, Home/End, and scroll hints into the current search-aware shared driver.
- `hermes_cli/subcommands/plugins.py`
  - Add `hermes plugins list --no-pager` in the current parser owner.
- `tests/hermes_cli/`
  - Add a constrained-viewport regression test proving the selected provider category is rendered.
  - Cover visual row mapping, extended navigation, scroll hints, pager selection, and `--no-pager` behavior.

## How to Test

1. Run the focused suite:
   ```bash
   python -m pytest \
     tests/hermes_cli/test_curses_ui.py \
     tests/hermes_cli/test_curses_arrow_keys.py \
     tests/hermes_cli/test_curses_ui_search.py \
     tests/hermes_cli/test_plugins_cmd_ui.py \
     tests/hermes_cli/test_plugins_cmd_list.py \
     tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py -q
   ```
2. In a short terminal, run `hermes plugins`, press End, and confirm the selected Context Engine row remains visible.
3. Run `hermes plugins list`, then compare with `hermes plugins list --no-pager`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] My PR contains only changes related to this fix.
- [x] I've added regression tests for the changed behavior.
- [x] I've tested on Linux / CachyOS.

### Documentation & Housekeeping

- [x] Documentation/config/schema changes are N/A.
- [x] I've considered cross-platform impact and the Windows-footgun diff check passes.

## Screenshots / Logs

Constrained 100×10 tmux verification after pressing End:

```text
  Provider Plugins
     Memory Provider          ▸ built-in
 →   Context Engine           ▸ compressor
↑ more  90/90
```

Focused result: `67 passed`.

Full local suite result: `41,694 passed, 3 failed`. The three failures are unrelated environment-sensitive tests (local AWS default region, existing profile aliases on PATH, and no local Chromium binary) and reproduce unchanged on current `main`.
