### PR TITLE
fix(slack): keep approval prompt under Block Kit limit

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2253,19 +2253,36 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            cmd_preview = command[:2900] + "..." if len(command) > 2900 else command
             thread_ts = self._resolve_thread_ts(None, metadata)
+
+            # Slack section text is capped at 3000 characters.  Reserve space
+            # for the wrapper and description before truncating the command;
+            # using a fixed 2900-character command preview can still exceed
+            # the Block Kit limit once the header, code fences, and reason are
+            # added.
+            desc_preview = (
+                description[:500] + "..." if len(description) > 500 else description
+            )
+            prefix = ":warning: *Command Approval Required*\n```"
+            suffix = f"```\nReason: {desc_preview}"
+            max_section_text = 3000
+            max_cmd_len = max_section_text - len(prefix) - len(suffix)
+            if max_cmd_len < 0:
+                desc_preview = desc_preview[:200] + "..." if len(desc_preview) > 200 else desc_preview
+                suffix = f"```\nReason: {desc_preview}"
+                max_cmd_len = max_section_text - len(prefix) - len(suffix)
+            if len(command) > max_cmd_len:
+                cmd_preview = command[: max(0, max_cmd_len - 3)] + "..."
+            else:
+                cmd_preview = command
+            section_text = f"{prefix}{cmd_preview}{suffix}"
 
             blocks = [
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": (
-                            f":warning: *Command Approval Required*\n"
-                            f"```{cmd_preview}```\n"
-                            f"Reason: {description}"
-                        ),
+                        "text": section_text,
                     },
                 },
                 {

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -140,7 +140,27 @@ class TestSlackExecApproval:
         kwargs = mock_client.chat_postMessage.call_args[1]
         section_text = kwargs["blocks"][0]["text"]["text"]
         assert "..." in section_text
-        assert len(section_text) < 5000
+        assert len(section_text) <= 3000
+
+    @pytest.mark.asyncio
+    async def test_truncates_long_command_with_reason_under_slack_section_limit(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1.2"})
+
+        long_cmd = "x" * 5000
+        await adapter.send_exec_approval(
+            chat_id="C1",
+            command=long_cmd,
+            session_key="s",
+            description="dangerous command",
+        )
+
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        section_text = kwargs["blocks"][0]["text"]["text"]
+        assert "..." in section_text
+        assert len(section_text) <= 3000
+        assert "Reason: dangerous command" in section_text
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- cap Slack approval prompt section text at the 3000-character Block Kit limit
- reserve space for code fences and the approval reason before truncating long commands
- add regression coverage for long command approval prompts so buttons are still sent

## Test Plan
- python -m pytest tests/gateway/test_slack_approval_buttons.py -q -o 'addopts='\n- python -m py_compile gateway/platforms/slack.py