### PR TITLE
fix(skills): follow symlinks during skill discovery (#35184)

### DIFF
--- a/tests/tools/test_skill_symlink_discovery.py
+++ b/tests/tools/test_skill_symlink_discovery.py
@@ -1,0 +1,58 @@
+"""Regression test: skill discovery follows symlinked category directories (#35184)."""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.skill_manager_tool import _find_skill
+
+
+def test_find_skill_follows_symlinks():
+    """#35184: _find_skill should discover skills under symlinked
+    category directories, not just direct subdirectories.
+
+    pathlib.Path.rglob() does not follow symlinks into directories,
+    so skills in symlinked categories were invisible.  The fix uses
+    iter_skill_index_files() which calls os.walk(followlinks=True).
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        # Create a real skills dir
+        skills_dir = Path(tmp) / "skills"
+        skills_dir.mkdir()
+
+        # Create a skill in a real subdirectory
+        real_cat = skills_dir / "real-cat"
+        real_cat.mkdir()
+        skill_dir = real_cat / "my-symlinked-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("# My Skill")
+
+        # Create a skill in an external location
+        alt_location = Path(tmp) / "alt-skills"
+        alt_location.mkdir()
+        symlinked_cat = alt_location / "symlinked-cat"
+        symlinked_cat.mkdir()
+        symlinked_skill = symlinked_cat / "my-symlinked-skill-2"
+        symlinked_skill.mkdir()
+        (symlinked_skill / "SKILL.md").write_text("# Symlinked Skill")
+
+        # Symlink the external category into skills dir
+        symlink = skills_dir / "linked-cat"
+        os.symlink(symlinked_cat, symlink, target_is_directory=True)
+
+        with patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills_dir]):
+            # Direct (non-symlinked) skill — always worked
+            result1 = _find_skill("my-symlinked-skill")
+            assert result1 is not None, "Direct skill should be found"
+            assert result1["path"] == skill_dir
+
+            # Symlinked skill — was broken with rglob, fixed with iter_skill_index_files
+            result2 = _find_skill("my-symlinked-skill-2")
+            assert result2 is not None, (
+                "Skill under symlinked category should be found "
+                "(regression: rglob does not follow symlinks)"
+            )
+            assert result2["path"].resolve() == symlinked_skill.resolve(), (
+                f"Expected {symlinked_skill.resolve()}, got {result2['path'].resolve()}"
+            )

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -283,13 +283,11 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+    from agent.skill_utils import get_all_skills_dirs, iter_skill_index_files
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
-            if is_excluded_skill_path(skill_md):
-                continue
+        for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
             if skill_md.parent.name == name:
                 return {"path": skill_md.parent}
     return None
@@ -307,7 +305,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
     matches: List[Tuple[str, Path]] = []
     try:
         from hermes_constants import get_default_hermes_root
-        from agent.skill_utils import is_excluded_skill_path
+        from agent.skill_utils import iter_skill_index_files
     except Exception:
         return matches
 
@@ -350,9 +348,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
         if not skills_dir.is_dir():
             continue
         try:
-            for skill_md in skills_dir.rglob("SKILL.md"):
-                if is_excluded_skill_path(skill_md):
-                    continue
+            for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
                 if skill_md.parent.name == name:
                     matches.append((profile_name, skill_md.parent))
                     break  # one match per profile is enough


### PR DESCRIPTION
## What does this PR do?

Skill discovery (`_find_skill` in `tools/skill_manager_tool.py`) uses
`Path.rglob()` which does not follow symlinks into directories. Skills
stored under symlinked category directories were invisible to the agent.

**Fix:** Replace `Path.rglob()` with `os.walk(followlinks=True)` via the
existing `iter_skill_index_files()` helper in the same module.

## Related Issue

Fixes #35184

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_manager_tool.py`: Replace `Path.rglob()` call with
  `iter_skill_index_files()` (which uses `os.walk(followlinks=True)`)
  for symlink-aware directory traversal.
- `tests/tools/test_skill_symlink_discovery.py`: **New** — regression
  test that creates a symlinked category directory and verifies skills
  under it are discovered.

## How to Test

1. Run `python3 -m pytest tests/tools/test_skill_symlink_discovery.py -v`
2. Verify skills in symlinked directories are found

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)