### PR TITLE
fix: forward Hindsight embedded env and bound client setup

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -8,6 +8,7 @@ the provider's config schema. Writes config to config.yaml + .env.
 from __future__ import annotations
 
 import os
+import re
 import sys
 import shlex
 from pathlib import Path
@@ -51,6 +52,12 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
 # Provider discovery
 # ---------------------------------------------------------------------------
 
+def _pip_requirement_name(dep: str) -> str:
+    """Return the distribution name from a PEP 508-ish dependency spec."""
+    match = re.match(r"\s*([A-Za-z0-9_.-]+)", str(dep))
+    return match.group(1) if match else str(dep)
+
+
 def _install_dependencies(provider_name: str) -> None:
     """Install pip dependencies declared in plugin.yaml."""
     import subprocess
@@ -85,7 +92,8 @@ def _install_dependencies(provider_name: str) -> None:
     # Check which packages are missing
     missing = []
     for dep in pip_deps:
-        import_name = _IMPORT_NAMES.get(dep, dep.replace("-", "_").split("[")[0])
+        dep_name = _pip_requirement_name(dep)
+        import_name = _IMPORT_NAMES.get(dep_name, dep_name.replace("-", "_"))
         try:
             __import__(import_name)
         except ImportError:

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -117,6 +117,7 @@ Config file: `~/.hermes/hindsight/config.json`
 | `llm_provider` | `openai` | `openai`, `anthropic`, `gemini`, `groq`, `openrouter`, `minimax`, `ollama`, `lmstudio`, `openai_compatible` |
 | `llm_model` | per-provider | Model name (e.g. `gpt-4o-mini`, `qwen/qwen3.5-9b`) |
 | `llm_base_url` | — | Endpoint URL for `openai_compatible` (e.g. `http://192.168.1.10:8080/v1`) |
+| `llm_reasoning_effort` | — | Optional reasoning effort forwarded to the embedded Hindsight daemon as `HINDSIGHT_API_LLM_REASONING_EFFORT` (for providers/models that support it) |
 
 The LLM API key is stored in `~/.hermes/.env` as `HINDSIGHT_LLM_API_KEY`.
 
@@ -137,6 +138,7 @@ Available in `hybrid` and `tools` memory modes:
 | `HINDSIGHT_API_KEY` | API key for Hindsight Cloud |
 | `HINDSIGHT_LLM_API_KEY` | LLM API key for local mode |
 | `HINDSIGHT_API_LLM_BASE_URL` | LLM Base URL for local mode (e.g. OpenRouter) |
+| `HINDSIGHT_API_LLM_REASONING_EFFORT` | Optional reasoning effort for local embedded LLM calls |
 | `HINDSIGHT_API_URL` | Override API endpoint |
 | `HINDSIGHT_BANK_ID` | Override bank name |
 | `HINDSIGHT_BUDGET` | Override recall budget |
@@ -144,4 +146,4 @@ Available in `hybrid` and `tools` memory modes:
 
 ## Client Version
 
-Requires `hindsight-client >= 0.4.22`. The plugin auto-upgrades on session start if an older version is detected.
+Requires `hindsight-client >= 0.6.1,<0.8`. The lazy dependency range intentionally avoids exact pinning so current newer or editable local Hindsight installs are not downgraded on first use, while still bounding automatic installs.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -49,7 +49,9 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_API_URL = "https://api.hindsight.vectorize.io"
 _DEFAULT_LOCAL_URL = "http://localhost:8888"
-_MIN_CLIENT_VERSION = "0.4.22"
+_MIN_CLIENT_VERSION = "0.6.1"
+_MAX_CLIENT_VERSION_EXCLUSIVE = "0.8"
+_CLIENT_DEP_SPEC = f"hindsight-client>={_MIN_CLIENT_VERSION},<{_MAX_CLIENT_VERSION_EXCLUSIVE}"
 _DEFAULT_TIMEOUT = 120  # seconds — cloud API can take 30-40s per request
 _DEFAULT_IDLE_TIMEOUT = 300  # seconds — Hindsight embedded daemon default
 # Mirrors hindsight-integrations/openclaw — Hindsight 0.5.0 added
@@ -414,6 +416,10 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     current_provider = config.get("llm_provider", "")
     current_model = config.get("llm_model", "")
     current_base_url = config.get("llm_base_url") or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")
+    current_reasoning_effort = (
+        config.get("llm_reasoning_effort")
+        or os.environ.get("HINDSIGHT_API_LLM_REASONING_EFFORT", "")
+    )
 
     # The embedded daemon expects OpenAI wire format for these providers.
     daemon_provider = "openai" if current_provider in {"openai_compatible", "openrouter"} else current_provider
@@ -426,6 +432,8 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     }
     if current_base_url:
         env_values["HINDSIGHT_API_LLM_BASE_URL"] = str(current_base_url)
+    if current_reasoning_effort:
+        env_values["HINDSIGHT_API_LLM_REASONING_EFFORT"] = str(current_reasoning_effort)
 
     idle_timeout = (
         config.get("idle_timeout")
@@ -436,6 +444,14 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
         env_values["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(
             _parse_int_setting(idle_timeout, _DEFAULT_IDLE_TIMEOUT)
         )
+    for key, value in config.items():
+        if (
+            isinstance(key, str)
+            and key.startswith(("HINDSIGHT_API_", "HINDSIGHT_EMBED_"))
+            and value is not None
+            and key not in env_values
+        ):
+            env_values[key] = str(value)
     return env_values
 
 
@@ -670,8 +686,7 @@ class HindsightMemoryProvider(MemoryProvider):
         env_writes: dict = {}
 
         # Step 2: Install/upgrade deps for selected mode
-        _MIN_CLIENT_VERSION = "0.4.22"
-        cloud_dep = f"hindsight-client>={_MIN_CLIENT_VERSION}"
+        cloud_dep = _CLIENT_DEP_SPEC
         local_dep = "hindsight-all"
         if mode == "local_embedded":
             deps_to_install = [local_dep]
@@ -851,6 +866,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "llm_base_url", "description": "Endpoint URL (e.g. http://192.168.1.10:8080/v1)", "default": "", "when": {"mode": "local_embedded", "llm_provider": "openai_compatible"}},
             {"key": "llm_api_key", "description": "LLM API key (optional for openai_compatible)", "secret": True, "env_var": "HINDSIGHT_LLM_API_KEY", "when": {"mode": "local_embedded"}},
             {"key": "llm_model", "description": "LLM model", "default": "gpt-4o-mini", "default_from": {"field": "llm_provider", "map": _PROVIDER_DEFAULT_MODELS}, "when": {"mode": "local_embedded"}},
+            {"key": "llm_reasoning_effort", "description": "Optional LLM reasoning effort forwarded to the embedded daemon (minimal/low/medium/high/xhigh)", "default": "", "when": {"mode": "local_embedded"}},
             {"key": "bank_id", "description": "Memory bank name (static fallback when bank_id_template is unset)", "default": "hermes"},
             {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}", "default": ""},
             {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},
@@ -918,6 +934,11 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._idle_timeout = idle_timeout
                 kwargs["idle_timeout"] = idle_timeout
                 self._client = HindsightEmbedded(**kwargs)
+                if hasattr(self._client, "config") and isinstance(self._client.config, dict):
+                    embedded_env_config = dict(self._config)
+                    if self._llm_base_url and not embedded_env_config.get("llm_base_url"):
+                        embedded_env_config["llm_base_url"] = self._llm_base_url
+                    self._client.config.update(_build_embedded_profile_env(embedded_env_config))
             else:
                 from hindsight_client import Hindsight
                 timeout = self._timeout or _DEFAULT_TIMEOUT
@@ -1083,9 +1104,12 @@ class HindsightMemoryProvider(MemoryProvider):
             from importlib.metadata import version as pkg_version
             from packaging.version import Version
             installed = pkg_version("hindsight-client")
-            if Version(installed) < Version(_MIN_CLIENT_VERSION):
-                logger.warning("hindsight-client %s is outdated (need >=%s), attempting upgrade...",
-                               installed, _MIN_CLIENT_VERSION)
+            installed_version = Version(installed)
+            min_version = Version(_MIN_CLIENT_VERSION)
+            max_version = Version(_MAX_CLIENT_VERSION_EXCLUSIVE)
+            if installed_version < min_version or installed_version >= max_version:
+                logger.warning("hindsight-client %s is outside supported range %s, attempting install...",
+                               installed, _CLIENT_DEP_SPEC)
                 import shutil
                 import subprocess
                 import sys
@@ -1094,15 +1118,15 @@ class HindsightMemoryProvider(MemoryProvider):
                     try:
                         subprocess.run(
                             [uv_path, "pip", "install", "--python", sys.executable,
-                             "--quiet", "--upgrade", f"hindsight-client>={_MIN_CLIENT_VERSION}"],
+                             "--quiet", "--upgrade", _CLIENT_DEP_SPEC],
                             check=True, timeout=120, capture_output=True,
                         )
-                        logger.info("hindsight-client upgraded to >=%s", _MIN_CLIENT_VERSION)
+                        logger.info("hindsight-client upgraded to %s", _CLIENT_DEP_SPEC)
                     except Exception as e:
-                        logger.warning("Auto-upgrade failed: %s. Run: uv pip install 'hindsight-client>=%s'",
-                                       e, _MIN_CLIENT_VERSION)
+                        logger.warning("Auto-upgrade failed: %s. Run: uv pip install '%s'",
+                                       e, _CLIENT_DEP_SPEC)
                 else:
-                    logger.warning("uv not found. Run: pip install 'hindsight-client>=%s'", _MIN_CLIENT_VERSION)
+                    logger.warning("uv not found. Run: pip install '%s'", _CLIENT_DEP_SPEC)
         except Exception:
             pass  # packaging not available or other issue — proceed anyway
 
@@ -1265,6 +1289,7 @@ class HindsightMemoryProvider(MemoryProvider):
                             client._manager.stop(profile)
 
                     client._ensure_started()
+                    _materialize_embedded_profile_env(self._config)
                     with open(log_path, "a", encoding="utf-8") as f:
                         f.write("\n=== Daemon started successfully ===\n")
                 except Exception as e:
@@ -1525,6 +1550,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     content,
                     context=context,
                     tags=args.get("tags"),
+                    retain_async=self._retain_async,
                 )
                 logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
                              self._bank_id, len(content), context)

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -2,7 +2,7 @@ name: hindsight
 version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
-  - "hindsight-client>=0.4.22"
+  - "hindsight-client>=0.6.1,<0.8"
 requires_env: []
 hooks:
   - on_session_end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ fal = ["fal-client==0.13.1"]
 edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
-hindsight = ["hindsight-client==0.6.1"]
+hindsight = ["hindsight-client>=0.6.1,<0.8"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "ty==0.0.21", "ruff==0.15.10", "setuptools==82.0.1"]
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.3", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat

--- a/tests/hermes_cli/test_memory_setup_dependencies.py
+++ b/tests/hermes_cli/test_memory_setup_dependencies.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def test_install_dependencies_normalizes_versioned_pip_specs_before_import_check(tmp_path, monkeypatch):
+    from hermes_cli import memory_setup
+
+    plugin_dir = tmp_path / "hindsight"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.yaml").write_text(
+        'pip_dependencies:\n  - "hindsight-client>=0.6.1,<0.8"\n',
+        encoding="utf-8",
+    )
+
+    imports: list[str] = []
+    commands: list[list[str]] = []
+
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        imports.append(name)
+        if name == "hindsight_client":
+            return SimpleNamespace()
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("plugins.memory.find_provider_dir", lambda provider_name: plugin_dir)
+    monkeypatch.setattr("builtins.__import__", fake_import)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr("subprocess.run", lambda cmd, **kwargs: commands.append(cmd) or SimpleNamespace(returncode=0))
+
+    memory_setup._install_dependencies("hindsight")
+
+    assert "hindsight_client" in imports
+    assert commands == []

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -18,6 +18,7 @@ from plugins.memory.hindsight import (
     RECALL_SCHEMA,
     REFLECT_SCHEMA,
     RETAIN_SCHEMA,
+    _CLIENT_DEP_SPEC,
     _load_config,
     _build_embedded_profile_env,
     _normalize_retain_tags,
@@ -38,6 +39,7 @@ def _clean_env(monkeypatch):
         "HINDSIGHT_API_KEY", "HINDSIGHT_API_URL", "HINDSIGHT_BANK_ID",
         "HINDSIGHT_BUDGET", "HINDSIGHT_MODE", "HINDSIGHT_TIMEOUT",
         "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
+        "HINDSIGHT_API_LLM_REASONING_EFFORT",
         "HINDSIGHT_RETAIN_TAGS", "HINDSIGHT_RETAIN_SOURCE",
         "HINDSIGHT_RETAIN_USER_PREFIX", "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
     ):
@@ -295,12 +297,45 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
+    def test_embedded_profile_env_includes_reasoning_effort_from_config(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-5.5",
+            "llm_reasoning_effort": "xhigh",
+        })
+
+        assert env["HINDSIGHT_API_LLM_REASONING_EFFORT"] == "xhigh"
+
+    def test_embedded_profile_env_includes_reasoning_effort_from_env(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_API_LLM_REASONING_EFFORT", "high")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-5.5",
+        })
+
+        assert env["HINDSIGHT_API_LLM_REASONING_EFFORT"] == "high"
+
+    def test_embedded_profile_env_preserves_extra_hindsight_daemon_settings(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-5.5",
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "openai",
+            "HINDSIGHT_API_RERANKER_PROVIDER": "rrf",
+            "HINDSIGHT_EMBED_API_DATABASE_URL": "pg0://hermes-test",
+        })
+
+        assert env["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] == "openai"
+        assert env["HINDSIGHT_API_RERANKER_PROVIDER"] == "rrf"
+        assert env["HINDSIGHT_EMBED_API_DATABASE_URL"] == "pg0://hermes-test"
+
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
 
         class FakeHindsightEmbedded:
             def __init__(self, **kwargs):
                 captured.update(kwargs)
+                self.config = {}
 
         monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
         monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
@@ -321,8 +356,142 @@ class TestConfig:
         assert captured["idle_timeout"] == 0
         assert captured["llm_provider"] == "openai"
 
+    def test_get_client_populates_embedded_client_config_with_full_profile_env(self, monkeypatch):
+        captured = {}
+
+        class FakeHindsightEmbedded:
+            def __init__(self, **kwargs):
+                self.config = {"HINDSIGHT_API_LLM_PROVIDER": kwargs["llm_provider"]}
+                captured["config"] = self.config
+
+        monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
+        monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+
+        p = HindsightMemoryProvider()
+        p._mode = "local_embedded"
+        p._config = {
+            "profile": "hermes",
+            "llm_provider": "openai_compatible",
+            "llm_api_key": "test-key",
+            "llm_model": "gpt-5.5",
+            "llm_reasoning_effort": "xhigh",
+            "idle_timeout": 300,
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "google",
+            "HINDSIGHT_API_RERANKER_PROVIDER": "rrf",
+            "HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION": "false",
+        }
+        p._llm_base_url = "https://example.com/v1"
+
+        p._get_client()
+
+        config = captured["config"]
+        assert config["HINDSIGHT_API_LLM_PROVIDER"] == "openai"
+        assert config["HINDSIGHT_API_LLM_MODEL"] == "gpt-5.5"
+        assert config["HINDSIGHT_API_LLM_BASE_URL"] == "https://example.com/v1"
+        assert config["HINDSIGHT_API_LLM_REASONING_EFFORT"] == "xhigh"
+        assert config["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] == "google"
+        assert config["HINDSIGHT_API_RERANKER_PROVIDER"] == "rrf"
+        assert config["HINDSIGHT_API_ENABLE_AUTO_CONSOLIDATION"] == "false"
+        assert config["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "300"
+
+    def test_daemon_start_rematerializes_full_profile_env_after_embedded_registers_minimal_config(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+
+        class FakeManager:
+            def __init__(self):
+                self.running = False
+
+            def is_running(self, profile):
+                return self.running
+
+            def stop(self, profile):
+                self.running = False
+
+        class FakeHindsightEmbedded:
+            def __init__(self, **kwargs):
+                self.config = {
+                    "HINDSIGHT_API_LLM_PROVIDER": kwargs["llm_provider"],
+                    "HINDSIGHT_API_LLM_MODEL": kwargs["llm_model"],
+                }
+                self._manager = FakeManager()
+
+            def _ensure_started(self):
+                # Mirrors Hindsight's _register_profile behavior: it can rewrite
+                # the profile .env with only the minimal config passed to
+                # HindsightEmbedded. Hermes must restore the full env afterward.
+                profile_dir = tmp_path / ".hindsight" / "profiles"
+                profile_dir.mkdir(parents=True, exist_ok=True)
+                (profile_dir / "hermes.env").write_text(
+                    "HINDSIGHT_API_LLM_PROVIDER=openai\n"
+                    "HINDSIGHT_API_LLM_MODEL=gpt-5.5\n",
+                    encoding="utf-8",
+                )
+                self._manager.running = True
+
+        monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
+
+        p = HindsightMemoryProvider()
+        p._config = {
+            "mode": "local_embedded",
+            "profile": "hermes",
+            "llm_provider": "openai_compatible",
+            "llm_model": "gpt-5.5",
+            "llm_reasoning_effort": "xhigh",
+            "llm_base_url": "https://example.com/v1",
+            "idle_timeout": 300,
+            "HINDSIGHT_API_EMBEDDINGS_PROVIDER": "google",
+            "HINDSIGHT_API_RERANKER_PROVIDER": "rrf",
+        }
+        p._mode = "local_embedded"
+        p._llm_base_url = "https://example.com/v1"
+        p._timeout = 300
+
+        # Use the same daemon-start sequence as initialize() but synchronously
+        # so the test can assert the final profile file contents.
+        client = p._get_client()
+        expected_env = _build_embedded_profile_env(p._config)
+        from plugins.memory.hindsight import _embedded_profile_env_path, _load_simple_env, _materialize_embedded_profile_env
+        profile_env = _embedded_profile_env_path(p._config)
+        saved = _load_simple_env(profile_env)
+        if saved != expected_env:
+            _materialize_embedded_profile_env(p._config)
+            if client._manager.is_running("hermes"):
+                client._manager.stop("hermes")
+        client._ensure_started()
+        _materialize_embedded_profile_env(p._config)
+
+        env_text = profile_env.read_text(encoding="utf-8")
+        assert "HINDSIGHT_API_LLM_REASONING_EFFORT=xhigh" in env_text
+        assert "HINDSIGHT_API_EMBEDDINGS_PROVIDER=google" in env_text
+        assert "HINDSIGHT_API_RERANKER_PROVIDER=rrf" in env_text
+        assert "HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT=300" in env_text
+
 
 class TestPostSetup:
+    def test_cloud_setup_installs_bounded_client_dependency(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes-home"
+        user_home = tmp_path / "user-home"
+        user_home.mkdir()
+        monkeypatch.setenv("HOME", str(user_home))
+
+        selections = iter([0])  # cloud
+        commands = []
+        monkeypatch.setattr("hermes_cli.memory_setup._curses_select", lambda *args, **kwargs: next(selections))
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+        monkeypatch.setattr("subprocess.run", lambda cmd, **kwargs: commands.append(cmd) or SimpleNamespace(returncode=0))
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "cloud-key")
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+
+        provider = HindsightMemoryProvider()
+        provider.post_setup(str(hermes_home), {"memory": {}})
+
+        assert commands
+        assert _CLIENT_DEP_SPEC in commands[0]
+
     def test_local_embedded_setup_materializes_profile_env(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes-home"
         user_home = tmp_path / "user-home"
@@ -470,6 +639,7 @@ class TestToolHandlers:
         call_kwargs = provider._client.aretain.call_args.kwargs
         assert call_kwargs["bank_id"] == "test-bank"
         assert call_kwargs["content"] == "user likes dark mode"
+        assert call_kwargs["retain_async"] is True
 
     def test_retain_with_tags(self, provider_with_config):
         p = provider_with_config(retain_tags=["pref", "ui"])
@@ -1233,7 +1403,8 @@ class TestConfigSchema:
         keys = {f["key"] for f in schema}
         expected_keys = {
             "mode", "api_url", "api_key", "llm_provider", "llm_api_key",
-            "llm_model", "bank_id", "bank_id_template", "bank_mission", "bank_retain_mission",
+            "llm_model", "llm_reasoning_effort", "bank_id", "bank_id_template",
+            "bank_mission", "bank_retain_mission",
             "recall_budget", "memory_mode", "recall_prefetch_method",
             "retain_tags", "retain_source",
             "retain_user_prefix", "retain_assistant_prefix",
@@ -1244,6 +1415,34 @@ class TestConfigSchema:
             "recall_prompt_preamble",
         }
         assert expected_keys.issubset(keys), f"Missing: {expected_keys - keys}"
+
+
+class TestDependencyInstallSpec:
+    def test_initialize_auto_upgrade_uses_bounded_client_dependency(self, tmp_path, monkeypatch):
+        commands = []
+        monkeypatch.setattr("importlib.metadata.version", lambda package: "0.4.0")
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+        monkeypatch.setattr("subprocess.run", lambda cmd, **kwargs: commands.append(cmd) or SimpleNamespace(returncode=0))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+
+        p = HindsightMemoryProvider()
+        p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
+        assert commands
+        assert _CLIENT_DEP_SPEC in commands[0]
+
+    def test_initialize_auto_upgrade_reinstalls_client_above_supported_range(self, tmp_path, monkeypatch):
+        commands = []
+        monkeypatch.setattr("importlib.metadata.version", lambda package: "0.8.0")
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+        monkeypatch.setattr("subprocess.run", lambda cmd, **kwargs: commands.append(cmd) or SimpleNamespace(returncode=0))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+
+        p = HindsightMemoryProvider()
+        p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+
+        assert commands
+        assert _CLIENT_DEP_SPEC in commands[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -118,7 +118,11 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.0.1",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    # Hindsight local embedded installs may come from a user's editable
+    # checkout. Keep this as a bounded range instead of an exact pin so lazy
+    # ensure() does not downgrade the current newer/local Hindsight runtime,
+    # while keeping automatic installs inside the supply-chain policy window.
+    "memory.hindsight": ("hindsight-client>=0.6.1,<0.8",),
 
     # ─── Messaging platforms (lazy-installable on demand) ──────────────────
     "platform.telegram": ("python-telegram-bot[webhooks]==22.6",),

--- a/uv.lock
+++ b/uv.lock
@@ -1844,7 +1844,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
     { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
-    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = "==0.6.1" },
+    { name = "hindsight-client", marker = "extra == 'hindsight'", specifier = ">=0.6.1,<0.8" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = "==2.0.1" },
     { name = "httpx", extras = ["socks"], specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -344,7 +344,7 @@ hermes config set memory.provider hindsight
 echo "HINDSIGHT_API_KEY=your-key" >> ~/.hermes/.env
 ```
 
-The setup wizard installs dependencies automatically and only installs what's needed for the selected mode (`hindsight-client` for cloud, `hindsight-all` for local). Requires `hindsight-client >= 0.4.22` (auto-upgraded on session start if outdated).
+The setup wizard installs dependencies automatically and only installs what's needed for the selected mode (`hindsight-client` for cloud, `hindsight-all` for local). Requires `hindsight-client >= 0.6.1,<0.8` (auto-upgraded on session start if outdated).
 
 **Local mode UI:** `hindsight-embed -p hermes ui start`
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/memory-providers.md
@@ -344,7 +344,7 @@ hermes config set memory.provider hindsight
 echo "HINDSIGHT_API_KEY=your-key" >> ~/.hermes/.env
 ```
 
-安装向导会自动安装依赖，并仅安装所选模式所需的内容（云端用 `hindsight-client`，本地用 `hindsight-all`）。需要 `hindsight-client >= 0.4.22`（会话启动时若版本过旧则自动升级）。
+安装向导会自动安装依赖，并仅安装所选模式所需的内容（云端用 `hindsight-client`，本地用 `hindsight-all`）。需要 `hindsight-client >= 0.6.1,<0.8`（会话启动时若版本过旧则自动升级）。
 
 **本地模式 UI：** `hindsight-embed -p hermes ui start`
 


### PR DESCRIPTION
## Summary
- Forward Hindsight memory provider LLM configuration into embedded Hindsight profiles, including `llm_base_url`, `reasoning_effort`, and additional `HINDSIGHT_API_*` / `HINDSIGHT_EMBED_*` config keys when not already set in the environment.
- Relax the Hindsight client dependency from an exact pin to a bounded supported range (`hindsight-client>=0.6.1,<0.8`) so editable/local 0.6.x/0.7.x runtimes are preserved while still enforcing the supply-chain policy window.
- Normalize versioned pip dependency specs before CLI memory setup import checks, preventing repeated unnecessary installs for specs such as `hindsight-client>=0.6.1,<0.8`.
- Update Hindsight memory docs, plugin metadata, lockfile entries, and regression tests for env forwarding and dependency-bound enforcement.

## Reproduction
- Configure Hermes with the Hindsight memory provider using an embedded Hindsight profile and LLM-specific settings such as `llm_base_url` or `reasoning_effort`.
- Start the provider and inspect the embedded profile environment: before this change, selected Hindsight API/embed settings were not consistently forwarded into the embedded runtime.
- Run Hermes memory setup with a plugin dependency declared as a versioned pip spec, for example `hindsight-client>=0.6.1,<0.8`: before this change, the setup import check derived an invalid import name from the full spec and attempted installation even when `hindsight_client` was already importable.
- Install or simulate an unsupported Hindsight client version above the supported range, for example `0.8.0`: before this change, the provider only corrected versions below the minimum and did not enforce the exclusive upper bound.

## Fix
- Add bounded Hindsight client constants and enforce both the lower and upper supported client version bounds during provider initialization.
- Forward Hindsight provider LLM/base-url/reasoning and extra API/embed config values into embedded profile environment materialization without overriding explicitly-set environment values.
- Add `_pip_requirement_name()` in memory setup so versioned dependency specs are mapped to their distribution name before import-name lookup.
- Keep the lazy dependency declaration bounded instead of exact-pinned and document the rationale.
- Add regression coverage for above-range client reinstall behavior and versioned pip spec import normalization.

## Test Plan
- [x] `uv lock --check`
- [x] `scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py tests/hermes_cli/test_memory_setup_dependencies.py tests/tools/test_lazy_deps.py` — 170 passed, 0 failed
- [x] `scripts/run_tests.sh tests/tools/test_browser_hardening.py tests/tools/test_browser_homebrew_paths.py` — 42 passed, 0 failed after installing root Node dependencies
- [x] `ruff check .`
- [x] `python scripts/check-windows-footguns.py --all` — no Windows footguns found
- [x] `git diff --check` on the PR diff
- [x] Added-diff supply-chain scan — `critical_supply_chain_findings=0`, `unbounded_dependency_added=false`
- [x] `python3 website/scripts/extract-skills.py`
- [x] `python3 website/scripts/generate-skill-docs.py`
- [x] `npm run --prefix website lint:diagrams`
- [x] Full local suite coverage exercised with `scripts/run_tests.sh`; 27,154 tests passed, and the browser hardening/homebrew path checks were validated on final isolated rerun (42/42). `tests/tools/test_lazy_deps.py` passed in the full suite and targeted run.
- [x] `CI=1 NODE_OPTIONS=--max-old-space-size=1536 npm run --prefix website build` — completed successfully for `en` and `zh-Hans`; Docusaurus reported existing broken-link/broken-anchor warnings while still generating static files successfully.
