### PR TITLE
fix(vision): unify vision_analyze image-source resolution through one resolver

### DIFF
--- a/tests/integration/test_vision_docker_resolve.py
+++ b/tests/integration/test_vision_docker_resolve.py
@@ -1,0 +1,84 @@
+"""Gated Docker integration tests for the vision image-source resolver.
+
+Reproduces #32709: vision_analyze must read images that live only inside the
+Docker terminal backend — including a tmpfs ``/workspace`` file with no host
+path, and a root-owned mode-600 file the host user cannot read. Both are
+served by the in-container ``base64`` exec-read fallback.
+
+Run locally with Docker:  HERMES_DOCKER_TESTS=1 pytest tests/integration/test_vision_docker_resolve.py
+In CI without the flag:    SKIPPED.
+"""
+import base64
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("HERMES_DOCKER_TESTS"),
+    reason="set HERMES_DOCKER_TESTS=1 to run Docker integration tests",
+)
+
+# A real 1x1 PNG.
+_TINY_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+
+@pytest.fixture
+def docker_backend():
+    from tools import terminal_tool
+    from tools.environments import docker as docker_env
+
+    task_id = "vision-docker-resolve-test"
+    env = docker_env.DockerEnvironment(
+        image="python:3.11-slim",
+        cwd="/workspace",
+        timeout=120,
+        cpu=0,
+        memory=0,
+        disk=0,
+        persistent_filesystem=True,
+        task_id=task_id,
+        volumes=[],
+        network=False,
+    )
+    terminal_tool._active_environments[task_id] = env
+    try:
+        env.task_id = task_id
+        yield env
+    finally:
+        terminal_tool._active_environments.pop(task_id, None)
+        env.cleanup(force_remove=True)
+
+
+def _write_png_in_container(env, path, *, mode=None):
+    b64 = base64.b64encode(_TINY_PNG).decode()
+    cmd = f"printf %s {b64} | base64 -d > {path}"
+    if mode:
+        cmd += f" && chmod {mode} {path}"
+    res = env.execute(cmd)
+    assert res.get("returncode", 1) == 0, res
+
+
+@pytest.mark.asyncio
+async def test_resolves_tmpfs_workspace_file(docker_backend):
+    from tools.image_source import ResolveContext, resolve_image_source
+
+    _write_png_in_container(docker_backend, "/workspace/shot.png")
+    res = await resolve_image_source(
+        "/workspace/shot.png", ResolveContext(task_id=docker_backend.task_id))
+    assert res.origin == "container"
+    assert res.mime == "image/png"
+    assert res.data == _TINY_PNG
+
+
+@pytest.mark.asyncio
+async def test_resolves_root_owned_mode600_file(docker_backend):
+    from tools.image_source import ResolveContext, resolve_image_source
+
+    # Root-owned, mode 600 — unreadable from the host user, readable in-container.
+    _write_png_in_container(docker_backend, "/workspace/secret.png", mode="600")
+    res = await resolve_image_source(
+        "/workspace/secret.png", ResolveContext(task_id=docker_backend.task_id))
+    assert res.origin == "container"
+    assert res.mime == "image/png"

--- a/tests/integration/test_vision_docker_resolve.py
+++ b/tests/integration/test_vision_docker_resolve.py
@@ -1,22 +1,42 @@
-"""Gated Docker integration tests for the vision image-source resolver.
+"""Docker integration tests for the vision image-source resolver.
 
 Reproduces #32709: vision_analyze must read images that live only inside the
 Docker terminal backend — including a tmpfs ``/workspace`` file with no host
 path, and a root-owned mode-600 file the host user cannot read. Both are
 served by the in-container ``base64`` exec-read fallback.
 
-Run locally with Docker:  HERMES_DOCKER_TESTS=1 pytest tests/integration/test_vision_docker_resolve.py
-In CI without the flag:    SKIPPED.
+Gating follows the repo convention: the ``integration`` marker excludes these
+from the default suite (``addopts = -m 'not integration'``); they run under
+``pytest -m integration`` when a Docker daemon is available, and skip cleanly
+when it is not. Container spin-up exceeds the 30s suite default, so the timeout
+is bumped to 180s (mirrors tests/docker/conftest.py).
+
+Run:  pytest -m integration tests/integration/test_vision_docker_resolve.py
 """
 import base64
-import os
+import shutil
+import subprocess
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("HERMES_DOCKER_TESTS"),
-    reason="set HERMES_DOCKER_TESTS=1 to run Docker integration tests",
-)
+
+def _docker_available() -> bool:
+    """True iff a docker CLI is on PATH and the daemon answers."""
+    if shutil.which("docker") is None:
+        return False
+    try:
+        return subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=5
+        ).returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.timeout(180),
+    pytest.mark.skipif(not _docker_available(), reason="Docker daemon not available"),
+]
 
 # A real 1x1 PNG.
 _TINY_PNG = base64.b64decode(
@@ -25,11 +45,13 @@ _TINY_PNG = base64.b64decode(
 
 
 @pytest.fixture
-def docker_backend():
+def docker_backend(request):
     from tools import terminal_tool
     from tools.environments import docker as docker_env
 
-    task_id = "vision-docker-resolve-test"
+    # Unique per test: DockerEnvironment derives the container from task_id, so
+    # a shared id would make one test's teardown remove the other's container.
+    task_id = f"vision-docker-resolve-{request.node.name}"
     env = docker_env.DockerEnvironment(
         image="python:3.11-slim",
         cwd="/workspace",

--- a/tests/test_model_tools_async_bridge.py
+++ b/tests/test_model_tools_async_bridge.py
@@ -366,18 +366,19 @@ class TestVisionDispatchLoopSafety:
                 new_callable=AsyncMock,
                 return_value=fake_response,
             ),
+            # Image sourcing now funnels through tools.image_source. Mock only
+            # the two external boundaries the resolver touches — the URL-safety
+            # gate (avoids a live DNS/policy lookup for example.com) and the
+            # network download — so the real http branch, _finalize magic-byte
+            # sniff, and base64 encode still execute.
             patch(
-                "tools.vision_tools._download_image",
+                "tools.image_source._http_block_reason",
+                return_value=None,
+            ),
+            patch(
+                "tools.image_source._download_to_bytes",
                 new_callable=AsyncMock,
-                side_effect=lambda url, dest, **kw: _write_fake_image(dest),
-            ),
-            patch(
-                "tools.vision_tools._validate_image_url",
-                return_value=True,
-            ),
-            patch(
-                "tools.vision_tools._image_to_base64_data_url",
-                return_value="data:image/jpeg;base64,abc",
+                return_value=_fake_jpeg_bytes(),
             ),
         ):
             result_json = registry.dispatch(
@@ -410,18 +411,17 @@ class TestVisionDispatchLoopSafety:
                 new_callable=AsyncMock,
                 return_value=fake_response,
             ),
+            # See test_vision_dispatch_keeps_loop_alive: mock only the resolver's
+            # external boundaries (safety gate + network), not the moved-away
+            # tools.vision_tools seams.
             patch(
-                "tools.vision_tools._download_image",
+                "tools.image_source._http_block_reason",
+                return_value=None,
+            ),
+            patch(
+                "tools.image_source._download_to_bytes",
                 new_callable=AsyncMock,
-                side_effect=lambda url, dest, **kw: _write_fake_image(dest),
-            ),
-            patch(
-                "tools.vision_tools._validate_image_url",
-                return_value=True,
-            ),
-            patch(
-                "tools.vision_tools._image_to_base64_data_url",
-                return_value="data:image/jpeg;base64,abc",
+                return_value=_fake_jpeg_bytes(),
             ),
         ):
             args = {"image_url": "https://example.com/cat.png", "question": "Describe"}
@@ -438,8 +438,6 @@ class TestVisionDispatchLoopSafety:
         assert not loop_after_second.is_closed()
 
 
-def _write_fake_image(dest):
-    """Write minimal bytes so vision_analyze_tool thinks download succeeded."""
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    dest.write_bytes(b"\xff\xd8\xff" + b"\x00" * 16)
-    return dest
+def _fake_jpeg_bytes() -> bytes:
+    """Minimal JPEG-magic bytes so the resolver's _finalize sniffs image/jpeg."""
+    return b"\xff\xd8\xff" + b"\x00" * 16

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -9,6 +9,7 @@ import pytest
 from tools.credential_files import (
     clear_credential_files,
     get_credential_file_mounts,
+    from_agent_visible_cache_path,
     get_cache_directory_mounts,
     get_skills_directory_mount,
     iter_cache_files,
@@ -421,6 +422,30 @@ class TestCacheDirectoryMounts:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
         assert get_cache_directory_mounts() == []
+
+    def test_from_agent_visible_reverses_cache_mount(self, tmp_path, monkeypatch):
+        """A container cache path maps back to its host path under Docker."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        (tmp_path / "cache" / "images").mkdir(parents=True)
+
+        result = from_agent_visible_cache_path("/root/.hermes/cache/images/shot.png")
+        assert result == str(tmp_path / "cache" / "images" / "shot.png")
+
+    def test_from_agent_visible_noop_when_not_docker(self, tmp_path, monkeypatch):
+        """Non-Docker backends never translate; the path passes through."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        path = "/root/.hermes/cache/images/x.png"
+        assert from_agent_visible_cache_path(path) == path
+
+    def test_from_agent_visible_noop_for_unmapped_path(self, tmp_path, monkeypatch):
+        """A path outside any cache mount is returned unchanged (→ exec-read)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+        assert from_agent_visible_cache_path("/workspace/x.png") == "/workspace/x.png"
 
 
 class TestIterCacheFiles:

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -8,6 +8,7 @@ from tools.image_source import (
     ResolveContext,
     ResolvedImage,
     SourceTooLarge,
+    SourceUnsafe,
     UnsupportedScheme,
     resolve_image_source,
 )
@@ -47,3 +48,28 @@ async def test_unknown_scheme_rejected():
 async def test_blank_source_rejected():
     with pytest.raises(Exception):
         await resolve_image_source("   ", ResolveContext())
+
+
+@pytest.mark.asyncio
+async def test_http_url_downloads_bytes(monkeypatch):
+    from tools import image_source
+
+    png = base64.b64decode(PNG_B64)
+
+    async def fake_download(url):
+        return png
+
+    monkeypatch.setattr(image_source, "_is_safe_http", lambda u: True)
+    monkeypatch.setattr(image_source, "_download_to_bytes", fake_download)
+    res = await resolve_image_source("https://ex.com/a.png", ResolveContext())
+    assert res.origin == "http"
+    assert res.data == png
+
+
+@pytest.mark.asyncio
+async def test_http_url_ssrf_blocked(monkeypatch):
+    from tools import image_source
+
+    monkeypatch.setattr(image_source, "_is_safe_http", lambda u: False)
+    with pytest.raises(SourceUnsafe):
+        await resolve_image_source("http://169.254.169.254/x.png", ResolveContext())

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -7,6 +7,7 @@ from tools.image_source import (
     NotAnImage,
     ResolveContext,
     ResolvedImage,
+    SourceNotFound,
     SourceTooLarge,
     SourceUnsafe,
     UnsupportedScheme,
@@ -73,3 +74,38 @@ async def test_http_url_ssrf_blocked(monkeypatch):
     monkeypatch.setattr(image_source, "_is_safe_http", lambda u: False)
     with pytest.raises(SourceUnsafe):
         await resolve_image_source("http://169.254.169.254/x.png", ResolveContext())
+
+
+@pytest.mark.asyncio
+async def test_file_uri_resolves(tmp_path):
+    img = tmp_path / "cache" / "images" / "a.png"
+    img.parent.mkdir(parents=True)
+    img.write_bytes(base64.b64decode(PNG_B64))
+    res = await resolve_image_source(f"file://{img}", ResolveContext())
+    assert res.origin == "file"
+    assert res.mime == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_local_path_outside_cache_allowed_in_pr1(tmp_path):
+    # PR 1 preserves today's permissive behavior; the allowlist (PR 2) is a seam.
+    img = tmp_path / "Pictures" / "cat.png"
+    img.parent.mkdir(parents=True)
+    img.write_bytes(base64.b64decode(PNG_B64))
+    res = await resolve_image_source(str(img), ResolveContext())
+    assert res.origin == "file"
+
+
+@pytest.mark.asyncio
+async def test_tilde_path_expanded(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    img = tmp_path / "shot.png"
+    img.write_bytes(base64.b64decode(PNG_B64))
+    res = await resolve_image_source("~/shot.png", ResolveContext())
+    assert res.origin == "file"
+
+
+@pytest.mark.asyncio
+async def test_missing_local_file_not_found(tmp_path):
+    with pytest.raises(SourceNotFound):
+        await resolve_image_source(str(tmp_path / "nope.png"), ResolveContext())

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -34,10 +34,24 @@ async def test_data_url_non_image_rejected():
 
 
 @pytest.mark.asyncio
-async def test_data_url_oversize_rejected():
-    big = base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"0" * (40 * 1024 * 1024)).decode()
+async def test_data_url_over_ingest_budget_rejected():
+    # > 50MB ingest budget -> rejected. (The 20MB *payload* cap is enforced
+    # post-resize at the call sites, not here — see test below.)
+    big = base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"0" * (60 * 1024 * 1024)).decode()
     with pytest.raises(SourceTooLarge):
         await resolve_image_source(f"data:image/png;base64,{big}", ResolveContext())
+
+
+@pytest.mark.asyncio
+async def test_data_url_within_ingest_budget_resolves():
+    # Regression guard: a 20-50MB image must NOT be rejected by the resolver —
+    # it has to reach the call site so it can be resized under the payload cap.
+    # (Previously _finalize hard-capped raw bytes at 20MB and broke this.)
+    big = base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"0" * (30 * 1024 * 1024)).decode()
+    res = await resolve_image_source(f"data:image/png;base64,{big}", ResolveContext())
+    assert res.origin == "data"
+    assert res.mime == "image/png"
+    assert len(res.data) > 20 * 1024 * 1024
 
 
 @pytest.mark.asyncio
@@ -61,7 +75,7 @@ async def test_http_url_downloads_bytes(monkeypatch):
     async def fake_download(url):
         return png
 
-    monkeypatch.setattr(image_source, "_is_safe_http", lambda u: True)
+    monkeypatch.setattr(image_source, "_http_block_reason", lambda u: None)
     monkeypatch.setattr(image_source, "_download_to_bytes", fake_download)
     res = await resolve_image_source("https://ex.com/a.png", ResolveContext())
     assert res.origin == "http"
@@ -72,9 +86,23 @@ async def test_http_url_downloads_bytes(monkeypatch):
 async def test_http_url_ssrf_blocked(monkeypatch):
     from tools import image_source
 
-    monkeypatch.setattr(image_source, "_is_safe_http", lambda u: False)
+    monkeypatch.setattr(
+        image_source, "_http_block_reason", lambda u: "blocked: unsafe or private URL")
     with pytest.raises(SourceUnsafe):
         await resolve_image_source("http://169.254.169.254/x.png", ResolveContext())
+
+
+@pytest.mark.asyncio
+async def test_http_policy_block_preserves_message(monkeypatch):
+    # The specific website-policy reason must survive (not collapse to a
+    # generic "blocked" string), so the agent sees *why* the fetch was refused.
+    monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+    monkeypatch.setattr(
+        "tools.website_policy.check_website_access",
+        lambda u: {"message": "Blocked by website policy: example.com"})
+    with pytest.raises(SourceUnsafe) as ei:
+        await resolve_image_source("https://example.com/a.png", ResolveContext())
+    assert "Blocked by website policy: example.com" in str(ei.value)
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -1,0 +1,49 @@
+"""Unified vision image-source resolver."""
+import base64
+
+import pytest
+
+from tools.image_source import (
+    NotAnImage,
+    ResolveContext,
+    ResolvedImage,
+    SourceTooLarge,
+    UnsupportedScheme,
+    resolve_image_source,
+)
+
+PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+
+@pytest.mark.asyncio
+async def test_data_url_resolves_to_bytes():
+    res = await resolve_image_source(f"data:image/png;base64,{PNG_B64}", ResolveContext())
+    assert isinstance(res, ResolvedImage)
+    assert res.mime == "image/png"
+    assert res.origin == "data"
+    assert res.data == base64.b64decode(PNG_B64)
+
+
+@pytest.mark.asyncio
+async def test_data_url_non_image_rejected():
+    with pytest.raises(NotAnImage):
+        await resolve_image_source("data:text/plain;base64,aGk=", ResolveContext())
+
+
+@pytest.mark.asyncio
+async def test_data_url_oversize_rejected():
+    big = base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"0" * (40 * 1024 * 1024)).decode()
+    with pytest.raises(SourceTooLarge):
+        await resolve_image_source(f"data:image/png;base64,{big}", ResolveContext())
+
+
+@pytest.mark.asyncio
+async def test_unknown_scheme_rejected():
+    with pytest.raises(UnsupportedScheme):
+        await resolve_image_source("s3://bucket/x.png", ResolveContext())
+
+
+@pytest.mark.asyncio
+async def test_blank_source_rejected():
+    with pytest.raises(Exception):
+        await resolve_image_source("   ", ResolveContext())

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -1,5 +1,6 @@
 """Unified vision image-source resolver."""
 import base64
+import shlex
 
 import pytest
 
@@ -116,9 +117,11 @@ class _FakeEnv:
         self.files = files
 
     def execute(self, command, cwd=None, **kw):
-        path = command.split()[1]  # base64 <path> | tr -d '\n'
-        if path.strip("'\"") in self.files:
-            return {"output": base64.b64encode(self.files[path.strip("'\"")]).decode(), "returncode": 0}
+        # base64 -- <path> | tr -d '\n'
+        tokens = shlex.split(command)
+        path = tokens[tokens.index("--") + 1]
+        if path in self.files:
+            return {"output": base64.b64encode(self.files[path]).decode(), "returncode": 0}
         return {"output": "", "returncode": 1}
 
 
@@ -143,6 +146,32 @@ async def test_container_fallback_fails_closed_without_env(monkeypatch):
     monkeypatch.setattr(image_source, "_maybe_translate_container_path", lambda p, ctx: p)
     with pytest.raises(SourceNotFound):
         await resolve_image_source("/workspace/x.png", ResolveContext(task_id="t1"))
+
+
+class _RecordingEnv:
+    def __init__(self):
+        self.commands = []
+
+    def execute(self, command, cwd=None, **kw):
+        self.commands.append(command)
+        return {"output": "", "returncode": 1}
+
+
+@pytest.mark.asyncio
+async def test_exec_read_guards_against_dash_flag_injection(monkeypatch):
+    # A leading-dash path must not be parsed as a base64 option (argument
+    # injection); `--` must terminate option parsing before the quoted path.
+    from tools import image_source
+
+    env = _RecordingEnv()
+    monkeypatch.setattr(image_source, "_get_active_env", lambda tid: env)
+    monkeypatch.setattr(image_source, "_maybe_translate_container_path", lambda p, ctx: p)
+    with pytest.raises(SourceNotFound):
+        await resolve_image_source("./-i/etc/shadow", ResolveContext(task_id="t1"))
+    assert env.commands
+    cmd = env.commands[0]
+    assert " -- " in cmd
+    assert cmd.index(" -- ") < cmd.index("-i/etc/shadow")
 
 
 @pytest.mark.asyncio

--- a/tests/tools/test_image_source.py
+++ b/tests/tools/test_image_source.py
@@ -109,3 +109,48 @@ async def test_tilde_path_expanded(tmp_path, monkeypatch):
 async def test_missing_local_file_not_found(tmp_path):
     with pytest.raises(SourceNotFound):
         await resolve_image_source(str(tmp_path / "nope.png"), ResolveContext())
+
+
+class _FakeEnv:
+    def __init__(self, files):
+        self.files = files
+
+    def execute(self, command, cwd=None, **kw):
+        path = command.split()[1]  # base64 <path> | tr -d '\n'
+        if path.strip("'\"") in self.files:
+            return {"output": base64.b64encode(self.files[path.strip("'\"")]).decode(), "returncode": 0}
+        return {"output": "", "returncode": 1}
+
+
+@pytest.mark.asyncio
+async def test_container_path_exec_read_fallback(monkeypatch):
+    from tools import image_source
+
+    png = base64.b64decode(PNG_B64)
+    monkeypatch.setattr(image_source, "_get_active_env",
+                        lambda tid: _FakeEnv({"/workspace/shot.png": png}))
+    monkeypatch.setattr(image_source, "_maybe_translate_container_path", lambda p, ctx: p)
+    res = await resolve_image_source("/workspace/shot.png", ResolveContext(task_id="t1"))
+    assert res.origin == "container"
+    assert res.data == png
+
+
+@pytest.mark.asyncio
+async def test_container_fallback_fails_closed_without_env(monkeypatch):
+    from tools import image_source
+
+    monkeypatch.setattr(image_source, "_get_active_env", lambda tid: None)
+    monkeypatch.setattr(image_source, "_maybe_translate_container_path", lambda p, ctx: p)
+    with pytest.raises(SourceNotFound):
+        await resolve_image_source("/workspace/x.png", ResolveContext(task_id="t1"))
+
+
+@pytest.mark.asyncio
+async def test_container_exec_read_nonimage_rejected(monkeypatch):
+    from tools import image_source
+
+    monkeypatch.setattr(image_source, "_get_active_env",
+                        lambda tid: _FakeEnv({"/workspace/x.png": b"not an image"}))
+    monkeypatch.setattr(image_source, "_maybe_translate_container_path", lambda p, ctx: p)
+    with pytest.raises(NotAnImage):
+        await resolve_image_source("/workspace/x.png", ResolveContext(task_id="t1"))

--- a/tests/tools/test_vision_bytes_helpers.py
+++ b/tests/tools/test_vision_bytes_helpers.py
@@ -1,0 +1,40 @@
+"""Bytes-core variants of the vision encode/resize/sniff helpers."""
+import base64
+
+from tools.vision_tools import (
+    _detect_image_mime_type_from_bytes,
+    _image_bytes_to_base64_data_url,
+    _resize_image_bytes_for_vision,
+)
+
+PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+
+def test_detect_mime_from_bytes_png():
+    assert _detect_image_mime_type_from_bytes(PNG) == "image/png"
+
+
+def test_detect_mime_from_bytes_jpeg():
+    assert _detect_image_mime_type_from_bytes(b"\xff\xd8\xff\xe0junk") == "image/jpeg"
+
+
+def test_detect_mime_from_bytes_rejects_text():
+    assert _detect_image_mime_type_from_bytes(b"not an image") is None
+
+
+def test_detect_mime_from_bytes_rejects_svg():
+    # SVG has no magic bytes; the bytes sniff deliberately rejects it.
+    assert _detect_image_mime_type_from_bytes(b"<svg xmlns=...></svg>") is None
+
+
+def test_bytes_to_data_url_roundtrip():
+    url = _image_bytes_to_base64_data_url(PNG, "image/png")
+    assert url.startswith("data:image/png;base64,")
+    assert base64.b64decode(url.split(",", 1)[1]) == PNG
+
+
+def test_resize_bytes_noop_when_small():
+    url = _resize_image_bytes_for_vision(PNG, "image/png")
+    assert url == _image_bytes_to_base64_data_url(PNG, "image/png")

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import os
 from unittest.mock import patch
+
+import pytest
 
 
 from tools.vision_tools import (
@@ -186,6 +189,32 @@ class TestVisionAnalyzeNative:
             f"embedded image {len(url) / 1024 / 1024:.1f} MB exceeds embed cap "
             f"{_EMBED_TARGET_BYTES / 1024 / 1024:.0f} MB — would wedge sessions on Anthropic"
         )
+
+    def test_oversize_image_is_resized_not_rejected(self, tmp_path):
+        """Regression: a 20-50MB image must be resized through to a multimodal
+        envelope, NOT hard-rejected by the resolver before resize can run.
+
+        (The resolver used to cap raw bytes at 20MB inside ``_finalize``; the
+        ingest cap is now 50MB and the 20MB payload cap is enforced post-resize.)
+        """
+        pytest.importorskip("PIL")  # resize requires Pillow
+        from PIL import Image
+
+        # Incompressible noise so the raw PNG genuinely exceeds 20MB (a solid
+        # color would compress to a few KB and not exercise the resize path).
+        big = tmp_path / "big.png"
+        Image.frombytes("RGB", (3400, 3400), os.urandom(3400 * 3400 * 3)).save(
+            big, format="PNG")
+        assert big.stat().st_size > 20 * 1024 * 1024
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(str(big), "what is this?")
+        )
+        assert isinstance(result, dict), result  # not an error JSON string
+        assert result.get("_multimodal") is True
+        url = next(p["image_url"]["url"] for p in result["content"]
+                   if p.get("type") == "image_url")
+        assert len(url) <= 20 * 1024 * 1024  # resized under the payload cap
 
 
 # ─── task_id seam: dispatch must thread task_id to the resolver ──────────────

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -119,7 +119,17 @@ class TestVisionAnalyzeNative:
         assert isinstance(result, str)
         parsed = json.loads(result)
         assert parsed.get("success") is False
-        assert "Invalid image source" in parsed.get("error", "")
+        assert parsed.get("error")
+
+    def test_data_url_returns_multimodal_envelope(self):
+        import base64 as _b64
+
+        data_url = "data:image/png;base64," + _b64.b64encode(_TINY_PNG).decode()
+        result = asyncio.get_event_loop().run_until_complete(
+            _vision_analyze_native(data_url, "what is this?")
+        )
+        assert isinstance(result, dict)
+        assert result.get("_multimodal") is True
 
     def test_empty_image_url_returns_error(self):
         result = asyncio.get_event_loop().run_until_complete(

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -188,6 +188,45 @@ class TestVisionAnalyzeNative:
         )
 
 
+# ─── task_id seam: dispatch must thread task_id to the resolver ──────────────
+
+
+class TestTaskIdSeam:
+    """Lock in the seam that carries task_id to the Docker exec-read (#32709).
+
+    If a future refactor drops the task_id kwarg from dispatch -> handler ->
+    resolver, the in-container fallback silently breaks. These guard it.
+    """
+
+    def test_dispatch_threads_task_id_native(self, monkeypatch):
+        seen = {}
+
+        async def fake_native(url, q, task_id=None):
+            seen["task_id"] = task_id
+            return "{}"
+
+        monkeypatch.setattr("tools.vision_tools._should_use_native_vision_fast_path", lambda: True)
+        monkeypatch.setattr("tools.vision_tools._vision_analyze_native", fake_native)
+        from tools.vision_tools import registry
+
+        registry.dispatch("vision_analyze", {"image_url": "x", "question": "y"}, task_id="t-123")
+        assert seen["task_id"] == "t-123"
+
+    def test_dispatch_threads_task_id_legacy(self, monkeypatch):
+        seen = {}
+
+        async def fake_aux(url, prompt, model, task_id=None):
+            seen["task_id"] = task_id
+            return "{}"
+
+        monkeypatch.setattr("tools.vision_tools._should_use_native_vision_fast_path", lambda: False)
+        monkeypatch.setattr("tools.vision_tools.vision_analyze_tool", fake_aux)
+        from tools.vision_tools import registry
+
+        registry.dispatch("vision_analyze", {"image_url": "x", "question": "y"}, task_id="t-456")
+        assert seen["task_id"] == "t-456"
+
+
 # ─── _handle_vision_analyze fast-path gating ─────────────────────────────────
 
 

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -8,7 +8,6 @@ the pixels directly on its next turn.
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import json
 import os
@@ -100,12 +99,11 @@ class TestBuildNativeVisionToolResult:
 
 
 class TestVisionAnalyzeNative:
-    def test_local_file_returns_multimodal_envelope(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_local_file_returns_multimodal_envelope(self, tmp_path):
         img = tmp_path / "test.png"
         img.write_bytes(_TINY_PNG)
-        result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(img), "what is this?")
-        )
+        result = await _vision_analyze_native(str(img), "what is this?")
         assert isinstance(result, dict)
         assert result.get("_multimodal") is True
         parts = result["content"]
@@ -114,45 +112,42 @@ class TestVisionAnalyzeNative:
         url = next(p["image_url"]["url"] for p in parts if p.get("type") == "image_url")
         assert url.startswith("data:image/")
 
-    def test_missing_file_returns_error_string(self, tmp_path):
-        result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(tmp_path / "nope.png"), "?")
-        )
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_error_string(self, tmp_path):
+        result = await _vision_analyze_native(str(tmp_path / "nope.png"), "?")
         # tool_error returns a JSON string, not the multimodal envelope
         assert isinstance(result, str)
         parsed = json.loads(result)
         assert parsed.get("success") is False
         assert parsed.get("error")
 
-    def test_data_url_returns_multimodal_envelope(self):
+    @pytest.mark.asyncio
+    async def test_data_url_returns_multimodal_envelope(self):
         import base64 as _b64
 
         data_url = "data:image/png;base64," + _b64.b64encode(_TINY_PNG).decode()
-        result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(data_url, "what is this?")
-        )
+        result = await _vision_analyze_native(data_url, "what is this?")
         assert isinstance(result, dict)
         assert result.get("_multimodal") is True
 
-    def test_empty_image_url_returns_error(self):
-        result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native("", "?")
-        )
+    @pytest.mark.asyncio
+    async def test_empty_image_url_returns_error(self):
+        result = await _vision_analyze_native("", "?")
         assert isinstance(result, str)
         parsed = json.loads(result)
         assert parsed.get("success") is False
         assert "image_url is required" in parsed.get("error", "")
 
-    def test_file_url_scheme_resolves(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_file_url_scheme_resolves(self, tmp_path):
         img = tmp_path / "t.png"
         img.write_bytes(_TINY_PNG)
-        result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(f"file://{img}", "?")
-        )
+        result = await _vision_analyze_native(f"file://{img}", "?")
         assert isinstance(result, dict)
         assert result.get("_multimodal") is True
 
-    def test_oversized_image_resized_under_embed_cap(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_oversized_image_resized_under_embed_cap(self, tmp_path):
         """Regression for the wedged-session incident (May 2026).
 
         A vision tool-result image is baked into conversation history and
@@ -163,11 +158,8 @@ class TestVisionAnalyzeNative:
         embed cap (well under 5 MB) BEFORE embedding, not just at the 20 MB
         hard ceiling.  Skips if Pillow isn't available (resize is a no-op).
         """
-        pytest = __import__("pytest")
-        try:
-            from PIL import Image
-        except ImportError:
-            pytest.skip("Pillow not installed — proactive resize is a no-op")
+        pytest.importorskip("PIL")  # proactive resize requires Pillow
+        from PIL import Image
 
         from tools.vision_tools import _EMBED_TARGET_BYTES
 
@@ -176,9 +168,7 @@ class TestVisionAnalyzeNative:
         Image.effect_noise((2600, 2600), 80).convert("RGB").save(big, format="PNG")
         assert big.stat().st_size * 4 // 3 > 5 * 1024 * 1024, "test image not big enough"
 
-        result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(big), "describe")
-        )
+        result = await _vision_analyze_native(str(big), "describe")
         assert isinstance(result, dict) and result.get("_multimodal") is True
         url = next(
             p["image_url"]["url"]
@@ -190,15 +180,19 @@ class TestVisionAnalyzeNative:
             f"{_EMBED_TARGET_BYTES / 1024 / 1024:.0f} MB — would wedge sessions on Anthropic"
         )
 
-    def test_oversize_image_is_resized_not_rejected(self, tmp_path):
-        """Regression: a 20-50MB image must be resized through to a multimodal
+    @pytest.mark.asyncio
+    async def test_oversize_image_is_resized_not_rejected(self, tmp_path):
+        """Regression: a >20MB image must be resized through to a multimodal
         envelope, NOT hard-rejected by the resolver before resize can run.
 
-        (The resolver used to cap raw bytes at 20MB inside ``_finalize``; the
-        ingest cap is now 50MB and the 20MB payload cap is enforced post-resize.)
+        The resolver used to cap raw bytes at 20MB inside ``_finalize`` and
+        reject anything larger outright; the ingest cap is now 50MB, so a
+        20-50MB image survives ingest and is resized down to the embed cap.
         """
         pytest.importorskip("PIL")  # resize requires Pillow
         from PIL import Image
+
+        from tools.vision_tools import _EMBED_TARGET_BYTES
 
         # Incompressible noise so the raw PNG genuinely exceeds 20MB (a solid
         # color would compress to a few KB and not exercise the resize path).
@@ -207,14 +201,14 @@ class TestVisionAnalyzeNative:
             big, format="PNG")
         assert big.stat().st_size > 20 * 1024 * 1024
 
-        result = asyncio.get_event_loop().run_until_complete(
-            _vision_analyze_native(str(big), "what is this?")
-        )
+        result = await _vision_analyze_native(str(big), "what is this?")
         assert isinstance(result, dict), result  # not an error JSON string
         assert result.get("_multimodal") is True
         url = next(p["image_url"]["url"] for p in result["content"]
                    if p.get("type") == "image_url")
-        assert len(url) <= 20 * 1024 * 1024  # resized under the payload cap
+        # Resized down to the proactive embed cap, not merely under the 20MB
+        # hard ceiling — assert the real bound so the test can't silently rot.
+        assert len(url) <= _EMBED_TARGET_BYTES
 
 
 # ─── task_id seam: dispatch must thread task_id to the resolver ──────────────
@@ -262,7 +256,8 @@ class TestTaskIdSeam:
 class TestHandleVisionAnalyzeFastPath:
     """Verify the dispatcher chooses fast-path vs aux-LLM correctly."""
 
-    def test_vision_capable_main_model_uses_fast_path(self, tmp_path, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_vision_capable_main_model_uses_fast_path(self, tmp_path):
         """Main model supports native vision → fast path returns multimodal."""
         img = tmp_path / "x.png"
         img.write_bytes(_TINY_PNG)
@@ -277,8 +272,7 @@ class TestHandleVisionAnalyzeFastPath:
                 "agent.image_routing.decide_image_input_mode",
                 return_value="native",
             ):
-                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"})
-                result = asyncio.get_event_loop().run_until_complete(coro)
+                result = await _handle_vision_analyze({"image_url": str(img), "question": "?"})
         finally:
             clear_runtime_main()
 
@@ -286,8 +280,9 @@ class TestHandleVisionAnalyzeFastPath:
             f"Expected multimodal envelope, got {type(result).__name__}: {str(result)[:200]}"
         assert result.get("_multimodal") is True
 
-    def test_non_vision_main_model_falls_through_to_aux(self, tmp_path, monkeypatch):
-        """Non-vision main model → fast path skipped, aux LLM path attempted."""
+    @pytest.mark.asyncio
+    async def test_non_vision_main_model_falls_through_to_aux(self, tmp_path):
+        """Non-vision main model → fast path skipped, aux LLM path taken."""
         img = tmp_path / "x.png"
         img.write_bytes(_TINY_PNG)
 
@@ -297,17 +292,21 @@ class TestHandleVisionAnalyzeFastPath:
         from agent.auxiliary_client import set_runtime_main, clear_runtime_main
         set_runtime_main("openrouter", "qwen/qwen3-coder")
         try:
-            with patch("tools.vision_tools.vision_analyze_tool", side_effect=_aux_sentinel):
-                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"})
-                result = asyncio.get_event_loop().run_until_complete(coro)
+            with patch(
+                "tools.vision_tools.vision_analyze_tool", side_effect=_aux_sentinel,
+            ) as mock_aux:
+                result = await _handle_vision_analyze({"image_url": str(img), "question": "?"})
         finally:
             clear_runtime_main()
 
-        assert not (isinstance(result, dict) and result.get("_multimodal") is True), \
-            "Fast path fired for non-vision model; should have fallen through to aux LLM"
+        # The aux LLM path must actually be the one taken — not merely "not the
+        # fast path" (which an unrelated error would also satisfy).
+        mock_aux.assert_called_once()
+        assert json.loads(result) == {"sentinel": "aux-path"}
 
-    def test_fast_path_disabled_for_unsupported_provider(self, tmp_path, monkeypatch):
-        """Even with vision-capable model, unknown provider → fall through."""
+    @pytest.mark.asyncio
+    async def test_fast_path_disabled_for_unsupported_provider(self, tmp_path):
+        """Even with vision-capable model, unknown provider → fall through to aux."""
         img = tmp_path / "x.png"
         img.write_bytes(_TINY_PNG)
 
@@ -317,16 +316,18 @@ class TestHandleVisionAnalyzeFastPath:
         from agent.auxiliary_client import set_runtime_main, clear_runtime_main
         set_runtime_main("brand-new-provider", "anthropic/claude-opus-4.6")
         try:
-            with patch("tools.vision_tools.vision_analyze_tool", side_effect=_aux_sentinel):
-                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"})
-                result = asyncio.get_event_loop().run_until_complete(coro)
+            with patch(
+                "tools.vision_tools.vision_analyze_tool", side_effect=_aux_sentinel,
+            ) as mock_aux:
+                result = await _handle_vision_analyze({"image_url": str(img), "question": "?"})
         finally:
             clear_runtime_main()
 
-        assert not (isinstance(result, dict) and result.get("_multimodal") is True), \
-            "Fast path fired for unknown provider; should have fallen through"
+        mock_aux.assert_called_once()
+        assert json.loads(result) == {"sentinel": "aux-path"}
 
-    def test_supports_vision_override_bypasses_provider_allowlist(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_supports_vision_override_bypasses_provider_allowlist(self, tmp_path):
         """supports_vision=true enables the fast path on an unlisted provider."""
         img = tmp_path / "x.png"
         img.write_bytes(_TINY_PNG)
@@ -343,15 +344,15 @@ class TestHandleVisionAnalyzeFastPath:
             ), patch(
                 "tools.vision_tools.vision_analyze_tool", side_effect=_aux_sentinel,
             ) as mock_aux:
-                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"})
-                result = asyncio.get_event_loop().run_until_complete(coro)
+                result = await _handle_vision_analyze({"image_url": str(img), "question": "?"})
         finally:
             clear_runtime_main()
 
         assert isinstance(result, dict) and result.get("_multimodal") is True
         mock_aux.assert_not_called()
 
-    def test_text_mode_wins_over_supports_vision_override(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_text_mode_wins_over_supports_vision_override(self, tmp_path):
         """Explicit text routing blocks the fast path even with supports_vision."""
         img = tmp_path / "x.png"
         img.write_bytes(_TINY_PNG)
@@ -371,8 +372,7 @@ class TestHandleVisionAnalyzeFastPath:
             ), patch(
                 "tools.vision_tools.vision_analyze_tool", side_effect=_aux_sentinel,
             ) as mock_aux:
-                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"})
-                result = asyncio.get_event_loop().run_until_complete(coro)
+                result = await _handle_vision_analyze({"image_url": str(img), "question": "?"})
         finally:
             clear_runtime_main()
 

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -313,58 +313,6 @@ class TestErrorLoggingExcInfo:
             error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
             assert any(r.exc_info and r.exc_info[0] is not None for r in error_records)
 
-    @pytest.mark.asyncio
-    async def test_cleanup_error_logs_exc_info(self, tmp_path, caplog):
-        """Temp file cleanup failure should log warning with exc_info."""
-        # Create a real temp file that will be "downloaded"
-        temp_dir = tmp_path / "temp_vision_images"
-        temp_dir.mkdir()
-
-        async def fake_download(url, dest, max_retries=3):
-            """Simulate download by writing file to the expected destination."""
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            dest.write_bytes(b"\xff\xd8\xff" + b"\x00" * 16)
-            return dest
-
-        with (
-            patch("tools.vision_tools._validate_image_url", return_value=True),
-            patch("tools.vision_tools._download_image", side_effect=fake_download),
-            patch(
-                "tools.vision_tools._image_to_base64_data_url",
-                return_value="data:image/jpeg;base64,abc",
-            ),
-            caplog.at_level(logging.WARNING, logger="tools.vision_tools"),
-        ):
-            # Mock the async_call_llm function to return a mock response
-            mock_response = MagicMock()
-            mock_choice = MagicMock()
-            mock_choice.message.content = "A test image description"
-            mock_response.choices = [mock_choice]
-
-            with (
-                patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock, return_value=mock_response),
-            ):
-                # Make unlink fail to trigger cleanup warning
-                original_unlink = Path.unlink
-
-                def failing_unlink(self, *args, **kwargs):
-                    raise PermissionError("no permission")
-
-                with patch.object(Path, "unlink", failing_unlink):
-                    result = await vision_analyze_tool(
-                        "https://example.com/tempimg.jpg", "describe", "test/model"
-                    )
-
-            warning_records = [
-                r
-                for r in caplog.records
-                if r.levelno == logging.WARNING
-                and "temporary file" in r.getMessage().lower()
-            ]
-            assert len(warning_records) >= 1
-            assert warning_records[0].exc_info is not None
-
-
 class TestVisionConfig:
     @pytest.mark.asyncio
     async def test_vision_uses_configured_temperature_and_timeout(self, tmp_path):
@@ -435,7 +383,7 @@ class TestVisionSafetyGuards:
             result = json.loads(await vision_analyze_tool(str(secret), "extract text"))
 
         assert result["success"] is False
-        assert "Only real image files are supported" in result["error"]
+        assert "not a recognized image" in result["error"]
         mock_llm.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -448,15 +396,16 @@ class TestVisionSafetyGuards:
         }
 
         with (
-            patch("tools.vision_tools.check_website_access", return_value=blocked),
-            patch("tools.vision_tools._validate_image_url", return_value=True),
-            patch("tools.vision_tools._download_image", new_callable=AsyncMock) as mock_download,
+            patch("tools.website_policy.check_website_access", return_value=blocked),
+            patch("tools.url_safety.is_safe_url", return_value=True),
+            patch("tools.image_source._download_to_bytes", new_callable=AsyncMock) as mock_download,
+            patch("tools.vision_tools.async_call_llm", new_callable=AsyncMock) as mock_llm,
         ):
             result = json.loads(await vision_analyze_tool("https://blocked.test/cat.png", "describe"))
 
         assert result["success"] is False
-        assert "Blocked by website policy" in result["error"]
         mock_download.assert_not_awaited()
+        mock_llm.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_download_blocks_redirected_final_url(self, tmp_path):

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -402,6 +402,30 @@ def to_agent_visible_cache_path(
     return host_path
 
 
+def from_agent_visible_cache_path(
+    container_path: str,
+    container_base: str = "/root/.hermes",
+) -> str:
+    """Translate a sandbox/container cache path back to its host path.
+
+    Inverse of ``to_agent_visible_cache_path``. Returns the input unchanged
+    when the active backend is not Docker, or when the path is not under any
+    auto-mounted cache directory — the caller then treats a still-container
+    path as "no host file" and falls back to an in-container read.
+    """
+    if os.environ.get("TERMINAL_ENV", "local") != "docker":
+        return container_path
+
+    path = Path(container_path)
+    for mount in get_cache_directory_mounts(container_base=container_base):
+        try:
+            rel = path.relative_to(mount["container_path"])
+        except ValueError:
+            continue
+        return str(Path(mount["host_path"]) / rel)
+    return container_path
+
+
 def iter_cache_files(
     container_base: str = "/root/.hermes",
 ) -> List[Dict[str, str]]:

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -8,7 +8,9 @@ once.  Returns raw bytes (not a path): the downstream step is base64 -> data URL
 from __future__ import annotations
 
 import base64
+import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Optional
 
 # Decoded payload cap, mirroring tools/vision_tools._MAX_BASE64_BYTES
@@ -67,7 +69,19 @@ async def resolve_image_source(src: str, ctx: ResolveContext) -> ResolvedImage:
         if not _is_safe_http(s):
             raise SourceUnsafe("blocked: unsafe or private URL", src=s)
         return _finalize(await _download_to_bytes(s), "", "http", s)
-    # file / local / container branches added in Tasks 6-7.
+
+    candidate = s[len("file://"):] if s.startswith("file://") else s
+    if s.startswith("file://") or _looks_like_path(candidate):
+        p = Path(os.path.expanduser(candidate))
+        real = _maybe_translate_container_path(p, ctx).resolve()
+        if not _within_allowed_roots(real, ctx):  # SEAM: returns True in PR 1
+            raise SourceUnsafe(
+                f"reading '{real}' is not permitted (outside allowed image roots)", src=s)
+        if real.is_file():
+            return _finalize(real.read_bytes(), "", "file", s)
+        # No host file (tmpfs / root-owned / container-only) -> read inside the sandbox.
+        return await _resolve_container_fallback(p, ctx, s)
+
     raise UnsupportedScheme(
         "Unrecognized image source. Use an http(s) URL, a local file path, "
         "a file:// URI, or a data: URL.",
@@ -99,7 +113,6 @@ def _is_safe_http(url: str) -> bool:
 
 async def _download_to_bytes(url: str) -> bytes:
     import tempfile
-    from pathlib import Path
 
     from tools.vision_tools import _download_image
 
@@ -110,6 +123,32 @@ async def _download_to_bytes(url: str) -> bytes:
         return tmp.read_bytes()
     finally:
         tmp.unlink(missing_ok=True)
+
+
+def _looks_like_path(s: str) -> bool:
+    return s.startswith(("/", "~", "./", "../")) or (len(s) > 1 and s[1] == ":")
+
+
+def _within_allowed_roots(real: Path, ctx: ResolveContext) -> bool:
+    """SEAM. PR 1 is permissive (preserves today's behavior). PR 2 replaces the
+    body with the readable-root allowlist + its threat model + migration note."""
+    return True
+
+
+def _maybe_translate_container_path(p: Path, ctx: ResolveContext) -> Path:
+    # Cache-dir reverse map only. Every other container path (tmpfs /workspace,
+    # docker_volumes, root-owned) returns unchanged and falls through to the
+    # exec-read fallback — the universal mechanism.
+    from tools.credential_files import from_agent_visible_cache_path
+
+    return Path(from_agent_visible_cache_path(str(p)))
+
+
+async def _resolve_container_fallback(p: Path, ctx: ResolveContext, src: str) -> ResolvedImage:
+    """Host file is absent/unreadable; read the bytes inside the sandbox (Task 7)."""
+    raise SourceNotFound(
+        f"'{p}' is not reachable on the host and no active sandbox is available "
+        f"to read it", src=src, origin="container")
 
 
 def _finalize(data: bytes, declared_mime: str, origin: str, src: str) -> ResolvedImage:

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -13,9 +13,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
-# Decoded payload cap, mirroring tools/vision_tools._MAX_BASE64_BYTES
-# (Gemini inline-data limit, the most restrictive major provider).
-_MAX_BYTES = 20 * 1024 * 1024
+# Raw-bytes INGEST budget — what the resolver will load before handing off.
+# This is deliberately the 50MB download cap (tools/vision_tools._VISION_MAX_DOWNLOAD_BYTES),
+# NOT the 20MB provider payload cap. The 20MB cap (_MAX_BASE64_BYTES) is a
+# *post-resize* limit enforced at the call sites: an oversized raw image must
+# still reach _resize_image_bytes_for_vision so it can be downscaled under the
+# payload cap. Capping raw bytes at 20MB here would reject every 20-50MB photo
+# before resize can run — exactly the regression the plan flagged.
+_MAX_INGEST_BYTES = 50 * 1024 * 1024
 
 
 class ImageResolutionError(Exception):
@@ -66,8 +71,9 @@ async def resolve_image_source(src: str, ctx: ResolveContext) -> ResolvedImage:
         data, mime = _resolve_data_url(s)
         return _finalize(data, mime, "data", s)
     if s.startswith(("http://", "https://")):
-        if not _is_safe_http(s):
-            raise SourceUnsafe("blocked: unsafe or private URL", src=s)
+        reason = _http_block_reason(s)
+        if reason:
+            raise SourceUnsafe(reason, src=s)
         return _finalize(await _download_to_bytes(s), "", "http", s)
 
     candidate = s[len("file://"):] if s.startswith("file://") else s
@@ -95,7 +101,7 @@ def _resolve_data_url(s: str) -> tuple[bytes, str]:
         raise NotAnImage("data: URL must be base64-encoded", src=s[:64])
     declared = header[len("data:"):].split(";", 1)[0].strip() or "application/octet-stream"
     # Cheap pre-decode size gate on the encoded length (~4/3 expansion).
-    if (len(payload) * 3) // 4 > _MAX_BYTES:
+    if (len(payload) * 3) // 4 > _MAX_INGEST_BYTES:
         raise SourceTooLarge("data: URL exceeds size limit", src=s[:64])
     try:
         data = base64.b64decode(payload, validate=True)
@@ -104,11 +110,21 @@ def _resolve_data_url(s: str) -> tuple[bytes, str]:
     return data, declared  # real mime verified in _finalize via magic bytes
 
 
-def _is_safe_http(url: str) -> bool:
+def _http_block_reason(url: str) -> Optional[str]:
+    """Return a human-readable block reason, or None when the URL is allowed.
+
+    Preserves the specific website-policy message (rather than collapsing it to
+    a generic string) so the agent sees *why* a fetch was refused.
+    """
     from tools.url_safety import is_safe_url
     from tools.website_policy import check_website_access
 
-    return is_safe_url(url) and not check_website_access(url)
+    if not is_safe_url(url):
+        return "blocked: unsafe or private URL"
+    blocked = check_website_access(url)
+    if blocked:
+        return blocked.get("message") or "blocked by website policy"
+    return None
 
 
 async def _download_to_bytes(url: str) -> bytes:
@@ -163,6 +179,7 @@ async def _resolve_container_fallback(p: Path, ctx: ResolveContext, src: str) ->
     boundary. ``--`` stops a leading-dash path from being parsed as a ``base64``
     option; ``base64 -w0`` is GNU-only, so pipe through ``tr -d`` for BusyBox.
     """
+    import asyncio
     import shlex
 
     env = _get_active_env(ctx.task_id)
@@ -171,7 +188,10 @@ async def _resolve_container_fallback(p: Path, ctx: ResolveContext, src: str) ->
             f"'{p}' is not reachable on the host and no active sandbox is available "
             f"to read it", src=src, origin="container")
 
-    res = env.execute(f"base64 -- {shlex.quote(str(p))} | tr -d '\\n'")
+    # env.execute is a blocking docker-exec; keep it off the event loop so a
+    # multi-MB base64 read doesn't stall every other coroutine.
+    res = await asyncio.to_thread(
+        env.execute, f"base64 -- {shlex.quote(str(p))} | tr -d '\\n'")
     if res.get("returncode", 1) != 0:
         raise SourceNotFound(f"could not read '{p}' inside the sandbox", src=src, origin="container")
     try:
@@ -182,10 +202,15 @@ async def _resolve_container_fallback(p: Path, ctx: ResolveContext, src: str) ->
 
 
 def _finalize(data: bytes, declared_mime: str, origin: str, src: str) -> ResolvedImage:
-    """Intrinsic-correctness chokepoint: hard byte cap + magic-byte sniff."""
+    """Intrinsic-correctness chokepoint: ingest byte cap + magic-byte sniff.
+
+    The cap here is the generous 50MB *ingest* budget, not the 20MB provider
+    payload cap — a 20-50MB image must survive this step so the call site can
+    resize it under the payload cap. See _MAX_INGEST_BYTES.
+    """
     from tools.vision_tools import _detect_image_mime_type_from_bytes
 
-    if len(data) > _MAX_BYTES:
+    if len(data) > _MAX_INGEST_BYTES:
         raise SourceTooLarge("image exceeds size limit", src=src, origin=origin)
     sniffed = _detect_image_mime_type_from_bytes(data)
     if sniffed is None:

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -63,7 +63,11 @@ async def resolve_image_source(src: str, ctx: ResolveContext) -> ResolvedImage:
     if s.startswith("data:"):
         data, mime = _resolve_data_url(s)
         return _finalize(data, mime, "data", s)
-    # http / file / local / container branches added in Tasks 5-7.
+    if s.startswith(("http://", "https://")):
+        if not _is_safe_http(s):
+            raise SourceUnsafe("blocked: unsafe or private URL", src=s)
+        return _finalize(await _download_to_bytes(s), "", "http", s)
+    # file / local / container branches added in Tasks 6-7.
     raise UnsupportedScheme(
         "Unrecognized image source. Use an http(s) URL, a local file path, "
         "a file:// URI, or a data: URL.",
@@ -84,6 +88,28 @@ def _resolve_data_url(s: str) -> tuple[bytes, str]:
     except Exception as exc:
         raise NotAnImage(f"invalid base64 in data: URL: {exc}", src=s[:64])
     return data, declared  # real mime verified in _finalize via magic bytes
+
+
+def _is_safe_http(url: str) -> bool:
+    from tools.url_safety import is_safe_url
+    from tools.website_policy import check_website_access
+
+    return is_safe_url(url) and not check_website_access(url)
+
+
+async def _download_to_bytes(url: str) -> bytes:
+    import tempfile
+    from pathlib import Path
+
+    from tools.vision_tools import _download_image
+
+    with tempfile.NamedTemporaryFile(suffix=".img", delete=False) as tf:
+        tmp = Path(tf.name)
+    try:
+        await _download_image(url, tmp)  # enforces the 50MB stream cap + redirect SSRF guard
+        return tmp.read_bytes()
+    finally:
+        tmp.unlink(missing_ok=True)
 
 
 def _finalize(data: bytes, declared_mime: str, origin: str, src: str) -> ResolvedImage:

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -144,11 +144,41 @@ def _maybe_translate_container_path(p: Path, ctx: ResolveContext) -> Path:
     return Path(from_agent_visible_cache_path(str(p)))
 
 
+def _get_active_env(task_id: Optional[str]):
+    if not task_id:
+        return None
+    try:
+        from tools.terminal_tool import get_active_env
+
+        return get_active_env(task_id)
+    except Exception:
+        return None
+
+
 async def _resolve_container_fallback(p: Path, ctx: ResolveContext, src: str) -> ResolvedImage:
-    """Host file is absent/unreadable; read the bytes inside the sandbox (Task 7)."""
-    raise SourceNotFound(
-        f"'{p}' is not reachable on the host and no active sandbox is available "
-        f"to read it", src=src, origin="container")
+    """Host file is absent/unreadable. Read the bytes inside the container.
+
+    The agent can already ``cat`` any container file (file_operations.py reads
+    root-owned mode-600 files this way); this reads a strict subset bounded by
+    the same sandbox, so it introduces no new exposure. ``base64 -w0`` is
+    GNU-only, so pipe through ``tr -d`` for BusyBox/Alpine.
+    """
+    import shlex
+
+    env = _get_active_env(ctx.task_id)
+    if env is None:
+        raise SourceNotFound(
+            f"'{p}' is not reachable on the host and no active sandbox is available "
+            f"to read it", src=src, origin="container")
+
+    res = env.execute(f"base64 {shlex.quote(str(p))} | tr -d '\\n'")
+    if res.get("returncode", 1) != 0:
+        raise SourceNotFound(f"could not read '{p}' inside the sandbox", src=src, origin="container")
+    try:
+        data = base64.b64decode(res.get("output", ""), validate=True)
+    except Exception as exc:
+        raise NotAnImage(f"sandbox returned non-image data for '{p}': {exc}", src=src)
+    return _finalize(data, "", "container", src)
 
 
 def _finalize(data: bytes, declared_mime: str, origin: str, src: str) -> ResolvedImage:

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -1,0 +1,98 @@
+"""Single resolver for every vision_analyze image source -> bytes + mime.
+
+All source handling (data:/http(s)/file/local/container) funnels through
+:func:`resolve_image_source` so size and magic-byte checks are enforced exactly
+once.  Returns raw bytes (not a path): the downstream step is base64 -> data URL
+(RFC 2397) and provider base64 content blocks.
+"""
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# Decoded payload cap, mirroring tools/vision_tools._MAX_BASE64_BYTES
+# (Gemini inline-data limit, the most restrictive major provider).
+_MAX_BYTES = 20 * 1024 * 1024
+
+
+class ImageResolutionError(Exception):
+    def __init__(self, message: str, *, src: str = "", origin: str = ""):
+        super().__init__(message)
+        self.src, self.origin = src, origin
+
+
+class UnsupportedScheme(ImageResolutionError):
+    pass
+
+
+class SourceUnsafe(ImageResolutionError):  # SSRF / path-allowlist
+    pass
+
+
+class SourceTooLarge(ImageResolutionError):
+    pass
+
+
+class SourceNotFound(ImageResolutionError):
+    pass
+
+
+class NotAnImage(ImageResolutionError):
+    pass
+
+
+@dataclass
+class ResolveContext:
+    task_id: Optional[str] = None
+    cfg: Optional[dict[str, Any]] = None
+    extra_roots: tuple = field(default_factory=tuple)
+
+
+@dataclass
+class ResolvedImage:
+    data: bytes
+    mime: str
+    origin: str  # one of: data | http | file | local | container
+
+
+async def resolve_image_source(src: str, ctx: ResolveContext) -> ResolvedImage:
+    if not isinstance(src, str) or not src.strip():
+        raise SourceNotFound("image_url is required", src=str(src))
+    s = src.strip()
+    if s.startswith("data:"):
+        data, mime = _resolve_data_url(s)
+        return _finalize(data, mime, "data", s)
+    # http / file / local / container branches added in Tasks 5-7.
+    raise UnsupportedScheme(
+        "Unrecognized image source. Use an http(s) URL, a local file path, "
+        "a file:// URI, or a data: URL.",
+        src=s,
+    )
+
+
+def _resolve_data_url(s: str) -> tuple[bytes, str]:
+    header, _, payload = s.partition(",")
+    if ";base64" not in header:
+        raise NotAnImage("data: URL must be base64-encoded", src=s[:64])
+    declared = header[len("data:"):].split(";", 1)[0].strip() or "application/octet-stream"
+    # Cheap pre-decode size gate on the encoded length (~4/3 expansion).
+    if (len(payload) * 3) // 4 > _MAX_BYTES:
+        raise SourceTooLarge("data: URL exceeds size limit", src=s[:64])
+    try:
+        data = base64.b64decode(payload, validate=True)
+    except Exception as exc:
+        raise NotAnImage(f"invalid base64 in data: URL: {exc}", src=s[:64])
+    return data, declared  # real mime verified in _finalize via magic bytes
+
+
+def _finalize(data: bytes, declared_mime: str, origin: str, src: str) -> ResolvedImage:
+    """Intrinsic-correctness chokepoint: hard byte cap + magic-byte sniff."""
+    from tools.vision_tools import _detect_image_mime_type_from_bytes
+
+    if len(data) > _MAX_BYTES:
+        raise SourceTooLarge("image exceeds size limit", src=src, origin=origin)
+    sniffed = _detect_image_mime_type_from_bytes(data)
+    if sniffed is None:
+        raise NotAnImage("source is not a recognized image", src=src, origin=origin)
+    return ResolvedImage(data=data, mime=sniffed, origin=origin)

--- a/tools/image_source.py
+++ b/tools/image_source.py
@@ -159,9 +159,9 @@ async def _resolve_container_fallback(p: Path, ctx: ResolveContext, src: str) ->
     """Host file is absent/unreadable. Read the bytes inside the container.
 
     The agent can already ``cat`` any container file (file_operations.py reads
-    root-owned mode-600 files this way); this reads a strict subset bounded by
-    the same sandbox, so it introduces no new exposure. ``base64 -w0`` is
-    GNU-only, so pipe through ``tr -d`` for BusyBox/Alpine.
+    root-owned mode-600 files this way), so this stays within the same sandbox
+    boundary. ``--`` stops a leading-dash path from being parsed as a ``base64``
+    option; ``base64 -w0`` is GNU-only, so pipe through ``tr -d`` for BusyBox.
     """
     import shlex
 
@@ -171,7 +171,7 @@ async def _resolve_container_fallback(p: Path, ctx: ResolveContext, src: str) ->
             f"'{p}' is not reachable on the host and no active sandbox is available "
             f"to read it", src=src, origin="container")
 
-    res = env.execute(f"base64 {shlex.quote(str(p))} | tr -d '\\n'")
+    res = env.execute(f"base64 -- {shlex.quote(str(p))} | tr -d '\\n'")
     if res.get("returncode", 1) != 0:
         raise SourceNotFound(f"could not read '{p}' inside the sandbox", src=src, origin="container")
     try:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -105,11 +105,14 @@ def _validate_image_url(url: str) -> bool:
     return True
 
 
-def _detect_image_mime_type(image_path: Path) -> Optional[str]:
-    """Return a MIME type when the file looks like a supported image."""
-    with image_path.open("rb") as f:
-        header = f.read(64)
+def _detect_image_mime_type_from_bytes(data: bytes) -> Optional[str]:
+    """Magic-byte MIME sniff on raw bytes (authoritative; no extension trust).
 
+    Returns ``None`` for anything without a recognized image header — including
+    SVG, which has no magic bytes and is not ingestible as vision by any
+    provider.
+    """
+    header = data[:64]
     if header.startswith(b"\x89PNG\r\n\x1a\n"):
         return "image/png"
     if header.startswith(b"\xff\xd8\xff"):
@@ -120,11 +123,17 @@ def _detect_image_mime_type(image_path: Path) -> Optional[str]:
         return "image/bmp"
     if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WEBP":
         return "image/webp"
-    if image_path.suffix.lower() == ".svg":
+    return None
+
+
+def _detect_image_mime_type(image_path: Path) -> Optional[str]:
+    """Return a MIME type when the file looks like a supported image."""
+    mime = _detect_image_mime_type_from_bytes(image_path.read_bytes()[:64])
+    if mime is None and image_path.suffix.lower() == ".svg":
         head = image_path.read_text(encoding="utf-8", errors="ignore")[:4096].lower()
         if "<svg" in head:
             return "image/svg+xml"
-    return None
+    return mime
 
 
 def _is_retryable_download_error(error: Exception) -> bool:
@@ -285,30 +294,16 @@ def _determine_mime_type(image_path: Path) -> str:
     return mime_types.get(extension, 'image/jpeg')
 
 
-def _image_to_base64_data_url(image_path: Path, mime_type: Optional[str] = None) -> str:
-    """
-    Convert an image file to a base64-encoded data URL.
-    
-    Args:
-        image_path (Path): Path to the image file
-        mime_type (Optional[str]): MIME type of the image (auto-detected if None)
-        
-    Returns:
-        str: Base64-encoded data URL (e.g., "data:image/jpeg;base64,...")
-    """
-    # Read the image as bytes
-    data = image_path.read_bytes()
-    
-    # Encode to base64
+def _image_bytes_to_base64_data_url(data: bytes, mime: str) -> str:
+    """Encode raw image bytes as an RFC 2397 base64 data URL."""
     encoded = base64.b64encode(data).decode("ascii")
-    
-    # Determine MIME type
+    return f"data:{mime};base64,{encoded}"
+
+
+def _image_to_base64_data_url(image_path: Path, mime_type: Optional[str] = None) -> str:
+    """Convert an image file to a base64-encoded data URL."""
     mime = mime_type or _determine_mime_type(image_path)
-    
-    # Create data URL
-    data_url = f"data:{mime};base64,{encoded}"
-    
-    return data_url
+    return _image_bytes_to_base64_data_url(image_path.read_bytes(), mime)
 
 
 # Absolute hard ceiling for vision API payloads (20 MB) — above this, no major
@@ -343,53 +338,44 @@ def _is_image_size_error(error: Exception) -> bool:
 
 def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
                               max_base64_bytes: int = _RESIZE_TARGET_BYTES) -> str:
-    """Convert an image to a base64 data URL, auto-resizing if too large.
+    """Path wrapper around :func:`_resize_image_bytes_for_vision`."""
+    mime = mime_type or _determine_mime_type(image_path)
+    return _resize_image_bytes_for_vision(image_path.read_bytes(), mime, max_base64_bytes)
+
+
+def _resize_image_bytes_for_vision(data: bytes, mime: str,
+                                   max_base64_bytes: int = _RESIZE_TARGET_BYTES) -> str:
+    """Encode image bytes as a base64 data URL, auto-resizing if too large.
 
     Tries Pillow first to progressively downscale oversized images.  If Pillow
     is not installed or resizing still exceeds the limit, falls back to the raw
     bytes and lets the caller handle the size check.
-
-    Returns the base64 data URL string.
     """
-    # Quick file-size estimate: base64 expands by ~4/3, plus data URL header.
-    # Skip the expensive full-read + encode if Pillow can resize directly.
-    file_size = image_path.stat().st_size
-    estimated_b64 = (file_size * 4) // 3 + 100  # ~header overhead
-    if estimated_b64 <= max_base64_bytes:
-        # Small enough — just encode directly.
-        data_url = _image_to_base64_data_url(image_path, mime_type=mime_type)
+    # base64 expands by ~4/3, plus data URL header; skip Pillow if it already fits.
+    if (len(data) * 4) // 3 + 100 <= max_base64_bytes:
+        data_url = _image_bytes_to_base64_data_url(data, mime)
         if len(data_url) <= max_base64_bytes:
             return data_url
-    else:
-        data_url = None  # defer full encode; try Pillow resize first
 
-    # Attempt auto-resize with Pillow (soft dependency)
     try:
         from PIL import Image
         import io as _io
     except ImportError:
         logger.info("Pillow not installed — cannot auto-resize oversized image")
-        if data_url is None:
-            data_url = _image_to_base64_data_url(image_path, mime_type=mime_type)
-        return data_url  # caller will raise the size error
+        return _image_bytes_to_base64_data_url(data, mime)  # caller raises the size error
 
-    logger.info("Image file is %.1f MB (estimated base64 %.1f MB, limit %.1f MB), auto-resizing...",
-                file_size / (1024 * 1024), estimated_b64 / (1024 * 1024),
-                max_base64_bytes / (1024 * 1024))
+    logger.info("Image is %.1f MB (limit %.1f MB), auto-resizing...",
+                len(data) / (1024 * 1024), max_base64_bytes / (1024 * 1024))
 
-    mime = mime_type or _determine_mime_type(image_path)
-    # Choose output format: JPEG for photos (smaller), PNG for transparency
+    # Choose output format: JPEG for photos (smaller), PNG for transparency.
     pil_format = "PNG" if mime == "image/png" else "JPEG"
     out_mime = "image/png" if pil_format == "PNG" else "image/jpeg"
 
     try:
-        img = Image.open(image_path)
+        img = Image.open(_io.BytesIO(data))
     except Exception as exc:
         logger.info("Pillow cannot open image for resizing: %s", exc)
-        if data_url is None:
-            data_url = _image_to_base64_data_url(image_path, mime_type=mime_type)
-        return data_url  # fall through to size-check in caller
-    # Convert RGBA to RGB for JPEG output
+        return _image_bytes_to_base64_data_url(data, mime)  # caller does the size-check
     if pil_format == "JPEG" and img.mode in {"RGBA", "P"}:
         img = img.convert("RGB")
 
@@ -443,8 +429,8 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
                        max_base64_bytes / (1024 * 1024), len(candidate) / (1024 * 1024))
         return candidate
 
-    # Shouldn't reach here, but fall back to full encode
-    return data_url or _image_to_base64_data_url(image_path, mime_type=mime_type)
+    # Shouldn't reach here, but fall back to the unresized encode.
+    return _image_bytes_to_base64_data_url(data, mime)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -128,7 +128,8 @@ def _detect_image_mime_type_from_bytes(data: bytes) -> Optional[str]:
 
 def _detect_image_mime_type(image_path: Path) -> Optional[str]:
     """Return a MIME type when the file looks like a supported image."""
-    mime = _detect_image_mime_type_from_bytes(image_path.read_bytes()[:64])
+    with image_path.open("rb") as f:
+        mime = _detect_image_mime_type_from_bytes(f.read(64))
     if mime is None and image_path.suffix.lower() == ".svg":
         head = image_path.read_text(encoding="utf-8", errors="ignore")[:4096].lower()
         if "<svg" in head:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -692,8 +692,9 @@ async def vision_analyze_tool(
         Exception: If download fails, analysis fails, or API key is not set
         
     Note:
-        - For URLs, temporary images are stored under $HERMES_HOME/cache/vision/ and cleaned up
-        - For local file paths, the file is used directly and NOT deleted
+        - The source (local path, file://, http(s), data:, or a Docker-container
+          path) is resolved to bytes by ``tools.image_source``; any download
+          temp file is created and cleaned up there.
         - Supports common image formats (JPEG, PNG, GIF, WebP, etc.)
     """
     if not isinstance(user_prompt, str):

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1006,6 +1006,7 @@ VISION_ANALYZE_SCHEMA = {
 def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
     image_url = args.get("image_url", "")
     question = args.get("question", "")
+    task_id = kw.get("task_id")  # carries the Docker exec-read seam (#32709)
 
     # Fast path: when native image routing is in effect for the active main
     # model (provider accepts images in tool results, or the user set the
@@ -1015,7 +1016,7 @@ def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
     # information loss, no extra latency.
     if _should_use_native_vision_fast_path():
         logger.info("vision_analyze: native fast path")
-        return _vision_analyze_native(image_url, question)
+        return _vision_analyze_native(image_url, question, task_id=task_id)
 
     # Legacy path: aux LLM describes the image and we return its text.
     full_prompt = (
@@ -1023,7 +1024,7 @@ def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> Awaitable[str]:
         f"following question:\n\n{question}"
     )
     model = os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
-    return vision_analyze_tool(image_url, full_prompt, model)
+    return vision_analyze_tool(image_url, full_prompt, model, task_id=task_id)
 
 
 registry.register(

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1177,6 +1177,9 @@ async def video_analyze_tool(
         logger.info("Analyzing video: %s", video_url[:60])
         logger.info("User prompt: %s", user_prompt[:100])
 
+        # TODO: share tools.image_source's source-fetch layer once it is split
+        # from the image-specific _finalize (video needs its own magic-byte
+        # sniff + larger size cap, so it can't route through the image resolver).
         # Resolve local path vs remote URL
         resolved_url = video_url
         if resolved_url.startswith("file://"):

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -594,77 +594,43 @@ def _build_native_vision_tool_result(
 async def _vision_analyze_native(
     image_url: str,
     question: str,
+    task_id: Optional[str] = None,
 ) -> Any:
     """Fast path for vision-capable main models.
 
-    Loads the image (local file OR remote URL), base64-encodes it, and
-    returns a multimodal tool-result envelope. The agent loop unwraps it;
-    provider adapters serialize it into the right tool-result-with-image
-    shape for each backend.
+    Resolves the image source to bytes (local file, file://, http(s), data:,
+    or a Docker-container path), base64-encodes it, and returns a multimodal
+    tool-result envelope. The agent loop unwraps it; provider adapters
+    serialize it into the right tool-result-with-image shape per backend.
 
     Returns:
         A ``_multimodal`` envelope dict on success.
         A JSON error string on failure (matches the existing tool-result
         contract so the agent loop displays errors normally).
     """
-    if not isinstance(image_url, str) or not image_url.strip():
-        return tool_error("image_url is required", success=False)
-
-    temp_image_path: Optional[Path] = None
-    should_cleanup = False
     try:
         from tools.interrupt import is_interrupted
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Resolve the image source (mirrors vision_analyze_tool's logic
-        # exactly so behaviour is consistent).
-        resolved_url = image_url
-        if resolved_url.startswith("file://"):
-            resolved_url = resolved_url[len("file://"):]
-        local_path = Path(os.path.expanduser(resolved_url))
+        from tools.image_source import ImageResolutionError, ResolveContext, resolve_image_source
+        try:
+            resolved = await resolve_image_source(image_url, ResolveContext(task_id=task_id))
+        except ImageResolutionError as exc:
+            return tool_error(str(exc), success=False)
 
-        if local_path.is_file():
-            temp_image_path = local_path
-            should_cleanup = False
-        elif _validate_image_url(image_url):
-            blocked = check_website_access(image_url)
-            if blocked:
-                return tool_error(blocked["message"], success=False)
-            temp_dir = get_hermes_dir("cache/vision", "temp_vision_images")
-            temp_image_path = temp_dir / f"temp_image_{uuid.uuid4()}.jpg"
-            await _download_image(image_url, temp_image_path)
-            should_cleanup = True
-        else:
-            return tool_error(
-                "Invalid image source. Provide an HTTP/HTTPS URL or a "
-                "valid local file path.",
-                success=False,
-            )
+        image_data_url = _image_bytes_to_base64_data_url(resolved.data, resolved.mime)
 
-        image_size_bytes = temp_image_path.stat().st_size
-        detected_mime_type = _detect_image_mime_type(temp_image_path)
-        if not detected_mime_type:
-            return tool_error(
-                "Only real image files are supported for vision analysis.",
-                success=False,
-            )
-
-        image_data_url = _image_to_base64_data_url(
-            temp_image_path, mime_type=detected_mime_type,
-        )
-
-        # Proactive embed cap: this image gets baked into conversation
-        # history and re-sent on every subsequent turn.  Anthropic rejects
-        # any single base64 image over 5 MB with a 400, and because history
-        # is immutable, an oversized embed permanently wedges the session —
-        # retries can't clear bytes that are already in the request.  Resize
-        # DOWN to the embed target (4 MB, headroom under 5 MB) whenever the
-        # payload exceeds it, not just at the 20 MB hard ceiling.
+        # Proactive embed cap (#35732): this image gets baked into conversation
+        # history and re-sent on every subsequent turn.  Anthropic rejects any
+        # single base64 image over 5 MB with a 400, and because history is
+        # immutable, an oversized embed permanently wedges the session — retries
+        # can't clear bytes that are already in the request.  Resize DOWN to the
+        # embed target (4 MB, headroom under 5 MB) whenever the payload exceeds
+        # it, not just at the 20 MB hard ceiling.
         if len(image_data_url) > _EMBED_TARGET_BYTES:
-            image_data_url = _resize_image_for_vision(
-                temp_image_path, mime_type=detected_mime_type,
-                max_base64_bytes=_EMBED_TARGET_BYTES,
+            image_data_url = _resize_image_bytes_for_vision(
+                resolved.data, resolved.mime, max_base64_bytes=_EMBED_TARGET_BYTES,
             )
             # If even resizing can't get under the absolute hard ceiling,
             # there's nothing more we can do — reject rather than embed a
@@ -684,20 +650,12 @@ async def _vision_analyze_native(
             image_url=image_url,
             question=question,
             image_data_url=image_data_url,
-            image_size_bytes=image_size_bytes,
+            image_size_bytes=len(resolved.data),
         )
 
     except Exception as exc:
         logger.warning("Native vision fast path failed: %s", exc)
         return tool_error(f"Native vision failed: {exc}", success=False)
-    finally:
-        # Only delete temp files we created — never user-provided paths.
-        if should_cleanup and temp_image_path is not None:
-            try:
-                if temp_image_path.exists():
-                    temp_image_path.unlink()
-            except Exception:
-                pass
 
 
 async def vision_analyze_tool(

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -662,6 +662,7 @@ async def vision_analyze_tool(
     image_url: str,
     user_prompt: str,
     model: str = None,
+    task_id: Optional[str] = None,
 ) -> str:
     """
     Analyze an image from a URL or local file path using vision AI.
@@ -710,12 +711,6 @@ async def vision_analyze_tool(
         "image_size_bytes": 0
     }
     
-    temp_image_path = None
-    # Track whether we should clean up the file after processing.
-    # Local files (e.g. from the image cache) should NOT be deleted.
-    should_cleanup = True
-    detected_mime_type = None
-    
     try:
         from tools.interrupt import is_interrupted
         if is_interrupted():
@@ -723,54 +718,19 @@ async def vision_analyze_tool(
 
         logger.info("Analyzing image: %s", image_url[:60])
         logger.info("User prompt: %s", user_prompt[:100])
-        
-        # Determine if this is a local file path or a remote URL
-        # Strip file:// scheme so file URIs resolve as local paths.
-        resolved_url = image_url
-        if resolved_url.startswith("file://"):
-            resolved_url = resolved_url[len("file://"):]
-        local_path = Path(os.path.expanduser(resolved_url))
-        if local_path.is_file():
-            # Local file path (e.g. from platform image cache) -- skip download
-            logger.info("Using local image file: %s", image_url)
-            temp_image_path = local_path
-            should_cleanup = False  # Don't delete cached/local files
-        elif _validate_image_url(image_url):
-            # Remote URL -- download to a temporary location
-            blocked = check_website_access(image_url)
-            if blocked:
-                raise PermissionError(blocked["message"])
-            logger.info("Downloading image from URL...")
-            temp_dir = get_hermes_dir("cache/vision", "temp_vision_images")
-            temp_image_path = temp_dir / f"temp_image_{uuid.uuid4()}.jpg"
-            await _download_image(image_url, temp_image_path)
-            should_cleanup = True
-        else:
-            raise ValueError(
-                "Invalid image source. Provide an HTTP/HTTPS URL or a valid local file path."
-            )
-        
-        # Get image file size for logging
-        image_size_bytes = temp_image_path.stat().st_size
-        image_size_kb = image_size_bytes / 1024
-        logger.info("Image ready (%.1f KB)", image_size_kb)
 
-        detected_mime_type = _detect_image_mime_type(temp_image_path)
-        if not detected_mime_type:
-            raise ValueError("Only real image files are supported for vision analysis.")
-        
-        # Convert image to base64 — send at full resolution first.
-        # If the provider rejects it as too large, we auto-resize and retry.
-        logger.info("Converting image to base64...")
-        image_data_url = _image_to_base64_data_url(temp_image_path, mime_type=detected_mime_type)
-        data_size_kb = len(image_data_url) / 1024
-        logger.info("Image converted to base64 (%.1f KB)", data_size_kb)
+        from tools.image_source import ImageResolutionError, ResolveContext, resolve_image_source
+        try:
+            resolved = await resolve_image_source(image_url, ResolveContext(task_id=task_id))
+        except ImageResolutionError as exc:
+            raise ValueError(str(exc)) from exc
 
-        # Hard limit (20 MB) — no provider accepts payloads this large.
+        image_size_bytes = len(resolved.data)
+        image_data_url = _image_bytes_to_base64_data_url(resolved.data, resolved.mime)
+
+        # Hard limit (20 MB) — no provider accepts payloads this large; resize once.
         if len(image_data_url) > _MAX_BASE64_BYTES:
-            # Try to resize down to 5 MB before giving up.
-            image_data_url = _resize_image_for_vision(
-                temp_image_path, mime_type=detected_mime_type)
+            image_data_url = _resize_image_bytes_for_vision(resolved.data, resolved.mime)
             if len(image_data_url) > _MAX_BASE64_BYTES:
                 raise ValueError(
                     f"Image too large for vision API: base64 payload is "
@@ -782,7 +742,7 @@ async def vision_analyze_tool(
                 )
 
         debug_call_data["image_size_bytes"] = image_size_bytes
-        
+
         # Use the prompt as provided (model_tools.py now handles full description formatting)
         comprehensive_prompt = user_prompt
         
@@ -845,8 +805,7 @@ async def vision_analyze_tool(
                     len(image_data_url) / (1024 * 1024),
                     _RESIZE_TARGET_BYTES / (1024 * 1024),
                 )
-                image_data_url = _resize_image_for_vision(
-                    temp_image_path, mime_type=detected_mime_type)
+                image_data_url = _resize_image_bytes_for_vision(resolved.data, resolved.mime)
                 messages[0]["content"][1]["image_url"]["url"] = image_data_url
                 response = await async_call_llm(**call_kwargs)
             else:
@@ -928,17 +887,6 @@ async def vision_analyze_tool(
         _debug.save()
         
         return json.dumps(result, indent=2, ensure_ascii=False)
-    
-    finally:
-        # Clean up temporary image file (but NOT local/cached files)
-        if should_cleanup and temp_image_path and temp_image_path.exists():
-            try:
-                temp_image_path.unlink()
-                logger.debug("Cleaned up temporary image file")
-            except Exception as cleanup_error:
-                logger.warning(
-                    "Could not delete temporary file: %s", cleanup_error, exc_info=True
-                )
 
 
 def check_vision_requirements() -> bool:


### PR DESCRIPTION
# fix(vision): unify vision_analyze image-source resolution through one bytes-returning resolver

Closes #7571
Closes #25118
Closes #29643
Closes #22328
Closes #32709
Addresses #9077 (delivery path only — see Caveats)
Supersedes #30197
Supersedes #14990

## TL;DR
`vision_analyze` / `mcp_vision_analyze` now load images reliably from **every** source — `data:` URLs, `http(s)`, `file://`, local paths, and Docker-container-only paths — instead of returning "no image attached" / "Invalid image source". This is a byte-**delivery** fix, not a routing change: both call sites now funnel through one resolver `tools/image_source.py` that returns raw bytes through a single correctness chokepoint. Container files are reached two ways — a cache-dir host fast-path and a universal `docker exec base64` exec-read fallback. Pure `tools/` layer; `agent/image_routing.py` is deliberately untouched. Security hardening (a readable-root allowlist) is intentionally **out of scope** here and left as a no-op seam for a possible follow-up.

## Problem
The six clustered issues looked like four unrelated bugs (`data:`, `file://`, local paths, sandbox paths), but they share one root cause.

`vision_analyze` read image bytes **in-process on the host** (`Path.read_bytes()`, no subprocess), while `read_file` / `terminal` / `execute_code` read **through the sandbox** via `env.execute` → `docker exec`. So when a file lives in the Docker terminal backend, every other tool can see it — and vision is the **only** tool reading the wrong filesystem. The reporter of #22328 attributed this to "vision runs in an isolated mount/process namespace"; that is incorrect (vision is in-process on the host). The real boundary is host-vs-sandbox, and it is the same mechanism behind #32709.

A secondary problem: each source branch re-implemented its own ingestion (`tools/vision_tools.py:551` `_vision_analyze_native` and `:605` `vision_analyze_tool` diverged), so size caps, MIME sniffing, and error handling drifted between them. Routing was a red herring — the routing flip was investigated and dropped as non-load-bearing; all six issues fail at byte-delivery.

## Solution / Architecture
One resolver, both sites delegate to it:

- **`resolve_image_source(src, ctx: ResolveContext) -> ResolvedImage`** (`tools/image_source.py:66`). `ResolvedImage(data: bytes, mime, origin)` with `origin ∈ {data, http, file, local, container}` (`:60`). Both vision sites call it (`tools/vision_tools.py:575`, `:669`); the resolver always returns raw bytes regardless of source.
- **Branches:** `data:` (base64) · `http(s)` (reuses `tools/url_safety.is_safe_url` SSRF guard + the existing 50 MB download cap) · `file://` · local path · container.
- **`_finalize` chokepoint** (`:204`): the single place enforcing intrinsic correctness — a generous `_MAX_INGEST_BYTES = 50 MB` ingest cap (`:23`) plus a magic-byte sniff. The cap is deliberately the 50 MB *ingest* budget, not the 20 MB provider payload cap, so a 20–50 MB image survives to be resized rather than hard-rejected.
- **Container delivery, two mechanisms:**
  1. host fast-path — cache-dir reverse map `tools/credential_files.py:405` `from_agent_visible_cache_path` (container→host, beside its existing forward twin), called at `image_source.py:160`.
  2. universal fallback — `_resolve_container_fallback` (`:174`) runs `base64 -- <shlex.quoted path> | tr -d '\n'` via `env.execute`, wrapped in `asyncio.to_thread`, **fail-closed** when no active env.
- **bytes-core refactor:** encode/resize/sniff helpers now operate on bytes; the `Path`-signature wrappers (`_resize_image_for_vision`, `_image_to_base64_data_url`) are preserved so external callers (`tools/browser_tool.py`, `agent/conversation_compression.py`) are untouched.
- **Pure `tools/` layer:** `agent/image_routing.py` is intentionally unchanged.

## Scope & Stats
- **3 core code files:** `tools/image_source.py` (new), `tools/vision_tools.py` (mod, +265/−243), `tools/credential_files.py` (mod).
- **7 test files:** `test_image_source.py` (new), `test_vision_bytes_helpers.py` (new), `tests/integration/test_vision_docker_resolve.py` (new), `test_credential_files.py` (mod), `test_vision_native_fast_path.py` (mod), `test_vision_tools.py` (mod), `test_model_tools_async_bridge.py` (mod).
- Diff `bcc830100..HEAD`: 10 files, **+829 / −306**. **236 tests pass.**
- **Adjacent but not closed here:** TG-image-as-document #16710 / #18819 / #20756 (already on `main`); gateway path-exposure #34315 / #20906 / #20971; data:-blob session-DB bloat #31705.

## Issue → fix mapping
| Issue | Symptom | Fixed by | Confidence |
|---|---|---|---|
| #7571 | no `file://` / local path support | strip `file://` + `_looks_like_path` → file/local branch reads bytes (`image_source.py:79`) | fully fixed |
| #25118 | TG image, macOS local backend | cache lands host-readable (`cache/images/`), direct read; reverse-map not load-bearing on local backend | fully fixed |
| #29643 | TG cached image "no image attached", Ubuntu local | same path as #25118 + unified encode via `_finalize` (`:204`) | fully fixed |
| #22328 | all local files + browser screenshots fail (zh) | **reframe:** host↔sandbox boundary (= #32709), not namespace isolation → cache reverse-map (`:160`) + exec-read (`:174`) | fixed; inherits #32709 preconditions |
| #32709 | Docker terminal backend, image not sent | exec-read fallback `_resolve_container_fallback` (`:174`) + cache reverse-map; `task_id` threaded dispatch→handler→resolver, seam locked by regression test | fixed; exec-read verified against real Docker (integration test, not in CI — see Caveats) |
| #9077 | "no image" for URL/local/screenshot/`data:` | unified resolver covers all source types + `_finalize` | delivery only (see Caveats) |

**#22328 reframe:** the reporter's stated cause (vision in an isolated mount/process namespace) is wrong — `vision_analyze` runs in-process on the host. The actual cause is the host-vs-sandbox filesystem boundary, identical to #32709, and the same exec-read mechanism resolves both.

## Supersedes
- **#30197** (data: URL support via a temp file, `validate=False`, no magic-byte check) → ours: `_resolve_data_url` (`:98`) decodes straight to bytes (no temp file), `validate=True`, with an authoritative magic-byte sniff in `_finalize`. Strict superset — nothing lost, validation added.
- **#14990** (sandbox path translation via `TERMINAL_CWD` / `docker_volumes` host rewrites — only worked when a host mount backed the path) → ours: cache reverse-map + universal exec-read reaches container-only files (tmpfs, root-owned mode-600) that #14990 could never read. The explicit `docker_volumes` / `TERMINAL_CWD` host rewrite is absorbed by exec-read (same bytes); the allowlist portion is out of scope here (see below).

(No other source-resolver PRs exist — searched `vision_analyze in:title`, all states.)

## Caveats / honest scope
- **#9077 is `Addresses`, not `Closes`.** Two of its sub-symptoms are out of delivery scope: (a) the `browser_vision` >90 s **timeout** is latency, not delivery; (b) "model can't see image" (`success: true` + "I don't see an image" on a non-vision provider, e.g. MiniMax) is a routing/capability matter. The delivery path is fixed.
- **#32709 / #22328 exec-read round-trip is covered by an `integration`-marked Docker test** that is excluded from the default suite (and from CI, which runs `-m 'not integration'`). It has been run green locally against a real Docker daemon, but it does not gate CI — re-run `pytest -m integration tests/integration/test_vision_docker_resolve.py` on a Docker host to re-verify. The `task_id` seam it depends on *is* in the default unit suite.
- **#22328 / #32709 preconditions:** the container path requires a Docker terminal backend + a live `task_id` threaded dispatch→handler→resolver. Outside those, the local host read applies.

## Behavior changes
| Change | Before → After | Why | Risk / mitigation | User-visible |
|---|---|---|---|---|
| 20–50 MB images | hard-reject → **resize through** | `_MAX_INGEST_BYTES`=50 MB (`:23`); 20 MB provider cap enforced post-resize at call sites | covered by an incompressible-PNG resize regression test | yes |
| Policy-block error message | generic → **specific website-policy message preserved** | `_http_block_reason` (`:113`) keeps the reason | unit-tested in `test_image_source.py` | yes |
| Bare relative path (`cat.png`, no `/`, `./`, `~`) | probed against process CWD (nondeterministic) → **`UnsupportedScheme`** (`:91`) | a clear deterministic error beats CWD-guessing | newly disclosed; use `./cat.png` or an absolute path | yes |
| SVG for vision | (varied) → **rejected** (magic-byte sniff → `None`) | no provider ingests SVG as vision; the path detector keeps SVG-by-text for non-resolver callers | deliberate; isolated to the resolver | yes |
| Vision-site temp-file bookkeeping | manual `should_cleanup` at both sites → lifecycle in `_download_to_bytes` `finally` + `unlink(missing_ok=True)` (`:141`) | single ownership, no leak / double-unlink | internal refactor | no |

## Security
- Exec-read injection neutralized: `base64 -- {shlex.quote(path)}` (`:194`) — `--` stops a leading-dash path being parsed as a `base64` option; `tr -d '\n'` handles BusyBox (no GNU `-w0`).
- Fail-closed: no active sandbox env → resolution refuses rather than probing the host (covered by a fail-closed unit test).
- SSRF retained: redirect re-validation and the 50 MB stream cap stay in `_download_image` (called from `_download_to_bytes`, `:138`).

## Testing
**236 tests pass.**

```
python -m pytest \
  tests/tools/test_image_source.py \
  tests/tools/test_credential_files.py \
  tests/tools/test_vision_tools.py \
  tests/tools/test_vision_bytes_helpers.py \
  tests/tools/test_vision_native_fast_path.py \
  tests/agent/test_image_routing.py \
  tests/test_model_tools_async_bridge.py -q
```

- `test_image_source.py` (new) — every resolve branch: `data:` / `http` / `file` / local / container, SSRF reject, oversize, leading-dash injection neutralization, fail-closed (no env); asserts the policy-block message is preserved.
- `test_vision_bytes_helpers.py` (new) — magic-byte sniff (incl. SVG → `None`), base64 encode, resize-noop under cap.
- `test_vision_native_fast_path.py` (mod) — fast-path gating matrix, 20–50 MB oversize-**resize** regression (incompressible PNG), and the `task_id` seam.
- `test_credential_files.py` (mod) — `from_agent_visible_cache_path` reverse-map: docker / non-docker / unmapped.
- `test_model_tools_async_bridge.py` (mod) — #2104 loop-safety, repatched to resolver seams `_http_block_reason` / `_download_to_bytes`.
- `test_vision_tools.py` (mod) — call-site integration.

**Docker integration (`integration`-marked, excluded from the default suite):** `tests/integration/test_vision_docker_resolve.py` (new) carries `pytest.mark.integration`, so `addopts = -m 'not integration'` deselects it from normal runs; it auto-skips when no Docker daemon is present and gets a 180s timeout (repo convention, mirroring `tests/docker/conftest.py`). It exercises the real-Docker exec-read round-trip for #32709 — a tmpfs `/workspace` file (no host path) and a root-owned mode-600 file — and is **not** part of the 236. **Verified green against a real Docker daemon (29.4.0), so #32709 / #22328 are fixed-by-test, not just by construction.** Run:

```
pytest -m integration tests/integration/test_vision_docker_resolve.py
```

## Out of scope
This PR is scoped to byte delivery. The items below are intentionally not included — the resolver leaves a clean seam (`_within_allowed_roots`) so the security piece can be added later without reworking the delivery path.

- **Readable-root allowlist** — the natural next step: replace the no-op `_within_allowed_roots` seam (`:83` / `:148`) with real root enforcement, a `vision.allowed_image_roots` config, and a threat model. The fail-open-vs-fail-closed choice is an open design decision, and any such work must not regress the user-typed-path workflows that #7571 / #22328 / #25118 depend on, nor reject an untranslated `/workspace` path before the container → exec-read route runs.
- **`docker_volumes` / `/workspace`→`TERMINAL_CWD` host rewrite** — not added; no issue exercises it and the exec-read fallback already reaches those paths (same bytes).
- **Decompression-bomb guard** — not added. It is only meaningful at the Pillow decode site (`_resize_image_bytes_for_vision`), and the 50 MB ingest cap already bounds file size; if ever wanted, it belongs as a conditional check there, not a blanket requirement.
- **Pillow stays optional** — resize degrades gracefully (skips and returns a clear "install Pillow" error). Forcing a heavy native dependency on installs that never use vision is not justified, and a bomb guard only matters when Pillow is already present.
