### PR TITLE
[codex] fix(gateway): default webhook listener to loopback

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -78,25 +78,7 @@ _BUILTIN_DELIVER_PLATFORMS = {
     "qqbot", "yuanbao",
 }
 
-# Default bind host. ``None`` tells aiohttp/asyncio's ``create_server`` to bind
-# BOTH address families (IPv4 + IPv6) — the portable dual-stack default.
-#
-# Why not "0.0.0.0" (the old default) or "::"?
-#   - "0.0.0.0" binds IPv4 ONLY. On IPv6-only private networks — notably Fly.io
-#     6PN, where an agent's ``<app>.internal`` name resolves to an ``fdaa:…``
-#     IPv6 address — an IPv4-only listener is unreachable. That is exactly why
-#     hosted-agent webhook routes were publicly unreachable: the edge router
-#     reverse-proxies to ``<app>.internal:8644`` over 6PN (IPv6) but the adapter
-#     was listening on 0.0.0.0 (v4 only) → connection refused.
-#   - "::" is NOT a safe fix: on hosts where the kernel sets IPV6_V6ONLY=1
-#     (verified on Fly machines), binding "::" yields an IPv6-ONLY socket, which
-#     then breaks the IPv4 loopback health check (``curl 127.0.0.1:8644/health``)
-#     and the AF_INET port-conflict probe in connect().
-#   - ``None`` asks the event loop to create a listening socket per resolved
-#     family, so both 127.0.0.1 (v4) and the 6PN fdaa (v6) are served regardless
-#     of the bindv6only sysctl. Users can still pin a specific host via
-#     ``platforms.webhook.extra.host``.
-DEFAULT_HOST = None
+DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8644
 _INSECURE_NO_AUTH = "INSECURE_NO_AUTH"
 _DYNAMIC_ROUTES_FILENAME = "webhook_subscriptions.json"

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1906,9 +1906,11 @@ def _setup_webhooks():
             return
 
     print()
-    print_warning("⚠  Webhook and SMS platforms require exposing gateway ports to the")
-    print_warning("   internet. For security, run the gateway in a sandboxed environment")
-    print_warning("   (Docker, VM, etc.) to limit blast radius from prompt injection.")
+    print_warning("⚠  Webhook and SMS platforms receive requests from external services.")
+    print_warning("   Keep the default loopback bind and use a tunnel or reverse proxy,")
+    print_warning("   or explicitly bind to 0.0.0.0 when exposing a gateway port.")
+    print_warning("   Run the gateway in a sandboxed environment (Docker, VM, etc.) to")
+    print_warning("   limit blast radius from prompt injection.")
     print()
     print_info("   Full guide: https://hermes-agent.nousresearch.com/docs/user-guide/messaging/webhooks/")
     print()
@@ -1933,7 +1935,10 @@ def _setup_webhooks():
     print_success("Webhooks enabled! Next steps:")
     from hermes_constants import display_hermes_home as _dhh
     print_info(f"   1. Define webhook routes in {_dhh()}/config.yaml")
-    print_info("   2. Point your service (GitHub, GitLab, etc.) at:")
+    print_info("   2. Expose the listener with a TLS-terminating tunnel or reverse")
+    print_info("      proxy, then point your service at:")
+    print_info("      https://your-public-url/webhooks/<route-name>")
+    print_info("      A direct 0.0.0.0 bind instead serves plain HTTP at:")
     print_info("      http://your-server:8644/webhooks/<route-name>")
     print()
     print_info("   Route configuration guide:")

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -96,7 +96,7 @@ def _is_webhook_enabled() -> bool:
 
 def _get_webhook_base_url() -> str:
     wh = _get_webhook_config().get("extra", {})
-    host = wh.get("host")
+    host = wh.get("host", "127.0.0.1")
     port = wh.get("port", 8644)
     display_host = "localhost" if not host or host in {"0.0.0.0", "::"} else host
     if ":" in display_host and not display_host.startswith("["):
@@ -117,6 +117,7 @@ def _setup_hint() -> str:
        webhook:
          enabled: true
          extra:
+           host: "127.0.0.1"
            port: 8644
            secret: "your-global-hmac-secret"
 

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -662,7 +662,7 @@ class TestBlueBubblesWebhookUrl:
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
+        # Default loopback webhook_host is normalized to localhost.
         assert "localhost" in adapter._webhook_url
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -31,6 +31,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import SendResult
 from gateway.platforms.webhook import (
+    DEFAULT_HOST,
     WebhookAdapter,
     _INSECURE_NO_AUTH,
     check_webhook_requirements,
@@ -46,17 +47,18 @@ def _make_config(
     secret="",
     rate_limit=30,
     max_body_bytes=1_048_576,
-    host="0.0.0.0",
+    host=None,
     port=0,  # let OS pick a free port in tests
 ):
     """Build a PlatformConfig suitable for WebhookAdapter."""
     extra = {
-        "host": host,
         "port": port,
         "routes": routes or {},
         "rate_limit": rate_limit,
         "max_body_bytes": max_body_bytes,
     }
+    if host is not None:
+        extra["host"] = host
     if secret:
         extra["secret"] = secret
     return PlatformConfig(enabled=True, extra=extra)
@@ -993,6 +995,17 @@ class TestHTTPHandling:
             assert data["status"] == "ok"
             assert data["platform"] == "webhook"
 
+    def test_default_host_is_loopback(self):
+        """The webhook adapter defaults to a local-only bind."""
+        adapter = _make_adapter()
+        assert DEFAULT_HOST == "127.0.0.1"
+        assert adapter._host == "127.0.0.1"
+
+    def test_explicit_public_host_is_preserved(self):
+        """Operators can still opt into a public bind explicitly."""
+        adapter = _make_adapter(host="0.0.0.0")
+        assert adapter._host == "0.0.0.0"
+
     @pytest.mark.asyncio
     async def test_connect_starts_server(self):
         """connect() starts the HTTP listener and marks adapter as connected."""
@@ -1574,60 +1587,37 @@ class TestInsecureNoAuthSafetyRail:
             await adapter.disconnect()
 
 
-class TestDualStackBind:
-    """The default bind host must serve BOTH IPv4 and IPv6.
+class TestLoopbackDefaultBind:
+    """The default bind stays local unless an operator configures exposure."""
 
-    Regression guard for the hosted-agent webhook reachability bug: Fly.io 6PN
-    (the private network the edge router reverse-proxies webhook traffic over)
-    is IPv6-only — an agent's ``<app>.internal`` name resolves to an ``fdaa:…``
-    address. The adapter used to default to ``host="0.0.0.0"`` (IPv4 only), so
-    the router's dial to ``<app>.internal:8644`` hit an address nothing was
-    listening on → connection refused → public webhooks unreachable.
-
-    The fix is ``DEFAULT_HOST = None`` (dual-stack). ``"::"`` is NOT a valid
-    substitute: on hosts with the ``bindv6only`` sysctl set (verified on Fly
-    machines) it yields an IPv6-ONLY socket, which would then break the IPv4
-    loopback health check and the AF_INET port-conflict probe.
-    """
-
-    def test_default_host_is_none_for_dual_stack(self):
-        """The module default is None (bind all families), not 0.0.0.0/::."""
+    def test_default_host_is_ipv4_loopback(self):
+        """The module default is the explicit IPv4 loopback address."""
         from gateway.platforms.webhook import DEFAULT_HOST
-        assert DEFAULT_HOST is None
 
-    def test_missing_host_key_resolves_to_none(self):
-        """Config with no host key → dual-stack (None), not a literal string."""
+        assert DEFAULT_HOST == "127.0.0.1"
+
+    def test_missing_host_key_resolves_to_loopback(self):
+        """Config without a host key uses the local-only default."""
         cfg = PlatformConfig(enabled=True, extra={"port": 0, "routes": {}})
         adapter = WebhookAdapter(cfg)
-        assert adapter._host is None
 
-    @pytest.mark.parametrize("empty", ["", None])
-    def test_empty_host_normalises_to_none(self, empty):
-        """An explicit empty-string/null host means dual-stack, not host=''.
-
-        Guards the old footgun where host='' was passed straight to TCPSite
-        AND treated as non-loopback — now it collapses to the None default.
-        """
-        adapter = _make_adapter(host=empty, port=0)
-        assert adapter._host is None
-
-    def test_pinned_host_is_preserved(self):
-        """A user can still pin a specific bind host via config.extra.host."""
-        adapter = _make_adapter(host="127.0.0.1", port=0)
         assert adapter._host == "127.0.0.1"
 
-    @pytest.mark.asyncio
-    async def test_default_bind_serves_both_families(self):
-        """Binding the real server with the default host opens v4 AND v6 sockets.
+    def test_empty_host_normalises_to_none(self):
+        """An explicit empty host retains the dual-stack escape hatch."""
+        adapter = _make_adapter(host="", port=0)
 
-        This is the behavioural proof: with host=None, asyncio.create_server
-        opens a listening socket per resolved family, so both 127.0.0.1 (v4)
-        and ::1 (v6) are reachable — exactly what 6PN needs. Uses a real bind
-        on an OS-assigned port (no mock) and inspects the runner's addresses.
-        """
-        # Build config WITHOUT a host key so the real DEFAULT_HOST (None)
-        # applies — _make_adapter's helper injects host="0.0.0.0" by default,
-        # which would mask the dual-stack default under test here.
+        assert adapter._host is None
+
+    def test_pinned_public_host_is_preserved(self):
+        """Operators can still opt into a wildcard public bind."""
+        adapter = _make_adapter(host="0.0.0.0", port=0)
+
+        assert adapter._host == "0.0.0.0"
+
+    @pytest.mark.asyncio
+    async def test_default_bind_serves_only_ipv4_loopback(self):
+        """The real default server binds one IPv4 loopback socket."""
         cfg = PlatformConfig(
             enabled=True,
             extra={
@@ -1636,29 +1626,21 @@ class TestDualStackBind:
             },
         )
         adapter = WebhookAdapter(cfg)
-        assert adapter._host is None
+        assert adapter._host == "127.0.0.1"
         try:
             with patch.object(adapter, "_reload_dynamic_routes"):
                 result = await adapter.connect()
             assert result is True
-            # runner.addresses lists one bound address per listening socket.
-            # An IPv6 sockaddr is a 4-tuple (host, port, flowinfo, scopeid);
-            # an IPv4 sockaddr is a 2-tuple (host, port). With the dual-stack
-            # default we expect BOTH — that is precisely what makes the adapter
-            # reachable over 6PN (v6) AND on the loopback health check (v4).
             addrs = list(adapter._runner.addresses)  # type: ignore[union-attr]
-            has_v6 = any(len(a) == 4 for a in addrs)
-            has_v4 = any(len(a) == 2 for a in addrs)
-            assert has_v4, f"IPv4 bind missing — got {addrs}"
-            assert has_v6, (
-                f"IPv6 bind missing (the 6PN reachability bug) — got {addrs}"
-            )
+            assert addrs
+            assert all(len(address) == 2 for address in addrs)
+            assert {address[0] for address in addrs} == {"127.0.0.1"}
         finally:
             await adapter.disconnect()
 
     @pytest.mark.asyncio
-    async def test_default_bind_rejects_existing_ipv6_listener(self):
-        """A specific IPv6 listener must block the wildcard dual-stack bind."""
+    async def test_default_bind_ignores_existing_ipv6_listener(self):
+        """An IPv6 listener does not conflict with the IPv4-only default."""
         blocker = await asyncio.start_server(
             lambda _reader, _writer: None,
             host="::1",
@@ -1680,9 +1662,9 @@ class TestDualStackBind:
         try:
             with patch.object(adapter, "_reload_dynamic_routes"):
                 result = await adapter.connect()
-            assert result is False
-            assert adapter._runner is None
-            assert adapter.is_connected is False
+            assert result is True
+            assert adapter._runner is not None
+            assert adapter.is_connected is True
         finally:
             await adapter.disconnect()
             blocker.close()

--- a/tests/hermes_cli/test_webhook.py
+++ b/tests/hermes_cli/test_webhook.py
@@ -1,0 +1,18 @@
+"""Regression tests for loopback-safe webhook CLI guidance."""
+
+from unittest.mock import patch
+
+import hermes_cli.webhook as webhook
+
+
+def test_base_url_defaults_to_loopback():
+    with patch.object(webhook, "_get_webhook_config", return_value={"extra": {}}):
+        assert webhook._get_webhook_base_url() == "http://127.0.0.1:8644"
+
+
+def test_setup_hint_scaffolds_loopback_bind():
+    with patch.object(webhook, "display_hermes_home", return_value="/tmp/hermes"):
+        hint = webhook._setup_hint()
+
+    assert 'host: "127.0.0.1"' in hint
+    assert 'host: "0.0.0.0"' not in hint

--- a/website/docs/guides/webhook-github-pr-review.md
+++ b/website/docs/guides/webhook-github-pr-review.md
@@ -76,6 +76,10 @@ platforms:
             pr_number: "{number}"
 ```
 
+The webhook listener binds to `127.0.0.1` by default. This works with local
+tunnels such as ngrok or cloudflared. If you intentionally expose the gateway
+directly on a network interface, set `extra.host: "0.0.0.0"` explicitly.
+
 **Key fields:**
 
 | Field | Description |
@@ -102,7 +106,7 @@ hermes gateway
 You should see:
 
 ```
-[webhook] Listening on 0.0.0.0:8644 — routes: github-pr-review
+[webhook] Listening on 127.0.0.1:8644 — routes: github-pr-review
 ```
 
 Verify it's running:
@@ -311,6 +315,7 @@ platforms:
   webhook:
     enabled: true
     extra:
+      host: "127.0.0.1"       # bind address (default: 127.0.0.1)
       port: 8644               # listen port (default: 8644)
       secret: ""               # optional global fallback secret
       rate_limit: 30           # requests per minute per route

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -54,6 +54,10 @@ WEBHOOK_PORT=8644        # default
 WEBHOOK_SECRET=your-global-secret
 ```
 
+The webhook adapter binds to `127.0.0.1` by default. Set
+`platforms.webhook.extra.host: "0.0.0.0"` only when you intentionally expose it
+through a public interface and have route secrets configured.
+
 ### Verify the server
 
 Once the gateway is running:
@@ -95,6 +99,7 @@ platforms:
   webhook:
     enabled: true
     extra:
+      host: "127.0.0.1"
       port: 8644
       secret: "global-fallback-secret"
       routes:

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/webhook-github-pr-review.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/webhook-github-pr-review.md
@@ -76,6 +76,10 @@ platforms:
             pr_number: "{number}"
 ```
 
+webhook 监听器默认绑定到 `127.0.0.1`。这适用于 ngrok 或 cloudflared
+等本地隧道。如果你有意直接在网络接口上暴露 gateway，请显式设置
+`extra.host: "0.0.0.0"`。
+
 **关键字段：**
 
 | 字段 | 说明 |
@@ -102,7 +106,7 @@ hermes gateway
 你应该看到：
 
 ```
-[webhook] Listening on 0.0.0.0:8644 — routes: github-pr-review
+[webhook] Listening on 127.0.0.1:8644 — routes: github-pr-review
 ```
 
 验证其是否正在运行：
@@ -303,7 +307,7 @@ platforms:
   webhook:
     enabled: true
     extra:
-      host: "0.0.0.0"         # 绑定地址（默认：0.0.0.0）
+      host: "127.0.0.1"       # 绑定地址（默认：127.0.0.1）
       port: 8644               # 监听端口（默认：8644）
       secret: ""               # 可选的全局回退 secret
       rate_limit: 30           # 每条路由每分钟请求数


### PR DESCRIPTION
## Summary

- Default the generic Webhook gateway listener to `127.0.0.1`.
- Keep explicit public binds available through `platforms.webhook.extra.host: "0.0.0.0"`.
- Align CLI discovery, setup guidance, regression tests, and translated Webhook documentation with the loopback default.

## Why

The Webhook adapter otherwise accepts an externally reachable bind when the platform is enabled. A loopback default makes direct network exposure an explicit deployment choice while still supporting tunnels, proxies, and intentionally public listeners.

## Maintainer History

The earlier rejected PR #4267 changed both the SMS and generic Webhook adapters to default to `127.0.0.1`. Teknium closed it because inbound receivers need external reachability unless users run a tunnel or reverse proxy.

Later history moved in both directions: #19745 merged the loopback default for SMS, while #63711 made the generic Webhook default dual-stack for hosted IPv4/IPv6 reachability. This PR keeps the generic loopback proposal explicit for maintainer decision, preserves an opt-in public bind, and aligns its supporting CLI, tests, and Webhook guides. The separate translated SMS documentation correction is now in #67950.

Fixes #4260.

## Validation

- `/home/mac/hermes/hermes-agent/.venv/bin/python -m pytest -q tests/hermes_cli/test_webhook.py tests/gateway/test_webhook_adapter.py tests/gateway/test_bluebubbles.py` (`158 passed`)
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Agent Disclosure

- Created by: GPT-5 in Codex
- Human directed the restored two-commit scope and manually signed both commits before publication.
