### PR TITLE
fix(usage): show Codex account limits before first message

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -124,22 +124,86 @@ def _resolve_codex_usage_url(base_url: str) -> str:
     return normalized + "/api/codex/usage"
 
 
+def _codex_usage_credential_candidates(primary: dict[str, Any]) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def add_candidate(token: Any, base_url: Any, status: Any = None, priority: Any = None) -> None:
+        token_text = str(token or "").strip()
+        if not token_text or token_text in seen:
+            return
+        seen.add(token_text)
+        candidates.append(
+            {
+                "api_key": token_text,
+                "base_url": str(base_url or primary.get("base_url") or "").strip(),
+                "last_status": status,
+                "priority": priority,
+            }
+        )
+
+    try:
+        from hermes_cli.auth import _auth_store_lock, _load_auth_store
+
+        with _auth_store_lock():
+            auth_store = _load_auth_store()
+        entries = ((auth_store.get("credential_pool") or {}).get("openai-codex") or [])
+        if isinstance(entries, list):
+            ordered = sorted(
+                [entry for entry in entries if isinstance(entry, dict)],
+                key=lambda entry: (
+                    0 if entry.get("last_status") == "ok" else 1,
+                    int(entry.get("priority", 100)),
+                ),
+            )
+            for entry in ordered:
+                add_candidate(
+                    entry.get("access_token"),
+                    entry.get("base_url"),
+                    entry.get("last_status"),
+                    entry.get("priority"),
+                )
+    except Exception:
+        pass
+
+    add_candidate(primary.get("api_key"), primary.get("base_url"))
+    return candidates
+
+
 def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
     creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
-    token_data = _read_codex_tokens()
-    tokens = token_data.get("tokens") or {}
-    account_id = str(tokens.get("account_id", "") or "").strip() or None
-    headers = {
-        "Authorization": f"Bearer {creds['api_key']}",
-        "Accept": "application/json",
-        "User-Agent": "codex-cli",
-    }
-    if account_id:
-        headers["ChatGPT-Account-Id"] = account_id
-    with httpx.Client(timeout=15.0) as client:
-        response = client.get(_resolve_codex_usage_url(creds.get("base_url", "")), headers=headers)
-        response.raise_for_status()
-    payload = response.json() or {}
+    try:
+        token_data = _read_codex_tokens()
+        tokens = token_data.get("tokens") or {}
+    except Exception:
+        tokens = {}
+    singleton_account_id = str(tokens.get("account_id", "") or "").strip() or None
+
+    last_error: Optional[Exception] = None
+    payload: dict[str, Any] = {}
+    from agent.auxiliary_client import _codex_cloudflare_headers
+
+    for candidate in _codex_usage_credential_candidates(creds):
+        access_token = str(candidate.get("api_key", "") or "").strip()
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/json",
+            **_codex_cloudflare_headers(access_token),
+        }
+        if singleton_account_id:
+            headers["ChatGPT-Account-ID"] = singleton_account_id
+        try:
+            with httpx.Client(timeout=15.0) as client:
+                response = client.get(_resolve_codex_usage_url(candidate.get("base_url", "")), headers=headers)
+                response.raise_for_status()
+            payload = response.json() or {}
+            break
+        except Exception as exc:
+            last_error = exc
+    else:
+        if last_error:
+            raise last_error
+        return None
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
     for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):

--- a/cli.py
+++ b/cli.py
@@ -10153,15 +10153,48 @@ class HermesCLI:
         return True
 
     def _show_usage(self):
-        """Show rate limits (if available) and session token usage."""
-        if not self.agent:
-            print("(._.) No active agent -- send a message first.")
+        """Show account limits, rate limits (if available), and session token usage."""
+        agent = self.agent
+        provider = getattr(agent, "provider", None) if agent else None
+        base_url = getattr(agent, "base_url", None) if agent else None
+        api_key = getattr(agent, "api_key", None) if agent else None
+        provider = provider or getattr(self, "provider", None)
+        base_url = base_url or getattr(self, "base_url", None)
+        api_key = api_key or getattr(self, "api_key", None)
+
+        # Account limits do not require an active in-memory agent. Fetch them
+        # before the session checks so `/usage` can answer immediately after
+        # launch for OAuth-backed subscription providers such as openai-codex.
+        from agent.account_usage import fetch_account_usage, render_account_usage_lines
+        account_snapshot = None
+        if provider:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
+                try:
+                    account_snapshot = _pool.submit(
+                        fetch_account_usage, provider,
+                        base_url=base_url, api_key=api_key,
+                    ).result(timeout=10.0)
+                except (concurrent.futures.TimeoutError, Exception):
+                    account_snapshot = None
+        account_lines = [f"  {line}" for line in render_account_usage_lines(account_snapshot)]
+
+        if not agent:
+            if account_lines:
+                for line in account_lines:
+                    print(line)
+                print()
+                print("(._.) No session token usage yet -- send a message first.")
+            else:
+                print("(._.) No active agent -- send a message first.")
             return
 
-        agent = self.agent
         calls = agent.session_api_calls
 
         if calls == 0:
+            if account_lines:
+                for line in account_lines:
+                    print(line)
+                print()
             print("(._.) No API calls made yet in this session.")
             return
 
@@ -10233,24 +10266,6 @@ class HermesCLI:
         if cost_result.status == "unknown":
             print(f"  Note:             Pricing unknown for {agent.model}")
 
-        # Account limits -- fetched off-thread with a hard timeout so slow
-        # provider APIs don't hang the prompt.
-        provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
-        base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
-        api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
-        # Lazy import — pulls the OpenAI SDK chain, only needed here.
-        from agent.account_usage import fetch_account_usage, render_account_usage_lines
-        account_snapshot = None
-        if provider:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
-                try:
-                    account_snapshot = _pool.submit(
-                        fetch_account_usage, provider,
-                        base_url=base_url, api_key=api_key,
-                    ).result(timeout=10.0)
-                except (concurrent.futures.TimeoutError, Exception):
-                    account_snapshot = None
-        account_lines = [f"  {line}" for line in render_account_usage_lines(account_snapshot)]
         if account_lines:
             print()
             for line in account_lines:

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from cli import HermesCLI
+from agent.account_usage import AccountUsageSnapshot, AccountUsageWindow
 
 
 def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
@@ -500,6 +501,33 @@ class TestCLIStatusBar:
 
 
 class TestCLIUsageReport:
+    def test_show_usage_without_agent_prints_account_limits(self, capsys, monkeypatch):
+        cli_obj = _make_cli(model="gpt-5.5")
+        cli_obj.provider = "openai-codex"
+        cli_obj.base_url = "https://chatgpt.com/backend-api/codex"
+        cli_obj.api_key = ""
+        cli_obj.verbose = False
+
+        monkeypatch.setattr(
+            "agent.account_usage.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: AccountUsageSnapshot(
+                provider=provider,
+                source="usage_api",
+                fetched_at=datetime.now(),
+                plan="Plus",
+                windows=(AccountUsageWindow(label="Session", used_percent=57),),
+            ),
+        )
+
+        cli_obj._show_usage()
+        output = capsys.readouterr().out
+
+        assert "Account limits" in output
+        assert "openai-codex (Plus)" in output
+        assert "Session: 43% remaining (57% used)" in output
+        assert "No session token usage yet" in output
+        assert "No active agent" not in output
+
     def test_show_usage_includes_estimated_cost(self, capsys):
         cli_obj = _attach_agent(
             _make_cli(),

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -1,3 +1,6 @@
+import base64
+import json
+from contextlib import nullcontext
 from datetime import datetime, timezone
 
 from agent.account_usage import (
@@ -49,6 +52,25 @@ class _RoutingClient:
         return _Response(self._payloads[url])
 
 
+def _make_codex_jwt(account_id="acct_123"):
+    def _b64url(payload):
+        return base64.urlsafe_b64encode(payload).rstrip(b"=").decode("ascii")
+
+    claims = {
+        "https://api.openai.com/auth": {
+            "chatgpt_account_id": account_id,
+            "chatgpt_plan_type": "plus",
+        }
+    }
+    return ".".join(
+        (
+            _b64url(b'{"alg":"RS256","typ":"JWT"}'),
+            _b64url(json.dumps(claims).encode("utf-8")),
+            _b64url(b"sig"),
+        )
+    )
+
+
 def test_fetch_account_usage_codex(monkeypatch):
     monkeypatch.setattr(
         "agent.account_usage.resolve_codex_runtime_credentials",
@@ -93,6 +115,82 @@ def test_fetch_account_usage_codex(monkeypatch):
     assert snapshot.windows[0].used_percent == 15.0
     assert snapshot.windows[0].reset_at == datetime.fromtimestamp(1_900_000_000, tz=timezone.utc)
     assert "Credits balance: $12.50" in snapshot.details
+
+
+def test_fetch_account_usage_codex_prefers_healthy_pool_token_when_singleton_missing(monkeypatch):
+    stale_token = _make_codex_jwt("acct_stale")
+    healthy_token = _make_codex_jwt("acct_ok")
+    requested = []
+
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_codex_runtime_credentials",
+        lambda refresh_if_expiring=True: {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": stale_token,
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage._read_codex_tokens",
+        lambda: (_ for _ in ()).throw(RuntimeError("singleton missing")),
+    )
+    monkeypatch.setattr("hermes_cli.auth._auth_store_lock", lambda: nullcontext())
+    monkeypatch.setattr(
+        "hermes_cli.auth._load_auth_store",
+        lambda: {
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "access_token": stale_token,
+                        "base_url": "https://chatgpt.com/backend-api/codex",
+                        "last_status": "exhausted",
+                        "priority": 0,
+                    },
+                    {
+                        "access_token": healthy_token,
+                        "base_url": "https://chatgpt.com/backend-api/codex",
+                        "last_status": "ok",
+                        "priority": 10,
+                    },
+                ]
+            }
+        },
+    )
+
+    class _PoolClient:
+        def __init__(self, timeout=15.0):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, headers=None):
+            requested.append((url, dict(headers or {})))
+            assert url == "https://chatgpt.com/backend-api/wham/usage"
+            assert headers["originator"] == "codex_cli_rs"
+            assert headers["User-Agent"].startswith("codex_cli_rs/")
+            assert headers["ChatGPT-Account-ID"] == "acct_ok"
+            assert "ChatGPT-Account-Id" not in headers
+            return _Response(
+                {
+                    "plan_type": "plus",
+                    "rate_limit": {
+                        "primary_window": {"used_percent": 33, "reset_at": 1_900_000_000},
+                    },
+                }
+            )
+
+    monkeypatch.setattr("agent.account_usage.httpx.Client", _PoolClient)
+
+    snapshot = fetch_account_usage("openai-codex")
+
+    assert snapshot is not None
+    assert snapshot.plan == "Plus"
+    assert snapshot.windows[0].used_percent == 33.0
+    assert len(requested) == 1
 
 
 def test_render_account_usage_lines_includes_reset_and_provider():


### PR DESCRIPTION
## Summary

- Show OAuth-backed account limits in CLI `/usage` before an active agent exists.
- Make Codex account usage prefer healthy `credential_pool.openai-codex` entries when singleton token state is absent.
- Reuse the existing Codex Cloudflare header helper for ChatGPT usage requests.

## Validation

- `git diff --check`
- `pytest tests/test_account_usage.py tests/cli/test_cli_status_bar.py::TestCLIUsageReport tests/gateway/test_usage_command.py tests/agent/test_codex_cloudflare_headers.py -q`
