### PR TITLE
fix(agent): emit fallback activation notice immediately instead of buffering

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1247,7 +1247,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 api_mode=agent.api_mode,
             )
 
-        agent._buffer_status(
+        agent._emit_status(
             f"🔄 Primary model failed — switching to fallback: "
             f"{fb_model} via {fb_provider}"
         )

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -305,3 +305,57 @@ class TestFallbackChainDedup:
 
         assert ok is False
         mock_resolve.assert_not_called()
+
+
+# ── Fallback notice visibility (#35419) ─────────────────────────────────
+
+
+class TestFallbackNoticeEmittedImmediately:
+    """Regression: fallback activation notice must be emitted immediately
+    via _emit_status, not buffered. Buffered notices are cleared on
+    successful recovery, making fallback invisible to users. See #35419."""
+
+    def test_fallback_emits_status_immediately(self):
+        """The fallback notice must reach _emit_status (not _buffer_status)."""
+        fbs = [{"provider": "zai", "model": "glm-4.7"}]
+        agent = _make_agent(fallback_model=fbs)
+
+        emitted = []
+        agent._emit_status = lambda message: emitted.append(message)
+
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client",
+                  return_value=(_mock_client(), "glm-4.7")),
+            patch("hermes_cli.model_normalize.normalize_model_for_provider",
+                  side_effect=lambda m, p: m),
+        ):
+            ok = agent._try_activate_fallback()
+
+        assert ok is True
+        # The notice was emitted immediately, not buffered.
+        assert any("switching to fallback" in m and "glm-4.7" in m for m in emitted), (
+            f"Expected fallback notice in emitted messages, got: {emitted}"
+        )
+
+    def test_fallback_notice_not_lost_on_clear(self):
+        """Even if _clear_status_buffer is called later, the notice was
+        already emitted and is not lost."""
+        fbs = [{"provider": "zai", "model": "glm-4.7"}]
+        agent = _make_agent(fallback_model=fbs)
+
+        emitted = []
+        agent._emit_status = lambda message: emitted.append(message)
+
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client",
+                  return_value=(_mock_client(), "glm-4.7")),
+            patch("hermes_cli.model_normalize.normalize_model_for_provider",
+                  side_effect=lambda m, p: m),
+        ):
+            agent._try_activate_fallback()
+
+        # Simulate success path — clear the buffer.
+        agent._clear_status_buffer()
+
+        # The notice was already emitted before the clear.
+        assert any("switching to fallback" in m for m in emitted)


### PR DESCRIPTION
## What does this PR do?

When a fallback provider is successfully activated after the primary model fails, the fallback notice was buffered via `_buffer_status()` and silently cleared on the success path (`_clear_status_buffer()`). This made fallback invisible to users — they could not tell whether the response came from the primary or fallback model. Changes the notice to emit immediately via `_emit_status()`.

## Related Issue

Fixes #35419

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: Changed `_buffer_status` to `_emit_status` for the fallback activation notice in `try_activate_fallback()`. Other retry chatter (rate-limit waits, compression attempts, empty-response warnings) remains buffered.
- `tests/run_agent/test_provider_fallback.py`: Added `TestFallbackNoticeEmittedImmediately` with 2 regression tests verifying the notice is emitted immediately and survives subsequent `_clear_status_buffer()` calls.

## How to Test

1. Configure a primary model that will fail (e.g., invalid API key) and a `fallback_providers` entry
2. Send a message — the gateway/CLI should show "🔄 Primary model failed — switching to fallback: <model> via <provider>" before the response
3. Run `pytest tests/run_agent/test_provider_fallback.py -x -q` — all 24 tests pass (including 2 new regression tests)
4. Run `pytest tests/run_agent/test_retry_status_buffer.py -x -q` — all 7 tests pass (buffer/clear/flush behavior unchanged)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/chat_completion_helpers.py:try_activate_fallback` (called from `agent/conversation_loop.py` at 7+ fallback trigger points)
- Blast radius: LOW — single-line change from `_buffer_status` to `_emit_status`; all existing retry/fallback tests pass
- Related patterns: `_buffer_status`/`_emit_status`/`_clear_status_buffer`/`_flush_status_buffer` in `run_agent.py` (lines 782-846); `_clear_status_buffer` at `conversation_loop.py:4207` clears buffer on success
