### PR TITLE
fix(tests): conftest.py files are missing in sdist package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,4 @@ recursive-include plugins plugin.yaml plugin.yml
 recursive-include gateway/assets *
 global-exclude __pycache__
 global-exclude *.py[cod]
+recursive-include tests conftest.py

--- a/tests/test_wheel_locales_e2e.py
+++ b/tests/test_wheel_locales_e2e.py
@@ -21,16 +21,36 @@ takes ~15-30s. Run with: pytest -m integration tests/test_wheel_locales_e2e.py
 from __future__ import annotations
 
 import glob
+import importlib.metadata
 import os
 import subprocess
 import sys
 import tarfile
+import tempfile
 import venv
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="module")
+def sdist_package() -> Generator[str]:
+    """Make sdist package and yield the path of generated tarball"""
+    with tempfile.TemporaryDirectory() as sdist_dir:
+        build = subprocess.run(
+            ["uv", "build", "--sdist", "--out-dir", str(sdist_dir), "."],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        assert build.returncode == 0, f"uv build --sdist failed:\n{build.stderr}"
+        tarballs = glob.glob(os.path.join(sdist_dir, "*.tar.gz"))
+        assert tarballs, "no sdist produced"
+        yield tarballs[0]
 
 
 @pytest.mark.integration
@@ -93,7 +113,7 @@ def test_installed_wheel_renders_i18n_strings(tmp_path):
 
 @pytest.mark.integration
 @pytest.mark.timeout(300)  # overrides the global --timeout=30; cold-CI sdist build can exceed it
-def test_built_sdist_ships_locale_catalogs(tmp_path):
+def test_built_sdist_ships_locale_catalogs(sdist_package):
     """The sdist must carry locales/ too.
 
     The wheel is covered above; the sdist is a separately shipped artifact
@@ -104,19 +124,7 @@ def test_built_sdist_ships_locale_catalogs(tmp_path):
     real tarball so that path can't rot silently. Closes the sdist half of
     #27632 / #35374 / #23943.
     """
-    sdist_dir = tmp_path / "sdist"
-    build = subprocess.run(
-        ["uv", "build", "--sdist", "--out-dir", str(sdist_dir), "."],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        timeout=600,
-    )
-    assert build.returncode == 0, f"uv build --sdist failed:\n{build.stderr}"
-    tarballs = glob.glob(str(sdist_dir / "*.tar.gz"))
-    assert tarballs, "no sdist produced"
-
-    with tarfile.open(tarballs[0]) as tf:
+    with tarfile.open(sdist_package) as tf:
         # Members are prefixed with the sdist root dir, e.g.
         # hermes_agent-0.15.1/locales/en.yaml — match on the suffix.
         catalogs = [m for m in tf.getnames() if "/locales/" in m and m.endswith(".yaml")]
@@ -135,3 +143,21 @@ def test_built_sdist_ships_locale_catalogs(tmp_path):
     assert any(m.endswith("/locales/en.yaml") for m in catalogs), (
         f"sdist missing locales/en.yaml; shipped: {catalogs[:5]}"
     )
+
+
+@pytest.mark.integration
+@pytest.mark.timeout(300)  # overrides the global --timeout=30; cold-CI sdist build can exceed it
+def test_built_sdist_ships_tests_conftest_files(sdist_package):
+    with tarfile.open(sdist_package) as tf:
+        # Members are prefixed with the sdist root dir, e.g. hermes_agent-0.15.1/locales/en.yaml
+        # Remove the prefix.
+        shipped_conftest_files = [
+            m[m.find("/")+1:] for m in tf.getnames() if m.endswith("/conftest.py")
+        ]
+
+    package_files = importlib.metadata.files("hermes-agent")
+    assert package_files, "Package metadata does not include files."
+    source_conftest_files = [str(item) for item in package_files if item.name == "conftest.py"]
+
+    assert sorted(shipped_conftest_files) == sorted(source_conftest_files), \
+        "sdist does not shipped all conftest.py files."


### PR DESCRIPTION
## What does this PR do?
I'm packaging hermes-agent Fedora package. While I was debugging a failure test `tests/test_live_system_guard_self_test.py::test_os_system_systemctl_blocked`, I noticed that `tests/conftest.py` is missing, which causes `os.system` is not patched. This pull request also includes other missing `conftest.py` files into sdist package as well.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Modify `MANIFEST.in` to include `tests/**/conftest.py` recursively 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `uv build`
2. `tar --list -vf dist/hermes_agent-0.15.1.tar.gz | grep conftest`


## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

