### PR TITLE
fix(update): handle uv-tool, pipx, and system-Python installs in hermes update (#29700)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -329,39 +329,31 @@ def stamp_install_method(method: str) -> None:
         pass
 
 
-def is_uv_tool_install(uv_path: Optional[str] = None) -> bool:
-    """Return True when Hermes is installed via ``uv tool install hermes-agent``.
+def is_uv_tool_install() -> bool:
+    """Return True when the *running* Hermes lives in a ``uv tool`` layout.
 
-    ``uv tool`` installs live outside any virtualenv, so ``uv pip install``
-    (the previous update path) fails with ``No virtual environment found``.
-    The fast path inspects ``sys.prefix`` for the standard uv tool layout
-    (``.../uv/tools/hermes-agent/...``); the authoritative fallback shells
-    out to ``uv tool list``. Returns False on any error so callers fall
-    back to the legacy pip path.
+    ``uv tool install hermes-agent`` places the install at
+    ``.../uv/tools/hermes-agent/...`` (default ``~/.local/share/uv/tools``,
+    or ``$UV_TOOL_DIR/...``). Such installs live outside any virtualenv, so
+    ``uv pip install`` fails with ``No virtual environment found`` and the
+    update path must use ``uv tool upgrade`` instead.
+
+    Detection is intentionally restricted to properties of the running
+    interpreter (``sys.prefix`` / ``sys.executable``). We deliberately do
+    NOT consult ``uv tool list``: it would also return True when
+    ``hermes-agent`` happens to be uv-tool-installed on the machine while
+    the *active* Hermes is a regular pip/venv install, causing
+    ``hermes update`` to upgrade the wrong copy. It would also block on a
+    subprocess call (~seconds) just to compute a recommendation string.
     """
-    prefix = os.path.normpath(sys.prefix).replace(os.sep, "/").lower()
-    if "/uv/tools/hermes-agent/" in prefix + "/":
+    def _has_uv_tool_marker(path: str) -> bool:
+        norm = os.path.normpath(path).replace(os.sep, "/").lower()
+        return "/uv/tools/hermes-agent/" in norm + "/"
+
+    if _has_uv_tool_marker(sys.prefix):
         return True
-    if uv_path is None:
-        import shutil
-        uv_path = shutil.which("uv")
-    if not uv_path:
-        return False
-    try:
-        result = subprocess.run(
-            [uv_path, "tool", "list"],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return False
-    if result.returncode != 0:
-        return False
-    for line in result.stdout.splitlines():
-        tokens = line.strip().split()
-        if tokens and tokens[0] == "hermes-agent":
-            return True
+    if _has_uv_tool_marker(sys.executable or ""):
+        return True
     return False
 
 
@@ -374,11 +366,10 @@ def recommended_update_command_for_method(method: str) -> str:
     if method == "docker":
         return "docker pull nousresearch/hermes-agent:latest"
     if method == "pip":
+        if is_uv_tool_install():
+            return "uv tool upgrade hermes-agent"
         import shutil
-        uv = shutil.which("uv")
-        if uv:
-            if is_uv_tool_install(uv):
-                return "uv tool upgrade hermes-agent"
+        if shutil.which("uv"):
             return "uv pip install --upgrade hermes-agent"
         return "pip install --upgrade hermes-agent"
     return "hermes update"

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -329,6 +329,42 @@ def stamp_install_method(method: str) -> None:
         pass
 
 
+def is_uv_tool_install(uv_path: Optional[str] = None) -> bool:
+    """Return True when Hermes is installed via ``uv tool install hermes-agent``.
+
+    ``uv tool`` installs live outside any virtualenv, so ``uv pip install``
+    (the previous update path) fails with ``No virtual environment found``.
+    The fast path inspects ``sys.prefix`` for the standard uv tool layout
+    (``.../uv/tools/hermes-agent/...``); the authoritative fallback shells
+    out to ``uv tool list``. Returns False on any error so callers fall
+    back to the legacy pip path.
+    """
+    prefix = os.path.normpath(sys.prefix).replace(os.sep, "/").lower()
+    if "/uv/tools/hermes-agent/" in prefix + "/":
+        return True
+    if uv_path is None:
+        import shutil
+        uv_path = shutil.which("uv")
+    if not uv_path:
+        return False
+    try:
+        result = subprocess.run(
+            [uv_path, "tool", "list"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if result.returncode != 0:
+        return False
+    for line in result.stdout.splitlines():
+        tokens = line.strip().split()
+        if tokens and tokens[0] == "hermes-agent":
+            return True
+    return False
+
+
 def recommended_update_command_for_method(method: str) -> str:
     """Return the update command or guidance for a given install method."""
     if method == "nixos":
@@ -341,6 +377,8 @@ def recommended_update_command_for_method(method: str) -> str:
         import shutil
         uv = shutil.which("uv")
         if uv:
+            if is_uv_tool_install(uv):
+                return "uv tool upgrade hermes-agent"
             return "uv pip install --upgrade hermes-agent"
         return "pip install --upgrade hermes-agent"
     return "hermes update"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8977,11 +8977,13 @@ def _cmd_update_pip(args):
     print("→ Checking PyPI for updates...")
 
     uv = shutil.which("uv")
-    if uv:
-        if is_uv_tool_install(uv):
-            cmd = [uv, "tool", "upgrade", "hermes-agent"]
-        else:
-            cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
+    if is_uv_tool_install():
+        if not uv:
+            print("✗ Detected a uv-tool install but `uv` is not on PATH; install uv and retry.")
+            sys.exit(1)
+        cmd = [uv, "tool", "upgrade", "hermes-agent"]
+    elif uv:
+        cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
     else:
         cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "hermes-agent"]
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8977,19 +8977,43 @@ def _cmd_update_pip(args):
     print("→ Checking PyPI for updates...")
 
     uv = shutil.which("uv")
+    in_venv = sys.prefix != sys.base_prefix
+    # pipx-managed installs live under .../pipx/venvs/<name>/...
+    pipx_managed = "pipx" in sys.prefix.split(os.sep)
+    pipx = shutil.which("pipx") if pipx_managed else None
+
+    # Only the ``uv pip install`` path inside a venv needs VIRTUAL_ENV
+    # exported (uv refuses to install without it when the launcher shim
+    # didn't activate the venv). ``uv tool upgrade`` / ``pipx upgrade``
+    # operate on a named environment and ignore VIRTUAL_ENV, so we don't
+    # set it for them.
+    export_virtualenv = False
+
     if is_uv_tool_install():
         if not uv:
             print("✗ Detected a uv-tool install but `uv` is not on PATH; install uv and retry.")
             sys.exit(1)
         cmd = [uv, "tool", "upgrade", "hermes-agent"]
+    elif pipx_managed and pipx:
+        # pipx owns its own venv; ``pipx upgrade`` is the only correct path.
+        # Matches scripts/auto-update.sh, which already uses pipx upgrade.
+        cmd = [pipx, "upgrade", "hermes-agent"]
     elif uv:
         cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
+        if in_venv:
+            # Launcher shim runs the venv interpreter but doesn't export
+            # VIRTUAL_ENV; without it uv errors "No virtual environment found".
+            export_virtualenv = True
+        else:
+            # Outside any venv, ``--system`` lets uv target the active
+            # interpreter, matching pip's default behaviour.
+            cmd.insert(3, "--system")
     else:
         cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "hermes-agent"]
 
     print(f"→ Running: {' '.join(cmd)}")
     run_kwargs = {}
-    if sys.prefix != sys.base_prefix:
+    if export_virtualenv:
         run_kwargs["env"] = {**os.environ, "VIRTUAL_ENV": sys.prefix}
     result = subprocess.run(cmd, **run_kwargs)
     if result.returncode != 0:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8971,13 +8971,17 @@ def cmd_update(args):
 def _cmd_update_pip(args):
     """Update Hermes via pip (for PyPI installs)."""
     from hermes_cli import __version__
+    from hermes_cli.config import is_uv_tool_install
 
     print(f"→ Current version: {__version__}")
     print("→ Checking PyPI for updates...")
 
     uv = shutil.which("uv")
     if uv:
-        cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
+        if is_uv_tool_install(uv):
+            cmd = [uv, "tool", "upgrade", "hermes-agent"]
+        else:
+            cmd = [uv, "pip", "install", "--upgrade", "hermes-agent"]
     else:
         cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "hermes-agent"]
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -651,6 +651,7 @@ AUTHOR_MAP = {
     "alexazzjjtt@163.com": "alexzhu0",
     "pub_forgreatagent@antgroup.com": "AntAISecurityLab",
     "252620095+briandevans@users.noreply.github.com": "briandevans",
+    "incharge.automation@gmail.com": "inchargeautomation-lab",
     "danielrpike9@gmail.com": "Bartok9",
     "96944678+ymylive@users.noreply.github.com": "sweetcornna",
     "skozyuk@cruxexperts.com": "CruxExperts",

--- a/tests/hermes_cli/test_uv_tool_update.py
+++ b/tests/hermes_cli/test_uv_tool_update.py
@@ -6,6 +6,10 @@ environment found``. ``is_uv_tool_install`` should detect this layout and
 both the user-facing recommended command and the actual
 ``_cmd_update_pip`` subprocess invocation should switch to
 ``uv tool upgrade hermes-agent``.
+
+Detection is restricted to properties of the running interpreter
+(``sys.prefix`` / ``sys.executable``) so a pip/venv install on a machine
+that also has ``uv tool install hermes-agent`` does not get misclassified.
 """
 from __future__ import annotations
 
@@ -26,68 +30,59 @@ class TestIsUvToolInstall:
         from hermes_cli import config
 
         with patch.object(config.sys, "prefix", "/home/user/.local/share/uv/tools/hermes-agent"):
-            assert config.is_uv_tool_install("uv") is True
+            assert config.is_uv_tool_install() is True
 
-    def test_returns_true_when_uv_tool_list_includes_hermes_agent(self):
-        from hermes_cli import config
-
-        completed = subprocess.CompletedProcess(
-            ["uv", "tool", "list"],
-            0,
-            stdout="hermes-agent v0.14.0\n- hermes\n- hermes-bot\nblack v23.0.0\n- black\n",
-            stderr="",
-        )
-        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
-             patch("subprocess.run", return_value=completed) as mock_run:
-            assert config.is_uv_tool_install("/usr/local/bin/uv") is True
-            mock_run.assert_called_once()
-            assert mock_run.call_args[0][0] == ["/usr/local/bin/uv", "tool", "list"]
-
-    def test_returns_false_when_uv_tool_list_lacks_hermes_agent(self):
-        from hermes_cli import config
-
-        completed = subprocess.CompletedProcess(
-            ["uv", "tool", "list"], 0, stdout="black v23.0.0\n- black\nruff v0.5.0\n- ruff\n", stderr=""
-        )
-        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
-             patch("subprocess.run", return_value=completed):
-            assert config.is_uv_tool_install("uv") is False
-
-    def test_returns_false_when_uv_tool_list_fails(self):
-        from hermes_cli import config
-
-        completed = subprocess.CompletedProcess(["uv", "tool", "list"], 2, stdout="", stderr="oops")
-        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
-             patch("subprocess.run", return_value=completed):
-            assert config.is_uv_tool_install("uv") is False
-
-    def test_returns_false_when_subprocess_raises(self):
+    def test_returns_true_when_sys_executable_matches_uv_tool_layout(self):
+        """Some uv-tool layouts surface the marker on ``sys.executable`` (bin/python)."""
         from hermes_cli import config
 
         with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
-             patch("subprocess.run", side_effect=subprocess.TimeoutExpired(["uv"], 15)):
-            assert config.is_uv_tool_install("uv") is False
+             patch.object(
+                 config.sys,
+                 "executable",
+                 "/home/user/.local/share/uv/tools/hermes-agent/bin/python",
+             ):
+            assert config.is_uv_tool_install() is True
 
-    def test_returns_false_when_no_uv_available(self):
+    def test_returns_false_when_neither_prefix_nor_executable_matches(self):
         from hermes_cli import config
 
         with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
-             patch("shutil.which", return_value=None):
+             patch.object(config.sys, "executable", "/usr/bin/python3"):
             assert config.is_uv_tool_install() is False
 
-    def test_indented_alias_line_does_not_false_positive(self):
-        """A tool whose alias line is ``- hermes-agent`` shouldn't match."""
+    def test_does_not_consult_uv_tool_list(self):
+        """Detection must NOT shell out: ``uv tool list`` would false-positive
+        when the active install is pip/venv but the machine also has
+        ``uv tool install hermes-agent`` somewhere on disk. Copilot review on
+        PR #29703 flagged this; the fix is to never call ``uv tool list``
+        from the detection path."""
         from hermes_cli import config
 
-        completed = subprocess.CompletedProcess(
-            ["uv", "tool", "list"],
-            0,
-            stdout="some-other-tool v1.0.0\n- hermes-agent\n",
-            stderr="",
-        )
         with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
-             patch("subprocess.run", return_value=completed):
-            assert config.is_uv_tool_install("uv") is False
+             patch.object(config.sys, "executable", "/usr/bin/python3"), \
+             patch("subprocess.run") as mock_run:
+            assert config.is_uv_tool_install() is False
+            mock_run.assert_not_called()
+
+    def test_case_insensitive_match(self):
+        """Match must be case-insensitive — Windows paths preserve case
+        (e.g. ``...AppData\\Local\\UV\\Tools\\hermes-agent``) and a case-sensitive
+        check would miss them. We exercise the lower-cased compare path here
+        without monkey-patching ``os.sep``, which would break the whole suite."""
+        from hermes_cli import config
+
+        with patch.object(
+            config.sys, "prefix", "/HOME/USER/.local/share/UV/Tools/hermes-agent"
+        ):
+            assert config.is_uv_tool_install() is True
+
+    def test_handles_empty_executable(self):
+        from hermes_cli import config
+
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch.object(config.sys, "executable", ""):
+            assert config.is_uv_tool_install() is False
 
 
 # ---------------------------------------------------------------------------
@@ -104,6 +99,16 @@ class TestRecommendedUpdateCommandForUvTool:
             cmd = config.recommended_update_command_for_method("pip")
             assert cmd == "uv tool upgrade hermes-agent"
 
+    def test_uv_tool_install_recommends_uv_tool_upgrade_even_without_uv_on_path(self):
+        """Recommendation reflects the *install method*, not whether ``uv`` is
+        currently on PATH — the user needs to know the right command to run."""
+        from hermes_cli import config
+
+        with patch("shutil.which", return_value=None), \
+             patch.object(config, "is_uv_tool_install", return_value=True):
+            cmd = config.recommended_update_command_for_method("pip")
+            assert cmd == "uv tool upgrade hermes-agent"
+
     def test_uv_pip_install_keeps_legacy_recommendation(self):
         """Existing behavior: uv is on PATH but Hermes is a regular pip install."""
         from hermes_cli import config
@@ -114,11 +119,27 @@ class TestRecommendedUpdateCommandForUvTool:
             assert cmd == "uv pip install --upgrade hermes-agent"
 
     def test_no_uv_falls_back_to_plain_pip(self):
-        from hermes_cli.config import recommended_update_command_for_method
+        from hermes_cli import config
 
-        with patch("shutil.which", return_value=None):
-            cmd = recommended_update_command_for_method("pip")
+        with patch("shutil.which", return_value=None), \
+             patch.object(config, "is_uv_tool_install", return_value=False):
+            cmd = config.recommended_update_command_for_method("pip")
             assert cmd == "pip install --upgrade hermes-agent"
+
+    def test_recommendation_does_not_spawn_subprocess(self):
+        """Computing the recommendation string must be cheap — no ``uv tool list``
+        spawn. Copilot review on PR #29703 flagged the prior subprocess hop
+        as adding overhead and a multi-second timeout window for what is
+        purely a display string."""
+        from hermes_cli import config
+
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch.object(config.sys, "executable", "/usr/bin/python3"), \
+             patch("shutil.which", return_value="/usr/local/bin/uv"), \
+             patch("subprocess.run") as mock_run:
+            cmd = config.recommended_update_command_for_method("pip")
+            mock_run.assert_not_called()
+            assert cmd == "uv pip install --upgrade hermes-agent"
 
 
 # ---------------------------------------------------------------------------
@@ -162,7 +183,8 @@ class TestCmdUpdatePipUsesUvTool:
         from hermes_cli.main import _cmd_update_pip
 
         mock_run.return_value = subprocess.CompletedProcess(["pip"], 0, stdout="", stderr="")
-        with patch("shutil.which", return_value=None):
+        with patch("shutil.which", return_value=None), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=False):
             _cmd_update_pip(SimpleNamespace())
 
         cmd = mock_run.call_args[0][0]
@@ -178,3 +200,18 @@ class TestCmdUpdatePipUsesUvTool:
             with pytest.raises(SystemExit) as exc_info:
                 _cmd_update_pip(SimpleNamespace())
         assert exc_info.value.code == 1
+
+    @patch("subprocess.run")
+    def test_uv_tool_install_without_uv_on_path_exits_with_hint(self, mock_run):
+        """If the running interpreter looks like a uv-tool install but ``uv`` is
+        somehow missing from PATH, surface a clear hint instead of silently
+        falling back to ``python -m pip``, which would either fail (no venv)
+        or upgrade the wrong copy."""
+        from hermes_cli.main import _cmd_update_pip
+
+        with patch("shutil.which", return_value=None), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=True):
+            with pytest.raises(SystemExit) as exc_info:
+                _cmd_update_pip(SimpleNamespace())
+        assert exc_info.value.code == 1
+        mock_run.assert_not_called()

--- a/tests/hermes_cli/test_uv_tool_update.py
+++ b/tests/hermes_cli/test_uv_tool_update.py
@@ -215,3 +215,97 @@ class TestCmdUpdatePipUsesUvTool:
                 _cmd_update_pip(SimpleNamespace())
         assert exc_info.value.code == 1
         mock_run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# pipx-managed installs, --system fallback, and VIRTUAL_ENV overlay
+# (issue #29700 / #35031 family — consolidated update-path handling)
+# ---------------------------------------------------------------------------
+
+
+class TestCmdUpdatePipInstallLayouts:
+    """The uv pip path must adapt to where the running interpreter lives:
+
+    - inside a venv (launcher shim)  -> export VIRTUAL_ENV, no ``--system``
+    - bare pip outside any venv      -> add ``--system``, no overlay
+    - pipx-managed                   -> ``pipx upgrade``
+    """
+
+    @patch("subprocess.run")
+    def test_pipx_managed_uses_pipx_upgrade(self, mock_run, monkeypatch):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        monkeypatch.setattr(hm.sys, "prefix", "/home/u/.local/pipx/venvs/hermes-agent")
+        monkeypatch.setattr(hm.sys, "base_prefix", "/usr")
+
+        def _which(name):
+            return {"uv": "/usr/bin/uv", "pipx": "/usr/bin/pipx"}.get(name)
+
+        with patch("shutil.which", side_effect=_which), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=False):
+            hm._cmd_update_pip(SimpleNamespace())
+
+        assert mock_run.call_args[0][0] == ["/usr/bin/pipx", "upgrade", "hermes-agent"]
+        # pipx upgrade ignores VIRTUAL_ENV; we must not set it.
+        assert "env" not in mock_run.call_args.kwargs
+
+    @patch("subprocess.run")
+    def test_pipx_layout_without_pipx_binary_treated_as_venv(
+        self, mock_run, monkeypatch
+    ):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        monkeypatch.setattr(hm.sys, "prefix", "/home/u/.local/pipx/venvs/hermes-agent")
+        monkeypatch.setattr(hm.sys, "base_prefix", "/usr")
+
+        # pipx layout detected via prefix, but pipx binary missing on PATH.
+        def _which(name):
+            return "/usr/bin/uv" if name == "uv" else None
+
+        with patch("shutil.which", side_effect=_which), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=False):
+            hm._cmd_update_pip(SimpleNamespace())
+
+        # prefix != base_prefix, so this is treated as a venv -> overlay, no --system.
+        assert mock_run.call_args[0][0] == [
+            "/usr/bin/uv", "pip", "install", "--upgrade", "hermes-agent",
+        ]
+        assert mock_run.call_args.kwargs["env"]["VIRTUAL_ENV"].endswith("hermes-agent")
+
+    @patch("subprocess.run")
+    def test_bare_pip_outside_venv_adds_system(self, mock_run, monkeypatch):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        # No venv: prefix == base_prefix.
+        monkeypatch.setattr(hm.sys, "prefix", "/usr")
+        monkeypatch.setattr(hm.sys, "base_prefix", "/usr")
+
+        with patch("shutil.which", return_value="/usr/bin/uv"), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=False):
+            hm._cmd_update_pip(SimpleNamespace())
+
+        assert mock_run.call_args[0][0] == [
+            "/usr/bin/uv", "pip", "install", "--system", "--upgrade", "hermes-agent",
+        ]
+        assert "env" not in mock_run.call_args.kwargs
+
+    @patch("subprocess.run")
+    def test_venv_exports_virtualenv_and_omits_system(self, mock_run, monkeypatch):
+        from hermes_cli import main as hm
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.setattr(hm.sys, "prefix", "/home/u/.hermes/hermes-agent/venv")
+        monkeypatch.setattr(hm.sys, "base_prefix", "/usr")
+
+        with patch("shutil.which", return_value="/usr/bin/uv"), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=False):
+            hm._cmd_update_pip(SimpleNamespace())
+
+        cmd = mock_run.call_args[0][0]
+        assert "--system" not in cmd
+        assert cmd == ["/usr/bin/uv", "pip", "install", "--upgrade", "hermes-agent"]
+        assert mock_run.call_args.kwargs["env"]["VIRTUAL_ENV"] == "/home/u/.hermes/hermes-agent/venv"

--- a/tests/hermes_cli/test_uv_tool_update.py
+++ b/tests/hermes_cli/test_uv_tool_update.py
@@ -1,0 +1,180 @@
+"""Tests for uv-tool install detection in the update path (issue #29700).
+
+``uv tool install hermes-agent`` lives outside any venv, so the previous
+``uv pip install --upgrade`` update path failed with ``No virtual
+environment found``. ``is_uv_tool_install`` should detect this layout and
+both the user-facing recommended command and the actual
+``_cmd_update_pip`` subprocess invocation should switch to
+``uv tool upgrade hermes-agent``.
+"""
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# is_uv_tool_install
+# ---------------------------------------------------------------------------
+
+
+class TestIsUvToolInstall:
+    def test_returns_true_when_sys_prefix_matches_uv_tool_layout(self):
+        from hermes_cli import config
+
+        with patch.object(config.sys, "prefix", "/home/user/.local/share/uv/tools/hermes-agent"):
+            assert config.is_uv_tool_install("uv") is True
+
+    def test_returns_true_when_uv_tool_list_includes_hermes_agent(self):
+        from hermes_cli import config
+
+        completed = subprocess.CompletedProcess(
+            ["uv", "tool", "list"],
+            0,
+            stdout="hermes-agent v0.14.0\n- hermes\n- hermes-bot\nblack v23.0.0\n- black\n",
+            stderr="",
+        )
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch("subprocess.run", return_value=completed) as mock_run:
+            assert config.is_uv_tool_install("/usr/local/bin/uv") is True
+            mock_run.assert_called_once()
+            assert mock_run.call_args[0][0] == ["/usr/local/bin/uv", "tool", "list"]
+
+    def test_returns_false_when_uv_tool_list_lacks_hermes_agent(self):
+        from hermes_cli import config
+
+        completed = subprocess.CompletedProcess(
+            ["uv", "tool", "list"], 0, stdout="black v23.0.0\n- black\nruff v0.5.0\n- ruff\n", stderr=""
+        )
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch("subprocess.run", return_value=completed):
+            assert config.is_uv_tool_install("uv") is False
+
+    def test_returns_false_when_uv_tool_list_fails(self):
+        from hermes_cli import config
+
+        completed = subprocess.CompletedProcess(["uv", "tool", "list"], 2, stdout="", stderr="oops")
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch("subprocess.run", return_value=completed):
+            assert config.is_uv_tool_install("uv") is False
+
+    def test_returns_false_when_subprocess_raises(self):
+        from hermes_cli import config
+
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch("subprocess.run", side_effect=subprocess.TimeoutExpired(["uv"], 15)):
+            assert config.is_uv_tool_install("uv") is False
+
+    def test_returns_false_when_no_uv_available(self):
+        from hermes_cli import config
+
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch("shutil.which", return_value=None):
+            assert config.is_uv_tool_install() is False
+
+    def test_indented_alias_line_does_not_false_positive(self):
+        """A tool whose alias line is ``- hermes-agent`` shouldn't match."""
+        from hermes_cli import config
+
+        completed = subprocess.CompletedProcess(
+            ["uv", "tool", "list"],
+            0,
+            stdout="some-other-tool v1.0.0\n- hermes-agent\n",
+            stderr="",
+        )
+        with patch.object(config.sys, "prefix", "/some/unrelated/venv"), \
+             patch("subprocess.run", return_value=completed):
+            assert config.is_uv_tool_install("uv") is False
+
+
+# ---------------------------------------------------------------------------
+# recommended_update_command_for_method
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendedUpdateCommandForUvTool:
+    def test_uv_tool_install_recommends_uv_tool_upgrade(self):
+        from hermes_cli import config
+
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), \
+             patch.object(config, "is_uv_tool_install", return_value=True):
+            cmd = config.recommended_update_command_for_method("pip")
+            assert cmd == "uv tool upgrade hermes-agent"
+
+    def test_uv_pip_install_keeps_legacy_recommendation(self):
+        """Existing behavior: uv is on PATH but Hermes is a regular pip install."""
+        from hermes_cli import config
+
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), \
+             patch.object(config, "is_uv_tool_install", return_value=False):
+            cmd = config.recommended_update_command_for_method("pip")
+            assert cmd == "uv pip install --upgrade hermes-agent"
+
+    def test_no_uv_falls_back_to_plain_pip(self):
+        from hermes_cli.config import recommended_update_command_for_method
+
+        with patch("shutil.which", return_value=None):
+            cmd = recommended_update_command_for_method("pip")
+            assert cmd == "pip install --upgrade hermes-agent"
+
+
+# ---------------------------------------------------------------------------
+# _cmd_update_pip subprocess command
+# ---------------------------------------------------------------------------
+
+
+class TestCmdUpdatePipUsesUvTool:
+    @patch("subprocess.run")
+    def test_runs_uv_tool_upgrade_when_uv_tool_install(self, mock_run):
+        """The actual subprocess invocation must switch to ``uv tool upgrade``."""
+        from hermes_cli.main import _cmd_update_pip
+
+        mock_run.return_value = subprocess.CompletedProcess(["uv"], 0, stdout="", stderr="")
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=True):
+            _cmd_update_pip(SimpleNamespace())
+
+        assert mock_run.call_args[0][0] == ["/usr/local/bin/uv", "tool", "upgrade", "hermes-agent"]
+
+    @patch("subprocess.run")
+    def test_runs_uv_pip_install_when_not_uv_tool(self, mock_run):
+        """Existing behavior preserved when uv is present but Hermes isn't a tool install."""
+        from hermes_cli.main import _cmd_update_pip
+
+        mock_run.return_value = subprocess.CompletedProcess(["uv"], 0, stdout="", stderr="")
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=False):
+            _cmd_update_pip(SimpleNamespace())
+
+        assert mock_run.call_args[0][0] == [
+            "/usr/local/bin/uv",
+            "pip",
+            "install",
+            "--upgrade",
+            "hermes-agent",
+        ]
+
+    @patch("subprocess.run")
+    def test_falls_back_to_pip_when_no_uv(self, mock_run):
+        from hermes_cli.main import _cmd_update_pip
+
+        mock_run.return_value = subprocess.CompletedProcess(["pip"], 0, stdout="", stderr="")
+        with patch("shutil.which", return_value=None):
+            _cmd_update_pip(SimpleNamespace())
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[1:] == ["-m", "pip", "install", "--upgrade", "hermes-agent"]
+
+    @patch("subprocess.run")
+    def test_exits_nonzero_on_subprocess_failure(self, mock_run):
+        from hermes_cli.main import _cmd_update_pip
+
+        mock_run.return_value = subprocess.CompletedProcess(["uv"], 1, stdout="", stderr="")
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), \
+             patch("hermes_cli.config.is_uv_tool_install", return_value=True):
+            with pytest.raises(SystemExit) as exc_info:
+                _cmd_update_pip(SimpleNamespace())
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary
`hermes update` now succeeds across every no-venv install layout, instead of failing with `No virtual environment found` whenever Hermes wasn't installed into an activatable virtualenv.

`_cmd_update_pip` always ran `uv pip install --upgrade hermes-agent` when uv was on PATH, but that errors out for `uv tool install`, `pipx install`, and bare system-Python installs — none of which expose an active venv. The update path now detects the actual layout and picks the right command.

## Changes
- `hermes_cli/config.py`: `is_uv_tool_install()` helper (detects `uv tool` layout from the running interpreter's `sys.prefix`/`sys.executable` only — never `uv tool list`, so a pip/venv Hermes on a machine that also has a uv-tool copy isn't misclassified). `recommended_update_command_for_method("pip")` routes through it.
- `hermes_cli/main.py` `_cmd_update_pip`:
  - `uv tool` install → `uv tool upgrade hermes-agent`
  - pipx-managed install (`sys.prefix` under `.../pipx/...`) → `pipx upgrade hermes-agent` (matches `scripts/auto-update.sh`)
  - real venv → `uv pip install --upgrade` + `VIRTUAL_ENV` overlay (preserves #35224)
  - bare pip outside any venv → `uv pip install --system --upgrade`
  - These four branches are mutually exclusive; `VIRTUAL_ENV` is exported only for the uv-pip-in-venv path (`uv tool`/`pipx upgrade` ignore it).
- `tests/hermes_cli/test_uv_tool_update.py`: uv-tool detection + recommendation + subprocess tests (from #29703), plus a new layout class covering pipx, `--system`, and the venv overlay.
- `scripts/release.py`: AUTHOR_MAP entry for the pipx co-author.

## Validation
| Layout | Command | VIRTUAL_ENV |
|---|---|---|
| `uv tool install` | `uv tool upgrade hermes-agent` | — |
| `pipx install` | `pipx upgrade hermes-agent` | — |
| venv (launcher shim) | `uv pip install --upgrade hermes-agent` | exported |
| bare pip, no venv | `uv pip install --system --upgrade hermes-agent` | — |
| no uv | `python -m pip install --upgrade hermes-agent` | — |

`tests/hermes_cli/test_uv_tool_update.py` + `test_cmd_update.py`: 43/43 pass. E2E verified against the real `_cmd_update_pip` with real imports for all five layouts above.

## Credit
Consolidates #29700's `hermes update` cluster:
- uv-tool detection cherry-picked from @briandevans (#29703), authorship preserved.
- pipx detection idea from @inchargeautomation-lab (#29852), credited via Co-authored-by.
- Supersedes #29707 (@Bartok9) and #29812 (@zombi3butt), which fixed the same uv-tool bug. Thanks to all four.

Fixes #29700.

## Infographic

![hermes-update-install-layout-aware](https://v3b.fal.media/files/b/0a9c441e/oijpkMOw1YbjImby4LLWl_5XLpAppH.png)

