### PR TITLE
fix(gateway): use drain-aware SIGUSR1 in launchd_restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3090,8 +3090,8 @@ def launchd_restart():
 
     try:
         pid = get_running_pid()
-        if pid is not None and _request_gateway_self_restart(pid):
-            print("✓ Service restart requested")
+        if pid is not None and _graceful_restart_via_sigusr1(pid, drain_timeout):
+            print("✓ Gateway exited gracefully — launchd will relaunch shortly")
             return
         if pid is not None:
             try:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -559,7 +559,7 @@ class TestLaunchdServiceRecovery:
         target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
 
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
-        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout: False)
         monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
         monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: calls.append(("term", pid, force)))
         monkeypatch.setattr(
@@ -580,17 +580,18 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", "-k", target],
         ]
 
-    def test_launchd_restart_self_requests_graceful_restart_without_kickstart(self, monkeypatch, capsys):
+    def test_launchd_restart_drain_aware_graceful_restart_without_kickstart(self, monkeypatch, capsys):
         calls = []
 
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
             lambda: 321,
         )
         monkeypatch.setattr(
             gateway_cli,
-            "_request_gateway_self_restart",
-            lambda pid: calls.append(("self", pid)) or True,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or True,
         )
         monkeypatch.setattr(
             gateway_cli.subprocess,
@@ -600,8 +601,8 @@ class TestLaunchdServiceRecovery:
 
         gateway_cli.launchd_restart()
 
-        assert calls == [("self", 321)]
-        assert "restart requested" in capsys.readouterr().out.lower()
+        assert calls == [("graceful", 321, 12.0)]
+        assert "exited gracefully" in capsys.readouterr().out.lower()
 
     def test_launchd_stop_uses_bootout_not_kill(self, monkeypatch):
         """launchd_stop must bootout the service so KeepAlive doesn't respawn it."""


### PR DESCRIPTION
## What does this PR do?

Fixes `launchd_restart()` to use the drain-aware `_graceful_restart_via_sigusr1()` helper instead of the ancestor-guarded `_request_gateway_self_restart()`. Previously, running `hermes gateway restart` from a fresh shell always fell through to SIGTERM because the shell is not a descendant of the gateway process, bypassing the drain path that cleanly finishes in-flight agent runs.

## Related Issue

Fixes #27745

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: Replace `_request_gateway_self_restart(pid)` with `_graceful_restart_via_sigusr1(pid, drain_timeout)` in `launchd_restart()`, and update the success message to reflect the drain-aware behavior.
- `tests/hermes_cli/test_gateway_service.py`: Update two launchd restart tests to mock `_graceful_restart_via_sigusr1` instead of `_request_gateway_self_restart`, adjust assertions for the new function signature and output message.

## How to Test

1. Run `pytest tests/hermes_cli/test_gateway_service.py -k "launchd_restart" -v` — all 3 launchd restart tests should pass.
2. On macOS with a running Hermes gateway managed by launchd: `hermes gateway restart` from a fresh terminal. The gateway should log a drain-aware restart (SIGUSR1) rather than an immediate SIGTERM.
3. Verify that in-flight agent runs complete before the gateway exits (check `gateway.log` for drain completion messages).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_gateway_service.py -q` and all launchd tests pass (systemd tests fail pre-existing on macOS)
- [x] I've added tests for my changes (updated existing tests to match new code path)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — SIGUSR1 is guarded by `hasattr(signal, 'SIGUSR1')`, returns False on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `launchd_restart()` in `hermes_cli/gateway.py` (callers: 2 — `gateway restart` CLI and `hermes update` flow)
- Analyzed: `_graceful_restart_via_sigusr1()` (callers: 2 — `systemd_restart` and now `launchd_restart`)
- Blast radius: LOW — single function call change, same pattern already used by `systemd_restart`
- Related patterns: `systemd_restart()` at line 2645 uses the same `_graceful_restart_via_sigusr1(pid, drain_timeout + 5)` pattern. The `+5` buffer is not needed for launchd because `launchctl kickstart` handles the relaunch after exit.
