### PR TITLE
fix: treat NO_REPLY as silent cron response

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -154,6 +154,10 @@ from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
 
+# Legacy sentinel used by older migrated jobs and some user-authored prompts.
+# Keep it exact-only so reports that merely mention "NO_REPLY" are still sent.
+LEGACY_SILENT_MARKERS = frozenset({"NO_REPLY"})
+
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _hermes_home: Path | None = None
 
@@ -168,6 +172,17 @@ def _get_lock_paths() -> tuple[Path, Path]:
     hermes_home = _get_hermes_home()
     lock_dir = hermes_home / "cron"
     return lock_dir, lock_dir / ".tick.lock"
+
+
+def _is_silent_cron_response(response: str) -> bool:
+    """Whether a successful cron final response should suppress delivery."""
+    stripped = str(response or "").strip()
+    if not stripped:
+        return False
+    upper = stripped.upper()
+    if SILENT_MARKER in upper:
+        return True
+    return upper in LEGACY_SILENT_MARKERS
 
 
 @contextmanager
@@ -1945,8 +1960,8 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 # responses: do not deliver a blank message, and let the
                 # empty-response guard below mark the run as a soft failure.
                 should_deliver = bool(deliver_content.strip())
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
-                    logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
+                if should_deliver and success and _is_silent_cron_response(deliver_content):
+                    logger.info("Job '%s': agent returned %s-compatible silent marker — skipping delivery", job["id"], SILENT_MARKER)
                     should_deliver = False
 
                 delivery_error = None

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,7 +7,16 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import (
+    _resolve_origin,
+    _resolve_delivery_target,
+    _deliver_result,
+    _send_media_via_adapter,
+    run_job,
+    SILENT_MARKER,
+    _build_job_prompt,
+    _is_silent_cron_response,
+)
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -1862,6 +1871,16 @@ class TestSilentDelivery:
             tick(verbose=False)
         deliver_mock.assert_not_called()
 
+    def test_legacy_no_reply_response_suppresses_delivery(self):
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "NO_REPLY", None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_not_called()
+
     def test_failed_job_always_delivers(self):
         """Failed jobs deliver regardless of [SILENT] in output."""
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
@@ -1902,6 +1921,33 @@ class TestSilentDelivery:
             "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
             delivery_error=None,
         )
+
+
+class TestSilentCronResponsePredicate:
+    @pytest.mark.parametrize(
+        "response",
+        [
+            "[SILENT]",
+            "[silent] nothing new",
+            "2 items filtered out\n\n[SILENT]",
+            "NO_REPLY",
+            " no_reply\n",
+        ],
+    )
+    def test_recognizes_silent_responses(self, response):
+        assert _is_silent_cron_response(response) is True
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            "",
+            "   ",
+            "Report mentions NO_REPLY but has content",
+            "NO_REPLY: nothing new",
+        ],
+    )
+    def test_does_not_suppress_non_silent_responses(self, response):
+        assert _is_silent_cron_response(response) is False
 
 
 class TestBuildJobPromptSilentHint:


### PR DESCRIPTION
## Summary
- treat exact `NO_REPLY` cron responses as a legacy silent marker
- keep `[SILENT]` behavior unchanged
- add regression coverage for delivery suppression and non-silent mentions of `NO_REPLY`

## Test Plan
- `PYTHONPATH=/tmp/hermes-agent-pr /opt/hermes/.venv/bin/python -m pytest /tmp/hermes-agent-pr/tests/cron/test_scheduler.py -q -o 'addopts='`
