### PR TITLE
fix(logging): tolerate locked agent.log rollover on Windows

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -296,33 +296,40 @@ def setup_verbose_logging() -> None:
 # ---------------------------------------------------------------------------
 
 class _ManagedRotatingFileHandler(RotatingFileHandler):
-    """RotatingFileHandler that ensures group-writable perms in managed mode
-    AND survives external rotation.
+    """RotatingFileHandler for shared Hermes logs.
 
-    Two responsibilities:
+    Responsibilities:
 
-    1.  In managed mode (NixOS), the stateDir uses setgid (2770) so new files
-        inherit the hermes group. However, both ``_open()`` (initial creation)
-        and ``doRollover()`` create files via ``open()``, which uses the
-        process umask — typically 0022, producing 0644. This subclass applies
-        ``chmod 0660`` after both operations so the gateway and interactive
-        users can share log files.
+    1. In managed mode (NixOS), the stateDir uses setgid (2770) so new files
+       inherit the hermes group. However, both ``_open()`` (initial creation)
+       and ``doRollover()`` create files via ``open()``, which uses the
+       process umask — typically 0022, producing 0644. This subclass applies
+       ``chmod 0660`` after both operations so the gateway and interactive
+       users can share log files.
 
-    2.  ``RotatingFileHandler`` keeps an open file descriptor.  If anything
-        rotates the file *externally* (``logrotate``, manual ``mv``,
-        another process rotating under us, a transient unlink), our fd
-        keeps pointing at the renamed/unlinked inode and every subsequent
-        write goes to ``gateway.log.1`` instead of ``gateway.log`` — silent
-        log loss for the file every operator expects to read.  Before each
-        emit we ``stat`` ``baseFilename`` and compare it against the open
-        stream's inode; on mismatch we reopen.  This is the same pattern
-        as stdlib ``WatchedFileHandler.reopenIfNeeded()``, adapted for
-        rotating handlers.
+    2. ``RotatingFileHandler`` keeps an open file descriptor. If anything
+       rotates the file *externally* (``logrotate``, manual ``mv``, another
+       process rotating under us, a transient unlink), our fd keeps pointing
+       at the renamed/unlinked inode and subsequent writes go to the wrong
+       file. Before each emit we ``stat`` ``baseFilename`` and compare it
+       against the open stream's inode; on mismatch we reopen. This mirrors
+       stdlib ``WatchedFileHandler.reopenIfNeeded()``, adapted for rotating
+       handlers.
+
+    3. On Windows, multiple Hermes processes can legitimately share the same
+       ``agent.log`` path (for example the gateway plus an interactive CLI
+       session). If the file has reached the rotation threshold, one process
+       may try to rename ``agent.log`` to ``agent.log.1`` while another still
+       holds the file open, producing ``PermissionError: [WinError 32]``. In
+       that case we disable further rollover attempts for this handler
+       instance and keep appending to the current file instead of spamming
+       stderr with logging tracebacks.
     """
 
     def __init__(self, *args, **kwargs):
         from hermes_cli.config import is_managed
         self._managed = is_managed()
+        self._rollover_disabled = False
         super().__init__(*args, **kwargs)
         # Snapshot the inode of the currently open stream so emit() can
         # detect external rotation without an extra fstat per write.
@@ -406,8 +413,21 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         self._chmod_if_managed()
         return stream
 
+    def shouldRollover(self, record):
+        if self._rollover_disabled:
+            return False
+        return super().shouldRollover(record)
+
     def doRollover(self):
-        super().doRollover()
+        if self._rollover_disabled:
+            return
+        try:
+            super().doRollover()
+        except PermissionError as exc:
+            if os.name == "nt" and getattr(exc, "winerror", None) == 32:
+                self._rollover_disabled = True
+                return
+            raise
         self._chmod_if_managed()
         # Our own rollover writes a new baseFilename; refresh the snapshot
         # so the next emit doesn't mistake it for external rotation.

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -177,6 +177,38 @@ class TestSetupLogging:
         assert "this is a warning" in agent_log.read_text()
         assert "this is a warning" in errors_log.read_text()
 
+    def test_windows_locked_rollover_falls_back_to_append(self, hermes_home):
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        root = logging.getLogger()
+        agent_handler = next(
+            h for h in root.handlers
+            if isinstance(h, RotatingFileHandler)
+            and "agent.log" in getattr(h, "baseFilename", "")
+        )
+
+        test_logger = logging.getLogger("test_hermes_logging.rollover_lock")
+        test_logger.info("seed message before forced rollover")
+        for h in root.handlers:
+            h.flush()
+
+        agent_handler.maxBytes = 1
+        locked_error = PermissionError(
+            32,
+            "The process cannot access the file because it is being used by another process",
+        )
+        locked_error.winerror = 32
+
+        with patch.object(agent_handler, "rotate", side_effect=locked_error):
+            test_logger.info("message after locked rollover")
+
+        for h in root.handlers:
+            h.flush()
+
+        agent_log = hermes_home / "logs" / "agent.log"
+        content = agent_log.read_text()
+        assert "message after locked rollover" in content
+        assert getattr(agent_handler, "_rollover_disabled", False) is True
+
     def test_info_not_in_errors_log(self, hermes_home):
         hermes_logging.setup_logging(hermes_home=hermes_home)
 


### PR DESCRIPTION
## Summary
- handle Windows `WinError 32` during shared `agent.log` rotation without emitting logging tracebacks to stderr
- disable further rollover attempts for that handler instance and continue appending to the current file
- add a regression test covering the locked-rollover path

## Context
When the gateway and an interactive Hermes CLI session both share `agent.log` on Windows, a fresh CLI invocation can hit log rotation immediately if the file is already at the size threshold. The stdlib rename step can fail with `PermissionError: [WinError 32]` because another Hermes process still has the file open. The command itself may otherwise succeed, but the terminal gets flooded with `--- Logging error ---` tracebacks.

## Test Plan
- [x] `python -m pytest tests/test_hermes_logging.py::TestSetupLogging::test_windows_locked_rollover_falls_back_to_append -o addopts='' -q`
- [x] `python -m pytest tests/test_hermes_logging.py::TestSetupLogging::test_writes_to_agent_log tests/test_hermes_logging.py::TestSetupLogging::test_warnings_appear_in_both_logs -o addopts='' -q`
- [x] `hermes chat -q 'Reply with exactly OK.' --quiet`
