### PR TITLE
fix(doctor): recognize Homebrew/uv-tool installs in venv entry point check

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1128,6 +1128,17 @@ def run_doctor(args):
                 _venv_bin = _candidate
                 break
 
+        # For non-venv installs (Homebrew, uv tool, pipx), check if the
+        # hermes command is available on PATH instead of requiring a local venv.
+        _is_non_venv_install = False
+        _method = "pip"
+        try:
+            from hermes_cli.config import detect_install_method, is_uv_tool_install
+            _method = detect_install_method(PROJECT_ROOT)
+            _is_non_venv_install = _method in ("homebrew", "docker", "nixos") or is_uv_tool_install()
+        except Exception:
+            pass
+
         # Determine the expected command link directory (mirrors install.sh logic)
         _prefix = os.environ.get("PREFIX", "")
         _is_termux_env = bool(os.environ.get("TERMUX_VERSION")) or "com.termux/files/usr" in _prefix
@@ -1139,7 +1150,17 @@ def run_doctor(args):
             _cmd_link_display = "~/.local/bin"
         _cmd_link = _cmd_link_dir / "hermes"
 
-        if _venv_bin is None:
+        if _venv_bin is None and _is_non_venv_install:
+            # Non-venv install: verify hermes is on PATH
+            _hermes_on_path = shutil.which("hermes")
+            if _hermes_on_path:
+                check_ok(f"Hermes on PATH ({_hermes_on_path}) — {_method} install, venv not required")
+            else:
+                check_warn(
+                    "Hermes not found on PATH",
+                    f"(detected {_method} install but 'hermes' is not on PATH)"
+                )
+        elif _venv_bin is None:
             check_warn(
                 "Venv entry point not found",
                 "(hermes not in venv/bin/ or .venv/bin/ — reinstall with pip install -e '.[all]')"

--- a/tests/hermes_cli/test_doctor_command_install.py
+++ b/tests/hermes_cli/test_doctor_command_install.py
@@ -239,6 +239,53 @@ class TestDoctorCommandInstallation:
         assert "Command Installation" in out
         assert "$PREFIX/bin" in out
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Symlink check is Unix-only")
+    def test_homebrew_install_no_venv_shows_ok(self, monkeypatch, tmp_path):
+        """Homebrew install without venv entry point should pass when hermes is on PATH."""
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+
+        project = tmp_path / "project"
+        project.mkdir(exist_ok=True)
+        # Do NOT create any venv entry point
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        except Exception:
+            pass
+        try:
+            import httpx
+            monkeypatch.setattr(httpx, "get", lambda *a, **kw: types.SimpleNamespace(status_code=200))
+        except Exception:
+            pass
+
+        # Mock detect_install_method to return "homebrew"
+        import hermes_cli.config as config_mod
+        monkeypatch.setattr(config_mod, "detect_install_method", lambda *a, **kw: "homebrew")
+        monkeypatch.setattr(config_mod, "is_uv_tool_install", lambda: False)
+
+        # Mock shutil.which to return a path
+        monkeypatch.setattr("shutil.which", lambda cmd: "/opt/homebrew/bin/hermes" if cmd == "hermes" else None)
+
+        out = _run_doctor(fix=False)
+        assert "Command Installation" in out
+        assert "Hermes on PATH" in out
+        assert "homebrew" in out
+        assert "Venv entry point not found" not in out
+
     def test_windows_skips_check(self, monkeypatch, tmp_path):
         """On Windows, the Command Installation section is skipped."""
         home = tmp_path / ".hermes"


### PR DESCRIPTION
## What does this PR do?

Fixes a false warning in `hermes doctor` for Homebrew, uv tool, and other non-venv installations. Previously, the Command Installation check only looked for `venv/bin/hermes` or `.venv/bin/hermes` under `PROJECT_ROOT`, producing a misleading "Venv entry point not found" warning for installs that don't use a local venv.

## Related Issue

Fixes #35293

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor.py`: Detect non-venv install methods (homebrew, docker, nixos, uv tool) and verify `hermes` is on PATH via `shutil.which()` instead of requiring a local venv entry point. Falls back to existing venv check behavior for pip/git installs.
- `tests/hermes_cli/test_doctor_command_install.py`: Added `test_homebrew_install_no_venv_shows_ok` test verifying Homebrew installs pass the check when hermes is on PATH.

## How to Test

1. Run `pytest tests/hermes_cli/test_doctor_command_install.py -x -q` — all 11 tests should pass
2. On a Homebrew install: `hermes doctor` should show "Hermes on PATH (/opt/homebrew/bin/hermes) — homebrew install, venv not required" instead of the venv warning
3. On a pip/git install with missing venv: the existing "Venv entry point not found" warning should still appear

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_doctor_command_install.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (check is Unix-only, Windows skips it)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/doctor.py:1121-1177` (Command Installation check section)
- Blast radius: LOW — isolated to `hermes doctor` output, no behavioral change for existing install methods
- Related patterns: `detect_install_method()` in `hermes_cli/config.py` already handles Homebrew detection; this PR bridges that knowledge into the doctor check
