### PR TITLE
fix(tui): use base64 encoding for PowerShell clipboard writes to preserve UTF-8

### DIFF
--- a/ui-tui/src/__tests__/clipboard.test.ts
+++ b/ui-tui/src/__tests__/clipboard.test.ts
@@ -269,7 +269,14 @@ describe('writeClipboardText', () => {
       expect.arrayContaining(['-NoProfile', '-NonInteractive']),
       expect.anything()
     )
-    expect(stdin.end).toHaveBeenCalledWith('wsl text')
+    // PowerShell uses base64-encoded UTF-8 via command argument, not stdin
+    expect(stdin.end).not.toHaveBeenCalled()
+    const calledArgs = start.mock.calls[0][1] as string[]
+    const commandIdx = calledArgs.indexOf('-Command')
+    expect(commandIdx).toBeGreaterThan(-1)
+    const script = calledArgs[commandIdx + 1]
+    expect(script).toContain('FromBase64String')
+    expect(script).toContain(Buffer.from('wsl text', 'utf8').toString('base64'))
   })
 
   it('prefers the Windows clipboard path over wl-copy inside WSLg', async () => {
@@ -300,7 +307,13 @@ describe('writeClipboardText', () => {
       expect.arrayContaining(['-NoProfile', '-NonInteractive']),
       expect.anything()
     )
-    expect(stdin.end).toHaveBeenCalledWith('wslg text')
+    // PowerShell uses base64-encoded UTF-8 via command argument, not stdin
+    expect(stdin.end).not.toHaveBeenCalled()
+    const calledArgs = start.mock.calls[0][1] as string[]
+    const commandIdx = calledArgs.indexOf('-Command')
+    const script = calledArgs[commandIdx + 1]
+    expect(script).toContain('FromBase64String')
+    expect(script).toContain(Buffer.from('wslg text', 'utf8').toString('base64'))
   })
 
   it('uses PowerShell on Windows', async () => {
@@ -325,5 +338,32 @@ describe('writeClipboardText', () => {
       expect.arrayContaining(['-NoProfile', '-NonInteractive']),
       expect.anything()
     )
+    // PowerShell uses base64-encoded UTF-8 via command argument, not stdin
+    expect(stdin.end).not.toHaveBeenCalled()
+  })
+
+  it('preserves CJK text via base64 encoding in PowerShell on WSL', async () => {
+    const stdin = { end: vi.fn() }
+
+    const child = {
+      once: vi.fn((event: string, cb: (code?: number) => void) => {
+        if (event === 'close') {
+          cb(0)
+        }
+
+        return child
+      }),
+      stdin
+    }
+
+    const start = vi.fn().mockReturnValue(child)
+    const cjkText = '你好世界，测试中文 🎉'
+
+    await expect(writeClipboardText(cjkText, 'linux', start as any, { WSL_INTEROP: '/tmp/socket' })).resolves.toBe(true)
+    const calledArgs = start.mock.calls[0][1] as string[]
+    const commandIdx = calledArgs.indexOf('-Command')
+    const script = calledArgs[commandIdx + 1]
+    expect(script).toContain(Buffer.from(cjkText, 'utf8').toString('base64'))
+    expect(script).toContain('UTF8.GetString')
   })
 })

--- a/ui-tui/src/lib/clipboard.ts
+++ b/ui-tui/src/lib/clipboard.ts
@@ -91,33 +91,44 @@ export async function readClipboardText(
   return null
 }
 
+type WriteCmd = { args: readonly string[]; cmd: string } & (
+  | { stdin: true }
+  | { stdin: false; psScript: (b64: string) => string }
+)
+
+function _powershellWriteScript(b64: string): string {
+  return `Set-Clipboard -Value ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('${b64}')))`
+}
+
 function writeClipboardCommands(
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv
-): Array<{ args: readonly string[]; cmd: string }> {
+): WriteCmd[] {
   if (platform === 'darwin') {
-    return [{ cmd: 'pbcopy', args: [] }]
+    return [{ cmd: 'pbcopy', args: [], stdin: true }]
   }
 
   if (platform === 'win32') {
-    return [{ cmd: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', 'Set-Clipboard -Value $input'] }]
+    return [{ cmd: 'powershell', args: ['-NoProfile', '-NonInteractive'], stdin: false, psScript: _powershellWriteScript }]
   }
 
-  const attempts: Array<{ args: readonly string[]; cmd: string }> = []
+  const attempts: WriteCmd[] = []
 
   if (env.WSL_INTEROP || env.WSL_DISTRO_NAME) {
     attempts.push({
       cmd: 'powershell.exe',
-      args: ['-NoProfile', '-NonInteractive', '-Command', 'Set-Clipboard -Value $input']
+      args: ['-NoProfile', '-NonInteractive'],
+      stdin: false,
+      psScript: _powershellWriteScript
     })
   }
 
   if (env.WAYLAND_DISPLAY) {
-    attempts.push({ cmd: 'wl-copy', args: ['--type', 'text/plain'] })
+    attempts.push({ cmd: 'wl-copy', args: ['--type', 'text/plain'], stdin: true })
   }
 
-  attempts.push({ cmd: 'xclip', args: ['-selection', 'clipboard', '-in'] })
-  attempts.push({ cmd: 'xsel', args: ['--clipboard', '--input'] })
+  attempts.push({ cmd: 'xclip', args: ['-selection', 'clipboard', '-in'], stdin: true })
+  attempts.push({ cmd: 'xsel', args: ['--clipboard', '--input'], stdin: true })
 
   return attempts
 }
@@ -144,14 +155,21 @@ export async function writeClipboardText(
 ): Promise<boolean> {
   const candidates = writeClipboardCommands(platform, env)
 
-  for (const { cmd, args } of candidates) {
+  for (const cmdEntry of candidates) {
     try {
       const ok = await new Promise<boolean>(resolve => {
-        const child = start(cmd, [...args], { stdio: ['pipe', 'ignore', 'ignore'], windowsHide: true })
-
-        child.once('error', () => resolve(false))
-        child.once('close', code => resolve(code === 0))
-        child.stdin?.end(text)
+        if (cmdEntry.stdin) {
+          const child = start(cmdEntry.cmd, [...cmdEntry.args], { stdio: ['pipe', 'ignore', 'ignore'], windowsHide: true })
+          child.once('error', () => resolve(false))
+          child.once('close', (code: number | null) => resolve(code === 0))
+          child.stdin?.end(text)
+        } else {
+          const b64 = Buffer.from(text, 'utf8').toString('base64')
+          const script = cmdEntry.psScript(b64)
+          const child = start(cmdEntry.cmd, [...cmdEntry.args, '-Command', script], { stdio: ['ignore', 'ignore', 'ignore'], windowsHide: true })
+          child.once('error', () => resolve(false))
+          child.once('close', (code: number | null) => resolve(code === 0))
+        }
       })
 
       if (ok) {


### PR DESCRIPTION
## Problem

When using `/copy` in TUI on WSL2, non-ASCII text (CJK, emoji, accented characters) becomes garbled when pasted on the Windows side.

**Root cause**: `writeClipboardText()` pipes text to `powershell.exe Set-Clipboard -Value $input` via stdin. PowerShell reads stdin using the Windows system's default ANSI code page (e.g. CP936 for Chinese Windows), not UTF-8. This reinterprets UTF-8 bytes as ANSI, producing garbled output.

**Example**: `你好世界` → `浣犲ソ涓栫晫`

## Fix

Encode text as base64 in Node.js and pass it as a PowerShell command argument instead of piping through stdin. PowerShell explicitly decodes from base64 using UTF-8:

```powershell
Set-Clipboard -Value ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('BASE64')))
```

This bypasses the ANSI code page entirely since the text is passed as a command argument (which PowerShell handles in UTF-8) rather than through stdin.

## Before vs After

| Text | Before (stdin pipe) | After (base64 arg) |
|------|--------------------|--------------------|
| `你好世界，测试中文` | `浣犲ソ涓栫晫锛屾祴璇曚腑鏂` | `你好世界，测试中文` ✅ |
| `café résumé` | `caf茅 r茅sum茅` | `café résumé` ✅ |
| `🎉 Hello` | garbled | `🎉 Hello` ✅ |

## Changes

- **`ui-tui/src/lib/clipboard.ts`**: PowerShell clipboard writes use base64-encoded UTF-8 via `-Command` argument instead of stdin piping. Other backends (pbcopy, wl-copy, xclip, xsel) continue using stdin as before.
- **`ui-tui/src/__tests__/clipboard.test.ts`**: Updated existing tests to verify base64 encoding, added CJK-specific regression test.

## Tests

All 19 clipboard tests pass (3 new assertions + 1 new test for CJK text).

Fixes #35107
