### PR TITLE
fix(doctor): recognize nvidia as vendor-slug-accepting provider

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -749,6 +749,7 @@ def run_doctor(args):
                 "huggingface",
                 "lmstudio",
                 "nous",
+                "nvidia",
             }
             if (
                 default_model

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -493,6 +493,7 @@ def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(mon
         ("opencode-zen", "anthropic/claude-sonnet-4.6"),
         ("kilocode", "anthropic/claude-sonnet-4.6"),
         ("kimi-coding", "kimi-k2"),
+        ("nvidia", "qwen/qwen3.5-122b-a10b"),
     ],
 )
 def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
@@ -533,7 +534,7 @@ def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
     out = buf.getvalue()
     assert f"model.provider '{provider}' is not a recognised provider" not in out
     assert f"model.provider '{provider}' is unknown" not in out
-    if provider in {"opencode-zen", "kilocode"}:
+    if provider in {"opencode-zen", "kilocode", "nvidia"}:
         assert (
             f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider}'"
             not in out


### PR DESCRIPTION
## What does this PR do?

Adds `nvidia` to the `providers_accepting_vendor_slugs` set in the doctor command, so that vendor-prefixed model IDs (e.g. `qwen/qwen3.5-122b-a10b`, `nvidia/nemotron-3-super-120b-a12b`) no longer trigger false-positive warnings when NVIDIA NIM is the configured provider.

## Related Issue

Fixes #35425

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor.py`: Added `"nvidia"` to the `providers_accepting_vendor_slugs` set (line 752)
- `tests/hermes_cli/test_doctor.py`: Added `("nvidia", "qwen/qwen3.5-122b-a10b")` to the parametrized test for vendor-slug-accepting providers

## How to Test

1. Set `model.provider: nvidia` and `model.default: qwen/qwen3.5-122b-a10b` in config.yaml
2. Run `hermes doctor` — should NOT show "vendor-prefixed slugs belong to aggregators like openrouter" warning
3. Run `pytest tests/hermes_cli/test_doctor.py::test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases -v` — all 4 parametrized cases should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/doctor.py:providers_accepting_vendor_slugs` (used in `run_doctor` vendor-slug validation check)
- Blast radius: LOW — single set membership addition; only affects doctor warning logic
- Related patterns: `_AGGREGATOR_PROVIDERS` in `model_normalize.py` (defines which providers consume vendor/model slugs); `_PROVIDER_MODELS["nvidia"]` in `models.py` (9 vendor-prefixed model entries)
