### PR TITLE
fix: warn after ineffective context compaction

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -268,6 +268,58 @@ def replay_compression_warning(agent: Any) -> None:
             pass
 
 
+def _emit_post_compression_pressure_advisory(
+    agent: Any,
+    *,
+    pre_tokens: Optional[int],
+    pre_message_count: int,
+    post_tokens: int,
+    post_message_count: int,
+) -> None:
+    """Warn immediately when a completed compaction did not relieve pressure.
+
+    This is intentionally a deterministic post-compression hook: it evaluates
+    the before/after shape of the compaction that just ran, emits through the
+    existing status/gateway warning plumbing, and performs no LLM calls or
+    scheduler/Kanban side effects.
+    """
+    raw_threshold = (
+        getattr(getattr(agent, "context_compressor", None), "threshold_tokens", 0)
+        or 0
+    )
+    if not isinstance(raw_threshold, (int, float)):
+        return
+    threshold = int(raw_threshold)
+    if threshold <= 0 or post_tokens < threshold:
+        return
+
+    token_delta = (
+        f"{pre_tokens:,}→{post_tokens:,}"
+        if pre_tokens is not None and pre_tokens > 0
+        else f"unknown→{post_tokens:,}"
+    )
+    message_delta = f"{pre_message_count:,}→{post_message_count:,} messages"
+    msg = (
+        "⚠ Compression pressure remains high after compaction: "
+        f"rough tokens {token_delta} (threshold {threshold:,}); "
+        f"messages {message_delta}. This post-compression hook only reports "
+        "the just-finished compaction result; it does not call an LLM, run a "
+        "scheduler, or create Kanban blockers. Consider /compress <focus> or "
+        "/new if the session keeps compacting."
+    )
+
+    # Deduplicate exact repeats from retry/fork edge cases while still warning
+    # for later compactions whose measured before/after shape changes.
+    key = (pre_tokens, pre_message_count, post_tokens, post_message_count, threshold)
+    if getattr(agent, "_last_post_compression_pressure_warning_key", None) == key:
+        return
+    agent._last_post_compression_pressure_warning_key = key
+    try:
+        agent._emit_warning(msg)
+    except Exception:
+        logger.debug("post-compression pressure advisory failed", exc_info=True)
+
+
 def compress_context(
     agent: Any,
     messages: list,
@@ -587,6 +639,13 @@ def compress_context(
     agent.context_compressor.last_prompt_tokens = -1
     agent.context_compressor.last_completion_tokens = 0
     agent.context_compressor.awaiting_real_usage_after_compression = True
+    _emit_post_compression_pressure_advisory(
+        agent,
+        pre_tokens=approx_tokens,
+        pre_message_count=_pre_msg_count,
+        post_tokens=_compressed_est,
+        post_message_count=len(compressed),
+    )
 
     # Clear the file-read dedup cache.  After compression the original
     # read content is summarised away — if the model re-reads the same

--- a/tests/agent/test_compression_post_compaction_monitor.py
+++ b/tests/agent/test_compression_post_compaction_monitor.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.conversation_compression import compress_context
+
+
+class _TodoStore:
+    def format_for_injection(self):
+        return ""
+
+
+def _make_agent(compressed_messages, *, threshold_tokens=50_000):
+    compressor = MagicMock()
+    compressor.compress.return_value = compressed_messages
+    compressor.compression_count = 1
+    compressor.threshold_tokens = threshold_tokens
+    compressor._last_compress_aborted = False
+    compressor._last_summary_error = None
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+
+    agent = SimpleNamespace(
+        session_id="session-1",
+        model="test/model",
+        tools=None,
+        context_compressor=compressor,
+        _compression_feasibility_checked=True,
+        _memory_manager=None,
+        _todo_store=_TodoStore(),
+        _session_db=None,
+        _cached_system_prompt=None,
+        _emit_status=MagicMock(),
+        _emit_warning=MagicMock(),
+        _vprint=MagicMock(),
+        _invalidate_system_prompt=MagicMock(),
+        _build_system_prompt=MagicMock(return_value="rebuilt system prompt"),
+    )
+    return agent
+
+
+def test_post_compaction_monitor_warns_inline_when_compressed_context_still_exceeds_threshold(monkeypatch):
+    """The monitor is a post-compress hook: it runs during compress_context, not on a scheduler."""
+    messages = [{"role": "user", "content": f"before {i}"} for i in range(12)]
+    compressed = [{"role": "user", "content": "summary"}, {"role": "user", "content": "tail"}]
+    agent = _make_agent(compressed, threshold_tokens=50_000)
+    monkeypatch.setattr(
+        "agent.conversation_compression.estimate_request_tokens_rough",
+        lambda *_args, **_kwargs: 55_000,
+    )
+
+    returned, _prompt = compress_context(agent, messages, "sys", approx_tokens=80_000)
+
+    assert returned == compressed
+    agent._emit_warning.assert_called_once()
+    warning = agent._emit_warning.call_args.args[0]
+    assert "Compression pressure remains high" in warning
+    assert "80,000→55,000" in warning
+    assert "12→2 messages" in warning
+    assert "post-compression hook" in warning
+
+
+def test_post_compaction_monitor_does_not_warn_when_post_pressure_is_low(monkeypatch):
+    messages = [{"role": "user", "content": f"before {i}"} for i in range(12)]
+    compressed = [{"role": "user", "content": "summary"}, {"role": "user", "content": "tail"}]
+    agent = _make_agent(compressed, threshold_tokens=50_000)
+    monkeypatch.setattr(
+        "agent.conversation_compression.estimate_request_tokens_rough",
+        lambda *_args, **_kwargs: 30_000,
+    )
+
+    compress_context(agent, messages, "sys", approx_tokens=80_000)
+
+    agent._emit_warning.assert_not_called()
+
+
+def test_post_compaction_monitor_is_not_a_periodic_scheduler(monkeypatch):
+    """The hook evaluates the just-executed compression result with no cron/scheduler dependency."""
+    messages = [{"role": "user", "content": f"before {i}"} for i in range(8)]
+    compressed = [{"role": "user", "content": "summary"}]
+    agent = _make_agent(compressed, threshold_tokens=10_000)
+    monkeypatch.setattr(
+        "agent.conversation_compression.estimate_request_tokens_rough",
+        lambda *_args, **_kwargs: 12_000,
+    )
+
+    compress_context(agent, messages, "sys", approx_tokens=20_000)
+
+    agent.context_compressor.compress.assert_called_once_with(
+        messages,
+        current_tokens=20_000,
+        focus_topic=None,
+        force=False,
+    )
+    agent._emit_warning.assert_called_once()


### PR DESCRIPTION
## Summary
- Adds a deterministic post-compression pressure advisory in agent/conversation_compression.py after the rough compressed estimate is computed.
- Emits through the existing warning/status callback only when the just-compressed context still meets/exceeds the compression threshold.
- Keeps the monitor source-level and scheduler-free; it does not call an LLM or create Kanban blockers.

## Test Plan
- python -m pytest tests/agent/test_compression_post_compaction_monitor.py tests/run_agent/test_compression_boundary_hook.py tests/agent/test_context_compressor.py tests/run_agent/test_compression_persistence.py tests/run_agent/test_compression_feasibility.py tests/run_agent/test_413_compression.py -q -o 'addopts='