### PR TITLE
feat(hooks): add thread_id to agent:start hook context

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9009,6 +9009,7 @@ class GatewayRunner:
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
                 "chat_id": source.chat_id or "",
+                "thread_id": source.thread_id or "",
                 "session_id": session_entry.session_id,
                 "message": message_text[:500],
             }


### PR DESCRIPTION
## Problem

Gateway hooks listening to  events have no access to . This makes it impossible to route messages to platform-specific threads (e.g. Telegram forum topics) from a hook.

## Solution

Added  to the  dict emitted with the  event.

## Use Case

Voice transcript echo hook — when a user sends a voice message in a Telegram forum topic, the hook echoes the transcript back. Without , the echo goes to the general chat instead of the correct topic thread.

## Changes

- : Added  to the  hook context