### PR TITLE
fix(simplex): extract group sender from chatDir.groupMember

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -354,13 +354,22 @@ class SimplexAdapter(BasePlatformAdapter):
             logger.debug("SimpleX: ignoring event with no chat_id")
             return
 
-        # Sender — for groups the message includes a chatItemMember sub-object
-        member = chat_item.get("chatItemMember") or {}
+        # Sender — current simplex-chat reports the group member under
+        # chatItem.chatDir.groupMember; older payloads used chatItemMember.
+        chat_dir = chat_item.get("chatDir") or {}
+        member = chat_dir.get("groupMember") or chat_item.get("chatItemMember") or {}
         if is_group and member:
-            sender_id = str(member.get("memberId") or member.get("id") or chat_id)
+            member_profile = member.get("memberProfile") or {}
+            sender_id = str(
+                member.get("memberId")
+                or member.get("groupMemberId")
+                or member.get("id")
+                or chat_id
+            )
             sender_name = (
                 member.get("displayName")
                 or member.get("localDisplayName")
+                or member_profile.get("displayName")
                 or sender_id
             )
         else:

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -263,6 +263,38 @@ async def test_handle_event_filters_own_corr_id():
     assert own not in adapter._pending_corr_ids  # discarded
 
 
+@pytest.mark.asyncio
+async def test_group_sender_from_chatdir_groupmember():
+    """current simplex-chat reports the group sender under
+    chatItem.chatDir.groupMember, not the legacy chatItemMember key."""
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    captured = AsyncMock()
+    adapter.handle_message = captured  # type: ignore
+
+    wrapper = {
+        "chatInfo": {"type": "group", "groupInfo": {"groupId": 7, "displayName": "hermes-agent"}},
+        "chatItem": {
+            "content": {"msgContent": {"type": "text", "text": "hello"}},
+            "meta": {"itemStatus": {"type": "rcvNew"}},
+            "chatDir": {
+                "type": "groupRcv",
+                "groupMember": {
+                    "memberId": "memb-abc",
+                    "memberProfile": {"displayName": "Brandon"},
+                },
+            },
+        },
+    }
+    await adapter._handle_new_chat_item(wrapper)
+
+    captured.assert_awaited_once()
+    event_obj = captured.await_args[0][0]
+    assert event_obj.source.user_id == "memb-abc"
+    assert event_obj.source.user_name == "Brandon"
+
+
 # ---------------------------------------------------------------------------
 # 9. Standalone (out-of-process) send for cron
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes group-message **sender extraction** in the SimpleX Chat platform adapter
(`plugins/platforms/simplex/adapter.py`).

For group messages, current `simplex-chat` reports the sending member under
`chatItem.chatDir.groupMember`. The adapter only read the legacy
`chatItem.chatItemMember` key, which is absent in this payload shape. As a
result `sender_id` fell back to the `chat_id` (e.g. `"group:1"`) — which is
never a real member id — and **downstream allowlist matching fails**, so the
bot can't identify who sent a group message even when delivery otherwise works.

The fix reads `chatDir.groupMember` first and falls back to `chatItemMember`
for older daemon payloads, and resolves the display name via `memberProfile`
when the member object doesn't carry it directly.

## Related Issue

Related to #30150, which documents three *other* SimpleX adapter bugs (missing
`/_start` subscribe, `newChatItems` resp-nesting, and `/_send` command syntax).
This PR addresses a **fourth, independent bug** — sender extraction — that is
not tracked by that issue. Happy to open a dedicated issue if maintainers
prefer one on file.

Fixes #35045

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/simplex/adapter.py` — read the group sender from
  `chatItem.chatDir.groupMember`, falling back to the legacy
  `chatItem.chatItemMember`; resolve `displayName` via `memberProfile`.
- `tests/gateway/test_simplex_plugin.py` — add
  `test_group_sender_from_chatdir_groupmember` asserting the correct
  `memberId`/display name are extracted from the `chatDir.groupMember` layout.

## How to Test

1. Run a `simplex-chat` daemon and join the bot to a group.
2. Send a group message from a phone and observe the inbound event: the member
   lives under `chatItem.chatDir.groupMember` (no `chatItemMember` key present).
3. **Before:** `sender_id` resolves to the `chat_id` (`"group:<n>"`), so the
   member is unidentifiable and allowlist checks against the real `memberId`
   fail. **After:** `sender_id` is the member's base64 `memberId` and the
   display name resolves correctly.
4. Unit test: `scripts/run_tests.sh tests/gateway/test_simplex_plugin.py`
   (28 passing here, incl. the new regression test).

> Note: reproducing the *full* phone→reply round-trip on a vanilla daemon also
> requires the three fixes in #26433 (without `/_start`, no events arrive at
> all). The added unit test exercises the sender-parsing path in isolation, so
> it stands on its own. Verified end-to-end on a live Ubuntu 24.04 deployment
> with the #26433 fixes applied — correct memberId + display name extracted.

## Relationship to existing PRs (duplicate check)

I searched open PRs before submitting:

- **#26433** (focused, open) fixes the three bugs in #30150 — but **not** this
  sender-extraction bug. This PR is complementary, not a duplicate; it isolates
  the one fix that's missing from that PR.
- **#4666** and **#27978** (large feature PRs, open) do include this same
  `chatDir.groupMember` change, but bundled inside hundreds of lines of other
  work. This PR offers it as a small, independently-reviewable fix.

If maintainers would rather fold this single change into #26433 or one of the
feature PRs, I'm happy to close this and move the diff there.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(simplex): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (see above)
- [x] My PR contains **only** changes related to this fix (one commit, two files)
- [x] I've run the test suite via `scripts/run_tests.sh` — SimpleX plugin suite **28/28 pass**. The full suite has some failures, but they are **pre-existing on unmodified `main`** (anthropic adapter, gateway service/WSL/systemd, TUI — environment-specific on macOS) and confirmed unrelated to this change; this PR introduces no new failures.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (live deployment) + macOS (unit tests)

### Documentation & Housekeeping

- [x] Docs — N/A (internal parsing fix, no user-facing surface)
- [x] `cli-config.yaml.example` — N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — N/A (pure dict parsing)
- [x] Tool descriptions/schemas — N/A
