### PR TITLE
fix(tui): preserve UTF-8 in PowerShell clipboard writes (CJK/emoji)

### DIFF
--- a/ui-tui/src/__tests__/clipboard.test.ts
+++ b/ui-tui/src/__tests__/clipboard.test.ts
@@ -269,7 +269,14 @@ describe('writeClipboardText', () => {
       expect.arrayContaining(['-NoProfile', '-NonInteractive']),
       expect.anything()
     )
-    expect(stdin.end).toHaveBeenCalledWith('wsl text')
+    // PowerShell uses base64-encoded UTF-8 via command argument, not stdin
+    expect(stdin.end).not.toHaveBeenCalled()
+    const calledArgs = start.mock.calls[0][1] as string[]
+    const commandIdx = calledArgs.indexOf('-Command')
+    expect(commandIdx).toBeGreaterThan(-1)
+    const script = calledArgs[commandIdx + 1]
+    expect(script).toContain('FromBase64String')
+    expect(script).toContain(Buffer.from('wsl text', 'utf8').toString('base64'))
   })
 
   it('prefers the Windows clipboard path over wl-copy inside WSLg', async () => {
@@ -300,7 +307,13 @@ describe('writeClipboardText', () => {
       expect.arrayContaining(['-NoProfile', '-NonInteractive']),
       expect.anything()
     )
-    expect(stdin.end).toHaveBeenCalledWith('wslg text')
+    // PowerShell uses base64-encoded UTF-8 via command argument, not stdin
+    expect(stdin.end).not.toHaveBeenCalled()
+    const calledArgs = start.mock.calls[0][1] as string[]
+    const commandIdx = calledArgs.indexOf('-Command')
+    const script = calledArgs[commandIdx + 1]
+    expect(script).toContain('FromBase64String')
+    expect(script).toContain(Buffer.from('wslg text', 'utf8').toString('base64'))
   })
 
   it('uses PowerShell on Windows', async () => {
@@ -325,5 +338,32 @@ describe('writeClipboardText', () => {
       expect.arrayContaining(['-NoProfile', '-NonInteractive']),
       expect.anything()
     )
+    // PowerShell uses base64-encoded UTF-8 via command argument, not stdin
+    expect(stdin.end).not.toHaveBeenCalled()
+  })
+
+  it('preserves CJK text via base64 encoding in PowerShell on WSL', async () => {
+    const stdin = { end: vi.fn() }
+
+    const child = {
+      once: vi.fn((event: string, cb: (code?: number) => void) => {
+        if (event === 'close') {
+          cb(0)
+        }
+
+        return child
+      }),
+      stdin
+    }
+
+    const start = vi.fn().mockReturnValue(child)
+    const cjkText = '你好世界，测试中文 🎉'
+
+    await expect(writeClipboardText(cjkText, 'linux', start as any, { WSL_INTEROP: '/tmp/socket' })).resolves.toBe(true)
+    const calledArgs = start.mock.calls[0][1] as string[]
+    const commandIdx = calledArgs.indexOf('-Command')
+    const script = calledArgs[commandIdx + 1]
+    expect(script).toContain(Buffer.from(cjkText, 'utf8').toString('base64'))
+    expect(script).toContain('UTF8.GetString')
   })
 })

--- a/ui-tui/src/lib/clipboard.ts
+++ b/ui-tui/src/lib/clipboard.ts
@@ -91,33 +91,44 @@ export async function readClipboardText(
   return null
 }
 
+type WriteCmd = { args: readonly string[]; cmd: string } & (
+  | { stdin: true }
+  | { stdin: false; psScript: (b64: string) => string }
+)
+
+function _powershellWriteScript(b64: string): string {
+  return `Set-Clipboard -Value ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('${b64}')))`
+}
+
 function writeClipboardCommands(
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv
-): Array<{ args: readonly string[]; cmd: string }> {
+): WriteCmd[] {
   if (platform === 'darwin') {
-    return [{ cmd: 'pbcopy', args: [] }]
+    return [{ cmd: 'pbcopy', args: [], stdin: true }]
   }
 
   if (platform === 'win32') {
-    return [{ cmd: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', 'Set-Clipboard -Value $input'] }]
+    return [{ cmd: 'powershell', args: ['-NoProfile', '-NonInteractive'], stdin: false, psScript: _powershellWriteScript }]
   }
 
-  const attempts: Array<{ args: readonly string[]; cmd: string }> = []
+  const attempts: WriteCmd[] = []
 
   if (env.WSL_INTEROP || env.WSL_DISTRO_NAME) {
     attempts.push({
       cmd: 'powershell.exe',
-      args: ['-NoProfile', '-NonInteractive', '-Command', 'Set-Clipboard -Value $input']
+      args: ['-NoProfile', '-NonInteractive'],
+      stdin: false,
+      psScript: _powershellWriteScript
     })
   }
 
   if (env.WAYLAND_DISPLAY) {
-    attempts.push({ cmd: 'wl-copy', args: ['--type', 'text/plain'] })
+    attempts.push({ cmd: 'wl-copy', args: ['--type', 'text/plain'], stdin: true })
   }
 
-  attempts.push({ cmd: 'xclip', args: ['-selection', 'clipboard', '-in'] })
-  attempts.push({ cmd: 'xsel', args: ['--clipboard', '--input'] })
+  attempts.push({ cmd: 'xclip', args: ['-selection', 'clipboard', '-in'], stdin: true })
+  attempts.push({ cmd: 'xsel', args: ['--clipboard', '--input'], stdin: true })
 
   return attempts
 }
@@ -144,14 +155,21 @@ export async function writeClipboardText(
 ): Promise<boolean> {
   const candidates = writeClipboardCommands(platform, env)
 
-  for (const { cmd, args } of candidates) {
+  for (const cmdEntry of candidates) {
     try {
       const ok = await new Promise<boolean>(resolve => {
-        const child = start(cmd, [...args], { stdio: ['pipe', 'ignore', 'ignore'], windowsHide: true })
-
-        child.once('error', () => resolve(false))
-        child.once('close', code => resolve(code === 0))
-        child.stdin?.end(text)
+        if (cmdEntry.stdin) {
+          const child = start(cmdEntry.cmd, [...cmdEntry.args], { stdio: ['pipe', 'ignore', 'ignore'], windowsHide: true })
+          child.once('error', () => resolve(false))
+          child.once('close', (code: number | null) => resolve(code === 0))
+          child.stdin?.end(text)
+        } else {
+          const b64 = Buffer.from(text, 'utf8').toString('base64')
+          const script = cmdEntry.psScript(b64)
+          const child = start(cmdEntry.cmd, [...cmdEntry.args, '-Command', script], { stdio: ['ignore', 'ignore', 'ignore'], windowsHide: true })
+          child.once('error', () => resolve(false))
+          child.once('close', (code: number | null) => resolve(code === 0))
+        }
       })
 
       if (ok) {

--- a/ui-tui/src/lib/clipboard.ts
+++ b/ui-tui/src/lib/clipboard.ts
@@ -91,10 +91,13 @@ export async function readClipboardText(
   return null
 }
 
-type WriteCmd = { args: readonly string[]; cmd: string } & (
-  | { stdin: true }
-  | { stdin: false; psScript: (b64: string) => string }
-)
+// PowerShell on Windows/WSL decodes piped stdin with the system ANSI code
+// page (e.g. CP936), not UTF-8, so $input-based writes mangle CJK/emoji. We
+// instead base64-encode the UTF-8 bytes and pass them as a -Command argument,
+// decoding with UTF8.GetString — this removes the stdin-encoding variable
+// entirely (also immune to BOM injection on redirect). PowerShell entries set
+// stdin=false; every other backend reads UTF-8 stdin natively.
+type WriteCmd = { args: readonly string[]; cmd: string; stdin: boolean }
 
 function _powershellWriteScript(b64: string): string {
   return `Set-Clipboard -Value ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String('${b64}')))`
@@ -109,18 +112,13 @@ function writeClipboardCommands(
   }
 
   if (platform === 'win32') {
-    return [{ cmd: 'powershell', args: ['-NoProfile', '-NonInteractive'], stdin: false, psScript: _powershellWriteScript }]
+    return [{ cmd: 'powershell', args: ['-NoProfile', '-NonInteractive'], stdin: false }]
   }
 
   const attempts: WriteCmd[] = []
 
   if (env.WSL_INTEROP || env.WSL_DISTRO_NAME) {
-    attempts.push({
-      cmd: 'powershell.exe',
-      args: ['-NoProfile', '-NonInteractive'],
-      stdin: false,
-      psScript: _powershellWriteScript
-    })
+    attempts.push({ cmd: 'powershell.exe', args: ['-NoProfile', '-NonInteractive'], stdin: false })
   }
 
   if (env.WAYLAND_DISPLAY) {
@@ -165,7 +163,7 @@ export async function writeClipboardText(
           child.stdin?.end(text)
         } else {
           const b64 = Buffer.from(text, 'utf8').toString('base64')
-          const script = cmdEntry.psScript(b64)
+          const script = _powershellWriteScript(b64)
           const child = start(cmdEntry.cmd, [...cmdEntry.args, '-Command', script], { stdio: ['ignore', 'ignore', 'ignore'], windowsHide: true })
           child.once('error', () => resolve(false))
           child.once('close', (code: number | null) => resolve(code === 0))


### PR DESCRIPTION
## Summary
`/copy` now preserves CJK, emoji, and accented text in WSL2 and native Windows. Previously the TUI piped UTF-8 bytes to `powershell.exe Set-Clipboard -Value $input`, but PowerShell decodes piped stdin with the system ANSI code page (CP936 on Chinese Windows), not UTF-8 — so `你好世界` became `浣犲ソ涓栫晫`.

Fixes #35107.

## Changes
- `ui-tui/src/lib/clipboard.ts`: PowerShell write paths (win32 + WSL) base64-encode the UTF-8 bytes and pass them as a `-Command` argument, decoding with `[System.Text.Encoding]::UTF8.GetString(...)`. This removes the stdin-encoding variable entirely (also immune to BOM injection on redirect). All other backends (pbcopy, wl-copy, xclip, xsel) keep reading UTF-8 stdin natively via a `stdin` flag.
- Test coverage for the CJK + emoji round-trip and that PowerShell entries don't use stdin.

## Validation
| | Before | After |
|---|---|---|
| `你好世界，测试中文 🎉 café` copied in WSL2 | `浣犲ソ涓栫晫锛屾祴璇曚腑鏂…` | `你好世界，测试中文 🎉 café` |

E2E: base64 round-trip recovers the exact original; decoding the same UTF-8 bytes as CP936 reproduces the issue's reported garble. `clipboard.test.ts` 19/19 pass; `src/lib/clipboard.ts` type-checks clean (the 18 pre-existing `execFileNoThrow.ts` type errors are unrelated and present on `main`).

## Credit
Salvaged from #35124 (@annguyenNous — base64-via-argument mechanism, authorship preserved) with the duplicate #35122 (@BROCCOLO1D — first to report + UTF-8 console-encoding approach) co-credited. Follow-up commit collapses the per-entry `psScript` callback to a shared script + `stdin` flag.

## Known sibling (not in scope)
The read path (`Get-Clipboard -Raw` → Node reads stdout as utf8) has the symmetric encoding gap in the Windows→TUI direction. The issue is write-only; read needs a different mechanism (can't base64 stdout without wrapping) and is left for a follow-up.



## Infographic

![utf8-clipboard-writes](https://v3b.fal.media/files/b/0a9c4378/iSVIJGB7iKahX35bKJnAI_O1NXw4De.png)
