### PR TITLE
docs: add lightweight AI code review skill

### DIFF
--- a/skills/software-development/ai-code-review-lite/SKILL.md
+++ b/skills/software-development/ai-code-review-lite/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: ai-code-review-lite
+description: "Use when reviewing AI-generated code or unfamiliar-language diffs without running a heavy verification process. A simple confidence gate based on scope, tests, risk triggers, and rollback."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [code-review, ai-generated-code, confidence, lightweight-review]
+    related_skills: [requesting-code-review, github-code-review, test-driven-development]
+---
+
+# AI Code Review Lite
+
+## Overview
+
+A lightweight review routine for AI-generated code. Use it when a full audit is too much, but blind trust is too little.
+
+The goal is simple: decide whether the change is safe enough to merge, needs more evidence, or should move to a heavier review.
+
+## When to Use
+
+Use this when:
+
+- An AI agent produced a small or medium code change.
+- The diff is in a language you do not know deeply.
+- You want a quick PR review with a confidence level.
+- The change is not obviously high-risk.
+
+Do not use this when the change touches auth, payments, permissions, secrets, database migrations, deployment, background jobs, or large refactors. Use `requesting-code-review` or a full review instead.
+
+## The Five Checks
+
+### 1. Scope
+
+Ask:
+
+- What was the task?
+- Which files changed?
+- Do the changed files match the task?
+
+Red flags:
+
+- unrelated files changed
+- generated or lock files changed without explanation
+- large diff for a small request
+
+### 2. Tests
+
+Require actual command output, not a claim.
+
+Good:
+
+```text
+npm test
+cargo test
+python -m pytest
+```
+
+For bug fixes, prefer proof that a test failed before and passed after.
+
+Red flags:
+
+- “should work”
+- “not tested”
+- tests only cover the happy path
+
+### 3. Risk Triggers
+
+Escalate to heavier review if the diff includes:
+
+- auth, roles, sessions, tokens
+- database schema, migrations, raw SQL
+- shell commands, filesystem writes/deletes
+- secrets or credentials
+- background jobs, queues, cron
+- concurrency or shared state
+- deploy, infra, CI/CD
+- `eval`, `exec`, unsafe deserialization
+- TypeScript `any` or broad `as SomeType` at API boundaries
+- Rust `unsafe`, `unwrap()`, or `expect()` in runtime paths
+
+### 4. Independent Pass
+
+Ask another reviewer agent to check only for blockers:
+
+```md
+Review this task, evidence, and diff. Return only:
+- approve / request changes / escalate
+- missing evidence
+- blocking correctness issues
+- blocking security issues
+- risky files to inspect manually
+```
+
+The implementer should not be the only reviewer.
+
+### 5. Rollback
+
+Ask:
+
+- Can this be reverted cleanly?
+- Is there a migration or irreversible side effect?
+- If it breaks, what command or PR reverts it?
+
+No rollback plan means no high confidence.
+
+## Output Template
+
+```md
+## AI Code Review Lite
+
+Verdict: Approve / Request changes / Escalate
+Confidence: Low / Medium / High
+
+### Evidence checked
+- Scope matches task: yes/no
+- Tests shown: yes/no, command:
+- Risk triggers found: yes/no
+- Independent pass: yes/no
+- Rollback clear: yes/no
+
+### Blocking issues
+- none / list
+
+### Manual spots checked
+- file: reason
+
+### Notes
+- short reviewer note
+```
+
+## Confidence Rules
+
+High confidence:
+
+- scope is tight
+- tests ran and match the change
+- no risk triggers
+- independent pass found no blockers
+- rollback is clear
+
+Medium confidence:
+
+- one minor piece of evidence is missing, but the diff is small and low-risk
+
+Low confidence:
+
+- missing tests, vague scope, unfamiliar-language danger pattern, unexpected files, or unclear rollback
+
+## Common Pitfalls
+
+1. **Reading every line first.** Start with scope and evidence. Open code only where risk appears.
+2. **Trusting summaries.** Summaries are useful, but command output is better.
+3. **Overusing this skill.** If risk triggers appear, escalate. Lite review is not a parachute.
+4. **Pretending language fluency.** In Rust or TypeScript, check the danger patterns before style.
+
+## Verification Checklist
+
+- [ ] Task and changed files are clear.
+- [ ] Test output is present or missing tests are explicitly called out.
+- [ ] Risk triggers were checked.
+- [ ] Another reviewer or review pass checked for blockers.
+- [ ] Rollback path is clear.
+- [ ] Verdict and confidence are stated plainly.

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -183,6 +183,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
+| [`ai-code-review-lite`](/docs/user-guide/skills/bundled/software-development/software-development-ai-code-review-lite) | Use when reviewing AI-generated code or unfamiliar-language diffs without running a heavy verification process. A simple confidence gate based on scope, tests, risk triggers, and rollback. | `software-development/ai-code-review-lite` |
 | [`debugging-hermes-tui-commands`](/docs/user-guide/skills/bundled/software-development/software-development-debugging-hermes-tui-commands) | Debug Hermes TUI slash commands: Python, gateway, Ink UI. | `software-development/debugging-hermes-tui-commands` |
 | [`hermes-agent-skill-authoring`](/docs/user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring) | Author in-repo SKILL.md: frontmatter, validator, structure. | `software-development/hermes-agent-skill-authoring` |
 | [`hermes-s6-container-supervision`](/docs/user-guide/skills/bundled/software-development/software-development-hermes-s6-container-supervision) | Modify, debug, or extend the s6-overlay supervision tree inside the Hermes Agent Docker image — adding new services, debugging profile gateways, understanding the Architecture B main-program pattern. | `software-development/hermes-s6-container-supervision` |

--- a/website/docs/user-guide/skills/bundled/software-development/software-development-ai-code-review-lite.md
+++ b/website/docs/user-guide/skills/bundled/software-development/software-development-ai-code-review-lite.md
@@ -1,0 +1,184 @@
+---
+title: "Ai Code Review Lite"
+sidebar_label: "Ai Code Review Lite"
+description: "Use when reviewing AI-generated code or unfamiliar-language diffs without running a heavy verification process"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Ai Code Review Lite
+
+Use when reviewing AI-generated code or unfamiliar-language diffs without running a heavy verification process. A simple confidence gate based on scope, tests, risk triggers, and rollback.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Bundled (installed by default) |
+| Path | `skills/software-development/ai-code-review-lite` |
+| Version | `1.0.0` |
+| Author | Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `code-review`, `ai-generated-code`, `confidence`, `lightweight-review` |
+| Related skills | [`requesting-code-review`](/docs/user-guide/skills/bundled/software-development/software-development-requesting-code-review), [`github-code-review`](/docs/user-guide/skills/bundled/github/github-github-code-review), [`test-driven-development`](/docs/user-guide/skills/bundled/software-development/software-development-test-driven-development) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# AI Code Review Lite
+
+## Overview
+
+A lightweight review routine for AI-generated code. Use it when a full audit is too much, but blind trust is too little.
+
+The goal is simple: decide whether the change is safe enough to merge, needs more evidence, or should move to a heavier review.
+
+## When to Use
+
+Use this when:
+
+- An AI agent produced a small or medium code change.
+- The diff is in a language you do not know deeply.
+- You want a quick PR review with a confidence level.
+- The change is not obviously high-risk.
+
+Do not use this when the change touches auth, payments, permissions, secrets, database migrations, deployment, background jobs, or large refactors. Use `requesting-code-review` or a full review instead.
+
+## The Five Checks
+
+### 1. Scope
+
+Ask:
+
+- What was the task?
+- Which files changed?
+- Do the changed files match the task?
+
+Red flags:
+
+- unrelated files changed
+- generated or lock files changed without explanation
+- large diff for a small request
+
+### 2. Tests
+
+Require actual command output, not a claim.
+
+Good:
+
+```text
+npm test
+cargo test
+python -m pytest
+```
+
+For bug fixes, prefer proof that a test failed before and passed after.
+
+Red flags:
+
+- “should work”
+- “not tested”
+- tests only cover the happy path
+
+### 3. Risk Triggers
+
+Escalate to heavier review if the diff includes:
+
+- auth, roles, sessions, tokens
+- database schema, migrations, raw SQL
+- shell commands, filesystem writes/deletes
+- secrets or credentials
+- background jobs, queues, cron
+- concurrency or shared state
+- deploy, infra, CI/CD
+- `eval`, `exec`, unsafe deserialization
+- TypeScript `any` or broad `as SomeType` at API boundaries
+- Rust `unsafe`, `unwrap()`, or `expect()` in runtime paths
+
+### 4. Independent Pass
+
+Ask another reviewer agent to check only for blockers:
+
+```md
+Review this task, evidence, and diff. Return only:
+- approve / request changes / escalate
+- missing evidence
+- blocking correctness issues
+- blocking security issues
+- risky files to inspect manually
+```
+
+The implementer should not be the only reviewer.
+
+### 5. Rollback
+
+Ask:
+
+- Can this be reverted cleanly?
+- Is there a migration or irreversible side effect?
+- If it breaks, what command or PR reverts it?
+
+No rollback plan means no high confidence.
+
+## Output Template
+
+```md
+## AI Code Review Lite
+
+Verdict: Approve / Request changes / Escalate
+Confidence: Low / Medium / High
+
+### Evidence checked
+- Scope matches task: yes/no
+- Tests shown: yes/no, command:
+- Risk triggers found: yes/no
+- Independent pass: yes/no
+- Rollback clear: yes/no
+
+### Blocking issues
+- none / list
+
+### Manual spots checked
+- file: reason
+
+### Notes
+- short reviewer note
+```
+
+## Confidence Rules
+
+High confidence:
+
+- scope is tight
+- tests ran and match the change
+- no risk triggers
+- independent pass found no blockers
+- rollback is clear
+
+Medium confidence:
+
+- one minor piece of evidence is missing, but the diff is small and low-risk
+
+Low confidence:
+
+- missing tests, vague scope, unfamiliar-language danger pattern, unexpected files, or unclear rollback
+
+## Common Pitfalls
+
+1. **Reading every line first.** Start with scope and evidence. Open code only where risk appears.
+2. **Trusting summaries.** Summaries are useful, but command output is better.
+3. **Overusing this skill.** If risk triggers appear, escalate. Lite review is not a parachute.
+4. **Pretending language fluency.** In Rust or TypeScript, check the danger patterns before style.
+
+## Verification Checklist
+
+- [ ] Task and changed files are clear.
+- [ ] Test output is present or missing tests are explicitly called out.
+- [ ] Risk triggers were checked.
+- [ ] Another reviewer or review pass checked for blockers.
+- [ ] Rollback path is clear.
+- [ ] Verdict and confidence are stated plainly.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -353,6 +353,7 @@ const sidebars: SidebarsConfig = {
                   key: 'skills-bundled-software-development',
                   collapsed: true,
                   items: [
+                    'user-guide/skills/bundled/software-development/software-development-ai-code-review-lite',
                     'user-guide/skills/bundled/software-development/software-development-debugging-hermes-tui-commands',
                     'user-guide/skills/bundled/software-development/software-development-hermes-agent-skill-authoring',
                     'user-guide/skills/bundled/software-development/software-development-hermes-s6-container-supervision',


### PR DESCRIPTION
## Summary
- Add a bundled `ai-code-review-lite` skill for simple confidence-gated review of AI-generated code
- Include generated skill docs, catalog entry, and sidebar link

## Test Plan
- `source venv/bin/activate && python -m pytest tests/website/test_generate_skill_docs.py tests/tools/test_skills_guard.py tests/test_packaging_metadata.py tests/test_project_metadata.py -q`
- Independent staged-diff review: approve / no blockers