### PR TITLE
fix(url_safety): exclude 198.18.0.0/15 benchmark range from SSRF private-IP blocking

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -166,11 +166,24 @@ class TestIsSafeUrl:
             # 100.0.0.1 is a global IP, not in CGNAT range
             assert is_safe_url("http://legit-host.example/") is True
 
-    def test_benchmark_ip_blocked_for_non_allowlisted_host(self):
+    def test_benchmark_range_allowed_for_any_host(self):
+        """198.18.0.0/15 (benchmark/DNS-filtering range) is not blocked."""
         with patch("socket.getaddrinfo", return_value=[
             (2, 1, 6, "", ("198.18.0.23", 0)),
         ]):
-            assert is_safe_url("https://example.com/file.jpg") is False
+            assert is_safe_url("https://example.com/file.jpg") is True
+
+    def test_cdimage_ubuntu_allowed_on_filtered_network(self):
+        """cdimage.ubuntu.com resolving to benchmark range should be allowed.
+
+        Regression test for https://github.com/NousResearch/hermes-agent/issues/35423
+        DNS-based content-filtering services (OpenDNS, etc.) may resolve
+        public domains into the 198.18.0.0/15 range.
+        """
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("198.18.0.65", 0)),
+        ]):
+            assert is_safe_url("https://cdimage.ubuntu.com/ubuntu/releases/26.04/release/") is True
 
     def test_qq_multimedia_hostname_allowed_with_benchmark_ip(self):
         with patch("socket.getaddrinfo", return_value=[
@@ -178,17 +191,27 @@ class TestIsSafeUrl:
         ]):
             assert is_safe_url("https://multimedia.nt.qq.com.cn/download?id=123") is True
 
-    def test_qq_multimedia_hostname_exception_is_exact_match(self):
-        with patch("socket.getaddrinfo", return_value=[
-            (2, 1, 6, "", ("198.18.0.23", 0)),
-        ]):
-            assert is_safe_url("https://sub.multimedia.nt.qq.com.cn/download?id=123") is False
+    def test_qq_multimedia_subdomain_also_allowed_via_benchmark_range(self):
+        """Subdomain is allowed because the entire benchmark range is allowed.
 
-    def test_qq_multimedia_hostname_exception_requires_https(self):
+        Previously only exact _TRUSTED_PRIVATE_IP_HOSTS entries were exempt;
+        now 198.18.0.0/15 is excluded from _is_blocked_ip entirely.
+        """
         with patch("socket.getaddrinfo", return_value=[
             (2, 1, 6, "", ("198.18.0.23", 0)),
         ]):
-            assert is_safe_url("http://multimedia.nt.qq.com.cn/download?id=123") is False
+            assert is_safe_url("https://sub.multimedia.nt.qq.com.cn/download?id=123") is True
+
+    def test_qq_multimedia_http_allowed_via_benchmark_range(self):
+        """HTTP is now allowed because the benchmark range is excluded from blocking.
+
+        Previously the QQ allowlist required HTTPS; now 198.18.0.0/15 is
+        excluded from _is_blocked_ip entirely, so both HTTP and HTTPS pass.
+        """
+        with patch("socket.getaddrinfo", return_value=[
+            (2, 1, 6, "", ("198.18.0.23", 0)),
+        ]):
+            assert is_safe_url("http://multimedia.nt.qq.com.cn/download?id=123") is True
 
     def test_qq_multimedia_hostname_dns_failure_still_blocked(self):
         with patch("socket.getaddrinfo", side_effect=socket.gaierror("Name resolution failed")):
@@ -201,7 +224,7 @@ class TestIsBlockedIp:
     @pytest.mark.parametrize("ip_str", [
         "127.0.0.1", "10.0.0.1", "172.16.0.1", "192.168.1.1",
         "169.254.169.254", "0.0.0.0", "224.0.0.1", "255.255.255.255",
-        "100.64.0.1", "100.100.100.100", "100.127.255.254", "198.18.0.23",
+        "100.64.0.1", "100.100.100.100", "100.127.255.254",
         "::1", "fe80::1", "fc00::1", "fd12::1", "ff02::1",
         "::ffff:127.0.0.1", "::ffff:169.254.169.254",
     ])
@@ -211,6 +234,7 @@ class TestIsBlockedIp:
 
     @pytest.mark.parametrize("ip_str", [
         "8.8.8.8", "93.184.216.34", "1.1.1.1", "100.0.0.1",
+        "198.18.0.23", "198.19.255.255",
         "2606:4700::1", "2001:4860:4860::8888",
     ])
     def test_allowed_ips(self, ip_str):
@@ -514,6 +538,7 @@ class TestIPv4MappedIPv6SSRF:
         "::ffff:8.8.8.8",          # Public DNS
         "::ffff:93.184.216.34",    # example.com
         "::ffff:100.0.0.1",        # Not in CGNAT range
+        "::ffff:198.18.0.65",      # Benchmark range (DNS filtering)
     ])
     def test_ipv4_mapped_allowed_ips(self, ip_str):
         """IPv4-mapped IPv6 addresses that should be allowed."""

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -69,7 +69,10 @@ _ALWAYS_BLOCKED_NETWORKS = (
 
 # Exact HTTPS hostnames allowed to resolve to private/benchmark-space IPs.
 # This is intentionally narrow: QQ media downloads can legitimately resolve
-# to 198.18.0.0/15 behind local proxy/benchmark infrastructure.
+# to private IPs behind local proxy infrastructure.  Note: the 198.18.0.0/15
+# benchmark range is now excluded from _is_blocked_ip entirely (see
+# _BENCHMARK_RANGE), so this allowlist only matters for hosts that resolve
+# to *other* private ranges.
 _TRUSTED_PRIVATE_IP_HOSTS = frozenset({
     "multimedia.nt.qq.com.cn",
 })
@@ -79,6 +82,16 @@ _TRUSTED_PRIVATE_IP_HOSTS = frozenset({
 # Must be blocked explicitly. Used by carrier-grade NAT, Tailscale/WireGuard
 # VPNs, and some cloud internal networks.
 _CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+
+# 198.18.0.0/15 (Benchmarking / DNS-filtering proxy range) IS marked as
+# is_private by Python's ipaddress module, but it is NOT a real private
+# network used for internal services.  DNS-based content-filtering services
+# (OpenDNS/Cisco Umbrella, CleanBrowsing, etc.) resolve blocked or
+# sinkholed domains into this range.  Public sites like cdimage.ubuntu.com
+# can legitimately resolve here on filtered networks.  Blocking the entire
+# range produces false positives without meaningful SSRF protection — the
+# actual SSRF targets (RFC 1918, cloud metadata) are handled separately.
+_BENCHMARK_RANGE = ipaddress.ip_network("198.18.0.0/15")
 
 # ---------------------------------------------------------------------------
 # Global toggle: allow private/internal IP resolution
@@ -152,6 +165,8 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     # by their embedded IPv4 address, not as IPv6
     if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
         embedded_ip = ip.ipv4_mapped
+        if embedded_ip in _BENCHMARK_RANGE:
+            return False
         return (embedded_ip.is_private or embedded_ip.is_loopback or
                 embedded_ip.is_link_local or embedded_ip.is_reserved or
                 embedded_ip.is_multicast or embedded_ip.is_unspecified or
@@ -159,6 +174,9 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
 
     # Standard IPv4/IPv6 address checking
     if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+        # Exclude 198.18.0.0/15 benchmark range — not a real private network
+        if ip in _BENCHMARK_RANGE:
+            return False
         return True
     if ip.is_multicast or ip.is_unspecified:
         return True


### PR DESCRIPTION
## What does this PR do?

Excludes the 198.18.0.0/15 benchmark/DNS-filtering range from SSRF private-IP blocking, fixing false-positive blocks on public sites like `cdimage.ubuntu.com` when accessed from networks using DNS-based content-filtering services.

## Related Issue

Fixes #35423

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/url_safety.py`: Added `_BENCHMARK_RANGE` (198.18.0.0/15) and excluded it from `_is_blocked_ip()` for both IPv4 and IPv4-mapped IPv6 addresses. Updated `_TRUSTED_PRIVATE_IP_HOSTS` comment to note the new range exclusion.
- `tests/tools/test_url_safety.py`: Updated existing tests and added regression tests for benchmark range IP allowance, including `cdimage.ubuntu.com` specific test case and IPv4-mapped IPv6 benchmark range test.

## How to Test

1. Run `pytest tests/tools/test_url_safety.py -v` — all 115 tests should pass
2. Verify `cdimage.ubuntu.com` (resolves to 198.18.0.65 on DNS-filtered networks) is no longer blocked by `is_safe_url()`
3. Verify that RFC 1918 private IPs (10.x, 172.16.x, 192.168.x) and cloud metadata (169.254.x.x) are still blocked
4. Verify CGNAT range (100.64.0.0/10) is still blocked

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/url_safety.py:_is_blocked_ip` (called by `is_safe_url`, `is_always_blocked_url`; callers: `web_tools.py`, `browser_tool.py`, `vision_tools.py`)
- Blast radius: LOW — narrow change to IP classification logic; cloud metadata, RFC 1918, and CGNAT blocking unchanged
- Related patterns: `_TRUSTED_PRIVATE_IP_HOSTS` (QQ media per-host exception for same range), `_CGNAT_NETWORK` (similar range-exclusion pattern)
