### PR TITLE
fix(config): run config migration on Docker container boot

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -2,6 +2,13 @@
 # Copy this file to cli-config.yaml and customize as needed.
 # This file configures the CLI behavior. Environment variables in .env take precedence.
 
+# On-disk config schema version. A freshly seeded config already carries the
+# latest schema, so stamp it here — otherwise an unversioned raw file is
+# treated as legacy (version 0) and runs every migration pass on first boot.
+# Keep in sync with DEFAULT_CONFIG["_config_version"] in hermes_cli/config.py
+# whenever a new migration is added.
+_config_version: 24
+
 # =============================================================================
 # Model Configuration
 # =============================================================================

--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -242,6 +242,20 @@ if [ ! -f "$HERMES_HOME/auth.json" ] && [ -n "${HERMES_AUTH_JSON_BOOTSTRAP:-}" ]
     chmod 600 "$HERMES_HOME/auth.json"
 fi
 
+# --- Migrate persisted config schema ---
+# Docker users update by pulling a newer image; `hermes update` (which runs
+# config migration for non-Docker installs) intentionally exits early for
+# Docker installs. Without this step, a persistent $HERMES_HOME volume can
+# carry an old/unversioned raw config.yaml across image updates and never have
+# version-gated schema migrations applied (#35406). Run the same migration
+# non-interactively, as the hermes user, against the active $HERMES_HOME.
+# Operators can opt out with HERMES_SKIP_CONFIG_MIGRATION=1 (honored inside the
+# script). Non-fatal: a migration hiccup must not block container start.
+if [ -f "$HERMES_HOME/config.yaml" ]; then
+    s6-setuidgid hermes "$INSTALL_DIR/.venv/bin/python" "$INSTALL_DIR/tools/docker_config_migrate.py" \
+        || echo "[stage2] Warning: config migration failed; continuing"
+fi
+
 # --- Sync bundled skills ---
 # Invoke the venv's python by absolute path so we don't need a `sh -c`
 # wrapper to source the activate script. This is safe because

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3662,11 +3662,26 @@ def get_custom_provider_context_length(
 def check_config_version() -> Tuple[int, int]:
     """
     Check config version.
-    
+
     Returns (current_version, latest_version).
+
+    The current version is read from the *raw* on-disk config.yaml rather
+    than the deep-merged effective config. ``load_config()`` starts from
+    ``DEFAULT_CONFIG``, so an unversioned/legacy raw file would otherwise
+    inherit the latest ``_config_version`` in memory and silently appear
+    current — making every pending schema migration a no-op (see #35406).
+    A missing raw ``_config_version`` means "never migrated" → version 0.
     """
-    config = load_config()
-    current = config.get("_config_version", 0)
+    raw = read_raw_config()
+    current = raw.get("_config_version", 0)
+    if not isinstance(current, int):
+        # A hand-edited config could carry a non-int here; treat anything
+        # unparseable as unversioned so migrations run rather than being
+        # skipped on a malformed marker.
+        try:
+            current = int(current)
+        except (TypeError, ValueError):
+            current = 0
     latest = DEFAULT_CONFIG.get("_config_version", 1)
     return current, latest
 
@@ -4494,6 +4509,92 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             print("  Set later with: hermes config set <key> <value>")
 
     return results
+
+
+# Operator opt-out for the unattended Docker-boot migration pass. Set to a
+# truthy value (1/true/yes/on) to skip automatic config migration on
+# container start — e.g. when an operator wants to apply migrations manually
+# after taking their own backup. See docker/stage2-hook.sh.
+SKIP_BOOT_MIGRATION_ENV = "HERMES_SKIP_CONFIG_MIGRATION"
+
+
+def run_boot_config_migration(quiet: bool = False) -> Dict[str, Any]:
+    """Run config migration non-interactively against the active config.yaml.
+
+    Intended for unattended environments — chiefly the official Docker image's
+    container-boot hook, which has no equivalent to the ``hermes update``
+    config-migration step (``hermes update`` intentionally exits early for
+    Docker installs). Without this, a persistent ``$HERMES_HOME`` volume can
+    carry a stale/unversioned raw config schema across image updates and never
+    have version-gated migrations applied (#35406).
+
+    Behavior:
+      * Honors the ``HERMES_SKIP_CONFIG_MIGRATION`` opt-out — returns early
+        with ``status="skipped_optout"`` and touches nothing.
+      * No-ops (``status="no_config"``) when no ``config.yaml`` exists yet —
+        a fresh install seeds the latest schema, so there is nothing to
+        migrate.
+      * No-ops (``status="up_to_date"``) when the raw on-disk config is
+        already current and no required fields are missing.
+      * Otherwise takes a full pre-migration backup of ``$HERMES_HOME`` (best
+        effort, never fatal) and runs ``migrate_config(interactive=False)``
+        so no API-key prompts can block container start.
+
+    Returns a dict ``{"status": ..., "results": <migrate_config results or
+    None>, "backup": <Path or None>}``. Never raises — boot must continue
+    even if migration fails; the gateway's own startup validation still warns
+    about a broken config.
+    """
+    outcome: Dict[str, Any] = {"status": "ok", "results": None, "backup": None}
+
+    if os.getenv(SKIP_BOOT_MIGRATION_ENV, "").strip().lower() in {"1", "true", "yes", "on"}:
+        if not quiet:
+            print(f"  ℹ {SKIP_BOOT_MIGRATION_ENV} set — skipping config migration")
+        outcome["status"] = "skipped_optout"
+        return outcome
+
+    config_path = get_config_path()
+    if not config_path.exists():
+        outcome["status"] = "no_config"
+        return outcome
+
+    try:
+        current_ver, latest_ver = check_config_version()
+        missing_env = get_missing_env_vars(required_only=True)
+        missing_config = get_missing_config_fields()
+    except Exception:
+        logger.warning("config migration pre-check failed", exc_info=True)
+        outcome["status"] = "error"
+        return outcome
+
+    if current_ver >= latest_ver and not missing_env and not missing_config:
+        outcome["status"] = "up_to_date"
+        return outcome
+
+    if not quiet:
+        if current_ver < latest_ver:
+            print(f"  → Migrating config.yaml schema: v{current_ver} → v{latest_ver}")
+        else:
+            print("  → Applying pending config migrations")
+
+    # Migration can rewrite config.yaml and .env in place, so snapshot first.
+    try:
+        from hermes_cli.backup import create_pre_migration_backup
+
+        backup_path = create_pre_migration_backup()
+        outcome["backup"] = backup_path
+        if backup_path and not quiet:
+            print(f"  ✓ Backed up HERMES_HOME before migration: {backup_path.name}")
+    except Exception:
+        logger.warning("pre-migration backup failed; continuing", exc_info=True)
+
+    try:
+        outcome["results"] = migrate_config(interactive=False, quiet=quiet)
+    except Exception:
+        logger.warning("config migration failed", exc_info=True)
+        outcome["status"] = "error"
+
+    return outcome
 
 
 def _deep_merge(base: dict, override: dict) -> dict:

--- a/tests/hermes_cli/test_config_boot_migration.py
+++ b/tests/hermes_cli/test_config_boot_migration.py
@@ -1,0 +1,105 @@
+"""Tests for raw-config version detection and the Docker-boot migration pass.
+
+Covers the #35406 fix: Docker image updates must run config migration with the
+same schema-safety guarantees as non-Docker ``hermes update``. The two moving
+parts are:
+
+  * ``check_config_version`` reading the *raw* on-disk ``_config_version``
+    (not the deep-merged effective config), so an unversioned/legacy file is
+    correctly treated as "never migrated" instead of inheriting the latest
+    version from ``DEFAULT_CONFIG``.
+  * ``run_boot_config_migration`` running migration non-interactively, honoring
+    the ``HERMES_SKIP_CONFIG_MIGRATION`` opt-out and backing up first.
+"""
+
+import os
+from unittest.mock import patch
+
+import yaml
+
+from hermes_cli.config import (
+    DEFAULT_CONFIG,
+    check_config_version,
+    get_config_path,
+    read_raw_config,
+    run_boot_config_migration,
+)
+
+LATEST = DEFAULT_CONFIG["_config_version"]
+
+
+def _write_config(data: dict) -> None:
+    path = get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+class TestCheckConfigVersion:
+    def test_unversioned_raw_config_reports_version_zero(self):
+        # A raw file with no _config_version must NOT inherit the latest
+        # version from DEFAULT_CONFIG via load_config()'s deep-merge (#35406).
+        _write_config({"model": {"default": "anthropic/claude-opus-4.6"}})
+        current, latest = check_config_version()
+        assert current == 0
+        assert latest == LATEST
+
+    def test_versioned_raw_config_reports_its_version(self):
+        _write_config({"_config_version": 5, "model": {"default": "x"}})
+        current, latest = check_config_version()
+        assert current == 5
+        assert latest == LATEST
+
+    def test_missing_config_file_reports_version_zero(self):
+        # No config.yaml on disk → unversioned.
+        path = get_config_path()
+        if path.exists():
+            path.unlink()
+        current, _ = check_config_version()
+        assert current == 0
+
+    def test_non_int_version_treated_as_unversioned(self):
+        _write_config({"_config_version": "garbage", "model": {"default": "x"}})
+        current, _ = check_config_version()
+        assert current == 0
+
+
+class TestRunBootConfigMigration:
+    def test_optout_env_var_skips_migration(self, monkeypatch):
+        _write_config({"model": {"default": "x"}})
+        monkeypatch.setenv("HERMES_SKIP_CONFIG_MIGRATION", "1")
+        with patch("hermes_cli.config.migrate_config") as mig:
+            outcome = run_boot_config_migration(quiet=True)
+        assert outcome["status"] == "skipped_optout"
+        mig.assert_not_called()
+
+    def test_no_config_file_is_noop(self):
+        path = get_config_path()
+        if path.exists():
+            path.unlink()
+        with patch("hermes_cli.config.migrate_config") as mig:
+            outcome = run_boot_config_migration(quiet=True)
+        assert outcome["status"] == "no_config"
+        mig.assert_not_called()
+
+    def test_current_config_is_up_to_date(self):
+        # Seed a config already stamped at the latest version with no missing
+        # required fields → migration must not run.
+        _write_config({"_config_version": LATEST, "model": {"default": "x"}})
+        with (
+            patch("hermes_cli.config.get_missing_env_vars", return_value=[]),
+            patch("hermes_cli.config.get_missing_config_fields", return_value=[]),
+            patch("hermes_cli.config.migrate_config") as mig,
+        ):
+            outcome = run_boot_config_migration(quiet=True)
+        assert outcome["status"] == "up_to_date"
+        mig.assert_not_called()
+
+    def test_unversioned_config_is_migrated_and_backed_up(self):
+        _write_config({"model": {"default": "x"}})
+        with patch("hermes_cli.backup.create_pre_migration_backup") as backup:
+            backup.return_value = None
+            outcome = run_boot_config_migration(quiet=True)
+        # Migration ran (status ok) and stamped the on-disk version forward.
+        assert outcome["status"] == "ok"
+        backup.assert_called_once()
+        assert read_raw_config().get("_config_version") == LATEST

--- a/tools/docker_config_migrate.py
+++ b/tools/docker_config_migrate.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Docker container-boot config migration.
+
+Runs the same non-interactive config-schema migration that ``hermes update``
+performs for non-Docker installs. ``hermes update`` intentionally exits early
+for Docker installs, and the container-boot hook only seeds missing files, so
+a persistent ``$HERMES_HOME`` volume can otherwise carry a stale/unversioned
+raw config schema across image updates and never have version-gated
+migrations applied (#35406).
+
+Invoked from docker/stage2-hook.sh as the ``hermes`` user against the active
+``$HERMES_HOME``. Honors ``HERMES_SKIP_CONFIG_MIGRATION=1`` as an operator
+opt-out (handled inside ``run_boot_config_migration``). Always exits 0 so a
+migration hiccup never blocks container start — the gateway's own startup
+validation still surfaces a broken config.
+"""
+
+import logging
+import sys
+
+from hermes_cli.config import run_boot_config_migration
+
+logging.basicConfig(level=logging.WARNING, format="[config-migrate] %(message)s")
+
+
+def main() -> int:
+    try:
+        outcome = run_boot_config_migration(quiet=False)
+    except Exception:  # defensive: run_boot_config_migration shouldn't raise
+        logging.getLogger(__name__).warning(
+            "container-boot config migration crashed; continuing", exc_info=True
+        )
+        return 0
+
+    status = outcome.get("status")
+    if status not in {"up_to_date", "no_config", "skipped_optout"}:
+        print(f"[config-migrate] done (status={status})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What does this PR do?

The official Docker image update path had no equivalent to the config-migration step that runs during `hermes update` for non-Docker installs. Docker users update by pulling/replacing the image, `hermes update` intentionally exits early for Docker installs, and the container-boot hook only seeds missing files and syncs bundled skills. As a result a persistent `$HERMES_HOME` volume could carry an old or unversioned raw `config.yaml` across image updates and never have version-gated schema migrations applied (e.g. `custom_providers` -> `providers`, legacy flat `stt.model`, display/tool-progress moves).

This was compounded by `check_config_version()` reading the deep-merged effective config from `load_config()` (which starts from `DEFAULT_CONFIG`): an unversioned raw file inherited the latest `_config_version` in memory and appeared already-current, so even a migration pass would have been a no-op.

This PR closes the gap by (a) detecting the schema version from the raw on-disk file and (b) running migration non-interactively on container boot, with an operator opt-out and a pre-migration backup.

## Related Issue

Fixes #35406

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`: `check_config_version()` now reads `_config_version` from the raw on-disk config (`read_raw_config()`) instead of the deep-merged effective config, so an unversioned/legacy file is treated as version 0 ("never migrated") rather than inheriting the latest version from `DEFAULT_CONFIG`. Non-int markers are also coerced to unversioned.
- `hermes_cli/config.py`: add `run_boot_config_migration()` — a non-interactive migration entry point that honors the `HERMES_SKIP_CONFIG_MIGRATION` opt-out, no-ops when no config exists or the config is already current, takes a best-effort `create_pre_migration_backup()` of `$HERMES_HOME` first, and runs `migrate_config(interactive=False)` so no API-key prompts can block startup. Never raises.
- `tools/docker_config_migrate.py`: small boot entry point that calls `run_boot_config_migration()` and always exits 0.
- `docker/stage2-hook.sh`: invoke the migration as the `hermes` user against the active `$HERMES_HOME` after config seeding and before skills sync; non-fatal on failure.
- `cli-config.yaml.example`: stamp `_config_version` so freshly seeded configs are correctly versioned and skip a pointless first-boot migration pass.
- `tests/hermes_cli/test_config_boot_migration.py`: coverage for raw-version detection and the boot-migration outcomes.

## How to Test

1. Create a persistent `HERMES_HOME` containing a `config.yaml` with no `_config_version` (legacy/unversioned).
2. Run `python -c "from hermes_cli.config import check_config_version; print(check_config_version())"` with `HERMES_HOME` pointed at it — it now reports `(0, <latest>)` instead of `(<latest>, <latest>)`.
3. Run `python tools/docker_config_migrate.py` (the same call the boot hook makes): observe a pre-migration backup zip under `$HERMES_HOME/backups/` and that `config.yaml` now carries `_config_version: <latest>`.
4. Re-run it: it reports up-to-date and does nothing.
5. Set `HERMES_SKIP_CONFIG_MIGRATION=1` and re-run against an unversioned config: migration is skipped and the file is untouched.
6. Automated: `pytest tests/hermes_cli/test_config_boot_migration.py -q`.

## What platforms tested on

- macOS on darwin-arm64 (local): `pytest tests/hermes_cli/test_config_boot_migration.py` (8 passed), plus `tests/hermes_cli/test_config.py`, `test_update_config_clears_custom_fields.py`, and `test_cmd_update.py` regression suites green.
- `scripts/check-windows-footguns.py` clean on the changed Python files; the boot hook is `docker/stage2-hook.sh` (Linux container only), and the Python migration path uses no POSIX-only primitives.
- Linux container path (Docker boot hook): exercised via the Python entry point; not run inside a built image in this environment — relying on GitHub CI for the image build.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant `pytest` suites locally and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated `cli-config.yaml.example` (added `_config_version`)
- [x] I've considered cross-platform impact (boot hook is Linux-container-only; Python path is portable)

<!-- autocontrib:worker-id=issue-new-f0d7cea1 kind=pr-open -->