### PR TITLE
[codex] Allow request-body history for chat completions sessions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -69,6 +69,8 @@ MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversation
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+CHAT_COMPLETIONS_HISTORY_SOURCE_HEADER = "X-Hermes-History-Source"
+CHAT_COMPLETIONS_HISTORY_SOURCE_VALUES = frozenset({"stored", "request"})
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -1119,6 +1121,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
+                "chat_completions_history_source_header": CHAT_COMPLETIONS_HISTORY_SOURCE_HEADER,
+                "chat_completions_history_source_values": sorted(CHAT_COMPLETIONS_HISTORY_SOURCE_VALUES),
                 "cors": bool(self._cors_origins),
             },
             "endpoints": {
@@ -1734,13 +1738,24 @@ class APIServerAdapter(BasePlatformAdapter):
             return key_err
 
         # Allow caller to continue an existing session by passing X-Hermes-Session-Id.
-        # When provided, history is loaded from state.db instead of from the request body.
+        # When provided, history is loaded from state.db instead of from the request body
+        # unless X-Hermes-History-Source: request makes the request body authoritative.
         #
         # Security: session continuation exposes conversation history, so it is
         # only allowed when the API key is configured and the request is
         # authenticated.  Without this gate, any unauthenticated client could
         # read arbitrary session history by guessing/enumerating session IDs.
         provided_session_id = request.headers.get("X-Hermes-Session-Id", "").strip()
+        history_source = request.headers.get(CHAT_COMPLETIONS_HISTORY_SOURCE_HEADER, "").strip().lower()
+        if history_source and history_source not in CHAT_COMPLETIONS_HISTORY_SOURCE_VALUES:
+            return web.json_response(
+                _openai_error(
+                    f"{CHAT_COMPLETIONS_HISTORY_SOURCE_HEADER} must be one of: request, stored",
+                    code="invalid_history_source",
+                    param=CHAT_COMPLETIONS_HISTORY_SOURCE_HEADER,
+                ),
+                status=400,
+            )
         if provided_session_id:
             if not self._api_key:
                 logger.warning(
@@ -1762,13 +1777,20 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=400,
                 )
             session_id = provided_session_id
-            try:
-                db = self._ensure_session_db()
-                if db is not None:
-                    history = db.get_messages_as_conversation(session_id)
-            except Exception as e:
-                logger.warning("Failed to load session history for %s: %s", session_id, e)
-                history = []
+            if history_source == "request":
+                logger.info(
+                    "Session %s: using request-body chat history (%s=request)",
+                    session_id,
+                    CHAT_COMPLETIONS_HISTORY_SOURCE_HEADER,
+                )
+            else:
+                try:
+                    db = self._ensure_session_db()
+                    if db is not None:
+                        history = db.get_messages_as_conversation(session_id)
+                except Exception as e:
+                    logger.warning("Failed to load session history for %s: %s", session_id, e)
+                    history = []
         else:
             # Derive a stable session ID from the conversation fingerprint so
             # that consecutive messages from the same Open WebUI (or similar)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3293,6 +3293,71 @@ class TestSessionIdHeader:
             assert call_kwargs["user_message"] == "new question"
 
     @pytest.mark.asyncio
+    async def test_provided_session_id_can_use_request_body_history(self, auth_adapter):
+        """X-Hermes-History-Source=request makes request messages authoritative."""
+        mock_result = {"final_response": "OK", "messages": [], "api_calls": 1}
+        request_history = [
+            {"role": "user", "content": "edited client message"},
+            {"role": "assistant", "content": "edited client reply"},
+        ]
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "stale stored message"},
+            {"role": "assistant", "content": "stale stored reply"},
+        ]
+        auth_adapter._session_db = mock_db
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "X-Hermes-Session-Id": "existing-session",
+                        "X-Hermes-History-Source": "request",
+                        "Authorization": "Bearer sk-secret",
+                    },
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            *request_history,
+                            {"role": "user", "content": "new question"},
+                        ],
+                    },
+                )
+
+            assert resp.status == 200
+            mock_db.get_messages_as_conversation.assert_not_called()
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["conversation_history"] == request_history
+            assert call_kwargs["user_message"] == "new question"
+
+    @pytest.mark.asyncio
+    async def test_invalid_history_source_header_returns_400(self, auth_adapter):
+        """Unknown X-Hermes-History-Source values fail before agent execution."""
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "X-Hermes-Session-Id": "existing-session",
+                        "X-Hermes-History-Source": "client",
+                        "Authorization": "Bearer sk-secret",
+                    },
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "Hi"}],
+                    },
+                )
+
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"]["code"] == "invalid_history_source"
+            mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_db_failure_falls_back_to_empty_history(self, auth_adapter):
         """If SessionDB raises, history falls back to empty and request still succeeds."""
         mock_result = {"final_response": "OK", "messages": [], "api_calls": 1}


### PR DESCRIPTION
## Summary
- add `X-Hermes-History-Source` for `/v1/chat/completions` session continuation
- keep existing default behavior: `X-Hermes-Session-Id` loads stored `state.db` history
- allow `X-Hermes-History-Source: request` so edited/regenerated client transcripts can be authoritative
- advertise the header in `/v1/capabilities` and cover request/invalid modes with tests

## Why
When an OpenAI-compatible client edits or regenerates part of a transcript, it may send the corrected `messages` array while reusing the same Hermes session id. The current API server ignores that request history and reloads stale `state.db` turns, causing the client and agent context to diverge.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server.py`
- manual aiohttp TestClient smoke test for `X-Hermes-History-Source: request`
- manual aiohttp TestClient smoke test for invalid history-source rejection

Note: pytest is not installed in the available local Python environments, so I ran focused equivalent aiohttp smoke tests directly.