### PR TITLE
fix: propagate Hindsight embedded daemon tuning

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -436,6 +436,27 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
         env_values["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(
             _parse_int_setting(idle_timeout, _DEFAULT_IDLE_TIMEOUT)
         )
+
+    # Local embedded Hindsight runs a standalone daemon whose configuration is
+    # read from this profile env file. Pass through a small allow-list of
+    # daemon-side Hindsight API knobs so local/private profiles can tune long
+    # structured-output jobs without leaking credentials or changing the global
+    # shell environment.
+    api_env_overrides = {
+        "llm_timeout": "HINDSIGHT_API_LLM_TIMEOUT",
+        "llm_max_retries": "HINDSIGHT_API_LLM_MAX_RETRIES",
+        "llm_initial_backoff": "HINDSIGHT_API_LLM_INITIAL_BACKOFF",
+        "llm_max_backoff": "HINDSIGHT_API_LLM_MAX_BACKOFF",
+        "retain_llm_max_retries": "HINDSIGHT_API_RETAIN_LLM_MAX_RETRIES",
+        "consolidation_llm_max_retries": "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_RETRIES",
+        "consolidation_max_attempts": "HINDSIGHT_API_CONSOLIDATION_MAX_ATTEMPTS",
+        "consolidation_llm_initial_backoff": "HINDSIGHT_API_CONSOLIDATION_LLM_INITIAL_BACKOFF",
+        "consolidation_llm_max_backoff": "HINDSIGHT_API_CONSOLIDATION_LLM_MAX_BACKOFF",
+    }
+    for config_key, env_key in api_env_overrides.items():
+        value = config.get(config_key)
+        if value is not None and value != "":
+            env_values[env_key] = str(value)
     return env_values
 
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -297,6 +297,19 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
+    def test_embedded_profile_env_includes_local_daemon_hindsight_api_overrides(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai_compatible",
+            "llm_model": "local-model",
+            "consolidation_llm_max_retries": 0,
+            "consolidation_max_attempts": 1,
+            "llm_timeout": 600,
+        })
+
+        assert env["HINDSIGHT_API_CONSOLIDATION_LLM_MAX_RETRIES"] == "0"
+        assert env["HINDSIGHT_API_CONSOLIDATION_MAX_ATTEMPTS"] == "1"
+        assert env["HINDSIGHT_API_LLM_TIMEOUT"] == "600"
+
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
 


### PR DESCRIPTION
## Summary
- Propagate selected Hindsight local embedded daemon tuning settings into the generated profile env file.
- Keep the allow-list small and non-secret: retry/backoff/timeout/consolidation knobs only.
- Add test coverage for config values reaching the env consumed by the standalone embedded daemon.

## Why
When Hindsight runs in local embedded mode, the standalone daemon reads its runtime settings from the generated profile env file. Before this change, `config.yaml` / profile config could contain daemon-side tuning values that were not materialized into that env file, so Hermes appeared configured while the embedded daemon still used defaults.

## Test plan
- `python -m pytest tests/plugins/memory/test_hindsight_provider.py::TestConfig::test_embedded_profile_env_includes_local_daemon_hindsight_api_overrides -q`
- `python -m pytest tests/plugins/memory/test_hindsight_provider.py -q`

Note: I also attempted the full `python -m pytest tests/ -o 'addopts=' -q` suite in a fresh worktree. It did not complete cleanly in this local environment because many unrelated tests errored/failed outside the touched Hindsight area; the targeted Hindsight provider tests above pass.