### PR TITLE
fix: support HERMES_UID=0 by skipping usermod and privilege drop

### DIFF
--- a/docker/main-wrapper.sh
+++ b/docker/main-wrapper.sh
@@ -30,14 +30,20 @@ cd /opt/data
 # shellcheck disable=SC1091
 . /opt/hermes/.venv/bin/activate
 
+if [ "${HERMES_RUN_AS_ROOT:-}" = "1" ]; then
+    _DROP=""
+else
+    _DROP="s6-setuidgid hermes"
+fi
+
 if [ $# -eq 0 ]; then
-    exec s6-setuidgid hermes hermes
+    exec $_DROP hermes
 fi
 
 if command -v "$1" >/dev/null 2>&1; then
     # Bare executable — pass through directly.
-    exec s6-setuidgid hermes "$@"
+    exec $_DROP "$@"
 fi
 
 # Hermes subcommand pass-through.
-exec s6-setuidgid hermes hermes "$@"
+exec $_DROP hermes "$@"

--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -43,8 +43,17 @@ HERMES_UID="${HERMES_UID:-${PUID:-}}"
 HERMES_GID="${HERMES_GID:-${PGID:-}}"
 
 if [ -n "${HERMES_UID:-}" ] && [ "$HERMES_UID" != "$(id -u hermes)" ]; then
-    echo "[stage2] Changing hermes UID to $HERMES_UID"
-    usermod -u "$HERMES_UID" hermes
+    if [ "$HERMES_UID" = "0" ]; then
+        # UID 0 is already taken by root — usermod would fail with
+        # "UID '0' already exists".  Instead, signal main-wrapper.sh to
+        # skip the s6-setuidgid privilege drop so the gateway runs as
+        # root directly.
+        echo "[stage2] HERMES_UID=0 — will run as root (skipping usermod)"
+        printf '1' > /run/s6/container_environment/HERMES_RUN_AS_ROOT
+    else
+        echo "[stage2] Changing hermes UID to $HERMES_UID"
+        usermod -u "$HERMES_UID" hermes
+    fi
 fi
 if [ -n "${HERMES_GID:-}" ] && [ "$HERMES_GID" != "$(id -g hermes)" ]; then
     echo "[stage2] Changing hermes GID to $HERMES_GID"


### PR DESCRIPTION
## Problem

`HERMES_UID=0` is documented as a way to run the gateway as root, but it does not work. `stage2-hook.sh` runs `usermod -u 0 hermes` which fails silently with:

```
usermod: UID '0' already exists
```

because UID 0 is already assigned to root. The gateway continues running as uid 10000 (hermes), and files created by `docker exec -u root` operations remain root-owned, causing `PermissionError` on `gateway.lock` and `errors.log` → gateway restart loop.

## Fix

Two files modified:

### `docker/stage2-hook.sh`
- When `HERMES_UID=0`, skip `usermod` (would fail anyway)
- Set `HERMES_RUN_AS_ROOT=1` in s6 container environment as a signal

### `docker/main-wrapper.sh`
- Check `HERMES_RUN_AS_ROOT` flag
- When set, skip `s6-setuidgid hermes` privilege drop
- Gateway runs directly as root

## Testing

Set `HERMES_UID=0` and `HERMES_GID=0` in docker-compose.yml:

```yaml
environment:
  - HERMES_UID=0
  - HERMES_GID=0
```

After `docker compose up -d`:
- `docker exec hermes-agent whoami` should return `root`
- No `PermissionError` in gateway logs
- Files created by root operations are accessible

## Related

Known issue documented in community skills:
> HERMES_UID=0 does NOT work despite stage2-hook.sh source code suggesting it should. Tested and confirmed non-functional as of v0.15.1.