### PR TITLE
fix(browser): surface Camofox loopback rewrite hint

### DIFF
--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -1,6 +1,8 @@
 """Tests for the Camofox browser backend."""
 
 import json
+
+import requests
 from unittest.mock import MagicMock, patch
 
 
@@ -18,6 +20,7 @@ from tools.browser_camofox import (
     camofox_vision,
     check_camofox_available,
     is_camofox_mode,
+    _loopback_rewrite_remediation,
     _rewrite_loopback_url_for_camofox,
 )
 
@@ -67,8 +70,17 @@ def _mock_response(status=200, json_data=None):
     resp.status_code = status
     resp.json.return_value = json_data or {}
     resp.content = b"\x89PNG\r\n\x1a\nfake"
+    resp.text = ""
     resp.raise_for_status = MagicMock()
     return resp
+
+
+def _mock_http_error(status=500, text=""):
+    resp = requests.Response()
+    resp.status_code = status
+    resp._content = text.encode("utf-8")
+    resp.url = "http://localhost:9377/tabs"
+    return requests.HTTPError(f"{status} Server Error", response=resp)
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +141,39 @@ class TestCamofoxLoopbackRewrite:
         assert metadata["from"] == "::1"
         assert metadata["to"] == "192.168.1.10"
 
+    @patch("tools.browser_camofox.load_config")
+    def test_loopback_refused_error_suggests_docker_rewrite(self, mock_config, monkeypatch):
+        monkeypatch.delenv("CAMOFOX_REWRITE_LOOPBACK_URLS", raising=False)
+        monkeypatch.delenv("CAMOFOX_LOOPBACK_HOST_ALIAS", raising=False)
+        mock_config.return_value = _config_with_camofox(rewrite_loopback_urls=False)
+        error = _mock_http_error(text="page.goto: NS_ERROR_CONNECTION_REFUSED")
+
+        remediation = _loopback_rewrite_remediation("http://127.0.0.1:8765/", error)
+
+        assert remediation is not None
+        assert "Docker" in remediation["likely_cause"]
+        assert remediation["config"] == {
+            "browser.camofox.rewrite_loopback_urls": True,
+            "browser.camofox.loopback_host_alias": "host.docker.internal",
+        }
+        assert remediation["command"] == "hermes config set browser.camofox.rewrite_loopback_urls true"
+
+    @patch("tools.browser_camofox.load_config")
+    def test_loopback_refused_error_omits_hint_when_rewrite_enabled(self, mock_config, monkeypatch):
+        monkeypatch.delenv("CAMOFOX_REWRITE_LOOPBACK_URLS", raising=False)
+        mock_config.return_value = _config_with_camofox(rewrite_loopback_urls=True)
+        error = _mock_http_error(text="page.goto: NS_ERROR_CONNECTION_REFUSED")
+
+        assert _loopback_rewrite_remediation("http://127.0.0.1:8765/", error) is None
+
+    @patch("tools.browser_camofox.load_config")
+    def test_non_loopback_refused_error_omits_rewrite_hint(self, mock_config, monkeypatch):
+        monkeypatch.delenv("CAMOFOX_REWRITE_LOOPBACK_URLS", raising=False)
+        mock_config.return_value = _config_with_camofox(rewrite_loopback_urls=False)
+        error = _mock_http_error(text="page.goto: NS_ERROR_CONNECTION_REFUSED")
+
+        assert _loopback_rewrite_remediation("https://example.com/", error) is None
+
 
 class TestCamofoxNavigate:
     @patch("tools.browser_camofox.requests.post")
@@ -176,6 +221,22 @@ class TestCamofoxNavigate:
         result = json.loads(camofox_navigate("https://example.com", task_id="t_err"))
         assert result["success"] is False
         assert "Cannot connect" in result["error"]
+
+    @patch("tools.browser_camofox.load_config")
+    @patch("tools.browser_camofox.requests.post")
+    def test_loopback_http_error_returns_rewrite_troubleshooting(self, mock_post, mock_config, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        monkeypatch.delenv("CAMOFOX_REWRITE_LOOPBACK_URLS", raising=False)
+        mock_config.return_value = _config_with_camofox(rewrite_loopback_urls=False)
+        error = _mock_http_error(text="page.goto: NS_ERROR_CONNECTION_REFUSED")
+        mock_post.side_effect = error
+
+        result = json.loads(camofox_navigate("http://localhost:8765/", task_id="t_loopback_error"))
+
+        assert result["success"] is False
+        assert "Navigation failed" in result["error"]
+        assert result["troubleshooting"]["config"]["browser.camofox.rewrite_loopback_urls"] is True
+        assert "host.docker.internal" in result["troubleshooting"]["suggested_fix"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -246,6 +246,57 @@ def _rewrite_loopback_url_for_camofox(url: str) -> tuple[str, Optional[Dict[str,
     }
 
 
+def _loopback_rewrite_remediation(url: str, exc: BaseException) -> Optional[Dict[str, Any]]:
+    """Return Docker-loopback troubleshooting metadata for Camofox failures.
+
+    Camofox often runs in Docker while Hermes runs on the host. In that setup
+    ``http://127.0.0.1:<port>`` is valid for Hermes to reach the Camofox control
+    API, but it is not valid as a page URL opened by the browser inside the
+    container. When the server reports a browser-side connection refusal for a
+    loopback page URL and rewriting is disabled, surface the likely fix instead
+    of a bare HTTP 500.
+    """
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return None
+    if parsed.scheme not in {"http", "https"} or not _is_loopback_hostname(parsed.hostname):
+        return None
+
+    camofox_cfg = _get_camofox_config()
+    if _loopback_rewrite_enabled(camofox_cfg):
+        return None
+
+    response = getattr(exc, "response", None)
+    response_text = ""
+    if response is not None:
+        try:
+            response_text = response.text or ""
+        except Exception:
+            response_text = ""
+    lowered = response_text.lower()
+    if not any(token in lowered for token in ("ns_error_connection_refused", "connection_refused", "econnrefused")):
+        return None
+
+    alias = _loopback_rewrite_host(camofox_cfg)
+    return {
+        "likely_cause": (
+            "Camofox is running outside the host network, commonly in Docker. "
+            "The browser opened the page URL from inside that environment, so "
+            f"{parsed.hostname} pointed at Camofox itself instead of the host running the web app."
+        ),
+        "suggested_fix": (
+            "Enable Camofox loopback rewriting so localhost page URLs are opened "
+            f"as {alias} from inside the browser environment."
+        ),
+        "config": {
+            "browser.camofox.rewrite_loopback_urls": True,
+            "browser.camofox.loopback_host_alias": alias,
+        },
+        "command": "hermes config set browser.camofox.rewrite_loopback_urls true",
+    }
+
+
 # ---------------------------------------------------------------------------
 # Session management
 # ---------------------------------------------------------------------------
@@ -476,6 +527,13 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
 
         return json.dumps(result)
     except requests.HTTPError as e:
+        remediation = _loopback_rewrite_remediation(url, e)
+        if remediation:
+            return tool_error(
+                f"Navigation failed: {e}",
+                success=False,
+                troubleshooting=remediation,
+            )
         return tool_error(f"Navigation failed: {e}", success=False)
     except requests.ConnectionError:
         return json.dumps({


### PR DESCRIPTION
## Summary
- add a Camofox navigation troubleshooting payload for loopback page URLs that fail with browser-side connection refused
- explain the Docker loopback cause and provide the exact config fix
- cover the helper and navigate error path with tests

## Verification
- python -m py_compile tools/browser_camofox.py
- python -m pytest tests/tools/test_browser_camofox.py -q
- python -m pytest tests/tools/test_browser_camofox.py tests/tools/test_browser_ssrf_local.py tests/tools/test_browser_hardening.py -q
- live browser_navigate to http://127.0.0.1:8765/ with Docker Camofox rewrites to host.docker.internal and succeeds