### PR TITLE
fix(gateway): use SIGUSR1 graceful restart for launchd

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3030,14 +3030,10 @@ def launchd_restart():
             print("✓ Service restart requested")
             return
         if pid is not None:
-            try:
-                terminate_pid(pid, force=False)
-            except (ProcessLookupError, PermissionError, OSError):
-                pid = None
-            if pid is not None:
-                exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
-                if not exited:
-                    print(f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart")
+            if _graceful_restart_via_sigusr1(pid, drain_timeout):
+                print("✓ Service restart requested")
+                return
+            print(f"⚠ Graceful gateway restart did not complete within {drain_timeout:.0f}s — forcing launchd restart")
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
     except subprocess.CalledProcessError as e:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -554,14 +554,48 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
-    def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch):
+    def test_launchd_restart_uses_sigusr1_restart_without_kickstart(self, monkeypatch, capsys):
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, timeout: calls.append(("sigusr1", pid, timeout)) or True,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "terminate_pid",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("terminate_pid should not run")),
+        )
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda: 321,
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("launchctl should not run")),
+        )
+
+        gateway_cli.launchd_restart()
+
+        assert calls == [("sigusr1", 321, 12.0)]
+        assert "restart requested" in capsys.readouterr().out.lower()
+
+    def test_launchd_restart_falls_back_to_kickstart_without_sigterm(self, monkeypatch):
         calls = []
         target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
 
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 12.0)
         monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
-        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
-        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: calls.append(("term", pid, force)))
+        monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "terminate_pid",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("terminate_pid should not run")),
+        )
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
             lambda: 321,
@@ -576,7 +610,6 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_restart()
 
         assert calls == [
-            ("term", 321, False),
             ["launchctl", "kickstart", "-k", target],
         ]
 


### PR DESCRIPTION
## Summary
- Use the existing SIGUSR1 drain-aware restart path for macOS launchd gateway restarts before falling back to `launchctl kickstart -k`.
- Avoid direct SIGTERM of the running gateway during `hermes gateway restart`, which can interrupt in-flight agent runs.
- Keep the existing fallback behavior when SIGUSR1 graceful restart cannot complete.

## Why
`_graceful_restart_via_sigusr1()` is already wired to the gateway restart flow: the gateway handles SIGUSR1 by requesting a service restart, drains active work up to the configured restart drain timeout, and then exits with the service restart code. On launchd, this gives the gateway the same drain-aware behavior instead of terminating the process first.

## Test Plan
- `git diff --check`
- `python -m py_compile hermes_cli/gateway.py hermes_cli/main.py gateway/restart.py gateway/status.py`
- `pytest tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery tests/hermes_cli/test_cron.py tests/cron/test_cron_profile.py -q -o 'addopts='`

Note: the branch was pushed from the fork's current main because the available GitHub OAuth token does not have the `workflow` scope needed to sync upstream workflow-only commits into the fork. The PR diff is limited to the gateway restart patch and its tests.
