### PR TITLE
fix(tool-guardrails): block deterministic tool retries

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -221,6 +221,45 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
     return False, ""
 
 
+def classify_non_retryable_tool_failure(tool_name: str, result: str | None) -> tuple[str, str] | None:
+    """Return guardrail metadata for deterministic failures that cannot self-heal.
+
+    These failures may be recoverable after the model changes arguments or the
+    user changes state, but an identical same-turn retry just repeats the same
+    outcome. The first failure gets guidance; a repeated identical call is
+    blocked before executing.
+    """
+    data = safe_json_loads(result or "")
+    if not isinstance(data, dict):
+        return None
+
+    error = str(data.get("error") or "")
+    error_lower = error.lower()
+    if tool_name == "memory" and data.get("success") is False:
+        if "exceed the limit" in error_lower or "exceeds the limit" in error_lower:
+            return (
+                "memory_quota_exceeded_non_retryable",
+                (
+                    "Shorten the memory content, replace a smaller entry, remove "
+                    "existing memory first, or skip the memory write. Retrying the "
+                    "same memory call unchanged cannot succeed while the store is full."
+                ),
+            )
+
+    if tool_name == "image_generate":
+        if data.get("success") is False and data.get("error_type") == "empty_response":
+            return (
+                "image_generate_empty_response_non_retryable",
+                (
+                    "The image provider returned no image_generation_call result. "
+                    "Do not repeat the same image_generate call unchanged; retry later, "
+                    "change the prompt/model/provider, or explain the temporary blocker."
+                ),
+            )
+
+    return None
+
+
 class ToolCallGuardrailController:
     """Per-turn controller for repeated failed/non-progressing tool calls."""
 
@@ -232,6 +271,7 @@ class ToolCallGuardrailController:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._non_retryable_failures: dict[ToolCallSignature, ToolGuardrailDecision] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
 
     @property
@@ -240,6 +280,19 @@ class ToolCallGuardrailController:
 
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
         signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
+        if signature in self._non_retryable_failures:
+            previous = self._non_retryable_failures[signature]
+            decision = ToolGuardrailDecision(
+                action="block",
+                code=previous.code,
+                message=previous.message,
+                tool_name=tool_name,
+                count=previous.count,
+                signature=signature,
+            )
+            self._halt_decision = decision
+            return decision
+
         if not self.config.hard_stop_enabled:
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -296,6 +349,21 @@ class ToolCallGuardrailController:
             failed, _ = classify_tool_failure(tool_name, result)
 
         if failed:
+            non_retryable = classify_non_retryable_tool_failure(tool_name, result)
+            if non_retryable is not None:
+                code, message = non_retryable
+                decision = ToolGuardrailDecision(
+                    action="warn",
+                    code=code,
+                    message=message,
+                    tool_name=tool_name,
+                    count=1,
+                    signature=signature,
+                )
+                self._non_retryable_failures[signature] = decision
+                self._no_progress.pop(signature, None)
+                return decision
+
             exact_count = self._exact_failure_counts.get(signature, 0) + 1
             self._exact_failure_counts[signature] = exact_count
             self._no_progress.pop(signature, None)
@@ -345,6 +413,7 @@ class ToolCallGuardrailController:
             return ToolGuardrailDecision(tool_name=tool_name, count=exact_count, signature=signature)
 
         self._exact_failure_counts.pop(signature, None)
+        self._non_retryable_failures.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
 
         if not self._is_idempotent(tool_name):

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -118,6 +118,52 @@ def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution()
     assert blocked.count == 2
 
 
+def test_memory_quota_failure_blocks_identical_retry_without_hard_stop():
+    controller = ToolCallGuardrailController()
+    args = {
+        "action": "add",
+        "target": "user",
+        "content": "same oversized memory",
+    }
+    result = json.dumps({
+        "success": False,
+        "error": "Memory at 1,371/1,375 chars. Adding this entry (256 chars) would exceed the limit. Replace or remove existing entries first.",
+    })
+
+    assert controller.before_call("memory", args).action == "allow"
+    first = controller.after_call("memory", args, result, failed=True)
+    assert first.action == "warn"
+    assert first.code == "memory_quota_exceeded_non_retryable"
+
+    blocked = controller.before_call("memory", args)
+    assert blocked.action == "block"
+    assert blocked.code == "memory_quota_exceeded_non_retryable"
+    assert "Shorten the memory content" in blocked.message
+
+
+def test_image_generate_empty_response_blocks_identical_retry_without_hard_stop():
+    controller = ToolCallGuardrailController()
+    args = {"prompt": "same image prompt", "size": "1024x1024"}
+    result = json.dumps({
+        "success": False,
+        "image": None,
+        "error": "Codex response contained no image_generation_call result",
+        "error_type": "empty_response",
+        "provider": "openai-codex",
+        "model": "gpt-image-2-medium",
+    })
+
+    assert controller.before_call("image_generate", args).action == "allow"
+    first = controller.after_call("image_generate", args, result, failed=True)
+    assert first.action == "warn"
+    assert first.code == "image_generate_empty_response_non_retryable"
+
+    blocked = controller.before_call("image_generate", args)
+    assert blocked.action == "block"
+    assert blocked.code == "image_generate_empty_response_non_retryable"
+    assert "same image_generate call unchanged" in blocked.message
+
+
 def test_success_resets_exact_signature_failure_streak():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(hard_stop_enabled=True, exact_failure_block_after=2, same_tool_failure_halt_after=99)


### PR DESCRIPTION
## Summary

This PR teaches the tool-loop guardrail to treat two deterministic tool failures as non-retryable for identical same-turn retries:

- `memory` quota overflow, where the store is already full and the same add/replace request cannot succeed unchanged.
- `image_generate` `empty_response`, where the provider returned no `image_generation_call` result for the completed request.

The first failure still reaches the model with a clear recovery hint. If the model repeats the same tool call with identical arguments in the same turn, Hermes blocks the duplicate execution before calling the tool again and returns a synthetic guardrail result.

Fixes #35120
Fixes #35121

## Why This Matters

Hermes already has general repeated-failure guardrails, but these two failure modes are more specific than "the same tool failed a few times." They are deterministic until something changes:

- A full memory store will remain full until content is shortened, replaced, removed, or the write is skipped.
- An `image_generate` response with no `image_generation_call` is not improved by immediately replaying the exact same request inside the same turn.

Without a first-class classification, the agent can spend extra iterations repeating a call that has no new information to offer. In gateway contexts this also produces noisy logs, slower user-facing recovery, and weaker guidance for the model about what action would actually help.

The expected contribution is modest but practical: reduce avoidable tool-loop churn while preserving the agent's ability to recover by changing arguments or strategy.

## Existing Upstream Work

This PR is intentionally scoped around the guardrail layer. It does not replace the existing image-generation provider work:

- #19979 addresses the `tool_choice` request-shape failure for the `openai-codex` image generation path, but explicitly leaves the later `empty_response` / no `image_generation_call` stage unresolved.
- #23505 improves exhausted empty final responses from the main agent loop. That is related at the symptom level, but it does not classify `image_generate` tool results or prevent same-turn duplicate image tool executions.

For memory quota overflow, I did not find an existing PR that treats the quota-exceeded result as a non-retryable same-turn tool failure.

## Behavior

After this change:

1. The first matching failure returns a `warn` decision.
2. Hermes appends recovery guidance to the original tool result so the model sees what to change next.
3. The same tool call with the same canonical arguments is recorded as non-retryable for the rest of the turn.
4. A repeated identical call is blocked before execution and returned as a synthetic guardrail result.
5. A changed call still gets a fresh attempt.

This preserves useful retries while avoiding deterministic duplicate work.

## Scope

This PR only changes the pure tool-call guardrail controller and its tests:

- `agent/tool_guardrails.py`
- `tests/agent/test_tool_guardrails.py`

It does not change the image-generation provider request shape, memory storage limits, or global hard-stop defaults.

## User And Developer Impact

For users, the visible effect should be less "stuck retrying" behavior when Hermes hits a full memory store or an image provider that completed without producing an image call. The agent should move sooner to an actionable recovery path: shorten/replace/remove memory content, skip the memory write, retry image generation later, or change the prompt/model/provider.

For developers and operators, the value is sharper failure semantics in a central guardrail primitive:

- The same structured failure can be tested without invoking provider APIs.
- Logs and synthetic guardrail metadata include stable codes:
  - `memory_quota_exceeded_non_retryable`
  - `image_generate_empty_response_non_retryable`
- The fix applies to both CLI and gateway paths that already use the tool guardrail controller.

## Validation

- `./scripts/run_tests.sh tests/agent/test_tool_guardrails.py` - 15 passed
- `./scripts/run_tests.sh tests/run_agent/test_tool_call_guardrail_runtime.py tests/agent/test_tool_guardrails.py` - 24 passed
- `uv run --with ruff ruff check agent/tool_guardrails.py tests/agent/test_tool_guardrails.py` - passed
- `git diff --check` - passed
