### PR TITLE
feat(minimax): add MiniMax-M3 to local provider catalog + context fallback

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -200,8 +200,9 @@ DEFAULT_CONTEXT_LENGTHS = {
     "qwen3-coder-plus": 1000000,  # 1M context
     "qwen3-coder": 262144,        # 256K context
     "qwen": 131072,
-    # MiniMax — official docs: 204,800 context for all models
+    # MiniMax — official docs: 204,800 context for M2.x; M3 supports 512K
     # https://platform.minimax.io/docs/api-reference/text-anthropic-api
+    "MiniMax-M3": 512000,  # M3: 512K context, multimodal
     "minimax": 204800,
     # GLM
     "glm": 202752,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -277,16 +277,19 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-0905-preview",
     ],
     "minimax": [
+        "MiniMax-M3",
         "MiniMax-M2.7",
         "MiniMax-M2.5",
         "MiniMax-M2.1",
         "MiniMax-M2",
     ],
     "minimax-oauth": [
+        "MiniMax-M3",
         "MiniMax-M2.7",
         "MiniMax-M2.7-highspeed",
     ],
     "minimax-cn": [
+        "MiniMax-M3",
         "MiniMax-M2.7",
         "MiniMax-M2.5",
         "MiniMax-M2.1",


### PR DESCRIPTION
## What

Two tiny additions so Hermes recognizes the new `MiniMax-M3` model when the live models.dev catalog is unreachable or stale.

## Files

| file | change |
|---|---|
| `hermes_cli/models.py` (minimax / minimax-oauth / minimax-cn lists) | prepend `MiniMax-M3` |
| `agent/model_metadata.py` (context_window fallback table) | add `"MiniMax-M3": 512000` above the broader `"minimax": 204800` entry — longest-substring lookup picks M3 first |

## Why this is enough

End-to-end verified against the M3 staging endpoint that Hermes already handles M3 correctly with **zero other patches**:

- `agent/image_routing.py` checks models.dev `attachment` / config `supports_vision` — once models.dev has M3 (separate PR to anomalyco/models.dev), vision routing just works
- `agent/anthropic_adapter.py` already strips the `context-1m-2025-08-07` beta header for minimax endpoints, and the runtime max_output_tokens shrink logic handles M3's 196608 server cap
- compression / compaction thresholds are percentage-based — they scale with the new 512K window automatically

So these two local-fallback nudges are all Hermes needs.

## M3 spec

- contextWindow: 512_000
- maxTokens: 196_608 (server hard cap)
- modalities: text + image input
- Anthropic Messages compatible