### PR TITLE
fix(docker): validate HERMES_UID/GID to prevent privilege escalation

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -32,6 +32,14 @@ INSTALL_DIR="/opt/hermes"
 # is a no-op if the dir already exists. (#18482, salvages #18488)
 mkdir -p "$HERMES_HOME"
 
+# Numeric UID/GID validation: must be digits only, 1000-65534
+validate_uid_gid() {
+    case "$1" in
+        ''|*[!0-9]*) return 1 ;;
+        *) [ "$1" -ge 1000 ] && [ "$1" -le 65534 ] ;;
+    esac
+}
+
 # --- UID/GID remap ---
 # Accept PUID/PGID as aliases for HERMES_UID/HERMES_GID.  NAS users (UGOS,
 # Synology, unRAID) expect the LinuxServer.io PUID/PGID convention and
@@ -42,11 +50,11 @@ mkdir -p "$HERMES_HOME"
 HERMES_UID="${HERMES_UID:-${PUID:-}}"
 HERMES_GID="${HERMES_GID:-${PGID:-}}"
 
-if [ -n "${HERMES_UID:-}" ] && [ "$HERMES_UID" != "$(id -u hermes)" ]; then
+if [ -n "${HERMES_UID:-}" ] && validate_uid_gid "$HERMES_UID" && [ "$HERMES_UID" != "$(id -u hermes)" ]; then
     echo "[stage2] Changing hermes UID to $HERMES_UID"
     usermod -u "$HERMES_UID" hermes
 fi
-if [ -n "${HERMES_GID:-}" ] && [ "$HERMES_GID" != "$(id -g hermes)" ]; then
+if [ -n "${HERMES_GID:-}" ] && validate_uid_gid "$HERMES_GID" && [ "$HERMES_GID" != "$(id -g hermes)" ]; then
     echo "[stage2] Changing hermes GID to $HERMES_GID"
     # -o allows non-unique GID (e.g. macOS GID 20 "staff" may already
     # exist as "dialout" in the Debian-based container image).


### PR DESCRIPTION
## Summary
`HERMES_UID=0` (or any non-numeric / out-of-range value) can no longer be passed straight to `usermod`/`groupmod` in the Docker stage2 hook — which previously would silently grant the `hermes` runtime user root (UID 0). UID/GID remap now requires a numeric value in the range 1000–65534.

Root cause: `HERMES_UID`/`HERMES_GID` (and their `PUID`/`PGID` aliases) were forwarded to `usermod -u` / `groupmod -g` with no validation.

## Changes
- `docker/stage2-hook.sh`: add `validate_uid_gid()` (POSIX `case` numeric check + range bounds); gate both the UID and GID remap conditionals on it.

## Validation
- `sh -n` clean.
- E2E (function extracted and exercised directly):
  - REJECT: `0`, empty, `0; rm -rf /`, `abc`, `999`, `65535`, `-5`, `1e4`
  - ACCEPT: `1000`, `10000` (hermes default), `1001` (typical NAS PUID), `65534`

The 1000 floor blocks UID 0 (the goal) while leaving the default UID 10000 and conventional NAS `PUID`/`PGID` values (≥1000) working.

Salvaged from #34119 by @sprmn24 — authorship preserved. Conflict resolved against the PUID/PGID alias block added to `main` after the PR was opened; validation applied to both UID and GID conditionals.

## Infographic

![uid-gid-validation](https://v3b.fal.media/files/b/0a9c48c8/J4zwm7FYRXVw0UY7OmDu3_mQwEV5B3.png)
