### PR TITLE
fix(test): add setuptools to dev extra so packaging test collects in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "ty==0.0.21", "ruff==0.15.10"]
+dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "ty==0.0.21", "ruff==0.15.10", "setuptools>=61.0"]
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.3", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.27.0", "slack-sdk==3.40.1", "aiohttp==3.13.3"]


### PR DESCRIPTION
## Summary
`tests/test_packaging_metadata.py` now collects reliably in every CI shard.

It imports `from setuptools import find_packages` at module top, but `setuptools` is only a `[build-system]` requirement — not installed in the CI test venv. The parallel runner slices test files across 6 shards by content, so the packaging test errored the **entire shard** whenever it landed in a slice where nothing else pulled setuptools in transitively. `main` has been green only by luck of the slicing; any PR that shifts the partition (e.g. adding a test file) can flip it red — which is exactly what surfaced it.

## Changes
- `pyproject.toml`: add `setuptools>=61.0` to the `dev` extra (installed via `.[all,dev]` in CI).

Chose this over `pytest.importorskip("setuptools")` deliberately — the test is a wheel-packaging regression guard (#34701 / #34034 / #28149). Skipping it would let the bug class it guards against slip through silently; we want it to actually run.

## Validation
| | Result |
|---|---|
| `tests/test_packaging_metadata.py` | 4/4 pass |
