### PR TITLE
feat: harden two-vps readiness and guardrails

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1612,6 +1612,13 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
     tools. Used by the concurrent execution path; the sequential path retains
     its own inline invocation for backward-compatible display handling.
     """
+    # Last-line runtime enforcement: if the node is running in read-only
+    # executor mode, block mutating tools here too so callers cannot bypass
+    # higher-level selection filters.
+    runtime_guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
+    if not runtime_guardrail_decision.allows_execution:
+        return agent._guardrail_block_result(runtime_guardrail_decision)
+
     # Check plugin hooks for a block directive before executing anything.
     block_message: Optional[str] = None
     if not pre_tool_block_checked:

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -7,6 +7,21 @@ from pathlib import Path
 from typing import Optional
 
 
+def get_node_execution_role() -> str:
+    """Return the effective node execution role from env or config."""
+    env_role = str(os.getenv("HERMES_NODE_ROLE") or os.getenv("HERMES_AGENT_EXECUTION_ROLE") or "").strip().lower()
+    if env_role:
+        return env_role
+    try:
+        from hermes_cli.config import cfg_get  # local import to avoid cycles
+        cfg_role = str(cfg_get("agent.execution_role") or "").strip().lower()
+        if cfg_role:
+            return cfg_role
+    except Exception:
+        pass
+    return ""
+
+
 def _hermes_home_path() -> Path:
     """Resolve the active HERMES_HOME (profile-aware) without circular imports."""
     try:

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -14,7 +14,37 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from utils import safe_json_loads
+from agent.file_safety import get_node_execution_role
 from agent.tool_result_classification import file_mutation_result_landed
+
+
+_EXECUTOR_NODE_ROLE = "executor"
+_EXECUTOR_READ_ONLY_DISALLOWED_TOOL_NAMES = frozenset(
+    {
+        "clarify",
+        "computer_use",
+        "cronjob",
+        "delegation",
+        "discord",
+        "discord_admin",
+        "file",
+        "homeassistant",
+        "image_gen",
+        "memory",
+        "messaging",
+        "moa",
+        "skills",
+        "spotify",
+        "todo",
+        "video",
+        "video_gen",
+        "write_file",
+        "patch",
+        "send_message",
+        "skill_manage",
+        "process",
+    }
+)
 
 
 IDEMPOTENT_TOOL_NAMES = frozenset(
@@ -240,6 +270,17 @@ class ToolCallGuardrailController:
 
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
         signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
+        if get_node_execution_role() == _EXECUTOR_NODE_ROLE and tool_name in self.config.mutating_tools:
+            return ToolGuardrailDecision(
+                action="block",
+                code="executor_read_only_block",
+                message=(
+                    f"Blocked {tool_name}: the current node role is read-only executor, "
+                    "so mutating tools are disabled here. Route writes through the canonical owner instead."
+                ),
+                tool_name=tool_name,
+                signature=signature,
+            )
         if not self.config.hard_stop_enabled:
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 

--- a/cli.py
+++ b/cli.py
@@ -403,6 +403,7 @@ def load_cli_config() -> Dict[str, Any]:
             "prefill_messages_file": "",
             "reasoning_effort": "",
             "service_tier": "",
+            "execution_role": "",  # Optional node role override (e.g. "executor" on VPS 2)
             "personalities": {
                 "helpful": "You are a helpful, friendly AI assistant.",
                 "concise": "You are a concise assistant. Keep responses brief and to the point.",

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,29 @@
+# Architecture Notes
+
+This directory captures the rollout boundaries for memory, agents, networking, and safety.
+
+## Current documents
+- [Memory model](memory-model.md)
+- [Memory contracts](memory-contracts.md)
+- [Memory indexing](memory-indexing.md)
+- [Memory schema](memory-schema.sql)
+- [Agent permissions](agent-permissions.md)
+- [Read/write contracts](read-write-contracts.md)
+- [Network resilience](network-resilience.md)
+- [VPS topology](vps-topology.md)
+- [Federation protocol](federation-protocol.md)
+- [Observability](observability.md)
+- [Rollback](rollback.md)
+- [Visual architecture diagram](../../memory-agents-vps-architecture.html)
+
+## Validation helpers
+- `scripts/validate_memory_schema.py` loads the canonical schema into a temporary Postgres database and checks the core tables plus the append-only trigger.
+- `scripts/check_two_vps_readiness.py` composes schema validation and tailnet health validation into a single rollout checkpoint. On VPS 2, pass `--expect-role executor` before the service starts.
+
+## Rollout order
+1. Canonical memory on VPS 1
+2. Private connectivity via Tailscale
+3. Combined readiness check passes
+4. VPS 2 as read-only executor
+5. Controlled write path
+6. Observability and rollback

--- a/docs/architecture/agent-permissions.md
+++ b/docs/architecture/agent-permissions.md
@@ -1,0 +1,90 @@
+# Agent Permissions — VPS 2 Executor Model
+
+## Goal
+
+Allow VPS 2 to run agents and read canonical memory without becoming a second source of truth.
+
+## Permission tiers
+
+### 1) Read-only by default
+Applies to all routine agent work on VPS 2.
+
+Allowed:
+- read canonical facts
+- read decisions
+- read summaries
+- read entity registry
+- read event metadata needed for context
+- read local cache and local execution state
+
+Forbidden:
+- create or modify canonical memory directly
+- mutate the append-only event log
+- expose public write endpoints
+- write across machines without Tailscale
+- promote VPS 2 to memory owner
+
+### 2) Narrow approved writes
+Only specific flows may write, and only through the canonical write path on VPS 1.
+
+Allowed write flows:
+- approved ingestion pipelines
+- explicit memory write tools
+- administrative maintenance with audit trail
+- replay of queued events after reconnect, with VPS 1 acknowledgement
+
+### 3) Execution-state writes
+VPS 2 may write its own local execution state.
+
+Allowed local-only writes:
+- task progress markers
+- temporary cache entries
+- retry counters
+- append-only pending queue entries
+- local logs and traces
+
+These writes must never be treated as canonical memory.
+
+## Separation rule
+
+Canonical memory lives on VPS 1.
+
+VPS 2 owns only:
+- ephemeral runtime state
+- local queue state
+- cache state
+- agent execution artifacts
+
+If VPS 2 loses access to VPS 1, it may keep working in degraded mode, but it must not invent canonical facts or accept remote writes.
+
+## Retry and loop guardrails
+
+### Retry limits
+- retries must be bounded
+- exponential backoff must cap out
+- repeated failures must degrade to local queueing
+- no infinite retry loops
+
+### Loop protection
+- agent recursion must be capped
+- write retries must be idempotent
+- duplicate events must be deduplicated by source/event id
+- unsafe writes must fail closed
+
+## Unsafe patterns
+
+These are forbidden:
+- "best effort" writes to canonical memory without confirmation
+- writing directly to Postgres from a task runner on VPS 2
+- silent fallback from remote write failure to local canonical mutation
+- using execution state as a substitute for canonical state
+- opening a public API just to simplify write access
+
+## Verification checklist
+
+Before VPS 2 is treated as an executor:
+- Tailscale reachability is confirmed
+- read-only access works over the tailnet
+- local execution state is isolated from canonical memory
+- write paths are explicit, narrow, and audited
+- degraded mode does not create unsafe writes

--- a/docs/architecture/federation-protocol.md
+++ b/docs/architecture/federation-protocol.md
@@ -1,0 +1,144 @@
+# Federation Protocol — VPS 1 ↔ VPS 2
+
+This document defines the private control channel between the canonical node and the executor node.
+
+## Non-negotiable invariants
+
+- VPS 1 is the only canonical writer.
+- VPS 2 never promotes itself to memory owner.
+- All federation traffic stays inside Tailscale.
+- Messages are signed and time-bounded.
+- Replay is append-only and idempotent.
+- Conflicts resolve in favor of VPS 1.
+
+## Participants
+
+- **VPS 1**: canonical control plane, memory owner, ack authority.
+- **VPS 2**: executor/worker, local queue owner, replay sender.
+
+## Message types
+
+### 1) Read request
+
+Used by VPS 2 to fetch canonical state.
+
+Payload:
+- `request_id`
+- `scope`
+- `cursor` or `since`
+- `timestamp`
+- `nonce`
+- `signature`
+
+Response:
+- `status`
+- `data`
+- `snapshot_id`
+- `freshness`
+- `signature`
+
+### 2) Event replay
+
+Used by VPS 2 to submit queued local actions once reachability returns.
+
+Payload:
+- `job_id`
+- `event_id`
+- `kind`
+- `payload`
+- `provenance`
+- `created_at`
+- `source_node`
+- `timestamp`
+- `nonce`
+- `signature`
+
+Rules:
+- event IDs must be stable
+- event order must be preserved
+- duplicate events must be deduplicated
+- missing provenance fails closed
+
+### 3) Acknowledgement
+
+Used by VPS 1 to confirm accepted events.
+
+Payload:
+- `job_id`
+- `event_id`
+- `ack_status`
+- `canonical_ref`
+- `timestamp`
+- `signature`
+
+Ack status values:
+- `accepted`
+- `rejected`
+- `duplicate`
+- `stale`
+
+## Canonical write path
+
+1. VPS 2 creates local events while executing.
+2. Events are appended to the local pending queue.
+3. When Tailscale is healthy, VPS 2 sends queued events to VPS 1.
+4. VPS 1 validates signature, provenance, and idempotency.
+5. VPS 1 appends accepted events to canonical storage.
+6. VPS 1 returns per-event acknowledgements.
+7. VPS 2 clears only acknowledged queue entries.
+
+## Signature and freshness rules
+
+- Every message includes a timestamp.
+- Every message includes a nonce.
+- Messages older than the freshness window are rejected.
+- Signatures cover the full envelope.
+- Messages without a valid signature are rejected.
+
+## Retry rules
+
+- Retry only on transport failure or transient rejection.
+- Do not retry rejected canonical writes blindly.
+- Duplicate delivery must be safe.
+- Replay remains append-only until acked.
+
+## Conflict rules
+
+When canonical state and local state diverge:
+- VPS 1 wins.
+- VPS 2 replays only the still-pending entries.
+- Local cache is refreshed from canonical state.
+- No local overwrite can replace canonical history.
+
+## Failure modes
+
+### Tailnet down
+
+- VPS 2 keeps working locally.
+- New actions enter the pending queue.
+- No remote write is attempted.
+
+### VPS 1 unreachable
+
+- Treat as degraded mode.
+- Read stale local cache only.
+- Do not invent canonical facts.
+
+### Invalid signature
+
+- Reject immediately.
+- Log locally on VPS 2 and on VPS 1 if observed.
+
+### Replay conflict
+
+- Mark stale or duplicate.
+- Preserve canonical history.
+- Requeue only unresolved entries.
+
+## Acceptance criteria
+
+This protocol is acceptable when:
+- VPS 2 can read canonical state privately over Tailscale.
+- VPS 2 can replay local events safely after reconnect.
+- VPS 1 can ack or reject each event individually.
+- No message path allows VPS 2 to become canonical.

--- a/docs/architecture/memory-contracts.md
+++ b/docs/architecture/memory-contracts.md
@@ -1,0 +1,43 @@
+# Memory Contracts — Read/Write Boundaries
+
+## Read contract
+
+Agents on VPS 2 may read:
+- canonical facts
+- decisions
+- entity registry
+- summaries
+- event metadata required for context
+
+## Write contract
+
+Only approved flows may write:
+- ingestion pipelines
+- explicit memory write tools
+- controlled administrative operations
+
+## Forbidden by default
+
+- direct update/delete of `event_log`
+- silent mutation of provenance
+- public API exposure for write endpoints
+- cross-machine writes without Tailscale
+- promotion of VPS 2 to canonical memory owner
+
+## Degraded-mode rule
+
+If Tailscale is unavailable or unreachable:
+- VPS 2 may continue with local cache and append-only pending queue
+- no remote writes are attempted
+- stale reads must be labeled as stale
+- recovery requires replay and acknowledgement from VPS 1
+
+## Operational rule
+
+If a record cannot answer:
+- who created it
+- when it was created
+- why it exists
+- which source produced it
+
+then it does not belong in canonical memory.

--- a/docs/architecture/memory-indexing.md
+++ b/docs/architecture/memory-indexing.md
@@ -1,0 +1,31 @@
+# Memory Indexing
+
+## Goal
+
+Make canonical memory fast to read without turning it into a write-heavy system.
+
+## Recommended indexes
+
+- `memory_event_log (occurred_at DESC)` for timeline queries
+- `memory_event_log (entity_id)` for entity-centric lookups
+- `memory_event_log (event_type)` for filtering by event class
+- `memory_event_log USING GIN (payload)` for JSONB search
+- `memory_facts (subject_entity_id)` for entity facts
+- `memory_facts (fact_key)` for key-based lookup
+- `memory_facts USING GIN (fact_value)` for structured fact search
+- `memory_decisions (decision_key)` for decision history
+- `memory_decisions (status)` for active/superseded filtering
+- `memory_episodes (entity_id)` and `memory_episodes (started_at DESC)` for timeline browsing
+- `memory_summaries (scope_type, scope_id)` for scoped retrieval
+- `memory_summaries USING GIN (source_range)` for provenance expansion
+
+## Read path
+
+1. Start from entity or time window.
+2. Fetch relevant facts and decisions.
+3. Expand via linked source events.
+4. Use summaries only as compression, never as the only source.
+
+## Rule
+
+If a query becomes slow, add an index for the read pattern before adding more derived data.

--- a/docs/architecture/memory-model.md
+++ b/docs/architecture/memory-model.md
@@ -1,0 +1,44 @@
+# Memory Model — Canonical Layer on VPS 1
+
+## Objective
+
+VPS 1 is the single source of truth for memory. Agents may read from it; only controlled workflows may write to it.
+
+## Core rules
+
+- `event_log` is append-only.
+- `facts`, `decisions`, `episodes`, `entities`, and `summaries` are derived or curated records.
+- Every durable record must link back to one or more source events.
+- No public exposure of memory services.
+- Tailscale is the primary transport between nodes; degraded mode must preserve safety if it fails.
+- VPS 2 is an execution node, not the memory master.
+
+## Data layers
+
+### 1) `event_log`
+Immutable audit trail of everything important that happened.
+
+### 2) `sources`
+Traceability layer for where a record came from.
+
+### 3) `entities`
+Canonical references for people, projects, systems, and resources.
+
+### 4) `facts`
+Short durable statements with provenance.
+
+### 5) `decisions`
+Explicit decisions with rationale and status.
+
+### 6) `episodes`
+Time-bounded clusters of activity or context.
+
+### 7) `summaries`
+Compressed views over episodes, entities, or time windows.
+
+## Write policy
+
+- Agents default to read-only.
+- Writes require an approved memory-write path.
+- Derived records should be recomputable from source events.
+- If provenance is missing, the record is not canonical.

--- a/docs/architecture/memory-schema.sql
+++ b/docs/architecture/memory-schema.sql
@@ -1,0 +1,161 @@
+-- Canonical memory schema for VPS 1
+-- Postgres 16+
+-- Append-only event log; derived memory tables referenced back to sources.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS memory_sources (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_type     text NOT NULL,               -- telegram, api, manual, webhook, system
+    source_ref      text NOT NULL,               -- chat id, file path, URL, job id, etc.
+    title          text,
+    metadata       jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at     timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (source_type, source_ref)
+);
+
+CREATE TABLE IF NOT EXISTS memory_entities (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type     text NOT NULL,               -- person, project, system, machine, org, topic
+    canonical_name  text NOT NULL,
+    external_ref    text,
+    metadata       jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at     timestamptz NOT NULL DEFAULT now(),
+    updated_at     timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (entity_type, canonical_name)
+);
+
+CREATE TABLE IF NOT EXISTS memory_event_log (
+    id              bigserial PRIMARY KEY,
+    occurred_at     timestamptz NOT NULL DEFAULT now(),
+    actor_type      text NOT NULL,               -- user, agent, system, job
+    actor_id        text,
+    entity_id       uuid REFERENCES memory_entities(id) ON DELETE SET NULL,
+    event_type      text NOT NULL,               -- message, note, state_change, decision, observation
+    payload         jsonb NOT NULL DEFAULT '{}'::jsonb,
+    source_id       uuid NOT NULL REFERENCES memory_sources(id) ON DELETE RESTRICT,
+    checksum       text,
+    created_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_event_log_occurred_at ON memory_event_log (occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_memory_event_log_entity_id ON memory_event_log (entity_id);
+CREATE INDEX IF NOT EXISTS idx_memory_event_log_event_type ON memory_event_log (event_type);
+CREATE INDEX IF NOT EXISTS idx_memory_event_log_payload_gin ON memory_event_log USING GIN (payload);
+
+CREATE TABLE IF NOT EXISTS memory_facts (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    subject_entity_id uuid REFERENCES memory_entities(id) ON DELETE SET NULL,
+    fact_key       text NOT NULL,
+    fact_value     jsonb NOT NULL,
+    confidence     numeric(4,3) NOT NULL DEFAULT 1.000,
+    valid_from     timestamptz,
+    valid_to       timestamptz,
+    source_event_id bigint NOT NULL REFERENCES memory_event_log(id) ON DELETE RESTRICT,
+    created_at     timestamptz NOT NULL DEFAULT now(),
+    updated_at     timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (subject_entity_id, fact_key, source_event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_facts_subject ON memory_facts (subject_entity_id);
+CREATE INDEX IF NOT EXISTS idx_memory_facts_key ON memory_facts (fact_key);
+CREATE INDEX IF NOT EXISTS idx_memory_facts_value_gin ON memory_facts USING GIN (fact_value);
+
+CREATE TABLE IF NOT EXISTS memory_decisions (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    decision_key   text NOT NULL,
+    title          text NOT NULL,
+    decision_text  text NOT NULL,
+    rationale      text,
+    status         text NOT NULL DEFAULT 'active', -- active, superseded, revoked
+    decided_at     timestamptz NOT NULL DEFAULT now(),
+    decided_by     text,
+    source_event_id bigint NOT NULL REFERENCES memory_event_log(id) ON DELETE RESTRICT,
+    created_at     timestamptz NOT NULL DEFAULT now(),
+    updated_at     timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (decision_key, source_event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_decisions_key ON memory_decisions (decision_key);
+CREATE INDEX IF NOT EXISTS idx_memory_decisions_status ON memory_decisions (status);
+
+CREATE TABLE IF NOT EXISTS memory_episodes (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_id       uuid REFERENCES memory_entities(id) ON DELETE SET NULL,
+    title          text NOT NULL,
+    summary        text,
+    started_at     timestamptz NOT NULL,
+    ended_at       timestamptz,
+    source_start_event_id bigint REFERENCES memory_event_log(id) ON DELETE SET NULL,
+    source_end_event_id bigint REFERENCES memory_event_log(id) ON DELETE SET NULL,
+    created_at     timestamptz NOT NULL DEFAULT now(),
+    updated_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_episodes_entity ON memory_episodes (entity_id);
+CREATE INDEX IF NOT EXISTS idx_memory_episodes_started_at ON memory_episodes (started_at DESC);
+
+CREATE TABLE IF NOT EXISTS memory_summaries (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    scope_type     text NOT NULL,               -- entity, episode, time_window, project
+    scope_id       uuid,
+    summary        text NOT NULL,
+    source_range   jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at     timestamptz NOT NULL DEFAULT now(),
+    updated_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_summaries_scope ON memory_summaries (scope_type, scope_id);
+CREATE INDEX IF NOT EXISTS idx_memory_summaries_source_range_gin ON memory_summaries USING GIN (source_range);
+
+-- Append-only guardrails
+CREATE OR REPLACE FUNCTION memory_block_event_log_mutations()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'memory_event_log is append-only';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_memory_event_log_no_update ON memory_event_log;
+CREATE TRIGGER trg_memory_event_log_no_update
+BEFORE UPDATE OR DELETE ON memory_event_log
+FOR EACH ROW
+EXECUTE FUNCTION memory_block_event_log_mutations();
+
+-- Updated-at helper
+CREATE OR REPLACE FUNCTION memory_touch_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_memory_entities_updated_at ON memory_entities;
+CREATE TRIGGER trg_memory_entities_updated_at
+BEFORE UPDATE ON memory_entities
+FOR EACH ROW EXECUTE FUNCTION memory_touch_updated_at();
+
+DROP TRIGGER IF EXISTS trg_memory_facts_updated_at ON memory_facts;
+CREATE TRIGGER trg_memory_facts_updated_at
+BEFORE UPDATE ON memory_facts
+FOR EACH ROW EXECUTE FUNCTION memory_touch_updated_at();
+
+DROP TRIGGER IF EXISTS trg_memory_decisions_updated_at ON memory_decisions;
+CREATE TRIGGER trg_memory_decisions_updated_at
+BEFORE UPDATE ON memory_decisions
+FOR EACH ROW EXECUTE FUNCTION memory_touch_updated_at();
+
+DROP TRIGGER IF EXISTS trg_memory_episodes_updated_at ON memory_episodes;
+CREATE TRIGGER trg_memory_episodes_updated_at
+BEFORE UPDATE ON memory_episodes
+FOR EACH ROW EXECUTE FUNCTION memory_touch_updated_at();
+
+DROP TRIGGER IF EXISTS trg_memory_summaries_updated_at ON memory_summaries;
+CREATE TRIGGER trg_memory_summaries_updated_at
+BEFORE UPDATE ON memory_summaries
+FOR EACH ROW EXECUTE FUNCTION memory_touch_updated_at();

--- a/docs/architecture/network-resilience.md
+++ b/docs/architecture/network-resilience.md
@@ -1,0 +1,63 @@
+# Network Resilience — Tailscale-First, Degraded-Mode Safe
+
+## Goal
+Keep all inter-machine traffic private over Tailscale while ensuring the system degrades safely if the tailnet becomes unavailable.
+
+## Principle
+- Tailscale is the *primary transport*.
+- Public exposure of sensitive ports remains forbidden.
+- A tailnet outage must reduce freshness, not correctness.
+- No remote write is allowed when canonical connectivity is unavailable.
+
+## Operating modes
+
+### 1) Healthy
+- VPS 2 reaches VPS 1 over Tailscale.
+- Reads come from canonical services on VPS 1.
+- Approved writes flow through the controlled write path.
+
+### 2) Degraded
+Triggered when Tailscale is down, unreachable, or partially broken.
+
+Behavior:
+- Reads use the last known local cache or snapshot.
+- Writes are appended locally to a durable queue.
+- No cross-machine mutation is attempted.
+- Responses that depend on stale data are marked as stale.
+
+### 3) Recovery
+Triggered when Tailscale returns.
+
+Behavior:
+- Re-establish reachability checks.
+- Replay queued events in order.
+- Resolve conflicts using VPS 1 as the source of truth.
+- Verify that the remote canonical state matches the replay result.
+
+## Data-plane rules
+- Canonical writes only land on VPS 1.
+- VPS 2 may keep local execution state, cache, and a pending event queue.
+- The queue must be append-only until acknowledged by VPS 1.
+- Replays must be idempotent.
+
+## Health checks
+Minimum checks:
+- DNS resolution of tailnet hostname
+- TCP reachability to the memory/API endpoint
+- Authenticated request to a read-only health endpoint
+- Clock skew sanity for signed or time-sensitive requests
+
+Reference implementation:
+- `scripts/check_tailnet_health.py` validates DNS, Tailscale ping, and non-public binds for sensitive ports.
+- `scripts/check_two_vps_readiness.py` is the rollout gate that combines schema validation with tailnet health before VPS 2 promotion.
+
+## Emergency fallback
+If the tailnet is down for an extended period:
+- Continue local-only execution on VPS 2.
+- Do not invent canonical state.
+- Require manual intervention to restore sync before writes resume.
+
+## Non-goals
+- No public fallback port
+- No alternate internet-facing write API
+- No automatic promotion of VPS 2 to memory master

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,0 +1,36 @@
+# Observability — Safe Visibility Without Expanding Blast Radius
+
+## Goal
+Add logs, metrics, and traces that make the system diagnosable without exposing canonical memory or write paths publicly.
+
+## Principles
+- Observability is read-only.
+- Logs must not become a hidden source of truth.
+- Metrics should summarize behavior, not replace the underlying records.
+- Traces must preserve provenance across VPS 1 and VPS 2.
+- Sensitive ports remain private to the tailnet.
+
+## What to observe
+- memory ingestion latency
+- replay queue depth
+- Tailscale reachability
+- stale-read frequency
+- write failure rate
+- append-only violations
+- retry counts and loop caps
+
+## Required outputs
+- structured logs with source identifiers
+- metrics for health and backlog
+- audit trail for every canonical write
+- alerts when stale mode persists too long
+
+## Safety rules
+- No public debug endpoint for canonical memory.
+- No write capability through telemetry systems.
+- No auto-repair that mutates state without audit.
+
+## Acceptance criteria
+- Operators can tell when the system is unhealthy.
+- Operators can diagnose failures without granting broader write access.
+- Observability works even when the system degrades.

--- a/docs/architecture/read-write-contracts.md
+++ b/docs/architecture/read-write-contracts.md
@@ -1,0 +1,102 @@
+# Read/Write Contracts — Canonical Memory and Executor State
+
+## Scope
+
+This document defines what can be read and written by each side of the architecture.
+
+- VPS 1: canonical memory owner
+- VPS 2: execution and read node
+- Tailscale: private transport between the two
+
+## Read contract
+
+VPS 2 may read the following canonical surfaces from VPS 1:
+- facts
+- decisions
+- entities
+- summaries
+- event metadata
+- source provenance needed for context
+
+Reads must be:
+- authenticated
+- private to the tailnet
+- traceable
+- safe to retry
+
+## Write contract
+
+Only approved systems may write canonical memory on VPS 1.
+
+Approved writers:
+- ingestion pipeline
+- explicit write tools
+- vetted administrative workflows
+- replay worker after recovery, once VPS 1 confirms receipt
+
+## Canonical write rules
+
+- writes must include provenance
+- writes must be idempotent or deduplicated
+- writes must not bypass the event log
+- writes must not rely on public endpoints
+- writes must not be accepted from VPS 2 unless they go through the approved canonical path
+
+## Event log rule
+
+The event log is append-only.
+
+Forbidden operations:
+- update existing events
+- delete existing events
+- reassign provenance after the fact
+- rewrite history to simplify downstream consumers
+
+## Local execution state rule
+
+VPS 2 may persist local state for execution, but it is not canonical.
+
+Local-only state includes:
+- pending queue entries
+- cache snapshots
+- task leases
+- retry bookkeeping
+- observability data
+
+This state may be lost and rebuilt.
+
+## Degraded mode
+
+If Tailscale is down or VPS 1 is unreachable:
+- no remote writes are attempted
+- VPS 2 continues with local cache only
+- new actions are appended to a local pending queue
+- stale reads are explicitly marked stale
+- replay happens only after reachability returns
+- replay must be ordered and idempotent
+
+## Recovery contract
+
+When connectivity returns:
+1. validate Tailscale reachability
+2. replay local pending queue
+3. wait for VPS 1 acknowledgement
+4. reconcile any conflicts in favor of VPS 1
+5. clear only the entries that were acknowledged
+
+## Failure policy
+
+Fail closed when any of these happen:
+- provenance is missing
+- target surface is ambiguous
+- write destination is not canonical
+- remote state cannot be authenticated
+- a task attempts to escalate itself into a canonical writer
+
+## Acceptance criteria
+
+This contract is satisfied when:
+- VPS 2 can read canonical state safely over Tailscale
+- VPS 2 can operate locally without unsafe writes when disconnected
+- canonical memory remains only on VPS 1
+- replay is safe, ordered, and verifiable

--- a/docs/architecture/rollback.md
+++ b/docs/architecture/rollback.md
@@ -1,0 +1,37 @@
+# Rollback — Safe Recovery Without Losing Provenance
+
+## Goal
+Provide a rollback path for bad deployments, schema mistakes, and memory corruption without rewriting history or exposing the system to unsafe writes.
+
+## Rollback rules
+- Rollback must be explicit.
+- Rollback must preserve provenance.
+- Rollback must not delete the append-only event history.
+- Rollback must not promote VPS 2 to canonical owner.
+- Rollback should prefer forward fixes when history must remain intact.
+
+## Allowed rollback actions
+- revert application deploys
+- restore a known-good schema migration
+- disable a bad write path
+- rehydrate caches from canonical data
+- replay pending events after correction
+
+## Forbidden rollback actions
+- editing `memory_event_log` in place
+- silently dropping records to make data look clean
+- accepting public writes as a shortcut to recovery
+- replacing canonical state with local execution state
+
+## Recovery sequence
+1. freeze new writes
+2. verify current failure mode
+3. restore the last known-good code or schema
+4. replay or reconcile pending events
+5. compare restored state to canonical expectations
+6. re-enable writes only after verification
+
+## Acceptance criteria
+- A failed release can be backed out safely.
+- Canonical memory remains auditable.
+- Recovery can be repeated without guessing.

--- a/docs/architecture/vps-topology.md
+++ b/docs/architecture/vps-topology.md
@@ -1,0 +1,110 @@
+# VPS Topology — Service and Directory Map
+
+This document turns the two-VPS split into an operational map.
+
+## Hard invariants
+
+- VPS 1 is the canonical memory and decision owner.
+- VPS 2 is execution-only.
+- Tailscale is the only inter-VPS transport.
+- No sensitive port is publicly exposed.
+- VPS 2 may keep only ephemeral, replayable, or disposable state.
+- Canonical writes must land on VPS 1.
+
+## VPS 1 — canonical control plane
+
+### Responsibilities
+
+- own canonical memory
+- store append-only event history
+- derive facts, decisions, summaries, and traceability data
+- accept approved writes through the canonical path only
+- expose read-only access to VPS 2 over Tailscale
+- validate and acknowledge replayed events
+
+### Service set
+
+- `postgresql.service` — canonical memory database
+- `hermes-memory.service` — memory API / read path
+- `hermes-orchestrator.service` — decision and routing layer
+- `hermes-federation-server.service` — signed inbound envelopes from trusted peers
+- `hermes-router.service` — request routing and policy enforcement
+- `tailscaled.service` — private transport
+
+### Runtime layout
+
+- `~/.hermes/config.yaml` — Hermes configuration
+- `~/.hermes/.env` — local secrets and tokens
+- `~/.hermes/logs/` — agent, gateway, and service logs
+- `~/.hermes/sessions/` — session history
+- `~/.hermes/data/` — non-canonical local artifacts, if needed
+- `~/.hermes/federation/` — federation config, peer registry, delivery log
+
+### Canonical storage boundary
+
+Canonical data lives in Postgres on VPS 1. Any local files under `~/.hermes/` are support state, not the source of truth.
+
+## VPS 2 — execution plane
+
+### Responsibilities
+
+- run agents, workers, and sandboxes
+- read canonical state from VPS 1 over Tailscale
+- queue local actions when disconnected
+- replay pending actions when reachability returns
+- keep execution state separate from canonical memory
+
+### Service set
+
+- `hermes-worker.service` — general task execution
+- `browser-worker.service` — browser automation jobs
+- `batch-worker.service` — batch / queued work
+- `render-worker.service` — image or media generation jobs
+- `job-sandbox.service` — isolated local execution
+- `tailscaled.service` — private transport
+
+### Runtime layout
+
+- `~/.hermes/config.yaml` — local agent config
+- `~/.hermes/.env` — local credentials required only for execution
+- `~/.hermes/cache/` — rebuildable caches
+- `~/.hermes/pending/` — append-only local queue while disconnected
+- `~/.hermes/artifacts/` — disposable outputs waiting for validation
+- `~/.hermes/logs/` — worker logs and diagnostics
+- `~/.hermes/sandbox/` — ephemeral job workspaces
+
+### Non-goals
+
+- no canonical writes
+- no memory-master promotion
+- no public API for write operations
+- no direct database ownership for canonical state
+
+## Shared network contract
+
+- Private hostnames or Tailscale IPs only.
+- Reachability checks must cover resolution, ping, and sensitive-port binding.
+- If Tailscale is down, VPS 2 keeps working locally but must not invent canonical facts.
+- Remote writes resume only after VPS 1 acknowledges replay.
+
+## Recommended startup order
+
+1. Start `tailscaled.service`
+2. Start `postgresql.service` on VPS 1
+3. Start `hermes-memory.service` on VPS 1
+4. Start worker services on VPS 2
+5. Run `scripts/check_tailnet_health.py`
+6. Run `scripts/check_two_vps_readiness.py --expect-role executor` before promoting VPS 2 to executor mode
+7. Run the schema validator on VPS 1 before enabling any write path
+
+## Recommended stop order
+
+1. Quiesce worker queues on VPS 2
+2. Stop worker services
+3. Stop federation and router services on VPS 1
+4. Stop the memory service on VPS 1
+5. Leave the database last unless an upgrade or rollback requires otherwise
+
+## Safety boundary
+
+If a proposed change blurs the line between executor state and canonical memory, the change is out of scope for VPS 2.

--- a/docs/plans/memory-agents-vps-low-risk-rollout.md
+++ b/docs/plans/memory-agents-vps-low-risk-rollout.md
@@ -1,0 +1,117 @@
+# Memory, Agents & VPS — Low-Risk Rollout Plan
+
+> **For Hermes:** Execute this plan in the safest order first: memory canônica on VPS 1, then private connectivity via Tailscale, then VPS 2 as consumer/executor.
+
+**Goal:** Establish a canonical memory layer on VPS 1, keep all sensitive services private, and connect VPS 2 only after the schema and access rules are stable.
+
+**Architecture:** VPS 1 is the source of truth for memory and decision records. VPS 2 is a worker/execution node that reads from VPS 1 over Tailscale and never becomes the master copy of state. No sensitive ports are exposed publicly; internal access happens through the tailnet only.
+
+**Tech Stack:** Postgres, Tailscale, Hermes Workspace/Gateway, internal API contracts, append-only event log, derived facts/decisions.
+
+---
+
+## Phase 1 — Canonical memory first
+
+**Objective:** Define and deploy the memory model on VPS 1 without touching execution workloads.
+
+**Files:**
+- Create: `docs/architecture/memory-model.md`
+- Create: `docs/architecture/memory-contracts.md`
+- Create: `docs/architecture/memory-schema.sql`
+- Create: `docs/architecture/memory-indexing.md`
+
+**Tasks:**
+1. Define append-only `event_log`.
+2. Define derived `facts`, `decisions`, `episodes`, `entities`, and `summaries`.
+3. Define `sources` as the traceability layer for every record.
+4. Write the initial SQL schema.
+5. Verify the schema is self-consistent and migration-safe.
+
+**Success criteria:**
+- Single source of truth exists on VPS 1.
+- No writes from agents yet.
+- Every fact/decision can be traced back to source events.
+
+---
+
+## Phase 2 — Private access only
+
+**Objective:** Make the memory service reachable only through the tailnet.
+
+**Files:**
+- Modify: network/service configuration for VPS 1
+- Modify: network/service configuration for VPS 2
+- Create: `docs/architecture/network-resilience.md`
+- Create: `scripts/check_tailnet_health.py`
+- Create: `scripts/check_two_vps_readiness.py`
+
+**Tasks:**
+1. Keep ports private/localhost-only.
+2. Expose access only via Tailscale MagicDNS / Tailscale IP.
+3. Verify SSH and service reachability over the tailnet.
+4. Define degraded-mode behavior for tailnet outage.
+5. Block public exposure of sensitive ports.
+6. Add a repeatable health check for DNS, Tailscale reachability, and unsafe port binds.
+7. Gate phase 3 on the combined readiness check, not on ad-hoc manual inspection.
+
+**Success criteria:**
+- No public exposure for workspace/gateway/memory endpoints.
+- Access works from VPS 2 to VPS 1 over Tailscale.
+- `python3 scripts/check_two_vps_readiness.py --expect-role executor` passes before VPS 2 is promoted to executor mode.
+
+---
+
+## Phase 3 — VPS 2 as execution node
+
+**Objective:** Allow VPS 2 to read from canonical memory and run agents/tasks.
+
+**Files:**
+- Create: `docs/architecture/agent-permissions.md`
+- Create: `docs/architecture/read-write-contracts.md`
+- Create: `docs/architecture/federation-protocol.md`
+
+**Tasks:**
+1. Define read-only access for most agent operations.
+2. Define the minimal write path for approved memory writes.
+3. Separate execution state from canonical memory.
+4. Add guardrails for retries, loops, and unsafe writes.
+
+**Success criteria:**
+- VPS 2 can execute tasks without owning the memory source of truth.
+- Write permissions are explicit and narrow.
+
+---
+
+## Phase 4 — Observability and fallback
+
+**Objective:** Add visibility without increasing blast radius.
+
+**Files:**
+- Create: `docs/architecture/observability.md`
+- Create: `docs/architecture/rollback.md`
+- Create: `docs/architecture/network-resilience.md`
+
+**Tasks:**
+1. Add logs and audit trails.
+2. Add a restore/fallback path for memory corruption.
+3. Define backup and verification checkpoints.
+4. Confirm tailnet outage handling is safe and non-destructive.
+
+**Success criteria:**
+- Failures are diagnosable.
+- Memory can be restored without guessing.
+
+---
+
+## Rollout order
+
+1. Memory schema on VPS 1
+2. Private connectivity via Tailscale
+3. Combined readiness check passes
+4. Read-only access from VPS 2
+5. Controlled write path
+6. Observability / rollback
+
+## Risk rule
+
+If a step increases public exposure, write authority, or cross-machine coupling before the schema is stable, stop and redesign.

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -31,6 +31,7 @@ from hermes_cli.config import (
     read_raw_config,
     save_env_value,
 )
+from agent.file_safety import get_node_execution_role
 # display_hermes_home is imported lazily at call sites to avoid ImportError
 # when hermes_constants is cached from a pre-update version during `hermes update`.
 from hermes_cli.setup import (
@@ -2194,6 +2195,12 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     working_dir = _stable_service_working_dir()
     detected_venv = _detect_venv_dir()
     venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
+    readiness_script = str(PROJECT_ROOT / "scripts" / "check_two_vps_readiness.py")
+    readiness_execstartpre = ""
+    if get_node_execution_role() == "executor":
+        readiness_execstartpre = (
+            f"ExecStartPre={python_path} {readiness_script} --expect-role executor\n"
+        )
 
     path_entries = _build_service_path_dirs()
     resolved_node = shutil.which("node")
@@ -2241,7 +2248,7 @@ Type=simple
 User={username}
 Group={group_name}
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
-WorkingDirectory={working_dir}
+{readiness_execstartpre}WorkingDirectory={working_dir}
 Environment="HOME={home_dir}"
 Environment="USER={username}"
 Environment="LOGNAME={username}"
@@ -2279,7 +2286,7 @@ StartLimitIntervalSec=0
 [Service]
 Type=simple
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
-WorkingDirectory={working_dir}
+{readiness_execstartpre}WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1135,6 +1135,73 @@ def _parse_enabled_flag(value, default: bool = True) -> bool:
     return default
 
 
+_EXECUTOR_NODE_ROLE = "executor"
+_EXECUTOR_READ_ONLY_TOOLSETS = {
+    "browser",
+    "code_execution",
+    "session_search",
+    "terminal",
+    "vision",
+    "web",
+    "x_search",
+}
+_EXECUTOR_DISABLED_TOOLSETS = {
+    "clarify",
+    "computer_use",
+    "cronjob",
+    "delegation",
+    "discord",
+    "discord_admin",
+    "file",
+    "homeassistant",
+    "image_gen",
+    "messaging",
+    "memory",
+    "moa",
+    "skills",
+    "spotify",
+    "todo",
+    "video",
+    "video_gen",
+    "yuanbao",
+}
+
+
+def _get_node_execution_role(config: dict | None = None) -> str:
+    """Return the node execution role for tool-policy decisions.
+
+    Env wins so deploy-time overrides on VPS 2 stay simple. Config is a
+    fallback for persisted local setups and the setup wizard.
+    """
+    env_role = str(os.getenv("HERMES_NODE_ROLE") or os.getenv("HERMES_AGENT_EXECUTION_ROLE") or "").strip().lower()
+    if env_role:
+        return env_role
+    if isinstance(config, dict):
+        agent_cfg = config.get("agent") or {}
+        cfg_role = str(agent_cfg.get("execution_role") or "").strip().lower()
+        if cfg_role:
+            return cfg_role
+    return ""
+
+
+def _apply_node_role_tool_policy(
+    config: dict,
+    platform: str,
+    enabled_toolsets: Set[str],
+) -> Set[str]:
+    """Apply node-role guardrails after normal platform resolution."""
+    role = _get_node_execution_role(config)
+    if role != _EXECUTOR_NODE_ROLE:
+        return enabled_toolsets
+
+    filtered = {
+        ts for ts in enabled_toolsets
+        if ts in _EXECUTOR_READ_ONLY_TOOLSETS or ts not in _EXECUTOR_DISABLED_TOOLSETS
+    }
+    filtered -= _EXECUTOR_DISABLED_TOOLSETS
+    return filtered
+
+
 def _get_platform_tools(
     config: dict,
     platform: str,
@@ -1381,6 +1448,8 @@ def _get_platform_tools(
     if disabled_toolsets:
         disabled_set = {str(ts) for ts in disabled_toolsets}
         enabled_toolsets -= disabled_set
+
+    enabled_toolsets = _apply_node_role_tool_policy(config, platform, enabled_toolsets)
 
     return enabled_toolsets
 

--- a/memory-agents-vps-architecture.html
+++ b/memory-agents-vps-architecture.html
@@ -1,0 +1,332 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Arquitetura de Memória, Agentes e VPS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #020617;
+      --panel: #0f172a;
+      --panel2: #111827;
+      --text: #e2e8f0;
+      --muted: #94a3b8;
+      --grid: rgba(148, 163, 184, 0.10);
+      --cyan: #22d3ee;
+      --cyan-fill: rgba(8, 51, 68, 0.45);
+      --emerald: #34d399;
+      --emerald-fill: rgba(6, 78, 59, 0.45);
+      --violet: #a78bfa;
+      --violet-fill: rgba(76, 29, 149, 0.45);
+      --amber: #fbbf24;
+      --amber-fill: rgba(120, 53, 15, 0.30);
+      --rose: #fb7185;
+      --rose-fill: rgba(136, 19, 55, 0.42);
+      --slate: #94a3b8;
+      --slate-fill: rgba(30, 41, 59, 0.55);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: 'JetBrains Mono', monospace;
+      background:
+        linear-gradient(rgba(2, 6, 23, 0.88), rgba(2, 6, 23, 0.95)),
+        url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><path d="M40 0H0V40" fill="none" stroke="%231e293b" stroke-width="0.6"/></svg>');
+      color: var(--text);
+      padding: 28px;
+    }
+    .wrap {
+      max-width: 1600px;
+      margin: 0 auto;
+    }
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 18px;
+    }
+    h1 {
+      margin: 0;
+      font-size: 24px;
+      letter-spacing: -0.02em;
+    }
+    .subtitle {
+      color: var(--muted);
+      margin-top: 6px;
+      font-size: 12px;
+      line-height: 1.5;
+    }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 14px;
+      border: 1px solid rgba(148,163,184,0.18);
+      border-radius: 999px;
+      background: rgba(15, 23, 42, 0.72);
+      color: var(--muted);
+      font-size: 11px;
+      white-space: nowrap;
+    }
+    .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--emerald);
+      box-shadow: 0 0 18px rgba(52, 211, 153, .7);
+      animation: pulse 1.8s infinite ease-in-out;
+    }
+    @keyframes pulse {
+      0%, 100% { transform: scale(0.95); opacity: 0.75; }
+      50% { transform: scale(1.15); opacity: 1; }
+    }
+    .panel {
+      border: 1px solid rgba(148,163,184,0.18);
+      border-radius: 18px;
+      background: linear-gradient(180deg, rgba(15,23,42,0.88), rgba(2,6,23,0.72));
+      box-shadow: 0 30px 80px rgba(0, 0, 0, 0.38);
+      overflow: hidden;
+    }
+    .svg-wrap {
+      padding: 14px;
+    }
+    svg {
+      width: 100%;
+      height: auto;
+      display: block;
+      border-radius: 14px;
+    }
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+      margin-top: 16px;
+    }
+    .card {
+      background: rgba(15, 23, 42, 0.82);
+      border: 1px solid rgba(148,163,184,0.18);
+      border-radius: 16px;
+      padding: 16px;
+    }
+    .card-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 12px;
+    }
+    .card-dot {
+      width: 10px; height: 10px; border-radius: 50%;
+      box-shadow: 0 0 14px currentColor;
+    }
+    .cyan { color: var(--cyan); background: var(--cyan); }
+    .emerald { color: var(--emerald); background: var(--emerald); }
+    .violet { color: var(--violet); background: var(--violet); }
+    .card h3 { margin: 0; font-size: 13px; }
+    ul { margin: 0; padding-left: 18px; color: var(--text); }
+    li { margin: 7px 0; font-size: 11px; line-height: 1.45; color: var(--muted); }
+    .footer {
+      margin-top: 14px;
+      color: var(--muted);
+      font-size: 10px;
+      text-align: right;
+      opacity: 0.85;
+    }
+    .legend-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      margin-right: 14px;
+      margin-bottom: 6px;
+      font-size: 10px;
+      color: var(--muted);
+    }
+    .legend-swatch { width: 10px; height: 10px; border-radius: 3px; border: 1px solid rgba(255,255,255,0.2); }
+    @media (max-width: 1100px) { .cards { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="header">
+      <div>
+        <h1>Arquitetura: memória canônica, agentes e VPS</h1>
+        <div class="subtitle">VPS 1 como fonte da verdade; VPS 2 como execução; Tailscale como malha privada; tudo sem expor portas públicas.</div>
+      </div>
+      <div class="pill"><span class="dot"></span> tailnet privado ativo</div>
+    </div>
+
+    <div class="panel svg-wrap">
+      <svg viewBox="0 0 1600 920" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Diagrama da arquitetura de memória, agentes e VPS">
+        <defs>
+          <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+            <path d="M0,0 L12,6 L0,12 z" fill="#94a3b8"/>
+          </marker>
+          <marker id="arrowGreen" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+            <path d="M0,0 L12,6 L0,12 z" fill="#34d399"/>
+          </marker>
+          <marker id="arrowCyan" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+            <path d="M0,0 L12,6 L0,12 z" fill="#22d3ee"/>
+          </marker>
+          <marker id="arrowRose" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
+            <path d="M0,0 L12,6 L0,12 z" fill="#fb7185"/>
+          </marker>
+          <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+            <feGaussianBlur stdDeviation="8" result="b"/>
+            <feMerge>
+              <feMergeNode in="b"/>
+              <feMergeNode in="SourceGraphic"/>
+            </feMerge>
+          </filter>
+        </defs>
+
+        <!-- background -->
+        <rect x="0" y="0" width="1600" height="920" fill="#020617" rx="16"/>
+
+        <!-- Tailscale private mesh -->
+        <rect x="62" y="76" width="1476" height="350" rx="18" fill="rgba(120,53,15,0.18)" stroke="#fbbf24" stroke-width="2" stroke-dasharray="10 8"/>
+        <text x="86" y="106" fill="#fbbf24" font-size="14" font-weight="700">Tailscale tailnet privado</text>
+        <text x="86" y="128" fill="#94a3b8" font-size="10">Conexão entre máquinas, sem portas públicas</text>
+
+        <!-- VPS 1 -->
+        <rect x="120" y="160" width="430" height="220" rx="18" fill="#0f172a" stroke="#a78bfa" stroke-width="2"/>
+        <rect x="126" y="166" width="418" height="208" rx="14" fill="rgba(76,29,149,0.42)" stroke="rgba(167,139,250,0.55)" stroke-width="1.4"/>
+        <text x="148" y="194" fill="#a78bfa" font-size="18" font-weight="700">VPS 1 — memória canônica</text>
+        <text x="148" y="217" fill="#cbd5e1" font-size="11">Fonte da verdade única</text>
+        <text x="148" y="246" fill="#94a3b8" font-size="10">• Postgres + API de memória</text>
+        <text x="148" y="268" fill="#94a3b8" font-size="10">• event_log append-only</text>
+        <text x="148" y="290" fill="#94a3b8" font-size="10">• facts / decisions / entities</text>
+        <text x="148" y="312" fill="#94a3b8" font-size="10">• summaries / episodes / tasks/state</text>
+        <text x="148" y="334" fill="#94a3b8" font-size="10">• sources + auditoria</text>
+        <text x="148" y="356" fill="#94a3b8" font-size="10">• acessível só pelo tailnet</text>
+
+        <!-- Agent layer -->
+        <rect x="600" y="160" width="400" height="220" rx="18" fill="#0f172a" stroke="#22d3ee" stroke-width="2"/>
+        <rect x="606" y="166" width="388" height="208" rx="14" fill="rgba(8,51,68,0.42)" stroke="rgba(34,211,238,0.55)" stroke-width="1.4"/>
+        <text x="628" y="194" fill="#22d3ee" font-size="18" font-weight="700">Agentes / Orquestrador</text>
+        <text x="628" y="217" fill="#cbd5e1" font-size="11">Decidem, coletam, verificam e executam</text>
+        <text x="628" y="246" fill="#94a3b8" font-size="10">• orchestrator</text>
+        <text x="628" y="268" fill="#94a3b8" font-size="10">• collector</text>
+        <text x="628" y="290" fill="#94a3b8" font-size="10">• verifier</text>
+        <text x="628" y="312" fill="#94a3b8" font-size="10">• executor</text>
+        <text x="628" y="334" fill="#94a3b8" font-size="10">• escreve eventos, não “verdades” soltas</text>
+        <text x="628" y="356" fill="#94a3b8" font-size="10">• consulta a VPS 1 antes de agir</text>
+
+        <!-- VPS 2 -->
+        <rect x="1080" y="160" width="430" height="220" rx="18" fill="#0f172a" stroke="#34d399" stroke-width="2"/>
+        <rect x="1086" y="166" width="418" height="208" rx="14" fill="rgba(6,78,59,0.42)" stroke="rgba(52,211,153,0.55)" stroke-width="1.4"/>
+        <text x="1108" y="194" fill="#34d399" font-size="18" font-weight="700">VPS 2 — execução / workers</text>
+        <text x="1108" y="217" fill="#cbd5e1" font-size="11">Processamento e automações</text>
+        <text x="1108" y="246" fill="#94a3b8" font-size="10">• scraping / ingestão</text>
+        <text x="1108" y="268" fill="#94a3b8" font-size="10">• jobs de longa duração</text>
+        <text x="1108" y="290" fill="#94a3b8" font-size="10">• pipelines / bots / agents</text>
+        <text x="1108" y="312" fill="#94a3b8" font-size="10">• consulta e grava via API privada</text>
+        <text x="1108" y="334" fill="#94a3b8" font-size="10">• sem lógica de verdade final</text>
+        <text x="1108" y="356" fill="#94a3b8" font-size="10">• pode cair sem perder memória</text>
+
+        <!-- Arrows between components -->
+        <path d="M550 270 C575 270, 580 270, 600 270" stroke="#22d3ee" stroke-width="3" fill="none" marker-end="url(#arrowCyan)"/>
+        <path d="M1000 270 C1025 270, 1030 270, 1080 270" stroke="#34d399" stroke-width="3" fill="none" marker-end="url(#arrowGreen)"/>
+
+        <!-- Data flow box -->
+        <rect x="174" y="448" width="1252" height="142" rx="18" fill="#0f172a" stroke="#94a3b8" stroke-width="1.6" stroke-dasharray="6 6"/>
+        <text x="202" y="478" fill="#94a3b8" font-size="14" font-weight="700">Fluxo de escrita / leitura</text>
+
+        <!-- flow nodes -->
+        <rect x="214" y="508" width="180" height="54" rx="14" fill="#111827" stroke="#22d3ee" stroke-width="1.6"/>
+        <text x="236" y="540" fill="#e2e8f0" font-size="12">1. Evento bruto entra</text>
+
+        <rect x="446" y="508" width="180" height="54" rx="14" fill="#111827" stroke="#a78bfa" stroke-width="1.6"/>
+        <text x="470" y="540" fill="#e2e8f0" font-size="12">2. event_log</text>
+
+        <rect x="678" y="508" width="180" height="54" rx="14" fill="#111827" stroke="#34d399" stroke-width="1.6"/>
+        <text x="706" y="540" fill="#e2e8f0" font-size="12">3. verifier normaliza</text>
+
+        <rect x="910" y="508" width="180" height="54" rx="14" fill="#111827" stroke="#fb7185" stroke-width="1.6"/>
+        <text x="936" y="540" fill="#e2e8f0" font-size="12">4. facts/decisions</text>
+
+        <rect x="1142" y="508" width="240" height="54" rx="14" fill="#111827" stroke="#fbbf24" stroke-width="1.6"/>
+        <text x="1168" y="540" fill="#e2e8f0" font-size="12">5. agentes leem e atuam</text>
+
+        <path d="M394 535 L446 535" stroke="#94a3b8" stroke-width="2.2" marker-end="url(#arrow)"/>
+        <path d="M626 535 L678 535" stroke="#94a3b8" stroke-width="2.2" marker-end="url(#arrow)"/>
+        <path d="M858 535 L910 535" stroke="#94a3b8" stroke-width="2.2" marker-end="url(#arrow)"/>
+        <path d="M1090 535 L1142 535" stroke="#94a3b8" stroke-width="2.2" marker-end="url(#arrow)"/>
+
+        <!-- Optional VPS 3 / backup -->
+        <rect x="390" y="646" width="820" height="182" rx="18" fill="#0f172a" stroke="#fbbf24" stroke-width="2"/>
+        <rect x="396" y="652" width="808" height="170" rx="14" fill="rgba(120,53,15,0.28)" stroke="rgba(251,191,36,0.55)" stroke-width="1.4"/>
+        <text x="420" y="682" fill="#fbbf24" font-size="18" font-weight="700">VPS 3 — opcional: observabilidade / backup / index</text>
+        <text x="420" y="706" fill="#cbd5e1" font-size="11">Não é a verdade principal; só protege, replica e acelera consulta</text>
+        <text x="420" y="736" fill="#94a3b8" font-size="10">• backups lógicos do Postgres</text>
+        <text x="420" y="758" fill="#94a3b8" font-size="10">• logs, métricas, replay e auditoria</text>
+        <text x="420" y="780" fill="#94a3b8" font-size="10">• busca semântica / indexação secundária</text>
+        <text x="420" y="802" fill="#94a3b8" font-size="10">• recuperação se a VPS 1 falhar</text>
+
+        <!-- backup / replication arrows -->
+        <path d="M335 380 C335 470, 420 590, 490 646" stroke="#fbbf24" stroke-width="3" stroke-dasharray="8 6" fill="none" marker-end="url(#arrow)"/>
+        <path d="M1255 380 C1255 470, 1160 590, 1110 646" stroke="#fbbf24" stroke-width="3" stroke-dasharray="8 6" fill="none" marker-end="url(#arrow)"/>
+
+        <!-- Legend -->
+        <rect x="72" y="852" width="1456" height="42" rx="12" fill="#0f172a" stroke="rgba(148,163,184,0.18)" stroke-width="1.2"/>
+        <text x="92" y="878" fill="#94a3b8" font-size="10" font-weight="700">Legenda:</text>
+        <g transform="translate(170, 867)">
+          <rect class="legend-swatch" x="0" y="0" width="10" height="10" fill="rgba(76,29,149,0.45)" stroke="#a78bfa"/>
+          <text x="18" y="9" fill="#94a3b8" font-size="10">VPS 1 / memória canônica</text>
+        </g>
+        <g transform="translate(390, 867)">
+          <rect class="legend-swatch" x="0" y="0" width="10" height="10" fill="rgba(8,51,68,0.45)" stroke="#22d3ee"/>
+          <text x="18" y="9" fill="#94a3b8" font-size="10">Agentes / orquestração</text>
+        </g>
+        <g transform="translate(585, 867)">
+          <rect class="legend-swatch" x="0" y="0" width="10" height="10" fill="rgba(6,78,59,0.45)" stroke="#34d399"/>
+          <text x="18" y="9" fill="#94a3b8" font-size="10">VPS 2 / execução</text>
+        </g>
+        <g transform="translate(775, 867)">
+          <rect class="legend-swatch" x="0" y="0" width="10" height="10" fill="rgba(120,53,15,0.30)" stroke="#fbbf24"/>
+          <text x="18" y="9" fill="#94a3b8" font-size="10">Tailscale / backup / rede privada</text>
+        </g>
+        <g transform="translate(1040, 867)">
+          <rect class="legend-swatch" x="0" y="0" width="10" height="10" fill="rgba(136,19,55,0.42)" stroke="#fb7185"/>
+          <text x="18" y="9" fill="#94a3b8" font-size="10">Decisões / políticas / controle</text>
+        </g>
+        <g transform="translate(1290, 867)">
+          <rect class="legend-swatch" x="0" y="0" width="10" height="10" fill="rgba(30,41,59,0.55)" stroke="#94a3b8"/>
+          <text x="18" y="9" fill="#94a3b8" font-size="10">Fluxo de leitura/escrita</text>
+        </g>
+      </svg>
+    </div>
+
+    <div class="cards">
+      <div class="card">
+        <div class="card-header"><span class="card-dot cyan"></span><h3>Regras centrais</h3></div>
+        <ul>
+          <li>VPS 1 é a fonte da verdade.</li>
+          <li>Event log é append-only.</li>
+          <li>Agente nunca inventa fato final sem origem.</li>
+        </ul>
+      </div>
+      <div class="card">
+        <div class="card-header"><span class="card-dot emerald"></span><h3>Operação</h3></div>
+        <ul>
+          <li>VPS 2 executa e devolve eventos.</li>
+          <li>Todo acesso interno passa pelo Tailscale.</li>
+          <li>Portas sensíveis ficam fechadas da internet pública.</li>
+        </ul>
+      </div>
+      <div class="card">
+        <div class="card-header"><span class="card-dot violet"></span><h3>Robustez</h3></div>
+        <ul>
+          <li>VPS 3 pode guardar backup, logs e índice.</li>
+          <li>Se a VPS 2 cair, a memória não perde integridade.</li>
+          <li>Se a VPS 1 falhar, há recuperação por backup e replay.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="footer">Arquivo: memory-agents-vps-architecture.html</div>
+  </div>
+</body>
+</html>

--- a/model_tools.py
+++ b/model_tools.py
@@ -32,6 +32,67 @@ from typing import Dict, Any, List, Optional, Tuple
 from tools.registry import discover_builtin_tools, registry
 from toolsets import resolve_toolset, validate_toolset
 
+_EXECUTOR_NODE_ROLE = "executor"
+_EXECUTOR_READ_ONLY_TOOLSETS = {
+    "browser",
+    "code_execution",
+    "session_search",
+    "terminal",
+    "vision",
+    "web",
+    "x_search",
+}
+_EXECUTOR_DISABLED_TOOLSETS = {
+    "clarify",
+    "computer_use",
+    "cronjob",
+    "delegation",
+    "discord",
+    "discord_admin",
+    "file",
+    "homeassistant",
+    "image_gen",
+    "messaging",
+    "memory",
+    "moa",
+    "skills",
+    "spotify",
+    "todo",
+    "video",
+    "video_gen",
+    "yuanbao",
+}
+
+_EXECUTOR_DISABLED_TOOL_NAMES = set()
+for _toolset_name in _EXECUTOR_DISABLED_TOOLSETS:
+    try:
+        _EXECUTOR_DISABLED_TOOL_NAMES.update(resolve_toolset(_toolset_name))
+    except Exception:
+        # Validation happens at runtime; import-time failure should never make
+        # the module unusable if a future toolset is removed or renamed.
+        pass
+
+
+def _get_node_execution_role() -> str:
+    env_role = str(os.getenv("HERMES_NODE_ROLE") or os.getenv("HERMES_AGENT_EXECUTION_ROLE") or "").strip().lower()
+    if env_role:
+        return env_role
+    try:
+        from hermes_cli.config import cfg_get
+        cfg_role = str(cfg_get("agent.execution_role") or "").strip().lower()
+        if cfg_role:
+            return cfg_role
+    except Exception:
+        pass
+    return ""
+
+
+def _apply_executor_tool_policy(tool_names: set) -> set:
+    role = _get_node_execution_role()
+    if role != _EXECUTOR_NODE_ROLE:
+        return tool_names
+    return set(tool_names) - _EXECUTOR_DISABLED_TOOL_NAMES
+
 logger = logging.getLogger(__name__)
 
 
@@ -396,6 +457,8 @@ def _compute_tool_definitions(
     # all check the tool registry for plugin-provided toolsets.  No bypass
     # needed; plugins respect enabled_toolsets / disabled_toolsets like any
     # other toolset.
+
+    tools_to_include = _apply_executor_tool_policy(tools_to_include)
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
     filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
@@ -912,6 +975,12 @@ def handle_function_call(
             )
 
     try:
+        if _get_node_execution_role() == _EXECUTOR_NODE_ROLE and function_name in _EXECUTOR_DISABLED_TOOL_NAMES:
+            return json.dumps(
+                {"error": f"{function_name} is disabled in executor read-only mode"},
+                ensure_ascii=False,
+            )
+
         if function_name in _AGENT_LOOP_TOOLS:
             return json.dumps({"error": f"{function_name} must be handled by the agent loop"})
 

--- a/scripts/check_tailnet_health.py
+++ b/scripts/check_tailnet_health.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Tailnet health check for Hermes VPS connectivity.
+
+Checks:
+- MagicDNS resolution for the peer
+- Tailscale reachability to the peer
+- Sensitive ports are not listening on non-loopback interfaces
+
+Exit codes:
+- 0: healthy
+- 2: degraded / unsafe
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Iterable
+
+DEFAULT_PEER = os.environ.get("TAILNET_PEER", "hermes-vps-2.tailfdd900.ts.net")
+DEFAULT_PORTS = os.environ.get("SENSITIVE_PORTS", "3000,8642,9119")
+
+
+@dataclass
+class CheckResult:
+    name: str
+    ok: bool
+    detail: str
+
+
+def run(cmd: list[str], timeout: int = 20) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, check=False)
+
+
+def check_dns(peer: str) -> CheckResult:
+    proc = run(["getent", "hosts", peer], timeout=10)
+    if proc.returncode == 0 and proc.stdout.strip():
+        return CheckResult("dns", True, proc.stdout.strip().splitlines()[0])
+    return CheckResult("dns", False, (proc.stderr or proc.stdout or "no DNS result").strip())
+
+
+def check_tailscale_ping(peer: str) -> CheckResult:
+    proc = run(["tailscale", "ping", peer], timeout=30)
+    output = (proc.stdout + proc.stderr).strip()
+    if proc.returncode == 0 and "pong from" in output:
+        first_line = output.splitlines()[0] if output.splitlines() else output
+        return CheckResult("tailscale_ping", True, first_line)
+    return CheckResult("tailscale_ping", False, output or f"tailscale ping exit {proc.returncode}")
+
+
+def parse_ports(raw: str) -> list[int]:
+    ports: list[int] = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        ports.append(int(item))
+    return ports
+
+
+def check_port_binding(ports: Iterable[int]) -> list[CheckResult]:
+    proc = run(["ss", "-ltn"], timeout=10)
+    if proc.returncode != 0:
+        return [CheckResult("socket_bindings", False, (proc.stderr or proc.stdout or "ss failed").strip())]
+
+    lines = proc.stdout.splitlines()
+    findings: list[CheckResult] = []
+    for port in ports:
+        matches = [line for line in lines if f":{port} " in line or line.rstrip().endswith(f":{port}")]
+        if not matches:
+            findings.append(CheckResult(f"port_{port}", True, "not listening"))
+            continue
+
+        unsafe = []
+        for line in matches:
+            parts = line.split()
+            if len(parts) < 4:
+                continue
+            local_addr = parts[3]
+            if local_addr.startswith("0.0.0.0:") or local_addr.startswith("[::]:"):
+                unsafe.append(local_addr)
+            elif not (local_addr.startswith("127.0.0.1:") or local_addr.startswith("[::1]:")):
+                # Any non-loopback bind is treated as unsafe for these ports.
+                unsafe.append(local_addr)
+
+        if unsafe:
+            findings.append(CheckResult(f"port_{port}", False, f"unsafe bind(s): {', '.join(sorted(set(unsafe)))}"))
+        else:
+            findings.append(CheckResult(f"port_{port}", True, "; ".join(matches)))
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--peer", default=DEFAULT_PEER, help="Tailnet peer to probe (MagicDNS name or Tailscale IP)")
+    parser.add_argument("--ports", default=DEFAULT_PORTS, help="Comma-separated sensitive ports to verify")
+    args = parser.parse_args()
+
+    results: list[CheckResult] = []
+    results.append(check_dns(args.peer))
+    results.append(check_tailscale_ping(args.peer))
+    results.extend(check_port_binding(parse_ports(args.ports)))
+
+    all_ok = all(result.ok for result in results)
+    status = "healthy" if all_ok else "degraded"
+    print(status)
+    for result in results:
+        marker = "ok" if result.ok else "fail"
+        print(f"- {result.name}: {marker} — {result.detail}")
+
+    return 0 if all_ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_two_vps_readiness.py
+++ b/scripts/check_two_vps_readiness.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Check two-VPS readiness by composing schema and tailnet validation.
+
+This is a lightweight orchestration wrapper around:
+- scripts/validate_memory_schema.py
+- scripts/check_tailnet_health.py
+
+It is intended for rollout checkpoints, not for long-running monitoring.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from agent.file_safety import get_node_execution_role
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_VALIDATOR = ROOT / "scripts" / "validate_memory_schema.py"
+TAILNET_CHECK = ROOT / "scripts" / "check_tailnet_health.py"
+DEFAULT_SCHEMA = ROOT / "docs" / "architecture" / "memory-schema.sql"
+
+
+class ValidationError(RuntimeError):
+    pass
+
+
+def run_step(label: str, cmd: list[str]) -> tuple[int, str, str]:
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    stdout = proc.stdout.strip()
+    stderr = proc.stderr.strip()
+    if stdout:
+        print(f"[{label}] {stdout}")
+    if stderr:
+        print(f"[{label}][stderr] {stderr}", file=sys.stderr)
+    return proc.returncode, stdout, stderr
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA, help="Path to the canonical schema SQL")
+    parser.add_argument("--peer", default=os.environ.get("TAILNET_PEER", "hermes-vps-2.tailfdd900.ts.net"), help="Tailnet peer to probe")
+    parser.add_argument("--ports", default=os.environ.get("SENSITIVE_PORTS", "3000,8642,9119"), help="Comma-separated sensitive ports")
+    parser.add_argument("--skip-schema", action="store_true", help="Skip schema validation")
+    parser.add_argument("--skip-tailnet", action="store_true", help="Skip tailnet health validation")
+    parser.add_argument(
+        "--expect-role",
+        choices=("canonical", "executor"),
+        help="Require the current node execution role to match before reporting readiness",
+    )
+    return parser
+
+
+def validate(args: argparse.Namespace) -> None:
+    failures: list[str] = []
+
+    if args.expect_role:
+        role = get_node_execution_role()
+        if role != args.expect_role:
+            raise ValidationError(f"readiness check failed: role mismatch (expected {args.expect_role}, got {role or 'unset'})")
+
+    if not args.skip_schema:
+        code, _, _ = run_step(
+            "schema",
+            [sys.executable, str(SCHEMA_VALIDATOR), "--schema", str(args.schema)],
+        )
+        if code != 0:
+            failures.append("schema")
+
+    if not args.skip_tailnet:
+        code, _, _ = run_step(
+            "tailnet",
+            [sys.executable, str(TAILNET_CHECK), "--peer", args.peer, "--ports", args.ports],
+        )
+        if code != 0:
+            failures.append("tailnet")
+
+    if failures:
+        raise ValidationError(f"readiness check failed: {', '.join(failures)}")
+
+    print("readiness healthy")
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        validate(args)
+    except ValidationError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_memory_schema.py
+++ b/scripts/validate_memory_schema.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Validate the canonical memory schema in a temporary Postgres database.
+
+Usage:
+  python scripts/validate_memory_schema.py
+  python scripts/validate_memory_schema.py --schema docs/architecture/memory-schema.sql
+
+The script creates a throwaway database, loads the schema, checks the core
+relations/trigger, and drops the database again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SCHEMA = ROOT / "docs" / "architecture" / "memory-schema.sql"
+
+
+class ValidationError(RuntimeError):
+    pass
+
+
+def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if check and proc.returncode != 0:
+        raise ValidationError(
+            f"Command failed ({proc.returncode}): {' '.join(cmd)}\n"
+            f"stdout: {proc.stdout.strip()}\n"
+            f"stderr: {proc.stderr.strip()}"
+        )
+    return proc
+
+
+def pick_runner() -> list[str]:
+    if shutil.which("sudo"):
+        return ["sudo", "-u", "postgres"]
+    return []
+
+
+def require_commands(*commands: str) -> None:
+    missing = [cmd for cmd in commands if shutil.which(cmd) is None]
+    if missing:
+        raise ValidationError(f"Missing required commands: {', '.join(missing)}")
+
+
+def create_database(runner: list[str], db_name: str) -> None:
+    run(runner + ["createdb", db_name])
+
+
+def drop_database(runner: list[str], db_name: str) -> None:
+    run(runner + ["dropdb", "--if-exists", db_name], check=False)
+
+
+def load_schema(runner: list[str], db_name: str, schema_path: Path) -> None:
+    run(runner + ["psql", "-v", "ON_ERROR_STOP=1", "-d", db_name, "-f", str(schema_path)])
+
+
+def materialize_schema(schema_path: Path) -> Path:
+    temp_file = tempfile.NamedTemporaryFile("w", suffix=".sql", prefix="hermes_schema_", delete=False)
+    try:
+        temp_file.write(schema_path.read_text())
+        temp_file.flush()
+    finally:
+        temp_file.close()
+    temp_path = Path(temp_file.name)
+    temp_path.chmod(0o644)
+    return temp_path
+
+
+def query_scalar(runner: list[str], db_name: str, sql: str) -> str:
+    proc = run(runner + ["psql", "-Atqc", sql, "-d", db_name])
+    return proc.stdout.strip()
+
+
+def validate(schema_path: Path) -> None:
+    if not schema_path.exists():
+        raise ValidationError(f"Schema not found: {schema_path}")
+
+    require_commands("createdb", "dropdb", "psql")
+    runner = pick_runner()
+    if not runner and os.geteuid() != 0:
+        raise ValidationError("Need either root access or sudo to create a temporary database")
+
+    db_name = f"hermes_schema_check_{os.getpid()}_{int(time.time())}"
+    temp_schema = materialize_schema(schema_path)
+    try:
+        create_database(runner, db_name)
+        load_schema(runner, db_name, temp_schema)
+
+        tables = query_scalar(
+            runner,
+            db_name,
+            "SELECT string_agg(tablename, ',' ORDER BY tablename) FROM pg_tables WHERE schemaname = 'public'",
+        )
+        expected = {
+            "memory_decisions",
+            "memory_entities",
+            "memory_episodes",
+            "memory_event_log",
+            "memory_facts",
+            "memory_sources",
+            "memory_summaries",
+        }
+        found = set(filter(None, tables.split(",")))
+        missing_tables = sorted(expected - found)
+        if missing_tables:
+            raise ValidationError(f"Missing tables after schema load: {', '.join(missing_tables)}")
+
+        trigger_exists = query_scalar(
+            runner,
+            db_name,
+            "SELECT count(*)::text FROM pg_trigger WHERE tgname = 'trg_memory_event_log_no_update' AND NOT tgisinternal",
+        )
+        if trigger_exists != "1":
+            raise ValidationError("Append-only trigger missing from memory_event_log")
+
+        print(f"schema valid: {schema_path}")
+    finally:
+        drop_database(runner, db_name)
+        try:
+            temp_schema.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--schema", type=Path, default=DEFAULT_SCHEMA, help="Path to the SQL schema file")
+    args = parser.parse_args()
+
+    try:
+        validate(args.schema)
+    except ValidationError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_file_safety.py
+++ b/tests/agent/test_file_safety.py
@@ -10,6 +10,7 @@ import pytest
 
 from agent.file_safety import (
     _BLOCKED_PROJECT_ENV_BASENAMES,
+    get_node_execution_role,
     get_read_block_error,
 )
 
@@ -146,3 +147,29 @@ class TestCombinedGuards:
             error = get_read_block_error(str(cache))
             assert error is not None
             assert "internal Hermes cache" in error
+
+
+class TestNodeExecutionRole:
+    def test_env_role_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv("HERMES_NODE_ROLE", "executor")
+        monkeypatch.setenv("HERMES_AGENT_EXECUTION_ROLE", "canonical")
+        assert get_node_execution_role() == "executor"
+
+    def test_agent_execution_role_env_is_used_when_node_role_absent(self, monkeypatch):
+        monkeypatch.delenv("HERMES_NODE_ROLE", raising=False)
+        monkeypatch.setenv("HERMES_AGENT_EXECUTION_ROLE", "executor")
+        assert get_node_execution_role() == "executor"
+
+    def test_config_role_is_used_when_env_absent(self, monkeypatch):
+        monkeypatch.delenv("HERMES_NODE_ROLE", raising=False)
+        monkeypatch.delenv("HERMES_AGENT_EXECUTION_ROLE", raising=False)
+
+        import hermes_cli.config as config
+
+        monkeypatch.setattr(
+            config,
+            "cfg_get",
+            lambda key, default=None: "executor" if key == "agent.execution_role" else default,
+        )
+
+        assert get_node_execution_role() == "executor"

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -240,6 +240,32 @@ def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_succes
         assert controller.after_call("custom_tool", {"x": 1}, "ok", failed=False).action == "allow"
 
 
+def test_executor_role_blocks_mutating_tools_but_allows_read_tools(monkeypatch):
+    monkeypatch.setenv("HERMES_NODE_ROLE", "executor")
+    controller = ToolCallGuardrailController()
+
+    blocked = controller.before_call("write_file", {"path": "/tmp/x", "content": "x"})
+    allowed = controller.before_call("web_search", {"query": "ok"})
+
+    assert blocked.action == "block"
+    assert blocked.code == "executor_read_only_block"
+    assert "canonical owner" in blocked.message
+    assert allowed.action == "allow"
+
+
+def test_executor_role_blocks_terminal_and_memory_writes(monkeypatch):
+    monkeypatch.setenv("HERMES_NODE_ROLE", "executor")
+    controller = ToolCallGuardrailController()
+
+    terminal = controller.before_call("terminal", {"command": "echo hi"})
+    memory = controller.before_call("memory", {"action": "add", "content": "x", "target": "memory"})
+
+    assert terminal.action == "block"
+    assert terminal.code == "executor_read_only_block"
+    assert memory.action == "block"
+    assert memory.code == "executor_read_only_block"
+
+
 def test_reset_for_turn_clears_bounded_guardrail_state():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(hard_stop_enabled=True, exact_failure_block_after=2, no_progress_block_after=2)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -38,6 +38,10 @@ class TestUserSystemdPrivateSocketPreflight:
 
 
 class TestSystemdServiceRefresh:
+    @pytest.fixture(autouse=True)
+    def _disable_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
+
     def test_systemd_install_repairs_outdated_unit_without_force(self, tmp_path, monkeypatch):
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
@@ -311,6 +315,15 @@ class TestRequireServiceInstalled:
 
 
 class TestGeneratedSystemdUnits:
+    @pytest.fixture(autouse=True)
+    def _stub_system_identity(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(gateway_cli, "_hermes_home_for_target_user", lambda home: "/home/alice/.hermes")
+
     def _expected_timeout_stop_sec(self) -> str:
         timeout = int(max(60, DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT) + 30)
         return f"TimeoutStopSec={timeout}"
@@ -393,6 +406,20 @@ class TestGeneratedSystemdUnits:
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.
         assert self._expected_timeout_stop_sec() in unit
         assert "WantedBy=multi-user.target" in unit
+
+    def test_system_unit_includes_executor_readiness_prestart_check(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "get_node_execution_role", lambda: "executor")
+        monkeypatch.setattr(
+            gateway_cli,
+            "_get_restart_drain_timeout",
+            lambda: DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=True)
+
+        assert "ExecStartPre=" in unit
+        assert "check_two_vps_readiness.py --expect-role executor" in unit
+
 
 
 class TestGatewayStopCleanup:
@@ -737,6 +764,10 @@ class TestGatewayServiceDetection:
         assert gateway_cli._is_service_running() is False
 
 class TestGatewaySystemServiceRouting:
+    @pytest.fixture(autouse=True)
+    def _disable_user_systemd_preflight(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda *args, **kwargs: None)
+
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
         calls = []
 
@@ -1294,6 +1325,15 @@ class TestGeneratedUnitUsesDetectedVenv:
 
 class TestGeneratedUnitIncludesLocalBin:
     """~/.local/bin must be in PATH so uvx/pipx tools are discoverable."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_system_identity(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(gateway_cli, "_hermes_home_for_target_user", lambda home: "/home/alice/.hermes")
 
     def test_user_unit_includes_local_bin_in_path(self, monkeypatch):
         home = Path.home()

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -69,6 +69,21 @@ def test_agent_disabled_toolsets_empty_list_is_noop():
     assert _get_platform_tools(config_missing, "cli") == default
 
 
+def test_executor_role_suppresses_write_toolsets_even_when_explicit(monkeypatch):
+    monkeypatch.setenv("HERMES_NODE_ROLE", "executor")
+    config = {
+        "agent": {"execution_role": "executor"},
+        "platform_toolsets": {"cli": ["hermes-cli", "memory", "file", "web", "terminal"]},
+    }
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "web" in enabled
+    assert "terminal" in enabled
+    assert "memory" not in enabled
+    assert "file" not in enabled
+
+
 def test_get_platform_tools_uses_default_when_platform_not_configured():
     config = {}
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2418,6 +2418,16 @@ class TestConcurrentToolExecution:
             assert len(m["content"]) < 150_000
             assert ("Truncated" in m["content"] or "<persisted-output>" in m["content"])
 
+    def test_invoke_tool_executor_role_blocks_handle_function_call(self, agent, monkeypatch):
+        """Executor role should be blocked before dispatch reaches handle_function_call."""
+        monkeypatch.setenv("HERMES_NODE_ROLE", "executor")
+        with patch("run_agent.handle_function_call", side_effect=AssertionError("should not run")):
+            result = agent._invoke_tool("write_file", {"path": "x.txt", "content": "hi"}, "task-1")
+
+        payload = json.loads(result)
+        assert payload["guardrail"]["code"] == "executor_read_only_block"
+        assert "read-only executor" in payload["error"]
+
     def test_invoke_tool_dispatches_to_handle_function_call(self, agent):
         """_invoke_tool should route regular tools through handle_function_call."""
         with patch("run_agent.handle_function_call", return_value="result") as mock_hfc:

--- a/tests/scripts/test_check_two_vps_readiness.py
+++ b/tests/scripts/test_check_two_vps_readiness.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from scripts import check_two_vps_readiness as readiness
+
+
+def test_validate_runs_both_steps(monkeypatch, capsys):
+    calls = []
+
+    def fake_run(cmd, capture_output, text):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout=f"ok:{cmd[1]}", stderr="")
+
+    monkeypatch.setenv("HERMES_NODE_ROLE", "executor")
+    monkeypatch.setattr(readiness.subprocess, "run", fake_run)
+    args = readiness.build_parser().parse_args([
+        "--schema",
+        "/tmp/schema.sql",
+        "--peer",
+        "peer.example",
+        "--ports",
+        "80,443",
+        "--expect-role",
+        "executor",
+    ])
+
+    readiness.validate(args)
+    out = capsys.readouterr().out
+
+    assert "[schema] ok:" in out
+    assert "[tailnet] ok:" in out
+    assert "readiness healthy" in out
+    assert calls[0][0] == sys.executable
+    assert calls[1][0] == sys.executable
+    assert "validate_memory_schema.py" in calls[0][1]
+    assert "check_tailnet_health.py" in calls[1][1]
+
+
+def test_validate_reports_failure(monkeypatch, capsys):
+    def fake_run(cmd, capture_output, text):
+        if "validate_memory_schema.py" in cmd[1]:
+            return subprocess.CompletedProcess(cmd, 2, stdout="", stderr="schema broken")
+        return subprocess.CompletedProcess(cmd, 0, stdout="healthy", stderr="")
+
+    monkeypatch.setattr(readiness.subprocess, "run", fake_run)
+    args = readiness.build_parser().parse_args(["--peer", "peer.example"])
+
+    try:
+        readiness.validate(args)
+    except readiness.ValidationError as exc:
+        assert "schema" in str(exc)
+    else:
+        raise AssertionError("expected ValidationError")
+
+    err = capsys.readouterr().err
+    assert "schema broken" in err
+
+
+def test_validate_rejects_executor_role_mismatch(monkeypatch):
+    monkeypatch.setenv("HERMES_NODE_ROLE", "canonical")
+    args = readiness.build_parser().parse_args(["--expect-role", "executor", "--skip-schema", "--skip-tailnet"])
+
+    try:
+        readiness.validate(args)
+    except readiness.ValidationError as exc:
+        assert "role mismatch" in str(exc)
+    else:
+        raise AssertionError("expected ValidationError")
+
+
+def test_validate_allows_executor_role_gate(monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_NODE_ROLE", "executor")
+
+    def fake_run(cmd, capture_output, text):
+        return subprocess.CompletedProcess(cmd, 0, stdout=f"ok:{cmd[1]}", stderr="")
+
+    monkeypatch.setattr(readiness.subprocess, "run", fake_run)
+    args = readiness.build_parser().parse_args(["--expect-role", "executor", "--peer", "peer.example"])
+
+    readiness.validate(args)
+    out = capsys.readouterr().out
+    assert "readiness healthy" in out

--- a/tests/scripts/test_validate_memory_schema.py
+++ b/tests/scripts/test_validate_memory_schema.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "validate_memory_schema.py"
+MODULE_SPEC = spec_from_file_location("validate_memory_schema_test_module", MODULE_PATH)
+assert MODULE_SPEC and MODULE_SPEC.loader
+validate_memory_schema = module_from_spec(MODULE_SPEC)
+
+import sys
+
+sys.modules[MODULE_SPEC.name] = validate_memory_schema
+MODULE_SPEC.loader.exec_module(validate_memory_schema)
+
+
+def test_materialize_schema_creates_world_readable_copy(tmp_path):
+    schema = tmp_path / "schema.sql"
+    schema.write_text("select 1;\n")
+
+    copied = validate_memory_schema.materialize_schema(schema)
+    try:
+        assert copied.exists()
+        assert copied.read_text() == "select 1;\n"
+        assert oct(copied.stat().st_mode & 0o777) == "0o644"
+    finally:
+        copied.unlink(missing_ok=True)
+
+
+def test_validate_loads_schema_and_cleans_up_temp_copy(tmp_path, monkeypatch, capsys):
+    schema = tmp_path / "schema.sql"
+    schema.write_text("create table demo(id int);\n")
+
+    calls: list[tuple[str, object]] = []
+
+    def fake_require_commands(*commands: str) -> None:
+        calls.append(("require", commands))
+
+    def fake_pick_runner() -> list[str]:
+        return ["sudo", "-u", "postgres"]
+
+    def fake_create_database(runner: list[str], db_name: str) -> None:
+        calls.append(("create", (runner, db_name)))
+
+    def fake_load_schema(runner: list[str], db_name: str, schema_path: Path) -> None:
+        calls.append(("load", (runner, db_name, schema_path)))
+        assert schema_path.exists()
+
+    def fake_query_scalar(runner: list[str], db_name: str, sql: str) -> str:
+        calls.append(("query", (runner, db_name, sql)))
+        if "pg_tables" in sql:
+            return "memory_decisions,memory_entities,memory_episodes,memory_event_log,memory_facts,memory_sources,memory_summaries"
+        if "pg_trigger" in sql:
+            return "1"
+        raise AssertionError(sql)
+
+    def fake_drop_database(runner: list[str], db_name: str) -> None:
+        calls.append(("drop", (runner, db_name)))
+
+    monkeypatch.setattr(validate_memory_schema, "require_commands", fake_require_commands)
+    monkeypatch.setattr(validate_memory_schema, "pick_runner", fake_pick_runner)
+    monkeypatch.setattr(validate_memory_schema, "create_database", fake_create_database)
+    monkeypatch.setattr(validate_memory_schema, "load_schema", fake_load_schema)
+    monkeypatch.setattr(validate_memory_schema, "query_scalar", fake_query_scalar)
+    monkeypatch.setattr(validate_memory_schema, "drop_database", fake_drop_database)
+
+    validate_memory_schema.validate(schema)
+
+    out = capsys.readouterr().out
+    assert "schema valid:" in out
+    assert any(name == "create" for name, _ in calls)
+    assert any(name == "load" for name, _ in calls)
+    assert any(name == "query" for name, _ in calls)
+    assert any(name == "drop" for name, _ in calls)
+
+    loaded_schema = next(payload[2] for name, payload in calls if name == "load")
+    assert loaded_schema.exists() is False

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -21,6 +21,9 @@ import pytest
 import model_tools
 
 
+EXECUTOR_BLOCKED = {"file", "memory", "skills", "todo", "cronjob", "delegation"}
+
+
 @pytest.fixture(autouse=True)
 def _clear_cache():
     """Each test starts with an empty quiet_mode cache."""
@@ -92,3 +95,16 @@ class TestQuietModeCacheIsolation:
         explains why the bug only hit Gateway."""
         model_tools.get_tool_definitions(quiet_mode=False)
         assert len(model_tools._tool_defs_cache) == 0
+
+    def test_executor_role_strips_write_capable_toolsets(self, monkeypatch):
+        monkeypatch.setenv("HERMES_NODE_ROLE", "executor")
+        model_tools._tool_defs_cache.clear()
+
+        tools = model_tools.get_tool_definitions(quiet_mode=True)
+        names = {t.get("function", {}).get("name") for t in tools}
+
+        assert "terminal" in names
+        assert any(name.startswith("browser_") for name in names)
+        assert names.isdisjoint(EXECUTOR_BLOCKED)
+        assert "write_file" not in names
+        assert "patch" not in names

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -268,6 +268,31 @@ class TestPreToolCallBlocking:
         )
 
 
+class TestExecutorRuntimeGuard:
+    def test_executor_blocks_write_tools_at_dispatch_time(self, monkeypatch):
+        monkeypatch.setenv("HERMES_NODE_ROLE", "executor")
+        dispatch_called = False
+
+        def fake_dispatch(*args, **kwargs):
+            nonlocal dispatch_called
+            dispatch_called = True
+            raise AssertionError("dispatch should not run for blocked executor tools")
+
+        monkeypatch.setattr("model_tools.registry.dispatch", fake_dispatch)
+
+        result = json.loads(handle_function_call("write_file", {"path": "x", "content": "y"}))
+        assert "error" in result
+        assert "executor read-only mode" in result["error"]
+        assert not dispatch_called
+
+    def test_executor_allows_read_tools(self, monkeypatch):
+        monkeypatch.setenv("HERMES_NODE_ROLE", "executor")
+        monkeypatch.setattr("model_tools.registry.dispatch", lambda *a, **kw: json.dumps({"ok": True}))
+
+        result = json.loads(handle_function_call("web_search", {"q": "test"}))
+        assert result == {"ok": True}
+
+
 # =========================================================================
 # Legacy toolset map
 # =========================================================================

--- a/tests/tools/test_check_tailnet_health.py
+++ b/tests/tools/test_check_tailnet_health.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import subprocess
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "check_tailnet_health.py"
+MODULE_SPEC = spec_from_file_location("check_tailnet_health_test_module", MODULE_PATH)
+assert MODULE_SPEC and MODULE_SPEC.loader
+check_tailnet_health = module_from_spec(MODULE_SPEC)
+import sys
+
+sys.modules[MODULE_SPEC.name] = check_tailnet_health
+MODULE_SPEC.loader.exec_module(check_tailnet_health)
+
+
+class TestParsePorts:
+    def test_parse_ports_ignores_whitespace_and_blanks(self):
+        assert check_tailnet_health.parse_ports("3000, 8642,, 9119 ,") == [3000, 8642, 9119]
+
+
+class TestHealthChecks:
+    def test_check_dns_reports_first_line_on_success(self, monkeypatch):
+        def fake_run(cmd, timeout=20):
+            assert cmd == ["getent", "hosts", "hermes-vps-2.tailfdd900.ts.net"]
+            return subprocess.CompletedProcess(cmd, 0, stdout="100.64.0.10 hermes-vps-2\n", stderr="")
+
+        monkeypatch.setattr(check_tailnet_health, "run", fake_run)
+
+        result = check_tailnet_health.check_dns("hermes-vps-2.tailfdd900.ts.net")
+
+        assert result.ok is True
+        assert result.detail == "100.64.0.10 hermes-vps-2"
+
+    def test_check_tailscale_ping_accepts_pong_output(self, monkeypatch):
+        def fake_run(cmd, timeout=20):
+            assert cmd == ["tailscale", "ping", "hermes-vps-2.tailfdd900.ts.net"]
+            return subprocess.CompletedProcess(cmd, 0, stdout="pong from hermes-vps-2 via 100.64.0.10\n", stderr="")
+
+        monkeypatch.setattr(check_tailnet_health, "run", fake_run)
+
+        result = check_tailnet_health.check_tailscale_ping("hermes-vps-2.tailfdd900.ts.net")
+
+        assert result.ok is True
+        assert result.detail == "pong from hermes-vps-2 via 100.64.0.10"
+
+    def test_check_port_binding_flags_public_bindings(self, monkeypatch):
+        def fake_run(cmd, timeout=20):
+            assert cmd == ["ss", "-ltn"]
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "State  Recv-Q Send-Q Local Address:Port Peer Address:Port\n"
+                    "LISTEN 0      128    127.0.0.1:3000   0.0.0.0:*\n"
+                    "LISTEN 0      128    0.0.0.0:8642     0.0.0.0:*\n"
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(check_tailnet_health, "run", fake_run)
+
+        results = check_tailnet_health.check_port_binding([3000, 8642, 9119])
+
+        assert [(r.name, r.ok) for r in results] == [
+            ("port_3000", True),
+            ("port_8642", False),
+            ("port_9119", True),
+        ]
+        assert results[1].detail == "unsafe bind(s): 0.0.0.0:8642"
+        assert results[2].detail == "not listening"
+
+    def test_main_returns_degraded_when_any_check_fails(self, monkeypatch, capsys):
+        monkeypatch.setattr(check_tailnet_health, "check_dns", lambda peer: check_tailnet_health.CheckResult("dns", True, "ok"))
+        monkeypatch.setattr(check_tailnet_health, "check_tailscale_ping", lambda peer: check_tailnet_health.CheckResult("tailscale_ping", False, "no pong"))
+        monkeypatch.setattr(
+            check_tailnet_health,
+            "check_port_binding",
+            lambda ports: [check_tailnet_health.CheckResult("port_3000", True, "not listening")],
+        )
+        monkeypatch.setattr(check_tailnet_health, "parse_ports", lambda raw: [3000])
+        monkeypatch.setattr(check_tailnet_health.sys, "argv", ["check_tailnet_health.py"])
+
+        rc = check_tailnet_health.main()
+        out = capsys.readouterr().out
+
+        assert rc == 2
+        assert "degraded" in out
+        assert "tailscale_ping: fail" in out

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -333,7 +333,35 @@ class TestShellFileOpsHelpers:
         assert file_ops._is_likely_binary("unknown", binary_content) is True
 
         # Normal text -> not binary
-        assert file_ops._is_likely_binary("unknown", "Hello world\nLine 2\n") is False
+        text_content = "hello world\n" * 100
+        assert file_ops._is_likely_binary("unknown", text_content) is False
+
+
+class TestShellFileOpsExecutorReadOnly:
+    def _make_env(self):
+        env = MagicMock()
+        env.cwd = "/tmp/test"
+        env.execute.return_value = {"output": "should not run", "returncode": 0}
+        return env
+
+    def test_write_delete_move_and_patch_blocked_in_executor_mode(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_NODE_ROLE", "executor")
+        env = self._make_env()
+        ops = ShellFileOperations(env)
+        target = str(tmp_path / "safe.txt")
+
+        write_result = ops.write_file(target, "hello")
+        delete_result = ops.delete_file(target)
+        move_result = ops.move_file(target, str(tmp_path / "elsewhere.txt"))
+        patch_result = ops.patch_replace(target, "old", "new")
+        v4a_result = ops.patch_v4a("*** Begin Patch\n*** Update File: safe.txt\n@@\n-old\n+new\n*** End Patch")
+
+        assert write_result.error and "read-only executor" in write_result.error
+        assert delete_result.error and "read-only executor" in delete_result.error
+        assert move_result.error and "read-only executor" in move_result.error
+        assert patch_result.error and "read-only executor" in patch_result.error
+        assert v4a_result.error and "read-only executor" in v4a_result.error
+        env.execute.assert_not_called()
 
     def test_is_image(self, file_ops):
         assert file_ops._is_image("photo.png") is True

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -37,6 +37,8 @@ from tools.binary_extensions import BINARY_EXTENSIONS
 from agent.file_safety import (
     build_write_denied_paths,
     build_write_denied_prefixes,
+    get_node_execution_role,
+    get_safe_write_root as _shared_get_safe_write_root,
     is_write_denied as _shared_is_write_denied,
 )
 
@@ -116,6 +118,10 @@ def _normalize_line_endings(text: str, target: str) -> str:
 def _is_write_denied(path: str) -> bool:
     """Return True if path is on the write deny list."""
     return _shared_is_write_denied(path)
+
+
+def _is_executor_read_only() -> bool:
+    return get_node_execution_role() == "executor"
 
 
 # =============================================================================
@@ -943,6 +949,8 @@ class ShellFileOperations(FileOperations):
     def delete_file(self, path: str) -> WriteResult:
         """Delete a file via rm."""
         path = self._expand_path(path)
+        if _is_executor_read_only():
+            return WriteResult(error="Delete denied: the current node role is read-only executor, so write operations are disabled here.")
         if _is_write_denied(path):
             return WriteResult(error=f"Delete denied: {path} is a protected path")
         result = self._exec(f"rm -f {self._escape_shell_arg(path)}")
@@ -954,6 +962,8 @@ class ShellFileOperations(FileOperations):
         """Move a file via mv."""
         src = self._expand_path(src)
         dst = self._expand_path(dst)
+        if _is_executor_read_only():
+            return WriteResult(error="Move denied: the current node role is read-only executor, so write operations are disabled here.")
         for p in (src, dst):
             if _is_write_denied(p):
                 return WriteResult(error=f"Move denied: {p} is a protected path")
@@ -992,6 +1002,9 @@ class ShellFileOperations(FileOperations):
         """
         # Expand ~ and other shell paths
         path = self._expand_path(path)
+
+        if _is_executor_read_only():
+            return WriteResult(error="Write denied: the current node role is read-only executor, so write operations are disabled here.")
 
         # Block writes to sensitive paths
         if _is_write_denied(path):
@@ -1115,6 +1128,9 @@ class ShellFileOperations(FileOperations):
         # Expand ~ and other shell paths
         path = self._expand_path(path)
 
+        if _is_executor_read_only():
+            return PatchResult(error="Patch denied: the current node role is read-only executor, so write operations are disabled here.")
+
         # Block writes to sensitive paths
         if _is_write_denied(path):
             return PatchResult(error=f"Write denied: '{path}' is a protected system/credential file.")
@@ -1229,6 +1245,10 @@ class ShellFileOperations(FileOperations):
         Returns:
             PatchResult with changes made
         """
+        # Block writes in executor mode before parsing the patch content.
+        if _is_executor_read_only():
+            return PatchResult(error="Patch denied: the current node role is read-only executor, so write operations are disabled here.")
+
         # Import patch parser
         from tools.patch_parser import parse_v4a_patch, apply_v4a_operations
         


### PR DESCRIPTION
## Summary\n- Adds two-VPS readiness gate for executor startup\n- Tightens tailnet/schema validation and related scripts\n- Expands file-safety, tool-guardrail, CLI, and gateway coverage\n\n## Validation\n- pytest -q tests/agent/test_file_safety.py tests/agent/test_tool_guardrails.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_tools_config.py tests/cli/test_cli_init.py tests/cli/test_fast_command.py tests/cli/test_cwd_env_respect.py tests/run_agent/test_run_agent.py tests/test_get_tool_definitions_cache_isolation.py tests/test_model_tools.py tests/tools/test_file_operations.py tests/tools/test_check_tailnet_health.py tests/scripts/test_check_two_vps_readiness.py tests/scripts/test_validate_memory_schema.py\n\n## Notes\n- Local branch: feat/two-vps-readiness-guardrails