### PR TITLE
fix(gateway): use detached watcher in manual restart path to prevent SIGTERM cascade

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5536,6 +5536,11 @@ def _gateway_command_inner(args):
                         service_stopped = True
                     except (subprocess.CalledProcessError, RuntimeError):
                         pass
+            # Capture old PID before killing all gateways so the detached
+            # watcher can poll for exit.  See the single-profile restart
+            # block below for the full rationale.
+            from gateway.status import get_running_pid
+            _old_pid = get_running_pid()
             killed = kill_gateway_processes(all_profiles=True)
             total = killed + (1 if service_stopped else 0)
             if total:
@@ -5558,7 +5563,12 @@ def _gateway_command_inner(args):
                 # stopped and can die before the replacement is stable.
                 gateway_windows.start()
             else:
-                run_gateway(verbose=0)
+                _profile = _profile_suffix() or "default"
+                if _old_pid and launch_detached_profile_gateway_restart(_profile, _old_pid):
+                    print("Starting gateway (detached)...")
+                else:
+                    print("Starting gateway...")
+                    run_gateway(verbose=0)
             return
         
         if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
@@ -5615,15 +5625,29 @@ def _gateway_command_inner(args):
                 print("  Fix the service, then retry: hermes gateway start")
                 sys.exit(1)
 
-            # Manual restart: stop only this profile's gateway
+            # Manual restart: stop only this profile's gateway.
+            # Capture the old PID *before* stopping so the detached
+            # watcher can poll for its exit.  Using
+            # ``launch_detached_profile_gateway_restart()`` instead of
+            # foreground ``run_gateway()`` prevents the new gateway from
+            # being killed when the old gateway's SIGTERM propagates to
+            # child processes (the common case when ``hermes gateway
+            # restart`` is invoked from an agent tool call inside the
+            # running gateway).
+            from gateway.status import get_running_pid
+            _old_pid = get_running_pid()
             if stop_profile_gateway():
                 print("✓ Stopped gateway for this profile")
 
             _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
 
-            # Start fresh
-            print("Starting gateway...")
-            run_gateway(verbose=0)
+            _profile = _profile_suffix() or "default"
+            if _old_pid and launch_detached_profile_gateway_restart(_profile, _old_pid):
+                print("Starting gateway (detached)...")
+            else:
+                # Fallback: watcher launch failed (e.g. stale PID file)
+                print("Starting gateway...")
+                run_gateway(verbose=0)
     
     elif subcmd == "status":
         deep = getattr(args, 'deep', False)

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -880,3 +880,34 @@ class TestGatewayDetachedWatcherWindowsFlags:
         assert 'if sys.platform == "win32":' in source
         # Windows branch uses windows_detach_popen_kwargs
         assert "windows_detach_popen_kwargs" in source
+
+    def test_manual_restart_uses_detached_watcher(self):
+        """The non-service manual restart path must use
+        ``launch_detached_profile_gateway_restart()`` instead of bare
+        ``run_gateway()`` to prevent the new gateway from being killed
+        when the old gateway's SIGTERM propagates to child processes.
+
+        Regression test for #35043.
+        """
+        root = Path(__file__).resolve().parents[2]
+        source = (root / "hermes_cli" / "gateway.py").read_text(encoding="utf-8")
+
+        # The manual restart block must capture old PID and use detached restart
+        assert "get_running_pid" in source, (
+            "gateway.py must import get_running_pid for detached restart"
+        )
+        assert "launch_detached_profile_gateway_restart" in source, (
+            "gateway.py must use launch_detached_profile_gateway_restart()"
+        )
+
+        # Verify the manual restart comment + detached pattern exists:
+        # get_running_pid -> stop_profile_gateway -> launch_detached
+        import re
+        manual_pattern = re.search(
+            r"Manual restart.*?get_running_pid.*?stop_profile_gateway.*?launch_detached_profile_gateway_restart",
+            source,
+            re.DOTALL,
+        )
+        assert manual_pattern is not None, (
+            "Manual restart path must: capture PID, stop gateway, then use detached restart"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes the manual gateway restart path so that the replacement gateway process survives SIGTERM propagation from the old gateway. In non-systemd environments (Docker containers, bare processes), `hermes gateway restart` killed the gateway ~50% of the time when invoked from inside the running gateway (e.g. via an agent terminal tool call).

## Related Issue

Fixes #35043

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: Replace bare `run_gateway(verbose=0)` in both the single-profile and `--all` manual restart paths with `launch_detached_profile_gateway_restart()`. Capture the old PID via `get_running_pid()` before stopping the gateway, then spawn a detached watcher that polls for the old PID's exit and respawns the gateway in an independent process tree. Falls back to `run_gateway()` if the watcher launch fails (e.g. stale PID file).
- `tests/tools/test_windows_native_support.py`: Add `test_manual_restart_uses_detached_watcher` regression test that verifies the manual restart path captures the old PID, stops the gateway, and uses the detached restart mechanism.

## How to Test

1. Run `pytest tests/tools/test_windows_native_support.py::TestGatewayDetachedWatcherWindowsFlags -v` — all 3 tests should pass
2. In a non-systemd environment (Docker container or bare process), start the gateway: `hermes gateway start`
3. From inside the gateway (e.g. via agent terminal tool), run `hermes gateway restart`
4. Verify the gateway comes back up: `hermes gateway status`
5. Repeat step 3 several times — the gateway should survive every restart (not just ~50%)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/gateway.py:_gateway_command_inner` restart subcmd (callers: CLI dispatch, gateway hooks)
- Blast radius: LOW — changes only the non-service manual restart fallback path; systemd/launchd/Windows service paths are unaffected
- Related patterns: `launch_detached_profile_gateway_restart()` already used by `hermes update` path (line 572); this PR routes the manual restart through the same mechanism
