### PR TITLE
fix(gateway): expand config env templates before auth bridging and model resolution

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -722,10 +722,12 @@ def load_gateway_config() -> GatewayConfig:
     # Primary source: config.yaml
     try:
         import yaml
+        from hermes_cli.config import _expand_env_vars
         config_yaml_path = _home / "config.yaml"
         if config_yaml_path.exists():
             with open(config_yaml_path, encoding="utf-8") as f:
                 yaml_cfg = yaml.safe_load(f) or {}
+            yaml_cfg = _expand_env_vars(yaml_cfg) or {}
 
             # Map config.yaml keys → GatewayConfig.from_dict() schema.
             # Each key overwrites whatever gateway.json may have set.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1466,7 +1466,12 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     back to the hardcoded default which fails when the active provider is
     openai-codex.
     """
-    cfg = config if config is not None else _load_gateway_config()
+    if config is None:
+        cfg = _load_gateway_runtime_config()
+    else:
+        from hermes_cli.config import _expand_env_vars
+
+        cfg = _expand_env_vars(config)
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, str):
         return model_cfg

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -369,6 +369,27 @@ class TestLoadGatewayConfig:
             "123456789012345678,999888777666555444"
         )
 
+    def test_bridges_telegram_allow_from_env_template_from_config_yaml(self, tmp_path, monkeypatch):
+        """telegram.allow_from should expand ${VAR} before auth env bridging."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  token: fake-token\n"
+            "  allow_from: ${TG_ALLOWED_USER}\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TG_ALLOWED_USER", "123456789")
+        monkeypatch.delenv("TELEGRAM_ALLOWED_USERS", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.TELEGRAM].extra["allow_from"] == "123456789"
+        assert os.environ.get("TELEGRAM_ALLOWED_USERS") == "123456789"
+
     def test_bridges_discord_platform_extra_allow_from_to_env(self, tmp_path, monkeypatch):
         """platforms.discord.extra.allow_from should reach DISCORD_ALLOWED_USERS too."""
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_runtime_config_env_expansion.py
+++ b/tests/gateway/test_runtime_config_env_expansion.py
@@ -33,6 +33,14 @@ def test_load_prefill_messages_expands_env_var_path(monkeypatch, gateway_home):
     assert gateway_run.GatewayRunner._load_prefill_messages() == prefill
 
 
+def test_resolve_gateway_model_expands_env_var_template(monkeypatch, gateway_home):
+    _write_config(gateway_home, "model: ${GW_MODEL}\n")
+    monkeypatch.setenv("GW_MODEL", "gpt-5.5")
+
+    assert gateway_run._resolve_gateway_model() == "gpt-5.5"
+    assert gateway_run._resolve_gateway_model({"model": "${GW_MODEL}"}) == "gpt-5.5"
+
+
 @pytest.mark.parametrize(
     ("config_body", "env_name", "env_value", "loader_name", "expected"),
     [


### PR DESCRIPTION
## Summary

Fix gateway-side `${VAR}` config expansion drift so gateway runtime and auth/env bridging behave the same way as the main config loader.

Before this change, some gateway paths read raw `config.yaml` values without expanding `${ENV_VAR}` templates first. That caused real mismatches such as:

- `model: ${GW_MODEL}` working in some config paths but not in gateway model resolution
- `telegram.allow_from: ${TG_ALLOWED_USER}` being bridged into `TELEGRAM_ALLOWED_USERS` as the literal string `${TG_ALLOWED_USER}` instead of the resolved user ID

This PR makes gateway config handling consistent with the documented config expansion behavior.

## Fix

- Expand `${VAR}` templates in `gateway.config.load_gateway_config()` immediately after loading `config.yaml`, before YAML values are mapped into gateway config fields or bridged into env vars.
- Update `gateway.run._resolve_gateway_model()` to read from expanded gateway runtime config when loading from disk.
- Also expand templates when `_resolve_gateway_model()` is given a config dict directly, so raw config callers do not bypass expansion.

## Testing

Added regression coverage for both broken paths:

- `tests/gateway/test_runtime_config_env_expansion.py`
  - verifies `_resolve_gateway_model()` expands `${GW_MODEL}` from `config.yaml`
  - verifies direct config-dict input also expands
- `tests/gateway/test_config.py`
  - verifies `telegram.allow_from: ${TG_ALLOWED_USER}` is expanded before bridging into `TELEGRAM_ALLOWED_USERS`

## Test Results

Passed:

- `tests/gateway/test_runtime_config_env_expansion.py`
- `tests/gateway/test_config.py`
- `tests/test_empty_model_fallback.py`
- `tests/gateway/test_api_server_toolset.py`
- `tests/gateway/test_api_server.py`
- `tests/gateway/test_telegram_group_gating.py`

Observed results:

- 73/73 tests passed in the targeted regression set
- 207/207 tests passed in the broader gateway/api_server/Telegram gating set