### PR TITLE
docs(whatsapp): clarify setup caveats

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -164,6 +164,7 @@ import argparse
 import json
 import shutil
 import subprocess
+import textwrap
 from pathlib import Path
 from typing import Optional
 
@@ -1906,7 +1907,8 @@ def cmd_whatsapp(args):
             print("  │  Easiest: Install WhatsApp Business (free app)  │")
             print("  │  on your phone with a second number:            │")
             print("  │    • Dual-SIM: use your 2nd SIM slot            │")
-            print("  │    • Google Voice: free US number (voice.google) │")
+            print("  │    • Google Voice: only if WhatsApp accepts it; │")
+            print("  │      many newly created Voice numbers fail      │")
             print("  │    • Prepaid SIM: $3-10, verify once            │")
             print("  │                                                 │")
             print("  │  WhatsApp Business runs alongside your personal │")
@@ -1947,10 +1949,14 @@ def cmd_whatsapp(args):
         if response.lower() in {"y", "yes"}:
             if wa_mode == "bot":
                 phone = input(
-                    "  Phone numbers that can message the bot (comma-separated): "
+                    "  Phone numbers that can message the bot "
+                    "(country code + area code, no +; comma-separated): "
                 ).strip()
             else:
-                phone = input("  Your phone number (e.g. 15551234567): ").strip()
+                phone = input(
+                    "  Your phone number "
+                    "(country code + area code, no +; e.g. 15551234567): "
+                ).strip()
             if phone:
                 save_env_value("WHATSAPP_ALLOWED_USERS", phone.replace(" ", ""))
                 print(f"  ✓ Updated to: {phone}")
@@ -1959,10 +1965,14 @@ def cmd_whatsapp(args):
         if wa_mode == "bot":
             print("  Who should be allowed to message the bot?")
             phone = input(
-                "  Phone numbers (comma-separated, or * for anyone): "
+                "  Phone numbers "
+                "(country code + area code, no +; comma-separated, or * for anyone): "
             ).strip()
         else:
-            phone = input("  Your phone number (e.g. 15551234567): ").strip()
+            phone = input(
+                "  Your phone number "
+                "(country code + area code, no +; e.g. 15551234567): "
+            ).strip()
         if phone:
             save_env_value("WHATSAPP_ALLOWED_USERS", phone.replace(" ", ""))
             print(f"  ✓ Allowed users set: {phone}")
@@ -11793,8 +11803,29 @@ def main():
     whatsapp_parser = subparsers.add_parser(
         "whatsapp",
         help="Set up WhatsApp integration",
-        description="Configure WhatsApp and pair via QR code",
+        description="Configure WhatsApp and pair via QR code.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            """\
+            Notes:
+              - Hermes uses the bundled Baileys WhatsApp Web bridge, not the
+                official WhatsApp Business Cloud API.
+              - Use a dedicated number for bot mode. WhatsApp often rejects
+                newly created Google Voice numbers; a Voice number is more
+                likely to work only if it was ported from a mobile carrier or
+                has an older acceptance history.
+              - WHATSAPP_ALLOWED_USERS must use the full phone number with
+                country code and area code, without '+', spaces, or dashes.
+                Example: 15551234567 for a US +1 (555) 123-4567 number.
+              - Set WHATSAPP_ALLOWED_USERS=* only if every sender should be
+                allowed to reach the agent.
+
+            More docs:
+              https://hermes-agent.nousresearch.com/docs/user-guide/messaging/whatsapp
+            """
+        ),
     )
+    whatsapp_parser.add_argument("-help", action="help", help=argparse.SUPPRESS)
     whatsapp_parser.set_defaults(func=cmd_whatsapp)
 
     # =========================================================================

--- a/tests/hermes_cli/test_whatsapp_setup_ordering.py
+++ b/tests/hermes_cli/test_whatsapp_setup_ordering.py
@@ -15,9 +15,11 @@ from __future__ import annotations
 
 import io
 import os
+import subprocess
+import sys
 from contextlib import redirect_stdout
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -138,3 +140,20 @@ def test_existing_pairing_skip_branch_enables_whatsapp(isolated_home, monkeypatc
 
     # The skip-rebar branch should have set the env var on its way out.
     assert _env_value(isolated_home, "WHATSAPP_ENABLED") == "true"
+
+
+@pytest.mark.parametrize("help_flag", ["-h", "-help", "--help"])
+def test_whatsapp_help_includes_setup_caveats(help_flag):
+    """The setup command help should surface the hard-to-discover bits."""
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "whatsapp", help_flag],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    out = result.stdout + result.stderr
+    assert "newly created Google Voice numbers" in out
+    assert "country code and area code" in out
+    assert "15551234567" in out

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -679,7 +679,7 @@ See [Subagent Delegation](../user-guide/features/delegation.md) for more on how 
 
 2. **Use cron jobs for specialized tasks.** For a shopping list tracker, set up a cron job that monitors a specific chat and manages the list — no separate agent needed.
 
-3. **Use separate numbers.** If you need truly independent agents, pair each profile with its own WhatsApp number. Virtual numbers from services like Google Voice work for this.
+3. **Use separate numbers.** If you need truly independent agents, pair each profile with its own WhatsApp number. Prefer a prepaid SIM or another mobile-carrier number; WhatsApp often rejects newly created Google Voice numbers unless they were ported from a carrier or already have an older acceptance history.
 
 4. **Use Telegram or Discord instead.** These platforms support per-chat binding more naturally — each Telegram group or Discord channel gets its own session, and you can run multiple bot tokens (one per profile) on the same account.
 

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -76,7 +76,7 @@ For bot mode, you need a phone number that isn't already registered with WhatsAp
 
 | Option | Cost | Notes |
 |--------|------|-------|
-| **Google Voice** | Free | US only. Get a number at [voice.google.com](https://voice.google.com). Verify WhatsApp via SMS through the Google Voice app. |
+| **Google Voice** | Free | US only. WhatsApp often rejects newly created Google Voice numbers. A Voice number is more likely to work if it was ported from a mobile carrier or has an older acceptance history. |
 | **Prepaid SIM** | $5–15 one-time | Any carrier. Activate, verify WhatsApp, then the SIM can sit in a drawer. Number must stay active (make a call every 90 days). |
 | **VoIP services** | Free–$5/month | TextNow, TextFree, or similar. Some VoIP numbers are blocked by WhatsApp — try a few if the first doesn't work. |
 
@@ -98,10 +98,15 @@ WHATSAPP_ENABLED=true
 WHATSAPP_MODE=bot                          # "bot" or "self-chat"
 
 # Access control — pick ONE of these options:
-WHATSAPP_ALLOWED_USERS=15551234567         # Comma-separated phone numbers (with country code, no +)
+WHATSAPP_ALLOWED_USERS=15551234567         # Comma-separated phone numbers (country code + area code, no +)
 # WHATSAPP_ALLOWED_USERS=*                 # OR use * to allow everyone
 # WHATSAPP_ALLOW_ALL_USERS=true            # OR set this flag instead (same effect as *)
 ```
+
+`WHATSAPP_ALLOWED_USERS` must match WhatsApp's numeric sender ID format:
+include the full country code and area code, and omit `+`, spaces, dashes,
+and parentheses. For example, enter a US number like `+1 (555) 123-4567`
+as `15551234567`, not `5551234567`.
 
 :::tip Allow-all shorthand
 Setting `WHATSAPP_ALLOWED_USERS=*` allows **all** senders (equivalent to `WHATSAPP_ALLOW_ALL_USERS=true`).
@@ -214,7 +219,8 @@ When the agent calls tools (web search, file operations, etc.), WhatsApp display
 | **Bridge crashes or reconnect loops** | Restart the gateway, update Hermes, and re-pair if the session was invalidated by a WhatsApp protocol change. |
 | **Bot stops working after WhatsApp update** | Update Hermes to get the latest bridge version, then re-pair. |
 | **macOS: "Node.js not installed" but node works in terminal** | launchd services don't inherit your shell PATH. Run `hermes gateway install` to re-snapshot your current PATH into the plist, then `hermes gateway start`. See the [Gateway Service docs](./index.md#macos-launchd) for details. |
-| **Messages not being received** | Verify `WHATSAPP_ALLOWED_USERS` includes the sender's number (with country code, no `+` or spaces), or set it to `*` to allow everyone. Set `WHATSAPP_DEBUG=true` in `.env` and restart the gateway to see raw message events in `bridge.log`. |
+| **Messages not being received** | Verify `WHATSAPP_ALLOWED_USERS` includes the sender's full number (country code + area code, no `+`, spaces, dashes, or parentheses), or set it to `*` to allow everyone. Set `WHATSAPP_DEBUG=true` in `.env` and restart the gateway to see raw message events in `bridge.log`. |
+| **WhatsApp rejects my Google Voice number** | This is common for newly created Google Voice numbers. Try a prepaid SIM or a number that was ported from a mobile carrier instead. |
 | **Bot replies to strangers with a pairing code** | Set `whatsapp.unauthorized_dm_behavior: ignore` in `~/.hermes/config.yaml` if you want unauthorized DMs to be silently ignored instead. |
 
 ---


### PR DESCRIPTION
## Summary
- clarify that newly created Google Voice numbers are often rejected by WhatsApp, and suggest prepaid/mobile-carrier numbers instead
- make `WHATSAPP_ALLOWED_USERS` formatting explicit: full country code + area code, no `+`, spaces, dashes, or parentheses
- add useful `hermes whatsapp -h` / `-help` setup guidance and cover it with a focused test

## Testing
- `uv run --with pytest --with pytest-timeout pytest tests/hermes_cli/test_whatsapp_setup_ordering.py -q`
- `uv run --with ruff ruff check hermes_cli/main.py tests/hermes_cli/test_whatsapp_setup_ordering.py`
- `git diff --check`

## Existing issue/PR search
- Checked for existing WhatsApp Google Voice / allowlist docs work. Found related allowlist/security work (#15108), but nothing covering this setup caveat or the `hermes whatsapp` help text.