### PR TITLE
fix(skills): route raw.githubusercontent.com URLs to GitHubSource for directory download

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1116,8 +1116,16 @@ class WellKnownSkillSource(SkillSource):
 
 
 # ---------------------------------------------------------------------------
-# Direct URL source adapter
+# URL source adapter
 # ---------------------------------------------------------------------------
+
+# Matches raw.githubusercontent.com URLs pointing to SKILL.md files.
+# Used to route URL installs to GitHubSource for full directory download.
+_RAW_GITHUB_RE = re.compile(
+    r"^https?://raw\.githubusercontent\.com/"
+    r"(?P<owner>[^/]+)/(?P<repo>[^/]+)/[^/]+/(?P<path>.+)/SKILL\.md$"
+)
+
 
 class UrlSource(SkillSource):
     """Fetch a single-file SKILL.md skill directly from an HTTP(S) URL.
@@ -1198,6 +1206,22 @@ class UrlSource(SkillSource):
         if not self._matches(identifier):
             return None
         url = identifier.strip()
+
+        # Route raw.githubusercontent.com URLs to GitHubSource for full
+        # directory download (references/, templates/, scripts/ etc.).
+        gh_match = _RAW_GITHUB_RE.match(url)
+        if gh_match:
+            owner = gh_match.group("owner")
+            repo = gh_match.group("repo")
+            path = gh_match.group("path")
+            github_source = GitHubSource(auth=GitHubAuth())
+            gh_identifier = f"{owner}/{repo}/{path}"
+            bundle = github_source.fetch(gh_identifier)
+            if bundle is not None:
+                return bundle
+            # Fall through to single-file download if GitHubSource fails
+            # (e.g. rate limit, private repo).
+
         text = self._fetch_text(url)
         if text is None:
             return None


### PR DESCRIPTION
## Problem

When installing a skill via a `raw.githubusercontent.com` URL (e.g. `hermes skills install https://raw.githubusercontent.com/supabase/agent-skills/main/skills/supabase-postgres-best-practices/SKILL.md`), only the SKILL.md file was downloaded. Supporting directories like `references/`, `templates/`, and `scripts/` were missed.

## Root Cause

`UrlSource.fetch` is hardcoded to download only the single SKILL.md file via a direct HTTP GET. It has no mechanism to discover or download companion directories.

## Fix

Detect `raw.githubusercontent.com` URLs in `UrlSource.fetch`, extract the `owner/repo/path` components, and delegate to `GitHubSource.fetch` which recursively downloads the entire skill directory via the GitHub API.

Key changes in `tools/skills_hub.py`:
- Added `_RAW_GITHUB_RE` regex to match `raw.githubusercontent.com` SKILL.md URLs
- Modified `UrlSource.fetch` to check for matching URLs at the start
- Routes matched URLs to `GitHubSource` for full directory download
- Falls back to single-file download if `GitHubSource` fails (rate limit, private repo, etc.)

## Testing

```bash
hermes skills install https://raw.githubusercontent.com/supabase/agent-skills/main/skills/supabase-postgres-best-practices/SKILL.md
```

This should now download the complete skill directory (SKILL.md + references/ etc.) instead of just SKILL.md.

Fixes #35125