### PR TITLE
docs: guide delegation use in system prompt

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -297,6 +297,21 @@ TASK_COMPLETION_GUIDANCE = (
     "is always better than inventing a result."
 )
 
+# Short, tool-aware guidance for the delegation tool. The full safety and usage
+# rules live in the delegate_task schema; this block only lifts the highest-value
+# routing heuristic into the stable system prompt so models do not bury it behind
+# ordinary single-tool workflows.
+DELEGATION_GUIDANCE = (
+    "# Delegation\n"
+    "When `delegate_task` is available, use it for bulky investigations, "
+    "independent parallel workstreams, or reasoning-heavy subtasks whose raw "
+    "tool output would flood the main conversation. Keep the parent thread for "
+    "decisions, synthesis, verification, and final delivery. Do not delegate "
+    "single tool calls, simple mechanical steps, work that needs user "
+    "interaction, or durable/background jobs; use the direct tool, `clarify`, "
+    "`cronjob`, or background `terminal` instead."
+)
+
 # OpenAI GPT/Codex-specific execution guidance.  Addresses known failure modes
 # where GPT models abandon work on partial results, skip prerequisite lookups,
 # hallucinate instead of using tools, and declare "done" without verification.

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY,
+    DELEGATION_GUIDANCE,
     GOOGLE_MODEL_OPERATIONAL_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
     KANBAN_GUIDANCE,
@@ -130,6 +131,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(KANBAN_GUIDANCE)
     if tool_guidance:
         stable_parts.append(" ".join(tool_guidance))
+
+    # Delegation is available in the default Hermes toolset, but the model may
+    # under-use it because detailed routing guidance lives in the tool schema.
+    # Add a compact nudge only when the tool is actually loaded.
+    if "delegate_task" in agent.valid_tool_names:
+        stable_parts.append(DELEGATION_GUIDANCE)
 
     # Computer-use (macOS) — goes in as its own block rather than being
     # merged into tool_guidance because the content is multi-paragraph.

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1323,6 +1323,44 @@ class TestToolUseEnforcementConfig:
             assert TOOL_USE_ENFORCEMENT_GUIDANCE not in prompt
 
 
+class TestDelegationGuidance:
+    """Tests for compact system-prompt guidance around delegate_task routing."""
+
+    def _make_agent(self, tools):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs(*tools)),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            a = AIAgent(
+                model="anthropic/claude-sonnet-4",
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            a.client = MagicMock()
+            return a
+
+    def test_injects_when_delegate_task_available(self):
+        from agent.prompt_builder import DELEGATION_GUIDANCE
+
+        agent = self._make_agent(["terminal", "delegate_task"])
+        prompt = agent._build_system_prompt()
+
+        assert DELEGATION_GUIDANCE in prompt
+        assert "bulky investigations" in prompt
+
+    def test_skips_when_delegate_task_unavailable(self):
+        from agent.prompt_builder import DELEGATION_GUIDANCE
+
+        agent = self._make_agent(["terminal"])
+        prompt = agent._build_system_prompt()
+
+        assert DELEGATION_GUIDANCE not in prompt
+
+
 class TestTaskCompletionGuidance:
     """Tests for the universal task-completion / no-fabrication guidance
     (config.yaml ``agent.task_completion_guidance``).


### PR DESCRIPTION
## Summary
- Adds compact system-prompt guidance for when to use `delegate_task`.
- Injects the guidance only when `delegate_task` is actually loaded.
- Adds prompt assembly tests for presence/absence of the delegation guidance.

## Why this shape
- Hermes already exposes delegation by default, but the strongest routing heuristics live in the tool schema where models may under-weight them.
- This is a small nudge, not automatic fan-out: it still tells the model not to delegate single tool calls, simple mechanical steps, user-interaction tasks, or durable/background work.
- Keeps existing safety/cost/runtime limits unchanged.

## Verification
- Ran `python -m pytest tests/run_agent/test_run_agent.py::TestDelegationGuidance tests/run_agent/test_run_agent.py::TestToolUseEnforcementConfig tests/run_agent/test_run_agent.py::TestTaskCompletionGuidance -q -o 'addopts='` using the repo venv.
- Result: `25 passed, 1 warning`.
- Ran `git diff --check`.

## Not included
- No automatic planner/router for subagents.
- No changes to delegation concurrency, nesting, approvals, or cost behavior.
