### PR TITLE
fix: add chat-prefix fallback for approval session key resolution

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1469,3 +1469,50 @@ class TestApprovalTimeoutIsNotConsent:
         assert last_post.get("choice") == "timeout", (
             f"hook choice should be 'timeout' on no-response, got {last_post.get('choice')!r}"
         )
+
+
+class TestChatPrefix:
+    def test_extracts_first_five_segments(self):
+        key = "agent:main:telegram:private:12345:user:thread1"
+        assert approval_module._chat_prefix(key) == "agent:main:telegram:private:12345"
+
+    def test_returns_full_key_when_fewer_than_five_segments(self):
+        key = "agent:main:telegram"
+        assert approval_module._chat_prefix(key) == key
+
+    def test_exactly_five_segments(self):
+        key = "agent:main:discord:guild:99"
+        assert approval_module._chat_prefix(key) == key
+
+
+class TestResolveQueueKey:
+    def setup_method(self):
+        self._saved = dict(approval_module._gateway_queues)
+        approval_module._gateway_queues.clear()
+
+    def teardown_method(self):
+        approval_module._gateway_queues.clear()
+        approval_module._gateway_queues.update(self._saved)
+
+    def test_exact_match(self):
+        key = "agent:main:telegram:private:12345"
+        approval_module._gateway_queues[key] = []
+        assert approval_module._resolve_queue_key(key) == key
+
+    def test_prefix_fallback(self):
+        queue_key = "agent:main:telegram:private:12345:user42"
+        approval_module._gateway_queues[queue_key] = []
+        lookup = "agent:main:telegram:private:12345:user99"
+        assert approval_module._resolve_queue_key(lookup) == queue_key
+
+    def test_multi_prefix_collision_prefers_exact_prefix(self):
+        exact_prefix = "agent:main:telegram:private:12345"
+        suffixed = "agent:main:telegram:private:12345:user42"
+        approval_module._gateway_queues[exact_prefix] = []
+        approval_module._gateway_queues[suffixed] = []
+        lookup = "agent:main:telegram:private:12345:user99"
+        assert approval_module._resolve_queue_key(lookup) == exact_prefix
+
+    def test_no_match_returns_none(self):
+        approval_module._gateway_queues["agent:main:discord:guild:99"] = []
+        assert approval_module._resolve_queue_key("agent:main:telegram:private:1") is None

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -579,10 +579,16 @@ def _resolve_queue_key(session_key: str) -> Optional[str]:
     if session_key in _gateway_queues:
         return session_key
     prefix = _chat_prefix(session_key)
+    first_match = None
     for key in _gateway_queues:
         if _chat_prefix(key) == prefix:
-            return key
-    return None
+            if key == prefix:
+                return key
+            if first_match is None:
+                first_match = key
+    if first_match is not None:
+        logger.debug("[approval] Prefix fallback: %s -> %s", session_key, first_match)
+    return first_match
 
 
 def resolve_gateway_approval(session_key: str, choice: str,
@@ -622,6 +628,8 @@ def has_blocking_approval(session_key: str) -> bool:
     with _lock:
         if _gateway_queues.get(session_key):
             return True
+        # O(n) scan over queue keys — acceptable since practical queue sizes
+        # are single-digit; lock-hold time is negligible.
         prefix = _chat_prefix(session_key)
         return any(
             _chat_prefix(key) == prefix

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -551,6 +551,40 @@ def unregister_gateway_notify(session_key: str) -> None:
         entry.event.set()
 
 
+def _chat_prefix(session_key: str) -> str:
+    """Extract the chat-identity prefix from a session key.
+
+    Session keys have the form ``agent:main:{platform}:{chat_type}:{chat_id}[:...]``.
+    The prefix is the first five colon-separated segments (up to and including
+    chat_id), which uniquely identify a chat regardless of per-user or
+    per-thread suffixes.  Returns the full key when it has fewer than five
+    segments (defensive fallback).
+    """
+    parts = session_key.split(":")
+    if len(parts) >= 5:
+        return ":".join(parts[:5])
+    return session_key
+
+
+def _resolve_queue_key(session_key: str) -> Optional[str]:
+    """Return the actual key in ``_gateway_queues`` for *session_key*.
+
+    Tries an exact match first.  When that fails, falls back to a
+    chat-prefix match so that ``/approve`` still works when the inbound
+    source produces a slightly different session key (e.g. weixin
+    content-dedup or bridge reshuffling user identifiers).
+
+    Must be called with ``_lock`` held.
+    """
+    if session_key in _gateway_queues:
+        return session_key
+    prefix = _chat_prefix(session_key)
+    for key in _gateway_queues:
+        if _chat_prefix(key) == prefix:
+            return key
+    return None
+
+
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False) -> int:
     """Called by the gateway's /approve or /deny handler to unblock
@@ -563,7 +597,10 @@ def resolve_gateway_approval(session_key: str, choice: str,
     Returns the number of approvals resolved (0 means nothing was pending).
     """
     with _lock:
-        queue = _gateway_queues.get(session_key)
+        actual_key = _resolve_queue_key(session_key)
+        if actual_key is None:
+            return 0
+        queue = _gateway_queues.get(actual_key)
         if not queue:
             return 0
         if resolve_all:
@@ -572,7 +609,7 @@ def resolve_gateway_approval(session_key: str, choice: str,
         else:
             targets = [queue.pop(0)]
         if not queue:
-            _gateway_queues.pop(session_key, None)
+            _gateway_queues.pop(actual_key, None)
 
     for entry in targets:
         entry.result = choice
@@ -583,7 +620,13 @@ def resolve_gateway_approval(session_key: str, choice: str,
 def has_blocking_approval(session_key: str) -> bool:
     """Check if a session has one or more blocking gateway approvals waiting."""
     with _lock:
-        return bool(_gateway_queues.get(session_key))
+        if _gateway_queues.get(session_key):
+            return True
+        prefix = _chat_prefix(session_key)
+        return any(
+            _chat_prefix(key) == prefix
+            for key in _gateway_queues
+        )
 
 
 def submit_pending(session_key: str, approval: dict):


### PR DESCRIPTION
## Problem

When a dangerous-command approval is pending (agent blocked on `threading.Event` in `tools/approval.py`) and the user sends `/approve` via Weixin, the approval handler (`resolve_gateway_approval`) may fail to find the pending approval because the inbound session key doesn't exactly match the key stored in `_gateway_queues`.

This happens because Weixin's content-dedup, bridge reshuffling, or per-user/thread suffixes create subtly different session keys.

## Fix

Add chat-prefix matching as a fallback in `tools/approval.py`:

- **`_chat_prefix(session_key)`**: Extracts the first 5 colon-separated segments (`agent:main:{platform}:{chat_type}:{chat_id}`) as the chat identity.
- **`_resolve_queue_key(session_key)`**: Tries exact match first, then falls back to comparing chat prefixes.
- Updated `resolve_gateway_approval()` and `has_blocking_approval()` to use the fallback.

## Verification

- All 45 passing approval tests continue to pass (1 pre-existing timeout-related failure unchanged)
- No changes needed in `gateway/run.py` — the handlers already delegate to the updated functions