### PR TITLE
fix(weixin): avoid cross-loop aiohttp session reuse in send_weixin_direct

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1982,7 +1982,12 @@ async def send_weixin_direct(
 
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
-    if live_adapter is not None and send_session is not None and not send_session.closed:
+    # Check if session belongs to current event loop to avoid aiohttp cross-loop error
+    # "Timeout context manager should be used inside a task"
+    current_loop = asyncio.get_running_loop()
+    session_loop = getattr(send_session, '_loop', None)
+    loop_compatible = session_loop is None or session_loop is current_loop
+    if live_adapter is not None and send_session is not None and not send_session.closed and loop_compatible:
         last_result: Optional[SendResult] = None
         cleaned = live_adapter.format_message(message)
         if cleaned:


### PR DESCRIPTION
## Bug

When the gateway is running, `send_message` tool calls to Weixin always fail with:

```
RuntimeError: Timeout context manager should be used inside a task
```

This affects both text and media delivery. Normal gateway replies work fine.

## Root Cause

`_run_async()` (called by `send_message_tool`) detects a running event loop and spins up a **new thread** with `asyncio.run()`, creating a fresh event loop. However, `send_weixin_direct()` path A reuses the `_LIVE_ADAPTERS` aiohttp session, which is bound to the **gateway**'s event loop. aiohttp raises `RuntimeError` when a session is used from a different loop than the one it was created on.

This explains the intermittent behavior:
- ✅ Gateway normal replies → same loop → works
- ❌ `send_message` tool → cross-loop conflict → fails
- ✅ Gateway not running → CLI path, no cross-loop → works

## Fix

Add a loop compatibility check before reusing the live adapter session. When loops differ, fall through to path B which creates a temporary session on the current loop.

```python
current_loop = asyncio.get_running_loop()
session_loop = getattr(send_session, '_loop', None)
loop_compatible = session_loop is None or session_loop is current_loop
if live_adapter is not None and send_session is not None and not send_session.closed and loop_compatible:
```

## Testing

| File Type | Size | Result |
|-----------|------|--------|
| .png image | 400KB | ✅ |
| .md document | 2KB | ✅ |
| .zip archive | 652KB | ✅ |
| .pdf document | 552KB | ✅ |
| Binary | 1MB | ✅ |
| Binary | 5MB | ✅ |