### PR TITLE
fix(tui): submit saved editor prompt

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1655,6 +1655,24 @@ def test_complete_slash_includes_tui_mouse_command():
     assert any(item["text"] == "/mouse" for item in resp["result"]["items"])
 
 
+def test_complete_slash_includes_tui_editor_command():
+    resp = server.handle_request(
+        {"id": "1", "method": "complete.slash", "params": {"text": "/edi"}}
+    )
+    assert isinstance(resp, dict)
+    result = resp.get("result") or {}
+
+    assert any(item["text"] == "/editor" for item in result.get("items", []))
+
+
+def test_commands_catalog_includes_tui_editor_command():
+    resp = server.handle_request({"id": "1", "method": "commands.catalog", "params": {}})
+    assert isinstance(resp, dict)
+    result = resp.get("result") or {}
+
+    assert ["/editor", "Open VS Code/default editor; saved text becomes the prompt"] in result.get("pairs", [])
+
+
 def test_complete_slash_details_args():
     resp_root = server.handle_request(
         {"id": "0", "method": "complete.slash", "params": {"text": "/details"}}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4741,6 +4741,7 @@ _TUI_HIDDEN: frozenset[str] = frozenset(
 
 _TUI_EXTRA: list[tuple[str, str, str]] = [
     ("/compact", "Toggle compact display mode", "TUI"),
+    ("/editor", "Open VS Code/default editor; saved text becomes the prompt", "TUI"),
     ("/logs", "Show recent gateway log lines", "TUI"),
     (
         "/mouse",
@@ -5621,6 +5622,11 @@ def _(rid, params: dict) -> dict:
                 "text": "/details",
                 "display": "/details",
                 "meta": "Control agent detail visibility",
+            },
+            {
+                "text": "/editor",
+                "display": "/editor",
+                "meta": "Open VS Code/default editor; saved text becomes the prompt",
             },
             {
                 "text": "/logs",

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -36,6 +36,22 @@ describe('createSlashHandler', () => {
     expect(ctx.transcript.sys).toHaveBeenCalledWith('ui redrawn')
   })
 
+  it('opens the local editor for /editor without slash worker fallback', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/editor')).toBe(true)
+    expect(ctx.composer.openEditor).toHaveBeenCalledWith('')
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
+  it('opens the local editor for /edit with draft text prefilled', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/edit make this the prompt')).toBe(true)
+    expect(ctx.composer.openEditor).toHaveBeenCalledWith('make this the prompt')
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
   it('exits locally for /quit', () => {
     const ctx = buildCtx()
 
@@ -761,6 +777,7 @@ const buildCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
 const buildComposer = () => ({
   enqueue: vi.fn(),
   hasSelection: false,
+  openEditor: vi.fn(() => Promise.resolve()),
   paste: vi.fn(),
   queueRef: { current: [] as string[] },
   selection: { copySelection: vi.fn(async () => '') },

--- a/ui-tui/src/__tests__/useSubmission.test.ts
+++ b/ui-tui/src/__tests__/useSubmission.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { submittedValueCanUseComposerCompletion } from '../app/useSubmission.js'
+
+describe('submittedValueCanUseComposerCompletion', () => {
+  it('ignores stale slash completions when editor submits saved text', () => {
+    expect(
+      submittedValueCanUseComposerCompletion({
+        completionCount: 1,
+        composerInput: '/editor',
+        value: 'run this saved prompt'
+      })
+    ).toBe(false)
+  })
+
+  it('allows completion only for the current composer draft', () => {
+    expect(
+      submittedValueCanUseComposerCompletion({
+        completionCount: 1,
+        composerInput: '/edi',
+        value: '/edi'
+      })
+    ).toBe(true)
+  })
+
+  it('does not apply completion when there are no completions', () => {
+    expect(
+      submittedValueCanUseComposerCompletion({
+        completionCount: 0,
+        composerInput: '/edi',
+        value: '/edi'
+      })
+    ).toBe(false)
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -143,7 +143,7 @@ export interface ComposerActions {
   dequeue: () => string | undefined
   enqueue: (text: string) => void
   handleTextPaste: (event: PasteEvent) => MaybePromise<ComposerPasteResult | null>
-  openEditor: () => Promise<void>
+  openEditor: (initialText?: string) => Promise<void>
   pushHistory: (text: string) => void
   removeQueue: (index: number) => void
   replaceQueue: (index: number, text: string) => void
@@ -268,6 +268,7 @@ export interface SlashHandlerContext {
   composer: {
     enqueue: (text: string) => void
     hasSelection: boolean
+    openEditor: (initialText?: string) => Promise<void>
     paste: (quiet?: boolean) => void
     queueRef: MutableRefObject<string[]>
     selection: SelectionApi

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -190,6 +190,17 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    aliases: ['edit'],
+    help: 'open VS Code/default editor; saved text becomes the prompt',
+    name: 'editor',
+    run: (arg, ctx) => {
+      ctx.composer.openEditor(arg.trim()).catch((err: unknown) => {
+        ctx.transcript.sys(err instanceof Error ? `failed to open editor: ${err.message}` : 'failed to open editor')
+      })
+    }
+  },
+
+  {
     help: 'show live session info',
     name: 'status',
     run: (_arg, ctx) => {

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -267,12 +267,12 @@ export function useComposerState({
     [handleResolvedPaste, onClipboardPaste, querier]
   )
 
-  const openEditor = useCallback(async () => {
+  const openEditor = useCallback(async (initialText?: string) => {
     const dir = mkdtempSync(join(tmpdir(), 'hermes-'))
     const file = join(dir, 'prompt.md')
     const [cmd, ...args] = resolveEditor()
 
-    writeFileSync(file, [...inputBuf, input].join('\n'))
+    writeFileSync(file, initialText ?? [...inputBuf, input].join('\n'))
 
     let exitCode: null | number = null
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -758,6 +758,7 @@ export function useMainApp(gw: GatewayClient) {
         composer: {
           enqueue: composerActions.enqueue,
           hasSelection,
+          openEditor: composerActions.openEditor,
           paste,
           queueRef: composerRefs.queueRef,
           selection,

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -24,6 +24,16 @@ const SESSION_BUSY_RE = /session busy|waiting for model response/i
 
 const isSessionBusyError = (e: unknown) => e instanceof Error && SESSION_BUSY_RE.test(e.message)
 
+export const submittedValueCanUseComposerCompletion = ({
+  completionCount,
+  composerInput,
+  value
+}: {
+  completionCount: number
+  composerInput: string
+  value: string
+}): boolean => completionCount > 0 && value === composerInput
+
 const expandSnips = (snips: PasteSnippet[]) => {
   const byLabel = new Map<string, string[]>()
 
@@ -360,7 +370,13 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
   const submit = useCallback(
     (value: string) => {
-      if (composerState.completions.length) {
+      if (
+        submittedValueCanUseComposerCompletion({
+          completionCount: composerState.completions.length,
+          composerInput: composerState.input,
+          value
+        })
+      ) {
         const row = composerState.completions[composerState.compIdx]
 
         if (row?.text) {

--- a/ui-tui/src/lib/editor.test.ts
+++ b/ui-tui/src/lib/editor.test.ts
@@ -35,6 +35,12 @@ describe('resolveEditor', () => {
     expect(resolveEditor({ PATH: dir, VISUAL: 'emacsclient -t' })).toEqual(['emacsclient', '-t'])
   })
 
+  it('adds --wait to explicit VS Code editor commands so Hermes sees the saved prompt', () => {
+    expect(resolveEditor({ EDITOR: 'code', PATH: dir })).toEqual(['code', '--wait'])
+    expect(resolveEditor({ EDITOR: 'code --reuse-window', PATH: dir })).toEqual(['code', '--reuse-window', '--wait'])
+    expect(resolveEditor({ EDITOR: 'code-insiders --wait', PATH: dir })).toEqual(['code-insiders', '--wait'])
+  })
+
   it('ignores whitespace-only env vars', () => {
     const expected = exe(dir, 'editor')
 
@@ -47,6 +53,13 @@ describe('resolveEditor', () => {
     const expected = exe(dir, 'editor')
 
     expect(resolveEditor({ PATH: dir })).toEqual([expected])
+  })
+
+  it('uses VS Code with --wait as the default fallback when code is on $PATH', () => {
+    const expected = exe(dir, 'code')
+    exe(dir, 'editor')
+
+    expect(resolveEditor({ PATH: dir })).toEqual([expected, '--wait'])
   })
 
   it('falls back to nano before vi when both exist', () => {

--- a/ui-tui/src/lib/editor.ts
+++ b/ui-tui/src/lib/editor.ts
@@ -1,11 +1,10 @@
 import { accessSync, constants } from 'node:fs'
 import { delimiter, join } from 'node:path'
 
-/**
- * Editor fallback chain when neither $VISUAL nor $EDITOR is set. Mirrors
- * prompt_toolkit's `Buffer.open_in_editor()` picker so the classic CLI and
- * the TUI launch the same editor on a given box.
- */
+const VSCODE_COMMANDS = new Set(['code', 'code-insiders', 'codium', 'vscodium'])
+const VSCODE_FALLBACKS = ['code', 'code-insiders', 'codium', 'vscodium']
+
+/** Editor fallback chain when neither $VISUAL nor $EDITOR is set. */
 const FALLBACKS = ['editor', 'nano', 'pico', 'vi', 'emacs']
 
 const isExecutable = (path: string): boolean => {
@@ -18,13 +17,32 @@ const isExecutable = (path: string): boolean => {
   }
 }
 
+const commandName = (cmd: string): string => cmd.split(/[\\/]/).pop()?.replace(/\.(cmd|exe)$/i, '') ?? cmd
+
+const findExecutable = (names: string[], env: NodeJS.ProcessEnv): null | string => {
+  const dirs = (env.PATH ?? '').split(delimiter).filter(Boolean)
+
+  return names.flatMap(name => dirs.map(d => join(d, name))).find(isExecutable) ?? null
+}
+
+const withBlockingArgs = (argv: string[]): string[] => {
+  const [cmd, ...args] = argv
+
+  if (!cmd || !VSCODE_COMMANDS.has(commandName(cmd))) {
+    return argv
+  }
+
+  return args.includes('--wait') ? argv : [cmd, ...args, '--wait']
+}
+
 /**
  * Resolve the editor invocation argv (without the file argument).
  *
  *   1. $VISUAL / $EDITOR, shell-tokenized so `EDITOR="code --wait"` works
- *   2. on POSIX: first FALLBACKS entry resolvable on $PATH
- *   3. on Windows: `notepad.exe`
- *   4. literal `['vi']` as the last-resort POSIX floor
+ *   2. on POSIX: VS Code (`code --wait`) when it is resolvable on $PATH
+ *   3. on POSIX: first FALLBACKS entry resolvable on $PATH
+ *   4. on Windows: `notepad.exe`
+ *   5. literal `['vi']` as the last-resort POSIX floor
  */
 export const resolveEditor = (
   env: NodeJS.ProcessEnv = process.env,
@@ -33,15 +51,20 @@ export const resolveEditor = (
   const explicit = env.VISUAL ?? env.EDITOR
 
   if (explicit?.trim()) {
-    return explicit.trim().split(/\s+/)
+    return withBlockingArgs(explicit.trim().split(/\s+/))
   }
 
   if (platform === 'win32') {
     return ['notepad.exe']
   }
 
-  const dirs = (env.PATH ?? '').split(delimiter).filter(Boolean)
-  const found = FALLBACKS.flatMap(name => dirs.map(d => join(d, name))).find(isExecutable)
+  const vscode = findExecutable(VSCODE_FALLBACKS, env)
+
+  if (vscode) {
+    return withBlockingArgs([vscode])
+  }
+
+  const found = findExecutable(FALLBACKS, env)
 
   return [found ?? 'vi']
 }


### PR DESCRIPTION
## Summary
- Add local TUI /editor command with /edit alias for drafting prompts in the external editor.
- Let /edit <text> prefill the editor buffer and submit saved text through the normal composer path.
- Add autocomplete/catalog coverage plus regression tests for stale slash completion handling.

## Test plan
- npm --prefix ui-tui test -- src/lib/editor.test.ts src/__tests__/createSlashHandler.test.ts src/__tests__/useSubmission.test.ts
- .venv/bin/python -m pytest -o addopts='' tests/test_tui_gateway_server.py::test_complete_slash_includes_tui_editor_command tests/test_tui_gateway_server.py::test_commands_catalog_includes_tui_editor_command -q
- npm --prefix ui-tui run build

## Note
This preserves the TUI editor slash feature across Hermes updates by getting it upstreamed instead of keeping it as a local-only patch.