### PR TITLE
fix(gateway): refuse shell-launched gateway when profile is supervised

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3193,17 +3193,113 @@ def _guard_official_docker_root_gateway() -> None:
     sys.exit(1)
 
 
-def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
+def _supervised_gateway_main_pid() -> int | None:
+    """Return the live MainPID of the supervisor-managed gateway for THIS
+    profile, or ``None`` when none is running.
+
+    Scoped to the current ``HERMES_HOME`` via the per-profile service name
+    (systemd) / label (launchd), so a sibling profile's service never trips a
+    false positive. Windows Scheduled-Task installs are not consulted: detached
+    ``pythonw.exe`` launches don't share the orphan-dispatcher footgun this
+    lookup guards against, and there is no cheap cross-profile MainPID query.
+    """
+    # systemd (Linux): query this profile's unit in both user and system scopes.
+    if supports_systemd_services():
+        svc = f"{get_service_name()}.service"
+        for scope_args in (["systemctl", "--user"], ["systemctl"]):
+            try:
+                show = subprocess.run(
+                    scope_args + ["show", svc, "--property=MainPID", "--value"],
+                    capture_output=True, text=True, timeout=5,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+                continue
+            try:
+                pid = int(show.stdout.strip())
+            except ValueError:
+                continue
+            if pid > 0:
+                return pid
+
+    # launchd (macOS): the label is already profile-scoped. `launchctl list
+    # <label>` prints a property-list dict whose `"PID" = N;` line is only
+    # present while the job is actually running.
+    if is_macos():
+        label = get_launchd_label()
+        try:
+            result = subprocess.run(
+                ["launchctl", "list", label],
+                capture_output=True, text=True, timeout=5,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            return None
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                if '"PID"' not in line:
+                    continue
+                digits = "".join(ch for ch in line if ch.isdigit())
+                if digits:
+                    pid = int(digits)
+                    if pid > 0:
+                        return pid
+    return None
+
+
+def _guard_against_supervised_gateway(force: bool = False) -> None:
+    """Refuse a foreground gateway run when this profile is already supervised.
+
+    Running ``hermes gateway run [--replace]`` — or falling back to a manual
+    ``gateway restart`` — from an interactive shell on a systemd/launchd host
+    spawns a second long-lived process that escapes the service cgroup, is
+    re-parented to PID 1, and becomes a silent concurrent writer on the shared
+    ``kanban.db``. That is the documented root cause of multi-writer SQLite WAL
+    corruption (issue #35240): two dispatchers each believe they own the file
+    and race on WAL frames. Refuse with a hint unless ``--force`` is given.
+    """
+    # The supervisor itself runs us as its ExecStart — never refuse there.
+    # systemd sets INVOCATION_ID for the managed unit; launchd starts us as the
+    # MainPID, which the self-pid check below covers.
+    if os.environ.get("INVOCATION_ID"):
+        return
+    pid = _supervised_gateway_main_pid()
+    if pid is None or pid == os.getpid():
+        return
+    if force:
+        print_warning(
+            f"A supervised gateway for this profile is already running (PID {pid}); "
+            "continuing anyway because --force was given."
+        )
+        return
+    if is_macos():
+        restart_hint = f"hermes gateway restart   # launchd-managed ({get_launchd_label()})"
+    else:
+        restart_hint = f"systemctl restart {get_service_name()}.service"
+    print_error(
+        f"A supervised gateway for this profile is already running (PID {pid})."
+    )
+    print(
+        "  Starting another one from a shell orphans a second dispatcher that "
+        "writes to the shared kanban.db concurrently and can corrupt it."
+    )
+    print(f"  Use the service manager instead:  {restart_hint}")
+    print("  Pass --force only if you really intend to run a second instance.")
+    sys.exit(1)
+
+
+def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False, force: bool = False):
     """Run the gateway in foreground.
-    
+
     Args:
         verbose: Stderr log verbosity count added on top of default WARNING (0=WARNING, 1=INFO, 2+=DEBUG).
         quiet: Suppress all stderr log output.
         replace: If True, kill any existing gateway instance before starting.
                  This prevents systemd restart loops when the old process
                  hasn't fully exited yet.
+        force: If True, skip the supervised-gateway guard and start even when a
+               systemd/launchd-managed gateway for this profile is alive.
     """
     _guard_official_docker_root_gateway()
+    _guard_against_supervised_gateway(force=force)
     sys.path.insert(0, str(PROJECT_ROOT))
 
     # Detached Windows gateway runs must ignore console-control broadcasts
@@ -5246,7 +5342,8 @@ def _gateway_command_inner(args):
         verbose = getattr(args, 'verbose', 0)
         quiet = getattr(args, 'quiet', False)
         replace = getattr(args, 'replace', False)
-        run_gateway(verbose, quiet=quiet, replace=replace)
+        force = getattr(args, 'force', False)
+        run_gateway(verbose, quiet=quiet, replace=replace, force=force)
         return
 
     if subcmd == "setup":
@@ -5558,7 +5655,7 @@ def _gateway_command_inner(args):
                 # stopped and can die before the replacement is stable.
                 gateway_windows.start()
             else:
-                run_gateway(verbose=0)
+                run_gateway(verbose=0, force=getattr(args, 'force', False))
             return
         
         if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
@@ -5623,8 +5720,8 @@ def _gateway_command_inner(args):
 
             # Start fresh
             print("Starting gateway...")
-            run_gateway(verbose=0)
-    
+            run_gateway(verbose=0, force=getattr(args, 'force', False))
+
     elif subcmd == "status":
         deep = getattr(args, 'deep', False)
         full = getattr(args, 'full', False)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11706,6 +11706,16 @@ def main():
         help="Replace any existing gateway instance (useful for systemd)",
     )
     gateway_run.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Start even when a systemd/launchd-managed gateway for this "
+            "profile is already running. Without this, running a gateway from "
+            "a shell on a supervised host is refused to avoid orphaning a "
+            "second dispatcher that corrupts the shared kanban.db."
+        ),
+    )
+    gateway_run.add_argument(
         "--no-supervise",
         action="store_true",
         help=(
@@ -11762,6 +11772,15 @@ def main():
         "--all",
         action="store_true",
         help="Kill ALL gateway processes across all profiles before restarting",
+    )
+    gateway_restart.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "When restart falls back to a manual foreground start, start even "
+            "if a systemd/launchd-managed gateway for this profile is already "
+            "running (otherwise refused to avoid orphaning a second dispatcher)."
+        ),
     )
 
     # gateway status

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -27,6 +27,11 @@ def _install_fake_gateway_run(monkeypatch, start_gateway):
     monkeypatch.setattr(
         gateway, "refresh_systemd_unit_if_needed", lambda system=False: False
     )
+    # ``run_gateway()`` also consults the supervised-gateway guard, which queries
+    # the *real* systemd/launchd for a live MainPID. On a developer box that runs
+    # its own Hermes gateway that query returns a PID and the guard would abort
+    # the run. Same sandboxing rationale as above — neutralize it.
+    monkeypatch.setattr(gateway, "_supervised_gateway_main_pid", lambda: None)
 
 
 def test_run_gateway_exits_cleanly_on_keyboard_interrupt(monkeypatch, capsys):

--- a/tests/hermes_cli/test_gateway_supervised_guard.py
+++ b/tests/hermes_cli/test_gateway_supervised_guard.py
@@ -1,0 +1,159 @@
+"""Guard against orphaning a second gateway dispatcher on a supervised host.
+
+Regression coverage for issue #35240: running ``hermes gateway run [--replace]``
+or a manual ``gateway restart`` fallback from an interactive shell while a
+systemd/launchd-managed gateway for the same profile is alive used to spawn a
+long-lived orphan that escaped the service cgroup and became a silent
+concurrent writer on the shared ``kanban.db`` — corrupting it.
+
+The guard lives in one place — ``_guard_against_supervised_gateway()``, called
+from ``run_gateway()`` — so every code path that reaches a foreground start
+(``run``, the manual ``restart`` fallback, ``start`` fallback) is covered.
+"""
+
+import subprocess
+
+import pytest
+
+
+class _FakeRun:
+    """Minimal stand-in for ``subprocess.run`` returning canned stdout."""
+
+    def __init__(self, stdout="", returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+
+class TestGuardAgainstSupervisedGateway:
+    def _patch_no_supervisor_env(self, monkeypatch):
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+
+    def test_refuses_when_supervised_and_not_self(self, monkeypatch, capsys):
+        import hermes_cli.gateway as gateway_mod
+
+        self._patch_no_supervisor_env(monkeypatch)
+        monkeypatch.setattr(gateway_mod, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_mod, "get_service_name", lambda: "hermes-gateway-argus")
+        monkeypatch.setattr(
+            gateway_mod, "_supervised_gateway_main_pid", lambda: 999_999
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            gateway_mod._guard_against_supervised_gateway(force=False)
+        assert exc.value.code == 1
+
+        out = capsys.readouterr().out
+        assert "already running (PID 999999)" in out
+        assert "systemctl restart hermes-gateway-argus.service" in out
+
+    def test_force_overrides_refusal(self, monkeypatch, capsys):
+        import hermes_cli.gateway as gateway_mod
+
+        self._patch_no_supervisor_env(monkeypatch)
+        monkeypatch.setattr(gateway_mod, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_mod, "get_service_name", lambda: "hermes-gateway")
+        monkeypatch.setattr(
+            gateway_mod, "_supervised_gateway_main_pid", lambda: 999_999
+        )
+
+        # Must not raise SystemExit.
+        gateway_mod._guard_against_supervised_gateway(force=True)
+        out = capsys.readouterr().out
+        assert "--force" in out
+
+    def test_skips_when_running_under_systemd(self, monkeypatch):
+        import hermes_cli.gateway as gateway_mod
+
+        monkeypatch.setenv("INVOCATION_ID", "deadbeefcafe")
+        # Even if a MainPID is reported, INVOCATION_ID means *we* are the unit.
+        monkeypatch.setattr(
+            gateway_mod, "_supervised_gateway_main_pid", lambda: 999_999
+        )
+        gateway_mod._guard_against_supervised_gateway(force=False)  # no raise
+
+    def test_skips_when_detected_pid_is_self(self, monkeypatch):
+        import os
+
+        import hermes_cli.gateway as gateway_mod
+
+        self._patch_no_supervisor_env(monkeypatch)
+        monkeypatch.setattr(
+            gateway_mod, "_supervised_gateway_main_pid", lambda: os.getpid()
+        )
+        gateway_mod._guard_against_supervised_gateway(force=False)  # no raise
+
+    def test_no_op_when_no_supervisor(self, monkeypatch):
+        import hermes_cli.gateway as gateway_mod
+
+        self._patch_no_supervisor_env(monkeypatch)
+        monkeypatch.setattr(gateway_mod, "_supervised_gateway_main_pid", lambda: None)
+        gateway_mod._guard_against_supervised_gateway(force=False)  # no raise
+
+    def test_macos_hint_mentions_launchd(self, monkeypatch, capsys):
+        import hermes_cli.gateway as gateway_mod
+
+        self._patch_no_supervisor_env(monkeypatch)
+        monkeypatch.setattr(gateway_mod, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_mod, "get_launchd_label", lambda: "com.hermes.gateway")
+        monkeypatch.setattr(
+            gateway_mod, "_supervised_gateway_main_pid", lambda: 999_999
+        )
+
+        with pytest.raises(SystemExit):
+            gateway_mod._guard_against_supervised_gateway(force=False)
+        out = capsys.readouterr().out
+        assert "hermes gateway restart" in out
+        assert "com.hermes.gateway" in out
+
+
+class TestSupervisedGatewayMainPid:
+    def test_systemd_main_pid_parsed(self, monkeypatch):
+        import hermes_cli.gateway as gateway_mod
+
+        monkeypatch.setattr(gateway_mod, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_mod, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_mod, "get_service_name", lambda: "hermes-gateway")
+        monkeypatch.setattr(subprocess, "run", _FakeRun(stdout="4154204\n"))
+
+        assert gateway_mod._supervised_gateway_main_pid() == 4154204
+
+    def test_systemd_zero_main_pid_means_not_running(self, monkeypatch):
+        import hermes_cli.gateway as gateway_mod
+
+        monkeypatch.setattr(gateway_mod, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_mod, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_mod, "get_service_name", lambda: "hermes-gateway")
+        # systemctl reports MainPID=0 for an inactive unit.
+        monkeypatch.setattr(subprocess, "run", _FakeRun(stdout="0\n"))
+
+        assert gateway_mod._supervised_gateway_main_pid() is None
+
+    def test_launchd_main_pid_parsed(self, monkeypatch):
+        import hermes_cli.gateway as gateway_mod
+
+        monkeypatch.setattr(gateway_mod, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_mod, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_mod, "get_launchd_label", lambda: "com.hermes.gateway")
+        plist = (
+            "{\n"
+            '\t"PID" = 4242;\n'
+            '\t"Label" = "com.hermes.gateway";\n'
+            "};\n"
+        )
+        monkeypatch.setattr(subprocess, "run", _FakeRun(stdout=plist, returncode=0))
+
+        assert gateway_mod._supervised_gateway_main_pid() == 4242
+
+    def test_launchd_not_loaded_returns_none(self, monkeypatch):
+        import hermes_cli.gateway as gateway_mod
+
+        monkeypatch.setattr(gateway_mod, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_mod, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_mod, "get_launchd_label", lambda: "com.hermes.gateway")
+        # Non-zero return code: job not loaded.
+        monkeypatch.setattr(subprocess, "run", _FakeRun(stdout="", returncode=1))
+
+        assert gateway_mod._supervised_gateway_main_pid() is None


### PR DESCRIPTION
## What does this PR do?

Running `hermes gateway run --replace` (or a manual `hermes gateway restart` that falls back to a foreground start) from an interactive shell on a systemd/launchd host spawns a second long-lived process. It escapes the service cgroup, is re-parented to PID 1, and becomes a silent concurrent writer on the shared `kanban.db` — the documented root cause of multi-writer SQLite WAL corruption in #35240 (two dispatchers each believe they own the file and race on WAL frames).

This adds a profile-scoped guard in `run_gateway()` that detects a live supervisor-managed gateway MainPID for the current `HERMES_HOME` (systemd user/system scope or launchd) and refuses to start a competing foreground instance, printing a `use systemctl restart …` hint. `--force` overrides it. The guard self-suppresses when the supervisor is starting *us* (systemd sets `INVOCATION_ID`; launchd starts us as the MainPID, which the self-PID check covers), so the normal `ExecStart=hermes gateway run --replace` service path is unaffected.

Placing the guard in `run_gateway()` covers every path that reaches a foreground start in one spot: the `run` subcommand and the manual `restart`/`start` fallbacks. The MainPID lookup queries `systemctl show <unit> --property=MainPID` directly, so it catches the live service even in the reported case where the unit-file existence check missed the per-profile unit.

This implements direction #1 of the reporter's suggested fixes. The flock-based single-writer guarantee (direction #3) is intentionally **not** part of this change — see Related Issue.

## Related Issue

Refs #35240

This PR lands the CLI guard (the reporter's most direct, lowest-risk suggestion) but not the deeper kanban-dispatcher `flock` single-writer guarantee they also propose, so it doesn't auto-close the issue. Using `Refs` leaves the maintainer to decide whether the guard alone closes #35240 or whether the defense-in-depth layer should follow.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`: add `_supervised_gateway_main_pid()` (profile-scoped systemd/launchd MainPID lookup) and `_guard_against_supervised_gateway()`; call the guard from `run_gateway()` and add a `force` parameter; thread `force` through the `run` handler and the manual `restart` fallbacks.
- `hermes_cli/main.py`: add `--force` to the `gateway run` and `gateway restart` argument parsers.
- `tests/hermes_cli/test_gateway_supervised_guard.py`: new tests covering refusal, `--force` override, `INVOCATION_ID`/self-PID suppression, no-supervisor no-op, and systemd/launchd MainPID parsing.
- `tests/hermes_cli/test_gateway.py`: neutralize the new host lookup in the shared `_install_fake_gateway_run` helper (same sandboxing rationale it already uses for `supports_systemd_services`).

## How to Test

1. With a `hermes-gateway.service` installed and running under systemd (or the launchd job on macOS), run `hermes gateway run --replace` from a shell — it now refuses with a hint to use `systemctl restart hermes-gateway.service` instead of spawning an orphan.
2. Confirm the override still works: `hermes gateway run --replace --force` starts despite the live service (prints a warning).
3. Confirm the service path is unaffected: `systemctl restart hermes-gateway.service` restarts cleanly (the guard self-suppresses via `INVOCATION_ID`).
4. Run the unit tests: `pytest tests/hermes_cli/test_gateway_supervised_guard.py tests/hermes_cli/test_gateway.py -q`.

## What platforms tested on

- macOS on darwin-arm64 (local): new guard tests pass (10/10) and the full `tests/hermes_cli/test_gateway.py` suite passes (33/33). Pre-existing `test_gateway_service.py` systemd failures are environmental (no systemd user D-Bus on macOS) and reproduce identically on `main` — unrelated to this change.
- Linux/systemd and native Windows: not exercised locally; covered by CI. Code paths are platform-guarded (`supports_systemd_services()` / `is_macos()`) and `scripts/check-windows-footguns.py` is clean for the changed files (subprocess uses list args, no `os.kill`/`termios`/POSIX-only signals).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — guard/helper carry rationale docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

<!-- autocontrib:worker-id=issue-new-23d78843 kind=pr-open -->