### PR TITLE
fix(gateway): guard kanban board_dir before connect() to prevent archived board resurrection

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4949,6 +4949,11 @@ class GatewayRunner:
                             )
                             continue
                         seen_db_paths.add(resolved_db_path)
+                        # If the board directory was archived since
+                        # list_boards(), skip it — connect() would
+                        # recreate it and resurrect the board.
+                        if not _kb.board_dir(slug).exists():
+                            continue
                         try:
                             conn = _kb.connect(board=slug)
                         except Exception as exc:
@@ -5593,6 +5598,11 @@ class GatewayRunner:
                         slug,
                     )
                 disabled_corrupt_boards.pop(slug, None)
+            # If the board directory no longer exists (e.g. it was archived
+            # since the last `list_boards` call), avoid `connect()` which
+            # would recreate the directory and resurrect the board.
+            if not _kb.board_dir(slug).exists():
+                return None
             try:
                 conn = _kb.connect(board=slug)
                 # `connect()` runs the schema + idempotent migration on
@@ -5683,6 +5693,8 @@ class GatewayRunner:
                 boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
             for b in boards:
                 slug = b.get("slug") or _kb.DEFAULT_BOARD
+                if not _kb.board_dir(slug).exists():
+                    continue
                 conn = None
                 try:
                     conn = _kb.connect(board=slug)


### PR DESCRIPTION
Closes #35211

## Problem

Archiving a kanban board from the dashboard (or via CLI `hermes kanban boards rm`) appears to not work — the board stays visible in the dashboard immediately after archiving.

## Root Cause

The gateway's kanban dispatcher (`_kanban_dispatcher_watcher`) and notifier (`_kanban_notifier_watcher`) work in a two-phase loop:
1. Enumerate boards via `list_boards(include_archived=False)`
2. Call `connect(board=slug)` on each

If a board is archived between step 1 and step 2, `connect()` — which does `mkdir(exist_ok=True)` on the board directory — **recreates an empty board directory**, resurrecting the archived board. From the user's perspective, the Archive action appears to do nothing.

## Fix

Add `board_dir(slug).exists()` guards in three places before calling `connect(board=slug)`:
- `_kanban_notifier_watcher` — board enumeration loop
- `_kanban_dispatcher_watcher._tick_once_for_board` — per-board dispatch
- `_kanban_dispatcher_watcher._ready_nonempty` — cheap probe for spawnable tasks

If the board directory no longer exists (it was archived since `list_boards()`), skip it instead of letting `connect()` resurrect it.

## Reproduction

1. Have a kanban board with active tasks
2. Run gateway with dispatcher enabled (`kanban.dispatch_in_gateway: true`)
3. Archive the board from dashboard or CLI
4. Within seconds, the board reappears in the board list

## Verification

- All existing kanban tests pass
- Manual verification: archived `project-dev-v2` and `token-harvest-20260528` boards, confirmed they stay gone after 13+ seconds with gateway dispatcher running