### PR TITLE
fix(nix): stop emitting deprecated MESSAGING_CWD on the systemd unit

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -630,6 +630,15 @@
         ) cfg.mcpServers;
       })
 
+      # Surface workingDirectory through the canonical settings.terminal.cwd
+      # so the unit no longer needs the deprecated MESSAGING_CWD env var.
+      # containerWorkDir translates host → in-container path for container mode.
+      {
+        services.hermes-agent.settings.terminal.cwd = lib.mkDefault (
+          if cfg.container.enable then containerWorkDir else cfg.workingDirectory
+        );
+      }
+
       # ── User / group ──────────────────────────────────────────────────
       (lib.mkIf cfg.createUser {
         users.groups.${cfg.group} = { };
@@ -874,7 +883,6 @@
             HOME = cfg.stateDir;
             HERMES_HOME = "${cfg.stateDir}/.hermes";
             HERMES_MANAGED = "true";
-            MESSAGING_CWD = cfg.workingDirectory;
           };
 
           serviceConfig = {
@@ -971,7 +979,6 @@
                 --env HERMES_HOME=${containerDataDir}/.hermes \
                 --env HERMES_MANAGED=true \
                 --env HOME=${containerHomeDir} \
-                --env MESSAGING_CWD=${containerWorkDir} \
                 ${lib.concatStringsSep " " cfg.container.extraOptions} \
                 ${cfg.container.image} \
                 ${containerDataDir}/current-package/bin/hermes gateway run --replace ${lib.concatStringsSep " " cfg.extraArgs}

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -197,7 +197,8 @@
     # Default: /var/lib/hermes/workspace → /data/workspace.
     # Custom paths outside stateDir pass through unchanged (user must add extraVolumes).
     containerWorkDir =
-      if lib.hasPrefix "${cfg.stateDir}/" cfg.workingDirectory
+      if cfg.workingDirectory == cfg.stateDir then containerDataDir
+      else if lib.hasPrefix "${cfg.stateDir}/" cfg.workingDirectory
       then "${containerDataDir}/${lib.removePrefix "${cfg.stateDir}/" cfg.workingDirectory}"
       else cfg.workingDirectory;
 
@@ -242,7 +243,11 @@
         type = types.str;
         default = "${cfg.stateDir}/workspace";
         defaultText = literalExpression ''"''${cfg.stateDir}/workspace"'';
-        description = "Working directory for the agent.";
+        description = ''
+          Working directory for the agent. Also seeds settings.terminal.cwd in
+          config.yaml, so changes here are reasserted on the on-disk config on
+          every deploy.
+        '';
       };
 
       # ── Declarative config ───────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

`hermes_cli/config.py::warn_deprecated_cwd_env_vars` (added by #11029 to deprecate `MESSAGING_CWD` in favour of `terminal.cwd` in `config.yaml`) warns whenever the env var is present in the process environment, **regardless of whether `terminal.cwd` is configured**:

```python
messaging_cwd = os.environ.get("MESSAGING_CWD")
...
if messaging_cwd:
    lines.append(f"  ⚠ MESSAGING_CWD={messaging_cwd} found in .env — this is deprecated.")
```

The NixOS module still emits `MESSAGING_CWD = cfg.workingDirectory;` on the native systemd unit and `--env MESSAGING_CWD=${containerWorkDir}` on the container `docker/podman create`, so **every** `services.hermes-agent.enable = true` host currently sees the warning on every restart with no way for an operator to silence it short of overriding the unit's `environment` themselves.

The fix:

1. Add a small merge block that defaults `services.hermes-agent.settings.terminal.cwd` from `cfg.workingDirectory` (using `lib.mkDefault` so users can override). For container mode the existing `containerWorkDir` helper does the host→container path translation, so `terminal.cwd` in the rendered `config.yaml` matches the in-container mount layout.
2. Drop `MESSAGING_CWD = cfg.workingDirectory;` from the native systemd unit's `environment`.
3. Drop `--env MESSAGING_CWD=${containerWorkDir} \` from the container's `${containerBin} create` invocation.

PRs #22050 (open) and #34781 (merged) only rewrote the option's *description* string — they don't touch the systemd env, so the warning persists post-#34781. This PR is the substantive companion fix.

### Backward compatibility

Preserved at two layers:

- Operators who **explicitly** set `services.hermes-agent.environment.MESSAGING_CWD = "..."` keep their override — the activation script still writes `cfg.environment` into `$HERMES_HOME/.env` verbatim, and the python loader honours `MESSAGING_CWD` from `.env` as the legacy fallback. They get the deprecation warning, which is correct (they opted in).
- `settings.terminal.cwd` uses `lib.mkDefault`, so any operator who already sets it explicitly is unaffected.

The default module-emitted env stops carrying the deprecated path.

## Related Issue

N/A — surfaced during operational use; no tracking issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `nix/nixosModules.nix` — three edits: add the `terminal.cwd` default merge block; drop `MESSAGING_CWD` from `systemd.services.hermes-agent.environment` (native); drop `--env MESSAGING_CWD=…` from the container `create` invocation.

## How to Test

Against a real deployment using this branch as the input:

```
nix eval --raw .#nixosConfigurations.<host>.config.systemd.services.hermes-agent.environment \
  --apply 'env: env.MESSAGING_CWD or "ABSENT"'
# → ABSENT (was: /var/lib/hermes/workspace)

nix eval --raw .#nixosConfigurations.<host>.config.services.hermes-agent.settings.terminal.cwd
# → /var/lib/hermes/workspace
```

After deploy, the previously-emitted line in the journal:

```
⚠ MESSAGING_CWD=/var/lib/hermes/workspace found in .env — this is deprecated.
```

no longer appears.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (#22050 and #34781 are docs-only siblings, not duplicates)
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` — not applicable (no python tests touched; NixOS module change). Smoke-evaluated the module instead.
- [ ] I've added tests — repo has no NixOS module test harness; eval-time + deploy-time verification documented above.
- [x] I've tested on my platform: NixOS 25.11 on Hetzner Cloud (x86_64-linux)

### Documentation & Housekeeping

- [x] Documentation — N/A (behaviour matches existing docs after #34781; the inline comment in the new merge block explains the why)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (NixOS-specific)
- [x] Tool descriptions/schemas — N/A
