### PR TITLE
fix(update): export launcher virtualenv to uv (#35031)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8889,7 +8889,10 @@ def _cmd_update_pip(args):
         cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "hermes-agent"]
 
     print(f"→ Running: {' '.join(cmd)}")
-    result = subprocess.run(cmd)
+    run_kwargs = {}
+    if sys.prefix != sys.base_prefix:
+        run_kwargs["env"] = {**os.environ, "VIRTUAL_ENV": sys.prefix}
+    result = subprocess.run(cmd, **run_kwargs)
     if result.returncode != 0:
         print("✗ Update failed")
         sys.exit(1)

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -39,6 +39,45 @@ def mock_args():
     return SimpleNamespace()
 
 
+class TestCmdUpdatePip:
+    """Regression tests for pip-install update flows."""
+
+    @patch("shutil.which", return_value="/usr/bin/uv")
+    @patch("subprocess.run")
+    def test_update_pip_exports_virtualenv_from_sys_prefix(
+        self, mock_run, _mock_which, mock_args, monkeypatch
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.setattr(hm.sys, "prefix", "/tmp/hermes-launcher-venv")
+        monkeypatch.setattr(hm.sys, "base_prefix", "/usr")
+
+        hm._cmd_update_pip(mock_args)
+
+        assert mock_run.call_count == 1
+        assert mock_run.call_args.args[0] == ["/usr/bin/uv", "pip", "install", "--upgrade", "hermes-agent"]
+        assert mock_run.call_args.kwargs["env"]["VIRTUAL_ENV"] == "/tmp/hermes-launcher-venv"
+
+    @patch("shutil.which", return_value="/usr/bin/uv")
+    @patch("subprocess.run")
+    def test_update_pip_does_not_export_virtualenv_for_system_python(
+        self, mock_run, _mock_which, mock_args, monkeypatch
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.setattr(hm.sys, "prefix", "/usr")
+        monkeypatch.setattr(hm.sys, "base_prefix", "/usr")
+
+        hm._cmd_update_pip(mock_args)
+
+        assert mock_run.call_count == 1
+        assert "env" not in mock_run.call_args.kwargs
+
+
 class TestCmdUpdateBranchFallback:
     """cmd_update falls back to main when current branch has no remote counterpart."""
 


### PR DESCRIPTION
## Summary
- export `VIRTUAL_ENV=sys.prefix` when `_cmd_update_pip()` is running inside a real virtualenv
- keep system-Python installs unchanged by only applying the env overlay when `sys.prefix != sys.base_prefix`
- add a regression test covering the launcher-shebang case where Hermes runs from a venv interpreter but the shell environment lacks `VIRTUAL_ENV`

## Why
`hermes update` could fail for PyPI installs launched from a venv-backed shim because `uv pip install --upgrade hermes-agent` inherited a shell without `VIRTUAL_ENV`, even though the running interpreter already knew its venv root via `sys.prefix`.

## Verification
- `uv run --frozen --with pytest-timeout pytest tests/hermes_cli/test_cmd_update.py`
- `git diff --check`
- `uv run --frozen ruff check hermes_cli/main.py tests/hermes_cli/test_cmd_update.py`

## Scope
- Fixes #35031
- Intentionally does not change non-virtualenv / system-Python update behavior
