### PR TITLE
fix(packaging): include locales/ i18n catalogs in wheel and sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,8 @@ graft optional-skills
 # built from the sdist (e.g. Homebrew, downstream packagers). package-data
 # below covers the wheel; this covers the sdist. See #34034 / #28149.
 recursive-include plugins plugin.yaml plugin.yml
+# i18n translation catalogs used by agent.i18n.t() — gateway slash commands
+# display raw dotted keys without these. See #35374.
+recursive-include locales *.yaml
 global-exclude __pycache__
 global-exclude *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,10 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]
 gateway = ["assets/**/*"]
+# i18n translation catalogs — agent.i18n.t() loads locales/<lang>.yaml from
+# the repo root.  Without this entry the wheel omits them and gateway slash
+# commands display raw dotted keys (e.g. "gateway.model.switched").  See #35374.
+"." = ["locales/*.yaml"]
 plugins = [
   "*/dashboard/manifest.json",
   "*/dashboard/dist/*",


### PR DESCRIPTION
## Problem

The PyPI/pipx-installed `hermes-agent` wheel omits the top-level `locales/*.yaml` translation catalogs used by `agent.i18n.t()`. As a result, gateway slash commands (`/model`, `/reasoning`, etc.) display raw dotted i18n keys (e.g. `gateway.model.switched`) instead of user-facing text.

**Root cause:** `locales/` sits at the repo root outside any Python package, so neither `[tool.setuptools.packages.find]` nor the default `package-data` globs pick it up.

## Fix

- **MANIFEST.in:** add `recursive-include locales *.yaml` for sdist
- **pyproject.toml:** add `"." = ["locales/*.yaml"]` to `[tool.setuptools.package-data]` for wheel

The `"."` key in `package-data` is setuptools' convention for including data files that live at the project root (not inside a sub-package).

## Files Changed

- `MANIFEST.in` — added locales glob
- `pyproject.toml` — added locales to package-data

Fixes #35374