### PR TITLE
fix(tui): preserve utf8 when copying via powershell

### DIFF
--- a/ui-tui/src/__tests__/clipboard.test.ts
+++ b/ui-tui/src/__tests__/clipboard.test.ts
@@ -269,6 +269,9 @@ describe('writeClipboardText', () => {
       expect.arrayContaining(['-NoProfile', '-NonInteractive']),
       expect.anything()
     )
+    expect(start.mock.calls[0][1]).toContain(
+      '[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false); Set-Clipboard -Value ([Console]::In.ReadToEnd())'
+    )
     expect(stdin.end).toHaveBeenCalledWith('wsl text')
   })
 
@@ -324,6 +327,9 @@ describe('writeClipboardText', () => {
       'powershell',
       expect.arrayContaining(['-NoProfile', '-NonInteractive']),
       expect.anything()
+    )
+    expect(start.mock.calls[0][1]).toContain(
+      '[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false); Set-Clipboard -Value ([Console]::In.ReadToEnd())'
     )
   })
 })

--- a/ui-tui/src/lib/clipboard.ts
+++ b/ui-tui/src/lib/clipboard.ts
@@ -5,6 +5,9 @@ const execFileAsync = promisify(execFile)
 const CLIPBOARD_MAX_BUFFER = 4 * 1024 * 1024
 const POWERSHELL_ARGS = ['-NoProfile', '-NonInteractive', '-Command', 'Get-Clipboard -Raw'] as const
 
+const POWERSHELL_WRITE_UTF8_COMMAND =
+  '[Console]::InputEncoding = [System.Text.UTF8Encoding]::new($false); Set-Clipboard -Value ([Console]::In.ReadToEnd())'
+
 type ClipboardRun = typeof execFileAsync
 
 export function isUsableClipboardText(text: null | string): text is string {
@@ -100,7 +103,7 @@ function writeClipboardCommands(
   }
 
   if (platform === 'win32') {
-    return [{ cmd: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', 'Set-Clipboard -Value $input'] }]
+    return [{ cmd: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', POWERSHELL_WRITE_UTF8_COMMAND] }]
   }
 
   const attempts: Array<{ args: readonly string[]; cmd: string }> = []
@@ -108,7 +111,7 @@ function writeClipboardCommands(
   if (env.WSL_INTEROP || env.WSL_DISTRO_NAME) {
     attempts.push({
       cmd: 'powershell.exe',
-      args: ['-NoProfile', '-NonInteractive', '-Command', 'Set-Clipboard -Value $input']
+      args: ['-NoProfile', '-NonInteractive', '-Command', POWERSHELL_WRITE_UTF8_COMMAND]
     })
   }
 


### PR DESCRIPTION
## Summary
- Fixes TUI `/copy` on WSL/Windows when text is written through PowerShell.
- Sets PowerShell stdin decoding to UTF-8 before reading piped clipboard text.
- Keeps the existing Linux/macOS clipboard fallback order unchanged.

## Why
WSL sends `/copy` text to `powershell.exe Set-Clipboard` over stdin. On systems with non-UTF-8 ANSI code pages, PowerShell can decode those UTF-8 bytes as the local code page before writing the Windows clipboard, which garbles CJK and other non-ASCII text.

## Changes
- Replace the `$input` PowerShell write path with `[Console]::In.ReadToEnd()` after setting `[Console]::InputEncoding` to UTF-8.
- Reuse the same UTF-8 PowerShell command for native Windows and WSL clipboard writes.
- Add clipboard unit assertions covering the UTF-8 PowerShell write command.

## Validation
- `cd ui-tui && npx eslint src/lib/clipboard.ts src/__tests__/clipboard.test.ts`
- `cd ui-tui && npm test -- --run src/__tests__/clipboard.test.ts`

## Scope
Focused on TUI clipboard writes through PowerShell. Clipboard reads and non-PowerShell Linux/macOS backends are unchanged.

Closes #35107
