### PR TITLE
fix(test): mock keychain lookup in anthropic oauth setup tests

### DIFF
--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -498,6 +498,13 @@ class TestRunOauthSetupToken:
         monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/claude")
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        # Keychain lookup calls subprocess.run internally — mock it out
+        # so the MagicMock from the patch("subprocess.run") context manager
+        # below doesn't leak into json.loads().
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
 
         # Pre-create credential files that will be found after subprocess
         cred_file = tmp_path / ".claude" / ".credentials.json"
@@ -528,6 +535,10 @@ class TestRunOauthSetupToken:
         monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "from-env-var")
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)
@@ -541,6 +552,10 @@ class TestRunOauthSetupToken:
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0)


### PR DESCRIPTION
## Problem

3 tests in `tests/agent/test_anthropic_adapter.py` fail on macOS:

```
FAILED TestRunOauthSetupToken::test_returns_token_from_credential_files
FAILED TestRunOauthSetupToken::test_returns_token_from_env_var
FAILED TestRunOauthSetupToken::test_returns_none_when_no_creds_found
```

All fail with:
```
TypeError: the JSON object must be str, bytes or bytearray, not MagicMock
```

## Root Cause

`_read_claude_code_credentials_from_keychain()` calls `subprocess.run` internally. The tests mock `subprocess.run` at the outer level via `patch("subprocess.run")`, but the MagicMock return value leaks into `json.loads()` inside the keychain helper.

This only manifests on **macOS** where keychain lookups are attempted. The upstream CI runs on Linux and skips the keychain path entirely, so it never hits this.

## Fix

`monkeypatch.setattr` the keychain helper to return `None` in the three affected tests, preventing the MagicMock from reaching `json.loads()`.

## Testing

```
Before: 3 FAILED, 150 passed
After:  153 passed
```