### PR TITLE
fix: recognize ssh:// URL format in fork detection

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7453,8 +7453,10 @@ def _restore_stashed_changes(
 OFFICIAL_REPO_URLS = {
     "https://github.com/NousResearch/hermes-agent.git",
     "git@github.com:NousResearch/hermes-agent.git",
+    "ssh://git@github.com/NousResearch/hermes-agent.git",
     "https://github.com/NousResearch/hermes-agent",
     "git@github.com:NousResearch/hermes-agent",
+    "ssh://git@github.com/NousResearch/hermes-agent",
 }
 OFFICIAL_REPO_URL = "https://github.com/NousResearch/hermes-agent.git"
 SKIP_UPSTREAM_PROMPT_FILE = ".skip_upstream_prompt"

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -659,3 +659,53 @@ termux = ["rich>=14"]
 
     assert hm._load_installable_optional_extras(group="all") == ["mcp"]
     assert hm._load_installable_optional_extras(group="termux-all") == ["termux", "mcp"]
+
+
+# ---------------------------------------------------------------------------
+# _is_fork() — recognizes all official URL formats
+# ---------------------------------------------------------------------------
+
+
+def test_is_fork_returns_false_for_official_https_with_dot_git():
+    from hermes_cli.main import _is_fork
+    assert _is_fork("https://github.com/NousResearch/hermes-agent.git") is False
+
+
+def test_is_fork_returns_false_for_official_https_without_dot_git():
+    from hermes_cli.main import _is_fork
+    assert _is_fork("https://github.com/NousResearch/hermes-agent") is False
+
+
+def test_is_fork_returns_false_for_official_git_at_format():
+    from hermes_cli.main import _is_fork
+    assert _is_fork("git@github.com:NousResearch/hermes-agent.git") is False
+
+
+def test_is_fork_returns_false_for_official_ssh_protocol_format():
+    from hermes_cli.main import _is_fork
+    assert _is_fork("ssh://git@github.com/NousResearch/hermes-agent.git") is False
+
+
+def test_is_fork_returns_false_for_official_ssh_protocol_without_dot_git():
+    from hermes_cli.main import _is_fork
+    assert _is_fork("ssh://git@github.com/NousResearch/hermes-agent") is False
+
+
+def test_is_fork_returns_true_for_user_fork():
+    from hermes_cli.main import _is_fork
+    assert _is_fork("https://github.com/Prontsevich/hermes-agent.git") is True
+
+
+def test_is_fork_returns_true_for_fork_ssh():
+    from hermes_cli.main import _is_fork
+    assert _is_fork("git@github.com:Prontsevich/hermes-agent.git") is True
+
+
+def test_is_fork_returns_false_for_none():
+    from hermes_cli.main import _is_fork
+    assert _is_fork(None) is False
+
+
+def test_is_fork_returns_false_for_empty_string():
+    from hermes_cli.main import _is_fork
+    assert _is_fork("") is False


### PR DESCRIPTION
## Problem

`_is_fork()` compares the origin URL against `OFFICIAL_REPO_URLS` to decide whether the user is updating from a fork. The set includes HTTPS and `git@` formats but is missing the `ssh://git@github.com/...` format.

Users with SSH remotes in the `ssh://` format (e.g. `ssh://git@github.com/NousResearch/hermes-agent.git`) see a false "Updating from fork" warning on every `hermes update`, even though their origin points to the official repo.

## Fix

Added the `ssh://` variants to `OFFICIAL_REPO_URLS`:
- `ssh://git@github.com/NousResearch/hermes-agent.git`
- `ssh://git@github.com/NousResearch/hermes-agent`

## Test plan

- [ ] `hermes update` with an `ssh://` origin URL no longer shows the fork warning
- [ ] `hermes update` with a real fork URL still shows the warning correctly

<!-- gk-ai-analysis-start:64e1566ee3b88afa80ca32e6207ce7be754b82b6 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiQWRkcyBzc2g6Ly8gVVJMIGZvcm1hdHMgdG8gT0ZGSUNJQUxfUkVQT19VUkxTIHRvIGNvcnJlY3RseSBwcmV2ZW50IGZhbHNlIGZvcmsgd2FybmluZ3MgZm9yIHVzZXJzIHdpdGggc3NoOi8vIHJlbW90ZXMuIiwia2V5SW5zaWdodHMiOlt7InRpdGxlIjoiRXhwYW5kZWQgb2ZmaWNpYWwgcmVwb3NpdG9yeSBVUkxzIiwiZGVzY3JpcHRpb24iOiJJbmNsdWRlZCBgc3NoOi8vZ2l0QGdpdGh1Yi5jb20vTm91c1Jlc2VhcmNoL2hlcm1lcy1hZ2VudC5naXRgIGFuZCBpdHMgbm9uLS5naXQgdmFyaWFudCBpbiBgT0ZGSUNJQUxfUkVQT19VUkxTYCB0byBjb3JyZWN0bHkgaWRlbnRpZnkgb2ZmaWNpYWwgb3JpZ2lucyB3aGVuIHRoZSBgc3NoOi8vYCBHaXQgcHJvdG9jb2wgVVJMIGZvcm1hdCBpcyB1c2VkLiIsInNldmVyaXR5IjoibG93IiwiZmlsZVBhdGgiOiJoZXJtZXNfY2xpL21haW4ucHkiLCJsaW5lU3RhcnQiOjc0NTN9LHsidGl0bGUiOiJGb3JrIGRldGVjdGlvbiB0ZXN0cyBhZGRlZCIsImRlc2NyaXB0aW9uIjoiQWRkZWQgY29tcHJlaGVuc2l2ZSB0ZXN0IGNhc2VzIGZvciB0aGUgYF9pc19mb3JrYCBmdW5jdGlvbiBjb3ZlcmluZyBIVFRQUywgYGdpdEBgLCBhbmQgYHNzaDovL2AgVVJMIGZvcm1hdHMsIGFzIHdlbGwgYXMgZWRnZSBjYXNlcyBsaWtlIGBOb25lYCBhbmQgZW1wdHkgc3RyaW5ncy4iLCJzZXZlcml0eSI6ImxvdyIsImZpbGVQYXRoIjoidGVzdHMvaGVybWVzX2NsaS90ZXN0X2NtZF91cGRhdGUucHkiLCJsaW5lU3RhcnQiOjY2Mn1dLCJpc3N1ZXMiOltdLCJzdWdnZXN0aW9ucyI6W10sInNlY3VyaXR5IjpbXX0= -->
<!-- gk-ai-analysis-end:64e1566ee3b88afa80ca32e6207ce7be754b82b6 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/NousResearch/hermes-agent/pull/35179?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->