### PR TITLE
fix: add HERMES_SKIP_PROFILE_OVERRIDE escape hatch for launcher sandboxes

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -338,7 +338,17 @@ sys.path.insert(0, str(PROJECT_ROOT))
 # Falls back to ~/.hermes/active_profile for sticky default.
 # ---------------------------------------------------------------------------
 def _apply_profile_override() -> None:
-    """Pre-parse --profile/-p and set HERMES_HOME before imports."""
+    """Pre-parse --profile/-p and set HERMES_HOME before module imports."""
+
+    # MeshBoard and other launchers spawn Hermes with a per-dispatch
+    # HERMES_HOME sandbox (e.g. for stream-tap proxy injection).  When
+    # the launcher has already set HERMES_HOME and wants it honoured
+    # verbatim, it passes HERMES_SKIP_PROFILE_OVERRIDE=1 so this
+    # function returns early instead of clobbering the sandbox with the
+    # active profile.  See meshboard task hermes-stream-tap-profile-override.
+    if os.environ.get("HERMES_SKIP_PROFILE_OVERRIDE", "").strip() == "1":
+        return
+
     argv = sys.argv[1:]
     profile_name = None
     consume = 0

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -241,6 +241,32 @@ class TestApplyProfileOverrideHermesHomeGuard:
         assert result.endswith("coder")
         assert sys.argv == ["hermes", "--continue"]
 
+    def test_hermes_skip_profile_override_env_var(self, tmp_path, monkeypatch):
+        """HERMES_SKIP_PROFILE_OVERRIDE must skip all profile resolution.
+
+        When HERMES_SKIP_PROFILE_OVERRIDE is set, _apply_profile_override
+        returns immediately without reading active_profile or modifying
+        HERMES_HOME.  This is used by MeshBoard stream-tap launcher to
+        force a specific HERMES_HOME without profile redirection.
+        """
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+        (hermes_root / "active_profile").write_text("coder")
+        profile_dir = hermes_root / "profiles" / "coder"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_root))
+        monkeypatch.setenv("HERMES_SKIP_PROFILE_OVERRIDE", "1")
+        monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "start"])
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        # HERMES_HOME must remain at the root, NOT redirected to profile
+        assert os.environ.get("HERMES_HOME") == str(hermes_root)
+        assert "profiles" not in os.environ.get("HERMES_HOME", "")
+
 
 class TestSupervisedChildIgnoresStickyProfile:
     """The reserved default gateway s6 slot must not follow active_profile.
@@ -322,4 +348,3 @@ class TestSupervisedChildIgnoresStickyProfile:
         result = os.environ.get("HERMES_HOME")
         assert result is not None
         assert result.endswith("coder")
-


### PR DESCRIPTION
## What


## Why


## How


## Scope

This PR is intentionally narrowed to the profile-override escape hatch only:

- `hermes_cli/main.py`
- `tests/hermes_cli/test_apply_profile_override.py`

The broader `HERMES_LLM_BASE_URL` runtime-provider work remains separate in #34332.

## Testing

```bash
python -m pytest tests/hermes_cli/test_apply_profile_override.py -q
```

Result: `5 passed in 0.23s`.

## Risks / gaps

- Low risk: this only affects dispatches that explicitly set `HERMES_SKIP_PROFILE_OVERRIDE=1`.
- Standard Hermes usage is unchanged.


### Relation to #22502
Main now trusts `HERMES_HOME` when its parent directory is literally named `profiles` (`_apply_profile_override` step 1.5). That heuristic does not cover launcher sandboxes whose scratch homes are not profile-shaped (e.g. `.../hermes-scratch/<run-id>/`), so the unconditional override still clobbers them; this escape hatch remains necessary for that case.