### PR TITLE
fix(weixin): deduplicate session expired error log in poll loop

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1269,6 +1269,7 @@ class WeixinAdapter(BasePlatformAdapter):
         sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
         timeout_ms = LONG_POLL_TIMEOUT_MS
         consecutive_failures = 0
+        session_expired_logged = False
 
         while self._running:
             try:
@@ -1288,7 +1289,11 @@ class WeixinAdapter(BasePlatformAdapter):
                 if ret not in {0, None} or errcode not in {0, None}:
                     if (ret == SESSION_EXPIRED_ERRCODE or errcode == SESSION_EXPIRED_ERRCODE
                             or _is_stale_session_ret(ret, errcode, response.get("errmsg"))):
-                        logger.error("[%s] Session expired; pausing for 10 minutes", self.name)
+                        if not session_expired_logged:
+                            logger.error("[%s] Session expired; pausing for 10 minutes", self.name)
+                            session_expired_logged = True
+                        else:
+                            logger.debug("[%s] Session still expired; retrying after pause", self.name)
                         await asyncio.sleep(600)
                         consecutive_failures = 0
                         continue
@@ -1308,6 +1313,9 @@ class WeixinAdapter(BasePlatformAdapter):
                     continue
 
                 consecutive_failures = 0
+                if session_expired_logged:
+                    logger.info("[%s] Session recovered after expiry", self.name)
+                    session_expired_logged = False
                 new_sync_buf = str(response.get("get_updates_buf") or "")
                 if new_sync_buf:
                     sync_buf = new_sync_buf

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -882,3 +882,122 @@ class TestWeixinContentDedup:
         assert adapter.handle_message.await_count == 0
         # is_duplicate should only be called for message_id, never for content
         assert all("content:" not in str(call) for call in adapter._dedup.is_duplicate.call_args_list)
+
+
+class TestWeixinSessionExpiredLogDedup:
+    """Regression test for #35215: session expired error log spam.
+
+    When the iLink session expires, the error should be logged once.
+    Subsequent retries during the expired state should use DEBUG level.
+    When the session recovers, an INFO message should be logged.
+    """
+
+    @pytest.mark.asyncio
+    async def test_session_expired_logged_only_once(self):
+        adapter = _make_adapter()
+        adapter._running = True
+        adapter._poll_session = object()
+        adapter._hermes_home = "/tmp/test-hermes"
+        adapter._account_id = "test-account"
+
+        # Return session expired 3 times, then stop the loop
+        call_count = 0
+        expired_response = {"ret": -14, "errcode": 0, "errmsg": "session expired"}
+
+        async def fake_get_updates(session, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 4:
+                adapter._running = False
+                return {"ret": 0, "errcode": 0, "msgs": []}
+            return expired_response
+
+        with (
+            patch("gateway.platforms.weixin._get_updates", side_effect=fake_get_updates),
+            patch("gateway.platforms.weixin._load_sync_buf", return_value=""),
+            patch("gateway.platforms.weixin._save_sync_buf"),
+            patch.object(weixin.logger, "error") as error_mock,
+            patch.object(weixin.logger, "debug") as debug_mock,
+            patch.object(weixin.logger, "info") as info_mock,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await adapter._poll_loop()
+
+        # Error logged exactly once
+        assert error_mock.call_count == 1
+        assert "Session expired" in str(error_mock.call_args)
+
+        # Debug logged for subsequent retries (2 more expired responses)
+        assert debug_mock.call_count == 2
+        assert all("Session still expired" in str(c) for c in debug_mock.call_args_list)
+
+        # No recovery log — loop ended with successful response which DOES trigger recovery
+        # (the 4th call returns ret=0 after 3 expired calls)
+        recovery_calls = [c for c in info_mock.call_args_list if "recovered" in str(c)]
+        assert len(recovery_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_session_recovery_logged_after_expiry(self):
+        adapter = _make_adapter()
+        adapter._running = True
+        adapter._poll_session = object()
+        adapter._hermes_home = "/tmp/test-hermes"
+        adapter._account_id = "test-account"
+
+        call_count = 0
+
+        async def fake_get_updates(session, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return {"ret": -14, "errcode": 0, "errmsg": "session expired"}
+            # Session recovers
+            adapter._running = False
+            return {"ret": 0, "errcode": 0, "msgs": []}
+
+        with (
+            patch("gateway.platforms.weixin._get_updates", side_effect=fake_get_updates),
+            patch("gateway.platforms.weixin._load_sync_buf", return_value=""),
+            patch("gateway.platforms.weixin._save_sync_buf"),
+            patch.object(weixin.logger, "error") as error_mock,
+            patch.object(weixin.logger, "info") as info_mock,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await adapter._poll_loop()
+
+        # Error logged exactly once
+        assert error_mock.call_count == 1
+
+        # Recovery logged
+        recovery_calls = [c for c in info_mock.call_args_list if "recovered" in str(c)]
+        assert len(recovery_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_session_expiry_no_extra_logging(self):
+        """When session never expires, no extra error/debug logging."""
+        adapter = _make_adapter()
+        adapter._running = True
+        adapter._poll_session = object()
+        adapter._hermes_home = "/tmp/test-hermes"
+        adapter._account_id = "test-account"
+
+        call_count = 0
+
+        async def fake_get_updates(session, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 3:
+                adapter._running = False
+            return {"ret": 0, "errcode": 0, "msgs": []}
+
+        with (
+            patch("gateway.platforms.weixin._get_updates", side_effect=fake_get_updates),
+            patch("gateway.platforms.weixin._load_sync_buf", return_value=""),
+            patch("gateway.platforms.weixin._save_sync_buf"),
+            patch.object(weixin.logger, "error") as error_mock,
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await adapter._poll_loop()
+
+        # No session expired errors
+        assert error_mock.call_count == 0


### PR DESCRIPTION
## What does this PR do?

Deduplicates the "Session expired" error log in the Weixin iLink poll loop. When the session expires, the error was logged on every poll cycle (every 10 minutes), flooding `gateway.error.log` with identical messages. Now logs ERROR once on first detection, uses DEBUG for subsequent retries, and logs INFO when the session recovers.

## Related Issue

Fixes #35215

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/weixin.py`: Added `session_expired_logged` flag to `_poll_loop()` that tracks whether the session expired error has already been logged. First expiry logs at ERROR level; subsequent retries during the expired state log at DEBUG level. When the session recovers (successful response after expiry), logs at INFO level.
- `tests/gateway/test_weixin.py`: Added `TestWeixinSessionExpiredLogDedup` class with 3 tests:
  - `test_session_expired_logged_only_once`: Verifies error logged once, debug for retries
  - `test_session_recovery_logged_after_expiry`: Verifies recovery message logged
  - `test_no_session_expiry_no_extra_logging`: Verifies no extra logging when session is healthy

## How to Test

1. Run `pytest tests/gateway/test_weixin.py::TestWeixinSessionExpiredLogDedup -xvs`
2. Run `pytest tests/gateway/test_weixin.py -x` to verify no regressions
3. In production: configure Weixin adapter, let session expire, verify only one ERROR line appears in `gateway.error.log` per expiry event

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/weixin.py:_poll_loop()` (callers: `_connect`, gateway startup)
- Blast radius: LOW — change is localized to the Weixin adapter's poll loop logging path
- Related patterns: Log dedup via boolean flag; consistent with existing `consecutive_failures` tracking in the same function
