### PR TITLE
fix(cli): stop OSC 11 bg probe from trapping users in a stray editor over SSH

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1542,8 +1542,16 @@ def _query_osc11_background() -> str | None:
     Most modern terminals reply with \x1b]11;rgb:RRRR/GGGG/BBBB\x1b\\
     within a few ms.  We wait up to 100ms total before giving up.
     Returns "#RRGGBB" or None on timeout / non-tty.
+
+    Skipped over SSH: the round-trip routinely exceeds our 100ms budget, so a
+    late reply lands after prompt_toolkit has grabbed the tty — its payload
+    leaks in as typed text and the BEL terminator reads as Ctrl+G (open
+    editor), trapping the user in a stray editor. Remote sessions fall back to
+    COLORFGBG / env hints / the dark default instead.
     """
     if not sys.stdin.isatty() or not sys.stdout.isatty():
+        return None
+    if any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")):
         return None
     try:
         import termios
@@ -1592,8 +1600,11 @@ def _query_osc11_background() -> str | None:
         r, g, b = norm(m.group(1)), norm(m.group(2)), norm(m.group(3))
         return f"#{r:02X}{g:02X}{b:02X}"
     finally:
+        # TCSAFLUSH discards any unread input as it restores the original
+        # attributes — scrubs a slow/partial OSC 11 reply out of the tty
+        # buffer before prompt_toolkit can read it as keystrokes.
         try:
-            termios.tcsetattr(fd, termios.TCSANOW, old)
+            termios.tcsetattr(fd, termios.TCSAFLUSH, old)
         except Exception:
             pass
 

--- a/tests/cli/test_cli_light_mode.py
+++ b/tests/cli/test_cli_light_mode.py
@@ -75,6 +75,27 @@ class TestLightModeDetection:
         assert cli_mod._detect_light_mode() is True
 
 
+class TestOsc11Probe:
+    """The OSC 11 background probe must never run where its reply can leak
+    into prompt_toolkit's input (a late BEL-terminated reply reads as Ctrl+G
+    = open-editor, trapping the user in a stray editor). Guard the cases we
+    refuse to probe in.
+    """
+
+    @pytest.mark.parametrize("var", ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"))
+    def test_skips_over_ssh(self, cli_mod, monkeypatch, var):
+        monkeypatch.setattr(cli_mod.sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(cli_mod.sys.stdout, "isatty", lambda: True, raising=False)
+        for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"):
+            monkeypatch.delenv(v, raising=False)
+        monkeypatch.setenv(var, "1.2.3.4 5555 22")
+        assert cli_mod._query_osc11_background() is None
+
+    def test_skips_when_not_a_tty(self, cli_mod, monkeypatch):
+        monkeypatch.setattr(cli_mod.sys.stdin, "isatty", lambda: False, raising=False)
+        assert cli_mod._query_osc11_background() is None
+
+
 class TestLightModeRemap:
     def test_remap_no_op_in_dark_mode(self, cli_mod, monkeypatch):
         monkeypatch.setenv("HERMES_LIGHT", "0")
@@ -133,7 +154,9 @@ class TestSkinConfigHook:
         after = SkinConfig.get_color
         assert before is after
 
-    def test_skin_color_remaps_through_wrapper_in_light_mode(self, cli_mod, monkeypatch):
+    def test_skin_color_remaps_through_wrapper_in_light_mode(
+        self, cli_mod, monkeypatch
+    ):
         from hermes_cli.skin_engine import SkinConfig
 
         cli_mod._LIGHT_MODE_CACHE = True


### PR DESCRIPTION
## Summary

Fixes a bug where, over SSH, launching `hermes` would sometimes drop the user into a stray editor (`vi`) containing garbage like `]11;rgb:1e1e/1e1e/1e1e` and no obvious way out — Enter does nothing, the user is stuck.

### Root cause
At startup the classic CLI calls `_query_osc11_background()` to detect the terminal background color, writing `\x1b]11;?` and waiting **100ms** for a reply. Over SSH the round-trip routinely exceeds that budget, so the function gives up — and the late reply then arrives *after* prompt_toolkit has grabbed the tty. prompt_toolkit injects the OSC payload as typed text and reads its terminator **BEL (`\x07` = Ctrl+G)** as a keystroke. Ctrl+G is the "open external editor" binding, so the user lands in `vi` with the 22-byte OSC payload, stuck.

(Note: the original report tagged this `--tui`, but the Ink TUI's `detectLightMode` is env-only and uses a different temp path. The reproducing screenshot — `/tmp/tmpXXXX.md` + OSC 11 leak — is the classic prompt_toolkit CLI editor path.)

### Fix
- Skip the OSC 11 probe on remote sessions (`SSH_CONNECTION` / `SSH_CLIENT` / `SSH_TTY`); fall back to `COLORFGBG` / env hints / the dark default.
- Restore the tty with `TCSAFLUSH` instead of `TCSANOW`, so any partial/late reply is scrubbed from the input buffer before prompt_toolkit reads it (defense-in-depth for the local path).

## Test plan
- [x] `scripts/run_tests.sh tests/cli/test_cli_light_mode.py` (20/20)
- Added regression tests: OSC 11 probe skips per SSH env var + non-tty guard.
- [ ] Manual: launch `hermes` over SSH on a slow link, confirm no stray editor.