### PR TITLE
fix(gateway): unlock /footer command dispatch during active agent execution

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7457,13 +7457,14 @@ class GatewayRunner:
 
             # Session-level toggles that are safe to run mid-agent —
             # /yolo can unblock a pending approval prompt, /verbose cycles
-            # the tool-progress display mode for the ongoing stream.
+            # the tool-progress display mode for the ongoing stream, and
+            # /footer updates the final-reply runtime metadata toggle.
             # Both modify session state without needing agent interaction
             # and must not be queued (the safety net would discard them).
             # /fast and /reasoning are config-only and take effect next
             # message, so they fall through to the catch-all busy response
             # below — users should wait and set them between turns.
-            if _cmd_def_inner and _cmd_def_inner.name in {"yolo", "verbose"}:
+            if _cmd_def_inner and _cmd_def_inner.name in {"yolo", "verbose", "footer"}:
                 if _cmd_def_inner.name == "yolo":
                     return await self._handle_yolo_command(event)
                 if _cmd_def_inner.name == "verbose":

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -109,7 +109,6 @@ def _make_runner(*, platform_extra: dict | None = None,
     runner._emit_gateway_run_progress = AsyncMock()
     return runner
 
-
 # ---------------------------------------------------------------------------
 # /whoami response shape — proves the handler is reachable AND uses the
 # resolver. We use /whoami because it's deterministic and short-circuits
@@ -123,6 +122,28 @@ async def test_whoami_unrestricted_when_no_admin_list():
     result = await runner._handle_message(_make_event("/whoami", _make_source(user_id="999")))
     assert "Tier: unrestricted" in result
     assert "no admin list configured" in result
+
+
+@pytest.mark.asyncio
+async def test_running_agent_fastpath_footer_allows_listed_user():
+    """/footer is documented as a running-agent fast-path command, so a
+    listed non-admin must reach the handler instead of the busy fallback."""
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["footer"],
+        }
+    )
+    src = _make_source(user_id="999")
+    sk = build_session_key(src)
+    runner._running_agents[sk] = MagicMock()
+    runner._running_agents_ts[sk] = 0
+    runner._handle_footer_command = AsyncMock(return_value="footer-handled")
+
+    result = await runner._handle_message(_make_event("/footer", src))
+    assert result == "footer-handled"
+    runner._handle_footer_command.assert_awaited_once()
+    assert "mid-turn" not in (result or "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Fix `/footer` dispatch while a gateway agent is already running.

## Fix
- Add `footer` to the running-agent fast-path session-toggle dispatch set in `gateway/run.py`.
- Keep `/footer` aligned with the existing mid-run-safe toggle commands instead of letting it fall through to the generic busy response.
- Add a regression test covering a listed non-admin user invoking `/footer` during an active run and reaching the dedicated handler.

## Testing
- Passed: `tests/gateway/test_slash_access_dispatch.py` (`19 passed`)

Command run:
- `.\.venv\Scripts\python.exe -m pytest -o addopts="-m 'not integration' -p no:timeout" tests\gateway\test_slash_access_dispatch.py -q`

