### PR TITLE
fix(google_meet): wire register_skill() so shipped SKILL.md loads

### DIFF
--- a/plugins/google_meet/__init__.py
+++ b/plugins/google_meet/__init__.py
@@ -101,3 +101,19 @@ def register(ctx) -> None:
     )
 
     ctx.register_hook("on_session_end", _on_session_end)
+
+    # Plugin-scoped skill (fixes #48): SKILL.md shipped but was never wired.
+    # Resolvable as 'google_meet:meet' via explicit load only.
+    if hasattr(ctx, "register_skill"):
+        from pathlib import Path  # noqa: PLC0415
+        try:
+            ctx.register_skill(
+                name="meet",
+                path=Path(__file__).parent / "SKILL.md",
+                description=(
+                    "Join a Google Meet call, transcribe live captions, optionally "
+                    "speak in realtime, and do the followup work afterwards."
+                ),
+            )
+        except Exception:
+            logger.debug("google_meet: register_skill failed", exc_info=True)


### PR DESCRIPTION
## Bug

`plugins/google_meet/SKILL.md` has been present since the plugin was introduced, but `register()` in `plugins/google_meet/__init__.py` never called `ctx.register_skill()`.  As a result the skill `google_meet:meet` is silently unresolvable at runtime — the file ships but the skill is never registered.

## Fix

Add a `ctx.register_skill()` call immediately after the existing `ctx.register_hook("on_session_end", …)` line.  The call is guarded with `hasattr(ctx, "register_skill")` so it is safe on any host where the API is not yet present.

```python
if hasattr(ctx, "register_skill"):
    from pathlib import Path  # noqa: PLC0415
    try:
        ctx.register_skill(
            name="meet",
            path=Path(__file__).parent / "SKILL.md",
            description=(
                "Join a Google Meet call, transcribe live captions, optionally "
                "speak in realtime, and do the followup work afterwards."
            ),
        )
    except Exception:
        logger.debug("google_meet: register_skill failed", exc_info=True)
```

`PluginContext.register_skill` is already defined in `hermes_cli/plugins.py` (line 954), so no API changes are needed.

## Testing

- Existing unit tests pass unchanged (the new block is guarded and error-swallowed).
- After the fix, `google_meet:meet` resolves correctly when loaded explicitly.