### PR TITLE
fix(state): persist mid-session model switch to database (#34850)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10549,6 +10549,22 @@ class GatewayRunner:
                             except Exception as exc:
                                 logger.warning("Picker model switch failed for cached agent: %s", exc)
 
+                        # Persist the new model to the session DB so the
+                        # dashboard shows the updated model (#34850).
+                        _sess_db = getattr(_self, "_session_db", None)
+                        if _sess_db is not None:
+                            try:
+                                _sess_entry = _self.session_store.get_or_create_session(
+                                    event.source
+                                )
+                                _sess_db.update_session_model(
+                                    _sess_entry.session_id, result.new_model
+                                )
+                            except Exception as exc:
+                                logger.debug(
+                                    "Failed to persist model switch to DB: %s", exc
+                                )
+
                         # Store model note + session override
                         if not hasattr(_self, "_pending_model_notes"):
                             _self._pending_model_notes = {}
@@ -10685,6 +10701,19 @@ class GatewayRunner:
                 )
             except Exception as exc:
                 logger.warning("In-place model switch failed for cached agent: %s", exc)
+
+        # Persist the new model to the session DB so the dashboard
+        # shows the updated model (#34850).
+        if self._session_db is not None:
+            try:
+                _sess_entry = self.session_store.get_or_create_session(source)
+                self._session_db.update_session_model(
+                    _sess_entry.session_id, result.new_model
+                )
+            except Exception as exc:
+                logger.debug(
+                    "Failed to persist model switch to DB: %s", exc
+                )
 
         # Store a note to prepend to the next user message so the model
         # knows about the switch (avoids system messages mid-history).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10704,10 +10704,11 @@ class GatewayRunner:
 
         # Persist the new model to the session DB so the dashboard
         # shows the updated model (#34850).
-        if self._session_db is not None:
+        _sess_db = getattr(self, "_session_db", None)
+        if _sess_db is not None:
             try:
                 _sess_entry = self.session_store.get_or_create_session(source)
-                self._session_db.update_session_model(
+                _sess_db.update_session_model(
                     _sess_entry.session_id, result.new_model
                 )
             except Exception as exc:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -965,6 +965,20 @@ class SessionDB:
             )
         self._execute_write(_do)
 
+    def update_session_model(self, session_id: str, model: str) -> None:
+        """Update the model for a session after a mid-session switch.
+
+        Unlike ``update_token_counts`` which uses ``COALESCE(model, ?)``
+        (only filling in NULL), this unconditionally sets the model column
+        so that the dashboard reflects the user's latest /model choice.
+        """
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET model = ? WHERE id = ?",
+                (model, session_id),
+            )
+        self._execute_write(_do)
+
     def update_token_counts(
         self,
         session_id: str,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "drpelagik@gmail.com": "SeaXen",
+    "lengr@users.noreply.github.com": "LengR",
     "metalclaudbot@gmail.com": "HashClawAI",
     "tonybear55665566@gmail.com": "TonyPepeBear",
     "kaspersniels@gmail.com": "nielskaspers",

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -152,6 +152,30 @@ class TestSessionLifecycle:
         session = db.get_session("s1")
         assert session["model"] == "anthropic/claude-opus-4.6"
 
+    def test_update_session_model_overwrites_existing(self, db):
+        """A mid-session /model switch must overwrite the stored model.
+
+        update_token_counts uses COALESCE(model, ?) (first-writer-wins), so
+        the dashboard kept showing the original model after a switch (#34850).
+        update_session_model sets the column unconditionally.
+        """
+        db.create_session(session_id="s1", source="telegram",
+                          model="xiaomi/mimo-v2.5-pro")
+        # Token updates never change the model once set.
+        db.update_token_counts("s1", input_tokens=10, output_tokens=5,
+                               model="xiaomi/mimo-v2.5-pro")
+        assert db.get_session("s1")["model"] == "xiaomi/mimo-v2.5-pro"
+
+        # Explicit switch overwrites it.
+        db.update_session_model("s1", "xiaomi/mimo-v2.5")
+        assert db.get_session("s1")["model"] == "xiaomi/mimo-v2.5"
+
+        # And a subsequent token update does NOT revert it (COALESCE no-ops
+        # because the column is now non-NULL).
+        db.update_token_counts("s1", input_tokens=10, output_tokens=5,
+                               model="xiaomi/mimo-v2.5-pro")
+        assert db.get_session("s1")["model"] == "xiaomi/mimo-v2.5"
+
     def test_parent_session(self, db):
         db.create_session(session_id="parent", source="cli")
         db.create_session(session_id="child", source="cli", parent_session_id="parent")


### PR DESCRIPTION
## Summary
The dashboard Models page now reflects the model a session actually switched to, not the one it was created with. A mid-session `/model` switch in the gateway updated the cached agent and the in-memory override but never wrote the new model to the DB — `update_token_counts()` uses `model = COALESCE(model, ?)` (first-writer-wins), so the `sessions.model` column kept the original value forever.

Salvages #35181 by @LengR (cherry-picked, authorship preserved). Closes #34850, also fixes #28637 (duplicate root cause).

## Changes
- **hermes_state.py**: new `update_session_model(session_id, model)` — unconditional `UPDATE sessions SET model = ?` (vs the COALESCE backfill in `update_token_counts`).
- **gateway/run.py**: both `/model` switch sites (interactive picker callback + text path) now resolve the session_id via `session_store.get_or_create_session(source)` and call `update_session_model`. Text path uses `getattr(self, "_session_db", None)` to match the picker path and stay safe under the `object.__new__()` gateway test pattern.
- **tests/test_hermes_state.py**: asserts `update_session_model` overwrites the COALESCE-pinned model AND that a subsequent token update doesn't revert it.

## Validation
| | Before | After |
|---|---|---|
| create(model=A) → token updates | A | A |
| `/model` switch to B | A (stale) | B |
| token update after switch | A | B (stable) |

`tests/test_hermes_state.py -k model` → 3 passed. E2E with real SessionDB I/O in isolated HERMES_HOME confirms the dashboard `SELECT model FROM sessions` reflects B after a switch and stays B across later token updates.

## Infographic

![mid-session-model-switch-persists](https://v3b.fal.media/files/b/0a9c43c4/knsX8TPvvRLFH2bqHbTYR_jRks00xy.png)
