### PR TITLE
fix: redact secrets in non-code files (.env, .yaml, .json)

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -20,6 +20,53 @@ from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Source-code file extensions for redaction heuristics.
+# Files with these extensions are treated as source code when calling
+# ``redact_sensitive_text(code_file=True)`` — which skips ENV-assignment
+# and JSON-field regex patterns to avoid false positives (e.g. MAX_TOKENS=100
+# in a Python file).  All other files (including .env, .yaml, .json, .conf,
+# .toml, .ini, .cfg, .properties, etc.) use ``code_file=False`` so that
+# secret-bearing patterns like ``API_KEY=<value>`` are properly redacted.
+# ---------------------------------------------------------------------------
+_SOURCE_CODE_EXTENSIONS = frozenset({
+    ".py", ".pyi", ".pyx",               # Python
+    ".js", ".mjs", ".cjs", ".jsx",       # JavaScript
+    ".ts", ".tsx", ".mts",               # TypeScript
+    ".go",                               # Go
+    ".rs",                               # Rust
+    ".java", ".kt", ".kts", ".scala",    # JVM
+    ".c", ".cpp", ".cc", ".cxx", ".h", ".hpp", ".hxx",  # C/C++
+    ".rb", ".erb",                       # Ruby
+    ".php",                              # PHP
+    ".swift",                            # Swift
+    ".lua",                              # Lua
+    ".r", ".R",                          # R
+    ".m", ".mm",                         # Objective-C
+    ".sh", ".bash", ".zsh", ".fish",     # Shell
+    ".pl", ".pm",                        # Perl
+    ".ex", ".exs",                       # Elixir
+    ".erl", ".hrl",                      # Erlang
+    ".hs", ".lhs",                       # Haskell
+    ".ml", ".mli",                       # OCaml
+    ".clj", ".cljs", ".cljc",           # Clojure
+    ".dart",                             # Dart
+    ".vue", ".svelte",                   # Frontend frameworks
+    ".sql",                              # SQL
+})
+
+
+def _is_source_code_file(path: str) -> bool:
+    """Return True if *path* looks like a source-code file.
+
+    Used to decide whether ``code_file=True`` should be passed to
+    ``redact_sensitive_text``.  Source-code files get ENV-assignment and
+    JSON-field patterns skipped to reduce false positives; config/env files
+    keep those patterns active so secrets are properly masked.
+    """
+    ext = os.path.splitext(path)[1].lower()
+    return ext in _SOURCE_CODE_EXTENSIONS
+
 
 _EXPECTED_WRITE_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS}
 
@@ -570,7 +617,9 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # ── Redact secrets (after guard check to skip oversized content) ──
         if result.content:
-            result.content = redact_sensitive_text(result.content, code_file=True)
+            result.content = redact_sensitive_text(
+                result.content, code_file=_is_source_code_file(path),
+            )
             result_dict["content"] = result.content
 
         # Large-file hint: if the file is big and the caller didn't ask
@@ -993,7 +1042,9 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         if hasattr(result, 'matches'):
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
-                    m.content = redact_sensitive_text(m.content, code_file=True)
+                    m.content = redact_sensitive_text(
+                        m.content, code_file=_is_source_code_file(m.path),
+                    )
         result_dict = result.to_dict()
 
         if count >= 3:


### PR DESCRIPTION
## Problem

`redact_sensitive_text` is called with `code_file=True` for ALL files in both `read_file` and `search_files` tools (see `tools/file_tools.py` lines 620 and 1045).  This skips the ENV-assignment and JSON-field regex patterns globally, which means secrets in config files like `.env`, `.yaml`, `.toml`, and `.json` are not properly redacted.

For example, `WEIXIN_TOKEN=abcdef123456` in a `.env` file would only be partially masked (by prefix patterns) instead of fully redacted by the ENV-assignment pattern.

## Fix

Introduce `_is_source_code_file(path)` that checks the file extension against a known set of source-code extensions (`.py`, `.js`, `.go`, `.rs`, `.ts`, `.java`, etc.).  Only source-code files use `code_file=True`; config and env files use `code_file=False` so that ENV-assignment and JSON-field patterns are applied.

This preserves the original intent (avoid false positives in source code like `MAX_TOKENS=100`) while properly protecting secrets in config files.

## Testing

- All existing `test_file_tools.py` tests pass (29/29)
- All redact-related tests pass (155 passed, 3 skipped)
- Verified manually: `.env` file contents are now fully redacted, `.py` files still skip ENV patterns

## Before/After

| File type | Before (`code_file=True`) | After (`code_file=False`) |
|-----------|---------------------------|----------------------------|
| `.env` `WEIXIN_TOKEN=abcdef...` | Partial mask `abcdef...7890` | Full mask `***` |
| `.env` `XIAOMI_API_KEY=sk-...` | Prefix pattern mask | ENV pattern full mask |
| `.py` `MAX_TOKENS=100` | Skipped (no false positive) | Skipped (unchanged) |