### PR TITLE
fix(cron): load .env before delivery to restore platform webhook URLs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -626,6 +626,21 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     Returns None on success, or an error string on failure.
     """
+    # Ensure .env variables (e.g. DINGTALK_WEBHOOK_URL) are available for
+    # delivery.  _run_job_impl loads .env inside _job_profile_context which
+    # snapshots and restores os.environ on exit, so by the time delivery runs
+    # the vars have been wiped.  For no_agent jobs the .env load is skipped
+    # entirely (early return path).  Loading here with override=False only
+    # fills in missing vars -- it never overwrites values already in the
+    # process environment.
+    try:
+        from dotenv import load_dotenv as _load_dotenv
+        _env_path = _get_hermes_home() / ".env"
+        if _env_path.exists():
+            _load_dotenv(str(_env_path), override=False)
+    except Exception:
+        pass
+
     targets = _resolve_delivery_targets(job)
     if not targets:
         if job.get("deliver", "local") != "local":


### PR DESCRIPTION
## Bug: Cron delivery fails - .env variables wiped before _deliver_result() runs

### Description

All cron job deliveries to DingTalk fail with:

```
DingTalk not configured. Set DINGTALK_WEBHOOK_URL env var or webhook_url in dingtalk platform extra config.
```

### Root Cause

**Path 1 - Agent jobs:** `_run_job_impl()` loads `.env` inside `_job_profile_context()`, which snapshots and restores `os.environ` on exit. By the time `_deliver_result()` runs, the loaded variables are gone.

**Path 2 - no_agent jobs:** `_run_job_impl()` returns early before the `load_dotenv` call.

### Fix

Load `.env` at the start of `_deliver_result()` with `override=False`:

```python
try:
    from dotenv import load_dotenv as _load_dotenv
    _env_path = _get_hermes_home() / ".env"
    if _env_path.exists():
        _load_dotenv(str(_env_path), override=False)
except Exception:
    pass
```

### Environment
- hermes-agent: 0.15.x (main)
- OS: WSL2 Ubuntu 24.04 / Python 3.11