### PR TITLE
fix(telegram): clear send_path_degraded immediately on successful reconnect

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -962,6 +962,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, attempt,
             )
             self._polling_network_error_count = 0
+            # Polling resumed — immediately restore the send path so
+            # outbound messages are not blocked for the 60-second
+            # heartbeat probe window (GH #35205).
+            if self._send_path_degraded:
+                logger.info(
+                    "[%s] Telegram send path restored after successful reconnect",
+                    self.name,
+                )
+                self._send_path_degraded = False
             # start_polling() returning is necessary but not sufficient:
             # PTB's Updater can be left in a state where `running` is True
             # but the underlying long-poll task is wedged on a stale httpx


### PR DESCRIPTION
## Fixes #35205

### Problem
After a transient network interruption, the Telegram gateway successfully reconnects polling but `_send_path_degraded` remains `True` for up to **60 seconds** (until the heartbeat probe runs in `_verify_polling_after_reconnect()`), blocking **all outbound `send()` calls** during that window.

### Root Cause
In `_handle_polling_network_error()`, the reconnect ladder at line ~964 resets `_polling_network_error_count = 0` but does NOT clear `_send_path_degraded`. The flag is only cleared inside `_verify_polling_after_reconnect()` (line ~1024) which runs after a 60-second `HEARTBEAT_PROBE_DELAY`.

### Fix
Clear `_send_path_degraded` immediately when `start_polling()` succeeds in the reconnect ladder, restoring the send path without waiting for the deferred probe. The probe still runs as a safety net and will re-set the flag if the connection is actually wedged.

### Changes
- `gateway/platforms/telegram.py`: +9 lines — clear `_send_path_degraded` after successful reconnect with info log
