### PR TITLE
feat(tts): add native Supertonic on-device TTS provider

### DIFF
--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -57,6 +57,7 @@ _BUILTIN_NAMES = frozenset({
     "kittentts",
     "piper",
     "deepinfra",
+    "supertonic",
 })
 
 

--- a/agent/tts_registry.py
+++ b/agent/tts_registry.py
@@ -58,6 +58,7 @@ _BUILTIN_NAMES = frozenset({
     "kittentts",
     "piper",
     "deepinfra",
+    "supertonic",
 })
 
 

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -349,7 +349,8 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
     'gemini',
     'neutts',
     'kittentts',
-    'piper'
+    'piper',
+    'supertonic'
   ],
   'stt.openai.model': ['whisper-1', 'gpt-4o-mini-transcribe', 'gpt-4o-transcribe', 'gpt-transcribe'],
   'stt.mistral.model': ['voxtral-mini-latest', 'voxtral-mini-2602'],
@@ -522,6 +523,12 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     deepinfra: {
       model: 'DeepInfra TTS Model',
       voice: 'DeepInfra Voice'
+    },
+    supertonic: {
+      voice: 'Supertonic Voice',
+      lang: 'Supertonic Language',
+      speed: 'Supertonic Speed',
+      totalSteps: 'Supertonic Quality Steps'
     }
   },
   memory: {
@@ -619,6 +626,12 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
     },
     neutts: {
       device: 'Local inference device for NeuTTS.'
+    },
+    supertonic: {
+      voice: 'Built-in voice style, M1-M5 or F1-F5.',
+      lang: 'Spoken language code for Supertonic synthesis.',
+      speed: 'Speech speed from 0.7 to 2.0.',
+      totalSteps: 'Quality/speed tradeoff from 5 to 12 steps.'
     }
   },
   stt: {
@@ -737,6 +750,12 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tts.piper.voice',
       'tts.deepinfra.model',
       'tts.deepinfra.voice',
+      'tts.deepinfra.model',
+      'tts.deepinfra.voice',
+      'tts.supertonic.voice',
+      'tts.supertonic.lang',
+      'tts.supertonic.speed',
+      'tts.supertonic.total_steps',
       'stt.local.model',
       'stt.local.language',
       'stt.openai.model',

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -750,8 +750,6 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tts.piper.voice',
       'tts.deepinfra.model',
       'tts.deepinfra.voice',
-      'tts.deepinfra.model',
-      'tts.deepinfra.voice',
       'tts.supertonic.voice',
       'tts.supertonic.lang',
       'tts.supertonic.speed',

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -336,7 +336,8 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
     'gemini',
     'neutts',
     'kittentts',
-    'piper'
+    'piper',
+    'supertonic'
   ],
   'stt.openai.model': ['whisper-1', 'gpt-4o-mini-transcribe', 'gpt-4o-transcribe', 'gpt-transcribe'],
   'stt.mistral.model': ['voxtral-mini-latest', 'voxtral-mini-2602'],
@@ -509,6 +510,12 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     deepinfra: {
       model: 'DeepInfra TTS Model',
       voice: 'DeepInfra Voice'
+    },
+    supertonic: {
+      voice: 'Supertonic Voice',
+      lang: 'Supertonic Language',
+      speed: 'Supertonic Speed',
+      totalSteps: 'Supertonic Quality Steps'
     }
   },
   memory: {
@@ -606,6 +613,12 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
     },
     neutts: {
       device: 'Local inference device for NeuTTS.'
+    },
+    supertonic: {
+      voice: 'Built-in voice style, M1-M5 or F1-F5.',
+      lang: 'Spoken language code for Supertonic synthesis.',
+      speed: 'Speech speed from 0.7 to 2.0.',
+      totalSteps: 'Quality/speed tradeoff from 5 to 12 steps.'
     }
   },
   stt: {
@@ -724,6 +737,12 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tts.piper.voice',
       'tts.deepinfra.model',
       'tts.deepinfra.voice',
+      'tts.deepinfra.model',
+      'tts.deepinfra.voice',
+      'tts.supertonic.voice',
+      'tts.supertonic.lang',
+      'tts.supertonic.speed',
+      'tts.supertonic.total_steps',
       'stt.local.model',
       'stt.local.language',
       'stt.openai.model',

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -737,8 +737,6 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tts.piper.voice',
       'tts.deepinfra.model',
       'tts.deepinfra.voice',
-      'tts.deepinfra.model',
-      'tts.deepinfra.voice',
       'tts.supertonic.voice',
       'tts.supertonic.lang',
       'tts.supertonic.speed',

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -191,6 +191,7 @@ describe('settings helpers', () => {
       expect(opts).toContain('xai')
       expect(opts).toContain('edge')
       expect(opts).toContain('elevenlabs')
+      expect(opts).toContain('supertonic')
     })
 
     it('renders a dropdown for the STT provider including xAI (Grok)', () => {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -525,6 +525,12 @@ export const ja = defineLocale({
         },
         piper: {
           voice: 'Piper 音声'
+        },
+        supertonic: {
+          voice: 'Supertonic 音声',
+          lang: 'Supertonic 言語',
+          speed: 'Supertonic 速度',
+          totalSteps: 'Supertonic 品質ステップ'
         }
       },
       memory: {
@@ -605,6 +611,14 @@ export const ja = defineLocale({
       },
       voice: {
         autoTts: 'アシスタントの応答を自動で読み上げます。'
+      },
+      tts: {
+        supertonic: {
+          voice: '内蔵の音声スタイル。M1〜M5 または F1〜F5。',
+          lang: 'Supertonic 合成に使用する話し言葉のコードです。',
+          speed: '話速は 0.7 から 2.0 の範囲です。',
+          totalSteps: '品質と速度のバランスは 5〜12 ステップです。'
+        }
       },
       stt: {
         enabled: 'ローカルまたはプロバイダーによる音声文字起こしを有効にします。',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -529,6 +529,12 @@ export const ja = defineLocale({
         },
         piper: {
           voice: 'Piper 音声'
+        },
+        supertonic: {
+          voice: 'Supertonic 音声',
+          lang: 'Supertonic 言語',
+          speed: 'Supertonic 速度',
+          totalSteps: 'Supertonic 品質ステップ'
         }
       },
       memory: {
@@ -609,6 +615,14 @@ export const ja = defineLocale({
       },
       voice: {
         autoTts: 'アシスタントの応答を自動で読み上げます。'
+      },
+      tts: {
+        supertonic: {
+          voice: '内蔵の音声スタイル。M1〜M5 または F1〜F5。',
+          lang: 'Supertonic 合成に使用する話し言葉のコードです。',
+          speed: '話速は 0.7 から 2.0 の範囲です。',
+          totalSteps: '品質と速度のバランスは 5〜12 ステップです。'
+        }
       },
       stt: {
         enabled: 'ローカルまたはプロバイダーによる音声文字起こしを有効にします。',

--- a/apps/desktop/src/i18n/runtime.test.ts
+++ b/apps/desktop/src/i18n/runtime.test.ts
@@ -53,6 +53,24 @@ describe('desktop i18n runtime translator', () => {
     expect(fieldCopyForSchemaKey(zh.settings.fieldDescriptions, field)).toBe('当后端提供推理内容时予以显示。')
   })
 
+  it('keeps Supertonic field copy localized', () => {
+    const fields = [
+      'tts.supertonic.voice',
+      'tts.supertonic.lang',
+      'tts.supertonic.speed',
+      'tts.supertonic.total_steps'
+    ]
+
+    for (const locale of ['ja', 'zh', 'zh-hant'] as const) {
+      for (const field of fields) {
+        expect(fieldCopyForSchemaKey(TRANSLATIONS[locale].settings.fieldLabels, field))
+          .not.toBe(fieldCopyForSchemaKey(TRANSLATIONS.en.settings.fieldLabels, field))
+        expect(fieldCopyForSchemaKey(TRANSLATIONS[locale].settings.fieldDescriptions, field))
+          .not.toBe(fieldCopyForSchemaKey(TRANSLATIONS.en.settings.fieldDescriptions, field))
+      }
+    }
+  })
+
   it('falls back to English when the active locale cannot resolve a key', () => {
     const boot = TRANSLATIONS.ja.boot as { ready?: string }
     const originalReady = boot.ready

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -513,6 +513,12 @@ export const zhHant = defineLocale({
         },
         piper: {
           voice: 'Piper 語音'
+        },
+        supertonic: {
+          voice: 'Supertonic 語音',
+          lang: 'Supertonic 語言',
+          speed: 'Supertonic 語速',
+          totalSteps: 'Supertonic 品質步數'
         }
       },
       memory: {
@@ -592,6 +598,14 @@ export const zhHant = defineLocale({
       },
       voice: {
         autoTts: '自動朗讀助手回覆。'
+      },
+      tts: {
+        supertonic: {
+          voice: '內建語音風格，M1–M5 或 F1–F5。',
+          lang: '用於 Supertonic 合成的口語語言代碼。',
+          speed: '語速範圍為 0.7 到 2.0。',
+          totalSteps: '品質與速度的權衡範圍為 5 到 12 步。'
+        }
       },
       stt: {
         enabled: '啟用本機或提供方支援的語音轉寫。',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -601,7 +601,7 @@ export const zhHant = defineLocale({
       },
       tts: {
         supertonic: {
-          voice: '內建語音風格，M1–M5 或 F1–F5。',
+          voice: '內建語音風格，M1-M5 或 F1-F5。',
           lang: '用於 Supertonic 合成的口語語言代碼。',
           speed: '語速範圍為 0.7 到 2.0。',
           totalSteps: '品質與速度的權衡範圍為 5 到 12 步。'

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -517,6 +517,12 @@ export const zhHant = defineLocale({
         },
         piper: {
           voice: 'Piper 語音'
+        },
+        supertonic: {
+          voice: 'Supertonic 語音',
+          lang: 'Supertonic 語言',
+          speed: 'Supertonic 語速',
+          totalSteps: 'Supertonic 品質步數'
         }
       },
       memory: {
@@ -596,6 +602,14 @@ export const zhHant = defineLocale({
       },
       voice: {
         autoTts: '自動朗讀助手回覆。'
+      },
+      tts: {
+        supertonic: {
+          voice: '內建語音風格，M1–M5 或 F1–F5。',
+          lang: '用於 Supertonic 合成的口語語言代碼。',
+          speed: '語速範圍為 0.7 到 2.0。',
+          totalSteps: '品質與速度的權衡範圍為 5 到 12 步。'
+        }
       },
       stt: {
         enabled: '啟用本機或提供方支援的語音轉寫。',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -605,7 +605,7 @@ export const zhHant = defineLocale({
       },
       tts: {
         supertonic: {
-          voice: '內建語音風格，M1–M5 或 F1–F5。',
+          voice: '內建語音風格，M1-M5 或 F1-F5。',
           lang: '用於 Supertonic 合成的口語語言代碼。',
           speed: '語速範圍為 0.7 到 2.0。',
           totalSteps: '品質與速度的權衡範圍為 5 到 12 步。'

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -725,7 +725,7 @@ export const zh: Translations = {
       },
       tts: {
         supertonic: {
-          voice: '内置语音风格，M1–M5 或 F1–F5。',
+          voice: '内置语音风格，M1-M5 或 F1-F5。',
           lang: '用于 Supertonic 合成的口语语言代码。',
           speed: '语速范围为 0.7 到 2.0。',
           totalSteps: '质量与速度的权衡范围为 5 到 12 步。'

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -637,6 +637,12 @@ export const zh: Translations = {
         },
         piper: {
           voice: 'Piper 语音'
+        },
+        supertonic: {
+          voice: 'Supertonic 语音',
+          lang: 'Supertonic 语言',
+          speed: 'Supertonic 语速',
+          totalSteps: 'Supertonic 质量步数'
         }
       },
       memory: {
@@ -716,6 +722,14 @@ export const zh: Translations = {
       },
       voice: {
         autoTts: '自动朗读助手回复。'
+      },
+      tts: {
+        supertonic: {
+          voice: '内置语音风格，M1–M5 或 F1–F5。',
+          lang: '用于 Supertonic 合成的口语语言代码。',
+          speed: '语速范围为 0.7 到 2.0。',
+          totalSteps: '质量与速度的权衡范围为 5 到 12 步。'
+        }
       },
       stt: {
         enabled: '启用本地或提供方支持的语音转写。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -743,7 +743,7 @@ export const zh: Translations = {
       },
       tts: {
         supertonic: {
-          voice: '内置语音风格，M1–M5 或 F1–F5。',
+          voice: '内置语音风格，M1-M5 或 F1-F5。',
           lang: '用于 Supertonic 合成的口语语言代码。',
           speed: '语速范围为 0.7 到 2.0。',
           totalSteps: '质量与速度的权衡范围为 5 到 12 步。'

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -655,6 +655,12 @@ export const zh: Translations = {
         },
         piper: {
           voice: 'Piper 语音'
+        },
+        supertonic: {
+          voice: 'Supertonic 语音',
+          lang: 'Supertonic 语言',
+          speed: 'Supertonic 语速',
+          totalSteps: 'Supertonic 质量步数'
         }
       },
       memory: {
@@ -734,6 +740,14 @@ export const zh: Translations = {
       },
       voice: {
         autoTts: '自动朗读助手回复。'
+      },
+      tts: {
+        supertonic: {
+          voice: '内置语音风格，M1–M5 或 F1–F5。',
+          lang: '用于 Supertonic 合成的口语语言代码。',
+          speed: '语速范围为 0.7 到 2.0。',
+          totalSteps: '质量与速度的权衡范围为 5 到 12 步。'
+        }
       },
       stt: {
         enabled: '启用本地或提供方支持的语音转写。',

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1424,7 +1424,7 @@ DEFAULT_CONFIG = {
     # Gemini 32000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
     "tts": {
         # Set explicitly to pin a backend:
-        # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local)
+        # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local) | "supertonic" (local)
         "provider": "edge",
         "edge": {
             "voice": "en-US-AriaNeural",
@@ -1498,6 +1498,15 @@ DEFAULT_CONFIG = {
             "model": "",  # empty = first tts-tagged model from the live catalog
             "voice": "default",
             # "base_url": "",  # override DEEPINFRA_BASE_URL for TTS only
+        },
+        "supertonic": {
+            "voice": "M1",          # M1-M5 (male) / F1-F5 (female)
+            "lang": "en",           # 31 languages + na neutral
+            "speed": 1.0,             # 0.7-2.0 (higher = faster)
+            "total_steps": 8,         # 5-12 (higher = better quality, slower)
+            # "voice_style_path": "",   # Path to a custom voice style (Voice Builder)
+            # "max_chunk_length": 300,  # Override internal text chunking (minimum: 10)
+            # "silence_duration": 0.0,  # Silence inserted between chunks (seconds)
         },
     },
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1494,7 +1494,7 @@ DEFAULT_CONFIG = {
     # Gemini 32000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
     "tts": {
         # Set explicitly to pin a backend:
-        # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local)
+        # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local) | "supertonic" (local)
         "provider": "edge",
         "edge": {
             "voice": "en-US-AriaNeural",
@@ -1568,6 +1568,15 @@ DEFAULT_CONFIG = {
             "model": "",  # empty = first tts-tagged model from the live catalog
             "voice": "default",
             # "base_url": "",  # override DEEPINFRA_BASE_URL for TTS only
+        },
+        "supertonic": {
+            "voice": "M1",          # M1-M5 (male) / F1-F5 (female)
+            "lang": "en",           # 31 languages + na neutral
+            "speed": 1.0,             # 0.7-2.0 (higher = faster)
+            "total_steps": 8,         # 5-12 (higher = better quality, slower)
+            # "voice_style_path": "",   # Path to a custom voice style (Voice Builder)
+            # "max_chunk_length": 300,  # Override internal text chunking (minimum: 10)
+            # "silence_duration": 0.0,  # Silence inserted between chunks (seconds)
         },
     },
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1316,7 +1316,6 @@ def _setup_tts_provider(config: dict):
     elif selected == "supertonic":
         # Check if already installed
         try:
-            import importlib.util
             already_installed = importlib.util.find_spec("supertonic") is not None
         except Exception:
             already_installed = False

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1344,15 +1344,12 @@ def _setup_tts_provider(config: dict):
                 selected = "edge"
 
         if selected == "supertonic":
+            from tools.tts_tool import SUPERTONIC_LANGUAGES, SUPERTONIC_VOICES
+
             st = dict(tts_config.get("supertonic", {}))
 
             # --- Language ---
-            # All 31 Supertonic languages (+ ``na`` neutral) for validating custom input.
-            all_langs = {
-                "en", "ko", "ja", "ar", "bg", "cs", "da", "de", "el", "es", "et", "fi",
-                "fr", "hi", "hr", "hu", "id", "it", "lt", "lv", "nl", "pl", "pt", "ro",
-                "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na",
-            }
+            all_langs = set(SUPERTONIC_LANGUAGES)
             curated = [
                 ("en", "English"), ("pl", "Polish"), ("de", "German"), ("es", "Spanish"),
                 ("fr", "French"), ("it", "Italian"), ("pt", "Portuguese"), ("uk", "Ukrainian"),
@@ -1379,7 +1376,7 @@ def _setup_tts_provider(config: dict):
                 "M1 — male", "M2 — male", "M3 — male", "M4 — male", "M5 — male",
                 "F1 — female", "F2 — female", "F3 — female", "F4 — female", "F5 — female",
             ]
-            voice_ids = ["M1", "M2", "M3", "M4", "M5", "F1", "F2", "F3", "F4", "F5"]
+            voice_ids = list(SUPERTONIC_VOICES)
             cur_voice = str(st.get("voice", "M1"))
             voice_default = voice_ids.index(cur_voice) if cur_voice in voice_ids else 0
             v_idx = prompt_choice("Select voice:", voice_choices, voice_default)
@@ -1406,7 +1403,10 @@ def _setup_tts_provider(config: dict):
                 "Very High (12 steps — best quality, slowest)",
             ]
             quality_steps = [5, 8, 10, 12]
-            cur_steps = int(st.get("total_steps", 8))
+            try:
+                cur_steps = int(st.get("total_steps", 8))
+            except (TypeError, ValueError):
+                cur_steps = 8
             quality_default = quality_steps.index(cur_steps) if cur_steps in quality_steps else 1
             q_idx = prompt_choice("Select quality:", quality_choices, quality_default)
             st["total_steps"] = quality_steps[q_idx]

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -564,6 +564,15 @@ def _print_setup_summary(config: dict, hermes_home):
             tool_status.append(("Text-to-Speech (KittenTTS local)", True, None))
         else:
             tool_status.append(("Text-to-Speech (KittenTTS — not installed)", False, "run 'hermes setup tts'"))
+    elif tts_provider == "supertonic":
+        try:
+            supertonic_ok = importlib.util.find_spec("supertonic") is not None
+        except Exception:
+            supertonic_ok = False
+        if supertonic_ok:
+            tool_status.append(("Text-to-Speech (Supertonic local)", True, None))
+        else:
+            tool_status.append(("Text-to-Speech (Supertonic - not installed)", False, "run 'hermes setup tts'"))
     else:
         tool_status.append(("Text-to-Speech (Edge TTS)", True, None))
 
@@ -1017,27 +1026,6 @@ def _install_kittentts_deps() -> bool:
     return False
 
 
-def _install_supertonic_deps() -> bool:
-    """Install Supertonic dependencies with user approval. Returns True on success."""
-    import subprocess
-    import sys
-
-    print()
-    print_info("Installing supertonic Python package (~400MB ONNX model downloaded on first use)...")
-    print()
-    try:
-        subprocess.run(
-            [sys.executable, "-m", "pip", "install", "-U", "supertonic>=1.3.1,<2", "--quiet"],
-            check=True, timeout=300,
-        )
-        print_success("supertonic installed successfully")
-        return True
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-        print_error(f"Failed to install supertonic: {e}")
-        print_info('Try manually: python -m pip install -U "supertonic>=1.3.1,<2"')
-        return False
-
-
 def _xai_oauth_logged_in_for_setup() -> bool:
     """True iff xAI Grok OAuth credentials are already stored locally.
 
@@ -1341,7 +1329,14 @@ def _setup_tts_provider(config: dict):
             print_info("The ~400MB model is downloaded on first use to ~/.cache/supertonic3/.")
             print()
             if prompt_yes_no("Install Supertonic now?", True):
-                if not _install_supertonic_deps():
+                from hermes_cli.tools_config import _run_post_setup
+
+                _run_post_setup("supertonic")
+                try:
+                    already_installed = importlib.util.find_spec("supertonic") is not None
+                except Exception:
+                    already_installed = False
+                if not already_installed:
                     print_warning("Supertonic installation incomplete. Falling back to Edge TTS.")
                     selected = "edge"
             else:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1354,7 +1354,7 @@ def _setup_tts_provider(config: dict):
                 ("fr", "French"), ("it", "Italian"), ("pt", "Portuguese"), ("uk", "Ukrainian"),
                 ("ru", "Russian"), ("ja", "Japanese"), ("ko", "Korean"),
             ]
-            lang_choices = [f"{code} — {name}" for code, name in curated]
+            lang_choices = [f"{code} - {name}" for code, name in curated]
             lang_choices.append("Other (enter ISO code)")
             cur_lang = str(st.get("lang", "en"))
             curated_codes = [c for c, _ in curated]
@@ -1372,8 +1372,8 @@ def _setup_tts_provider(config: dict):
 
             # --- Voice ---
             voice_choices = [
-                "M1 — male", "M2 — male", "M3 — male", "M4 — male", "M5 — male",
-                "F1 — female", "F2 — female", "F3 — female", "F4 — female", "F5 — female",
+                "M1 - male", "M2 - male", "M3 - male", "M4 - male", "M5 - male",
+                "F1 - female", "F2 - female", "F3 - female", "F4 - female", "F5 - female",
             ]
             voice_ids = list(SUPERTONIC_VOICES)
             cur_voice = str(st.get("voice", "M1"))
@@ -1383,7 +1383,7 @@ def _setup_tts_provider(config: dict):
 
             # --- Speed ---
             while True:
-                raw = prompt("Speed (0.7–2.0, higher = faster)", default=str(st.get("speed", 1.0)))
+                raw = prompt("Speed (0.7-2.0, higher = faster)", default=str(st.get("speed", 1.0)))
                 try:
                     speed = float(raw)
                 except (TypeError, ValueError):
@@ -1396,10 +1396,10 @@ def _setup_tts_provider(config: dict):
 
             # --- Quality (total_steps) ---
             quality_choices = [
-                "Fast (5 steps — quickest, lower quality)",
-                "Balanced (8 steps — recommended)",
-                "High (10 steps — better quality)",
-                "Very High (12 steps — best quality, slowest)",
+                "Fast (5 steps - quickest, lower quality)",
+                "Balanced (8 steps - recommended)",
+                "High (10 steps - better quality)",
+                "Very High (12 steps - best quality, slowest)",
             ]
             quality_steps = [5, 8, 10, 12]
             try:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1017,6 +1017,27 @@ def _install_kittentts_deps() -> bool:
     return False
 
 
+def _install_supertonic_deps() -> bool:
+    """Install Supertonic dependencies with user approval. Returns True on success."""
+    import subprocess
+    import sys
+
+    print()
+    print_info("Installing supertonic Python package (~400MB ONNX model downloaded on first use)...")
+    print()
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "-U", "supertonic>=1.3.1,<2", "--quiet"],
+            check=True, timeout=300,
+        )
+        print_success("supertonic installed successfully")
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        print_error(f"Failed to install supertonic: {e}")
+        print_info('Try manually: python -m pip install -U "supertonic>=1.3.1,<2"')
+        return False
+
+
 def _xai_oauth_logged_in_for_setup() -> bool:
     """True iff xAI Grok OAuth credentials are already stored locally.
 
@@ -1090,6 +1111,7 @@ def _setup_tts_provider(config: dict):
         "gemini": "Google Gemini TTS",
         "neutts": "NeuTTS",
         "kittentts": "KittenTTS",
+        "supertonic": "Supertonic",
     }
     current_label = provider_labels.get(current_provider, current_provider)
 
@@ -1114,9 +1136,10 @@ def _setup_tts_provider(config: dict):
             "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
+            "Supertonic (local on-device, fast, free, multilingual, ~400MB model)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "supertonic"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1301,6 +1324,104 @@ def _setup_tts_provider(config: dict):
             else:
                 print_info("Skipping install. Set tts.provider to 'kittentts' after installing manually.")
                 selected = "edge"
+
+    elif selected == "supertonic":
+        # Check if already installed
+        try:
+            import importlib.util
+            already_installed = importlib.util.find_spec("supertonic") is not None
+        except Exception:
+            already_installed = False
+
+        if already_installed:
+            print_success("Supertonic is already installed")
+        else:
+            print()
+            print_info("Supertonic is a local ONNX TTS (free, no API key, 31 languages, expressive).")
+            print_info("The ~400MB model is downloaded on first use to ~/.cache/supertonic3/.")
+            print()
+            if prompt_yes_no("Install Supertonic now?", True):
+                if not _install_supertonic_deps():
+                    print_warning("Supertonic installation incomplete. Falling back to Edge TTS.")
+                    selected = "edge"
+            else:
+                print_info("Skipping install. Set tts.provider to 'supertonic' after installing manually.")
+                selected = "edge"
+
+        if selected == "supertonic":
+            st = dict(tts_config.get("supertonic", {}))
+
+            # --- Language ---
+            # All 31 Supertonic languages (+ ``na`` neutral) for validating custom input.
+            all_langs = {
+                "en", "ko", "ja", "ar", "bg", "cs", "da", "de", "el", "es", "et", "fi",
+                "fr", "hi", "hr", "hu", "id", "it", "lt", "lv", "nl", "pl", "pt", "ro",
+                "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na",
+            }
+            curated = [
+                ("en", "English"), ("pl", "Polish"), ("de", "German"), ("es", "Spanish"),
+                ("fr", "French"), ("it", "Italian"), ("pt", "Portuguese"), ("uk", "Ukrainian"),
+                ("ru", "Russian"), ("ja", "Japanese"), ("ko", "Korean"),
+            ]
+            lang_choices = [f"{code} — {name}" for code, name in curated]
+            lang_choices.append("Other (enter ISO code)")
+            cur_lang = str(st.get("lang", "en"))
+            curated_codes = [c for c, _ in curated]
+            lang_default = curated_codes.index(cur_lang) if cur_lang in curated_codes else 0
+            l_idx = prompt_choice("Select language:", lang_choices, lang_default)
+            if l_idx < len(curated):
+                st["lang"] = curated[l_idx][0]
+            else:
+                while True:
+                    code = (prompt("Language ISO code (e.g. nl, sv, tr)", default=cur_lang) or "").strip().lower()
+                    if code in all_langs:
+                        st["lang"] = code
+                        break
+                    print_warning(f"'{code}' is not a supported Supertonic language. Try again.")
+
+            # --- Voice ---
+            voice_choices = [
+                "M1 — male", "M2 — male", "M3 — male", "M4 — male", "M5 — male",
+                "F1 — female", "F2 — female", "F3 — female", "F4 — female", "F5 — female",
+            ]
+            voice_ids = ["M1", "M2", "M3", "M4", "M5", "F1", "F2", "F3", "F4", "F5"]
+            cur_voice = str(st.get("voice", "M1"))
+            voice_default = voice_ids.index(cur_voice) if cur_voice in voice_ids else 0
+            v_idx = prompt_choice("Select voice:", voice_choices, voice_default)
+            st["voice"] = voice_ids[v_idx]
+
+            # --- Speed ---
+            while True:
+                raw = prompt("Speed (0.7–2.0, higher = faster)", default=str(st.get("speed", 1.0)))
+                try:
+                    speed = float(raw)
+                except (TypeError, ValueError):
+                    print_warning("Enter a number between 0.7 and 2.0.")
+                    continue
+                if 0.7 <= speed <= 2.0:
+                    st["speed"] = speed
+                    break
+                print_warning("Speed must be between 0.7 and 2.0.")
+
+            # --- Quality (total_steps) ---
+            quality_choices = [
+                "Fast (5 steps — quickest, lower quality)",
+                "Balanced (8 steps — recommended)",
+                "High (10 steps — better quality)",
+                "Very High (12 steps — best quality, slowest)",
+            ]
+            quality_steps = [5, 8, 10, 12]
+            cur_steps = int(st.get("total_steps", 8))
+            quality_default = quality_steps.index(cur_steps) if cur_steps in quality_steps else 1
+            q_idx = prompt_choice("Select quality:", quality_choices, quality_default)
+            st["total_steps"] = quality_steps[q_idx]
+
+            tts_config["supertonic"] = st
+            config["tts"] = tts_config
+            print_success(
+                f"Supertonic: voice {st['voice']}, lang {st['lang']}, "
+                f"speed {st['speed']}, {st['total_steps']} steps"
+            )
 
     # Save the selection
     if "tts" not in config:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1885,7 +1885,7 @@ def _run_post_setup(post_setup_key: str):
                 _print_warning("    supertonic install timed out (>5min)")
                 _print_info('    Run manually: uv pip install -U "supertonic>=1.3.1,<2"')
                 return
-        _print_info("    Voices: M1–M5 (male) / F1–F5 (female); 31 languages; expression tags <laugh>/<breath>/<sigh>")
+        _print_info("    Voices: M1-M5 (male) / F1-F5 (female); 31 languages; expression tags <laugh>/<breath>/<sigh>")
         _print_info("    The ~400MB model downloads on first TTS call to ~/.cache/supertonic3/")
         _print_info("    Tune via tts.supertonic.* (voice, lang, speed, total_steps) in ~/.hermes/config.yaml")
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -409,6 +409,14 @@ TOOL_CATEGORIES = {
                 ],
                 "tts_provider": "deepinfra",
             },
+            {
+                "name": "Supertonic",
+                "badge": "local · free",
+                "tag": "Fast on-device ONNX TTS, 31 languages (~400MB)",
+                "env_vars": [],
+                "tts_provider": "supertonic",
+                "post_setup": "supertonic",
+            },
         ],
     },
     "stt": {
@@ -1857,6 +1865,29 @@ def _run_post_setup(post_setup_key: str):
         _print_info("    Default voice: en_US-lessac-medium (downloaded on first TTS call)")
         _print_info("    Full voice list: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md")
         _print_info("    Switch voices by setting tts.piper.voice in ~/.hermes/config.yaml")
+
+    elif post_setup_key == "supertonic":
+        try:
+            __import__("supertonic")
+            _print_success("    supertonic is already installed")
+        except ImportError:
+            _print_info("    Installing supertonic (~400MB ONNX model downloaded on first use)...")
+            try:
+                result = _pip_install(["-U", "supertonic>=1.3.1,<2", "--quiet"], timeout=300)
+                if result.returncode == 0:
+                    _print_success("    supertonic installed")
+                else:
+                    _print_warning("    supertonic install failed:")
+                    _print_info(f"      {(result.stderr or '').strip()[:300]}")
+                    _print_info('    Run manually: uv pip install -U "supertonic>=1.3.1,<2"')
+                    return
+            except subprocess.TimeoutExpired:
+                _print_warning("    supertonic install timed out (>5min)")
+                _print_info('    Run manually: uv pip install -U "supertonic>=1.3.1,<2"')
+                return
+        _print_info("    Voices: M1–M5 (male) / F1–F5 (female); 31 languages; expression tags <laugh>/<breath>/<sigh>")
+        _print_info("    The ~400MB model downloads on first TTS call to ~/.cache/supertonic3/")
+        _print_info("    Tune via tts.supertonic.* (voice, lang, speed, total_steps) in ~/.hermes/config.yaml")
 
     elif post_setup_key == "ddgs":
         try:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -412,6 +412,14 @@ TOOL_CATEGORIES = {
                 ],
                 "tts_provider": "deepinfra",
             },
+            {
+                "name": "Supertonic",
+                "badge": "local · free",
+                "tag": "Fast on-device ONNX TTS, 31 languages (~400MB)",
+                "env_vars": [],
+                "tts_provider": "supertonic",
+                "post_setup": "supertonic",
+            },
         ],
     },
     "stt": {
@@ -1894,6 +1902,29 @@ def _run_post_setup(post_setup_key: str):
         _print_info("    Default voice: en_US-lessac-medium (downloaded on first TTS call)")
         _print_info("    Full voice list: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md")
         _print_info("    Switch voices by setting tts.piper.voice in ~/.hermes/config.yaml")
+
+    elif post_setup_key == "supertonic":
+        try:
+            __import__("supertonic")
+            _print_success("    supertonic is already installed")
+        except ImportError:
+            _print_info("    Installing supertonic (~400MB ONNX model downloaded on first use)...")
+            try:
+                result = _pip_install(["-U", "supertonic>=1.3.1,<2", "--quiet"], timeout=300)
+                if result.returncode == 0:
+                    _print_success("    supertonic installed")
+                else:
+                    _print_warning("    supertonic install failed:")
+                    _print_info(f"      {(result.stderr or '').strip()[:300]}")
+                    _print_info('    Run manually: uv pip install -U "supertonic>=1.3.1,<2"')
+                    return
+            except subprocess.TimeoutExpired:
+                _print_warning("    supertonic install timed out (>5min)")
+                _print_info('    Run manually: uv pip install -U "supertonic>=1.3.1,<2"')
+                return
+        _print_info("    Voices: M1–M5 (male) / F1–F5 (female); 31 languages; expression tags <laugh>/<breath>/<sigh>")
+        _print_info("    The ~400MB model downloads on first TTS call to ~/.cache/supertonic3/")
+        _print_info("    Tune via tts.supertonic.* (voice, lang, speed, total_steps) in ~/.hermes/config.yaml")
 
     elif post_setup_key == "ddgs":
         try:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1922,7 +1922,7 @@ def _run_post_setup(post_setup_key: str):
                 _print_warning("    supertonic install timed out (>5min)")
                 _print_info('    Run manually: uv pip install -U "supertonic>=1.3.1,<2"')
                 return
-        _print_info("    Voices: M1–M5 (male) / F1–F5 (female); 31 languages; expression tags <laugh>/<breath>/<sigh>")
+        _print_info("    Voices: M1-M5 (male) / F1-F5 (female); 31 languages; expression tags <laugh>/<breath>/<sigh>")
         _print_info("    The ~400MB model downloads on first TTS call to ~/.cache/supertonic3/")
         _print_info("    Tune via tts.supertonic.* (voice, lang, speed, total_steps) in ~/.hermes/config.yaml")
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -911,7 +911,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "tts.provider": {
         "type": "select",
         "description": "Text-to-speech provider",
-        "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper"],
+        "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper", "supertonic"],
     },
     "stt.provider": {
         "type": "select",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -928,7 +928,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "tts.provider": {
         "type": "select",
         "description": "Text-to-speech provider",
-        "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper"],
+        "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper", "supertonic"],
     },
     "stt.provider": {
         "type": "select",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,7 @@ matrix = ["mautrix[encryption]==0.21.0", "aiosqlite==0.22.1", "asyncpg==0.31.0",
 wecom = ["defusedxml==0.7.1"]
 cli = ["simple-term-menu==1.6.6"]
 tts-premium = ["elevenlabs==1.59.0"]
-# Supertonic — local ONNX neural TTS (multilingual, expressive). Pulls
+# Supertonic - local ONNX neural TTS (multilingual, expressive). Pulls
 # onnxruntime/numpy/soundfile/huggingface-hub transitively; the ~400MB model
 # is downloaded on first use. Kept out of [all] like the other TTS backends.
 supertonic-tts = ["supertonic>=1.3.1,<2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,10 @@ matrix = ["mautrix[encryption]==0.21.0", "aiosqlite==0.22.1", "asyncpg==0.31.0",
 wecom = ["defusedxml==0.7.1"]
 cli = ["simple-term-menu==1.6.6"]
 tts-premium = ["elevenlabs==1.59.0"]
+# Supertonic — local ONNX neural TTS (multilingual, expressive). Pulls
+# onnxruntime/numpy/soundfile/huggingface-hub transitively; the ~400MB model
+# is downloaded on first use. Kept out of [all] like the other TTS backends.
+supertonic-tts = ["supertonic>=1.3.1,<2"]
 voice = [
   # Local STT pulls in wheel-only transitive deps (ctranslate2, onnxruntime).
   "faster-whisper==1.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,7 @@ matrix = ["mautrix[encryption]==0.21.1", "aiosqlite==0.22.1", "asyncpg==0.31.0",
 # here to keep the dependency local to wecom_callback's threat model.
 wecom = ["defusedxml==0.7.1"]
 tts-premium = ["elevenlabs==1.59.0"]
-# Supertonic — local ONNX neural TTS (multilingual, expressive). Pulls
+# Supertonic - local ONNX neural TTS (multilingual, expressive). Pulls
 # onnxruntime/numpy/soundfile/huggingface-hub transitively; the ~400MB model
 # is downloaded on first use. Kept out of [all] like the other TTS backends.
 supertonic-tts = ["supertonic>=1.3.1,<2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,6 +193,10 @@ matrix = ["mautrix[encryption]==0.21.1", "aiosqlite==0.22.1", "asyncpg==0.31.0",
 # here to keep the dependency local to wecom_callback's threat model.
 wecom = ["defusedxml==0.7.1"]
 tts-premium = ["elevenlabs==1.59.0"]
+# Supertonic — local ONNX neural TTS (multilingual, expressive). Pulls
+# onnxruntime/numpy/soundfile/huggingface-hub transitively; the ~400MB model
+# is downloaded on first use. Kept out of [all] like the other TTS backends.
+supertonic-tts = ["supertonic>=1.3.1,<2"]
 voice = [
   # Local STT pulls in wheel-only transitive deps (ctranslate2, onnxruntime).
   "faster-whisper==1.2.1",

--- a/tests/hermes_cli/test_setup_supertonic.py
+++ b/tests/hermes_cli/test_setup_supertonic.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import setup
+
+
+def _select_supertonic(question, choices, default=0):
+    if question == "Select TTS provider:":
+        return next(i for i, choice in enumerate(choices) if choice.startswith("Supertonic "))
+    if question == "Select quality:":
+        return 1
+    return default
+
+
+def test_supertonic_setup_uses_shared_post_setup(monkeypatch):
+    probes = iter([None, object()])
+    post_setup_calls = []
+    config = {}
+
+    monkeypatch.setattr(setup, "managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr(
+        setup,
+        "get_nous_subscription_features",
+        lambda _config: SimpleNamespace(nous_auth_present=False),
+    )
+    monkeypatch.setattr(setup, "prompt_choice", _select_supertonic)
+    monkeypatch.setattr(setup, "prompt_yes_no", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(setup, "prompt", lambda *_args, **kwargs: kwargs.get("default", ""))
+    monkeypatch.setattr(setup.importlib.util, "find_spec", lambda _name: next(probes))
+    monkeypatch.setattr("hermes_cli.tools_config._run_post_setup", post_setup_calls.append)
+    monkeypatch.setattr(setup, "save_config", lambda _config: None)
+
+    setup.setup_tts(config)
+
+    assert post_setup_calls == ["supertonic"]
+    assert config["tts"]["provider"] == "supertonic"
+
+
+@pytest.mark.parametrize(
+    ("installed", "expected"),
+    [
+        (True, "Text-to-Speech (Supertonic local)"),
+        (False, "Text-to-Speech (Supertonic - not installed)"),
+    ],
+)
+def test_setup_summary_reports_supertonic(tmp_path, monkeypatch, capsys, installed, expected):
+    monkeypatch.setattr(setup.importlib.util, "find_spec", lambda name: object() if name == "supertonic" and installed else None)
+
+    setup._print_setup_summary({"tts": {"provider": "supertonic"}}, tmp_path)
+
+    assert expected in capsys.readouterr().out

--- a/tests/hermes_cli/test_setup_supertonic.py
+++ b/tests/hermes_cli/test_setup_supertonic.py
@@ -37,6 +37,35 @@ def test_supertonic_setup_uses_shared_post_setup(monkeypatch):
     assert config["tts"]["provider"] == "supertonic"
 
 
+def test_supertonic_integration_preserves_existing_provider_probe(monkeypatch):
+    installs = []
+    config = {}
+
+    monkeypatch.setattr(setup, "managed_nous_tools_enabled", lambda: False)
+    monkeypatch.setattr(
+        setup,
+        "get_nous_subscription_features",
+        lambda _config: SimpleNamespace(nous_auth_present=False),
+    )
+    monkeypatch.setattr(
+        setup,
+        "prompt_choice",
+        lambda question, choices, default=0: (
+            next(i for i, choice in enumerate(choices) if choice.startswith("KittenTTS "))
+            if question == "Select TTS provider:"
+            else default
+        ),
+    )
+    monkeypatch.setattr(setup.importlib.util, "find_spec", lambda _name: object())
+    monkeypatch.setattr(setup, "_install_kittentts_deps", lambda: installs.append(True) or True)
+    monkeypatch.setattr(setup, "save_config", lambda _config: None)
+
+    setup.setup_tts(config)
+
+    assert installs == []
+    assert config["tts"]["provider"] == "kittentts"
+
+
 @pytest.mark.parametrize(
     ("installed", "expected"),
     [

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1186,6 +1186,9 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         return resp.json()["fields"][key]["options"]
 
+    def test_config_schema_lists_supertonic_provider(self):
+        assert "supertonic" in self._schema_provider_options("tts.provider")
+
 
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1015,6 +1015,9 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         return resp.json()["fields"][key]["options"]
 
+    def test_config_schema_lists_supertonic_provider(self):
+        assert "supertonic" in self._schema_provider_options("tts.provider")
+
 
 
 

--- a/tests/tools/test_tts_supertonic.py
+++ b/tests/tools/test_tts_supertonic.py
@@ -1,0 +1,230 @@
+"""
+Tests for the native Supertonic TTS provider.
+
+These tests pin the registration / caching / dispatch paths for Supertonic
+without requiring the ``supertonic`` package to actually be installed (the
+synthesis step is monkey-patched to avoid needing the ONNX wheel or the
+~400MB model download).
+"""
+
+import json
+import wave
+from pathlib import Path
+
+import pytest
+
+from tools import tts_tool
+from tools.tts_tool import (
+    BUILTIN_TTS_PROVIDERS,
+    DEFAULT_SUPERTONIC_VOICE,
+    PROVIDER_MAX_TEXT_LENGTH,
+    _check_supertonic_available,
+    check_tts_requirements,
+    text_to_speech_tool,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry / constants
+# ---------------------------------------------------------------------------
+
+class TestSupertonicRegistration:
+    def test_supertonic_is_a_builtin_provider(self):
+        assert "supertonic" in BUILTIN_TTS_PROVIDERS
+
+    def test_supertonic_has_a_text_length_cap(self):
+        assert PROVIDER_MAX_TEXT_LENGTH.get("supertonic", 0) > 0
+
+
+# ---------------------------------------------------------------------------
+# _check_supertonic_available
+# ---------------------------------------------------------------------------
+
+class TestCheckSupertonicAvailable:
+    def test_returns_bool_without_raising(self):
+        # We don't care about the current environment's answer — just that
+        # the probe never raises on a machine without supertonic installed.
+        assert isinstance(_check_supertonic_available(), bool)
+
+
+# ---------------------------------------------------------------------------
+# _generate_supertonic_tts — stubbed so we don't need supertonic installed
+# ---------------------------------------------------------------------------
+
+def _write_min_wav(path: str) -> None:
+    """Write a minimal valid WAV so file-size checks pass."""
+    with wave.open(path, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(44100)
+        wav_file.writeframes(b"\x00\x00" * 1024)
+
+
+class _StubSupertonicTTS:
+    """Stand-in for supertonic.TTS used by the synthesis tests."""
+
+    instances: list["_StubSupertonicTTS"] = []
+    synth_calls: list[dict] = []
+
+    def __init__(self, auto_download=False):
+        self.auto_download = auto_download
+        _StubSupertonicTTS.instances.append(self)
+
+    def get_voice_style(self, voice_name):
+        return {"voice_name": voice_name}
+
+    def get_voice_style_from_path(self, path):
+        return {"voice_style_path": path}
+
+    def synthesize(self, text, voice_style, lang, total_steps, speed, **extra):
+        _StubSupertonicTTS.synth_calls.append({
+            "text": text,
+            "voice_style": voice_style,
+            "lang": lang,
+            "total_steps": total_steps,
+            "speed": speed,
+            "extra": extra,
+        })
+        return ("FAKE_WAV", 44100)
+
+    def save_audio(self, wav, out):
+        _write_min_wav(out)
+
+
+@pytest.fixture(autouse=True)
+def _reset_supertonic_cache(monkeypatch):
+    """Clear the module-level engine cache and stub state between tests."""
+    tts_tool._supertonic_tts_cache.clear()
+    _StubSupertonicTTS.instances = []
+    _StubSupertonicTTS.synth_calls = []
+    monkeypatch.setattr(tts_tool, "_import_supertonic", lambda: _StubSupertonicTTS)
+    yield
+    tts_tool._supertonic_tts_cache.clear()
+
+
+class TestGenerateSupertonicTts:
+    def test_loads_engine_and_writes_wav(self, tmp_path):
+        out_path = str(tmp_path / "out.wav")
+        config = {"supertonic": {"voice": "M2", "lang": "pl"}}
+
+        result = tts_tool._generate_supertonic_tts("cześć", out_path, config)
+
+        assert result == out_path
+        assert Path(out_path).exists()
+        assert Path(out_path).stat().st_size > 0
+        call = _StubSupertonicTTS.synth_calls[0]
+        assert call["text"] == "cześć"
+        assert call["lang"] == "pl"
+        assert call["voice_style"] == {"voice_name": "M2"}
+
+    def test_engine_cache_reused_across_calls(self, tmp_path):
+        config = {"supertonic": {"voice": "M1"}}
+        tts_tool._generate_supertonic_tts("one", str(tmp_path / "a.wav"), config)
+        tts_tool._generate_supertonic_tts("two", str(tmp_path / "b.wav"), config)
+
+        # TTS() should have been constructed exactly once (model is global).
+        assert len(_StubSupertonicTTS.instances) == 1
+        assert [c["text"] for c in _StubSupertonicTTS.synth_calls] == ["one", "two"]
+
+    def test_defaults_applied_when_config_empty(self, tmp_path):
+        result = tts_tool._generate_supertonic_tts("hi", str(tmp_path / "out.wav"), {})
+        assert Path(result).exists()
+        call = _StubSupertonicTTS.synth_calls[0]
+        assert call["voice_style"] == {"voice_name": DEFAULT_SUPERTONIC_VOICE}
+        assert call["lang"] == "en"
+        assert call["speed"] == 1.0
+        assert call["total_steps"] == 8
+
+    def test_speed_and_total_steps_clamped(self, tmp_path):
+        config = {"supertonic": {"speed": 9.0, "total_steps": 99}}
+        tts_tool._generate_supertonic_tts("hi", str(tmp_path / "out.wav"), config)
+        call = _StubSupertonicTTS.synth_calls[0]
+        assert call["speed"] == 2.0       # clamped to SUPERTONIC_SPEED_MAX
+        assert call["total_steps"] == 12  # clamped to SUPERTONIC_TOTAL_STEPS_MAX
+
+        _StubSupertonicTTS.synth_calls.clear()
+        config = {"supertonic": {"speed": 0.1, "total_steps": 1}}
+        tts_tool._generate_supertonic_tts("hi", str(tmp_path / "out2.wav"), config)
+        call = _StubSupertonicTTS.synth_calls[0]
+        assert call["speed"] == 0.7       # clamped to SUPERTONIC_SPEED_MIN
+        assert call["total_steps"] == 5   # clamped to SUPERTONIC_TOTAL_STEPS_MIN
+
+    def test_voice_style_path_takes_precedence(self, tmp_path):
+        style = tmp_path / "my_voice.style"
+        style.write_bytes(b"fake style")
+        config = {"supertonic": {"voice": "M1", "voice_style_path": str(style)}}
+        tts_tool._generate_supertonic_tts("hi", str(tmp_path / "out.wav"), config)
+        call = _StubSupertonicTTS.synth_calls[0]
+        assert call["voice_style"] == {"voice_style_path": str(style)}
+
+    def test_optional_knobs_forwarded_when_set(self, tmp_path):
+        config = {
+            "supertonic": {
+                "max_chunk_length": 120,
+                "silence_duration": 0.25,
+            },
+        }
+        tts_tool._generate_supertonic_tts("hi", str(tmp_path / "out.wav"), config)
+        extra = _StubSupertonicTTS.synth_calls[0]["extra"]
+        assert extra["max_chunk_length"] == 120
+        assert extra["silence_duration"] == 0.25
+
+
+# ---------------------------------------------------------------------------
+# text_to_speech_tool end-to-end (provider == "supertonic")
+# ---------------------------------------------------------------------------
+
+class TestTextToSpeechToolWithSupertonic:
+    def test_dispatches_to_supertonic(self, tmp_path, monkeypatch):
+        cfg = {"provider": "supertonic", "supertonic": {"voice": "M1"}}
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: cfg)
+
+        result = text_to_speech_tool(text="hi", output_path=str(tmp_path / "clip.wav"))
+        data = json.loads(result)
+
+        assert data["success"] is True, data
+        assert data["provider"] == "supertonic"
+        assert Path(data["file_path"]).exists()
+
+    def test_missing_package_surfaces_error(self, tmp_path, monkeypatch):
+        def raise_import():
+            raise ImportError("No module named 'supertonic'")
+
+        monkeypatch.setattr(tts_tool, "_import_supertonic", raise_import)
+
+        cfg = {"provider": "supertonic"}
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: cfg)
+
+        result = text_to_speech_tool(text="hi", output_path=str(tmp_path / "clip.wav"))
+        data = json.loads(result)
+
+        assert data["success"] is False
+        assert "supertonic" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# check_tts_requirements
+# ---------------------------------------------------------------------------
+
+class TestCheckTtsRequirementsSupertonic:
+    def test_supertonic_install_satisfies_requirements(self, monkeypatch):
+        # Drop every other provider so we can isolate the supertonic signal.
+        monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: (_ for _ in ()).throw(ImportError()))
+        monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: (_ for _ in ()).throw(ImportError()))
+        monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: (_ for _ in ()).throw(ImportError()))
+        monkeypatch.setattr(tts_tool, "_import_mistral_client", lambda: (_ for _ in ()).throw(ImportError()))
+        monkeypatch.setattr(tts_tool, "_check_neutts_available", lambda: False)
+        monkeypatch.setattr(tts_tool, "_check_kittentts_available", lambda: False)
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: False)
+        monkeypatch.setattr(tts_tool, "_has_any_command_tts_provider", lambda: False)
+        monkeypatch.setattr(tts_tool, "_has_openai_audio_backend", lambda: False)
+        for env in ("MINIMAX_API_KEY", "XAI_API_KEY", "GEMINI_API_KEY",
+                    "GOOGLE_API_KEY", "MISTRAL_API_KEY", "ELEVENLABS_API_KEY"):
+            monkeypatch.delenv(env, raising=False)
+
+        # Now toggle the supertonic check on and off.
+        monkeypatch.setattr(tts_tool, "_check_supertonic_available", lambda: False)
+        assert check_tts_requirements() is False
+
+        monkeypatch.setattr(tts_tool, "_check_supertonic_available", lambda: True)
+        assert check_tts_requirements() is True

--- a/tests/tools/test_tts_supertonic.py
+++ b/tests/tools/test_tts_supertonic.py
@@ -135,6 +135,15 @@ class TestGenerateSupertonicTts:
         assert call["speed"] == 1.0
         assert call["total_steps"] == 8
 
+    def test_invalid_voice_and_language_fall_back_to_defaults(self, tmp_path):
+        config = {"supertonic": {"voice": "unknown", "lang": "xx"}}
+
+        tts_tool._generate_supertonic_tts("hi", str(tmp_path / "out.wav"), config)
+
+        call = _StubSupertonicTTS.synth_calls[0]
+        assert call["voice_style"] == {"voice_name": DEFAULT_SUPERTONIC_VOICE}
+        assert call["lang"] == "en"
+
     def test_speed_and_total_steps_clamped(self, tmp_path):
         config = {"supertonic": {"speed": 9.0, "total_steps": 99}}
         tts_tool._generate_supertonic_tts("hi", str(tmp_path / "out.wav"), config)

--- a/tests/tools/test_tts_supertonic.py
+++ b/tests/tools/test_tts_supertonic.py
@@ -172,6 +172,15 @@ class TestGenerateSupertonicTts:
         assert call["speed"] == 1.0
         assert call["total_steps"] == 8
 
+    def test_global_speed_applied_and_provider_overrides_it(self, tmp_path):
+        tts_tool._generate_supertonic_tts("hi", str(tmp_path / "global.wav"), {"speed": 1.5})
+        assert _StubSupertonicTTS.synth_calls[-1]["speed"] == 1.5
+
+        tts_tool._generate_supertonic_tts(
+            "hi", str(tmp_path / "provider.wav"), {"speed": 1.5, "supertonic": {"speed": 1.25}}
+        )
+        assert _StubSupertonicTTS.synth_calls[-1]["speed"] == 1.25
+
     def test_invalid_voice_and_language_fall_back_to_defaults(self, tmp_path):
         config = {"supertonic": {"voice": "unknown", "lang": "xx"}}
 

--- a/tests/tools/test_tts_supertonic.py
+++ b/tests/tools/test_tts_supertonic.py
@@ -8,7 +8,10 @@ synthesis step is monkey-patched to avoid needing the ONNX wheel or the
 """
 
 import json
+import threading
+import time
 import wave
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -126,6 +129,40 @@ class TestGenerateSupertonicTts:
         assert len(_StubSupertonicTTS.instances) == 1
         assert [c["text"] for c in _StubSupertonicTTS.synth_calls] == ["one", "two"]
 
+    def test_engine_initialization_and_synthesis_are_serialized(self, tmp_path, monkeypatch):
+        class RacingSupertonicTTS(_StubSupertonicTTS):
+            active = 0
+            max_active = 0
+            state_lock = threading.Lock()
+
+            def __init__(self, auto_download=False):
+                time.sleep(0.05)
+                super().__init__(auto_download=auto_download)
+
+            def synthesize(self, *args, **kwargs):
+                with self.state_lock:
+                    type(self).active += 1
+                    type(self).max_active = max(type(self).max_active, type(self).active)
+                time.sleep(0.05)
+                with self.state_lock:
+                    type(self).active -= 1
+                return super().synthesize(*args, **kwargs)
+
+        monkeypatch.setattr(tts_tool, "_import_supertonic", lambda: RacingSupertonicTTS)
+        barrier = threading.Barrier(2)
+
+        def generate(index):
+            barrier.wait()
+            tts_tool._generate_supertonic_tts(
+                str(index), str(tmp_path / f"{index}.wav"), {}
+            )
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            list(pool.map(generate, range(2)))
+
+        assert len(_StubSupertonicTTS.instances) == 1
+        assert RacingSupertonicTTS.max_active == 1
+
     def test_defaults_applied_when_config_empty(self, tmp_path):
         result = tts_tool._generate_supertonic_tts("hi", str(tmp_path / "out.wav"), {})
         assert Path(result).exists()
@@ -178,6 +215,40 @@ class TestGenerateSupertonicTts:
         assert extra["max_chunk_length"] == 120
         assert extra["silence_duration"] == 0.25
 
+    def test_invalid_max_chunk_length_uses_engine_default(self, tmp_path):
+        config = {"supertonic": {"max_chunk_length": 0}}
+
+        tts_tool._generate_supertonic_tts("hi", str(tmp_path / "out.wav"), config)
+
+        assert "max_chunk_length" not in _StubSupertonicTTS.synth_calls[0]["extra"]
+
+    def test_returns_wav_path_when_ffmpeg_is_unavailable(self, tmp_path, monkeypatch):
+        requested = tmp_path / "out.mp3"
+        monkeypatch.setattr(tts_tool.shutil, "which", lambda _name: None)
+
+        result = tts_tool._generate_supertonic_tts("hi", str(requested), {})
+
+        output = Path(result)
+        assert output == requested.with_suffix(".wav")
+        assert output.read_bytes().startswith(b"RIFF")
+        assert not requested.exists()
+
+    def test_ffmpeg_uses_windows_safe_subprocess_options(self, tmp_path, monkeypatch):
+        requested = tmp_path / "out.mp3"
+        run_kwargs = {}
+
+        def fake_run(command, **kwargs):
+            run_kwargs.update(kwargs)
+            Path(command[-1]).write_bytes(b"MP3")
+
+        monkeypatch.setattr(tts_tool.shutil, "which", lambda _name: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(tts_tool.subprocess, "run", fake_run)
+
+        tts_tool._generate_supertonic_tts("hi", str(requested), {})
+
+        assert run_kwargs["stdin"] is tts_tool.subprocess.DEVNULL
+        assert run_kwargs["creationflags"] == tts_tool.windows_hide_flags()
+
 
 # ---------------------------------------------------------------------------
 # text_to_speech_tool end-to-end (provider == "supertonic")
@@ -194,6 +265,32 @@ class TestTextToSpeechToolWithSupertonic:
         assert data["success"] is True, data
         assert data["provider"] == "supertonic"
         assert Path(data["file_path"]).exists()
+
+    def test_default_output_stays_wav_without_ffmpeg(self, tmp_path, monkeypatch):
+        cfg = {"provider": "supertonic", "supertonic": {"voice": "M1"}}
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: cfg)
+        monkeypatch.setattr(tts_tool, "DEFAULT_OUTPUT_DIR", str(tmp_path))
+        monkeypatch.setattr(tts_tool.shutil, "which", lambda _name: None)
+
+        data = json.loads(text_to_speech_tool(text="hi"))
+        output = Path(data["file_path"])
+
+        assert output.suffix == ".wav"
+        assert output.read_bytes().startswith(b"RIFF")
+
+    def test_explicit_compressed_output_reports_wav_fallback_without_ffmpeg(
+        self, tmp_path, monkeypatch
+    ):
+        cfg = {"provider": "supertonic", "supertonic": {"voice": "M1"}}
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: cfg)
+        monkeypatch.setattr(tts_tool.shutil, "which", lambda _name: None)
+
+        data = json.loads(
+            text_to_speech_tool(text="hi", output_path=str(tmp_path / "clip.mp3"))
+        )
+
+        assert data["success"] is True
+        assert Path(data["file_path"]).suffix == ".wav"
 
     def test_missing_package_surfaces_error(self, tmp_path, monkeypatch):
         def raise_import():

--- a/tests/tools/test_tts_supertonic.py
+++ b/tests/tools/test_tts_supertonic.py
@@ -45,13 +45,13 @@ class TestSupertonicRegistration:
 
 class TestCheckSupertonicAvailable:
     def test_returns_bool_without_raising(self):
-        # We don't care about the current environment's answer — just that
+        # We don't care about the current environment's answer - just that
         # the probe never raises on a machine without supertonic installed.
         assert isinstance(_check_supertonic_available(), bool)
 
 
 # ---------------------------------------------------------------------------
-# _generate_supertonic_tts — stubbed so we don't need supertonic installed
+# _generate_supertonic_tts - stubbed so we don't need supertonic installed
 # ---------------------------------------------------------------------------
 
 def _write_min_wav(path: str) -> None:
@@ -323,21 +323,8 @@ class TestTextToSpeechToolWithSupertonic:
 
 class TestCheckTtsRequirementsSupertonic:
     def test_supertonic_install_satisfies_requirements(self, monkeypatch):
-        # Drop every other provider so we can isolate the supertonic signal.
-        monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: (_ for _ in ()).throw(ImportError()))
-        monkeypatch.setattr(tts_tool, "_import_elevenlabs", lambda: (_ for _ in ()).throw(ImportError()))
-        monkeypatch.setattr(tts_tool, "_import_openai_client", lambda: (_ for _ in ()).throw(ImportError()))
-        monkeypatch.setattr(tts_tool, "_import_mistral_client", lambda: (_ for _ in ()).throw(ImportError()))
-        monkeypatch.setattr(tts_tool, "_check_neutts_available", lambda: False)
-        monkeypatch.setattr(tts_tool, "_check_kittentts_available", lambda: False)
-        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: False)
-        monkeypatch.setattr(tts_tool, "_has_any_command_tts_provider", lambda: False)
-        monkeypatch.setattr(tts_tool, "_has_openai_audio_backend", lambda: False)
-        for env in ("MINIMAX_API_KEY", "XAI_API_KEY", "GEMINI_API_KEY",
-                    "GOOGLE_API_KEY", "MISTRAL_API_KEY", "ELEVENLABS_API_KEY"):
-            monkeypatch.delenv(env, raising=False)
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "supertonic"})
 
-        # Now toggle the supertonic check on and off.
         monkeypatch.setattr(tts_tool, "_check_supertonic_available", lambda: False)
         assert check_tts_requirements() is False
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2788,7 +2788,7 @@ def _generate_supertonic_tts(text: str, output_path: str, tts_config: Dict[str, 
 
     # Clamp tunables to the engine's supported ranges.
     try:
-        speed = float(st_config.get("speed", DEFAULT_SUPERTONIC_SPEED))
+        speed = float(st_config.get("speed", tts_config.get("speed", DEFAULT_SUPERTONIC_SPEED)))
     except (TypeError, ValueError):
         speed = DEFAULT_SUPERTONIC_SPEED
     speed = max(SUPERTONIC_SPEED_MIN, min(SUPERTONIC_SPEED_MAX, speed))

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -210,7 +210,7 @@ def _import_supertonic():
     on ONNX Runtime (99M params, no torch). ``pip install supertonic`` pulls
     cross-platform wheels; the ~400MB model is downloaded on first use to
     ``~/.cache/supertonic3/``. Supports 31 languages, male/female voices
-    (M1–M5 / F1–F5) and expression tags ``<laugh>`` / ``<breath>`` / ``<sigh>``.
+    (M1-M5 / F1-F5) and expression tags ``<laugh>`` / ``<breath>`` / ``<sigh>``.
     """
     from supertonic import TTS
     return TTS
@@ -233,10 +233,10 @@ MANAGED_OPENAI_TTS_MODELS = frozenset({"gpt-4o-mini-tts"})
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_PIPER_VOICE = "en_US-lessac-medium"  # balanced size/quality
-DEFAULT_SUPERTONIC_VOICE = "M1"  # M1–M5 (male) / F1–F5 (female)
+DEFAULT_SUPERTONIC_VOICE = "M1"  # M1-M5 (male) / F1-F5 (female)
 DEFAULT_SUPERTONIC_LANG = "en"
-DEFAULT_SUPERTONIC_SPEED = 1.0  # 0.7–2.0 (higher = faster)
-DEFAULT_SUPERTONIC_TOTAL_STEPS = 8  # 5–12 (higher = better quality, slower)
+DEFAULT_SUPERTONIC_SPEED = 1.0  # 0.7-2.0 (higher = faster)
+DEFAULT_SUPERTONIC_TOTAL_STEPS = 8  # 5-12 (higher = better quality, slower)
 # Built-in voice styles shipped with the Supertonic model.
 SUPERTONIC_VOICES = ("M1", "M2", "M3", "M4", "M5", "F1", "F2", "F3", "F4", "F5")
 # Supertonic supports 31 languages (+ ``na`` neutral/accentless fallback).
@@ -2801,7 +2801,7 @@ def _generate_supertonic_tts(text: str, output_path: str, tts_config: Dict[str, 
         SUPERTONIC_TOTAL_STEPS_MIN, min(SUPERTONIC_TOTAL_STEPS_MAX, total_steps)
     )
 
-    # Optional, rarely-tuned synthesis knobs — only forwarded when configured
+    # Optional, rarely-tuned synthesis knobs - only forwarded when configured
     # so we stay compatible with the installed engine version.
     extra: Dict[str, Any] = {}
     if "max_chunk_length" in st_config:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2774,8 +2774,15 @@ def _generate_supertonic_tts(text: str, output_path: str, tts_config: Dict[str, 
     TTS = _import_supertonic()
 
     st_config = tts_config.get("supertonic", {}) if isinstance(tts_config, dict) else {}
-    voice = st_config.get("voice") or DEFAULT_SUPERTONIC_VOICE
-    lang = st_config.get("lang") or DEFAULT_SUPERTONIC_LANG
+    voice = str(st_config.get("voice") or DEFAULT_SUPERTONIC_VOICE).upper()
+    if voice not in SUPERTONIC_VOICES:
+        logger.warning("[Supertonic] Unknown voice %r; using %s", voice, DEFAULT_SUPERTONIC_VOICE)
+        voice = DEFAULT_SUPERTONIC_VOICE
+
+    lang = str(st_config.get("lang") or DEFAULT_SUPERTONIC_LANG).lower()
+    if lang not in SUPERTONIC_LANGUAGES:
+        logger.warning("[Supertonic] Unknown language %r; using %s", lang, DEFAULT_SUPERTONIC_LANG)
+        lang = DEFAULT_SUPERTONIC_LANG
     voice_style_path = st_config.get("voice_style_path")
 
     # Clamp tunables to the engine's supported ranges.

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -13,6 +13,7 @@ Built-in TTS providers:
 - NeuTTS (local, free, no API key): On-device TTS via neutts
 - KittenTTS (local, free, no API key): On-device 25MB model
 - Piper (local, free, no API key): OHF-Voice/piper1-gpl neural VITS, 44 languages
+- Supertonic (local, free, no API key): ONNX neural TTS, 31 languages, expressive
 
 Custom command providers:
 - Users can declare any number of named providers with ``type: command``
@@ -202,6 +203,19 @@ def _import_piper():
     return PiperVoice
 
 
+def _import_supertonic():
+    """Lazy import Supertonic. Returns the TTS class or raises ImportError.
+
+    Supertonic (Supertonic-3) is a light, fully-local neural TTS engine built
+    on ONNX Runtime (99M params, no torch). ``pip install supertonic`` pulls
+    cross-platform wheels; the ~400MB model is downloaded on first use to
+    ``~/.cache/supertonic3/``. Supports 31 languages, male/female voices
+    (M1–M5 / F1–F5) and expression tags ``<laugh>`` / ``<breath>`` / ``<sigh>``.
+    """
+    from supertonic import TTS
+    return TTS
+
+
 # ===========================================================================
 # Defaults
 # ===========================================================================
@@ -219,6 +233,23 @@ MANAGED_OPENAI_TTS_MODELS = frozenset({"gpt-4o-mini-tts"})
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_PIPER_VOICE = "en_US-lessac-medium"  # balanced size/quality
+DEFAULT_SUPERTONIC_VOICE = "M1"  # M1–M5 (male) / F1–F5 (female)
+DEFAULT_SUPERTONIC_LANG = "en"
+DEFAULT_SUPERTONIC_SPEED = 1.0  # 0.7–2.0 (higher = faster)
+DEFAULT_SUPERTONIC_TOTAL_STEPS = 8  # 5–12 (higher = better quality, slower)
+# Built-in voice styles shipped with the Supertonic model.
+SUPERTONIC_VOICES = ("M1", "M2", "M3", "M4", "M5", "F1", "F2", "F3", "F4", "F5")
+# Supertonic supports 31 languages (+ ``na`` neutral/accentless fallback).
+SUPERTONIC_LANGUAGES = (
+    "en", "ko", "ja", "ar", "bg", "cs", "da", "de", "el", "es", "et", "fi",
+    "fr", "hi", "hr", "hu", "id", "it", "lt", "lv", "nl", "pl", "pt", "ro",
+    "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na",
+)
+# Supertonic speed / quality bounds (from the official synthesize() API).
+SUPERTONIC_SPEED_MIN = 0.7
+SUPERTONIC_SPEED_MAX = 2.0
+SUPERTONIC_TOTAL_STEPS_MIN = 5
+SUPERTONIC_TOTAL_STEPS_MAX = 12
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_MINIMAX_MODEL = "speech-02-hd"
@@ -282,6 +313,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
+    "supertonic": 5000,   # local ONNX model; chunked internally, practical cap
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -620,6 +652,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "kittentts",
     "piper",
     "deepinfra",
+    "supertonic",
 })
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
@@ -2714,6 +2747,108 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
 
 
 # ===========================================================================
+# Provider: Supertonic (local, ONNX, multilingual)
+# ===========================================================================
+
+# Module-level cache for the Supertonic TTS engine instance. The ~400MB model
+# is global (not voice-specific), so one instance is reused for the process.
+_supertonic_tts_cache: Dict[str, Any] = {}
+
+
+def _check_supertonic_available() -> bool:
+    """Check whether the supertonic package is importable."""
+    try:
+        import importlib.util
+        return importlib.util.find_spec("supertonic") is not None
+    except Exception:
+        return False
+
+
+def _generate_supertonic_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using the local Supertonic engine.
+
+    Loads the engine once per process (the model is global, cached by a stable
+    key) and writes a 44.1kHz 16-bit WAV. Caller is responsible for converting
+    to MP3/Opus via ffmpeg when a different output format is required.
+    """
+    TTS = _import_supertonic()
+
+    st_config = tts_config.get("supertonic", {}) if isinstance(tts_config, dict) else {}
+    voice = st_config.get("voice") or DEFAULT_SUPERTONIC_VOICE
+    lang = st_config.get("lang") or DEFAULT_SUPERTONIC_LANG
+    voice_style_path = st_config.get("voice_style_path")
+
+    # Clamp tunables to the engine's supported ranges.
+    try:
+        speed = float(st_config.get("speed", DEFAULT_SUPERTONIC_SPEED))
+    except (TypeError, ValueError):
+        speed = DEFAULT_SUPERTONIC_SPEED
+    speed = max(SUPERTONIC_SPEED_MIN, min(SUPERTONIC_SPEED_MAX, speed))
+
+    try:
+        total_steps = int(st_config.get("total_steps", DEFAULT_SUPERTONIC_TOTAL_STEPS))
+    except (TypeError, ValueError):
+        total_steps = DEFAULT_SUPERTONIC_TOTAL_STEPS
+    total_steps = max(
+        SUPERTONIC_TOTAL_STEPS_MIN, min(SUPERTONIC_TOTAL_STEPS_MAX, total_steps)
+    )
+
+    # Optional, rarely-tuned synthesis knobs — only forwarded when configured
+    # so we stay compatible with the installed engine version.
+    extra: Dict[str, Any] = {}
+    if "max_chunk_length" in st_config:
+        extra["max_chunk_length"] = int(st_config["max_chunk_length"])
+    if "silence_duration" in st_config:
+        extra["silence_duration"] = float(st_config["silence_duration"])
+
+    # The model is global; cache a single engine instance per process.
+    cache_key = "supertonic"
+    global _supertonic_tts_cache
+    if cache_key not in _supertonic_tts_cache:
+        logger.info("[Supertonic] Loading engine (downloads ~400MB model on first use)...")
+        _supertonic_tts_cache[cache_key] = TTS(auto_download=True)
+        logger.info("[Supertonic] Engine loaded")
+    engine = _supertonic_tts_cache[cache_key]
+
+    if voice_style_path:
+        style = engine.get_voice_style_from_path(str(Path(voice_style_path).expanduser()))
+    else:
+        style = engine.get_voice_style(voice_name=voice)
+
+    wav, _ = engine.synthesize(
+        text=text,
+        voice_style=style,
+        lang=lang,
+        total_steps=total_steps,
+        speed=speed,
+        **extra,
+    )
+
+    # Supertonic outputs WAV. Caller handles downstream MP3/Opus conversion.
+    wav_path = output_path
+    if not output_path.endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+
+    engine.save_audio(wav, wav_path)
+
+    # Convert to desired format if caller requested mp3/ogg
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            subprocess.run(conv_cmd, check=True, timeout=30)
+            try:
+                os.remove(wav_path)
+            except OSError:
+                pass
+        else:
+            # No ffmpeg — keep WAV and return that path
+            os.rename(wav_path, output_path)
+
+    return output_path
+
+
+# ===========================================================================
 # Provider: KittenTTS (local, lightweight)
 # ===========================================================================
 
@@ -3041,6 +3176,19 @@ def text_to_speech_tool(
             logger.info("Generating speech with Piper (local)...")
             _generate_piper_tts(text, file_str, tts_config)
 
+        elif provider == "supertonic":
+            try:
+                _import_supertonic()
+            except ImportError:
+                return json.dumps({
+                    "success": False,
+                    "error": "Supertonic provider selected but 'supertonic' package not installed. "
+                             "Run 'hermes setup tts' and choose Supertonic, or install manually: "
+                             "pip install \"supertonic>=1.3.1,<2\"",
+                }, ensure_ascii=False)
+            logger.info("Generating speech with Supertonic (local)...")
+            _generate_supertonic_tts(text, file_str, tts_config)
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -3114,7 +3262,7 @@ def text_to_speech_tool(
                 voice_compatible = file_str.endswith(".ogg")
         elif (
             want_opus
-            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}
+            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper", "supertonic"}
             and not file_str.endswith(".ogg")
         ):
             opus_path = _convert_to_opus(file_str)
@@ -3227,6 +3375,8 @@ def check_tts_requirements() -> bool:
         return _check_kittentts_available()
     if provider == "piper":
         return _check_piper_available()
+    if provider == "supertonic":
+        return _check_supertonic_available()
 
     try:
         from agent.tts_registry import get_provider
@@ -3895,6 +4045,8 @@ if __name__ == "__main__":
         minimax_status = f"unavailable ({exc})"
     print(f"  MiniMax:    {minimax_status}")
     print(f"  Piper:      {'installed' if _check_piper_available() else 'not installed (pip install piper-tts)'}")
+    _supertonic_status = "installed" if _check_supertonic_available() else 'not installed (pip install "supertonic>=1.3.1,<2")'
+    print(f"  Supertonic: {_supertonic_status}")
     print(f"  ffmpeg:     {'✅ found' if _has_ffmpeg() else '❌ not found (needed for Telegram Opus)'}")
     print(f"\n  Output dir: {DEFAULT_OUTPUT_DIR}")
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2753,6 +2753,7 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
 # Module-level cache for the Supertonic TTS engine instance. The ~400MB model
 # is global (not voice-specific), so one instance is reused for the process.
 _supertonic_tts_cache: Dict[str, Any] = {}
+_supertonic_tts_lock = threading.Lock()
 
 
 def _check_supertonic_available() -> bool:
@@ -2804,53 +2805,63 @@ def _generate_supertonic_tts(text: str, output_path: str, tts_config: Dict[str, 
     # so we stay compatible with the installed engine version.
     extra: Dict[str, Any] = {}
     if "max_chunk_length" in st_config:
-        extra["max_chunk_length"] = int(st_config["max_chunk_length"])
+        try:
+            max_chunk_length = int(st_config["max_chunk_length"])
+        except (TypeError, ValueError):
+            max_chunk_length = 0
+        if max_chunk_length >= 10:
+            extra["max_chunk_length"] = max_chunk_length
     if "silence_duration" in st_config:
         extra["silence_duration"] = float(st_config["silence_duration"])
-
-    # The model is global; cache a single engine instance per process.
-    cache_key = "supertonic"
-    global _supertonic_tts_cache
-    if cache_key not in _supertonic_tts_cache:
-        logger.info("[Supertonic] Loading engine (downloads ~400MB model on first use)...")
-        _supertonic_tts_cache[cache_key] = TTS(auto_download=True)
-        logger.info("[Supertonic] Engine loaded")
-    engine = _supertonic_tts_cache[cache_key]
-
-    if voice_style_path:
-        style = engine.get_voice_style_from_path(str(Path(voice_style_path).expanduser()))
-    else:
-        style = engine.get_voice_style(voice_name=voice)
-
-    wav, _ = engine.synthesize(
-        text=text,
-        voice_style=style,
-        lang=lang,
-        total_steps=total_steps,
-        speed=speed,
-        **extra,
-    )
 
     # Supertonic outputs WAV. Caller handles downstream MP3/Opus conversion.
     wav_path = output_path
     if not output_path.endswith(".wav"):
         wav_path = output_path.rsplit(".", 1)[0] + ".wav"
 
-    engine.save_audio(wav, wav_path)
+    # The model and its ONNX sessions are process-global and not thread-safe.
+    cache_key = "supertonic"
+    global _supertonic_tts_cache
+    with _supertonic_tts_lock:
+        if cache_key not in _supertonic_tts_cache:
+            logger.info("[Supertonic] Loading engine (downloads ~400MB model on first use)...")
+            _supertonic_tts_cache[cache_key] = TTS(auto_download=True)
+            logger.info("[Supertonic] Engine loaded")
+        engine = _supertonic_tts_cache[cache_key]
+
+        if voice_style_path:
+            style = engine.get_voice_style_from_path(str(Path(voice_style_path).expanduser()))
+        else:
+            style = engine.get_voice_style(voice_name=voice)
+
+        wav, _ = engine.synthesize(
+            text=text,
+            voice_style=style,
+            lang=lang,
+            total_steps=total_steps,
+            speed=speed,
+            **extra,
+        )
+        engine.save_audio(wav, wav_path)
 
     # Convert to desired format if caller requested mp3/ogg
     if wav_path != output_path:
         ffmpeg = shutil.which("ffmpeg")
         if ffmpeg:
             conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
-            subprocess.run(conv_cmd, check=True, timeout=30)
+            subprocess.run(
+                conv_cmd,
+                check=True,
+                timeout=30,
+                stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
+            )
             try:
                 os.remove(wav_path)
             except OSError:
                 pass
         else:
-            # No ffmpeg — keep WAV and return that path
-            os.rename(wav_path, output_path)
+            return wav_path
 
     return output_path
 
@@ -3054,6 +3065,8 @@ def text_to_speech_tool(
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
+        elif provider == "supertonic":
+            file_path = out_dir / f"tts_{timestamp}.wav"
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
         elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
@@ -3194,7 +3207,7 @@ def text_to_speech_tool(
                              "pip install \"supertonic>=1.3.1,<2\"",
                 }, ensure_ascii=False)
             logger.info("Generating speech with Supertonic (local)...")
-            _generate_supertonic_tts(text, file_str, tts_config)
+            file_str = _generate_supertonic_tts(text, file_str, tts_config)
 
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3122,8 +3122,15 @@ def _generate_supertonic_tts(text: str, output_path: str, tts_config: Dict[str, 
     TTS = _import_supertonic()
 
     st_config = tts_config.get("supertonic", {}) if isinstance(tts_config, dict) else {}
-    voice = st_config.get("voice") or DEFAULT_SUPERTONIC_VOICE
-    lang = st_config.get("lang") or DEFAULT_SUPERTONIC_LANG
+    voice = str(st_config.get("voice") or DEFAULT_SUPERTONIC_VOICE).upper()
+    if voice not in SUPERTONIC_VOICES:
+        logger.warning("[Supertonic] Unknown voice %r; using %s", voice, DEFAULT_SUPERTONIC_VOICE)
+        voice = DEFAULT_SUPERTONIC_VOICE
+
+    lang = str(st_config.get("lang") or DEFAULT_SUPERTONIC_LANG).lower()
+    if lang not in SUPERTONIC_LANGUAGES:
+        logger.warning("[Supertonic] Unknown language %r; using %s", lang, DEFAULT_SUPERTONIC_LANG)
+        lang = DEFAULT_SUPERTONIC_LANG
     voice_style_path = st_config.get("voice_style_path")
 
     # Clamp tunables to the engine's supported ranges.

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3101,6 +3101,7 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
 # Module-level cache for the Supertonic TTS engine instance. The ~400MB model
 # is global (not voice-specific), so one instance is reused for the process.
 _supertonic_tts_cache: Dict[str, Any] = {}
+_supertonic_tts_lock = threading.Lock()
 
 
 def _check_supertonic_available() -> bool:
@@ -3152,53 +3153,63 @@ def _generate_supertonic_tts(text: str, output_path: str, tts_config: Dict[str, 
     # so we stay compatible with the installed engine version.
     extra: Dict[str, Any] = {}
     if "max_chunk_length" in st_config:
-        extra["max_chunk_length"] = int(st_config["max_chunk_length"])
+        try:
+            max_chunk_length = int(st_config["max_chunk_length"])
+        except (TypeError, ValueError):
+            max_chunk_length = 0
+        if max_chunk_length >= 10:
+            extra["max_chunk_length"] = max_chunk_length
     if "silence_duration" in st_config:
         extra["silence_duration"] = float(st_config["silence_duration"])
-
-    # The model is global; cache a single engine instance per process.
-    cache_key = "supertonic"
-    global _supertonic_tts_cache
-    if cache_key not in _supertonic_tts_cache:
-        logger.info("[Supertonic] Loading engine (downloads ~400MB model on first use)...")
-        _supertonic_tts_cache[cache_key] = TTS(auto_download=True)
-        logger.info("[Supertonic] Engine loaded")
-    engine = _supertonic_tts_cache[cache_key]
-
-    if voice_style_path:
-        style = engine.get_voice_style_from_path(str(Path(voice_style_path).expanduser()))
-    else:
-        style = engine.get_voice_style(voice_name=voice)
-
-    wav, _ = engine.synthesize(
-        text=text,
-        voice_style=style,
-        lang=lang,
-        total_steps=total_steps,
-        speed=speed,
-        **extra,
-    )
 
     # Supertonic outputs WAV. Caller handles downstream MP3/Opus conversion.
     wav_path = output_path
     if not output_path.endswith(".wav"):
         wav_path = output_path.rsplit(".", 1)[0] + ".wav"
 
-    engine.save_audio(wav, wav_path)
+    # The model and its ONNX sessions are process-global and not thread-safe.
+    cache_key = "supertonic"
+    global _supertonic_tts_cache
+    with _supertonic_tts_lock:
+        if cache_key not in _supertonic_tts_cache:
+            logger.info("[Supertonic] Loading engine (downloads ~400MB model on first use)...")
+            _supertonic_tts_cache[cache_key] = TTS(auto_download=True)
+            logger.info("[Supertonic] Engine loaded")
+        engine = _supertonic_tts_cache[cache_key]
+
+        if voice_style_path:
+            style = engine.get_voice_style_from_path(str(Path(voice_style_path).expanduser()))
+        else:
+            style = engine.get_voice_style(voice_name=voice)
+
+        wav, _ = engine.synthesize(
+            text=text,
+            voice_style=style,
+            lang=lang,
+            total_steps=total_steps,
+            speed=speed,
+            **extra,
+        )
+        engine.save_audio(wav, wav_path)
 
     # Convert to desired format if caller requested mp3/ogg
     if wav_path != output_path:
         ffmpeg = shutil.which("ffmpeg")
         if ffmpeg:
             conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
-            subprocess.run(conv_cmd, check=True, timeout=30)
+            subprocess.run(
+                conv_cmd,
+                check=True,
+                timeout=30,
+                stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
+            )
             try:
                 os.remove(wav_path)
             except OSError:
                 pass
         else:
-            # No ffmpeg — keep WAV and return that path
-            os.rename(wav_path, output_path)
+            return wav_path
 
     return output_path
 
@@ -3378,6 +3389,8 @@ def _text_to_speech_single(
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
+        elif provider == "supertonic":
+            file_path = out_dir / f"tts_{timestamp}.wav"
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
         elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
@@ -3518,7 +3531,7 @@ def _text_to_speech_single(
                              "pip install \"supertonic>=1.3.1,<2\"",
                 }, ensure_ascii=False)
             logger.info("Generating speech with Supertonic (local)...")
-            _generate_supertonic_tts(text, file_str, tts_config)
+            file_str = _generate_supertonic_tts(text, file_str, tts_config)
 
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -13,6 +13,7 @@ Built-in TTS providers:
 - NeuTTS (local, free, no API key): On-device TTS via neutts
 - KittenTTS (local, free, no API key): On-device 25MB model
 - Piper (local, free, no API key): OHF-Voice/piper1-gpl neural VITS, 44 languages
+- Supertonic (local, free, no API key): ONNX neural TTS, 31 languages, expressive
 
 Custom command providers:
 - Users can declare any number of named providers with ``type: command``
@@ -203,6 +204,19 @@ def _import_piper():
     return PiperVoice
 
 
+def _import_supertonic():
+    """Lazy import Supertonic. Returns the TTS class or raises ImportError.
+
+    Supertonic (Supertonic-3) is a light, fully-local neural TTS engine built
+    on ONNX Runtime (99M params, no torch). ``pip install supertonic`` pulls
+    cross-platform wheels; the ~400MB model is downloaded on first use to
+    ``~/.cache/supertonic3/``. Supports 31 languages, male/female voices
+    (M1–M5 / F1–F5) and expression tags ``<laugh>`` / ``<breath>`` / ``<sigh>``.
+    """
+    from supertonic import TTS
+    return TTS
+
+
 # ===========================================================================
 # Defaults
 # ===========================================================================
@@ -220,6 +234,23 @@ MANAGED_OPENAI_TTS_MODELS = frozenset({"gpt-4o-mini-tts"})
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_PIPER_VOICE = "en_US-lessac-medium"  # balanced size/quality
+DEFAULT_SUPERTONIC_VOICE = "M1"  # M1–M5 (male) / F1–F5 (female)
+DEFAULT_SUPERTONIC_LANG = "en"
+DEFAULT_SUPERTONIC_SPEED = 1.0  # 0.7–2.0 (higher = faster)
+DEFAULT_SUPERTONIC_TOTAL_STEPS = 8  # 5–12 (higher = better quality, slower)
+# Built-in voice styles shipped with the Supertonic model.
+SUPERTONIC_VOICES = ("M1", "M2", "M3", "M4", "M5", "F1", "F2", "F3", "F4", "F5")
+# Supertonic supports 31 languages (+ ``na`` neutral/accentless fallback).
+SUPERTONIC_LANGUAGES = (
+    "en", "ko", "ja", "ar", "bg", "cs", "da", "de", "el", "es", "et", "fi",
+    "fr", "hi", "hr", "hu", "id", "it", "lt", "lv", "nl", "pl", "pt", "ro",
+    "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na",
+)
+# Supertonic speed / quality bounds (from the official synthesize() API).
+SUPERTONIC_SPEED_MIN = 0.7
+SUPERTONIC_SPEED_MAX = 2.0
+SUPERTONIC_TOTAL_STEPS_MIN = 5
+SUPERTONIC_TOTAL_STEPS_MAX = 12
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_MINIMAX_MODEL = "speech-02-hd"
@@ -283,6 +314,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
+    "supertonic": 5000,   # local ONNX model; chunked internally, practical cap
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -780,6 +812,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "kittentts",
     "piper",
     "deepinfra",
+    "supertonic",
 })
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
@@ -3062,6 +3095,108 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
 
 
 # ===========================================================================
+# Provider: Supertonic (local, ONNX, multilingual)
+# ===========================================================================
+
+# Module-level cache for the Supertonic TTS engine instance. The ~400MB model
+# is global (not voice-specific), so one instance is reused for the process.
+_supertonic_tts_cache: Dict[str, Any] = {}
+
+
+def _check_supertonic_available() -> bool:
+    """Check whether the supertonic package is importable."""
+    try:
+        import importlib.util
+        return importlib.util.find_spec("supertonic") is not None
+    except Exception:
+        return False
+
+
+def _generate_supertonic_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using the local Supertonic engine.
+
+    Loads the engine once per process (the model is global, cached by a stable
+    key) and writes a 44.1kHz 16-bit WAV. Caller is responsible for converting
+    to MP3/Opus via ffmpeg when a different output format is required.
+    """
+    TTS = _import_supertonic()
+
+    st_config = tts_config.get("supertonic", {}) if isinstance(tts_config, dict) else {}
+    voice = st_config.get("voice") or DEFAULT_SUPERTONIC_VOICE
+    lang = st_config.get("lang") or DEFAULT_SUPERTONIC_LANG
+    voice_style_path = st_config.get("voice_style_path")
+
+    # Clamp tunables to the engine's supported ranges.
+    try:
+        speed = float(st_config.get("speed", DEFAULT_SUPERTONIC_SPEED))
+    except (TypeError, ValueError):
+        speed = DEFAULT_SUPERTONIC_SPEED
+    speed = max(SUPERTONIC_SPEED_MIN, min(SUPERTONIC_SPEED_MAX, speed))
+
+    try:
+        total_steps = int(st_config.get("total_steps", DEFAULT_SUPERTONIC_TOTAL_STEPS))
+    except (TypeError, ValueError):
+        total_steps = DEFAULT_SUPERTONIC_TOTAL_STEPS
+    total_steps = max(
+        SUPERTONIC_TOTAL_STEPS_MIN, min(SUPERTONIC_TOTAL_STEPS_MAX, total_steps)
+    )
+
+    # Optional, rarely-tuned synthesis knobs — only forwarded when configured
+    # so we stay compatible with the installed engine version.
+    extra: Dict[str, Any] = {}
+    if "max_chunk_length" in st_config:
+        extra["max_chunk_length"] = int(st_config["max_chunk_length"])
+    if "silence_duration" in st_config:
+        extra["silence_duration"] = float(st_config["silence_duration"])
+
+    # The model is global; cache a single engine instance per process.
+    cache_key = "supertonic"
+    global _supertonic_tts_cache
+    if cache_key not in _supertonic_tts_cache:
+        logger.info("[Supertonic] Loading engine (downloads ~400MB model on first use)...")
+        _supertonic_tts_cache[cache_key] = TTS(auto_download=True)
+        logger.info("[Supertonic] Engine loaded")
+    engine = _supertonic_tts_cache[cache_key]
+
+    if voice_style_path:
+        style = engine.get_voice_style_from_path(str(Path(voice_style_path).expanduser()))
+    else:
+        style = engine.get_voice_style(voice_name=voice)
+
+    wav, _ = engine.synthesize(
+        text=text,
+        voice_style=style,
+        lang=lang,
+        total_steps=total_steps,
+        speed=speed,
+        **extra,
+    )
+
+    # Supertonic outputs WAV. Caller handles downstream MP3/Opus conversion.
+    wav_path = output_path
+    if not output_path.endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+
+    engine.save_audio(wav, wav_path)
+
+    # Convert to desired format if caller requested mp3/ogg
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            subprocess.run(conv_cmd, check=True, timeout=30)
+            try:
+                os.remove(wav_path)
+            except OSError:
+                pass
+        else:
+            # No ffmpeg — keep WAV and return that path
+            os.rename(wav_path, output_path)
+
+    return output_path
+
+
+# ===========================================================================
 # Provider: KittenTTS (local, lightweight)
 # ===========================================================================
 
@@ -3365,6 +3500,19 @@ def _text_to_speech_single(
             logger.info("Generating speech with Piper (local)...")
             _generate_piper_tts(text, file_str, tts_config)
 
+        elif provider == "supertonic":
+            try:
+                _import_supertonic()
+            except ImportError:
+                return json.dumps({
+                    "success": False,
+                    "error": "Supertonic provider selected but 'supertonic' package not installed. "
+                             "Run 'hermes setup tts' and choose Supertonic, or install manually: "
+                             "pip install \"supertonic>=1.3.1,<2\"",
+                }, ensure_ascii=False)
+            logger.info("Generating speech with Supertonic (local)...")
+            _generate_supertonic_tts(text, file_str, tts_config)
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -3438,7 +3586,7 @@ def _text_to_speech_single(
                 voice_compatible = file_str.endswith(".ogg")
         elif (
             want_opus
-            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}
+            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper", "supertonic"}
             and not file_str.endswith(".ogg")
         ):
             opus_path = _convert_to_opus(file_str)
@@ -3765,6 +3913,8 @@ def check_tts_requirements() -> bool:
         return _check_kittentts_available()
     if provider == "piper":
         return _check_piper_available()
+    if provider == "supertonic":
+        return _check_supertonic_available()
 
     try:
         from agent.tts_registry import get_provider
@@ -4433,6 +4583,8 @@ if __name__ == "__main__":
         minimax_status = f"unavailable ({exc})"
     print(f"  MiniMax:    {minimax_status}")
     print(f"  Piper:      {'installed' if _check_piper_available() else 'not installed (pip install piper-tts)'}")
+    _supertonic_status = "installed" if _check_supertonic_available() else 'not installed (pip install "supertonic>=1.3.1,<2")'
+    print(f"  Supertonic: {_supertonic_status}")
     print(f"  ffmpeg:     {'✅ found' if _has_ffmpeg() else '❌ not found (needed for Telegram Opus)'}")
     print(f"\n  Output dir: {DEFAULT_OUTPUT_DIR}")
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -211,7 +211,7 @@ def _import_supertonic():
     on ONNX Runtime (99M params, no torch). ``pip install supertonic`` pulls
     cross-platform wheels; the ~400MB model is downloaded on first use to
     ``~/.cache/supertonic3/``. Supports 31 languages, male/female voices
-    (M1–M5 / F1–F5) and expression tags ``<laugh>`` / ``<breath>`` / ``<sigh>``.
+    (M1-M5 / F1-F5) and expression tags ``<laugh>`` / ``<breath>`` / ``<sigh>``.
     """
     from supertonic import TTS
     return TTS
@@ -234,10 +234,10 @@ MANAGED_OPENAI_TTS_MODELS = frozenset({"gpt-4o-mini-tts"})
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_PIPER_VOICE = "en_US-lessac-medium"  # balanced size/quality
-DEFAULT_SUPERTONIC_VOICE = "M1"  # M1–M5 (male) / F1–F5 (female)
+DEFAULT_SUPERTONIC_VOICE = "M1"  # M1-M5 (male) / F1-F5 (female)
 DEFAULT_SUPERTONIC_LANG = "en"
-DEFAULT_SUPERTONIC_SPEED = 1.0  # 0.7–2.0 (higher = faster)
-DEFAULT_SUPERTONIC_TOTAL_STEPS = 8  # 5–12 (higher = better quality, slower)
+DEFAULT_SUPERTONIC_SPEED = 1.0  # 0.7-2.0 (higher = faster)
+DEFAULT_SUPERTONIC_TOTAL_STEPS = 8  # 5-12 (higher = better quality, slower)
 # Built-in voice styles shipped with the Supertonic model.
 SUPERTONIC_VOICES = ("M1", "M2", "M3", "M4", "M5", "F1", "F2", "F3", "F4", "F5")
 # Supertonic supports 31 languages (+ ``na`` neutral/accentless fallback).
@@ -3149,7 +3149,7 @@ def _generate_supertonic_tts(text: str, output_path: str, tts_config: Dict[str, 
         SUPERTONIC_TOTAL_STEPS_MIN, min(SUPERTONIC_TOTAL_STEPS_MAX, total_steps)
     )
 
-    # Optional, rarely-tuned synthesis knobs — only forwarded when configured
+    # Optional, rarely-tuned synthesis knobs - only forwarded when configured
     # so we stay compatible with the installed engine version.
     extra: Dict[str, Any] = {}
     if "max_chunk_length" in st_config:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3136,7 +3136,7 @@ def _generate_supertonic_tts(text: str, output_path: str, tts_config: Dict[str, 
 
     # Clamp tunables to the engine's supported ranges.
     try:
-        speed = float(st_config.get("speed", DEFAULT_SUPERTONIC_SPEED))
+        speed = float(st_config.get("speed", tts_config.get("speed", DEFAULT_SUPERTONIC_SPEED)))
     except (TypeError, ValueError):
         speed = DEFAULT_SUPERTONIC_SPEED
     speed = max(SUPERTONIC_SPEED_MIN, min(SUPERTONIC_SPEED_MAX, speed))

--- a/uv.lock
+++ b/uv.lock
@@ -1731,6 +1731,9 @@ sms = [
 supermemory = [
     { name = "supermemory" },
 ]
+supertonic-tts = [
+    { name = "supertonic" },
+]
 teams = [
     { name = "aiohttp" },
     { name = "microsoft-teams-apps" },
@@ -1926,6 +1929,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'mcp'", specifier = "==1.3.1" },
     { name = "starlette", marker = "extra == 'web'", specifier = "==1.3.1" },
     { name = "supermemory", marker = "extra == 'supermemory'", specifier = "==3.50.0" },
+    { name = "supertonic", marker = "extra == 'supertonic-tts'", specifier = ">=1.3.1,<2" },
     { name = "tenacity", specifier = "==9.1.4" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.21" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = "==2025.3" },
@@ -1936,7 +1940,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "supertonic-tts", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -4239,6 +4243,27 @@ wheels = [
 ]
 
 [[package]]
+name = "soundfile"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/db/949331952a6fb1c5b12e9de80fd08747966c2039d1a61db4764fbd3981c2/soundfile-0.14.0.tar.gz", hash = "sha256:ba1c1a2d618bca5c406647c83b89f07cc8810fa506a50622a6993ba130c1de11", size = 47842, upload-time = "2026-06-06T08:58:47.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/d1/5e338af9ca6ed0786cd5bb03f6d60de1c325728c1189014f3b59aae7403c/soundfile-0.14.0-py2.py3-none-any.whl", hash = "sha256:8ba81ae3a89fd5ab3bef8a8eb481fbbe794e806309675a89b4df48b8d31908a8", size = 26799, upload-time = "2026-06-06T08:58:33.269Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/72/c6b21e58d3113596e7e8de0a08d6f1d95173492cfbca0a4db14148cbba2a/soundfile-0.14.0-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:19be05428da76ed61a4cad29b8e4bcf43a3e5c100089d2ec81dc961eed1b0dd4", size = 1144568, upload-time = "2026-06-06T08:58:35.231Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/dfdd6f8c748988427119f75eb860a3cedd858d1aea1fe28f39ad8559ef22/soundfile-0.14.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d828d35a059626da52f1415b5faee610aeab393319cb3fc4a9aef47b619fc14c", size = 1103726, upload-time = "2026-06-06T08:58:37.948Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f8/fc39fad6f879633461d27394cd1ddaf1f769ffa0597dca35872f51b16461/soundfile-0.14.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:e85724a90bc99a6e8062c0b4ddf725f53b2a3b70afd4da875e9d2cfc4e92f377", size = 1238050, upload-time = "2026-06-06T08:58:39.932Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a2/70fd4432b924684c372df8b0a45708c36c057ef3596c9eb53e0a806b980b/soundfile-0.14.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:1e38bac1853412871318e82a1ba69a8be677619b56025bbfcccdb41b6cafe82d", size = 1315963, upload-time = "2026-06-06T08:58:41.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/34/c9e80783d83eab739a9531fdee03675d53e0bf1b2ccb4bb3af5844675046/soundfile-0.14.0-py2.py3-none-win32.whl", hash = "sha256:0a6ae43c50c71b4e020cc55382925cb89451c1ed1a0c3d0f5d802da269226849", size = 902199, upload-time = "2026-06-06T08:58:43.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/97/b39c18ac1df45e755ca22b8b00e872929da5d107998a207a5e4ac831bfda/soundfile-0.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:299491d3499460fb1b74bb4bd78b57ffc2d243a5fafa7b6ec1b264875c78453e", size = 1021480, upload-time = "2026-06-06T08:58:45.016Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/83/55c65e61cf457805ce2ec157c1c6ae17715d0851aa2374422de0538838ca/soundfile-0.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:e090704718e124e7c844695236f1fce8d18a5e761eaf7c82dfcd124620805f98", size = 888858, upload-time = "2026-06-06T08:58:46.593Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.51"
 source = { registry = "https://pypi.org/simple" }
@@ -4313,6 +4338,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/62/867fead9beac94a1f27f90fce9bc5b5def4464e182cd75eab0ac0d40232a/supermemory-3.50.0.tar.gz", hash = "sha256:f74b56b9f1df05fc7de0bd04722a5f5b3ab22f6388585dc7f66fe15a566ad972", size = 174419, upload-time = "2026-06-24T09:29:13.139Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/be/caf3b7d4b21851c7d8ddec7661f22089d95bb55bc7b4bdd79dea1001604e/supermemory-3.50.0-py3-none-any.whl", hash = "sha256:f6e2dd142934ec213d561414aeb0164ee408a34d339b84ed93440f03f4ca2290", size = 155533, upload-time = "2026-06-24T09:29:12.012Z" },
+]
+
+[[package]]
+name = "supertonic"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "soundfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/fe/1431393433d0c0570b54b8bd1307502fa0231238ed2cd9506c3e2799a12a/supertonic-1.3.1.tar.gz", hash = "sha256:4367e8f61afea618dac948f6bee55fed4721ad66ca2d3fc90771a2a66740731e", size = 54853, upload-time = "2026-05-18T09:50:39.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/9f/d3c0367115b378d09a3866502609841c283fbd48c5b8f58902a03f81b752/supertonic-1.3.1-py3-none-any.whl", hash = "sha256:0079c9d4166008b8a6eeae95f20c092148786b7232192dd3dd9f358960c6c077", size = 51871, upload-time = "2026-05-18T09:50:38.376Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1731,6 +1731,9 @@ sms = [
 supermemory = [
     { name = "supermemory" },
 ]
+supertonic-tts = [
+    { name = "supertonic" },
+]
 teams = [
     { name = "aiohttp" },
     { name = "microsoft-teams-apps" },
@@ -1921,6 +1924,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'mcp'", specifier = "==1.3.1" },
     { name = "starlette", marker = "extra == 'web'", specifier = "==1.3.1" },
     { name = "supermemory", marker = "extra == 'supermemory'", specifier = "==3.50.0" },
+    { name = "supertonic", marker = "extra == 'supertonic-tts'", specifier = ">=1.3.1,<2" },
     { name = "tenacity", specifier = "==9.1.4" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.21" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = "==2025.3" },
@@ -1931,7 +1935,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "tts-premium", "supertonic-tts", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -4225,6 +4229,27 @@ wheels = [
 ]
 
 [[package]]
+name = "soundfile"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "numpy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/db/949331952a6fb1c5b12e9de80fd08747966c2039d1a61db4764fbd3981c2/soundfile-0.14.0.tar.gz", hash = "sha256:ba1c1a2d618bca5c406647c83b89f07cc8810fa506a50622a6993ba130c1de11", size = 47842, upload-time = "2026-06-06T08:58:47.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/d1/5e338af9ca6ed0786cd5bb03f6d60de1c325728c1189014f3b59aae7403c/soundfile-0.14.0-py2.py3-none-any.whl", hash = "sha256:8ba81ae3a89fd5ab3bef8a8eb481fbbe794e806309675a89b4df48b8d31908a8", size = 26799, upload-time = "2026-06-06T08:58:33.269Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/72/c6b21e58d3113596e7e8de0a08d6f1d95173492cfbca0a4db14148cbba2a/soundfile-0.14.0-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:19be05428da76ed61a4cad29b8e4bcf43a3e5c100089d2ec81dc961eed1b0dd4", size = 1144568, upload-time = "2026-06-06T08:58:35.231Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/dfdd6f8c748988427119f75eb860a3cedd858d1aea1fe28f39ad8559ef22/soundfile-0.14.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d828d35a059626da52f1415b5faee610aeab393319cb3fc4a9aef47b619fc14c", size = 1103726, upload-time = "2026-06-06T08:58:37.948Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f8/fc39fad6f879633461d27394cd1ddaf1f769ffa0597dca35872f51b16461/soundfile-0.14.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:e85724a90bc99a6e8062c0b4ddf725f53b2a3b70afd4da875e9d2cfc4e92f377", size = 1238050, upload-time = "2026-06-06T08:58:39.932Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a2/70fd4432b924684c372df8b0a45708c36c057ef3596c9eb53e0a806b980b/soundfile-0.14.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:1e38bac1853412871318e82a1ba69a8be677619b56025bbfcccdb41b6cafe82d", size = 1315963, upload-time = "2026-06-06T08:58:41.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/34/c9e80783d83eab739a9531fdee03675d53e0bf1b2ccb4bb3af5844675046/soundfile-0.14.0-py2.py3-none-win32.whl", hash = "sha256:0a6ae43c50c71b4e020cc55382925cb89451c1ed1a0c3d0f5d802da269226849", size = 902199, upload-time = "2026-06-06T08:58:43.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/97/b39c18ac1df45e755ca22b8b00e872929da5d107998a207a5e4ac831bfda/soundfile-0.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:299491d3499460fb1b74bb4bd78b57ffc2d243a5fafa7b6ec1b264875c78453e", size = 1021480, upload-time = "2026-06-06T08:58:45.016Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/83/55c65e61cf457805ce2ec157c1c6ae17715d0851aa2374422de0538838ca/soundfile-0.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:e090704718e124e7c844695236f1fce8d18a5e761eaf7c82dfcd124620805f98", size = 888858, upload-time = "2026-06-06T08:58:46.593Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.51"
 source = { registry = "https://pypi.org/simple" }
@@ -4299,6 +4324,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/62/867fead9beac94a1f27f90fce9bc5b5def4464e182cd75eab0ac0d40232a/supermemory-3.50.0.tar.gz", hash = "sha256:f74b56b9f1df05fc7de0bd04722a5f5b3ab22f6388585dc7f66fe15a566ad972", size = 174419, upload-time = "2026-06-24T09:29:13.139Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/be/caf3b7d4b21851c7d8ddec7661f22089d95bb55bc7b4bdd79dea1001604e/supermemory-3.50.0-py3-none-any.whl", hash = "sha256:f6e2dd142934ec213d561414aeb0164ee408a34d339b84ed93440f03f4ca2290", size = 155533, upload-time = "2026-06-24T09:29:12.012Z" },
+]
+
+[[package]]
+name = "supertonic"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "onnxruntime" },
+    { name = "soundfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/fe/1431393433d0c0570b54b8bd1307502fa0231238ed2cd9506c3e2799a12a/supertonic-1.3.1.tar.gz", hash = "sha256:4367e8f61afea618dac948f6bee55fed4721ad66ca2d3fc90771a2a66740731e", size = 54853, upload-time = "2026-05-18T09:50:39.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/9f/d3c0367115b378d09a3866502609841c283fbd48c5b8f58902a03f81b752/supertonic-1.3.1-py3-none-any.whl", hash = "sha256:0079c9d4166008b8a6eeae95f20c092148786b7232192dd3dd9f358960c6c077", size = 51871, upload-time = "2026-05-18T09:50:38.376Z" },
 ]
 
 [[package]]

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -150,6 +150,7 @@ ELEVENLABS_API_KEY=***
 - `elevenlabs` → best quality
 - `openai` → good middle ground
 - `mistral` → multilingual, native Opus
+- `supertonic` → free local TTS with expressive voices
 
 ### If you use `hermes setup`
 

--- a/website/docs/user-guide/features/overview.md
+++ b/website/docs/user-guide/features/overview.md
@@ -36,7 +36,7 @@ Hermes Agent includes a rich set of capabilities that extend far beyond basic ch
 - **[Browser Automation](browser.md)** — Full browser automation with multiple backends: Browserbase cloud, Browser Use cloud, local Chrome/Brave/Chromium/Edge via CDP, or local Chromium. Navigate websites, fill forms, and extract information.
 - **[Vision & Image Paste](vision.md)** — Multimodal vision support. Paste images from your clipboard into the CLI and ask the agent to analyze, describe, or work with them using any vision-capable model.
 - **[Image Generation](image-generation.md)** — Generate images from text prompts using FAL.ai. Eleven models supported (FLUX 2 Klein/Pro, GPT-Image 1.5/2, Nano Banana Pro, Ideogram V3, Recraft V4 Pro, Qwen, Z-Image Turbo, Krea V2 Medium/Large); pick one via `hermes tools`.
-- **[Voice & TTS](tts.md)** — Text-to-speech output and voice message transcription across all messaging platforms, with ten native provider options: Edge TTS (free), ElevenLabs, OpenAI TTS, MiniMax, Mistral Voxtral, Google Gemini, xAI, NeuTTS, KittenTTS, and Piper — plus custom command providers for any local TTS CLI.
+- **[Voice & TTS](tts.md)** - Text-to-speech output and voice message transcription across all messaging platforms, with eleven native provider options: Edge TTS (free), ElevenLabs, OpenAI TTS, MiniMax, Mistral Voxtral, Google Gemini, xAI, NeuTTS, KittenTTS, Piper, and Supertonic - plus custom command providers for any local TTS CLI.
 
 ## Integrations
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -110,7 +110,7 @@ tts:
     speed: 1.0                                  # 0.7 - 2.0 (higher = faster)
     total_steps: 8                              # 5 - 12 (higher = better quality, slower)
     # voice_style_path: ''                      # custom voice style from the Supertonic Voice Builder
-    # max_chunk_length: 0                        # override internal text chunking
+    # max_chunk_length: 300                      # override internal text chunking (minimum: 10)
     # silence_duration: 0.0                      # silence between chunks (seconds)
 ```
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -29,6 +29,7 @@ Convert text to speech with eleven providers:
 | **NeuTTS** | Good | Free (local) | None needed |
 | **KittenTTS** | Good | Free (local) | None needed |
 | **Piper** | Good | Free (local) | None needed |
+| **Supertonic** | Good | Free (local) | None needed |
 
 ### Platform Delivery
 
@@ -44,7 +45,7 @@ Convert text to speech with eleven providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "deepinfra" | "neutts" | "kittentts" | "piper"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "deepinfra" | "neutts" | "kittentts" | "piper" | "supertonic"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -103,6 +104,14 @@ tts:
     # noise_w_scale: 0.8
     # volume: 1.0                               # 0.5 = half as loud
     # normalize_audio: true
+  supertonic:
+    voice: M1                                   # M1–M5 (male) / F1–F5 (female)
+    lang: en                                    # 31 languages + 'na' neutral (see list below)
+    speed: 1.0                                  # 0.7 - 2.0 (higher = faster)
+    total_steps: 8                              # 5 - 12 (higher = better quality, slower)
+    # voice_style_path: ''                      # custom voice style from the Supertonic Voice Builder
+    # max_chunk_length: 0                        # override internal text chunking
+    # silence_duration: 0.0                      # silence between chunks (seconds)
 ```
 
 MiniMax TTS selects its region, endpoint, and credential together:
@@ -163,6 +172,7 @@ Each provider has a documented per-request input-character cap. Hermes truncates
 | NeuTTS | 2000 |
 | KittenTTS | 2000 |
 | Piper | 5000 |
+| Supertonic | 5000 |
 
 **ElevenLabs** picks a cap from the configured `model_id`:
 
@@ -196,6 +206,7 @@ Telegram voice bubbles require Opus/OGG audio format:
 - **NeuTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 - **KittenTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 - **Piper** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
+- **Supertonic** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 
 ```bash
 # Ubuntu/Debian
@@ -208,7 +219,7 @@ brew install ffmpeg
 sudo dnf install ffmpeg
 ```
 
-Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, and Piper audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
+Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, Piper, and Supertonic audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
 
 :::tip
 If you want voice bubbles without installing ffmpeg, switch to the OpenAI, ElevenLabs, or Mistral provider.
@@ -255,6 +266,48 @@ tts:
 ```
 
 **Advanced knobs** (`tts.piper.length_scale` / `noise_scale` / `noise_w_scale` / `volume` / `normalize_audio`, `use_cuda`) correspond 1:1 to Piper's `SynthesisConfig`. They're ignored on older `piper-tts` versions.
+
+### Supertonic (local, 31 languages)
+
+Supertonic is a light, fully-local neural TTS engine built on ONNX Runtime (99M params, no PyTorch). It runs on CPU, supports **31 languages**, ships with male/female voices, understands inline **expression tags**, and needs no API key.
+
+**Install via `hermes tools`** → Voice & TTS → Supertonic — Hermes runs `pip install "supertonic>=1.3.1,<2"` for you. You can also pick it interactively via `hermes setup tts` (which lets you choose voice, language, speed, and quality), or install manually: `pip install "supertonic>=1.3.1,<2"`.
+
+On the first TTS call, Supertonic downloads its ~400MB model into `~/.cache/supertonic3/`. Subsequent calls reuse the cached model (loaded once per process).
+
+**Switch to Supertonic:**
+
+```yaml
+tts:
+  provider: supertonic
+  supertonic:
+    voice: M1            # M1–M5 (male) / F1–F5 (female)
+    lang: en
+    speed: 1.0           # 0.7 - 2.0 (higher = faster)
+    total_steps: 8       # 5 - 12 (higher = better quality, slower)
+```
+
+**Voices.** Ten built-in voice styles: `M1`–`M5` (male) and `F1`–`F5` (female).
+
+**Languages.** Set `tts.supertonic.lang` to one of the 31 supported ISO codes (plus `na` for a neutral/accentless rendering):
+
+`en, ko, ja, ar, bg, cs, da, de, el, es, et, fi, fr, hi, hr, hu, id, it, lt, lv, nl, pl, pt, ro, ru, sk, sl, sv, tr, uk, vi, na`
+
+**Expression tags.** Embed `<laugh>`, `<breath>`, or `<sigh>` directly in the text to add non-verbal expression, e.g. `That's hilarious <laugh> — anyway, where were we?`
+
+**Custom voices.** If you built a voice with the Supertonic Voice Builder, point `tts.supertonic.voice_style_path` at the exported style file; it takes precedence over `voice`.
+
+**Polish example** (matches a known-good production setup):
+
+```yaml
+tts:
+  provider: supertonic
+  supertonic:
+    voice: M3
+    lang: pl
+    speed: 1.4
+    total_steps: 10
+```
 
 ### Custom command providers
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -105,7 +105,7 @@ tts:
     # volume: 1.0                               # 0.5 = half as loud
     # normalize_audio: true
   supertonic:
-    voice: M1                                   # M1–M5 (male) / F1–F5 (female)
+    voice: M1                                   # M1-M5 (male) / F1-F5 (female)
     lang: en                                    # 31 languages + 'na' neutral (see list below)
     speed: 1.0                                  # 0.7 - 2.0 (higher = faster)
     total_steps: 8                              # 5 - 12 (higher = better quality, slower)
@@ -271,7 +271,7 @@ tts:
 
 Supertonic is a light, fully-local neural TTS engine built on ONNX Runtime (99M params, no PyTorch). It runs on CPU, supports **31 languages**, ships with male/female voices, understands inline **expression tags**, and needs no API key.
 
-**Install via `hermes tools`** → Voice & TTS → Supertonic — Hermes runs `pip install "supertonic>=1.3.1,<2"` for you. You can also pick it interactively via `hermes setup tts` (which lets you choose voice, language, speed, and quality), or install manually: `pip install "supertonic>=1.3.1,<2"`.
+**Install via `hermes tools`** -> Voice & TTS -> Supertonic - Hermes runs `pip install "supertonic>=1.3.1,<2"` for you. You can also pick it interactively via `hermes setup tts` (which lets you choose voice, language, speed, and quality), or install manually: `pip install "supertonic>=1.3.1,<2"`.
 
 On the first TTS call, Supertonic downloads its ~400MB model into `~/.cache/supertonic3/`. Subsequent calls reuse the cached model (loaded once per process).
 
@@ -281,19 +281,19 @@ On the first TTS call, Supertonic downloads its ~400MB model into `~/.cache/supe
 tts:
   provider: supertonic
   supertonic:
-    voice: M1            # M1–M5 (male) / F1–F5 (female)
+    voice: M1            # M1-M5 (male) / F1-F5 (female)
     lang: en
     speed: 1.0           # 0.7 - 2.0 (higher = faster)
     total_steps: 8       # 5 - 12 (higher = better quality, slower)
 ```
 
-**Voices.** Ten built-in voice styles: `M1`–`M5` (male) and `F1`–`F5` (female).
+**Voices.** Ten built-in voice styles: `M1`-`M5` (male) and `F1`-`F5` (female).
 
 **Languages.** Set `tts.supertonic.lang` to one of the 31 supported ISO codes (plus `na` for a neutral/accentless rendering):
 
 `en, ko, ja, ar, bg, cs, da, de, el, es, et, fi, fr, hi, hr, hu, id, it, lt, lv, nl, pl, pt, ro, ru, sk, sl, sv, tr, uk, vi, na`
 
-**Expression tags.** Embed `<laugh>`, `<breath>`, or `<sigh>` directly in the text to add non-verbal expression, e.g. `That's hilarious <laugh> — anyway, where were we?`
+**Expression tags.** Embed `<laugh>`, `<breath>`, or `<sigh>` directly in the text to add non-verbal expression, e.g. `That's hilarious <laugh> - anyway, where were we?`
 
 **Custom voices.** If you built a voice with the Supertonic Voice Builder, point `tts.supertonic.voice_style_path` at the exported style file; it takes precedence over `voice`.
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -29,6 +29,7 @@ Convert text to speech with eleven providers:
 | **NeuTTS** | Good | Free (local) | None needed |
 | **KittenTTS** | Good | Free (local) | None needed |
 | **Piper** | Good | Free (local) | None needed |
+| **Supertonic** | Good | Free (local) | None needed |
 
 ### Platform Delivery
 
@@ -44,7 +45,7 @@ Convert text to speech with eleven providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "deepinfra" | "neutts" | "kittentts" | "piper"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "deepinfra" | "neutts" | "kittentts" | "piper" | "supertonic"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -103,6 +104,14 @@ tts:
     # noise_w_scale: 0.8
     # volume: 1.0                               # 0.5 = half as loud
     # normalize_audio: true
+  supertonic:
+    voice: M1                                   # M1–M5 (male) / F1–F5 (female)
+    lang: en                                    # 31 languages + 'na' neutral (see list below)
+    speed: 1.0                                  # 0.7 - 2.0 (higher = faster)
+    total_steps: 8                              # 5 - 12 (higher = better quality, slower)
+    # voice_style_path: ''                      # custom voice style from the Supertonic Voice Builder
+    # max_chunk_length: 0                        # override internal text chunking
+    # silence_duration: 0.0                      # silence between chunks (seconds)
 ```
 
 MiniMax TTS selects its region, endpoint, and credential together:
@@ -163,6 +172,7 @@ Each provider has a documented per-request input-character cap. Hermes splits lo
 | NeuTTS | 2000 |
 | KittenTTS | 2000 |
 | Piper | 5000 |
+| Supertonic | 5000 |
 
 **ElevenLabs** picks a cap from the configured `model_id`:
 
@@ -196,6 +206,7 @@ Telegram voice bubbles require Opus/OGG audio format:
 - **NeuTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 - **KittenTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 - **Piper** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
+- **Supertonic** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
 
 ```bash
 # Ubuntu/Debian
@@ -208,7 +219,7 @@ brew install ffmpeg
 sudo dnf install ffmpeg
 ```
 
-Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, and Piper audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
+Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, Piper, and Supertonic audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
 
 :::tip
 If you want voice bubbles without installing ffmpeg, switch to the OpenAI, ElevenLabs, or Mistral provider.
@@ -255,6 +266,48 @@ tts:
 ```
 
 **Advanced knobs** (`tts.piper.length_scale` / `noise_scale` / `noise_w_scale` / `volume` / `normalize_audio`, `use_cuda`) correspond 1:1 to Piper's `SynthesisConfig`. They're ignored on older `piper-tts` versions.
+
+### Supertonic (local, 31 languages)
+
+Supertonic is a light, fully-local neural TTS engine built on ONNX Runtime (99M params, no PyTorch). It runs on CPU, supports **31 languages**, ships with male/female voices, understands inline **expression tags**, and needs no API key.
+
+**Install via `hermes tools`** → Voice & TTS → Supertonic — Hermes runs `pip install "supertonic>=1.3.1,<2"` for you. You can also pick it interactively via `hermes setup tts` (which lets you choose voice, language, speed, and quality), or install manually: `pip install "supertonic>=1.3.1,<2"`.
+
+On the first TTS call, Supertonic downloads its ~400MB model into `~/.cache/supertonic3/`. Subsequent calls reuse the cached model (loaded once per process).
+
+**Switch to Supertonic:**
+
+```yaml
+tts:
+  provider: supertonic
+  supertonic:
+    voice: M1            # M1–M5 (male) / F1–F5 (female)
+    lang: en
+    speed: 1.0           # 0.7 - 2.0 (higher = faster)
+    total_steps: 8       # 5 - 12 (higher = better quality, slower)
+```
+
+**Voices.** Ten built-in voice styles: `M1`–`M5` (male) and `F1`–`F5` (female).
+
+**Languages.** Set `tts.supertonic.lang` to one of the 31 supported ISO codes (plus `na` for a neutral/accentless rendering):
+
+`en, ko, ja, ar, bg, cs, da, de, el, es, et, fi, fr, hi, hr, hu, id, it, lt, lv, nl, pl, pt, ro, ru, sk, sl, sv, tr, uk, vi, na`
+
+**Expression tags.** Embed `<laugh>`, `<breath>`, or `<sigh>` directly in the text to add non-verbal expression, e.g. `That's hilarious <laugh> — anyway, where were we?`
+
+**Custom voices.** If you built a voice with the Supertonic Voice Builder, point `tts.supertonic.voice_style_path` at the exported style file; it takes precedence over `voice`.
+
+**Polish example** (matches a known-good production setup):
+
+```yaml
+tts:
+  provider: supertonic
+  supertonic:
+    voice: M3
+    lang: pl
+    speed: 1.4
+    total_steps: 10
+```
 
 ### Custom command providers
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -109,7 +109,7 @@ tts:
     lang: en                                    # 31 languages + 'na' neutral (see list below)
     speed: 1.0                                  # 0.7 - 2.0 (higher = faster)
     total_steps: 8                              # 5 - 12 (higher = better quality, slower)
-    # voice_style_path: ''                      # custom voice style from the Supertonic Voice Builder
+    # voice_style_path: ''                      # previously exported custom voice style
     # max_chunk_length: 300                      # override internal text chunking (minimum: 10)
     # silence_duration: 0.0                      # silence between chunks (seconds)
 ```
@@ -275,6 +275,12 @@ Supertonic is a light, fully-local neural TTS engine built on ONNX Runtime (99M 
 
 On the first TTS call, Supertonic downloads its ~400MB model into `~/.cache/supertonic3/`. Subsequent calls reuse the cached model (loaded once per process).
 
+:::caution Upstream support ending
+Supertone [announced](https://github.com/supertone-inc/supertonic) that the open-source Supertonic repositories will be archived and official model support will end. Its Voice Builder will become unavailable after August 31, 2026. Local synthesis with downloaded models and built-in or previously exported voice styles does not depend on that service, but future upstream fixes should not be expected.
+:::
+
+The Python package and sample code use the MIT license. The downloaded model weights use the [OpenRAIL-M license](https://huggingface.co/Supertone/supertonic-3/blob/main/LICENSE), including its use restrictions and redistribution terms.
+
 **Switch to Supertonic:**
 
 ```yaml
@@ -295,7 +301,7 @@ tts:
 
 **Expression tags.** Embed `<laugh>`, `<breath>`, or `<sigh>` directly in the text to add non-verbal expression, e.g. `That's hilarious <laugh> - anyway, where were we?`
 
-**Custom voices.** If you built a voice with the Supertonic Voice Builder, point `tts.supertonic.voice_style_path` at the exported style file; it takes precedence over `voice`.
+**Existing custom voices.** Point `tts.supertonic.voice_style_path` at a previously exported style file; it takes precedence over `voice`. The hosted Voice Builder will not be available after August 31, 2026.
 
 **Polish example** (matches a known-good production setup):
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -434,7 +434,7 @@ stt:
 
 # Text-to-Speech
 tts:
-  provider: "edge"                 # "edge" (free) | "elevenlabs" | "openai" | "neutts" | "minimax" | "mistral" | "gemini" | "xai" | "kittentts" | "piper"
+  provider: "edge"                 # "edge" (free) | "elevenlabs" | "openai" | "neutts" | "minimax" | "mistral" | "gemini" | "xai" | "kittentts" | "piper" | "supertonic"
   edge:
     voice: "en-US-AriaNeural"      # 322 voices, 74 languages
   elevenlabs:


### PR DESCRIPTION
## What does this PR do?
  
  Adds **Supertonic** as a native, built-in TTS provider, mirroring the existing Piper integration.

  Until now Supertonic could only be used through the generic `tts.providers.<name>: type: command` escape hatch (a separate venv + a custom CLI script), with no setup UX, no config schema, and no discoverability.
  Supertonic is a fully local, fast ONNX engine (no torch, ~400MB model, 31 languages, voices M1–M5 / F1–F5) — exactly the class of the existing Piper provider — so it deserves first-class support.

  This PR wires it in end-to-end: runtime synthesis + dispatch, interactive `hermes setup tts` flow (language → voice → speed → quality), the `hermes tools` picker with a post-setup installer, config defaults,
  docs, and tests. Install is via pip with lazy-import, no runtime auto-install (explicit setup required), and no API keys (fully local). The pattern deliberately follows the existing Piper provider for
  consistency.
  
  ## Related Issue

  Fixes #35396 
  
  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨  New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [ ] ✅ Tests  (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made
  
  - `tools/tts_tool.py` — lazy `_import_supertonic`, `_generate_supertonic_tts`, register `supertonic` in `BUILTIN_TTS_PROVIDERS`, dispatch branch, `PROVIDER_MAX_TEXT_LENGTH` cap, WAV→Opus for Telegram voice
  notes, `check_tts_requirements`, status line.
  - `agent/tts_registry.py` — add `supertonic` to `_BUILTIN_NAMES` (kept in sync with `BUILTIN_TTS_PROVIDERS`).
  - `hermes_cli/setup.py` — interactive Supertonic flow: language → voice (M1–M5 / F1–F5) → speed (0.7–2.0) → quality via `total_steps` (Fast 5 / Balanced 8 / High 10 / Very High 12), with dependency install +
  edge fallback.
  - `hermes_cli/tools_config.py` — `hermes tools` picker entry + post-setup installer.
  - `hermes_cli/config.py` — `tts.supertonic.{voice,lang,speed,total_steps}` defaults (M1 / en / 1.0 / 8).
  - `pyproject.toml` / `uv.lock` — bounded `supertonic-tts = ["supertonic>=1.3.1,<2"]` optional extra and regenerated lock data (kept out of `[all]`, like the other TTS backends).
  - `website/docs/user-guide/features/tts.md` — provider table, config example, limits, ffmpeg note, and a dedicated Supertonic section.
  - Tests cover registration, setup/install reuse, schema exposure, synthesis, invalid-config fallback, clamping, dispatch, and requirements.

  ## How to Test

  1. `pip install -e ".[supertonic-tts]"` (or run `hermes setup tts` and pick **Supertonic** to install it on demand).
  2. Run `hermes setup tts` → choose **Supertonic** → pick language → voice → speed → quality, and confirm it writes `tts.provider: supertonic` + `tts.supertonic.*` to `~/.hermes/config.yaml`.
  3. Real synthesis (downloads the ~400MB model on first use):
     `python -c "from tools.tts_tool import text_to_speech_tool; print(text_to_speech_tool(text='Cześć, to jest test Supertonic.', output_path='/tmp/st.wav'))"` with `provider=supertonic`, `lang=pl`, `voice=M3` →
  expect `success: True` and an existing audio file.
  4. Current-main verification:
     - `scripts/run_tests.sh tests/tools/test_tts_supertonic.py tests/hermes_cli/test_setup_supertonic.py tests/hermes_cli/test_web_server.py` → **395 passed**.
     - `npm --prefix apps/desktop run test:ui -- src/app/settings/helpers.test.ts` → **19 passed**.
     - `npm --prefix apps/desktop run typecheck` → passed.
     - `.venv/bin/ruff check ...` (all changed Python files), `python3 scripts/check-windows-footguns.py --diff upstream/main`, `uv lock --check`, and `git diff --check upstream/main...HEAD` → passed.
     - Imported `supertonic==1.3.1` in an isolated environment and verified the live `TTS`, `synthesize`, voice-style, and `save_audio` signatures used here.

  ## Checklist

  ### Code

  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - [x] I've run the affected suites through the repository's canonical `scripts/run_tests.sh` plus desktop UI/typecheck checks
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: macOS 15 (Sequoia) + Ubuntu (Linux test host)
  
  ### Documentation & Housekeeping
  
  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - [x] N/A — no new keys in `cli-config.yaml.example` (TTS provider defaults live in `hermes_cli/config.py`)
  - [x] N/A — no architecture/workflow changes to `CONTRIBUTING.md` or `AGENTS.md` 
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
  
  ## Screenshots / Logs
  
<img width="798" height="334" alt="image" src="https://github.com/user-attachments/assets/1d876c76-a4f4-4fbe-92f3-c7e93126e600" />

