### PR TITLE
fix(lazy-deps): honor bool-ish lazy install opt-out

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -127,6 +127,15 @@ class TestSecurityGating:
         )
         assert ld._allow_lazy_installs() is False
 
+    @pytest.mark.parametrize("value", ["false", "0", "off"])
+    def test_disabled_via_boolish_config_string(self, monkeypatch, value):
+        monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"security": {"allow_lazy_installs": value}},
+        )
+        assert ld._allow_lazy_installs() is False
+
     def test_default_allows(self, monkeypatch):
         monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
         monkeypatch.setattr(

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -61,6 +61,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from utils import is_truthy_value
+
 logger = logging.getLogger(__name__)
 
 
@@ -239,7 +241,7 @@ def _allow_lazy_installs() -> bool:
         return True
     sec = cfg.get("security") or {}
     val = sec.get("allow_lazy_installs", True)
-    return bool(val)
+    return is_truthy_value(val, default=True)
 
 
 def _spec_is_safe(spec: str) -> bool:


### PR DESCRIPTION
## Summary
- Treat `security.allow_lazy_installs` with the shared bool-ish config parser instead of Python `bool()`.
- Add regression coverage for string opt-out values (`"false"`, `"0"`, `"off"`).

## Problem
`security.allow_lazy_installs` is documented as a boolean config flag, but YAML/env-derived config can arrive as strings. The previous implementation used `bool(val)`, so any non-empty string was truthy. A user setting `security.allow_lazy_installs: "false"` therefore still allowed runtime lazy installs, defeating the documented security opt-out.

## Fix approach
- Import the existing project helper `is_truthy_value()` from `utils`.
- Replace `bool(val)` in `_allow_lazy_installs()` with `is_truthy_value(val, default=True)`.
- Preserve the existing default-open behavior when the key is absent or config loading fails.
- Cover the common string-disable values that previously regressed: `"false"`, `"0"`, and `"off"`.

## Why this is safe
The change only affects config coercion for this one boolean gate. Native booleans keep the same behavior, absent config still defaults to enabled, and explicit false-like strings now match the documented opt-out.

## Test plan
- `uv run python -m pytest -o addopts='' tests/tools/test_lazy_deps.py -q`