### PR TITLE
fix(cli): pop Kitty keyboard protocol before curses wizards

### DIFF
--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -32,6 +32,33 @@ def flush_stdin() -> None:
         pass
 
 
+def pop_kitty_keyboard() -> None:
+    """Disable the Kitty keyboard protocol before a curses session.
+
+    The interactive front-end (Hermes TUI / prompt_toolkit session) may leave
+    the terminal in Kitty keyboard protocol mode.  Terminals that implement it
+    (Ghostty, Kitty, foot, WezTerm) then encode arrow keys as CSI-u sequences
+    (e.g. ``\\x1b[57352u``) instead of the legacy ``\\x1bOA`` form.  Python's
+    ``curses`` was built against the legacy terminfo definition and cannot
+    decode CSI-u, so ``getch()`` returns a bare ``ESC`` (27) — which every
+    wizard treats as cancel, making arrow keys "advance the page" instead of
+    moving the selection.  Terminals without the protocol (Konsole, xterm) are
+    unaffected.
+
+    Emitting the pop sequence (``CSI < u`` — the same escape cli.py already
+    uses on prompt return) before ``curses.wrapper()`` forces legacy encoding
+    for the duration of the curses screen, so arrow keys decode correctly.
+    No-op on non-TTY stdout.
+    """
+    try:
+        if not sys.stdout.isatty():
+            return
+        sys.stdout.write("\x1b[<u")
+        sys.stdout.flush()
+    except Exception:
+        pass
+
+
 # Normalized menu actions returned by ``read_menu_key``.  Using sentinels keeps
 # every menu's key-handling branch identical and free of raw escape-byte logic.
 NAV_UP = "up"
@@ -212,6 +239,7 @@ def _run_curses_menu(
                         result_holder[0] = outcome
                         return
 
+        pop_kitty_keyboard()
         curses.wrapper(_draw)
         flush_stdin()
         return result_holder[0] if result_holder[0] is not _KEEP else cancel_value

--- a/tests/test_curses_ui_kitty.py
+++ b/tests/test_curses_ui_kitty.py
@@ -1,0 +1,112 @@
+"""Tests for the Kitty keyboard protocol mitigation in ``hermes_cli.curses_ui``.
+
+Regression coverage for the bug where config wizards (``hermes tools``,
+``hermes skills``, plugin selectors) ignored arrow keys under terminals that
+implement the Kitty keyboard protocol (Ghostty, Kitty, foot, WezTerm).
+
+When that protocol is active the terminal encodes arrow keys as CSI-u
+sequences (e.g. ``\\x1b[57352u``) instead of the legacy ``\\x1bOA`` form.
+Python's ``curses`` was built against the legacy terminfo definition and
+cannot decode CSI-u, so ``getch()`` returns a bare ``ESC`` (27) which every
+wizard treats as cancel. ``pop_kitty_keyboard()`` disables the protocol
+before each ``curses.wrapper()`` so legacy encoding is used for the duration
+of the curses screen.
+"""
+
+import io
+
+import curses as _curses
+
+import hermes_cli.curses_ui as curses_ui
+
+# The pop sequence Hermes uses elsewhere (cli.py) to leave Kitty keyboard mode.
+POP_SEQ = "\x1b[<u"
+
+
+class _FakeTTY(io.StringIO):
+    """StringIO that reports as a TTY (or not, per ``_isatty``)."""
+
+    def __init__(self, isatty=True):
+        super().__init__()
+        self._isatty = isatty
+
+    def isatty(self):
+        return self._isatty
+
+
+def test_pop_kitty_keyboard_emits_sequence_on_tty(monkeypatch):
+    fake = _FakeTTY(isatty=True)
+    monkeypatch.setattr(curses_ui.sys, "stdout", fake)
+    curses_ui.pop_kitty_keyboard()
+    assert fake.getvalue() == POP_SEQ
+
+
+def test_pop_kitty_keyboard_noop_on_non_tty(monkeypatch):
+    fake = _FakeTTY(isatty=False)
+    monkeypatch.setattr(curses_ui.sys, "stdout", fake)
+    curses_ui.pop_kitty_keyboard()
+    assert fake.getvalue() == ""
+
+
+def test_pop_kitty_keyboard_swallows_exceptions(monkeypatch):
+    class _Boom:
+        def isatty(self):
+            return True
+
+        def write(self, _):
+            raise OSError("broken pipe")
+
+        def flush(self):
+            raise OSError("broken pipe")
+
+    monkeypatch.setattr(curses_ui.sys, "stdout", _Boom())
+    # Must not raise — terminal-control failures should never crash a wizard.
+    curses_ui.pop_kitty_keyboard()
+
+
+def _assert_pops_before_wrapper(monkeypatch, func, *args, **kwargs):
+    """Run ``func`` with curses.wrapper stubbed and assert pop happened first."""
+    calls = []
+
+    def fake_pop():
+        calls.append("pop")
+
+    def fake_wrapper(draw, *a, **k):
+        calls.append("wrapper")
+        # Do not invoke ``draw`` — it needs a real curses screen. The function
+        # under test falls through to its post-wrapper return logic.
+        return None
+
+    # The wizards short-circuit when stdin is not a TTY (e.g. under pytest),
+    # returning before the pop/wrapper path. Force the TTY branch.
+    class _TTYStdin:
+        def isatty(self):
+            return True
+
+    monkeypatch.setattr(curses_ui.sys, "stdin", _TTYStdin())
+    monkeypatch.setattr(curses_ui, "pop_kitty_keyboard", fake_pop)
+    monkeypatch.setattr(_curses, "wrapper", fake_wrapper)
+    monkeypatch.setattr(curses_ui, "flush_stdin", lambda: None)
+
+    func(*args, **kwargs)
+    assert calls == ["pop", "wrapper"], (
+        f"{func.__name__}: expected pop before wrapper, got {calls}"
+    )
+
+
+def test_checklist_pops_before_wrapper(monkeypatch):
+    _assert_pops_before_wrapper(
+        monkeypatch, curses_ui.curses_checklist, "Title", ["a", "b", "c"], set()
+    )
+
+
+def test_radiolist_pops_before_wrapper(monkeypatch):
+    _assert_pops_before_wrapper(
+        monkeypatch, curses_ui.curses_radiolist, "Title", ["a", "b", "c"], 0
+    )
+
+
+def test_single_select_pops_before_wrapper(monkeypatch):
+    _assert_pops_before_wrapper(
+        monkeypatch, curses_ui.curses_single_select, "Title", ["a", "b", "c"], 0
+    )


### PR DESCRIPTION
## What does this PR do?

Config wizards (`hermes tools`, `hermes skills`, plugin selectors) ignore the arrow keys under terminals that implement the **Kitty keyboard protocol** (Ghostty, Kitty, foot, WezTerm). Instead of moving the selection, an arrow press silently cancels the dialog and advances to the next screen. Terminals without the protocol (Konsole, xterm) are unaffected.

### Root cause

The interactive front-end (Hermes TUI / prompt_toolkit session) can leave the terminal in Kitty keyboard protocol mode. Those terminals then encode arrow keys as CSI-u sequences (e.g. `\x1b[57352u`) instead of the legacy `\x1bOA` form.

Python's `curses` was built against the legacy terminfo definition (`kcuu1=\EOA`) and cannot decode CSI-u, so `getch()` returns a bare `ESC` (27). Every wizard in `hermes_cli/curses_ui.py` treats `27` as cancel:

```python
elif key in {27, ord("q")}:
    result_holder[0] = cancel_returns
    return
```

so the dialog closes and the flow advances — exactly the reported symptom.

### Fix

Add a `pop_kitty_keyboard()` helper that emits the `CSI < u` pop sequence (the same escape `cli.py` already uses on prompt return) and call it immediately before each `curses.wrapper()` in `curses_checklist`, `curses_radiolist`, and `curses_single_select`. This forces legacy encoding for the duration of the curses screen, so arrow keys decode correctly. It is a harmless no-op on non-Kitty terminals and on non-TTY stdout.

## Related Issue

No existing issue; reproduced and diagnosed locally.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/curses_ui.py`: add `pop_kitty_keyboard()`; call it before `curses.wrapper()` in `curses_checklist`, `curses_radiolist`, `curses_single_select`.
- `tests/test_curses_ui_kitty.py`: new tests (stdlib + pytest only, no network).

## How to Test

1. In a Kitty-protocol terminal (Ghostty/Kitty/foot/WezTerm), run `hermes tools` or `hermes skills`.
2. Before the fix: arrow keys cancel the dialog and advance the page.
3. After the fix: arrow keys move the selection as expected. Konsole/xterm behavior is unchanged (pop sequence is a no-op there).
4. `pytest tests/test_curses_ui_kitty.py -v` → 6 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cli):`, `test(cli):`)
- [x] I searched for existing PRs to avoid duplicates
- [x] My PR contains only changes related to this fix
- [x] I've run the new tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Solus), Ghostty

### Documentation & Housekeeping

- [x] Documentation update — N/A (internal terminal-handling fix)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered: helper uses only `sys.stdout.write`/`flush` guarded by `isatty()`; no `termios`/`fcntl`; no-op on Windows and non-TTY
- [x] Tool descriptions/schemas — N/A
