### PR TITLE
fix(install): prevent installer from installing gateway twice

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2245,6 +2245,27 @@ def _setup_webhooks():
     print_info("   Open config in your editor:  hermes config edit")
 
 
+def _gateway_setup_marker_path() -> Path:
+    """Path of the marker the wizard drops after it installs the gateway.
+
+    The shell installers (scripts/install.sh, scripts/install.ps1) check for
+    this file and skip their own post-setup gateway step so the gateway is not
+    installed twice (issue #35200). Keep the filename in sync across all three.
+    """
+    home = os.environ.get("HERMES_HOME") or (Path.home() / ".hermes")
+    return Path(home) / ".gateway_setup_done"
+
+
+def _write_gateway_setup_marker() -> None:
+    """Record an installer-requested gateway setup result, best-effort."""
+    if os.environ.get("HERMES_INSTALLER_GATEWAY_MARKER") != "1":
+        return
+    try:
+        _gateway_setup_marker_path().write_text("")
+    except OSError:
+        logger.warning("Failed to write gateway setup marker.", exc_info=True)
+
+
 def setup_gateway(config: dict):
     """Configure messaging platform integrations."""
     from hermes_cli.gateway import _all_platforms, _platform_status, _configure_platform
@@ -2440,6 +2461,10 @@ def setup_gateway(config: dict):
                         gateway_windows.install(force=False)
                         did_install = True
                         started_inline = True
+                    if did_install:
+                        # Tell the shell installers not to install the gateway
+                        # again in their own post-setup step (issue #35200).
+                        _write_gateway_setup_marker()
                     print()
                     if did_install and not started_inline and prompt_yes_no("  Start the service now?", True):
                         try:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1851,18 +1851,32 @@ function Invoke-SetupWizard {
     Write-Host ""
 
     Push-Location $InstallDir
+    Remove-Item (Join-Path $HermesHome ".gateway_setup_done") -Force -ErrorAction SilentlyContinue
+    $env:HERMES_INSTALLER_GATEWAY_MARKER = "1"
 
     # Run hermes setup using the venv Python directly (no activation needed)
-    if (-not $NoVenv) {
-        & ".\venv\Scripts\python.exe" -m hermes_cli.main setup
-    } else {
-        python -m hermes_cli.main setup
+    try {
+        if (-not $NoVenv) {
+            & ".\venv\Scripts\python.exe" -m hermes_cli.main setup
+        } else {
+            python -m hermes_cli.main setup
+        }
+    } finally {
+        Remove-Item Env:HERMES_INSTALLER_GATEWAY_MARKER -ErrorAction SilentlyContinue
+        Pop-Location
     }
-
-    Pop-Location
 }
 
 function Start-GatewayIfConfigured {
+    # The setup wizard (hermes setup) installs the gateway itself when a
+    # messaging platform is configured, and writes this marker when it does.
+    # Skip the prompt/install here so the gateway is not set up twice (#35200).
+    if (Test-Path (Join-Path $HermesHome ".gateway_setup_done")) {
+        Remove-Item (Join-Path $HermesHome ".gateway_setup_done") -Force -ErrorAction SilentlyContinue
+        Write-Info "Gateway already configured during setup."
+        return
+    }
+
     $envPath = "$HermesHome\.env"
     if (-not (Test-Path $envPath)) { return }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1772,16 +1772,30 @@ run_setup_wizard() {
 
     cd "$INSTALL_DIR"
 
+    # This marker is only meaningful for the setup run immediately below.
+    # Discard a stale result from an earlier installer invocation first.
+    rm -f "$HERMES_HOME/.gateway_setup_done"
+
     # Run hermes setup using the venv Python directly (no activation needed).
     # Redirect stdin from /dev/tty so interactive prompts work when piped from curl.
     if [ "$USE_VENV" = true ]; then
-        "$INSTALL_DIR/venv/bin/python" -m hermes_cli.main setup < /dev/tty
+        HERMES_HOME="$HERMES_HOME" HERMES_INSTALLER_GATEWAY_MARKER=1 \
+            "$INSTALL_DIR/venv/bin/python" -m hermes_cli.main setup < /dev/tty
     else
-        python -m hermes_cli.main setup < /dev/tty
+        HERMES_HOME="$HERMES_HOME" HERMES_INSTALLER_GATEWAY_MARKER=1 \
+            python -m hermes_cli.main setup < /dev/tty
     fi
 }
 
 maybe_start_gateway() {
+    # The setup wizard (hermes setup) installs the gateway itself when a
+    # messaging platform is configured, and writes this marker when it does.
+    # Skip the prompt/install here so the gateway is not set up twice (#35200).
+    if [ -f "$HERMES_HOME/.gateway_setup_done" ]; then
+        rm -f "$HERMES_HOME/.gateway_setup_done"
+        return 0
+    fi
+
     # Check if any messaging platform tokens were configured
     ENV_FILE="$HERMES_HOME/.env"
     if [ ! -f "$ENV_FILE" ]; then

--- a/tests/test_install_sh_gateway_double_install.py
+++ b/tests/test_install_sh_gateway_double_install.py
@@ -1,0 +1,120 @@
+"""Regression tests for issue #35200 (installer installed the gateway twice).
+
+When a messaging platform is configured, the ``hermes setup`` wizard installs
+the gateway and writes a ``<hermes_home>/.gateway_setup_done`` marker. The shell
+installers (``scripts/install.sh`` and ``scripts/install.ps1``) then ran their
+own post-setup gateway step, which re-detected the messaging token and installed
+/ started the gateway a second time (the ``Service already installed ... Use
+--force`` path the reporter saw).
+
+These tests pin the installer-scoped marker contract:
+  * the installers read the marker and bail out of their gateway step before
+    they probe the ``.env`` for messaging tokens, and
+  * the installers discard stale markers and request a fresh marker only for
+    their own setup invocation.
+"""
+
+from pathlib import Path
+
+from hermes_cli import setup
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+MARKER_NAME = ".gateway_setup_done"
+
+
+# ---------------------------------------------------------------------------
+# Static assertions: the shell installers guard on the marker file, before
+# they inspect the .env for messaging tokens (which is what triggers the
+# duplicate install/prompt).
+# ---------------------------------------------------------------------------
+def test_install_sh_checks_marker_before_messaging_detection():
+    text = INSTALL_SH.read_text(encoding="utf-8")
+
+    fn_idx = text.index("maybe_start_gateway() {")
+    marker_idx = text.index(f'-f "$HERMES_HOME/{MARKER_NAME}"', fn_idx)
+    # Messaging-token detection / the gateway prompt come after the guard.
+    detect_idx = text.index("HAS_MESSAGING=false", fn_idx)
+
+    assert fn_idx < marker_idx < detect_idx
+    consume_idx = text.index(f'rm -f "$HERMES_HOME/{MARKER_NAME}"', marker_idx)
+
+    assert marker_idx < consume_idx < detect_idx
+
+
+def test_install_ps1_checks_marker_before_messaging_detection():
+    text = INSTALL_PS1.read_text(encoding="utf-8")
+
+    fn_idx = text.index("function Start-GatewayIfConfigured")
+    marker_idx = text.index(MARKER_NAME, fn_idx)
+    detect_idx = text.index("$hasMessaging = $false", fn_idx)
+
+    assert fn_idx < marker_idx < detect_idx
+    consume_idx = text.index("Remove-Item (Join-Path $HermesHome \".gateway_setup_done\")", marker_idx)
+
+    assert marker_idx < consume_idx < detect_idx
+
+
+def test_installers_clear_stale_marker_before_wizard_and_request_a_fresh_one():
+    shell_text = INSTALL_SH.read_text(encoding="utf-8")
+    shell_fn = shell_text.index("run_setup_wizard() {")
+    shell_clear = shell_text.index(f'rm -f "$HERMES_HOME/{MARKER_NAME}"', shell_fn)
+    shell_launch = shell_text.index("HERMES_INSTALLER_GATEWAY_MARKER=1", shell_fn)
+
+    assert shell_clear < shell_launch
+    assert 'HERMES_HOME="$HERMES_HOME" HERMES_INSTALLER_GATEWAY_MARKER=1' in shell_text
+
+    ps_text = INSTALL_PS1.read_text(encoding="utf-8")
+    ps_fn = ps_text.index("function Invoke-SetupWizard")
+    ps_clear = ps_text.index("Remove-Item (Join-Path $HermesHome \".gateway_setup_done\")", ps_fn)
+    ps_launch = ps_text.index('$env:HERMES_INSTALLER_GATEWAY_MARKER = "1"', ps_fn)
+
+    assert ps_clear < ps_launch
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: the wizard writes an installer-requested marker under HERMES_HOME.
+# ---------------------------------------------------------------------------
+def test_marker_path_honors_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    assert setup._gateway_setup_marker_path() == tmp_path / MARKER_NAME
+
+
+def test_marker_path_defaults_to_home_hermes(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr(setup.Path, "home", classmethod(lambda cls: tmp_path))
+
+    assert setup._gateway_setup_marker_path() == tmp_path / ".hermes" / MARKER_NAME
+
+
+def test_write_marker_creates_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_INSTALLER_GATEWAY_MARKER", "1")
+
+    setup._write_gateway_setup_marker()
+
+    assert (tmp_path / MARKER_NAME).is_file()
+
+
+def test_write_marker_requires_installer_request(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_INSTALLER_GATEWAY_MARKER", raising=False)
+
+    setup._write_gateway_setup_marker()
+
+    assert not (tmp_path / MARKER_NAME).exists()
+
+
+def test_write_marker_swallows_oserror(tmp_path, monkeypatch):
+    # Point HERMES_HOME at a path whose parent is a file, so write_text raises
+    # OSError. The helper must log and not propagate.
+    not_a_dir = tmp_path / "regular_file"
+    not_a_dir.write_text("")
+    monkeypatch.setenv("HERMES_HOME", str(not_a_dir / "sub"))
+    monkeypatch.setenv("HERMES_INSTALLER_GATEWAY_MARKER", "1")
+
+    setup._write_gateway_setup_marker()  # must not raise
+
+    assert not (not_a_dir / "sub" / MARKER_NAME).exists()


### PR DESCRIPTION
Configures the gateway exactly once across `hermes setup` and the shell installers, by introducing a `.gateway_setup_done` marker.

## What does this PR do?

Fixes the installer installing the gateway service twice (#35200). The `hermes setup` wizard installs the gateway as a background service when a messaging platform is configured. `scripts/install.sh` (`maybe_start_gateway`) and `scripts/install.ps1` (`Start-GatewayIfConfigured`) then ran their own post-setup gateway step, re-detected the same token, and installed/started the gateway a second time — the `Service already installed at: ... Use --force to reinstall` output the reporter saw.

There was no marker coordinating the two paths. This PR adds one: the wizard records that it installed the gateway, and the shell installers skip their post-setup gateway step when that record is present.

## Related Issue

Fixes #35200

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/setup.py`: add `_gateway_setup_marker_path()` and best-effort `_write_gateway_setup_marker()` (writes `<hermes_home>/.gateway_setup_done`; `<hermes_home>` = `$HERMES_HOME` or `~/.hermes`), and call it from `setup_gateway()` only after a gateway install actually succeeds (`did_install`).
- `scripts/install.sh`: `maybe_start_gateway()` returns early when `[ -f "$HERMES_HOME/.gateway_setup_done" ]`.
- `scripts/install.ps1`: `Start-GatewayIfConfigured` returns early when the marker exists (lockstep with install.sh).
- `tests/test_install_sh_gateway_double_install.py`: new regression tests — the marker helper resolves/writes under `HERMES_HOME` and swallows `OSError`; both shell installers guard on the marker before inspecting `.env`.

The marker is written on the success path only (not on decline or failure), so declining the gateway in the wizard still leaves the installer's post-setup offer intact. `run_setup_wizard` runs before `maybe_start_gateway` in install.sh, so the marker exists by the time the guard is checked.

## How to Test

1. Configure a messaging token (e.g. `TELEGRAM_BOT_TOKEN=...`) in `~/.hermes/.env`.
2. Run `bash scripts/install.sh` and accept the gateway install at the wizard's `Install the gateway as a systemd service?` prompt.
3. Confirm the installer does **not** prompt/attempt a second gateway install afterward, and no `Service already installed ... Use --force` message appears.
4. Re-run and decline the gateway in the wizard; confirm the post-setup step still offers it (no marker written).
5. `pytest tests/test_install_sh_gateway_double_install.py -q` and `pytest tests/ -k install -q`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(install):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -k install -q` and all tests pass (13 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — install.sh and install.ps1 updated in lockstep; `scripts/check-windows-footguns.py` clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## What platforms tested on

- macOS on darwin-arm64 (local): `pytest tests/ -k install -q` (13 passed), `ruff check` clean, `scripts/check-windows-footguns.py` clean, `git diff --check` clean.
- Linux/systemd and native-Windows install paths are exercised by the static install-script assertions and the platform-independent marker-helper unit tests; not run on real systemd/Windows hosts locally — trusting CI.

<!-- autocontrib:worker-id=issue-new-78376bac kind=pr-open -->