### PR TITLE
feat: i18n for dangerous-command approval reason descriptions

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1871,6 +1871,8 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            from tools.approval import get_gateway_approval_strings
+            strings = get_gateway_approval_strings()
             approval_id = next(self._approval_counter)
             cmd_preview = command[:3000] + "..." if len(command) > 3000 else command
 
@@ -1885,21 +1887,21 @@ class FeishuAdapter(BasePlatformAdapter):
             card = {
                 "config": {"wide_screen_mode": True},
                 "header": {
-                    "title": {"content": "⚠️ Command Approval Required", "tag": "plain_text"},
+                    "title": {"content": strings["header"], "tag": "plain_text"},
                     "template": "orange",
                 },
                 "elements": [
                     {
                         "tag": "markdown",
-                        "content": f"```\n{cmd_preview}\n```\n**Reason:** {description}",
+                        "content": f"```\n{cmd_preview}\n```\n**{strings['reason_label']}：**{description}",
                     },
                     {
                         "tag": "action",
                         "actions": [
-                            _btn("✅ Allow Once", "approve_once", "primary"),
-                            _btn("✅ Session", "approve_session"),
-                            _btn("✅ Always", "approve_always"),
-                            _btn("❌ Deny", "deny", "danger"),
+                            _btn(strings["btn_allow_once"], "approve_once", "primary"),
+                            _btn(strings["btn_allow_session"], "approve_session"),
+                            _btn(strings["btn_allow_always"], "approve_always"),
+                            _btn(strings["btn_deny"], "deny", "danger"),
                         ],
                     },
                 ],

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1274,14 +1274,13 @@ class MatrixAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        from tools.approval import get_gateway_approval_strings
+        strings = get_gateway_approval_strings()
+
         cmd_preview = command[:2000] + "..." if len(command) > 2000 else command
-        text = (
-            "⚠️ **Dangerous command requires approval**\n"
-            f"```\n{cmd_preview}\n```\n"
-            f"Reason: {description}\n\n"
-            "Reply `/approve` to execute, `/approve session` to approve this pattern for the session, "
-            "`/approve always` to approve permanently, or `/deny` to cancel.\n\n"
-            "You can also click the reaction to approve:\n"
+        text = strings["fallback_text"].format(command=cmd_preview, reason=description)
+        text += (
+            "\n\nYou can also click the reaction to approve:\n"
             "✅ = /approve\n"
             "❎ = /deny"
         )

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2253,6 +2253,8 @@ class SlackAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            from tools.approval import get_gateway_approval_strings
+            strings = get_gateway_approval_strings()
             cmd_preview = command[:2900] + "..." if len(command) > 2900 else command
             thread_ts = self._resolve_thread_ts(None, metadata)
 
@@ -2262,9 +2264,9 @@ class SlackAdapter(BasePlatformAdapter):
                     "text": {
                         "type": "mrkdwn",
                         "text": (
-                            f":warning: *Command Approval Required*\n"
+                            f":warning: *{strings['header']}*\n"
                             f"```{cmd_preview}```\n"
-                            f"Reason: {description}"
+                            f"{strings['reason_label']}：{description}"
                         ),
                     },
                 },
@@ -2273,26 +2275,26 @@ class SlackAdapter(BasePlatformAdapter):
                     "elements": [
                         {
                             "type": "button",
-                            "text": {"type": "plain_text", "text": "Allow Once"},
+                            "text": {"type": "plain_text", "text": strings["btn_allow_once"]},
                             "style": "primary",
                             "action_id": "hermes_approve_once",
                             "value": session_key,
                         },
                         {
                             "type": "button",
-                            "text": {"type": "plain_text", "text": "Allow Session"},
+                            "text": {"type": "plain_text", "text": strings["btn_allow_session"]},
                             "action_id": "hermes_approve_session",
                             "value": session_key,
                         },
                         {
                             "type": "button",
-                            "text": {"type": "plain_text", "text": "Always Allow"},
+                            "text": {"type": "plain_text", "text": strings["btn_allow_always"]},
                             "action_id": "hermes_approve_always",
                             "value": session_key,
                         },
                         {
                             "type": "button",
-                            "text": {"type": "plain_text", "text": "Deny"},
+                            "text": {"type": "plain_text", "text": strings["btn_deny"]},
                             "style": "danger",
                             "action_id": "hermes_deny",
                             "value": session_key,
@@ -2300,10 +2302,11 @@ class SlackAdapter(BasePlatformAdapter):
                     ],
                 },
             ]
+            fallback_text = f"{strings['header']}：{cmd_preview[:100]}"
 
             kwargs: Dict[str, Any] = {
                 "channel": chat_id,
-                "text": f"⚠️ Command approval required: {cmd_preview[:100]}",
+                "text": fallback_text,
                 "blocks": blocks,
             }
             if thread_ts:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2591,11 +2591,13 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            from tools.approval import get_gateway_approval_strings
+            strings = get_gateway_approval_strings()
             cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
             text = (
-                f"⚠️ <b>Command Approval Required</b>\n\n"
+                f"{strings['header_html']}\n\n"
                 f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
-                f"Reason: {_html.escape(description)}"
+                f"{strings['reason_label']}：{_html.escape(description)}"
             )
 
             # Resolve thread context for thread replies
@@ -2611,12 +2613,16 @@ class TelegramAdapter(BasePlatformAdapter):
 
             keyboard = InlineKeyboardMarkup([
                 [
-                    InlineKeyboardButton("✅ Allow Once", callback_data=f"ea:once:{approval_id}"),
-                    InlineKeyboardButton("✅ Session", callback_data=f"ea:session:{approval_id}"),
+                    InlineKeyboardButton(
+                        strings["btn_allow_once"], callback_data=f"ea:once:{approval_id}"),
+                    InlineKeyboardButton(
+                        strings["btn_allow_session"], callback_data=f"ea:session:{approval_id}"),
                 ],
                 [
-                    InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{approval_id}"),
-                    InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{approval_id}"),
+                    InlineKeyboardButton(
+                        strings["btn_allow_always"], callback_data=f"ea:always:{approval_id}"),
+                    InlineKeyboardButton(
+                        strings["btn_deny"], callback_data=f"ea:deny:{approval_id}"),
                 ],
             ])
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17356,13 +17356,9 @@ class GatewayRunner:
 
                 # Fallback: plain text approval prompt
                 cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
-                msg = (
-                    f"⚠️ **Dangerous command requires approval:**\n"
-                    f"```\n{cmd_preview}\n```\n"
-                    f"Reason: {desc}\n\n"
-                    f"Reply `/approve` to execute, `/approve session` to approve this pattern "
-                    f"for the session, `/approve always` to approve permanently, or `/deny` to cancel."
-                )
+                from tools.approval import get_gateway_approval_strings
+                strings = get_gateway_approval_strings()
+                msg = strings["fallback_text"].format(command=cmd_preview, reason=desc)
                 try:
                     _approval_send_fut = safe_schedule_threadsafe(
                         _status_adapter.send(

--- a/locales/approval_reasons/zh.yaml
+++ b/locales/approval_reasons/zh.yaml
@@ -1,0 +1,80 @@
+# Hermes 审批原因描述中文翻译
+# 由 tools/approval.py 的 _translate_reason() 直接读取
+# 添加新语言：复制此文件为 <lang>.yaml 并翻译即可
+
+# File deletion
+"delete in root path": "在根路径下删除"
+"recursive delete": "递归删除"
+"recursive delete (long flag)": "递归删除（长标志）"
+"recursive delete of root filesystem": "递归删除根文件系统"
+"recursive delete of system directory": "递归删除系统目录"
+"recursive delete of home directory": "递归删除用户主目录"
+# Permissions
+"world/other-writable permissions": "全局/其他用户可写权限"
+"recursive world/other-writable (long flag)": "递归全局可写（长标志）"
+"recursive chown to root": "递归更改所有者为 root"
+"recursive chown to root (long flag)": "递归更改所有者为 root（长标志）"
+# Filesystem
+"format filesystem": "格式化文件系统"
+"format filesystem (mkfs)": "格式化文件系统 (mkfs)"
+"disk copy": "磁盘复制"
+"write to block device": "写入块设备"
+"dd to raw block device": "dd 写入裸块设备"
+"redirect to raw block device": "重定向到裸块设备"
+# SQL
+"SQL DROP": "SQL DROP"
+"SQL DELETE without WHERE": "SQL DELETE 不含 WHERE"
+"SQL TRUNCATE": "SQL TRUNCATE"
+# System config
+"overwrite system config": "覆盖系统配置"
+"stop/restart system service": "停止/重启系统服务"
+"overwrite system file via tee": "通过 tee 覆盖系统文件"
+"overwrite system file via redirection": "通过重定向覆盖系统文件"
+"overwrite project env/config via tee": "通过 tee 覆盖项目环境/配置文件"
+"overwrite project env/config via redirection": "通过重定向覆盖项目环境/配置文件"
+"overwrite project env/config file": "覆盖项目环境/配置文件"
+"in-place edit of system config": "就地编辑系统配置"
+"in-place edit of system config (long flag)": "就地编辑系统配置（长标志）"
+"copy/move file into system config path": "复制/移动文件到系统配置路径"
+# Process management
+"kill all processes": "终止所有进程"
+"force kill processes": "强制终止进程"
+"force kill processes (killall -KILL)": "强制终止进程 (killall -KILL)"
+"force kill processes (killall -s KILL)": "强制终止进程 (killall -s KILL)"
+"kill processes by regex (killall -r)": "按正则终止进程 (killall -r)"
+"kill hermes/gateway process (self-termination)": "终止 hermes/gateway 进程（自我终止）"
+"kill process via pgrep expansion (self-termination)": "通过 pgrep 终止进程（自我终止）"
+"kill process via backtick pgrep expansion (self-termination)": "通过反引号 pgrep 终止进程（自我终止）"
+# Fork bomb
+"fork bomb": "fork 炸弹"
+# Shell/script execution
+"shell command via -c/-lc flag": "通过 -c/-lc 标志执行 shell"
+"script execution via -e/-c flag": "通过 -e/-c 标志执行脚本"
+"script execution via heredoc": "通过 heredoc 执行脚本"
+"pipe remote content to shell": "将远程内容管道传输给 shell"
+"execute remote script via process substitution": "通过进程替换执行远程脚本"
+# File operations
+"xargs with rm": "xargs 配合 rm"
+"find -exec/-execdir rm": "find -exec/-execdir rm"
+"find -delete": "find -delete"
+"chmod +x followed by immediate execution": "chmod +x 后立即执行"
+# Git
+"git reset --hard (destroys uncommitted changes)": "git reset --hard（销毁未提交的更改）"
+"git force push (rewrites remote history)": "git force push（重写远程历史）"
+"git force push short flag (rewrites remote history)": "git force push 短标志（重写远程历史）"
+"git clean with force (deletes untracked files)": "git clean 强制删除（删除未跟踪文件）"
+"git branch force delete": "git branch 强制删除"
+# Gateway / Docker
+"stop/restart hermes gateway (kills running agents)": "停止/重启 hermes gateway（终止正在运行的代理）"
+"hermes update (restarts gateway, kills running agents)": "hermes 更新（重启 gateway，终止正在运行的代理）"
+"docker compose restart/stop/kill/down (container lifecycle)": "docker compose restart/stop/kill/down（容器生命周期）"
+"docker restart/stop/kill (container lifecycle)": "docker restart/stop/kill（容器生命周期）"
+"start gateway outside systemd (use 'systemctl --user restart hermes-gateway')": "在 systemd 外启动 gateway（请使用 systemctl）"
+# System
+"system shutdown/reboot": "系统关机/重启"
+"init 0/6 (shutdown/reboot)": "init 0/6（关机/重启）"
+"systemctl poweroff/reboot": "systemctl 关机/重启"
+"telinit 0/6 (shutdown/reboot)": "telinit 0/6（关机/重启）"
+# Sudo
+"sudo with privilege flag (stdin/askpass/shell/list)": "sudo 提权标志（stdin/askpass/shell/list）"
+"sudo with combined-flag privilege escalation": "sudo 组合标志提权"

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1469,3 +1469,103 @@ class TestApprovalTimeoutIsNotConsent:
         assert last_post.get("choice") == "timeout", (
             f"hook choice should be 'timeout' on no-response, got {last_post.get('choice')!r}"
         )
+
+
+class TestTranslateReason:
+    """Tests for _translate_reason — i18n of dangerous-command descriptions."""
+
+    @staticmethod
+    def _write_zh_reasons(tmp_path):
+        """Write a minimal approval_reasons/zh.yaml into a temp locales dir."""
+        import yaml
+        reasons_dir = tmp_path / "approval_reasons"
+        reasons_dir.mkdir(parents=True, exist_ok=True)
+        zh_file = reasons_dir / "zh.yaml"
+        data = {
+            "recursive delete": "递归删除",
+            "script execution via -e/-c flag": "通过 -e/-c 标志执行脚本",
+            "SQL DROP": "SQL DROP",
+            "fork bomb": "fork 炸弹",
+        }
+        zh_file.write_text(yaml.dump(data, allow_unicode=True), encoding="utf-8")
+        return tmp_path
+
+    def test_translates_known_reason_in_zh(self, tmp_path, monkeypatch):
+        """Known reason descriptions are translated to Chinese."""
+        locales_dir = self._write_zh_reasons(tmp_path)
+        monkeypatch.setattr("agent.i18n.get_language", lambda: "zh")
+        monkeypatch.setattr("agent.i18n._locales_dir", lambda: locales_dir)
+
+        from tools.approval import _translate_reason
+        assert _translate_reason("recursive delete") == "递归删除"
+        assert _translate_reason("script execution via -e/-c flag") == "通过 -e/-c 标志执行脚本"
+
+    def test_returns_original_for_unknown_reason(self, tmp_path, monkeypatch):
+        locales_dir = self._write_zh_reasons(tmp_path)
+        monkeypatch.setattr("agent.i18n.get_language", lambda: "zh")
+        monkeypatch.setattr("agent.i18n._locales_dir", lambda: locales_dir)
+
+        from tools.approval import _translate_reason
+        assert _translate_reason("some new pattern") == "some new pattern"
+
+    def test_returns_original_when_lang_is_en(self, tmp_path, monkeypatch):
+        locales_dir = self._write_zh_reasons(tmp_path)
+        monkeypatch.setattr("agent.i18n.get_language", lambda: "en")
+        monkeypatch.setattr("agent.i18n._locales_dir", lambda: locales_dir)
+
+        from tools.approval import _translate_reason
+        assert _translate_reason("recursive delete") == "recursive delete"
+
+    def test_returns_original_when_no_zh_file(self, tmp_path, monkeypatch):
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        monkeypatch.setattr("agent.i18n.get_language", lambda: "zh")
+        monkeypatch.setattr("agent.i18n._locales_dir", lambda: empty_dir)
+
+        from tools.approval import _translate_reason
+        assert _translate_reason("recursive delete") == "recursive delete"
+
+    def test_returns_original_on_any_exception(self, monkeypatch):
+        monkeypatch.setattr("agent.i18n.get_language", lambda: "zh")
+        monkeypatch.setattr("agent.i18n._locales_dir", lambda: Path("/nonexistent/path/definitely"))
+
+        from tools.approval import _translate_reason
+        assert _translate_reason("recursive delete") == "recursive delete"
+
+
+class TestGatewayApprovalStrings:
+    """Tests for get_gateway_approval_strings."""
+
+    def test_returns_english_by_default(self, monkeypatch):
+        monkeypatch.setattr("agent.i18n.get_language", lambda: "en")
+        from tools.approval import get_gateway_approval_strings
+        s = get_gateway_approval_strings()
+        assert s["header"] == "⚠️ Command Approval Required"
+        assert s["reason_label"] == "Reason"
+        assert s["btn_allow_once"] == "Allow Once"
+        assert s["btn_deny"] == "Deny"
+
+    def test_returns_chinese_when_lang_is_zh(self, monkeypatch):
+        monkeypatch.setattr("agent.i18n.get_language", lambda: "zh")
+        from tools.approval import get_gateway_approval_strings
+        s = get_gateway_approval_strings()
+        assert s["header"] == "⚠️ 需要批准命令"
+        assert s["reason_label"] == "原因"
+        assert s["btn_allow_once"] == "允许一次"
+        assert s["btn_deny"] == "拒绝"
+
+    def test_fallback_text_formats_correctly(self, monkeypatch):
+        monkeypatch.setattr("agent.i18n.get_language", lambda: "zh")
+        from tools.approval import get_gateway_approval_strings
+        s = get_gateway_approval_strings()
+        result = s["fallback_text"].format(command="rm -rf /tmp/x", reason="递归删除")
+        assert "rm -rf /tmp/x" in result
+        assert "/approve" in result
+
+    def test_all_keys_present(self, monkeypatch):
+        from tools.approval import get_gateway_approval_strings
+        monkeypatch.setattr("agent.i18n.get_language", lambda: "en")
+        en_keys = set(get_gateway_approval_strings().keys())
+        monkeypatch.setattr("agent.i18n.get_language", lambda: "zh")
+        zh_keys = set(get_gateway_approval_strings().keys())
+        assert en_keys == zh_keys, f"Key mismatch: {en_keys ^ zh_keys}"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -286,11 +286,12 @@ def detect_hardline_command(command: str) -> tuple:
 
 def _hardline_block_result(description: str) -> dict:
     """Build the standard block result for a hardline match."""
+    display_desc = _translate_reason(description)
     return {
         "approved": False,
         "hardline": True,
         "message": (
-            f"BLOCKED (hardline): {description}. "
+            f"BLOCKED (hardline): {display_desc}. "
             "This command is on the unconditional blocklist and cannot "
             "be executed via the agent — not even with --yolo, /yolo, "
             "approvals.mode=off, or cron approve mode. If you genuinely "
@@ -707,6 +708,77 @@ def save_permanent_allowlist(patterns: set):
 # Approval prompting + orchestration
 # =========================================================================
 
+def _translate_reason(description: str) -> str:
+    """Translate a dangerous-command reason description via i18n.
+    
+    Loads the reason mapping from ``locales/approval_reasons/<lang>.yaml``,
+    bypassing the main i18n catalog (which enforces key parity across all
+    locale files).  Falls back to the original English description when no
+    translation is available.
+    """
+    try:
+        from agent.i18n import get_language, _locales_dir
+        import yaml
+        lang = get_language()
+        if lang == "en":
+            return description
+        path = _locales_dir() / "approval_reasons" / f"{lang}.yaml"
+        if path.is_file():
+            with path.open("r", encoding="utf-8") as f:
+                raw = yaml.safe_load(f) or {}
+            translated = raw.get(description)
+            if translated and translated != description:
+                return translated
+    except Exception:
+        pass
+    return description
+
+def get_gateway_approval_strings() -> dict:
+    """Return localized strings for gateway approval prompts.
+
+    Each platform adapter calls this to get the correct header, reason label,
+    and button labels for the current language.  Falls back to English.
+    """
+    try:
+        from agent.i18n import get_language
+        lang = get_language()
+    except Exception:
+        lang = "en"
+
+    if lang == "zh":
+        return {
+            "header": "⚠️ 需要批准命令",
+            "header_html": "⚠️ <b>需要批准命令</b>",
+            "reason_label": "原因",
+            "btn_allow_once": "允许一次",
+            "btn_allow_session": "本次会话",
+            "btn_allow_always": "永久允许",
+            "btn_deny": "拒绝",
+            "fallback_text": (
+                "⚠️ **危险命令需要批准：**\n```\n{command}\n```\n"
+                "原因：{reason}\n\n"
+                "回复 `/approve` 执行，`/approve session` 本次会话允许，"
+                "`/approve always` 永久允许，或 `/deny` 取消。"
+            ),
+        }
+    return {
+        "header": "⚠️ Command Approval Required",
+        "header_html": "⚠️ <b>Command Approval Required</b>",
+        "reason_label": "Reason",
+        "btn_allow_once": "Allow Once",
+        "btn_allow_session": "Session",
+        "btn_allow_always": "Always",
+        "btn_deny": "Deny",
+        "fallback_text": (
+            "⚠️ **Dangerous command requires approval:**\n```\n{command}\n```\n"
+            "Reason: {reason}\n\n"
+            "Reply `/approve` to execute, `/approve session` to approve "
+            "this pattern for the session, `/approve always` to approve "
+            "permanently, or `/deny` to cancel."
+        ),
+    }
+
+
 def prompt_dangerous_approval(command: str, description: str,
                               timeout_seconds: int | None = None,
                               allow_permanent: bool = True,
@@ -766,9 +838,10 @@ def prompt_dangerous_approval(command: str, description: str,
         # Resolve the active UI language once per prompt so we don't re-read
         # config/YAML inside the retry loop below.
         from agent.i18n import t
+        display_desc = _translate_reason(description)
         while True:
             print()
-            print(f"  {t('approval.dangerous_header', description=description)}")
+            print(f"  {t('approval.dangerous_header', description=display_desc)}")
             print(f"      {command}")
             print()
             if allow_permanent:
@@ -1210,10 +1283,11 @@ def check_all_command_guards(command: str, env_type: str,
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
                 if is_dangerous:
+                    display_desc = _translate_reason(description)
                     return {
                         "approved": False,
                         "message": (
-                            f"BLOCKED: Command flagged as dangerous ({description}) "
+                            f"BLOCKED: Command flagged as dangerous ({display_desc}) "
                             "but cron jobs run without a user present to approve it. "
                             "Find an alternative approach that avoids this command. "
                             "To allow dangerous commands in cron jobs, set "
@@ -1292,7 +1366,7 @@ def check_all_command_guards(command: str, env_type: str,
     # --- Phase 3: Approval ---
 
     # Combine descriptions for a single approval prompt
-    combined_desc = "; ".join(desc for _, desc, _ in warnings)
+    combined_desc = "; ".join(_translate_reason(desc) for _, desc, _ in warnings)
     primary_key = warnings[0][0]
     all_keys = [key for key, _, _ in warnings]
     has_tirith = any(is_t for _, _, is_t in warnings)


### PR DESCRIPTION
## Summary

Add Chinese (zh) translation support for the ~60 dangerous-command reason descriptions shown in approval prompts, plus localize gateway approval UI strings (headers, buttons, fallback text) for Telegram, Slack, Feishu, and Matrix.

## Motivation

Currently, when Hermes Agent needs user approval for a dangerous command, the reason descriptions are always in English (e.g. "script execution via -e/-c flag", "recursive delete"). For non-English-speaking users, this makes it harder to understand what the agent is asking permission for.

## Changes

### New file
- `locales/approval_reasons/zh.yaml` — Chinese translations for all ~60 dangerous-command reason descriptions

### Core
- `tools/approval.py`
  - `_translate_reason()` — translates a reason description by reading `locales/approval_reasons/<lang>.yaml`, falls back to English
  - `get_gateway_approval_strings()` — returns localized header/label/button strings for gateway approval prompts, eliminating ~120 lines of duplicated `if is_zh` logic across 4 platform adapters
  - All display sites (CLI prompt, hardline block, cron block, gateway approval data) now call `_translate_reason()`

### Gateway platforms
- `gateway/platforms/telegram.py` — use shared helper for header, reason label, and 4 button labels
- `gateway/platforms/slack.py` — same
- `gateway/platforms/feishu.py` — same
- `gateway/platforms/matrix.py` — same
- `gateway/run.py` — fallback text approval uses `get_gateway_approval_strings()`

### Tests
- `tests/tools/test_approval.py` — +9 test cases:
  - `TestTranslateReason` (5 tests): translation lookup, unknown fallback, en fallback, missing file, exception safety
  - `TestGatewayApprovalStrings` (4 tests): EN default, ZH strings, placeholder formatting, key parity

### No changes to
- `locales/en.yaml` — unchanged (no catalog parity breakage)
- `locales/zh.yaml` — unchanged (no catalog parity breakage)
- Other locale files — unaffected

## How it works

1. User sets `display.language: zh` in `config.yaml`
2. `_translate_reason()` reads `locales/approval_reasons/zh.yaml` and returns the Chinese version
3. `get_gateway_approval_strings()` returns Chinese UI strings for gateway prompts
4. Gateway platforms use these strings for their approval messages

## Verification
- All 240 existing + new tests pass (`tests/agent/test_i18n.py` + `tests/tools/test_approval.py`)
- Manually verified: `HERMES_LANGUAGE=zh` triggers correct Chinese translations
- Gateway restarted and confirmed approval prompts show Chinese on Telegram

## Adding more languages
Copy `locales/approval_reasons/zh.yaml` to `<lang>.yaml`, translate the values, and extend `get_gateway_approval_strings()` with the new language branch.