### PR TITLE
[codex] Expose chat completions reasoning SSE

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -958,6 +958,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
+        reasoning_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
@@ -1006,6 +1007,7 @@ class APIServerAdapter(BasePlatformAdapter):
             session_id=session_id,
             platform="api_server",
             stream_delta_callback=stream_delta_callback,
+            reasoning_callback=reasoning_callback,
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
@@ -1801,6 +1803,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 if delta is not None:
                     _stream_q.put(delta)
 
+            def _on_reasoning(delta):
+                if delta:
+                    _stream_q.put(("__reasoning__", {"text": str(delta)}))
+
             # Track which tool_call_ids we've emitted a "running" lifecycle
             # event for, so a "completed" event without a matching "running"
             # (e.g. internal/filtered tools) is silently dropped instead of
@@ -1864,6 +1870,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
+                reasoning_callback=_on_reasoning,
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
@@ -2040,13 +2047,21 @@ class APIServerAdapter(BasePlatformAdapter):
                 Tagged tuples ``("__tool_progress__", payload)`` are sent
                 as a custom ``event: hermes.tool.progress`` SSE event so
                 frontends can display them without storing the markers in
-                conversation history.  See #6972 for the original event,
-                #16588 for the ``toolCallId``/``status`` lifecycle fields.
+                conversation history.  Tagged reasoning payloads are emitted
+                as ``event: hermes.reasoning`` so clients can render model
+                reasoning separately from assistant text. See #6972 for the
+                original event, #16588 for the ``toolCallId``/``status``
+                lifecycle fields.
                 """
                 if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
                     event_data = json.dumps(item[1])
                     await response.write(
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
+                    )
+                elif isinstance(item, tuple) and len(item) == 2 and item[0] == "__reasoning__":
+                    event_data = json.dumps(item[1])
+                    await response.write(
+                        f"event: hermes.reasoning\ndata: {event_data}\n\n".encode()
                     )
                 else:
                     content_chunk = {
@@ -3430,6 +3445,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
+        reasoning_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
@@ -3454,6 +3470,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
                 stream_delta_callback=stream_delta_callback,
+                reasoning_callback=reasoning_callback,
                 tool_progress_callback=tool_progress_callback,
                 tool_start_callback=tool_start_callback,
                 tool_complete_callback=tool_complete_callback,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -894,6 +894,55 @@ class TestChatCompletionsEndpoint:
                 assert "Hello!" in body
 
     @pytest.mark.asyncio
+    async def test_stream_includes_reasoning_event(self, adapter):
+        """reasoning_callback deltas are emitted as custom SSE events."""
+        import asyncio
+        import json as _json
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                reasoning_cb = kwargs.get("reasoning_callback")
+                text_cb = kwargs.get("stream_delta_callback")
+                if reasoning_cb:
+                    reasoning_cb("checking constraints")
+                if text_cb:
+                    await asyncio.sleep(0.05)
+                    text_cb("final answer")
+                return (
+                    {"final_response": "final answer", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            assert callable(mock_run.call_args.kwargs["reasoning_callback"])
+            assert "event: hermes.reasoning" in body
+            assert '"text": "checking constraints"' in body
+
+            # Reasoning is out-of-band metadata, not assistant delta content.
+            for line in body.splitlines():
+                if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+                    continue
+                try:
+                    chunk = _json.loads(line[len("data: "):])
+                except _json.JSONDecodeError:
+                    continue
+                if chunk.get("object") == "chat.completion.chunk":
+                    for choice in chunk.get("choices", []):
+                        assert choice.get("delta", {}).get("content") != "checking constraints"
+
+    @pytest.mark.asyncio
     async def test_stream_string_false_returns_json_completion(self, adapter):
         """Quoted false must not route chat completions into SSE mode."""
         mock_result = {


### PR DESCRIPTION
## Summary
- wire the API server chat-completions path to AIAgent.reasoning_callback
- emit reasoning deltas as `event: hermes.reasoning` instead of assistant content chunks
- add a regression test covering the out-of-band event

## Why
`/v1/chat/completions` already streams assistant text and Hermes tool progress, but model reasoning was only available inside the agent path. Clients that render reasoning panels need a structured event that does not pollute assistant message text.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server.py`
- manual aiohttp TestClient smoke test for `event: hermes.reasoning` because pytest is not installed in the available local Python environments