### PR TITLE
fix(tools): guard json.loads against non-JSON HTTP responses in discord_tool and osv_check

### DIFF
--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -87,7 +87,14 @@ def _discord_request(
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             if resp.status == 204:
                 return None
-            return json.loads(resp.read().decode("utf-8"))
+            raw = resp.read().decode("utf-8")
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                raise DiscordAPIError(
+                    resp.status,
+                    f"Non-JSON response: {raw[:200]}",
+                ) from None
     except urllib.error.HTTPError as e:
         error_body = ""
         try:

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -147,8 +147,12 @@ def _query_osv(
         method="POST",
     )
 
-    with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
-        result = json.loads(resp.read())
+    try:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
+            result = json.loads(resp.read())
+    except json.JSONDecodeError:
+        logger.debug("OSV API returned non-JSON response")
+        return []
 
     vulns = result.get("vulns", [])
     # Only malware advisories — ignore regular CVEs


### PR DESCRIPTION
## Problem

`tools/discord_tool.py` and `tools/osv_check.py` call `json.loads()` on HTTP response bodies inside `try/except` blocks that only catch `HTTPError` — not `json.JSONDecodeError`. If a proxy, WAF, CDN, or rate-limiter returns an HTML/text body on a 200 response, the unhandled `JSONDecodeError` crashes the tool with an uncaught exception.

## Fix

### discord_tool.py

Wrap `json.loads()` in an inner `try/except json.JSONDecodeError`. On failure, re-raise as `DiscordAPIError` with the truncated response body for debugging context. This preserves the existing error handling contract — callers already handle `DiscordAPIError`.

### osv_check.py

Wrap `json.loads()` in `try/except json.JSONDecodeError`. On failure, log at DEBUG and return an empty list. This is consistent with the existing network error handling which also fails open (returns `[]` on `URLError`).

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Discord API returns HTML on 200 | Uncaught `JSONDecodeError` | `DiscordAPIError(200, "Non-JSON response: ...")` |
| OSV API returns non-JSON | Uncaught `JSONDecodeError` | Returns `[]` (fail-open) |

## Tests

- `tests/tools/test_discord_tool.py`: 90/90 pass
- `tests/tools/test_osv_check.py`: 24/24 pass
