### PR TITLE
fix(feishu): use interactive-operator auth for approval clicks instead of group allowlist

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2581,13 +2581,17 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
-            logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
-            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
-
         callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
         expected_chat_id = str(state.get("chat_id", "") or "")
+
+        # Gate approval clicks through interactive-operator authorization
+        # (considers admins + allowed_users with a permissive default when
+        # neither is configured) instead of the group-message allowlist.
+        # The group allowlist rejects everyone when no admins/allowlist is
+        # configured, which silently breaks DM approval callbacks.
+        if not self._is_interactive_operator_authorized(open_id):
+            logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
         if callback_chat_id and expected_chat_id and callback_chat_id != expected_chat_id:
             logger.warning(
                 "[Feishu] Approval callback chat mismatch for %s (expected=%s, got=%s)",


### PR DESCRIPTION
## Problem

`_handle_approval_card_action` uses `_allow_group_message()` to gate Feishu approval button clicks. This check uses the group-policy allowlist (default: `allowlist`) which rejects **everyone** when no admins or allowed users are configured — silently breaking **DM approval callbacks**.

### Symptoms

Gateway logs show repeated:
```
[Feishu] Unauthorized approval click by ou_xxx
```

The approval button appears in the Feishu DM, but every click is rejected.

## Root Cause

`_allow_group_message()` checks the group-message allowlist. For DM conversations where no admins or allowed users are explicitly configured, the default `allowlist` policy returns `False` for everyone — causing all DM approval clicks to be rejected.

## Fix

Replace `_allow_group_message()` with `_is_interactive_operator_authorized()` in the sync gate. This method already exists and is used by:
- `_resolve_approval` (the async handler — provides the second auth check)
- `_handle_update_prompt_card_action` (update prompt clicks)

`_is_interactive_operator_authorized()` considers both `admins` and `allowed_group_users` with a **permissive fallback** (allow when neither is configured), making the gate consistent.

## Changes

- `gateway/platforms/feishu.py`: In `_handle_approval_card_action`, replace `_allow_group_message()` with `_is_interactive_operator_authorized()`
- Remove unused `sender_id` construction