### PR TITLE
fix(tools): narrow /private/var/ sensitive prefix to avoid blocking macOS TMPDIR

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -169,7 +169,17 @@ def _is_blocked_device(filepath: str) -> bool:
 # terminal tool's approval system.  These match prefixes after os.path.realpath.
 _SENSITIVE_PATH_PREFIXES = (
     "/etc/", "/boot/", "/usr/lib/systemd/",
-    "/private/etc/", "/private/var/",
+    "/private/etc/",
+    # On macOS /var is a symlink to /private/var, so realpath() expands it.
+    # /private/var/ as a blanket prefix blocks TMPDIR which lives under
+    # /private/var/folders/ on every macOS box.  List the specific system
+    # sub-trees instead.
+    "/private/var/db/", "/private/var/audit/", "/private/var/log/",
+    "/private/var/lib/", "/private/var/backups/",
+    "/private/var/at/", "/private/var/root/",
+    # Corresponding /var/ prefixes (before symlink resolution).
+    "/var/db/", "/var/audit/", "/var/log/", "/var/lib/",
+    "/var/backups/", "/var/at/", "/var/root/",
 )
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 


### PR DESCRIPTION
## Problem

On macOS, 7 tests in `test_cross_profile_guard.py` fail because `_SENSITIVE_PATH_PREFIXES` contains the blanket prefix `/private/var/`, which matches TMPDIR (`/private/var/folders/...`):

```
FAILED TestWriteFileCrossProfileGuard::test_in_profile_write_allowed
FAILED TestWriteFileCrossProfileGuard::test_cross_profile_write_blocked_by_default
FAILED TestWriteFileCrossProfileGuard::test_cross_profile_True_bypass
FAILED TestWriteFileCrossProfileGuard::test_non_hermes_path_unaffected
FAILED TestPatchCrossProfileGuard::test_cross_profile_patch_blocked
FAILED TestPatchCrossProfileGuard::test_cross_profile_patch_bypass
FAILED TestPatchCrossProfileGuard::test_v4a_patch_extracts_path_for_guard
```

This also affects real usage on macOS — any write to a path that resolves through `/private/var/` (e.g. temp directories) is rejected by `_check_sensitive_path`.

## Root Cause

On macOS, `/var` is a symlink to `/private/var`. `os.path.realpath()` expands it, so any path under TMPDIR (`/private/var/folders/...`) matches the `/private/var/` prefix. The upstream CI runs on Linux where `/var` is a real directory, so this never triggers.

## Fix

Replace the blanket `/private/var/` prefix with 7 specific system sub-trees that actually contain sensitive data:

- `/private/var/db/` — system databases (OpenDirectory, etc.)
- `/private/var/audit/` — audit logs
- `/private/var/log/` — system logs
- `/private/var/lib/` — system state
- `/private/var/backups/` — system backups
- `/private/var/at/` — at/atrm job spool
- `/private/var/root/` — root user home

Also add corresponding `/var/` prefixes for paths before symlink resolution.

Excluded paths (`/private/var/folders/`, `/private/var/tmp/`) do not contain sensitive system data.

## Testing

```
Before (macOS): 7 FAILED in test_cross_profile_guard
After:          12 passed (cross_profile) + 274 passed (all file_safety tests)
```