### PR TITLE
fix(telegram): clear send_path_degraded immediately on successful reconnect

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -962,6 +962,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, attempt,
             )
             self._polling_network_error_count = 0
+            # Polling is confirmed working — clear the degraded flag so
+            # send() can attempt delivery immediately instead of waiting
+            # 60 s for the heartbeat probe.  If the send-side httpx pool
+            # is also stale, send()'s own retry + error_callback will
+            # re-enter the reconnect ladder.
+            self._send_path_degraded = False
             # start_polling() returning is necessary but not sufficient:
             # PTB's Updater can be left in a state where `running` is True
             # but the underlying long-poll task is wedged on a stale httpx

--- a/tests/gateway/test_telegram_send_path_health.py
+++ b/tests/gateway/test_telegram_send_path_health.py
@@ -5,6 +5,7 @@ can enter a wedged state where ``bot.send_message()`` returns a valid Message
 but nothing reaches the recipient.  ``_send_path_degraded`` short-circuits
 ``send()`` so cron's live-adapter branch falls through to standalone HTTP.
 """
+import asyncio
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -65,15 +66,19 @@ async def test_send_short_circuits_when_path_degraded():
 
 
 @pytest.mark.asyncio
-async def test_reconnect_storm_sets_and_heartbeat_clears_flag(monkeypatch):
-    """_handle_polling_network_error sets the flag; a successful heartbeat
-    probe in _verify_polling_after_reconnect clears it."""
+async def test_reconnect_clears_degraded_flag_on_successful_start_polling(monkeypatch):
+    """After a successful start_polling() reconnect, _send_path_degraded must
+    be cleared immediately — not deferred to the 60-second heartbeat probe.
+
+    Regression test for #35205: send_path_degraded stayed True for 60 s after
+    reconnect, blocking all outbound messages.
+    """
     adapter = _make_adapter()
     adapter._app = MagicMock()
     adapter._app.updater = MagicMock()
     adapter._app.updater.running = True
     adapter._app.updater.stop = AsyncMock()
-    adapter._app.updater.start_polling = AsyncMock()
+    adapter._app.updater.start_polling = AsyncMock()  # succeeds
     adapter._app.bot = MagicMock()
     adapter._app.bot.get_me = AsyncMock(return_value=MagicMock())
     adapter._polling_error_callback_ref = AsyncMock()
@@ -82,8 +87,48 @@ async def test_reconnect_storm_sets_and_heartbeat_clears_flag(monkeypatch):
     )
 
     await adapter._handle_polling_network_error(OSError("Bad Gateway"))
-    assert adapter._send_path_degraded is True
+    # Flag must be cleared immediately after successful start_polling()
+    assert adapter._send_path_degraded is False
 
+    # Heartbeat probe still runs and confirms the flag stays cleared
     with patch("gateway.platforms.telegram.asyncio.sleep", new_callable=AsyncMock):
         await adapter._verify_polling_after_reconnect()
     assert adapter._send_path_degraded is False
+
+
+@pytest.mark.asyncio
+async def test_degraded_flag_stays_true_when_start_polling_fails(monkeypatch):
+    """When start_polling() fails, _send_path_degraded must remain True
+    so send() continues to short-circuit until recovery succeeds."""
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 1
+
+    mock_updater = MagicMock()
+    mock_updater.running = True
+    mock_updater.stop = AsyncMock()
+    mock_updater.start_polling = AsyncMock(side_effect=Exception("Timed out"))
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+    adapter._polling_error_callback_ref = AsyncMock()
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Update", MagicMock(ALL_TYPES=[])
+    )
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_network_error(Exception("Bad Gateway"))
+
+    # Flag must stay True since reconnect failed
+    assert adapter._send_path_degraded is True
+
+    # Clean up pending retry tasks
+    for t in list(adapter._background_tasks):
+        t.cancel()
+        try:
+            await t
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+


### PR DESCRIPTION
## What does this PR do?

Clears `_send_path_degraded` immediately after a successful `start_polling()` reconnect, instead of deferring it to the 60-second heartbeat probe. This prevents all outbound `send()` calls from being blocked for 60 seconds after the Telegram gateway recovers from a network interruption.

## Related Issue

Fixes #35205

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: Clear `_send_path_degraded = False` immediately after successful `start_polling()` in `_handle_polling_network_error()`, alongside the existing `_polling_network_error_count = 0` reset. Added comment explaining the rationale.
- `tests/gateway/test_telegram_send_path_health.py`: Updated `test_reconnect_storm_sets_and_heartbeat_clears_flag` → `test_reconnect_clears_degraded_flag_on_successful_start_polling` to verify the flag is cleared immediately. Added `test_degraded_flag_stays_true_when_start_polling_fails` to verify the flag remains `True` when reconnect fails (negative case).

## How to Test

1. Run `pytest tests/gateway/test_telegram_send_path_health.py -v` — all 4 tests should pass
2. Run `pytest tests/gateway/test_telegram_network_reconnect.py -v` — all 15 tests should pass (no regressions)
3. Manual: trigger a Telegram network error (e.g., disconnect WiFi), reconnect, and verify outbound messages are delivered immediately without the 60-second delay

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/telegram.py` `TelegramAdapter._handle_polling_network_error` (called by polling error callback, triggers reconnect ladder)
- Blast radius: LOW — single flag reset in a well-isolated error recovery path; `send()` retry logic handles stale pool case
- Related patterns: `_verify_polling_after_reconnect()` heartbeat probe still runs as secondary safety net; `_drain_polling_connections()` resets polling pool but not general request pool (documented limitation)
