### PR TITLE
fix(cli): fail closed on empty oneshot responses

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -191,11 +191,15 @@ def run_oneshot(
         except Exception:
             pass
 
-    if response:
-        real_stdout.write(response)
-        if not response.endswith("\n"):
-            real_stdout.write("\n")
-        real_stdout.flush()
+    if not (response or "").strip():
+        sys.stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
+        sys.stderr.flush()
+        return 1
+
+    real_stdout.write(response)
+    if not response.endswith("\n"):
+        real_stdout.write("\n")
+    real_stdout.flush()
     return 0
 
 

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -638,6 +638,30 @@ def test_oneshot_rejects_invalid_only_toolsets(monkeypatch, capsys):
     assert "did not contain any valid toolsets" in err
 
 
+def test_oneshot_fails_closed_on_empty_final_response(monkeypatch, capsys):
+    _stub_plugin_discovery(monkeypatch)
+    import hermes_cli.oneshot as oneshot_mod
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", lambda *_args, **_kwargs: "")
+
+    assert oneshot_mod.run_oneshot("hello") == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "no final response" in captured.err
+
+
+def test_oneshot_prints_nonempty_final_response(monkeypatch, capsys):
+    _stub_plugin_discovery(monkeypatch)
+    import hermes_cli.oneshot as oneshot_mod
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", lambda *_args, **_kwargs: "done")
+
+    assert oneshot_mod.run_oneshot("hello") == 0
+    captured = capsys.readouterr()
+    assert captured.out == "done\n"
+    assert captured.err == ""
+
+
 def test_oneshot_filters_invalid_toolsets_before_redirect(monkeypatch, capsys):
     _stub_plugin_discovery(monkeypatch)
     from hermes_cli.oneshot import _validate_explicit_toolsets


### PR DESCRIPTION
Fixes #35294

## Summary
- Make `hermes -z` / oneshot mode return exit code 1 when the agent produces no non-empty final response.
- Emit a short stderr diagnostic for that fail-closed path while preserving stdout as final-response-only for successful runs.
- Add regression tests for empty final responses and normal non-empty output.

## Why
Non-interactive callers use `-z` as a foreground command contract. If the model/provider returns no usable final text, exiting 0 with no stdout makes a silent no-op indistinguishable from a successful completed answer unless every caller wraps Hermes with extra stdout checks.

## Tests
- `.venv-bma-sidecar/bin/python -m py_compile hermes_cli/oneshot.py tests/hermes_cli/test_tui_resume_flow.py`
- ============================= test session starts ==============================
platform darwin -- Python 3.12.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/briancl/repos/hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1, timeout-2.4.0, asyncio-1.3.0
timeout: 30.0s
timeout method: signal
timeout func_only: False
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 43 items / 31 deselected / 12 selected

tests/hermes_cli/test_tui_resume_flow.py ............                    [100%]

====================== 12 passed, 31 deselected in 0.28s =======================
- `uvx ruff check hermes_cli/oneshot.py tests/hermes_cli/test_tui_resume_flow.py`
