### PR TITLE
fix(opencode-go): drop thinking toggle for kimi-k2 to avoid 400 error

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -56,17 +56,17 @@ class OpenCodeGoProfile(ProviderProfile):
         top_level: dict[str, Any] = {}
 
         if _is_kimi_k2_model(model):
-            # Kimi K2 on OpenCode Go uses Moonshot's native wire shape:
-            # extra_body.thinking (binary toggle) + top-level reasoning_effort
-            # (low|medium|high). Mirrors the KimiProfile (api.moonshot.ai/v1).
+            # Kimi K2 on OpenCode Go: the Go proxy rejects the combination
+            # of extra_body.thinking + top-level reasoning_effort (400:
+            # "cannot specify both 'thinking' and 'reasoning_effort'").
+            # Only send reasoning_effort — the upstream moonshot API
+            # accepts it standalone.
             if not isinstance(reasoning_config, dict):
-                # No config → leave server defaults alone.
                 return extra_body, top_level
 
             enabled = reasoning_config.get("enabled") is not False
-            extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
-
             if not enabled:
+                extra_body["thinking"] = {"type": "disabled"}
                 return extra_body, top_level
 
             effort = (reasoning_config.get("effort") or "").strip().lower()

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -17,14 +17,19 @@ def opencode_go_profile():
 
 
 class TestOpenCodeGoKimiReasoning:
-    """Kimi K2 models use Moonshot's thinking + reasoning_effort shape on OpenCode Go."""
+    """Kimi K2 models on OpenCode Go: send reasoning_effort without thinking.
 
-    def test_high_effort_emits_thinking_and_effort(self, opencode_go_profile):
+    The Go proxy rejects requests that include both extra_body.thinking and
+    top-level reasoning_effort (HTTP 400). The upstream moonshot API accepts
+    reasoning_effort standalone, so we only send that when reasoning is enabled.
+    """
+
+    def test_high_effort_emits_only_reasoning_effort(self, opencode_go_profile):
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "high"},
             model="kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
 
     def test_disabled_emits_thinking_disabled_without_effort(self, opencode_go_profile):
@@ -35,13 +40,13 @@ class TestOpenCodeGoKimiReasoning:
         assert extra_body == {"thinking": {"type": "disabled"}}
         assert top_level == {}
 
-    def test_minimal_effort_enables_thinking_without_effort(self, opencode_go_profile):
-        # "minimal" is not a Moonshot-supported value — drop it, keep thinking on.
+    def test_minimal_effort_emits_nothing(self, opencode_go_profile):
+        # "minimal" is not a Moonshot-supported value — omit both fields.
         extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "minimal"},
             model="kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {}
 
     @pytest.mark.parametrize(
@@ -56,7 +61,7 @@ class TestOpenCodeGoKimiReasoning:
             reasoning_config={"enabled": True, "effort": effort},
             model="moonshotai/kimi-k2.6",
         )
-        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert extra_body == {}
         assert top_level == {"reasoning_effort": "high"}
 
     def test_low_and_medium_pass_through(self, opencode_go_profile):
@@ -65,7 +70,7 @@ class TestOpenCodeGoKimiReasoning:
                 reasoning_config={"enabled": True, "effort": effort},
                 model="kimi-k2.5",
             )
-            assert extra_body == {"thinking": {"type": "enabled"}}
+            assert extra_body == {}
             assert top_level == {"reasoning_effort": effort}
 
     def test_no_config_preserves_server_default(self, opencode_go_profile):
@@ -149,7 +154,7 @@ class TestOpenCodeGoModelGating:
 class TestOpenCodeGoFullKwargsIntegration:
     """End-to-end transport kwargs include the profile-provided controls."""
 
-    def test_kimi_reasoning_reaches_extra_body_and_top_level(self, opencode_go_profile):
+    def test_kimi_reasoning_reaches_top_level(self, opencode_go_profile):
         from agent.transports.chat_completions import ChatCompletionsTransport
 
         kwargs = ChatCompletionsTransport().build_kwargs(
@@ -160,7 +165,9 @@ class TestOpenCodeGoFullKwargsIntegration:
             reasoning_config={"enabled": True, "effort": "high"},
             base_url="https://opencode.ai/zen/go/v1",
         )
-        assert kwargs["extra_body"] == {"thinking": {"type": "enabled"}}
+        # OpenCode Go proxy rejects both thinking + reasoning_effort together.
+        # We only send reasoning_effort (no thinking toggle).
+        assert "thinking" not in kwargs.get("extra_body", {})
         assert kwargs["reasoning_effort"] == "high"
 
     def test_deepseek_thinking_reaches_extra_body_and_top_level(


### PR DESCRIPTION
## Problem

Kimi K2.5 and K2.6 models on the `opencode-go` provider fail immediately with a non-retryable `BadRequestError`:

```
HTTP 400: Error from provider: cannot specify both 'thinking' and 'reasoning_effort'
```

This has been reported in **4 separate issues**: #31636, #32040, #32223, #32327 — none fixed on `main`.

## Root Cause

Commit `70aaa774b` added top-level `reasoning_effort` alongside `extra_body.thinking` for kimi-k2 models, mirroring the `KimiProfile` (direct moonshot API). But the OpenCode Go proxy (`opencode.ai/zen/go/v1`) forwards to a Moonshot backend that **rejects both parameters simultaneously**.

## Fix

For kimi-k2 models with reasoning **enabled**, only send `reasoning_effort` — remove the `extra_body.thinking` toggle. The upstream moonshot API accepts `reasoning_effort` standalone (verified via direct API call).

For kimi-k2 models with reasoning **disabled**, keep `extra_body.thinking = {"type": "disabled"}` to correctly opt out.

DeepSeek models are **unchanged** — they still need both fields (DeepSeek's backend requires the `thinking` toggle to avoid the infamous `reasoning_content must be passed back` error in multi-turn).

## Changes

| File | Change |
|------|--------|
| `plugins/model-providers/opencode-zen/__init__.py` | Remove `extra_body["thinking"]` from kimi-k2 enabled branch |
| `tests/plugins/model_providers/test_opencode_go_profile.py` | Update 6 kimi tests to expect no thinking field |

## Verification

```bash
hermes chat -q "Say OK" --provider opencode-go -m kimi-k2.6 -Q
# OK (was: HTTP 400)

hermes chat -q "Say OK" --provider opencode-go -m deepseek-v4-pro -Q
# OK (unchanged)

pytest tests/plugins/model_providers/test_opencode_go_profile.py -v
# 21 passed
```