### PR TITLE
fix(agent): use atomic writes for context length YAML cache

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 import requests
 import yaml
 
-from utils import base_url_host_matches, base_url_hostname
+from utils import atomic_yaml_write, base_url_host_matches, base_url_hostname
 
 from hermes_constants import OPENROUTER_MODELS_URL
 
@@ -846,9 +846,7 @@ def save_context_length(model: str, base_url: str, length: int) -> None:
     cache[key] = length
     path = _get_context_cache_path()
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            yaml.dump({"context_lengths": cache}, f, default_flow_style=False)
+        atomic_yaml_write(path, {"context_lengths": cache})
         logger.info("Cached context length %s -> %s tokens", key, f"{length:,}")
     except Exception as e:
         logger.debug("Failed to save context length cache: %s", e)
@@ -870,9 +868,7 @@ def _invalidate_cached_context_length(model: str, base_url: str) -> None:
     del cache[key]
     path = _get_context_cache_path()
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            yaml.dump({"context_lengths": cache}, f, default_flow_style=False)
+        atomic_yaml_write(path, {"context_lengths": cache})
     except Exception as e:
         logger.debug("Failed to invalidate context length cache entry %s: %s", key, e)
 


### PR DESCRIPTION
## Problem

`save_context_length()` and `_invalidate_cached_context_length()` in `agent/model_metadata.py` write directly to the YAML context length cache file using `open(path, "w") + yaml.dump()`. If the process crashes mid-write, the file is truncated to zero or partial bytes, corrupting the cache and losing all cached context lengths.

The codebase already has `atomic_yaml_write()` in `utils.py` which uses the correct temp-file + fsync + `os.replace()` pattern.

## Fix

Replace direct `open(path, "w") + yaml.dump()` calls with `atomic_yaml_write(path, data)`. The existing helper handles directory creation, temp file, fsync, atomic rename, and file permission preservation.

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Crash during write | Cache file corrupted (0 bytes or partial YAML) | Previous cache version intact |
| Normal write | Direct write to target | Temp file → fsync → atomic rename |

## Tests

All 102 model_metadata tests pass, including:
- `TestContextLengthCache::test_save_and_load`
- `TestContextLengthCache::test_corrupted_yaml_returns_empty`
- `TestContextLengthCache::test_idempotent_save`
