### PR TITLE
fix(bluebubbles): cap inbound attachment downloads

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -42,6 +42,8 @@ DEFAULT_WEBHOOK_HOST = "127.0.0.1"
 DEFAULT_WEBHOOK_PORT = 8645
 DEFAULT_WEBHOOK_PATH = "/bluebubbles-webhook"
 MAX_TEXT_LENGTH = 4000
+DEFAULT_MAX_INBOUND_MEDIA_BYTES = 128 * 1024 * 1024
+MAX_INBOUND_MEDIA_BYTES_ENV = "HERMES_MAX_INBOUND_MEDIA_BYTES"
 
 # Tapback reaction codes (BlueBubbles associatedMessageType values)
 _TAPBACK_ADDED = {
@@ -66,6 +68,43 @@ def _redact(text: str) -> str:
     text = _PHONE_RE.sub("[REDACTED]", text)
     text = _EMAIL_RE.sub("[REDACTED]", text)
     return text
+
+
+def _max_inbound_media_bytes() -> int:
+    raw = os.getenv(MAX_INBOUND_MEDIA_BYTES_ENV, "").strip()
+    if not raw:
+        return DEFAULT_MAX_INBOUND_MEDIA_BYTES
+    try:
+        parsed = int(raw)
+    except ValueError:
+        logger.warning(
+            "[bluebubbles] invalid %s=%r; using default %d",
+            MAX_INBOUND_MEDIA_BYTES_ENV,
+            raw,
+            DEFAULT_MAX_INBOUND_MEDIA_BYTES,
+        )
+        return DEFAULT_MAX_INBOUND_MEDIA_BYTES
+    if parsed <= 0:
+        logger.warning(
+            "[bluebubbles] non-positive %s=%r; using default %d",
+            MAX_INBOUND_MEDIA_BYTES_ENV,
+            raw,
+            DEFAULT_MAX_INBOUND_MEDIA_BYTES,
+        )
+        return DEFAULT_MAX_INBOUND_MEDIA_BYTES
+    return parsed
+
+
+def _attachment_size_hint(att_meta: Dict[str, Any]) -> Optional[int]:
+    for key in ("size", "fileSize", "file_size", "totalBytes", "total_bytes", "byteSize"):
+        raw = att_meta.get(key)
+        if raw is None or raw == "":
+            continue
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            continue
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -703,14 +742,22 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not self.client:
             return None
         try:
+            max_bytes = _max_inbound_media_bytes()
+            size_hint = _attachment_size_hint(att_meta)
+            if size_hint is not None and size_hint > max_bytes:
+                logger.warning(
+                    "[bluebubbles] skipping attachment %s: size %d exceeds cap %d",
+                    _redact(att_guid),
+                    size_hint,
+                    max_bytes,
+                )
+                return None
+
             encoded = quote(att_guid, safe="")
-            resp = await self.client.get(
+            data = await self._download_attachment_bytes(
                 self._api_url(f"/api/v1/attachment/{encoded}/download"),
-                timeout=60,
-                follow_redirects=True,
+                max_bytes=max_bytes,
             )
-            resp.raise_for_status()
-            data = resp.content
 
             mime = (att_meta.get("mimeType") or "").lower()
             transfer_name = att_meta.get("transferName", "")
@@ -752,6 +799,36 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 exc,
             )
             return None
+
+    async def _download_attachment_bytes(self, url: str, *, max_bytes: int) -> bytes:
+        """Stream an attachment with a hard byte cap before caching."""
+        total = 0
+        chunks = bytearray()
+        async with self.client.stream(
+            "GET",
+            url,
+            timeout=60,
+            follow_redirects=True,
+        ) as resp:
+            resp.raise_for_status()
+            content_length = resp.headers.get("content-length")
+            if content_length:
+                try:
+                    declared = int(content_length)
+                except ValueError:
+                    declared = None
+                if declared is not None and declared > max_bytes:
+                    raise ValueError(
+                        f"Attachment content-length {declared} exceeds cap {max_bytes}"
+                    )
+            async for chunk in resp.aiter_bytes():
+                total += len(chunk)
+                if total > max_bytes:
+                    raise ValueError(
+                        f"Attachment download exceeded cap {max_bytes}"
+                    )
+                chunks.extend(chunk)
+        return bytes(chunks)
 
     # ------------------------------------------------------------------
     # Webhook handling

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -295,6 +295,37 @@ class TestBlueBubblesGuidResolution:
         assert result is None
 
 
+class _MockStreamResponse:
+    def __init__(self, chunks, headers=None):
+        self._chunks = list(chunks)
+        self.headers = headers or {}
+        self.iterated = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        pass
+
+    async def aiter_bytes(self):
+        self.iterated = True
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _MockStreamClient:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def stream(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return self.response
+
+
 class TestBlueBubblesAttachmentDownload:
     """Verify _download_attachment routes to the correct cache helper."""
 
@@ -303,18 +334,9 @@ class TestBlueBubblesAttachmentDownload:
         adapter = _make_adapter(monkeypatch)
         import asyncio
 
-        # Mock the HTTP client response
-        class MockResponse:
-            status_code = 200
-            content = b"\x89PNG\r\n\x1a\n"
-
-            def raise_for_status(self):
-                pass
-
-        async def mock_get(*args, **kwargs):
-            return MockResponse()
-
-        adapter.client = type("MockClient", (), {"get": mock_get})()
+        adapter.client = _MockStreamClient(
+            _MockStreamResponse([b"\x89PNG\r\n\x1a\n"])
+        )
 
         cached_path = None
 
@@ -339,17 +361,9 @@ class TestBlueBubblesAttachmentDownload:
         adapter = _make_adapter(monkeypatch)
         import asyncio
 
-        class MockResponse:
-            status_code = 200
-            content = b"fake-audio-data"
-
-            def raise_for_status(self):
-                pass
-
-        async def mock_get(*args, **kwargs):
-            return MockResponse()
-
-        adapter.client = type("MockClient", (), {"get": mock_get})()
+        adapter.client = _MockStreamClient(
+            _MockStreamResponse([b"fake-audio-data"])
+        )
 
         cached_path = None
 
@@ -374,17 +388,9 @@ class TestBlueBubblesAttachmentDownload:
         adapter = _make_adapter(monkeypatch)
         import asyncio
 
-        class MockResponse:
-            status_code = 200
-            content = b"fake-doc-data"
-
-            def raise_for_status(self):
-                pass
-
-        async def mock_get(*args, **kwargs):
-            return MockResponse()
-
-        adapter.client = type("MockClient", (), {"get": mock_get})()
+        adapter.client = _MockStreamClient(
+            _MockStreamResponse([b"fake-doc-data"])
+        )
 
         cached_path = None
 
@@ -414,6 +420,70 @@ class TestBlueBubblesAttachmentDownload:
             adapter._download_attachment("att-guid", {"mimeType": "image/png"})
         )
         assert result is None
+
+    def test_download_skips_attachment_when_metadata_size_exceeds_cap(
+        self, monkeypatch
+    ):
+        """Known-oversized attachments should not be requested at all."""
+        adapter = _make_adapter(monkeypatch)
+        monkeypatch.setenv("HERMES_MAX_INBOUND_MEDIA_BYTES", "4")
+        response = _MockStreamResponse([b"not-used"])
+        adapter.client = _MockStreamClient(response)
+        import asyncio
+
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter._download_attachment(
+                "att-guid-large",
+                {"mimeType": "image/png", "size": 5},
+            )
+        )
+
+        assert result is None
+        assert adapter.client.calls == []
+        assert response.iterated is False
+
+    def test_download_rejects_oversized_content_length(self, monkeypatch):
+        """Content-Length above cap should abort before reading the body."""
+        adapter = _make_adapter(monkeypatch)
+        monkeypatch.setenv("HERMES_MAX_INBOUND_MEDIA_BYTES", "4")
+        response = _MockStreamResponse([b"not-used"], headers={"content-length": "5"})
+        adapter.client = _MockStreamClient(response)
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.cache_image_from_bytes",
+            lambda *_args, **_kwargs: pytest.fail("oversized body was cached"),
+        )
+        import asyncio
+
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter._download_attachment("att-guid-large", {"mimeType": "image/png"})
+        )
+
+        assert result is None
+        assert len(adapter.client.calls) == 1
+        assert response.iterated is False
+
+    def test_download_rejects_chunked_overflow(self, monkeypatch):
+        """Chunked responses without Content-Length should still enforce cap."""
+        adapter = _make_adapter(monkeypatch)
+        monkeypatch.setenv("HERMES_MAX_INBOUND_MEDIA_BYTES", "4")
+        response = _MockStreamResponse([b"abc", b"de"])
+        adapter.client = _MockStreamClient(response)
+        monkeypatch.setattr(
+            "gateway.platforms.bluebubbles.cache_document_from_bytes",
+            lambda *_args, **_kwargs: pytest.fail("oversized body was cached"),
+        )
+        import asyncio
+
+        result = asyncio.get_event_loop().run_until_complete(
+            adapter._download_attachment(
+                "att-guid-large",
+                {"mimeType": "application/octet-stream", "transferName": "big.bin"},
+            )
+        )
+
+        assert result is None
+        assert len(adapter.client.calls) == 1
+        assert response.iterated is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- stream BlueBubbles inbound attachment downloads instead of loading `response.content`
- enforce `HERMES_MAX_INBOUND_MEDIA_BYTES` (default 128 MiB) from metadata, Content-Length, and chunked reads
- add regression coverage for metadata skip, Content-Length rejection, and chunked overflow

## Why
BlueBubbles inbound attachments used `await client.get(...); response.content`, which fully buffered the attachment before routing it to cache helpers. Large attachments can spike gateway memory. This is the same memory-exhaustion class tracked for Discord in #13145, but the BlueBubbles adapter had no existing issue or PR.

## Testing
- `..\hermes-agent\.venv\Scripts\python.exe -m pytest tests\gateway\test_bluebubbles.py -q -o addopts= --timeout-method=thread` -> 53 passed, 2 warnings
- `..\hermes-agent\.venv\Scripts\ruff.exe check .` -> passed
- `..\hermes-agent\.venv\Scripts\python.exe -m py_compile gateway\platforms\bluebubbles.py tests\gateway\test_bluebubbles.py` -> passed
- `git diff --check` -> passed
- Note: `bash scripts/run_tests.sh tests/gateway/test_bluebubbles.py -q` fails in this Windows worktree before pytest due CRLF in the script (`$'\r': command not found`, `pipefail\r`).