### PR TITLE
fix(weixin): allow tokenless retry when no cached context_token exists

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1567,7 +1567,7 @@ class WeixinAdapter(BasePlatformAdapter):
                             or _is_stale_session_ret(ret, errcode, resp.get("errmsg"))
                         )
                         # Session expired — strip token and retry once
-                        if is_session_expired and not retried_without_token and context_token:
+                        if is_session_expired and not retried_without_token:
                             retried_without_token = True
                             context_token = None
                             self._token_store._cache.pop(

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -613,6 +613,70 @@ class TestWeixinBlankMessagePrevention:
             )
 
 
+class TestWeixinTokenlessRetryWithoutCachedToken:
+    """Regression: tokenless retry must fire even when context_token is None.
+
+    Issue #35062: cron-initiated pushes to long-inactive chats fail because
+    the ``and context_token`` guard prevents the retry branch from executing
+    when no cached token exists.  iLink accepts tokenless sends as a degraded
+    fallback, so the guard should only check ``not retried_without_token``.
+    """
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_tokenless_retry_fires_when_context_token_is_none(self, send_mock):
+        """Session-expired + no cached token → retry fires, then succeeds."""
+        adapter = _make_adapter()
+        adapter._send_session = object()
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        # No cached context_token for this chat
+        adapter._token_store._cache = {}
+
+        # First call: stale session (ret=-3, errmsg=unknown error)
+        # Second call: success
+        send_mock.side_effect = [
+            {"ret": -3, "errmsg": "unknown error"},
+            {"ret": 0},
+        ]
+
+        # Should NOT raise — retry fires and second call succeeds
+        asyncio.run(adapter._send_text_chunk(
+            chat_id="wxid_test",
+            chunk="hello",
+            context_token=None,
+            client_id="cid",
+        ))
+
+        # Two calls: initial attempt + tokenless retry
+        assert send_mock.await_count == 2
+        # Second call should have context_token=None (already was, but confirm)
+        second_call_kwargs = send_mock.await_args_list[1].kwargs
+        assert second_call_kwargs.get("context_token") is None
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_tokenless_retry_fires_for_errcode_minus_14(self, send_mock):
+        """errcode=-14 (classic session expired) + no cached token → retry fires."""
+        adapter = _make_adapter()
+        adapter._send_session = object()
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._token_store._cache = {}
+
+        send_mock.side_effect = [
+            {"errcode": -14},
+            {"ret": 0},
+        ]
+
+        asyncio.run(adapter._send_text_chunk(
+            chat_id="wxid_test",
+            chunk="hello",
+            context_token=None,
+            client_id="cid",
+        ))
+
+        assert send_mock.await_count == 2
+
+
 class TestWeixinStreamingCursorSuppression:
     """WeChat doesn't support message editing — cursor must be suppressed."""
 


### PR DESCRIPTION
## What does this PR do?

Removes the `and context_token` guard from the tokenless retry branch in `_send_text_chunk`, allowing cron-initiated pushes to long-inactive WeChat chats to fall back to tokenless sends when no cached context token exists.

## Related Issue

Fixes #35062

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/weixin.py`: Remove `and context_token` from the session-expired retry guard at line 1570 so the tokenless fallback fires regardless of whether a cached token existed.
- `tests/gateway/test_weixin.py`: Add `TestWeixinTokenlessRetryWithoutCachedToken` with two regression tests covering `ret=-3` (stale session) and `errcode=-14` (classic session expired) when `context_token` is `None`.

## How to Test

1. Run `pytest tests/gateway/test_weixin.py -xvs -k TestWeixinTokenlessRetryWithoutCachedToken` — both new tests should pass.
2. Run `pytest tests/gateway/test_weixin.py -xvs` — all 56 tests should pass (no regressions).
3. Verify the fix logic: when `_send_message` returns `ret=-3, errmsg="unknown error"` and `context_token=None`, the adapter should retry once without a token (the degraded fallback), then succeed on the second attempt.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_weixin.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_send_text_chunk` in `gateway/platforms/weixin.py` (line 1531-1625)
- Blast radius: LOW — single condition change in one platform adapter's retry path; only affects Weixin/WeChat cron-initiated pushes to inactive chats
- Related patterns: `_is_stale_session_ret()` detects `ret=-2/-3` with `errmsg="unknown error"` as stale session signals; the same guard pattern exists in `_poll_loop` (line 1289) for get_updates, but that path handles session expiry differently (10-minute pause, no token concept)
