### PR TITLE
Add Hermes dynamic workflow runtime and contest harness

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -17,6 +17,7 @@ Usage:
     hermes cron                # Manage cron jobs
     hermes cron list           # List cron jobs
     hermes cron status         # Check if cron scheduler is running
+    hermes workflow run "task" # Run local Dynamic Workflow MVP
     hermes doctor              # Check configuration and dependencies
     hermes honcho setup                    # Configure Honcho AI memory integration
     hermes honcho status                   # Show Honcho config and connection status
@@ -10987,6 +10988,17 @@ def cmd_logs(args):
         since=getattr(args, "since", None),
         component=getattr(args, "component", None),
     )
+
+
+def cmd_workflow(args):
+    """Run the local Dynamic Workflow orchestrator."""
+    from hermes_cli.workflow.cli import workflow_command
+
+    code = workflow_command(args)
+    if code:
+        sys.exit(code)
+
+
 # Top-level subcommands that argparse knows about WITHOUT running plugin
 # discovery.  Used to short-circuit eager plugin imports (which can take
 # 500ms+ pulling in google.cloud.pubsub_v1, aiohttp, grpc, etc.) when the
@@ -11006,7 +11018,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "model", "pairing", "plugins", "portal", "postinstall", "profile", "proxy",
         "send", "sessions", "setup",
         "skills", "slack", "status", "tools", "uninstall", "update",
-        "version", "webhook", "whatsapp", "chat", "secrets", "security",
+        "version", "webhook", "whatsapp", "workflow", "chat", "secrets", "security",
         # Help-ish invocations — plugin commands not being listed in
         # top-level --help is an acceptable trade-off for skipping an
         # expensive eager import of every bundled plugin module.
@@ -12253,6 +12265,14 @@ def main():
 
     kanban_parser = _build_kanban_parser(subparsers)
     kanban_parser.set_defaults(func=cmd_kanban)
+
+    # =========================================================================
+    # workflow command - local Dynamic Workflow MVP
+    # =========================================================================
+    from hermes_cli.workflow.cli import add_parser as _add_workflow_parser
+
+    workflow_parser = _add_workflow_parser(subparsers)
+    workflow_parser.set_defaults(func=cmd_workflow)
 
     # =========================================================================
     # hooks command — shell-hook inspection and management

--- a/hermes_cli/workflow/README.md
+++ b/hermes_cli/workflow/README.md
@@ -1,53 +1,108 @@
-# Hermes Dynamic Workflow MVP
+# Hermes Dynamic Workflow
 
 This folder contains a local, optional Dynamic Workflow system for Hermes.
+It is Python-native and keeps normal Hermes behavior unchanged unless the
+`hermes workflow` command is used.
 
 ## Structure
 
 ```text
 hermes_cli/workflow/
   orchestrator.py          Analyzer, planner, router, worker runner, evaluator, synthesizer
-  cli.py                   `hermes workflow run` parser and dispatcher
-  config/workflow.yaml     Agent and routing configuration
+  runtime.py               Runtime, scheduler, agent executor, evaluator loop
+  state.py                 SQLite run state and event history
+  script_api.py            Reusable Python workflow script helpers
+  cli.py                   `hermes workflow ...` parser and dispatcher
+  config/workflow.yaml     Agent, execution, safety, and routing configuration
   prompts/*.md             Prompt files for agents, evaluator, and synthesizer
   examples/example_run.md  Dry-run and model-backed examples
 ```
 
 ## Usage
 
+Run a foreground workflow:
+
 ```bash
 hermes workflow run "user task here"
 ```
 
-Use `--dry-run` to exercise the workflow without model calls:
+Exercise the workflow without model calls:
 
 ```bash
 hermes workflow run --dry-run "Plan tests for a new Python CLI"
 ```
 
-Use a custom config:
+Run dependency-ready subtasks concurrently:
 
 ```bash
-hermes workflow run --config ./workflow.yaml "research this migration"
+hermes workflow run --parallel --dry-run "Plan a release checklist"
+```
+
+Queue an explicit background run:
+
+```bash
+hermes workflow run --background --dry-run "Research options and summarize risks"
+hermes workflow status <run_id>
+hermes workflow logs <run_id>
+```
+
+Pause, resume, or cancel a persisted run:
+
+```bash
+hermes workflow pause <run_id>
+hermes workflow resume <run_id>
+hermes workflow cancel <run_id>
+```
+
+Format output for Codex Goal Mode:
+
+```bash
+hermes workflow run --codex-plan --dry-run "Break down the multi-role login rollout"
+```
+
+Run a reusable Python workflow script:
+
+```python
+# workflow_example.py
+research = task(
+    "Compare workflow runtime options",
+    worker="researcher",
+    context="Keep this local and safe by default.",
+    risk_level="low",
+)
+plan = task(
+    "Turn findings into an implementation plan",
+    worker="product_planner",
+    depends_on=[research],
+)
+parallel([research], max_concurrency=2)
+```
+
+```bash
+hermes workflow script --dry-run ./workflow_example.py
 ```
 
 ## Behavior
 
-The MVP runs sequentially:
+The runtime:
 
-1. Analyze task type and complexity.
-2. Plan 1 to 8 subtasks.
-3. Route each subtask to a worker type.
-4. Run each worker with configured model/provider.
-5. Evaluate acceptance criteria.
-6. Run one revision cycle if evaluation fails.
-7. Synthesize a concise final answer.
+1. Analyzes task type and complexity.
+2. Plans 1 to 8 structured subtasks.
+3. Assigns worker types from routing rules and agent descriptions.
+4. Persists run state, subtasks, outputs, evaluator scores, and events.
+5. Executes sequentially by default, or in dependency-aware parallel mode with
+   `--parallel`.
+6. Evaluates each output and performs one bounded revision cycle if needed.
+7. Synthesizes a concise final answer or a Codex Goal checklist.
 
-Logs are appended to `~/.hermes/logs/workflow_runs.jsonl`.
+JSONL logs are appended to `~/.hermes/logs/workflow_runs.jsonl`. Durable run
+state is stored in `~/.hermes/workflow_runs.db` unless `execution.state_db` is
+set in the config.
 
 ## Safety
 
-The bundled config disables worker toolsets by default. That means model-backed
-workers produce plans and analysis, not autonomous file changes. Destructive
-commands, credential exposure, background execution, and cross-project access
-remain out of scope for this MVP.
+No workflow runs automatically. Background execution requires `--background`.
+Worker toolsets are disabled unless both the global safety config and the
+specific agent allow file writes. Destructive commands still require explicit
+confirmation. Logged payloads pass through Hermes redaction before being written
+to JSONL or SQLite events.

--- a/hermes_cli/workflow/README.md
+++ b/hermes_cli/workflow/README.md
@@ -67,6 +67,9 @@ hermes workflow run --contest --cross-review --codex-plan \
   "Choose the best next plan for the multi-role login rollout"
 ```
 
+Model-backed foreground runs print progress to stderr so `--json` stdout stays
+machine-readable. Use `--no-progress` to suppress those messages.
+
 Run a reusable Python workflow script:
 
 ```python

--- a/hermes_cli/workflow/README.md
+++ b/hermes_cli/workflow/README.md
@@ -60,6 +60,13 @@ Format output for Codex Goal Mode:
 hermes workflow run --codex-plan --dry-run "Break down the multi-role login rollout"
 ```
 
+Run a contest harness with adversarial cross-review:
+
+```bash
+hermes workflow run --contest --cross-review --codex-plan \
+  "Choose the best next plan for the multi-role login rollout"
+```
+
 Run a reusable Python workflow script:
 
 ```python
@@ -92,8 +99,11 @@ The runtime:
 4. Persists run state, subtasks, outputs, evaluator scores, and events.
 5. Executes sequentially by default, or in dependency-aware parallel mode with
    `--parallel`.
-6. Evaluates each output and performs one bounded revision cycle if needed.
-7. Synthesizes a concise final answer or a Codex Goal checklist.
+6. Optionally runs contest mode where multiple workers independently answer a
+   subtask, reviewer/tester workers cross-review the candidates, and the best
+   candidate is selected.
+7. Evaluates each output and performs one bounded revision cycle if needed.
+8. Synthesizes a concise final answer or a Codex Goal checklist.
 
 JSONL logs are appended to `~/.hermes/logs/workflow_runs.jsonl`. Durable run
 state is stored in `~/.hermes/workflow_runs.db` unless `execution.state_db` is

--- a/hermes_cli/workflow/README.md
+++ b/hermes_cli/workflow/README.md
@@ -1,0 +1,53 @@
+# Hermes Dynamic Workflow MVP
+
+This folder contains a local, optional Dynamic Workflow system for Hermes.
+
+## Structure
+
+```text
+hermes_cli/workflow/
+  orchestrator.py          Analyzer, planner, router, worker runner, evaluator, synthesizer
+  cli.py                   `hermes workflow run` parser and dispatcher
+  config/workflow.yaml     Agent and routing configuration
+  prompts/*.md             Prompt files for agents, evaluator, and synthesizer
+  examples/example_run.md  Dry-run and model-backed examples
+```
+
+## Usage
+
+```bash
+hermes workflow run "user task here"
+```
+
+Use `--dry-run` to exercise the workflow without model calls:
+
+```bash
+hermes workflow run --dry-run "Plan tests for a new Python CLI"
+```
+
+Use a custom config:
+
+```bash
+hermes workflow run --config ./workflow.yaml "research this migration"
+```
+
+## Behavior
+
+The MVP runs sequentially:
+
+1. Analyze task type and complexity.
+2. Plan 1 to 8 subtasks.
+3. Route each subtask to a worker type.
+4. Run each worker with configured model/provider.
+5. Evaluate acceptance criteria.
+6. Run one revision cycle if evaluation fails.
+7. Synthesize a concise final answer.
+
+Logs are appended to `~/.hermes/logs/workflow_runs.jsonl`.
+
+## Safety
+
+The bundled config disables worker toolsets by default. That means model-backed
+workers produce plans and analysis, not autonomous file changes. Destructive
+commands, credential exposure, background execution, and cross-project access
+remain out of scope for this MVP.

--- a/hermes_cli/workflow/__init__.py
+++ b/hermes_cli/workflow/__init__.py
@@ -1,0 +1,5 @@
+"""Local Dynamic Workflow MVP for Hermes."""
+
+from hermes_cli.workflow.orchestrator import WorkflowOrchestrator, run_workflow
+
+__all__ = ["WorkflowOrchestrator", "run_workflow"]

--- a/hermes_cli/workflow/cli.py
+++ b/hermes_cli/workflow/cli.py
@@ -4,7 +4,9 @@ import argparse
 import json
 import sys
 
-from hermes_cli.workflow.orchestrator import WorkflowError, run_workflow
+from hermes_cli.workflow.orchestrator import WorkflowConfig, WorkflowError, run_workflow
+from hermes_cli.workflow.runtime import WorkflowRuntime
+from hermes_cli.workflow.state import RunStore
 
 
 def add_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
@@ -12,9 +14,9 @@ def add_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argume
         "workflow",
         help="Run a local dynamic workflow orchestrator",
         description=(
-            "Analyze a request, optionally split it into subtasks, route those "
-            "subtasks to specialized workers, evaluate outputs, and synthesize "
-            "a concise final response."
+            "Analyze a request, split it into subtasks, route those subtasks "
+            "to specialized workers, evaluate outputs, and synthesize a concise "
+            "final response."
         ),
     )
     sub = workflow_parser.add_subparsers(dest="workflow_command")
@@ -22,64 +24,266 @@ def add_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argume
     run_parser = sub.add_parser(
         "run",
         help="Run a workflow for a user task",
-        description="Run the Dynamic Workflow MVP for a single user request.",
+        description="Run a Dynamic Workflow request.",
+    )
+    _add_execution_flags(run_parser)
+    run_parser.add_argument(
+        "--resume-run-id",
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    run_parser.add_argument(
+        "--internal-background-worker",
+        action="store_true",
+        help=argparse.SUPPRESS,
     )
     run_parser.add_argument(
         "task",
         nargs=argparse.REMAINDER,
         help='Task text. Example: hermes workflow run "plan this feature"',
     )
-    run_parser.add_argument(
-        "--config",
-        default=None,
-        help="Path to a workflow YAML config. Defaults to bundled MVP config.",
+
+    script_parser = sub.add_parser(
+        "script",
+        help="Run a reusable Python workflow script",
+        description="Run a Python-native Hermes workflow script.",
     )
-    run_parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Use deterministic worker outputs without calling configured models.",
-    )
-    run_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Print the full workflow run as JSON.",
-    )
-    run_parser.add_argument(
-        "--max-subtasks",
-        type=int,
-        default=None,
-        help="Limit planner output to 1-8 subtasks.",
-    )
+    _add_execution_flags(script_parser)
+    script_parser.add_argument("path", help="Path to a Python workflow script.")
+
+    status_parser = sub.add_parser("status", help="Show workflow run status")
+    _add_config_flag(status_parser)
+    status_parser.add_argument("run_id")
+    status_parser.add_argument("--json", action="store_true")
+
+    logs_parser = sub.add_parser("logs", help="Show workflow run event logs")
+    _add_config_flag(logs_parser)
+    logs_parser.add_argument("run_id")
+    logs_parser.add_argument("--json", action="store_true")
+    logs_parser.add_argument("--tail", type=int, default=None)
+
+    for command in ("pause", "cancel"):
+        parser = sub.add_parser(command, help=f"{command.title()} a workflow run")
+        _add_config_flag(parser)
+        parser.add_argument("run_id")
+
+    resume_parser = sub.add_parser("resume", help="Resume a paused workflow run")
+    _add_config_flag(resume_parser)
+    resume_parser.add_argument("run_id")
+    resume_parser.add_argument("--json", action="store_true")
     return workflow_parser
 
 
 def workflow_command(args: argparse.Namespace) -> int:
     command = getattr(args, "workflow_command", None)
-    if command != "run":
-        print('Usage: hermes workflow run "user task here"', file=sys.stderr)
-        return 2
-
-    request = " ".join(getattr(args, "task", []) or []).strip()
-    if not request:
-        print("Error: workflow run requires a task string.", file=sys.stderr)
-        return 2
-
     try:
-        result = run_workflow(
-            request,
-            config_path=getattr(args, "config", None),
-            dry_run=bool(getattr(args, "dry_run", False)),
-            max_subtasks=getattr(args, "max_subtasks", None),
-        )
+        if command == "run":
+            return _cmd_run(args)
+        if command == "script":
+            return _cmd_script(args)
+        if command == "status":
+            return _cmd_status(args)
+        if command == "logs":
+            return _cmd_logs(args)
+        if command == "pause":
+            return _cmd_mark(args, "paused")
+        if command == "cancel":
+            return _cmd_mark(args, "cancelled")
+        if command == "resume":
+            return _cmd_resume(args)
     except WorkflowError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
 
+    print('Usage: hermes workflow run "user task here"', file=sys.stderr)
+    return 2
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    resume_run_id = getattr(args, "resume_run_id", None)
+    request = " ".join(getattr(args, "task", []) or []).strip()
+    if not request and not resume_run_id:
+        print("Error: workflow run requires a task string.", file=sys.stderr)
+        return 2
+
+    dry_run = bool(getattr(args, "dry_run", False))
+    parallel = bool(getattr(args, "parallel", False))
+    codex_plan = bool(getattr(args, "codex_plan", False))
+    if resume_run_id:
+        record = _store(args).get_run(resume_run_id)
+        if record:
+            dry_run = bool(record["dry_run"])
+            parallel = str(record["mode"]) == "parallel"
+            codex_plan = bool(record["codex_plan"])
+
+    result = run_workflow(
+        request or "Resumed workflow run.",
+        config_path=getattr(args, "config", None),
+        dry_run=dry_run,
+        max_subtasks=getattr(args, "max_subtasks", None),
+        parallel=parallel,
+        background=bool(getattr(args, "background", False)),
+        codex_plan=codex_plan,
+        run_id=resume_run_id,
+        resume=bool(resume_run_id),
+    )
+    if getattr(args, "internal_background_worker", False):
+        return 0
+    _print_run(result, json_output=bool(getattr(args, "json", False)))
+    return 0
+
+
+def _cmd_script(args: argparse.Namespace) -> int:
+    config = WorkflowConfig.load(getattr(args, "config", None))
+    runtime = WorkflowRuntime(
+        config=config,
+        dry_run=bool(getattr(args, "dry_run", False)),
+        max_subtasks=getattr(args, "max_subtasks", None),
+        parallel=bool(getattr(args, "parallel", False)),
+        codex_plan=bool(getattr(args, "codex_plan", False)),
+    )
+    result = runtime.run_script(
+        getattr(args, "path"),
+        background=bool(getattr(args, "background", False)),
+    )
+    _print_run(result, json_output=bool(getattr(args, "json", False)))
+    return 0
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    store = _store(args)
+    record = store.get_run(getattr(args, "run_id"))
+    if not record:
+        raise WorkflowError(f"Workflow run not found: {getattr(args, 'run_id')}")
+    subtasks = store.load_subtasks(record["run_id"])
+    outputs = store.load_outputs(record["run_id"])
+    payload = {
+        "run_id": record["run_id"],
+        "status": record["status"],
+        "mode": record["mode"],
+        "dry_run": bool(record["dry_run"]),
+        "codex_plan": bool(record["codex_plan"]),
+        "pid": record["pid"],
+        "created_at": record["created_at"],
+        "updated_at": record["updated_at"],
+        "subtasks": len(subtasks),
+        "completed_outputs": len(outputs),
+        "error": record["error"],
+        "state_path": str(store.path),
+    }
     if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        print(f"Run id: {payload['run_id']}")
+        print(f"Status: {payload['status']}")
+        print(f"Mode: {payload['mode']}")
+        print(f"Progress: {payload['completed_outputs']}/{payload['subtasks']}")
+        if payload["pid"]:
+            print(f"PID: {payload['pid']}")
+        if payload["error"]:
+            print(f"Error: {payload['error']}")
+        print(f"State: {payload['state_path']}")
+    return 0
+
+
+def _cmd_logs(args: argparse.Namespace) -> int:
+    store = _store(args)
+    run_id = getattr(args, "run_id")
+    if not store.get_run(run_id):
+        raise WorkflowError(f"Workflow run not found: {run_id}")
+    events = store.events(run_id, limit=getattr(args, "tail", None))
+    if getattr(args, "json", False):
+        print(json.dumps(events, indent=2, ensure_ascii=False))
+    else:
+        for event in events:
+            print(f"{event['ts']} {event['event']}: {json.dumps(event['payload'], ensure_ascii=False)}")
+    return 0
+
+
+def _cmd_mark(args: argparse.Namespace, status: str) -> int:
+    store = _store(args)
+    run_id = getattr(args, "run_id")
+    if not store.get_run(run_id):
+        raise WorkflowError(f"Workflow run not found: {run_id}")
+    store.update_run(run_id, status=status)
+    store.append_event(run_id, "status", {"status": status})
+    print(f"Workflow run {run_id} marked {status}.")
+    return 0
+
+
+def _cmd_resume(args: argparse.Namespace) -> int:
+    store = _store(args)
+    run_id = getattr(args, "run_id")
+    record = store.get_run(run_id)
+    if not record:
+        raise WorkflowError(f"Workflow run not found: {run_id}")
+    result = run_workflow(
+        "Resumed workflow run.",
+        config_path=getattr(args, "config", None),
+        dry_run=bool(record["dry_run"]),
+        parallel=str(record["mode"]) == "parallel",
+        codex_plan=bool(record["codex_plan"]),
+        run_id=run_id,
+        resume=True,
+    )
+    _print_run(result, json_output=bool(getattr(args, "json", False)))
+    return 0
+
+
+def _print_run(result, *, json_output: bool) -> None:
+    if json_output:
         print(json.dumps(result.to_dict(), indent=2, ensure_ascii=False))
     else:
         print(result.final_response)
         print()
         print(f"Run id: {result.run_id}")
+        print(f"Status: {result.status}")
         print(f"Log: {result.log_path}")
-    return 0
+        if result.state_path:
+            print(f"State: {result.state_path}")
+
+
+def _add_config_flag(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to a workflow YAML config. Defaults to bundled config.",
+    )
+
+
+def _add_execution_flags(parser: argparse.ArgumentParser) -> None:
+    _add_config_flag(parser)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Use deterministic worker outputs without calling configured models.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON output.")
+    parser.add_argument(
+        "--max-subtasks",
+        type=int,
+        default=None,
+        help="Limit planner output to 1-8 subtasks.",
+    )
+    parser.add_argument(
+        "--parallel",
+        action="store_true",
+        help="Run dependency-ready subtasks concurrently.",
+    )
+    parser.add_argument(
+        "--background",
+        action="store_true",
+        help="Queue the workflow in an explicit background worker process.",
+    )
+    parser.add_argument(
+        "--codex-plan",
+        action="store_true",
+        help="Format the final response as a Codex Goal execution checklist.",
+    )
+
+
+def _store(args: argparse.Namespace) -> RunStore:
+    return RunStore.from_config(WorkflowConfig.load(getattr(args, "config", None)))

--- a/hermes_cli/workflow/cli.py
+++ b/hermes_cli/workflow/cli.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from hermes_cli.workflow.orchestrator import WorkflowError, run_workflow
+
+
+def add_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
+    workflow_parser = parent_subparsers.add_parser(
+        "workflow",
+        help="Run a local dynamic workflow orchestrator",
+        description=(
+            "Analyze a request, optionally split it into subtasks, route those "
+            "subtasks to specialized workers, evaluate outputs, and synthesize "
+            "a concise final response."
+        ),
+    )
+    sub = workflow_parser.add_subparsers(dest="workflow_command")
+
+    run_parser = sub.add_parser(
+        "run",
+        help="Run a workflow for a user task",
+        description="Run the Dynamic Workflow MVP for a single user request.",
+    )
+    run_parser.add_argument(
+        "task",
+        nargs=argparse.REMAINDER,
+        help='Task text. Example: hermes workflow run "plan this feature"',
+    )
+    run_parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to a workflow YAML config. Defaults to bundled MVP config.",
+    )
+    run_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Use deterministic worker outputs without calling configured models.",
+    )
+    run_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the full workflow run as JSON.",
+    )
+    run_parser.add_argument(
+        "--max-subtasks",
+        type=int,
+        default=None,
+        help="Limit planner output to 1-8 subtasks.",
+    )
+    return workflow_parser
+
+
+def workflow_command(args: argparse.Namespace) -> int:
+    command = getattr(args, "workflow_command", None)
+    if command != "run":
+        print('Usage: hermes workflow run "user task here"', file=sys.stderr)
+        return 2
+
+    request = " ".join(getattr(args, "task", []) or []).strip()
+    if not request:
+        print("Error: workflow run requires a task string.", file=sys.stderr)
+        return 2
+
+    try:
+        result = run_workflow(
+            request,
+            config_path=getattr(args, "config", None),
+            dry_run=bool(getattr(args, "dry_run", False)),
+            max_subtasks=getattr(args, "max_subtasks", None),
+        )
+    except WorkflowError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if getattr(args, "json", False):
+        print(json.dumps(result.to_dict(), indent=2, ensure_ascii=False))
+    else:
+        print(result.final_response)
+        print()
+        print(f"Run id: {result.run_id}")
+        print(f"Log: {result.log_path}")
+    return 0

--- a/hermes_cli/workflow/cli.py
+++ b/hermes_cli/workflow/cli.py
@@ -112,12 +112,16 @@ def _cmd_run(args: argparse.Namespace) -> int:
     dry_run = bool(getattr(args, "dry_run", False))
     parallel = bool(getattr(args, "parallel", False))
     codex_plan = bool(getattr(args, "codex_plan", False))
+    contest = bool(getattr(args, "contest", False))
+    cross_review = bool(getattr(args, "cross_review", False))
     if resume_run_id:
         record = _store(args).get_run(resume_run_id)
         if record:
             dry_run = bool(record["dry_run"])
-            parallel = str(record["mode"]) == "parallel"
+            parallel = "parallel" in str(record["mode"])
             codex_plan = bool(record["codex_plan"])
+            contest = bool(record["contest"])
+            cross_review = bool(record["cross_review"])
 
     result = run_workflow(
         request or "Resumed workflow run.",
@@ -127,6 +131,8 @@ def _cmd_run(args: argparse.Namespace) -> int:
         parallel=parallel,
         background=bool(getattr(args, "background", False)),
         codex_plan=codex_plan,
+        contest=contest,
+        cross_review=cross_review,
         run_id=resume_run_id,
         resume=bool(resume_run_id),
     )
@@ -144,6 +150,8 @@ def _cmd_script(args: argparse.Namespace) -> int:
         max_subtasks=getattr(args, "max_subtasks", None),
         parallel=bool(getattr(args, "parallel", False)),
         codex_plan=bool(getattr(args, "codex_plan", False)),
+        contest=bool(getattr(args, "contest", False)),
+        cross_review=bool(getattr(args, "cross_review", False)),
     )
     result = runtime.run_script(
         getattr(args, "path"),
@@ -166,6 +174,8 @@ def _cmd_status(args: argparse.Namespace) -> int:
         "mode": record["mode"],
         "dry_run": bool(record["dry_run"]),
         "codex_plan": bool(record["codex_plan"]),
+        "contest": bool(record["contest"]),
+        "cross_review": bool(record["cross_review"]),
         "pid": record["pid"],
         "created_at": record["created_at"],
         "updated_at": record["updated_at"],
@@ -180,6 +190,8 @@ def _cmd_status(args: argparse.Namespace) -> int:
         print(f"Run id: {payload['run_id']}")
         print(f"Status: {payload['status']}")
         print(f"Mode: {payload['mode']}")
+        if payload["contest"]:
+            print(f"Contest: enabled (cross-review={payload['cross_review']})")
         print(f"Progress: {payload['completed_outputs']}/{payload['subtasks']}")
         if payload["pid"]:
             print(f"PID: {payload['pid']}")
@@ -224,8 +236,10 @@ def _cmd_resume(args: argparse.Namespace) -> int:
         "Resumed workflow run.",
         config_path=getattr(args, "config", None),
         dry_run=bool(record["dry_run"]),
-        parallel=str(record["mode"]) == "parallel",
+        parallel="parallel" in str(record["mode"]),
         codex_plan=bool(record["codex_plan"]),
+        contest=bool(record["contest"]),
+        cross_review=bool(record["cross_review"]),
         run_id=run_id,
         resume=True,
     )
@@ -282,6 +296,16 @@ def _add_execution_flags(parser: argparse.ArgumentParser) -> None:
         "--codex-plan",
         action="store_true",
         help="Format the final response as a Codex Goal execution checklist.",
+    )
+    parser.add_argument(
+        "--contest",
+        action="store_true",
+        help="Run multiple candidate workers for each subtask and select the best result.",
+    )
+    parser.add_argument(
+        "--cross-review",
+        action="store_true",
+        help="Have reviewer/tester workers adversarially review contest candidates.",
     )
 
 

--- a/hermes_cli/workflow/cli.py
+++ b/hermes_cli/workflow/cli.py
@@ -133,6 +133,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         codex_plan=codex_plan,
         contest=contest,
         cross_review=cross_review,
+        progress_callback=_progress_callback(args, dry_run),
         run_id=resume_run_id,
         resume=bool(resume_run_id),
     )
@@ -152,6 +153,7 @@ def _cmd_script(args: argparse.Namespace) -> int:
         codex_plan=bool(getattr(args, "codex_plan", False)),
         contest=bool(getattr(args, "contest", False)),
         cross_review=bool(getattr(args, "cross_review", False)),
+        progress_callback=_progress_callback(args, bool(getattr(args, "dry_run", False))),
     )
     result = runtime.run_script(
         getattr(args, "path"),
@@ -240,6 +242,7 @@ def _cmd_resume(args: argparse.Namespace) -> int:
         codex_plan=bool(record["codex_plan"]),
         contest=bool(record["contest"]),
         cross_review=bool(record["cross_review"]),
+        progress_callback=_progress_callback(args, bool(record["dry_run"])),
         run_id=run_id,
         resume=True,
     )
@@ -307,6 +310,69 @@ def _add_execution_flags(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Have reviewer/tester workers adversarially review contest candidates.",
     )
+    parser.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Disable foreground progress messages on stderr.",
+    )
+
+
+def _progress_callback(args: argparse.Namespace, dry_run: bool):
+    if dry_run:
+        return None
+    if getattr(args, "internal_background_worker", False):
+        return None
+    if getattr(args, "background", False):
+        return None
+    if getattr(args, "no_progress", False):
+        return None
+
+    def emit(event: str, payload: dict) -> None:
+        message = _progress_message(event, payload)
+        if message:
+            print(message, file=sys.stderr, flush=True)
+
+    return emit
+
+
+def _progress_message(event: str, payload: dict) -> str:
+    if event == "planned":
+        count = len(payload.get("subtasks") or [])
+        mode = payload.get("mode", "workflow")
+        return f"[workflow] planned {count} subtask(s), mode={mode}"
+    if event == "worker_selected":
+        return (
+            f"[workflow] {payload.get('subtask_id')}: "
+            f"worker={payload.get('selected_worker')} "
+            f"model={payload.get('model')}"
+        )
+    if event == "contest_candidate":
+        return (
+            f"[workflow] {payload.get('subtask_id')}: candidate "
+            f"{payload.get('worker_type')} score={payload.get('score')}"
+        )
+    if event == "cross_review_result":
+        return (
+            f"[workflow] {payload.get('subtask_id')}: cross-review "
+            f"{payload.get('reviewer')} score={payload.get('score')}"
+        )
+    if event == "contest_selected":
+        return (
+            f"[workflow] {payload.get('subtask_id')}: winner "
+            f"{payload.get('winner_worker')} score={payload.get('winner_score')}"
+        )
+    if event == "worker_result":
+        return f"[workflow] {payload.get('subtask_id')}: worker result saved"
+    if event == "evaluation":
+        return (
+            f"[workflow] {payload.get('subtask_id')}: evaluator "
+            f"score={payload.get('evaluator_score')} passed={payload.get('passed')}"
+        )
+    if event == "final":
+        return "[workflow] final response ready"
+    if event == "error":
+        return f"[workflow] error: {payload.get('error')}"
+    return ""
 
 
 def _store(args: argparse.Namespace) -> RunStore:

--- a/hermes_cli/workflow/config/workflow.yaml
+++ b/hermes_cli/workflow/config/workflow.yaml
@@ -4,10 +4,15 @@ execution:
   mode: sequential
   max_subtasks: 8
   max_revision_cycles: 1
-  parallel_enabled: false
+  parallel_enabled: true
+  max_concurrency: 3
+  background_enabled: true
+  state_db: ""
+  default_permission_mode: read-only
 
 safety:
-  allow_background_execution: false
+  allow_background_execution: true
+  require_background_flag: true
   allow_file_changes: false
   require_destructive_confirmation: true
   redact_credentials: true
@@ -18,40 +23,68 @@ logging:
 
 agents:
   coder:
+    description: Implement narrowly scoped code changes when explicitly allowed.
     provider: ""
     model: ""
     prompt: prompts/worker_coder.md
+    tools: []
     toolsets: []
+    max_turns: 15
+    can_write_files: false
   debugger:
+    description: Diagnose failures, root causes, and regression risks.
     provider: ""
     model: ""
     prompt: prompts/worker_debugger.md
+    tools: []
     toolsets: []
+    max_turns: 15
+    can_write_files: false
   uiux_designer:
+    description: Design user flows, screens, interaction states, and UX tradeoffs.
     provider: ""
     model: ""
     prompt: prompts/worker_uiux_designer.md
+    tools: []
     toolsets: []
+    max_turns: 15
+    can_write_files: false
   product_planner:
+    description: Turn product goals into MVP slices, requirements, and rollout steps.
     provider: ""
     model: ""
     prompt: prompts/worker_product_planner.md
+    tools: []
     toolsets: []
+    max_turns: 15
+    can_write_files: false
   researcher:
+    description: Gather findings, compare options, and summarize sourced tradeoffs.
     provider: ""
     model: ""
     prompt: prompts/worker_researcher.md
+    tools: []
     toolsets: []
+    max_turns: 15
+    can_write_files: false
   reviewer:
+    description: Check outputs for correctness, risks, contradictions, and gaps.
     provider: ""
     model: ""
     prompt: prompts/worker_reviewer.md
+    tools: []
     toolsets: []
+    max_turns: 15
+    can_write_files: false
   tester:
+    description: Define and run verification steps, examples, and acceptance checks.
     provider: ""
     model: ""
     prompt: prompts/worker_tester.md
+    tools: []
     toolsets: []
+    max_turns: 15
+    can_write_files: false
 
 routing:
   task_type:

--- a/hermes_cli/workflow/config/workflow.yaml
+++ b/hermes_cli/workflow/config/workflow.yaml
@@ -9,6 +9,9 @@ execution:
   background_enabled: true
   state_db: ""
   default_permission_mode: read-only
+  contest_candidates: 3
+  contest_workers: [researcher, product_planner, reviewer]
+  cross_review_workers: [reviewer, tester]
 
 safety:
   allow_background_execution: true

--- a/hermes_cli/workflow/config/workflow.yaml
+++ b/hermes_cli/workflow/config/workflow.yaml
@@ -1,0 +1,76 @@
+version: 1
+
+execution:
+  mode: sequential
+  max_subtasks: 8
+  max_revision_cycles: 1
+  parallel_enabled: false
+
+safety:
+  allow_background_execution: false
+  allow_file_changes: false
+  require_destructive_confirmation: true
+  redact_credentials: true
+  allow_cross_project_access: false
+
+logging:
+  path: ""
+
+agents:
+  coder:
+    provider: ""
+    model: ""
+    prompt: prompts/worker_coder.md
+    toolsets: []
+  debugger:
+    provider: ""
+    model: ""
+    prompt: prompts/worker_debugger.md
+    toolsets: []
+  uiux_designer:
+    provider: ""
+    model: ""
+    prompt: prompts/worker_uiux_designer.md
+    toolsets: []
+  product_planner:
+    provider: ""
+    model: ""
+    prompt: prompts/worker_product_planner.md
+    toolsets: []
+  researcher:
+    provider: ""
+    model: ""
+    prompt: prompts/worker_researcher.md
+    toolsets: []
+  reviewer:
+    provider: ""
+    model: ""
+    prompt: prompts/worker_reviewer.md
+    toolsets: []
+  tester:
+    provider: ""
+    model: ""
+    prompt: prompts/worker_tester.md
+    toolsets: []
+
+routing:
+  task_type:
+    code: coder
+    debug: debugger
+    UI/UX: uiux_designer
+    product design: product_planner
+    research: researcher
+    writing: researcher
+    planning: product_planner
+    review: reviewer
+  keywords:
+    - worker: tester
+      match: ["test", "tests", "verification", "example run"]
+    - worker: reviewer
+      match: ["review", "evaluate", "risk", "security", "acceptance"]
+    - worker: debugger
+      match: ["debug", "root cause", "failing", "error"]
+    - worker: uiux_designer
+      match: ["ui", "ux", "screen", "visual", "figma"]
+    - worker: product_planner
+      match: ["product", "scope", "mvp", "requirements", "phased"]

--- a/hermes_cli/workflow/examples/example_run.md
+++ b/hermes_cli/workflow/examples/example_run.md
@@ -1,0 +1,46 @@
+# Example Run
+
+```bash
+hermes workflow run --dry-run "Create a README and tests for a small Python CLI"
+```
+
+The dry run does not call models. It exercises analyzer, planner, router,
+evaluator, synthesizer, JSONL logging, and SQLite run state.
+
+Run dependency-ready subtasks in parallel:
+
+```bash
+hermes workflow run --dry-run --parallel "Plan research, review, and tests for a release"
+```
+
+Queue a background run and inspect it:
+
+```bash
+hermes workflow run --dry-run --background "Plan a workflow status smoke test"
+hermes workflow status <run_id>
+hermes workflow logs <run_id> --tail 5
+```
+
+Generate a Codex Goal checklist:
+
+```bash
+hermes workflow run --dry-run --codex-plan "Break down the multi-role login rollout"
+```
+
+For a model-backed run, omit `--dry-run`:
+
+```bash
+hermes workflow run "Plan a migration for the billing webhook"
+```
+
+Runtime logs are written to:
+
+```text
+~/.hermes/logs/workflow_runs.jsonl
+```
+
+Durable state is written to:
+
+```text
+~/.hermes/workflow_runs.db
+```

--- a/hermes_cli/workflow/examples/example_run.md
+++ b/hermes_cli/workflow/examples/example_run.md
@@ -27,6 +27,13 @@ Generate a Codex Goal checklist:
 hermes workflow run --dry-run --codex-plan "Break down the multi-role login rollout"
 ```
 
+Run a contest harness with cross-review:
+
+```bash
+hermes workflow run --dry-run --contest --cross-review --codex-plan \
+  "Choose the best next plan for homeowner, contractor, and worker adoption"
+```
+
 For a model-backed run, omit `--dry-run`:
 
 ```bash

--- a/hermes_cli/workflow/orchestrator.py
+++ b/hermes_cli/workflow/orchestrator.py
@@ -83,6 +83,8 @@ class Subtask:
     acceptance_criteria: list[str]
     risk_level: str
     worker_type: str | None = None
+    depends_on: list[str] = field(default_factory=list)
+    can_parallel: bool = True
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -93,7 +95,23 @@ class Subtask:
             "acceptance_criteria": list(self.acceptance_criteria),
             "risk_level": self.risk_level,
             "worker_type": self.worker_type,
+            "depends_on": list(self.depends_on),
+            "can_parallel": self.can_parallel,
         }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Subtask":
+        return cls(
+            id=str(data.get("id") or ""),
+            objective=str(data.get("objective") or ""),
+            input_context=str(data.get("input_context") or ""),
+            expected_output=str(data.get("expected_output") or ""),
+            acceptance_criteria=[str(item) for item in data.get("acceptance_criteria") or []],
+            risk_level=str(data.get("risk_level") or "medium"),
+            worker_type=str(data.get("worker_type") or "") or None,
+            depends_on=[str(item) for item in data.get("depends_on") or []],
+            can_parallel=bool(data.get("can_parallel", True)),
+        )
 
 
 @dataclass
@@ -117,6 +135,18 @@ class EvaluationResult:
             "notes": self.notes,
         }
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "EvaluationResult":
+        return cls(
+            passed=bool(data.get("passed", False)),
+            score=float(data.get("score", 0.0)),
+            missing_steps=[str(item) for item in data.get("missing_steps") or []],
+            contradictions=[str(item) for item in data.get("contradictions") or []],
+            unsafe_actions=[str(item) for item in data.get("unsafe_actions") or []],
+            unclear_assumptions=[str(item) for item in data.get("unclear_assumptions") or []],
+            notes=str(data.get("notes") or ""),
+        )
+
 
 @dataclass
 class WorkerOutput:
@@ -139,6 +169,18 @@ class WorkerOutput:
             "revision_used": self.revision_used,
         }
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "WorkerOutput":
+        return cls(
+            subtask=Subtask.from_dict(data.get("subtask") or {}),
+            worker_type=str(data.get("worker_type") or "researcher"),
+            provider=str(data.get("provider") or ""),
+            model=str(data.get("model") or ""),
+            output=str(data.get("output") or ""),
+            evaluation=EvaluationResult.from_dict(data.get("evaluation") or {}),
+            revision_used=bool(data.get("revision_used", False)),
+        )
+
 
 @dataclass
 class WorkflowRun:
@@ -149,16 +191,22 @@ class WorkflowRun:
     worker_outputs: list[WorkerOutput]
     final_response: str
     log_path: Path
+    status: str = "completed"
+    state_path: Path | None = None
+    codex_plan: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "run_id": self.run_id,
             "original_request": self.original_request,
+            "status": self.status,
             "analysis": self.analysis.to_dict(),
             "subtasks": [item.to_dict() for item in self.subtasks],
             "worker_outputs": [item.to_dict() for item in self.worker_outputs],
             "final_response": self.final_response,
             "log_path": str(self.log_path),
+            "state_path": str(self.state_path) if self.state_path else "",
+            "codex_plan": self.codex_plan,
         }
 
 
@@ -169,6 +217,10 @@ class AgentConfig:
     model: str = ""
     prompt: str = ""
     toolsets: list[str] = field(default_factory=list)
+    description: str = ""
+    tools: list[str] = field(default_factory=list)
+    max_turns: int = 15
+    can_write_files: bool = False
 
     @property
     def display_provider(self) -> str:
@@ -204,7 +256,11 @@ class WorkflowConfig:
                 provider=str(item.get("provider") or ""),
                 model=str(item.get("model") or ""),
                 prompt=str(item.get("prompt") or f"prompts/worker_{worker_type}.md"),
-                toolsets=list(item.get("toolsets") or []),
+                toolsets=list(item.get("toolsets") or item.get("tools") or []),
+                description=str(item.get("description") or ""),
+                tools=list(item.get("tools") or item.get("toolsets") or []),
+                max_turns=int(item.get("max_turns") or 15),
+                can_write_files=bool(item.get("can_write_files", False)),
             )
 
         return cls(
@@ -231,6 +287,31 @@ class WorkflowConfig:
     def allow_file_changes(self) -> bool:
         return bool(self.safety.get("allow_file_changes", False))
 
+    @property
+    def parallel_enabled(self) -> bool:
+        return bool(self.execution.get("parallel_enabled", False))
+
+    @property
+    def background_enabled(self) -> bool:
+        return bool(self.execution.get("background_enabled", False))
+
+    @property
+    def allow_background_execution(self) -> bool:
+        value = self.safety.get("allow_background_execution", False)
+        return value is True or str(value).lower() in {"true", "explicit-only"}
+
+    @property
+    def max_concurrency(self) -> int:
+        return max(1, int(self.execution.get("max_concurrency", 2)))
+
+    @property
+    def default_permission_mode(self) -> str:
+        return str(self.execution.get("default_permission_mode") or "read-only")
+
+    @property
+    def state_db(self) -> str:
+        return str(self.execution.get("state_db") or "")
+
 
 def package_root() -> Path:
     return Path(__file__).resolve().parent
@@ -246,13 +327,26 @@ def run_workflow(
     config_path: str | Path | None = None,
     dry_run: bool = False,
     max_subtasks: int | None = None,
+    parallel: bool = False,
+    background: bool = False,
+    codex_plan: bool = False,
+    run_id: str | None = None,
+    resume: bool = False,
 ) -> WorkflowRun:
-    orchestrator = WorkflowOrchestrator(
+    from hermes_cli.workflow.runtime import WorkflowRuntime
+
+    runtime = WorkflowRuntime(
         config=WorkflowConfig.load(config_path),
         dry_run=dry_run,
         max_subtasks=max_subtasks,
+        parallel=parallel,
+        codex_plan=codex_plan,
     )
-    return orchestrator.run(request)
+    if resume:
+        if not run_id:
+            raise WorkflowError("resume requires a run_id.")
+        return runtime.resume(run_id)
+    return runtime.run(request, background=background, run_id=run_id)
 
 
 class TaskAnalyzer:
@@ -544,7 +638,11 @@ class WorkerRunner:
             return self._dry_run_output(subtask, analysis, previous_outputs), provider, model
 
         prompt = self._build_prompt(subtask, analysis, previous_outputs, agent_config)
-        toolsets = agent_config.toolsets if self.config.allow_file_changes else []
+        toolsets = (
+            agent_config.toolsets
+            if self.config.allow_file_changes and agent_config.can_write_files
+            else []
+        )
         try:
             from hermes_cli.oneshot import _run_agent
 

--- a/hermes_cli/workflow/orchestrator.py
+++ b/hermes_cli/workflow/orchestrator.py
@@ -1,0 +1,962 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+TASK_TYPES = (
+    "code",
+    "debug",
+    "UI/UX",
+    "product design",
+    "research",
+    "writing",
+    "planning",
+    "review",
+)
+
+WORKER_TYPES = (
+    "coder",
+    "debugger",
+    "uiux_designer",
+    "product_planner",
+    "researcher",
+    "reviewer",
+    "tester",
+)
+
+_STOPWORDS = {
+    "about",
+    "acceptance",
+    "addresses",
+    "criteria",
+    "deliverable",
+    "expected",
+    "include",
+    "input",
+    "output",
+    "produce",
+    "relevant",
+    "request",
+    "should",
+    "subtask",
+    "task",
+    "that",
+    "when",
+    "with",
+}
+
+
+class WorkflowError(RuntimeError):
+    """Raised when a workflow run cannot continue."""
+
+
+@dataclass
+class TaskAnalysis:
+    task_type: str
+    complexity: str
+    execute_directly: bool
+    rationale: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_type": self.task_type,
+            "complexity": self.complexity,
+            "execute_directly": self.execute_directly,
+            "rationale": self.rationale,
+        }
+
+
+@dataclass
+class Subtask:
+    id: str
+    objective: str
+    input_context: str
+    expected_output: str
+    acceptance_criteria: list[str]
+    risk_level: str
+    worker_type: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "objective": self.objective,
+            "input_context": self.input_context,
+            "expected_output": self.expected_output,
+            "acceptance_criteria": list(self.acceptance_criteria),
+            "risk_level": self.risk_level,
+            "worker_type": self.worker_type,
+        }
+
+
+@dataclass
+class EvaluationResult:
+    passed: bool
+    score: float
+    missing_steps: list[str] = field(default_factory=list)
+    contradictions: list[str] = field(default_factory=list)
+    unsafe_actions: list[str] = field(default_factory=list)
+    unclear_assumptions: list[str] = field(default_factory=list)
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "score": self.score,
+            "missing_steps": list(self.missing_steps),
+            "contradictions": list(self.contradictions),
+            "unsafe_actions": list(self.unsafe_actions),
+            "unclear_assumptions": list(self.unclear_assumptions),
+            "notes": self.notes,
+        }
+
+
+@dataclass
+class WorkerOutput:
+    subtask: Subtask
+    worker_type: str
+    provider: str
+    model: str
+    output: str
+    evaluation: EvaluationResult
+    revision_used: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "subtask": self.subtask.to_dict(),
+            "worker_type": self.worker_type,
+            "provider": self.provider,
+            "model": self.model,
+            "output": self.output,
+            "evaluation": self.evaluation.to_dict(),
+            "revision_used": self.revision_used,
+        }
+
+
+@dataclass
+class WorkflowRun:
+    run_id: str
+    original_request: str
+    analysis: TaskAnalysis
+    subtasks: list[Subtask]
+    worker_outputs: list[WorkerOutput]
+    final_response: str
+    log_path: Path
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "original_request": self.original_request,
+            "analysis": self.analysis.to_dict(),
+            "subtasks": [item.to_dict() for item in self.subtasks],
+            "worker_outputs": [item.to_dict() for item in self.worker_outputs],
+            "final_response": self.final_response,
+            "log_path": str(self.log_path),
+        }
+
+
+@dataclass
+class AgentConfig:
+    worker_type: str
+    provider: str = ""
+    model: str = ""
+    prompt: str = ""
+    toolsets: list[str] = field(default_factory=list)
+
+    @property
+    def display_provider(self) -> str:
+        return self.provider or "configured-default"
+
+    @property
+    def display_model(self) -> str:
+        return self.model or "configured-default"
+
+
+@dataclass
+class WorkflowConfig:
+    path: Path
+    agents: dict[str, AgentConfig]
+    routing: dict[str, Any]
+    execution: dict[str, Any]
+    safety: dict[str, Any]
+    logging: dict[str, Any]
+
+    @classmethod
+    def load(cls, path: str | Path | None = None) -> "WorkflowConfig":
+        config_path = Path(path).expanduser() if path else default_config_path()
+        if not config_path.exists():
+            raise WorkflowError(f"Workflow config not found: {config_path}")
+
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        agents: dict[str, AgentConfig] = {}
+        agent_root = raw.get("agents") or {}
+        for worker_type in WORKER_TYPES:
+            item = agent_root.get(worker_type) or {}
+            agents[worker_type] = AgentConfig(
+                worker_type=worker_type,
+                provider=str(item.get("provider") or ""),
+                model=str(item.get("model") or ""),
+                prompt=str(item.get("prompt") or f"prompts/worker_{worker_type}.md"),
+                toolsets=list(item.get("toolsets") or []),
+            )
+
+        return cls(
+            path=config_path,
+            agents=agents,
+            routing=dict(raw.get("routing") or {}),
+            execution=dict(raw.get("execution") or {}),
+            safety=dict(raw.get("safety") or {}),
+            logging=dict(raw.get("logging") or {}),
+        )
+
+    def agent_for(self, worker_type: str) -> AgentConfig:
+        return self.agents.get(worker_type) or self.agents["researcher"]
+
+    @property
+    def max_revision_cycles(self) -> int:
+        return int(self.execution.get("max_revision_cycles", 1))
+
+    @property
+    def max_subtasks(self) -> int:
+        return int(self.execution.get("max_subtasks", 8))
+
+    @property
+    def allow_file_changes(self) -> bool:
+        return bool(self.safety.get("allow_file_changes", False))
+
+
+def package_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def default_config_path() -> Path:
+    return package_root() / "config" / "workflow.yaml"
+
+
+def run_workflow(
+    request: str,
+    *,
+    config_path: str | Path | None = None,
+    dry_run: bool = False,
+    max_subtasks: int | None = None,
+) -> WorkflowRun:
+    orchestrator = WorkflowOrchestrator(
+        config=WorkflowConfig.load(config_path),
+        dry_run=dry_run,
+        max_subtasks=max_subtasks,
+    )
+    return orchestrator.run(request)
+
+
+class TaskAnalyzer:
+    _KEYWORDS: dict[str, tuple[str, ...]] = {
+        "code": (
+            "add",
+            "api",
+            "build",
+            "cli",
+            "code",
+            "command",
+            "implement",
+            "module",
+            "python",
+            "script",
+            "test",
+        ),
+        "debug": (
+            "bug",
+            "debug",
+            "error",
+            "exception",
+            "failing",
+            "fix",
+            "regression",
+            "root cause",
+            "traceback",
+        ),
+        "UI/UX": (
+            "design system",
+            "figma",
+            "frontend",
+            "screen",
+            "ui",
+            "ux",
+            "visual",
+            "wireframe",
+        ),
+        "product design": (
+            "customer",
+            "feature",
+            "journey",
+            "mvp",
+            "prd",
+            "product",
+            "requirements",
+            "user story",
+        ),
+        "research": (
+            "best practice",
+            "compare",
+            "investigate",
+            "latest",
+            "look up",
+            "research",
+            "source",
+            "study",
+        ),
+        "writing": (
+            "article",
+            "copy",
+            "draft",
+            "email",
+            "essay",
+            "readme",
+            "rewrite",
+            "write",
+        ),
+        "planning": (
+            "architecture",
+            "break down",
+            "plan",
+            "planning",
+            "roadmap",
+            "schedule",
+            "strategy",
+            "workflow",
+        ),
+        "review": (
+            "audit",
+            "evaluate",
+            "feedback",
+            "review",
+            "risks",
+            "security",
+            "verify",
+        ),
+    }
+
+    def analyze(self, request: str) -> TaskAnalysis:
+        text = request.lower()
+        scores = {task_type: 0 for task_type in TASK_TYPES}
+        for task_type, keywords in self._KEYWORDS.items():
+            for keyword in keywords:
+                if keyword in text:
+                    scores[task_type] += 2 if " " in keyword else 1
+
+        task_type = max(scores, key=lambda item: scores[item])
+        if scores[task_type] == 0:
+            task_type = "planning"
+
+        marker_count = len(
+            re.findall(r"(?m)^\s*(?:[-*]|\d+\.|[A-Z][A-Za-z /&-]{2,}:)", request)
+        )
+        word_count = len(re.findall(r"\w+", request))
+        complex_terms = (
+            "architecture",
+            "orchestrator",
+            "required modules",
+            "safety requirements",
+            "subtasks",
+            "system",
+        )
+        if word_count > 260 or marker_count >= 6 or any(term in text for term in complex_terms):
+            complexity = "complex"
+        elif word_count > 80 or marker_count >= 3:
+            complexity = "medium"
+        else:
+            complexity = "simple"
+
+        execute_directly = complexity == "simple" and not any(
+            term in text for term in ("split", "subtask", "orchestrator", "workflow")
+        )
+        rationale = (
+            f"Matched task type '{task_type}' from request keywords; "
+            f"word_count={word_count}, requirement_markers={marker_count}."
+        )
+        return TaskAnalysis(task_type, complexity, execute_directly, rationale)
+
+
+class Planner:
+    def __init__(self, max_subtasks: int = 8):
+        self.max_subtasks = max(1, min(8, max_subtasks))
+
+    def plan(self, request: str, analysis: TaskAnalysis) -> list[Subtask]:
+        if analysis.execute_directly:
+            return [
+                self._build_subtask(
+                    "1",
+                    "Complete the request directly",
+                    request,
+                    "A concise answer or implementation plan that satisfies the request.",
+                    "low" if analysis.task_type in {"writing", "research"} else "medium",
+                )
+            ]
+
+        objectives = self._objectives_for(analysis.task_type)
+        if analysis.complexity == "medium":
+            objectives = objectives[:4]
+        objectives = objectives[: self.max_subtasks]
+        return [
+            self._build_subtask(
+                str(index),
+                objective,
+                request,
+                self._expected_output_for(objective),
+                self._risk_for(objective, request),
+            )
+            for index, objective in enumerate(objectives, start=1)
+        ]
+
+    def _objectives_for(self, task_type: str) -> list[str]:
+        if task_type in {"code", "debug"}:
+            return [
+                "Confirm scope, integration points, and safety constraints",
+                "Design the minimal module and configuration structure",
+                "Implement the core orchestration behavior",
+                "Wire the optional command entrypoint",
+                "Add focused tests and an example run",
+                "Review evaluator results, risks, and next action",
+            ]
+        if task_type == "UI/UX":
+            return [
+                "Clarify target users, workflows, and screen states",
+                "Define information architecture and interaction model",
+                "Draft visual and component direction",
+                "Review accessibility, responsiveness, and edge cases",
+            ]
+        if task_type == "product design":
+            return [
+                "Clarify user problem, scope, and success criteria",
+                "Define MVP behavior and non-goals",
+                "Break the product work into phased deliverables",
+                "Review risks, dependencies, and validation steps",
+            ]
+        if task_type == "research":
+            return [
+                "Frame the research question and source needs",
+                "Collect relevant findings and tradeoffs",
+                "Compare options against the request constraints",
+                "Summarize recommendations and open questions",
+            ]
+        if task_type == "review":
+            return [
+                "Identify the review target and risk model",
+                "Inspect behavior against stated requirements",
+                "List findings by severity with evidence",
+                "Summarize residual risk and follow-up checks",
+            ]
+        return [
+            "Clarify the goal, constraints, and assumptions",
+            "Break the work into practical phases",
+            "Draft the requested artifact or plan",
+            "Review gaps, risks, and next action",
+        ]
+
+    def _build_subtask(
+        self,
+        subtask_id: str,
+        objective: str,
+        request: str,
+        expected_output: str,
+        risk_level: str,
+    ) -> Subtask:
+        return Subtask(
+            id=f"wf-{subtask_id}",
+            objective=objective,
+            input_context=_truncate(
+                "Original request:\n"
+                f"{request.strip()}\n\n"
+                "Use previous worker outputs as context when available.",
+                2400,
+            ),
+            expected_output=expected_output,
+            acceptance_criteria=[
+                f"Addresses objective: {objective}",
+                f"Produces expected output: {expected_output}",
+                "Calls out assumptions, risks, or blockers when relevant.",
+            ],
+            risk_level=risk_level,
+        )
+
+    def _expected_output_for(self, objective: str) -> str:
+        lower = objective.lower()
+        if "test" in lower or "example" in lower:
+            return "Verification steps, example output, and any failing checks."
+        if "wire" in lower or "entrypoint" in lower or "command" in lower:
+            return "A CLI integration plan or implementation notes."
+        if "implement" in lower:
+            return "Concrete implementation details with module responsibilities."
+        if "review" in lower:
+            return "Risks, evaluator observations, and recommended next action."
+        return "A concise plan fragment that can be merged into the final answer."
+
+    def _risk_for(self, objective: str, request: str) -> str:
+        text = f"{objective} {request}".lower()
+        if any(term in text for term in ("credential", "secret", "destructive", "delete", "payment")):
+            return "high"
+        if any(term in text for term in ("code", "command", "implement", "file", "debug", "security")):
+            return "medium"
+        return "low"
+
+
+class Router:
+    def __init__(self, config: WorkflowConfig):
+        self.config = config
+
+    def assign(self, subtask: Subtask, analysis: TaskAnalysis) -> str:
+        text = f"{subtask.objective} {subtask.expected_output}".lower()
+        for rule in self.config.routing.get("keywords", []) or []:
+            worker = str(rule.get("worker") or "")
+            matches = rule.get("match") or []
+            if worker in WORKER_TYPES and any(str(item).lower() in text for item in matches):
+                return worker
+
+        task_routes = self.config.routing.get("task_type") or {}
+        worker = str(task_routes.get(analysis.task_type) or "")
+        if worker in WORKER_TYPES:
+            return worker
+        return "researcher"
+
+
+class WorkerRunner:
+    def __init__(self, config: WorkflowConfig, dry_run: bool = False):
+        self.config = config
+        self.dry_run = dry_run
+
+    def run(
+        self,
+        subtask: Subtask,
+        analysis: TaskAnalysis,
+        previous_outputs: list[WorkerOutput],
+    ) -> tuple[str, str, str]:
+        agent_config = self.config.agent_for(subtask.worker_type or "researcher")
+        provider = agent_config.display_provider
+        model = agent_config.display_model
+
+        if self.dry_run:
+            return self._dry_run_output(subtask, analysis, previous_outputs), provider, model
+
+        prompt = self._build_prompt(subtask, analysis, previous_outputs, agent_config)
+        toolsets = agent_config.toolsets if self.config.allow_file_changes else []
+        try:
+            from hermes_cli.oneshot import _run_agent
+
+            output = _run_agent(
+                prompt,
+                model=agent_config.model or None,
+                provider=agent_config.provider or None,
+                toolsets=toolsets,
+                use_config_toolsets=False,
+            )
+        except Exception as exc:
+            raise WorkflowError(
+                f"Worker {subtask.worker_type} failed using provider={provider}, "
+                f"model={model}: {exc}"
+            ) from exc
+        return output.strip(), provider, model
+
+    def revise(
+        self,
+        subtask: Subtask,
+        analysis: TaskAnalysis,
+        previous_outputs: list[WorkerOutput],
+        first_output: str,
+        evaluation: EvaluationResult,
+    ) -> str:
+        if self.dry_run:
+            return first_output
+
+        agent_config = self.config.agent_for(subtask.worker_type or "researcher")
+        revision_prompt = (
+            self._build_prompt(subtask, analysis, previous_outputs, agent_config)
+            + "\n\nRevision required.\n"
+            + f"Previous output:\n{first_output}\n\n"
+            + f"Evaluator feedback:\n{json.dumps(evaluation.to_dict(), indent=2)}\n\n"
+            + "Revise once. Keep the answer concise and address the missing criteria."
+        )
+        try:
+            from hermes_cli.oneshot import _run_agent
+
+            return _run_agent(
+                revision_prompt,
+                model=agent_config.model or None,
+                provider=agent_config.provider or None,
+                toolsets=[],
+                use_config_toolsets=False,
+            ).strip()
+        except Exception as exc:
+            raise WorkflowError(f"Revision failed for {subtask.id}: {exc}") from exc
+
+    def _build_prompt(
+        self,
+        subtask: Subtask,
+        analysis: TaskAnalysis,
+        previous_outputs: list[WorkerOutput],
+        agent_config: AgentConfig,
+    ) -> str:
+        template = _read_prompt(agent_config.prompt)
+        return _render_prompt(
+            template,
+            {
+                "worker_type": subtask.worker_type or agent_config.worker_type,
+                "task_type": analysis.task_type,
+                "complexity": analysis.complexity,
+                "objective": subtask.objective,
+                "input_context": subtask.input_context,
+                "expected_output": subtask.expected_output,
+                "acceptance_criteria": _format_list(subtask.acceptance_criteria),
+                "risk_level": subtask.risk_level,
+                "previous_outputs": _previous_output_context(previous_outputs),
+            },
+        )
+
+    def _dry_run_output(
+        self,
+        subtask: Subtask,
+        analysis: TaskAnalysis,
+        previous_outputs: list[WorkerOutput],
+    ) -> str:
+        prior = "No prior worker outputs." if not previous_outputs else (
+            f"Uses {len(previous_outputs)} prior worker output(s) as context."
+        )
+        return (
+            f"Dry-run worker output for {subtask.worker_type}.\n"
+            f"Task type: {analysis.task_type}; complexity: {analysis.complexity}.\n"
+            f"Objective addressed: {subtask.objective}.\n"
+            f"Expected output produced: {subtask.expected_output}.\n"
+            f"Acceptance criteria addressed: {_format_list(subtask.acceptance_criteria)}\n"
+            f"Risk note: {subtask.risk_level} risk. {prior}"
+        )
+
+
+class Evaluator:
+    _UNSAFE_PATTERNS = (
+        r"\brm\s+-rf\b",
+        r"\bgit\s+reset\s+--hard\b",
+        r"\bgit\s+checkout\s+--\b",
+        r"\bprintenv\b.*(?:KEY|TOKEN|SECRET|PASSWORD)",
+        r"\bcat\b.*(?:\.env|credentials|secrets?)",
+    )
+
+    def evaluate(self, subtask: Subtask, output: str) -> EvaluationResult:
+        stripped = output.strip()
+        if not stripped:
+            return EvaluationResult(
+                passed=False,
+                score=0.0,
+                missing_steps=list(subtask.acceptance_criteria),
+                notes="Worker returned no output.",
+            )
+
+        lowered = stripped.lower()
+        unsafe = [
+            pattern for pattern in self._UNSAFE_PATTERNS if re.search(pattern, lowered)
+        ]
+        contradictions = self._detect_contradictions(lowered)
+        unclear = []
+        if "assume " in lowered and "assumption" not in lowered:
+            unclear.append("Uses assumptions without clearly labelling them.")
+
+        criterion_matches = 0
+        missing: list[str] = []
+        for criterion in subtask.acceptance_criteria:
+            words = _keywords(criterion)
+            if not words or any(word in lowered for word in words):
+                criterion_matches += 1
+            else:
+                missing.append(criterion)
+
+        objective_words = _keywords(subtask.objective)
+        objective_hit = any(word in lowered for word in objective_words)
+        score = 0.35
+        score += 0.35 * (criterion_matches / max(1, len(subtask.acceptance_criteria)))
+        score += 0.2 if objective_hit else 0.0
+        score += 0.1 if not unsafe and not contradictions else 0.0
+        score -= 0.2 * len(unsafe)
+        score -= 0.15 * len(contradictions)
+        score = max(0.0, min(1.0, score))
+
+        passed = score >= 0.68 and not unsafe and not contradictions
+        return EvaluationResult(
+            passed=passed,
+            score=round(score, 2),
+            missing_steps=missing,
+            contradictions=contradictions,
+            unsafe_actions=unsafe,
+            unclear_assumptions=unclear,
+            notes="Heuristic MVP evaluator.",
+        )
+
+    def _detect_contradictions(self, lowered: str) -> list[str]:
+        contradictions: list[str] = []
+        if "file changes" in lowered and "no file changes" in lowered:
+            contradictions.append("Mentions both file changes and no file changes.")
+        if "background execution" in lowered and "no background execution" in lowered:
+            contradictions.append(
+                "Mentions both background execution and no background execution."
+            )
+        return contradictions
+
+
+class FinalSynthesizer:
+    def synthesize(
+        self,
+        analysis: TaskAnalysis,
+        outputs: list[WorkerOutput],
+        *,
+        dry_run: bool,
+    ) -> str:
+        completed = [item for item in outputs if item.evaluation.passed]
+        failed = [item for item in outputs if not item.evaluation.passed]
+        high_risk = [item.subtask.id for item in outputs if item.subtask.risk_level == "high"]
+
+        done_lines = [
+            f"- {item.subtask.id} ({item.worker_type}): {item.subtask.objective}"
+            for item in outputs
+        ]
+        risk_lines = []
+        if failed:
+            risk_lines.append(
+                f"- {len(failed)} subtask(s) did not pass evaluator threshold."
+            )
+        if high_risk:
+            risk_lines.append(f"- High-risk subtasks: {', '.join(high_risk)}.")
+        if dry_run:
+            risk_lines.append("- Dry-run mode did not call configured models.")
+        if not risk_lines:
+            risk_lines.append("- No evaluator-blocking risks were detected.")
+
+        next_action = (
+            "Review failed subtasks and rerun with clearer scope."
+            if failed
+            else "Use the synthesized plan as the next implementation step."
+        )
+
+        return "\n".join(
+            [
+                "What was done",
+                *(done_lines or ["- No subtasks were produced."]),
+                "",
+                "Key decisions",
+                f"- Classified request as {analysis.task_type} / {analysis.complexity}.",
+                f"- Execution mode: {'dry-run' if dry_run else 'model-backed'}, sequential workers.",
+                f"- Evaluator passed {len(completed)}/{len(outputs)} worker output(s).",
+                "",
+                "Risks",
+                *risk_lines,
+                "",
+                "Next action",
+                f"- {next_action}",
+            ]
+        )
+
+
+class WorkflowLogger:
+    def __init__(self, config: WorkflowConfig):
+        self.path = self._resolve_path(config)
+
+    def log(self, run_id: str, event: str, payload: dict[str, Any]) -> None:
+        record = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "run_id": run_id,
+            "event": event,
+            **_redact_payload(payload),
+        }
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+
+    def _resolve_path(self, config: WorkflowConfig) -> Path:
+        configured = str(config.logging.get("path") or "").strip()
+        if configured:
+            path = Path(configured).expanduser()
+            if not path.is_absolute():
+                path = config.path.parent / path
+            return path
+        try:
+            from hermes_constants import get_hermes_home
+
+            return get_hermes_home() / "logs" / "workflow_runs.jsonl"
+        except Exception:
+            return Path.home() / ".hermes" / "logs" / "workflow_runs.jsonl"
+
+
+class WorkflowOrchestrator:
+    def __init__(
+        self,
+        *,
+        config: WorkflowConfig,
+        dry_run: bool = False,
+        max_subtasks: int | None = None,
+    ):
+        self.config = config
+        self.dry_run = dry_run
+        self.max_subtasks = max_subtasks or config.max_subtasks
+        self.analyzer = TaskAnalyzer()
+        self.planner = Planner(max_subtasks=self.max_subtasks)
+        self.router = Router(config)
+        self.runner = WorkerRunner(config, dry_run=dry_run)
+        self.evaluator = Evaluator()
+        self.synthesizer = FinalSynthesizer()
+        self.logger = WorkflowLogger(config)
+
+    def run(self, request: str) -> WorkflowRun:
+        clean_request = request.strip()
+        if not clean_request:
+            raise WorkflowError("Workflow request cannot be empty.")
+
+        run_id = f"wf-{time.strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:8]}"
+        self.logger.log(run_id, "request", {"original_request": clean_request})
+
+        analysis = self.analyzer.analyze(clean_request)
+        self.logger.log(run_id, "analysis", analysis.to_dict())
+
+        subtasks = self.planner.plan(clean_request, analysis)
+        worker_outputs: list[WorkerOutput] = []
+
+        for subtask in subtasks:
+            worker_type = self.router.assign(subtask, analysis)
+            subtask.worker_type = worker_type
+            agent_config = self.config.agent_for(worker_type)
+            self.logger.log(
+                run_id,
+                "worker_selected",
+                {
+                    "subtask_id": subtask.id,
+                    "selected_worker": worker_type,
+                    "provider": agent_config.display_provider,
+                    "model": agent_config.display_model,
+                },
+            )
+
+            output, provider, model = self.runner.run(subtask, analysis, worker_outputs)
+            evaluation = self.evaluator.evaluate(subtask, output)
+            revision_used = False
+            if not evaluation.passed and self.config.max_revision_cycles > 0:
+                output = self.runner.revise(
+                    subtask, analysis, worker_outputs, output, evaluation
+                )
+                evaluation = self.evaluator.evaluate(subtask, output)
+                revision_used = True
+
+            worker_output = WorkerOutput(
+                subtask=subtask,
+                worker_type=worker_type,
+                provider=provider,
+                model=model,
+                output=output,
+                evaluation=evaluation,
+                revision_used=revision_used,
+            )
+            worker_outputs.append(worker_output)
+            self.logger.log(
+                run_id,
+                "worker_result",
+                {
+                    "subtask_id": subtask.id,
+                    "selected_worker": worker_type,
+                    "provider": provider,
+                    "model": model,
+                    "result": output,
+                    "revision_used": revision_used,
+                },
+            )
+            self.logger.log(
+                run_id,
+                "evaluation",
+                {
+                    "subtask_id": subtask.id,
+                    "evaluator_score": evaluation.score,
+                    "passed": evaluation.passed,
+                    "missing_steps": evaluation.missing_steps,
+                    "contradictions": evaluation.contradictions,
+                    "unsafe_actions": evaluation.unsafe_actions,
+                    "unclear_assumptions": evaluation.unclear_assumptions,
+                },
+            )
+
+        final_response = self.synthesizer.synthesize(
+            analysis, worker_outputs, dry_run=self.dry_run
+        )
+        self.logger.log(run_id, "final", {"result": final_response})
+        return WorkflowRun(
+            run_id=run_id,
+            original_request=clean_request,
+            analysis=analysis,
+            subtasks=subtasks,
+            worker_outputs=worker_outputs,
+            final_response=final_response,
+            log_path=self.logger.path,
+        )
+
+
+def _read_prompt(prompt_ref: str) -> str:
+    path = Path(prompt_ref)
+    if not path.is_absolute():
+        path = package_root() / prompt_ref
+    if not path.exists():
+        path = package_root() / "prompts" / "worker_researcher.md"
+    return path.read_text(encoding="utf-8")
+
+
+def _render_prompt(template: str, values: dict[str, Any]) -> str:
+    rendered = template
+    for key, value in values.items():
+        rendered = rendered.replace("{{ " + key + " }}", str(value))
+        rendered = rendered.replace("{{" + key + "}}", str(value))
+    return rendered
+
+
+def _format_list(items: list[str]) -> str:
+    return "\n".join(f"- {item}" for item in items)
+
+
+def _previous_output_context(outputs: list[WorkerOutput]) -> str:
+    if not outputs:
+        return "No previous worker outputs."
+    chunks = []
+    for item in outputs:
+        chunks.append(
+            f"{item.subtask.id} ({item.worker_type}, score={item.evaluation.score}):\n"
+            f"{_truncate(item.output, 900)}"
+        )
+    return "\n\n".join(chunks)
+
+
+def _keywords(text: str) -> list[str]:
+    return [
+        word
+        for word in re.findall(r"[a-zA-Z][a-zA-Z0-9_-]{3,}", text.lower())
+        if word not in _STOPWORDS
+    ][:8]
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 20)].rstrip() + "\n...[truncated]"
+
+
+def _redact_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    try:
+        from agent.redact import redact_sensitive_text
+    except Exception:
+        redact_sensitive_text = None
+
+    def redact(value: Any) -> Any:
+        if isinstance(value, str):
+            return redact_sensitive_text(value) if redact_sensitive_text else value
+        if isinstance(value, list):
+            return [redact(item) for item in value]
+        if isinstance(value, dict):
+            return {str(k): redact(v) for k, v in value.items()}
+        return value
+
+    return {str(key): redact(value) for key, value in payload.items()}

--- a/hermes_cli/workflow/orchestrator.py
+++ b/hermes_cli/workflow/orchestrator.py
@@ -194,6 +194,8 @@ class WorkflowRun:
     status: str = "completed"
     state_path: Path | None = None
     codex_plan: bool = False
+    contest: bool = False
+    cross_review: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -207,6 +209,8 @@ class WorkflowRun:
             "log_path": str(self.log_path),
             "state_path": str(self.state_path) if self.state_path else "",
             "codex_plan": self.codex_plan,
+            "contest": self.contest,
+            "cross_review": self.cross_review,
         }
 
 
@@ -305,6 +309,22 @@ class WorkflowConfig:
         return max(1, int(self.execution.get("max_concurrency", 2)))
 
     @property
+    def contest_candidates(self) -> int:
+        return max(2, min(5, int(self.execution.get("contest_candidates", 3))))
+
+    @property
+    def contest_workers(self) -> list[str]:
+        workers = [str(item) for item in self.execution.get("contest_workers") or []]
+        valid = [worker for worker in workers if worker in WORKER_TYPES]
+        return valid or ["researcher", "product_planner", "reviewer"]
+
+    @property
+    def cross_review_workers(self) -> list[str]:
+        workers = [str(item) for item in self.execution.get("cross_review_workers") or []]
+        valid = [worker for worker in workers if worker in WORKER_TYPES]
+        return valid or ["reviewer", "tester"]
+
+    @property
     def default_permission_mode(self) -> str:
         return str(self.execution.get("default_permission_mode") or "read-only")
 
@@ -330,6 +350,8 @@ def run_workflow(
     parallel: bool = False,
     background: bool = False,
     codex_plan: bool = False,
+    contest: bool = False,
+    cross_review: bool = False,
     run_id: str | None = None,
     resume: bool = False,
 ) -> WorkflowRun:
@@ -341,6 +363,8 @@ def run_workflow(
         max_subtasks=max_subtasks,
         parallel=parallel,
         codex_plan=codex_plan,
+        contest=contest,
+        cross_review=cross_review,
     )
     if resume:
         if not run_id:

--- a/hermes_cli/workflow/orchestrator.py
+++ b/hermes_cli/workflow/orchestrator.py
@@ -6,7 +6,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import yaml
 
@@ -352,6 +352,7 @@ def run_workflow(
     codex_plan: bool = False,
     contest: bool = False,
     cross_review: bool = False,
+    progress_callback: Callable[[str, dict[str, Any]], None] | None = None,
     run_id: str | None = None,
     resume: bool = False,
 ) -> WorkflowRun:
@@ -365,6 +366,7 @@ def run_workflow(
         codex_plan=codex_plan,
         contest=contest,
         cross_review=cross_review,
+        progress_callback=progress_callback,
     )
     if resume:
         if not run_id:

--- a/hermes_cli/workflow/prompts/analyzer.md
+++ b/hermes_cli/workflow/prompts/analyzer.md
@@ -1,0 +1,12 @@
+You are the Hermes Workflow task analyzer.
+
+Classify the user request into one task type:
+code, debug, UI/UX, product design, research, writing, planning, review.
+
+Classify complexity as simple, medium, or complex.
+
+Return only compact JSON with:
+- task_type
+- complexity
+- execute_directly
+- rationale

--- a/hermes_cli/workflow/prompts/evaluator.md
+++ b/hermes_cli/workflow/prompts/evaluator.md
@@ -1,0 +1,10 @@
+You are the Hermes Workflow evaluator.
+
+Check whether the worker output satisfies every acceptance criterion.
+Flag:
+- missing steps
+- contradictions
+- unsafe actions
+- unclear assumptions
+
+Return a score from 0.0 to 1.0 and a short pass/fail rationale.

--- a/hermes_cli/workflow/prompts/final_synthesizer.md
+++ b/hermes_cli/workflow/prompts/final_synthesizer.md
@@ -1,0 +1,9 @@
+You are the Hermes Workflow final synthesizer.
+
+Merge worker outputs into a concise final answer with:
+- what was done
+- key decisions
+- risks
+- next action
+
+Do not include unnecessary implementation detail.

--- a/hermes_cli/workflow/prompts/planner.md
+++ b/hermes_cli/workflow/prompts/planner.md
@@ -1,0 +1,10 @@
+You are the Hermes Workflow planner.
+
+Break complex work into 3 to 8 practical subtasks. Each subtask must include:
+- objective
+- input context
+- expected output
+- acceptance criteria
+- risk level
+
+Keep the plan small. Do not invent work outside the user request.

--- a/hermes_cli/workflow/prompts/worker_coder.md
+++ b/hermes_cli/workflow/prompts/worker_coder.md
@@ -1,0 +1,29 @@
+You are the coder worker in a local Hermes workflow.
+
+Worker type: {{ worker_type }}
+Task type: {{ task_type }}
+Complexity: {{ complexity }}
+Risk level: {{ risk_level }}
+
+Objective:
+{{ objective }}
+
+Input context:
+{{ input_context }}
+
+Previous worker outputs:
+{{ previous_outputs }}
+
+Expected output:
+{{ expected_output }}
+
+Acceptance criteria:
+{{ acceptance_criteria }}
+
+Safety rules:
+- Do not claim file changes unless the prompt explicitly asks you to produce an implementation plan.
+- Do not propose destructive commands without confirmation.
+- Do not expose credentials.
+- Do not access other projects unless the user explicitly scoped them.
+
+Return a concise implementation-focused output.

--- a/hermes_cli/workflow/prompts/worker_debugger.md
+++ b/hermes_cli/workflow/prompts/worker_debugger.md
@@ -1,0 +1,19 @@
+You are the debugger worker in a local Hermes workflow.
+
+Objective:
+{{ objective }}
+
+Context:
+{{ input_context }}
+
+Previous worker outputs:
+{{ previous_outputs }}
+
+Expected output:
+{{ expected_output }}
+
+Acceptance criteria:
+{{ acceptance_criteria }}
+
+Find likely causes, isolate checks, and propose the smallest safe fix path.
+Do not run or recommend destructive commands without confirmation.

--- a/hermes_cli/workflow/prompts/worker_product_planner.md
+++ b/hermes_cli/workflow/prompts/worker_product_planner.md
@@ -1,0 +1,18 @@
+You are the product planner worker in a local Hermes workflow.
+
+Objective:
+{{ objective }}
+
+Context:
+{{ input_context }}
+
+Previous worker outputs:
+{{ previous_outputs }}
+
+Expected output:
+{{ expected_output }}
+
+Acceptance criteria:
+{{ acceptance_criteria }}
+
+Clarify scope, non-goals, sequencing, dependencies, and risks. Keep the plan actionable.

--- a/hermes_cli/workflow/prompts/worker_researcher.md
+++ b/hermes_cli/workflow/prompts/worker_researcher.md
@@ -1,0 +1,18 @@
+You are the researcher worker in a local Hermes workflow.
+
+Objective:
+{{ objective }}
+
+Context:
+{{ input_context }}
+
+Previous worker outputs:
+{{ previous_outputs }}
+
+Expected output:
+{{ expected_output }}
+
+Acceptance criteria:
+{{ acceptance_criteria }}
+
+Summarize findings, tradeoffs, assumptions, and what would need live verification.

--- a/hermes_cli/workflow/prompts/worker_reviewer.md
+++ b/hermes_cli/workflow/prompts/worker_reviewer.md
@@ -1,0 +1,19 @@
+You are the reviewer worker in a local Hermes workflow.
+
+Objective:
+{{ objective }}
+
+Context:
+{{ input_context }}
+
+Previous worker outputs:
+{{ previous_outputs }}
+
+Expected output:
+{{ expected_output }}
+
+Acceptance criteria:
+{{ acceptance_criteria }}
+
+Prioritize correctness, safety, contradictions, missing steps, and unclear assumptions.
+Return findings first, then residual risk and next action.

--- a/hermes_cli/workflow/prompts/worker_tester.md
+++ b/hermes_cli/workflow/prompts/worker_tester.md
@@ -1,0 +1,18 @@
+You are the tester worker in a local Hermes workflow.
+
+Objective:
+{{ objective }}
+
+Context:
+{{ input_context }}
+
+Previous worker outputs:
+{{ previous_outputs }}
+
+Expected output:
+{{ expected_output }}
+
+Acceptance criteria:
+{{ acceptance_criteria }}
+
+Define focused checks that prove the behavior works. Include exact commands when relevant, but avoid destructive commands.

--- a/hermes_cli/workflow/prompts/worker_uiux_designer.md
+++ b/hermes_cli/workflow/prompts/worker_uiux_designer.md
@@ -1,0 +1,18 @@
+You are the UI/UX designer worker in a local Hermes workflow.
+
+Objective:
+{{ objective }}
+
+Context:
+{{ input_context }}
+
+Previous worker outputs:
+{{ previous_outputs }}
+
+Expected output:
+{{ expected_output }}
+
+Acceptance criteria:
+{{ acceptance_criteria }}
+
+Focus on user workflow, information hierarchy, states, accessibility, and practical implementation constraints.

--- a/hermes_cli/workflow/runtime.py
+++ b/hermes_cli/workflow/runtime.py
@@ -1,0 +1,541 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+from pathlib import Path
+from typing import Any, Callable
+
+from hermes_cli.workflow.orchestrator import (
+    EvaluationResult,
+    Evaluator,
+    FinalSynthesizer,
+    Planner,
+    Router,
+    Subtask,
+    TaskAnalysis,
+    TaskAnalyzer,
+    WorkerOutput,
+    WorkerRunner,
+    WorkflowConfig,
+    WorkflowError,
+    WorkflowLogger,
+    WorkflowRun,
+)
+from hermes_cli.workflow.state import RunStore, analysis_from_record
+
+
+class WorkflowPaused(WorkflowError):
+    """Raised when a persisted run was paused by the user."""
+
+
+class AgentExecutor:
+    """Runs a subtask through the configured worker model/provider."""
+
+    def __init__(self, config: WorkflowConfig, dry_run: bool):
+        self.runner = WorkerRunner(config, dry_run=dry_run)
+
+    def execute(
+        self,
+        subtask: Subtask,
+        analysis: TaskAnalysis,
+        previous_outputs: list[WorkerOutput],
+    ) -> tuple[str, str, str]:
+        return self.runner.run(subtask, analysis, previous_outputs)
+
+    def revise(
+        self,
+        subtask: Subtask,
+        analysis: TaskAnalysis,
+        previous_outputs: list[WorkerOutput],
+        first_output: str,
+        evaluation: EvaluationResult,
+    ) -> str:
+        return self.runner.revise(
+            subtask, analysis, previous_outputs, first_output, evaluation
+        )
+
+
+class EvaluatorLoop:
+    """Evaluator-optimizer loop with one bounded revision cycle by default."""
+
+    def __init__(self, config: WorkflowConfig):
+        self.config = config
+        self.evaluator = Evaluator()
+
+    def evaluate(
+        self,
+        *,
+        subtask: Subtask,
+        analysis: TaskAnalysis,
+        previous_outputs: list[WorkerOutput],
+        output: str,
+        executor: AgentExecutor,
+    ) -> tuple[str, EvaluationResult, bool]:
+        evaluation = self.evaluator.evaluate(subtask, output)
+        revision_used = False
+        if not evaluation.passed and self.config.max_revision_cycles > 0:
+            output = executor.revise(
+                subtask, analysis, previous_outputs, output, evaluation
+            )
+            evaluation = self.evaluator.evaluate(subtask, output)
+            revision_used = True
+        return output, evaluation, revision_used
+
+
+class Scheduler:
+    """Executes pending subtasks sequentially or with dependency-aware parallelism."""
+
+    def __init__(
+        self,
+        *,
+        store: RunStore,
+        run_id: str,
+        parallel: bool,
+        max_concurrency: int,
+    ):
+        self.store = store
+        self.run_id = run_id
+        self.parallel = parallel
+        self.max_concurrency = max(1, max_concurrency)
+
+    def run(
+        self,
+        subtasks: list[Subtask],
+        completed_outputs: list[WorkerOutput],
+        execute_one: Callable[[Subtask, list[WorkerOutput]], WorkerOutput],
+    ) -> list[WorkerOutput]:
+        if not self.parallel:
+            return self._run_sequential(subtasks, completed_outputs, execute_one)
+        return self._run_parallel(subtasks, completed_outputs, execute_one)
+
+    def _run_sequential(
+        self,
+        subtasks: list[Subtask],
+        completed_outputs: list[WorkerOutput],
+        execute_one: Callable[[Subtask, list[WorkerOutput]], WorkerOutput],
+    ) -> list[WorkerOutput]:
+        outputs = list(completed_outputs)
+        completed_ids = {item.subtask.id for item in outputs}
+        for subtask in subtasks:
+            if subtask.id in completed_ids:
+                continue
+            self._ensure_active()
+            worker_output = execute_one(subtask, outputs)
+            outputs.append(worker_output)
+            completed_ids.add(subtask.id)
+        return outputs
+
+    def _run_parallel(
+        self,
+        subtasks: list[Subtask],
+        completed_outputs: list[WorkerOutput],
+        execute_one: Callable[[Subtask, list[WorkerOutput]], WorkerOutput],
+    ) -> list[WorkerOutput]:
+        ordered_ids = [item.id for item in subtasks]
+        outputs_by_id = {item.subtask.id: item for item in completed_outputs}
+        remaining = {item.id: item for item in subtasks if item.id not in outputs_by_id}
+
+        with ThreadPoolExecutor(max_workers=self.max_concurrency) as pool:
+            futures: dict[Any, Subtask] = {}
+            while remaining or futures:
+                self._ensure_active()
+                ready = [
+                    item
+                    for item in remaining.values()
+                    if all(dep in outputs_by_id for dep in item.depends_on)
+                ]
+                if ready and not futures:
+                    serial = [item for item in ready if not item.can_parallel]
+                    batch = serial[:1] if serial else ready[: self.max_concurrency]
+                    for subtask in batch:
+                        previous = self._previous_context(subtask, outputs_by_id)
+                        futures[pool.submit(execute_one, subtask, previous)] = subtask
+                        remaining.pop(subtask.id, None)
+                if not futures:
+                    missing = {
+                        dep
+                        for item in remaining.values()
+                        for dep in item.depends_on
+                        if dep not in outputs_by_id
+                    }
+                    raise WorkflowError(
+                        "No runnable workflow subtasks; unresolved dependencies: "
+                        + ", ".join(sorted(missing))
+                    )
+                done, _ = wait(futures, return_when=FIRST_COMPLETED)
+                for future in done:
+                    subtask = futures.pop(future)
+                    outputs_by_id[subtask.id] = future.result()
+
+        return [outputs_by_id[item_id] for item_id in ordered_ids if item_id in outputs_by_id]
+
+    def _previous_context(
+        self, subtask: Subtask, outputs_by_id: dict[str, WorkerOutput]
+    ) -> list[WorkerOutput]:
+        if subtask.depends_on:
+            return [outputs_by_id[item] for item in subtask.depends_on if item in outputs_by_id]
+        return list(outputs_by_id.values())
+
+    def _ensure_active(self) -> None:
+        record = self.store.get_run(self.run_id)
+        status = str((record or {}).get("status") or "")
+        if status == "cancelled":
+            raise WorkflowError(f"Workflow run {self.run_id} was cancelled.")
+        if status == "paused":
+            raise WorkflowPaused(f"Workflow run {self.run_id} was paused.")
+
+
+class WorkflowRuntime:
+    """Top-level runtime for local dynamic workflows."""
+
+    def __init__(
+        self,
+        *,
+        config: WorkflowConfig,
+        dry_run: bool = False,
+        max_subtasks: int | None = None,
+        parallel: bool = False,
+        codex_plan: bool = False,
+    ):
+        self.config = config
+        self.dry_run = dry_run
+        self.max_subtasks = max_subtasks or config.max_subtasks
+        if parallel and not config.parallel_enabled:
+            raise WorkflowError("Parallel workflow execution is disabled in config.")
+        self.parallel = bool(parallel)
+        self.codex_plan = bool(codex_plan)
+        self.analyzer = TaskAnalyzer()
+        self.planner = Planner(max_subtasks=self.max_subtasks)
+        self.router = Router(config)
+        self.executor = AgentExecutor(config, dry_run=dry_run)
+        self.evaluator_loop = EvaluatorLoop(config)
+        self.synthesizer = FinalSynthesizer()
+        self.logger = WorkflowLogger(config)
+        self.store = RunStore.from_config(config)
+
+    def run(
+        self,
+        request: str,
+        *,
+        background: bool = False,
+        run_id: str | None = None,
+        preplanned_subtasks: list[Subtask] | None = None,
+        analysis: TaskAnalysis | None = None,
+    ) -> WorkflowRun:
+        prepared = self.prepare_run(
+            request,
+            run_id=run_id,
+            preplanned_subtasks=preplanned_subtasks,
+            analysis=analysis,
+            status="queued" if background else "running",
+        )
+        if background:
+            return self._start_background(prepared)
+        return self._execute_existing(prepared.run_id)
+
+    def resume(self, run_id: str) -> WorkflowRun:
+        return self._execute_existing(run_id)
+
+    def prepare_run(
+        self,
+        request: str,
+        *,
+        run_id: str | None = None,
+        preplanned_subtasks: list[Subtask] | None = None,
+        analysis: TaskAnalysis | None = None,
+        status: str = "queued",
+    ) -> WorkflowRun:
+        clean_request = request.strip()
+        if not clean_request:
+            raise WorkflowError("Workflow request cannot be empty.")
+
+        run_id = run_id or _new_run_id()
+        if self.store.get_run(run_id):
+            raise WorkflowError(f"Workflow run already exists: {run_id}")
+
+        analysis = analysis or self.analyzer.analyze(clean_request)
+        subtasks = list(preplanned_subtasks or self.planner.plan(clean_request, analysis))
+        for index, subtask in enumerate(subtasks):
+            if index > 0 and not subtask.depends_on and analysis.task_type in {"code", "debug"}:
+                subtask.depends_on = [subtasks[index - 1].id]
+                subtask.can_parallel = False
+            if not subtask.worker_type:
+                subtask.worker_type = self.router.assign(subtask, analysis)
+
+        mode = "parallel" if self.parallel else "sequential"
+        self.store.create_run(
+            run_id=run_id,
+            original_request=clean_request,
+            analysis=analysis,
+            mode=mode,
+            dry_run=self.dry_run,
+            codex_plan=self.codex_plan,
+            status=status,
+        )
+        self._record(run_id, "request", {"original_request": clean_request})
+        self._record(run_id, "analysis", analysis.to_dict())
+        self._record(
+            run_id,
+            "planned",
+            {"subtasks": [subtask.to_dict() for subtask in subtasks], "mode": mode},
+        )
+        for subtask in subtasks:
+            self.store.save_subtask(run_id, subtask)
+            agent_config = self.config.agent_for(subtask.worker_type or "researcher")
+            self._record(
+                run_id,
+                "worker_selected",
+                {
+                    "subtask_id": subtask.id,
+                    "selected_worker": subtask.worker_type,
+                    "provider": agent_config.display_provider,
+                    "model": agent_config.display_model,
+                },
+            )
+
+        return WorkflowRun(
+            run_id=run_id,
+            original_request=clean_request,
+            analysis=analysis,
+            subtasks=subtasks,
+            worker_outputs=[],
+            final_response="Workflow run queued." if status == "queued" else "",
+            log_path=self.logger.path,
+            status=status,
+            state_path=self.store.path,
+            codex_plan=self.codex_plan,
+        )
+
+    def run_script(self, path: str | Path, *, background: bool = False) -> WorkflowRun:
+        from hermes_cli.workflow.script_api import load_script
+
+        script = load_script(path)
+        if not script.subtasks:
+            raise WorkflowError(f"Workflow script produced no tasks: {path}")
+        if script.max_concurrency is not None:
+            self.config.execution["max_concurrency"] = script.max_concurrency
+        analysis = TaskAnalysis(
+            task_type="planning",
+            complexity="complex" if len(script.subtasks) > 3 else "medium",
+            execute_directly=False,
+            rationale=f"Loaded {len(script.subtasks)} subtask(s) from workflow script.",
+        )
+        return self.run(
+            f"Workflow script: {Path(path).expanduser()}",
+            background=background,
+            preplanned_subtasks=script.subtasks,
+            analysis=analysis,
+        )
+
+    def _execute_existing(self, run_id: str) -> WorkflowRun:
+        record = self.store.get_run(run_id)
+        if not record:
+            raise WorkflowError(f"Workflow run not found: {run_id}")
+        if record["status"] == "completed":
+            return self._build_run_from_store(record)
+        if record["status"] == "cancelled":
+            raise WorkflowError(f"Workflow run {run_id} is cancelled.")
+
+        self.store.update_run(run_id, status="running")
+        self._record(run_id, "status", {"status": "running"})
+        try:
+            analysis = analysis_from_record(record)
+            subtasks = self.store.load_subtasks(run_id)
+            completed_outputs = self.store.load_outputs(run_id)
+            scheduler = Scheduler(
+                store=self.store,
+                run_id=run_id,
+                parallel=self.parallel,
+                max_concurrency=self.config.max_concurrency,
+            )
+            outputs = scheduler.run(subtasks, completed_outputs, self._execute_subtask(run_id, analysis))
+            self.codex_plan = bool(record["codex_plan"])
+            final_response = self._final_response(analysis, outputs)
+            self.store.update_run(run_id, status="completed", final_response=final_response)
+            self._record(run_id, "final", {"result": final_response})
+            return WorkflowRun(
+                run_id=run_id,
+                original_request=str(record["original_request"]),
+                analysis=analysis,
+                subtasks=subtasks,
+                worker_outputs=outputs,
+                final_response=final_response,
+                log_path=self.logger.path,
+                status="completed",
+                state_path=self.store.path,
+                codex_plan=bool(record["codex_plan"]),
+            )
+        except WorkflowPaused:
+            self._record(run_id, "status", {"status": "paused"})
+            return self._build_run_from_store(self.store.get_run(run_id) or record)
+        except Exception as exc:
+            self.store.update_run(run_id, status="failed", error=str(exc))
+            self._record(run_id, "error", {"error": str(exc)})
+            raise
+
+    def _execute_subtask(
+        self, run_id: str, analysis: TaskAnalysis
+    ) -> Callable[[Subtask, list[WorkerOutput]], WorkerOutput]:
+        def execute(subtask: Subtask, previous_outputs: list[WorkerOutput]) -> WorkerOutput:
+            self.store.update_subtask_status(
+                run_id, subtask.id, "running", subtask.worker_type
+            )
+            output, provider, model = self.executor.execute(
+                subtask, analysis, previous_outputs
+            )
+            output, evaluation, revision_used = self.evaluator_loop.evaluate(
+                subtask=subtask,
+                analysis=analysis,
+                previous_outputs=previous_outputs,
+                output=output,
+                executor=self.executor,
+            )
+            worker_output = WorkerOutput(
+                subtask=subtask,
+                worker_type=subtask.worker_type or "researcher",
+                provider=provider,
+                model=model,
+                output=output,
+                evaluation=evaluation,
+                revision_used=revision_used,
+            )
+            self.store.save_output(run_id, worker_output)
+            self._record(
+                run_id,
+                "worker_result",
+                {
+                    "subtask_id": subtask.id,
+                    "selected_worker": worker_output.worker_type,
+                    "provider": provider,
+                    "model": model,
+                    "result": output,
+                    "revision_used": revision_used,
+                },
+            )
+            self._record(
+                run_id,
+                "evaluation",
+                {
+                    "subtask_id": subtask.id,
+                    "evaluator_score": evaluation.score,
+                    "passed": evaluation.passed,
+                    "missing_steps": evaluation.missing_steps,
+                    "contradictions": evaluation.contradictions,
+                    "unsafe_actions": evaluation.unsafe_actions,
+                    "unclear_assumptions": evaluation.unclear_assumptions,
+                },
+            )
+            return worker_output
+
+        return execute
+
+    def _start_background(self, prepared: WorkflowRun) -> WorkflowRun:
+        if not self.config.background_enabled or not self.config.allow_background_execution:
+            raise WorkflowError("Background workflow execution is disabled in config.")
+
+        log_file = self.logger.path.parent / f"workflow_background_{prepared.run_id}.log"
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        cmd = [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "workflow",
+            "run",
+            "--config",
+            str(self.config.path),
+            "--resume-run-id",
+            prepared.run_id,
+            "--internal-background-worker",
+        ]
+        if self.dry_run:
+            cmd.append("--dry-run")
+        if self.parallel:
+            cmd.append("--parallel")
+        if self.codex_plan:
+            cmd.append("--codex-plan")
+        with log_file.open("ab") as handle:
+            process = subprocess.Popen(
+                cmd,
+                cwd=os.getcwd(),
+                stdout=handle,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+        self.store.update_run(prepared.run_id, pid=process.pid)
+        self._record(
+            prepared.run_id,
+            "background_started",
+            {"pid": process.pid, "background_log": str(log_file)},
+        )
+        prepared.final_response = (
+            f"Workflow run queued in background.\n"
+            f"Run id: {prepared.run_id}\n"
+            f"Status: hermes workflow status {prepared.run_id}"
+        )
+        prepared.status = "queued"
+        return prepared
+
+    def _build_run_from_store(self, record: dict[str, Any]) -> WorkflowRun:
+        analysis = analysis_from_record(record)
+        return WorkflowRun(
+            run_id=str(record["run_id"]),
+            original_request=str(record["original_request"]),
+            analysis=analysis,
+            subtasks=self.store.load_subtasks(str(record["run_id"])),
+            worker_outputs=self.store.load_outputs(str(record["run_id"])),
+            final_response=str(record.get("final_response") or ""),
+            log_path=self.logger.path,
+            status=str(record["status"]),
+            state_path=self.store.path,
+            codex_plan=bool(record["codex_plan"]),
+        )
+
+    def _final_response(self, analysis: TaskAnalysis, outputs: list[WorkerOutput]) -> str:
+        if self.codex_plan:
+            return _codex_plan_response(analysis, outputs, dry_run=self.dry_run)
+        return self.synthesizer.synthesize(analysis, outputs, dry_run=self.dry_run)
+
+    def _record(self, run_id: str, event: str, payload: dict[str, Any]) -> None:
+        self.logger.log(run_id, event, payload)
+        self.store.append_event(run_id, event, payload)
+
+
+def _codex_plan_response(
+    analysis: TaskAnalysis, outputs: list[WorkerOutput], *, dry_run: bool
+) -> str:
+    lines = [
+        "Codex Goal Plan",
+        "",
+        f"- Classification: {analysis.task_type} / {analysis.complexity}",
+        f"- Execution source: {'dry-run' if dry_run else 'model-backed'} Hermes workflow",
+        "",
+        "Phases",
+    ]
+    for index, item in enumerate(outputs, start=1):
+        status = "passed" if item.evaluation.passed else "needs attention"
+        lines.append(
+            f"{index}. {item.subtask.objective} "
+            f"({item.worker_type}, score={item.evaluation.score}, {status})"
+        )
+    risks = [
+        item
+        for item in outputs
+        if not item.evaluation.passed or item.subtask.risk_level == "high"
+    ]
+    lines.extend(["", "Risks"])
+    if risks:
+        for item in risks:
+            lines.append(f"- {item.subtask.id}: {item.evaluation.notes or item.subtask.risk_level}")
+    else:
+        lines.append("- No evaluator-blocking risks were detected.")
+    lines.extend(["", "Next action", "- Use this as the Codex Goal execution checklist."])
+    return "\n".join(lines)
+
+
+def _new_run_id() -> str:
+    return f"wf-{time.strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:8]}"

--- a/hermes_cli/workflow/runtime.py
+++ b/hermes_cli/workflow/runtime.py
@@ -87,6 +87,227 @@ class EvaluatorLoop:
         return output, evaluation, revision_used
 
 
+class ContestHarness:
+    """Runs competing workers for one subtask and selects the strongest output."""
+
+    def __init__(
+        self,
+        *,
+        config: WorkflowConfig,
+        executor: AgentExecutor,
+        evaluator_loop: EvaluatorLoop,
+        record: Callable[[str, dict[str, Any]], None],
+        cross_review: bool,
+    ):
+        self.config = config
+        self.executor = executor
+        self.evaluator_loop = evaluator_loop
+        self.record = record
+        self.cross_review = cross_review
+
+    def run(
+        self,
+        subtask: Subtask,
+        analysis: TaskAnalysis,
+        previous_outputs: list[WorkerOutput],
+    ) -> WorkerOutput:
+        candidates: list[WorkerOutput] = []
+        for worker_type in self._candidate_workers(subtask):
+            candidate = self._candidate_subtask(subtask, worker_type)
+            output, provider, model = self.executor.execute(
+                candidate, analysis, previous_outputs
+            )
+            output, evaluation, revision_used = self.evaluator_loop.evaluate(
+                subtask=candidate,
+                analysis=analysis,
+                previous_outputs=previous_outputs,
+                output=output,
+                executor=self.executor,
+            )
+            worker_output = WorkerOutput(
+                subtask=candidate,
+                worker_type=worker_type,
+                provider=provider,
+                model=model,
+                output=output,
+                evaluation=evaluation,
+                revision_used=revision_used,
+            )
+            candidates.append(worker_output)
+            self.record(
+                "contest_candidate",
+                {
+                    "subtask_id": subtask.id,
+                    "candidate_id": candidate.id,
+                    "worker_type": worker_type,
+                    "provider": provider,
+                    "model": model,
+                    "score": evaluation.score,
+                    "passed": evaluation.passed,
+                    "revision_used": revision_used,
+                    "result": output,
+                },
+            )
+
+        reviews = self._cross_review(subtask, analysis, previous_outputs, candidates)
+        selected = self._select_winner(candidates, reviews)
+        winner = WorkerOutput(
+            subtask=subtask,
+            worker_type=f"{selected.worker_type}:contest_winner",
+            provider=selected.provider,
+            model=selected.model,
+            output=self._winner_output(selected, candidates, reviews),
+            evaluation=selected.evaluation,
+            revision_used=selected.revision_used,
+        )
+        self.record(
+            "contest_selected",
+            {
+                "subtask_id": subtask.id,
+                "winner_worker": winner.worker_type,
+                "winner_candidate_id": selected.subtask.id,
+                "winner_score": winner.evaluation.score,
+                "candidate_count": len(candidates),
+                "cross_review_count": len(reviews),
+            },
+        )
+        return winner
+
+    def _candidate_workers(self, subtask: Subtask) -> list[str]:
+        workers = [subtask.worker_type or "researcher", *self.config.contest_workers]
+        unique: list[str] = []
+        for worker in workers:
+            if worker not in unique:
+                unique.append(worker)
+        return unique[: self.config.contest_candidates]
+
+    def _candidate_subtask(self, subtask: Subtask, worker_type: str) -> Subtask:
+        return Subtask(
+            id=f"{subtask.id}:candidate:{worker_type}",
+            objective=(
+                f"{subtask.objective}\n\n"
+                "Contest mode: produce the strongest independent answer. "
+                "Do not assume other candidates are correct."
+            ),
+            input_context=subtask.input_context,
+            expected_output=subtask.expected_output,
+            acceptance_criteria=subtask.acceptance_criteria,
+            risk_level=subtask.risk_level,
+            worker_type=worker_type,
+            depends_on=list(subtask.depends_on),
+            can_parallel=subtask.can_parallel,
+        )
+
+    def _cross_review(
+        self,
+        subtask: Subtask,
+        analysis: TaskAnalysis,
+        previous_outputs: list[WorkerOutput],
+        candidates: list[WorkerOutput],
+    ) -> list[WorkerOutput]:
+        if not self.cross_review:
+            return []
+
+        candidate_context = "\n\n".join(
+            f"{item.subtask.id} ({item.worker_type}, score={item.evaluation.score}):\n"
+            f"{item.output}"
+            for item in candidates
+        )
+        reviews: list[WorkerOutput] = []
+        for worker_type in self.config.cross_review_workers:
+            review_subtask = Subtask(
+                id=f"{subtask.id}:cross-review:{worker_type}",
+                objective=(
+                    "Adversarially review contest candidates and identify the "
+                    "best answer, gaps, contradictions, unsafe actions, and "
+                    "unclear assumptions."
+                ),
+                input_context=(
+                    f"Original subtask: {subtask.objective}\n\n"
+                    f"Acceptance criteria:\n{json.dumps(subtask.acceptance_criteria, ensure_ascii=False)}\n\n"
+                    f"Candidate outputs:\n{candidate_context}"
+                ),
+                expected_output="A ranked review of candidates with risks and a recommended winner.",
+                acceptance_criteria=[
+                    "Ranks or compares candidate outputs.",
+                    "Calls out gaps, contradictions, unsafe actions, or unclear assumptions.",
+                    "Recommends the strongest candidate or a merge direction.",
+                ],
+                risk_level=subtask.risk_level,
+                worker_type=worker_type,
+            )
+            output, provider, model = self.executor.execute(
+                review_subtask, analysis, previous_outputs + candidates
+            )
+            output, evaluation, revision_used = self.evaluator_loop.evaluate(
+                subtask=review_subtask,
+                analysis=analysis,
+                previous_outputs=previous_outputs + candidates,
+                output=output,
+                executor=self.executor,
+            )
+            review = WorkerOutput(
+                subtask=review_subtask,
+                worker_type=worker_type,
+                provider=provider,
+                model=model,
+                output=output,
+                evaluation=evaluation,
+                revision_used=revision_used,
+            )
+            reviews.append(review)
+            self.record(
+                "cross_review_result",
+                {
+                    "subtask_id": subtask.id,
+                    "reviewer": worker_type,
+                    "score": evaluation.score,
+                    "passed": evaluation.passed,
+                    "result": output,
+                },
+            )
+        return reviews
+
+    def _select_winner(
+        self, candidates: list[WorkerOutput], reviews: list[WorkerOutput]
+    ) -> WorkerOutput:
+        review_text = "\n".join(item.output.lower() for item in reviews)
+
+        def score(candidate: WorkerOutput) -> tuple[float, int, int]:
+            mentions = review_text.count(candidate.subtask.id.lower())
+            worker_mentions = review_text.count(candidate.worker_type.lower())
+            return candidate.evaluation.score, mentions, worker_mentions
+
+        return max(candidates, key=score)
+
+    def _winner_output(
+        self,
+        winner: WorkerOutput,
+        candidates: list[WorkerOutput],
+        reviews: list[WorkerOutput],
+    ) -> str:
+        summary = [
+            winner.output,
+            "",
+            "Contest harness",
+            f"- Winner: {winner.subtask.id} via {winner.worker_type} "
+            f"(score={winner.evaluation.score}).",
+            "- Candidates: "
+            + ", ".join(
+                f"{item.subtask.id}/{item.worker_type}/score={item.evaluation.score}"
+                for item in candidates
+            ),
+        ]
+        if reviews:
+            summary.append(
+                "- Cross-reviewers: "
+                + ", ".join(
+                    f"{item.worker_type}/score={item.evaluation.score}" for item in reviews
+                )
+            )
+        return "\n".join(summary)
+
+
 class Scheduler:
     """Executes pending subtasks sequentially or with dependency-aware parallelism."""
 
@@ -201,6 +422,8 @@ class WorkflowRuntime:
         max_subtasks: int | None = None,
         parallel: bool = False,
         codex_plan: bool = False,
+        contest: bool = False,
+        cross_review: bool = False,
     ):
         self.config = config
         self.dry_run = dry_run
@@ -209,6 +432,8 @@ class WorkflowRuntime:
             raise WorkflowError("Parallel workflow execution is disabled in config.")
         self.parallel = bool(parallel)
         self.codex_plan = bool(codex_plan)
+        self.contest = bool(contest)
+        self.cross_review = bool(cross_review)
         self.analyzer = TaskAnalyzer()
         self.planner = Planner(max_subtasks=self.max_subtasks)
         self.router = Router(config)
@@ -267,7 +492,12 @@ class WorkflowRuntime:
             if not subtask.worker_type:
                 subtask.worker_type = self.router.assign(subtask, analysis)
 
-        mode = "parallel" if self.parallel else "sequential"
+        mode_parts = ["parallel" if self.parallel else "sequential"]
+        if self.contest:
+            mode_parts.append("contest")
+        if self.cross_review:
+            mode_parts.append("cross-review")
+        mode = "+".join(mode_parts)
         self.store.create_run(
             run_id=run_id,
             original_request=clean_request,
@@ -275,6 +505,8 @@ class WorkflowRuntime:
             mode=mode,
             dry_run=self.dry_run,
             codex_plan=self.codex_plan,
+            contest=self.contest,
+            cross_review=self.cross_review,
             status=status,
         )
         self._record(run_id, "request", {"original_request": clean_request})
@@ -309,6 +541,8 @@ class WorkflowRuntime:
             status=status,
             state_path=self.store.path,
             codex_plan=self.codex_plan,
+            contest=self.contest,
+            cross_review=self.cross_review,
         )
 
     def run_script(self, path: str | Path, *, background: bool = False) -> WorkflowRun:
@@ -345,6 +579,8 @@ class WorkflowRuntime:
         self._record(run_id, "status", {"status": "running"})
         try:
             analysis = analysis_from_record(record)
+            self.contest = bool(record["contest"])
+            self.cross_review = bool(record["cross_review"])
             subtasks = self.store.load_subtasks(run_id)
             completed_outputs = self.store.load_outputs(run_id)
             scheduler = Scheduler(
@@ -369,6 +605,8 @@ class WorkflowRuntime:
                 status="completed",
                 state_path=self.store.path,
                 codex_plan=bool(record["codex_plan"]),
+                contest=bool(record["contest"]),
+                cross_review=bool(record["cross_review"]),
             )
         except WorkflowPaused:
             self._record(run_id, "status", {"status": "paused"})
@@ -385,6 +623,45 @@ class WorkflowRuntime:
             self.store.update_subtask_status(
                 run_id, subtask.id, "running", subtask.worker_type
             )
+            if self.contest:
+                harness = ContestHarness(
+                    config=self.config,
+                    executor=self.executor,
+                    evaluator_loop=self.evaluator_loop,
+                    record=lambda event, payload: self._record(run_id, event, payload),
+                    cross_review=self.cross_review,
+                )
+                worker_output = harness.run(subtask, analysis, previous_outputs)
+                self.store.save_output(run_id, worker_output)
+                self._record(
+                    run_id,
+                    "worker_result",
+                    {
+                        "subtask_id": subtask.id,
+                        "selected_worker": worker_output.worker_type,
+                        "provider": worker_output.provider,
+                        "model": worker_output.model,
+                        "result": worker_output.output,
+                        "revision_used": worker_output.revision_used,
+                        "contest": True,
+                        "cross_review": self.cross_review,
+                    },
+                )
+                self._record(
+                    run_id,
+                    "evaluation",
+                    {
+                        "subtask_id": subtask.id,
+                        "evaluator_score": worker_output.evaluation.score,
+                        "passed": worker_output.evaluation.passed,
+                        "missing_steps": worker_output.evaluation.missing_steps,
+                        "contradictions": worker_output.evaluation.contradictions,
+                        "unsafe_actions": worker_output.evaluation.unsafe_actions,
+                        "unclear_assumptions": worker_output.evaluation.unclear_assumptions,
+                    },
+                )
+                return worker_output
+
             output, provider, model = self.executor.execute(
                 subtask, analysis, previous_outputs
             )
@@ -458,6 +735,10 @@ class WorkflowRuntime:
             cmd.append("--parallel")
         if self.codex_plan:
             cmd.append("--codex-plan")
+        if self.contest:
+            cmd.append("--contest")
+        if self.cross_review:
+            cmd.append("--cross-review")
         with log_file.open("ab") as handle:
             process = subprocess.Popen(
                 cmd,
@@ -493,6 +774,8 @@ class WorkflowRuntime:
             status=str(record["status"]),
             state_path=self.store.path,
             codex_plan=bool(record["codex_plan"]),
+            contest=bool(record["contest"]),
+            cross_review=bool(record["cross_review"]),
         )
 
     def _final_response(self, analysis: TaskAnalysis, outputs: list[WorkerOutput]) -> str:

--- a/hermes_cli/workflow/runtime.py
+++ b/hermes_cli/workflow/runtime.py
@@ -424,6 +424,7 @@ class WorkflowRuntime:
         codex_plan: bool = False,
         contest: bool = False,
         cross_review: bool = False,
+        progress_callback: Callable[[str, dict[str, Any]], None] | None = None,
     ):
         self.config = config
         self.dry_run = dry_run
@@ -434,6 +435,7 @@ class WorkflowRuntime:
         self.codex_plan = bool(codex_plan)
         self.contest = bool(contest)
         self.cross_review = bool(cross_review)
+        self.progress_callback = progress_callback
         self.analyzer = TaskAnalyzer()
         self.planner = Planner(max_subtasks=self.max_subtasks)
         self.router = Router(config)
@@ -611,6 +613,11 @@ class WorkflowRuntime:
         except WorkflowPaused:
             self._record(run_id, "status", {"status": "paused"})
             return self._build_run_from_store(self.store.get_run(run_id) or record)
+        except KeyboardInterrupt:
+            self.store.update_run(run_id, status="cancelled", error="Interrupted by user.")
+            self._record(run_id, "status", {"status": "cancelled"})
+            self._record(run_id, "error", {"error": "Interrupted by user."})
+            raise
         except Exception as exc:
             self.store.update_run(run_id, status="failed", error=str(exc))
             self._record(run_id, "error", {"error": str(exc)})
@@ -786,6 +793,8 @@ class WorkflowRuntime:
     def _record(self, run_id: str, event: str, payload: dict[str, Any]) -> None:
         self.logger.log(run_id, event, payload)
         self.store.append_event(run_id, event, payload)
+        if self.progress_callback:
+            self.progress_callback(event, payload)
 
 
 def _codex_plan_response(

--- a/hermes_cli/workflow/script_api.py
+++ b/hermes_cli/workflow/script_api.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hermes_cli.workflow.orchestrator import Subtask, WORKER_TYPES, _truncate
+
+
+@dataclass
+class LoadedWorkflowScript:
+    path: Path
+    subtasks: list[Subtask]
+    max_concurrency: int | None = None
+
+
+class WorkflowScriptBuilder:
+    def __init__(self) -> None:
+        self.subtasks: list[Subtask] = []
+        self.max_concurrency: int | None = None
+
+    def task(
+        self,
+        objective: str,
+        worker: str = "researcher",
+        context: str | dict[str, Any] | None = None,
+        depends_on: list[str] | tuple[str, ...] | None = None,
+        expected_output: str | None = None,
+        acceptance_criteria: list[str] | tuple[str, ...] | None = None,
+        risk_level: str = "medium",
+    ) -> str:
+        if worker not in WORKER_TYPES:
+            worker = "researcher"
+        task_id = f"script-{len(self.subtasks) + 1}"
+        context_text = context if isinstance(context, str) else repr(context or {})
+        subtask = Subtask(
+            id=task_id,
+            objective=objective.strip(),
+            input_context=_truncate(context_text, 2400),
+            expected_output=expected_output or "A focused worker output for this scripted task.",
+            acceptance_criteria=list(
+                acceptance_criteria
+                or [
+                    f"Addresses objective: {objective.strip()}",
+                    "Calls out assumptions, risks, or blockers when relevant.",
+                ]
+            ),
+            risk_level=risk_level if risk_level in {"low", "medium", "high"} else "medium",
+            worker_type=worker,
+            depends_on=[str(item) for item in depends_on or []],
+            can_parallel=True,
+        )
+        self.subtasks.append(subtask)
+        return task_id
+
+    def parallel(
+        self,
+        items: list[str] | tuple[str, ...],
+        max_concurrency: int | None = None,
+    ) -> list[str]:
+        ids = {str(item) for item in items}
+        for subtask in self.subtasks:
+            if subtask.id in ids:
+                subtask.can_parallel = True
+        if max_concurrency is not None:
+            self.max_concurrency = max(1, int(max_concurrency))
+        return list(items)
+
+    def evaluate(self, output: str, criteria: list[str] | tuple[str, ...]) -> dict[str, Any]:
+        lowered = output.lower()
+        missing = [item for item in criteria if item.lower() not in lowered]
+        return {"passed": not missing, "missing": missing}
+
+    def revise(self, task_id: str, feedback: str) -> dict[str, str]:
+        return {"task_id": task_id, "feedback": feedback}
+
+    def synthesize(self, outputs: list[str] | tuple[str, ...]) -> str:
+        return "\n\n".join(str(item) for item in outputs)
+
+
+def load_script(path: str | Path) -> LoadedWorkflowScript:
+    script_path = Path(path).expanduser().resolve()
+    if not script_path.exists():
+        raise FileNotFoundError(f"Workflow script not found: {script_path}")
+
+    builder = WorkflowScriptBuilder()
+    namespace = {
+        "task": builder.task,
+        "parallel": builder.parallel,
+        "evaluate": builder.evaluate,
+        "revise": builder.revise,
+        "synthesize": builder.synthesize,
+    }
+    code = compile(script_path.read_text(encoding="utf-8"), str(script_path), "exec")
+    exec(code, namespace, {})
+    return LoadedWorkflowScript(
+        path=script_path,
+        subtasks=builder.subtasks,
+        max_concurrency=builder.max_concurrency,
+    )

--- a/hermes_cli/workflow/state.py
+++ b/hermes_cli/workflow/state.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import Any
+
+from hermes_cli.workflow.orchestrator import (
+    Subtask,
+    TaskAnalysis,
+    WorkerOutput,
+    WorkflowConfig,
+    _redact_payload,
+)
+
+
+class RunStore:
+    """SQLite state for resumable workflow runs."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    @classmethod
+    def from_config(cls, config: WorkflowConfig) -> "RunStore":
+        configured = config.state_db.strip()
+        if configured:
+            path = Path(configured).expanduser()
+            if not path.is_absolute():
+                path = config.path.parent / path
+        else:
+            try:
+                from hermes_constants import get_hermes_home
+
+                path = get_hermes_home() / "workflow_runs.db"
+            except Exception:
+                path = Path.home() / ".hermes" / "workflow_runs.db"
+        return cls(path)
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS workflow_runs (
+                    run_id TEXT PRIMARY KEY,
+                    original_request TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    mode TEXT NOT NULL,
+                    dry_run INTEGER NOT NULL,
+                    codex_plan INTEGER NOT NULL,
+                    analysis_json TEXT NOT NULL,
+                    final_response TEXT NOT NULL DEFAULT '',
+                    error TEXT NOT NULL DEFAULT '',
+                    pid INTEGER,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS workflow_subtasks (
+                    run_id TEXT NOT NULL,
+                    subtask_id TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    worker_type TEXT NOT NULL DEFAULT '',
+                    output_json TEXT NOT NULL DEFAULT '',
+                    evaluation_json TEXT NOT NULL DEFAULT '',
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (run_id, subtask_id)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS workflow_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_id TEXT NOT NULL,
+                    ts TEXT NOT NULL,
+                    event TEXT NOT NULL,
+                    payload_json TEXT NOT NULL
+                )
+                """
+            )
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def create_run(
+        self,
+        *,
+        run_id: str,
+        original_request: str,
+        analysis: TaskAnalysis,
+        mode: str,
+        dry_run: bool,
+        codex_plan: bool,
+        status: str = "queued",
+    ) -> None:
+        now = _now()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO workflow_runs (
+                    run_id, original_request, status, mode, dry_run, codex_plan,
+                    analysis_json, created_at, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    original_request,
+                    status,
+                    mode,
+                    int(dry_run),
+                    int(codex_plan),
+                    json.dumps(analysis.to_dict(), ensure_ascii=False),
+                    now,
+                    now,
+                ),
+            )
+
+    def update_run(
+        self,
+        run_id: str,
+        *,
+        status: str | None = None,
+        final_response: str | None = None,
+        error: str | None = None,
+        pid: int | None = None,
+    ) -> None:
+        fields: list[str] = []
+        values: list[Any] = []
+        if status is not None:
+            fields.append("status = ?")
+            values.append(status)
+        if final_response is not None:
+            fields.append("final_response = ?")
+            values.append(final_response)
+        if error is not None:
+            fields.append("error = ?")
+            values.append(error)
+        if pid is not None:
+            fields.append("pid = ?")
+            values.append(pid)
+        fields.append("updated_at = ?")
+        values.append(_now())
+        values.append(run_id)
+        with self._connect() as conn:
+            conn.execute(
+                f"UPDATE workflow_runs SET {', '.join(fields)} WHERE run_id = ?",
+                values,
+            )
+
+    def get_run(self, run_id: str) -> dict[str, Any] | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM workflow_runs WHERE run_id = ?", (run_id,)
+            ).fetchone()
+        return dict(row) if row else None
+
+    def save_subtask(self, run_id: str, subtask: Subtask, status: str = "pending") -> None:
+        now = _now()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO workflow_subtasks (
+                    run_id, subtask_id, payload_json, status, worker_type,
+                    output_json, evaluation_json, updated_at
+                )
+                VALUES (
+                    ?, ?, ?, ?,
+                    COALESCE((SELECT worker_type FROM workflow_subtasks WHERE run_id=? AND subtask_id=?), ?),
+                    COALESCE((SELECT output_json FROM workflow_subtasks WHERE run_id=? AND subtask_id=?), ''),
+                    COALESCE((SELECT evaluation_json FROM workflow_subtasks WHERE run_id=? AND subtask_id=?), ''),
+                    ?
+                )
+                """,
+                (
+                    run_id,
+                    subtask.id,
+                    json.dumps(subtask.to_dict(), ensure_ascii=False),
+                    status,
+                    run_id,
+                    subtask.id,
+                    subtask.worker_type or "",
+                    run_id,
+                    subtask.id,
+                    run_id,
+                    subtask.id,
+                    now,
+                ),
+            )
+
+    def update_subtask_status(
+        self, run_id: str, subtask_id: str, status: str, worker_type: str | None = None
+    ) -> None:
+        fields = ["status = ?", "updated_at = ?"]
+        values: list[Any] = [status, _now()]
+        if worker_type is not None:
+            fields.insert(1, "worker_type = ?")
+            values.insert(1, worker_type)
+        values.extend([run_id, subtask_id])
+        with self._connect() as conn:
+            conn.execute(
+                f"""
+                UPDATE workflow_subtasks
+                SET {', '.join(fields)}
+                WHERE run_id = ? AND subtask_id = ?
+                """,
+                values,
+            )
+
+    def save_output(self, run_id: str, output: WorkerOutput) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE workflow_subtasks
+                SET status = ?, worker_type = ?, output_json = ?,
+                    evaluation_json = ?, updated_at = ?
+                WHERE run_id = ? AND subtask_id = ?
+                """,
+                (
+                    "completed" if output.evaluation.passed else "failed",
+                    output.worker_type,
+                    json.dumps(output.to_dict(), ensure_ascii=False),
+                    json.dumps(output.evaluation.to_dict(), ensure_ascii=False),
+                    _now(),
+                    run_id,
+                    output.subtask.id,
+                ),
+            )
+
+    def load_subtasks(self, run_id: str) -> list[Subtask]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT payload_json
+                FROM workflow_subtasks
+                WHERE run_id = ?
+                ORDER BY rowid
+                """,
+                (run_id,),
+            ).fetchall()
+        return [Subtask.from_dict(json.loads(row["payload_json"])) for row in rows]
+
+    def load_outputs(self, run_id: str) -> list[WorkerOutput]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT output_json
+                FROM workflow_subtasks
+                WHERE run_id = ? AND output_json != ''
+                ORDER BY rowid
+                """,
+                (run_id,),
+            ).fetchall()
+        return [WorkerOutput.from_dict(json.loads(row["output_json"])) for row in rows]
+
+    def append_event(self, run_id: str, event: str, payload: dict[str, Any]) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO workflow_events (run_id, ts, event, payload_json)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    _now(),
+                    event,
+                    json.dumps(_redact_payload(payload), ensure_ascii=False, sort_keys=True),
+                ),
+            )
+
+    def events(self, run_id: str, limit: int | None = None) -> list[dict[str, Any]]:
+        sql = (
+            "SELECT ts, event, payload_json FROM workflow_events "
+            "WHERE run_id = ? ORDER BY id"
+        )
+        params: tuple[Any, ...] = (run_id,)
+        if limit is not None:
+            sql += " DESC LIMIT ?"
+            params = (run_id, limit)
+        with self._connect() as conn:
+            rows = conn.execute(sql, params).fetchall()
+        events = [
+            {
+                "ts": row["ts"],
+                "event": row["event"],
+                "payload": json.loads(row["payload_json"]),
+            }
+            for row in rows
+        ]
+        if limit is not None:
+            events.reverse()
+        return events
+
+
+def analysis_from_record(record: dict[str, Any]) -> TaskAnalysis:
+    data = json.loads(record.get("analysis_json") or "{}")
+    return TaskAnalysis(
+        task_type=str(data.get("task_type") or "planning"),
+        complexity=str(data.get("complexity") or "medium"),
+        execute_directly=bool(data.get("execute_directly", False)),
+        rationale=str(data.get("rationale") or "Loaded from workflow state."),
+    )
+
+
+def _now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())

--- a/hermes_cli/workflow/state.py
+++ b/hermes_cli/workflow/state.py
@@ -50,6 +50,8 @@ class RunStore:
                     mode TEXT NOT NULL,
                     dry_run INTEGER NOT NULL,
                     codex_plan INTEGER NOT NULL,
+                    contest INTEGER NOT NULL DEFAULT 0,
+                    cross_review INTEGER NOT NULL DEFAULT 0,
                     analysis_json TEXT NOT NULL,
                     final_response TEXT NOT NULL DEFAULT '',
                     error TEXT NOT NULL DEFAULT '',
@@ -59,6 +61,8 @@ class RunStore:
                 )
                 """
             )
+            self._ensure_run_column(conn, "contest", "INTEGER NOT NULL DEFAULT 0")
+            self._ensure_run_column(conn, "cross_review", "INTEGER NOT NULL DEFAULT 0")
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS workflow_subtasks (
@@ -91,6 +95,16 @@ class RunStore:
         conn.row_factory = sqlite3.Row
         return conn
 
+    def _ensure_run_column(
+        self, conn: sqlite3.Connection, name: str, definition: str
+    ) -> None:
+        columns = {
+            str(row["name"])
+            for row in conn.execute("PRAGMA table_info(workflow_runs)").fetchall()
+        }
+        if name not in columns:
+            conn.execute(f"ALTER TABLE workflow_runs ADD COLUMN {name} {definition}")
+
     def create_run(
         self,
         *,
@@ -100,6 +114,8 @@ class RunStore:
         mode: str,
         dry_run: bool,
         codex_plan: bool,
+        contest: bool = False,
+        cross_review: bool = False,
         status: str = "queued",
     ) -> None:
         now = _now()
@@ -108,9 +124,9 @@ class RunStore:
                 """
                 INSERT INTO workflow_runs (
                     run_id, original_request, status, mode, dry_run, codex_plan,
-                    analysis_json, created_at, updated_at
+                    contest, cross_review, analysis_json, created_at, updated_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     run_id,
@@ -119,6 +135,8 @@ class RunStore:
                     mode,
                     int(dry_run),
                     int(codex_plan),
+                    int(contest),
+                    int(cross_review),
                     json.dumps(analysis.to_dict(), ensure_ascii=False),
                     now,
                     now,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,16 @@ hermes-acp = "acp_adapter.entry:main"
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils"]
 
 [tool.setuptools.package-data]
-hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]
+hermes_cli = [
+  "web_dist/**/*",
+  "tui_dist/**/*",
+  "scripts/install.sh",
+  "scripts/install.ps1",
+  "workflow/README.md",
+  "workflow/config/*.yaml",
+  "workflow/examples/*.md",
+  "workflow/prompts/*.md",
+]
 gateway = ["assets/**/*"]
 plugins = [
   "*/dashboard/manifest.json",

--- a/tests/hermes_cli/test_workflow.py
+++ b/tests/hermes_cli/test_workflow.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import time
 from pathlib import Path
+
+import pytest
 
 from hermes_cli.workflow.cli import add_parser
 from hermes_cli.workflow.orchestrator import (
@@ -11,8 +14,12 @@ from hermes_cli.workflow.orchestrator import (
     Subtask,
     TaskAnalyzer,
     WorkflowConfig,
+    WorkflowError,
     run_workflow,
 )
+from hermes_cli.workflow.runtime import WorkflowRuntime
+from hermes_cli.workflow.script_api import load_script
+from hermes_cli.workflow.state import RunStore
 
 
 def test_analyzer_detects_complex_code_request():
@@ -100,3 +107,119 @@ def test_workflow_parser_accepts_run_task():
     assert args.workflow_command == "run"
     assert args.dry_run is True
     assert args.task == ["ship", "it"]
+
+
+def test_config_loads_runtime_agent_fields():
+    config = WorkflowConfig.load()
+
+    assert config.parallel_enabled is True
+    assert config.background_enabled is True
+    assert config.allow_background_execution is True
+    assert config.max_concurrency >= 1
+    assert config.default_permission_mode == "read-only"
+    assert config.agent_for("coder").description
+    assert config.agent_for("coder").can_write_files is False
+
+
+def test_parallel_dry_run_persists_sqlite_state(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    result = run_workflow(
+        "Plan a product launch checklist with research, review, and tests.",
+        dry_run=True,
+        parallel=True,
+        max_subtasks=4,
+    )
+
+    assert result.status == "completed"
+    assert result.state_path == hermes_home / "workflow_runs.db"
+    store = RunStore(result.state_path)
+    record = store.get_run(result.run_id)
+    assert record is not None
+    assert record["status"] == "completed"
+    assert record["mode"] == "parallel"
+    assert len(store.load_outputs(result.run_id)) == len(result.worker_outputs)
+    assert any(event["event"] == "planned" for event in store.events(result.run_id))
+
+
+def test_runtime_pause_resume_and_cancel_state(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    runtime = WorkflowRuntime(config=WorkflowConfig.load(), dry_run=True)
+
+    prepared = runtime.prepare_run("Plan a short writing task.", status="queued")
+    runtime.store.update_run(prepared.run_id, status="paused")
+    resumed = runtime.resume(prepared.run_id)
+    assert resumed.status == "completed"
+
+    cancelled = runtime.prepare_run("Plan another short task.", status="queued")
+    runtime.store.update_run(cancelled.run_id, status="cancelled")
+    with pytest.raises(WorkflowError):
+        runtime.resume(cancelled.run_id)
+
+
+def test_background_dry_run_can_be_queried(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    result = run_workflow(
+        "Plan a concise research workflow.",
+        dry_run=True,
+        background=True,
+        max_subtasks=3,
+    )
+
+    store = RunStore(result.state_path)
+    deadline = time.time() + 8
+    record = store.get_run(result.run_id)
+    while record and record["status"] not in {"completed", "failed"} and time.time() < deadline:
+        time.sleep(0.2)
+        record = store.get_run(result.run_id)
+
+    assert record is not None
+    assert record["status"] == "completed"
+    assert len(store.events(result.run_id)) >= 3
+
+
+def test_workflow_script_loader_and_runner(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    script_path = tmp_path / "workflow_script.py"
+    script_path.write_text(
+        """
+research = task("Research options", worker="researcher", risk_level="low")
+review = task("Review risks", worker="reviewer", depends_on=[research])
+parallel([research], max_concurrency=2)
+""",
+        encoding="utf-8",
+    )
+
+    loaded = load_script(script_path)
+    assert [item.id for item in loaded.subtasks] == ["script-1", "script-2"]
+    assert loaded.subtasks[1].depends_on == ["script-1"]
+
+    runtime = WorkflowRuntime(
+        config=WorkflowConfig.load(),
+        dry_run=True,
+        parallel=True,
+    )
+    result = runtime.run_script(script_path)
+    assert result.status == "completed"
+    assert len(result.worker_outputs) == 2
+
+
+def test_workflow_parser_accepts_new_commands():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    workflow_parser = add_parser(subparsers)
+    workflow_parser.set_defaults(func=lambda args: 0)
+
+    args = parser.parse_args(["workflow", "status", "wf-123", "--json"])
+    assert args.workflow_command == "status"
+    assert args.run_id == "wf-123"
+    assert args.json is True
+
+    args = parser.parse_args(["workflow", "script", "--dry-run", "flow.py"])
+    assert args.workflow_command == "script"
+    assert args.path == "flow.py"

--- a/tests/hermes_cli/test_workflow.py
+++ b/tests/hermes_cli/test_workflow.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from hermes_cli.workflow.cli import add_parser
+from hermes_cli.workflow.orchestrator import (
+    Planner,
+    Router,
+    Subtask,
+    TaskAnalyzer,
+    WorkflowConfig,
+    run_workflow,
+)
+
+
+def test_analyzer_detects_complex_code_request():
+    request = """
+    Build a local Dynamic Workflow system for Hermes.
+    Required modules:
+    1. Task Analyzer
+    2. Planner
+    3. Router
+    4. Worker Runner
+    5. Evaluator
+    6. Final Synthesizer
+    """
+
+    analysis = TaskAnalyzer().analyze(request)
+
+    assert analysis.task_type == "code"
+    assert analysis.complexity == "complex"
+    assert analysis.execute_directly is False
+
+
+def test_planner_creates_required_subtask_fields():
+    request = "Build a Python CLI workflow orchestrator with config, prompts, and tests."
+    analysis = TaskAnalyzer().analyze(request)
+    subtasks = Planner(max_subtasks=5).plan(request, analysis)
+
+    assert 3 <= len(subtasks) <= 5
+    for subtask in subtasks:
+        assert subtask.objective
+        assert subtask.input_context
+        assert subtask.expected_output
+        assert subtask.acceptance_criteria
+        assert subtask.risk_level in {"low", "medium", "high"}
+
+
+def test_router_prefers_keyword_rules_for_tests():
+    config = WorkflowConfig.load()
+    analysis = TaskAnalyzer().analyze("Build a Python CLI")
+    subtask = Subtask(
+        id="wf-test",
+        objective="Add focused tests and an example run",
+        input_context="",
+        expected_output="Verification steps",
+        acceptance_criteria=["Includes tests"],
+        risk_level="medium",
+    )
+
+    assert Router(config).assign(subtask, analysis) == "tester"
+
+
+def test_dry_run_workflow_writes_jsonl_log(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    result = run_workflow(
+        "Build a Python workflow CLI with config, prompts, docs, and tests.",
+        dry_run=True,
+        max_subtasks=4,
+    )
+
+    assert "What was done" in result.final_response
+    assert result.analysis.task_type == "code"
+    assert len(result.worker_outputs) <= 4
+    assert result.log_path == hermes_home / "logs" / "workflow_runs.jsonl"
+    assert result.log_path.exists()
+
+    records = [
+        json.loads(line)
+        for line in result.log_path.read_text(encoding="utf-8").splitlines()
+    ]
+    events = {record["event"] for record in records}
+    assert {"request", "analysis", "worker_selected", "worker_result", "evaluation", "final"} <= events
+    assert any("evaluator_score" in record for record in records)
+
+
+def test_workflow_parser_accepts_run_task():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    workflow_parser = add_parser(subparsers)
+    workflow_parser.set_defaults(func=lambda args: 0)
+
+    args = parser.parse_args(["workflow", "run", "--dry-run", "ship", "it"])
+
+    assert args.command == "workflow"
+    assert args.workflow_command == "run"
+    assert args.dry_run is True
+    assert args.task == ["ship", "it"]

--- a/tests/hermes_cli/test_workflow.py
+++ b/tests/hermes_cli/test_workflow.py
@@ -272,6 +272,7 @@ def test_workflow_parser_accepts_contest_flags():
             "--dry-run",
             "--contest",
             "--cross-review",
+            "--no-progress",
             "choose",
             "best",
         ]
@@ -280,3 +281,4 @@ def test_workflow_parser_accepts_contest_flags():
     assert args.workflow_command == "run"
     assert args.contest is True
     assert args.cross_review is True
+    assert args.no_progress is True

--- a/tests/hermes_cli/test_workflow.py
+++ b/tests/hermes_cli/test_workflow.py
@@ -116,6 +116,8 @@ def test_config_loads_runtime_agent_fields():
     assert config.background_enabled is True
     assert config.allow_background_execution is True
     assert config.max_concurrency >= 1
+    assert config.contest_candidates >= 2
+    assert "reviewer" in config.cross_review_workers
     assert config.default_permission_mode == "read-only"
     assert config.agent_for("coder").description
     assert config.agent_for("coder").can_write_files is False
@@ -223,3 +225,58 @@ def test_workflow_parser_accepts_new_commands():
     args = parser.parse_args(["workflow", "script", "--dry-run", "flow.py"])
     assert args.workflow_command == "script"
     assert args.path == "flow.py"
+
+
+def test_contest_cross_review_selects_winner_and_logs_events(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    result = run_workflow(
+        "Choose the best plan for a multi-role login rollout.",
+        dry_run=True,
+        contest=True,
+        cross_review=True,
+        codex_plan=True,
+        max_subtasks=2,
+    )
+
+    assert result.status == "completed"
+    assert result.contest is True
+    assert result.cross_review is True
+    assert "Codex Goal Plan" in result.final_response
+    assert all("contest_winner" in item.worker_type for item in result.worker_outputs)
+    assert all("Contest harness" in item.output for item in result.worker_outputs)
+
+    store = RunStore(result.state_path)
+    record = store.get_run(result.run_id)
+    assert record is not None
+    assert record["contest"] == 1
+    assert record["cross_review"] == 1
+    assert "contest" in record["mode"]
+    events = [event["event"] for event in store.events(result.run_id)]
+    assert "contest_candidate" in events
+    assert "cross_review_result" in events
+    assert "contest_selected" in events
+
+
+def test_workflow_parser_accepts_contest_flags():
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    workflow_parser = add_parser(subparsers)
+    workflow_parser.set_defaults(func=lambda args: 0)
+
+    args = parser.parse_args(
+        [
+            "workflow",
+            "run",
+            "--dry-run",
+            "--contest",
+            "--cross-review",
+            "choose",
+            "best",
+        ]
+    )
+
+    assert args.workflow_command == "run"
+    assert args.contest is True
+    assert args.cross_review is True


### PR DESCRIPTION
## Summary
- Add a local Dynamic Workflow runtime with SQLite state, parallel/background execution hooks, script API, and Codex plan output
- Add contest and cross-review harness for multi-worker candidate selection
- Improve foreground progress handling and cancellation state for long model-backed runs

## Tests
- uv run --extra dev pytest tests/hermes_cli/test_workflow.py -q
- uv run --extra dev ruff check hermes_cli/workflow tests/hermes_cli/test_workflow.py
- uv run --extra dev python -m compileall -q hermes_cli/workflow

## Notes
- Normal Hermes behavior remains unchanged unless hermes workflow is invoked
- Background, parallel, contest, and cross-review modes require explicit CLI flags