### PR TITLE
fix: guard flock(LOCK_UN) against OSError in kanban_db and google_oauth

### DIFF
--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -227,7 +227,7 @@ def _credentials_lock(timeout_seconds: float = LOCK_TIMEOUT_SECONDS):
                     import fcntl
 
                     fcntl.flock(fd, fcntl.LOCK_UN)
-                except ImportError:
+                except (ImportError, OSError):
                     try:
                         import msvcrt  # type: ignore[import-not-found]
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1072,7 +1072,10 @@ def _cross_process_init_lock(path: Path):
             else:
                 import fcntl
 
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
         finally:
             handle.close()
 


### PR DESCRIPTION
## Problem

Two files had unguarded `fcntl.flock(LOCK_UN)` calls in `finally` blocks that could raise `OSError` and propagate as unhandled exceptions.

- **`hermes_cli/kanban_db.py:1075`**: `flock(LOCK_UN)` in `finally` block without `try/except` — if unlock fails, the exception propagates even though `handle.close()` still runs in the outer `finally`.
- **`agent/google_oauth.py:229`**: `flock(LOCK_UN)` inside `try/except ImportError` (for msvcrt fallback) but `OSError` was not caught. The msvcrt path already had proper `OSError` guarding, but the fcntl path did not.

## Fix

- `kanban_db.py`: Wrap `flock(LOCK_UN)` in `try/except OSError: pass`
- `google_oauth.py`: Change `except ImportError` to `except (ImportError, OSError)` so both import failures and lock failures are handled

## Before vs After

| File | Before | After |
|------|--------|-------|
| `kanban_db.py` | `flock(UN)` bare in finally | Wrapped in `try/except OSError` |
| `google_oauth.py` | `except ImportError` only | `except (ImportError, OSError)` |

## Pattern Consistency

Both fixes follow the existing pattern already used in:
- `tools/skill_usage.py:91` — `except (OSError, IOError): pass`
- `tools/memory_tool.py:234` — `except (OSError, IOError): pass`
- `hermes_cli/auth.py:1012` — `except (OSError, IOError): pass`
- `cron/scheduler.py:2027` — `except Exception: pass`
- `gateway/status.py:416` — `except OSError: pass`

The two files in this PR were the remaining unguarded sites across the codebase.
