### PR TITLE
fix(state): clamp session DB pagination limits for search and listing

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -29,6 +29,30 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 logger = logging.getLogger(__name__)
 
+_SESSION_QUERY_MAX_LIMIT = 200
+
+
+def _clamp_pagination(
+    limit: int,
+    offset: int,
+    *,
+    default_limit: int = 20,
+    max_limit: int = _SESSION_QUERY_MAX_LIMIT,
+) -> Tuple[int, int]:
+    """Return safe LIMIT/OFFSET values for session DB list/search queries."""
+    try:
+        parsed_limit = int(limit)
+    except (TypeError, ValueError):
+        parsed_limit = default_limit
+    try:
+        parsed_offset = int(offset)
+    except (TypeError, ValueError):
+        parsed_offset = 0
+    safe_limit = max(1, min(max_limit, parsed_limit))
+    safe_offset = max(0, parsed_offset)
+    return safe_limit, safe_offset
+
+
 T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
@@ -1425,6 +1449,7 @@ class SessionDB:
         a recursive CTE that walks compression-continuation edges, so LIMIT
         and OFFSET still apply efficiently.
         """
+        limit, offset = _clamp_pagination(limit, offset)
         where_clauses = []
         params = []
 
@@ -2381,6 +2406,8 @@ class SessionDB:
         else:
             sort_norm = None
 
+        limit, offset = _clamp_pagination(limit, offset)
+
         # ORDER BY shared across the main FTS5 path and trigram CJK path.
         # With sort set, timestamp is primary and rank is the tiebreaker.
         if sort_norm == "newest":
@@ -2645,6 +2672,7 @@ class SessionDB:
         message timestamp for the session, falling back to ``started_at``),
         ordered by most-recently-used first.
         """
+        limit, offset = _clamp_pagination(limit, offset)
         select_with_last_active = (
             "SELECT s.*, COALESCE(m.last_active, s.started_at) AS last_active "
             "FROM sessions s "

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -688,6 +688,12 @@ class TestFTS5Search:
         assert db.search_messages("") == []
         assert db.search_messages("   ") == []
 
+    def test_search_messages_rejects_excessive_limit(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="pagination clamp test keyword")
+        results = db.search_messages("pagination", limit=9999)
+        assert len(results) <= 200
+
     def test_search_with_source_filter(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="user", content="CLI question about Python")
@@ -1144,6 +1150,20 @@ class TestCJKSearchFallback:
 # Session search and listing
 # =========================================================================
 
+class TestPaginationBounds:
+    def test_clamp_pagination_invalid_values(self):
+        from hermes_state import _clamp_pagination
+        limit, offset = _clamp_pagination("bad", "also-bad", default_limit=20)
+        assert limit == 20
+        assert offset == 0
+
+    def test_clamp_pagination_caps_excessive_limit(self):
+        from hermes_state import _clamp_pagination
+        limit, offset = _clamp_pagination(9999, -5)
+        assert limit == 200
+        assert offset == 0
+
+
 class TestSearchSessions:
     def test_list_all_sessions(self, db):
         db.create_session(session_id="s1", source="cli")
@@ -1169,6 +1189,18 @@ class TestSearchSessions:
         assert len(page1) == 2
         assert len(page2) == 2
         assert page1[0]["id"] != page2[0]["id"]
+
+    def test_search_sessions_zero_limit_clamped(self, db):
+        for i in range(3):
+            db.create_session(session_id=f"s{i}", source="cli")
+        sessions = db.search_sessions(limit=0)
+        assert len(sessions) == 1
+
+    def test_search_sessions_excessive_limit_capped(self, db):
+        for i in range(3):
+            db.create_session(session_id=f"s{i}", source="cli")
+        sessions = db.search_sessions(limit=9999)
+        assert len(sessions) == 3
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary

This PR hardens `SessionDB` pagination for session search and listing APIs by clamping `limit` and `offset` to safe values before they reach SQLite.

## Problem

`search_messages`, `search_sessions`, and `list_sessions_rich` accepted unbounded or invalid pagination input (e.g. `limit=0`, negative offsets, or very large limits). That could produce surprising query behavior or unnecessary load on FTS/list queries—especially from UI layers that pass through user-controlled values.

## Solution

- Add a shared `_clamp_pagination()` helper (default limit 20, max 200, minimum limit 1, non-negative offset).
- Apply it in:
  - `search_messages` (FTS5, trigram, and LIKE paths share the same clamped values)
  - `search_sessions`
  - `list_sessions_rich`

## Tests

- Unit tests for the clamp helper.
- Regression tests for `search_sessions` and `search_messages` with `limit=0` and excessive limits.

`tests/test_hermes_state.py`: 234 passed locally.

## Notes

- No workflow or unrelated file changes—single focused commit on top of current `main`.
- Backward compatible for normal callers using default/small limits.