### PR TITLE
fix: quiet missing auxiliary provider probes

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1508,7 +1508,11 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
     if pool_present:
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
         if not or_key:
-            _mark_provider_unhealthy("openrouter", ttl=60)
+            # Missing credentials means OpenRouter is simply unavailable for
+            # this installation; do not mark it as a payment/credit failure.
+            # Explicit callers get a precise warning from
+            # resolve_provider_client(), while auto mode can quietly continue
+            # to the next configured provider.
             return None, None
         base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
         logger.debug("Auxiliary client: OpenRouter via pool")
@@ -1517,7 +1521,8 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
 
     or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
     if not or_key:
-        _mark_provider_unhealthy("openrouter", ttl=60)
+        # Missing credentials means OpenRouter is simply unavailable for this
+        # installation; do not mark it as a payment/credit failure.
         return None, None
     logger.debug("Auxiliary client: OpenRouter")
     return OpenAI(api_key=or_key, base_url=OPENROUTER_BASE_URL,
@@ -1557,11 +1562,9 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
     nous = _read_nous_auth()
     runtime = _resolve_nous_runtime_api(force_refresh=False)
     if runtime is None and not nous:
-        logger.warning(
-            "Auxiliary Nous client unavailable: no Nous authentication found "
-            "(run: hermes auth)."
+        logger.debug(
+            "Auxiliary Nous client unavailable: no Nous authentication found."
         )
-        _mark_provider_unhealthy("nous", ttl=60)
         return None, None
     if runtime is None and nous:
         logger.debug(
@@ -3061,7 +3064,8 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
         tried.append(label)
     logger.warning("Auxiliary auto-detect: no provider available (tried: %s). "
                    "Compression, summarization, and memory flush will not work. "
-                   "Set OPENROUTER_API_KEY or configure a local model in config.yaml.",
+                   "Configure auxiliary.<task>.provider (for example, gemini) "
+                   "or set a supported provider credential.",
                    ", ".join(tried))
     return None, None
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -681,13 +681,10 @@ class TestExpiredCodexFallback:
         import base64
         import time as _time
 
-        # Belt-and-suspenders: _try_openrouter marks openrouter unhealthy
-        # when OPENROUTER_API_KEY is absent (which the preceding test in
-        # this class exercises).  The file-level _clean_env autouse fixture
-        # clears the cache, but fixture ordering with the conftest
-        # _hermetic_environment autouse can leave a narrow window where
-        # the mark reappears.  Explicitly clear here so this test is
-        # independent of run order.
+        # Clear the process-local unhealthy cache so this test is independent
+        # of any previous provider-fallback test. Missing OpenRouter
+        # credentials no longer mark the provider as a payment failure, but
+        # real 402/rate-limit tests still can.
         import agent.auxiliary_client as _aux_mod
         _aux_mod._aux_unhealthy_until.clear()
         _aux_mod._aux_unhealthy_logged_at.clear()
@@ -860,6 +857,20 @@ class TestExplicitProviderRouting:
             "OPENROUTER_API_KEY not set" in record.message
             for record in caplog.records
         )
+
+    def test_missing_openrouter_credentials_do_not_mark_payment_unhealthy(self, monkeypatch, caplog):
+        """Absent OpenRouter credentials are not a billing/credit failure."""
+        import agent.auxiliary_client as aux
+
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        aux._reset_aux_unhealthy_cache()
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+                client, model = aux._try_openrouter()
+        assert client is None
+        assert model is None
+        assert not aux._is_provider_unhealthy("openrouter")
+        assert not any("payment / credit error" in record.message for record in caplog.records)
 
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""


### PR DESCRIPTION
## Summary

Avoid marking OpenRouter or Nous auxiliary providers as unhealthy when credentials are simply absent.

## Why

Missing credentials are configuration state, not a payment or credit failure. Marking the provider unhealthy can make auto-detection noisier and less predictable across later auxiliary calls. Explicit provider resolution still reports the missing credential clearly.

## Validation

`/home/hopewell/.hermes/hermes-agent/venv/bin/pytest tests/agent/test_auxiliary_client.py`

Result: `192 passed, 1 warning`
