### PR TITLE
Fix: base media fallbacks leak host file paths into chat

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2454,7 +2454,7 @@ class BasePlatformAdapter(ABC):
         or file attachments (Discord). Default falls back to sending the
         file path as text.
         """
-        text = f"🔊 Audio: {audio_path}"
+        text = "🔊 [voice message]"
         if caption:
             text = f"{caption}\n{text}"
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
@@ -2495,7 +2495,7 @@ class BasePlatformAdapter(ABC):
         Override in subclasses to send videos as inline playable media.
         Default falls back to sending the file path as text.
         """
-        text = f"🎬 Video: {video_path}"
+        text = "🎬 [video]"
         if caption:
             text = f"{caption}\n{text}"
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
@@ -2516,7 +2516,7 @@ class BasePlatformAdapter(ABC):
         Override in subclasses to send files as downloadable attachments.
         Default falls back to sending the file path as text.
         """
-        text = f"📎 File: {file_path}"
+        text = f"📎 [file: {file_name}]" if file_name else "📎 [file]"
         if caption:
             text = f"{caption}\n{text}"
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
@@ -2537,7 +2537,7 @@ class BasePlatformAdapter(ABC):
         Override in subclasses for native photo attachments.
         Default falls back to sending the file path as text.
         """
-        text = f"🖼️ Image: {image_path}"
+        text = "🖼️ [image]"
         if caption:
             text = f"{caption}\n{text}"
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)

--- a/tests/gateway/test_base_media_no_path_leak.py
+++ b/tests/gateway/test_base_media_no_path_leak.py
@@ -1,0 +1,54 @@
+"""Regression test: base media fallbacks must not leak host filesystem paths.
+
+The default ``send_voice``/``send_video``/``send_document``/``send_image_file``
+fallbacks (used by adapters that don't override them) fabricated a chat message
+containing the local cache file path (e.g. ``🔊 Audio: /home/.../x.ogg``), leaking
+host paths into user-visible output. They must send a generic notice instead.
+
+Calls the base methods with a duck-typed ``self`` to avoid instantiating the ABC.
+"""
+import asyncio
+
+import gateway.platforms.base as base
+
+_LEAK = "/home/alice/.hermes/cache/audio/secret-12345.ogg"
+_SECRET_DIR = "/home/alice/.hermes/cache"
+
+
+class _CapturingAdapter:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(content)
+        return None
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_send_voice_no_path_leak():
+    a = _CapturingAdapter()
+    _run(base.BasePlatformAdapter.send_voice(a, "chat", _LEAK))
+    assert _SECRET_DIR not in a.sent[0]
+
+
+def test_send_video_no_path_leak():
+    a = _CapturingAdapter()
+    _run(base.BasePlatformAdapter.send_video(a, "chat", "/home/alice/.hermes/cache/clip.mp4"))
+    assert "/home/alice" not in a.sent[0]
+
+
+def test_send_image_no_path_leak():
+    a = _CapturingAdapter()
+    _run(base.BasePlatformAdapter.send_image_file(a, "chat", "/home/alice/.hermes/cache/pic.png"))
+    assert "/home/alice" not in a.sent[0]
+
+
+def test_send_document_uses_name_not_path():
+    a = _CapturingAdapter()
+    _run(base.BasePlatformAdapter.send_document(
+        a, "chat", "/home/alice/.hermes/cache/report.pdf", file_name="report.pdf"))
+    assert "/home/alice" not in a.sent[0]
+    assert "report.pdf" in a.sent[0]


### PR DESCRIPTION
## Problem
The default media-send fallbacks in `gateway/platforms/base.py` (`send_voice`, `send_video`, `send_document`, `send_image_file`) — used by any adapter that doesn't override them — put the **local cache file path** into the outgoing chat message:
```python
text = f"🔊 Audio: {audio_path}"   # -> "🔊 Audio: /home/<user>/.hermes/cache/audio/xxxx.ogg"
```
So on platforms without a native media override, users (and anyone in the chat) see host filesystem paths instead of media — a minor info-leak and a confusing UX.

## Fix
Send a generic notice instead of the path; `send_document` uses the caller-supplied `file_name` (a display name, never the absolute path). Captions are still preserved. No path ever reaches user-visible output.

## Test
Adds `tests/gateway/test_base_media_no_path_leak.py` — asserts none of the four fallbacks emit a host path, and that `send_document` surfaces `file_name`.
```
pytest tests/gateway/test_base_media_no_path_leak.py  ->  4 passed
```

<sub>Found and validated via a RubberDuck-backed audit (rubberduck.com).</sub>