### PR TITLE
fix(skills): transactional skills reset --restore + read-only Nix tree cleanup (#34972)

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -845,3 +845,31 @@ class TestResetBundledSkill:
             post_manifest = _read_manifest()
             assert "google-workspace" in post_manifest
         assert (skills_dir / "productivity" / "google-workspace" / "SKILL.md").exists()
+
+    def test_reset_restore_preserves_manifest_on_rmtree_failure(self, tmp_path):
+        """#34972: when rmtree fails (e.g. read-only Nix-store files), the manifest
+        entry must NOT be deleted — otherwise the skill enters a limbo state."""
+        import os, stat
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        dest = skills_dir / "productivity" / "google-workspace"
+        dest.mkdir(parents=True)
+        (dest / "SKILL.md").write_text("# user version\n")
+        # Make directory read-only to simulate Nix-store permissions
+        os.chmod(dest, stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH)
+        manifest_file.write_text("google-workspace:STALEHASH000000000000000000000000\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = reset_bundled_skill("google-workspace", restore=True)
+
+        # Restore failed, but manifest must be preserved
+        assert result["ok"] is False
+        assert result["action"] == "not_reset"
+        assert "Manifest entry preserved" in result["message"]
+        # Manifest still has the old entry (not deleted)
+        manifest_after = manifest_file.read_text()
+        assert "google-workspace" in manifest_after
+        # Cleanup: restore permissions for tmp_path removal
+        os.chmod(dest, stat.S_IRWXU)

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -846,10 +846,59 @@ class TestResetBundledSkill:
             assert "google-workspace" in post_manifest
         assert (skills_dir / "productivity" / "google-workspace" / "SKILL.md").exists()
 
+    def test_reset_restore_succeeds_on_readonly_nix_tree(self, tmp_path):
+        """#34972: --restore must succeed even when the user copy is a fully
+        read-only tree (r-xr-xr-x dirs + files), as produced by copying a
+        Nix-store source. The manifest is re-baselined and bundled re-copied."""
+        import os
+        import stat
+
+        bundled = self._setup_bundled(tmp_path)
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        dest = skills_dir / "productivity" / "google-workspace"
+        sub = dest / "references"
+        sub.mkdir(parents=True)
+        (dest / "SKILL.md").write_text("# user version\n")
+        (sub / "ref.md").write_text("# nested ref\n")
+        manifest_file.write_text(
+            "google-workspace:STALEHASH000000000000000000000000\n"
+        )
+
+        # Read-only files AND directories — the real Nix-store case.
+        ro_dir = (
+            stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP
+            | stat.S_IROTH | stat.S_IXOTH
+        )
+        os.chmod(sub / "ref.md", stat.S_IREAD)
+        os.chmod(dest / "SKILL.md", stat.S_IREAD)
+        os.chmod(sub, ro_dir)
+        os.chmod(dest, ro_dir)
+
+        try:
+            with self._patches(bundled, skills_dir, manifest_file):
+                result = reset_bundled_skill("google-workspace", restore=True)
+
+            assert result["ok"] is True
+            assert result["action"] == "restored"
+            # Bundled version was re-copied over the (deleted) user copy.
+            assert "upstream" in (dest / "SKILL.md").read_text()
+            # The read-only nested user dir/file was fully removed, not left behind.
+            assert not (sub / "ref.md").exists()
+            # Manifest now tracks the skill again (re-baselined, not in limbo).
+            manifest_after = _read_manifest()
+            assert "google-workspace" in manifest_after
+        finally:
+            # Restore perms so tmp_path teardown can remove anything left.
+            for p in (sub, dest):
+                if p.exists():
+                    os.chmod(p, stat.S_IRWXU)
+
     def test_reset_restore_preserves_manifest_on_rmtree_failure(self, tmp_path):
-        """#34972: when rmtree fails (e.g. read-only Nix-store files), the manifest
-        entry must NOT be deleted — otherwise the skill enters a limbo state."""
-        import os, stat
+        """#34972: when the user copy genuinely cannot be removed, the manifest
+        entry must NOT be deleted — otherwise the skill enters a limbo state
+        where future syncs silently skip it forever."""
         bundled = self._setup_bundled(tmp_path)
         skills_dir = tmp_path / "user_skills"
         manifest_file = skills_dir / ".bundled_manifest"
@@ -857,19 +906,25 @@ class TestResetBundledSkill:
         dest = skills_dir / "productivity" / "google-workspace"
         dest.mkdir(parents=True)
         (dest / "SKILL.md").write_text("# user version\n")
-        # Make directory read-only to simulate Nix-store permissions
-        os.chmod(dest, stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH)
-        manifest_file.write_text("google-workspace:STALEHASH000000000000000000000000\n")
+        manifest_file.write_text(
+            "google-workspace:STALEHASH000000000000000000000000\n"
+        )
 
-        with self._patches(bundled, skills_dir, manifest_file):
+        # Simulate an unremovable tree (e.g. a busy mountpoint or a path even
+        # chmod can't rescue) by making the removal helper raise.
+        def _boom(_path):
+            raise PermissionError(13, "Permission denied")
+
+        with self._patches(bundled, skills_dir, manifest_file), patch(
+            "tools.skills_sync._rmtree_writable", side_effect=_boom
+        ):
             result = reset_bundled_skill("google-workspace", restore=True)
 
-        # Restore failed, but manifest must be preserved
+        # Restore failed, and the manifest must be left untouched.
         assert result["ok"] is False
         assert result["action"] == "not_reset"
         assert "Manifest entry preserved" in result["message"]
-        # Manifest still has the old entry (not deleted)
         manifest_after = manifest_file.read_text()
         assert "google-workspace" in manifest_after
-        # Cleanup: restore permissions for tmp_path removal
-        os.chmod(dest, stat.S_IRWXU)
+        # User copy is still on disk (we changed nothing).
+        assert (dest / "SKILL.md").exists()

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -886,9 +886,8 @@ class TestResetBundledSkill:
             assert "upstream" in (dest / "SKILL.md").read_text()
             # The read-only nested user dir/file was fully removed, not left behind.
             assert not (sub / "ref.md").exists()
-            # Manifest now tracks the skill again (re-baselined, not in limbo).
-            manifest_after = _read_manifest()
-            assert "google-workspace" in manifest_after
+            # sync ran and re-copied the skill (not stuck in limbo).
+            assert "google-workspace" in result["synced"]["copied"]
         finally:
             # Restore perms so tmp_path teardown can remove anything left.
             for p in (sub, dest):

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -517,7 +517,10 @@ def sync_skills(quiet: bool = False) -> dict:
                         if not quiet:
                             print(f"  ↑ {skill_name} (updated)")
                         # Remove backup after successful copy
-                        shutil.rmtree(backup, ignore_errors=True)
+                        try:
+                            _rmtree_writable(backup)
+                        except (OSError, IOError):
+                            logger.debug("Could not remove backup %s", backup, exc_info=True)
                     except (OSError, IOError):
                         # Restore from backup
                         if backup.exists() and not dest.exists():
@@ -563,6 +566,21 @@ def sync_skills(quiet: bool = False) -> dict:
     }
 
 
+def _rmtree_writable(path: Path) -> None:
+    """Remove a directory tree, making read-only files writable first.
+
+    Handles immutable package sources (Nix store, deb/rpm installs) that
+    preserve read-only permissions on copied files.  See #34860, #34972.
+    """
+    def _on_error(func, fpath, exc_info):
+        # Make the file/directory writable and retry
+        import stat
+        os.chmod(fpath, stat.S_IWRITE)
+        func(fpath)
+
+    shutil.rmtree(path, onerror=_on_error)
+
+
 def reset_bundled_skill(name: str, restore: bool = False) -> dict:
     """
     Reset a bundled skill's manifest tracking so future syncs work normally.
@@ -606,12 +624,9 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
             "synced": None,
         }
 
-    # Step 1: drop the manifest entry so next sync treats it as new
-    if in_manifest:
-        del manifest[name]
-        _write_manifest(manifest)
-
-    # Step 2 (optional): delete the user's copy so next sync re-copies bundled
+    # Step 1 (optional): delete the user's copy so next sync re-copies bundled.
+    # Must happen BEFORE manifest deletion so that a failed rmtree does not
+    # leave the skill in a manifest-less limbo state (see #34972).
     deleted_user_copy = False
     if restore:
         if not is_bundled:
@@ -619,27 +634,31 @@ def reset_bundled_skill(name: str, restore: bool = False) -> dict:
                 "ok": False,
                 "action": "bundled_missing",
                 "message": (
-                    f"'{name}' has no bundled source — manifest entry cleared "
+                    f"'{name}' has no bundled source — manifest entry preserved "
                     f"but cannot restore from bundled (skill was removed upstream)."
                 ),
                 "synced": None,
             }
-        # The destination mirrors the bundled path relative to bundled_dir.
         dest = _compute_relative_dest(bundled_by_name[name], bundled_dir)
         if dest.exists():
             try:
-                shutil.rmtree(dest)
+                _rmtree_writable(dest)
                 deleted_user_copy = True
             except (OSError, IOError) as e:
                 return {
                     "ok": False,
-                    "action": "manifest_cleared",
+                    "action": "not_reset",
                     "message": (
-                        f"Cleared manifest entry for '{name}' but could not "
-                        f"delete user copy at {dest}: {e}"
+                        f"Could not delete user copy at {dest}: {e}. "
+                        f"Manifest entry preserved — nothing was changed."
                     ),
                     "synced": None,
                 }
+
+    # Step 2: drop the manifest entry so next sync treats it as new
+    if in_manifest:
+        del manifest[name]
+        _write_manifest(manifest)
 
     # Step 3: run sync to re-baseline (or re-copy if we deleted)
     synced = sync_skills(quiet=True)

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -567,15 +567,24 @@ def sync_skills(quiet: bool = False) -> dict:
 
 
 def _rmtree_writable(path: Path) -> None:
-    """Remove a directory tree, making read-only files writable first.
+    """Remove a directory tree, making read-only entries writable first.
 
     Handles immutable package sources (Nix store, deb/rpm installs) that
-    preserve read-only permissions on copied files.  See #34860, #34972.
+    preserve read-only permissions on copied files *and* directories
+    (``r-xr-xr-x``).  Removing a child requires write permission on its
+    parent directory, so the retry handler makes the failing path **and its
+    parent** writable before re-attempting.  See #34860, #34972.
     """
+    import stat
+
     def _on_error(func, fpath, exc_info):
-        # Make the file/directory writable and retry
-        import stat
-        os.chmod(fpath, stat.S_IWRITE)
+        # Unlinking a child requires the parent dir to be writable, so chmod
+        # the parent as well as the failing path, then retry.
+        for target in (os.path.dirname(fpath), fpath):
+            try:
+                os.chmod(target, stat.S_IRWXU)
+            except OSError:
+                pass
         func(fpath)
 
     shutil.rmtree(path, onerror=_on_error)


### PR DESCRIPTION
## Summary
`hermes skills reset <name> --restore` is now transactional and survives read-only Nix-store skill copies — it no longer corrupts the manifest into a permanent limbo state.

Root cause: `reset_bundled_skill` deleted the manifest entry *before* `shutil.rmtree(dest)`. On Nix-store installs (read-only `r-xr-xr-x` dirs), rmtree failed and the function returned early — but the manifest entry was already gone, so future `sync_skills` runs silently skipped the skill forever (`user-modified-UNTRACKED`).

Closes #34972.

## Changes
- `tools/skills_sync.py`:
  - Reorder so the user copy is removed **before** the manifest entry is dropped. A failed removal now leaves the manifest untouched (`action: "not_reset"`, message "Manifest entry preserved").
  - `_rmtree_writable()` chmods read-only entries and retries via `onerror`. The retry handler now chmods the **parent directory** as well as the failing path — unlinking a child requires write permission on its parent, so the original (file-only chmod) still failed on a true read-only tree.
  - Backup cleanup in `sync_skills` uses the same writable rmtree.
- `tests/tools/test_skills_sync.py`: two regression tests —
  - restore **succeeds** on a full read-only tree (real Nix case: `r-xr-xr-x` dirs + `r--` files), and
  - manifest is **preserved** when removal genuinely cannot proceed.

## Validation
| Scenario | Before | After |
|---|---|---|
| `--restore` on read-only files only | works | works |
| `--restore` on read-only dirs+files (Nix store) | rmtree fails → manifest corrupted | succeeds, re-baselined |
| Removal genuinely impossible | manifest entry deleted → limbo | manifest preserved, nothing changed |

E2E verified against a real read-only tree (isolated `HERMES_HOME`, real `reset_bundled_skill`): restore succeeds, nested read-only file removed, bundled re-copied, manifest re-tracked. Targeted suite: `tests/tools/test_skills_sync.py` 51/51 pass.

## Credit
Salvaged from #35131 by @annguyenNous (transaction reordering + initial `_rmtree_writable`), cherry-picked onto current `main` with authorship preserved. Follow-up commit fixes the parent-dir chmod gap and corrects the regression test.

Supersedes #35182 (@TKwave — read-only backup cleanup, a strict subset of this fix).

## Infographic

![skills-reset-transactional-fix](https://v3b.fal.media/files/b/0a9c4393/VcvpABxPc_V-SbI2F1gVb_bk0zaRQ4.png)
