### PR TITLE
fix(gateway): name what the /status token number actually is

### DIFF
--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -255,7 +255,7 @@ gateway:
     title:                 "**Titel:** {title}"
     created:               "**Geskep:** {timestamp}"
     last_activity:         "**Laaste aktiwiteit:** {timestamp}"
-    tokens:                "**Tokens:** {tokens}"
+    tokens:                "**Sessiegebruik (kumulatief):** {tokens}"
     agent_running:         "**Agent loop:** {state}"
     state_yes:             "Ja ⚡"
     state_no:              "Nee"

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -255,7 +255,7 @@ gateway:
     title:                 "**Titel:** {title}"
     created:               "**Geskep:** {timestamp}"
     last_activity:         "**Laaste aktiwiteit:** {timestamp}"
-    tokens:                "**Sessiegebruik (kumulatief):** {tokens}"
+    tokens:                "**Kumulatiewe API-tokens (elke oproep weer gestuur):** {tokens}"
     agent_running:         "**Agent loop:** {state}"
     state_yes:             "Ja ⚡"
     state_no:              "Nee"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -255,7 +255,7 @@ gateway:
     title:                 "**Titel:** {title}"
     created:               "**Erstellt:** {timestamp}"
     last_activity:         "**Letzte Aktivität:** {timestamp}"
-    tokens:                "**Tokens:** {tokens}"
+    tokens:                "**Sitzungsnutzung (kumulativ):** {tokens}"
     agent_running:         "**Agent läuft:** {state}"
     state_yes:             "Ja ⚡"
     state_no:              "Nein"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -255,7 +255,7 @@ gateway:
     title:                 "**Titel:** {title}"
     created:               "**Erstellt:** {timestamp}"
     last_activity:         "**Letzte Aktivität:** {timestamp}"
-    tokens:                "**Sitzungsnutzung (kumulativ):** {tokens}"
+    tokens:                "**Kumulierte API-Tokens (bei jedem Aufruf erneut gesendet):** {tokens}"
     agent_running:         "**Agent läuft:** {state}"
     state_yes:             "Ja ⚡"
     state_no:              "Nein"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -270,7 +270,7 @@ gateway:
     title:                 "**Title:** {title}"
     created:               "**Created:** {timestamp}"
     last_activity:         "**Last Activity:** {timestamp}"
-    tokens:                "**Tokens:** {tokens}"
+    tokens:                "**Session usage (cumulative):** {tokens}"
     agent_running:         "**Agent Running:** {state}"
     state_yes:             "Yes ⚡"
     state_no:              "No"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -270,7 +270,7 @@ gateway:
     title:                 "**Title:** {title}"
     created:               "**Created:** {timestamp}"
     last_activity:         "**Last Activity:** {timestamp}"
-    tokens:                "**Session usage (cumulative):** {tokens}"
+    tokens:                "**Cumulative API tokens (re-sent each call):** {tokens}"
     agent_running:         "**Agent Running:** {state}"
     state_yes:             "Yes ⚡"
     state_no:              "No"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -255,7 +255,7 @@ gateway:
     title:                 "**Título:** {title}"
     created:               "**Creado:** {timestamp}"
     last_activity:         "**Última actividad:** {timestamp}"
-    tokens:                "**Tokens:** {tokens}"
+    tokens:                "**Uso de sesión (acumulado):** {tokens}"
     agent_running:         "**Agente activo:** {state}"
     state_yes:             "Sí ⚡"
     state_no:              "No"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -255,7 +255,7 @@ gateway:
     title:                 "**Título:** {title}"
     created:               "**Creado:** {timestamp}"
     last_activity:         "**Última actividad:** {timestamp}"
-    tokens:                "**Uso de sesión (acumulado):** {tokens}"
+    tokens:                "**Tokens de API acumulados (reenviados en cada llamada):** {tokens}"
     agent_running:         "**Agente activo:** {state}"
     state_yes:             "Sí ⚡"
     state_no:              "No"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -255,7 +255,7 @@ gateway:
     title:                 "**Título:** {title}"
     created:               "**Criada:** {timestamp}"
     last_activity:         "**Última atividade:** {timestamp}"
-    tokens:                "**Uso da sessão (cumulativo):** {tokens}"
+    tokens:                "**Tokens de API cumulativos (reenviados a cada chamada):** {tokens}"
     agent_running:         "**Agente em execução:** {state}"
     state_yes:             "Sim ⚡"
     state_no:              "Não"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -255,7 +255,7 @@ gateway:
     title:                 "**Título:** {title}"
     created:               "**Criada:** {timestamp}"
     last_activity:         "**Última atividade:** {timestamp}"
-    tokens:                "**Tokens:** {tokens}"
+    tokens:                "**Uso da sessão (cumulativo):** {tokens}"
     agent_running:         "**Agente em execução:** {state}"
     state_yes:             "Sim ⚡"
     state_no:              "Não"

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -97,7 +97,7 @@ async def test_status_command_reports_running_agent_without_interrupt(monkeypatc
     result = await runner._handle_message(_make_event("/status"))
 
     assert "**Session ID:** `sess-1`" in result
-    assert "**Session usage (cumulative):** 321" in result
+    assert "**Cumulative API tokens (re-sent each call):** 321" in result
     assert "**Agent Running:** Yes ⚡" in result
     assert "**Title:**" not in result
     running_agent.interrupt.assert_not_called()
@@ -150,7 +150,7 @@ async def test_status_command_reads_token_totals_from_session_db():
     result = await runner._handle_message(_make_event("/status"))
 
     # 1000 + 250 + 500 + 100 + 50 = 1,900
-    assert "**Session usage (cumulative):** 1,900" in result
+    assert "**Cumulative API tokens (re-sent each call):** 1,900" in result
 
 
 @pytest.mark.asyncio
@@ -171,7 +171,7 @@ async def test_status_command_tokens_zero_when_session_db_row_missing():
 
     result = await runner._handle_message(_make_event("/status"))
 
-    assert "**Session usage (cumulative):** 0" in result
+    assert "**Cumulative API tokens (re-sent each call):** 0" in result
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -97,7 +97,7 @@ async def test_status_command_reports_running_agent_without_interrupt(monkeypatc
     result = await runner._handle_message(_make_event("/status"))
 
     assert "**Session ID:** `sess-1`" in result
-    assert "**Tokens:** 321" in result
+    assert "**Session usage (cumulative):** 321" in result
     assert "**Agent Running:** Yes ⚡" in result
     assert "**Title:**" not in result
     running_agent.interrupt.assert_not_called()
@@ -150,7 +150,7 @@ async def test_status_command_reads_token_totals_from_session_db():
     result = await runner._handle_message(_make_event("/status"))
 
     # 1000 + 250 + 500 + 100 + 50 = 1,900
-    assert "**Tokens:** 1,900" in result
+    assert "**Session usage (cumulative):** 1,900" in result
 
 
 @pytest.mark.asyncio
@@ -171,7 +171,7 @@ async def test_status_command_tokens_zero_when_session_db_row_missing():
 
     result = await runner._handle_message(_make_event("/status"))
 
-    assert "**Tokens:** 0" in result
+    assert "**Session usage (cumulative):** 0" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
The `/status` token line now names what the number actually is: cumulative provider-reported API tokens, re-sent on each call — not current context size, and not a total across all sessions.

A Discord user read a one-hour session's `Tokens: 68M` as either a broken counter or an all-sessions total. It's neither. The value is real per-call `usage` summed across every API call in the active session row (`SessionDB`). In an agentic loop the same context is re-sent each iteration, so a tool-heavy hour legitimately reaches tens of millions.

## Changes
- `locales/{en,es,de,pt,af}.yaml`: `/status` token label → "Cumulative API tokens (re-sent each call)"
- `tests/gateway/test_status_command.py`: assertions updated to match

## Validation
| | Before | After |
|---|---|---|
| Label | `Tokens: 68,000,000` (reads like context size / all sessions) | `Cumulative API tokens (re-sent each call): 68,000,000` |
| Accounting logic | unchanged | unchanged |
| `tests/gateway/test_status_command.py` | — | 14/14 pass |

## Credit
Cherry-picked @helix4u's original label fix (#34967), authorship preserved. Follow-up commit sharpens the wording to explain the magnitude. Closes #34967.



## Infographic

![status-token-label](https://v3b.fal.media/files/b/0a9c3a6b/v_47DHpjUxI9AlCFq-xSx_yFVT44E4.png)
