### PR TITLE
fix(whatsapp): accept own self-chat messages delivered with fromMe=false (LID)

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -29,6 +29,7 @@ import { execSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { deriveSelfIdentifiers, isOwnSelfChat } from './selfchat.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -264,6 +265,12 @@ async function startSocket() {
       const isGroup = chatId.endsWith('@g.us');
       const senderNumber = senderId.replace(/@.*/, '');
 
+      // Identify the user's own self-chat once, for use by both the fromMe
+      // and !fromMe branches. WhatsApp's LID addressing can deliver our own
+      // self-chat messages with fromMe=false, so this decision is derived from
+      // the chat identifier (number or LID) rather than the fromMe flag.
+      const ownSelfChat = isOwnSelfChat(chatId, deriveSelfIdentifiers(sock.user));
+
       // Handle fromMe messages based on mode
       if (msg.key.fromMe) {
         if (isGroup || chatId.includes('status')) continue;
@@ -273,15 +280,8 @@ async function startSocket() {
           continue;
         }
 
-        // Self-chat mode: only allow messages in the user's own self-chat
-        // WhatsApp now uses LID (Linked Identity Device) format: 67427329167522@lid
-        // AND classic format: 34652029134@s.whatsapp.net
-        // sock.user has both: { id: "number:10@s.whatsapp.net", lid: "lid_number:10@lid" }
-        const myNumber = (sock.user?.id || '').replace(/:.*@/, '@').replace(/@.*/, '');
-        const myLid = (sock.user?.lid || '').replace(/:.*@/, '@').replace(/@.*/, '');
-        const chatNumber = chatId.replace(/@.*/, '');
-        const isSelfChat = (myNumber && chatNumber === myNumber) || (myLid && chatNumber === myLid);
-        if (!isSelfChat) continue;
+        // Self-chat mode: only allow messages in the user's own self-chat.
+        if (!ownSelfChat) continue;
       }
 
       // Handle !fromMe messages (from other people) based on mode.
@@ -291,15 +291,21 @@ async function startSocket() {
       // to arbitrary incoming messages (#8389).
       if (!msg.key.fromMe) {
         if (WHATSAPP_MODE === 'self-chat') {
-          try {
-            console.log(JSON.stringify({
-              event: 'ignored',
-              reason: 'self_chat_mode_rejects_non_self',
-              chatId,
-              senderId,
-            }));
-          } catch {}
-          continue;
+          // WhatsApp's LID addressing can deliver the user's OWN self-chat
+          // messages with fromMe=false. Accept those (they carry the user's
+          // own chatId); only reject messages genuinely from someone else
+          // (stranger DMs / group pings) — preserving the #8389 guard.
+          if (!ownSelfChat) {
+            try {
+              console.log(JSON.stringify({
+                event: 'ignored',
+                reason: 'self_chat_mode_rejects_non_self',
+                chatId,
+                senderId,
+              }));
+            } catch {}
+            continue;
+          }
         }
         if (!matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
           try {
@@ -401,7 +407,9 @@ async function startSocket() {
       }
 
       // Ignore Hermes' own reply messages in self-chat mode to avoid loops.
-      if (msg.key.fromMe && ((REPLY_PREFIX && body.startsWith(REPLY_PREFIX)) || recentlySentIds.has(msg.key.id))) {
+      // Not gated on fromMe: LID addressing can echo our own reply back with
+      // fromMe=false, so match on the reply prefix / recently-sent id regardless.
+      if ((REPLY_PREFIX && body.startsWith(REPLY_PREFIX)) || recentlySentIds.has(msg.key.id)) {
         if (WHATSAPP_DEBUG) {
           try { console.log(JSON.stringify({ event: 'ignored', reason: 'agent_echo', chatId, messageId: msg.key.id })); } catch {}
         }

--- a/scripts/whatsapp-bridge/selfchat.js
+++ b/scripts/whatsapp-bridge/selfchat.js
@@ -1,0 +1,41 @@
+// Pure helpers for WhatsApp self-chat gating decisions.
+//
+// WhatsApp's multi-device stack now addresses accounts with a LID (Linked
+// Identity Device) identifier — e.g. `158939576553626@lid` — alongside the
+// classic phone-number JID — e.g. `923344176856@s.whatsapp.net`. As a result,
+// a user's own "Message Yourself" messages can be delivered to a linked device
+// with `key.fromMe === false`. The bridge must therefore recognise the user's
+// own self-chat from the chat identifier itself, independently of `fromMe`,
+// otherwise legitimate self-chat messages are dropped as "non-self".
+//
+// Kept as a side-effect-free module (mirrors allowlist.js) so the decision is
+// unit-testable without booting a Baileys socket.
+
+/**
+ * Derive the account's own phone-number and LID identifiers from a Baileys
+ * `sock.user` object, stripping the device suffix (`:NN`) and JID host.
+ *
+ * @param {{ id?: string, lid?: string } | null | undefined} user
+ * @returns {{ myNumber: string, myLid: string }}
+ */
+export function deriveSelfIdentifiers(user) {
+  const strip = (value) => (value || '').replace(/:.*@/, '@').replace(/@.*/, '');
+  return { myNumber: strip(user?.id), myLid: strip(user?.lid) };
+}
+
+/**
+ * Decide whether `chatId` is the account's own self-chat (the "Message
+ * Yourself" conversation). Groups and status broadcasts are never self-chats.
+ * Intentionally `fromMe`-agnostic: LID addressing can flip that flag, so the
+ * decision relies solely on the chat identifier matching our own number/LID.
+ *
+ * @param {string} chatId Baileys remoteJid, e.g. `923344176856@s.whatsapp.net`.
+ * @param {{ myNumber?: string, myLid?: string }} self From deriveSelfIdentifiers.
+ * @returns {boolean}
+ */
+export function isOwnSelfChat(chatId, { myNumber, myLid } = {}) {
+  if (!chatId) return false;
+  if (chatId.endsWith('@g.us') || chatId.includes('status')) return false;
+  const chatNumber = chatId.replace(/@.*/, '');
+  return Boolean((myNumber && chatNumber === myNumber) || (myLid && chatNumber === myLid));
+}

--- a/scripts/whatsapp-bridge/selfchat.test.mjs
+++ b/scripts/whatsapp-bridge/selfchat.test.mjs
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { deriveSelfIdentifiers, isOwnSelfChat } from './selfchat.js';
+
+test('deriveSelfIdentifiers strips device suffix and host from id and lid', () => {
+  const self = deriveSelfIdentifiers({
+    id: '923344176856:58@s.whatsapp.net',
+    lid: '158939576553626:58@lid',
+  });
+  assert.deepEqual(self, { myNumber: '923344176856', myLid: '158939576553626' });
+});
+
+test('deriveSelfIdentifiers tolerates missing fields', () => {
+  assert.deepEqual(deriveSelfIdentifiers(null), { myNumber: '', myLid: '' });
+  assert.deepEqual(deriveSelfIdentifiers({}), { myNumber: '', myLid: '' });
+});
+
+test('isOwnSelfChat accepts the user\'s own number JID', () => {
+  const self = { myNumber: '923344176856', myLid: '158939576553626' };
+  assert.equal(isOwnSelfChat('923344176856@s.whatsapp.net', self), true);
+});
+
+test('isOwnSelfChat accepts the user\'s own LID JID (regression: fromMe=false self-chat)', () => {
+  // WhatsApp delivers the user's own self-chat addressed by LID with
+  // fromMe=false; recognising it by LID is the core of the bug fix.
+  const self = { myNumber: '923344176856', myLid: '158939576553626' };
+  assert.equal(isOwnSelfChat('158939576553626@lid', self), true);
+});
+
+test('isOwnSelfChat rejects a stranger DM', () => {
+  const self = { myNumber: '923344176856', myLid: '158939576553626' };
+  assert.equal(isOwnSelfChat('19175395595@s.whatsapp.net', self), false);
+});
+
+test('isOwnSelfChat rejects groups and status broadcasts', () => {
+  const self = { myNumber: '923344176856', myLid: '158939576553626' };
+  assert.equal(isOwnSelfChat('120363024639251251@g.us', self), false);
+  assert.equal(isOwnSelfChat('status@broadcast', self), false);
+});
+
+test('isOwnSelfChat handles empty inputs safely', () => {
+  assert.equal(isOwnSelfChat('', { myNumber: '923344176856' }), false);
+  assert.equal(isOwnSelfChat('923344176856@s.whatsapp.net', {}), false);
+});


### PR DESCRIPTION
## What does this PR do?

In WhatsApp **self-chat mode**, the agent never replied to the user's own
"Message Yourself" messages. WhatsApp's multi-device **LID** (Linked Identity
Device) addressing can deliver a user's own messages to a linked device with
`key.fromMe === false`, and addressed by LID (e.g. `158939576553626@lid`)
rather than the phone-number JID (`923344176856@s.whatsapp.net`).

The Node bridge only accepted `fromMe` messages in self-chat mode and then
**unconditionally dropped every `!fromMe` message** as
`self_chat_mode_rejects_non_self`. So legitimate self-chat messages were
silently ignored and no reply was ever generated.

This PR recognises the user's own self-chat from the **chat identifier**
(number or LID), independently of the `fromMe` flag, and only rejects messages
that are genuinely from someone else — preserving the `#8389` guard against
stranger DMs / group pings.

## Related Issue

Fixes # <!-- maintainers: happy to open a tracking issue if preferred -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/whatsapp-bridge/selfchat.js` (new): side-effect-free helpers
  `deriveSelfIdentifiers(user)` and `isOwnSelfChat(chatId, self)`, mirroring
  the existing `allowlist.js` module so the gating decision is unit-testable.
- `scripts/whatsapp-bridge/bridge.js`: derive `ownSelfChat` once from the chat
  identifier (LID or number) and use it in both the `fromMe` and `!fromMe`
  branches; accept own self-chat messages that arrive with `fromMe=false`
  while still rejecting non-self messages. The agent-echo loop guard is no
  longer gated on `fromMe` (our own reply can echo back with `fromMe=false`
  under LID; the reply-prefix / recently-sent-id match still suppresses it).
- `scripts/whatsapp-bridge/selfchat.test.mjs` (new): `node:test` coverage for
  the LID self-chat regression, own-number acceptance, stranger/group
  rejection, and empty-input safety.

## How to Test

Reproduction (before the fix):
1. `hermes whatsapp` → choose **personal number (self-chat)** → pair.
2. `hermes gateway run`, then send yourself a message in the "Message
   Yourself" chat.
3. Bridge logs `{"event":"ignored","reason":"self_chat_mode_rejects_non_self",
   "chatId":"<your-number>@s.whatsapp.net", ...}` and no reply arrives.

After the fix:
- The same self-message is accepted and the agent replies.
- Automated: `cd scripts/whatsapp-bridge && node --test` → all pass
  (existing `allowlist.test.mjs` + new `selfchat.test.mjs`).

Verified live on Ubuntu 24.04 (arm64), provider xAI Grok via OAuth: the
previously-dropped self-message now reaches the gateway and is answered.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(whatsapp): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the bridge tests (`node --test`) and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (arm64)

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing config/behaviour change beyond the fix)
- [x] `cli-config.yaml.example` — N/A (no config keys added/changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — helpers are pure string ops; no
      platform-specific APIs
