### PR TITLE
fix(honcho): respect saveMessages in sync_turn

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -1124,6 +1124,8 @@ class HonchoMemoryProvider(MemoryProvider):
         """
         if self._cron_skipped:
             return
+        if self._config is not None and not self._config.save_messages:
+            return
         if not self._manager or not self._session_key:
             return
 

--- a/tests/test_honcho_save_messages.py
+++ b/tests/test_honcho_save_messages.py
@@ -1,0 +1,65 @@
+"""Tests for Honcho saveMessages write behavior."""
+
+from types import SimpleNamespace
+
+from plugins.memory.honcho import HonchoMemoryProvider
+
+
+class _RecordingSession:
+    def __init__(self):
+        self.messages = []
+
+    def add_message(self, role, content):
+        self.messages.append((role, content))
+
+
+class _RecordingManager:
+    def __init__(self):
+        self.session = _RecordingSession()
+        self.get_or_create_calls = []
+        self.flush_calls = []
+
+    def get_or_create(self, session_key):
+        self.get_or_create_calls.append(session_key)
+        return self.session
+
+    def _flush_session(self, session):
+        self.flush_calls.append(session)
+
+
+def _provider_with_save_messages(save_messages):
+    provider = HonchoMemoryProvider()
+    provider._manager = _RecordingManager()
+    provider._session_key = "test-session"
+    provider._config = SimpleNamespace(
+        save_messages=save_messages,
+        message_max_chars=25000,
+    )
+    return provider
+
+
+def test_sync_turn_skips_honcho_message_persistence_when_save_messages_false():
+    provider = _provider_with_save_messages(False)
+
+    provider.sync_turn("user message", "assistant message", session_id="test-session")
+    if provider._sync_thread:
+        provider._sync_thread.join(timeout=1)
+
+    assert provider._manager.get_or_create_calls == []
+    assert provider._manager.session.messages == []
+    assert provider._manager.flush_calls == []
+
+
+def test_sync_turn_persists_honcho_messages_when_save_messages_true():
+    provider = _provider_with_save_messages(True)
+
+    provider.sync_turn("user message", "assistant message", session_id="test-session")
+    if provider._sync_thread:
+        provider._sync_thread.join(timeout=1)
+
+    assert provider._manager.get_or_create_calls == ["test-session"]
+    assert provider._manager.session.messages == [
+        ("user", "user message"),
+        ("assistant", "assistant message"),
+    ]
+    assert provider._manager.flush_calls == [provider._manager.session]


### PR DESCRIPTION
## Summary

- respect Honcho `saveMessages: false` in `HonchoMemoryProvider.sync_turn()`
- add regression tests for both disabled and enabled message persistence behavior
- preserve explicit memory/conclusion writes (`honcho_conclude`) while blocking raw turn persistence

## Why

`HonchoClientConfig` correctly parses `saveMessages` into `save_messages`, but `sync_turn()` did not check it before adding user/assistant messages and flushing them to Honcho. This meant users could configure tools-only / explicit-memory Honcho setups and still have full conversation turns persisted.

## Test Plan

```text
venv/bin/python -m pytest tests/test_honcho_save_messages.py -q
# 2 passed

venv/bin/python -m pytest tests/test_honcho_session_context.py tests/test_honcho_client_config.py -q
# 10 passed

venv/bin/python -m py_compile plugins/memory/honcho/__init__.py tests/test_honcho_save_messages.py
# passed
```

Live self-hosted Honcho validation with a `honcho-test` profile configured with `saveMessages: false`:

```text
messages_before: 0
messages_after_sync_turn: 0
auto_sync_leaked_count: 0
conclude_ok: true
search_contains_fact: true
context_contains_fact: true
```

Fixes #35209
