### PR TITLE
feat(memory): add tiered vector memory index

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1327,6 +1327,23 @@ DEFAULT_CONFIG = {
         # "hindsight", "holographic", "retaindb", "byterover".
         # Only ONE external provider is allowed at a time.
         "provider": "",
+        # Optional local tiered/vector index for built-in memory. Disabled by
+        # default; when enabled it stores profile-scoped MEMORY.md/USER.md
+        # entries in a SQLite index with hashed local embeddings and hot/warm/
+        # cold metadata. Cross-profile search is denied unless explicitly
+        # enabled and bounded by authorized_profiles.
+        "tiered": {
+            "enabled": False,
+            "embedding_backend": "local-hash",
+            "embedding_dim": 128,
+            "hot_limit": 8,
+            "warm_limit": 12,
+            "cold_min_score": 0.72,
+            "cross_profile_enabled": False,
+            "authorized_profiles": [],
+            "db_path": "",
+            "dream_apply": False,
+        },
     },
 
     # Subagent delegation — override the provider:model used by delegate_task

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12784,6 +12784,24 @@ Examples:
         "setup", help="Interactive provider selection and configuration"
     )
     memory_sub.add_parser("status", help="Show current memory provider config")
+    memory_sub.add_parser("index", help="Show built-in tiered/vector memory index status")
+    _rebuild_parser = memory_sub.add_parser(
+        "rebuild",
+        help="Rebuild the local tiered/vector memory index from MEMORY.md/USER.md",
+    )
+    _rebuild_parser.add_argument(
+        "--profiles",
+        help="Comma-separated profile names to index; cross-profile indexing requires memory.tiered.cross_profile_enabled",
+    )
+    _dream_parser = memory_sub.add_parser(
+        "dream",
+        help="Review memory usage/duplicates/staleness and propose hot/warm/cold tier changes",
+    )
+    _dream_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply proposed tier metadata changes; never rewrites MEMORY.md/USER.md",
+    )
     memory_sub.add_parser("off", help="Disable external provider (built-in only)")
     _reset_parser = memory_sub.add_parser(
         "reset",

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -445,6 +445,60 @@ def cmd_status(args) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Local tiered/vector index commands
+# ---------------------------------------------------------------------------
+
+def _tiered_cfg():
+    from hermes_cli.config import load_config
+    from tools.memory_index import MemoryIndexConfig
+    return MemoryIndexConfig.from_config(load_config())
+
+
+def cmd_index_status(args) -> None:
+    from tools.memory_index import index_status
+
+    status = index_status(cfg=_tiered_cfg())
+    print("\nMemory index status\n" + "─" * 40)
+    print(f"  Enabled: {status.get('enabled')}")
+    print(f"  DB:      {status.get('db_path')}")
+    print(f"  Exists:  {status.get('exists')}")
+    counts = status.get("counts") or {}
+    if counts:
+        print("\n  Counts:")
+        for key, value in sorted(counts.items()):
+            print(f"    {key}: {value}")
+    meta = status.get("meta") or {}
+    if meta:
+        print("\n  Meta:")
+        for key, value in sorted(meta.items()):
+            print(f"    {key}: {value}")
+    print()
+
+
+def cmd_index_rebuild(args) -> None:
+    from tools.memory_index import rebuild_index
+
+    profiles = getattr(args, "profiles", None) or None
+    if isinstance(profiles, str):
+        profiles = [p.strip() for p in profiles.split(",") if p.strip()]
+    result = rebuild_index(profiles=profiles, cfg=_tiered_cfg())
+    print("\nMemory index rebuild complete\n" + "─" * 40)
+    print(f"  Profiles:          {', '.join(result['profiles'])}")
+    print(f"  Scanned entries:   {result['scanned']}")
+    print(f"  Indexed entries:   {result['indexed']}")
+    print(f"  Sensitive skipped: {result['skipped_sensitive']}")
+    print(f"  DB:                {result['db_path']}\n")
+
+
+def cmd_index_dream(args) -> None:
+    import json
+    from tools.memory_index import dream_index
+
+    result = dream_index(apply=bool(getattr(args, "apply", False)), cfg=_tiered_cfg())
+    print(json.dumps(result, indent=2))
+
+
+# ---------------------------------------------------------------------------
 # Router
 # ---------------------------------------------------------------------------
 
@@ -455,5 +509,11 @@ def memory_command(args) -> None:
         cmd_setup(args)
     elif sub == "status":
         cmd_status(args)
+    elif sub == "index":
+        cmd_index_status(args)
+    elif sub == "rebuild":
+        cmd_index_rebuild(args)
+    elif sub == "dream":
+        cmd_index_dream(args)
     else:
         cmd_status(args)

--- a/tests/tools/test_memory_index.py
+++ b/tests/tools/test_memory_index.py
@@ -1,0 +1,226 @@
+from pathlib import Path
+
+from tools.memory_tool import ENTRY_DELIMITER
+from tools.memory_index import (
+    MemoryIndexConfig,
+    connect,
+    dream_index,
+    index_path,
+    index_status,
+    rebuild_index,
+    search_index,
+)
+
+
+def _write_profile(home: Path, profile: str, target: str, entries: list[str]) -> Path:
+    profile_home = home.parent / profile
+    mem_dir = profile_home / "memories"
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    filename = "USER.md" if target == "user" else "MEMORY.md"
+    (mem_dir / filename).write_text(ENTRY_DELIMITER.join(entries), encoding="utf-8")
+    return profile_home
+
+
+def test_rebuild_and_search_profile_local_memory(tmp_path):
+    hermes_home = tmp_path / "profiles" / "anulu"
+    _write_profile(hermes_home, "anulu", "memory", [
+        "Project Alpha uses FastAPI and Postgres",
+        "User prefers concise terminal summaries",
+    ])
+    cfg = MemoryIndexConfig(enabled=True)
+
+    result = rebuild_index(hermes_home=hermes_home, cfg=cfg)
+
+    assert result["scanned"] == 2
+    assert result["indexed"] == 2
+    hits = search_index("FastAPI database", hermes_home=hermes_home, cfg=cfg)
+    assert hits
+    assert hits[0]["profile"] == "anulu"
+    assert "FastAPI" in hits[0]["content"]
+
+
+def test_rebuild_skips_sensitive_entries(tmp_path):
+    hermes_home = tmp_path / "profiles" / "anulu"
+    _write_profile(hermes_home, "anulu", "memory", [
+        "Normal stable project convention",
+        "api_key sk-1234567890abcdef1234567890abcdef should never be indexed",
+    ])
+    cfg = MemoryIndexConfig(enabled=True)
+
+    result = rebuild_index(hermes_home=hermes_home, cfg=cfg)
+
+    assert result["scanned"] == 2
+    assert result["indexed"] == 1
+    assert result["skipped_sensitive"] == 1
+    hits = search_index("abcdef", hermes_home=hermes_home, cfg=cfg, include_cold=True)
+    assert hits == []
+
+
+def test_cross_profile_rebuild_is_denied_by_default(tmp_path):
+    hermes_home = tmp_path / "profiles" / "anulu"
+    _write_profile(hermes_home, "anulu", "memory", ["Anulu local fact"])
+    _write_profile(hermes_home, "researcher", "memory", ["Researcher private fact"])
+    cfg = MemoryIndexConfig(enabled=True, cross_profile_enabled=False)
+
+    result = rebuild_index(hermes_home=hermes_home, profiles=("anulu", "researcher"), cfg=cfg)
+    status = index_status(hermes_home=hermes_home, cfg=cfg)
+
+    assert result["indexed"] == 1
+    assert result["profiles"] == ["anulu"]
+    assert status["counts"] == {"anulu:warm": 1}
+
+
+def test_cross_profile_rebuild_requires_authorization(tmp_path):
+    hermes_home = tmp_path / "profiles" / "anulu"
+    _write_profile(hermes_home, "anulu", "memory", ["Anulu local fact"])
+    _write_profile(hermes_home, "researcher", "memory", ["Researcher searchable fact"])
+    cfg = MemoryIndexConfig(
+        enabled=True,
+        cross_profile_enabled=True,
+        authorized_profiles=("researcher",),
+    )
+
+    result = rebuild_index(hermes_home=hermes_home, profiles=("researcher",), cfg=cfg)
+    status = index_status(hermes_home=hermes_home, cfg=cfg)
+
+    assert result["indexed"] == 1
+    assert status["counts"] == {"researcher:warm": 1}
+
+
+def test_search_records_usage_and_hot_tier_wins_order(tmp_path):
+    hermes_home = tmp_path / "profiles" / "anulu"
+    _write_profile(hermes_home, "anulu", "memory", [
+        "FastAPI hot project uses Postgres",
+        "FastAPI warm project uses SQLite",
+    ])
+    cfg = MemoryIndexConfig(enabled=True)
+    rebuild_index(hermes_home=hermes_home, cfg=cfg)
+    path = index_path(hermes_home, cfg)
+    with connect(path) as conn:
+        conn.execute(
+            "UPDATE memory_index_entries SET tier = 'hot' WHERE content LIKE '%Postgres%'"
+        )
+        conn.execute(
+            "UPDATE memory_index_entries SET tier = 'warm' WHERE content LIKE '%SQLite%'"
+        )
+        conn.commit()
+
+    hits = search_index("FastAPI project", hermes_home=hermes_home, cfg=cfg)
+
+    assert hits[0]["tier"] == "hot"
+    assert "Postgres" in hits[0]["content"]
+    with connect(path) as conn:
+        used = conn.execute(
+            "SELECT use_count, last_used_at, relevance FROM memory_index_entries WHERE id = ?",
+            (hits[0]["id"],),
+        ).fetchone()
+    assert used["use_count"] == 1
+    assert used["last_used_at"] is not None
+    assert used["relevance"] > 0
+
+
+def test_rebuild_preserves_updated_at_for_unchanged_entries(tmp_path):
+    hermes_home = tmp_path / "profiles" / "anulu"
+    _write_profile(hermes_home, "anulu", "memory", ["Stable old memory"])
+    cfg = MemoryIndexConfig(enabled=True)
+    rebuild_index(hermes_home=hermes_home, cfg=cfg)
+    path = index_path(hermes_home, cfg)
+    old_ts = 1000.0
+    with connect(path) as conn:
+        conn.execute("UPDATE memory_index_entries SET updated_at = ?", (old_ts,))
+        conn.commit()
+
+    rebuild_index(hermes_home=hermes_home, cfg=cfg)
+
+    with connect(path) as conn:
+        row = conn.execute("SELECT updated_at FROM memory_index_entries").fetchone()
+    assert row["updated_at"] == old_ts
+
+
+def test_rebuild_purges_deleted_and_edited_entries(tmp_path):
+    hermes_home = tmp_path / "profiles" / "anulu"
+    mem_dir = _write_profile(hermes_home, "anulu", "memory", ["Old secret-free fact", "Keep FastAPI fact"]) / "memories"
+    cfg = MemoryIndexConfig(enabled=True)
+    rebuild_index(hermes_home=hermes_home, cfg=cfg)
+
+    (mem_dir / "MEMORY.md").write_text("Keep FastAPI fact" + ENTRY_DELIMITER + "New replacement fact", encoding="utf-8")
+    rebuild_index(hermes_home=hermes_home, cfg=cfg)
+
+    hits = search_index("Old secret-free fact", hermes_home=hermes_home, cfg=cfg, include_cold=True)
+    assert all("Old secret-free fact" not in hit["content"] for hit in hits)
+    with connect(index_path(hermes_home, cfg)) as conn:
+        rows = conn.execute("SELECT content FROM memory_index_entries ORDER BY content").fetchall()
+    assert [row["content"] for row in rows] == ["Keep FastAPI fact", "New replacement fact"]
+
+
+def test_rebuild_purges_entry_that_becomes_sensitive(tmp_path):
+    hermes_home = tmp_path / "profiles" / "anulu"
+    mem_dir = _write_profile(hermes_home, "anulu", "memory", ["Normal project token note"]) / "memories"
+    cfg = MemoryIndexConfig(enabled=True)
+    rebuild_index(hermes_home=hermes_home, cfg=cfg)
+
+    (mem_dir / "MEMORY.md").write_text("api_key sk-1234567890abcdef now sensitive", encoding="utf-8")
+    result = rebuild_index(hermes_home=hermes_home, cfg=cfg)
+
+    assert result["skipped_sensitive"] == 1
+    with connect(index_path(hermes_home, cfg)) as conn:
+        rows = conn.execute("SELECT content FROM memory_index_entries").fetchall()
+    assert rows == []
+
+
+def test_search_denies_unauthorized_profile_rows_already_in_db(tmp_path):
+    hermes_home = tmp_path / "profiles" / "anulu"
+    _write_profile(hermes_home, "researcher", "memory", ["Researcher private vector fact"])
+    allowed_cfg = MemoryIndexConfig(enabled=True, cross_profile_enabled=True, authorized_profiles=("researcher",))
+    rebuild_index(hermes_home=hermes_home, profiles=("researcher",), cfg=allowed_cfg)
+
+    locked_cfg = MemoryIndexConfig(enabled=True, cross_profile_enabled=False)
+
+    assert search_index("Researcher private", hermes_home=hermes_home, profile="researcher", cfg=locked_cfg) == []
+    assert index_status(hermes_home=hermes_home, cfg=locked_cfg)["counts"] == {}
+
+
+def test_dream_scopes_to_active_or_authorized_profiles(tmp_path):
+    hermes_home = tmp_path / "profiles" / "anulu"
+    _write_profile(hermes_home, "researcher", "memory", ["Researcher stale duplicate"])
+    allowed_cfg = MemoryIndexConfig(enabled=True, cross_profile_enabled=True, authorized_profiles=("researcher",))
+    rebuild_index(hermes_home=hermes_home, profiles=("researcher",), cfg=allowed_cfg)
+
+    locked_report = dream_index(hermes_home=hermes_home, cfg=MemoryIndexConfig(enabled=True), apply=False)
+    assert locked_report["tier_changes"] == []
+    assert locked_report["duplicates"] == []
+    assert locked_report["stale_candidates"] == []
+
+    allowed_report = dream_index(hermes_home=hermes_home, cfg=allowed_cfg, apply=False)
+    assert any("Researcher" in item["content_preview"] for item in allowed_report["tier_changes"])
+
+
+def test_cross_profile_default_profile_resolves_to_root_home(tmp_path):
+    hermes_home = tmp_path / "profiles" / "anulu"
+    default_mem_dir = tmp_path / "memories"
+    default_mem_dir.mkdir(parents=True)
+    (default_mem_dir / "MEMORY.md").write_text("Default root profile memory", encoding="utf-8")
+    cfg = MemoryIndexConfig(enabled=True, cross_profile_enabled=True, authorized_profiles=("default",))
+
+    result = rebuild_index(hermes_home=hermes_home, profiles=("default",), cfg=cfg)
+
+    assert result["indexed"] == 1
+    hits = search_index("root profile", hermes_home=hermes_home, profile="default", cfg=cfg)
+    assert hits and hits[0]["profile"] == "default"
+
+
+def test_dream_reports_and_applies_tier_changes_without_deleting(tmp_path):
+    hermes_home = tmp_path / "profiles" / "anulu"
+    _write_profile(hermes_home, "anulu", "memory", ["Recently rebuilt memory should become hot"])
+    cfg = MemoryIndexConfig(enabled=True)
+    rebuild_index(hermes_home=hermes_home, cfg=cfg)
+
+    report = dream_index(hermes_home=hermes_home, cfg=cfg, apply=False)
+    assert report["apply"] is False
+    assert report["tier_changes"]
+    assert report["tier_changes"][0]["to"] == "hot"
+
+    applied = dream_index(hermes_home=hermes_home, cfg=cfg, apply=True)
+    assert applied["apply"] is True
+    status = index_status(hermes_home=hermes_home, cfg=cfg)
+    assert status["counts"] == {"anulu:hot": 1}

--- a/tools/memory_index.py
+++ b/tools/memory_index.py
@@ -1,0 +1,462 @@
+"""Local tiered/vector index for built-in Hermes memory files.
+
+This module is intentionally dependency-light: it uses SQLite plus a small
+hashed bag-of-words embedding so memory recall can be ranked semantically-ish
+without requiring a network embedding provider or sqlite-vss.  Future backends
+can replace ``HashedEmbeddingBackend`` behind the same public functions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+from hermes_constants import get_hermes_home
+from tools.memory_tool import ENTRY_DELIMITER
+from tools.threat_patterns import scan_for_threats
+
+_TIERS = ("hot", "warm", "cold")
+_TARGET_FILES = {"memory": "MEMORY.md", "user": "USER.md"}
+_TOKEN_RE = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_\-]{1,}")
+_SECRET_RE = re.compile(
+    r"(?i)(api[_-]?key|secret|token|password|bearer\s+[A-Za-z0-9._\-]{16,}|sk-[A-Za-z0-9]{16,})"
+)
+
+
+@dataclass(frozen=True)
+class MemoryIndexConfig:
+    enabled: bool = False
+    dim: int = 128
+    hot_limit: int = 8
+    warm_limit: int = 12
+    cross_profile_enabled: bool = False
+    authorized_profiles: tuple[str, ...] = ()
+    cold_min_score: float = 0.72
+    db_path: str = ""
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any] | None = None) -> "MemoryIndexConfig":
+        memory_cfg = (config or {}).get("memory", {}) if isinstance(config, dict) else {}
+        tiered = memory_cfg.get("tiered", {}) if isinstance(memory_cfg, dict) else {}
+        if not isinstance(tiered, dict):
+            tiered = {}
+        profiles = tiered.get("authorized_profiles", [])
+        if isinstance(profiles, str):
+            profiles = [p.strip() for p in profiles.split(",") if p.strip()]
+        elif not isinstance(profiles, list):
+            profiles = []
+        return cls(
+            enabled=bool(tiered.get("enabled", False)),
+            dim=int(tiered.get("embedding_dim", 128) or 128),
+            hot_limit=int(tiered.get("hot_limit", 8) or 8),
+            warm_limit=int(tiered.get("warm_limit", 12) or 12),
+            cross_profile_enabled=bool(tiered.get("cross_profile_enabled", False)),
+            authorized_profiles=tuple(str(p) for p in profiles),
+            cold_min_score=float(tiered.get("cold_min_score", 0.72) or 0.72),
+            db_path=str(tiered.get("db_path", "") or ""),
+        )
+
+
+def index_path(hermes_home: Path | None = None, cfg: MemoryIndexConfig | None = None) -> Path:
+    if cfg and cfg.db_path:
+        return Path(os.path.expanduser(cfg.db_path))
+    home = hermes_home or get_hermes_home()
+    return home / "memories" / "memory_index.sqlite3"
+
+
+class HashedEmbeddingBackend:
+    """Deterministic local embedding fallback with no external dependencies."""
+
+    def __init__(self, dim: int = 128) -> None:
+        self.dim = max(16, int(dim or 128))
+
+    def embed(self, text: str) -> list[float]:
+        vec = [0.0] * self.dim
+        for token in _tokens(text):
+            digest = hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest()
+            bucket = int.from_bytes(digest[:4], "big") % self.dim
+            sign = -1.0 if digest[4] & 1 else 1.0
+            vec[bucket] += sign
+        norm = math.sqrt(sum(v * v for v in vec))
+        if norm:
+            vec = [round(v / norm, 6) for v in vec]
+        return vec
+
+
+def _tokens(text: str) -> list[str]:
+    return [m.group(0).lower() for m in _TOKEN_RE.finditer(text or "")]
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    if not a or not b:
+        return 0.0
+    return float(sum(x * y for x, y in zip(a, b)))
+
+
+def _entry_hash(profile: str, target: str, content: str) -> str:
+    data = f"{profile}\0{target}\0{content}".encode("utf-8")
+    return hashlib.sha256(data).hexdigest()
+
+
+def _content_hash(content: str) -> str:
+    return hashlib.sha256(content.strip().encode("utf-8")).hexdigest()
+
+
+def is_sensitive_memory(content: str) -> bool:
+    """Return true if content should not be indexed/injected from aggregate search."""
+    if not content:
+        return False
+    return bool(_SECRET_RE.search(content) or scan_for_threats(content, scope="strict"))
+
+
+def _read_memory_entries(mem_dir: Path, target: str) -> list[str]:
+    path = mem_dir / _TARGET_FILES[target]
+    if not path.exists():
+        return []
+    text = path.read_text(encoding="utf-8")
+    if not text.strip():
+        return []
+    entries = [e.strip() for e in text.split(ENTRY_DELIMITER) if e.strip()]
+    return list(dict.fromkeys(entries))
+
+
+def _profile_home(root_home: Path, profile: str) -> Path:
+    if profile == "default":
+        return root_home.parent.parent if root_home.parent.name == "profiles" else root_home
+    if root_home.parent.name == "profiles":
+        return root_home.parent / profile
+    return root_home / "profiles" / profile
+
+
+def _active_profile_name(hermes_home: Path) -> str:
+    if hermes_home.parent.name == "profiles":
+        return hermes_home.name
+    return "default"
+
+
+def _profile_allowed(profile: str, active_profile: str, cfg: MemoryIndexConfig) -> bool:
+    """Enforce profile isolation for every index read/write path."""
+    if profile == active_profile:
+        return True
+    if not cfg.cross_profile_enabled:
+        return False
+    # Cross-profile access must be explicitly bounded.  An empty allowlist means
+    # no non-active profiles are authorized, not "all profiles".
+    return profile in set(cfg.authorized_profiles)
+
+
+def connect(db_path: Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    _init_schema(conn)
+    return conn
+
+
+def _init_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        PRAGMA journal_mode=WAL;
+        CREATE TABLE IF NOT EXISTS memory_index_entries (
+            id TEXT PRIMARY KEY,
+            profile TEXT NOT NULL,
+            namespace TEXT NOT NULL DEFAULT '',
+            target TEXT NOT NULL,
+            content TEXT NOT NULL,
+            content_hash TEXT NOT NULL,
+            tier TEXT NOT NULL CHECK(tier IN ('hot','warm','cold')),
+            sensitivity TEXT NOT NULL DEFAULT 'normal',
+            use_count INTEGER NOT NULL DEFAULT 0,
+            relevance REAL NOT NULL DEFAULT 0,
+            last_used_at REAL,
+            created_at REAL NOT NULL,
+            updated_at REAL NOT NULL,
+            embedding TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_memory_index_profile_tier
+            ON memory_index_entries(profile, namespace, tier);
+        CREATE INDEX IF NOT EXISTS idx_memory_index_content_hash
+            ON memory_index_entries(content_hash);
+        CREATE TABLE IF NOT EXISTS memory_index_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        """
+    )
+    conn.commit()
+
+
+def rebuild_index(
+    *,
+    hermes_home: Path | None = None,
+    profiles: Sequence[str] | None = None,
+    namespace: str = "",
+    cfg: MemoryIndexConfig | None = None,
+) -> dict[str, Any]:
+    """Rebuild index rows from MEMORY.md/USER.md without mutating source files."""
+    home = hermes_home or get_hermes_home()
+    cfg = cfg or MemoryIndexConfig()
+    active_profile = _active_profile_name(home)
+    selected_profiles = tuple(profiles or (active_profile,))
+    embedder = HashedEmbeddingBackend(cfg.dim)
+    now = time.time()
+    scanned = indexed = skipped_sensitive = 0
+    processed_profiles: list[str] = []
+
+    with connect(index_path(home, cfg)) as conn:
+        for profile in selected_profiles:
+            if not _profile_allowed(profile, active_profile, cfg):
+                continue
+            processed_profiles.append(profile)
+            mem_dir = _profile_home(home, profile) / "memories"
+            for target in _TARGET_FILES:
+                current_ids: set[str] = set()
+                for entry in _read_memory_entries(mem_dir, target):
+                    scanned += 1
+                    entry_id = _entry_hash(profile, target, entry)
+                    current_ids.add(entry_id)
+                    sensitive = is_sensitive_memory(entry)
+                    if sensitive:
+                        skipped_sensitive += 1
+                        # Remove any stale cleartext copy from an older index build.
+                        conn.execute(
+                            "DELETE FROM memory_index_entries WHERE id = ?",
+                            (entry_id,),
+                        )
+                        continue
+                    existing = conn.execute(
+                        "SELECT tier, use_count, last_used_at, relevance, created_at, updated_at FROM memory_index_entries WHERE id = ?",
+                        (entry_id,),
+                    ).fetchone()
+                    tier = existing["tier"] if existing else "warm"
+                    use_count = int(existing["use_count"] if existing else 0)
+                    last_used_at = existing["last_used_at"] if existing else None
+                    relevance = float(existing["relevance"] if existing else 0.0)
+                    created_at = float(existing["created_at"] if existing else now)
+                    updated_at = float(existing["updated_at"] if existing and "updated_at" in existing.keys() else now)
+                    conn.execute(
+                        """
+                        INSERT OR REPLACE INTO memory_index_entries
+                          (id, profile, namespace, target, content, content_hash, tier,
+                           sensitivity, use_count, relevance, last_used_at, created_at,
+                           updated_at, embedding)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, 'normal', ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            entry_id,
+                            profile,
+                            namespace,
+                            target,
+                            entry,
+                            _content_hash(entry),
+                            tier,
+                            use_count,
+                            relevance,
+                            last_used_at,
+                            created_at,
+                            updated_at,
+                            json.dumps(embedder.embed(entry)),
+                        ),
+                    )
+                    indexed += 1
+                # A rebuild is also a privacy purge: remove rows for entries
+                # deleted, edited, or newly classified as sensitive in source.
+                if current_ids:
+                    placeholders = ",".join("?" for _ in current_ids)
+                    conn.execute(
+                        f"""
+                        DELETE FROM memory_index_entries
+                        WHERE profile = ? AND namespace = ? AND target = ?
+                          AND id NOT IN ({placeholders})
+                        """,
+                        (profile, namespace, target, *current_ids),
+                    )
+                else:
+                    conn.execute(
+                        """
+                        DELETE FROM memory_index_entries
+                        WHERE profile = ? AND namespace = ? AND target = ?
+                        """,
+                        (profile, namespace, target),
+                    )
+        conn.execute(
+            "INSERT OR REPLACE INTO memory_index_meta(key, value) VALUES ('last_rebuild_at', ?)",
+            (str(now),),
+        )
+        conn.commit()
+    return {
+        "profiles": processed_profiles,
+        "scanned": scanned,
+        "indexed": indexed,
+        "skipped_sensitive": skipped_sensitive,
+        "db_path": str(index_path(home, cfg)),
+    }
+
+
+def search_index(
+    query: str,
+    *,
+    hermes_home: Path | None = None,
+    profile: str | None = None,
+    namespace: str = "",
+    limit: int = 10,
+    include_cold: bool = False,
+    record_usage: bool = True,
+    cfg: MemoryIndexConfig | None = None,
+) -> list[dict[str, Any]]:
+    home = hermes_home or get_hermes_home()
+    cfg = cfg or MemoryIndexConfig()
+    profile = profile or _active_profile_name(home)
+    active_profile = _active_profile_name(home)
+    if not _profile_allowed(profile, active_profile, cfg):
+        return []
+    embedder = HashedEmbeddingBackend(cfg.dim)
+    qvec = embedder.embed(query)
+    qtokens = set(_tokens(query))
+    tiers = ("hot", "warm", "cold") if include_cold else ("hot", "warm")
+    per_tier_limit = {"hot": cfg.hot_limit, "warm": cfg.warm_limit, "cold": max(limit, cfg.warm_limit)}
+    rows: list[dict[str, Any]] = []
+    now = time.time()
+    with connect(index_path(home, cfg)) as conn:
+        for tier in tiers:
+            fetched = conn.execute(
+                """
+                SELECT * FROM memory_index_entries
+                WHERE profile = ? AND namespace = ? AND tier = ? AND sensitivity = 'normal'
+                """,
+                (profile, namespace, tier),
+            ).fetchall()
+            scored: list[tuple[float, sqlite3.Row]] = []
+            for row in fetched:
+                emb = json.loads(row["embedding"] or "[]")
+                semantic = _cosine(qvec, emb)
+                rtokens = set(_tokens(row["content"]))
+                exact = len(qtokens & rtokens) / max(1, len(qtokens))
+                age_days = (now - float(row["last_used_at"] or row["updated_at"] or now)) / 86400.0
+                recency = 1.0 / (1.0 + max(0.0, age_days) / 30.0)
+                frequency = math.log1p(int(row["use_count"] or 0)) / 5.0
+                tier_boost = {"hot": 0.18, "warm": 0.06, "cold": -0.04}[tier]
+                score = (semantic * 0.52) + (exact * 0.25) + (recency * 0.12) + frequency + tier_boost
+                min_score = 0.20 if tier != "cold" else cfg.cold_min_score
+                if score >= min_score:
+                    scored.append((score, row))
+            scored.sort(key=lambda x: x[0], reverse=True)
+            for score, row in scored[:per_tier_limit[tier]]:
+                rows.append({
+                    "id": row["id"],
+                    "profile": row["profile"],
+                    "target": row["target"],
+                    "tier": row["tier"],
+                    "score": round(score, 4),
+                    "content": row["content"],
+                })
+            if len(rows) >= limit:
+                break
+        rows = rows[:limit]
+        if record_usage and rows:
+            hit_ids = [row["id"] for row in rows]
+            conn.executemany(
+                """
+                UPDATE memory_index_entries
+                SET use_count = use_count + 1, last_used_at = ?, relevance = MAX(relevance, ?)
+                WHERE id = ?
+                """,
+                [(now, float(row["score"]), row_id) for row, row_id in zip(rows, hit_ids)],
+            )
+            conn.commit()
+    return rows
+
+
+def dream_index(
+    *,
+    hermes_home: Path | None = None,
+    apply: bool = False,
+    cfg: MemoryIndexConfig | None = None,
+) -> dict[str, Any]:
+    """Review indexed rows and propose/apply non-destructive tier changes."""
+    home = hermes_home or get_hermes_home()
+    cfg = cfg or MemoryIndexConfig()
+    now = time.time()
+    proposals: list[dict[str, Any]] = []
+    duplicates: list[dict[str, Any]] = []
+    stale: list[dict[str, Any]] = []
+    active_profile = _active_profile_name(home)
+    allowed_profiles = [active_profile, *cfg.authorized_profiles] if cfg.cross_profile_enabled else [active_profile]
+    # Deduplicate while preserving order; active profile is always first.
+    allowed_profiles = list(dict.fromkeys(p for p in allowed_profiles if _profile_allowed(p, active_profile, cfg)))
+    with connect(index_path(home, cfg)) as conn:
+        placeholders = ",".join("?" for _ in allowed_profiles)
+        rows = conn.execute(
+            f"SELECT * FROM memory_index_entries WHERE sensitivity = 'normal' AND profile IN ({placeholders})",
+            tuple(allowed_profiles),
+        ).fetchall()
+        seen: dict[str, sqlite3.Row] = {}
+        for row in rows:
+            age_days = (now - float(row["last_used_at"] or row["updated_at"] or now)) / 86400.0
+            use_count = int(row["use_count"] or 0)
+            if use_count >= 5 or age_days <= 14:
+                desired = "hot"
+            elif use_count >= 1 or age_days <= 90:
+                desired = "warm"
+            else:
+                desired = "cold"
+            if desired != row["tier"]:
+                proposals.append({"id": row["id"], "from": row["tier"], "to": desired, "content_preview": row["content"][:120]})
+                if apply:
+                    conn.execute("UPDATE memory_index_entries SET tier = ?, updated_at = ? WHERE id = ?", (desired, now, row["id"]))
+            if age_days > 180 and use_count == 0:
+                stale.append({"id": row["id"], "tier": row["tier"], "content_preview": row["content"][:120]})
+            ch = row["content_hash"]
+            if ch in seen:
+                duplicates.append({
+                    "keep_id": seen[ch]["id"],
+                    "duplicate_id": row["id"],
+                    "content_preview": row["content"][:120],
+                })
+            else:
+                seen[ch] = row
+        if apply:
+            conn.execute("INSERT OR REPLACE INTO memory_index_meta(key, value) VALUES ('last_dream_at', ?)", (str(now),))
+            conn.commit()
+    return {
+        "apply": apply,
+        "tier_changes": proposals,
+        "duplicates": duplicates,
+        "stale_candidates": stale,
+        "note": "Dreaming never deletes or rewrites MEMORY.md/USER.md; duplicates/stale entries are reports for human review.",
+    }
+
+
+def index_status(*, hermes_home: Path | None = None, cfg: MemoryIndexConfig | None = None) -> dict[str, Any]:
+    home = hermes_home or get_hermes_home()
+    cfg = cfg or MemoryIndexConfig()
+    path = index_path(home, cfg)
+    if not path.exists():
+        return {"enabled": cfg.enabled, "db_path": str(path), "exists": False, "counts": {}}
+    active_profile = _active_profile_name(home)
+    allowed_profiles = [active_profile, *cfg.authorized_profiles] if cfg.cross_profile_enabled else [active_profile]
+    allowed_profiles = list(dict.fromkeys(p for p in allowed_profiles if _profile_allowed(p, active_profile, cfg)))
+    with connect(path) as conn:
+        placeholders = ",".join("?" for _ in allowed_profiles)
+        counts = {
+            f"{row['profile']}:{row['tier']}": int(row["n"])
+            for row in conn.execute(
+                f"""
+                SELECT profile, tier, COUNT(*) AS n
+                FROM memory_index_entries
+                WHERE profile IN ({placeholders})
+                GROUP BY profile, tier
+                """,
+                tuple(allowed_profiles),
+            )
+        }
+        meta = {row["key"]: row["value"] for row in conn.execute("SELECT key, value FROM memory_index_meta")}
+    return {"enabled": cfg.enabled, "db_path": str(path), "exists": True, "counts": counts, "meta": meta}

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -164,6 +164,12 @@ class MemoryStore:
         sanitized_memory = self._sanitize_entries_for_snapshot(self.memory_entries, "MEMORY.md")
         sanitized_user = self._sanitize_entries_for_snapshot(self.user_entries, "USER.md")
 
+        # Optional tiered memory index: build a local SQLite/vector index and
+        # order prompt snapshots hot → warm → cold. Disabled by default so the
+        # legacy prompt shape and prefix-cache behavior remain unchanged.
+        sanitized_memory = self._tier_ordered_entries_for_snapshot("memory", sanitized_memory)
+        sanitized_user = self._tier_ordered_entries_for_snapshot("user", sanitized_user)
+
         # Capture frozen snapshot for system prompt injection
         self._system_prompt_snapshot = {
             "memory": self._render_block("memory", sanitized_memory),
@@ -440,6 +446,41 @@ class MemoryStore:
             self.save_to_disk(target)
 
         return self._success_response(target, "Entry removed.")
+
+    def _tier_ordered_entries_for_snapshot(self, target: str, entries: List[str]) -> List[str]:
+        """Return entries ordered by optional hot/warm/cold index metadata.
+
+        The index is disabled by default. When enabled, rebuild from the active
+        profile's memory files at session start, then sort the already-sanitized
+        snapshot entries by tier. This keeps injection bounded to the same
+        profile-scoped MEMORY.md/USER.md content while allowing hot memories to
+        appear first.
+        """
+        try:
+            from hermes_cli.config import load_config
+            from tools.memory_index import MemoryIndexConfig, index_path, rebuild_index, connect, _active_profile_name, _entry_hash
+
+            cfg = MemoryIndexConfig.from_config(load_config())
+            if not cfg.enabled:
+                return entries
+            home = get_hermes_home()
+            profile = _active_profile_name(home)
+            rebuild_index(hermes_home=home, profiles=(profile,), cfg=cfg)
+            tier_rank = {"hot": 0, "warm": 1, "cold": 2}
+            order: Dict[str, tuple[int, float]] = {}
+            with connect(index_path(home, cfg)) as conn:
+                for row in conn.execute(
+                    "SELECT id, tier, updated_at FROM memory_index_entries WHERE profile = ? AND target = ?",
+                    (profile, target),
+                ):
+                    order[row["id"]] = (tier_rank.get(row["tier"], 1), -float(row["updated_at"] or 0))
+            return sorted(
+                entries,
+                key=lambda entry: order.get(_entry_hash(profile, target, entry), (1, 0)),
+            )
+        except Exception as exc:
+            logger.debug("tiered memory snapshot ordering skipped: %s", exc)
+            return entries
 
     def format_for_system_prompt(self, target: str) -> Optional[str]:
         """

--- a/website/docs/developer-guide/tiered-memory-rfc.md
+++ b/website/docs/developer-guide/tiered-memory-rfc.md
@@ -1,0 +1,82 @@
+# RFC: Tiered Vector Memory and Dreaming Organizer
+
+## Goals
+
+Hermes currently injects curated `MEMORY.md` and `USER.md` entries as bounded text snapshots. This RFC adds a safe, opt-in local memory index that improves recall order and prepares Hermes for faster semantic search across profile-scoped memory.
+
+## Phase 1 shipped in this branch
+
+- Add a dependency-light SQLite memory index at `<HERMES_HOME>/memories/memory_index.sqlite3`.
+- Index built-in memory entries with deterministic local hashed embeddings (`local-hash`) so it works without API keys or network calls.
+- Track per-entry metadata: profile, namespace, target (`memory` or `user`), content hash, tier (`hot`, `warm`, `cold`), sensitivity, use count, relevance, last used, created, updated, and embedding.
+- Preserve profile isolation by default. Rebuilding another profile is ignored unless `memory.tiered.cross_profile_enabled` is true and optional `authorized_profiles` allows it.
+- Skip sensitive entries rather than storing cleartext in the index when threat-pattern or token/secret-like content is detected.
+- Add non-destructive CLI commands:
+  - `hermes memory index` — status and counts.
+  - `hermes memory rebuild [--profiles a,b]` — backfill from `MEMORY.md`/`USER.md`.
+  - `hermes memory dream [--apply]` — propose/apply tier metadata changes only; never rewrites memory files.
+- Add optional prompt snapshot ordering behind `memory.tiered.enabled`: active profile entries are rebuilt at session start and ordered hot → warm → cold while keeping the frozen snapshot/prefix-cache invariant.
+- Record retrieval usage (`use_count`, `last_used_at`, best relevance) when `search_index()` returns hits; index rebuilds preserve `updated_at` for unchanged entries so dreaming can still identify stale memories.
+
+## Retrieval pipeline
+
+Phase 1 exposes `tools.memory_index.search_index()` for internal callers. Ranking combines:
+
+1. local hashed-vector cosine score,
+2. exact token overlap,
+3. recency,
+4. frequency (`use_count`),
+5. tier boost (`hot` > `warm` > `cold`).
+
+Hot and warm are searched by default. Cold entries are only returned when requested and the combined score clears `memory.tiered.cold_min_score`.
+
+## Dreaming organizer
+
+The dream pass is intentionally conservative:
+
+- proposes/promotes `hot` when use count is high or memory was updated/used recently,
+- keeps useful less-recent entries `warm`,
+- demotes unused old entries to `cold`,
+- reports duplicate content hashes and stale candidates,
+- never deletes, summarizes, or rewrites `MEMORY.md`/`USER.md`.
+
+Future phases can wire this into cron/curator with a review report artifact before any destructive or summarizing action.
+
+## Privacy and cross-profile safety
+
+Default behavior is profile-local only. Aggregate indexing requires explicit config:
+
+```yaml
+memory:
+  tiered:
+    enabled: true
+    cross_profile_enabled: true
+    authorized_profiles: [anulu, researcher]
+```
+
+Even with aggregate indexing, sensitive entries are skipped from the local DB. The initial implementation does not expose a cross-profile tool to the model; it only provides CLI/admin rebuild and internal APIs.
+
+## Migration/backfill
+
+No migration runs automatically while the feature is disabled. To backfill the active profile:
+
+```bash
+hermes config set memory.tiered.enabled true
+hermes memory rebuild
+hermes memory index
+```
+
+To review tier changes:
+
+```bash
+hermes memory dream
+hermes memory dream --apply   # metadata only; safe/non-destructive
+```
+
+## Future phases
+
+1. Add pluggable embedding backend interface for hosted/local embedding models while keeping `local-hash` as fallback.
+2. Wire `search_index()` into memory prefetch/tool recall with usage updates (`last_used_at`, `use_count`).
+3. Add a scheduled dreaming job that emits review reports/diffs and can create curator tasks.
+4. Extend indexing to session summaries once a summarization privacy policy is defined.
+5. Add admin UI/dashboard visibility for tier counts, stale candidates, and duplicate reports.

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -211,6 +211,37 @@ memory:
   user_char_limit: 1375     # ~500 tokens
 ```
 
+## Tiered Vector Index (experimental)
+
+Hermes can optionally build a local SQLite index for the built-in `MEMORY.md` and `USER.md` files. The index stores deterministic local hashed embeddings plus hot/warm/cold tier metadata, so Hermes can order frequently used or recent memories ahead of colder archive facts without requiring API keys or a network embedding service.
+
+It is disabled by default. Enable and backfill the active profile:
+
+```bash
+hermes config set memory.tiered.enabled true
+hermes memory rebuild
+hermes memory index
+```
+
+Review the non-destructive "dreaming" organizer report:
+
+```bash
+hermes memory dream          # report proposed tier changes, duplicates, stale candidates
+hermes memory dream --apply  # apply tier metadata only; does not rewrite memory files
+```
+
+Cross-profile indexing is denied unless explicitly enabled and bounded in config:
+
+```yaml
+memory:
+  tiered:
+    enabled: true
+    cross_profile_enabled: true
+    authorized_profiles: [researcher, coder]
+```
+
+Sensitive/token-like entries are skipped from the index. Search usage updates index metadata (`use_count`, `last_used_at`, relevance) but never writes back into your memory source files. The feature preserves the frozen system-prompt snapshot invariant: mid-session writes still only affect disk and the next session.
+
 ## External Memory Providers
 
 For deeper, persistent memory that goes beyond MEMORY.md and USER.md, Hermes ships with 8 external memory provider plugins — including Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, and Supermemory.


### PR DESCRIPTION
## Summary
- Add opt-in tiered/vector memory index backed by local SQLite and deterministic hashed embeddings
- Add memory index/rebuild/dream CLI commands and documentation
- Enforce profile isolation, authorized cross-profile access, stale/sensitive purge, and scoped dream/status reporting

## Verification
- python -m py_compile tools/memory_index.py tools/memory_tool.py hermes_cli/memory_setup.py hermes_cli/main.py
- python -m pytest tests/tools/test_memory_index.py tests/tools/test_memory_tool.py tests/hermes_cli/test_memory_reset.py -q -o 'addopts='
- Result: 89 passed in 1.23s
- Temp HERMES_HOME CLI smoke: rebuild indexed 2 entries and index status reported anulu:warm: 2

## Review
- Independent review initially found privacy/scope blockers
- Fixed blockers and added regression tests
- Independent re-review passed