### PR TITLE
feat(relay): add relay platform adapter for agent-to-agent communication

### DIFF
--- a/plugins/platforms/relay/__init__.py
+++ b/plugins/platforms/relay/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/relay/adapter.py
+++ b/plugins/platforms/relay/adapter.py
@@ -532,7 +532,7 @@ def register(ctx):
         # LLM guidance
         platform_hint=(
             "You are connected to an agent relay network. You can send "
-            "messages to other agents (e.g. 周芷若) by writing to the outbox "
+            "messages to other agents (e.g. Worker) by writing to the outbox "
             "file or using the relay_send tool. Incoming messages from other "
             "agents appear as user messages in this session."
         ),

--- a/plugins/platforms/relay/adapter.py
+++ b/plugins/platforms/relay/adapter.py
@@ -78,15 +78,15 @@ class RelayAdapter(BasePlatformAdapter):
         Format in config.yaml:
             extra:
               endpoints:
-                zhizhiruo: "http://127.0.0.1:8767"
-                zhongwuyan: "http://127.0.0.1:8768"
+                worker-a: "http://127.0.0.1:8767"
+                worker-b: "http://127.0.0.1:8768"
         """
         endpoints = extra.get("endpoints", {})
         if isinstance(endpoints, dict):
             self._agent_endpoints.update(endpoints)
-        # Default: sidecar_url for zhizhiruo
-        if "zhizhiruo" not in self._agent_endpoints:
-            self._agent_endpoints["zhizhiruo"] = self.sidecar_url
+        # Default: sidecar_url for worker-a
+        if "worker-a" not in self._agent_endpoints:
+            self._agent_endpoints["worker-a"] = self.sidecar_url
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -239,7 +239,7 @@ class RelayAdapter(BasePlatformAdapter):
         """Send a message to an external agent via HTTP POST.
 
         chat_id format: "relay:<target_agent>"
-        e.g. "relay:zhizhiruo" → POST to zhizhiruo's endpoint
+        e.g. "relay:worker-a" → POST to worker-a's endpoint
         """
         # Extract target agent from chat_id
         if chat_id.startswith("relay:"):
@@ -415,7 +415,7 @@ async def _standalone_send(
     ``deliver=relay`` cron jobs fail with "No live adapter for platform".
 
     ``chat_id`` format: ``relay:<target_agent>``
-    e.g. ``relay:zhizhiruo`` → POST to zhizhiruo's endpoint.
+    e.g. ``relay:worker-a`` → POST to worker-a's endpoint.
 
     ``thread_id`` and ``media_files`` are accepted for signature parity
     only — relay has no thread or attachment primitive.
@@ -442,13 +442,13 @@ async def _standalone_send(
         extra.get("sidecar_url")
         or os.getenv("RELAY_SIDECAR_URL", "http://127.0.0.1:8767")
     )
-    # Default: sidecar_url for zhizhiruo
+    # Default: sidecar_url for worker-a
     if isinstance(endpoints, dict):
         endpoint_url = endpoints.get(target_agent)
     else:
         endpoint_url = None
     if not endpoint_url:
-        if target_agent == "zhizhiruo":
+        if target_agent == "worker-a":
             endpoint_url = sidecar_url
         else:
             return {

--- a/plugins/platforms/relay/adapter.py
+++ b/plugins/platforms/relay/adapter.py
@@ -1,0 +1,539 @@
+"""
+Agent Relay Platform Adapter for Hermes Agent.
+
+A plugin-based gateway adapter that receives and sends inter-agent messages
+via HTTP. Runs inside the Hermes gateway process as an aiohttp server.
+
+Other agents (cc-connect sidecar, custom agents) POST messages to this
+adapter, which routes them through the standard gateway pipeline. Outbound
+messages are POSTed to the target agent's HTTP endpoint.
+
+Configuration in config.yaml::
+
+    platforms:
+      relay:
+        enabled: true
+        extra:
+          port: 8766
+          host: "127.0.0.1"
+          sidecar_url: "http://127.0.0.1:8767"
+
+Or via environment variables:
+    RELAY_PORT, RELAY_HOST, RELAY_SIDECAR_URL
+"""
+
+import asyncio
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Lazy imports — BasePlatformAdapter lives in the main repo.
+# ---------------------------------------------------------------------------
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    SendResult,
+    MessageEvent,
+    MessageType,
+)
+from gateway.config import Platform
+
+
+# ---------------------------------------------------------------------------
+# Relay Adapter
+# ---------------------------------------------------------------------------
+
+class RelayAdapter(BasePlatformAdapter):
+    """HTTP-based adapter for agent-to-agent relay communication.
+
+    Listens on a local HTTP port for incoming messages from other agents,
+    and sends outbound messages via HTTP POST to target agent endpoints.
+    """
+
+    def __init__(self, config, **kwargs):
+        platform = Platform("relay")
+        super().__init__(config=config, platform=platform)
+
+        extra = getattr(config, "extra", {}) or {}
+        self.port = int(
+            os.getenv("RELAY_PORT") or extra.get("port", 8766)
+        )
+        self.host = os.getenv("RELAY_HOST") or extra.get("host", "127.0.0.1")
+        self.sidecar_url = (
+            os.getenv("RELAY_SIDECAR_URL")
+            or extra.get("sidecar_url", "http://127.0.0.1:8767")
+        )
+        self._runner = None
+        self._agent_endpoints: Dict[str, str] = {}
+        self._load_endpoints(extra)
+
+    def _load_endpoints(self, extra: dict) -> None:
+        """Load agent endpoint mappings from config.
+
+        Format in config.yaml:
+            extra:
+              endpoints:
+                zhizhiruo: "http://127.0.0.1:8767"
+                zhongwuyan: "http://127.0.0.1:8768"
+        """
+        endpoints = extra.get("endpoints", {})
+        if isinstance(endpoints, dict):
+            self._agent_endpoints.update(endpoints)
+        # Default: sidecar_url for zhizhiruo
+        if "zhizhiruo" not in self._agent_endpoints:
+            self._agent_endpoints["zhizhiruo"] = self.sidecar_url
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> bool:
+        """Start the HTTP server to receive messages from other agents."""
+        try:
+            from aiohttp import web
+        except ImportError:
+            logger.error("[relay] aiohttp not installed — cannot start HTTP server")
+            return False
+
+        # Port conflict detection
+        import socket as _socket
+        try:
+            with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _s:
+                _s.settimeout(1)
+                _s.connect((self.host, self.port))
+            logger.error(
+                "[relay] Port %d already in use. Set a different port: "
+                "platforms.relay.extra.port",
+                self.port,
+            )
+            return False
+        except (ConnectionRefusedError, OSError):
+            pass  # port is free
+
+        app = web.Application()
+        app.router.add_post("/message", self._handle_incoming)
+        app.router.add_get("/health", self._handle_health)
+        app.router.add_post("/register", self._handle_register)
+
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.host, self.port)
+        await site.start()
+        self._mark_connected()
+
+        logger.info(
+            "[relay] Listening on %s:%d — endpoints: %s",
+            self.host,
+            self.port,
+            list(self._agent_endpoints.keys()),
+        )
+        return True
+
+    async def disconnect(self) -> None:
+        """Stop the HTTP server."""
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+        self._mark_disconnected()
+        logger.info("[relay] Disconnected")
+
+    # ------------------------------------------------------------------
+    # HTTP handlers
+    # ------------------------------------------------------------------
+
+    async def _handle_incoming(self, request):
+        """Handle incoming POST /message from external agents."""
+        from aiohttp import web
+
+        try:
+            data = await request.json()
+        except Exception:
+            return web.json_response(
+                {"status": "error", "detail": "Invalid JSON"}, status=400
+            )
+
+        text = data.get("content", "")
+        from_agent = data.get("from", "unknown")
+        msg_id = data.get("id", f"relay_{int(time.time())}")
+
+        if not text:
+            return web.json_response(
+                {"status": "error", "detail": "Empty content"}, status=400
+            )
+
+        logger.info(
+            "[relay] Incoming from %s: %s", from_agent, text[:100]
+        )
+
+        # Build source — use relay:<from_agent> as chat_id
+        source = self.build_source(
+            chat_id=f"relay:{from_agent}",
+            chat_name=f"relay/{from_agent}",
+            chat_type="dm",
+            user_id=from_agent,
+            user_name=from_agent,
+        )
+
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=data,
+            message_id=msg_id,
+        )
+
+        # Process through gateway pipeline (non-blocking)
+        await self.handle_message(event)
+
+        return web.json_response({"status": "ok", "message_id": msg_id})
+
+    async def _handle_health(self, request):
+        """Health check endpoint."""
+        from aiohttp import web
+        return web.json_response({
+            "status": "ok",
+            "component": "relay-adapter",
+            "port": self.port,
+            "endpoints": list(self._agent_endpoints.keys()),
+        })
+
+    async def _handle_register(self, request):
+        """Register an agent endpoint dynamically.
+
+        POST /register {"agent": "name", "url": "http://..."}
+        """
+        from aiohttp import web
+        try:
+            data = await request.json()
+        except Exception:
+            return web.json_response(
+                {"status": "error", "detail": "Invalid JSON"}, status=400
+            )
+
+        agent = data.get("agent", "")
+        url = data.get("url", "")
+        if agent and url:
+            self._agent_endpoints[agent] = url
+            logger.info("[relay] Registered endpoint: %s → %s", agent, url)
+            return web.json_response({"status": "ok"})
+        return web.json_response(
+            {"status": "error", "detail": "Missing agent or url"}, status=400
+        )
+
+    # ------------------------------------------------------------------
+    # Send — route messages to target agent
+    # ------------------------------------------------------------------
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a message to an external agent via HTTP POST.
+
+        chat_id format: "relay:<target_agent>"
+        e.g. "relay:zhizhiruo" → POST to zhizhiruo's endpoint
+        """
+        # Extract target agent from chat_id
+        if chat_id.startswith("relay:"):
+            target_agent = chat_id[6:]
+        else:
+            target_agent = chat_id
+
+        # Resolve endpoint
+        endpoint_url = None
+        if metadata and metadata.get("sidecar_url"):
+            endpoint_url = metadata["sidecar_url"]
+        else:
+            endpoint_url = self._agent_endpoints.get(target_agent)
+
+        if not endpoint_url:
+            # No endpoint — message was processed, just can't send response back.
+            # This is normal for relay: the agent processes the message and
+            # the response goes to the user's current chat, not back through relay.
+            logger.info(
+                "[relay] No endpoint for agent '%s' — response logged (not sent back)",
+                target_agent,
+            )
+            return SendResult(success=True, message_id=None)
+
+        # POST message to target agent
+        message_url = endpoint_url.rstrip("/") + "/message"
+        payload = {
+            "from": "zhangwuji",
+            "to": target_agent,
+            "content": content,
+            "id": reply_to or f"msg_{int(time.time())}",
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        }
+
+        try:
+            import aiohttp
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    message_url,
+                    json=payload,
+                    timeout=aiohttp.ClientTimeout(total=10),
+                ) as resp:
+                    success = resp.status == 200
+                    if not success:
+                        text = await resp.text()
+                        logger.warning(
+                            "[relay] Send to %s failed (%d): %s",
+                            target_agent,
+                            resp.status,
+                            text[:200],
+                        )
+                    return SendResult(
+                        success=success,
+                        message_id=payload["id"],
+                    )
+        except asyncio.TimeoutError:
+            logger.warning("[relay] Send to %s timed out", target_agent)
+            return SendResult(success=False, error="Timeout")
+        except Exception as e:
+            logger.error("[relay] Send to %s failed: %s", target_agent, e)
+            return SendResult(success=False, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Typing indicators (no-op for relay)
+    # ------------------------------------------------------------------
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """Relay doesn't support typing indicators."""
+        pass
+
+    async def stop_typing(self, chat_id: str) -> None:
+        pass
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Return chat info for a relay chat_id."""
+        agent = chat_id.replace("relay:", "") if chat_id.startswith("relay:") else chat_id
+        return {
+            "name": f"relay/{agent}",
+            "type": "dm",
+            "chat_id": chat_id,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+def check_requirements() -> bool:
+    """Check if aiohttp is available."""
+    try:
+        import aiohttp
+        return True
+    except ImportError:
+        return False
+
+
+def validate_config(config) -> bool:
+    """Validate relay platform configuration."""
+    return True  # Minimal config needed
+
+
+def is_connected(config) -> bool:
+    """Check if relay platform is connected."""
+    return config.enabled if hasattr(config, "enabled") else True
+
+
+def _env_enablement():
+    """Seed PlatformConfig.extra from env vars."""
+    port = os.getenv("RELAY_PORT")
+    host = os.getenv("RELAY_HOST")
+    sidecar_url = os.getenv("RELAY_SIDECAR_URL")
+    extra = {}
+    if port:
+        extra["port"] = int(port)
+    if host:
+        extra["host"] = host
+    if sidecar_url:
+        extra["sidecar_url"] = sidecar_url
+    return extra or None
+
+
+# ---------------------------------------------------------------------------
+# YAML → env config bridge (apply_yaml_config_fn)
+# ---------------------------------------------------------------------------
+
+
+def _apply_yaml_config(yaml_cfg: dict, platform_cfg: dict) -> dict | None:
+    """Translate ``config.yaml`` ``relay:`` keys into env vars.
+
+    Implements the ``apply_yaml_config_fn`` contract (#24836 / #25443).
+
+    The RelayAdapter reads its runtime configuration via ``os.getenv()``
+    for ``RELAY_PORT``, ``RELAY_HOST``, and ``RELAY_SIDECAR_URL``.
+    Rather than rewrite those call sites to read from
+    ``PlatformConfig.extra``, this hook keeps the env-driven model and
+    owns the YAML→env translation here, next to the adapter that
+    consumes it.
+
+    Env vars take precedence over YAML — every assignment is guarded
+    by ``not os.getenv(...)`` so an explicit env var survives a
+    config.yaml update.  Returns ``None`` because no extras are seeded
+    into ``PlatformConfig.extra`` directly (everything flows through
+    env).
+    """
+    if "port" in yaml_cfg and not os.getenv("RELAY_PORT"):
+        os.environ["RELAY_PORT"] = str(yaml_cfg["port"])
+    if "host" in yaml_cfg and not os.getenv("RELAY_HOST"):
+        os.environ["RELAY_HOST"] = str(yaml_cfg["host"])
+    if "sidecar_url" in yaml_cfg and not os.getenv("RELAY_SIDECAR_URL"):
+        os.environ["RELAY_SIDECAR_URL"] = str(yaml_cfg["sidecar_url"])
+    return None  # all settings flow through env; nothing to merge into extras
+
+
+# ---------------------------------------------------------------------------
+# Standalone sender (for cron jobs / out-of-process delivery)
+# ---------------------------------------------------------------------------
+
+
+async def _standalone_send(
+    pconfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_files: Optional[list] = None,
+    force_document: bool = False,
+) -> Dict[str, Any]:
+    """Send a message to an external agent via HTTP POST without a live adapter.
+
+    Used by ``tools/send_message_tool._send_via_adapter`` and the cron
+    scheduler when the gateway runner is not in this process (e.g.
+    ``hermes cron`` running standalone). Without this hook,
+    ``deliver=relay`` cron jobs fail with "No live adapter for platform".
+
+    ``chat_id`` format: ``relay:<target_agent>``
+    e.g. ``relay:zhizhiruo`` → POST to zhizhiruo's endpoint.
+
+    ``thread_id`` and ``media_files`` are accepted for signature parity
+    only — relay has no thread or attachment primitive.
+    """
+    try:
+        import aiohttp as _aiohttp
+    except ImportError:
+        return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+
+    extra = getattr(pconfig, "extra", {}) or {}
+
+    # Resolve target agent from chat_id
+    if chat_id.startswith("relay:"):
+        target_agent = chat_id[6:]
+    else:
+        target_agent = chat_id
+
+    if not target_agent:
+        return {"error": "relay standalone send: chat_id must be relay:<agent>"}
+
+    # Resolve endpoint URL from config extra or env vars
+    endpoints = extra.get("endpoints", {})
+    sidecar_url = (
+        extra.get("sidecar_url")
+        or os.getenv("RELAY_SIDECAR_URL", "http://127.0.0.1:8767")
+    )
+    # Default: sidecar_url for zhizhiruo
+    if isinstance(endpoints, dict):
+        endpoint_url = endpoints.get(target_agent)
+    else:
+        endpoint_url = None
+    if not endpoint_url:
+        if target_agent == "zhizhiruo":
+            endpoint_url = sidecar_url
+        else:
+            return {
+                "error": (
+                    f"relay standalone send: no endpoint configured for "
+                    f"agent '{target_agent}'. Add it to "
+                    f"platforms.relay.extra.endpoints in config.yaml "
+                    f"or set RELAY_SIDECAR_URL."
+                )
+            }
+
+    message_url = endpoint_url.rstrip("/") + "/message"
+    msg_id = f"relay_cron_{int(time.time())}"
+    payload = {
+        "from": "zhangwuji",
+        "to": target_agent,
+        "content": message,
+        "id": msg_id,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    }
+
+    try:
+        async with _aiohttp.ClientSession(
+            timeout=_aiohttp.ClientTimeout(total=30),
+        ) as session:
+            async with session.post(
+                message_url, json=payload,
+            ) as resp:
+                success = resp.status == 200
+                if not success:
+                    body = await resp.text()
+                    return {
+                        "error": (
+                            f"relay HTTP {resp.status} from "
+                            f"{target_agent}: {body[:200]}"
+                        )
+                    }
+                return {
+                    "success": True,
+                    "platform": "relay",
+                    "chat_id": chat_id,
+                    "message_id": msg_id,
+                }
+    except _aiohttp.ClientError as exc:
+        return {"error": f"relay standalone send failed: {exc}"}
+    except Exception as exc:
+        return {"error": f"relay standalone send failed: {exc}"}
+
+
+def register(ctx):
+    """Plugin entry point: called by the Hermes plugin system."""
+    ctx.register_platform(
+        name="relay",
+        label="Agent Relay",
+        adapter_factory=lambda cfg: RelayAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=[],
+        install_hint="No extra packages needed (aiohttp already included)",
+        env_enablement_fn=_env_enablement,
+        # YAML→env config bridge — owns the translation of
+        # ``config.yaml`` ``relay:`` keys (port, host, sidecar_url) into
+        # ``RELAY_*`` env vars that the adapter reads via ``os.getenv()``.
+        # Hook contract: #24836 / #25443.
+        apply_yaml_config_fn=_apply_yaml_config,
+        # Auth — relay doesn't have user auth (agent-to-agent only)
+        allowed_users_env="",
+        allow_all_env="RELAY_ALLOW_ALL_AGENTS",
+        # Cron home-channel delivery — `deliver=relay` cron jobs
+        # route to RELAY_HOME_CHANNEL when set.
+        cron_deliver_env_var="RELAY_HOME_CHANNEL",
+        # Out-of-process cron delivery. Without this hook, deliver=relay
+        # cron jobs fail with "No live adapter" when cron runs separately
+        # from the gateway.
+        standalone_sender_fn=_standalone_send,
+        # Display
+        emoji="🔗",
+        pii_safe=False,
+        allow_update_command=False,
+        # LLM guidance
+        platform_hint=(
+            "You are connected to an agent relay network. You can send "
+            "messages to other agents (e.g. 周芷若) by writing to the outbox "
+            "file or using the relay_send tool. Incoming messages from other "
+            "agents appear as user messages in this session."
+        ),
+    )

--- a/plugins/platforms/relay/cc_sidecar.py
+++ b/plugins/platforms/relay/cc_sidecar.py
@@ -21,7 +21,7 @@ CONFIG = {
     "host": os.getenv("SIDECAR_HOST", "127.0.0.1"),
     "relay_url": os.getenv("RELAY_URL", "http://127.0.0.1:8766/message"),
     "inbox_dir": Path(os.getenv("SIDECAR_DIR", str(Path.home() / "content/工具/agent-relay"))),
-    "project": os.getenv("CC_PROJECT", "zhizhiruo"),
+    "project": os.getenv("CC_PROJECT", "worker-a"),
     "poll_interval": float(os.getenv("POLL_INTERVAL", "0.5")),
 }
 
@@ -224,7 +224,7 @@ class CCSidecar:
                 resp = await session.post(
                     CONFIG["relay_url"],
                     json={
-                        "from": "zhizhiruo",
+                        "from": "worker-a",
                         "to": msg.get("to", "zhangwuji"),
                         "content": msg.get("content", ""),
                         "id": msg.get("id"),

--- a/plugins/platforms/relay/cc_sidecar.py
+++ b/plugins/platforms/relay/cc_sidecar.py
@@ -2,7 +2,7 @@
 """cc-connect sidecar — 桥接 relay 适配器和 cc-connect。
 
 端口 8767，只绑定 127.0.0.1。
-- HTTP POST /message：接收张无忌的消息，转发给周芷若
+- HTTP POST /message：接收Manager的消息，转发给Worker
 - 监控 outbox.jsonl：新消息 POST 到 http://127.0.0.1:8766/message
 - GET /health：健康检查
 """
@@ -131,7 +131,7 @@ class CCSidecar:
         server.shutdown()
 
     async def handle_incoming(self, request):
-        """aiohttp handler：接收张无忌的消息，转发给周芷若。"""
+        """aiohttp handler：接收Manager的消息，转发给Worker。"""
         from aiohttp import web
         data = await request.json()
         result = await self._process_incoming(data)
@@ -158,14 +158,14 @@ class CCSidecar:
         with open(self.inbox_file, "a") as f:
             f.write(json.dumps(msg, ensure_ascii=False) + "\n")
 
-        # 通过 cc-connect send 注入周芷若 session
+        # 通过 cc-connect send 注入Worker session
         try:
             result = subprocess.run(
                 ["cc-connect", "send", "-p", CONFIG["project"], "-m", content],
                 capture_output=True, text=True, timeout=10,
             )
             if result.returncode == 0:
-                print(f"[sidecar] Forwarded to 周芷若: {content[:80]}")
+                print(f"[sidecar] Forwarded to Worker: {content[:80]}")
                 return {"status": "ok"}
             else:
                 print(f"[sidecar] cc-connect send failed: {result.stderr}")

--- a/plugins/platforms/relay/cc_sidecar.py
+++ b/plugins/platforms/relay/cc_sidecar.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""cc-connect sidecar — 桥接 relay 适配器和 cc-connect。
+
+端口 8767，只绑定 127.0.0.1。
+- HTTP POST /message：接收张无忌的消息，转发给周芷若
+- 监控 outbox.jsonl：新消息 POST 到 http://127.0.0.1:8766/message
+- GET /health：健康检查
+"""
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# 配置
+CONFIG = {
+    "port": int(os.getenv("SIDECAR_PORT", "8767")),
+    "host": os.getenv("SIDECAR_HOST", "127.0.0.1"),
+    "relay_url": os.getenv("RELAY_URL", "http://127.0.0.1:8766/message"),
+    "inbox_dir": Path(os.getenv("SIDECAR_DIR", str(Path.home() / "content/工具/agent-relay"))),
+    "project": os.getenv("CC_PROJECT", "zhizhiruo"),
+    "poll_interval": float(os.getenv("POLL_INTERVAL", "0.5")),
+}
+
+
+class CCSidecar:
+    def __init__(self):
+        self.inbox_file = CONFIG["inbox_dir"] / "inbox.jsonl"
+        self.outbox_file = CONFIG["inbox_dir"] / "outbox.jsonl"
+        self.offset_file = CONFIG["inbox_dir"] / "outbox.offset"
+        self._runner = None
+
+    async def start(self):
+        """启动 sidecar：HTTP 服务器 + outbox 监控。"""
+        try:
+            from aiohttp import web
+            await self._start_aiohttp(web)
+        except ImportError:
+            print("[sidecar] aiohttp not found, falling back to http.server")
+            await self._start_fallback()
+
+    async def _start_aiohttp(self, web):
+        """使用 aiohttp 启动 HTTP 服务器。"""
+        app = web.Application()
+        app.router.add_post("/message", self.handle_incoming)
+        app.router.add_get("/health", self.handle_health)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, CONFIG["host"], CONFIG["port"])
+        await site.start()
+        print(f"[sidecar] aiohttp listening on {CONFIG['host']}:{CONFIG['port']}")
+
+        # 启动 outbox 监控
+        asyncio.create_task(self.watch_outbox())
+
+        # 保持运行
+        stop_event = asyncio.Event()
+
+        def _signal_handler():
+            stop_event.set()
+
+        loop = asyncio.get_event_loop()
+        for sig_name in ("SIGINT", "SIGTERM"):
+            try:
+                loop.add_signal_handler(getattr(__import__("signal"), sig_name), _signal_handler)
+            except (NotImplementedError, AttributeError):
+                pass  # Windows 不支持
+
+        await stop_event.wait()
+        await self._cleanup()
+
+    async def _start_fallback(self):
+        """aiohttp 不可用时，使用 http.server fallback。"""
+        import http.server
+        import socketserver
+        import threading
+
+        sidecar = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_POST(self):
+                if self.path == "/message":
+                    content_length = int(self.headers.get("Content-Length", 0))
+                    body = self.rfile.read(content_length)
+                    try:
+                        data = json.loads(body)
+                        asyncio.get_event_loop().call_soon_threadsafe(
+                            asyncio.ensure_future,
+                            sidecar.handle_incoming_fallback(data),
+                        )
+                        self.send_response(200)
+                        self.send_header("Content-Type", "application/json")
+                        self.end_headers()
+                        self.wfile.write(b'{"status":"ok"}')
+                    except Exception as e:
+                        self.send_response(500)
+                        self.send_header("Content-Type", "application/json")
+                        self.end_headers()
+                        self.wfile.write(json.dumps({"status": "error", "detail": str(e)}).encode())
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+
+            def do_GET(self):
+                if self.path == "/health":
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(b'{"status":"ok","component":"cc-sidecar","backend":"fallback"}')
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+
+            def log_message(self, format, *args):
+                print(f"[sidecar-fallback] {args[0]}")
+
+        server = socketserver.TCPServer((CONFIG["host"], CONFIG["port"]), Handler)
+        server.daemon_threads = True
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        print(f"[sidecar] fallback http.server listening on {CONFIG['host']}:{CONFIG['port']}")
+
+        # 启动 outbox 监控
+        asyncio.create_task(self.watch_outbox())
+
+        # 保持运行
+        await asyncio.Event().wait()
+        server.shutdown()
+
+    async def handle_incoming(self, request):
+        """aiohttp handler：接收张无忌的消息，转发给周芷若。"""
+        from aiohttp import web
+        data = await request.json()
+        result = await self._process_incoming(data)
+        return web.json_response(result)
+
+    async def handle_incoming_fallback(self, data):
+        """fallback handler：处理消息。"""
+        await self._process_incoming(data)
+
+    async def _process_incoming(self, data):
+        """处理收到的消息：写 inbox + cc-connect send。"""
+        content = data.get("content", "")
+        from_agent = data.get("from", "zhangwuji")
+        msg_id = data.get("id", "")
+
+        # 写入 inbox 记录
+        msg = {
+            "from": from_agent,
+            "content": content,
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%S"),
+            "id": msg_id,
+        }
+        self.inbox_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.inbox_file, "a") as f:
+            f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+
+        # 通过 cc-connect send 注入周芷若 session
+        try:
+            result = subprocess.run(
+                ["cc-connect", "send", "-p", CONFIG["project"], "-m", content],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode == 0:
+                print(f"[sidecar] Forwarded to 周芷若: {content[:80]}")
+                return {"status": "ok"}
+            else:
+                print(f"[sidecar] cc-connect send failed: {result.stderr}")
+                return {"status": "error", "detail": result.stderr}
+        except Exception as e:
+            print(f"[sidecar] Error: {e}")
+            return {"status": "error", "detail": str(e)}
+
+    async def handle_health(self, request):
+        """健康检查。"""
+        from aiohttp import web
+        return web.json_response({
+            "status": "ok",
+            "component": "cc-sidecar",
+            "port": CONFIG["port"],
+            "project": CONFIG["project"],
+        })
+
+    async def watch_outbox(self):
+        """监控 outbox 文件，发现新消息就 POST 给 relay 适配器。"""
+        offset = 0
+        if self.offset_file.exists():
+            try:
+                offset = int(self.offset_file.read_text().strip() or "0")
+            except ValueError:
+                offset = 0
+
+        print(f"[sidecar] Watching outbox: {self.outbox_file} (offset={offset})")
+
+        while True:
+            try:
+                if self.outbox_file.exists():
+                    content = self.outbox_file.read_text()
+                    lines = content.strip().split("\n")
+                    new_lines = lines[offset:]
+                    for line in new_lines:
+                        line = line.strip()
+                        if line:
+                            try:
+                                msg = json.loads(line)
+                                await self.send_to_relay(msg)
+                                offset += 1
+                            except json.JSONDecodeError as e:
+                                print(f"[sidecar] Bad JSON in outbox: {e}")
+                                offset += 1  # 跳过坏行
+                    self.offset_file.write_text(str(offset))
+            except Exception as e:
+                print(f"[sidecar] Watch error: {e}")
+            await asyncio.sleep(CONFIG["poll_interval"])
+
+    async def send_to_relay(self, msg):
+        """POST 消息到 Hermes relay 适配器。"""
+        try:
+            import aiohttp
+            async with aiohttp.ClientSession() as session:
+                resp = await session.post(
+                    CONFIG["relay_url"],
+                    json={
+                        "from": "zhizhiruo",
+                        "to": msg.get("to", "zhangwuji"),
+                        "content": msg.get("content", ""),
+                        "id": msg.get("id"),
+                    },
+                    timeout=aiohttp.ClientTimeout(total=10),
+                )
+                if resp.status == 200:
+                    print(f"[sidecar] Sent to relay: {msg.get('content', '')[:50]}")
+                else:
+                    print(f"[sidecar] Relay returned {resp.status}")
+        except Exception as e:
+            print(f"[sidecar] Send to relay failed: {e}")
+
+    async def _cleanup(self):
+        """清理资源。"""
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+        print("[sidecar] Stopped.")
+
+
+def main():
+    """入口函数。"""
+    sidecar = CCSidecar()
+    print(f"[sidecar] Starting cc-connect sidecar...")
+    print(f"[sidecar] Port: {CONFIG['port']}")
+    print(f"[sidecar] Relay URL: {CONFIG['relay_url']}")
+    print(f"[sidecar] Project: {CONFIG['project']}")
+    print(f"[sidecar] Inbox: {sidecar.inbox_file}")
+    print(f"[sidecar] Outbox: {sidecar.outbox_file}")
+
+    asyncio.run(sidecar.start())
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/platforms/relay/plugin.yaml
+++ b/plugins/platforms/relay/plugin.yaml
@@ -22,6 +22,6 @@ optional_env:
     prompt: "Bind host"
     password: false
   - name: RELAY_HOME_CHANNEL
-    description: "Default chat_id for cron / notification delivery (e.g. relay:zhizhiruo)"
+    description: "Default chat_id for cron / notification delivery (e.g. relay:worker-a)"
     prompt: "Home channel chat_id"
     password: false

--- a/plugins/platforms/relay/plugin.yaml
+++ b/plugins/platforms/relay/plugin.yaml
@@ -6,7 +6,7 @@ description: >
   Agent-to-agent relay platform for Hermes.
   Enables real-time communication between Hermes and external agents
   (cc-connect, other Hermes instances, custom agents) via HTTP.
-author: 地产K线
+author: TKwave
 requires_env:
   - name: RELAY_PORT
     description: "HTTP port for receiving messages (default: 8766)"

--- a/plugins/platforms/relay/plugin.yaml
+++ b/plugins/platforms/relay/plugin.yaml
@@ -1,0 +1,27 @@
+name: relay-platform
+label: Agent Relay
+kind: platform
+version: 1.0.0
+description: >
+  Agent-to-agent relay platform for Hermes.
+  Enables real-time communication between Hermes and external agents
+  (cc-connect, other Hermes instances, custom agents) via HTTP.
+author: 地产K线
+requires_env:
+  - name: RELAY_PORT
+    description: "HTTP port for receiving messages (default: 8766)"
+    prompt: "Relay port"
+    password: false
+optional_env:
+  - name: RELAY_SIDECAR_URL
+    description: "URL of the cc-connect sidecar (default: http://127.0.0.1:8767)"
+    prompt: "Sidecar URL"
+    password: false
+  - name: RELAY_HOST
+    description: "Bind address (default: 127.0.0.1)"
+    prompt: "Bind host"
+    password: false
+  - name: RELAY_HOME_CHANNEL
+    description: "Default chat_id for cron / notification delivery (e.g. relay:zhizhiruo)"
+    prompt: "Home channel chat_id"
+    password: false

--- a/plugins/platforms/relay/relay_send_tool.py
+++ b/plugins/platforms/relay/relay_send_tool.py
@@ -14,7 +14,7 @@ def relay_send(target: str, content: str, task_id: str = None) -> str:
     """Send a message to another agent via the relay platform.
 
     Args:
-        target: Target agent name (e.g. "zhizhiruo" for 周芷若)
+        target: Target agent name (e.g. "worker" for Worker)
         content: Message content to send
 
     Returns:
@@ -78,13 +78,13 @@ registry.register(
     toolset="relay",
     schema={
         "name": "relay_send",
-        "description": "Send a message to another agent (e.g. 周芷若/zhizhiruo) via the relay platform. Use this for real-time inter-agent communication.",
+        "description": "Send a message to another agent (e.g. Worker/worker) via the relay platform. Use this for real-time inter-agent communication.",
         "parameters": {
             "type": "object",
             "properties": {
                 "target": {
                     "type": "string",
-                    "description": "Target agent name, e.g. 'zhizhiruo' for 周芷若",
+                    "description": "Target agent name, e.g. 'zhizhiruo' for Worker",
                 },
                 "content": {
                     "type": "string",

--- a/plugins/platforms/relay/relay_send_tool.py
+++ b/plugins/platforms/relay/relay_send_tool.py
@@ -84,7 +84,7 @@ registry.register(
             "properties": {
                 "target": {
                     "type": "string",
-                    "description": "Target agent name, e.g. 'zhizhiruo' for Worker",
+                    "description": "Target agent name, e.g. 'worker-a' for Worker",
                 },
                 "content": {
                     "type": "string",

--- a/plugins/platforms/relay/relay_send_tool.py
+++ b/plugins/platforms/relay/relay_send_tool.py
@@ -1,0 +1,102 @@
+"""
+Relay Send Tool — 向其他 agent 发送消息。
+
+通过 relay 平台适配器发送消息到指定 agent。
+"""
+
+import json
+import os
+import time
+from tools.registry import registry
+
+
+def relay_send(target: str, content: str, task_id: str = None) -> str:
+    """Send a message to another agent via the relay platform.
+
+    Args:
+        target: Target agent name (e.g. "zhizhiruo" for 周芷若)
+        content: Message content to send
+
+    Returns:
+        JSON string with success status
+    """
+    import requests
+
+    sidecar_url = os.getenv("RELAY_SIDECAR_URL", "http://127.0.0.1:8767")
+    relay_port = os.getenv("RELAY_PORT", "8766")
+
+    # Method 1: POST to relay adapter (if gateway is running)
+    relay_url = f"http://127.0.0.1:{relay_port}/message"
+    payload = {
+        "from": "zhangwuji",
+        "to": target,
+        "content": content,
+        "id": f"msg_{int(time.time())}",
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+    }
+
+    try:
+        resp = requests.post(relay_url, json=payload, timeout=10)
+        if resp.status_code == 200:
+            return json.dumps({
+                "success": True,
+                "target": target,
+                "method": "relay",
+                "message_id": payload["id"],
+            })
+    except requests.ConnectionError:
+        pass  # Relay not running, try sidecar directly
+    except Exception:
+        pass
+
+    # Method 2: POST directly to sidecar (fallback)
+    sidecar_msg_url = f"{sidecar_url}/message"
+    try:
+        resp = requests.post(sidecar_msg_url, json=payload, timeout=10)
+        if resp.status_code == 200:
+            return json.dumps({
+                "success": True,
+                "target": target,
+                "method": "sidecar",
+                "message_id": payload["id"],
+            })
+        return json.dumps({
+            "success": False,
+            "error": f"Sidecar returned {resp.status_code}",
+        })
+    except requests.ConnectionError:
+        return json.dumps({
+            "success": False,
+            "error": "Neither relay adapter nor sidecar is reachable",
+        })
+    except Exception as e:
+        return json.dumps({"success": False, "error": str(e)})
+
+
+registry.register(
+    name="relay_send",
+    toolset="relay",
+    schema={
+        "name": "relay_send",
+        "description": "Send a message to another agent (e.g. 周芷若/zhizhiruo) via the relay platform. Use this for real-time inter-agent communication.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "target": {
+                    "type": "string",
+                    "description": "Target agent name, e.g. 'zhizhiruo' for 周芷若",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Message content to send",
+                },
+            },
+            "required": ["target", "content"],
+        },
+    },
+    handler=lambda args, **kw: relay_send(
+        target=args.get("target", ""),
+        content=args.get("content", ""),
+        task_id=kw.get("task_id"),
+    ),
+)

--- a/plugins/platforms/relay/start_sidecar.sh
+++ b/plugins/platforms/relay/start_sidecar.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# 启动 cc-connect sidecar
+# 用法: bash start_sidecar.sh
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+PID_FILE="$DIR/sidecar.pid"
+LOG_FILE="$DIR/sidecar.log"
+
+# 检查是否已运行
+if [ -f "$PID_FILE" ]; then
+    PID=$(cat "$PID_FILE")
+    if kill -0 "$PID" 2>/dev/null; then
+        echo "[sidecar] Already running (PID=$PID)"
+        exit 0
+    else
+        echo "[sidecar] Stale PID file, removing..."
+        rm -f "$PID_FILE"
+    fi
+fi
+
+# 检查 Python（优先用 Hermes venv 的 Python，有 aiohttp）
+HERMES_PYTHON="$HOME/.hermes/hermes-agent/venv/bin/python"
+if [ -x "$HERMES_PYTHON" ] && "$HERMES_PYTHON" -c "import aiohttp" 2>/dev/null; then
+    PYTHON="$HERMES_PYTHON"
+    echo "[sidecar] Using Hermes venv Python: $PYTHON"
+else
+    PYTHON=$(command -v python3 || echo "")
+    if [ -z "$PYTHON" ]; then
+        echo "[sidecar] ERROR: python3 not found"
+        exit 1
+    fi
+    echo "[sidecar] WARNING: Using system Python (aiohttp may not be available)"
+fi
+
+echo "[sidecar] Starting..."
+cd "$DIR"
+nohup "$PYTHON" cc_sidecar.py >> "$LOG_FILE" 2>&1 &
+echo $! > "$PID_FILE"
+echo "[sidecar] Started (PID=$(cat "$PID_FILE")), log: $LOG_FILE"

--- a/plugins/platforms/relay/stop_sidecar.sh
+++ b/plugins/platforms/relay/stop_sidecar.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# 停止 cc-connect sidecar
+# 用法: bash stop_sidecar.sh
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+PID_FILE="$DIR/sidecar.pid"
+
+if [ ! -f "$PID_FILE" ]; then
+    echo "[sidecar] No PID file, not running"
+    exit 0
+fi
+
+PID=$(cat "$PID_FILE")
+if kill -0 "$PID" 2>/dev/null; then
+    echo "[sidecar] Stopping PID=$PID..."
+    kill "$PID"
+    # 等待退出
+    for i in $(seq 1 10); do
+        if ! kill -0 "$PID" 2>/dev/null; then
+            echo "[sidecar] Stopped"
+            rm -f "$PID_FILE"
+            exit 0
+        fi
+        sleep 0.5
+    done
+    # 强制杀
+    echo "[sidecar] Force killing PID=$PID..."
+    kill -9 "$PID" 2>/dev/null || true
+    rm -f "$PID_FILE"
+    echo "[sidecar] Force stopped"
+else
+    echo "[sidecar] PID=$PID not running, cleaning up"
+    rm -f "$PID_FILE"
+fi


### PR DESCRIPTION
## Summary

Adds a new platform adapter that enables **real-time bidirectional communication** between Hermes agents and external agents (cc-connect, Claude Code, custom agents) via HTTP.

## The Problem

Hermes agents on different platforms (Feishu, Telegram, etc.) cannot directly see each other's messages. Bot messages don't trigger other bots' Event Subscriptions, making multi-agent coordination impossible without human intermediaries.

## The Solution

A lightweight HTTP relay that runs as a Hermes plugin:

```
Agent A (Hermes) ←HTTP→ Relay Adapter (:8766) ←HTTP→ Sidecar (:8767) ←→ Agent B
```

## Features

- **Zero core changes** — pure plugin system, follows Plugin Path convention
- **Sub-second latency** — HTTP POST, no polling
- **Cross-language** — any agent that speaks HTTP can connect
- **Persistent** — file-based message queue survives restarts
- **Dynamic registration** — add/remove agents at runtime
- **Full plugin hooks** — env_enablement, apply_yaml_config, cron delivery, standalone sender

## Use Cases

- **Hermes ↔ cc-connect** — Feishu multi-agent collaboration
- **Hermes ↔ Claude Code** — code task delegation
- **Multiple Hermes instances** — cross-platform agent communication

## Components

| File | Purpose |
|------|---------|
| `adapter.py` | Main platform adapter, HTTP server, message routing |
| `plugin.yaml` | Plugin metadata, env vars, hooks |
| `relay_send_tool.py` | Hermes tool for agents to send messages |
| `cc_sidecar.py` | Bridge to cc-connect sessions |
| `start_sidecar.sh` | Sidecar launcher script |
| `stop_sidecar.sh` | Sidecar stopper script |

## Plugin Hooks Implemented

- `env_enablement_fn` — seeds config from `RELAY_*` env vars
- `apply_yaml_config_fn` — translates `relay:` YAML block to env vars
- `cron_deliver_env_var` — enables `deliver=relay` cron jobs
- `standalone_sender_fn` — out-of-process delivery for cron jobs

## Testing

```bash
# Install plugin
cp -r plugins/platforms/relay/ ~/.hermes/hermes-agent/plugins/platforms/relay/

# Add to config.yaml
platforms:
  relay:
    enabled: true

# Restart gateway
hermes gateway restart

# Verify
curl http://127.0.0.1:8766/health
```

## Related

- Standalone repo: https://github.com/TKwave/hermes-relay
- Inspired by the need for multi-agent coordination in Feishu workspaces
