### PR TITLE
fix(kanban): prevent budget exhaustion from creating permanent sticky blocks

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4373,6 +4373,7 @@ def run_conversation(
                             "budget_used": api_call_count,
                             "budget_max": agent.max_iterations,
                         },
+                        is_budget_exhaustion=True,
                     )
                     logger.info(
                         "recorded budget-exhausted failure for task %s (%d/%d)",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5032,6 +5032,7 @@ def _record_task_failure(
     release_claim: bool = False,
     end_run: bool = False,
     event_payload_extra: Optional[dict] = None,
+    is_budget_exhaustion: bool = False,
 ) -> bool:
     """Record a non-success outcome (spawn_failed / crashed / timed_out)
     and maybe trip the circuit breaker.
@@ -5055,11 +5056,13 @@ def _record_task_failure(
       Caller has ALREADY flipped the task to ``ready`` and closed the
       run with the appropriate outcome. This just increments the
       counter; if the breaker trips, the task is re-transitioned
-      ``ready → blocked`` and a ``gave_up`` event is emitted.
+      ``ready → blocked`` and a ``gave_up`` event is emitted (or a
+      ``budget_exhausted`` event when ``is_budget_exhaustion=True``).
 
-    ``event_payload_extra`` merges into the ``gave_up`` event payload
-    when the breaker trips, so callers can include outcome-specific
-    context (e.g. pid on crash, elapsed on timeout).
+    ``event_payload_extra`` merges into the ``gave_up`` /
+    ``budget_exhausted`` event payload when the breaker trips, so
+    callers can include outcome-specific context (e.g. pid on crash,
+    elapsed on timeout).
 
     Resolution order for the effective threshold:
       1. per-task ``max_retries`` if set (nothing else overrides)
@@ -5113,12 +5116,18 @@ def _record_task_failure(
                     "WHERE id = ? AND status IN ('ready', 'running')",
                     (failures, error[:500], task_id),
                 )
+            # Use "budget_exhausted" event instead of "gave_up" when the
+            # failure was caused by iteration-budget exhaustion.  This
+            # ensures that ``_has_sticky_block`` cannot match an old
+            # manual "blocked" event to keep the task permanently stuck
+            # (#35072).
+            circuit_event = "budget_exhausted" if is_budget_exhaustion else "gave_up"
             run_id = None
             if end_run:
                 # Only the spawn path has an open run to close.
                 run_id = _end_run(
                     conn, task_id,
-                    outcome="gave_up", status="gave_up",
+                    outcome=circuit_event, status=circuit_event,
                     error=error[:500],
                     metadata={
                         "failures": failures,
@@ -5137,7 +5146,7 @@ def _record_task_failure(
             if event_payload_extra:
                 payload.update(event_payload_extra)
             _append_event(
-                conn, task_id, "gave_up", payload, run_id=run_id,
+                conn, task_id, circuit_event, payload, run_id=run_id,
             )
             blocked = True
         else:


### PR DESCRIPTION
## Problem

When a kanban worker exhausts its iteration budget and the circuit breaker trips (`consecutive_failures >= failure_limit`), `_record_task_failure()` emits a `"gave_up"` event and sets the task to `status='blocked'`.

While `_has_sticky_block()` already excludes `"gave_up"` from its sticky-block check, if the task had a **prior manual `"blocked"` event** (from a worker/operator `kanban_block` call) without a corresponding `"unblocked"`, the task can become **permanently stuck**: `recompute_ready` sees the old `"blocked"` event, returns `True` from `_has_sticky_block()`, and refuses to auto-promote the task back to `ready` (#35072).

## Root Cause

`_has_sticky_block()` queries for `kind IN ('blocked', 'unblocked')` and returns `True` if the most recent one is `"blocked"`. A circuit-breaker `"gave_up"` event doesn't clear this state. So any task that was previously manually blocked (and not explicitly unblocked) will stay stuck forever once the circuit breaker fires — regardless of whether the failure was a genuine error or just budget exhaustion.

## Fix

1. **`hermes_cli/kanban_db.py`** — Add `is_budget_exhaustion: bool = False` parameter to `_record_task_failure()`. When `True`, emit a `"budget_exhausted"` event instead of `"gave_up"`. This makes the event type explicitly distinguishable from fatal errors and gives downstream code a clear signal that the task simply ran out of iterations.

2. **`agent/conversation_loop.py`** — Pass `is_budget_exhaustion=True` when recording a budget-exhausted failure (the existing call site at line ~4360).

The `"budget_exhausted"` event is not in the `kind IN ('blocked', 'unblocked')` set that `_has_sticky_block()` queries, so it is naturally excluded from sticky-block detection.

## Changes

```diff
# hermes_cli/kanban_db.py
+    is_budget_exhaustion: bool = False,
     ...
+    circuit_event = "budget_exhausted" if is_budget_exhaustion else "gave_up"
     # _end_run and _append_event now use circuit_event instead of hardcoded "gave_up"

# agent/conversation_loop.py
+    is_budget_exhaustion=True,
```

## Testing

1. **Manual test**: Create a kanban task, manually block it (`kanban block <id>`), then run a worker that will exhaust its iteration budget. Verify the task transitions to `blocked` with a `"budget_exhausted"` event (not `"gave_up"`) and that `recompute_ready` can recover it.

2. **Unit test**: Add a test that creates a task, emits a manual `"blocked"` event, then calls `_record_task_failure(is_budget_exhaustion=True)` which should trip the circuit breaker. Verify the emitted event is `"budget_exhausted"` (not `"gave_up"`).

3. **Regression**: Ensure existing `"gave_up"` behavior is preserved for non-budget-exhaustion failures (crashes, spawn failures, timeouts without budget exhaustion).