### PR TITLE
fix(skill_manager): follow symlinks when discovering skills (#35184)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -570,6 +570,7 @@ LEGACY_AUTHOR_MAP = {
     "marek.les@seznam.cz": "maxcz79",
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
+    "linux2010@github.com": "Linux2010",
     "kenyon1977@gmail.com": "kenyonxu",
     "cipherframe@users.noreply.github.com": "CipherFrame",
     "donovan-yohan@users.noreply.github.com": "donovan-yohan",

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -330,7 +330,10 @@ class TestFindSkillSymlinks:
         (real_category / "SKILL.md").write_text(VALID_SKILL_CONTENT)
 
         # Symlink the category into skills_dir
-        (skills_dir / "real_category").symlink_to(tmp_path / "real_category")
+        try:
+            (skills_dir / "real_category").symlink_to(tmp_path / "real_category")
+        except OSError:
+            pytest.skip("Symlinks not supported on this platform")
 
         with patch("tools.skill_manager_tool.SKILLS_DIR", skills_dir), \
              patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills_dir]):
@@ -354,7 +357,10 @@ class TestFindSkillSymlinks:
         (real_root / "SKILL.md").write_text(VALID_SKILL_CONTENT)
 
         # Symlink the top-level outside dir into skills
-        (skills_dir / "outside").symlink_to(tmp_path / "outside")
+        try:
+            (skills_dir / "outside").symlink_to(tmp_path / "outside")
+        except OSError:
+            pytest.skip("Symlinks not supported on this platform")
 
         with patch("tools.skill_manager_tool.SKILLS_DIR", skills_dir), \
              patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills_dir]):
@@ -362,6 +368,57 @@ class TestFindSkillSymlinks:
             result = _find_skill("deep-skill")
 
         assert result is not None, "Nested symlinked skill should be found"
+
+    def test_symlinked_skill_found_via_other_profile(self, tmp_path, monkeypatch):
+        """Regression: _find_skill_in_other_profiles must follow symlinks too.
+
+        A skill in a non-active profile that is reachable only through a
+        symlink must appear in the cross-profile matches list.
+        """
+        # Active profile skills dir — empty, so _find_skill returns None
+        active_skills = tmp_path / "active-skills"
+        active_skills.mkdir()
+
+        # Other profile: skill is nested under a symlink category
+        profile_skills = tmp_path / "other-profile-skills"
+        profile_skills.mkdir()
+        real_cat = tmp_path / "real-cat" / "cross-skill"
+        real_cat.mkdir(parents=True)
+        (real_cat / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+        try:
+            (profile_skills / "real-cat").symlink_to(tmp_path / "real-cat")
+        except OSError:
+            pytest.skip("Symlinks not supported on this platform")
+
+        # Stub hermes root so the profile scan finds profile_skills.
+        # _find_skill_in_other_profiles scans root/profiles/*/skills.
+        root = tmp_path / "hermes"
+        root.mkdir()
+        profiles_root = root / "profiles"
+        profiles_root.mkdir()
+        other_profile = profiles_root / "other"
+        other_profile.mkdir()
+        (other_profile / "skills").symlink_to(profile_skills)
+
+        monkeypatch.setattr(
+            "tools.skill_manager_tool.SKILLS_DIR",
+            active_skills,
+        )
+        monkeypatch.setattr(
+            "hermes_constants.get_default_hermes_root",
+            lambda: root,
+        )
+        monkeypatch.setattr(
+            "tools.skill_manager_tool._skills_dir",
+            lambda: active_skills,
+        )
+
+        with patch("agent.skill_utils.get_all_skills_dirs", return_value=[active_skills]):
+            from tools.skill_manager_tool import _find_skill_in_other_profiles
+            matches = _find_skill_in_other_profiles("cross-skill")
+
+        assert matches, "Symlinked skill should be found in other profile"
+        assert matches[0][0] == "other"
 
 
 class TestEditSkill:

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -316,6 +316,51 @@ class TestCreateSkill:
         assert extract_skill_description(fm) in result["system_prompt_preview"]
 
 
+class TestFindSkillSymlinks:
+    """Regression tests for #35184 — rglob does not follow symlinks."""
+
+    def test_symlinked_skill_dir_is_found(self, tmp_path):
+        """Skills under a symlinked category directory must be discoverable."""
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        # Create a real category dir outside skills_dir
+        real_category = tmp_path / "real_category" / "my-skill"
+        real_category.mkdir(parents=True)
+        (real_category / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+
+        # Symlink the category into skills_dir
+        (skills_dir / "real_category").symlink_to(tmp_path / "real_category")
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", skills_dir), \
+             patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills_dir]):
+            from tools.skill_manager_tool import _find_skill
+            result = _find_skill("my-skill")
+
+        assert result is not None, "Symlinked skill should be found"
+        assert result["path"] == real_category
+
+    def test_nested_symlinked_skill_is_found(self, tmp_path):
+        """Skills nested under multiple symlinked dirs must be discoverable."""
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        # Create real nested dirs outside
+        real_root = tmp_path / "outside" / "nested" / "deep-skill"
+        real_root.mkdir(parents=True)
+        (real_root / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+
+        # Symlink the top-level outside dir into skills
+        (skills_dir / "outside").symlink_to(tmp_path / "outside")
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", skills_dir), \
+             patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills_dir]):
+            from tools.skill_manager_tool import _find_skill
+            result = _find_skill("deep-skill")
+
+        assert result is not None, "Nested symlinked skill should be found"
+
+
 class TestEditSkill:
     def test_edit_existing_skill(self, tmp_path):
         with _skill_dir(tmp_path):

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -338,7 +338,10 @@ class TestFindSkillSymlinks:
             result = _find_skill("my-skill")
 
         assert result is not None, "Symlinked skill should be found"
-        assert result["path"] == real_category
+        # iter_skill_index_files returns the path through the symlink,
+        # not the symlink's target path
+        expected_path = skills_dir / "real_category" / "my-skill"
+        assert result["path"] == expected_path
 
     def test_nested_symlinked_skill_is_found(self, tmp_path):
         """Skills nested under multiple symlinked dirs must be discoverable."""

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -631,11 +631,11 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path, iter_skill_index_files
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
+        for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
             if skill_md.parent.name == name:
@@ -655,7 +655,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
     matches: List[Tuple[str, Path]] = []
     try:
         from hermes_constants import get_default_hermes_root
-        from agent.skill_utils import is_excluded_skill_path
+        from agent.skill_utils import is_excluded_skill_path, iter_skill_index_files
     except Exception:
         return matches
 
@@ -699,7 +699,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
         if not skills_dir.is_dir():
             continue
         try:
-            for skill_md in skills_dir.rglob("SKILL.md"):
+            for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
                 if is_excluded_skill_path(skill_md):
                     continue
                 if skill_md.parent.name == name:


### PR DESCRIPTION
## What broke
`_find_skill()` and `_find_skill_in_other_profiles()` in `tools/skill_manager_tool.py` used `Path.rglob("SKILL.md")` to discover skills. Python's `pathlib.rglob()` does NOT follow symbolic links into directories. This caused `skill_manage` to fail with "Skill not found in active profile" for any skill located under a symlinked category directory.

Meanwhile, `prompt_builder.py` uses `iter_skill_index_files()` → `os.walk(followlinks=True)`, which DOES follow symlinks. This inconsistency meant skills appeared in the system prompt index but could not be managed via `skill_manage`.

## Root cause
`rglob()` does not follow symlinks by design. The two discovery paths (`skill_manager_tool.py` vs `prompt_builder.py`) used different mechanisms, and the `rglob` path missed symlinked skills.

## Why this fix is minimal
Replaces `rglob("SKILL.md")` with `iter_skill_index_files(skills_dir, "SKILL.md")` from `agent.skill_utils`, which already uses `os.walk(followlinks=True)` and handles `EXCLUDED_SKILL_DIRS` filtering. Only two call sites changed; no new dependencies or behavioral changes.

## What I tested
Added `TestFindSkillSymlinks` class with two tests:
- `test_symlinked_skill_dir_is_found` — verifies a skill under a symlinked category directory is discovered
- `test_nested_symlinked_skill_is_found` — verifies deeply nested skills under symlinked dirs are discovered

## What I intentionally did not change
- The security symlink-escape guards (write/remove still blocked)
- Any other skill discovery code paths
- External skill dirs behavior