### PR TITLE
tools/mcp_tool: fully close breaker on session-expired retry success

### DIFF
--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -302,6 +302,49 @@ def test_session_expired_handler_returns_none_when_retry_also_fails(
         mcp_tool._servers.pop("srv-retry-fail", None)
 
 
+@pytest.mark.parametrize("retry_result", ['{"ok": true}', 'plain non-json text'])
+def test_session_expired_retry_success_fully_closes_breaker(
+    monkeypatch, tmp_path, retry_result
+):
+    """A session-expired reconnect+retry success must FULLY close the breaker
+    — clearing _server_breaker_opened_at, not just the failure count — matching
+    the auth-recovery path (_handle_auth_error_and_retry). A partial reset
+    (count only) leaves a stale open-timestamp. Covers both the JSON-success
+    (no "error" key) and non-JSON-success retry branches."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _handle_session_expired_and_retry
+
+    server, _ = _install_stub_server("brk")
+    mcp_tool._servers["brk"] = server
+    # Simulate a breaker that had tripped: both count (at threshold) and
+    # open-timestamp set. (Calling the handler directly bypasses the gate,
+    # which would otherwise short-circuit an open+fresh breaker.)
+    mcp_tool._server_error_counts["brk"] = mcp_tool._CIRCUIT_BREAKER_THRESHOLD
+    mcp_tool._server_breaker_opened_at["brk"] = time.monotonic()
+
+    try:
+        out = _handle_session_expired_and_retry(
+            "brk",
+            RuntimeError("Invalid or expired session"),
+            lambda: retry_result,            # retry succeeds
+            "tools/call",
+        )
+        assert out == retry_result           # retry result returned
+        assert mcp_tool._server_error_counts.get("brk", 0) == 0
+        assert "brk" not in mcp_tool._server_breaker_opened_at, (
+            "session-expired retry success must clear the breaker open-"
+            "timestamp (full _reset_server_error), not just the count — a "
+            "stale opened_at diverges from the auth-recovery path and the "
+            "_reset_server_error contract."
+        )
+    finally:
+        mcp_tool._servers.pop("brk", None)
+        mcp_tool._server_error_counts.pop("brk", None)
+        mcp_tool._server_breaker_opened_at.pop("brk", None)
+
+
 # ---------------------------------------------------------------------------
 # Parallel coverage for resources/list, resources/read, prompts/list,
 # prompts/get — all four handlers share the same exception path.

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2177,10 +2177,10 @@ def _handle_session_expired_and_retry(
         try:
             parsed = json.loads(result)
             if "error" not in parsed:
-                _server_error_counts[server_name] = 0
+                _reset_server_error(server_name)
                 return result
         except (json.JSONDecodeError, TypeError):
-            _server_error_counts[server_name] = 0
+            _reset_server_error(server_name)
             return result
     except Exception as retry_exc:
         logger.warning(


### PR DESCRIPTION
## Summary

`_handle_session_expired_and_retry` cleared the consecutive-failure count on
retry success (`_server_error_counts[name] = 0`) but did not clear
`_server_breaker_opened_at`. The auth-recovery sibling
(`_handle_auth_error_and_retry`) already calls `_reset_server_error` on
success, which clears both. This uses the same helper in the session-expiry
path, so both success paths fully close the breaker — matching
`_reset_server_error`'s documented "call on any unambiguous success signal
(successful tool call, successful reconnect, …)" contract.

## Impact

Low-severity consistency fix. A stale `opened_at` with count=0 is harmless
(the gate only fires when count ≥ threshold, and the next bump re-stamps
`opened_at`), so this is hygiene rather than an active bug — but the two
recovery handlers should behave identically on their success paths.

## Test

Adds `test_session_expired_retry_success_fully_closes_breaker` (parametrized
over the JSON-success and non-JSON-success retry branches) asserting the
open-timestamp is cleared, not just the count.

## Note

Verified by inspection + red/green reasoning; the contributor's local
environment couldn't run the suite (repo requires Python ≥3.11). CI executes it.