### PR TITLE
fix(compressor): stale Active Task no longer hijacks resumed sessions (#35344)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -40,14 +40,24 @@ SUMMARY_PREFIX = (
     "window — treat it as background reference, NOT as active instructions. "
     "Do NOT answer questions or fulfill requests mentioned in this summary; "
     "they were already addressed. "
-    "Your current task is identified in the '## Active Task' section of the "
-    "summary — resume exactly from there. "
+    "Respond ONLY to the latest user message that appears AFTER this "
+    "summary — that message is the single source of truth for what to do "
+    "right now. "
+    "If the latest user message is consistent with the '## Active Task' "
+    "section, you may use the summary as background. If the latest user "
+    "message contradicts, supersedes, changes topic from, or in any way "
+    "diverges from '## Active Task' / '## In Progress' / '## Pending User "
+    "Asks' / '## Remaining Work', the latest message WINS — discard those "
+    "stale items entirely and do not 'wrap up the old task first'. "
+    "Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll "
+    "back', 'just verify', 'don't do that anymore', 'never mind', a new "
+    "topic) must immediately end any in-flight work described in the "
+    "summary; do not re-surface it in later turns. "
     "IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system "
     "prompt is ALWAYS authoritative and active — never ignore or deprioritize "
     "memory content due to this compaction note. "
-    "Respond ONLY to the latest user message "
-    "that appears AFTER this summary. The current session state (files, "
-    "config, etc.) may reflect work described here — avoid repeating it:"
+    "The current session state (files, config, etc.) may reflect work "
+    "described here — avoid repeating it:"
 )
 LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 
@@ -1241,6 +1251,11 @@ task assignment verbatim — the exact words they used. If multiple tasks
 were requested and only some are done, list only the ones NOT yet completed.
 Continuation should pick up exactly here. Example:
 "User asked: 'Now refactor the auth module to use JWT instead of sessions'"
+If the user's most recent message was a reverse signal (stop, undo, roll
+back, never mind, just verify, change of topic) that supersedes earlier
+work, write the reverse signal verbatim and DO NOT carry forward the
+cancelled task. Example: "User asked: 'Stop the i18n refactor and just
+verify the current diff' — earlier i18n in-flight work is cancelled."
 If no outstanding task exists, write "None."]
 
 ## Goal

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1246,11 +1246,22 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
 
         # Shared structured template (used by both paths).
         _template_sections = f"""## Active Task
-[THE SINGLE MOST IMPORTANT FIELD. Copy the user's most recent request or
-task assignment verbatim — the exact words they used. If multiple tasks
-were requested and only some are done, list only the ones NOT yet completed.
-Continuation should pick up exactly here. Example:
+[THE SINGLE MOST IMPORTANT FIELD. Capture the user's most recent unfulfilled
+input verbatim — the exact words they used. This includes:
+- Explicit task assignments ("refactor the auth module")
+- Questions awaiting an answer ("waarom staat X op Y?", "wat zijn de volgende stappen?")
+- Decisions awaiting input ("optie A of B?")
+- Ongoing discussions where the assistant owes the next substantive reply
+A conversation where the user just asked a question IS an active task — the
+task is "answer that question with full context". Do NOT write "None" merely
+because the user did not issue an imperative command; reserve "None" for the
+rare case where the last exchange was fully resolved and the user said
+something like "thanks, that's all".
+If multiple items are outstanding, list only the ones NOT yet completed.
+Continuation should pick up exactly here. Examples:
 "User asked: 'Now refactor the auth module to use JWT instead of sessions'"
+"User asked: 'Waarom stond provider ineens op openrouter?' — needs investigation + answer"
+"User chose option A; awaiting implementation of step 2"
 If the user's most recent message was a reverse signal (stop, undo, roll
 back, never mind, just verify, change of topic) that supersedes earlier
 work, write the reverse signal verbatim and DO NOT carry forward the
@@ -1321,7 +1332,7 @@ PREVIOUS SUMMARY:
 NEW TURNS TO INCORPORATE:
 {content_to_summarize}
 
-Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled request — this is the most important field for task continuity.
+Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled input — this includes any question, decision request, or discussion turn that the assistant has not yet answered. Only write "None" if the last exchange was fully resolved.
 
 {_template_sections}"""
         else:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -61,6 +61,26 @@ SUMMARY_PREFIX = (
 )
 LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 
+# Handoff prefixes that shipped in earlier releases. A summary persisted under
+# one of these can be inherited into a resumed lineage (#35344); when it is
+# re-normalized on re-compaction we must strip the OLD prefix too, otherwise the
+# stale directive it carried (e.g. "resume exactly from Active Task") survives
+# embedded in the body and keeps hijacking replies. Keep newest-first; entries
+# are matched literally. Add a frozen copy here whenever SUMMARY_PREFIX changes.
+_HISTORICAL_SUMMARY_PREFIXES = (
+    # Pre-#35344: contained the self-contradicting "resume exactly" directive.
+    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
+    "into the summary below. This is a handoff from a previous context "
+    "window — treat it as background reference, NOT as active instructions. "
+    "Do NOT answer questions or fulfill requests mentioned in this summary; "
+    "they were already addressed. "
+    "Your current task is identified in the '## Active Task' section of the "
+    "summary — resume exactly from there. "
+    "Respond ONLY to the latest user message "
+    "that appears AFTER this summary. The current session state (files, "
+    "config, etc.) may reflect work described here — avoid repeating it:",
+)
+
 # Minimum tokens for the summary output
 _MIN_SUMMARY_TOKENS = 2000
 # Proportion of compressed content to allocate for summary
@@ -1496,9 +1516,16 @@ The user has requested that this compaction PRIORITISE preserving all informatio
 
     @staticmethod
     def _strip_summary_prefix(summary: str) -> str:
-        """Return summary body without the current or legacy handoff prefix."""
+        """Return summary body without the current, legacy, or any historical
+        handoff prefix.
+
+        Historical prefixes must be stripped too: a handoff persisted under an
+        older prefix can be inherited into a resumed lineage (#35344), and if we
+        only re-prepend the current prefix without removing the old one, the
+        stale directive it carried stays embedded in the body.
+        """
         text = (summary or "").strip()
-        for prefix in (SUMMARY_PREFIX, LEGACY_SUMMARY_PREFIX):
+        for prefix in (SUMMARY_PREFIX, LEGACY_SUMMARY_PREFIX, *_HISTORICAL_SUMMARY_PREFIXES):
             if text.startswith(prefix):
                 return text[len(prefix):].lstrip()
         return text
@@ -1512,7 +1539,9 @@ The user has requested that this compaction PRIORITISE preserving all informatio
     @staticmethod
     def _is_context_summary_content(content: Any) -> bool:
         text = _content_text_for_contains(content).lstrip()
-        return text.startswith(SUMMARY_PREFIX) or text.startswith(LEGACY_SUMMARY_PREFIX)
+        if text.startswith(SUMMARY_PREFIX) or text.startswith(LEGACY_SUMMARY_PREFIX):
+            return True
+        return any(text.startswith(p) for p in _HISTORICAL_SUMMARY_PREFIXES)
 
     @classmethod
     def _find_latest_context_summary(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,8 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "zhipengli@thebrainly.ai": "a1245582339",
+    "mathijs.vd.hurk@gmail.com": "mathijsvandenhurk",
     "drpelagik@gmail.com": "SeaXen",
     "lengr@users.noreply.github.com": "LengR",
     "metalclaudbot@gmail.com": "HashClawAI",

--- a/tests/agent/test_resume_stale_active_task.py
+++ b/tests/agent/test_resume_stale_active_task.py
@@ -1,0 +1,141 @@
+"""Regression coverage for #35344: a resumed session must not let a stale
+``## Active Task`` from an inherited compaction handoff hijack the reply to a
+new, unrelated user message.
+
+The failure mode (real report): a lineage was compacted, producing a handoff
+whose ``## Active Task`` described task A. The lineage was resumed later and
+the user asked about an unrelated task B. The model answered with A because
+the handoff's resume directive outranked the fresh ask.
+
+The structural fix lives in ``SUMMARY_PREFIX``: the handoff is framed as
+reference-only and the latest user message explicitly *wins* on conflict, with
+named reverse-signal verbs. Two invariants guard the resume path specifically:
+
+  1. A handoff persisted under the OLD (conflicting) prefix is re-normalized to
+     the CURRENT prefix when it is re-compacted on a resumed lineage — so a
+     pre-fix stale handoff cannot keep its "resume exactly" directive forever.
+
+  2. The current handoff prefix contains an unambiguous "latest message wins /
+     discard stale Active Task" rule, so an unrelated new ask is privileged over
+     the inherited ``## Active Task``.
+
+These are content/structural assertions (no live model call) — they pin the
+mechanism that makes the stale task historical rather than active.
+"""
+
+from agent.context_compressor import (
+    SUMMARY_PREFIX,
+    LEGACY_SUMMARY_PREFIX,
+    ContextCompressor,
+)
+
+
+# The conflicting prefix that shipped before the #35344 fix. A handoff
+# persisted in a resumed lineage could carry this verbatim.
+_OLD_CONFLICTING_PREFIX = (
+    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
+    "into the summary below. This is a handoff from a previous context "
+    "window — treat it as background reference, NOT as active instructions. "
+    "Do NOT answer questions or fulfill requests mentioned in this summary; "
+    "they were already addressed. "
+    "Your current task is identified in the '## Active Task' section of the "
+    "summary — resume exactly from there. "
+    "Respond ONLY to the latest user message "
+    "that appears AFTER this summary. The current session state (files, "
+    "config, etc.) may reflect work described here — avoid repeating it:"
+)
+
+
+def test_latest_message_wins_over_inherited_active_task():
+    """The handoff must explicitly privilege the latest user message over a
+    stale ``## Active Task`` — the core #35344 contract."""
+    lower = SUMMARY_PREFIX.lower()
+    assert "latest user message" in lower
+    assert "## active task" in lower
+    # Conflict-resolution must be explicit, not implied.
+    assert "wins" in lower or "supersede" in lower
+    assert "discard" in lower
+
+
+def test_no_resume_exactly_directive_can_hijack():
+    """The directive that caused the hijack ("resume exactly from Active
+    Task") must be gone."""
+    assert "resume exactly" not in SUMMARY_PREFIX.lower()
+
+
+def test_resumed_stale_handoff_gets_renormalized_to_current_prefix():
+    """A handoff persisted under the OLD conflicting prefix (e.g. saved before
+    the fix and inherited into a resumed lineage) is upgraded to the CURRENT
+    prefix when re-normalized on re-compaction — so the "resume exactly"
+    directive cannot survive into a resumed session."""
+    stale_body = (
+        "## Active Task\n"
+        "User asked: 'Migrate the billing module to Stripe'\n\n"
+        "## Goal\nMigrate billing.\n"
+    )
+    stale_handoff = f"{_OLD_CONFLICTING_PREFIX}\n{stale_body}"
+
+    # Sanity: the fixture really does carry the old directive.
+    assert "resume exactly" in stale_handoff.lower()
+
+    renormalized = ContextCompressor._with_summary_prefix(stale_handoff)
+
+    # The body is preserved...
+    assert "Migrate the billing module to Stripe" in renormalized
+    # ...but the conflicting directive is stripped and replaced with the
+    # current latest-message-wins framing.
+    assert "resume exactly" not in renormalized.lower()
+    assert renormalized.startswith(SUMMARY_PREFIX)
+    assert "wins" in renormalized.lower()
+
+
+def test_legacy_prefix_handoff_also_renormalized():
+    """The same upgrade applies to the oldest ``[CONTEXT SUMMARY]:`` handoff
+    format that may sit in a long-lived resumed lineage."""
+    legacy = f"{LEGACY_SUMMARY_PREFIX} ## Active Task\nUser asked: 'task A'"
+    renormalized = ContextCompressor._with_summary_prefix(legacy)
+    assert renormalized.startswith(SUMMARY_PREFIX)
+    assert LEGACY_SUMMARY_PREFIX not in renormalized
+    assert "task A" in renormalized
+
+
+def test_inherited_handoff_detected_in_resumed_protected_head():
+    """On a resumed lineage the handoff commonly sits right after the system
+    prompt (in the protected head). ``_find_latest_context_summary`` must
+    detect it there so re-compaction rehydrates state from it rather than
+    serializing it as a fresh user turn (which is what let the stale Active
+    Task read as live intent)."""
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": f"{SUMMARY_PREFIX}\n## Active Task\nUser asked: 'task A'"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "Unrelated task B: what's the capital of France?"},
+    ]
+    # Search the whole post-system range.
+    idx, body = ContextCompressor._find_latest_context_summary(
+        messages, 1, len(messages)
+    )
+    assert idx == 1, "handoff in protected head must be found"
+    assert "task A" in body
+    # The detected body is stripped of the prefix (treated as state, not a
+    # standalone instruction message).
+    assert not body.startswith(SUMMARY_PREFIX)
+
+
+def test_historical_prefixed_handoff_detected_and_stripped():
+    """A pre-fix handoff (old conflicting prefix) inherited into a resumed
+    lineage must still be recognized as a context summary AND have its old
+    directive stripped on detection — otherwise re-compaction serializes the
+    stale 'resume exactly' text as a fresh turn."""
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": f"{_OLD_CONFLICTING_PREFIX}\n## Active Task\nUser asked: 'task A'"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "user", "content": "Unrelated task B"},
+    ]
+    idx, body = ContextCompressor._find_latest_context_summary(
+        messages, 1, len(messages)
+    )
+    assert idx == 1
+    assert "task A" in body
+    assert "resume exactly" not in body.lower()

--- a/tests/agent/test_summary_prefix_semantics.py
+++ b/tests/agent/test_summary_prefix_semantics.py
@@ -1,0 +1,62 @@
+"""Pin the semantics of SUMMARY_PREFIX so the compaction handoff doesn't
+re-introduce conflicting instructions.
+
+Background: SUMMARY_PREFIX previously contained two contradictory directives:
+
+  1. "treat it as background reference, NOT as active instructions"
+     "Do NOT answer questions or fulfill requests mentioned in this summary"
+     "Respond ONLY to the latest user message that appears AFTER this summary"
+
+  2. "Your current task is identified in the '## Active Task' section of the
+     summary — resume exactly from there."
+
+When the latest user message contradicted Active Task (e.g. "stop the
+i18n refactor", "never mind, look at grafana"), the model often followed
+(2) anyway because "resume exactly" is a strong directive — leading to
+the agent repeatedly re-surfacing already-cancelled work across turns.
+
+These tests pin the post-fix invariants so the conflict cannot regress.
+"""
+
+from agent.context_compressor import SUMMARY_PREFIX
+
+
+def test_no_resume_exactly_directive():
+    """The prefix must not tell the model to resume Active Task verbatim."""
+    assert "resume exactly" not in SUMMARY_PREFIX.lower()
+
+
+def test_latest_message_wins_on_conflict():
+    """The prefix must explicitly say latest user message wins on conflict."""
+    lower = SUMMARY_PREFIX.lower()
+    assert "latest user message" in lower
+    # Must have an explicit conflict-resolution rule.
+    assert "wins" in lower or "supersede" in lower or "discard" in lower
+
+
+def test_reverse_signals_called_out():
+    """Reverse signals (stop/undo/never mind/topic change) must be named so
+    the model recognizes them as cancellation triggers, not just background."""
+    lower = SUMMARY_PREFIX.lower()
+    # At least a few of the canonical reverse-signal verbs should appear.
+    reverse_terms = ["stop", "undo", "roll back", "never mind", "just verify"]
+    hits = sum(1 for t in reverse_terms if t in lower)
+    assert hits >= 3, (
+        f"Expected ≥3 reverse-signal terms in SUMMARY_PREFIX, found {hits}. "
+        "Without naming them the model treats reverse signals as ordinary "
+        "context and keeps pushing the cancelled task."
+    )
+
+
+def test_summary_marked_reference_only():
+    """The REFERENCE ONLY framing must remain — it's the entire point."""
+    assert "REFERENCE ONLY" in SUMMARY_PREFIX
+    assert "background reference" in SUMMARY_PREFIX
+    assert "NOT as active instructions" in SUMMARY_PREFIX
+
+
+def test_memory_authority_preserved():
+    """The fix must not weaken the MEMORY.md / USER.md authority clause."""
+    assert "MEMORY.md" in SUMMARY_PREFIX
+    assert "USER.md" in SUMMARY_PREFIX
+    assert "authoritative" in SUMMARY_PREFIX


### PR DESCRIPTION
## Summary
A resumed session no longer answers a new, unrelated user message with instructions from a stale `## Active Task` inherited via context compaction (#35344). Fixes the conflicting compaction handoff directive **and** the resume-path gap where an old-format handoff kept its stale directive forever.

Root cause: `SUMMARY_PREFIX` carried two fighting directives — "resume exactly from `## Active Task`" vs "respond ONLY to the latest user message." "Resume exactly" is the stronger phrasing, so on a resumed lineage the model followed the stale task. Compounding it, `_strip_summary_prefix` only matched the *current/legacy* prefix literal, so a handoff persisted under the old prefix and re-compacted on resume kept its "resume exactly" text embedded in the body.

## Changes
- `agent/context_compressor.py`:
  - **Prefix rewrite** (salvaged from #26290, @a1245582339): drops "resume exactly"; makes latest-user-message the single source of truth that **wins** on conflict; names reverse-signal verbs (stop / undo / roll back / never mind / just verify / topic change) so cancellation is recognized, not treated as background.
  - **Active Task capture** (salvaged from #32787, @mathijsvandenhurk): the field now also captures open questions and pending decisions, so post-compaction work isn't dropped as `None`. Reconciled with the prefix change — both intents kept.
  - **Resume-path fix** (ours): `_HISTORICAL_SUMMARY_PREFIXES` + updated `_strip_summary_prefix` / `_is_context_summary_content` so a handoff persisted under an old prefix is detected and re-normalized to the current latest-message-wins framing on re-compaction.
- `tests/agent/test_resume_stale_active_task.py`: regression coverage for the resume-contamination shape the issue asks for.
- `scripts/release.py`: AUTHOR_MAP entries for both salvaged contributors.

## Why combine, not pick one
#35344 = "Active Task too sticky, hijacks new asks." #32787 = "Active Task drops too much (writes None)." These are inverse failure modes. Fixing only one regresses the other. The prefix controls *how the field is treated on conflict*; the template controls *what gets captured*. Combined, the summary captures the real outstanding ask but a fresh/contradicting message always overrides it. #17506 (reference-only framing) is superseded — its framing already landed on main; its `## Active Task` → `## Outstanding Work Metadata` rename fights #32787 and churns the iterative-summary template.

## Validation
| | Before | After |
|---|---|---|
| `SUMMARY_PREFIX` directive | "resume exactly" vs "latest message" conflict | latest message wins, explicit discard of stale items |
| Old-prefix handoff on resume | "resume exactly" survives in body | stripped + re-framed to current prefix |
| Active Task on a bare question | `None` → recap instead of answer | captured as active task |
| Targeted tests | — | `test_context_compressor` 91✓ + `test_summary_prefix_semantics` 5✓ + new `test_resume_stale_active_task` 6✓ = 102/102 |

E2E: simulated a resumed lineage with a pre-fix handoff in the protected head + an unrelated new ask — handoff detected, stale directive stripped, body preserved, latest-wins framing applied.

Closes #35344. Supersedes #26290, #32787, #17506.

Co-authored-by: Zhipeng Li <zhipengli@thebrainly.ai>
Co-authored-by: Mathijs van den Hurk <mathijs.vd.hurk@gmail.com>

## Infographic

![stale-active-task-resume-fix](https://v3b.fal.media/files/b/0a9c4b5a/_eXy6xNewc4y1EG-M3fwu_B8Dme9vl.png)
