### PR TITLE
fix(hindsight): log why HindsightMemoryProvider fails to register instead of failing silently

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -96,6 +96,7 @@ def _check_local_runtime() -> tuple[bool, str | None]:
         importlib.import_module("hindsight_embed.daemon_embed_manager")
         return True, None
     except Exception as exc:
+        logger.warning("Hindsight local runtime check failed: %s", exc)
         return False, str(exc)
 
 
@@ -605,7 +606,13 @@ class HindsightMemoryProvider(MemoryProvider):
             cfg = _load_config()
             mode = cfg.get("mode", "cloud")
             if mode in {"local", "local_embedded"}:
-                available, _ = _check_local_runtime()
+                available, reason = _check_local_runtime()
+                if not available:
+                    logger.warning(
+                        "Hindsight provider unavailable (mode=%s): %s — "
+                        "hindsight_recall/hindsight_retain will not be registered",
+                        mode, reason,
+                    )
                 return available
             if mode == "local_external":
                 return True
@@ -616,7 +623,8 @@ class HindsightMemoryProvider(MemoryProvider):
             )
             has_url = bool(cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", ""))
             return has_key or has_url
-        except Exception:
+        except Exception as exc:
+            logger.warning("Hindsight is_available() check raised: %s", exc)
             return False
 
     def save_config(self, values, hermes_home):


### PR DESCRIPTION
## Problem

`HindsightMemoryProvider.is_available()` silently swallows failures, so when the provider is skipped at agent boot, `hindsight_recall`/`hindsight_retain`/`hindsight_reflect` never appear in the tool list and there is **no log line** explaining why. The agent falls back to built-in memory with no diagnostic.

Three nested bare handlers discard the reason:
- `_check_local_runtime()` → `return False, str(exc)` (reason returned but never logged)
- `is_available()` `local_embedded` gate → `available, _ = _check_local_runtime()` (reason discarded)
- `is_available()` outer `except Exception:` → `return False` (exception swallowed)

This is intermittent in practice: for `mode=local_embedded`, `_check_local_runtime()` imports `hindsight_embed.daemon_embed_manager`, which can fail on a cold process (NumPy ABI / AVX runtime error / incomplete venv) while succeeding when the package is already warm from a prior process. Same machine, different sessions, opposite outcomes — with zero log output either way.

## Fix

Surface the swallowed reason as `logger.warning` at all three sites. No behavior change beyond logging — registration architecture is untouched; only the silent gate becomes diagnosable.

## Notes

The provider's `_DEFAULT_LOCAL_URL` fallback (`http://localhost:8888`) is also stale relative to the embedded daemon's current default port, but `config.json`'s `api_url` is authoritative and the `local_embedded` gate never reads the URL, so that is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)