### PR TITLE
fix(weixin): asyncio.wait_for timeout in _api_post/_api_get (+ regression tests, cluster closure)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -378,12 +378,16 @@ async def _api_post(
 ) -> Dict[str, Any]:
     body = _json_dumps({**payload, "base_info": _base_info()})
     url = f"{base_url.rstrip('/')}/{endpoint}"
-    timeout = aiohttp.ClientTimeout(total=timeout_ms / 1000)
-    async with session.post(url, data=body, headers=_headers(token, body), timeout=timeout) as response:
-        raw = await response.text()
-        if not response.ok:
-            raise RuntimeError(f"iLink POST {endpoint} HTTP {response.status}: {raw[:200]}")
-        return json.loads(raw)
+    # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
+    # "Timeout context manager should be used inside a task" errors when
+    # invoked via asyncio.run_coroutine_threadsafe() from cron jobs.
+    async def _do() -> Dict[str, Any]:
+        async with session.post(url, data=body, headers=_headers(token, body)) as response:
+            raw = await response.text()
+            if not response.ok:
+                raise RuntimeError(f"iLink POST {endpoint} HTTP {response.status}: {raw[:200]}")
+            return json.loads(raw)
+    return await asyncio.wait_for(_do(), timeout=timeout_ms / 1000)
 
 
 async def _api_get(
@@ -398,12 +402,16 @@ async def _api_get(
         "iLink-App-Id": ILINK_APP_ID,
         "iLink-App-ClientVersion": str(ILINK_APP_CLIENT_VERSION),
     }
-    timeout = aiohttp.ClientTimeout(total=timeout_ms / 1000)
-    async with session.get(url, headers=headers, timeout=timeout) as response:
-        raw = await response.text()
-        if not response.ok:
-            raise RuntimeError(f"iLink GET {endpoint} HTTP {response.status}: {raw[:200]}")
-        return json.loads(raw)
+    # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
+    # "Timeout context manager should be used inside a task" errors when
+    # invoked via asyncio.run_coroutine_threadsafe() from cron jobs.
+    async def _do() -> Dict[str, Any]:
+        async with session.get(url, headers=headers) as response:
+            raw = await response.text()
+            if not response.ok:
+                raise RuntimeError(f"iLink GET {endpoint} HTTP {response.status}: {raw[:200]}")
+            return json.loads(raw)
+    return await asyncio.wait_for(_do(), timeout=timeout_ms / 1000)
 
 
 async def _get_updates(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1194,6 +1194,7 @@ AUTHOR_MAP = {
     "zhicheng.han@mathematik.uni-goettingen.de": "hanzckernel",  # PR #20311 (api-server approval events)
     "agentsmithlaor@gmail.com": "oferlaor",  # PR #22356 salvage (cron origin sender identity)
     "jhin.lee@unity3d.com": "leehack",  # PR #22053 salvage (telegram DM topic reply fallback)
+    "caojiguang@gmail.com": "caojiguang",  # PR #35117 carries #31853 (weixin _api_post/_api_get wait_for)
     # pander: empty email, salvaged via PR #19665 from #16126 by @ms-alan
     "ayman.a.kamal@hotmail.com": "A-kamal",  # PR #18678 (xAI image resolution fix)
     # Kanban bug-fix batch salvage (May 2026)

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -968,3 +968,148 @@ class TestWeixinTextDebounce:
 
         asyncio.run(_drive())
         assert dispatched == ["one\ntwo\nthree"]
+
+
+class _StubResponse:
+    def __init__(self, *, status=200, body="{}", delay=0.0):
+        self.status = status
+        self.ok = 200 <= status < 300
+        self._body = body
+        self._delay = delay
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def text(self):
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        return self._body
+
+
+class _StubSession:
+    """Records request kwargs and returns a configurable async-CM response.
+
+    Unlike aiohttp.ClientSession it installs no TimerContext, so it cannot
+    reproduce aiohttp's cross-loop crash directly; these tests instead pin the
+    observable contract of the asyncio.wait_for migration.
+    """
+
+    def __init__(self, response):
+        self._response = response
+        self.post_calls = []
+        self.get_calls = []
+
+    def post(self, url, **kwargs):
+        self.post_calls.append((url, kwargs))
+        return self._response
+
+    def get(self, url, **kwargs):
+        self.get_calls.append((url, kwargs))
+        return self._response
+
+
+class TestWeixinApiTimeout:
+    def test_api_post_does_not_pass_aiohttp_timeout_kwarg(self):
+        session = _StubSession(_StubResponse(body='{"ret": 0}'))
+        result = asyncio.run(
+            weixin._api_post(
+                session,
+                base_url="https://weixin.example.com",
+                endpoint="ep",
+                payload={"k": "v"},
+                token="tok",
+                timeout_ms=5000,
+            )
+        )
+        assert result == {"ret": 0}
+        # The fix enforces the timeout via asyncio.wait_for, so ClientTimeout is
+        # gone and `timeout` is no longer forwarded to session.post().
+        [(_url, kwargs)] = session.post_calls
+        assert "timeout" not in kwargs
+
+    def test_api_get_does_not_pass_aiohttp_timeout_kwarg(self):
+        session = _StubSession(_StubResponse(body='{"ret": 0}'))
+        result = asyncio.run(
+            weixin._api_get(
+                session,
+                base_url="https://weixin.example.com",
+                endpoint="ep",
+                timeout_ms=5000,
+            )
+        )
+        assert result == {"ret": 0}
+        [(_url, kwargs)] = session.get_calls
+        assert "timeout" not in kwargs
+
+    def test_api_post_raises_timeout_when_response_is_slow(self):
+        # 1 ms budget against a 1 s response: wait_for must cancel and raise.
+        session = _StubSession(_StubResponse(delay=1.0))
+        with pytest.raises(asyncio.TimeoutError):
+            asyncio.run(
+                weixin._api_post(
+                    session,
+                    base_url="https://weixin.example.com",
+                    endpoint="ep",
+                    payload={"k": "v"},
+                    token="tok",
+                    timeout_ms=1,
+                )
+            )
+
+    def test_api_get_raises_timeout_when_response_is_slow(self):
+        session = _StubSession(_StubResponse(delay=1.0))
+        with pytest.raises(asyncio.TimeoutError):
+            asyncio.run(
+                weixin._api_get(
+                    session,
+                    base_url="https://weixin.example.com",
+                    endpoint="ep",
+                    timeout_ms=1,
+                )
+            )
+
+    def test_api_post_raises_runtime_error_on_non_ok_status(self):
+        # The non-2xx branch now lives inside the wait_for-wrapped inner coro;
+        # confirm it still raises with the HTTP status and truncated body.
+        session = _StubSession(_StubResponse(status=500, body="boom"))
+        with pytest.raises(RuntimeError, match="iLink POST ep HTTP 500: boom"):
+            asyncio.run(
+                weixin._api_post(
+                    session,
+                    base_url="https://weixin.example.com",
+                    endpoint="ep",
+                    payload={"k": "v"},
+                    token="tok",
+                    timeout_ms=5000,
+                )
+            )
+
+    def test_api_get_raises_runtime_error_on_non_ok_status(self):
+        session = _StubSession(_StubResponse(status=500, body="boom"))
+        with pytest.raises(RuntimeError, match="iLink GET ep HTTP 500: boom"):
+            asyncio.run(
+                weixin._api_get(
+                    session,
+                    base_url="https://weixin.example.com",
+                    endpoint="ep",
+                    timeout_ms=5000,
+                )
+            )
+
+    def test_get_updates_returns_empty_sentinel_on_timeout(self):
+        # wait_for raises asyncio.TimeoutError, which _get_updates swallows into
+        # an empty long-poll batch rather than propagating.
+        session = _StubSession(_StubResponse(delay=1.0))
+        result = asyncio.run(
+            weixin._get_updates(
+                session,
+                base_url="https://weixin.example.com",
+                token="tok",
+                sync_buf="buf-123",
+                timeout_ms=1,
+            )
+        )
+        assert result == {"ret": 0, "msgs": [], "get_updates_buf": "buf-123"}


### PR DESCRIPTION
> **Credit:** the production fix is authored by **@caojiguang** (#31853), carried here with their git authorship preserved. This PR adds the regression suite and resolves the broader Weixin asyncio-timeout cluster. Independent fix + test work by **@ryan-flow** (#32179) is acknowledged.

## Problem
Cron and other non-gateway WeChat sends fail with:
```
RuntimeError: Timeout context manager should be used inside a task
```
`send_message` runs `_api_post`/`_api_get` in a worker thread with its own event loop (via `_run_async`), while the aiohttp session is bound to the gateway loop. `aiohttp.ClientTimeout` is implemented through `async_timeout.TimerContext`, whose `__enter__` calls `asyncio.current_task(loop=session._loop)` — the *gateway* loop, not the worker loop — which returns `None` and raises. The request never reaches the wire. The long-poll path was unaffected (already inside a Task), which is why this only bit cron / out-of-band sends.

## Fix
Replace the per-request `aiohttp.ClientTimeout` with `asyncio.wait_for(coro, timeout=timeout_ms/1000)`, wrapping each request body in a local coroutine. `wait_for` `ensure_future`-wraps the coroutine into a real Task and enforces the deadline via `loop.call_later` + `fut.cancel()` — it never calls `current_task()`, so it is event-loop-context-agnostic.

This **completes the migration begun in #21196**, which moved the sibling helpers `_upload_ciphertext` / `_download_bytes` / `_download_remote_media` to the same `wait_for` pattern; `_api_post` / `_api_get` were the last two helpers still on per-request `ClientTimeout`. All five Weixin HTTP helpers now use one timeout mechanism.

Supporting context (unchanged, already on main): the send session is built with `aiohttp.ClientTimeout(total=None, connect=None, sock_connect=None, sock_read=None)`, so the session-level aiohttp timer is fully disabled and all timeout budget is owned by the per-request `wait_for`.

## Scope / non-goals
Two files: `gateway/platforms/weixin.py`, `tests/gateway/test_weixin.py`. This PR does **not** touch:
- `model_tools.py` loop handling — the persistent/recreated-loop residuals (#16570, #8043) live there and are out of scope.
- Cross-loop session reuse / "Future attached to a different loop" — already fixed on main by #19141.
- Telegram or any non-Weixin platform; the media-handling half — see #34844.

## Behavior / compatibility
- **Timeout budget unchanged** — the per-request `ClientTimeout` already bounded these calls by the same `timeout_ms` (`API_TIMEOUT_MS=15s`, `CONFIG_TIMEOUT_MS=10s`, `LONG_POLL_TIMEOUT_MS=35s`); `wait_for` enforces the identical budget. No truncation of previously-successful calls.
- On timeout, `wait_for` raises `asyncio.TimeoutError`; on Python 3.12 this is `TimeoutError` and is **not** a `CancelledError` subclass, so the poll loop's `except CancelledError` does not swallow it — real sends retry then re-raise.
- `_get_updates` long-poll swallow is unchanged: it still catches `asyncio.TimeoutError` and returns the empty-batch sentinel `{"ret": 0, "msgs": [], "get_updates_buf": sync_buf}`.
- On timeout, `wait_for` cancels the inner coroutine mid-`async with session.post(...)`; aiohttp's response context manager releases the connection in `__aexit__` — no leaked connection. Same pattern as the production sibling helpers.

## Tests
```
python -m pytest tests/gateway/test_weixin.py tests/test_model_tools_async_bridge.py -q
# 73 passed
```
`TestWeixinApiTimeout` (7 cases):

| Test | Helper | Contract |
|------|--------|----------|
| happy-path | `_api_post` / `_api_get` | returns parsed JSON; **no `timeout=` kwarg forwarded** to the session call (regression guard against reintroducing `ClientTimeout`) |
| slow response | `_api_post` / `_api_get` | `wait_for` actually fires and raises `asyncio.TimeoutError` (real timeout, not mocked) |
| non-2xx | `_api_post` / `_api_get` | raises `RuntimeError` carrying HTTP status + truncated body |
| long-poll | `_get_updates` | underlying `asyncio.TimeoutError` is swallowed into the empty-batch sentinel (loop survives) |

Note: tests pin the observable contract (no `timeout=` forwarded; `wait_for` raises; `_get_updates` swallows) rather than reproducing the loop-context crash in-process, which requires real aiohttp request machinery and is impractical to unit-test.

## Cluster closure
Resolves the Weixin asyncio-timeout cluster (15 active items). The eight issues below all report the timeout-context crash on the text-send path this fix removes:

```
Closes #13099, Closes #13281, Closes #16293, Closes #17347, Closes #18014, Closes #18836, Closes #20229, Closes #24142
```

Referenced, **not** closed by this diff:
- `Refs #13365, #23371, #18437` — the cross-loop "Future attached to a different loop" half (session reuse across event loops); already fixed on main by #19141, not this diff.
- `Refs #17595` — media/file sends failing via cross-loop session reuse (#19141) plus the media-handling half (#34844); not this diff.
- `Refs #32179` — @ryan-flow's independent duplicate (closed as a duplicate of #31853).

Supersedes:
- `Supersedes #18714` — its WeChat event-loop guard and Telegram proxy are already on main in stronger form (#19141 + the host-scoped Telegram proxy); only its out-of-cluster rate-limit backoff is unaddressed here.
- `Supersedes #31853` — carries @caojiguang's commit; close as incorporated once this merges.

Known residuals / out of scope: **#16570, #8043** — their timeout paths live in `model_tools.py`, untouched by this diff.

## Infographic

![gateway-reliability-three-fixes](https://v3b.fal.media/files/b/0a9c9d5a/O9pd6WmMTWT83Zv7ZvVta_sMmNoSsQ.png)
