### PR TITLE
feat(providers): add OpenCode Free provider plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,14 @@
 # OPENCODE_GO_API_KEY=
 
 # =============================================================================
+# LLM PROVIDER (OpenCode Free)
+# =============================================================================
+# OpenCode Free provides free models (big-pickle, deepseek-v4-flash-free, etc.)
+# No API key required — the env var is for auto-detection only; its value is
+# never sent as a Bearer token. The free tier rejects Authorization headers.
+# OPENCODE_FREE_API_KEY=   # Any value works (e.g. "free")
+
+# =============================================================================
 # LLM PROVIDER (Hugging Face Inference Providers)
 # =============================================================================
 # Hugging Face routes to 20+ open models via unified OpenAI-compatible endpoint.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1324,6 +1324,27 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
         keepalive_http = agent._build_keepalive_http_client(client_kwargs.get("base_url", ""))
         if keepalive_http is not None:
             client_kwargs["http_client"] = keepalive_http
+
+    # OpenCode Free: the free tier rejects any Authorization header entirely.
+    # The OpenAI SDK always injects "Authorization: Bearer <api_key>" even when
+    # api_key is empty.  Wrap the existing httpx client (or create a fresh one)
+    # with an event hook that strips the Authorization header before it hits the
+    # wire.
+    if agent.provider == "opencode-free":
+        import httpx
+
+        _inner = client_kwargs.get("http_client") or httpx.Client()
+
+        def _strip_auth(request: httpx.Request) -> httpx.Request:
+            request.headers.pop("Authorization", None)
+            return request
+
+        _wrapped = httpx.Client(
+            transport=_inner._transport,
+            headers={k: v for k, v in _inner.headers.items() if k.lower() != "authorization"},
+        )
+        _wrapped.event_hooks["request"].append(_strip_auth)
+        client_kwargs["http_client"] = _wrapped
     # Uses the module-level `OpenAI` name, resolved lazily on first
     # access via __getattr__ below. Tests patch via `run_agent.OpenAI`.
     client = _ra().OpenAI(**client_kwargs)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -383,6 +383,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("OPENCODE_GO_API_KEY",),
         base_url_env_var="OPENCODE_GO_BASE_URL",
     ),
+    "opencode-free": ProviderConfig(
+        id="opencode-free",
+        name="OpenCode Free",
+        auth_type="api_key",
+        inference_base_url="https://opencode.ai/zen/v1",
+        api_key_env_vars=("OPENCODE_FREE_API_KEY",),
+    ),
     "kilocode": ProviderConfig(
         id="kilocode",
         name="Kilo Code",
@@ -1500,6 +1507,7 @@ def resolve_provider(
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
         "opencode": "opencode-zen", "zen": "opencode-zen",
+        "free": "opencode-free", "opencode_free": "opencode-free",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth", "google-gemini-cli": "google-gemini-cli", "gemini-cli": "google-gemini-cli", "gemini-oauth": "google-gemini-cli",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
         "mimo": "xiaomi", "xiaomi-mimo": "xiaomi",
@@ -5837,6 +5845,12 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
     if not api_key and provider_id == "lmstudio":
         api_key = LMSTUDIO_NOAUTH_PLACEHOLDER
         key_source = key_source or "default"
+
+    # OpenCode Free: no API key required — the free tier accepts unauthenticated
+    # requests.  The env var OPENCODE_FREE_API_KEY exists solely for provider
+    # auto-detection; its value must not be sent as a Bearer token.
+    if provider_id == "opencode-free":
+        api_key = ""
 
     env_url = ""
     if pconfig.base_url_env_var:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2468,6 +2468,7 @@ def select_provider_and_model(args=None):
         "kilocode",
         "opencode-zen",
         "opencode-go",
+        "opencode-free",
         "alibaba",
         "huggingface",
         "xiaomi",
@@ -5783,6 +5784,43 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
                     print(
                         f'  Showing {len(model_list)} curated models — use "Enter custom model name" for others.'
                     )
+    elif provider_id == "opencode-free":
+        # OpenCode Free: fetch from models.dev with same filter as
+        # opencode CLI — cost.input == 0 AND status != "deprecated".
+        from agent.models_dev import fetch_models_dev as _fetch_mdev
+
+        try:
+            _mdev = _fetch_mdev()
+            _pd = _mdev.get("opencode", {})
+            _mmodels = _pd.get("models", {}) if isinstance(_pd, dict) else {}
+            if isinstance(_mmodels, dict):
+                model_list = sorted(
+                    mid for mid, m in _mmodels.items()
+                    if isinstance(m, dict)
+                    and isinstance(m.get("cost"), dict)
+                    and m["cost"].get("input") == 0
+                    and m.get("status") != "deprecated"
+                )
+                if model_list:
+                    print(f"  Found {len(model_list)} model(s) for OpenCode Free")
+                else:
+                    model_list = _PROVIDER_MODELS.get(provider_id, [])
+                    if model_list:
+                        print(
+                            "  Using curated model list — models.dev had no free models."
+                        )
+            else:
+                model_list = _PROVIDER_MODELS.get(provider_id, [])
+                if model_list:
+                    print(
+                        f'  Showing {len(model_list)} curated models — use "Enter custom model name" for others.'
+                    )
+        except Exception:
+            model_list = _PROVIDER_MODELS.get(provider_id, [])
+            if model_list:
+                print(
+                    f'  Showing {len(model_list)} curated models — use "Enter custom model name" for others.'
+                )
     else:
         curated = _PROVIDER_MODELS.get(provider_id, [])
 
@@ -5831,7 +5869,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
                     )
             # else: no defaults either, will fall through to raw input
 
-    if provider_id in {"opencode-zen", "opencode-go"}:
+    if provider_id in {"opencode-zen", "opencode-go", "opencode-free"}:
         model_list = [
             normalize_opencode_model_id(provider_id, mid) for mid in model_list
         ]
@@ -5847,7 +5885,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             selected = None
 
     if selected:
-        if provider_id in {"opencode-zen", "opencode-go"}:
+        if provider_id in {"opencode-zen", "opencode-go", "opencode-free"}:
             selected = normalize_opencode_model_id(provider_id, selected)
 
         _save_model_choice(selected)
@@ -5860,7 +5898,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             cfg["model"] = model
         model["provider"] = provider_id
         model["base_url"] = effective_base
-        if provider_id in {"opencode-zen", "opencode-go"}:
+        if provider_id in {"opencode-zen", "opencode-go", "opencode-free"}:
             model["api_mode"] = opencode_model_api_mode(provider_id, selected)
         else:
             model.pop("api_mode", None)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -369,6 +369,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "qwen3-coder",
         "big-pickle",
     ],
+    "opencode-free": [
+        "big-pickle",
+        "deepseek-v4-flash-free",
+        "mimo-v2.5-free",
+        "nemotron-3-super-free",
+    ],
     "opencode-go": [
         "kimi-k2.6",
         "kimi-k2.5",
@@ -2025,6 +2031,32 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                 return ids
         except Exception:
             pass
+
+    # OpenCode Free: match the exact same logic as opencode CLI.
+    # models.dev has cost+status metadata missing from /zen/v1/models.
+    # Filter: cost.input == 0 (free) AND status != "deprecated".
+    if normalized == "opencode-free":
+        try:
+            from agent.models_dev import fetch_models_dev
+            data = fetch_models_dev()
+            provider_data = data.get("opencode")
+            if isinstance(provider_data, dict):
+                mdev_models = provider_data.get("models", {})
+                if isinstance(mdev_models, dict):
+                    free_active = [
+                        mid for mid, m in mdev_models.items()
+                        if isinstance(m, dict)
+                        and isinstance(m.get("cost"), dict)
+                        and m["cost"].get("input") == 0
+                        and m.get("status") != "deprecated"
+                    ]
+                    if free_active:
+                        return sorted(free_active)
+        except Exception:
+            pass
+        curated_static = list(_PROVIDER_MODELS.get(normalized, []))
+        if curated_static:
+            return curated_static
 
     # ── Profile-based generic live fetch (all simple api-key providers) ──
     # Handles any provider registered in providers/ with auth_type="api_key".

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -153,6 +153,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         is_aggregator=True,
         base_url_env_var="OPENCODE_GO_BASE_URL",
     ),
+    "opencode-free": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        base_url_override="https://opencode.ai/zen/v1",
+    ),
     "kilo": HermesOverlay(
         transport="openai_chat",
         is_aggregator=True,
@@ -294,6 +299,10 @@ ALIASES: Dict[str, str] = {
     "go": "opencode-go",
     "opencode-go-sub": "opencode-go",
 
+    # opencode-free
+    "free": "opencode-free",
+    "opencode_free": "opencode-free",
+
     # kilo (models.dev ID for KiloCode)
     "kilocode": "kilo",
     "kilo-code": "kilo",
@@ -378,6 +387,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "bedrock": "AWS Bedrock",
     "ollama-cloud": "Ollama Cloud",
     "xai-oauth": "xAI Grok OAuth (SuperGrok / Premium+)",
+    "opencode-free": "OpenCode Free",
 }
 
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -102,6 +102,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
     "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
     "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
+    "opencode-free": ["big-pickle", "deepseek-v4-flash-free", "mimo-v2.5-free", "nemotron-3-super-free"],
     "opencode-go": ["kimi-k2.6", "kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5", "qwen3.7-max", "qwen3.6-plus", "qwen3.5-plus"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",

--- a/plugins/model-providers/opencode-free/__init__.py
+++ b/plugins/model-providers/opencode-free/__init__.py
@@ -1,0 +1,21 @@
+"""OpenCode Free provider profile.
+
+Provides access to OpenCode's free model tier via the Zen endpoint.
+No paid API key required — activate via OPENCODE_FREE_API_KEY env var
+or select explicitly via ``/model free``.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+opencode_free = ProviderProfile(
+    name="opencode-free",
+    aliases=("free", "opencode_free"),
+    env_vars=("OPENCODE_FREE_API_KEY",),
+    base_url="https://opencode.ai/zen/v1",
+    display_name="OpenCode Free",
+    description="OpenCode free models (no API key required)",
+    default_aux_model="big-pickle",
+)
+
+register_provider(opencode_free)

--- a/plugins/model-providers/opencode-free/plugin.yaml
+++ b/plugins/model-providers/opencode-free/plugin.yaml
@@ -1,0 +1,5 @@
+name: opencode-free-provider
+kind: model-provider
+version: 1.0.0
+description: OpenCode Free Models
+author: bilboquet

--- a/tests/agent/test_opencode_free_provider.py
+++ b/tests/agent/test_opencode_free_provider.py
@@ -1,0 +1,98 @@
+"""Tests for OpenCode Free provider — registration, env var detection, aliases, fallback."""
+
+import os
+from unittest.mock import patch
+
+
+class TestOpenCodeFreeProviderRegistration:
+    """Verify the opencode-free provider registers correctly."""
+
+    def test_provider_is_registered(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("opencode-free")
+        assert profile is not None
+        assert profile.name == "opencode-free"
+
+    def test_provider_has_correct_base_url(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("opencode-free")
+        assert profile.base_url == "https://opencode.ai/zen/v1"
+
+    def test_provider_has_no_env_vars_requirement(self):
+        """OPENCODE_FREE_API_KEY is declared but empty string is acceptable."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("opencode-free")
+        assert "OPENCODE_FREE_API_KEY" in profile.env_vars
+
+    def test_provider_uses_chat_completions_mode(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("opencode-free")
+        assert profile.api_mode == "chat_completions"
+
+
+class TestOpenCodeFreeAliases:
+    """Verify alias resolution for the opencode-free provider."""
+
+    def test_alias_free(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("free")
+        assert profile is not None
+        assert profile.name == "opencode-free"
+
+    def test_alias_opencode_free(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("opencode_free")
+        assert profile is not None
+        assert profile.name == "opencode-free"
+
+
+class TestOpenCodeFreeAuthAlias:
+    """Verify the hardcoded alias in auth.py resolve_provider()."""
+
+    def test_resolve_provider_free_alias(self):
+        from hermes_cli.auth import resolve_provider
+        # "free" should resolve to "opencode-free" without needing the env var
+        result = resolve_provider("free")
+        assert result == "opencode-free"
+
+
+class TestOpenCodeFreeFallbackModels:
+    """Verify fallback models are registered in _DEFAULT_PROVIDER_MODELS."""
+
+    def test_fallback_models_exist(self):
+        from hermes_cli.setup import _DEFAULT_PROVIDER_MODELS
+        assert "opencode-free" in _DEFAULT_PROVIDER_MODELS
+
+    def test_fallback_models_content(self):
+        from hermes_cli.setup import _DEFAULT_PROVIDER_MODELS
+        models = _DEFAULT_PROVIDER_MODELS["opencode-free"]
+        assert "big-pickle" in models
+        assert "deepseek-v4-flash-free" in models
+        assert "mimo-v2.5-free" in models
+        assert "nemotron-3-super-free" in models
+        assert len(models) == 4
+
+
+class TestOpenCodeFreeEnvVarDetection:
+    """Verify env var triggers auto-detection."""
+
+    def test_auto_detect_with_env_var(self):
+        from hermes_cli.auth import resolve_provider
+        with patch.dict(os.environ, {"OPENCODE_FREE_API_KEY": "test-key"}):
+            result = resolve_provider("auto")
+            assert result == "opencode-free"
+
+    def test_no_auto_detect_without_env_var(self):
+        from hermes_cli.auth import resolve_provider
+        # Remove the env var if present
+        env = os.environ.copy()
+        env.pop("OPENCODE_FREE_API_KEY", None)
+        with patch.dict(os.environ, env, clear=True):
+            # Without the env var, auto-detect should NOT return opencode-free
+            # (it may return another provider or raise)
+            try:
+                result = resolve_provider("auto")
+                assert result != "opencode-free"
+            except Exception:
+                # Expected — no provider configured
+                pass

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -37,6 +37,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Tencent TokenHub** | `TOKENHUB_API_KEY` in `~/.hermes/.env` (provider: `tencent-tokenhub`, aliases: `tencent`, `tokenhub`, `tencentmaas`) |
 | **OpenCode Zen** | `OPENCODE_ZEN_API_KEY` in `~/.hermes/.env` (provider: `opencode-zen`) |
 | **OpenCode Go** | `OPENCODE_GO_API_KEY` in `~/.hermes/.env` (provider: `opencode-go`) |
+| **OpenCode Free** | `OPENCODE_FREE_API_KEY` in `~/.hermes/.env` (provider: `opencode-free`, aliases: `free`, `opencode_free`) — no API key needed, any value works |
 | **DeepSeek** | `DEEPSEEK_API_KEY` in `~/.hermes/.env` (provider: `deepseek`) |
 | **Hugging Face** | `HF_TOKEN` in `~/.hermes/.env` (provider: `huggingface`, aliases: `hf`) |
 | **Google / Gemini** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) in `~/.hermes/.env` (provider: `gemini`) |


### PR DESCRIPTION
# Summary

Adds a new opencode-free provider plugin for Hermes, giving users access
to OpenCode's free-tier models without needing a paid API key.

## What changed

New plugin (plugins/model-providers/opencode-free/):
- Registers the provider with auto-detection via OPENCODE_FREE_API_KEY env var
- Aliases: free, opencode_free
- Default auxiliary model: big-pickle

Provider registration (hermes_cli/auth.py):
- PROVIDER_REGISTRY entry pointing to https://opencode.ai/zen/v1
- Auth bypass: the env var is for auto-detection only — its value is never
  sent as a Bearer token (free tier rejects Authorization headers entirely)

Runtime (agent/agent_runtime_helpers.py):
- Strips the Authorization header at the httpx transport level for
  opencode-free, since the OpenAI SDK always injects one even with an
  empty api_key

Model picker — CLI (hermes_cli/main.py):
- Dispatches to _model_flow_api_key_provider for hermes model
- Lists available free models via models.dev with the same filter logic
  as the opencode CLI: cost.input == 0 AND status != "deprecated"
- Normalises model IDs and sets api_mode correctly

Model picker — TUI (hermes_cli/models.py, hermes_cli/providers.py):
- provider_model_ids() fetches from models.dev's opencode provider,
  applying the same cost+status filter
- _LABEL_OVERRIDES ensures the provider displays as "OpenCode Free"
  (not "OpenCode Zen") in the picker
- HERMES_OVERLAYS and ALIASES wired up

Setup (hermes_cli/setup.py):
- Fallback curated model list for offline / first-time setup

Tests (tests/agent/test_opencode_free_provider.py):
- 11 tests covering registration, aliases, auth resolution, fallback
  models, and env-var-based auto-detection

## Why

OpenCode offers a free tier (big-pickle, deepseek-v4-flash-free,
mimo-v2.5-free, nemotron-3-super-free) that requires no API key. This
provider makes it a first-class option in Hermes alongside opencode-zen
and opencode-go, with proper model discovery and zero-config setup.

## How to test

1. Set the env var (required for auto-detection, value is ignored)
echo 'OPENCODE_FREE_API_KEY=free' >> ~/.hermes/.env

2. Run the model picker
hermes model --refresh
Select "OpenCode Free" → should list exactly 4 free models

3. Switch to a free model
Select deepseek-v4-flash-free (or any free model)

4. Verify runtime works
hermes chat -q "Hello, what model are you?"

5. TUI
Run hermes, then /model → should show "OpenCode Free (4 models)"

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
  To be clear, a lot of tests are failing in main, with my commit nothing changed.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs
Please see it in action: 
<img width="399" height="216" alt="image" src="https://github.com/user-attachments/assets/b9116113-0721-444a-8a5e-fc81bd32e42b" />
<img width="359" height="188" alt="image" src="https://github.com/user-attachments/assets/5c1fa588-9fb0-493f-baca-01c010fb72bd" />

