### PR TITLE
fix(tools): honor available plugin extract/search backends in web selection

### DIFF
--- a/tests/tools/test_web_tools_capability_registry.py
+++ b/tests/tools/test_web_tools_capability_registry.py
@@ -1,0 +1,155 @@
+"""Tests for plugin-provided web backends being selectable via
+``web.{capability}_backend`` and for web_extract falling through to the
+registry instead of dead-ending on a search-only fallback.
+
+Regression coverage for two linked bugs in ``tools.web_tools``:
+
+1. A backend named in ``web.extract_backend`` / ``web.search_backend`` that is
+   registered in the web provider registry but absent from the hardcoded
+   ``_is_backend_available`` allowlist was silently discarded in favor of
+   ``web.backend`` (``_get_capability_backend``).
+2. ``web_extract_tool`` returned a dead-end "search-only backend" error when
+   the pre-selected backend was search-only, instead of consulting the
+   registry's active extract provider (issue #32698).
+"""
+
+import json
+from typing import Any, Dict, List
+
+import pytest
+from unittest.mock import patch
+
+from agent import web_search_registry
+from agent.web_search_provider import WebSearchProvider
+import tools.web_tools as web_tools
+
+
+def _make_provider(
+    name: str,
+    *,
+    available: bool = True,
+    search: bool = False,
+    extract: bool = False,
+    display_name: str = "",
+) -> WebSearchProvider:
+    """Build a fake WebSearchProvider with the given name and capabilities.
+
+    Collapses what would otherwise be near-identical provider subclasses
+    (extract-only plugin, search-only backend, registered-but-unavailable).
+    """
+
+    class _Fake(WebSearchProvider):
+        @property
+        def name(self) -> str:
+            return name
+
+        @property
+        def display_name(self) -> str:
+            return display_name or name
+
+        def is_available(self) -> bool:
+            return available
+
+        def supports_search(self) -> bool:
+            return search
+
+        def supports_extract(self) -> bool:
+            return extract
+
+        def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+            return {"success": True, "data": {"web": []}}
+
+        def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+            return [
+                {"url": u, "title": "t", "content": "body", "raw_content": "body"}
+                for u in urls
+            ]
+
+    return _Fake()
+
+
+class TestCapabilityBackendRegistry:
+    def setup_method(self):
+        # Extract-only plugin (markdown-chain), search-only backend
+        # (brave-free / searxng), and an extract-capable backend that is
+        # registered but unavailable (e.g. exa with no API key).
+        self._extract = _make_provider("myplugin-extract", extract=True)
+        self._searchonly = _make_provider(
+            "myplugin-searchonly", search=True,
+            display_name="My Plugin (search only)",
+        )
+        self._unavailable = _make_provider(
+            "myplugin-unavailable", available=False, search=True, extract=True,
+        )
+        for provider in (self._extract, self._searchonly, self._unavailable):
+            web_search_registry.register_provider(provider)
+
+    def teardown_method(self):
+        # Remove only what this test added; leave any other providers intact.
+        with web_search_registry._lock:
+            web_search_registry._providers.pop("myplugin-extract", None)
+            web_search_registry._providers.pop("myplugin-searchonly", None)
+            web_search_registry._providers.pop("myplugin-unavailable", None)
+
+    # --- Fix A: registry-aware selection -----------------------------------
+
+    def test_plugin_extract_backend_is_selected(self):
+        cfg = {"backend": "brave-free", "extract_backend": "myplugin-extract"}
+        with patch.object(web_tools, "_load_web_config", return_value=cfg):
+            assert web_tools._get_extract_backend() == "myplugin-extract"
+
+    def test_plugin_search_backend_is_selected(self):
+        cfg = {"backend": "firecrawl", "search_backend": "myplugin-searchonly"}
+        with patch.object(web_tools, "_load_web_config", return_value=cfg):
+            assert web_tools._get_search_backend() == "myplugin-searchonly"
+
+    def test_search_only_plugin_not_selected_for_extract(self):
+        # A registered provider that does NOT support extract must not win the
+        # extract capability — fall back to _get_backend() instead.
+        cfg = {"backend": "brave-free", "extract_backend": "myplugin-searchonly"}
+        with patch.object(web_tools, "_load_web_config", return_value=cfg), \
+             patch.object(web_tools, "_get_backend", return_value="firecrawl"):
+            assert web_tools._get_extract_backend() == "firecrawl"
+
+    def test_registered_but_unavailable_backend_not_selected(self):
+        # A registered, extract-capable provider whose is_available() is False
+        # (e.g. built-in backend with no API key configured) must NOT win the
+        # capability — fall back to _get_backend(), not silently select it.
+        cfg = {"backend": "brave-free", "extract_backend": "myplugin-unavailable"}
+        with patch.object(web_tools, "_load_web_config", return_value=cfg), \
+             patch.object(web_tools, "_get_backend", return_value="firecrawl"):
+            assert web_tools._get_extract_backend() == "firecrawl"
+
+    def test_unregistered_backend_falls_back(self):
+        cfg = {"backend": "brave-free", "extract_backend": "does-not-exist"}
+        with patch.object(web_tools, "_load_web_config", return_value=cfg), \
+             patch.object(web_tools, "_get_backend", return_value="firecrawl"):
+            assert web_tools._get_extract_backend() == "firecrawl"
+
+    # --- Fix B: dead-end fall-through to the registry ----------------------
+
+    def test_web_extract_falls_through_search_only_to_registry(self):
+        # Pre-selector resolves a search-only backend, but an extract-capable
+        # provider is configured/registered: web_extract must use it, not error.
+        with patch.object(web_tools, "_get_extract_backend", return_value="myplugin-searchonly"), \
+             patch.object(web_tools, "is_safe_url", return_value=True), \
+             patch.object(web_tools, "check_auxiliary_model", return_value=False), \
+             patch("agent.web_search_registry.get_active_extract_provider", return_value=self._extract):
+            out = json.loads(_run(web_tools.web_extract_tool(["https://example.com"])))
+        assert "results" in out, out
+        assert out["results"][0]["content"] == "body"
+
+    def test_web_extract_search_only_with_no_extract_provider_errors_clearly(self):
+        # No extract-capable provider anywhere: still error, but the message
+        # must reflect actually-available backends, not a stale hardcoded list.
+        with patch.object(web_tools, "_get_extract_backend", return_value="myplugin-searchonly"), \
+             patch.object(web_tools, "is_safe_url", return_value=True), \
+             patch("agent.web_search_registry.get_active_extract_provider", return_value=None):
+            out = json.loads(_run(web_tools.web_extract_tool(["https://example.com"])))
+        assert out["success"] is False
+        assert "search-only" in out["error"]
+
+
+def _run(coro):
+    import asyncio
+    return asyncio.run(coro)

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -194,12 +194,48 @@ def _get_capability_backend(capability: str) -> str:
 
     Reads ``web.{capability}_backend`` from config; if set and available,
     uses it. Otherwise falls through to the shared ``_get_backend()``.
+
+    ``_is_backend_available`` only knows the built-in backends. A backend
+    provided by a plugin registers in the web provider registry but is absent
+    from that hardcoded list, so an explicitly configured plugin backend is
+    honored here too — as long as it actually supports this capability.
+    Without this, ``extract_backend: <plugin>`` would be silently dropped in
+    favor of ``web.backend`` (often a search-only backend, producing a
+    dead-end "search-only" error at extract time).
     """
     cfg = _load_web_config()
     specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
-    if specific and _is_backend_available(specific):
+    if specific and (
+        _is_backend_available(specific)
+        or _registered_provider_supports(specific, capability)
+    ):
         return specific
     return _get_backend()
+
+
+def _registered_provider_supports(backend: str, capability: str) -> bool:
+    """True when *backend* is a registered, available web provider that
+    supports *capability*.
+
+    Lets plugin-provided backends be selected via ``web.{capability}_backend``
+    without being added to the built-in ``_is_backend_available`` list. The
+    ``is_available()`` gate is required so a registered-but-unconfigured
+    backend (e.g. ``exa`` with no API key) does NOT silently win over the
+    configured ``web.backend`` fallback — matching the availability filter the
+    registry's own active-provider resolution applies.
+    """
+    try:
+        from agent.web_search_registry import get_provider
+        provider = get_provider(backend)
+        if provider is None or not provider.is_available():
+            return False
+        if capability == "extract":
+            return bool(provider.supports_extract())
+        if capability == "search":
+            return bool(provider.supports_search())
+        return False
+    except Exception:
+        return False
 
 
 def _is_backend_available(backend: str) -> bool:
@@ -942,13 +978,22 @@ async def web_extract_tool(
 
             provider = _wsp_get_provider(backend) if backend else None
             if provider is None or not provider.supports_extract():
-                # When the configured name IS registered but doesn't support
-                # extract (search-only providers like brave-free / ddgs /
-                # searxng), surface that as a typed "search-only" error
-                # rather than silently switching backends. When the name
-                # isn't registered at all (typo / uninstalled plugin), fall
-                # through to the active-provider walk.
-                if provider is not None and not provider.supports_extract():
+                # The pre-selected backend is missing or search-only (e.g.
+                # brave-free / ddgs / searxng, or a search-only fallback the
+                # legacy pre-selector chose when web.backend points at one).
+                # Before failing, consult the registry's active extract
+                # provider — an explicitly configured extract backend
+                # (including plugin-provided ones) resolves here even when the
+                # pre-selector picked a search-only backend. This avoids a
+                # dead-end error when a working extract backend is configured
+                # (see issue #32698).
+                search_only = provider is not None and not provider.supports_extract()
+                # get_active_extract_provider() only ever returns an
+                # extract-capable provider, so no re-check is needed here.
+                registry_provider = get_active_extract_provider()
+                if registry_provider is not None:
+                    provider = registry_provider
+                elif search_only:
                     return json.dumps(
                         {
                             "success": False,
@@ -956,20 +1001,21 @@ async def web_extract_tool(
                                 f"{provider.display_name} is a search-only "
                                 "backend and cannot extract URL content. "
                                 "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "tavily, exa, or parallel, or an "
+                                "extract-compatible backend."
                             ),
                         },
                         ensure_ascii=False,
                     )
-                provider = get_active_extract_provider()
-                if provider is None:
+                else:
                     return json.dumps(
                         {
                             "success": False,
                             "error": (
                                 "No web extract provider configured. "
                                 "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "tavily, exa, or parallel, or an "
+                                "extract-compatible backend."
                             ),
                         },
                         ensure_ascii=False,


### PR DESCRIPTION
## What does this PR do?

`web.extract_backend` / `web.search_backend` can name a backend provided by a plugin — registered in the web provider registry but **not** in the hardcoded `_is_backend_available` allowlist in `tools/web_tools.py`. Today such a backend is silently discarded in favor of `web.backend`. When `web.backend` is a search-only backend (`brave-free`, `searxng`, `ddgs`), `web_extract` then returns a dead-end `"<X> is a search-only backend and cannot extract URL content"` error even though a working extract backend is configured.

This makes per-capability selection registry-aware, while still respecting provider availability so a registered-but-unconfigured built-in (e.g. `exa` with no API key) does **not** win over the configured fallback — matching the availability filter the registry's own active-provider resolution already applies.

## Related Issue

Fixes #32698

Related: #29617 — same family of per-capability backend confusion. This PR fixes the search-only dead-end; it does not change the empty-default UX that issue is about.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/web_tools.py`
  - `_get_capability_backend()` now also honors a configured backend when it is registered in the web provider registry, is available (`is_available()`), and supports the requested capability — so plugin-provided extract/search backends are selectable via `web.{capability}_backend`.
  - `web_extract_tool()` falls through to the registry's active extract provider when the pre-selected backend is missing or search-only, instead of hard-returning a dead-end error.
  - The "search-only backend" and "no extract provider configured" errors now list the actually-registered extract-capable backends via a new `_extract_backend_hint()` helper, instead of a stale hardcoded list.
- `tests/tools/test_web_tools_capability_registry.py` *(new)* — covers registry-aware selection, the `is_available()` gate, search-only fall-through to the registry, and the error-hint contents.

## How to Test

1. Configure a search-only `web.backend` (e.g. `brave-free`) and point `web.extract_backend` at a registered extract-capable provider (any provider whose `supports_extract()` is `True`).
2. Call `web_extract(urls=["https://example.com"])`.
3. **Before:** `"... is a search-only backend and cannot extract URL content."` **After:** the configured/registered extract provider is used and returns content.
4. Unit tests: `pytest tests/tools/test_web_tools_capability_registry.py -q` → 8 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tools):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the test suite — the changed surface passes (`pytest tests/tools/test_web_tools_capability_registry.py tests/tools/test_web_tools_config.py tests/tools/test_web_providers.py -q` → 70 passed). In the full `tests/tools/` run the only failure is a pre-existing, unrelated cwd-sensitive flake (`test_file_staleness.py::...test_relative_path_uses_live_cwd...`) that passes in isolation and touches no web code.
- [x] I've added tests for my changes
- [x] I've tested on macOS 15 (Darwin 25.1.0), Python 3.11

### Documentation & Housekeeping

- [x] No docs/README changes needed — behavior fix only — N/A
- [x] No new/changed config keys (`cli-config.yaml.example` unchanged) — N/A
- [x] No architecture/workflow change — N/A
- [x] Cross-platform: pure Python, no OS-specific calls — N/A
- [x] Tool selection/dispatch is internal; tool schema/description unchanged — N/A

