### PR TITLE
feat(image-gen): support Codex reference images

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -19,8 +19,11 @@ Output is saved as PNG under ``$HERMES_HOME/cache/images/``.
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
+import mimetypes
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.image_gen_provider import (
@@ -143,7 +146,64 @@ def _read_codex_access_token() -> Optional[str]:
         return None
 
 
-def _build_responses_payload(*, prompt: str, size: str, quality: str) -> Dict[str, Any]:
+def _coerce_input_images(value: Any) -> List[str]:
+    """Normalize the optional ``input_images`` kwarg to a clean string list."""
+    if value is None or value == "":
+        return []
+    if isinstance(value, str):
+        items = [value]
+    elif isinstance(value, (list, tuple)):
+        items = list(value)
+    else:
+        raise ValueError("input_images must be a list of image paths/URLs or a single string")
+
+    out: List[str] = []
+    for idx, item in enumerate(items):
+        if not isinstance(item, str):
+            raise ValueError(f"input_images[{idx}] must be a string path or URL")
+        cleaned = item.strip()
+        if cleaned:
+            out.append(cleaned)
+    return out
+
+
+def _image_ref_to_input_part(ref: str) -> Dict[str, str]:
+    """Convert a local path/URL/data URL into a Responses ``input_image`` part."""
+    lowered = ref.lower()
+    if lowered.startswith(("http://", "https://")):
+        return {"type": "input_image", "image_url": ref}
+    if lowered.startswith("data:image/"):
+        return {"type": "input_image", "image_url": ref}
+
+    path = Path(ref).expanduser()
+    if not path.exists():
+        raise ValueError(f"input image not found: {ref}")
+    if not path.is_file():
+        raise ValueError(f"input image is not a file: {ref}")
+
+    mime, _ = mimetypes.guess_type(str(path))
+    if not mime or not mime.startswith("image/"):
+        raise ValueError(f"input image file type is not recognized as an image: {ref}")
+
+    data = base64.b64encode(path.read_bytes()).decode("ascii")
+    return {"type": "input_image", "image_url": f"data:{mime};base64,{data}"}
+
+
+def _build_input_content(prompt: str, input_images: Optional[List[str]] = None) -> List[Dict[str, str]]:
+    """Build Responses message content with text plus optional reference images."""
+    content: List[Dict[str, str]] = [{"type": "input_text", "text": prompt}]
+    for ref in input_images or []:
+        content.append(_image_ref_to_input_part(ref))
+    return content
+
+
+def _build_responses_payload(
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    input_images: Optional[List[str]] = None,
+) -> Dict[str, Any]:
     """Build the Codex Responses request body for an image_generation call."""
     return {
         "model": _CODEX_CHAT_MODEL,
@@ -152,7 +212,7 @@ def _build_responses_payload(*, prompt: str, size: str, quality: str) -> Dict[st
         "input": [{
             "type": "message",
             "role": "user",
-            "content": [{"type": "input_text", "text": prompt}],
+            "content": _build_input_content(prompt, input_images),
         }],
         "tools": [{
             "type": "image_generation",
@@ -242,7 +302,14 @@ def _iter_sse_json(response: Any):
         yield payload
 
 
-def _collect_image_b64(token: str, *, prompt: str, size: str, quality: str) -> Optional[str]:
+def _collect_image_b64(
+    token: str,
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    input_images: Optional[List[str]] = None,
+) -> Optional[str]:
     """Stream a Codex Responses image_generation call and return the b64 image."""
     import httpx
     from agent.auxiliary_client import _codex_cloudflare_headers
@@ -253,7 +320,12 @@ def _collect_image_b64(token: str, *, prompt: str, size: str, quality: str) -> O
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     })
-    payload = _build_responses_payload(prompt=prompt, size=size, quality=quality)
+    payload = _build_responses_payload(
+        prompt=prompt,
+        size=size,
+        quality=quality,
+        input_images=input_images,
+    )
     timeout = httpx.Timeout(300.0, connect=30.0, read=300.0, write=30.0, pool=30.0)
 
     image_b64: Optional[str] = None
@@ -344,6 +416,20 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
+        try:
+            input_images = _coerce_input_images(kwargs.get("input_images"))
+            # Validate local paths and MIME types early so user mistakes surface
+            # as argument errors, not opaque API failures.
+            _build_input_content(prompt, input_images)
+        except ValueError as exc:
+            return error_response(
+                error=str(exc),
+                error_type="invalid_argument",
+                provider="openai-codex",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
         if not _read_codex_access_token():
             return error_response(
                 error=(
@@ -388,6 +474,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 prompt=prompt,
                 size=size,
                 quality=meta["quality"],
+                input_images=input_images,
             )
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)
@@ -428,7 +515,11 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             prompt=prompt,
             aspect_ratio=aspect,
             provider="openai-codex",
-            extra={"size": size, "quality": meta["quality"]},
+            extra={
+                "size": size,
+                "quality": meta["quality"],
+                "input_image_count": len(input_images),
+            },
         )
 
 

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -129,11 +129,12 @@ class TestGenerate:
 
         captured = {}
 
-        def _collect(token, *, prompt, size, quality):
+        def _collect(token, *, prompt, size, quality, input_images=None):
             captured.update(codex_plugin._build_responses_payload(
                 prompt=prompt,
                 size=size,
                 quality=quality,
+                input_images=input_images,
             ))
             return _b64_png()
 
@@ -159,6 +160,64 @@ class TestGenerate:
         assert tool["output_format"] == "png"
         assert tool["background"] == "opaque"
         assert tool["partial_images"] == 1
+
+    def test_codex_stream_request_includes_input_images(self, provider, monkeypatch, tmp_path):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        img = tmp_path / "mother.png"
+        img.write_bytes(bytes.fromhex(_PNG_HEX))
+
+        captured = {}
+
+        def _collect(token, *, prompt, size, quality, input_images=None):
+            captured.update(codex_plugin._build_responses_payload(
+                prompt=prompt,
+                size=size,
+                quality=quality,
+                input_images=input_images,
+            ))
+            return _b64_png()
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        result = provider.generate("make a family card", aspect_ratio="square", input_images=[str(img)])
+        assert result["success"] is True
+        assert result["input_image_count"] == 1
+
+        content = captured["input"][0]["content"]
+        assert content[0] == {"type": "input_text", "text": "make a family card"}
+        assert content[1]["type"] == "input_image"
+        assert content[1]["image_url"].startswith("data:image/png;base64,")
+
+    def test_codex_accepts_remote_input_image_urls(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        captured = {}
+
+        def _collect(token, *, prompt, size, quality, input_images=None):
+            captured.update(codex_plugin._build_responses_payload(
+                prompt=prompt,
+                size=size,
+                quality=quality,
+                input_images=input_images,
+            ))
+            return _b64_png()
+
+        monkeypatch.setattr(codex_plugin, "_collect_image_b64", _collect)
+
+        result = provider.generate("use reference", input_images=["https://example.com/ref.webp"])
+        assert result["success"] is True
+        assert captured["input"][0]["content"][1] == {
+            "type": "input_image",
+            "image_url": "https://example.com/ref.webp",
+        }
+
+    def test_missing_input_image_returns_invalid_argument(self, provider, monkeypatch):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        result = provider.generate("use reference", input_images=["/no/such/image.png"])
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert "input image not found" in result["error"]
 
     def test_partial_image_event_used_when_done_missing(self):
         """If output_item.done is missing, partial_image_b64 is accepted."""

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -30,7 +30,27 @@ class _FakeCodexProvider(ImageGenProvider):
         }
 
 
+class _CapturingProvider(ImageGenProvider):
+    def __init__(self):
+        self.calls = []
+
+    @property
+    def name(self) -> str:
+        return "codex"
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        self.calls.append({"prompt": prompt, "aspect_ratio": aspect_ratio, **kwargs})
+        return {
+            "success": True,
+            "image": "/tmp/codex-test.png",
+            "model": "gpt-image-2-high",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "provider": "codex",
+        }
+
 class TestPluginDispatch:
+
     def test_dispatch_routes_to_codex_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool
         from agent import image_gen_registry as registry_module
@@ -97,3 +117,34 @@ class TestPluginDispatch:
         assert payload["success"] is True
         assert payload["provider"] == "codex"
         assert payload["aspect_ratio"] == "portrait"
+
+    def test_dispatch_forwards_model_and_input_images(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+        from agent import image_gen_registry as registry_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n  provider: codex\n  model: gpt-image-2-high\n"
+        )
+
+        provider = _CapturingProvider()
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "codex")
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_model", lambda: "gpt-image-2-high")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: provider if name == "codex" else None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider(
+            "make a card",
+            "portrait",
+            input_images=["/tmp/mother.png", "/tmp/father.png"],
+        )
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is True
+        assert provider.calls == [{
+            "prompt": "make a card",
+            "aspect_ratio": "portrait",
+            "model": "gpt-image-2-high",
+            "input_images": ["/tmp/mother.png", "/tmp/father.png"],
+        }]

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -906,6 +906,16 @@ IMAGE_GENERATE_SCHEMA = {
                 "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
             },
+            "input_images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional reference/input images for providers that support image editing or "
+                    "reference-guided generation. Values may be local file paths, HTTP(S) URLs, "
+                    "or data:image/... URLs. Currently supported by the openai-codex GPT Image "
+                    "2 backend."
+                ),
+            },
         },
         "required": ["prompt"],
     },
@@ -951,7 +961,7 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, input_images=None):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -1008,6 +1018,8 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
         if configured_model:
             kwargs["model"] = configured_model
+        if input_images is not None:
+            kwargs["input_images"] = input_images
         result = provider.generate(**kwargs)
     except Exception as exc:
         logger.warning(
@@ -1035,12 +1047,19 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    input_images = args.get("input_images")
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio, input_images=input_images)
     if dispatched is not None:
         return dispatched
+
+    if input_images:
+        return tool_error(
+            "input_images requires an image generation provider that supports "
+            "reference/edit inputs, such as image_gen.provider: openai-codex"
+        )
 
     return image_generate_tool(
         prompt=prompt,


### PR DESCRIPTION
## Summary
- Add `input_images` support to the `openai-codex` image generation provider
- Accept local image files, remote image URLs, and data URLs as Responses `input_image` parts
- Surface invalid local image paths/MIME types as argument errors

## Test plan
- `python -m py_compile plugins/image_gen/openai-codex/__init__.py tools/image_generation_tool.py tests/plugins/image_gen/test_openai_codex_provider.py tests/tools/test_image_generation_plugin_dispatch.py`
- `python -m pytest tests/plugins/image_gen/test_openai_codex_provider.py tests/tools/test_image_generation_plugin_dispatch.py -q`

Local result: 25 passed.