### PR TITLE
fix(slack): wire up mention_patterns config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -972,6 +972,8 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(ac, list):
                         ac = ",".join(str(v) for v in ac)
                     os.environ["SLACK_ALLOWED_CHANNELS"] = str(ac)
+                if "mention_patterns" in slack_cfg and not os.getenv("SLACK_MENTION_PATTERNS"):
+                    os.environ["SLACK_MENTION_PATTERNS"] = json.dumps(slack_cfg["mention_patterns"])
 
             # Bridge top-level require_mention to Telegram when the telegram: section
             # does not already provide one.  Users often write "require_mention: true"

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -369,6 +369,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
         self._socket_watchdog_interval_s = 15.0
+        self._mention_patterns: List[re.Pattern] = self._compile_mention_patterns()
 
     def _start_socket_mode_handler(self) -> None:
         """Start the Slack Socket Mode background task."""
@@ -2333,10 +2334,12 @@ class SlackAdapter(BasePlatformAdapter):
                     thread_ts=event_thread_ts,
                     user_id=user_id,
                 )
+                matches_pattern = self._message_matches_mention_patterns(routing_text)
                 if (
                     not reply_to_bot_thread
                     and not in_mentioned_thread
                     and not has_session
+                    and not matches_pattern
                 ):
                     return
 
@@ -3517,3 +3520,46 @@ class SlackAdapter(BasePlatformAdapter):
         if isinstance(raw, str) and raw.strip():
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
+
+    def _compile_mention_patterns(self) -> List[re.Pattern]:
+        """Compile optional regex wake-word patterns for channel triggers."""
+        patterns = self.config.extra.get("mention_patterns") if self.config.extra else None
+        if patterns is None:
+            raw = os.getenv("SLACK_MENTION_PATTERNS", "").strip()
+            if raw:
+                try:
+                    loaded = json.loads(raw)
+                except Exception:
+                    loaded = [part.strip() for part in raw.splitlines() if part.strip()]
+                    if not loaded:
+                        loaded = [part.strip() for part in raw.split(",") if part.strip()]
+                patterns = loaded
+
+        if patterns is None:
+            return []
+        if isinstance(patterns, str):
+            patterns = [patterns]
+        if not isinstance(patterns, list):
+            logger.warning(
+                "[%s] slack mention_patterns must be a list or string; got %s",
+                self.name,
+                type(patterns).__name__,
+            )
+            return []
+
+        compiled: List[re.Pattern] = []
+        for pattern in patterns:
+            if not isinstance(pattern, str) or not pattern.strip():
+                continue
+            try:
+                compiled.append(re.compile(pattern, re.IGNORECASE))
+            except re.error as exc:
+                logger.warning("[%s] Invalid Slack mention pattern %r: %s", self.name, pattern, exc)
+        if compiled:
+            logger.info("[%s] Loaded %d Slack mention pattern(s)", self.name, len(compiled))
+        return compiled
+
+    def _message_matches_mention_patterns(self, text: str) -> bool:
+        if not text or not self._mention_patterns:
+            return False
+        return any(pattern.search(text) for pattern in self._mention_patterns)

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -55,7 +55,13 @@ CHANNEL_ID = "C0AQWDLHY9M"
 OTHER_CHANNEL_ID = "C9999999999"
 
 
-def _make_adapter(require_mention=None, strict_mention=None, free_response_channels=None, allowed_channels=None):
+def _make_adapter(
+    require_mention=None,
+    strict_mention=None,
+    free_response_channels=None,
+    allowed_channels=None,
+    mention_patterns=None,
+):
     extra = {}
     if require_mention is not None:
         extra["require_mention"] = require_mention
@@ -65,12 +71,15 @@ def _make_adapter(require_mention=None, strict_mention=None, free_response_chann
         extra["free_response_channels"] = free_response_channels
     if allowed_channels is not None:
         extra["allowed_channels"] = allowed_channels
+    if mention_patterns is not None:
+        extra["mention_patterns"] = mention_patterns
 
     adapter = object.__new__(SlackAdapter)
     adapter.platform = Platform.SLACK
     adapter.config = PlatformConfig(enabled=True, extra=extra)
     adapter._bot_user_id = BOT_USER_ID
     adapter._team_bot_user_ids = {}
+    adapter._mention_patterns = adapter._compile_mention_patterns()
     return adapter
 
 
@@ -687,3 +696,129 @@ def test_config_bridges_slack_allowed_channels_env_takes_precedence(monkeypatch,
     import os as _os
     # env var must not be overwritten by config.yaml
     assert _os.environ["SLACK_ALLOWED_CHANNELS"] == OTHER_CHANNEL_ID
+
+
+# ---------------------------------------------------------------------------
+# Tests: mention_patterns (regex wake-words)
+# ---------------------------------------------------------------------------
+
+def test_mention_patterns_empty_by_default():
+    adapter = _make_adapter()
+    assert adapter._mention_patterns == []
+    assert adapter._message_matches_mention_patterns("hello") is False
+
+
+def test_mention_patterns_match_custom_wake_word():
+    adapter = _make_adapter(mention_patterns=[r"^\s*chompy\b"])
+    assert adapter._message_matches_mention_patterns("chompy status") is True
+    assert adapter._message_matches_mention_patterns("   chompy help") is True
+    # Pattern is anchored at start — middle/end matches do not trigger.
+    assert adapter._message_matches_mention_patterns("hey chompy") is False
+
+
+def test_mention_patterns_match_is_case_insensitive():
+    adapter = _make_adapter(mention_patterns=[r"\bhermes\b"])
+    assert adapter._message_matches_mention_patterns("Hey HERMES, ping") is True
+
+
+def test_mention_patterns_accept_string_form():
+    """A single string is normalised into a one-item list (mirrors telegram)."""
+    adapter = _make_adapter(mention_patterns=r"^\s*chompy\b")
+    assert adapter._message_matches_mention_patterns("chompy status") is True
+
+
+def test_mention_patterns_invalid_regex_is_ignored():
+    """An unparsable pattern is dropped; valid ones still compile."""
+    adapter = _make_adapter(mention_patterns=[r"(", r"^\s*chompy\b"])
+    assert adapter._message_matches_mention_patterns("chompy status") is True
+    assert adapter._message_matches_mention_patterns("hello everyone") is False
+
+
+def test_mention_patterns_non_list_logged_and_ignored(caplog):
+    import logging
+    caplog.set_level(logging.WARNING, logger="gateway.platforms.slack")
+    adapter = _make_adapter(mention_patterns={"not": "a list"})
+    assert adapter._mention_patterns == []
+    assert "must be a list or string" in caplog.text
+
+
+def test_mention_patterns_empty_text_returns_false():
+    adapter = _make_adapter(mention_patterns=[r"hermes"])
+    assert adapter._message_matches_mention_patterns("") is False
+
+
+def test_mention_patterns_env_var_fallback(monkeypatch):
+    import json as _json
+    monkeypatch.setenv("SLACK_MENTION_PATTERNS", _json.dumps([r"^\s*chompy\b"]))
+    adapter = _make_adapter()
+    assert adapter._message_matches_mention_patterns("chompy status") is True
+
+
+def test_mention_patterns_env_var_multiline_fallback(monkeypatch):
+    """Newline-separated env value falls back when JSON parse fails."""
+    monkeypatch.setenv("SLACK_MENTION_PATTERNS", "chompy\nhermes")
+    adapter = _make_adapter()
+    assert adapter._message_matches_mention_patterns("chompy status") is True
+    assert adapter._message_matches_mention_patterns("hey hermes there") is True
+
+
+def test_mention_patterns_config_extra_overrides_env(monkeypatch):
+    monkeypatch.setenv("SLACK_MENTION_PATTERNS", r"\bshould-not-trigger\b")
+    adapter = _make_adapter(mention_patterns=[r"^\s*chompy\b"])
+    assert adapter._message_matches_mention_patterns("chompy status") is True
+    assert adapter._message_matches_mention_patterns("should-not-trigger") is False
+
+
+def test_config_bridges_slack_mention_patterns(monkeypatch, tmp_path):
+    """yaml slack.mention_patterns flows into SLACK_MENTION_PATTERNS env var."""
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  mention_patterns:\n"
+        "    - \"^\\\\s*chompy\\\\b\"\n"
+        "    - \"\\\\bhermes\\\\b\"\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SLACK_MENTION_PATTERNS", raising=False)
+
+    config = load_gateway_config()
+
+    import json as _json
+    import os as _os
+    assert _json.loads(_os.environ["SLACK_MENTION_PATTERNS"]) == [
+        r"^\s*chompy\b",
+        r"\bhermes\b",
+    ]
+    slack_cfg = config.platforms.get(Platform.SLACK)
+    assert slack_cfg is not None
+    assert slack_cfg.extra.get("mention_patterns") == [
+        r"^\s*chompy\b",
+        r"\bhermes\b",
+    ]
+
+
+def test_config_bridges_slack_mention_patterns_env_takes_precedence(monkeypatch, tmp_path):
+    """Pre-set SLACK_MENTION_PATTERNS is not overwritten by config.yaml."""
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  mention_patterns:\n"
+        "    - \"\\\\bfrom-yaml\\\\b\"\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SLACK_MENTION_PATTERNS", r'["\\bfrom-env\\b"]')
+
+    load_gateway_config()
+
+    import os as _os
+    assert _os.environ["SLACK_MENTION_PATTERNS"] == r'["\\bfrom-env\\b"]'


### PR DESCRIPTION
## What does this PR do?

`telegram.py` (PR #3870) and `dingtalk.py` (PR #11564) both implement `mention_patterns`, which lets a platform adapter treat a configured regex match as a wake trigger (for example, wake on a leading bot name or on any URL) even when the message does not `@mention` the bot.

PR #4644 (merged 2026-04-02) documented `slack.mention_patterns` in `website/docs/user-guide/messaging/slack.md`. The Slack adapter, however, never implemented it. The YAML key is silently accepted by `gateway/config.py`'s generic platform-key loop and then ignored, and `gateway/platforms/slack.py` has zero references to `mention_patterns` on `main`. Anyone who follows the Slack docs and sets `slack.mention_patterns` gets a silent no-op.

This PR closes that docs-vs-code drift by giving Slack the same `mention_patterns` support Telegram and DingTalk already ship.

*Surfaced while wiring a Slack summarizer bot on Hermes: the documented `slack.mention_patterns` had no effect, because the adapter never reads the key.*

### Example config.yaml

```yaml
slack:
  mention_patterns:
    - "^\\s*hermes\\b"     # wake on a leading "hermes"
    - "https?://"          # wake on any URL
```

### Behavior

When a channel message does not `@mention` the bot, it is now accepted as a trigger if it matches any configured regex, alongside the existing reply-to-bot, mentioned-thread, and active-session conditions.

`strict_mention: true` still requires an explicit `@mention` every turn; regex triggers cannot bypass it (matches Telegram's semantics). DMs are unaffected. When `mention_patterns` is absent or empty, the channel gate chain is byte-identical to current behavior.

## Related Issue

No dedicated tracking issue; the gap surfaced from PR #4644 documenting `slack.mention_patterns` without the matching adapter implementation landing.

A broader prior attempt (#20723 / #20726) bundled this same `mention_patterns` wiring with unrelated Slack changes (strict-mode behavior tweaks, slash-command aliases, `run_agent` adjustments) across 6 files. It was withdrawn by its author and not reviewed on merits. This PR isolates only the documented `mention_patterns` support plus tests (3 files, +189 / -2), mirroring the existing `telegram.py` / `dingtalk.py` implementations.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/slack.py`: add `_compile_mention_patterns()` and `_message_matches_mention_patterns(text)` helpers; `__init__` caches the compiled patterns. The channel gate chain accepts a regex match as a valid trigger alongside the thread and session conditions. Mirrors `telegram.py:4568, 4753, 4824` and `dingtalk.py:419, 487, 518`.
- `gateway/config.py`: bridge `slack.mention_patterns` from YAML to `SLACK_MENTION_PATTERNS`, keeping Slack symmetric with the existing per-platform bridges (`TELEGRAM_MENTION_PATTERNS`, `WHATSAPP_MENTION_PATTERNS`, `DINGTALK_MENTION_PATTERNS`).
- `tests/gateway/test_slack_mention.py`: 12 new cases covering empty default, regex matching, case-insensitivity, single-string form, invalid-regex skipping, non-list rejection, empty-text early return, env-var JSON / multiline fallback, config-extra precedence over env, YAML-to-env bridging, and env-already-set precedence.

## How to Test

1. Add `slack.mention_patterns` to `~/.hermes/config.yaml`:
   ```yaml
   slack:
     mention_patterns:
       - "^\\s*hermes\\b"
       - "https?://"
   ```
2. Start the Slack gateway and send channel messages without `@mentioning` the bot:
   - `"hello there"` → silently ignored (no pattern match)
   - `"hermes what's up"` → bot responds (matches `^\s*hermes\b`)
   - `"check https://example.com"` → bot responds (matches `https?://`)
3. Set `slack.strict_mention: true` and repeat. All three messages should be ignored unless the bot is explicitly `@mentioned` (regex triggers do not bypass strict mode, by design).
4. Remove `mention_patterns` from config. Behavior is byte-identical to current `main`.

Automated coverage on this branch (rebased onto `5f84c9144`):

- `bash scripts/run_tests.sh tests/gateway/` passes 273 files / 6032 tests / 0 failed in 44.0s.
- `bash scripts/run_tests.sh tests/gateway/test_slack_mention.py` passes 67/67 (55 pre-existing + 12 new).
- `python scripts/check-windows-footguns.py` clean on the three changed files.
- `ruff check` clean (`PLW1514`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(slack): wire up mention_patterns config`)
- [x] I searched [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) for duplicates (#20723 / #20726 were author-withdrawn; #29393 adds the same feature on the Discord side and is currently open)
- [x] My PR contains **only** changes related to this fix (3 files, +189 / -2)
- [x] I've run the gateway test suite (`bash scripts/run_tests.sh tests/gateway/`) and all 6032 tests pass; the change is gateway-only so I scoped local runs there, CI will exercise the full `tests/` suite
- [x] I've added tests for my changes (12 new cases in `tests/gateway/test_slack_mention.py`)
- [x] I've tested on my platform: macOS (Darwin 25.5.0), Python 3.11.9 via a `uv`-managed venv

### Documentation & Housekeeping

- [x] Documentation already exists from PR #4644 (`website/docs/user-guide/messaging/slack.md`, the `mention_patterns:` block); no further docs changes needed.
- [x] N/A. `cli-config.yaml.example` has no `slack:` block today (and no per-platform `mention_patterns` examples for Telegram / WhatsApp / DingTalk either), so there is nothing to extend for parity.
- [x] N/A. No architecture or workflow changes.
- [x] I've considered cross-platform impact: gateway code is platform-neutral, no OS-specific calls added, `check-windows-footguns.py` passes.
- [x] N/A. No tool schema changes.

## Screenshots / Logs

Expected channel-message behavior with the example config (covered by `tests/gateway/test_slack_mention.py`, 67/67 passing):

```text
"hello there"             → ignored        (no pattern matches)
"hermes what's up"        → bot responds   (matches ^\s*hermes\b)
"check https://x.com"     → bot responds   (matches https?://)
strict_mention: true      → all ignored unless explicitly @mentioned
```

## Adjacent in-flight work

PR #29393 (open, currently conflicting) adds the same feature on the Discord side and introduces shared helpers in `gateway/platforms/base.py`. If it merges first, I will rebase onto those helpers.