### PR TITLE
fix: support OpenCode ACP delegation

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -26,6 +26,12 @@ from agent.redact import redact_sensitive_text
 
 ACP_MARKER_BASE_URL = "acp://copilot"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
+_OPENCODE_DEFAULT_FALLBACK_MODELS = (
+    "opencode/deepseek-v4-flash-free",
+    "opencode/mimo-v2.5-free",
+    "opencode/nemotron-3-super-free",
+    "opencode/big-pickle",
+)
 
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 _TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
@@ -103,9 +109,11 @@ def _resolve_home_dir() -> str:
     return "/tmp"
 
 
-def _build_subprocess_env() -> dict[str, str]:
+def _build_subprocess_env(extra_env: dict[str, str] | None = None) -> dict[str, str]:
     env = os.environ.copy()
     env["HOME"] = _resolve_home_dir()
+    if extra_env:
+        env.update(extra_env)
     return env
 
 
@@ -137,13 +145,22 @@ def _format_messages_as_prompt(
     model: str | None = None,
     tools: list[dict[str, Any]] | None = None,
     tool_choice: Any = None,
+    native_acp_tools: bool = False,
 ) -> str:
-    sections: list[str] = [
-        "You are being used as the active ACP agent backend for Hermes.",
-        "Use ACP capabilities to complete tasks.",
-        "IMPORTANT: If you take an action with a tool, you MUST output tool calls using <tool_call>{...}</tool_call> blocks with JSON exactly in OpenAI function-call shape.",
-        "If no tool is needed, answer normally.",
-    ]
+    if native_acp_tools:
+        sections: list[str] = [
+            "You are being used as the active ACP agent backend for Hermes.",
+            "Use your native ACP/OpenCode tools normally to complete tasks.",
+            "Do not emit Hermes <tool_call>{...}</tool_call> JSON blocks; call the tools exposed by your ACP runtime directly.",
+            "When finished, answer with a concise summary of files changed, validation, and issues.",
+        ]
+    else:
+        sections = [
+            "You are being used as the active ACP agent backend for Hermes.",
+            "Use ACP capabilities to complete tasks.",
+            "IMPORTANT: If you take an action with a tool, you MUST output tool calls using <tool_call>{...}</tool_call> blocks with JSON exactly in OpenAI function-call shape.",
+            "If no tool is needed, answer normally.",
+        ]
     if model:
         sections.append(f"Hermes requested model hint: {model}")
 
@@ -318,6 +335,42 @@ def _ensure_path_within_cwd(path_text: str, cwd: str) -> Path:
     return resolved
 
 
+def _is_opencode_command(command: str) -> bool:
+    name = Path(command).name.lower()
+    return name == "opencode" or name.startswith("opencode.")
+
+
+def _opencode_fallback_models() -> tuple[str, ...]:
+    raw = os.getenv("HERMES_OPENCODE_ACP_FALLBACK_MODELS", "").strip()
+    if not raw:
+        return _OPENCODE_DEFAULT_FALLBACK_MODELS
+    models = [part.strip() for part in re.split(r"[,\s]+", raw) if part.strip()]
+    return tuple(dict.fromkeys(models)) or _OPENCODE_DEFAULT_FALLBACK_MODELS
+
+
+def _opencode_config_content_for_model(model: str) -> str:
+    agent_names = ("build", "plan", "general", "explore", "summary", "title", "compaction")
+    agents: dict[str, Any] = {name: {"model": model} for name in agent_names}
+    agents["build"]["permission"] = {
+        "read": "allow",
+        "glob": "allow",
+        "grep": "allow",
+        "list": "allow",
+        "edit": "allow",
+        "bash": "allow",
+        "external_directory": "deny",
+    }
+    return json.dumps(
+        {
+            "$schema": "https://opencode.ai/config.json",
+            "model": model,
+            "small_model": model,
+            "agent": agents,
+        },
+        ensure_ascii=False,
+    )
+
+
 class _ACPChatCompletions:
     def __init__(self, client: "CopilotACPClient"):
         self._client = client
@@ -385,11 +438,13 @@ class CopilotACPClient:
         tool_choice: Any = None,
         **_: Any,
     ) -> Any:
+        native_acp_tools = _is_opencode_command(self._acp_command)
         prompt_text = _format_messages_as_prompt(
             messages or [],
             model=model,
-            tools=tools,
-            tool_choice=tool_choice,
+            tools=None if native_acp_tools else tools,
+            tool_choice=None if native_acp_tools else tool_choice,
+            native_acp_tools=native_acp_tools,
         )
         # Normalise timeout: run_agent.py may pass an httpx.Timeout object
         # (used natively by the OpenAI SDK) rather than a plain float.
@@ -436,6 +491,41 @@ class CopilotACPClient:
         )
 
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+        if not _is_opencode_command(self._acp_command):
+            return self._run_prompt_once(prompt_text, timeout_seconds=timeout_seconds)
+
+        failures: list[str] = []
+        attempts: list[tuple[str | None, dict[str, str] | None]] = [(None, None)]
+        attempts.extend(
+            (
+                model,
+                {"OPENCODE_CONFIG_CONTENT": _opencode_config_content_for_model(model)},
+            )
+            for model in _opencode_fallback_models()
+        )
+        seen: set[str | None] = set()
+        for model, extra_env in attempts:
+            if model in seen:
+                continue
+            seen.add(model)
+            try:
+                return self._run_prompt_once(
+                    prompt_text,
+                    timeout_seconds=timeout_seconds,
+                    extra_env=extra_env,
+                )
+            except Exception as exc:
+                label = model or "configured-default"
+                failures.append(f"{label}: {type(exc).__name__}: {exc}")
+        raise RuntimeError("OpenCode ACP failed for all configured fallback models: " + " | ".join(failures))
+
+    def _run_prompt_once(
+        self,
+        prompt_text: str,
+        *,
+        timeout_seconds: float,
+        extra_env: dict[str, str] | None = None,
+    ) -> tuple[str, str]:
         try:
             proc = subprocess.Popen(
                 [self._acp_command] + self._acp_args,
@@ -445,7 +535,7 @@ class CopilotACPClient:
                 text=True,
                 bufsize=1,
                 cwd=self._acp_cwd,
-                env=_build_subprocess_env(),
+                env=_build_subprocess_env(extra_env),
             )
         except FileNotFoundError as exc:
             raise RuntimeError(


### PR DESCRIPTION
## Summary
- let OpenCode ACP use its native tool runtime instead of Hermes XML tool-call blocks
- add OpenCode ACP model fallback order with DeepSeek V4 Flash Free as primary
- allow fallback override via HERMES_OPENCODE_ACP_FALLBACK_MODELS

## Validation
- PYTHONPATH=. venv/bin/python -m compileall -q agent/copilot_acp_client.py
- smoke-tested OpenCode ACP create/read file flow locally after rebase

## Notes
- preserves existing Copilot ACP behavior
- OpenCode primary remains opencode/deepseek-v4-flash-free