### PR TITLE
fix(update): verify uv binary can execute before using it on Termux

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7738,6 +7738,17 @@ def _update_via_zip(args):
     if not uv_bin:
         uv_bin = _ensure_uv_for_termux(pip_cmd)
     if uv_bin:
+        try:
+            subprocess.run(
+                [uv_bin, "--version"],
+                capture_output=True,
+                timeout=10,
+                check=True,
+            )
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            print(f"  → uv found at {uv_bin} but cannot execute — falling back to pip")
+            uv_bin = None
+    if uv_bin:
         uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
         if _is_termux_env(uv_env):
             uv_env.pop("PYTHONPATH", None)
@@ -9939,6 +9950,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
         pip_cmd = [sys.executable, "-m", "pip"]
         if not uv_bin:
             uv_bin = _ensure_uv_for_termux(pip_cmd)
+        if uv_bin:
+            try:
+                subprocess.run(
+                    [uv_bin, "--version"],
+                    capture_output=True,
+                    timeout=10,
+                    check=True,
+                )
+            except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+                print(f"  → uv found at {uv_bin} but cannot execute — falling back to pip")
+                uv_bin = None
         install_group = "all"
 
         if uv_bin:


### PR DESCRIPTION
## Problem

On Android/Termux, the `uv` binary exists at the expected path and is found by `shutil.which("uv")`, but it cannot execute — it's an ELF built for Linux with dynamic linker `/lib/ld-linux-aarch64.so.1` which doesn't exist on Android.

`hermes update` then fails with:
```
FileNotFoundError: [Errno 2] No such file or directory: '/data/data/com.termux/files/usr/bin/uv'
```

## Fix

Probe `uv --version` before using it at all three call sites:
- `_update_via_zip()` — standalone ZIP installer path
- `_cmd_update_impl()` — main `hermes update` path
- `_ensure_uv_for_termux()` — uv bootstrap helper

On `OSError`, `CalledProcessError`, or `TimeoutExpired`, fall back to `pip` with a clear message.

## Testing

Verified on Termux/Android (aarch64, Python 3.13): `hermes update` completes cleanly with an incompatible uv binary present.