### PR TITLE
fix(dashboard): allow insecure WS peers on explicit non-loopback binds

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3375,10 +3375,14 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     ``?token=<_SESSION_TOKEN>`` path is the only auth we have, so we
     don't want LAN hosts guessing tokens.
 
-    All-interfaces insecure bind (``--host 0.0.0.0 --insecure`` or
-    ``--host :: --insecure``): allow any peer. The operator explicitly
-    opted into LAN/public exposure in this mode, so the loopback-only peer
-    restriction should not apply.
+    Explicit non-loopback bind (``--host 0.0.0.0``, ``--host ::``, or a
+    specific address such as a Tailscale/LAN IP, always with
+    ``--insecure``): allow any peer. The operator explicitly opted into
+    non-loopback exposure, so the loopback-only peer restriction does not
+    apply. DNS-rebinding is still blocked by the Host/Origin guard in
+    :func:`_ws_host_origin_is_allowed`, which mirrors the HTTP layer and
+    requires the Host header to match the bound interface — the same
+    defence ``_is_accepted_host`` applies to non-loopback HTTP requests.
 
     Gated mode: any peer is allowed — uvicorn's ``proxy_headers=True``
     (enabled when the OAuth gate is active so cookies can pick up
@@ -3390,8 +3394,13 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     """
     if getattr(app.state, "auth_required", False):
         return True
-    bound_host = getattr(app.state, "bound_host", "")
-    if bound_host in {"0.0.0.0", "::"}:
+    # Any explicit non-loopback bind (0.0.0.0, ::, or a specific LAN /
+    # Tailscale address) means the operator opted into non-loopback
+    # access via --insecure.  The loopback-only peer gate only applies to
+    # an actual loopback bind; otherwise the WS handshake is rejected even
+    # though same-bind HTTP requests pass _is_accepted_host.
+    bound_host = (getattr(app.state, "bound_host", "") or "").strip().lower()
+    if bound_host and bound_host not in _LOOPBACK_HOSTS:
         return True
     client_host = ws.client.host if ws.client else ""
     if not client_host:

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -162,6 +162,30 @@ class TestWsTicketEndpoint:
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture
+def insecure_explicit_host_app():
+    """web_server.app bound to an explicit non-loopback host (--insecure).
+
+    Models `--host 100.64.0.10 --insecure` (e.g. a Tailscale IP behind
+    `tailscale serve`) — a specific address rather than the all-interfaces
+    0.0.0.0 wildcard.
+    """
+    _reset_for_tests()
+    clear_providers()
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "100.64.0.10"
+    web_server.app.state.bound_port = 9119
+    web_server.app.state.auth_required = False
+    client = TestClient(web_server.app, base_url="http://100.64.0.10:9119")
+    yield client
+    _reset_for_tests()
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
 def _fake_ws(*, query: dict, client_host: str = "127.0.0.1", path: str = "/api/pty"):
     """Build a stand-in for starlette.WebSocket good enough for _ws_auth_ok."""
 
@@ -314,6 +338,33 @@ class TestWsRequestIsAllowedGated:
             "origin": "http://192.168.0.222:9120",
         }
         assert web_server._ws_request_is_allowed(ws) is True
+
+    def test_peer_allowed_on_explicit_non_loopback_bind(self, insecure_explicit_host_app):
+        """`--host 100.64.0.10 --insecure` (Tailscale/LAN IP) is an explicit
+        non-loopback opt-in too — not just the 0.0.0.0 wildcard.
+
+        Regression coverage: the merged 0.0.0.0/:: fix did not cover binding
+        directly to a specific tailnet/LAN address, so `/chat` HTML loaded but
+        WS upgrades were still rejected by the loopback-only peer guard.
+        """
+        ws = _fake_ws(query={}, client_host="100.64.0.99")
+        ws.headers = {
+            "host": "100.64.0.10:9119",
+            "origin": "http://100.64.0.10:9119",
+        }
+        assert web_server._ws_request_is_allowed(ws) is True
+
+    def test_rebinding_host_rejected_on_explicit_non_loopback_bind(
+        self, insecure_explicit_host_app
+    ):
+        """Lifting the peer-IP gate for an explicit bind must NOT lift the
+        DNS-rebinding Host guard: a mismatched Host header is still rejected,
+        because an explicit non-loopback bind requires an exact Host match in
+        `_is_accepted_host` (unlike the 0.0.0.0 wildcard, which accepts any).
+        """
+        ws = _fake_ws(query={}, client_host="100.64.0.99")
+        ws.headers = {"host": "evil.example.com"}
+        assert web_server._ws_request_is_allowed(ws) is False
 
     def test_host_origin_guard_still_runs_in_gated_mode(self, gated_app):
         """Bypassing the peer-IP check must not bypass the DNS-rebinding


### PR DESCRIPTION
## Summary
Binding the dashboard to a specific non-loopback address with `--insecure` (e.g. a Tailscale/LAN IP via `--host 100.64.0.10 --insecure`) now works for the `/chat` WebSocket, not just the `0.0.0.0`/`::` wildcard.

Root cause: the merged wildcard fix (#35141) only early-returned `_ws_client_is_allowed` for `0.0.0.0`/`::`. An explicit non-loopback bind fell through to the loopback-only peer gate, so the dashboard HTML loaded over the tailnet/LAN but every WS upgrade was rejected with 403 — `/chat` connected and then silently received no data.

## Changes
- `hermes_cli/web_server.py`: generalize `_ws_client_is_allowed` — lift the loopback-only peer gate for **any** explicit non-loopback bound host, not just the wildcard. DNS-rebinding remains blocked because `_ws_host_origin_is_allowed` already requires an exact Host-header match for explicit binds (mirrors `_is_accepted_host` on the HTTP layer); the `0.0.0.0`/`::` wildcard still accepts any Host, as before.
- `tests/hermes_cli/test_dashboard_auth_ws_auth.py`: `insecure_explicit_host_app` fixture + 2 tests (peer allowed on matching explicit bind; rebind Host still rejected).

## Validation
| Bind | Peer | Host header | auth | Before | After |
|---|---|---|---|---|---|
| `127.0.0.1` | LAN | `127.0.0.1` | off | reject | reject |
| `0.0.0.0` --insecure | LAN | bound | off | allow | allow |
| `100.64.0.10` --insecure | tailnet | `100.64.0.10` | off | **reject** | **allow** |
| `100.64.0.10` --insecure | tailnet | `evil.example.com` | off | reject | reject |
| explicit bind | any | bound | on (gated) | allow | allow |

24/24 in `test_dashboard_auth_ws_auth.py`, 161/161 across `test_web_server*.py`. E2E matrix (8 scenarios, real `_ws_request_is_allowed`) all green including both negative cases.

## Credit
Salvages the explicit-non-loopback-bind gap raised in #32357 (@pxdsgnco) and #25072 — both targeted the same scenario the wildcard fix left unsolved. @pxdsgnco co-authored via the commit trailer; #25072 credited here as co-reporter (its commit carried an unattributable generated-agent email, so it couldn't be cherry-picked cleanly).

Closes #32357, closes #25072.

## Infographic

![dashboard-ws-explicit-bind](https://v3b.fal.media/files/b/0a9c4b60/5TCGXy9P03nYW_d4Su_SM_VabD249o.png)
