### PR TITLE
fix(weixin): guard json.loads against non-JSON API responses

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -383,7 +383,10 @@ async def _api_post(
         raw = await response.text()
         if not response.ok:
             raise RuntimeError(f"iLink POST {endpoint} HTTP {response.status}: {raw[:200]}")
-        return json.loads(raw)
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"iLink POST {endpoint}: invalid JSON response ({exc})") from exc
 
 
 async def _api_get(
@@ -403,7 +406,10 @@ async def _api_get(
         raw = await response.text()
         if not response.ok:
             raise RuntimeError(f"iLink GET {endpoint} HTTP {response.status}: {raw[:200]}")
-        return json.loads(raw)
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"iLink GET {endpoint}: invalid JSON response ({exc})") from exc
 
 
 async def _get_updates(


### PR DESCRIPTION
## Problem

`_api_post()` and `_api_get()` in the WeChat/iLink adapter parse HTTP response bodies with `json.loads()` but have no `JSONDecodeError` handling. If the iLink server returns a non-JSON response (HTML error page, empty body, truncated data), the unhandled exception crashes the adapter with an opaque traceback instead of a clean error message.

## Fix

Add `try/except json.JSONDecodeError` around both `json.loads()` calls, re-raising as `RuntimeError` with a descriptive message that includes the endpoint name and the original parse error.

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Server returns HTML error | Unhandled `JSONDecodeError` crash | `RuntimeError: iLink POST /msg: invalid JSON response (...)` |
| Empty response body | Same crash | Same clean error |
| Valid JSON | Works normally | Works normally (zero behavioral change) |

## Files Changed

- `gateway/platforms/weixin.py` — 2 `json.loads()` calls guarded (+6 lines)