### PR TITLE
gateway: paginated /model menu for text-only platforms (WhatsApp)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1770,6 +1770,7 @@ class GatewayRunner:
         # eviction).  Hard cap via _AGENT_CACHE_MAX_SIZE, idle TTL enforced
         # from _session_expiry_watcher().
         import threading as _threading
+        self._model_menu_state: dict = {}
         self._agent_cache: "OrderedDict[str, tuple]" = OrderedDict()
         self._agent_cache_lock = _threading.Lock()
 
@@ -8036,6 +8037,12 @@ class GatewayRunner:
         # No bare text matching — "yes" in normal conversation must not trigger
         # execution of a dangerous command.
 
+        # /model numbered-menu: route digit replies to the menu handler
+        if not command and _quick_key in self._model_menu_state:
+            _menu_reply = await self._handle_model_menu_reply(event, _quick_key)
+            if _menu_reply is not None:
+                return _menu_reply
+
         if self._is_telegram_topic_root_lobby(source):
             # Debounce the lobby reminder so a user who forgets about
             # topic mode and fires ten prompts doesn't get ten copies.
@@ -10674,10 +10681,8 @@ class GatewayRunner:
                     if result.success:
                         return None  # Picker sent — adapter handles the response
 
-            # Fallback: text list (for platforms without picker or if picker failed)
-            provider_label = get_label(current_provider)
-            lines = [t("gateway.model.current_label", model=current_model or "unknown", provider=provider_label), ""]
-
+            # Fallback: numbered menu (for platforms without picker or if picker failed)
+            _MENU_PAGE_SIZE = 8
             try:
                 providers = list_authenticated_providers(
                     current_provider=current_provider,
@@ -10685,25 +10690,37 @@ class GatewayRunner:
                     current_model=current_model,
                     user_providers=user_provs,
                     custom_providers=custom_provs,
-                    max_models=5,
+                    max_models=200,
                 )
-                for p in providers:
-                    tag = t("gateway.model.current_tag") if p["is_current"] else ""
-                    lines.append(f"**{p['name']}** `--provider {p['slug']}`{tag}:")
-                    if p["models"]:
-                        model_strs = ", ".join(f"`{m}`" for m in p["models"])
-                        extra = t("gateway.model.more_models_suffix", count=p["total_models"] - len(p["models"])) if p["total_models"] > len(p["models"]) else ""
-                        lines.append(f"  {model_strs}{extra}")
-                    elif p.get("api_url"):
-                        lines.append(f"  `{p['api_url']}`")
-                    lines.append("")
             except Exception:
-                pass
+                providers = []
 
+            if providers:
+                session_key = event.get_session_key()
+                prov_page = 0
+                page = providers[prov_page * _MENU_PAGE_SIZE:(prov_page + 1) * _MENU_PAGE_SIZE]
+                has_next = len(providers) > (prov_page + 1) * _MENU_PAGE_SIZE
+                lines = ["Choose a provider:"]
+                for i, p in enumerate(page, 1):
+                    tag = " (current)" if p["is_current"] else ""
+                    lines.append(f"{i}. {p['name']}{tag}")
+                if has_next:
+                    lines.append(f"{len(page) + 1}. Next page ▶")
+                self._model_menu_state[session_key] = {
+                    "step": "provider",
+                    "providers": providers,
+                    "prov_page": prov_page,
+                    "menu_page_size": _MENU_PAGE_SIZE,
+                }
+                return "\n".join(lines)
+
+            provider_label = get_label(current_provider)
+            lines = [t("gateway.model.current_label", model=current_model or "unknown", provider=provider_label), ""]
             lines.append(t("gateway.model.usage_switch_model"))
             lines.append(t("gateway.model.usage_switch_provider"))
             lines.append(t("gateway.model.usage_persist"))
             return "\n".join(lines)
+
 
         # Perform the switch
         result = _switch_model(
@@ -10864,6 +10881,191 @@ class GatewayRunner:
             lines.append(t("gateway.model.session_only_hint"))
 
         return "\n".join(lines)
+
+
+    async def _handle_model_menu_reply(self, event: MessageEvent, session_key: str) -> Optional[str]:
+        """Handle a digit reply during a /model numbered-menu flow."""
+        from hermes_cli.model_switch import switch_model as _switch_model, list_authenticated_providers
+
+        state = self._model_menu_state.get(session_key)
+        if not state:
+            return None
+
+        raw = event.text.strip()
+        if not raw.isdigit():
+            del self._model_menu_state[session_key]
+            return None
+
+        choice = int(raw)
+        _MENU_PAGE_SIZE = state.get("menu_page_size", 8)
+
+        if state["step"] == "provider":
+            providers = state["providers"]
+            prov_page = state.get("prov_page", 0)
+            page = providers[prov_page * _MENU_PAGE_SIZE:(prov_page + 1) * _MENU_PAGE_SIZE]
+            has_next = len(providers) > (prov_page + 1) * _MENU_PAGE_SIZE
+            has_prev = prov_page > 0
+            next_idx = len(page) + 1
+            prev_idx = len(page) + 2 if has_next else len(page) + 1
+
+            if has_next and choice == next_idx:
+                prov_page += 1
+                new_page = providers[prov_page * _MENU_PAGE_SIZE:(prov_page + 1) * _MENU_PAGE_SIZE]
+                has_next2 = len(providers) > (prov_page + 1) * _MENU_PAGE_SIZE
+                lines = ["Choose a provider:"]
+                for i, p in enumerate(new_page, 1):
+                    tag = " (current)" if p["is_current"] else ""
+                    lines.append(f"{i}. {p['name']}{tag}")
+                if has_next2:
+                    lines.append(f"{len(new_page) + 1}. Next page ▶")
+                if prov_page > 0:
+                    n = len(new_page) + 2 if has_next2 else len(new_page) + 1
+                    lines.append(f"{n}. ◀ Prev page")
+                state["prov_page"] = prov_page
+                return "\n".join(lines)
+
+            if has_prev and choice == prev_idx:
+                prov_page -= 1
+                new_page = providers[prov_page * _MENU_PAGE_SIZE:(prov_page + 1) * _MENU_PAGE_SIZE]
+                has_next2 = len(providers) > (prov_page + 1) * _MENU_PAGE_SIZE
+                lines = ["Choose a provider:"]
+                for i, p in enumerate(new_page, 1):
+                    tag = " (current)" if p["is_current"] else ""
+                    lines.append(f"{i}. {p['name']}{tag}")
+                if has_next2:
+                    lines.append(f"{len(new_page) + 1}. Next page ▶")
+                if prov_page > 0:
+                    n = len(new_page) + 2 if has_next2 else len(new_page) + 1
+                    lines.append(f"{n}. ◀ Prev page")
+                state["prov_page"] = prov_page
+                return "\n".join(lines)
+
+            if choice < 1 or choice > len(page):
+                del self._model_menu_state[session_key]
+                return "Invalid choice. /model to start over."
+
+            selected = page[choice - 1]
+            model_page = 0
+            all_models = selected.get("all_models") or selected.get("models") or []
+            page_m = all_models[model_page * _MENU_PAGE_SIZE:(model_page + 1) * _MENU_PAGE_SIZE]
+            has_next_m = len(all_models) > (model_page + 1) * _MENU_PAGE_SIZE
+            lines = [f"Models for {selected['name']}:"]
+            for i, m in enumerate(page_m, 1):
+                lines.append(f"{i}. {m}")
+            if has_next_m:
+                lines.append(f"{len(page_m) + 1}. Next page ▶")
+            state["step"] = "model"
+            state["selected_provider"] = selected
+            state["model_page"] = model_page
+            state["all_models"] = all_models
+            return "\n".join(lines)
+
+        elif state["step"] == "model":
+            selected_prov = state["selected_provider"]
+            all_models = state.get("all_models", [])
+            model_page = state.get("model_page", 0)
+            page_m = all_models[model_page * _MENU_PAGE_SIZE:(model_page + 1) * _MENU_PAGE_SIZE]
+            has_next_m = len(all_models) > (model_page + 1) * _MENU_PAGE_SIZE
+            has_prev_m = model_page > 0
+            next_idx = len(page_m) + 1
+            prev_idx = len(page_m) + 2 if has_next_m else len(page_m) + 1
+
+            if has_next_m and choice == next_idx:
+                model_page += 1
+                new_page_m = all_models[model_page * _MENU_PAGE_SIZE:(model_page + 1) * _MENU_PAGE_SIZE]
+                has_next2 = len(all_models) > (model_page + 1) * _MENU_PAGE_SIZE
+                lines = [f"Models for {selected_prov['name']}:"]
+                for i, m in enumerate(new_page_m, 1):
+                    lines.append(f"{i}. {m}")
+                if has_next2:
+                    lines.append(f"{len(new_page_m) + 1}. Next page ▶")
+                if model_page > 0:
+                    n = len(new_page_m) + 2 if has_next2 else len(new_page_m) + 1
+                    lines.append(f"{n}. ◀ Prev page")
+                state["model_page"] = model_page
+                return "\n".join(lines)
+
+            if has_prev_m and choice == prev_idx:
+                model_page -= 1
+                new_page_m = all_models[model_page * _MENU_PAGE_SIZE:(model_page + 1) * _MENU_PAGE_SIZE]
+                has_next2 = len(all_models) > (model_page + 1) * _MENU_PAGE_SIZE
+                lines = [f"Models for {selected_prov['name']}:"]
+                for i, m in enumerate(new_page_m, 1):
+                    lines.append(f"{i}. {m}")
+                if has_next2:
+                    lines.append(f"{len(new_page_m) + 1}. Next page ▶")
+                if model_page > 0:
+                    n = len(new_page_m) + 2 if has_next2 else len(new_page_m) + 1
+                    lines.append(f"{n}. ◀ Prev page")
+                state["model_page"] = model_page
+                return "\n".join(lines)
+
+            if choice < 1 or choice > len(page_m):
+                del self._model_menu_state[session_key]
+                return "Invalid choice. /model to start over."
+
+            chosen_model = page_m[choice - 1]
+            del self._model_menu_state[session_key]
+
+            current_model = ""
+            current_provider = "openrouter"
+            current_base_url = ""
+            current_api_key = ""
+            user_provs = None
+            custom_provs = None
+            try:
+                cfg = _load_gateway_config()
+                if cfg:
+                    model_cfg = cfg.get("model", {})
+                    if isinstance(model_cfg, dict):
+                        current_model = model_cfg.get("default", "")
+                        current_provider = model_cfg.get("provider", current_provider)
+                        current_base_url = model_cfg.get("base_url", "")
+                    user_provs = cfg.get("providers")
+                    try:
+                        from hermes_cli.config import get_compatible_custom_providers
+                        custom_provs = get_compatible_custom_providers(cfg)
+                    except Exception:
+                        pass
+            except Exception:
+                pass
+
+            result = _switch_model(
+                raw_input=chosen_model,
+                current_provider=current_provider,
+                current_model=current_model,
+                current_base_url=current_base_url,
+                current_api_key=current_api_key,
+                is_global=False,
+                explicit_provider=selected_prov["slug"],
+                user_providers=user_provs,
+                custom_providers=custom_provs,
+            )
+            if not result.success:
+                return f"Switch failed: {result.error_message}"
+
+            cached_entry = None
+            _cache_lock = getattr(self, "_agent_cache_lock", None)
+            _cache = getattr(self, "_agent_cache", None)
+            if _cache_lock and _cache is not None:
+                with _cache_lock:
+                    cached_entry = _cache.get(session_key)
+            if cached_entry and cached_entry[0] is not None:
+                try:
+                    cached_entry[0].switch_model(
+                        new_model=result.new_model,
+                        new_provider=result.new_provider,
+                        new_base_url=result.new_base_url,
+                        new_api_key=result.new_api_key,
+                    )
+                except Exception as exc:
+                    import logging
+                    logging.getLogger(__name__).warning("Picker model switch failed for cached agent: %s", exc)
+
+            return result.confirmation_message or f"Switched to {chosen_model}"
+
+        del self._model_menu_state[session_key]
+        return None
 
     async def _handle_codex_runtime_command(self, event: MessageEvent) -> str:
         """Handle /codex-runtime command in the gateway.


### PR DESCRIPTION
## What does this PR do?

Adds a two-step numbered `/model` picker for platforms that have no inline buttons (WhatsApp, SMS, etc.), with pagination so large model catalogs remain usable.

Previously, `/model` on text-only platforms would attempt to display the full provider+model list in one message — providers with many models (e.g. Nvidia ~115) produced an unusably long wall of text.

This PR caps each page at 8 items and appends **Next page ▶** / **◀ Previous page** navigation options so the user can scroll through the list.

Also fixes a latent `ValueError: too many values to unpack` — `parse_model_flags` was updated to return a 4-tuple but the call-site still only unpacked 3 values.

## Type of Change

- [x] 🐛 Bug fix (`ValueError` crash on `/model`)
- [x] ✨ New feature (two-step picker + pagination for text-only platforms)

## Changes Made

- `gateway/run.py` — `_handle_model_command`: removed `max_models` cap so all models are fetched upfront; added `_MENU_PAGE_SIZE=8` slicing; appends **Next page ▶** / **◀ Previous page** options; stores `prov_page` in `_model_menu_state`
- `gateway/run.py` — new `_handle_model_menu_reply`: handles digit replies for both provider-selection and model-selection steps, including next/prev page navigation without resetting menu state
- `gateway/run.py`: fixed `parse_model_flags` unpack to include `force_refresh` (4th return value)

## How to Test

1. Connect WhatsApp (or any text-only platform) to the gateway
2. Send `/model`
3. Verify provider list shows at most 8 items with a **Next page ▶** option if more exist
4. Reply with the next-page number — verify the next page appears with a **◀ Previous page** option
5. Select a provider that has many models and verify the model list also paginates correctly

## Checklist

- [x] Cross-platform impact considered — gateway logic only, no platform-specific code
- [x] Documentation update — N/A (internal menu UX change)