### PR TITLE
fix(cron): surface media attachment delivery failures

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -567,18 +567,23 @@ def _send_media_via_adapter(
     loop,
     job: dict,
     platform=None,
-) -> None:
+) -> list[str]:
     """Send extracted MEDIA files as native platform attachments via a live adapter.
 
     Routes each file to the appropriate adapter method (send_voice, send_image_file,
     send_video, send_document) based on file extension — mirroring the routing logic
     in ``BasePlatformAdapter._process_message_background``.
+
+    Returns a list of per-attachment delivery errors.  Callers use this to avoid
+    marking cron delivery as successful when text delivery succeeded but a native
+    media attachment failed.
     """
     from pathlib import Path
 
     from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
 
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    delivery_errors: list[str] = []
 
     for media_path, _is_voice in media_files:
         try:
@@ -596,23 +601,31 @@ def _send_media_via_adapter(
             from agent.async_utils import safe_schedule_threadsafe
             future = safe_schedule_threadsafe(coro, loop)
             if future is None:
+                msg = f"cannot send media {media_path}, gateway loop unavailable"
                 logger.warning(
                     "Job '%s': cannot send media %s, gateway loop unavailable",
                     job.get("id", "?"), media_path,
                 )
-                return
+                delivery_errors.append(msg)
+                continue
             try:
                 result = future.result(timeout=30)
             except TimeoutError:
                 future.cancel()
                 raise
             if result and not getattr(result, "success", True):
+                err = getattr(result, "error", "unknown")
+                msg = f"media send failed for {media_path}: {err}"
                 logger.warning(
                     "Job '%s': media send failed for %s: %s",
-                    job.get("id", "?"), media_path, getattr(result, "error", "unknown"),
+                    job.get("id", "?"), media_path, err,
                 )
+                delivery_errors.append(msg)
         except Exception as e:
+            delivery_errors.append(f"failed to send media {media_path}: {e}")
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
+
+    return delivery_errors
 
 
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
@@ -756,9 +769,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             logger.warning("Job '%s': %s", job["id"], msg)
                             delivery_errors.append(msg)
 
-                # Send extracted media files as native attachments via the live adapter
+                # Send extracted media files as native attachments via the live adapter.
+                # A failed attachment means cron delivery is only partial: do not fall
+                # back to the standalone path after text may already have been sent
+                # (that risks duplicating the text), but do surface the failure so the
+                # run is not marked clean.
+                media_delivery_errors = []
                 if adapter_ok and media_files:
-                    _send_media_via_adapter(
+                    media_delivery_errors = _send_media_via_adapter(
                         runtime_adapter,
                         chat_id,
                         media_files,
@@ -767,8 +785,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         job,
                         platform=platform,
                     )
+                    if media_delivery_errors:
+                        delivery_errors.extend(media_delivery_errors)
+                        logger.warning(
+                            "Job '%s': live adapter delivery to %s:%s had media attachment failure(s): %s",
+                            job["id"], platform_name, chat_id, "; ".join(media_delivery_errors),
+                        )
+                        delivered = True
 
-                if adapter_ok:
+                if adapter_ok and not media_delivery_errors:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     delivered = True
             except Exception as e:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -701,6 +701,65 @@ class TestDeliverResultWrapping:
         assert adapter.send_image_file.call_args[1]["image_path"] == str(media_path)
         adapter.send_voice.assert_not_called()
 
+    def test_live_adapter_media_failure_returns_delivery_error_without_false_success(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """A failed live-adapter MEDIA attachment must surface as a cron
+        delivery error instead of being logged as a clean delivery.
+        """
+        from gateway.config import Platform
+        from concurrent.futures import Future
+        media_path = self._safe_media_path(tmp_path, monkeypatch, "chart.png")
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+        adapter.send_image_file.return_value = MagicMock(success=False, error="Connection Closed")
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.WHATSAPP: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        text_future = Future()
+        text_future.set_result(MagicMock(success=True))
+        media_future = Future()
+        media_future.set_result(MagicMock(success=False, error="Connection Closed"))
+        futures_iter = iter([text_future, media_future])
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return next(futures_iter)
+
+        job = {
+            "id": "comic-job",
+            "deliver": "origin",
+            "origin": {"platform": "whatsapp", "chat_id": "123@s.whatsapp.net"},
+        }
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        caplog.set_level(logging.INFO, logger="cron.scheduler")
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            result = _deliver_result(
+                job,
+                f"Comic ready\nMEDIA:{media_path}",
+                adapters={Platform.WHATSAPP: adapter},
+                loop=loop,
+            )
+
+        assert result == f"media send failed for {media_path}: Connection Closed"
+        adapter.send_image_file.assert_called_once()
+        standalone_send.assert_not_awaited()
+        assert not any(
+            "Job 'comic-job': delivered to whatsapp:123@s.whatsapp.net via live adapter" in r.message
+            for r in caplog.records
+        )
+
     def test_live_adapter_media_only_no_text(self, tmp_path, monkeypatch):
         """When content is ONLY a MEDIA tag with no text, media should still be sent."""
         from gateway.config import Platform
@@ -2281,6 +2340,34 @@ class TestSendMediaViaAdapter:
         media_files = [(str(voice_path), False), (str(photo_path), False)]
         self._run_with_loop(adapter, "123", media_files, None, {"id": "j3"})
         adapter.send_voice.assert_called_once()
+        adapter.send_image_file.assert_called_once()
+
+    def test_media_failure_returned_to_caller(self, tmp_path, monkeypatch):
+        from concurrent.futures import Future
+
+        adapter = MagicMock()
+        adapter.send_image_file = AsyncMock()
+        media_path = self._safe_media_path(tmp_path, monkeypatch, "photo.png")
+        media_files = [(str(media_path), False)]
+
+        failed_future = Future()
+        failed_future.set_result(MagicMock(success=False, error="Connection Closed"))
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return failed_future
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            errors = _send_media_via_adapter(
+                adapter,
+                "123",
+                media_files,
+                None,
+                MagicMock(),
+                {"id": "j4"},
+            )
+
+        assert errors == [f"media send failed for {media_path}: Connection Closed"]
         adapter.send_image_file.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- return per-attachment errors from live cron MEDIA delivery
- treat live-adapter media attachment failures as delivery errors instead of clean success
- avoid standalone fallback after text may already have been sent, preventing duplicate text on partial media failure
- add regression tests for failed MEDIA delivery and error propagation

## Verification
- python -m py_compile cron/scheduler.py
- python -m pytest tests/cron/test_scheduler.py -q
- python -m pytest tests/cron -q

## Context
A cron job that returned a valid `MEDIA:/path` image could log a native media send failure, e.g. a transient WhatsApp bridge `Connection Closed`, but still report `delivered ... via live adapter` and leave the run looking green. This PR makes those attachment failures visible to cron delivery status.
