### PR TITLE
fix(telegram): guard against None result from vision_analyze_tool in sticker analysis

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5586,6 +5586,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 image_url=cached_path,
                 user_prompt=STICKER_VISION_PROMPT,
             )
+            if not result_json:
+                logger.warning("[Telegram] Sticker vision returned empty result for %s", sticker.file_unique_id)
+                event.text = build_sticker_injection(
+                    f"a sticker with emoji {emoji}" if emoji else "a sticker",
+                    emoji, set_name,
+                )
+                return
             result = json.loads(result_json)
 
             if result.get("success"):


### PR DESCRIPTION
## Problem

`vision_analyze_tool()` may return `None` on internal failure. The Telegram sticker analysis code at `gateway/platforms/telegram.py:5589` passes the result directly to `json.loads()` which raises `TypeError` on `None`. While caught by the outer `except Exception`, it masks the real error behind a generic "Sticker analysis error" message, making debugging harder.

## Fix

Add an explicit `None`/empty guard before `json.loads()` with a descriptive warning log that includes the sticker `file_unique_id` for debugging. On empty result, fall back to the emoji-based description (same as the error path).

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| vision_analyze_tool returns None | `except Exception: "Sticker analysis error: ..."` | `logger.warning("Sticker vision returned empty result for %s")` + clean fallback |
| vision_analyze_tool returns valid JSON | Works normally | Works normally (zero behavioral change) |

## Files Changed

- `gateway/platforms/telegram.py` — 7-line None guard added (+7 lines)