### PR TITLE
fix: install full bundles from raw GitHub skill URLs

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1096,6 +1096,53 @@ class TestUrlSource:
         assert bundle.name == "my-skill"
 
     @patch("tools.skills_hub.httpx.get")
+    @patch.object(GitHubSource, "fetch")
+    def test_fetch_delegates_raw_github_skill_to_github_source(self, mock_fetch, mock_get):
+        mock_fetch.return_value = SkillBundle(
+            name="supabase-postgres-best-practices",
+            files={
+                "SKILL.md": "---\nname: supabase-postgres-best-practices\n---\n",
+                "references/patterns.md": "ref",
+                "scripts/install.sh": "#!/bin/sh\n",
+            },
+            source="github",
+            identifier="supabase/agent-skills/skills/supabase-postgres-best-practices",
+            trust_level="community",
+        )
+
+        bundle = self._source().fetch(
+            "https://raw.githubusercontent.com/supabase/agent-skills/main/skills/supabase-postgres-best-practices/SKILL.md"
+        )
+
+        assert bundle is not None
+        assert bundle.source == "github"
+        assert bundle.identifier == "supabase/agent-skills/skills/supabase-postgres-best-practices"
+        assert "references/patterns.md" in bundle.files
+        assert "scripts/install.sh" in bundle.files
+        mock_get.assert_not_called()
+
+    @patch("tools.skills_hub.httpx.get")
+    @patch.object(GitHubSource, "inspect")
+    def test_inspect_delegates_raw_github_skill_to_github_source(self, mock_inspect, mock_get):
+        mock_inspect.return_value = SkillMeta(
+            name="supabase-postgres-best-practices",
+            description="Best practices.",
+            source="github",
+            identifier="supabase/agent-skills/skills/supabase-postgres-best-practices",
+            trust_level="community",
+            path="skills/supabase-postgres-best-practices",
+        )
+
+        meta = self._source().inspect(
+            "https://raw.githubusercontent.com/supabase/agent-skills/main/skills/supabase-postgres-best-practices/SKILL.md"
+        )
+
+        assert meta is not None
+        assert meta.source == "github"
+        assert meta.identifier == "supabase/agent-skills/skills/supabase-postgres-best-practices"
+        mock_get.assert_not_called()
+
+    @patch("tools.skills_hub.httpx.get")
     def test_fetch_returns_none_on_404(self, mock_get):
         mock_get.return_value = MagicMock(status_code=404)
         assert self._source().fetch("https://example.com/SKILL.md") is None

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1123,9 +1123,11 @@ class UrlSource(SkillSource):
     """Fetch a single-file SKILL.md skill directly from an HTTP(S) URL.
 
     The identifier IS the URL (e.g. ``https://example.com/path/SKILL.md``).
-    Only single-file skills are supported — multi-file skills with
-    ``references/`` or ``scripts/`` subfolders need a manifest we can't
-    discover from a bare URL.
+    Bare URLs stay single-file only. If the URL is a raw GitHub skill
+    pointing at ``raw.githubusercontent.com/.../skills/.../SKILL.md``, we
+    delegate to :class:`GitHubSource` so the full directory bundle
+    (``references/``, ``scripts/``, etc.) is installed instead of only the
+    markdown file.
 
     The skill name is read from the ``name:`` field in the SKILL.md YAML
     frontmatter (with a URL-slug fallback). Trust level is always
@@ -1165,10 +1167,52 @@ class UrlSource(SkillSource):
             return False
         return path.lower().endswith(".md")
 
+    @staticmethod
+    def _raw_github_skill_identifier(url: str) -> Optional[str]:
+        """Translate raw GitHub skill URLs into GitHubSource identifiers.
+
+        We only special-case raw.githubusercontent.com URLs that point at a
+        skill directory (``.../skills/.../SKILL.md``). That lets the GitHub
+        adapter fetch the full directory bundle while leaving generic direct
+        URLs alone.
+        """
+        try:
+            parsed = urlparse(url)
+        except ValueError:
+            return None
+        if parsed.netloc.lower() != "raw.githubusercontent.com":
+            return None
+
+        parts = [part for part in parsed.path.split("/") if part]
+        if len(parts) < 5 or parts[-1].lower() != "skill.md":
+            return None
+
+        try:
+            skill_dir_start = next(i for i, part in enumerate(parts) if part == "skills")
+        except StopIteration:
+            return None
+
+        if skill_dir_start < 3 or skill_dir_start >= len(parts) - 1:
+            return None
+
+        skill_dir = "/".join(parts[skill_dir_start:-1])
+        if not skill_dir:
+            return None
+
+        owner, repo = parts[0], parts[1]
+        return f"{owner}/{repo}/{skill_dir}"
+
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
         if not self._matches(identifier):
             return None
         url = identifier.strip()
+
+        github_identifier = self._raw_github_skill_identifier(url)
+        if github_identifier:
+            meta = GitHubSource(auth=GitHubAuth()).inspect(github_identifier)
+            if meta is not None:
+                return meta
+
         text = self._fetch_text(url)
         if text is None:
             return None
@@ -1194,10 +1238,18 @@ class UrlSource(SkillSource):
             extra={"url": url, "awaiting_name": name is None},
         )
 
+
     def fetch(self, identifier: str) -> Optional[SkillBundle]:
         if not self._matches(identifier):
             return None
         url = identifier.strip()
+
+        github_identifier = self._raw_github_skill_identifier(url)
+        if github_identifier:
+            bundle = GitHubSource(auth=GitHubAuth()).fetch(github_identifier)
+            if bundle is not None:
+                return bundle
+
         text = self._fetch_text(url)
         if text is None:
             return None
@@ -1226,6 +1278,7 @@ class UrlSource(SkillSource):
             trust_level="community",
             metadata={"url": url, "awaiting_name": not skill_name},
         )
+
 
     @staticmethod
     def _fetch_text(url: str) -> Optional[str]:

--- a/website/docs/guides/work-with-skills.md
+++ b/website/docs/guides/work-with-skills.md
@@ -95,7 +95,9 @@ hermes skills install official/research/arxiv
 # Install from the hub in a chat session
 /skills install official/creative/songwriting-and-ai-music
 
-# Install a single-file SKILL.md directly from any HTTP(S) URL
+# Install a SKILL.md directly from any HTTP(S) URL (raw GitHub skill URLs
+# under raw.githubusercontent.com/.../skills/.../SKILL.md are expanded to
+# install the full bundle)
 hermes skills install https://sharethis.chat/SKILL.md
 /skills install https://example.com/SKILL.md --name my-skill
 ```

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -968,7 +968,7 @@ Notes:
 - `--source skills-sh` searches the public `skills.sh` directory.
 - `--source well-known` lets you point Hermes at a site exposing `/.well-known/skills/index.json`.
 - `--source browse-sh` searches [browse.sh](https://browse.sh)'s catalog of 200+ site-specific browser-automation skills. Identifiers look like `browse-sh/airbnb.com/search-listings-ddgioa`.
-- Passing an `http(s)://…/*.md` URL installs a single-file SKILL.md directly. When frontmatter has no `name:` and the URL slug isn't a valid identifier, an interactive terminal prompts for a name; non-interactive surfaces (`/skills install` inside the TUI, gateway platforms) require `--name <x>` instead.
+- Passing an `http(s)://…/*.md` URL installs a SKILL.md directly. Raw GitHub skill URLs under `raw.githubusercontent.com/.../skills/.../SKILL.md` are expanded to install the full bundle. When frontmatter has no `name:` and the URL slug isn't a valid identifier, an interactive terminal prompts for a name; non-interactive surfaces (`/skills install` inside the TUI, gateway platforms) require `--name <x>` instead.
 
 ## `hermes bundles`
 

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -388,7 +388,7 @@ hermes skills install openai/skills/k8s           # Install with security scan
 hermes skills install official/security/1password
 hermes skills install skills-sh/vercel-labs/json-render/json-render-react --force
 hermes skills install well-known:https://mintlify.com/docs/.well-known/skills/mintlify
-hermes skills install https://sharethis.chat/SKILL.md              # Direct URL (single-file SKILL.md)
+hermes skills install https://sharethis.chat/SKILL.md              # Direct URL (raw GitHub skill URLs expand to full bundles)
 hermes skills install https://example.com/SKILL.md --name my-skill # Override name when frontmatter has none
 hermes skills list --source hub                   # List hub-installed skills
 hermes skills check                               # Check installed hub skills for upstream updates


### PR DESCRIPTION
## Summary
- Detect raw.githubusercontent.com/.../skills/.../SKILL.md URLs and delegate them to GitHubSource
- Preserve plain direct URL behavior for generic HTTP(S) SKILL.md files
- Update docs to reflect raw GitHub bundle installs

## Why
This is the fix for the known raw GitHub skill install bug reported in #35125. Before this change, raw GitHub skill URLs were treated like generic direct URLs, so installs only brought down SKILL.md and skipped references/, scripts/, and other bundle files.

Closes #35125

## How to Test
- `pytest -o addopts='' -p no:timeout tests/tools/test_skills_hub.py -q -k 'test_fetch_builds_single_file_bundle or test_fetch_delegates_raw_github_skill_to_github_source or test_inspect_delegates_raw_github_skill_to_github_source'`
- Manual install test: `hermes skills install https://raw.githubusercontent.com/supabase/agent-skills/main/skills/supabase-postgres-best-practices/SKILL.md --yes`
  - Verified bundle install included references/ files
- Manual fallback test: `hermes skills install https://sharethis.chat/SKILL.md --yes --force`
  - Verified generic direct URL still installs as single-file

## Platforms Tested
- Windows 10 (local)

## Notes
- The full `tests/tools/test_skills_hub.py` file still has 3 unrelated pre-existing failures outside this change.
