### PR TITLE
Recover Codex auth from fresh CLI tokens

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -782,6 +782,12 @@ def format_auth_error(error: Exception) -> str:
         return str(error)
 
     if error.relogin_required:
+        if error.provider == "openai-codex":
+            return (
+                f"{error} Hermes will try to import fresh Codex CLI tokens from "
+                "`~/.codex/auth.json` automatically. If this still fails, run "
+                "`codex` once, then retry."
+            )
         return f"{error} Run `hermes model` to re-authenticate."
 
     if error.code == "subscription_required":
@@ -3568,6 +3574,24 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
         return None
 
 
+def _import_codex_cli_tokens_to_auth_store() -> Optional[Dict[str, Any]]:
+    """Adopt a fresh Codex CLI login into Hermes' isolated auth store.
+
+    This is intentionally a rescue path, not pool seeding. Hermes normally
+    keeps its own Codex OAuth session to avoid sharing a rotating refresh token
+    with Codex CLI / VS Code. If Hermes' copy is missing or terminally stale,
+    though, a freshly restored ``~/.codex/auth.json`` is the best available
+    source of truth and should repair both the singleton and device-code pool
+    entries.
+    """
+    tokens = _import_codex_cli_tokens()
+    if not tokens:
+        return None
+    last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    _save_codex_tokens(tokens, last_refresh=last_refresh)
+    return {"tokens": tokens, "last_refresh": last_refresh}
+
+
 def resolve_codex_runtime_credentials(
     *,
     force_refresh: bool = False,
@@ -3587,26 +3611,32 @@ def resolve_codex_runtime_credentials(
     """
     try:
         data = _read_codex_tokens()
-    except AuthError:
-        pool_token = _pool_codex_access_token()
-        if pool_token:
-            base_url = (
-                os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
-                or DEFAULT_CODEX_BASE_URL
-            )
-            return {
-                "provider": "openai-codex",
-                "base_url": base_url,
-                "api_key": pool_token,
-                "source": "credential_pool",
-                "last_refresh": None,
-                "auth_mode": "chatgpt",
-            }
-        raise
+    except AuthError as original_error:
+        imported = _import_codex_cli_tokens_to_auth_store()
+        if imported:
+            data = imported
+        else:
+            pool_token = _pool_codex_access_token()
+            if pool_token:
+                base_url = (
+                    os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+                    or DEFAULT_CODEX_BASE_URL
+                )
+                return {
+                    "provider": "openai-codex",
+                    "base_url": base_url,
+                    "api_key": pool_token,
+                    "source": "credential_pool",
+                    "last_refresh": None,
+                    "auth_mode": "chatgpt",
+                }
+            raise original_error
 
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
     refresh_timeout_seconds = float(os.getenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "20"))
+
+    terminal_refresh_error: Optional[AuthError] = None
 
     should_refresh = bool(force_refresh)
     if (not should_refresh) and refresh_if_expiring:
@@ -3623,8 +3653,23 @@ def resolve_codex_runtime_credentials(
                 should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
 
             if should_refresh:
-                tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
-                access_token = str(tokens.get("access_token", "") or "").strip()
+                try:
+                    tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
+                except AuthError as exc:
+                    if _is_terminal_codex_oauth_refresh_error(exc):
+                        terminal_refresh_error = exc
+                    else:
+                        raise
+                else:
+                    access_token = str(tokens.get("access_token", "") or "").strip()
+
+    if terminal_refresh_error is not None:
+        imported = _import_codex_cli_tokens_to_auth_store()
+        if not imported:
+            raise terminal_refresh_error
+        data = imported
+        tokens = dict(data["tokens"])
+        access_token = str(tokens.get("access_token", "") or "").strip()
 
     base_url = (
         os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -14,6 +14,7 @@ from hermes_cli.auth import (
     PROVIDER_REGISTRY,
     _read_codex_tokens,
     _save_codex_tokens,
+    format_auth_error,
     _import_codex_cli_tokens,
     _login_openai_codex,
     refresh_codex_oauth_pure,
@@ -41,6 +42,16 @@ def _setup_hermes_auth(hermes_home: Path, *, access_token: str = "access", refre
     }
     auth_file = hermes_home / "auth.json"
     auth_file.write_text(json.dumps(auth_store, indent=2))
+    return auth_file
+
+
+def _setup_codex_cli_auth(codex_home: Path, *, access_token: str = "cli-at", refresh_token: str = "cli-rt"):
+    """Write a Codex CLI auth file that Hermes can adopt as a rescue path."""
+    codex_home.mkdir(parents=True, exist_ok=True)
+    auth_file = codex_home / "auth.json"
+    auth_file.write_text(json.dumps({
+        "tokens": {"access_token": access_token, "refresh_token": refresh_token},
+    }))
     return auth_file
 
 
@@ -72,15 +83,35 @@ def test_read_codex_tokens_missing(tmp_path, monkeypatch):
     assert exc.value.code == "codex_auth_missing"
 
 
-def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkeypatch):
+def test_resolve_codex_runtime_credentials_missing_access_token_without_cli_import(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home, access_token="")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
 
     with pytest.raises(AuthError) as exc:
         resolve_codex_runtime_credentials()
     assert exc.value.code == "codex_auth_missing_access_token"
     assert exc.value.relogin_required is True
+
+
+def test_resolve_codex_runtime_credentials_imports_cli_tokens_when_singleton_broken(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    codex_home = tmp_path / "codex-cli"
+    _setup_hermes_auth(hermes_home, access_token="", refresh_token="dead-refresh")
+    _setup_codex_cli_auth(codex_home, access_token="fresh-cli-at", refresh_token="fresh-cli-rt")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    resolved = resolve_codex_runtime_credentials()
+
+    assert resolved["api_key"] == "fresh-cli-at"
+    assert resolved["source"] == "hermes-auth-store"
+
+    auth = json.loads((hermes_home / "auth.json").read_text())
+    tokens = auth["providers"]["openai-codex"]["tokens"]
+    assert tokens["access_token"] == "fresh-cli-at"
+    assert tokens["refresh_token"] == "fresh-cli-rt"
 
 
 def test_resolve_codex_runtime_credentials_refreshes_expiring_token(tmp_path, monkeypatch):
@@ -153,6 +184,7 @@ def test_resolve_codex_runtime_credentials_falls_back_to_pool_when_singleton_emp
     }
     (hermes_home / "auth.json").write_text(json.dumps(auth_store))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
 
     resolved = resolve_codex_runtime_credentials()
     assert resolved["api_key"] == "pool-fallback-token"
@@ -187,6 +219,7 @@ def test_resolve_codex_runtime_credentials_pool_fallback_skips_exhausted(tmp_pat
     }
     (hermes_home / "auth.json").write_text(json.dumps(auth_store))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
 
     resolved = resolve_codex_runtime_credentials()
     assert resolved["api_key"] == "usable-token"
@@ -208,6 +241,7 @@ def test_resolve_codex_runtime_credentials_pool_fallback_no_usable_entry(tmp_pat
     }
     (hermes_home / "auth.json").write_text(json.dumps(auth_store))
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-cli"))
 
     with pytest.raises(AuthError) as exc:
         resolve_codex_runtime_credentials()
@@ -433,6 +467,33 @@ def test_resolve_returns_hermes_auth_store_source(tmp_path, monkeypatch):
     assert creds["base_url"] == DEFAULT_CODEX_BASE_URL
 
 
+def test_resolve_codex_runtime_credentials_imports_cli_tokens_after_terminal_refresh(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    codex_home = tmp_path / "codex-cli"
+    _setup_hermes_auth(hermes_home, access_token="stale-hermes-at", refresh_token="reused-rt")
+    _setup_codex_cli_auth(codex_home, access_token="restored-cli-at", refresh_token="restored-cli-rt")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    def _raise_reused(tokens, timeout_seconds):
+        raise AuthError(
+            "Codex refresh token was already consumed by another client.",
+            provider="openai-codex",
+            code="refresh_token_reused",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr("hermes_cli.auth._refresh_codex_auth_tokens", _raise_reused)
+
+    resolved = resolve_codex_runtime_credentials(force_refresh=True, refresh_if_expiring=False)
+
+    assert resolved["api_key"] == "restored-cli-at"
+    auth = json.loads((hermes_home / "auth.json").read_text())
+    tokens = auth["providers"]["openai-codex"]["tokens"]
+    assert tokens["access_token"] == "restored-cli-at"
+    assert tokens["refresh_token"] == "restored-cli-rt"
+
+
 class _StubHTTPResponse:
     def __init__(self, status_code: int, payload, headers=None):
         self.status_code = status_code
@@ -620,6 +681,21 @@ def test_is_rate_limited_auth_error_distinguishes_credential_errors():
     assert is_rate_limited_auth_error(rate_limited) is True
     assert is_rate_limited_auth_error(missing_creds) is False
     assert is_rate_limited_auth_error(ValueError("nope")) is False
+
+
+def test_format_auth_error_for_codex_mentions_cli_auto_import():
+    err = AuthError(
+        "Codex refresh token was already consumed by another client.",
+        provider="openai-codex",
+        code="refresh_token_reused",
+        relogin_required=True,
+    )
+
+    rendered = format_auth_error(err)
+
+    assert "~/.codex/auth.json" in rendered
+    assert "automatically" in rendered
+    assert "run `codex` once" in rendered
 
 
 def test_login_openai_codex_force_new_login_skips_existing_reuse_prompt(monkeypatch):


### PR DESCRIPTION
## Summary
- auto-adopt fresh Codex CLI tokens from ~/.codex/auth.json when Hermes Codex auth is missing/broken
- recover from terminal Codex OAuth refresh failures such as refresh_token_reused by reimporting the fresh CLI login into Hermes' isolated auth store and pool
- make Codex relogin errors clearer for Telegram/runtime users

## Tests
- /Users/montymac/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_auth_codex_provider.py -q
- /Users/montymac/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/auth.py
- git diff --check HEAD~1..HEAD

## Notes
- upstream push is blocked for Bunrieu-sketch (READ on NousResearch/hermes-agent), so this PR is from the Bunrieu-sketch fork
