### PR TITLE
fix(cli): set terminal title on idle/working transitions for hermes

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -715,6 +715,14 @@ class KawaiiSpinner:
                 time.sleep(0.1)
                 continue
             frame = self.spinner_frames[self.frame_idx % len(self.spinner_frames)]
+            try:
+                agent_name = os.environ.get("AGENT_PERSONA") or os.path.basename(sys.argv[0]) or "unleash"
+                if agent_name.endswith(".py"):
+                    agent_name = agent_name[:-3]
+                self._out.write(f"\x1b]2;{frame} {agent_name}\x07")
+                self._out.flush()
+            except Exception:
+                pass
             elapsed = time.time() - self.start_time
             if wings:
                 left, right = wings[self.frame_idx % len(wings)]
@@ -763,6 +771,14 @@ class KawaiiSpinner:
 
         is_tty = self._is_tty
         if is_tty:
+            try:
+                agent_name = os.environ.get("AGENT_PERSONA") or os.path.basename(sys.argv[0]) or "unleash"
+                if agent_name.endswith(".py"):
+                    agent_name = agent_name[:-3]
+                self._out.write(f"\x1b]2;✳ {agent_name}\x07")
+                self._out.flush()
+            except Exception:
+                pass
             # Clear the spinner line with spaces instead of \033[K to avoid
             # garbled escape codes when prompt_toolkit's patch_stdout is active.
             blanks = ' ' * max(self.last_line_len + 5, 40)

--- a/cli.py
+++ b/cli.py
@@ -14958,6 +14958,16 @@ class HermesCLI:
                     pass  # No running loop -- nothing to patch
                 except Exception:
                     pass
+                try:
+                    import os as _title_os
+                    import sys as _title_sys
+                    _agent_name = _title_os.environ.get("AGENT_PERSONA") or _title_os.path.basename(_title_sys.argv[0]) or "unleash"
+                    if _agent_name.endswith(".py"):
+                        _agent_name = _agent_name[:-3]
+                    _title_sys.stdout.write(f"\x1b]2;✳ {_agent_name}\x07")
+                    _title_sys.stdout.flush()
+                except Exception:
+                    pass
                 app.run()
         except (EOFError, KeyboardInterrupt, BrokenPipeError):
             pass


### PR DESCRIPTION
Sets terminal title to ✳ [agent] on idle transitions and updates with the Braille spinner character during active runs to ensure correct state detection.