### PR TITLE
fix(kanban): count stale-claim reclaims toward circuit breaker

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2872,6 +2872,30 @@ def release_stale_claims(
                 run_id=run_id,
             )
             reclaimed += 1
+        # Increment the unified failure counter so the circuit breaker
+        # eventually fires for tasks that crash before their first
+        # heartbeat (inside the crash-grace window).  Without this,
+        # ``detect_crashed_workers`` skips them (grace-period guard) and
+        # the task respawns every dispatch interval with
+        # ``consecutive_failures`` stuck at 0.  The pattern mirrors
+        # ``enforce_max_runtime`` which also calls ``_record_task_failure``
+        # after flipping the task to ``ready``.  Only count reclaims on
+        # this host — cross-host reclaims indicate a stale lock from a
+        # dead dispatcher, not a worker crash.
+        if host_local:
+            _record_task_failure(
+                conn, row["id"],
+                error=f"stale claim reclaimed: {row['claim_lock']}",
+                outcome="reclaimed",
+                release_claim=False,
+                end_run=False,
+                event_payload_extra={
+                    "worker_pid": (
+                        int(row["worker_pid"])
+                        if row["worker_pid"] is not None else None
+                    ),
+                },
+            )
     return reclaimed
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -542,6 +542,51 @@ def test_stale_claim_reclaim_event_records_diagnostic_payload(
         assert payload["host_local"] is True
 
 
+def test_stale_claim_increments_failure_counter(kanban_home, monkeypatch):
+    """``release_stale_claims`` must increment ``consecutive_failures`` so
+    the circuit breaker eventually fires for tasks that crash before their
+    first heartbeat (inside the crash-grace window).  Without this, the
+    task respawns every dispatch interval with the counter stuck at 0.
+    """
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 12345)
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (int(time.time()) - 3600, t),
+        )
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+
+        # First reclaim — counter should go from 0 → 1.
+        reclaimed = kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None)
+        assert reclaimed == 1
+        task = kb.get_task(conn, t)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 1
+
+        # Simulate repeated crashes: re-claim, rewind expiry, reclaim again.
+        # After DEFAULT_FAILURE_LIMIT reclaims the task should auto-block.
+        limit = _kb.DEFAULT_FAILURE_LIMIT
+        for _ in range(limit - 1):
+            kb.claim_task(conn, t, claimer=f"{host}:worker")
+            kb._set_worker_pid(conn, t, 12345)
+            conn.execute(
+                "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+                (int(time.time()) - 3600, t),
+            )
+            kb.release_stale_claims(conn, signal_fn=lambda _p, _s: None)
+
+        task = kb.get_task(conn, t)
+        assert task.status == "blocked", (
+            f"Expected blocked after {limit} stale reclaims, got {task.status}"
+        )
+        assert task.consecutive_failures >= limit
+
+
 def test_detect_crashed_workers_systemic_failure_fast_block(
     kanban_home, monkeypatch,
 ):


### PR DESCRIPTION
## What does this PR do?

Fixes the kanban circuit breaker so that tasks crashing before their first heartbeat (inside the 30s crash-grace window) are counted toward `consecutive_failures` and eventually auto-blocked. Without this fix, such tasks respawn every dispatch interval indefinitely with the failure counter stuck at 0.

## Related Issue

Fixes #35202

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: Added `_record_task_failure()` call in `release_stale_claims()` after reclaiming a host-local task with a dead PID. This increments `consecutive_failures` so the circuit breaker fires after `failure_limit` consecutive stale-claim reclaims. Only applies to host-local reclaims (cross-host reclaims indicate a dead dispatcher, not a worker crash).
- `tests/hermes_cli/test_kanban_db.py`: Added `test_stale_claim_increments_failure_counter` — verifies that repeated stale-claim reclaims increment the failure counter and eventually auto-block the task.

## How to Test

1. Create a kanban task with an invalid skill name: `hermes kanban create --board test --body "test" --skills nonexistent-skill`
2. Set `kanban.failure_limit: 2` in config
3. Run `hermes kanban dispatch` (or let the daemon tick)
4. Observe: task should be auto-blocked after 2 stale-claim reclaims instead of respawning indefinitely
5. Run `pytest tests/hermes_cli/test_kanban_db.py::test_stale_claim_increments_failure_counter -xvs` to verify the regression test

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `release_stale_claims()` in `hermes_cli/kanban_db.py` (callers: `dispatch_once`, `run_daemon` tick; callees: `_record_task_failure`, `_terminate_reclaimed_worker`)
- Blast radius: LOW — single function, additive behavior (failure counter increment), gated on `host_local` check
- Related patterns: mirrors `enforce_max_runtime()` which also calls `_record_task_failure()` after flipping task to `ready`; mirrors `detect_crashed_workers()` circuit-breaker pattern
