### PR TITLE
fix(doctor): add version consistency check between pyproject.toml and __init__.py

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -510,6 +510,50 @@ def run_doctor(args):
     else:
         check_warn("Not in virtual environment", "(recommended)")
     
+    _section("Version Consistency")
+    try:
+        import tomllib
+    except ImportError:
+        try:
+            import tomli as tomllib  # type: ignore[no-redef]
+        except ImportError:
+            tomllib = None  # type: ignore[assignment]
+    
+    pyproject_path = PROJECT_ROOT / "pyproject.toml"
+    init_path = PROJECT_ROOT / "hermes_cli" / "__init__.py"
+    
+    pyproject_version = None
+    init_version = None
+    
+    if tomllib:
+        try:
+            with open(pyproject_path, "rb") as f:
+                pyproject_version = tomllib.load(f).get("version")
+        except Exception:
+            pass
+    
+    try:
+        with open(init_path, "r") as f:
+            for line in f:
+                if line.startswith("__version__"):
+                    init_version = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    break
+    except Exception:
+        pass
+    
+    if pyproject_version and init_version:
+        if pyproject_version == init_version:
+            check_ok(f"Version {init_version} (pyproject.toml ✓ __init__.py ✓)")
+        else:
+            _fail_and_issue(
+                f"Version mismatch: pyproject.toml={pyproject_version} vs __init__.py={init_version}",
+                "(upgrade may have left stale files)",
+                "Run: cd ~/.hermes/hermes-agent && git pull && uv pip install -e .",
+                issues,
+            )
+    else:
+        check_warn("Could not verify version consistency")
+    
     _section("Required Packages")
     required_packages = [
         ("openai", "OpenAI SDK"),


### PR DESCRIPTION
## Summary

After git conflict resolution or partial upgrades, `hermes_cli/__init__.py` can get reverted to an older version while `pyproject.toml` stays current. This causes `hermes --version` to report the wrong version and may break version-gated logic.

This adds a **Version Consistency** section to `hermes doctor` that compares the version in `pyproject.toml` with `__version__` in `hermes_cli/__init__.py` and warns/fails if they don't match.

## Changes

- Added version consistency check in `hermes_cli/doctor.py`
- Reads version from `pyproject.toml` (via `tomllib`)
- Reads `__version__` from `hermes_cli/__init__.py`
- Reports OK if versions match, fails with remediation instructions if they differ

## Testing

```bash
# Normal case (versions match)
hermes doctor | grep -A2 "Version Consistency"

# Simulate mismatch
sed -i 's/__version__ = "0.15.1"/__version__ = "0.14.0"/' hermes_cli/__init__.py
hermes doctor | grep -A2 "Version Consistency"
```

Fixes #35070
