### PR TITLE
fix(cli): oneshot (-z) fails closed on empty response or agent crash

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -191,11 +191,15 @@ def run_oneshot(
         except Exception:
             pass
 
-    if response:
-        real_stdout.write(response)
-        if not response.endswith("\n"):
-            real_stdout.write("\n")
-        real_stdout.flush()
+    if not (response or "").strip():
+        sys.stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
+        sys.stderr.flush()
+        return 1
+
+    real_stdout.write(response)
+    if not response.endswith("\n"):
+        real_stdout.write("\n")
+    real_stdout.flush()
     return 0
 
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -174,28 +174,51 @@ def run_oneshot(
     # Redirect stderr AND stdout to devnull for the entire call tree.
     # We'll print the final response to the real stdout at the end.
     real_stdout = sys.stdout
+    real_stderr = sys.stderr
     devnull = open(os.devnull, "w", encoding="utf-8")
 
+    response: Optional[str] = None
+    failure: BaseException | None = None
     try:
         with redirect_stdout(devnull), redirect_stderr(devnull):
-            response = _run_agent(
-                prompt,
-                model=model,
-                provider=provider,
-                toolsets=explicit_toolsets,
-                use_config_toolsets=use_config_toolsets,
-            )
+            try:
+                response = _run_agent(
+                    prompt,
+                    model=model,
+                    provider=provider,
+                    toolsets=explicit_toolsets,
+                    use_config_toolsets=use_config_toolsets,
+                )
+            except BaseException as exc:  # noqa: BLE001
+                # Capture anything that escapes the agent (including OSError
+                # from prompt_toolkit/Vt100 when stdout is a non-TTY pipe,
+                # KeyboardInterrupt, SystemExit, etc.) so we can surface it on
+                # the real stderr instead of crashing past the redirect with a
+                # traceback that the caller never sees. A silent exit in a
+                # cron / SSH / subprocess context is the worst failure mode.
+                # See #30623.
+                failure = exc
     finally:
         try:
             devnull.close()
         except Exception:
             pass
 
-    if not (response or "").strip():
-        sys.stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
-        sys.stderr.flush()
+    if failure is not None:
+        # Re-raise control-flow exceptions so the parent handles them as usual
+        # (Ctrl-C / explicit sys.exit() inside the agent).
+        if isinstance(failure, (KeyboardInterrupt, SystemExit)):
+            raise failure
+        real_stderr.write(f"hermes -z: agent failed: {failure}\n")
+        real_stderr.flush()
         return 1
 
+    if not (response or "").strip():
+        real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
+        real_stderr.flush()
+        return 1
+
+    assert response is not None  # narrowed by the empty-response guard above
     real_stdout.write(response)
     if not response.endswith("\n"):
         real_stdout.write("\n")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -656,6 +656,7 @@ AUTHOR_MAP = {
     "incharge.automation@gmail.com": "inchargeautomation-lab",
     "danielrpike9@gmail.com": "Bartok9",
     "96944678+ymylive@users.noreply.github.com": "sweetcornna",
+    "laflamme@illinoisalumni.org": "briancl2",
     "skozyuk@cruxexperts.com": "CruxExperts",
     "154585401+LeonSGP43@users.noreply.github.com": "LeonSGP43",
     "12250313+Kailigithub@users.noreply.github.com": "Kailigithub",

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -662,6 +662,36 @@ def test_oneshot_prints_nonempty_final_response(monkeypatch, capsys):
     assert captured.err == ""
 
 
+def test_oneshot_fails_closed_on_agent_exception(monkeypatch, capsys):
+    _stub_plugin_discovery(monkeypatch)
+    import hermes_cli.oneshot as oneshot_mod
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("not a TTY")
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", _boom)
+
+    assert oneshot_mod.run_oneshot("hello") == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "agent failed" in captured.err
+    assert "not a TTY" in captured.err
+
+
+def test_oneshot_reraises_keyboard_interrupt(monkeypatch):
+    _stub_plugin_discovery(monkeypatch)
+    import hermes_cli.oneshot as oneshot_mod
+    import pytest as _pytest
+
+    def _interrupt(*_args, **_kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", _interrupt)
+
+    with _pytest.raises(KeyboardInterrupt):
+        oneshot_mod.run_oneshot("hello")
+
+
 def test_oneshot_filters_invalid_toolsets_before_redirect(monkeypatch, capsys):
     _stub_plugin_discovery(monkeypatch)
     from hermes_cli.oneshot import _validate_explicit_toolsets

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -638,6 +638,30 @@ def test_oneshot_rejects_invalid_only_toolsets(monkeypatch, capsys):
     assert "did not contain any valid toolsets" in err
 
 
+def test_oneshot_fails_closed_on_empty_final_response(monkeypatch, capsys):
+    _stub_plugin_discovery(monkeypatch)
+    import hermes_cli.oneshot as oneshot_mod
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", lambda *_args, **_kwargs: "")
+
+    assert oneshot_mod.run_oneshot("hello") == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "no final response" in captured.err
+
+
+def test_oneshot_prints_nonempty_final_response(monkeypatch, capsys):
+    _stub_plugin_discovery(monkeypatch)
+    import hermes_cli.oneshot as oneshot_mod
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", lambda *_args, **_kwargs: "done")
+
+    assert oneshot_mod.run_oneshot("hello") == 0
+    captured = capsys.readouterr()
+    assert captured.out == "done\n"
+    assert captured.err == ""
+
+
 def test_oneshot_filters_invalid_toolsets_before_redirect(monkeypatch, capsys):
     _stub_plugin_discovery(monkeypatch)
     from hermes_cli.oneshot import _validate_explicit_toolsets


### PR DESCRIPTION
## Summary
`hermes -z` oneshot now fails closed (rc=1 + stderr diagnostic) when the agent produces no final text or crashes mid-run, instead of exiting 0 silently. Successful runs still print only the final text to stdout and exit 0.

Closes #35294 (empty-response contract). Also closes #30623 (non-TTY crash surfaces as silent rc=0).

Root cause: `run_oneshot()` printed only when `response` was truthy, then unconditionally `return 0` — an empty/None response produced no output and still exited 0. A second gap: exceptions raised under the `redirect_stderr` block (e.g. OSError from prompt_toolkit/Vt100 on a non-TTY pipe) crashed past the redirect with no signal to the caller.

## Changes
- `hermes_cli/oneshot.py`:
  - Empty/whitespace-only final response → write diagnostic to stderr, return 1 (briancl2, #35295).
  - Wrap the agent call in `try/except BaseException`; surface the error to real stderr with rc=1. Re-raise `KeyboardInterrupt`/`SystemExit` so Ctrl-C and explicit exits propagate (adapts sweetcornna, #33818).
- `tests/hermes_cli/test_tui_resume_flow.py`: empty-response, nonempty-response, agent-exception, and KeyboardInterrupt-reraise cases.
- `scripts/release.py`: AUTHOR_MAP entry for briancl2.

Scope is the `-z` contract only — no retries, queues, schedulers, or background behavior.

## Validation
| Case | Before | After |
|---|---|---|
| Empty final response | rc 0, empty stdout | rc 1, stderr diagnostic |
| Agent raises (non-TTY) | rc 0 / traceback past redirect | rc 1, `agent failed: <err>` on stderr |
| Real text | rc 0, text to stdout | rc 0, text to stdout (unchanged) |
| Ctrl-C | — | re-raised |

Targeted tests: 14/14 oneshot tests pass. E2E verified against real `run_oneshot` with isolated HERMES_HOME for all four paths.

Salvaged from #35295 (@briancl2, empty-response) + #33818 (@sweetcornna, exception guard). Closes #31505 as superseded.

## Infographic

![oneshot-fails-closed](https://v3b.fal.media/files/b/0a9c4b5b/VW9JPL3kuAgMleMMpPyww_DaAsiVeG.png)
