### PR TITLE
fix: rglob follow symlinks for skill discovery

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -62,6 +62,30 @@ def is_excluded_skill_path(path) -> bool:
     return any(part in EXCLUDED_SKILL_DIRS for part in parts)
 
 
+def rglob_follow(root: Path, pattern: str):
+    """Like ``Path.rglob(pattern)`` but follows symlinks into subdirectories.
+
+    Python's ``Path.rglob()`` intentionally does **not** descend into
+    symlinked directories (see https://bugs.python.org/issue40358).
+    This helper uses ``os.walk(followlinks=True)`` so that symlinked
+    skill directories (e.g. ``~/.hermes/skills/redpiggy -> workspace/skills``)
+    are discovered correctly.
+    """
+    import fnmatch
+
+    for dirpath, dirnames, filenames in os.walk(str(root), followlinks=True):
+        # Prune excluded dirs (same as rglob's natural traversal)
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDED_SKILL_DIRS]
+        dirpath_p = Path(dirpath)
+        for fname in filenames:
+            if fnmatch.fnmatch(fname, pattern):
+                yield dirpath_p / fname
+        # Also match the pattern against directory names if needed
+        for dname in dirnames:
+            if fnmatch.fnmatch(dname, pattern):
+                yield dirpath_p / dname
+
+
 # ── Lazy YAML loader ─────────────────────────────────────────────────────
 
 _yaml_load_fn = None

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -283,11 +283,11 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path, rglob_follow
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
+        for skill_md in rglob_follow(skills_dir, "SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
             if skill_md.parent.name == name:
@@ -307,7 +307,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
     matches: List[Tuple[str, Path]] = []
     try:
         from hermes_constants import get_default_hermes_root
-        from agent.skill_utils import is_excluded_skill_path
+        from agent.skill_utils import is_excluded_skill_path, rglob_follow
     except Exception:
         return matches
 
@@ -350,7 +350,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
         if not skills_dir.is_dir():
             continue
         try:
-            for skill_md in skills_dir.rglob("SKILL.md"):
+            for skill_md in rglob_follow(skills_dir, "SKILL.md"):
                 if is_excluded_skill_path(skill_md):
                     continue
                 if skill_md.parent.name == name:

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import is_excluded_skill_path, rglob_follow
 
 logger = logging.getLogger(__name__)
 
@@ -236,7 +236,7 @@ def list_agent_created_skill_names() -> List[str]:
 
     names: List[str] = []
     # Top-level SKILL.md files (flat layout) AND nested category/skill/SKILL.md
-    for skill_md in base.rglob("SKILL.md"):
+    for skill_md in rglob_follow(base, "SKILL.md"):
         # Skip Hermes metadata, VCS, virtualenv/dependency, and cache dirs
         if is_excluded_skill_path(skill_md):
             continue
@@ -251,6 +251,9 @@ def list_agent_created_skill_names() -> List[str]:
             continue
         names.append(name)
     return sorted(set(names))
+
+
+# ---------------------------------------------------------------------------
 
 
 def list_archived_skill_names() -> List[str]:
@@ -576,7 +579,7 @@ def _find_skill_dir(skill_name: str) -> Optional[Path]:
     base = _skills_dir()
     if not base.exists():
         return None
-    for skill_md in base.rglob("SKILL.md"):
+    for skill_md in rglob_follow(base, "SKILL.md"):
         if is_excluded_skill_path(skill_md):
             continue
         if _read_skill_name(skill_md, fallback=skill_md.parent.name) == skill_name:


### PR DESCRIPTION
## Problem

Python's `Path.rglob()` does not descend into symlinked directories (see [python/cpython#77609](https://bugs.python.org/issue40358)). This means skills located behind a symlink — such as `~/.hermes/skills/redpiggy -> ~/Documents/redpiggy-workspace/skills/` — are invisible to `skill_manage` and `skill_usage` tools.

The root cause is that `iter_skill_index_files()` uses `os.walk(followlinks=True)` (which follows symlinks), but `_find_skill()` and related functions in the skill manager and usage tools use `Path.rglob()` (which does not).

## Fix

Add a `rglob_follow()` helper in `agent/skill_utils.py` that uses `os.walk(followlinks=True)` to traverse symlinked directories, matching the behavior already used by `iter_skill_index_files()`.

Update all four `rglob('SKILL.md')` call sites across:
- `tools/skill_manager_tool.py` — `_find_skill()` and `_find_skill_in_other_profiles()`
- `tools/skill_usage.py` — `list_agent_created_skill_names()` and `_find_skill_dir()`

## Testing
- Verified that symlinked skills (e.g., `redpiggy`) are now discoverable by `skill_manage` and `skill_usage` tools.
- The `rglob_follow()` helper also prunes excluded directories (`.git`, `.venv`, `node_modules`, etc.) during traversal, consistent with `is_excluded_skill_path()`.