### PR TITLE
fix(cli): restore TTS provider parity across setup and tools menus

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -912,6 +912,23 @@ def setup_model_provider(config: dict, *, quick: bool = False):
 # =============================================================================
 
 
+# Built-in TTS providers offered by the interactive ``hermes setup tts`` menu,
+# in display order. Kept in parity with ``BUILTIN_TTS_PROVIDERS`` in
+# ``tools.tts_tool`` (enforced by tests/hermes_cli/test_tts_picker.py).
+SETUP_TTS_BUILTIN_PROVIDERS = [
+    "edge",
+    "elevenlabs",
+    "openai",
+    "xai",
+    "minimax",
+    "mistral",
+    "gemini",
+    "neutts",
+    "kittentts",
+    "piper",
+]
+
+
 def _check_espeak_ng() -> bool:
     """Check if espeak-ng is installed."""
     return shutil.which("espeak-ng") is not None or shutil.which("espeak") is not None
@@ -992,6 +1009,27 @@ def _install_kittentts_deps() -> bool:
         return False
 
 
+def _install_piper_deps() -> bool:
+    """Install Piper TTS dependencies with user approval. Returns True on success."""
+    import subprocess
+    import sys
+
+    print()
+    print_info("Installing piper-tts Python package (~14MB wheel, voices downloaded on first use)...")
+    print()
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "-U", "piper-tts", "--quiet"],
+            check=True, timeout=300,
+        )
+        print_success("piper-tts installed successfully")
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        print_error(f"Failed to install piper-tts: {e}")
+        print_info("Try manually: python -m pip install -U piper-tts")
+        return False
+
+
 def _xai_oauth_logged_in_for_setup() -> bool:
     """True iff xAI Grok OAuth credentials are already stored locally.
 
@@ -1060,6 +1098,7 @@ def _setup_tts_provider(config: dict):
         "gemini": "Google Gemini TTS",
         "neutts": "NeuTTS",
         "kittentts": "KittenTTS",
+        "piper": "Piper TTS",
     }
     current_label = provider_labels.get(current_provider, current_provider)
 
@@ -1084,9 +1123,10 @@ def _setup_tts_provider(config: dict):
             "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
+            "Piper (local on-device, free, fast neural TTS, 44 languages)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(SETUP_TTS_BUILTIN_PROVIDERS)
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1271,6 +1311,31 @@ def _setup_tts_provider(config: dict):
                     selected = "edge"
             else:
                 print_info("Skipping install. Set tts.provider to 'kittentts' after installing manually.")
+                selected = "edge"
+
+    elif selected == "piper":
+        try:
+            import importlib.util
+            already_installed = importlib.util.find_spec("piper") is not None
+        except Exception:
+            already_installed = False
+
+        if already_installed:
+            print_success("Piper is already installed")
+        else:
+            print()
+            print_info("Piper is lightweight (~14MB wheel, CPU-only, no API key required).")
+            print_info(
+                "Voices download on first use; list: "
+                "https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md"
+            )
+            print()
+            if prompt_yes_no("Install Piper now?", True):
+                if not _install_piper_deps():
+                    print_warning("Piper installation incomplete. Falling back to Edge TTS.")
+                    selected = "edge"
+            else:
+                print_info("Skipping install. Set tts.provider to 'piper' after installing manually.")
                 selected = "edge"
 
     # Save the selection

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -264,6 +264,15 @@ TOOL_CATEGORIES = {
                 "tts_provider": "gemini",
             },
             {
+                "name": "MiniMax TTS",
+                "badge": "paid",
+                "tag": "High quality with voice cloning",
+                "env_vars": [
+                    {"key": "MINIMAX_API_KEY", "prompt": "MiniMax API key", "url": "https://www.minimax.io/platform/user-center/basic-information/interface-key"},
+                ],
+                "tts_provider": "minimax",
+            },
+            {
                 "name": "KittenTTS",
                 "badge": "local · free",
                 "tag": "Lightweight local ONNX TTS (~25MB), no API key",
@@ -278,6 +287,14 @@ TOOL_CATEGORIES = {
                 "env_vars": [],
                 "tts_provider": "piper",
                 "post_setup": "piper",
+            },
+            {
+                "name": "NeuTTS",
+                "badge": "local · free",
+                "tag": "Local on-device, ~300MB model (needs espeak-ng)",
+                "env_vars": [],
+                "tts_provider": "neutts",
+                "post_setup": "neutts",
             },
         ],
     },
@@ -964,6 +981,38 @@ def _run_post_setup(post_setup_key: str):
         _print_info("    Default voice: en_US-lessac-medium (downloaded on first TTS call)")
         _print_info("    Full voice list: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md")
         _print_info("    Switch voices by setting tts.piper.voice in ~/.hermes/config.yaml")
+
+    elif post_setup_key == "neutts":
+        try:
+            __import__("neutts")
+            _print_success("    neutts is already installed")
+        except ImportError:
+            # NeuTTS phonemizes through espeak-ng. The picker installs only
+            # Python packages, so warn (instead of sudo-installing a system
+            # package) and point at the platform command, mirroring how
+            # `hermes setup tts` documents the espeak-ng requirement.
+            if not (shutil.which("espeak-ng") or shutil.which("espeak")):
+                _print_warning("    neutts needs the espeak-ng system package for phonemization.")
+                if sys.platform == "darwin":
+                    _print_info("    Install with: brew install espeak-ng")
+                elif sys.platform == "win32":
+                    _print_info("    Install with: choco install espeak-ng")
+                else:
+                    _print_info("    Install with: sudo apt install espeak-ng")
+            _print_info("    Installing neutts (~50MB install + ~300MB model on first use)...")
+            try:
+                result = _pip_install(["-U", "neutts[all]", "--quiet"], timeout=300)
+                if result.returncode == 0:
+                    _print_success("    neutts installed")
+                else:
+                    _print_warning("    neutts install failed:")
+                    _print_info(f"      {(result.stderr or '').strip()[:300]}")
+                    _print_info("    Run manually: uv pip install -U 'neutts[all]'")
+                    return
+            except subprocess.TimeoutExpired:
+                _print_warning("    neutts install timed out (>5min)")
+                _print_info("    Run manually: uv pip install -U 'neutts[all]'")
+                return
 
     elif post_setup_key == "ddgs":
         try:

--- a/tests/hermes_cli/test_tts_picker.py
+++ b/tests/hermes_cli/test_tts_picker.py
@@ -185,3 +185,49 @@ class TestVisibleProvidersInjectsTTSPlugins:
         assert all(not row.get("tts_plugin_name") for row in visible)
         # Hardcoded rows still present (sample one of the always-visible ones)
         assert "Microsoft Edge TTS" in names
+
+
+class TestBuiltinTTSSurfaceParity:
+    """Every built-in TTS provider must be reachable from both CLI selection
+    surfaces — the interactive ``hermes setup tts`` menu and the ``hermes
+    tools`` picker (issue #35439).
+
+    ``tests/agent/test_tts_registry.py::TestBuiltinSync`` already guards the
+    two runtime-internal lists (``_BUILTIN_NAMES`` vs
+    ``BUILTIN_TTS_PROVIDERS``); these tests extend the same guarantee to the
+    user-facing menus, which had drifted: ``piper`` was missing from
+    ``setup tts`` and ``minimax`` / ``neutts`` were missing from the picker.
+    """
+
+    @staticmethod
+    def _picker_builtin_providers() -> set:
+        return {
+            row["tts_provider"]
+            for row in tools_config.TOOL_CATEGORIES["tts"]["providers"]
+            if row.get("tts_provider")
+        }
+
+    def test_setup_menu_offers_every_builtin_provider(self):
+        from hermes_cli.setup import SETUP_TTS_BUILTIN_PROVIDERS
+        from tools.tts_tool import BUILTIN_TTS_PROVIDERS
+
+        menu = set(SETUP_TTS_BUILTIN_PROVIDERS)
+        assert menu == BUILTIN_TTS_PROVIDERS, (
+            "`hermes setup tts` menu drifted from BUILTIN_TTS_PROVIDERS:\n"
+            f"  missing from menu: {sorted(BUILTIN_TTS_PROVIDERS - menu)}\n"
+            f"  extra in menu:     {sorted(menu - BUILTIN_TTS_PROVIDERS)}"
+        )
+
+    def test_setup_menu_has_no_duplicates(self):
+        from hermes_cli.setup import SETUP_TTS_BUILTIN_PROVIDERS
+
+        assert len(SETUP_TTS_BUILTIN_PROVIDERS) == len(set(SETUP_TTS_BUILTIN_PROVIDERS))
+
+    def test_tools_picker_offers_every_builtin_provider(self):
+        from tools.tts_tool import BUILTIN_TTS_PROVIDERS
+
+        missing = BUILTIN_TTS_PROVIDERS - self._picker_builtin_providers()
+        assert not missing, (
+            "`hermes tools` TTS picker is missing built-in providers: "
+            f"{sorted(missing)}"
+        )


### PR DESCRIPTION
## What does this PR do?

Restores parity of the built-in TTS provider set across the two CLI selection surfaces. The runtime registry exposes 10 built-ins (`BUILTIN_TTS_PROVIDERS`), but the two menus had drifted:

- **`piper`** was missing from `hermes setup tts` (it is in the runtime set and the `hermes tools` picker) — classic-setup users could not select Piper without hand-editing `config.yaml`.
- **`minimax`** and **`neutts`** were missing from the `hermes tools` picker (both are offered by `hermes setup tts`).

`tests/agent/test_tts_registry.py::TestBuiltinSync` only guards the two runtime-internal lists (`_BUILTIN_NAMES` ↔ `BUILTIN_TTS_PROVIDERS`); nothing tied the user-facing menus back to that set, so a provider added to one surface but not the other passed CI.

## Related Issue

Fixes #35439

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/setup.py`: add Piper to the `setup tts` menu (label + choice + a `_install_piper_deps` install branch mirroring `kittentts`); lift the hardcoded provider list (former line 1089) into an importable module-level `SETUP_TTS_BUILTIN_PROVIDERS` constant.
- `hermes_cli/tools_config.py`: add **MiniMax** (API-key row) and **NeuTTS** (local row + a new `neutts` handler in `_run_post_setup`) to `TOOL_CATEGORIES["tts"]`. The NeuTTS handler installs `neutts[all]` and *warns* about the `espeak-ng` system package (printing the per-OS command) rather than auto-installing it, mirroring `setup.py::_install_neutts_deps`.
- `tests/hermes_cli/test_tts_picker.py`: add `TestBuiltinTTSSurfaceParity` asserting both CLI surfaces cover `BUILTIN_TTS_PROVIDERS`.

## How to Test

1. `pytest tests/hermes_cli/test_tts_picker.py tests/agent/test_tts_registry.py -q` → **60 passed**.
2. Regression proof:
   - Reverting only the `tools_config.py` rows makes the new picker test fail with `AssertionError: ... missing built-in providers: ['minimax', 'neutts']`.
   - The pre-fix provider list (`git show HEAD~1:hermes_cli/setup.py`) lacks `piper`.
3. `ruff check hermes_cli/ tests/` → All checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(cli): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` for the affected suites and all tests pass
- [x] I've added tests for my changes (`TestBuiltinTTSSurfaceParity`)
- [x] I've tested on my platform: macOS (Darwin 25)

### Documentation & Housekeeping

- [x] Docs — N/A (the menus are self-describing; no doc surface lists providers)
- [x] `cli-config.yaml.example` — N/A (no new config keys; these are already valid `tts.provider` values)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform — considered: the NeuTTS handler prints per-OS `espeak-ng` install commands (brew/choco/apt); Piper is pure-pip
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

```
$ pytest tests/hermes_cli/test_tts_picker.py tests/agent/test_tts_registry.py -q
............................................................   60 passed

# regression (rows reverted): picker parity test fails before the fix
AssertionError: `hermes tools` TTS picker is missing built-in providers: ['minimax', 'neutts']
```

**Note for maintainers:** the issue explicitly flagged the NeuTTS/espeak-ng picker handling as a decision point. This PR takes the conservative route — the picker `post_setup` installs the Python package and *warns* about `espeak-ng` with the per-OS command, but does not `sudo`-install a system package from the picker. Happy to adjust if you'd prefer a different approach (or to drop the NeuTTS row and keep only the `piper`/`minimax` parity fixes).

Made with [Cursor](https://cursor.com)