### PR TITLE
fix(state): persist mid-session model switch to database

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10549,6 +10549,22 @@ class GatewayRunner:
                             except Exception as exc:
                                 logger.warning("Picker model switch failed for cached agent: %s", exc)
 
+                        # Persist the new model to the session DB so the
+                        # dashboard shows the updated model (#34850).
+                        _sess_db = getattr(_self, "_session_db", None)
+                        if _sess_db is not None:
+                            try:
+                                _sess_entry = _self.session_store.get_or_create_session(
+                                    event.source
+                                )
+                                _sess_db.update_session_model(
+                                    _sess_entry.session_id, result.new_model
+                                )
+                            except Exception as exc:
+                                logger.debug(
+                                    "Failed to persist model switch to DB: %s", exc
+                                )
+
                         # Store model note + session override
                         if not hasattr(_self, "_pending_model_notes"):
                             _self._pending_model_notes = {}
@@ -10685,6 +10701,19 @@ class GatewayRunner:
                 )
             except Exception as exc:
                 logger.warning("In-place model switch failed for cached agent: %s", exc)
+
+        # Persist the new model to the session DB so the dashboard
+        # shows the updated model (#34850).
+        if self._session_db is not None:
+            try:
+                _sess_entry = self.session_store.get_or_create_session(source)
+                self._session_db.update_session_model(
+                    _sess_entry.session_id, result.new_model
+                )
+            except Exception as exc:
+                logger.debug(
+                    "Failed to persist model switch to DB: %s", exc
+                )
 
         # Store a note to prepend to the next user message so the model
         # knows about the switch (avoids system messages mid-history).

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -965,6 +965,20 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def update_session_model(self, session_id: str, model: str) -> None:
+        """Update the model for a session after a mid-session switch.
+
+        Unlike ``update_token_counts`` which uses ``COALESCE(model, ?)``
+        (only filling in NULL), this unconditionally sets the model column
+        so that the dashboard reflects the user's latest /model choice.
+        """
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET model = ? WHERE id = ?",
+                (model, session_id),
+            )
+        self._execute_write(_do)
+
     def update_token_counts(
         self,
         session_id: str,


### PR DESCRIPTION
## Summary

When users switch models mid-session via /model, the gateway updates the in-memory agent and session overrides, but the database is never updated. The dashboard always shows the original model.

## Root Cause

In `hermes_state.py`, `update_token_counts()` uses `COALESCE(model, ?)` which only fills NULL values. Since the session was created with the original model, switching doesn't update the DB.

## Fix

1. Added `SessionDB.update_session_model()` method in `hermes_state.py`
2. Added DB update calls in `gateway/run.py` in both model switch paths (interactive picker and direct /model command)
3. Wrapped in try/except to avoid breaking model switching if DB is unavailable

## Testing

1. Start a session, note the model in /status
2. Switch model with /model
3. Check dashboard — should show the new model

Fixes #34850