### PR TITLE
fix(session): survive, prevent, and explain missing SQLite FTS5

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -380,6 +380,7 @@ class SessionDB:
 
         self._lock = threading.Lock()
         self._write_count = 0
+        self._fts_enabled = False
         try:
             self._conn = sqlite3.connect(
                 str(self.db_path),
@@ -388,7 +389,6 @@ class SessionDB:
                 # handles contention instead of sitting in SQLite's internal
                 # busy handler for up to 30s.
                 timeout=1.0,
-                # Autocommit mode: Python's default isolation_level=""
                 # auto-starts transactions on DML, which conflicts with our
                 # explicit BEGIN IMMEDIATE.  None = we manage transactions
                 # ourselves.
@@ -724,8 +724,22 @@ class SessionDB:
         # FTS5 setup (separate because CREATE VIRTUAL TABLE can't be in executescript with IF NOT EXISTS reliably)
         try:
             cursor.execute("SELECT * FROM messages_fts LIMIT 0")
-        except sqlite3.OperationalError:
-            cursor.executescript(FTS_SQL)
+            self._fts_enabled = True
+        except sqlite3.OperationalError as exc:
+            if "no such table" not in str(exc).lower():
+                raise
+            try:
+                cursor.executescript(FTS_SQL)
+                self._fts_enabled = True
+            except sqlite3.OperationalError as fts_exc:
+                err = str(fts_exc).lower()
+                if "fts5" not in err and "no such module" not in err:
+                    raise
+                logger.warning(
+                    "SQLite FTS5 unavailable for %s; full-text search disabled: %s",
+                    self.db_path,
+                    fts_exc,
+                )
 
         # Trigram FTS5 for CJK/substring search
         try:
@@ -2317,6 +2331,9 @@ class SessionDB:
         ignores ``sort``. The trigram CJK path honours ``sort`` like the main
         FTS5 path.
         """
+        if not self._fts_enabled:
+            return []
+
         if not query or not query.strip():
             return []
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -744,8 +744,18 @@ class SessionDB:
         # Trigram FTS5 for CJK/substring search
         try:
             cursor.execute("SELECT * FROM messages_fts_trigram LIMIT 0")
-        except sqlite3.OperationalError:
-            cursor.executescript(FTS_TRIGRAM_SQL)
+        except sqlite3.OperationalError as exc:
+            if "no such table" not in str(exc).lower():
+                raise
+            try:
+                cursor.executescript(FTS_TRIGRAM_SQL)
+            except sqlite3.OperationalError as fts_exc:
+                err = str(fts_exc).lower()
+                if "fts5" not in err and "no such module" not in err:
+                    raise
+                # Same FTS5-unavailable cause already warned about above for
+                # messages_fts; the trigram table is an additional CJK index,
+                # so just degrade silently here. CJK search falls back to LIKE.
 
         self._conn.commit()
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -736,7 +736,13 @@ class SessionDB:
                 if "fts5" not in err and "no such module" not in err:
                     raise
                 logger.warning(
-                    "SQLite FTS5 unavailable for %s; full-text search disabled: %s",
+                    "SQLite FTS5 unavailable for %s; full-text session search "
+                    "disabled. This usually means Hermes is running on an "
+                    "unsupported install (e.g. a pip-installed or pip-managed "
+                    "Python whose bundled SQLite lacks FTS5) rather than a "
+                    "mainline install. Some features may be missing or behave "
+                    "differently. Install the supported way: "
+                    "https://hermes-agent.nousresearch.com (underlying error: %s)",
                     self.db_path,
                     fts_exc,
                 )

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -473,6 +473,7 @@ check_python() {
     if PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_VERSION" 2>/dev/null)"; then
         PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
         log_success "Python found: $PYTHON_FOUND_VERSION"
+        ensure_fts5
         return 0
     fi
 
@@ -482,10 +483,56 @@ check_python() {
         PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_VERSION")"
         PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
         log_success "Python installed: $PYTHON_FOUND_VERSION"
+        ensure_fts5
     else
         log_error "Failed to install Python $PYTHON_VERSION"
         log_info "Install Python $PYTHON_VERSION manually, then re-run this script"
         exit 1
+    fi
+}
+
+# Probe whether $1 (a python executable) links a SQLite with the FTS5
+# module compiled in. Hermes' session store (hermes_state.py) creates FTS5
+# virtual tables for full-text session search; a SQLite without FTS5 makes
+# the bundled-python path unusable for that feature. Returns 0 if FTS5 works.
+_python_has_fts5() {
+    "$1" - <<'PY' 2>/dev/null
+import sqlite3, sys
+try:
+    sqlite3.connect(":memory:").execute("CREATE VIRTUAL TABLE t USING fts5(x)")
+except Exception:
+    sys.exit(1)
+PY
+}
+
+# Guarantee the resolved uv-managed interpreter ships FTS5. uv's Python
+# distributions only gained FTS5 in mid-2025 (python-build-standalone #694),
+# so a stale interpreter already in uv's store — which `uv python find`
+# happily reuses — can lack it. When that happens, force a reinstall of the
+# latest patch for $PYTHON_VERSION (which has FTS5) and re-resolve. This keeps
+# the supported install path's session search working without bundling a
+# second SQLite or asking the user to do anything.
+ensure_fts5() {
+    [ -n "${PYTHON_PATH:-}" ] || return 0
+    if _python_has_fts5 "$PYTHON_PATH"; then
+        return 0
+    fi
+
+    log_warn "Resolved Python's SQLite lacks the FTS5 module (session search needs it)."
+    log_info "Reinstalling a current Python $PYTHON_VERSION with FTS5 via uv..."
+    if "$UV_CMD" python install "$PYTHON_VERSION" --reinstall >/dev/null 2>&1; then
+        PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_VERSION" 2>/dev/null)"
+        PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
+    fi
+
+    if [ -n "${PYTHON_PATH:-}" ] && _python_has_fts5 "$PYTHON_PATH"; then
+        log_success "FTS5 available ($PYTHON_FOUND_VERSION)"
+    else
+        # Could not obtain an FTS5-capable interpreter (offline, pinned env,
+        # etc.). Install proceeds — Hermes degrades gracefully and disables
+        # only full-text session search — but warn so it isn't a silent gap.
+        log_warn "Could not obtain an FTS5-capable Python. Hermes will run, but"
+        log_warn "full-text session search will be disabled until FTS5 is present."
     fi
 }
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -11,12 +11,16 @@ class _NoFtsCursor(sqlite3.Cursor):
     """Simulate a SQLite build without the fts5 module."""
 
     def execute(self, sql, parameters=()):
-        if sql.strip() == "SELECT * FROM messages_fts LIMIT 0":
-            raise sqlite3.OperationalError("no such table: messages_fts")
+        probe = sql.strip()
+        if probe in (
+            "SELECT * FROM messages_fts LIMIT 0",
+            "SELECT * FROM messages_fts_trigram LIMIT 0",
+        ):
+            raise sqlite3.OperationalError("no such table: " + probe.split()[-3])
         return super().execute(sql, parameters)
 
     def executescript(self, sql_script):
-        if "CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5" in sql_script:
+        if "USING fts5" in sql_script:
             raise sqlite3.OperationalError("no such module: fts5")
         return super().executescript(sql_script)
 
@@ -167,6 +171,10 @@ class TestSessionLifecycle:
         db = SessionDB(db_path=tmp_path / "state.db")
         try:
             assert db._fts_enabled is False
+            # Neither FTS5 virtual table should have been created on a build
+            # that lacks the fts5 module — both init paths must degrade.
+            assert db._fts_table_exists("messages_fts") is False
+            assert db._fts_table_exists("messages_fts_trigram") is False
 
             db.create_session(session_id="s1", source="cli")
             db.append_message("s1", role="user", content="hello from sqlite without fts")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,9 +1,29 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import sqlite3
 import time
 import pytest
 
 from hermes_state import SessionDB
+
+
+class _NoFtsCursor(sqlite3.Cursor):
+    """Simulate a SQLite build without the fts5 module."""
+
+    def execute(self, sql, parameters=()):
+        if sql.strip() == "SELECT * FROM messages_fts LIMIT 0":
+            raise sqlite3.OperationalError("no such table: messages_fts")
+        return super().execute(sql, parameters)
+
+    def executescript(self, sql_script):
+        if "CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5" in sql_script:
+            raise sqlite3.OperationalError("no such module: fts5")
+        return super().executescript(sql_script)
+
+
+class _NoFtsConnection(sqlite3.Connection):
+    def cursor(self, factory=None):
+        return super().cursor(factory or _NoFtsCursor)
 
 
 @pytest.fixture()
@@ -134,6 +154,29 @@ class TestSessionLifecycle:
 
         child = db.get_session("child")
         assert child["parent_session_id"] == "parent"
+
+    def test_db_initializes_without_fts5_module(self, tmp_path, monkeypatch):
+        real_connect = sqlite3.connect
+
+        def connect_without_fts(*args, **kwargs):
+            kwargs["factory"] = _NoFtsConnection
+            return real_connect(*args, **kwargs)
+
+        monkeypatch.setattr("hermes_state.sqlite3.connect", connect_without_fts)
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            assert db._fts_enabled is False
+
+            db.create_session(session_id="s1", source="cli")
+            db.append_message("s1", role="user", content="hello from sqlite without fts")
+
+            messages = db.get_messages("s1")
+            assert len(messages) == 1
+            assert messages[0]["content"] == "hello from sqlite without fts"
+            assert db.search_messages("hello") == []
+        finally:
+            db.close()
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary
Hermes no longer dies with `Could not open session database: no such module: fts5` on installs whose bundled SQLite lacks FTS5, and the supported installer now guarantees an FTS5-capable Python so it doesn't happen in the first place.

Three layers:
1. **Survive it** — `SessionDB` opens without FTS5, keeping session/message persistence and disabling only full-text search.
2. **Prevent it** — `install.sh` probes the resolved uv-managed Python for FTS5 and reinstalls a current build if a stale one lacks it.
3. **Explain it** — when FTS5 is genuinely missing at runtime, the warning names the likely cause (unsupported / pip-managed Python) and links the supported install.

Supersedes #10972 — includes @LeonSGP43's graceful-degradation commit (authorship preserved) plus follow-ups. Fixes #10897.

## Root cause
`SessionDB.__init__` unconditionally runs `CREATE VIRTUAL TABLE ... USING fts5(...)`. SQLite builds compiled without the FTS5 module raise `OperationalError: no such module: fts5`, which propagated out of `__init__` and took down the entire session store. uv's python-build-standalone distributions only gained FTS5 in mid-2025 (astral-sh/python-build-standalone#694), so a stale interpreter already in uv's store — which `uv python find` reuses without checking — can ship a SQLite 3.49.x without FTS5.

## Changes
- `hermes_state.py`: `_fts_enabled` flag; guard both `messages_fts` and the `messages_fts_trigram` CJK index so an FTS5-unavailable error degrades (one warning) instead of raising. `search_messages()` early-returns `[]` when disabled. Warning now points at the supported install.
- `scripts/install.sh`: `_python_has_fts5()` probe + `ensure_fts5()` — after `check_python` resolves an interpreter, verify FTS5; if missing, `uv python install <ver> --reinstall` and re-resolve. Warns and continues if an FTS5 build still can't be obtained (offline / pinned env).
- `tests/test_hermes_state.py`: regression test simulating a no-FTS5 SQLite runtime; mock fails **both** virtual tables so the test exercises a faithful no-FTS5 build.

## Validation
| | Before | After |
|---|---|---|
| Init on no-FTS5 build | `OperationalError` (DB unusable) | opens, `_fts_enabled=False`, one actionable warning |
| Session/message persistence | dead | works |
| `search_messages()` (no FTS5) | n/a | `[]` |
| `optimize_fts()` (no FTS5) | n/a | safe no-op |
| Normal FTS5 build | works | unchanged (`_fts_enabled=True`, search hits) |
| Supported install w/ stale Python | silently no FTS5 | reinstalls to an FTS5 build |

Installer probe verified both ways against real interpreters (true-positive on FTS5 python, true-negative on a simulated no-FTS5 one); runtime path E2E-verified with real imports; targeted tests 4/4.

Closes #10897. Supersedes #10972.



## Infographic

![sqlite-fts5-survive-prevent-explain](https://v3b.fal.media/files/b/0a9c3bbe/Wedg6Pf24XQzISUe7lkae_IiGoaLqD.png)
