### PR TITLE
fix(gateway): block shell gateway run when a service supervises the profile

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3621,6 +3621,69 @@ def _is_official_docker_checkout() -> bool:
     )
 
 
+def _running_under_gateway_supervisor() -> bool:
+    """Return True when this process IS the gateway a service manager launched.
+
+    The conflict guard below must never fire on the service's own startup, or
+    it would wedge the unit into a respawn/refuse loop. Each supervisor exports
+    a reliable marker into the child's environment:
+
+      - systemd sets ``INVOCATION_ID`` for every unit it launches (the same
+        marker ``gateway/run.py`` already uses to pick the restart path).
+      - launchd sets ``XPC_SERVICE_NAME`` to the job label for jobs it spawns;
+        interactive shells inherit the sentinel ``"0"`` instead.
+      - the s6-overlay container longrun exports ``HERMES_S6_SUPERVISED_CHILD``.
+    """
+    if os.environ.get("INVOCATION_ID"):
+        return True
+    if os.environ.get("HERMES_S6_SUPERVISED_CHILD"):
+        return True
+    xpc_service = os.environ.get("XPC_SERVICE_NAME", "")
+    if xpc_service and xpc_service != "0":
+        return True
+    return False
+
+
+def _guard_supervised_gateway_conflict(force: bool = False) -> None:
+    """Refuse a foreground gateway when a service manager already supervises one.
+
+    Running ``hermes gateway run [--replace]`` (or the manual-restart fallback)
+    from a shell on a systemd/launchd host spawns a second, long-lived
+    dispatcher that escapes the service cgroup, survives
+    ``systemctl restart``, and becomes a silent concurrent writer on the shared
+    kanban DB — the documented root cause of multi-writer SQLite WAL corruption
+    (issue #35240). Pass ``--force`` to start anyway.
+    """
+    if force or _running_under_gateway_supervisor():
+        return
+    try:
+        snapshot = get_gateway_runtime_snapshot()
+    except Exception:
+        # Best-effort guard: a probe failure must never block a real startup.
+        logger.debug("Supervised-gateway conflict probe failed", exc_info=True)
+        return
+    if not (snapshot.service_installed and snapshot.service_running):
+        return
+
+    print_error(
+        f"A gateway is already running under {snapshot.manager} for this profile."
+    )
+    print(
+        "  Starting another one from a shell leaves an orphan dispatcher that\n"
+        "  escapes the service, survives restarts, and writes to the same kanban\n"
+        "  DB concurrently — which can corrupt it. Restart the supervised gateway\n"
+        "  instead:"
+    )
+    print()
+    print("    hermes gateway restart")
+    print()
+    print(
+        "  Pass --force to start a foreground gateway anyway (not recommended\n"
+        "  while the service is running)."
+    )
+    sys.exit(1)
+
+
 def _guard_official_docker_root_gateway() -> None:
     """Refuse gateway startup when the official Docker privilege drop was bypassed."""
     if not hasattr(os, "geteuid") or os.geteuid() != 0:
@@ -3648,7 +3711,7 @@ def _guard_official_docker_root_gateway() -> None:
     sys.exit(1)
 
 
-def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
+def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, force: bool = False):
     """Run the gateway in foreground.
 
     Args:
@@ -3657,8 +3720,11 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
         replace: If True, kill any existing gateway instance before starting.
                  This prevents systemd restart loops when the old process
                  hasn't fully exited yet.
+        force: Skip the supervised-gateway conflict guard and start even when a
+               systemd/launchd service is already supervising this profile.
     """
     _guard_official_docker_root_gateway()
+    _guard_supervised_gateway_conflict(force=force)
     sys.path.insert(0, str(PROJECT_ROOT))
 
     # Detached Windows gateway runs must ignore console-control broadcasts
@@ -6204,7 +6270,8 @@ def _gateway_command_inner(args):
         verbose = getattr(args, "verbose", 0)
         quiet = getattr(args, "quiet", False)
         replace = getattr(args, "replace", False)
-        run_gateway(verbose, quiet=quiet, replace=replace)
+        force = getattr(args, "force", False)
+        run_gateway(verbose, quiet=quiet, replace=replace, force=force)
         return
 
     if subcmd == "setup":

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -319,6 +319,38 @@ def _require_tty(command_name: str) -> None:
         sys.exit(1)
 
 
+def _add_gateway_run_force_flag(subparsers) -> None:
+    """Re-apply gateway-run-only flags after parser extraction refactors."""
+    gateway_parser = subparsers.choices.get("gateway")
+    if gateway_parser is None:
+        return
+    gateway_subparsers = next(
+        (
+            action
+            for action in gateway_parser._actions
+            if isinstance(action, argparse._SubParsersAction)
+        ),
+        None,
+    )
+    if gateway_subparsers is None:
+        return
+    gateway_run = gateway_subparsers.choices.get("run")
+    if gateway_run is None:
+        return
+    if any("--force" in action.option_strings for action in gateway_run._actions):
+        return
+    gateway_run.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Start a foreground gateway even when a systemd/launchd service is "
+            "already supervising this profile. Without --force, the command "
+            "refuses, because a second dispatcher escapes the service and can "
+            "corrupt the shared kanban DB."
+        ),
+    )
+
+
 # Add project root to path
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
@@ -13239,6 +13271,7 @@ def main():
     # gateway + proxy commands  (parsers built in hermes_cli/subcommands/gateway.py)
     # =========================================================================
     build_gateway_parser(subparsers, cmd_gateway=cmd_gateway, cmd_proxy=cmd_proxy)
+    _add_gateway_run_force_flag(subparsers)
 
     # =========================================================================
     # lsp command

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1,5 +1,6 @@
 """Tests for hermes_cli.gateway."""
 
+import argparse
 import sys
 from types import ModuleType, SimpleNamespace
 
@@ -26,6 +27,15 @@ def _install_fake_gateway_run(monkeypatch, start_gateway):
     monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
     monkeypatch.setattr(
         gateway, "refresh_systemd_unit_if_needed", lambda system=False: False
+    )
+    # Neutralize the supervised-gateway conflict guard by default so these
+    # end-to-end tests don't trip over a launchd/systemd gateway that happens
+    # to be installed+running on the developer's machine. Conflict-guard tests
+    # override this snapshot after calling the helper.
+    monkeypatch.setattr(
+        gateway,
+        "get_gateway_runtime_snapshot",
+        lambda *a, **k: gateway.GatewayRuntimeSnapshot(manager="manual process"),
     )
 
 
@@ -102,6 +112,136 @@ def test_run_gateway_root_guard_has_escape_hatch(monkeypatch):
     gateway.run_gateway(verbose=2, replace=True)
 
     assert calls == [(True, 2)]
+
+
+def _clear_supervisor_markers(monkeypatch):
+    """Make ``_running_under_gateway_supervisor()`` report a plain shell."""
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
+    # Interactive macOS shells inherit XPC_SERVICE_NAME="0"; launchd jobs get
+    # the real label. Default to the shell sentinel so the guard can fire.
+    monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+
+
+def _running_snapshot(manager="systemd (user)"):
+    return gateway.GatewayRuntimeSnapshot(
+        manager=manager, service_installed=True, service_running=True
+    )
+
+
+def test_run_gateway_refuses_when_service_supervising(monkeypatch, capsys):
+    """A shell `gateway run --replace` must not become a second writer."""
+    calls = []
+
+    def fake_start_gateway(*, replace, verbosity):
+        calls.append((replace, verbosity))
+        return object()
+
+    _install_fake_gateway_run(monkeypatch, fake_start_gateway)
+    _clear_supervisor_markers(monkeypatch)
+    monkeypatch.setattr(gateway, "get_gateway_runtime_snapshot", _running_snapshot)
+
+    with pytest.raises(SystemExit) as exc_info:
+        gateway.run_gateway(replace=True)
+
+    assert exc_info.value.code == 1
+    assert calls == []  # dispatcher never started
+    out = capsys.readouterr().out
+    assert "already running under systemd (user)" in out
+    assert "hermes gateway restart" in out
+    assert "--force" in out
+
+
+def test_run_gateway_force_overrides_supervised_conflict(monkeypatch):
+    calls = []
+
+    def fake_start_gateway(*, replace, verbosity):
+        calls.append((replace, verbosity))
+        return object()
+
+    _install_fake_gateway_run(monkeypatch, fake_start_gateway)
+    _clear_supervisor_markers(monkeypatch)
+    monkeypatch.setattr(gateway, "get_gateway_runtime_snapshot", _running_snapshot)
+    monkeypatch.setattr(gateway.asyncio, "run", lambda coro: True)
+
+    gateway.run_gateway(replace=True, force=True)
+
+    assert calls == [(True, 0)]
+
+
+def test_run_gateway_allows_service_managed_startup(monkeypatch):
+    """systemd's own ExecStart (INVOCATION_ID set) must not be blocked."""
+    calls = []
+
+    def fake_start_gateway(*, replace, verbosity):
+        calls.append((replace, verbosity))
+        return object()
+
+    _install_fake_gateway_run(monkeypatch, fake_start_gateway)
+    _clear_supervisor_markers(monkeypatch)
+    monkeypatch.setenv("INVOCATION_ID", "deadbeefcafe")
+    # Even with a "running" snapshot, the supervisor marker means *we* are it.
+    monkeypatch.setattr(gateway, "get_gateway_runtime_snapshot", _running_snapshot)
+    monkeypatch.setattr(gateway.asyncio, "run", lambda coro: True)
+
+    gateway.run_gateway(replace=True)
+
+    assert calls == [(True, 0)]
+
+
+def test_run_gateway_allows_when_service_not_running(monkeypatch):
+    """Installed-but-stopped service: a foreground run is not a conflict."""
+    calls = []
+
+    def fake_start_gateway(*, replace, verbosity):
+        calls.append((replace, verbosity))
+        return object()
+
+    _install_fake_gateway_run(monkeypatch, fake_start_gateway)
+    _clear_supervisor_markers(monkeypatch)
+    monkeypatch.setattr(
+        gateway,
+        "get_gateway_runtime_snapshot",
+        lambda: gateway.GatewayRuntimeSnapshot(
+            manager="systemd (user)", service_installed=True, service_running=False
+        ),
+    )
+    monkeypatch.setattr(gateway.asyncio, "run", lambda coro: True)
+
+    gateway.run_gateway()
+
+    assert calls == [(False, 0)]
+
+
+def test_running_under_gateway_supervisor_markers(monkeypatch):
+    _clear_supervisor_markers(monkeypatch)
+    assert gateway._running_under_gateway_supervisor() is False
+
+    monkeypatch.setenv("XPC_SERVICE_NAME", "org.nousresearch.hermes.gateway")
+    assert gateway._running_under_gateway_supervisor() is True
+
+    monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+    monkeypatch.setenv("INVOCATION_ID", "abc123")
+    assert gateway._running_under_gateway_supervisor() is True
+
+
+def test_gateway_run_force_flag_survives_parser_extraction():
+    from hermes_cli.main import _add_gateway_run_force_flag
+    from hermes_cli.subcommands.gateway import build_gateway_parser
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+
+    build_gateway_parser(
+        subparsers,
+        cmd_gateway=lambda _args: None,
+        cmd_proxy=lambda _args: None,
+    )
+    _add_gateway_run_force_flag(subparsers)
+
+    args = parser.parse_args(["gateway", "run", "--force"])
+
+    assert args.force is True
 
 
 def test_run_gateway_windows_foreground_keeps_ctrl_c_enabled(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

On a systemd/launchd host, running `hermes gateway run --replace` (or `hermes gateway restart` when it falls back to a manual start) from a shell spawns a second, long-lived gateway dispatcher. That process escapes the service cgroup, survives `systemctl restart hermes-gateway.service`, re-parents to PID 1, and becomes a silent **concurrent writer** on the shared `~/.hermes/kanban.db` — the documented root cause of the multi-writer SQLite WAL corruption in #35240 (`disk I/O error` → `database disk image is malformed` → dispatcher quarantine).

This PR implements the reporter's **fix-direction #1 (CLI guard)**: `run_gateway()` now refuses to start a foreground gateway when a service manager is already supervising one for the current profile, and points the user at `hermes gateway restart` instead. A new `--force` flag overrides the guard for the rare intentional case.

The guard must never block the service's *own* startup (both systemd and launchd run `gateway run --replace` as their `ExecStart`/`ProgramArguments`), so it exempts the supervised process using markers each supervisor already exports into the child environment:

- systemd sets `INVOCATION_ID` (the same marker `gateway/run.py` already uses to choose the restart path);
- launchd sets `XPC_SERVICE_NAME` to the job label (interactive shells inherit the sentinel `"0"`);
- the s6-overlay container longrun sets `HERMES_S6_SUPERVISED_CHILD`.

The guard only fires when a service is both **installed and running** for the profile, so installed-but-stopped services and pure manual/`tmux`/`nohup` setups are unaffected.

## Related Issue

Refs #35240

This PR addresses the producer-side guard only. The reporter also proposes a flock-based single-writer guarantee on the dispatcher loop (their direction #3) as defense-in-depth that would catch corruption regardless of how an orphan arose, plus the cross-profile shared-`HERMES_HOME` scenario. Those are deliberately deferred to keep this change focused and low-risk, hence `Refs` rather than `Fixes`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`: add `_running_under_gateway_supervisor()` (detects systemd/launchd/s6 supervision via env markers) and `_guard_supervised_gateway_conflict()`; call the guard at the top of `run_gateway()`; thread a new `force` parameter through `run_gateway()` and the `gateway run` dispatch.
- `hermes_cli/main.py`: add the `--force` flag to the `gateway run` subparser.
- `tests/hermes_cli/test_gateway.py`: cover refusal when a service supervises the profile, `--force` override, exemption of the service's own startup (`INVOCATION_ID`) and a `launchd`-spawned job (`XPC_SERVICE_NAME`), the installed-but-stopped no-conflict case, and the supervisor-marker detection helper. The shared `_install_fake_gateway_run` helper now neutralizes the guard by default so existing end-to-end tests stay deterministic on machines that happen to have a gateway service running.

## How to Test

1. Install and start the gateway as a service (`hermes gateway install` then `hermes gateway start`, or have `hermes-gateway.service` active under systemd).
2. From a shell, run `hermes gateway run --replace`. Before this change it would start a second dispatcher; now it refuses with an error naming the service manager and suggesting `hermes gateway restart`, and exits non-zero. No orphan process is created (`ps -o pid,ppid,cmd` shows nothing new under PID 1).
3. Confirm `hermes gateway run --replace --force` still starts a foreground gateway when you genuinely intend to.
4. Confirm the supervised service itself still starts normally (it runs `gateway run --replace` with `INVOCATION_ID`/`XPC_SERVICE_NAME` set, so the guard is bypassed).
5. Run the unit tests: `pytest tests/hermes_cli/test_gateway.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- ran the gateway suite: tests/hermes_cli/test_gateway*.py (49 passed); did not run the full suite -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64), local

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the guard is platform-aware (systemd `INVOCATION_ID`, launchd `XPC_SERVICE_NAME`, s6 marker) and the env-marker reads use no Unix-only APIs; `scripts/check-windows-footguns.py` is clean on the changed files.

<!-- autocontrib:worker-id=issue-new-1e4b9bbf kind=pr-open -->