### PR TITLE
fix(anthropic): drop spurious empty-data SSE flushes from upstream SDK

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -55,6 +55,75 @@ def _get_anthropic_sdk():
 
 logger = logging.getLogger(__name__)
 
+_ANTHROPIC_SSE_DECODER_PATCHED_ATTR = "_hermes_empty_data_flush_patch_applied"
+_ORIGINAL_ANTHROPIC_SSE_ITER_BYTES_ATTR = "_hermes_original_iter_bytes"
+_ORIGINAL_ANTHROPIC_SSE_AITER_BYTES_ATTR = "_hermes_original_aiter_bytes"
+
+
+def _is_empty_data_sse_flush(sse) -> bool:
+    """Return True for SDK SSE events that have an event name but no data.
+
+    Some reverse-proxied Anthropic-wire endpoints intermittently emit an
+    empty-data event flush (for example ``event: content_block_delta`` followed
+    by a blank line before the data line arrives).  Anthropic's SDK decodes that
+    as a complete event with ``data == \"\"`` and then attempts to JSON-decode
+    it downstream, raising ``JSONDecodeError: Expecting value``.  Dropping only
+    named empty-data events preserves normal data-bearing events and anonymous
+    keepalives/comments.
+    """
+    return bool(getattr(sse, "event", None)) and getattr(sse, "data", None) == ""
+
+
+def _patch_anthropic_sse_decoder(_anthropic_sdk=None) -> None:
+    """Drop spurious named SSE events with empty data from Anthropic SDK streams.
+
+    The patch is intentionally narrow, idempotent, and best-effort.  If the SDK
+    internals move in a future release, Hermes logs a warning and continues
+    unpatched rather than preventing client construction.
+    """
+    try:
+        if _anthropic_sdk is None:
+            _anthropic_sdk = _get_anthropic_sdk()
+        if _anthropic_sdk is None:
+            return
+
+        try:
+            from anthropic._streaming import SSEDecoder
+        except Exception:
+            streaming = getattr(_anthropic_sdk, "_streaming", None)
+            SSEDecoder = getattr(streaming, "SSEDecoder", None)
+        if SSEDecoder is None:
+            raise AttributeError("anthropic._streaming.SSEDecoder not found")
+
+        if getattr(SSEDecoder, _ANTHROPIC_SSE_DECODER_PATCHED_ATTR, False):
+            return
+
+        original_iter_bytes = getattr(SSEDecoder, "iter_bytes", None)
+        original_aiter_bytes = getattr(SSEDecoder, "aiter_bytes", None)
+        if original_iter_bytes is None or original_aiter_bytes is None:
+            raise AttributeError("SSEDecoder.iter_bytes/aiter_bytes not found")
+
+        def iter_bytes(self, iterator):
+            for sse in original_iter_bytes(self, iterator):
+                if _is_empty_data_sse_flush(sse):
+                    continue
+                yield sse
+
+        async def aiter_bytes(self, iterator):
+            async for sse in original_aiter_bytes(self, iterator):
+                if _is_empty_data_sse_flush(sse):
+                    continue
+                yield sse
+
+        setattr(SSEDecoder, _ORIGINAL_ANTHROPIC_SSE_ITER_BYTES_ATTR, original_iter_bytes)
+        setattr(SSEDecoder, _ORIGINAL_ANTHROPIC_SSE_AITER_BYTES_ATTR, original_aiter_bytes)
+        setattr(SSEDecoder, "iter_bytes", iter_bytes)
+        setattr(SSEDecoder, "aiter_bytes", aiter_bytes)
+        setattr(SSEDecoder, _ANTHROPIC_SSE_DECODER_PATCHED_ATTR, True)
+    except Exception as exc:
+        logger.warning("Failed to patch Anthropic SDK SSE decoder: %s", exc)
+
+
 THINKING_BUDGET = {"xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
 # Hermes effort → Anthropic adaptive-thinking effort (output_config.effort).
 # Anthropic exposes 5 levels on 4.7+: low, medium, high, xhigh, max.
@@ -597,6 +666,7 @@ def _build_anthropic_client_with_bearer_hook(
             "The 'anthropic' package is required for Azure Foundry Anthropic-style "
             "endpoints with Entra ID auth. Install with: pip install 'anthropic>=0.39.0'"
         )
+    _patch_anthropic_sse_decoder(_anthropic_sdk)
 
     normalize_proxy_env_vars()
 
@@ -681,6 +751,7 @@ def build_anthropic_client(
             "The 'anthropic' package is required for the Anthropic provider. "
             "Install it with: pip install 'anthropic>=0.39.0'"
         )
+    _patch_anthropic_sse_decoder(_anthropic_sdk)
 
     # Callable api_key → Entra ID bearer provider path. Delegated to a
     # helper so the existing static-key code below stays unchanged.

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -12,6 +12,7 @@ from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
     _is_azure_anthropic_endpoint,
     _is_oauth_token,
+    _patch_anthropic_sse_decoder,
     _refresh_oauth_token,
     _to_plain_data,
     _write_claude_code_credentials,
@@ -27,6 +28,28 @@ from agent.anthropic_adapter import (
     run_oauth_setup_token,
 )
 from agent.transports import get_transport
+
+
+def _reset_anthropic_sse_decoder_patch():
+    from anthropic._streaming import SSEDecoder
+
+    original_iter_bytes = getattr(SSEDecoder, "_hermes_original_iter_bytes", None)
+    original_aiter_bytes = getattr(SSEDecoder, "_hermes_original_aiter_bytes", None)
+    if original_iter_bytes is not None:
+        SSEDecoder.iter_bytes = original_iter_bytes
+    if original_aiter_bytes is not None:
+        SSEDecoder.aiter_bytes = original_aiter_bytes
+    for attr in (
+        "_hermes_empty_data_flush_patch_applied",
+        "_hermes_original_iter_bytes",
+        "_hermes_original_aiter_bytes",
+    ):
+        if hasattr(SSEDecoder, attr):
+            delattr(SSEDecoder, attr)
+
+
+def _sse_events_to_tuples(events):
+    return [(event.event, event.data) for event in events]
 
 
 # ---------------------------------------------------------------------------
@@ -59,6 +82,26 @@ class TestIsOAuthToken:
 
 
 class TestBuildAnthropicClient:
+    def test_patches_sse_decoder_for_static_key_client(self):
+        with patch("agent.anthropic_adapter._patch_anthropic_sse_decoder") as mock_patch:
+            with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+                build_anthropic_client("sk-ant...hing")
+                mock_patch.assert_called_once_with(mock_sdk)
+
+    def test_patches_sse_decoder_for_callable_token_client(self):
+        with patch("agent.anthropic_adapter._patch_anthropic_sse_decoder") as mock_patch:
+            with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+                token_provider = lambda: "fresh-entra-token"
+                build_anthropic_client(
+                    token_provider,
+                    base_url="https://example.services.ai.azure.com/models/anthropic",
+                )
+                # build_anthropic_client patches before dispatching to the
+                # callable-token helper; the helper patches again after its own
+                # SDK check.  The patch itself is idempotent.
+                assert mock_patch.call_count == 2
+                mock_patch.assert_any_call(mock_sdk)
+
     def test_setup_token_uses_auth_token(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
             build_anthropic_client("sk-ant-oat01-" + "x" * 60)
@@ -191,6 +234,71 @@ class TestBuildAnthropicClient:
             # Azure keeps the 1M-context beta (it's not MiniMax).
             betas = kwargs["default_headers"]["anthropic-beta"]
             assert "context-1m-2025-08-07" in betas
+
+
+class TestPatchAnthropicSSEDecoder:
+    def setup_method(self):
+        _reset_anthropic_sse_decoder_patch()
+
+    def teardown_method(self):
+        _reset_anthropic_sse_decoder_patch()
+
+    def test_iter_bytes_drops_named_empty_data_events_and_keeps_valid_data(self):
+        from anthropic._streaming import SSEDecoder
+
+        _patch_anthropic_sse_decoder()
+
+        chunks = [
+            b"event: content_block_delta\n\n",
+            b'event: content_block_delta\ndata: {"type":"text_delta","text":"hi"}\n\n',
+        ]
+        events = list(SSEDecoder().iter_bytes(iter(chunks)))
+
+        assert _sse_events_to_tuples(events) == [
+            ("content_block_delta", '{"type":"text_delta","text":"hi"}')
+        ]
+
+    def test_iter_bytes_preserves_comments_and_data_only_events(self):
+        from anthropic._streaming import SSEDecoder
+
+        _patch_anthropic_sse_decoder()
+
+        chunks = [
+            b": ping\n\n",
+            b'data: {"type":"message_start"}\n\n',
+        ]
+        events = list(SSEDecoder().iter_bytes(iter(chunks)))
+
+        assert _sse_events_to_tuples(events) == [
+            (None, '{"type":"message_start"}')
+        ]
+
+    def test_patch_is_idempotent(self):
+        from anthropic._streaming import SSEDecoder
+
+        _patch_anthropic_sse_decoder()
+        first_iter_bytes = SSEDecoder.iter_bytes
+        first_aiter_bytes = SSEDecoder.aiter_bytes
+
+        _patch_anthropic_sse_decoder()
+
+        assert SSEDecoder.iter_bytes is first_iter_bytes
+        assert SSEDecoder.aiter_bytes is first_aiter_bytes
+
+    @pytest.mark.asyncio
+    async def test_aiter_bytes_drops_named_empty_data_events_and_keeps_valid_data(self):
+        from anthropic._streaming import SSEDecoder
+
+        async def chunks():
+            yield b"event: content_block_delta\n\n"
+            yield b'event: content_block_delta\ndata: {"type":"text_delta","text":"hi"}\n\n'
+
+        _patch_anthropic_sse_decoder()
+        events = [event async for event in SSEDecoder().aiter_bytes(chunks())]
+
+        assert _sse_events_to_tuples(events) == [
+            ("content_block_delta", '{"type":"text_delta","text":"hi"}')
+        ]
 
 
 class TestReadClaudeCodeCredentials:
@@ -488,6 +596,13 @@ class TestResolveWithRefresh:
 
 
 class TestRunOauthSetupToken:
+    @pytest.fixture(autouse=True)
+    def no_keychain(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+            lambda: None,
+        )
+
     def test_raises_when_claude_not_installed(self, monkeypatch):
         monkeypatch.setattr("shutil.which", lambda _: None)
         with pytest.raises(FileNotFoundError, match="claude.*CLI.*not installed"):


### PR DESCRIPTION
## Summary
- Patch Anthropic SDK SSE decoding at client construction time to drop named events whose `data` field is empty.
- Wire the patch into both static-key and callable-token Anthropic client builders.
- Add regression coverage for sync and async byte decoders, valid data preservation, idempotency, and both client construction paths.

## Why
Reverse-proxied Anthropic-wire endpoints such as SAP Hai Proxy via ngrok can intermittently flush an SSE frame with an event name but no `data:` payload. The Anthropic SDK treats that as a complete event and downstream stream handling attempts to JSON-decode `""`, producing:

```text
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## Safety
This only drops events where `event` is set and `data == ""`. Data-bearing Anthropic events are preserved, data-only events are preserved, and comment/keepalive frames remain ignored by the SDK. If Anthropic SDK internals move or the monkey-patch cannot be applied, Hermes logs a warning and continues without raising. The vendored/site-packages SDK is not modified.

## Tests
- `scripts/run_tests.sh tests/agent/test_anthropic_adapter.py`
- `tests/agent/test_chat_completion_helpers.py` is not present in this checkout.
