### PR TITLE
fix: add Piper to TTS setup wizard

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -992,6 +992,28 @@ def _install_kittentts_deps() -> bool:
         return False
 
 
+def _install_piper_deps() -> bool:
+    """Install Piper TTS dependencies with user approval. Returns True on success."""
+    import subprocess
+    import sys
+
+    print()
+    print_info("Installing piper-tts Python package (~14MB wheel, voices downloaded on first use)...")
+    print()
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "-U", "piper-tts", "--quiet"],
+            check=True,
+            timeout=300,
+        )
+        print_success("piper-tts installed successfully")
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        print_error(f"Failed to install piper-tts: {e}")
+        print_info("Try manually: python -m pip install -U piper-tts")
+        return False
+
+
 def _xai_oauth_logged_in_for_setup() -> bool:
     """True iff xAI Grok OAuth credentials are already stored locally.
 
@@ -1060,6 +1082,7 @@ def _setup_tts_provider(config: dict):
         "gemini": "Google Gemini TTS",
         "neutts": "NeuTTS",
         "kittentts": "KittenTTS",
+        "piper": "Piper",
     }
     current_label = provider_labels.get(current_provider, current_provider)
 
@@ -1084,9 +1107,10 @@ def _setup_tts_provider(config: dict):
             "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
+            "Piper (local on-device, free, 44 languages, voices ~20-90MB)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1253,7 +1277,6 @@ def _setup_tts_provider(config: dict):
     elif selected == "kittentts":
         # Check if already installed
         try:
-            import importlib.util
             already_installed = importlib.util.find_spec("kittentts") is not None
         except Exception:
             already_installed = False
@@ -1271,6 +1294,28 @@ def _setup_tts_provider(config: dict):
                     selected = "edge"
             else:
                 print_info("Skipping install. Set tts.provider to 'kittentts' after installing manually.")
+                selected = "edge"
+
+    elif selected == "piper":
+        # Check if already installed
+        try:
+            already_installed = importlib.util.find_spec("piper") is not None
+        except Exception:
+            already_installed = False
+
+        if already_installed:
+            print_success("Piper is already installed")
+        else:
+            print()
+            print_info("Piper is a local neural TTS engine with 44 languages.")
+            print_info("Default voice: en_US-lessac-medium, downloaded on first TTS call.")
+            print()
+            if prompt_yes_no("Install Piper now?", True):
+                if not _install_piper_deps():
+                    print_warning("Piper installation incomplete. Falling back to Edge TTS.")
+                    selected = "edge"
+            else:
+                print_info("Skipping install. Set tts.provider to 'piper' after installing manually.")
                 selected = "edge"
 
     # Save the selection

--- a/tests/hermes_cli/test_tts_picker.py
+++ b/tests/hermes_cli/test_tts_picker.py
@@ -12,7 +12,9 @@ import pytest
 
 from agent import tts_registry
 from agent.tts_provider import TTSProvider
+from hermes_cli import setup as setup_mod
 from hermes_cli import tools_config
+from tools.tts_tool import BUILTIN_TTS_PROVIDERS
 
 
 class _FakeTTSProvider(TTSProvider):
@@ -185,3 +187,26 @@ class TestVisibleProvidersInjectsTTSPlugins:
         assert all(not row.get("tts_plugin_name") for row in visible)
         # Hardcoded rows still present (sample one of the always-visible ones)
         assert "Microsoft Edge TTS" in names
+
+    def test_setup_tts_menu_covers_builtin_runtime_providers(self, monkeypatch):
+        """The classic setup TTS menu must expose every runtime built-in provider."""
+        captured: dict[str, list[str]] = {}
+
+        def capture_choices(question, choices, default=0, description=None):
+            if question == "Select TTS provider:":
+                captured["choices"] = choices
+            return default
+
+        monkeypatch.setattr(setup_mod, "prompt_choice", capture_choices)
+        monkeypatch.setattr(setup_mod, "managed_nous_tools_enabled", lambda: False)
+        monkeypatch.setattr(
+            setup_mod,
+            "get_nous_subscription_features",
+            lambda _config: type("Features", (), {"nous_auth_present": False})(),
+        )
+
+        setup_mod._setup_tts_provider({"tts": {"provider": "edge"}})
+
+        menu_text = "\n".join(captured["choices"]).lower()
+        for provider in sorted(BUILTIN_TTS_PROVIDERS):
+            assert provider in menu_text


### PR DESCRIPTION
## What does this PR do?

Adds Piper to the classic `hermes setup tts` provider menu so users can select the built-in local Piper TTS provider from the setup wizard.

The fix also adds an install prompt for `piper-tts`, mirrors the existing local-provider flow used by KittenTTS/NeuTTS, and adds a regression test that keeps the setup menu aligned with runtime built-in TTS providers.

## Related Issue

Fixes #35439

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/setup.py`
  - Adds `piper` to the TTS provider labels, menu choices, and provider mapping.
  - Adds `_install_piper_deps()` for the setup wizard's Piper install flow.
  - Adds selection handling for Piper, including install prompt and fallback to Edge if installation is skipped or fails.
- `tests/hermes_cli/test_tts_picker.py`
  - Adds a regression test that verifies `hermes setup tts` exposes every runtime built-in TTS provider.

## How to Test

1. Reproduced the regression with the new test before the fix:
   - `scripts/run_tests.sh tests/hermes_cli/test_tts_picker.py`
   - Failed because `piper` was missing from the classic setup TTS menu.
2. Verified the targeted test file after the fix:
   - `scripts/run_tests.sh tests/hermes_cli/test_tts_picker.py`
   - Result: 11 passed, 0 failed.
3. Verified related setup tests:
   - `scripts/run_tests.sh tests/hermes_cli/test_tts_picker.py tests/hermes_cli/test_setup*.py`
   - Result: 111 passed, 0 failed.
4. Ran `git diff --check` for the changed files.
5. Ran an added-line static scan for hardcoded secrets, shell injection, eval/exec, and pickle loads; no findings.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/hermes_cli/test_tts_picker.py
=> 11 tests passed, 0 failed

scripts/run_tests.sh tests/hermes_cli/test_tts_picker.py tests/hermes_cli/test_setup*.py
=> 111 tests passed, 0 failed
```
