### PR TITLE
fix(telegram): respect HERMES_HOME path resolution in gmail-triage callback

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3509,8 +3509,8 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.error("Failed to write update response from callback: %s", exc)
 
     # Maps `gt:<verb>` -> (script-name, extra-args, success-label, is_state).
-    # Scripts live in ~/.hermes/scripts/gmail-triage/. `arg` from the callback
-    # data is always passed as the first positional arg.
+    # Scripts live under HERMES_HOME/scripts/gmail-triage/. `arg` from the
+    # callback data is always passed as the first positional arg.
     # is_state=True means the verb is a sticky sender-rule change (mute, trust,
     # vip) that should leave the keyboard tappable for follow-on actions.
     # is_state=False is a per-email one-shot (send, archive, draft, spam) that
@@ -3562,7 +3562,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         script_name, extra_args, success_label, is_state_verb = entry
 
-        script_path = _Path.home() / ".hermes" / "scripts" / "gmail-triage" / script_name
+        from hermes_constants import get_hermes_home
+
+        script_path = get_hermes_home() / "scripts" / "gmail-triage" / script_name
         if not script_path.exists():
             await query.answer(text=f"❌ {script_name} missing")
             logger.error("[%s] gmail-triage script missing: %s", self.name, script_path)

--- a/tests/gateway/test_telegram_gmail_triage.py
+++ b/tests/gateway/test_telegram_gmail_triage.py
@@ -1,0 +1,95 @@
+"""Tests for Telegram gmail-triage callbacks."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _ensure_telegram_mock():
+    """Install a minimal telegram mock so TelegramAdapter can import."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from gateway.platforms.telegram import TelegramAdapter
+
+
+@pytest.fixture()
+def adapter():
+    tg_adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    tg_adapter._is_callback_user_authorized = lambda *_a, **_kw: True
+    return tg_adapter
+
+
+class _FakeProc:
+    returncode = 0
+
+    async def communicate(self):
+        return b"", b""
+
+
+@pytest.mark.asyncio
+async def test_gmail_triage_callback_uses_hermes_home_for_script_lookup(
+    adapter, tmp_path, monkeypatch
+):
+    hermes_home = tmp_path / "profile-home"
+    script_dir = hermes_home / "scripts" / "gmail-triage"
+    script_dir.mkdir(parents=True)
+    script_path = script_dir / "send-draft.sh"
+    script_path.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    legacy_home = tmp_path / "legacy-home"
+    legacy_home.mkdir()
+
+    query = SimpleNamespace(
+        from_user=SimpleNamespace(id=123, first_name="Ada"),
+        message=SimpleNamespace(text="Original email"),
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+    )
+    seen = {}
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        seen["cmd"] = cmd
+        seen["kwargs"] = kwargs
+        return _FakeProc()
+
+    with patch.object(Path, "home", return_value=legacy_home), patch(
+        "gateway.platforms.telegram.asyncio.create_subprocess_exec",
+        side_effect=fake_create_subprocess_exec,
+    ):
+        await adapter._handle_gmail_triage_callback(
+            query,
+            "gt:send:msg-123",
+            query_chat_id="12345",
+            query_chat_type="private",
+            query_thread_id=None,
+            query_user_name="Ada",
+        )
+
+    assert seen["cmd"] == (str(script_path), "msg-123")
+    assert seen["kwargs"]["stdout"] is not None
+    assert seen["kwargs"]["stderr"] is not None
+    query.answer.assert_awaited_once()
+    assert "missing" not in query.answer.await_args.kwargs["text"].lower()
+    query.edit_message_text.assert_awaited_once()


### PR DESCRIPTION
## Summary

Fix Telegram gmail-triage callback script lookup to respect `HERMES_HOME`.

## Fix

The Telegram gmail-triage inline callback handler was resolving scripts from
`Path.home() / ".hermes" / "scripts" / "gmail-triage"`, which breaks named
profiles, custom `HERMES_HOME` setups, and containerized installs.

This change updates the callback path resolution to use
`get_hermes_home() / "scripts" / "gmail-triage"` instead, matching the repo’s
profile-safe path rules in `AGENTS.md`.

It also adds a regression test that proves the callback uses `HERMES_HOME`
even when `Path.home()` points somewhere else.

## Testing

Passed:
- `git diff --check`
- `python -m ruff check gateway/platforms/telegram.py tests/gateway/test_telegram_gmail_triage.py`
- `python -m pytest -o addopts="" tests/gateway/test_telegram_gmail_triage.py tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_telegram_model_picker.py tests/gateway/test_telegram_callback_auth_fail_closed.py`

Result:
- `43 passed in 1.77s`