### PR TITLE
fix(gateway): upgrade error handler log levels from debug to warning

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3392,7 +3392,7 @@ class GatewayRunner:
                 metadata=thread_meta,
             )
         except Exception as e:
-            logger.debug("Failed to send busy-ack: %s", e)
+            logger.warning("Failed to send busy-ack: %s", e)
 
         return True
 
@@ -3434,7 +3434,7 @@ class GatewayRunner:
                 agent.interrupt(reason)
                 logger.debug("Interrupted running agent for session %s during shutdown", session_key)
             except Exception as e:
-                logger.debug("Failed interrupting agent during shutdown: %s", e)
+                logger.warning("Failed interrupting agent during shutdown: %s", e)
 
     async def _notify_active_sessions_of_shutdown(self) -> None:
         """Send shutdown/restart notifications to active chats and home channels.
@@ -4179,7 +4179,7 @@ class GatewayRunner:
             if stuck:
                 logger.warning("Auto-suspended %d stuck-loop session(s)", stuck)
         except Exception as e:
-            logger.debug("Stuck-loop detection failed: %s", e)
+            logger.warning("Stuck-loop detection failed: %s", e)
 
         connected_count = 0
         enabled_platform_count = 0


### PR DESCRIPTION
## Problem

Three error handlers in `gateway/run.py` log failures at `logger.debug()` level, making them invisible in production logs unless operators run at debug level. These failures affect user-visible behavior and operational health.

## Changes

1. **Busy-ack send failure** (line 3395): Users get no feedback that their message was received while the agent is busy. → `logger.warning()`

2. **Agent interrupt during shutdown** (line 3437): Failure to interrupt an agent during shutdown can cause the gateway to hang or SIGKILL. → `logger.warning()`

3. **Stuck-loop detection failure** (line 4182): If stuck-loop detection fails, sessions may loop forever without being auto-suspended. → `logger.warning()`

## Files Changed

- `gateway/run.py` — 3 `logger.debug()` → `logger.warning()` in error handlers