### PR TITLE
fix(honcho): cap auto-injected representation to fix context bloat at scale

### DIFF
--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -91,6 +91,33 @@ def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
     tools = getattr(agent, "tools", None) or []
     tools_json = json.dumps(tools, ensure_ascii=False)
 
+    # Honcho memory budget posture. The actual per-turn injected block
+    # (representation + cards + summary + dialectic) is fetched from the Honcho
+    # server at request time, so it can't be measured offline here. What we can
+    # surface without a network call is the configured budget — specifically
+    # whether the unbounded peer representation is capped. Uncapped is the
+    # common cause of multi-hundred-KB injection at scale (see hermes honcho
+    # tokens --representation N).
+    honcho_info: Dict[str, Any] = {"active": False}
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        memory_cfg = cfg.get("memory") if isinstance(cfg.get("memory"), dict) else {}
+        if str(memory_cfg.get("provider", "")).lower() == "honcho":
+            from plugins.memory.honcho.client import HonchoClientConfig
+
+            hcfg = HonchoClientConfig.from_global_config()
+            honcho_info = {
+                "active": True,
+                "representation_max_conclusions": hcfg.representation_max_conclusions,  # None = uncapped
+                "context_tokens": hcfg.context_tokens,                # None = uncapped
+                "dialectic_max_chars": hcfg.dialectic_max_chars,
+                "recall_mode": getattr(hcfg, "recall_mode", None),
+            }
+    except Exception:
+        pass
+
     sections: List[Tuple[str, int, int]] = [
         ("stable (identity/guidance/skills)", len(stable), _bytes(stable)),
         ("context (AGENTS.md/cwd files)", len(context), _bytes(context)),
@@ -105,6 +132,7 @@ def compute_prompt_breakdown(platform: str = "cli") -> Dict[str, Any]:
         "memory": {"chars": len(memory_block), "bytes": _bytes(memory_block)},
         "user_profile": {"chars": len(user_block), "bytes": _bytes(user_block)},
         "tools": {"count": len(tools), "json_bytes": _bytes(tools_json)},
+        "honcho": honcho_info,
         "sections": sections,
     }
 
@@ -135,6 +163,20 @@ def render_breakdown(data: Dict[str, Any]) -> str:
     lines.append("")
     tools = data["tools"]
     lines.append(f"  Tool schemas         : {tools['json_bytes']:>8,} B  ({_fmt_kb(tools['json_bytes'])}, {tools['count']} tools)")
+
+    honcho = data.get("honcho") or {}
+    if honcho.get("active"):
+        lines.append("")
+        lines.append("  Honcho memory budget (injected per turn, fetched live — not measured here):")
+        rep = honcho.get("representation_max_conclusions")
+        if rep:
+            lines.append(f"    representation cap : {rep} conclusions (server-filtered)")
+        else:
+            lines.append("    representation cap : UNCAPPED — can bloat at scale; set with")
+            lines.append("                         hermes honcho tokens --representation 25")
+        ctx = honcho.get("context_tokens")
+        lines.append(f"    overall context cap: {(str(ctx) + ' tokens') if ctx else 'uncapped'}")
+        lines.append(f"    dialectic cap      : {honcho.get('dialectic_max_chars', '?')} chars")
     return "\n".join(lines)
 
 

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -1200,23 +1200,42 @@ def cmd_tokens(args) -> None:
 
     context = getattr(args, "context", None)
     dialectic = getattr(args, "dialectic", None)
+    representation = getattr(args, "representation", None)
 
-    if context is None and dialectic is None:
-        ctx_tokens = hermes.get("contextTokens") or cfg.get("contextTokens") or "(Honcho default)"
+    if context is None and dialectic is None and representation is None:
+        ctx_raw = hermes.get("contextTokens", cfg.get("contextTokens"))
+        ctx_tokens = "uncapped (no limit — grows at scale)" if ctx_raw in (None, "") else f"{ctx_raw} tokens"
+        rep_raw = hermes.get("representationMaxConclusions", cfg.get("representationMaxConclusions"))
+        from plugins.memory.honcho.client import HonchoClientConfig
+        _rep_default = HonchoClientConfig.__dataclass_fields__["representation_max_conclusions"].default
+        if rep_raw in (None, ""):
+            rep_display = f"{_rep_default} conclusions (default)" if _rep_default else "uncapped"
+        elif int(rep_raw) <= 0:
+            rep_display = "uncapped (explicitly disabled)"
+        else:
+            rep_display = f"{rep_raw} conclusions"
         d_chars = hermes.get("dialecticMaxChars") or cfg.get("dialecticMaxChars") or 600
         d_level = hermes.get("dialecticReasoningLevel") or cfg.get("dialecticReasoningLevel") or "low"
         print("\nHoncho budgets\n" + "─" * 40)
         print()
-        print(f"  Context     {ctx_tokens} tokens")
-        print("    Raw memory retrieval. Honcho returns stored facts/history about")
-        print("    the user and session, injected directly into the system prompt.")
+        print(f"  Context     {ctx_tokens}")
+        print("    Overall cap on the auto-injected context block (summary +")
+        print("    representation + cards). Blunt client-side truncation; prefer")
+        print("    the per-section representation cap below for large memories.")
+        print()
+        print(f"  Representation   {rep_display}")
+        print("    Cap on how many conclusions the auto-injected representation")
+        print("    (the raw observation log, which grows unbounded at scale) may")
+        print("    contain. Filtered server-side by Honcho. Cards and session")
+        print("    summary are NOT affected by this cap.")
         print()
         print(f"  Dialectic   {d_chars} chars, reasoning: {d_level}")
         print("    AI-to-AI inference. Hermes asks Honcho's AI peer a question")
         print("    (e.g. \"what were we working on?\") and Honcho runs its own model")
         print("    to synthesize an answer. Used for first-turn session continuity.")
         print("    Level controls how much reasoning Honcho spends on the answer.")
-        print("\n  Set with: hermes honcho tokens [--context N] [--dialectic N]\n")
+        print("\n  Set with: hermes honcho tokens [--context N] [--representation N] [--dialectic N]")
+        print("  (--representation is a conclusion count, 1-100; 0 disables the cap)\n")
         return
 
     host = _host_key()
@@ -1229,6 +1248,13 @@ def cmd_tokens(args) -> None:
     if dialectic is not None:
         cfg.setdefault("hosts", {}).setdefault(host, {})["dialecticMaxChars"] = dialectic
         print(f"  {label}dialectic cap  -> {dialectic} chars")
+        changed = True
+    if representation is not None:
+        cfg.setdefault("hosts", {}).setdefault(host, {})["representationMaxConclusions"] = representation
+        if representation <= 0:
+            print(f"  {label}representation -> uncapped (cap disabled)")
+        else:
+            print(f"  {label}representation -> {representation} conclusions")
         changed = True
 
     if changed:
@@ -1656,6 +1682,10 @@ def register_cli(subparser) -> None:
     tokens_parser.add_argument(
         "--context", type=int, metavar="N",
         help="Max tokens Honcho returns from session.context() per turn",
+    )
+    tokens_parser.add_argument(
+        "--representation", type=int, metavar="N",
+        help="Max conclusions in the auto-injected representation (1-100; 0 = uncapped)",
     )
     tokens_parser.add_argument(
         "--dialectic", type=int, metavar="N",

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -133,6 +133,24 @@ def _parse_context_tokens(host_val, root_val) -> int | None:
     return None
 
 
+def _parse_representation_max_conclusions(host_val, root_val, default: int) -> int | None:
+    """Parse representationMaxConclusions: host wins, then root, then the default.
+
+    An explicit 0 (or negative) means uncapped (returns None). Positive values
+    are clamped to the Honcho SDK's accepted range (1..100).
+    """
+    for val in (host_val, root_val):
+        if val is not None:
+            try:
+                parsed = int(val)
+            except (ValueError, TypeError):
+                continue
+            if parsed <= 0:
+                return None
+            return max(1, min(100, parsed))
+    return default
+
+
 def _parse_int_config(host_val, root_val, default: int) -> int:
     """Parse an integer config: host wins, then root, then default."""
     for val in (host_val, root_val):
@@ -323,6 +341,16 @@ class HonchoClientConfig:
     write_frequency: str | int = "async"
     # Prefetch budget (None = no cap; set to an integer to bound auto-injected context)
     context_tokens: int | None = None
+    # Cap on how many conclusions the auto-injected peer *representation* may
+    # contain. The representation is the raw observation log, which grows
+    # unbounded at scale. Passed to the Honcho SDK as max_conclusions on
+    # peer.context()/peer.representation() so Honcho filters server-side
+    # (relevance-ranked, most-frequent-first) — we never fetch the full object
+    # and slice it locally. SDK clamps to 1..100. Defaults to a bounded value
+    # so fresh/at-scale installs don't inject the entire log every turn. Cards
+    # and session summary are fetched separately and are unaffected.
+    # Set to 0 to disable the cap (uncapped — return Honcho's default).
+    representation_max_conclusions: int | None = 25
     # Dialectic (peer.chat) settings
     # reasoning_level: "minimal" | "low" | "medium" | "high" | "max"
     dialectic_reasoning_level: str = "low"
@@ -538,6 +566,11 @@ class HonchoClientConfig:
             context_tokens=_parse_context_tokens(
                 host_block.get("contextTokens"),
                 raw.get("contextTokens"),
+            ),
+            representation_max_conclusions=_parse_representation_max_conclusions(
+                host_block.get("representationMaxConclusions"),
+                raw.get("representationMaxConclusions"),
+                default=cls.__dataclass_fields__["representation_max_conclusions"].default,
             ),
             dialectic_reasoning_level=(
                 host_block.get("dialecticReasoningLevel")

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -962,6 +962,16 @@ class HonchoSessionManager:
                 context_kwargs["target"] = target
             if search_query is not None:
                 context_kwargs["search_query"] = search_query
+            # Cap the representation server-side: ask Honcho for at most N
+            # conclusions so a large observation log is filtered at the source
+            # rather than fetched whole and sliced. We deliberately do NOT pass
+            # include_most_frequent — frequency bias keeps oft-restated but
+            # stale conclusions; Honcho's default ordering favors recency/
+            # relevance, which is what we want for a per-turn snapshot.
+            # None = uncapped (Honcho's default count).
+            rep_cap = getattr(self._config, "representation_max_conclusions", None) if self._config else None
+            if rep_cap:
+                context_kwargs["max_conclusions"] = rep_cap
             ctx = peer.context(**context_kwargs) if context_kwargs else peer.context()
             representation = (
                 getattr(ctx, "representation", None)
@@ -974,8 +984,14 @@ class HonchoSessionManager:
 
         if not representation:
             try:
+                rep_cap = getattr(self._config, "representation_max_conclusions", None) if self._config else None
+                rep_kwargs: dict[str, Any] = {}
+                if target is not None:
+                    rep_kwargs["target"] = target
+                if rep_cap:
+                    rep_kwargs["max_conclusions"] = rep_cap
                 representation = (
-                    peer.representation(target=target) if target is not None else peer.representation()
+                    peer.representation(**rep_kwargs) if rep_kwargs else peer.representation()
                 ) or ""
             except Exception as e:
                 logger.debug("Direct peer.representation() failed for '%s': %s", peer_id, e)

--- a/tests/honcho_plugin/test_representation_cap.py
+++ b/tests/honcho_plugin/test_representation_cap.py
@@ -1,0 +1,107 @@
+"""Tests for the Honcho representation cap (context bloat fix).
+
+Covers:
+- representationMaxConclusions parsing: default applies when unset, host > root
+  precedence, explicit 0/negative means uncapped (None), positive values
+  clamped to the SDK's 1..100 range.
+- The cap is passed through to peer.context(max_conclusions=...) on the
+  prefetch path so Honcho filters the representation server-side, while cards
+  and session summary are not affected by it.
+"""
+
+from unittest.mock import MagicMock
+
+from plugins.memory.honcho.client import (
+    HonchoClientConfig,
+    _parse_representation_max_conclusions,
+)
+from plugins.memory.honcho.session import HonchoSessionManager
+
+_DEFAULT = HonchoClientConfig.__dataclass_fields__["representation_max_conclusions"].default
+
+
+class TestParseRepresentationMaxConclusions:
+    def test_unset_returns_default(self):
+        assert _parse_representation_max_conclusions(None, None, default=25) == 25
+
+    def test_host_wins_over_root(self):
+        assert _parse_representation_max_conclusions(40, 10, default=25) == 40
+
+    def test_root_used_when_host_unset(self):
+        assert _parse_representation_max_conclusions(None, 10, default=25) == 10
+
+    def test_explicit_zero_means_uncapped(self):
+        assert _parse_representation_max_conclusions(0, None, default=25) is None
+
+    def test_negative_means_uncapped(self):
+        assert _parse_representation_max_conclusions(-1, None, default=25) is None
+
+    def test_clamped_to_sdk_max(self):
+        assert _parse_representation_max_conclusions(500, None, default=25) == 100
+
+    def test_clamped_to_sdk_min(self):
+        # A positive sub-1 value can't occur for ints, but 1 is the floor.
+        assert _parse_representation_max_conclusions(1, None, default=25) == 1
+
+    def test_garbage_falls_through_to_default(self):
+        assert _parse_representation_max_conclusions("nan", None, default=25) == 25
+
+    def test_string_int_parsed(self):
+        assert _parse_representation_max_conclusions("30", None, default=25) == 30
+
+
+class TestDataclassDefault:
+    def test_has_bounded_default(self):
+        """The default must be a bounded positive int, not None — an unset
+        install must not inject an uncapped representation."""
+        cfg = HonchoClientConfig()
+        assert isinstance(cfg.representation_max_conclusions, int)
+        assert 1 <= cfg.representation_max_conclusions <= 100
+
+
+class TestCapThreadedToPeerContext:
+    def _peer_returning(self, representation: str, card):
+        peer = MagicMock()
+        ctx = MagicMock()
+        ctx.representation = representation
+        ctx.peer_card = card
+        peer.context.return_value = ctx
+        return peer
+
+    def test_cap_passed_as_max_conclusions_kwarg(self):
+        """A set cap must reach peer.context(max_conclusions=...). We do not
+        force include_most_frequent — Honcho's default ordering favors recency."""
+        mgr = HonchoSessionManager()
+        mgr._config = HonchoClientConfig(representation_max_conclusions=25)
+        peer = self._peer_returning("rep text", ["Name: X"])
+        mgr._get_or_create_peer = MagicMock(return_value=peer)
+
+        out = mgr._fetch_peer_context("peer-1", target="peer-1")
+
+        assert out["representation"] == "rep text"
+        _, kwargs = peer.context.call_args
+        assert kwargs.get("max_conclusions") == 25
+        assert "include_most_frequent" not in kwargs
+
+    def test_uncapped_omits_max_conclusions_kwarg(self):
+        """representation_max_conclusions=None must NOT pass max_conclusions= (uncapped)."""
+        mgr = HonchoSessionManager()
+        mgr._config = HonchoClientConfig(representation_max_conclusions=None)
+        peer = self._peer_returning("rep text", ["Name: X"])
+        mgr._get_or_create_peer = MagicMock(return_value=peer)
+
+        mgr._fetch_peer_context("peer-1", target="peer-1")
+
+        _, kwargs = peer.context.call_args
+        assert "max_conclusions" not in kwargs
+
+    def test_card_unaffected_by_cap(self):
+        """The peer card comes back whole regardless of the representation cap."""
+        mgr = HonchoSessionManager()
+        mgr._config = HonchoClientConfig(representation_max_conclusions=5)
+        peer = self._peer_returning("rep", ["Name: X", "Role: dev", "Pref: dark"])
+        mgr._get_or_create_peer = MagicMock(return_value=peer)
+
+        out = mgr._fetch_peer_context("peer-1", target="peer-1")
+
+        assert out["card"] == ["Name: X", "Role: dev", "Pref: dark"]


### PR DESCRIPTION
## Summary

Self-hosted and at-scale Honcho deployments could inject 1M+ tokens of accumulated context into every turn, driving multi-minute response times. Reported in the wild on v0.15.1 (VPS + Honcho + Discord). This caps the unbounded part by default via server-side filtering, makes the budget legible, and surfaces it in `hermes prompt-size`.

## The bug, plainly

Honcho auto-injects a context block every turn: session summary + **user representation** + user peer card + AI representation + AI card + dialectic.

The **representation** is the raw, append-only observation log — it grows forever. The only existing cap, `contextTokens`, **defaulted to uncapped**, and when set it did a blunt client-side char-slice on the whole combined block, which could truncate away the high-signal peer card while keeping the front of the firehose. So a long-lived deployment's representation grew until it dominated the prompt. Disabling Honcho "fixed" speed but killed persistence; that's amputation, not a fix.

## What changed

- **`representationMaxConclusions` (default 25)** — a cap on how many conclusions the injected representation may contain, passed to the Honcho SDK as `max_conclusions` on `peer.context()` / `peer.representation()`. Honcho filters **server-side** — we never fetch the full object and slice it locally. We deliberately do **not** pass `include_most_frequent`: frequency bias keeps oft-restated but stale conclusions sticky (e.g. a topic hammered on months ago keeps resurfacing), so we let Honcho's default ordering — which favors recency/relevance — pick which conclusions survive. Value is clamped to the SDK's accepted range (1–100); set to `0` for uncapped. Cards and session summary are fetched separately and are unaffected. The existing `search_query` (already passed) keeps the selection topic-relevant. `contextTokens` is unchanged (still the overall backstop, still defaults uncapped — no silent behavior change for anyone who set it).
- **`hermes honcho tokens` display** — was misleading: showed `(Honcho default)` for an unset context cap, hiding that it means uncapped. Now labels it `uncapped (no limit — grows at scale)`, adds a Representation row showing the conclusion cap, and exposes `--representation N` (a conclusion count, 1–100; `0` = uncapped).
- **`hermes prompt-size`** — measured the system prompt but missed Honcho's per-turn injection (it goes into the user message, fetched live). The actual injected size can't be computed offline, but the configured budget can — so it now reports whether the representation is capped and flags an uncapped representation as the bloat cause, pointing at `hermes honcho tokens --representation N`.

## Why a default cap

This is a cost/safety win, not a feature toggle — a fresh or long-running install should not inject an unbounded representation. The default (25 conclusions) keeps the representation lean while cards + summary + dialectic (already bounded) stay whole. Users who relied on a larger representation set `representationMaxConclusions` higher or `0`.

## Why conclusion count, not a token budget

The Honcho SDK's `peer.context()` / `peer.representation()` don't accept a `tokens` parameter — that's only on `session.context()`. The representation surface filters by `max_conclusions` / `search_query`. Capping by conclusion count is server-side selection, strictly better than a client-side token char-slice that can cut mid-fact. We omit `include_most_frequent` so old, frequently-restated conclusions don't stay sticky — recency/relevance ordering is what keeps a per-turn snapshot fresh.

## Test plan

- `scripts/run_tests.sh tests/honcho_plugin/test_representation_cap.py tests/honcho_plugin/test_session.py tests/honcho_plugin/test_cli.py tests/test_honcho_client_config.py` — 167 passed, 0 failed.
- New `tests/honcho_plugin/test_representation_cap.py`: parsing (default applies, host>root, 0/negative = uncapped, clamp to 1..100, garbage falls through), bounded-default invariant, and that the cap reaches `peer.context(max_conclusions=...)` (and does NOT pass `include_most_frequent`) while the card is unaffected.
- Smoke-tested both CLI surfaces (`hermes honcho tokens`, `hermes prompt-size`) render correctly with the new default.

