### PR TITLE
docs: clarify compression threshold is derived from the main model's context window

### DIFF
--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -111,6 +111,17 @@ tail_token_budget    = 100,000 × 0.20 = 20,000
 max_summary_tokens   = min(200,000 × 0.05, 12,000) = 10,000
 ```
 
+:::note Threshold is derived from the MAIN model's context window
+`threshold_tokens` is always `threshold × context_length`, where `context_length`
+is the **main agent model's** context window — never the auxiliary/summary
+model's. On a 262,144-token model at the default `0.50`, the threshold is
+`262,144 × 0.50 = 131,072`. That number being close to a common "128K context"
+is a coincidence of the percentage, not a sign that the auxiliary model's window
+is the trigger. The auxiliary model's context window is a separate concern — see
+the "Summary model context length" warning below for how it affects whether a
+summary can be produced, not when compression fires.
+:::
+
 
 ## Compression Algorithm
 


### PR DESCRIPTION
## Summary
Clarifies that the compression threshold is derived from the **main agent model's** context window, not the auxiliary/summary model's — preempting a recurring misreading where the 131,072 default looks like an auxiliary "128K context" limit.

## Changes
- `website/docs/developer-guide/context-compression-and-caching.md`: adds a `:::note` after the worked example explaining that `threshold_tokens = threshold × context_length` always uses the main model's window. On a 262,144-token model at the default `0.50`, the threshold is `131,072` — close to a common 128K figure by coincidence of the percentage, not because the auxiliary model's window is the trigger. Points to the existing "Summary model context length" warning for the separate concern of whether a summary can be produced.

## Why
A support thread surfaced the confusion: a user saw `Preflight compression: ~144,669 tokens >= 131,072 threshold` and was told 131,072 was their auxiliary model's context limit. It isn't — it's `0.50 × 262,144`. The docs already computed the threshold correctly but didn't preempt the misread; this note does.

## Validation
Docs-only `.md` change. Admonition syntax matches the existing `:::warning` block in the same file; marker pairs verified balanced.

## Infographic

![compression-threshold-source](https://v3b.fal.media/files/b/0a9c3ae8/QLQDlN_DBRfOOO-8pToCh_Y2STdImZ.png)
