### PR TITLE
fix: finish James Telegram admin R8 gates

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -41,13 +41,16 @@ import re
 import sqlite3
 import time
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 try:
+    import aiohttp
     from aiohttp import web
     AIOHTTP_AVAILABLE = True
 except ImportError:
+    aiohttp = None  # type: ignore[assignment]
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
 
@@ -717,6 +720,40 @@ class APIServerAdapter(BasePlatformAdapter):
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._internal_notify_token: str = str(
+            extra.get("internal_notify_token")
+            or os.getenv("INTERNAL_NOTIFY_TOKEN", "")
+        ).strip()
+        self._internal_notify_dedup_seconds: int = self._coerce_positive_int(
+            extra.get("internal_notify_dedup_seconds")
+            or os.getenv("INTERNAL_NOTIFY_DEDUP_SECONDS", "300"),
+            default=300,
+        )
+        self._internal_notify_allowed_ips: tuple[str, ...] = self._parse_csv_tuple(
+            extra.get("internal_notify_allowed_ips")
+            or os.getenv("INTERNAL_NOTIFY_ALLOWED_IPS", "127.0.0.1,::1"),
+        )
+        self._internal_notify_last_sent: Dict[str, float] = {}
+
+    @staticmethod
+    def _coerce_positive_int(value: Any, default: int) -> int:
+        try:
+            parsed = int(value)
+            return parsed if parsed > 0 else default
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _parse_csv_tuple(value: Any) -> tuple[str, ...]:
+        if not value:
+            return ()
+        if isinstance(value, str):
+            items = value.split(",")
+        elif isinstance(value, (list, tuple, set)):
+            items = value
+        else:
+            items = [str(value)]
+        return tuple(str(item).strip() for item in items if str(item).strip())
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -1014,6 +1051,257 @@ class APIServerAdapter(BasePlatformAdapter):
             gateway_session_key=gateway_session_key,
         )
         return agent
+
+    # ------------------------------------------------------------------
+    # Internal notification helpers
+    # ------------------------------------------------------------------
+
+    _INTERNAL_NOTIFY_SEVERITIES = frozenset({"info", "warning", "critical", "resolved"})
+    _INTERNAL_NOTIFY_SENSITIVE_KEY_RE = re.compile(
+        r"(token|secret|password|passwd|senha|cookie|api[_-]?key|captcha[_-]?key|har|private|cert|a1|cpf|cnpj|renavam|placa|telefone|phone|celular|documento)",
+        re.IGNORECASE,
+    )
+    _INTERNAL_NOTIFY_SECRET_ASSIGNMENT_RE = re.compile(
+        r"\b(token|api[_-]?key|password|passwd|secret|senha)\s*[:=]\s*[^\s,;&]+",
+        re.IGNORECASE,
+    )
+    _INTERNAL_NOTIFY_CPF_RE = re.compile(r"(?<!\d)\d{3}\.?\d{3}\.?\d{3}-?\d{2}(?!\d)")
+    _INTERNAL_NOTIFY_CNPJ_RE = re.compile(r"(?<!\d)\d{2}\.?\d{3}\.?\d{3}/?\d{4}-?\d{2}(?!\d)")
+    _INTERNAL_NOTIFY_LONG_ID_RE = re.compile(r"(?<![\d.,])\d{9,14}(?![\d.,])")
+    _INTERNAL_NOTIFY_BR_PHONE_RE = re.compile(
+        r"(?<!\d)(?:\+?55[\s.-]?)?(?:\(?\d{2}\)?[\s.-]?)?(?:9\d{4}|[2-5]\d{3})[\s.-]?\d{4}(?!\d)"
+    )
+    _INTERNAL_NOTIFY_PLATE_RE = re.compile(r"\b[A-Z]{3}[-\s]?\d[A-Z0-9]\d{2}\b", re.IGNORECASE)
+
+    @classmethod
+    def _internal_notify_redact_text(cls, text: str) -> str:
+        """Redact PII/secrets before any /internal/notify text leaves the process."""
+        redacted = cls._INTERNAL_NOTIFY_SECRET_ASSIGNMENT_RE.sub(
+            lambda match: f"{match.group(1)}=[dado sensível ocultado]",
+            text,
+        )
+        for pattern in (
+            cls._INTERNAL_NOTIFY_CNPJ_RE,
+            cls._INTERNAL_NOTIFY_CPF_RE,
+            cls._INTERNAL_NOTIFY_BR_PHONE_RE,
+            cls._INTERNAL_NOTIFY_PLATE_RE,
+            cls._INTERNAL_NOTIFY_LONG_ID_RE,
+        ):
+            redacted = pattern.sub("[dado sensível ocultado]", redacted)
+        return redacted
+
+    def _internal_notify_auth_error(self, request: "web.Request") -> Optional["web.Response"]:
+        if not self._internal_notify_token:
+            return web.json_response(
+                {"error": {"message": "Internal notify endpoint is not configured", "code": "not_configured"}},
+                status=503,
+            )
+
+        peer_ip = self._request_audit_context(request).get("peer_ip") or self._request_audit_context(request).get("remote")
+        if self._internal_notify_allowed_ips and peer_ip not in self._internal_notify_allowed_ips:
+            logger.warning(
+                "Internal notify rejected disallowed source: %s",
+                self._request_audit_log_suffix(request),
+            )
+            return web.json_response(
+                {"error": {"message": "Source IP not allowed", "code": "source_not_allowed"}},
+                status=403,
+            )
+
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            token = auth_header[7:].strip()
+            if hmac.compare_digest(token, self._internal_notify_token):
+                return None
+
+        logger.warning(
+            "Internal notify rejected invalid token: %s",
+            self._request_audit_log_suffix(request),
+        )
+        return web.json_response(
+            {"error": {"message": "Invalid internal notify token", "code": "invalid_token"}},
+            status=401,
+        )
+
+    @classmethod
+    def _internal_notify_clean_value(cls, value: Any, *, max_len: int = 240) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, (dict, list, tuple, set)):
+            try:
+                text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+            except Exception:
+                text = str(value)
+        else:
+            text = str(value)
+        text = text.replace("\r", " ").replace("\n", " ").strip()
+        text = cls._internal_notify_redact_text(text)
+        return text[:max_len]
+
+    @classmethod
+    def _internal_notify_safe_details_lines(cls, details: Any) -> list[str]:
+        if not isinstance(details, dict):
+            return []
+        lines: list[str] = []
+        for key in sorted(details):
+            if len(lines) >= 8:
+                break
+            key_text = str(key).strip()
+            if not key_text or cls._INTERNAL_NOTIFY_SENSITIVE_KEY_RE.search(key_text):
+                continue
+            value = details.get(key)
+            lines.append(f"{key_text}: {cls._internal_notify_clean_value(value, max_len=160)}")
+        return lines
+
+    @staticmethod
+    def _internal_notify_format_timestamp(value: Any) -> str:
+        if isinstance(value, str) and value.strip():
+            raw = value.strip()
+            try:
+                parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+                local_dt = parsed.astimezone()
+                return local_dt.strftime("%d/%m/%Y %H:%M:%S %z")
+            except Exception:
+                return raw[:80]
+        return datetime.now(timezone.utc).astimezone().strftime("%d/%m/%Y %H:%M:%S %z")
+
+    def _internal_notify_render_message(self, payload: Dict[str, Any]) -> str:
+        severity = str(payload.get("severity") or "info").strip().lower()
+        source = self._internal_notify_clean_value(payload.get("source") or "unknown", max_len=80)
+        title = self._internal_notify_clean_value(payload.get("title") or "Alerta Hermes", max_len=120)
+        message = self._internal_notify_clean_value(payload.get("message") or "", max_len=1200)
+        details = payload.get("details") if isinstance(payload.get("details"), dict) else {}
+        status = self._internal_notify_clean_value(details.get("status") if isinstance(details, dict) else severity, max_len=80) or severity
+        timestamp = self._internal_notify_format_timestamp(payload.get("timestamp"))
+
+        lines = [
+            f"[{severity.upper()}] {source}",
+            title,
+        ]
+        if message:
+            lines.extend(["", message])
+        lines.extend(["", f"Status geral: {status}", f"Horário: {timestamp}"])
+        safe_detail_lines = self._internal_notify_safe_details_lines(details)
+        if safe_detail_lines:
+            lines.extend(["", "Detalhes:", *safe_detail_lines])
+        return "\n".join(lines)[:3900]
+
+    def _internal_notify_dedup_key(self, payload: Dict[str, Any]) -> str:
+        source = str(payload.get("source") or "").strip().lower()
+        severity = str(payload.get("severity") or "info").strip().lower()
+        title = str(payload.get("title") or "").strip().lower()
+        raw = f"{source}\0{severity}\0{title}"
+        return hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()
+
+    def _internal_notify_is_duplicate(self, payload: Dict[str, Any]) -> tuple[bool, str, float]:
+        key = self._internal_notify_dedup_key(payload)
+        now = time.time()
+        last = self._internal_notify_last_sent.get(key, 0.0)
+        if last and now - last < self._internal_notify_dedup_seconds:
+            return True, key, self._internal_notify_dedup_seconds - (now - last)
+        return False, key, 0.0
+
+    async def _internal_notify_send_telegram(self, text: str) -> Dict[str, Any]:
+        from gateway.config import load_gateway_config
+
+        gateway_config = load_gateway_config()
+        telegram_config = gateway_config.platforms.get(Platform.TELEGRAM)
+        if not telegram_config or not telegram_config.enabled or not telegram_config.token:
+            raise RuntimeError("Telegram platform is not configured")
+        if not telegram_config.home_channel or not telegram_config.home_channel.chat_id:
+            raise RuntimeError("Telegram home channel is not configured")
+
+        body: Dict[str, Any] = {
+            "chat_id": telegram_config.home_channel.chat_id,
+            "text": text,
+            "disable_web_page_preview": True,
+        }
+        if telegram_config.home_channel.thread_id:
+            try:
+                body["message_thread_id"] = int(telegram_config.home_channel.thread_id)
+            except ValueError:
+                body["message_thread_id"] = telegram_config.home_channel.thread_id
+
+        timeout = aiohttp.ClientTimeout(total=15) if "aiohttp" in globals() else None
+        async with aiohttp.ClientSession(timeout=timeout) as session:  # type: ignore[name-defined]
+            async with session.post(
+                f"https://api.telegram.org/bot{telegram_config.token}/sendMessage",
+                json=body,
+            ) as resp:
+                data = await resp.json(content_type=None)
+                if resp.status >= 400 or not data.get("ok"):
+                    description = str(data.get("description") or f"HTTP {resp.status}")[:200]
+                    raise RuntimeError(f"Telegram send failed: {description}")
+                result = data.get("result") or {}
+                return {"message_id": result.get("message_id"), "chat_id": str((result.get("chat") or {}).get("id", ""))}
+
+    async def _handle_internal_notify(self, request: "web.Request") -> "web.Response":
+        """POST /internal/notify — authenticated internal alert ingress for host watchers."""
+        auth_err = self._internal_notify_auth_error(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            payload = await request.json()
+        except Exception:
+            return web.json_response(
+                {"error": {"message": "Invalid JSON payload", "code": "invalid_json"}},
+                status=400,
+            )
+        if not isinstance(payload, dict):
+            return web.json_response(
+                {"error": {"message": "Payload must be a JSON object", "code": "invalid_payload"}},
+                status=400,
+            )
+
+        source = self._internal_notify_clean_value(payload.get("source") or "", max_len=80)
+        severity = str(payload.get("severity") or "info").strip().lower()
+        title = self._internal_notify_clean_value(payload.get("title") or "", max_len=120)
+        message = self._internal_notify_clean_value(payload.get("message") or "", max_len=1200)
+        if not source or not title or not message:
+            return web.json_response(
+                {"error": {"message": "source, title and message are required", "code": "missing_required_fields"}},
+                status=400,
+            )
+        if severity not in self._INTERNAL_NOTIFY_SEVERITIES:
+            return web.json_response(
+                {"error": {"message": "severity must be info, warning, critical or resolved", "code": "invalid_severity"}},
+                status=400,
+            )
+
+        duplicate, dedup_key, retry_after = self._internal_notify_is_duplicate(payload)
+        if duplicate:
+            return web.json_response({
+                "ok": True,
+                "sent": False,
+                "deduplicated": True,
+                "retry_after_seconds": int(retry_after),
+            })
+
+        text = self._internal_notify_render_message(payload)
+        try:
+            result = await self._internal_notify_send_telegram(text)
+        except Exception as exc:
+            logger.warning("Internal notify Telegram delivery failed: %s", exc)
+            return web.json_response(
+                {"error": {"message": "Telegram delivery failed", "code": "delivery_failed"}},
+                status=502,
+            )
+
+        self._internal_notify_last_sent[dedup_key] = time.time()
+        logger.info(
+            "Internal notify delivered: source=%r severity=%r title=%r message_id=%r",
+            source,
+            severity,
+            title,
+            result.get("message_id"),
+        )
+        return web.json_response({
+            "ok": True,
+            "sent": True,
+            "deduplicated": False,
+            "message_id": result.get("message_id"),
+        })
 
     # ------------------------------------------------------------------
     # HTTP Handlers
@@ -4050,6 +4338,7 @@ class APIServerAdapter(BasePlatformAdapter):
             assert self._app is not None
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
+            self._app.router.add_post("/internal/notify", self._handle_internal_notify)
             self._app.router.add_get("/v1/health", self._handle_health)
             self._app.router.add_get("/v1/models", self._handle_models)
             self._app.router.add_get("/v1/capabilities", self._handle_capabilities)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1153,8 +1153,8 @@ class APIServerAdapter(BasePlatformAdapter):
             lines.append(f"{key_text}: {cls._internal_notify_clean_value(value, max_len=160)}")
         return lines
 
-    @staticmethod
-    def _internal_notify_format_timestamp(value: Any) -> str:
+    @classmethod
+    def _internal_notify_format_timestamp(cls, value: Any) -> str:
         if isinstance(value, str) and value.strip():
             raw = value.strip()
             try:
@@ -1162,11 +1162,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 local_dt = parsed.astimezone()
                 return local_dt.strftime("%d/%m/%Y %H:%M:%S %z")
             except Exception:
-                return raw[:80]
+                return cls._internal_notify_clean_value(raw, max_len=80)
         return datetime.now(timezone.utc).astimezone().strftime("%d/%m/%Y %H:%M:%S %z")
 
     def _internal_notify_render_message(self, payload: Dict[str, Any]) -> str:
         severity = str(payload.get("severity") or "info").strip().lower()
+        if severity not in self._INTERNAL_NOTIFY_SEVERITIES:
+            severity = "info"
         source = self._internal_notify_clean_value(payload.get("source") or "unknown", max_len=80)
         title = self._internal_notify_clean_value(payload.get("title") or "Alerta Hermes", max_len=120)
         message = self._internal_notify_clean_value(payload.get("message") or "", max_len=1200)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -73,8 +73,13 @@ _JAMES_VEHICLE_COMMANDS = {
     "licenca": "licenca",
     "licenciamento": "licenca",
     "transferencia": "transferencia",
+    "trasnferencia": "transferencia",
 }
+_JAMES_ADMIN_COMMANDS = frozenset({"james", "licenca", "transferencia", "status_james", "proposta"})
 _JAMES_RENAVAM_RE = re.compile(r"(?<!\d)(?:\d[.\-\s]?){9,11}(?!\d)")
+_JAMES_LONG_ID_RE = re.compile(r"(?<!\d)(?:\d[.\-\s]?){9,14}(?!\d)")
+_JAMES_PLATE_RE = re.compile(r"(?<![A-Z0-9])(?:[A-Z]{3}[-\s]?\d{4}|[A-Z]{3}\d[A-Z0-9]\d{2})(?![A-Z0-9])", re.I)
+_JAMES_SECRET_RE = re.compile(r"(?i)\b(api[_-]?key|token|secret|password|passwd|senha)\s*[:=]\s*[^\s,;]+")
 
 
 def _normalize_james_vehicle_command(command: str | None) -> str | None:
@@ -93,6 +98,42 @@ def _extract_james_renavam(text: str) -> str | None:
         if 9 <= len(candidate) <= 11:
             return candidate
     return None
+
+
+def _collect_james_sensitive_values(value: Any) -> set[str]:
+    sensitive_keys = {"renavam", "placa", "documento", "cpf", "cnpj", "cpfcnpj", "nome", "token", "secret"}
+    found: set[str] = set()
+
+    def _walk(obj: Any, key_hint: str = "") -> None:
+        if isinstance(obj, dict):
+            for key, nested in obj.items():
+                _walk(nested, str(key).lower())
+            return
+        if isinstance(obj, list):
+            for nested in obj:
+                _walk(nested, key_hint)
+            return
+        if not key_hint or not any(part in key_hint.replace("_", "") for part in sensitive_keys):
+            return
+        text = str(obj or "").strip()
+        if len(text) >= 3:
+            found.add(text)
+
+    _walk(value)
+    return found
+
+
+def _sanitize_james_text(value: Any, sensitive_values: set[str] | None = None) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    for raw in sorted(sensitive_values or set(), key=len, reverse=True):
+        if raw:
+            text = text.replace(raw, "[dado sensível ocultado]")
+    text = _JAMES_SECRET_RE.sub(lambda m: f"{m.group(1)}=[dado sensível ocultado]", text)
+    text = _JAMES_PLATE_RE.sub("[placa ocultada]", text)
+    text = _JAMES_LONG_ID_RE.sub("[dado sensível ocultado]", text)
+    return text
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
@@ -7470,6 +7511,13 @@ class GatewayRunner:
             if _denied is not None:
                 return _denied
 
+        # James operational commands are stricter than the generic slash ACL:
+        # deny non-admins before command hooks can observe or act on James input.
+        if canonical in _JAMES_ADMIN_COMMANDS:
+            _james_denied = self._check_james_admin_access(source, canonical)
+            if _james_denied is not None:
+                return _james_denied
+
         # Fire the ``command:<canonical>`` hook for any recognized slash
         # command — built-in OR plugin-registered. Handlers can return a
         # dict with ``{"decision": "deny" | "handled" | "rewrite", ...}``
@@ -7553,6 +7601,12 @@ class GatewayRunner:
 
         if canonical == "commands":
             return await self._handle_commands_command(event)
+
+        if canonical == "james":
+            _james_denied = self._check_james_admin_access(source, canonical)
+            if _james_denied is not None:
+                return _james_denied
+            return self._handle_james_help_command(event)
         
         if canonical == "profile":
             return await self._handle_profile_command(event)
@@ -7690,6 +7744,17 @@ class GatewayRunner:
 
         if self._draining:
             return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
+
+        if canonical in _JAMES_ADMIN_COMMANDS:
+            _james_denied = self._check_james_admin_access(source, canonical)
+            if _james_denied is not None:
+                return _james_denied
+
+        if canonical == "status_james":
+            return await self._handle_james_status_command(event)
+
+        if canonical == "proposta":
+            return await self._handle_james_proposta_command(event)
 
         james_vehicle_command = _normalize_james_vehicle_command(command)
         if james_vehicle_command:
@@ -9366,6 +9431,21 @@ class GatewayRunner:
 
         return "\n".join(lines)
 
+    def _handle_james_help_command(self, event: MessageEvent) -> str:
+        return (
+            "Comandos do James\n"
+            "Atalhos admin-only para uso local/lab.\n"
+            "Toque no comando e depois envie o RENAVAM quando solicitado.\n\n"
+            "/licenca — consultar licenciamento\n"
+            "/transferencia — consultar transferência\n"
+            "/status_james — checar saúde local/lab sem restart\n"
+            "/proposta — gerar rascunho local/lab, sem envio a cliente\n\n"
+            "Se já tiver o RENAVAM, pode mandar direto:\n"
+            "/licenca 123456789\n"
+            "/transferencia 123456789\n"
+            "/proposta 123456789"
+        )
+
     async def _handle_james_vehicle_direct_command(self, event: MessageEvent, command: str) -> str:
         args = event.get_command_args().strip()
         renavam = _extract_james_renavam(args)
@@ -9419,21 +9499,191 @@ class GatewayRunner:
         label = "Licenciamento" if command == "licenca" else "Transferência"
         status = result.get("status")
         body = str(result.get("body") or "")
+
+        def _money(value: Any) -> str | None:
+            if value is None:
+                return None
+            try:
+                amount = float(value)
+            except (TypeError, ValueError):
+                return None
+            formatted = f"{amount:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
+            return f"R$ {formatted}"
+
         try:
-            parsed = json.loads(body)
-            body = json.dumps(parsed, ensure_ascii=False, indent=2, sort_keys=True)
+            parsed = json.loads(body) if body else {}
         except Exception:
-            pass
-        if len(body) > 3300:
-            body = body[:3300].rstrip() + "\n...[truncado]"
-        placa_note = "sem PLACA" if "placa" not in payload else f"PLACA {payload['placa']}"
-        return (
-            f"James direto — {label}\n"
-            f"Adapter: {path}\n"
-            f"Payload: RENAVAM {payload['renavam']} ({placa_note})\n"
-            f"HTTP: {status}\n"
-            f"Retorno:\n{body}"
+            parsed = {}
+
+        if not isinstance(parsed, dict):
+            parsed = {}
+
+        sensitive_values = _collect_james_sensitive_values(parsed)
+        ocorrencia = parsed.get("ocorrencia") if isinstance(parsed.get("ocorrencia"), dict) else {}
+        categoria = _sanitize_james_text(ocorrencia.get("categoria"), sensitive_values)
+        codigo = _sanitize_james_text(ocorrencia.get("codigo"), sensitive_values)
+        descricao = _sanitize_james_text(ocorrencia.get("descricao"), sensitive_values)
+        try:
+            status_code = int(status) if status is not None else None
+        except (TypeError, ValueError):
+            status_code = None
+        acao = "OK" if result.get("ok") and status_code and 200 <= status_code < 300 else "Falha"
+        resultado = descricao or categoria or ("consulta concluída" if acao == "OK" else "adapter não retornou JSON tratável")
+
+        lines = [
+            f"James direto — {label}",
+            f"Status: {acao} (HTTP {status or 'sem resposta'})",
+            f"Resultado: {resultado}",
+        ]
+        if codigo:
+            lines.append(f"Código: {codigo}")
+
+        value_lines: list[str] = []
+        for field, field_label in (
+            ("valorFinal", "Valor base retornado"),
+            ("valorTaxas", "Taxas"),
+            ("valorMultas", "Multas"),
+            ("valorIpvas", "IPVA"),
+        ):
+            formatted = _money(parsed.get(field))
+            if formatted is not None:
+                value_lines.append(f"{field_label}: {formatted}")
+        if value_lines:
+            lines.append("Valores:")
+            lines.extend(value_lines)
+            lines.append("Honorários do Despachante ainda devem ser somados antes de passar ao cliente.")
+
+        if not parsed and body:
+            lines.append("Retorno técnico sem JSON tratável ocultado para evitar exposição de dados sensíveis.")
+
+        lines.append("Dados sensíveis ocultados: RENAVAM, placa, CPF/CNPJ e nome.")
+        return "\n".join(lines)
+
+    async def _call_james_health_endpoint(self, base_url: str) -> dict[str, Any]:
+        url = f"{base_url.rstrip('/')}/health"
+
+        def _get() -> dict[str, Any]:
+            request = urllib.request.Request(
+                url,
+                headers={"Accept": "application/json"},
+                method="GET",
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=5) as response:
+                    raw = response.read().decode("utf-8", errors="replace")
+                    return {"ok": True, "status": response.status, "body": raw}
+            except urllib.error.HTTPError as exc:
+                raw = exc.read().decode("utf-8", errors="replace")
+                return {"ok": False, "status": exc.code, "body": raw}
+            except Exception as exc:
+                return {"ok": False, "status": None, "body": f"health_request_failed: {type(exc).__name__}"}
+
+        return await asyncio.to_thread(_get)
+
+    async def _handle_james_status_command(self, event: MessageEvent) -> str:
+        api_base = os.environ.get("JAMES_TELEGRAM_API_SERVER_BASE_URL", "http://127.0.0.1:8642").rstrip("/")
+        adapter_base = os.environ.get("JAMES_TELEGRAM_DIRECT_ADAPTER_BASE_URL", "http://127.0.0.1:18083").rstrip("/")
+        api_result, adapter_result = await asyncio.gather(
+            self._call_james_health_endpoint(api_base),
+            self._call_james_health_endpoint(adapter_base),
         )
+
+        def _line(label: str, result: dict[str, Any]) -> str:
+            status = result.get("status")
+            try:
+                status_code = int(status) if status is not None else None
+            except (TypeError, ValueError):
+                status_code = None
+            ok = bool(result.get("ok")) and status_code is not None and 200 <= status_code < 300
+            return f"{label}: {'OK' if ok else 'Falha'} (HTTP {status or 'sem resposta'})"
+
+        return "\n".join(
+            [
+                "Status James 2.0 — local/lab",
+                _line("API Server local/lab", api_result),
+                _line("Adapter James local/lab", adapter_result),
+                "Operação segura: somente health-check; sem restart, sem envio externo e sem side effects reais.",
+            ]
+        )
+
+    async def _handle_james_proposta_command(self, event: MessageEvent) -> str:
+        args = event.get_command_args().strip()
+        renavam = _extract_james_renavam(args)
+        if not renavam:
+            return (
+                "Me manda o RENAVAM para montar o rascunho local/lab.\n"
+                "Exemplo: /proposta 123456789\n"
+                "Nada será enviado ao cliente automaticamente."
+            )
+
+        service_path = "/api-interna/consultar-licenciamento"
+        result = await self._call_james_vehicle_direct_adapter(service_path, {"renavam": renavam})
+        return self._format_james_proposta_response(result)
+
+    def _format_james_proposta_response(self, result: dict[str, Any]) -> str:
+        status = result.get("status")
+        body = str(result.get("body") or "")
+
+        def _money(value: Any) -> str | None:
+            if value is None:
+                return None
+            try:
+                amount = float(value)
+            except (TypeError, ValueError):
+                return None
+            formatted = f"{amount:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
+            return f"R$ {formatted}"
+
+        try:
+            parsed = json.loads(body) if body else {}
+        except Exception:
+            parsed = {}
+        if not isinstance(parsed, dict):
+            parsed = {}
+
+        try:
+            status_code = int(status) if status is not None else None
+        except (TypeError, ValueError):
+            status_code = None
+        ok = bool(result.get("ok")) and status_code is not None and 200 <= status_code < 300
+        sensitive_values = _collect_james_sensitive_values(parsed)
+        ocorrencia = parsed.get("ocorrencia") if isinstance(parsed.get("ocorrencia"), dict) else {}
+        descricao = _sanitize_james_text(ocorrencia.get("descricao"), sensitive_values)
+
+        lines = [
+            "Rascunho local/lab — proposta James",
+            "NÃO enviar ao cliente automaticamente; revisar valores, honorários e contexto antes de qualquer atendimento real.",
+            f"Status da consulta: {'OK' if ok else 'Falha'} (HTTP {status or 'sem resposta'})",
+        ]
+        if descricao:
+            lines.append(f"Base consultada: {descricao}")
+
+        value_lines: list[str] = []
+        for field, field_label in (
+            ("valorFinal", "Total base retornado"),
+            ("valorTaxas", "Taxas"),
+            ("valorMultas", "Multas"),
+            ("valorIpvas", "IPVA"),
+        ):
+            formatted = _money(parsed.get(field))
+            if formatted is not None:
+                value_lines.append(f"{field_label}: {formatted}")
+        if value_lines:
+            lines.append("Valores para rascunho:")
+            lines.extend(value_lines)
+            lines.append("Honorários do Despachante devem ser definidos/revisados manualmente antes da proposta final.")
+        else:
+            lines.append("Sem valores tratáveis no retorno; revisar manualmente antes de propor qualquer coisa ao cliente.")
+
+        lines.extend(
+            [
+                "Texto-base sugerido (editar antes de usar):",
+                "Conferi os débitos e taxas do veículo no ambiente local/lab. Posso te passar o fechamento após validar honorários e dados do atendimento.",
+                "Dados sensíveis ocultados: RENAVAM, placa, CPF/CNPJ e nome.",
+                "Side effects bloqueados: WhatsApp real, PIX real, campanha real e baixa financeira.",
+            ]
+        )
+        return "\n".join(lines)
 
     async def _handle_reset_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /new or /reset command."""
@@ -9598,6 +9848,29 @@ class GatewayRunner:
 
         return "\n".join(lines)
 
+
+    def _check_james_admin_access(self, source: SessionSource, canonical_cmd: str) -> Optional[str]:
+        """James operational shortcuts are admin-only when slash admin lists exist.
+
+        If a platform scope has no ``allow_admin_from`` configured, preserve the
+        existing gateway behavior: every already-authorized operator can use
+        gateway-only shortcuts. Once an admin list exists, James commands ignore
+        ``user_allowed_commands`` and require the sender to be in the admin list.
+        """
+        from gateway.slash_access import policy_for_source as _policy_for_source
+
+        if canonical_cmd not in _JAMES_ADMIN_COMMANDS:
+            return None
+        policy = _policy_for_source(self.config, source)
+        if not policy.enabled or policy.is_admin(source.user_id):
+            return None
+        logger.info(
+            "James command /%s denied for %s:%s (admin-only)",
+            canonical_cmd,
+            source.platform.value if source.platform else "?",
+            source.user_id,
+        )
+        return f"⛔ /{canonical_cmd} is admin-only here. Use /whoami to check your current access."
 
     def _check_slash_access(
         self, source: SessionSource, canonical_cmd: str

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -38,6 +38,9 @@ import tempfile
 import threading
 import time
 import sqlite3
+import unicodedata
+import urllib.error
+import urllib.request
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
@@ -66,6 +69,30 @@ _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
+_JAMES_VEHICLE_COMMANDS = {
+    "licenca": "licenca",
+    "licenciamento": "licenca",
+    "transferencia": "transferencia",
+}
+_JAMES_RENAVAM_RE = re.compile(r"(?<!\d)(?:\d[.\-\s]?){9,11}(?!\d)")
+
+
+def _normalize_james_vehicle_command(command: str | None) -> str | None:
+    if not command:
+        return None
+    raw = command.strip().lower().replace("_", "-")
+    normalized = "".join(
+        ch for ch in unicodedata.normalize("NFKD", raw) if not unicodedata.combining(ch)
+    ).replace("-", "_")
+    return _JAMES_VEHICLE_COMMANDS.get(normalized)
+
+
+def _extract_james_renavam(text: str) -> str | None:
+    for match in _JAMES_RENAVAM_RE.finditer(text or ""):
+        candidate = re.sub(r"\D", "", match.group(0))
+        if 9 <= len(candidate) <= 11:
+            return candidate
+    return None
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
@@ -7664,6 +7691,10 @@ class GatewayRunner:
         if self._draining:
             return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
 
+        james_vehicle_command = _normalize_james_vehicle_command(command)
+        if james_vehicle_command:
+            return await self._handle_james_vehicle_direct_command(event, james_vehicle_command)
+
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
             if isinstance(self.config, dict):
@@ -9334,6 +9365,75 @@ class GatewayRunner:
             lines.append(f"◆ Endpoint: {base_url}")
 
         return "\n".join(lines)
+
+    async def _handle_james_vehicle_direct_command(self, event: MessageEvent, command: str) -> str:
+        args = event.get_command_args().strip()
+        renavam = _extract_james_renavam(args)
+        if not renavam:
+            example = f"/{command} 123456789"
+            return (
+                "Me manda o RENAVAM para continuar.\n"
+                f"Exemplo: {example}\n"
+                "Pode mandar só os números."
+            )
+
+        service_path = {
+            "licenca": "/api-interna/consultar-licenciamento",
+            "transferencia": "/api-interna/consultar-transferencia",
+        }[command]
+        payload = {"renavam": renavam}
+        result = await self._call_james_vehicle_direct_adapter(service_path, payload)
+        return self._format_james_vehicle_direct_response(command, service_path, payload, result)
+
+    async def _call_james_vehicle_direct_adapter(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        base_url = os.environ.get("JAMES_TELEGRAM_DIRECT_ADAPTER_BASE_URL", "http://127.0.0.1:18083").rstrip("/")
+        url = f"{base_url}{path}"
+
+        def _post() -> dict[str, Any]:
+            body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+            request = urllib.request.Request(
+                url,
+                data=body,
+                headers={"Content-Type": "application/json", "Accept": "application/json"},
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=30) as response:
+                    raw = response.read().decode("utf-8", errors="replace")
+                    return {"ok": True, "status": response.status, "body": raw}
+            except urllib.error.HTTPError as exc:
+                raw = exc.read().decode("utf-8", errors="replace")
+                return {"ok": False, "status": exc.code, "body": raw}
+            except Exception as exc:
+                return {"ok": False, "status": None, "body": f"adapter_request_failed: {exc}"}
+
+        return await asyncio.to_thread(_post)
+
+    def _format_james_vehicle_direct_response(
+        self,
+        command: str,
+        path: str,
+        payload: dict[str, Any],
+        result: dict[str, Any],
+    ) -> str:
+        label = "Licenciamento" if command == "licenca" else "Transferência"
+        status = result.get("status")
+        body = str(result.get("body") or "")
+        try:
+            parsed = json.loads(body)
+            body = json.dumps(parsed, ensure_ascii=False, indent=2, sort_keys=True)
+        except Exception:
+            pass
+        if len(body) > 3300:
+            body = body[:3300].rstrip() + "\n...[truncado]"
+        placa_note = "sem PLACA" if "placa" not in payload else f"PLACA {payload['placa']}"
+        return (
+            f"James direto — {label}\n"
+            f"Adapter: {path}\n"
+            f"Payload: RENAVAM {payload['renavam']} ({placa_note})\n"
+            f"HTTP: {status}\n"
+            f"Retorno:\n{body}"
+        )
 
     async def _handle_reset_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /new or /reset command."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -196,10 +196,16 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Tools & Skills", cli_only=True),
 
     # James 2.0 operational shortcuts
-    CommandDef("licenca", "James: consultar licenciamento direto por RENAVAM", "James",
+    CommandDef("james", "James: mostrar atalhos operacionais", "Info",
+               gateway_only=True),
+    CommandDef("licenca", "James: consultar licenciamento direto por RENAVAM", "Info",
                aliases=("licença", "licenciamento"), args_hint="<renavam>", gateway_only=True),
-    CommandDef("transferencia", "James: consultar transferência direto por RENAVAM", "James",
-               aliases=("transferência",), args_hint="<renavam>", gateway_only=True),
+    CommandDef("transferencia", "James: consultar transferência direto por RENAVAM", "Info",
+               aliases=("transferência", "trasnferencia"), args_hint="<renavam>", gateway_only=True),
+    CommandDef("status_james", "James: checar saúde local/lab sem restart", "Info",
+               gateway_only=True),
+    CommandDef("proposta", "James: gerar rascunho local/lab de proposta por RENAVAM", "Info",
+               args_hint="<renavam>", gateway_only=True),
 
     # Info
     CommandDef("commands", "Browse all commands and skills (paginated)", "Info",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -195,6 +195,12 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("plugins", "List installed plugins and their status",
                "Tools & Skills", cli_only=True),
 
+    # James 2.0 operational shortcuts
+    CommandDef("licenca", "James: consultar licenciamento direto por RENAVAM", "James",
+               aliases=("licença", "licenciamento"), args_hint="<renavam>", gateway_only=True),
+    CommandDef("transferencia", "James: consultar transferência direto por RENAVAM", "James",
+               aliases=("transferência",), args_hint="<renavam>", gateway_only=True),
+
     # Info
     CommandDef("commands", "Browse all commands and skills (paginated)", "Info",
                gateway_only=True, args_hint="[page]"),

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -410,6 +410,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app["api_server_adapter"] = adapter
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
+    app.router.add_post("/internal/notify", adapter._handle_internal_notify)
     app.router.add_get("/v1/health", adapter._handle_health)
     app.router.add_get("/v1/models", adapter._handle_models)
     app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
@@ -563,8 +564,99 @@ class TestHealthDetailedEndpoint:
 
 
 # ---------------------------------------------------------------------------
-# /v1/models endpoint
+# /internal/notify endpoint
 # ---------------------------------------------------------------------------
+
+
+class TestInternalNotifyEndpoint:
+    def _adapter(self) -> APIServerAdapter:
+        config = PlatformConfig(enabled=True, extra={
+            "internal_notify_token": "notify-secret",
+            "internal_notify_dedup_seconds": 300,
+            "internal_notify_allowed_ips": "127.0.0.1,::1",
+        })
+        return APIServerAdapter(config)
+
+    @staticmethod
+    def _payload(**overrides):
+        payload = {
+            "source": "api-watcher",
+            "severity": "warning",
+            "title": "Alerta Itamaraty",
+            "message": "2Captcha abaixo do saldo mínimo",
+            "details": {"status": "warning", "provider": "2captcha", "balance": 1.72},
+            "timestamp": "2026-05-27T20:00:00.000Z",
+        }
+        payload.update(overrides)
+        return payload
+
+    @pytest.mark.asyncio
+    async def test_requires_dedicated_token(self):
+        adapter = self._adapter()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/internal/notify", json=self._payload())
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_sends_alert_and_deduplicates(self):
+        adapter = self._adapter()
+        adapter._internal_notify_send_telegram = AsyncMock(return_value={"message_id": 123})
+        app = _create_app(adapter)
+        headers = {"Authorization": "Bearer notify-secret"}
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post("/internal/notify", json=self._payload(), headers=headers)
+            assert first.status == 200
+            first_data = await first.json()
+            assert first_data["sent"] is True
+            assert first_data["message_id"] == 123
+
+            second = await cli.post("/internal/notify", json=self._payload(), headers=headers)
+            assert second.status == 200
+            second_data = await second.json()
+            assert second_data["sent"] is False
+            assert second_data["deduplicated"] is True
+
+        adapter._internal_notify_send_telegram.assert_awaited_once()
+
+    def test_render_message_redacts_sensitive_detail_keys(self):
+        adapter = self._adapter()
+        text = adapter._internal_notify_render_message(self._payload(
+            details={
+                "status": "warning",
+                "provider": "2captcha",
+                "api_key": "SHOULD_NOT_APPEAR",
+                "cookie": "SHOULD_NOT_APPEAR",
+            },
+        ))
+        assert "[WARNING] api-watcher" in text
+        assert "2Captcha abaixo do saldo mínimo" in text
+        assert "provider: 2captcha" in text
+        assert "SHOULD_NOT_APPEAR" not in text
+        assert "api_key" not in text
+        assert "cookie" not in text
+
+    def test_render_message_redacts_pii_and_secret_patterns_everywhere(self):
+        adapter = self._adapter()
+        text = adapter._internal_notify_render_message(self._payload(
+            source="watcher ABC1D23",
+            title="CPF 00000000000 token=abc123",
+            message="RENAVAM 123456789 placa ABC1D23 telefone +55 16 99999-9999",
+            details={
+                "status": "critical token=abc123",
+                "cpf": "00000000000",
+                "placa": "ABC1D23",
+                "renavam": "123456789",
+                "safe_note": "documento 00000000000 placa ABC1D23 renavam 123456789 token=abc123",
+            },
+        ))
+
+        for leaked in ("00000000000", "123456789", "ABC1D23", "abc123"):
+            assert leaked not in text
+        for sensitive_key in ("cpf:", "placa:", "renavam:"):
+            assert sensitive_key not in text.lower()
+        assert "token=[dado sensível ocultado]" in text
+        assert "safe_note: documento [dado sensível ocultado]" in text
 
 
 class TestModelsEndpoint:

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -133,6 +133,56 @@ async def test_unknown_slash_command_underscored_form_also_guarded(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_james_accented_license_command_prompts_for_renavam(monkeypatch):
+    """/licença is a James direct shortcut, not an unknown Hermes command."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(side_effect=AssertionError("James shortcut leaked to the agent"))
+    runner._call_james_vehicle_direct_adapter = AsyncMock(side_effect=AssertionError("should not call adapter without RENAVAM"))
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/licença"))
+
+    assert result is not None
+    assert "Unknown command" not in result
+    assert "Me manda o RENAVAM" in result
+    assert "/licenca 123456789" in result
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_james_transfer_command_calls_adapter_directly(monkeypatch):
+    """/transferência <renavam> bypasses the agent/Core and calls Adapter."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(side_effect=AssertionError("James shortcut leaked to the agent"))
+    runner._call_james_vehicle_direct_adapter = AsyncMock(
+        return_value={"ok": True, "status": 200, "body": '{"valorFinal":469.91}'}
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/transferência 123.456.789"))
+
+    assert result is not None
+    assert "James direto — Transferência" in result
+    assert "consultar-transferencia" in result
+    assert "123456789" in result
+    assert "valorFinal" in result
+    runner._call_james_vehicle_direct_adapter.assert_awaited_once_with(
+        "/api-interna/consultar-transferencia", {"renavam": "123456789"}
+    )
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_known_slash_command_not_flagged_as_unknown(monkeypatch):
     """A real built-in like /status must NOT hit the unknown-command guard."""
     runner = _make_runner()

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -155,6 +155,29 @@ async def test_james_accented_license_command_prompts_for_renavam(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_james_help_command_lists_direct_shortcuts(monkeypatch):
+    """/james returns a compact James-only command menu for Telegram."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(side_effect=AssertionError("James help leaked to the agent"))
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/james"))
+
+    assert result is not None
+    assert "Comandos do James" in result
+    assert "/licenca" in result
+    assert "/transferencia" in result
+    assert "RENAVAM" in result
+    assert "Unknown command" not in result
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_james_transfer_command_calls_adapter_directly(monkeypatch):
     """/transferência <renavam> bypasses the agent/Core and calls Adapter."""
     import gateway.run as gateway_run
@@ -162,23 +185,245 @@ async def test_james_transfer_command_calls_adapter_directly(monkeypatch):
     runner = _make_runner()
     runner._run_agent = AsyncMock(side_effect=AssertionError("James shortcut leaked to the agent"))
     runner._call_james_vehicle_direct_adapter = AsyncMock(
-        return_value={"ok": True, "status": 200, "body": '{"valorFinal":469.91}'}
+        return_value={
+            "ok": True,
+            "status": 200,
+            "body": (
+                '{'
+                '"valorFinal":602.79,'
+                '"valorTaxas":469.91,'
+                '"valorMultas":132.88,'
+                '"valorIpvas":0,'
+                '"renavam":"123456789",'
+                '"placa":"ABC1D23",'
+                '"documento":"00000000000",'
+                '"documentoTipo":"CPF",'
+                '"nome":"CLIENTE TESTE",'
+                '"ocorrencia":{"codigo":"00","categoria":"sucesso","descricao":"TRANSAÇÃO CONFIRMADA E APROVADA"}'
+                '}'
+            ),
+        }
     )
 
     monkeypatch.setattr(
         gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
     )
 
-    result = await runner._handle_message(_make_event("/transferência 123.456.789"))
+    result = await runner._handle_message(_make_event("/trasnferencia 123.456.789"))
 
     assert result is not None
     assert "James direto — Transferência" in result
-    assert "consultar-transferencia" in result
-    assert "123456789" in result
-    assert "valorFinal" in result
+    assert "Status: OK (HTTP 200)" in result
+    assert "TRANSAÇÃO CONFIRMADA E APROVADA" in result
+    assert "Valor base retornado: R$ 602,79" in result
+    assert "Taxas: R$ 469,91" in result
+    assert "Multas: R$ 132,88" in result
+    assert "Honorários do Despachante" in result
+    assert "Dados sensíveis ocultados" in result
+    assert "consultar-transferencia" not in result
+    assert "123456789" not in result
+    assert "ABC1D23" not in result
+    assert "00000000000" not in result
+    assert "CLIENTE TESTE" not in result
+    assert "valorFinal" not in result
     runner._call_james_vehicle_direct_adapter.assert_awaited_once_with(
         "/api-interna/consultar-transferencia", {"renavam": "123456789"}
     )
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_james_direct_command_hides_non_json_adapter_body(monkeypatch):
+    """Non-JSON adapter bodies may contain PII and must not be echoed to chat."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(side_effect=AssertionError("James shortcut leaked to the agent"))
+    runner._call_james_vehicle_direct_adapter = AsyncMock(
+        return_value={
+            "ok": False,
+            "status": 502,
+            "body": "erro RENAVAM 123456789 placa ABC1D23 cpf 00000000000 CLIENTE TESTE",
+        }
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/licenca 123456789"))
+
+    assert result is not None
+    assert "Retorno técnico sem JSON tratável ocultado" in result
+    assert "123456789" not in result
+    assert "ABC1D23" not in result
+    assert "00000000000" not in result
+    assert "CLIENTE TESTE" not in result
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_james_direct_command_sanitizes_occurrence_text(monkeypatch):
+    """PII copied into occurrence text must be redacted before chat output."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(side_effect=AssertionError("James shortcut leaked to the agent"))
+    runner._call_james_vehicle_direct_adapter = AsyncMock(
+        return_value={
+            "ok": True,
+            "status": 200,
+            "body": (
+                '{'
+                '"valorFinal":602.79,'
+                '"renavam":"123456789",'
+                '"placa":"ABC1D23",'
+                '"documento":"00000000000",'
+                '"nome":"CLIENTE TESTE",'
+                '"ocorrencia":{'
+                '"codigo":"token=abc123456",'
+                '"categoria":"placa ABC1D23",'
+                '"descricao":"RENAVAM 123456789 CPF 00000000000 CLIENTE TESTE"'
+                '}'
+                '}'
+            ),
+        }
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/licenca 123456789"))
+
+    assert result is not None
+    assert "token=abc123456" not in result
+    assert "123456789" not in result
+    assert "ABC1D23" not in result
+    assert "00000000000" not in result
+    assert "CLIENTE TESTE" not in result
+    assert "[dado sensível ocultado]" in result
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_james_status_command_reports_local_lab_health(monkeypatch):
+    """/status_james reports James lab health without invoking the agent."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(side_effect=AssertionError("James status leaked to the agent"))
+    runner._call_james_health_endpoint = AsyncMock(
+        side_effect=[
+            {"ok": True, "status": 200, "body": '{"ok":true}'},
+            {"ok": False, "status": 503, "body": "degraded"},
+        ]
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/status_james"))
+
+    assert result is not None
+    assert "Status James 2.0" in result
+    assert "API Server local/lab: OK (HTTP 200)" in result
+    assert "Adapter James local/lab: Falha (HTTP 503)" in result
+    assert "sem restart" in result
+    assert "Unknown command" not in result
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_james_proposta_generates_sanitized_local_draft(monkeypatch):
+    """/proposta <renavam> consults the lab adapter and returns only a local draft."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(side_effect=AssertionError("James proposta leaked to the agent"))
+    runner._call_james_vehicle_direct_adapter = AsyncMock(
+        return_value={
+            "ok": True,
+            "status": 200,
+            "body": (
+                '{'
+                '"valorFinal":602.79,'
+                '"valorTaxas":469.91,'
+                '"valorMultas":132.88,'
+                '"renavam":"123456789",'
+                '"placa":"ABC1D23",'
+                '"documento":"00000000000",'
+                '"nome":"CLIENTE TESTE",'
+                '"ocorrencia":{"descricao":"TRANSAÇÃO CONFIRMADA E APROVADA"}'
+                '}'
+            ),
+        }
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/proposta 123.456.789"))
+
+    assert result is not None
+    assert "Rascunho local/lab — proposta James" in result
+    assert "NÃO enviar ao cliente automaticamente" in result
+    assert "Total base retornado: R$ 602,79" in result
+    assert "Taxas: R$ 469,91" in result
+    assert "Multas: R$ 132,88" in result
+    assert "Honorários do Despachante" in result
+    assert "Dados sensíveis ocultados" in result
+    assert "123456789" not in result
+    assert "ABC1D23" not in result
+    assert "00000000000" not in result
+    assert "CLIENTE TESTE" not in result
+    assert "Unknown command" not in result
+    runner._call_james_vehicle_direct_adapter.assert_awaited_once_with(
+        "/api-interna/consultar-licenciamento", {"renavam": "123456789"}
+    )
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("text", "canonical"),
+    [
+        ("/james", "james"),
+        ("/licenca 123456789", "licenca"),
+        ("/licença 123456789", "licenca"),
+        ("/transferencia 123456789", "transferencia"),
+        ("/transferência 123456789", "transferencia"),
+        ("/status_james", "status_james"),
+        ("/proposta 123456789", "proposta"),
+    ],
+)
+async def test_james_commands_require_admin_when_slash_admins_configured(monkeypatch, text, canonical):
+    """James operational shortcuts stay admin-only even if a non-admin has slash commands."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner.config.platforms[Platform.TELEGRAM].extra = {
+        "allow_admin_from": ["admin-user"],
+        "user_allowed_commands": ["james", "status_james", "proposta", "licenca", "transferencia"],
+    }
+    runner._run_agent = AsyncMock(side_effect=AssertionError("James shortcut leaked to the agent"))
+    runner._call_james_vehicle_direct_adapter = AsyncMock(side_effect=AssertionError("non-admin reached adapter"))
+    runner._call_james_health_endpoint = AsyncMock(side_effect=AssertionError("non-admin reached health check"))
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event(text))
+
+    assert result is not None
+    assert "admin-only" in result
+    assert f"/{canonical}" in result
+    runner._call_james_vehicle_direct_adapter.assert_not_called()
+    runner._call_james_health_endpoint.assert_not_called()
+    runner.hooks.emit_collect.assert_not_awaited()
     runner._run_agent.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- Hardens James Telegram vehicle command handling and admin gates.
- Adds/finalizes internal notify sanitization used by the local James 2.0 safety gates.
- Publishes the validated R8 branch from the Loureiro Tech fork because this environment does not have push permission to the upstream repository.

## Test plan
- `git diff --check`
- `python -m pytest tests/gateway/test_unknown_command.py tests/gateway/test_api_server.py -q -o addopts=`

## Operational context
This is part of the James 2.0 local lab safety-gate closure. The changes were validated locally before publishing from the fork.
