### PR TITLE
fix: sync Telegram DM topic name on /title command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13229,6 +13229,14 @@ class GatewayRunner:
             # Set the title
             try:
                 if self._session_db.set_session_title(session_id, sanitized):
+                    # Mirror the title to the Telegram DM topic name (same as
+                    # auto-title does).  Best-effort; don't fail the command.
+                    try:
+                        await self._rename_telegram_topic_for_session_title(
+                            source, session_id, sanitized
+                        )
+                    except Exception:
+                        pass
                     return t("gateway.title.set_to", title=sanitized)
                 else:
                     return t("gateway.title.not_found")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1406,6 +1406,7 @@ AUTHOR_MAP = {
     "peter.yuqin@gmail.com": "WuKongAI-CMU",  # PR #10082 (reject symlinked audio inputs)
     "sunil.nitie@gmail.com": "Sunil123135",  # PR #31031 (Windows Docker Desktop compose)
     "weichangyuwcy@gmail.com": "ChyuWei",  # PR #30987 (TUI TTS env var on voice off)
+    "dillweed@users.noreply.github.com": "dillweed",  # PR #35400 (sync Telegram topic on /title)
 }
 
 


### PR DESCRIPTION
## Problem

The auto-title flow (background audit) already renames the Telegram DM topic via `_rename_telegram_topic_for_session_title()`, but the manual `/title` slash command only updated the session DB title. The Telegram topic stayed as "New Thread".

## Fix

Call the existing `_rename_telegram_topic_for_session_title()` from `_handle_title_command()` after a successful DB title set — the same method the auto-title path already uses. This method handles all the guards (platform check, disable_topic_auto_rename config, operator-declared topics, session binding verification) so no logic is duplicated.

Best-effort only; failures from the rename are silently swallowed so a Telegram API hiccup doesn't break the title command itself.

## Change

+5 lines in `gateway/run.py` — `_handle_title_command()`

## Testing

Tested live: `/title` on a Telegram DM topic session renamed both the session DB title and the Telegram forum topic name.
