### PR TITLE
fix(gateway): auto-recover auto-paused platforms after transient failures

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2780,7 +2780,7 @@ class GatewayRunner:
     # watcher when a retryable failure recurs past a threshold, and by the
     # /platform pause|resume slash command for manual control.
     # ------------------------------------------------------------------
-    def _pause_failed_platform(self, platform, *, reason: str = "") -> None:
+    def _pause_failed_platform(self, platform, *, reason: str = "", manual: bool = False) -> None:
         """Mark a queued platform as paused — keep it in ``_failed_platforms``
         but stop the reconnect watcher from hammering it.
 
@@ -2788,6 +2788,10 @@ class GatewayRunner:
         retryable failures, and by ``/platform pause <name>`` for manual
         intervention.  Paused platforms are surfaced in ``/platform list``
         and resumed with ``/platform resume <name>``.
+
+        Auto-paused platforms (``manual=False``) are eligible for periodic
+        auto-recovery attempts by the reconnect watcher.  Manually paused
+        platforms require an explicit ``/platform resume``.
         """
         info = getattr(self, "_failed_platforms", {}).get(platform)
         if info is None:
@@ -2795,7 +2799,9 @@ class GatewayRunner:
         if info.get("paused"):
             return
         info["paused"] = True
+        info["pause_mode"] = "manual" if manual else "auto"
         info["pause_reason"] = reason or "auto-paused after repeated failures"
+        info["paused_at"] = time.monotonic()
         # Push next_retry far enough out that even if "paused" is missed
         # by a stale code path, the watcher won't fire on it.
         info["next_retry"] = float("inf")
@@ -2828,6 +2834,8 @@ class GatewayRunner:
             return False
         info["paused"] = False
         info.pop("pause_reason", None)
+        info.pop("pause_mode", None)
+        info.pop("paused_at", None)
         info["attempts"] = 0
         info["next_retry"] = time.monotonic()  # retry on next watcher tick
         try:
@@ -5874,6 +5882,7 @@ class GatewayRunner:
         """
         _BACKOFF_CAP = 300  # 5 minutes max between retries
         _PAUSE_AFTER_FAILURES = 10  # circuit-breaker threshold
+        _AUTO_RESUME_INTERVAL = 300  # 5 minutes between auto-recovery attempts
 
         await asyncio.sleep(10)  # initial delay — let startup finish
         while self._running:
@@ -5890,10 +5899,29 @@ class GatewayRunner:
                 if not self._running:
                     return
                 info = self._failed_platforms[platform]
-                # Skip paused platforms entirely — they need explicit
-                # /platform resume to come back.
+                # Manually paused platforms need explicit /platform resume.
+                # Auto-paused platforms (circuit breaker) get periodic
+                # recovery attempts so transient failures like DNS outages
+                # self-heal without manual intervention.
                 if info.get("paused"):
-                    continue
+                    if info.get("pause_mode") == "manual":
+                        continue
+                    # Auto-paused: check if it's time for a recovery attempt
+                    paused_at = info.get("paused_at", 0)
+                    if now - paused_at < _AUTO_RESUME_INTERVAL:
+                        continue
+                    logger.info(
+                        "Auto-recovery: attempting to reconnect %s "
+                        "(paused for %ds)...",
+                        platform.value, int(now - paused_at),
+                    )
+                    # Reset for a single retry attempt; if it fails,
+                    # _pause_failed_platform will set paused_at again.
+                    info["paused"] = False
+                    info.pop("pause_mode", None)
+                    info.pop("pause_reason", None)
+                    info["attempts"] = 0
+                    info["next_retry"] = now  # try immediately
                 if now < info["next_retry"]:
                     continue  # not time yet
 
@@ -10175,7 +10203,7 @@ class GatewayRunner:
                     )
                 if failed[platform].get("paused"):
                     return f"{platform.value} is already paused."
-                self._pause_failed_platform(platform, reason="paused via /platform pause")
+                self._pause_failed_platform(platform, reason="paused via /platform pause", manual=True)
                 return (
                     f"✓ {platform.value} paused. "
                     f"Resume with `/platform resume {platform.value}` or "

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -350,6 +350,7 @@ class TestPlatformReconnectWatcher:
             "attempts": 10,
             "next_retry": time.monotonic() - 1,  # would normally retry now
             "paused": True,
+            "pause_mode": "manual",
             "pause_reason": "paused via /platform pause",
         }
 
@@ -713,4 +714,213 @@ class TestPlatformSlashCommand:
         runner = _make_runner()
         out = await runner._handle_platform_command(self._make_event("/platform"))
         assert "Gateway platforms" in out
+
+    def test_pause_records_mode_auto(self):
+        """Auto-pause (circuit breaker) sets pause_mode='auto'."""
+        runner = _make_runner()
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": PlatformConfig(enabled=True, token="t"),
+            "attempts": 10,
+            "next_retry": time.monotonic() + 30,
+        }
+        runner._pause_failed_platform(Platform.TELEGRAM, reason="circuit breaker")
+        info = runner._failed_platforms[Platform.TELEGRAM]
+        assert info["paused"] is True
+        assert info["pause_mode"] == "auto"
+        assert "paused_at" in info
+
+    def test_pause_records_mode_manual(self):
+        """Manual pause (/platform pause) sets pause_mode='manual'."""
+        runner = _make_runner()
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": PlatformConfig(enabled=True, token="t"),
+            "attempts": 3,
+            "next_retry": time.monotonic() + 30,
+        }
+        runner._pause_failed_platform(Platform.TELEGRAM, reason="user action", manual=True)
+        info = runner._failed_platforms[Platform.TELEGRAM]
+        assert info["paused"] is True
+        assert info["pause_mode"] == "manual"
+        assert "paused_at" in info
+
+
+class TestAutoRecovery:
+    """Tests for auto-recovery of auto-paused platforms."""
+
+    @pytest.mark.asyncio
+    async def test_auto_paused_platform_recovers_after_interval(self):
+        """An auto-paused platform should be retried after _AUTO_RESUME_INTERVAL."""
+        runner = _make_runner()
+        platform_config = PlatformConfig(enabled=True, token="test")
+        now = time.monotonic()
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": platform_config,
+            "attempts": 10,
+            "next_retry": float("inf"),
+            "paused": True,
+            "pause_mode": "auto",
+            "pause_reason": "circuit breaker",
+            "paused_at": now - 301,  # paused 301 seconds ago (> 300s interval)
+        }
+
+        real_sleep = asyncio.sleep
+
+        with patch.object(runner, "_create_adapter") as mock_create:
+            mock_adapter = AsyncMock()
+            mock_adapter.has_fatal_error = False
+            mock_adapter.fatal_error_retryable = True
+            mock_create.return_value = mock_adapter
+
+            with patch.object(runner, "_connect_adapter_with_timeout", return_value=True):
+                async def run_one_iteration():
+                    runner._running = True
+                    call_count = 0
+
+                    async def fake_sleep(n):
+                        nonlocal call_count
+                        call_count += 1
+                        if call_count > 1:
+                            runner._running = False
+                        await real_sleep(0)
+
+                    with patch("asyncio.sleep", side_effect=fake_sleep):
+                        with patch.object(runner, "_sync_voice_mode_state_to_adapter"):
+                            with patch("gateway.channel_directory.build_channel_directory", new_callable=AsyncMock):
+                                await runner._platform_reconnect_watcher()
+
+                await run_one_iteration()
+
+        # Platform should be removed from failed queue (successfully reconnected)
+        assert Platform.TELEGRAM not in runner._failed_platforms
+        mock_create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_manually_paused_platform_stays_paused(self):
+        """A manually paused platform should NOT be auto-recovered."""
+        runner = _make_runner()
+        platform_config = PlatformConfig(enabled=True, token="test")
+        now = time.monotonic()
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": platform_config,
+            "attempts": 10,
+            "next_retry": float("inf"),
+            "paused": True,
+            "pause_mode": "manual",
+            "pause_reason": "paused via /platform pause",
+            "paused_at": now - 600,  # paused 10 minutes ago
+        }
+
+        real_sleep = asyncio.sleep
+
+        with patch.object(runner, "_create_adapter") as mock_create:
+            async def run_one_iteration():
+                runner._running = True
+                call_count = 0
+
+                async def fake_sleep(n):
+                    nonlocal call_count
+                    call_count += 1
+                    if call_count > 1:
+                        runner._running = False
+                    await real_sleep(0)
+
+                with patch("asyncio.sleep", side_effect=fake_sleep):
+                    await runner._platform_reconnect_watcher()
+
+            await run_one_iteration()
+
+        # Platform should stay paused
+        assert Platform.TELEGRAM in runner._failed_platforms
+        assert runner._failed_platforms[Platform.TELEGRAM]["paused"] is True
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_auto_paused_not_recovered_before_interval(self):
+        """Auto-paused platform should NOT be recovered before _AUTO_RESUME_INTERVAL."""
+        runner = _make_runner()
+        platform_config = PlatformConfig(enabled=True, token="test")
+        now = time.monotonic()
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": platform_config,
+            "attempts": 10,
+            "next_retry": float("inf"),
+            "paused": True,
+            "pause_mode": "auto",
+            "pause_reason": "circuit breaker",
+            "paused_at": now - 100,  # only 100 seconds ago (< 300s interval)
+        }
+
+        real_sleep = asyncio.sleep
+
+        with patch.object(runner, "_create_adapter") as mock_create:
+            async def run_one_iteration():
+                runner._running = True
+                call_count = 0
+
+                async def fake_sleep(n):
+                    nonlocal call_count
+                    call_count += 1
+                    if call_count > 1:
+                        runner._running = False
+                    await real_sleep(0)
+
+                with patch("asyncio.sleep", side_effect=fake_sleep):
+                    await runner._platform_reconnect_watcher()
+
+            await run_one_iteration()
+
+        # Platform should stay paused (not enough time elapsed)
+        assert Platform.TELEGRAM in runner._failed_platforms
+        assert runner._failed_platforms[Platform.TELEGRAM]["paused"] is True
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_auto_recovery_failure_repauses(self):
+        """If auto-recovery attempt fails, platform stays in retry queue."""
+        runner = _make_runner()
+        platform_config = PlatformConfig(enabled=True, token="test")
+        now = time.monotonic()
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": platform_config,
+            "attempts": 10,
+            "next_retry": float("inf"),
+            "paused": True,
+            "pause_mode": "auto",
+            "pause_reason": "circuit breaker",
+            "paused_at": now - 301,
+        }
+
+        real_sleep = asyncio.sleep
+
+        with patch.object(runner, "_create_adapter") as mock_create:
+            mock_adapter = AsyncMock()
+            mock_adapter.has_fatal_error = True
+            mock_adapter.fatal_error_retryable = True
+            mock_adapter.fatal_error_message = "connection failed"
+            mock_create.return_value = mock_adapter
+
+            with patch.object(runner, "_connect_adapter_with_timeout", return_value=False):
+                async def run_one_iteration():
+                    runner._running = True
+                    call_count = 0
+
+                    async def fake_sleep(n):
+                        nonlocal call_count
+                        call_count += 1
+                        if call_count > 1:
+                            runner._running = False
+                        await real_sleep(0)
+
+                    with patch("asyncio.sleep", side_effect=fake_sleep):
+                        await runner._platform_reconnect_watcher()
+
+                await run_one_iteration()
+
+        # Platform should stay in retry queue (auto-recovery failed, then 1 attempt
+        # doesn't trigger circuit breaker at _PAUSE_AFTER_FAILURES=10)
+        assert Platform.TELEGRAM in runner._failed_platforms
+        # The attempt counter was reset to 0 and then incremented to 1
+        info = runner._failed_platforms[Platform.TELEGRAM]
+        assert info["attempts"] == 1
+        # Not paused yet (1 < 10), but will be retried with backoff
 


### PR DESCRIPTION
## What does this PR do?

Adds auto-recovery for auto-paused platforms (circuit breaker). When a platform is paused after 10 consecutive failures (e.g., due to a transient DNS outage), the reconnect watcher now attempts a single reconnection every 5 minutes. If the underlying issue has resolved, the platform reconnects automatically without manual intervention.

## Related Issue

Fixes #35284

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Add `pause_mode` tracking (`auto` vs `manual`) to `_pause_failed_platform()`, auto-recovery logic in `_platform_reconnect_watcher()`, and cleanup in `_resume_paused_platform()`. Manual pauses (`/platform pause`) are not affected.
- `tests/gateway/test_platform_reconnect.py`: Add 4 tests for auto-recovery behavior (auto-paused recovers after interval, manual stays paused, not recovered before interval, failure re-queues). Update existing paused-platform test to set `pause_mode="manual"`.

## How to Test

1. Run `python3 -m pytest tests/gateway/test_platform_reconnect.py -q` — all 35 tests should pass
2. Simulate a transient DNS failure in a gateway instance and verify the Telegram adapter auto-recovers after ~5 minutes when DNS resolves again
3. Manually pause a platform with `/platform pause telegram` and verify it does NOT auto-recover

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/run.py:_platform_reconnect_watcher`, `gateway/run.py:_pause_failed_platform`, `gateway/run.py:_resume_paused_platform`
- Blast radius: LOW — changes are scoped to the reconnect watcher's pause/resume logic; no new API surface
- Related patterns: Circuit breaker auto-recovery, exponential backoff with pause/resume lifecycle
