### PR TITLE
fix(tests): skip packaging test gracefully when setuptools is absent

### DIFF
--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,7 +1,17 @@
 from pathlib import Path
+import importlib.util
 import tomllib
 
-from setuptools import find_packages
+import pytest
+
+# setuptools is a *build-system* requirement ([build-system].requires in
+# pyproject.toml), not a runtime or test dependency. Lean test
+# environments that install only runtime + dev deps (some CI slices, slim
+# containers) may not have it importable. Detect availability without a
+# module-level ``from setuptools import ...`` — that import raised
+# ModuleNotFoundError at collection time and failed the ENTIRE test slice,
+# taking the other three packaging tests down with it.
+_HAVE_SETUPTOOLS = importlib.util.find_spec("setuptools") is not None
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -12,6 +22,10 @@ def _packages_find_include():
     return data["tool"]["setuptools"]["packages"]["find"]["include"]
 
 
+@pytest.mark.skipif(
+    not _HAVE_SETUPTOOLS,
+    reason="setuptools (a build-only dependency) is not installed in this environment",
+)
 def test_every_on_disk_subpackage_is_covered_by_packages_find():
     """Regression test for #34701 (and the bug class behind #34034 / #28149).
 
@@ -29,6 +43,8 @@ def test_every_on_disk_subpackage_is_covered_by_packages_find():
     any listed package without the matching wildcard fails here instead of in a
     user's container.
     """
+    from setuptools import find_packages
+
     include = _packages_find_include()
 
     # What the real include list actually selects.


### PR DESCRIPTION
## Summary

`tests/test_packaging_metadata.py` no longer fails the whole test slice when `setuptools` isn't installed.

## Root cause

The module imported `from setuptools import find_packages` at the top level. `setuptools` is only a **build-system** requirement (`[build-system].requires` in `pyproject.toml`), not a runtime or test dependency. In lean test environments that install only runtime + dev deps (some CI slices, slim containers), `setuptools` may be absent — and the module-level import then raised `ModuleNotFoundError` at **collection** time, which failed the entire `test (N)` slice and took the other three packaging tests (faster-whisper, MANIFEST, plugin-manifest) down with it, even though they never use setuptools.

Observed on the slice-1 shard: `4795 tests passed, 0 failed`, but the slice still exited 1 because of this single collection error.

## Changes

- `tests/test_packaging_metadata.py`:
  - Detect availability via `importlib.util.find_spec("setuptools")` at module level (no import, no collection error).
  - Gate the one test that needs `find_packages` behind `@pytest.mark.skipif`.
  - Defer the actual `from setuptools import find_packages` into the test body.

## Validation

| | Before | After |
|---|---|---|
| setuptools present | 4 passed | 4 passed |
| setuptools absent | **collection error → whole slice fails** | 1 skipped, 3 passed |
