### PR TITLE
fix(simplex): read group sender from chatDir.groupMember instead of chatItemMember

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -354,13 +354,23 @@ class SimplexAdapter(BasePlatformAdapter):
             logger.debug("SimpleX: ignoring event with no chat_id")
             return
 
-        # Sender — for groups the message includes a chatItemMember sub-object
-        member = chat_item.get("chatItemMember") or {}
+        # Sender — for groups the message includes a chatItemMember sub-object.
+        # SimpleX now puts the member under chatDir.groupMember (newer versions)
+        # but older versions still use chatItemMember, so we check both.
+        chat_dir = chat_item.get("chatDir") or {}
+        member = chat_dir.get("groupMember") or chat_item.get("chatItemMember") or {}
         if is_group and member:
-            sender_id = str(member.get("memberId") or member.get("id") or chat_id)
+            member_profile = member.get("memberProfile") or {}
+            sender_id = str(
+                member.get("memberId")
+                or member.get("groupMemberId")
+                or member.get("id")
+                or chat_id
+            )
             sender_name = (
                 member.get("displayName")
                 or member.get("localDisplayName")
+                or member_profile.get("displayName")
                 or sender_id
             )
         else:


### PR DESCRIPTION
## Problem

SimpleX now places group member information under `chatItem.chatDir.groupMember` instead of `chatItem.chatItemMember`. The old code only checked `chatItemMember`, causing allowlist matching to fail and group messages to be rejected.

## Impact

- Group messages from SimpleX are silently dropped
- Sender allowlist matching fails because member identity cannot be extracted

## Fix

- Read member from `chatDir.groupMember` first (new API), then fall back to `chatItemMember` (old API) for backwards compatibility
- Also check `memberProfile` for display names and `groupMemberId` as an alternative member ID field

## Testing

Verified the fix applies cleanly against the current `main` branch.