### PR TITLE
fix(gateway): preserve HOME after s6 privilege drop (#35059)

### DIFF
--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -615,10 +615,10 @@ class S6ServiceManager:
         # guard.
         lines.append("export HERMES_S6_SUPERVISED_CHILD=1")
         if profile == "default":
-            lines.append("exec s6-setuidgid hermes hermes gateway run")
+            lines.append("exec s6-setuidgid hermes env HOME=/opt/data hermes gateway run")
         else:
             lines.append(
-                f"exec s6-setuidgid hermes hermes -p {shlex.quote(profile)} gateway run"
+                f"exec s6-setuidgid hermes env HOME=/opt/data hermes -p {shlex.quote(profile)} gateway run"
             )
         return "\n".join(lines) + "\n"
 

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -535,7 +535,7 @@ def test_s6_register_creates_service_dir_and_triggers_scan(
     run_text = run_path.read_text()
     assert "export HOME=/opt/data" in run_text
     assert "hermes -p coder gateway run" in run_text
-    assert "s6-setuidgid hermes" in run_text
+    assert "exec s6-setuidgid hermes env HOME=/opt/data" in run_text
     # Sentinel marking this as the supervised-child invocation. Without
     # it, the supervised `gateway run` would re-enter the s6 redirect
     # in `_gateway_command_inner` and recurse. See the matching guard
@@ -588,7 +588,15 @@ def test_render_run_script_resets_home_before_exec() -> None:
     run_text = S6ServiceManager._render_run_script("coder", {})
 
     assert "export HOME=/opt/data" in run_text
-    assert "exec s6-setuidgid hermes hermes -p coder gateway run" in run_text
+    assert "exec s6-setuidgid hermes env HOME=/opt/data hermes -p coder gateway run" in run_text
+
+
+def test_render_run_script_resets_home_for_default_profile() -> None:
+
+    run_text = S6ServiceManager._render_run_script("default", {})
+
+    assert "export HOME=/opt/data" in run_text
+    assert "exec s6-setuidgid hermes env HOME=/opt/data hermes gateway run" in run_text
 
 
 def test_s6_register_rejects_invalid_profile_name(s6_scandir) -> None:


### PR DESCRIPTION
## Summary
- inject `HOME=/opt/data` in the supervised s6 `exec` line after `s6-setuidgid hermes`
- keep both default-profile and named-profile gateway run scripts aligned
- extend the service-manager regression tests to cover both script variants

## Why
The generated run script already exported `HOME=/opt/data` before `with-contenv` re-entered the child process, but the final `exec s6-setuidgid hermes hermes ...` still let root's HOME leak into the launched gateway in some s6 flows. Moving the HOME override into the post-drop `env` invocation keeps SSH expansion pointed at `/opt/data/.ssh/config`.

## Verification
- `uv run --frozen --with pytest-timeout pytest tests/hermes_cli/test_service_manager.py`
- `git diff --check`
- `uv run --frozen ruff check hermes_cli/service_manager.py tests/hermes_cli/test_service_manager.py`

## Scope
- Fixes #35059
- Intentionally limited to the s6 gateway run-script generator and its tests
