### PR TITLE
fix(auxiliary): guard against empty choices in extract_content_or_reasoning

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5280,6 +5280,8 @@ def extract_content_or_reasoning(response) -> str:
     """
     import re
 
+    if not response or not getattr(response, 'choices', None):
+        return ""
     msg = response.choices[0].message
     content = (msg.content or "").strip()
 


### PR DESCRIPTION
## Problem

`extract_content_or_reasoning()` in `agent/auxiliary_client.py` accesses `response.choices[0].message` without checking if the response has a non-empty `choices` list. If the LLM returns an empty choices array (filtered response, API error edge case), this raises an unhandled `IndexError`.

## Fix

Add a guard at function entry that returns `""` when the response is `None` or has no choices, consistent with the function's documented return contract ("best available text or empty string").

## Files Changed

- `agent/auxiliary_client.py` — 2-line guard added (+2 lines)