### PR TITLE
fix: bump retrieval_count in list_facts()

### DIFF
--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -348,7 +348,16 @@ class MemoryStore:
                 LIMIT ?
             """
             rows = self._conn.execute(sql, params).fetchall()
-            return [self._row_to_dict(r) for r in rows]
+            results = [self._row_to_dict(r) for r in rows]
+            if results:
+                ids = [r["fact_id"] for r in results]
+                placeholders = ",".join("?" * len(ids))
+                self._conn.execute(
+                    f"UPDATE facts SET retrieval_count = retrieval_count + 1 WHERE fact_id IN ({placeholders})",
+                    ids,
+                )
+                self._conn.commit()
+            return results
 
     def record_feedback(self, fact_id: int, helpful: bool) -> dict:
         """Record user feedback and adjust trust asymmetrically.


### PR DESCRIPTION
## Bug

`HolographicStore.list_facts()` did not increment `retrieval_count` on returned facts. All other retrieval methods (`search`, `probe`, `related`, `reason`, `contradict`) correctly call `_bump_retrieval_count()`, but `list` — which is the primary way agents browse the fact store — was silently skipping it.

This meant facts frequently accessed via `list` never had their usage tracked, so the trust score system's frequency data was incomplete.

## Fix

Added the same `UPDATE facts SET retrieval_count = retrieval_count + 1` pattern used in `search_facts()` to `list_facts()`, applied after the SELECT and before returning results.

## Testing

- Verified fix produces incrementing `retrieval_count` values across consecutive `list` calls
- Confirmed SQL UPDATE fires correctly against live database
- Gateway restart required to load patched module (old process had cached bytecode)
- All existing `search`/`probe`/`related`/`reason`/`contradict` bump behavior unchanged