### PR TITLE
fix: ignore PR comment guard before worker runs

### DIFF
--- a/docs/plans/2026-06-02-alert-notification-routing.md
+++ b/docs/plans/2026-06-02-alert-notification-routing.md
@@ -1,0 +1,82 @@
+# Alert notification routing decision
+
+Task: t_2773e8e2
+Parent decision: t_46a89f4e confirmed the alert classes and deferred delivery mechanics.
+Scope: Hermes Maintenance notification behavior across Matrix, Kanban, GitHub, watchdogs, and general project operation.
+
+## Canonical alert classes
+
+- SILENT/INFO: routine, log-only, or FYI outcomes.
+- ATTENTION: awareness or degraded-risk states where automation can continue.
+- BLOCKED_HUMAN: concrete active work that cannot proceed without human action.
+- INCIDENT: high-severity system integrity, routing, data-loss, security, or blast-radius failures.
+
+`blocked` remains human-only. Non-human waits, retries, CI, worker availability, dependency waits, schedules, and active automated repair stay `waiting`/ATTENTION unless they cross an INCIDENT threshold.
+
+## Routing decision
+
+| Alert class | Matrix/user chat | Kanban | GitHub | Watchdogs/cron | Durable audit |
+| --- | --- | --- | --- | --- | --- |
+| SILENT/INFO | No proactive user ping. Allow delivery only when user is already subscribed to that task/thread or requested a summary. | Record as event/comment/run metadata when tied to a task. Do not change live status. | No issue/PR/comment unless already part of a PR/test run. | Silent stdout for no-agent watchdogs unless a user explicitly configured heartbeat delivery. | Logs plus Kanban run/event metadata when task-scoped. |
+| ATTENTION | One low-urgency notice to the active project room or subscribed task room when the condition affects project awareness but automation can continue. No DM escalation by default. | Use `waiting` for non-human waits or add a comment for degraded-but-continuing states. Never mark `blocked`. | PR/issue comment only if the attention item changes review/merge expectations. | Emit a bounded notification with rate limit and stable dedupe key. | Kanban comment/event with class=ATTENTION, reason, source, dedupe key, and next automated action. |
+| BLOCKED_HUMAN | Direct user-visible ping in the relevant room/channel, including the exact human decision/action needed. If a dedicated profile room exists and is validated, use it; otherwise use the subscribed origin/home route. | `kanban_block(reason=...)` with a concise human-action reason. Add a comment first when context is longer than one sentence. | Create/comment only if the blocker is GitHub-native, e.g. PR review required, missing issue decision, or merge/release approval. | Watchdogs should not create BLOCKED_HUMAN unless a human action is the only resolution. | Block event, comment thread context, and any linked GitHub URL/decision handle. |
+| INCIDENT | Immediate user-visible ping to the most reliable configured home route plus the responsible project room when available. Use short, high-signal text. | Create or update an incident card if one does not already exist for the dedupe key; keep affected work `waiting` unless a human action is required. | Open/comment an issue only for repo-affecting incidents or persistent reproducible bugs. | Incident watchdogs may notify on first detection, then throttle repeats while appending audit records. | Incident card/comment, source logs/handles, first-seen/last-seen timestamps, mitigation status, and closure note. |
+
+## Dedupe and throttle policy
+
+1. Every proactive alert must carry a stable dedupe key: `class:source:scope:subject`.
+   - Examples: `INCIDENT:gateway:matrix:profile-room-isolation`, `BLOCKED_HUMAN:kanban:t_abc123:review-required`, `ATTENTION:github:pr-19:ci-wait`.
+2. SILENT/INFO is never proactive, so no throttle is needed beyond ordinary logs.
+3. ATTENTION sends at most once per dedupe key per 6 hours unless the summary changes materially.
+4. BLOCKED_HUMAN sends when the card first blocks and again only after an unblock/reblock cycle or changed human-action request.
+5. INCIDENT sends immediately on first detection, then at most once per hour per dedupe key while still active, with a required closure/mitigation audit note when resolved.
+6. Kanban notification cursors remain the dedupe mechanism for task terminal events; subscriptions should survive retry-loop events until task finality (`done`/archived) so repeated real cycles still reach the user.
+
+## Escalation policy
+
+- SILENT/INFO never escalates.
+- ATTENTION escalates to INCIDENT if it threatens data loss, routing integrity, security, project-wide dispatch, or repeated notification failure beyond the configured retry limit.
+- ATTENTION escalates to BLOCKED_HUMAN only when automation can name a specific human action that is required now.
+- BLOCKED_HUMAN may become INCIDENT only if the blocked condition reveals high-severity integrity/security/blast-radius risk; otherwise it stays a human blocker.
+- INCIDENT may create BLOCKED_HUMAN follow-up only when mitigation requires a concrete human decision.
+
+## Channel-specific behavior
+
+### Matrix
+
+- Use Matrix for project/profile-aware user-visible notices.
+- Validate room isolation and gateway activation before using a dedicated profile room for direct user contact.
+- Do not create new Matrix rooms as part of notification routing without an explicit encrypted/unencrypted choice.
+- Include the profile identity, alert class, task/PR handle if any, and the one-line requested action or next automated action.
+
+### Kanban
+
+- Kanban is the durable system of record for task-scoped alerts.
+- `blocked` is only for BLOCKED_HUMAN.
+- Non-human waits and automated repair states are `waiting` with ATTENTION comments when user awareness is useful.
+- `done` is completion history only, not a live notification/availability state.
+
+### GitHub
+
+- GitHub is not a general notification sink.
+- Use GitHub comments/issues for repository-native review, CI, bug, release, and PR state.
+- Do not duplicate Matrix/Kanban alerts into GitHub unless the GitHub artifact is where the user or reviewer must act.
+
+### Watchdogs and cron
+
+- Default watchdog behavior stays quiet when healthy and emits only when a threshold class is reached.
+- Script-only watchdogs should produce empty stdout for SILENT/INFO, bounded prose for ATTENTION/INCIDENT, and explicit human-action text for BLOCKED_HUMAN.
+- Watchdogs must include dedupe keys in their durable state or output metadata so the gateway/Kanban layer can suppress repeat noise.
+
+### General project operation
+
+- Routine project summaries are pull-based or scheduled digest material, not immediate pings.
+- Active profile status lines stay canonical: `Self status` and `Lineage status` with working/waiting/blocked/dormant.
+- Use BLOCKED only for human action blockers in status lines and Kanban states.
+
+## Implementation implications for the next phase
+
+- Add a small alert-routing helper or policy module rather than scattering class-specific routing in gateway, Kanban, GitHub, and watchdog code.
+- Expose fields for `alert_class`, `dedupe_key`, `source`, `scope`, `subject`, `human_action`, and `audit_ref` in task comments/events or notification payloads where practical.
+- Keep existing Kanban notifier behavior that advances cursors for dedupe and unsubscribes only on true finality.
+- Add tests for: non-human waits not producing `blocked`, repeat BLOCKED_HUMAN after unblock/reblock, ATTENTION throttle, INCIDENT repeat throttle, and GitHub-not-a-default-sink behavior.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1804,9 +1804,13 @@ def _cmd_comment(args: argparse.Namespace) -> int:
             suffix = f"\n\n[trimmed to {args.max_len} chars by --max-len]"
             body = body[: max(0, args.max_len - len(suffix))].rstrip() + suffix
     author = args.author or _profile_author()
+    warning = None
     with kb.connect() as conn:
         kb.add_comment(conn, args.task_id, author, body)
+        warning = kb.blocked_comment_action_warning(conn, args.task_id, body)
     print(f"Comment added to {args.task_id}")
+    if warning:
+        print(f"WARNING: {warning}", file=sys.stderr)
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4492,8 +4492,10 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds) after at least one prior
+        worker run exists for the task.  A prior worker already opened a PR;
+        re-spawning risks a duplicate PR on the same task. Fresh tasks with
+        no runs are not guarded by comment PR URLs alone.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -4524,6 +4526,15 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         return "recent_success"
 
     # 3. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    # Fresh tasks with no worker run can legitimately mention related PRs in
+    # coordinator/reporting comments; do not let those comments suppress the
+    # first worker spawn.
+    if not conn.execute(
+        "SELECT id FROM task_runs WHERE task_id = ? LIMIT 1",
+        (task_id,),
+    ).fetchone():
+        return None
+
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1805,16 +1805,27 @@ def add_comment(
         raise ValueError("comment author is required")
     now = int(time.time())
     with write_txn(conn):
-        if not conn.execute(
-            "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
-        ).fetchone():
+        task_row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if not task_row:
             raise ValueError(f"unknown task {task_id}")
+        warning = None
+        if task_row["status"] == "blocked" and _BLOCKED_COMMENT_ACTION_RE.search(body):
+            warning = BLOCKED_COMMENT_ACTION_WARNING
         cur = conn.execute(
             "INSERT INTO task_comments (task_id, author, body, created_at) "
             "VALUES (?, ?, ?, ?)",
             (task_id, author.strip(), body.strip(), now),
         )
         _append_event(conn, task_id, "commented", {"author": author, "len": len(body)})
+        if warning:
+            _append_event(
+                conn,
+                task_id,
+                "blocked_comment_action_warning",
+                {"warning": warning},
+            )
         return int(cur.lastrowid or 0)
 
 
@@ -2558,6 +2569,41 @@ def _verify_created_cards(
 # ``_new_task_id`` below. Kept permissive on length for forward compat:
 # accept 8+ hex chars after the ``t_`` prefix.
 _TASK_ID_PROSE_RE = re.compile(r"\bt_[a-f0-9]{8,}\b")
+
+
+_BLOCKED_COMMENT_ACTION_RE = re.compile(
+    r"\b("
+    r"ask|call|contact|dm|email|message|notify|ping|reach\s+out|send|tell|"
+    r"please|must|should|need(?:s)?\s+to|follow\s+up"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+BLOCKED_COMMENT_ACTION_WARNING = (
+    "Comment recorded only: this task is blocked, so no worker will be "
+    "spawned or woken by this comment. To make an assignee act, send the "
+    "message yourself, create a new assigned contact task, or explicitly "
+    "unblock/re-dispatch the blocked task with the instruction."
+)
+
+
+def blocked_comment_action_warning(
+    conn: sqlite3.Connection, task_id: str, body: str
+) -> Optional[str]:
+    """Return deterministic guidance for action-looking comments on blocked tasks.
+
+    Comments are durable context, not executable dispatch requests. A comment
+    added after a task has blocked does not wake the assignee; only a new ready
+    task or an explicit unblock/re-dispatch enters the dispatcher queue. Keep
+    this helper small and heuristic: it is a safety warning, not a policy gate.
+    """
+    if not body or not _BLOCKED_COMMENT_ACTION_RE.search(body):
+        return None
+    row = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    if row and row["status"] == "blocked":
+        return BLOCKED_COMMENT_ACTION_WARNING
+    return None
 
 
 def _scan_prose_for_phantom_ids(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -95,10 +95,38 @@ _log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
+LIVE_STATUSES = {"working", "waiting", "blocked", "dormant"}
+LIVE_TO_STORAGE_STATUS = {
+    # Canonical live/user statuses are a presentation/API boundary during the
+    # migration.  They must never be persisted verbatim in ``tasks.status``
+    # while the dispatcher still coordinates on legacy workflow statuses.
+    "working": "ready",
+    "waiting": "todo",
+    "blocked": "blocked",
+    "dormant": "triage",
+}
+_LEAKED_ACTIVE_STORAGE_STATUSES = {"running", "ready", "blocked", "working"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
+
+
+def storage_status_for_request(status: str | None) -> str:
+    """Return a dispatcher-compatible storage status for a user/API status.
+
+    Dashboard/API clients may speak canonical live statuses during the Kanban
+    simplification migration.  Convert those to the internal workflow alias
+    before any direct ``tasks.status`` write so canonical values such as
+    ``working`` cannot corrupt the storage column and strand running workers.
+    Legacy storage statuses pass through unchanged for compatibility.
+    """
+    normalized = str(status or "").strip().lower()
+    if normalized in VALID_STATUSES:
+        return normalized
+    if normalized in LIVE_TO_STORAGE_STATUS:
+        return LIVE_TO_STORAGE_STATUS[normalized]
+    raise ValueError(f"unknown status: {status}")
 
 # A running task's claim is valid for 15 minutes by default; after that the
 # next dispatcher tick reclaims it. Workers that outlive this window should
@@ -2425,7 +2453,7 @@ def reclaim_task(
         cur = conn.execute(
             "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
             "claim_expires = NULL, worker_pid = NULL "
-            "WHERE id = ? AND status IN ('running', 'ready', 'blocked') "
+            "WHERE id = ? AND status IN ('running', 'ready', 'blocked', 'working') "
             "AND claim_lock IS ?",
             (task_id, prev_lock),
         )
@@ -2736,7 +2764,7 @@ def complete_task(
                        claim_expires= NULL,
                        worker_pid   = NULL
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ('running', 'ready', 'blocked', 'working')
                 """,
                 (result, now, task_id),
             )
@@ -2751,7 +2779,7 @@ def complete_task(
                        claim_expires= NULL,
                        worker_pid   = NULL
                  WHERE id = ?
-                   AND status IN ('running', 'ready', 'blocked')
+                   AND status IN ('running', 'ready', 'blocked', 'working')
                    AND current_run_id = ?
                 """,
                 (result, now, task_id, int(expected_run_id)),
@@ -2985,7 +3013,7 @@ def block_task(
                        claim_expires= NULL,
                        worker_pid   = NULL
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
+                   AND status IN ('running', 'ready', 'working')
                 """,
                 (task_id,),
             )
@@ -2998,7 +3026,7 @@ def block_task(
                        claim_expires= NULL,
                        worker_pid   = NULL
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
+                   AND status IN ('running', 'ready', 'working')
                    AND current_run_id = ?
                 """,
                 (task_id, int(expected_run_id)),
@@ -4375,7 +4403,7 @@ def _record_task_failure(
                     "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
                     "consecutive_failures = ?, last_failure_error = ? "
-                    "WHERE id = ? AND status IN ('running', 'ready')",
+                    "WHERE id = ? AND status IN ('running', 'ready', 'working')",
                     (failures, error[:500], task_id),
                 )
             else:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -124,6 +124,156 @@ def _conn(board: Optional[str] = None):
     return kanban_db.connect(board=board)
 
 
+def _append_assignment_trigger_event(
+    conn: sqlite3.Connection,
+    task_id: str,
+    kind: str,
+    payload: Optional[dict[str, Any]] = None,
+) -> None:
+    """Append a dashboard assignment-trigger audit event.
+
+    Dashboard assignment is an operator action, so make both positive and
+    skipped trigger decisions visible in the drawer/tail before the dispatcher
+    either claims the task or intentionally ignores it.
+    """
+    with kanban_db.write_txn(conn):
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (
+                task_id,
+                kind,
+                json.dumps(payload) if payload is not None else None,
+                int(time.time()),
+            ),
+        )
+
+
+def _profile_is_spawnable(profile: Optional[str]) -> bool:
+    """True only for real Hermes profiles the dispatcher may spawn.
+
+    Fails closed so dashboard-created work does not accidentally try to start
+    PA/master/control-plane lane names that are pulled manually rather than via
+    ``hermes -p <profile>`` workers.
+    """
+    if not profile:
+        return False
+    try:
+        from hermes_cli.profiles import profile_exists
+    except Exception:
+        return False
+    try:
+        return bool(profile_exists(profile))
+    except Exception:
+        return False
+
+
+def _dispatch_kwargs_from_config() -> dict[str, Any]:
+    """Mirror the gateway embedded-dispatcher config for opportunistic ticks."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception:
+        cfg = {}
+    kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+    kwargs: dict[str, Any] = {}
+    if kanban_cfg.get("max_spawn") is not None:
+        kwargs["max_spawn"] = kanban_cfg.get("max_spawn")
+    raw_max_in_progress = kanban_cfg.get("max_in_progress")
+    if raw_max_in_progress is not None:
+        try:
+            max_in_progress = int(raw_max_in_progress)
+        except (TypeError, ValueError):
+            max_in_progress = None
+        if max_in_progress and max_in_progress > 0:
+            kwargs["max_in_progress"] = max_in_progress
+    raw_failure_limit = kanban_cfg.get("failure_limit")
+    if raw_failure_limit is not None:
+        try:
+            failure_limit = int(raw_failure_limit)
+        except (TypeError, ValueError):
+            failure_limit = None
+        if failure_limit and failure_limit > 0:
+            kwargs["failure_limit"] = failure_limit
+    raw_stale_timeout = kanban_cfg.get("dispatch_stale_timeout_seconds")
+    if raw_stale_timeout is not None:
+        try:
+            kwargs["stale_timeout_seconds"] = int(raw_stale_timeout or 0)
+        except (TypeError, ValueError):
+            pass
+    return kwargs
+
+
+def _trigger_assignment_dispatch(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    board: Optional[str],
+    source: str,
+) -> Optional[dict[str, Any]]:
+    """Run a same-process dispatcher tick for a newly assigned task.
+
+    The gateway embedded dispatcher still performs periodic fleet ticks, but
+    dashboard create/reassign should not rely on a future 60-second poll to
+    wake a project profile. This helper validates that the task is a ready or
+    review task assigned to a real Hermes profile, records a visible trigger
+    event, and then invokes the same ``kanban_db.dispatch_once`` code path the
+    gateway uses. The dispatcher's own profile-existence guard remains the
+    final safety net.
+    """
+    task = kanban_db.get_task(conn, task_id)
+    if task is None:
+        return None
+    payload_base = {"source": source, "assignee": task.assignee, "status": task.status}
+    if task.status not in {"ready", "review"}:
+        return None
+    if not task.assignee:
+        return None
+    if not _profile_is_spawnable(task.assignee):
+        _append_assignment_trigger_event(
+            conn,
+            task_id,
+            "assignment_dispatch_skipped",
+            {**payload_base, "reason": "nonspawnable_assignee"},
+        )
+        return {"ok": False, "reason": "nonspawnable_assignee"}
+
+    _append_assignment_trigger_event(
+        conn,
+        task_id,
+        "assignment_dispatch_requested",
+        payload_base,
+    )
+    try:
+        result = kanban_db.dispatch_once(
+            conn,
+            board=board,
+            **_dispatch_kwargs_from_config(),
+        )
+    except Exception as exc:
+        log.warning("dashboard assignment dispatch failed for %s: %s", task_id, exc)
+        _append_assignment_trigger_event(
+            conn,
+            task_id,
+            "assignment_dispatch_failed",
+            {**payload_base, "error": str(exc)},
+        )
+        return {"ok": False, "reason": "dispatch_failed", "error": str(exc)}
+
+    spawned = [
+        {"task_id": tid, "assignee": who, "workspace": workspace}
+        for tid, who, workspace in getattr(result, "spawned", [])
+    ]
+    return {
+        "ok": True,
+        "spawned": spawned,
+        "spawned_task_ids": [row["task_id"] for row in spawned],
+        "promoted": getattr(result, "promoted", 0),
+        "skipped_nonspawnable": list(getattr(result, "skipped_nonspawnable", [])),
+        "skipped_unassigned": list(getattr(result, "skipped_unassigned", [])),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Serialization helpers
 # ---------------------------------------------------------------------------
@@ -586,8 +736,16 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             max_runtime_seconds=payload.max_runtime_seconds,
             skills=payload.skills,
         )
+        assignment_trigger = _trigger_assignment_dispatch(
+            conn,
+            task_id,
+            board=board,
+            source="dashboard_create",
+        )
         task = kanban_db.get_task(conn, task_id)
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}
+        if assignment_trigger is not None:
+            body["assignment_trigger"] = assignment_trigger
         # Surface a dispatcher-presence warning so the UI can show a
         # banner when a `ready` task would otherwise sit idle because no
         # gateway is running (or dispatch_in_gateway=false). Only emit
@@ -636,6 +794,8 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
         task = kanban_db.get_task(conn, task_id)
         if task is None:
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
+
+        assignment_trigger: Optional[dict[str, Any]] = None
 
         # --- assignee ----------------------------------------------------
         if payload.assignee is not None:
@@ -741,8 +901,21 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     (task_id, int(time.time())),
                 )
 
+        assignment_changed = payload.assignee is not None
+        ready_requested = payload.status in {"ready", "review"}
+        if assignment_changed or ready_requested:
+            assignment_trigger = _trigger_assignment_dispatch(
+                conn,
+                task_id,
+                board=board,
+                source="dashboard_update",
+            )
+
         updated = kanban_db.get_task(conn, task_id)
-        return {"task": _task_dict(updated) if updated else None}
+        body: dict[str, Any] = {"task": _task_dict(updated) if updated else None}
+        if assignment_trigger is not None:
+            body["assignment_trigger"] = assignment_trigger
+        return body
     finally:
         conn.close()
 
@@ -1439,7 +1612,16 @@ def reassign_task_endpoint(
                     "running (pass reclaim_first=true to release the claim first)"
                 ),
             )
-        return {"ok": True, "task_id": task_id, "assignee": payload.profile or None}
+        assignment_trigger = _trigger_assignment_dispatch(
+            conn,
+            task_id,
+            board=board,
+            source="dashboard_reassign",
+        )
+        body: dict[str, Any] = {"ok": True, "task_id": task_id, "assignee": payload.profile or None}
+        if assignment_trigger is not None:
+            body["assignment_trigger"] = assignment_trigger
+        return body
     finally:
         conn.close()
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -810,7 +810,11 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
 
         # --- status -------------------------------------------------------
         if payload.status is not None:
-            s = payload.status
+            requested_status = payload.status
+            try:
+                s = kanban_db.storage_status_for_request(requested_status)
+            except ValueError:
+                raise HTTPException(status_code=400, detail=f"unknown status: {requested_status}")
             ok = True
             if s == "done":
                 ok = kanban_db.complete_task(
@@ -841,7 +845,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             elif s in ("todo", "triage", "scheduled"):
                 ok = _set_status_direct(conn, task_id, s)
             else:
-                raise HTTPException(status_code=400, detail=f"unknown status: {s}")
+                raise HTTPException(status_code=400, detail=f"unknown status: {requested_status}")
             if not ok:
                 # For ``ready``, name the blocking parent(s) so the dashboard
                 # can render an actionable toast instead of a silent no-op.
@@ -967,12 +971,16 @@ def _set_status_direct(
     structured complete/block/unblock/archive verbs (e.g. todo<->ready,
     running<->ready). Appends a ``status`` event row for the live feed.
 
+    Canonical live-status requests are normalized before storage writes so the
+    dashboard cannot persist ``working|waiting|dormant`` into ``tasks.status``.
+
     When this transitions OFF ``running`` to anything other than the
     terminal verbs above (which own their own run closing), we close the
     active run with outcome='reclaimed' so attempt history isn't
     orphaned. ``running -> ready`` via drag-drop is the common case
     (user yanking a stuck worker back to the queue).
     """
+    new_status = kanban_db.storage_status_for_request(new_status)
     with kanban_db.write_txn(conn):
         # Snapshot current state so we know whether to close a run.
         prev = conn.execute(
@@ -1167,7 +1175,13 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                     if not kanban_db.archive_task(conn, tid):
                         entry.update(ok=False, error="archive refused")
                 if payload.status is not None and not payload.archive:
-                    s = payload.status
+                    requested_status = payload.status
+                    try:
+                        s = kanban_db.storage_status_for_request(requested_status)
+                    except ValueError:
+                        entry.update(ok=False, error=f"unknown status {requested_status!r}")
+                        results.append(entry)
+                        continue
                     if s == "done":
                         ok = kanban_db.complete_task(
                             conn, tid,
@@ -1198,7 +1212,7 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                     elif s in {"todo", "triage"}:
                         ok = _set_status_direct(conn, tid, s)
                     else:
-                        entry.update(ok=False, error=f"unknown status {s!r}")
+                        entry.update(ok=False, error=f"unknown status {requested_status!r}")
                         results.append(entry)
                         continue
                     if not ok:

--- a/skills/devops/kanban-orchestrator/SKILL.md
+++ b/skills/devops/kanban-orchestrator/SKILL.md
@@ -51,6 +51,7 @@ Your job description says "route, don't execute." The rules that enforce that:
 - **Split multi-lane requests before creating cards.** A user prompt can contain several independent workstreams. Extract those lanes first, then create one card per lane instead of bundling unrelated work into a single implementer card.
 - **Run independent lanes in parallel.** If two cards do not need each other's output, leave them unlinked so the dispatcher can fan them out. Link only true data dependencies.
 - **Never create dependent work as independent ready cards.** If a card must wait for another card, pass `parents=[...]` in the original `kanban_create` call. Do not create it first and link it later, and do not rely on prose like "wait for T1" inside the body.
+- **A comment on a blocked task is not a dispatch request.** If a blocked worker must contact Yunuen or perform any other action, you must either send the message yourself, create a new assigned contact/action task, or explicitly unblock/re-dispatch the blocked task with the exact instruction. A plain comment is only recorded context and does not wake the worker; do not auto-unblock human blockers just to deliver a message.
 - **If no specialist fits the available profiles, ask the user which profile to create or which existing profile to use.** Do not invent profile names; the dispatcher will silently drop unknown assignees.
 - **Decompose, route, and summarize — that's the whole job.**
 

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -148,6 +148,21 @@ def test_run_slash_comment_max_len_trims_long_body(kanban_home):
     assert "x" * 30 not in show
 
 
+def test_run_slash_comment_to_blocked_action_warns(kanban_home):
+    out = kc.run_slash("create 'blocked contact' --assignee alice")
+    import re
+    m = re.search(r"(t_[a-f0-9]+)", out)
+    assert m
+    tid = m.group(1)
+    kc.run_slash(f"claim {tid}")
+    kc.run_slash(f"block {tid} 'need approval'")
+
+    out = kc.run_slash(f"comment {tid} 'please contact Yunuen directly'")
+    assert "Comment added" in out
+    assert "WARNING:" in out
+    assert "no worker will be spawned or woken" in out
+
+
 def test_run_slash_block_unblock_cycle(kanban_home):
     out = kc.run_slash("create 'x' --assignee alice")
     import re

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1230,16 +1230,34 @@ def test_respawn_guard_stale_success_not_guarded(kanban_home):
     assert reason is None
 
 
-def test_respawn_guard_active_pr_in_comment(kanban_home):
-    """A GitHub PR URL in a recent comment triggers active_pr."""
+def test_respawn_guard_active_pr_in_comment_after_worker_run(kanban_home):
+    """A GitHub PR URL in a recent comment triggers active_pr after a worker run."""
     with kb.connect() as conn:
         t = kb.create_task(conn, title="has-pr", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'blocked', 'blocked', ?, ?)",
+            (t, now - 300, now - 60),
+        )
         kb.add_comment(
             conn, t, "worker",
             "PR created: https://github.com/totemx-AI/subsidysmart/pull/42",
         )
         reason = kb.check_respawn_guard(conn, t)
     assert reason == "active_pr"
+
+
+def test_respawn_guard_pr_comment_without_worker_run_not_guarded(kanban_home):
+    """A PR URL alone must not block fresh coordinator/readiness tasks."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="readiness-report", assignee="alice")
+        kb.add_comment(
+            conn, t, "coordinator",
+            "Related implementation PR: https://github.com/acme/project/pull/42",
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
 
 
 def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
@@ -1339,6 +1357,12 @@ def test_dispatch_respawn_guard_skips_active_pr(
 
     with kb.connect() as conn:
         t = kb.create_task(conn, title="has-pr", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'blocked', 'blocked', ?, ?)",
+            (t, now - 300, now - 60),
+        )
         kb.add_comment(
             conn, t, "worker",
             "Opened https://github.com/totemx-AI/subsidysmart/pull/99",
@@ -1350,6 +1374,28 @@ def test_dispatch_respawn_guard_skips_active_pr(
     assert t not in res.auto_blocked
     with kb.connect() as conn:
         assert kb.get_task(conn, t).status == "ready"
+
+
+def test_dispatch_respawn_guard_allows_pr_url_comment_without_worker_run(
+    kanban_home, all_assignees_spawnable
+):
+    """dispatch_once spawns fresh tasks even when comments mention PR URLs."""
+    spawned_ids = []
+
+    def fake_spawn(task, workspace):
+        spawned_ids.append(task.id)
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="readiness-report", assignee="alice")
+        kb.add_comment(
+            conn, t, "coordinator",
+            "Related PR for context: https://github.com/acme/project/pull/42",
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert t in spawned_ids
+    assert not res.respawn_guarded
+    assert t not in res.auto_blocked
 
 
 def test_dispatch_respawn_guard_dry_run_no_auto_block(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -650,6 +650,57 @@ def test_complete_records_result(kanban_home):
     assert task.completed_at is not None
 
 
+def test_complete_repairs_leaked_working_storage_status(kanban_home):
+    """Canonical live ``working`` must not strand an otherwise active run."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        claimed = kb.claim_task(conn, t, claimer="host:worker")
+        assert claimed is not None
+        active = kb.get_task(conn, t)
+        assert active is not None
+        run_id = active.current_run_id
+        conn.execute("UPDATE tasks SET status = 'working' WHERE id = ?", (t,))
+        conn.commit()
+
+        assert kb.complete_task(
+            conn, t, result="done", expected_run_id=run_id,
+        )
+        task = kb.get_task(conn, t)
+        run = kb.list_runs(conn, t)[-1]
+
+    assert task.status == "done"
+    assert run.outcome == "completed"
+
+
+def test_storage_status_for_request_maps_live_aliases_without_persisting_them(kanban_home):
+    assert kb.storage_status_for_request("working") == "ready"
+    assert kb.storage_status_for_request("waiting") == "todo"
+    assert kb.storage_status_for_request("dormant") == "triage"
+    assert kb.storage_status_for_request("blocked") == "blocked"
+    assert kb.storage_status_for_request("ready") == "ready"
+    with pytest.raises(ValueError, match="unknown status"):
+        kb.storage_status_for_request("banana")
+
+
+def test_block_repairs_leaked_working_storage_status(kanban_home):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        claimed = kb.claim_task(conn, t, claimer="host:worker")
+        assert claimed is not None
+        active = kb.get_task(conn, t)
+        assert active is not None
+        run_id = active.current_run_id
+        conn.execute("UPDATE tasks SET status = 'working' WHERE id = ?", (t,))
+        conn.commit()
+
+        assert kb.block_task(conn, t, reason="need human", expected_run_id=run_id)
+        task = kb.get_task(conn, t)
+        run = kb.list_runs(conn, t)[-1]
+
+    assert task.status == "blocked"
+    assert run.outcome == "blocked"
+
+
 def test_block_then_unblock(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="a")

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -114,6 +114,153 @@ def test_create_task_appears_on_board(client):
     assert "researcher" in data["assignees"]
 
 
+def test_dashboard_create_assigned_task_triggers_dispatch(client, monkeypatch):
+    """Dashboard-created ready work should wake a real project profile now.
+
+    Regression: dashboard assignment used to create only a ``created`` event;
+    the assignee waited for a future/manual dispatcher path with no visible
+    trigger evidence.
+    """
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: name == "worker")
+
+    calls = []
+
+    def _fake_dispatch(conn, **kwargs):
+        calls.append(kwargs)
+        row = conn.execute(
+            "SELECT id, assignee FROM tasks WHERE status = 'ready'"
+        ).fetchone()
+        assert row is not None
+        return kb.DispatchResult(spawned=[(row["id"], row["assignee"], "/tmp/ws")])
+
+    monkeypatch.setattr(kb, "dispatch_once", _fake_dispatch)
+
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "dashboard work", "assignee": "worker"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    task_id = data["task"]["id"]
+    assert data["assignment_trigger"]["ok"] is True
+    assert data["assignment_trigger"]["spawned_task_ids"] == [task_id]
+    assert calls and calls[0]["board"] is None
+
+    detail = client.get(f"/api/plugins/kanban/tasks/{task_id}").json()
+    events = detail["events"]
+    trigger = [e for e in events if e["kind"] == "assignment_dispatch_requested"]
+    assert trigger
+    assert trigger[-1]["payload"] == {
+        "source": "dashboard_create",
+        "assignee": "worker",
+        "status": "ready",
+    }
+
+
+def test_dashboard_update_assignee_triggers_dispatch(client, monkeypatch):
+    """Generic dashboard PATCH assignment should return trigger metadata too."""
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: name == "worker")
+
+    calls = []
+
+    def _fake_dispatch(conn, **kwargs):
+        calls.append(kwargs)
+        row = conn.execute(
+            "SELECT id, assignee FROM tasks WHERE status = 'ready'"
+        ).fetchone()
+        assert row is not None
+        return kb.DispatchResult(spawned=[(row["id"], row["assignee"], "/tmp/ws")])
+
+    monkeypatch.setattr(kb, "dispatch_once", _fake_dispatch)
+
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "patch assigned work"},
+    ).json()["task"]
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{task['id']}",
+        json={"assignee": "worker"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["assignment_trigger"]["ok"] is True
+    assert data["assignment_trigger"]["spawned_task_ids"] == [task["id"]]
+    assert calls
+
+    detail = client.get(f"/api/plugins/kanban/tasks/{task['id']}").json()
+    trigger = [e for e in detail["events"] if e["kind"] == "assignment_dispatch_requested"]
+    assert trigger[-1]["payload"]["source"] == "dashboard_update"
+
+
+def test_dashboard_reassign_triggers_dispatch(client, monkeypatch):
+    """Drawer reassign to a real profile should immediately poke dispatch."""
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: name == "worker")
+
+    spawned = []
+
+    def _fake_dispatch(conn, **kwargs):
+        row = conn.execute(
+            "SELECT id, assignee FROM tasks WHERE status = 'ready'"
+        ).fetchone()
+        assert row is not None
+        spawned.append(row["id"])
+        return kb.DispatchResult(spawned=[(row["id"], row["assignee"], "/tmp/ws")])
+
+    monkeypatch.setattr(kb, "dispatch_once", _fake_dispatch)
+
+    task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "unassigned work"},
+    ).json()["task"]
+
+    r = client.post(
+        f"/api/plugins/kanban/tasks/{task['id']}/reassign",
+        json={"profile": "worker"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["assignment_trigger"]["ok"] is True
+    assert data["assignment_trigger"]["spawned_task_ids"] == [task["id"]]
+    assert spawned == [task["id"]]
+
+    detail = client.get(f"/api/plugins/kanban/tasks/{task['id']}").json()
+    kinds = [e["kind"] for e in detail["events"]]
+    assert "assigned" in kinds
+    assert "assignment_dispatch_requested" in kinds
+
+
+def test_dashboard_assignment_does_not_dispatch_nonspawnable_assignee(client, monkeypatch):
+    """Control-plane/non-project assignees are audited but not spawned."""
+    from hermes_cli import profiles
+
+    monkeypatch.setattr(profiles, "profile_exists", lambda name: False)
+
+    def _fake_dispatch(conn, **kwargs):  # pragma: no cover - should not run
+        raise AssertionError("nonspawnable assignee must not dispatch")
+
+    monkeypatch.setattr(kb, "dispatch_once", _fake_dispatch)
+
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "manual lane work", "assignee": "pa-master"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["assignment_trigger"] == {"ok": False, "reason": "nonspawnable_assignee"}
+
+    detail = client.get(f"/api/plugins/kanban/tasks/{data['task']['id']}").json()
+    skipped = [e for e in detail["events"] if e["kind"] == "assignment_dispatch_skipped"]
+    assert skipped
+    assert skipped[-1]["payload"]["reason"] == "nonspawnable_assignee"
+
+
 def test_scheduled_tasks_have_their_own_column_not_todo(client):
     """Scheduled/time-delay tasks must not be silently bucketed into todo."""
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -713,6 +713,33 @@ def test_comment_rejects_empty_body(worker_env):
     assert json.loads(out).get("error")
 
 
+def test_comment_on_blocked_task_with_action_verb_warns(worker_env):
+    """Action-looking comments on blocked tasks are context, not dispatch."""
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        assert kb.block_task(conn, worker_env, reason="waiting for human approval")
+    finally:
+        conn.close()
+
+    from tools import kanban_tools as kt
+    out = kt._handle_comment({
+        "task_id": worker_env,
+        "body": "Please contact Yunuen directly from your room.",
+    })
+    payload = json.loads(out)
+    assert payload["ok"] is True
+    assert "warning" in payload
+    assert "no worker will be spawned or woken" in payload["warning"]
+
+    conn = kb.connect()
+    try:
+        events = kb.list_events(conn, worker_env)
+        assert any(e.kind == "blocked_comment_action_warning" for e in events)
+    finally:
+        conn.close()
+
+
 def test_comment_ignores_caller_supplied_author(worker_env):
     """``args["author"]`` is no longer honored — the author is always
     derived from ``HERMES_PROFILE`` so a worker can't forge a comment

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -625,7 +625,11 @@ def _handle_comment(args: dict, **kw) -> str:
     try:
         kb, conn = _connect(board=board)
         try:
-            cid = kb.add_comment(conn, tid, author=author, body=str(body))
+            text = str(body)
+            cid = kb.add_comment(conn, tid, author=author, body=text)
+            warning = kb.blocked_comment_action_warning(conn, tid, text)
+            if warning:
+                return _ok(task_id=tid, comment_id=cid, warning=warning)
             return _ok(task_id=tid, comment_id=cid)
         finally:
             conn.close()

--- a/website/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator.md
@@ -69,6 +69,7 @@ Your job description says "route, don't execute." The rules that enforce that:
 - **Split multi-lane requests before creating cards.** A user prompt can contain several independent workstreams. Extract those lanes first, then create one card per lane instead of bundling unrelated work into a single implementer card.
 - **Run independent lanes in parallel.** If two cards do not need each other's output, leave them unlinked so the dispatcher can fan them out. Link only true data dependencies.
 - **Never create dependent work as independent ready cards.** If a card must wait for another card, pass `parents=[...]` in the original `kanban_create` call. Do not create it first and link it later, and do not rely on prose like "wait for T1" inside the body.
+- **A comment on a blocked task is not a dispatch request.** If a blocked worker must contact Yunuen or perform any other action, you must either send the message yourself, create a new assigned contact/action task, or explicitly unblock/re-dispatch the blocked task with the exact instruction. A plain comment is only recorded context and does not wake the worker; do not auto-unblock human blockers just to deliver a message.
 - **If no specialist fits the available profiles, ask the user which profile to create or which existing profile to use.** Do not invent profile names; the dispatcher will silently drop unknown assignees.
 - **Decompose, route, and summarize — that's the whole job.**
 


### PR DESCRIPTION
## Summary
- require an existing worker run before PR-comment respawn guard suppresses spawning
- keep PR URL comment detection from blocking first-time dispatch
- add regression coverage for first dispatch vs prior-run cases

## Test plan
- python -m pytest tests/hermes_cli/test_kanban_db.py -q -o 'addopts='

## Boundary note
This PR intentionally contains only the generic respawn-guard bugfix. The Hermes Maintenance queue/in_progress/waiting/blocked/done policy rewrite is kept downstream as a separate overlay/fork patch.