### PR TITLE
fix(dashboard): allow chat websockets on insecure public bind (salvage #33278)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3371,9 +3371,14 @@ _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
 def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     """Check if the WebSocket client IP is acceptable.
 
-    Loopback mode: only loopback clients allowed — the legacy
+    Loopback bind: only loopback clients allowed — the legacy
     ``?token=<_SESSION_TOKEN>`` path is the only auth we have, so we
     don't want LAN hosts guessing tokens.
+
+    All-interfaces insecure bind (``--host 0.0.0.0 --insecure`` or
+    ``--host :: --insecure``): allow any peer. The operator explicitly
+    opted into LAN/public exposure in this mode, so the loopback-only peer
+    restriction should not apply.
 
     Gated mode: any peer is allowed — uvicorn's ``proxy_headers=True``
     (enabled when the OAuth gate is active so cookies can pick up
@@ -3384,6 +3389,9 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     blocks DNS-rebinding here, not the peer IP.
     """
     if getattr(app.state, "auth_required", False):
+        return True
+    bound_host = getattr(app.state, "bound_host", "")
+    if bound_host in {"0.0.0.0", "::"}:
         return True
     client_host = ws.client.host if ws.client else ""
     if not client_host:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "drpelagik@gmail.com": "SeaXen",
     "metalclaudbot@gmail.com": "HashClawAI",
     "tonybear55665566@gmail.com": "TonyPepeBear",
     "kaspersniels@gmail.com": "nielskaspers",

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -80,6 +80,25 @@ def loopback_app():
     web_server.app.state.auth_required = prev_required
 
 
+@pytest.fixture
+def insecure_public_app():
+    """web_server.app configured for all-interfaces insecure mode."""
+    _reset_for_tests()
+    clear_providers()
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "0.0.0.0"
+    web_server.app.state.bound_port = 9120
+    web_server.app.state.auth_required = False
+    client = TestClient(web_server.app, base_url="http://192.168.0.222:9120")
+    yield client
+    _reset_for_tests()
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
 def _logged_in(client: TestClient) -> None:
     """Drive the stub OAuth round trip so the client holds session cookies."""
     r1 = client.get("/auth/login?provider=stub", follow_redirects=False)
@@ -279,6 +298,21 @@ class TestWsRequestIsAllowedGated:
     def test_loopback_peer_allowed_in_loopback_mode(self, loopback_app):
         ws = _fake_ws(query={}, client_host="127.0.0.1")
         ws.headers = {"host": "127.0.0.1:8080"}
+        assert web_server._ws_request_is_allowed(ws) is True
+
+    def test_non_loopback_peer_allowed_in_insecure_public_mode(self, insecure_public_app):
+        """`--host 0.0.0.0 --insecure` is an explicit LAN/public opt-in.
+
+        Regression coverage for the dashboard `/chat` breakage where the
+        HTML shell loaded on 9120 but every WebSocket upgrade was rejected
+        with 403 because the loopback-only peer guard still ran even though
+        the operator intentionally exposed the dashboard on all interfaces.
+        """
+        ws = _fake_ws(query={}, client_host="192.168.0.55")
+        ws.headers = {
+            "host": "192.168.0.222:9120",
+            "origin": "http://192.168.0.222:9120",
+        }
         assert web_server._ws_request_is_allowed(ws) is True
 
     def test_host_origin_guard_still_runs_in_gated_mode(self, gated_app):


### PR DESCRIPTION
## Summary
Dashboard chat WebSockets (`/api/ws`, `/api/events`, `/api/pty`, `/api/pub`) now connect on an all-interfaces insecure bind (`--host 0.0.0.0 --insecure`), matching the HTTP/REST endpoints that were already public in that mode.

Root cause: `_ws_client_is_allowed()` hard-rejected any non-loopback peer unless the OAuth gate was active. `--insecure` leaves `auth_required=False`, so the loopback-only peer guard still ran and 403'd every LAN/public WebSocket upgrade — even though HTTP worked fine (HTTP has no peer-IP check). This broke the Chat tab and live event feed for every Docker dashboard deployment using `--insecure` on a trusted LAN.

Salvage of #33278 by @SeaXen, cherry-picked onto current main with authorship preserved.

## Changes
- `hermes_cli/web_server.py`: `_ws_client_is_allowed()` returns True when `bound_host in {"0.0.0.0", "::"}` — a bind only reachable via `--insecure` (otherwise the OAuth gate engages or `start_server` refuses to bind).
- `tests/hermes_cli/test_dashboard_auth_ws_auth.py`: regression test driving the real `_ws_request_is_allowed` path with Host/Origin headers, proving the DNS-rebind guard still runs.
- `scripts/release.py`: AUTHOR_MAP entry for @SeaXen.

## Validation
| Scenario | Before | After |
|---|---|---|
| Loopback bind, LAN peer | reject | reject (unchanged) |
| Loopback bind, loopback peer | allow | allow (unchanged) |
| `0.0.0.0` + `--insecure`, LAN peer | **403** | **allow** |
| `0.0.0.0` + `--insecure`, attacker Origin | rely on operator net controls | unchanged (pre-existing 0.0.0.0 Host-guard behavior) |
| OAuth-gated bind, remote peer | allow (ticket auth) | allow (unchanged) |

Targeted suite: `tests/hermes_cli/test_dashboard_auth_ws_auth.py` 22/22 pass. E2E verified all five binds above against the real resolution path.

Fixes #34396. Closes #34227 (duplicate report). Supersedes #32614, #31772.



## Infographic

![dashboard-websockets-insecure-bind](https://v3b.fal.media/files/b/0a9c41ab/HaKispYmJrpxX7GOIdmgB_gTz7PmuF.png)
