### PR TITLE
fix(agent): add config gate for title generation across all run modes

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12178,28 +12178,36 @@ class HermesCLI:
             if response and result and not result.get("failed") and not result.get("partial"):
                 try:
                     from agent.title_generator import maybe_auto_title
-                    # Route title-generation failures through the agent's
-                    # user-visible warning channel so a depleted auxiliary
-                    # provider doesn't silently leave sessions untitled
-                    # (issue #15775).
-                    _title_failure_cb = getattr(
-                        self.agent, "_emit_auxiliary_failure", None
-                    ) if self.agent else None
-                    maybe_auto_title(
-                        self._session_db,
-                        self.session_id,
-                        message,
-                        response,
-                        self.conversation_history,
-                        failure_callback=_title_failure_cb,
-                        main_runtime={
-                            "model": self.model,
-                            "provider": self.provider,
-                            "base_url": self.base_url,
-                            "api_key": self.api_key,
-                            "api_mode": self.api_mode,
-                        },
+                    from hermes_cli.config import read_raw_config
+
+                    _title_cfg = (read_raw_config().get("auxiliary") or {}).get(
+                        "title_generation", {}
                     )
+                    if isinstance(_title_cfg, dict) and _title_cfg.get("enabled", True) is False:
+                        pass  # title generation disabled by config
+                    else:
+                        # Route title-generation failures through the agent's
+                        # user-visible warning channel so a depleted auxiliary
+                        # provider doesn't silently leave sessions untitled
+                        # (issue #15775).
+                        _title_failure_cb = getattr(
+                            self.agent, "_emit_auxiliary_failure", None
+                        ) if self.agent else None
+                        maybe_auto_title(
+                            self._session_db,
+                            self.session_id,
+                            message,
+                            response,
+                            self.conversation_history,
+                            failure_callback=_title_failure_cb,
+                            main_runtime={
+                                "model": self.model,
+                                "provider": self.provider,
+                                "base_url": self.base_url,
+                                "api_key": self.api_key,
+                                "api_mode": self.api_mode,
+                            },
+                        )
                 except Exception:
                     pass
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17658,45 +17658,51 @@ class GatewayRunner:
             # Reset to 0 so the gateway writes ALL compressed messages.
             _effective_history_offset = 0 if _session_was_split else len(agent_history)
 
-            # Auto-generate session title after first exchange (non-blocking)
+             # Auto-generate session title after first exchange (non-blocking)
             if final_response and self._session_db:
                 try:
                     from agent.title_generator import maybe_auto_title
-                    all_msgs = result_holder[0].get("messages", []) if result_holder[0] else []
-                    # In Gateway mode, auto-title failures must NOT be
-                    # surfaced as user-visible messages (fixes #23246).
-                    # Log them at debug level only — they are not actionable
-                    # to the end user. CLI mode keeps the existing behaviour
-                    # via the agent's _emit_auxiliary_failure path.
-                    def _title_failure_cb(task: str, exc: BaseException) -> None:
-                        logger.debug(
-                            "Gateway auto-title failure suppressed (not user-visible): %s: %s",
-                            task, exc,
-                        )
-                    maybe_auto_title_kwargs = {
-                        "failure_callback": _title_failure_cb,
-                        "main_runtime": {
-                            "model": getattr(agent, "model", None),
-                            "provider": getattr(agent, "provider", None),
-                            "base_url": getattr(agent, "base_url", None),
-                            "api_key": getattr(agent, "api_key", None),
-                            "api_mode": getattr(agent, "api_mode", None),
-                        } if agent else None,
-                    }
-                    if self._is_telegram_topic_lane(source):
-                        maybe_auto_title_kwargs["title_callback"] = lambda title: self._schedule_telegram_topic_title_rename(
-                            source,
-                            effective_session_id,
-                            title,
-                        )
-                    maybe_auto_title(
-                        self._session_db,
-                        effective_session_id,
-                        message,
-                        final_response,
-                        all_msgs,
-                        **maybe_auto_title_kwargs,
+                    from hermes_cli.config import read_raw_config
+
+                    _title_cfg = (read_raw_config().get("auxiliary") or {}).get(
+                        "title_generation", {}
                     )
+                    if not (isinstance(_title_cfg, dict) and _title_cfg.get("enabled", True) is False):
+                        all_msgs = result_holder[0].get("messages", []) if result_holder[0] else []
+                        # In Gateway mode, auto-title failures must NOT be
+                        # surfaced as user-visible messages (fixes #23246).
+                        # Log them at debug level only — they are not actionable
+                        # to the end user. CLI mode keeps the existing behaviour
+                        # via the agent's _emit_auxiliary_failure path.
+                        def _title_failure_cb(task: str, exc: BaseException) -> None:
+                            logger.debug(
+                                "Gateway auto-title failure suppressed (not user-visible): %s: %s",
+                                task, exc,
+                            )
+                        maybe_auto_title_kwargs = {
+                            "failure_callback": _title_failure_cb,
+                            "main_runtime": {
+                                "model": getattr(agent, "model", None),
+                                "provider": getattr(agent, "provider", None),
+                                "base_url": getattr(agent, "base_url", None),
+                                "api_key": getattr(agent, "api_key", None),
+                                "api_mode": getattr(agent, "api_mode", None),
+                            } if agent else None,
+                        }
+                        if self._is_telegram_topic_lane(source):
+                            maybe_auto_title_kwargs["title_callback"] = lambda title: self._schedule_telegram_topic_title_rename(
+                                source,
+                                effective_session_id,
+                                title,
+                            )
+                        maybe_auto_title(
+                            self._session_db,
+                            effective_session_id,
+                            message,
+                            final_response,
+                            all_msgs,
+                            **maybe_auto_title_kwargs,
+                        )
                 except Exception:
                     pass
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3791,6 +3791,49 @@ def test_prompt_submit_skips_auto_title_when_response_empty(monkeypatch):
     mock_title.assert_not_called()
 
 
+
+def test_prompt_submit_skips_auto_title_when_config_disabled(monkeypatch):
+    """When auxiliary.title_generation.enabled is False, maybe_auto_title must NOT be called."""
+
+    class _Agent:
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            return {
+                "final_response": "Rome was founded in 753 BC.",
+                "messages": [
+                    {"role": "user", "content": "Tell me about Rome"},
+                    {"role": "assistant", "content": "Rome was founded in 753 BC."},
+                ],
+            }
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "read_raw_config",
+        lambda: {"auxiliary": {"title_generation": {"enabled": False}}},
+    )
+
+    with patch("agent.title_generator.maybe_auto_title") as mock_title:
+        server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "Tell me about Rome"},
+            }
+        )
+
+    mock_title.assert_not_called()
+
+
 def test_prompt_submit_surfaces_backend_error_as_visible_text(monkeypatch):
     """When the backend fails with no visible response (e.g. invalid model slug
     → provider 4xx), the TUI must surface result['error'] as visible text

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3752,14 +3752,19 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             ):
                 try:
                     from agent.title_generator import maybe_auto_title
+                    from hermes_cli.config import read_raw_config
 
-                    maybe_auto_title(
-                        _get_db(),
-                        session.get("session_key") or sid,
-                        text,
-                        raw,
-                        session.get("history", []),
+                    _title_cfg = (read_raw_config().get("auxiliary") or {}).get(
+                        "title_generation", {}
                     )
+                    if not (isinstance(_title_cfg, dict) and _title_cfg.get("enabled", True) is False):
+                        maybe_auto_title(
+                            _get_db(),
+                            session.get("session_key") or sid,
+                            text,
+                            raw,
+                            session.get("history", []),
+                        )
                 except Exception:
                     pass
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
Add auxiliary.title_generation.enabled config key to control whether auto-generated session titles are created. When set to false, the maybe_auto_title() call is skipped in CLI, gateway, and TUI modes.

Backward compatible: if the key is absent, defaults to true (existing behavior).


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- cli.py: gate in HermesCLI.process_command() after first exchange
- gateway/run.py: gate in GatewayRunner._run_turn()
- tui_gateway/server.py: gate in _run_prompt_submit()
- tests/test_tui_gateway_server.py: add test for disabled config gate

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

