### PR TITLE
fix(nous_account): lock account-info cache to prevent TOCTOU race

### DIFF
--- a/hermes_cli/nous_account.py
+++ b/hermes_cli/nous_account.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import threading
 import time
 import urllib.request
 from dataclasses import dataclass
@@ -15,6 +16,7 @@ NousAccountInfoSource = Literal["jwt", "account_api", "inference_key", "none", "
 
 _ACCOUNT_INFO_CACHE_TTL = 60
 _account_info_cache: tuple[str, float, "NousPortalAccountInfo"] | None = None
+_ACCOUNT_INFO_CACHE_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -302,10 +304,11 @@ def _fresh_account_info(
         portal_base_url = _portal_base_url(refreshed_state) or portal_base_url
         cache_key = _cache_key(access_token, portal_base_url)
 
-        if not force_fresh and _account_info_cache is not None:
-            cached_key, cached_at, cached_info = _account_info_cache
-            if cached_key == cache_key and (time.monotonic() - cached_at) < _ACCOUNT_INFO_CACHE_TTL:
-                return cached_info
+        with _ACCOUNT_INFO_CACHE_LOCK:
+            if not force_fresh and _account_info_cache is not None:
+                cached_key, cached_at, cached_info = _account_info_cache
+                if cached_key == cache_key and (time.monotonic() - cached_at) < _ACCOUNT_INFO_CACHE_TTL:
+                    return cached_info
 
         payload = _fetch_nous_account_info(access_token, portal_base_url)
         if not payload:
@@ -327,7 +330,8 @@ def _fresh_account_info(
             state=refreshed_state,
             portal_base_url=portal_base_url,
         )
-        _account_info_cache = (cache_key, time.monotonic(), info)
+        with _ACCOUNT_INFO_CACHE_LOCK:
+            _account_info_cache = (cache_key, time.monotonic(), info)
         return info
     except Exception as exc:
         return _error_info(


### PR DESCRIPTION
## Summary
Concurrent `_fresh_account_info()` calls can no longer corrupt the Nous Portal account-info cache tuple. The module-level `_account_info_cache` read and write are now guarded by a `threading.Lock`.

Root cause: the cache `None`/TTL check and the cache write were unsynchronized, so two threads could interleave a read against a partially-written tuple (TOCTOU on the shared cache state).

## Changes
- `hermes_cli/nous_account.py`: add `_ACCOUNT_INFO_CACHE_LOCK`; wrap the cache read block and the cache write in the lock.

## Validation
- py_compile clean.
- E2E: 8 concurrent threads through `_fresh_account_info()` with a stubbed network fetch — all return valid info, cache populates, no deadlock.

Note: the lock intentionally does not span the network call, so a rare double-fetch under a cold cache is still possible (serializing the HTTP call would block all callers). This fix targets cache-tuple corruption, not the double-fetch.

Salvaged from #34114 by @sprmn24 — authorship preserved.

## Infographic

![toctou-cache-lock](https://v3b.fal.media/files/b/0a9c48b7/8u9UbIVUvwj4HM0jetYCj_600PWyDf.png)
