### PR TITLE
fix(model_switch): merge live API models with user-configured models …

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1515,10 +1515,11 @@ def list_authenticated_providers(
                     if fb:
                         models_list = list(fb)
 
-            # Prefer the endpoint's live /models list when credentials are
-            # available, unless the provider explicitly opts out via
-            # discover_models: false (e.g. dedicated endpoints that expose
-            # the entire aggregator catalog via /models).
+            # Merge the endpoint's live /models response with the
+            # user-configured list when credentials are available, unless
+            # the provider explicitly opts out via discover_models: false
+            # (e.g. dedicated endpoints that expose the entire aggregator
+            # catalog via /models).
             api_key = str(ep_cfg.get("api_key", "") or "").strip()
             if not api_key:
                 key_env = str(ep_cfg.get("key_env", "") or "").strip()
@@ -1531,7 +1532,12 @@ def list_authenticated_providers(
                     from hermes_cli.models import fetch_api_models
                     live_models = fetch_api_models(api_key, api_url)
                     if live_models:
-                        models_list = live_models
+                        # Merge live /models response with user-configured
+                        # list — don't discard models the user explicitly
+                        # specified under ``providers:``.
+                        for m in live_models:
+                            if m and m not in models_list:
+                                models_list.append(m)
                 except Exception:
                     pass
 
@@ -1700,9 +1706,10 @@ def list_authenticated_providers(
             # the Telegram/Discord picker should do the same for parity.
             # Live-discovery policy:
             # - With an api_key, the user has explicitly opted into the
-            #   endpoint and live /models is the source of truth — replace
-            #   the (possibly partial) ``models:`` subset configured for
-            #   context-length overrides with the full live catalog.
+            #   endpoint.  Live /models is used as an additional source
+            #   of models — merged into (not replacing) the user-configured
+            #   ``models:`` list so that explicitly-specified entries are
+            #   never silently dropped.
             #   This is the Bifrost / aggregator-gateway case.
             # - Without an api_key but with an explicit ``models:`` list
             #   (or top-level ``model:``), the user is narrowing a public
@@ -1719,8 +1726,13 @@ def list_authenticated_providers(
 
                     live_models = fetch_api_models(api_key, api_url)
                     if live_models:
-                        grp["models"] = live_models
-                        grp["total_models"] = len(live_models)
+                        # Merge live /models response with user-configured
+                        # list — don't discard models the user explicitly
+                        # specified under ``custom_providers:``.
+                        for m in live_models:
+                            if m and m not in grp["models"]:
+                                grp["models"].append(m)
+                        grp["total_models"] = len(grp["models"])
                 except Exception:
                     pass
             results.append({

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -589,6 +589,55 @@ def test_list_authenticated_providers_dedup_honors_base_url_env_override(monkeyp
     )
 
 
+def test_list_authenticated_providers_merges_live_models_for_custom_providers(monkeypatch):
+    """custom_providers live discovery should add models, not replace explicit ones.
+
+    Regression: section 4 previously assigned ``grp["models"] = live_models``.
+    That dropped models explicitly configured by the user whenever the live
+    /models endpoint returned a different catalog.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url):
+        calls.append((api_key, base_url))
+        return ["", "configured-model", "live-only-model"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    custom_providers = [
+        {
+            "name": "Private Relay — configured",
+            "base_url": "https://relay.example.internal/v1",
+            "api_key": "sk-relay-test",
+            "model": "configured-model",
+            "models": {
+                "configured-model": {"context_length": 200000},
+                "manual-only-model": {"context_length": 128000},
+            },
+        }
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="custom:private-relay",
+        user_providers={},
+        custom_providers=custom_providers,
+        max_models=50,
+    )
+
+    row = next((p for p in providers if p["slug"] == "custom:private-relay"), None)
+    assert row is not None
+    assert calls == [("sk-relay-test", "https://relay.example.internal/v1")]
+    assert row["models"] == [
+        "configured-model",
+        "manual-only-model",
+        "live-only-model",
+    ]
+    assert row["total_models"] == 3
+
+
 # =============================================================================
 # Tests for _get_named_custom_provider with providers: dict
 # =============================================================================


### PR DESCRIPTION
Related Issue

Fixes #36639

What does this PR do?

Fixes `list_authenticated_providers()` so live `/models` discovery merges API-reported models with user-configured models instead of replacing them.

Previously, when a provider had valid API credentials, live model discovery replaced the entire user-configured model list. This could silently drop models explicitly configured under `providers:` or `custom_providers:`.

This PR preserves user-configured entries and only appends additional live-discovered models that are not already present.

Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

Changes Made

Section 3 (`providers:`) in `hermes_cli/model_switch.py`: changed live discovery from replacement to deduplicated merge, preserving explicitly configured models.

Section 4 (`custom_providers:`) in `hermes_cli/model_switch.py`: changed `grp["models"] = live_models` to deduplicated append, preserving explicitly configured custom provider models.

Filters empty model IDs from live `/models` responses for consistency with existing config model handling.

Added regression test for `custom_providers:` live model merge behavior.

How to Test

venv/bin/pytest tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_list_picker_providers.py -q


Result: 40 passed.

Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've run relevant tests
- [x] I've added tests for my changes
- [x] I've tested on my platform
- [x] I've updated relevant documentation, comments, or docstrings where needed
- [x] I've considered cross-platform impact
- [ ] I've updated tool descriptions if tool behavior changed

For New Skills

N/A

Screenshots / Logs

N/A