### PR TITLE
fix(cli): load full model list in picker

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7711,7 +7711,14 @@ class HermesCLI:
             try:
                 if ctx is None:
                     raise RuntimeError("inventory context unavailable")
-                providers = build_models_payload(ctx, max_models=50)["providers"]
+                # The prompt-toolkit picker already virtualizes long lists via
+                # _compute_model_picker_viewport(), so do not truncate the
+                # selectable model inventory here.  Providers can have more
+                # than 50 models (e.g. Nous Portal); capping the payload makes
+                # entries after index 49 unreachable even though total_models
+                # advertises them.  Passing None preserves all models while
+                # keeping preview-oriented callers free to request a cap.
+                providers = build_models_payload(ctx, max_models=None)["providers"]
             except Exception:
                 providers = []
 

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -114,7 +114,7 @@ def build_models_payload(
     include_unconfigured: bool = False,
     picker_hints: bool = False,
     canonical_order: bool = False,
-    max_models: int = 50,
+    max_models: int | None = 50,
 ) -> dict:
     """Build the ``{providers, model, provider}`` shape every consumer
     needs from a single substrate call.

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1043,7 +1043,7 @@ def list_authenticated_providers(
     current_base_url: str = "",
     user_providers: dict = None,
     custom_providers: list | None = None,
-    max_models: int = 8,
+    max_models: int | None = 8,
     current_model: str = "",
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
@@ -1752,7 +1752,7 @@ def list_picker_providers(
     current_base_url: str = "",
     user_providers: dict = None,
     custom_providers: list | None = None,
-    max_models: int = 8,
+    max_models: int | None = 8,
     current_model: str = "",
 ) -> List[dict]:
     """Interactive-picker variant of :func:`list_authenticated_providers`.

--- a/tests/cli/test_model_picker_payload_limit.py
+++ b/tests/cli/test_model_picker_payload_limit.py
@@ -1,0 +1,58 @@
+from hermes_cli.inventory import ConfigContext
+
+
+def test_cli_model_picker_requests_uncapped_model_inventory(monkeypatch):
+    """The CLI /model picker must load the full selectable model list.
+
+    build_models_payload() may expose total_models larger than len(models), but
+    the prompt-toolkit picker can only select entries present in models. Passing
+    max_models=50 reproduces #35443 by making models past index 49 unreachable.
+    """
+    from cli import HermesCLI
+
+    seen = {}
+    ctx = ConfigContext(
+        current_provider="nous",
+        current_model="model-1",
+        current_base_url="",
+        user_providers={},
+        custom_providers=[],
+    )
+    providers = [
+        {
+            "slug": "nous",
+            "name": "Nous",
+            "is_current": True,
+            "is_user_defined": False,
+            "models": [f"model-{i}" for i in range(75)],
+            "total_models": 75,
+            "source": "hermes",
+        }
+    ]
+
+    def fake_build_models_payload(received_ctx, *, max_models=50, **kwargs):
+        seen["ctx"] = received_ctx
+        seen["max_models"] = max_models
+        return {"providers": providers, "model": "model-1", "provider": "nous"}
+
+    opened = {}
+
+    def fake_open_model_picker(self, received_providers, current_model, current_provider, **kwargs):
+        opened["providers"] = received_providers
+        opened["current_model"] = current_model
+        opened["current_provider"] = current_provider
+
+    monkeypatch.setattr("hermes_cli.inventory.load_picker_context", lambda: ctx)
+    monkeypatch.setattr("hermes_cli.inventory.build_models_payload", fake_build_models_payload)
+    monkeypatch.setattr(HermesCLI, "_open_model_picker", fake_open_model_picker)
+
+    cli = HermesCLI(compact=True, max_turns=1)
+    cli.model = "model-1"
+    cli.provider = "nous"
+
+    cli._handle_model_switch("/model")
+
+    assert seen["ctx"].current_provider == "nous"
+    assert seen["ctx"].current_model == "model-1"
+    assert seen["max_models"] is None
+    assert opened["providers"][0]["models"][-1] == "model-74"


### PR DESCRIPTION
## Summary

- load the full model inventory for the prompt-toolkit CLI `/model` picker instead of capping selectable models at 50
- keep preview-oriented callers able to request a cap via `max_models`
- add a regression test that asserts the CLI picker requests uncapped inventory

Fixes #35443

## Test Plan

- `venv/bin/python3 -m pytest tests/cli/test_model_picker_payload_limit.py tests/hermes_cli/test_inventory.py tests/hermes_cli/test_model_picker_viewport.py -q -o 'addopts='`
- Sanity check: `build_models_payload(ctx, max_models=None)` now reports `nous: shown=247 total=247` in my configured install, where the previous picker payload showed `shown=50 total=247`.

## Notes

This intentionally scopes the behavior change to the prompt-toolkit CLI picker. Other preview/API surfaces still pass explicit caps where they want abbreviated model lists.