### PR TITLE
feat(skills): add searchable progressive catalog

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1213,51 +1213,67 @@ def build_skills_system_prompt(
     if not skills_by_category:
         result = ""
     else:
-        index_lines = []
+        category_lines = []
         for category in sorted(skills_by_category.keys()):
             cat_desc = category_descriptions.get(category, "")
+            skill_count = len({name for name, _desc in skills_by_category[category]})
             if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
+                category_lines.append(f"  - {category} ({skill_count}): {cat_desc}")
             else:
-                index_lines.append(f"  {category}:")
-            # Deduplicate and sort skills within each category
-            seen = set()
+                category_lines.append(f"  - {category} ({skill_count})")
+
+        # Keep a tiny set of high-risk routing skills visible by name.  The
+        # complete skill catalog remains discoverable through skills_list()
+        # and skill_view(); this pinned list prevents regressions for core
+        # Hermes administration and prompt/skill-governance tasks while
+        # avoiding the old 150+ line always-on catalog.
+        pinned_names = {
+            "hermes-agent",
+            "hermes-administration",
+            "system-prompt-skill-governance",
+            "global-skill-authoring-standards",
+        }
+        pinned_lines = []
+        seen_pinned = set()
+        for category in sorted(skills_by_category.keys()):
             for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
-                if name in seen:
+                if name not in pinned_names or name in seen_pinned:
                     continue
-                seen.add(name)
+                seen_pinned.add(name)
                 if desc:
-                    index_lines.append(f"    - {name}: {desc}")
+                    pinned_lines.append(f"  - {name}: {desc}")
                 else:
-                    index_lines.append(f"    - {name}")
+                    pinned_lines.append(f"  - {name}")
+
+        pinned_block = ""
+        if pinned_lines:
+            pinned_block = "\n<pinned_critical_skills>\n" + "\n".join(pinned_lines) + "\n</pinned_critical_skills>\n"
 
         result = (
             "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
+            "Hermes skills use progressive disclosure: the system prompt only shows "
+            "skill categories and a few critical routing skills. Do not assume an "
+            "unlisted skill is unavailable. For any task that may need a reusable "
+            "workflow, domain/toolchain procedure, output standard, API details, "
+            "pitfalls, or verification pattern, discover the catalog just-in-time "
+            "with skills_list(category=...) or skills_list(query=...), then load "
+            "the best match with skill_view(name). Do not load skills for simple "
+            "questions or a single obvious tool call.\n"
             "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
             "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
             "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
             "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
             "`hermes setup`) so you don't have to guess or invent workarounds.\n"
-            "If a skill has issues, fix it with skill_manage(action='patch').\n"
-            "After difficult/iterative tasks, offer to save as a skill. "
-            "If a skill you loaded was missing steps, had wrong commands, or needed "
-            "pitfalls you discovered, update it before finishing.\n"
+            "If a skill has issues, fix it with skill_manage(action='patch'). After "
+            "difficult/iterative tasks, offer to save or update a skill.\n"
             "\n"
-            "<available_skills>\n"
-            + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
+            "<skill_categories>\n"
+            + "\n".join(category_lines) + "\n"
+            "</skill_categories>\n"
+            + pinned_block +
             "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
+            "Only proceed without loading a skill if genuinely none are relevant after "
+            "considering the categories or performing just-in-time discovery."
         )
 
     # ── Store in LRU cache ────────────────────────────────────────────

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -261,9 +261,11 @@ class TestBuildSkillsSystemPrompt:
             "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
         )
         result = build_skills_system_prompt()
-        assert "python-debug" in result
-        assert "Debug Python scripts" in result
-        assert "available_skills" in result
+        assert "coding (1)" in result
+        assert "python-debug" not in result
+        assert "Debug Python scripts" not in result
+        assert "skill_categories" in result
+        assert "skills_list(query=...)" in result
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -273,8 +275,9 @@ class TestBuildSkillsSystemPrompt:
             d.mkdir(parents=True, exist_ok=True)
             (d / "SKILL.md").write_text("---\ndescription: Search stuff\n---\n")
         result = build_skills_system_prompt()
-        # "search" should appear only once per category
-        assert result.count("- search") == 1
+        # Category-only prompt should count the skill once without listing it.
+        assert "tools (1)" in result
+        assert "- search" not in result
 
     def test_excludes_incompatible_platform_skills(self, monkeypatch, tmp_path):
         """Skills with platforms: [macos] should not appear on Linux."""
@@ -302,7 +305,8 @@ class TestBuildSkillsSystemPrompt:
             mock_sys.platform = "linux"
             result = build_skills_system_prompt()
 
-        assert "web-search" in result
+        assert "apple (1)" in result
+        assert "web-search" not in result
         assert "imessage" not in result
 
     def test_includes_matching_platform_skills(self, monkeypatch, tmp_path):
@@ -321,8 +325,9 @@ class TestBuildSkillsSystemPrompt:
             mock_sys.platform = "darwin"
             result = build_skills_system_prompt()
 
-        assert "imessage" in result
-        assert "Send iMessages" in result
+        assert "apple (1)" in result
+        assert "imessage" not in result
+        assert "Send iMessages" not in result
 
     def test_excludes_disabled_skills(self, monkeypatch, tmp_path):
         """Skills in the user's disabled list should not appear in the system prompt."""
@@ -350,7 +355,7 @@ class TestBuildSkillsSystemPrompt:
         ):
             result = build_skills_system_prompt()
 
-        assert "web-search" in result
+        assert "tools (1)" in result
         assert "old-tool" not in result
 
     def test_rebuilds_prompt_when_disabled_skills_change(self, monkeypatch, tmp_path):
@@ -362,14 +367,14 @@ class TestBuildSkillsSystemPrompt:
         )
 
         first = build_skills_system_prompt()
-        assert "cached-skill" in first
+        assert "tools (1)" in first
 
         (tmp_path / "config.yaml").write_text(
             "skills:\n  disabled: [cached-skill]\n"
         )
 
         second = build_skills_system_prompt()
-        assert "cached-skill" not in second
+        assert second == ""
 
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -390,8 +395,9 @@ class TestBuildSkillsSystemPrompt:
         )
 
         result = build_skills_system_prompt()
-        assert "free-skill" in result
-        assert "gated-skill" in result
+        assert "media (2)" in result
+        assert "free-skill" not in result
+        assert "gated-skill" not in result
 
     def test_includes_skills_with_met_prerequisites(self, monkeypatch, tmp_path):
         """Skills with satisfied prerequisites should appear normally."""
@@ -407,7 +413,8 @@ class TestBuildSkillsSystemPrompt:
         )
 
         result = build_skills_system_prompt()
-        assert "ready-skill" in result
+        assert "media (1)" in result
+        assert "ready-skill" not in result
 
     def test_non_local_backend_keeps_skill_visible_without_probe(
         self, monkeypatch, tmp_path
@@ -425,7 +432,8 @@ class TestBuildSkillsSystemPrompt:
         )
 
         result = build_skills_system_prompt()
-        assert "backend-skill" in result
+        assert "media (1)" in result
+        assert "backend-skill" not in result
 
 
 class TestBuildNousSubscriptionPrompt:
@@ -1090,7 +1098,8 @@ class TestBuildSkillsSystemPromptConditional:
             available_tools=set(),
             available_toolsets=set(),
         )
-        assert "duckduckgo" in result
+        assert "search (1)" in result
+        assert "duckduckgo" not in result
 
     def test_requires_skill_hidden_when_toolset_missing(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -1116,7 +1125,8 @@ class TestBuildSkillsSystemPromptConditional:
             available_tools=set(),
             available_toolsets={"terminal"},
         )
-        assert "openhue" in result
+        assert "iot (1)" in result
+        assert "openhue" not in result
 
     def test_unconditional_skill_always_shown(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -1129,10 +1139,11 @@ class TestBuildSkillsSystemPromptConditional:
             available_tools=set(),
             available_toolsets=set(),
         )
-        assert "notes" in result
+        assert "general (1)" in result
+        assert "notes" not in result
 
-    def test_no_args_shows_all_skills(self, monkeypatch, tmp_path):
-        """Backward compat: calling with no args shows everything."""
+    def test_no_args_shows_all_skill_categories(self, monkeypatch, tmp_path):
+        """Calling with no args shows categories, not every skill name."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         skill_dir = tmp_path / "skills" / "search" / "duckduckgo"
         skill_dir.mkdir(parents=True)
@@ -1140,7 +1151,8 @@ class TestBuildSkillsSystemPromptConditional:
             "---\nname: duckduckgo\ndescription: Free web search\nmetadata:\n  hermes:\n    fallback_for_toolsets: [web]\n---\n"
         )
         result = build_skills_system_prompt()
-        assert "duckduckgo" in result
+        assert "search (1)" in result
+        assert "duckduckgo" not in result
 
     def test_null_metadata_does_not_crash(self, monkeypatch, tmp_path):
         """Regression: metadata key present but null should not AttributeError."""
@@ -1155,7 +1167,8 @@ class TestBuildSkillsSystemPromptConditional:
             available_tools=set(),
             available_toolsets=set(),
         )
-        assert "safe-skill" in result
+        assert "general (1)" in result
+        assert "safe-skill" not in result
 
     def test_null_hermes_under_metadata_does_not_crash(self, monkeypatch, tmp_path):
         """Regression: metadata.hermes present but null should not crash."""
@@ -1169,7 +1182,8 @@ class TestBuildSkillsSystemPromptConditional:
             available_tools=set(),
             available_toolsets=set(),
         )
-        assert "nested-null" in result
+        assert "general (1)" in result
+        assert "nested-null" not in result
 
 
 # =========================================================================

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -357,6 +357,42 @@ class TestSkillsList:
         assert result["categories"] == ["linked"]
         assert result["skills"][0]["name"] == "knowledge-brain"
 
+    def test_query_search_finds_hyphenated_skill_name(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "system-prompt-skill-governance",
+                category="autonomous-ai-agents",
+                body="Govern system prompts and skill placement.",
+            )
+            _make_skill(tmp_path, "unrelated", category="creative")
+            raw = skills_list(query="system prompt governance")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["query"] == "system prompt governance"
+        assert result["count"] >= 1
+        assert result["skills"][0]["name"] == "system-prompt-skill-governance"
+
+    def test_query_search_matches_tags_and_limit(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "llm-training-operations",
+                frontmatter_extra="metadata:\n  hermes:\n    tags: [fine-tuning, llm]\n",
+                category="mlops",
+            )
+            _make_skill(tmp_path, "fine-tuning-with-trl", category="mlops")
+            raw = skills_list(query="fine tuning", limit=1)
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["skills"][0]["name"] in {
+            "fine-tuning-with-trl",
+            "llm-training-operations",
+        }
+
 
 # ---------------------------------------------------------------------------
 # skill_view

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -68,6 +68,7 @@ Usage:
 
 import json
 import logging
+import math
 
 from hermes_constants import get_hermes_home, display_hermes_home
 import os
@@ -604,12 +605,20 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                     description = description[:MAX_DESCRIPTION_LENGTH - 3] + "..."
 
                 category = _get_category_from_path(skill_md)
+                metadata = frontmatter.get("metadata")
+                hermes_meta = metadata.get("hermes", {}) if isinstance(metadata, dict) else {}
 
                 seen_names.add(name)
                 skills.append({
                     "name": name,
                     "description": description,
                     "category": category,
+                    "tags": _parse_tags(hermes_meta.get("tags", []))
+                    if isinstance(hermes_meta, dict)
+                    else [],
+                    "related_skills": hermes_meta.get("related_skills", [])
+                    if isinstance(hermes_meta, dict)
+                    else [],
                 })
 
             except (UnicodeDecodeError, PermissionError) as e:
@@ -629,7 +638,123 @@ def _sort_skills(skills: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return sorted(skills, key=lambda s: (s.get("category") or "", s["name"]))
 
 
-def skills_list(category: str = None, task_id: str = None) -> str:
+def _normalize_skill_search_text(value: Any) -> str:
+    """Normalize user queries and skill metadata for forgiving matching."""
+    text = str(value or "").lower()
+    # Treat punctuation such as hyphens/underscores/slashes as separators so
+    # queries like "system prompt" find "system-prompt-skill-governance".
+    return re.sub(r"[^0-9a-z가-힣]+", " ", text).strip()
+
+
+def _skill_search_blob(skill: Dict[str, Any]) -> str:
+    parts: List[str] = [
+        skill.get("name") or "",
+        skill.get("description") or "",
+        skill.get("category") or "",
+    ]
+    for key in ("tags", "related_skills"):
+        value = skill.get(key)
+        if isinstance(value, list):
+            parts.extend(str(item) for item in value)
+        elif value:
+            parts.append(str(value))
+    return _normalize_skill_search_text(" ".join(parts))
+
+
+def _score_skill_for_query(skill: Dict[str, Any], query: str) -> int:
+    """Return a simple deterministic relevance score for skills_list(query=...)."""
+    norm_query = _normalize_skill_search_text(query)
+    if not norm_query:
+        return 0
+    terms = [term for term in norm_query.split() if term]
+    if not terms:
+        return 0
+
+    name = _normalize_skill_search_text(skill.get("name"))
+    category = _normalize_skill_search_text(skill.get("category"))
+    desc = _normalize_skill_search_text(skill.get("description"))
+    blob = _skill_search_blob(skill)
+
+    score = 0
+    if norm_query == name:
+        score += 1000
+    if norm_query in name:
+        score += 500
+    if norm_query in category:
+        score += 120
+    if norm_query in desc:
+        score += 80
+
+    matched_terms = 0
+    for term in terms:
+        if term in blob:
+            matched_terms += 1
+            if term in name:
+                score += 80
+            elif term in category:
+                score += 40
+            else:
+                score += 15
+
+    # Prefer skills that match every term, but still keep partial matches so
+    # typo-ish or broad natural-language searches do not hide existing skills.
+    if matched_terms == len(terms):
+        score += 200
+    elif matched_terms:
+        score += int(25 * matched_terms / math.sqrt(len(terms)))
+
+    return score
+
+
+def _load_category_description(category_dir: Path) -> Optional[str]:
+    """
+    Load category description from DESCRIPTION.md if it exists.
+
+    Args:
+        category_dir: Path to the category directory
+
+    Returns:
+        Description string or None if not found
+    """
+    desc_file = category_dir / "DESCRIPTION.md"
+    if not desc_file.exists():
+        return None
+
+    try:
+        content = desc_file.read_text(encoding="utf-8")
+        # Parse frontmatter if present
+        frontmatter, body = _parse_frontmatter(content)
+
+        # Prefer frontmatter description, fall back to first non-header line
+        description = frontmatter.get("description", "")
+        if not description:
+            for line in body.strip().split("\n"):
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    description = line
+                    break
+
+        # Truncate to reasonable length
+        if len(description) > MAX_DESCRIPTION_LENGTH:
+            description = description[: MAX_DESCRIPTION_LENGTH - 3] + "..."
+
+        return description if description else None
+    except (UnicodeDecodeError, PermissionError) as e:
+        logger.debug("Failed to read category description %s: %s", desc_file, e)
+        return None
+    except Exception as e:
+        logger.warning(
+            "Error parsing category description %s: %s", desc_file, e, exc_info=True
+        )
+        return None
+
+
+def skills_list(
+    category: Optional[str] = None,
+    query: Optional[str] = None,
+    limit: Optional[int] = None,
+    task_id: Optional[str] = None,
+) -> str:
     """
     List all available skills (progressive disclosure tier 1 - minimal metadata).
 
@@ -638,6 +763,10 @@ def skills_list(category: str = None, task_id: str = None) -> str:
 
     Args:
         category: Optional category filter (e.g., "mlops")
+        query: Optional search query. Matches skill names, descriptions,
+            categories, tags, and related skill metadata.
+        limit: Optional maximum number of query results to return. Defaults to
+            25 for query searches and unlimited for category/all listings.
         task_id: Optional task identifier used to probe the active backend
 
     Returns:
@@ -674,12 +803,38 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         if category:
             all_skills = [s for s in all_skills if s.get("category") == category]
 
-        # Sort by category then name
-        all_skills = _sort_skills(all_skills)
+        total_before_query = len(all_skills)
+
+        if query:
+            scored = [
+                (score, skill)
+                for skill in all_skills
+                if (score := _score_skill_for_query(skill, query)) > 0
+            ]
+            scored.sort(
+                key=lambda item: (
+                    -item[0],
+                    item[1].get("category") or "",
+                    item[1].get("name") or "",
+                )
+            )
+            if limit is None:
+                effective_limit = 25
+            else:
+                try:
+                    effective_limit = max(1, min(int(limit), 100))
+                except (TypeError, ValueError):
+                    effective_limit = 25
+            all_skills = [skill for _score, skill in scored[:effective_limit]]
+
+        # Sort non-query listings by category then name. Query listings already
+        # carry a relevance order from the scoring pass above.
+        if not query:
+            all_skills = _sort_skills(all_skills)
 
         # Extract unique categories
         categories = sorted(
-            {s.get("category") for s in all_skills if s.get("category")}
+            {str(s.get("category")) for s in all_skills if s.get("category")}
         )
 
         return json.dumps(
@@ -688,7 +843,9 @@ def skills_list(category: str = None, task_id: str = None) -> str:
                 "skills": all_skills,
                 "categories": categories,
                 "count": len(all_skills),
-                "hint": "Use skill_view(name) to see full content, tags, and linked files",
+                "total_before_query": total_before_query if query else None,
+                "query": query or None,
+                "hint": "Use skill_view(name) to see full content, tags, and linked files. Use skills_list(query=...) to search the catalog when the system prompt only shows categories.",
             },
             ensure_ascii=False,
         )
@@ -1447,13 +1604,21 @@ if __name__ == "__main__":
 
 SKILLS_LIST_SCHEMA = {
     "name": "skills_list",
-    "description": "List available skills (name + description). Use skill_view(name) to load full content.",
+    "description": "List or search available skills (name + description). Use query to find skills by task/domain/toolchain when the system prompt only shows categories, then skill_view(name) to load full content.",
     "parameters": {
         "type": "object",
         "properties": {
             "category": {
                 "type": "string",
                 "description": "Optional category filter to narrow results",
+            },
+            "query": {
+                "type": "string",
+                "description": "Optional search query matched against skill names, descriptions, categories, tags, and related skill metadata",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Optional max results for query searches (default 25, max 100)",
             }
         },
         "required": [],
@@ -1484,7 +1649,10 @@ registry.register(
     toolset="skills",
     schema=SKILLS_LIST_SCHEMA,
     handler=lambda args, **kw: skills_list(
-        category=args.get("category"), task_id=kw.get("task_id")
+        category=args.get("category"),
+        query=args.get("query"),
+        limit=args.get("limit"),
+        task_id=kw.get("task_id"),
     ),
     check_fn=check_skills_requirements,
     emoji="📚",


### PR DESCRIPTION
## Summary
- Reduce always-on skill prompt overhead by showing skill categories plus a few critical pinned routing skills
- Add `skills_list(query=..., limit=...)` search across names, descriptions, categories, tags, and related skill metadata
- Preserve just-in-time discovery through `skills_list` + `skill_view`

## Test plan
- `python -m py_compile agent/prompt_builder.py tools/skills_tool.py tests/agent/test_prompt_builder.py tests/tools/test_skills_tool.py`
- `python -m pytest tests/agent/test_prompt_builder.py tests/tools/test_skills_tool.py -q`

Local result: 216 passed.