### PR TITLE
fix(weixin): retry on session/rate-limit errors in send_weixin_direct

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2106,11 +2106,35 @@ async def send_weixin_direct(
         adapter._token_store = token_store
 
         last_result: Optional[SendResult] = None
-        cleaned = adapter.format_message(message)
-        if cleaned:
-            last_result = await adapter.send(chat_id, cleaned)
-            if not last_result.success:
-                return {"error": f"Weixin send failed: {last_result.error}"}
+
+        async def _try_send_with_refresh() -> Optional[SendResult]:
+            nonlocal last_result
+            cleaned = adapter.format_message(message)
+            if cleaned:
+                last_result = await adapter.send(chat_id, cleaned)
+            return last_result
+
+        # Retry once on session/rate-limit errors, then give an
+        # actionable error so cron/send_message can surface it.
+        for _retry in range(2):
+            last_result = await _try_send_with_refresh()
+            if last_result and last_result.success:
+                break
+            err = last_result.error if last_result else ""
+            is_rate = "rate limited" in err or "ret=-2" in err
+            is_session = "session" in err.lower()
+            if not is_rate and not is_session:
+                break
+            # Clear stale context_token and retry once without it
+            if context_token:
+                token_store._cache.pop(
+                    token_store._key(account_id, chat_id), None
+                )
+                context_token = None
+            await asyncio.sleep(3.0)
+
+        if not last_result or not last_result.success:
+            return {"error": f"Weixin send failed: {last_result.error if last_result else 'unknown'}"}
 
         for media_path, _is_voice in media_files or []:
             ext = Path(media_path).suffix.lower()


### PR DESCRIPTION
## What does this PR do?

When `send_weixin_direct()` hits rate-limit errors (`ret=-2`) or session timeout errors (`errcode=-14`), it now retries once with a 3-second backoff. The stale `context_token` is cleared from the token store before retrying, allowing a tokenless fallback send.

Previously, these errors caused immediate failure — after a gateway restart, stale `context_tokens` caused persistent delivery failures until manual intervention.

## Background

This is a **partial cherry-pick** from the now-superseded PR #32604. The MEDIA regex whitelist changes from that PR were consolidated into #34844 and have already landed. The WeChat retry logic was orthogonal to #34844 and is still unaddressed on `main`.

## Changes Made

- `gateway/platforms/weixin.py` — wrap the send call in a retry loop (up to 2 attempts) that:
  - Checks for rate-limit (`ret=-2`, "rate limited") and session error patterns
  - Clears stale `context_token` from the token store before retry
  - Falls back to tokenless send on retry
  - Waits 3 seconds between attempts
  - Returns an actionable error if both attempts fail

## Checklist

### Code

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(weixin): ...`)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I have tested on my platform: macOS 15.x

### Documentation

- [x] I have updated relevant documentation — N/A (internal implementation change)
