### PR TITLE
fix(kanban): rebuild tables with TEXT PK to INTEGER AUTOINCREMENT on open

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1637,6 +1637,181 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             (new, old),
         )
 
+    # One-shot schema rebuild: detect tables whose column types don't
+    # match the current SCHEMA_SQL definitions (e.g. ``TEXT PRIMARY KEY``
+    # instead of ``INTEGER PRIMARY KEY AUTOINCREMENT``) and rebuild them
+    # in-place, preserving existing data.  ``CREATE TABLE IF NOT EXISTS``
+    # silently skips tables that already exist regardless of schema
+    # correctness, and ``_add_column_if_missing`` only adds columns —
+    # neither mechanism can fix type/constraint mismatches.
+    #
+    # Affected tables (introduced between releases):
+    #   task_events.id        TEXT → INTEGER AUTOINCREMENT
+    #   task_comments.id      TEXT → INTEGER AUTOINCREMENT
+    #   task_runs.id          TEXT → INTEGER AUTOINCREMENT
+    #   kanban_notify_subs.last_event_id  TEXT (no default) → INTEGER NOT NULL DEFAULT 0
+    #
+    # See: https://github.com/NousResearch/hermes-agent/issues/35096
+    _migrate_autoincrement_schema(conn)
+
+
+def _migrate_autoincrement_schema(conn: sqlite3.Connection) -> None:
+    """Rebuild tables whose PK or column types drifted from SCHEMA_SQL.
+
+    Older releases defined ``task_events``, ``task_comments``, and
+    ``task_runs`` with ``TEXT PRIMARY KEY``.  The current schema uses
+    ``INTEGER PRIMARY KEY AUTOINCREMENT``.  ``CREATE TABLE IF NOT EXISTS``
+    cannot fix this because it silently skips existing tables.
+
+    Similarly, ``kanban_notify_subs.last_event_id`` was originally
+    ``TEXT`` with no default; new rows get ``NULL`` which crashes
+    ``int(row["last_event_id"])`` in ``unseen_events_for_sub()``.
+
+    This function detects the mismatch via ``PRAGMA table_info`` and
+    rebuilds each affected table using the standard SQLite migration
+    pattern: CREATE new → INSERT SELECT → DROP old → RENAME new.
+    """
+
+    # -- task_events, task_comments, task_runs: TEXT id → INTEGER AUTOINCREMENT --
+    _AUTOINCREMENT_TABLES = {
+        "task_events": (
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "task_id TEXT NOT NULL, "
+            "run_id INTEGER, "
+            "kind TEXT NOT NULL, "
+            "payload TEXT, "
+            "created_at INTEGER NOT NULL"
+        ),
+        "task_comments": (
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "task_id TEXT NOT NULL, "
+            "author TEXT NOT NULL, "
+            "body TEXT NOT NULL, "
+            "created_at INTEGER NOT NULL"
+        ),
+        "task_runs": (
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "task_id TEXT NOT NULL, "
+            "profile TEXT, "
+            "step_key TEXT, "
+            "status TEXT NOT NULL, "
+            "claim_lock TEXT, "
+            "claim_expires INTEGER, "
+            "worker_pid INTEGER, "
+            "max_runtime_seconds INTEGER, "
+            "last_heartbeat_at INTEGER, "
+            "started_at INTEGER NOT NULL, "
+            "ended_at INTEGER, "
+            "outcome TEXT, "
+            "summary TEXT, "
+            "metadata TEXT, "
+            "error TEXT"
+        ),
+    }
+
+    for table_name, new_columns_ddl in _AUTOINCREMENT_TABLES.items():
+        exists = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table_name,),
+        ).fetchone() is not None
+        if not exists:
+            continue
+
+        col_info = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+        id_col = next((c for c in col_info if c["name"] == "id"), None)
+        if id_col is None:
+            continue
+
+        # Check if id is already INTEGER AUTOINCREMENT
+        col_type = (id_col["type"] or "").upper()
+        pk = id_col["pk"]
+        if col_type == "INTEGER" and pk == 1:
+            continue  # already correct
+
+        # Rebuild the table
+        _log.info(
+            "kanban migration: rebuilding %s (id type=%r, pk=%d → INTEGER AUTOINCREMENT)",
+            table_name, col_type, pk,
+        )
+        old_cols = [c["name"] for c in col_info]
+        old_cols_str = ", ".join(old_cols)
+
+        # Collect existing column names from the new schema to build the
+        # INSERT INTO ... SELECT mapping.  For columns that exist in the
+        # old table but not in the new schema (shouldn't happen for these
+        # specific tables), they are silently dropped.
+        new_col_names = [
+            line.strip().split()[0]
+            for line in new_columns_ddl.split(",")
+            if line.strip()
+        ]
+        # Use only columns present in both old and new schemas, excluding
+        # ``id`` which will be auto-assigned by AUTOINCREMENT.  Old TEXT
+        # IDs (e.g. "event-1") are not valid INTEGER values.
+        select_cols = [c for c in old_cols if c in set(new_col_names) and c != "id"]
+        select_str = ", ".join(select_cols)
+        insert_str = ", ".join(select_cols)
+
+        tmp_name = f"{table_name}_migration_tmp"
+        conn.execute(f"DROP TABLE IF EXISTS {tmp_name}")
+        conn.execute(f"CREATE TABLE {tmp_name} ({new_columns_ddl})")
+        conn.execute(
+            f"INSERT INTO {tmp_name} ({insert_str}) SELECT {select_str} FROM {table_name}"
+        )
+        conn.execute(f"DROP TABLE {table_name}")
+        conn.execute(f"ALTER TABLE {tmp_name} RENAME TO {table_name}")
+
+    # -- kanban_notify_subs.last_event_id: TEXT → INTEGER NOT NULL DEFAULT 0 --
+    notify_exists = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_notify_subs'"
+    ).fetchone() is not None
+    if not notify_exists:
+        return
+
+    notify_cols = {
+        row["name"]: row
+        for row in conn.execute("PRAGMA table_info(kanban_notify_subs)")
+    }
+    lei = notify_cols.get("last_event_id")
+    if lei is None:
+        return
+
+    lei_type = (lei["type"] or "").upper()
+    if lei_type == "INTEGER":
+        return  # already correct
+
+    _log.info(
+        "kanban migration: rebuilding kanban_notify_subs.last_event_id (type=%r → INTEGER)",
+        lei_type,
+    )
+    # Full column list matches SCHEMA_SQL exactly
+    notify_new_ddl = (
+        "task_id TEXT NOT NULL, "
+        "platform TEXT NOT NULL, "
+        "chat_id TEXT NOT NULL, "
+        "thread_id TEXT NOT NULL DEFAULT '', "
+        "user_id TEXT, "
+        "notifier_profile TEXT, "
+        "created_at INTEGER NOT NULL, "
+        "last_event_id INTEGER NOT NULL DEFAULT 0, "
+        "PRIMARY KEY (task_id, platform, chat_id, thread_id)"
+    )
+    tmp_name = "kanban_notify_subs_migration_tmp"
+    conn.execute(f"DROP TABLE IF EXISTS {tmp_name}")
+    conn.execute(f"CREATE TABLE {tmp_name} ({notify_new_ddl})")
+    old_cols_str = "task_id, platform, chat_id, thread_id, user_id, created_at"
+    # Include notifier_profile if it exists (added by earlier migration)
+    if "notifier_profile" in notify_cols:
+        old_cols_str += ", notifier_profile"
+    # For last_event_id: cast old TEXT values to INTEGER, defaulting NULL/empty to 0
+    conn.execute(
+        f"INSERT INTO {tmp_name} ({old_cols_str}, last_event_id) "
+        f"SELECT {old_cols_str}, COALESCE(CAST(last_event_id AS INTEGER), 0) "
+        f"FROM kanban_notify_subs"
+    )
+    conn.execute("DROP TABLE kanban_notify_subs")
+    conn.execute(f"ALTER TABLE {tmp_name} RENAME TO kanban_notify_subs")
+
 
 def _check_file_length_invariant(conn: sqlite3.Connection) -> None:
     """Read the SQLite header page_count and compare against actual file size.

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 import threading
 from pathlib import Path
 
@@ -36,3 +37,232 @@ def test_connect_initialization_is_thread_safe(tmp_path, monkeypatch):
     with kb.connect(board="default") as conn:
         cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
     assert "max_retries" in cols
+
+
+def _create_legacy_db(path: Path) -> None:
+    """Create a kanban DB with the old TEXT PRIMARY KEY schema."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript("""
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            body TEXT,
+            status TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0,
+            assignee TEXT,
+            parent_id TEXT,
+            created_at INTEGER NOT NULL,
+            claim_lock TEXT,
+            claim_expires INTEGER,
+            started_at INTEGER
+        );
+        CREATE TABLE task_links (
+            parent_id TEXT NOT NULL,
+            child_id TEXT NOT NULL,
+            PRIMARY KEY (parent_id, child_id)
+        );
+        CREATE TABLE task_comments (
+            id TEXT PRIMARY KEY,
+            task_id TEXT NOT NULL,
+            author TEXT NOT NULL,
+            body TEXT NOT NULL,
+            created_at INTEGER NOT NULL
+        );
+        CREATE TABLE task_events (
+            id TEXT PRIMARY KEY,
+            task_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        );
+        CREATE TABLE task_runs (
+            id TEXT PRIMARY KEY,
+            task_id TEXT NOT NULL,
+            profile TEXT,
+            status TEXT NOT NULL,
+            claim_lock TEXT,
+            claim_expires INTEGER,
+            worker_pid INTEGER,
+            max_runtime_seconds INTEGER,
+            last_heartbeat_at INTEGER,
+            started_at INTEGER NOT NULL,
+            ended_at INTEGER,
+            outcome TEXT,
+            summary TEXT,
+            metadata TEXT,
+            error TEXT
+        );
+        CREATE TABLE kanban_notify_subs (
+            task_id TEXT NOT NULL,
+            platform TEXT NOT NULL,
+            chat_id TEXT NOT NULL,
+            thread_id TEXT NOT NULL DEFAULT '',
+            user_id TEXT,
+            created_at INTEGER NOT NULL,
+            last_event_id TEXT,
+            PRIMARY KEY (task_id, platform, chat_id, thread_id)
+        );
+    """)
+    # Insert sample data
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at) VALUES (?, ?, ?, ?)",
+        ("task-1", "Test task", "done", 1000),
+    )
+    conn.execute(
+        "INSERT INTO task_comments (id, task_id, author, body, created_at) VALUES (?, ?, ?, ?, ?)",
+        ("comment-1", "task-1", "agent", "hello", 1500),
+    )
+    conn.execute(
+        "INSERT INTO task_events (id, task_id, kind, created_at) VALUES (?, ?, ?, ?)",
+        ("event-1", "task-1", "completed", 2000),
+    )
+    conn.execute(
+        "INSERT INTO task_runs (id, task_id, status, started_at) VALUES (?, ?, ?, ?)",
+        ("run-1", "task-1", "done", 1000),
+    )
+    conn.execute(
+        "INSERT INTO kanban_notify_subs (task_id, platform, chat_id, created_at, last_event_id) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("task-1", "telegram", "123", 1000, "event-1"),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_migrate_autoincrement_schema_rebuilds_text_pk_tables(tmp_path, monkeypatch):
+    """Tables with TEXT PRIMARY KEY should be rebuilt as INTEGER AUTOINCREMENT."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    db_path = home / "kanban" / "test.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    _create_legacy_db(db_path)
+
+    # Clear init cache so connect() runs migration
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with kb.connect(db_path) as conn:
+        # Verify task_events.id is now INTEGER
+        ev_cols = {row["name"]: row for row in conn.execute("PRAGMA table_info(task_events)")}
+        assert ev_cols["id"]["type"].upper() == "INTEGER"
+        assert ev_cols["id"]["pk"] == 1
+
+        # Verify task_comments.id is now INTEGER
+        cm_cols = {row["name"]: row for row in conn.execute("PRAGMA table_info(task_comments)")}
+        assert cm_cols["id"]["type"].upper() == "INTEGER"
+        assert cm_cols["id"]["pk"] == 1
+
+        # Verify task_runs.id is now INTEGER
+        run_cols = {row["name"]: row for row in conn.execute("PRAGMA table_info(task_runs)")}
+        assert run_cols["id"]["type"].upper() == "INTEGER"
+        assert run_cols["id"]["pk"] == 1
+
+        # Verify kanban_notify_subs.last_event_id is now INTEGER
+        notify_cols = {
+            row["name"]: row for row in conn.execute("PRAGMA table_info(kanban_notify_subs)")
+        }
+        assert notify_cols["last_event_id"]["type"].upper() == "INTEGER"
+
+        # Verify data was preserved
+        tasks = conn.execute("SELECT * FROM tasks").fetchall()
+        assert len(tasks) == 1
+
+        events = conn.execute("SELECT * FROM task_events").fetchall()
+        assert len(events) == 1
+        assert events[0]["kind"] == "completed"
+
+        comments = conn.execute("SELECT * FROM task_comments").fetchall()
+        assert len(comments) == 1
+
+        runs = conn.execute("SELECT * FROM task_runs").fetchall()
+        assert len(runs) == 1
+
+        # Verify last_event_id was cast to INTEGER (0 for non-numeric values)
+        subs = conn.execute("SELECT * FROM kanban_notify_subs").fetchall()
+        assert len(subs) == 1
+        # "event-1" is not numeric, so CAST returns 0
+        assert subs[0]["last_event_id"] == 0
+
+
+def test_migrate_autoincrement_schema_idempotent(tmp_path, monkeypatch):
+    """Running migration twice should not break anything."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    db_path = home / "kanban" / "test.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    _create_legacy_db(db_path)
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    # First migration
+    with kb.connect(db_path) as conn:
+        pass
+
+    # Second migration (should be no-op)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with kb.connect(db_path) as conn:
+        ev_cols = {row["name"]: row for row in conn.execute("PRAGMA table_info(task_events)")}
+        assert ev_cols["id"]["type"].upper() == "INTEGER"
+        events = conn.execute("SELECT * FROM task_events").fetchall()
+        assert len(events) == 1
+
+
+def test_migrate_autoincrement_schema_fresh_db_unchanged(tmp_path, monkeypatch):
+    """A fresh DB with correct schema should not be touched by migration."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    db_path = home / "kanban" / "test.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    # Create fresh DB via connect (runs SCHEMA_SQL + migrations)
+    with kb.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO tasks (id, title, status, created_at) VALUES (?, ?, ?, ?)",
+            ("task-1", "Test", "running", 1000),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) VALUES (?, ?, ?)",
+            ("task-1", "completed", 3000),
+        )
+
+    # Verify AUTOINCREMENT works (first insert gets id=1)
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+    with kb.connect(db_path) as conn:
+        events = conn.execute("SELECT * FROM task_events ORDER BY id").fetchall()
+        assert len(events) == 1
+        assert events[0]["id"] == 1  # AUTOINCREMENT starts at 1
+
+
+def test_unseen_events_for_sub_with_migrated_db(tmp_path, monkeypatch):
+    """After migration, unseen_events_for_sub should not crash on int(None)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    db_path = home / "kanban" / "test.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    _create_legacy_db(db_path)
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with kb.connect(db_path) as conn:
+        # This should not raise TypeError: int() argument must be a string...
+        max_id, events = kb.unseen_events_for_sub(
+            conn,
+            task_id="task-1",
+            platform="telegram",
+            chat_id="123",
+        )
+        # After migration, last_event_id was cast to 0, so all events are unseen
+        assert isinstance(max_id, int)


### PR DESCRIPTION
## What does this PR do?

Fixes kanban notification delivery for databases created by older Hermes releases. Tables that were defined with `TEXT PRIMARY KEY` are now automatically rebuilt as `INTEGER PRIMARY KEY AUTOINCREMENT` when the database is opened, and `kanban_notify_subs.last_event_id` is migrated from `TEXT` (nullable) to `INTEGER NOT NULL DEFAULT 0` — fixing the `int(None)` crash that silently killed all kanban notifications.

## Related Issue

Fixes #35096

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: Added `_migrate_autoincrement_schema()` function that detects `TEXT` vs `INTEGER` type mismatches in `task_events.id`, `task_comments.id`, `task_runs.id`, and `kanban_notify_subs.last_event_id` via `PRAGMA table_info`, then rebuilds each affected table using the standard SQLite migration pattern (CREATE new → INSERT SELECT → DROP old → RENAME). Called from `_migrate_add_optional_columns()` at the end of the existing migration chain.
- `tests/hermes_cli/test_kanban_db_init.py`: Added 5 tests covering legacy DB rebuild, data preservation, idempotency, fresh DB passthrough, and `unseen_events_for_sub()` crash prevention.

## How to Test

1. Create a kanban board with an older version of Hermes (or manually create a DB with `TEXT PRIMARY KEY` tables)
2. Upgrade to this version
3. Run `hermes kanban init` — migration should log "kanban migration: rebuilding task_events" etc.
4. Create tasks, subscribe to notifications (`kanban notify-subscribe`), complete tasks — notifications should now arrive
5. Run `pytest tests/hermes_cli/test_kanban_db_init.py tests/hermes_cli/test_kanban_db.py tests/gateway/test_kanban_notifier.py -x` — all tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_kanban_db_init.py tests/hermes_cli/test_kanban_db.py tests/gateway/test_kanban_notifier.py -x` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/kanban_db.py:_migrate_autoincrement_schema` (called from `_migrate_add_optional_columns`, which runs on every `connect()`)
- Blast radius: LOW — migration is one-shot (idempotent), only triggers on legacy DBs with TEXT PK, preserves all data
- Related patterns: `_migrate_add_optional_columns` (column addition), `_add_column_if_missing` (additive ALTER TABLE), `write_txn` (concurrent-safe writes)
