### PR TITLE
fix(dashboard): responsive model picker layout for mobile screens

### DIFF
--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -250,7 +250,7 @@ export function ModelPickerDialog(props: Props) {
           </div>
         </div>
 
-        <div className="flex-1 min-h-0 grid grid-cols-[200px_1fr] overflow-hidden">
+        <div className="flex-1 min-h-0 grid grid-cols-[140px_1fr] md:grid-cols-[200px_1fr] overflow-hidden">
           <ProviderColumn
             loading={loading}
             error={error}
@@ -451,7 +451,7 @@ function ModelColumn({
               <Check
                 className={`h-3 w-3 shrink-0 ${active ? "text-primary" : "text-transparent"}`}
               />
-              <span className="flex-1 truncate">{m}</span>
+              <span className="flex-1 break-all">{m}</span>
               {isCurrent && <CurrentTag />}
             </ListItem>
           );


### PR DESCRIPTION
## What does this PR do?

Fixes the model picker dialog on mobile screens where the fixed 200px provider column leaves insufficient space for long model names, causing quantization suffixes (e.g., `@q6_k_xl` vs `@Q4_K_M`) to be silently clipped and making models indistinguishable.

## Related Issue

Fixes #35115

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/components/ModelPickerDialog.tsx`: Narrow provider column from 200px to 140px on small screens (restored on `md+` breakpoints via responsive Tailwind prefix); replace `truncate` with `break-all` on model name spans so long quantization suffixes wrap instead of being clipped

## How to Test

1. Open the Hermes dashboard on a mobile device (or use browser DevTools responsive mode at ~375px width)
2. Navigate to Model Provider settings
3. Select a provider with long model names (e.g., LM Studio with quantized models like `qwen3.6-35b-a3b-mtp@q6_k_xl`)
4. Verify that model names are fully readable — quantization suffixes should wrap to the next line rather than being clipped
5. On desktop (md+ breakpoint), verify the provider column is still 200px wide and the two-column layout is unchanged

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (or N/A — CSS-only change in a component without test infrastructure)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (CSS-only, Tailwind responsive classes work cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `web/src/components/ModelPickerDialog.tsx` — `ModelPickerDialog` component (grid layout at L253, model name rendering at L454)
- Blast radius: LOW — CSS-only change, no logic modified, Tailwind responsive classes are additive
- Related patterns: Provider column uses `truncate` on provider names (L376, L379) which is fine since provider names are short; only model names with quantization suffixes need wrapping
