### PR TITLE
fix(context-engine): honor quiet compaction status

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -29,6 +29,39 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List
 
 
+def automatic_compaction_status_message(
+    engine: Any,
+    *,
+    phase: str,
+    default_message: str,
+    **context: Any,
+) -> str | None:
+    """Resolve host-visible status for an automatic compaction event.
+
+    Engines can suppress routine automatic status with
+    ``emit_automatic_compaction_status = False`` or customize it by defining
+    ``get_automatic_compaction_status_message(...)``. Empty strings and
+    ``None`` mean "do not emit a lifecycle status".
+    """
+    if not getattr(engine, "emit_automatic_compaction_status", True):
+        return None
+
+    formatter = getattr(engine, "get_automatic_compaction_status_message", None)
+    if callable(formatter):
+        message = formatter(
+            phase=phase,
+            default_message=default_message,
+            **context,
+        )
+    else:
+        message = default_message
+
+    if message is None:
+        return None
+    message = str(message).strip()
+    return message or None
+
+
 class ContextEngine(ABC):
     """Base class all context engines must implement."""
 
@@ -64,6 +97,12 @@ class ContextEngine(ABC):
     threshold_percent: float = 0.75
     protect_first_n: int = 3
     protect_last_n: int = 6
+
+    # User-visible lifecycle status for automatic host-triggered compaction.
+    # Alternative engines that treat compaction as routine background
+    # maintenance can set this false to keep successful automatic passes silent;
+    # warnings, errors, and explicit manual commands should still surface.
+    emit_automatic_compaction_status: bool = True
 
     # -- Core interface ----------------------------------------------------
 
@@ -123,6 +162,27 @@ class ContextEngine(ABC):
         engines can ignore it safely.
         """
         return False
+
+    def get_automatic_compaction_status_message(
+        self,
+        *,
+        phase: str,
+        default_message: str,
+        **context: Any,
+    ) -> str | None:
+        """Return user-visible status for automatic host-triggered compaction.
+
+        Return ``None`` to suppress successful automatic lifecycle status for
+        this compaction event. ``phase`` identifies the host call site (for
+        example ``"preflight"`` or ``"compress"``). ``context`` contains
+        best-effort fields such as ``approx_tokens`` and ``threshold_tokens``.
+
+        This hook does not control warning/error messages or explicit manual
+        commands such as ``/compress``.
+        """
+        if not self.emit_automatic_compaction_status:
+            return None
+        return default_message
 
     # -- Optional: manual /compress preflight ------------------------------
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -36,6 +36,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional, Tuple
 
+from agent.context_engine import automatic_compaction_status_message
 from agent.model_metadata import estimate_request_tokens_rough
 
 logger = logging.getLogger(__name__)
@@ -334,7 +335,19 @@ def compress_context(
         f"{approx_tokens:,}" if approx_tokens else "unknown", agent.model,
         focus_topic,
     )
-    agent._emit_status(COMPACTION_STATUS)
+    _compaction_status = COMPACTION_STATUS
+    if not force:
+        _compaction_status = automatic_compaction_status_message(
+            agent.context_compressor,
+            phase="compress",
+            default_message=_compaction_status,
+            approx_tokens=approx_tokens,
+            message_count=_pre_msg_count,
+            model=agent.model,
+            focus_topic=focus_topic,
+        )
+    if _compaction_status:
+        agent._emit_status(_compaction_status)
 
     # ── Compression lock ────────────────────────────────────────────────
     # Atomic, state.db-backed lock per session_id.  Without this, two

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -28,6 +28,7 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.context_engine import automatic_compaction_status_message
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -28,7 +28,6 @@ import uuid
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
-from agent.context_engine import automatic_compaction_status_message
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.iteration_budget import IterationBudget

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -28,6 +28,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from agent.context_engine import automatic_compaction_status_message
 from agent.iteration_budget import IterationBudget
 from agent.model_metadata import estimate_request_tokens_rough
 
@@ -306,11 +307,21 @@ def build_turn_context(
                 agent.model,
                 f"{_compressor.context_length:,}",
             )
-            agent._emit_status(
-                f"📦 Preflight compression: ~{_preflight_tokens:,} tokens "
-                f">= {_compressor.threshold_tokens:,} threshold. "
-                "This may take a moment."
+            _preflight_status = automatic_compaction_status_message(
+                _compressor,
+                phase="preflight",
+                default_message=(
+                    f"📦 Preflight compression: ~{_preflight_tokens:,} tokens "
+                    f">= {_compressor.threshold_tokens:,} threshold. "
+                    "This may take a moment."
+                ),
+                approx_tokens=_preflight_tokens,
+                threshold_tokens=_compressor.threshold_tokens,
+                context_length=_compressor.context_length,
+                model=agent.model,
             )
+            if _preflight_status:
+                agent._emit_status(_preflight_status)
             for _pass in range(3):
                 _orig_len = len(messages)
                 messages, active_system_prompt = agent._compress_context(

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -479,6 +479,9 @@ class TestPreflightCompression:
 
     def test_compress_context_suppresses_automatic_status_when_engine_opts_out(self, agent):
         """Plugin engines can make successful automatic compaction silent."""
+        # Keep this isolated from the lazy aux-provider feasibility warning,
+        # which is unrelated to automatic compaction lifecycle status.
+        agent.compression_enabled = False
         events = []
         agent.status_callback = lambda ev, msg: events.append((ev, msg))
         agent.context_compressor.emit_automatic_compaction_status = False
@@ -504,6 +507,9 @@ class TestPreflightCompression:
 
     def test_compress_context_force_keeps_manual_status_when_engine_opts_out(self, agent):
         """Manual /compress remains visible even for quiet automatic engines."""
+        # Keep this isolated from the lazy aux-provider feasibility warning,
+        # which is unrelated to manual compression lifecycle status.
+        agent.compression_enabled = False
         events = []
         agent.status_callback = lambda ev, msg: events.append((ev, msg))
         agent.context_compressor.emit_automatic_compaction_status = False

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -477,6 +477,57 @@ class TestPreflightCompression:
         assert "Compacting context" in events[0][1]
         assert events[1] == ("compress", "started")
 
+    def test_compress_context_suppresses_automatic_status_when_engine_opts_out(self, agent):
+        """Plugin engines can make successful automatic compaction silent."""
+        events = []
+        agent.status_callback = lambda ev, msg: events.append((ev, msg))
+        agent.context_compressor.emit_automatic_compaction_status = False
+
+        def _fake_compress(messages, current_tokens=None, focus_topic=None):
+            events.append(("compress", "started"))
+            return [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
+
+        with (
+            patch.object(agent.context_compressor, "compress", side_effect=_fake_compress),
+            patch.object(agent, "_build_system_prompt", return_value="new system prompt"),
+            patch("run_agent.estimate_request_tokens_rough", return_value=42),
+        ):
+            compressed, new_system_prompt = agent._compress_context(
+                [{"role": "user", "content": "hello"}],
+                "system prompt",
+                approx_tokens=1234,
+            )
+
+        assert compressed == [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
+        assert new_system_prompt == "new system prompt"
+        assert events == [("compress", "started")]
+
+    def test_compress_context_force_keeps_manual_status_when_engine_opts_out(self, agent):
+        """Manual /compress remains visible even for quiet automatic engines."""
+        events = []
+        agent.status_callback = lambda ev, msg: events.append((ev, msg))
+        agent.context_compressor.emit_automatic_compaction_status = False
+
+        def _fake_compress(messages, current_tokens=None, focus_topic=None, force=False):
+            events.append(("compress", "started"))
+            return [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}]
+
+        with (
+            patch.object(agent.context_compressor, "compress", side_effect=_fake_compress),
+            patch.object(agent, "_build_system_prompt", return_value="new system prompt"),
+            patch("run_agent.estimate_request_tokens_rough", return_value=42),
+        ):
+            agent._compress_context(
+                [{"role": "user", "content": "hello"}],
+                "system prompt",
+                approx_tokens=1234,
+                force=True,
+            )
+
+        assert events[0][0] == "lifecycle"
+        assert "Compacting context" in events[0][1]
+        assert events[1] == ("compress", "started")
+
     def test_preflight_compresses_oversized_history(self, agent):
         """When loaded history exceeds the model's context threshold, compress before API call."""
         agent.compression_enabled = True
@@ -528,6 +579,98 @@ class TestPreflightCompression:
             ev == "lifecycle" and "Preflight compression" in msg
             for ev, msg in status_messages
         )
+
+    def test_preflight_suppresses_status_when_context_engine_opts_out(self, agent):
+        """LCM-style engines can keep routine automatic preflight maintenance silent."""
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 100_000
+        agent.context_compressor.emit_automatic_compaction_status = False
+
+        big_history = []
+        for i in range(20):
+            big_history.append({"role": "user", "content": f"Message {i} padded"})
+            big_history.append({"role": "assistant", "content": f"Response {i} padded"})
+
+        ok_resp = _mock_response(content="After quiet preflight", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+        status_messages = []
+        agent.status_callback = lambda ev, msg: status_messages.append((ev, msg))
+
+        _rough_calls = {"n": 0}
+
+        def _rough_estimate(*_args, **_kwargs):
+            _rough_calls["n"] += 1
+            return 114_000 if _rough_calls["n"] == 1 else 40_000
+
+        with (
+            patch("agent.conversation_loop.estimate_request_tokens_rough", side_effect=_rough_estimate),
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}],
+                "new system prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=big_history)
+
+        mock_compress.assert_called_once()
+        assert result["completed"] is True
+        assert not any(
+            ev == "lifecycle" and "Preflight compression" in msg
+            for ev, msg in status_messages
+        )
+
+    def test_preflight_uses_context_engine_custom_status_message(self, agent):
+        """Plugin engines can replace generic built-in-compressor wording."""
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 100_000
+
+        def _custom_status(**kwargs):
+            assert kwargs["phase"] == "preflight"
+            assert kwargs["approx_tokens"] == 114_000
+            assert kwargs["threshold_tokens"] == 100_000
+            return "🔧 LCM context maintenance: preparing compacted context."
+
+        agent.context_compressor.get_automatic_compaction_status_message = _custom_status
+
+        big_history = []
+        for i in range(20):
+            big_history.append({"role": "user", "content": f"Message {i} padded"})
+            big_history.append({"role": "assistant", "content": f"Response {i} padded"})
+
+        ok_resp = _mock_response(content="After custom preflight", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+        status_messages = []
+        agent.status_callback = lambda ev, msg: status_messages.append((ev, msg))
+
+        _rough_calls = {"n": 0}
+
+        def _rough_estimate(*_args, **_kwargs):
+            _rough_calls["n"] += 1
+            return 114_000 if _rough_calls["n"] == 1 else 40_000
+
+        with (
+            patch("agent.conversation_loop.estimate_request_tokens_rough", side_effect=_rough_estimate),
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            mock_compress.return_value = (
+                [{"role": "user", "content": f"{SUMMARY_PREFIX}\nPrevious conversation"}],
+                "new system prompt",
+            )
+            result = agent.run_conversation("hello", conversation_history=big_history)
+
+        mock_compress.assert_called_once()
+        assert result["completed"] is True
+        lifecycle_messages = [msg for ev, msg in status_messages if ev == "lifecycle"]
+        assert "🔧 LCM context maintenance: preparing compacted context." in lifecycle_messages
+        assert not any("Preflight compression" in msg for msg in lifecycle_messages)
 
     def test_preflight_defers_when_recent_real_usage_fit(self, agent):
         """A noisy rough estimate should not re-compact a recently fitting request."""

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -610,6 +610,7 @@ class TestPreflightCompression:
             return 114_000 if _rough_calls["n"] == 1 else 40_000
 
         with (
+            patch("agent.turn_context.estimate_request_tokens_rough", side_effect=_rough_estimate),
             patch("agent.conversation_loop.estimate_request_tokens_rough", side_effect=_rough_estimate),
             patch.object(agent, "_compress_context") as mock_compress,
             patch.object(agent, "_persist_session"),
@@ -660,6 +661,7 @@ class TestPreflightCompression:
             return 114_000 if _rough_calls["n"] == 1 else 40_000
 
         with (
+            patch("agent.turn_context.estimate_request_tokens_rough", side_effect=_rough_estimate),
             patch("agent.conversation_loop.estimate_request_tokens_rough", side_effect=_rough_estimate),
             patch.object(agent, "_compress_context") as mock_compress,
             patch.object(agent, "_persist_session"),


### PR DESCRIPTION
## What does this PR do?

Allows context engines to control successful automatic compaction lifecycle status instead of always showing built-in-compressor wording.

The default compressor still emits the existing `📦 Preflight compression...` and `🗜️ Compacting context...` messages. Alternative engines can now either:

- set `emit_automatic_compaction_status = False` to keep routine automatic compaction silent
- override `get_automatic_compaction_status_message(...)` to return engine-specific text or `None`

Manual `/compress` remains visible, and warning/error paths are unchanged.

This is the narrow host-contract path for LCM-style engines that treat automatic compaction as routine maintenance rather than built-in lossy compression. Related prior art: #26956. Downstream context: LCM-style context engines treat automatic compaction as routine maintenance.

## Related Issue

Fixes #25115

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_engine.py`
  - Adds `emit_automatic_compaction_status` default capability.
  - Adds `get_automatic_compaction_status_message(...)` hook for suppression or engine-specific automatic compaction status text.
  - Adds `automatic_compaction_status_message(...)` host helper for call sites.
- `agent/turn_context.py`
  - Routes preflight lifecycle status through the active context engine.
- `agent/conversation_compression.py`
  - Routes generic automatic compaction lifecycle status through the active context engine while preserving forced/manual status.
- `tests/run_agent/test_413_compression.py`
  - Adds regressions for automatic status suppression, custom preflight status, default built-in behavior, and manual forced visibility.
  - Updates preflight estimate patching for the current `agent.turn_context` prologue split.

## How to Test

Focused compression/context-engine validation:

```bash
python -m py_compile \
  agent/context_engine.py \
  agent/conversation_compression.py \
  agent/turn_context.py \
  tests/run_agent/test_413_compression.py

python -m pytest \
  tests/agent/test_context_engine.py \
  tests/run_agent/test_413_compression.py \
  -q -o 'addopts='

scripts/run_tests.sh \
  tests/run_agent/test_413_compression.py \
  tests/agent/test_context_engine.py \
  tests/agent/test_context_engine_host_contract.py \
  tests/run_agent/test_plugin_context_engine_init.py \
  -- -q --tb=short

git diff --check
```

Additional CI-slice reproduction for the current red check:

```bash
python -m pytest \
  tests/test_tui_gateway_server.py::test_notification_poller_delivers_completion \
  -q --tb=short -o 'addopts='

python -m pytest tests/test_tui_gateway_server.py -q --tb=short -o 'addopts='

python scripts/run_tests_parallel.py --slice 6/6
```

## Validation Status

Current head: `12e8ef6640187e0880f80e94714cd303331424e2`

Merge-forwarded onto current `origin/main` at `4829f8d2c5f72496d5ccdf50c35ab6dee5274252`. The PR had previously been red from a transient ripgrep download 504 before project tests ran; this update picks up the latest green base and reruns CI.

Local validation is green:

- `py_compile` on touched Python files: passed
- `python -m pytest tests/agent/test_context_engine.py tests/run_agent/test_413_compression.py -q -o 'addopts='`: `47 passed, 1 warning`
- `scripts/run_tests.sh tests/run_agent/test_413_compression.py tests/agent/test_context_engine.py tests/agent/test_context_engine_host_contract.py tests/run_agent/test_plugin_context_engine_init.py -- -q --tb=short`: `60 tests passed, 0 failed`
- `git diff --check`: passed
- `python -m pytest tests/test_tui_gateway_server.py::test_notification_poller_delivers_completion -q --tb=short -o 'addopts='`: `1 passed`
- `python -m pytest tests/test_tui_gateway_server.py -q --tb=short -o 'addopts='`: `257 passed`
- `python scripts/run_tests_parallel.py --slice 6/6`: `4616 tests passed, 0 failed`

GitHub Actions after refresh:

- All current checks passed except `test (6)`.
- `test (6)` failed one unrelated node in `tests/test_tui_gateway_server.py::test_notification_poller_delivers_completion` with `AttributeError: 'types.SimpleNamespace' object has no attribute 'run_conversation'`.
- This branch does not touch `tui_gateway/server.py` or `tests/test_tui_gateway_server.py`, and the exact node, full file, and local slice 6 pass locally. I do not want to mix that unrelated flake into this context-engine PR.
- Rerunning the failed GitHub job requires maintainer/admin permissions; `gh run rerun --failed` is denied for this fork PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested in a local Linux/Python 3.14 project venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior or N/A

## For New Skills

N/A.

## Screenshots / Logs

```text
RED checks before latest refresh:
- e2e, test (2), and test (3) failed while downloading ripgrep from GitHub Releases with curl 504, before project tests ran.

GREEN local validation after latest refresh:
- 47 focused compression/context-engine tests passed.
- 60 focused context-engine/compression tests passed through scripts/run_tests.sh.
- CI failing node passed locally as a single test, as a full test file, and inside local slice 6.
```