### PR TITLE
fix: let Desktop suppress auto gateway launch

### DIFF
--- a/hermes
+++ b/hermes
@@ -6,6 +6,54 @@ This wrapper should behave like the installed `hermes` command, including
 subcommands such as `gateway`, `cron`, and `doctor`.
 """
 
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _desktop_auto_gateway_disabled() -> bool:
+    """Return True when Desktop's local auto-gateway spawn should be suppressed."""
+    config_path = Path.home() / ".hermes" / "desktop.json"
+    try:
+        data = json.loads(config_path.read_text(encoding="utf-8")) if config_path.exists() else {}
+    except Exception:
+        data = {}
+    return bool(data.get("disableAutoGateway"))
+
+
+def _parent_is_hermes_desktop() -> bool:
+    """Detect the macOS Electron app as the direct parent, without affecting CLI use."""
+    test_cmd = os.environ.get("HERMES_DESKTOP_PARENT_CMD_TEST")
+    if test_cmd is not None:
+        return "Hermes Agent.app" in test_cmd or "/Applications/Hermes Agent.app/" in test_cmd
+    try:
+        parent_cmd = subprocess.check_output(
+            ["/bin/ps", "-p", str(os.getppid()), "-o", "command="],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        )
+    except Exception:
+        return False
+    return "Hermes Agent.app" in parent_cmd or "/Applications/Hermes Agent.app/" in parent_cmd
+
+
+def _maybe_suppress_desktop_auto_gateway() -> None:
+    if len(sys.argv) < 2 or sys.argv[1] != "gateway":
+        return
+    if not _desktop_auto_gateway_disabled():
+        return
+    if not _parent_is_hermes_desktop():
+        return
+    print("Hermes Desktop auto gateway start suppressed by ~/.hermes/desktop.json disableAutoGateway=true")
+    raise SystemExit(0)
+
+
 if __name__ == "__main__":
+    _maybe_suppress_desktop_auto_gateway()
     from hermes_cli.main import main
     main()

--- a/tests/hermes_cli/test_launcher.py
+++ b/tests/hermes_cli/test_launcher.py
@@ -1,5 +1,6 @@
 """Tests for the top-level `./hermes` launcher script."""
 
+import json
 import runpy
 import sys
 import types
@@ -36,6 +37,65 @@ def test_launcher_delegates_to_argparse_entrypoint(monkeypatch):
     monkeypatch.setitem(sys.modules, "fire", fake_fire_module)
 
     monkeypatch.setattr(sys, "argv", [str(launcher_path), "gateway", "status"])
+
+    runpy.run_path(str(launcher_path), run_name="__main__")
+
+    assert called == ["hermes_cli.main"]
+
+
+def test_launcher_suppresses_desktop_auto_gateway_when_configured(monkeypatch, tmp_path, capsys):
+    """Desktop can opt out of spawning a local gateway from the app wrapper."""
+    launcher_path = Path(__file__).resolve().parents[2] / "hermes"
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "desktop.json").write_text(
+        json.dumps({"disableAutoGateway": True}), encoding="utf-8"
+    )
+
+    fake_main_module = types.ModuleType("hermes_cli.main")
+
+    def fake_main():
+        raise AssertionError("suppressed Desktop gateway start should not call main")
+
+    fake_main_module.main = fake_main
+    monkeypatch.setitem(sys.modules, "hermes_cli.main", fake_main_module)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv(
+        "HERMES_DESKTOP_PARENT_CMD_TEST",
+        "/Applications/Hermes Agent.app/Contents/MacOS/Hermes Agent",
+    )
+    monkeypatch.setattr(sys, "argv", [str(launcher_path), "gateway", "run"])
+
+    try:
+        runpy.run_path(str(launcher_path), run_name="__main__")
+    except SystemExit as exc:
+        assert exc.code == 0
+    else:
+        raise AssertionError("expected launcher suppression to exit")
+
+    assert "auto gateway start suppressed" in capsys.readouterr().out
+
+
+def test_launcher_does_not_suppress_non_desktop_gateway(monkeypatch, tmp_path):
+    """The Desktop guard must not affect normal CLI gateway use."""
+    launcher_path = Path(__file__).resolve().parents[2] / "hermes"
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "desktop.json").write_text(
+        json.dumps({"disableAutoGateway": True}), encoding="utf-8"
+    )
+    called = []
+
+    fake_main_module = types.ModuleType("hermes_cli.main")
+
+    def fake_main():
+        called.append("hermes_cli.main")
+
+    fake_main_module.main = fake_main
+    monkeypatch.setitem(sys.modules, "hermes_cli.main", fake_main_module)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_DESKTOP_PARENT_CMD_TEST", "/bin/zsh")
+    monkeypatch.setattr(sys, "argv", [str(launcher_path), "gateway", "run"])
 
     runpy.run_path(str(launcher_path), run_name="__main__")
 


### PR DESCRIPTION
Summary
- Add a launcher guard that lets Hermes Desktop suppress automatic `hermes gateway ...` starts when `~/.hermes/desktop.json` sets `disableAutoGateway: true`.
- Scope the guard to the macOS Desktop parent process so normal CLI gateway usage still delegates to `hermes_cli.main`.
- Add launcher tests for Desktop suppression and non-Desktop gateway behavior.

Verification
- `python -m pytest tests/hermes_cli/test_launcher.py -q -o 'addopts='` → 3 passed
- `/Users/lidises/.hermes/hermes-office`: `npm run smoke:hermes-desktop` → passed
- `/Users/lidises/.hermes/hermes-office`: `npm run smoke:dev-server` → passed

Safety
- Does not print or touch secrets.
- Does not change Telegram config; Mac Telegram remains disabled for the user's VPS-owned Telegram topology.
- Suppression only applies when launched by Hermes Desktop and the local Desktop config explicitly opts in.
