### PR TITLE
fix(install): make Playwright browser install interruptible

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1585,10 +1585,25 @@ run_browser_install_with_timeout() {
     local timeout_seconds="$1"
     shift
 
-    if command -v timeout >/dev/null 2>&1; then
-        timeout "$timeout_seconds" "$@"
-    else
+    if ! command -v timeout >/dev/null 2>&1; then
+        # No `timeout` (common on stock macOS) — run directly so the user
+        # keeps normal terminal Ctrl+C behaviour.
         "$@"
+        return $?
+    fi
+
+    # GNU `timeout` runs COMMAND in its own process group, so a terminal Ctrl+C
+    # is delivered to `timeout` but not the child: the Playwright download then
+    # looks frozen and ignores Ctrl+C (#35166). `--foreground` keeps COMMAND in
+    # the shell's foreground process group so Ctrl+C reaches it, and `-k` forces
+    # a SIGKILL if COMMAND ignores the SIGTERM sent at the deadline — otherwise a
+    # download wedged in an uninterruptible state keeps `timeout` waiting past
+    # the deadline, defeating the timeout entirely. Both flags are GNU-only;
+    # probe once and fall back to plain `timeout` on BusyBox / other variants.
+    if timeout --foreground -k 10 1 true >/dev/null 2>&1; then
+        timeout --foreground -k 10 "$timeout_seconds" "$@"
+    else
+        timeout "$timeout_seconds" "$@"
     fi
 }
 

--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -39,6 +39,20 @@ def test_playwright_installs_are_timeout_guarded() -> None:
     assert "run_browser_install_with_timeout 600 npx playwright install --with-deps chromium" in text
 
 
+def test_browser_install_timeout_stays_interruptible() -> None:
+    """The browser-install timeout must forward terminal Ctrl+C and hard-kill a
+    wedged download, so the Playwright step never looks frozen / uninterruptible
+    (regression for #35166)."""
+    text = INSTALL_SH.read_text()
+
+    # --foreground keeps the child in the shell's foreground process group so a
+    # terminal Ctrl+C reaches it; -k guarantees a SIGKILL if SIGTERM is ignored
+    # at the deadline. Both are GNU-only and must be probed before use so
+    # BusyBox/macOS fall back to plain `timeout` / direct exec.
+    assert "timeout --foreground -k 10 1 true" in text
+    assert "timeout --foreground -k 10 \"$timeout_seconds\" \"$@\"" in text
+
+
 def test_install_script_supports_skip_browser_flag() -> None:
     """--skip-browser (and --no-playwright alias) skips the Playwright install."""
     text = INSTALL_SH.read_text()


### PR DESCRIPTION
Makes the installer's Playwright Chromium step interruptible so it no longer appears frozen and ignores Ctrl+C.

## What does this PR do?

Fixes the installer hanging uninterruptibly at "Installing Playwright Chromium..." reported in #35166. `run_browser_install_with_timeout` wraps the download in GNU `timeout`, which runs the command in its **own process group**. A terminal Ctrl+C is therefore delivered to `timeout` but not to the child, so the download looks frozen and cannot be interrupted. Worse, without a kill-after grace, a download wedged in an uninterruptible state keeps `timeout` waiting past the deadline, defeating the timeout entirely.

The fix adds two GNU `timeout` flags:
- `--foreground` — keeps the command in the shell's foreground process group so a terminal Ctrl+C reaches it.
- `-k 10` — sends SIGKILL 10s after the deadline if the command ignores the SIGTERM, guaranteeing the timeout actually terminates a stuck download.

Both flags are GNU-only, so the function probes support once (`timeout --foreground -k 10 1 true`) and falls back to plain `timeout` on BusyBox (Alpine) and to direct exec when `timeout` is absent (stock macOS, where Ctrl+C already works natively).

## Related Issue

Refs #35166

This PR resolves the issue's primary symptom (the install hangs at the Playwright step and Ctrl+C does not interrupt it). The issue's secondary "Expected Behavior" request — showing progress during the SSH clone — is a separate UX change with its own trade-off (the SSH clone's `2>/dev/null` deliberately suppresses auth-failure noise on the common no-key fallback path) and is deliberately deferred to keep this change focused. Using `Refs` rather than `Fixes` so the issue stays open for that remaining item.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh`: `run_browser_install_with_timeout` now uses `timeout --foreground -k 10` when GNU `timeout` is detected (probed at runtime), falling back to plain `timeout`, and to direct exec when `timeout` is unavailable.
- `tests/test_install_sh_browser_install.py`: added `test_browser_install_timeout_stays_interruptible`, a regression assertion that the `--foreground`/`-k` guard and its probe are present.

## How to Test

1. `pytest tests/test_install_sh_browser_install.py -q` — 6 passed (5 existing + new regression test).
2. `bash -n scripts/install.sh` — syntax check passes.
3. Behavioral check on a GNU/coreutils box: `bash -c 'source <(sed -n "/^run_browser_install_with_timeout()/,/^}/p" scripts/install.sh); run_browser_install_with_timeout 30 sleep 60'` then press Ctrl+C — the sleep is interrupted immediately (previously the keypress was not delivered to the child).

## What platforms tested on

- macOS on darwin-arm64 (local): `pytest`, `bash -n`, and the GNU `timeout --foreground -k` probe all pass.
- Linux behavior reasoned through GNU coreutils `timeout` semantics; BusyBox/macOS handled via the probe + fallback (no GNU flags emitted there).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

<!-- autocontrib:worker-id=issue-new-f26d9d59 kind=pr-open -->