### PR TITLE
feat(slack): use markdown block for native table rendering

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -778,32 +778,52 @@ class SlackAdapter(BasePlatformAdapter):
                     slash_ctx, content,
                 )
 
-            # Convert standard markdown → Slack mrkdwn
-            formatted = self.format_message(content)
-
-            # Split long messages, preserving code block boundaries
-            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
-
             thread_ts = self._resolve_thread_ts(reply_to, metadata)
-            last_result = None
-
-            # reply_broadcast: also post thread replies to the main channel.
-            # Controlled via platform config: gateway.slack.reply_broadcast
             broadcast = self.config.extra.get("reply_broadcast", False)
 
-            for i, chunk in enumerate(chunks):
-                kwargs = {
+            # Slack's markdown block (April 2026) natively renders standard
+            # markdown including tables, bold, links, code blocks, and lists.
+            # Limit: 12,000 chars per markdown block. For longer messages,
+            # fall back to legacy mrkdwn text path with chunking.
+            MARKDOWN_BLOCK_LIMIT = 12000
+            if len(content) <= MARKDOWN_BLOCK_LIMIT:
+                # Use markdown block for native rendering.
+                # format_message() output serves as text fallback for
+                # notifications, search, and accessibility.
+                blocks = [{"type": "markdown", "text": content}]
+                fallback_text = self.format_message(content)
+                kwargs: dict = {
                     "channel": chat_id,
-                    "text": chunk,
-                    "mrkdwn": True,
+                    "text": fallback_text,
+                    "blocks": blocks,
                 }
                 if thread_ts:
                     kwargs["thread_ts"] = thread_ts
-                    # Only broadcast the first chunk of the first reply
-                    if broadcast and i == 0:
+                    if broadcast:
                         kwargs["reply_broadcast"] = True
 
                 last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+            else:
+                # Convert standard markdown → Slack mrkdwn
+                formatted = self.format_message(content)
+
+                # Split long messages, preserving code block boundaries
+                chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+
+                last_result = None
+                for i, chunk in enumerate(chunks):
+                    kwargs = {
+                        "channel": chat_id,
+                        "text": chunk,
+                        "mrkdwn": True,
+                    }
+                    if thread_ts:
+                        kwargs["thread_ts"] = thread_ts
+                        # Only broadcast the first chunk of the first reply
+                        if broadcast and i == 0:
+                            kwargs["reply_broadcast"] = True
+
+                    last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
@@ -880,12 +900,24 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
         try:
-            formatted = self.format_message(content)
-            await self._get_client(chat_id).chat_update(
-                channel=chat_id,
-                ts=message_id,
-                text=formatted,
-            )
+            # Use markdown block for native rendering (tables, bold, etc.)
+            # Limit: 12,000 chars. Fall back to mrkdwn text for longer content.
+            MARKDOWN_BLOCK_LIMIT = 12000
+            if len(content) <= MARKDOWN_BLOCK_LIMIT:
+                fallback_text = self.format_message(content)
+                await self._get_client(chat_id).chat_update(
+                    channel=chat_id,
+                    ts=message_id,
+                    text=fallback_text,
+                    blocks=[{"type": "markdown", "text": content}],
+                )
+            else:
+                formatted = self.format_message(content)
+                await self._get_client(chat_id).chat_update(
+                    channel=chat_id,
+                    ts=message_id,
+                    text=formatted,
+                )
             if finalize:
                 await self.stop_typing(chat_id)
             return SendResult(success=True, message_id=message_id)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -582,11 +582,9 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     media_files = media_files or []
 
     if platform == Platform.SLACK and message:
-        try:
-            slack_adapter = SlackAdapter.__new__(SlackAdapter)
-            message = slack_adapter.format_message(message)
-        except Exception:
-            logger.debug("Failed to apply Slack mrkdwn formatting in _send_to_platform", exc_info=True)
+        # Do NOT call format_message() here — the markdown block (used in
+        # _send_slack) expects raw standard markdown, not Slack mrkdwn.
+        pass
 
     # Platform message length limits (from adapter class attributes for
     # built-in platforms; from PlatformEntry.max_message_length for plugins).
@@ -1034,7 +1032,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 
 
 async def _send_slack(token, chat_id, message):
-    """Send via Slack Web API."""
+    """Send via Slack Web API using markdown blocks for native rendering."""
     try:
         import aiohttp
     except ImportError:
@@ -1045,8 +1043,20 @@ async def _send_slack(token, chat_id, message):
         _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
         url = "https://slack.com/api/chat.postMessage"
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
+
+        # Slack markdown block (April 2026): natively renders standard
+        # markdown including tables, bold, links, code blocks, and lists.
+        # Limit: 12,000 chars. For longer messages, fall back to mrkdwn text.
+        MARKDOWN_BLOCK_LIMIT = 12000
+        if len(message) <= MARKDOWN_BLOCK_LIMIT:
+            payload = {
+                "channel": chat_id,
+                "text": message,
+                "blocks": [{"type": "markdown", "text": message}],
+            }
+        else:
             payload = {"channel": chat_id, "text": message, "mrkdwn": True}
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             async with session.post(url, headers=headers, json=payload, **_req_kw) as resp:
                 data = await resp.json()
                 if data.get("ok"):


### PR DESCRIPTION
Replaces legacy mrkdwn text path with Slack's markdown block type (April 2026), which natively renders standard markdown including tables, bold, links, code blocks, lists, and headers.

Fixes #26947. Related: #8552.

## Changes

### gateway/platforms/slack.py
- send(): Wraps content in {"type": "markdown", "text": content} block. format_message() output as text fallback. >12K chars falls back to legacy mrkdwn path.
- edit_message(): Same markdown block treatment for streaming edits.

### tools/send_message_tool.py
- _send_slack(): Uses markdown blocks instead of mrkdwn: True.
- _send_to_platform(): No longer calls format_message() for Slack — raw markdown must be preserved for the markdown block.