### PR TITLE
fix(feishu): use consistent auth check for approval card actions

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2581,8 +2581,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        if not self._is_interactive_operator_authorized(open_id):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -638,6 +638,41 @@ class TestCardActionCallbackResponse:
         assert response.card is None
         mock_submit.assert_not_called()
 
+    def test_approval_allowed_when_no_admins_configured(self, _patch_callback_card_types):
+        """When no admins or allowed users are configured, anyone can approve.
+
+        Regression test: _handle_approval_card_action previously used
+        _allow_group_message() which blocks everyone when the allowlist is
+        empty.  It should use _is_interactive_operator_authorized() which
+        allows everyone when no admins are configured (open policy).
+        """
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        # No _admins, no _allowed_group_users — open policy
+        adapter._admins = set()
+        adapter._allowed_group_users = set()
+        adapter._approval_state[7] = {
+            "session_key": "sess-7",
+            "message_id": "msg-7",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 7},
+            open_id="ou_anyone",
+        )
+        adapter._sender_name_cache["ou_anyone"] = ("Anyone", 9999999999)
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.type == "raw"
+        card = response.card.data
+        assert card["header"]["template"] == "green"
+        assert "Approved once" in card["header"]["title"]["content"]
+
     def test_returns_card_for_update_prompt_yes(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = MagicMock()


### PR DESCRIPTION
## What does this PR do?

Fixes Feishu approval buttons silently rejecting all clicks when no admins are configured. The `_handle_approval_card_action` method used `_allow_group_message()` which blocks everyone when the allowlist is empty, while other card-action handlers correctly use `_is_interactive_operator_authorized()` which allows everyone in the unconfigured state.

## Related Issue

Fixes #35032

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/feishu.py`: Replace `_allow_group_message()` with `_is_interactive_operator_authorized()` in `_handle_approval_card_action` (line 2585), consistent with other card-action handlers at lines 2643 and 2675
- `tests/gateway/test_feishu_approval_buttons.py`: Add `test_approval_allowed_when_no_admins_configured` regression test verifying approval buttons work when no admins/allowed_users are configured

## How to Test

1. Configure Feishu without `admins` or `FEISHU_ALLOWED_USERS`
2. Send a command requiring `/execute` approval
3. Click the approval button — it should now work instead of silently failing
4. Run `pytest tests/gateway/test_feishu_approval_buttons.py -v` — all 36 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/feishu.py:_handle_approval_card_action` (callers: 1 via `_on_card_action_trigger`)
- Blast radius: LOW — single function in Feishu platform adapter, only affects approval card action handling
- Related patterns: `_is_interactive_operator_authorized` is the canonical auth check for card actions (used at lines 2643, 2675); `_allow_group_message` is for group message filtering (different concern)
