### PR TITLE
fix(packaging): include mcp_serve in py-modules so hermes mcp serve works on pip installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]
-py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils"]
+py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]


### PR DESCRIPTION
## What does this PR do?

Adds the missing `mcp_serve` module to the setuptools `py-modules` list in `pyproject.toml`, fixing `hermes mcp serve` crashing with `ModuleNotFoundError: No module named 'mcp_serve'` on standard pip installs.

## Related Issue

Fixes #34871

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `pyproject.toml`: Added `"mcp_serve"` to the `[tool.setuptools]` `py-modules` list so the top-level module is included in built wheels

## How to Test

1. Install hermes-agent via pip: `pip install hermes-agent`
2. Run `hermes mcp serve`
3. Verify it no longer crashes with `ModuleNotFoundError: No module named 'mcp_serve'`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/test_mcp_serve.py tests/hermes_cli/test_mcp_config*.py -q` and all tests pass (119 passed)
- [x] I've added tests for my changes -- or N/A (packaging metadata change, existing tests cover the module)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) -- or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys -- or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows -- or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide -- or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- or N/A

## Code Intelligence

- GitNexus unavailable -- grep-based fallback used.
- Checked: `pyproject.toml` (py-modules list), `hermes_cli/mcp_config.py:794` (from mcp_serve import run_mcp_server), `mcp_serve.py` (root module, 897 lines)
- Blast radius: LOW -- single packaging metadata line, no code logic changes
- Related patterns: Other top-level modules (run_agent, model_tools, etc.) already in the list; mcp_serve was the only missing one



## Infographic

![mcp_serve packaging fix](https://v3b.fal.media/files/b/0a9c4395/RFg51udFpln9rf8d1AmNR_8RoTSB8b.png)
