### PR TITLE
feat: isolate Feishu top-level message sessions

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -854,6 +854,11 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
                 if "reply_in_thread" in platform_cfg:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
+                if plat == Platform.FEISHU and "auto_thread_top_level_messages" in platform_cfg:
+                    bridged["auto_thread_top_level_messages"] = _coerce_bool(
+                        platform_cfg.get("auto_thread_top_level_messages"),
+                        False,
+                    )
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if plat == Platform.TELEGRAM and "allowed_chats" in platform_cfg:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3058,6 +3058,19 @@ class FeishuAdapter(BasePlatformAdapter):
                 text = f"{hint}\n\n{text}" if text else hint
 
         thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        config_extra = getattr(getattr(self, "config", None), "extra", {}) or {}
+        if (
+            not thread_id
+            and message_id
+            and chat_type != "p2p"
+            and bool(config_extra.get("auto_thread_top_level_messages", False))
+        ):
+            # Feishu/Lark top-level group messages have no thread/root id until
+            # somebody replies in a thread.  When this opt-in is enabled, use
+            # the seed message id as the provisional thread lane so the first
+            # bot answer is sent with reply_in_thread=True and the gateway
+            # session key is isolated from other top-level conversations.
+            thread_id = message_id
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -474,6 +474,22 @@ class TestLoadGatewayConfig:
         assert telegram.token == "top-token"
         assert telegram.extra["reply_prefix"] == "top"
 
+    def test_bridges_feishu_auto_thread_top_level_messages_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "feishu:\n"
+            "  auto_thread_top_level_messages: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.FEISHU].extra["auto_thread_top_level_messages"] is True
+
     def test_bridges_quoted_false_session_notify_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4426,6 +4426,7 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
             return_value={"user_id": "u1", "user_name": "Alice", "user_id_alt": None}
         )
         adapter._resolve_source_chat_type = Mock(return_value="group")
+        adapter.config = SimpleNamespace(extra={})
         adapter.build_source = Mock(return_value=SimpleNamespace(thread_id=None))
         adapter._dispatch_inbound_event = AsyncMock()
         return adapter
@@ -4593,6 +4594,117 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
             )
         )
         adapter._dispatch_inbound_event.assert_not_called()
+
+    def test_auto_thread_top_level_group_message_uses_message_id_as_thread_lane(self):
+        adapter = self._build_adapter()
+        adapter.config.extra["auto_thread_top_level_messages"] = True
+        message = SimpleNamespace(
+            content=json.dumps({"text": "start isolated work"}),
+            message_type="text",
+            message_id="om_topic_seed",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            root_id=None,
+            thread_id=None,
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="om_topic_seed",
+            )
+        )
+
+        adapter.build_source.assert_called_once()
+        self.assertEqual(adapter.build_source.call_args.kwargs["thread_id"], "om_topic_seed")
+
+    def test_auto_thread_top_level_default_disabled_keeps_plain_group_session(self):
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "plain group lane"}),
+            message_type="text",
+            message_id="om_no_auto_thread",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            root_id=None,
+            thread_id=None,
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="om_no_auto_thread",
+            )
+        )
+
+        adapter.build_source.assert_called_once()
+        self.assertIsNone(adapter.build_source.call_args.kwargs["thread_id"])
+
+    def test_auto_thread_top_level_does_not_apply_to_p2p(self):
+        adapter = self._build_adapter()
+        adapter.config.extra["auto_thread_top_level_messages"] = True
+        message = SimpleNamespace(
+            content=json.dumps({"text": "dm should remain dm"}),
+            message_type="text",
+            message_id="om_dm",
+            mentions=[],
+            chat_id="oc_dm",
+            parent_id=None,
+            upper_message_id=None,
+            root_id=None,
+            thread_id=None,
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="p2p",
+                message_id="om_dm",
+            )
+        )
+
+        adapter.build_source.assert_called_once()
+        self.assertIsNone(adapter.build_source.call_args.kwargs["thread_id"])
+
+    def test_auto_thread_top_level_does_not_override_existing_thread_id(self):
+        adapter = self._build_adapter()
+        adapter.config.extra["auto_thread_top_level_messages"] = True
+        message = SimpleNamespace(
+            content=json.dumps({"text": "continue topic"}),
+            message_type="text",
+            message_id="om_reply",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id="om_seed",
+            upper_message_id=None,
+            root_id="om_seed",
+            thread_id="omt_existing",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="om_reply",
+            )
+        )
+
+        adapter.build_source.assert_called_once()
+        self.assertEqual(adapter.build_source.call_args.kwargs["thread_id"], "omt_existing")
 
 
 class TestFeishuFetchMessageText(unittest.TestCase):


### PR DESCRIPTION
## What does this PR do?

This PR adds an opt-in Feishu/Lark gateway behavior that isolates top-level group messages into their own thread/session lane.
    
Today, Feishu group conversations can share the same chat-level session unless the inbound message already has a Feishu thread/root id. That means multiple independent top-level conversations in the same group can end up sharing context and being processed serially through the same gateway session.
    
This change introduces a Feishu-specific config option:
yaml
feishu:
  auto_thread_top_level_messages: true

When enabled, if a non-DM Feishu/Lark message has no thread_id or root_id, Hermes uses the message's own message_id as a provisional thread lane. This makes the first bot response reply into that message's topic/thread and gives each top-level conversation its own isolated gateway session key. Existing Feishu threads keep using their real thread_id/root_id, and the behavior is disabled by default for backwards compatibility.


## Related Issue
N/A
## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
    
    - gateway/platforms/feishu.py
      - Adds opt-in logic for Feishu/Lark top-level group messages.
      - If auto_thread_top_level_messages is enabled and a group message has no thread_id/root_id, the adapter uses the inbound message_id as the provisional thread lane.
      - Keeps existing thread ids untouched.
      - Does not apply the behavior to p2p / DM chats.
    
    - gateway/config.py
      - Bridges the new top-level YAML config key:
        yaml
        feishu:
          auto_thread_top_level_messages: true
        
        into the Feishu platform extra config.
    
    - tests/gateway/test_feishu.py
      - Adds coverage for:
        - top-level Feishu group messages using message_id as the thread lane when enabled
        - default disabled behavior preserving plain group sessions
        - p2p/DM chats not being affected
        - existing Feishu thread_id values not being overwritten
    
    - tests/gateway/test_config.py
      - Adds coverage for loading feishu.auto_thread_top_level_messages from config.yaml.
    
## How to Test
    
    1. Run the targeted gateway tests:
    
       bash
       cd /usr/local/lib/hermes-agent
       venv/bin/python -m pytest \
         tests/gateway/test_config.py::TestLoadGatewayConfig::test_bridges_feishu_auto_thread_top_level_messages_from_config_yaml \
         tests/gateway/test_config.py::TestLoadGatewayConfig::test_bridges_nested_gateway_platforms_from_config_yaml \
         tests/gateway/test_config.py::TestLoadGatewayConfig::test_top_level_platforms_override_nested_gateway_platforms \
         tests/gateway/test_feishu.py \
         -q -o 'addopts='
       
    
    2. Expected result from local testing:
    
       text
       212 passed, 2 warnings in 9.50s
       
    
    3. Manual gateway verification:
    
       Configure:
    
       yaml
       feishu:
         auto_thread_top_level_messages: true
       
    
       Restart the gateway:
    
       bash
       hermes gateway restart
       
    
       Then in a Feishu/Lark group:
    
       - Send a new top-level message mentioning Hermes.
       - Verify Hermes replies in that message's thread/topic.
       - Send another independent top-level message.
       - Verify the two conversations do not share context.
    
## Checklist
    
    Code
    
    - [ ] I've read the Contributing Guide
    - [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
    - [ ] I searched for existing PRs to make sure this isn't a duplicate
    - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
    - [ ] I've run pytest tests/ -q and all tests pass
    - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
    - [x] I've tested on my platform: Linux / Ubuntu-style server environment
    
    Documentation & Housekeeping
    
    - [ ] I've updated relevant documentation (README, docs/, docstrings) — or N/A
    - [ ] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
    - [ ] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
    - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
    - [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
    
## For New Skills
    
    N/A

## Screenshots / Logs
<img width="705" height="400" alt="image" src="https://github.com/user-attachments/assets/e821e0f4-5bb0-4eb7-9f85-476a79d870d6" />


