### PR TITLE
test: guard browser and Keychain side effects

### DIFF
--- a/tests/agent/test_anthropic_keychain.py
+++ b/tests/agent/test_anthropic_keychain.py
@@ -3,12 +3,18 @@
 import json
 from unittest.mock import patch, MagicMock
 
+import pytest
 
 from agent.anthropic_adapter import (
     _read_claude_code_credentials_from_keychain,
     read_claude_code_credentials,
     _refresh_oauth_token,
 )
+
+
+# This module exercises the reader itself with explicit platform and subprocess
+# mocks, so it opts out of the suite-wide guard without touching a real Keychain.
+pytestmark = pytest.mark.allow_macos_keychain
 
 
 class TestReadClaudeCodeCredentialsFromKeychain:
@@ -334,4 +340,3 @@ class TestRefreshOAuthTokenAdoptsFreshCredential:
         assert result == "newly-minted"
         # Prefers the live source's refresh token over the caller's stale copy.
         assert captured["refresh_token"] == "live-refresh"
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -402,6 +402,56 @@ def _isolate_hermes_home(_hermetic_environment):
     return None
 
 
+@pytest.fixture(autouse=True)
+def _neutralize_webbrowser(monkeypatch):
+    """Record browser-open attempts instead of opening real browser windows."""
+    import webbrowser as _webbrowser
+
+    opened: list[object] = []
+
+    def _record(url=None, *_args, **_kwargs):
+        opened.append(url)
+        return True
+
+    class _RecordingBrowser:
+        def open(self, url, *_args, **_kwargs):
+            return _record(url)
+
+        def open_new(self, url, *_args, **_kwargs):
+            return _record(url)
+
+        def open_new_tab(self, url, *_args, **_kwargs):
+            return _record(url)
+
+    browser = _RecordingBrowser()
+
+    for name in ("open", "open_new", "open_new_tab"):
+        monkeypatch.setattr(_webbrowser, name, _record, raising=False)
+    monkeypatch.setattr(_webbrowser, "get", lambda *_args, **_kwargs: browser)
+
+    return opened
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_macos_keychain_creds(request, monkeypatch):
+    """Default Anthropic credential resolution away from the real macOS Keychain."""
+    if request.node.get_closest_marker(_ALLOW_MACOS_KEYCHAIN_MARK):
+        return None
+
+    try:
+        import agent.anthropic_adapter as _anthropic_adapter
+    except Exception:
+        return None
+
+    monkeypatch.setattr(
+        _anthropic_adapter,
+        "_read_claude_code_credentials_from_keychain",
+        lambda *_args, **_kwargs: None,
+        raising=False,
+    )
+    return None
+
+
 # ── Module-level state reset — replaced by per-file process isolation ──────
 #
 # Each test FILE runs in a freshly-spawned ``python -m pytest <file>``
@@ -524,6 +574,7 @@ def _ensure_current_event_loop(request):
 # delivery is harmless.
 
 _LIVE_SYSTEM_GUARD_BYPASS_MARK = "live_system_guard_bypass"
+_ALLOW_MACOS_KEYCHAIN_MARK = "allow_macos_keychain"
 
 
 def pytest_configure(config):  # noqa: D401 — pytest hook
@@ -533,6 +584,11 @@ def pytest_configure(config):  # noqa: D401 — pytest hook
         f"{_LIVE_SYSTEM_GUARD_BYPASS_MARK}: bypass the live-system guard "
         "(only for tests that genuinely need real os.kill / subprocess "
         "behaviour — e.g. PTY tests that signal their own child).",
+    )
+    config.addinivalue_line(
+        "markers",
+        f"{_ALLOW_MACOS_KEYCHAIN_MARK}: allow a test to exercise the macOS "
+        "Keychain credential reader with its own subprocess/platform mocks.",
     )
 
     # The pyproject addopts pin ``--timeout-method=signal`` relies on

--- a/tests/test_hermetic_side_effect_guards.py
+++ b/tests/test_hermetic_side_effect_guards.py
@@ -1,0 +1,66 @@
+"""Regression tests for hermetic guards around local desktop side effects."""
+
+from __future__ import annotations
+
+import webbrowser
+
+
+def test_webbrowser_open_calls_are_neutralized(monkeypatch):
+    """OAuth/browser tests should never reach the real browser registry."""
+
+    def _real_browser_lookup_reached(*_args, **_kwargs):
+        raise AssertionError("test reached the real webbrowser registry")
+
+    monkeypatch.setattr(webbrowser, "get", _real_browser_lookup_reached)
+
+    url = "https://provider.example.invalid/oauth/authorize"
+
+    assert webbrowser.open(url) is True
+    assert webbrowser.open_new(url) is True
+    assert webbrowser.open_new_tab(url) is True
+
+
+def test_webbrowser_get_controller_is_neutralized(_neutralize_webbrowser):
+    """Direct controller access should still stay inside the test recorder."""
+    url = "https://provider.example.invalid/oauth/authorize"
+
+    controller = webbrowser.get("hermes-test-browser")
+
+    assert controller.open(url) is True
+    assert controller.open_new(url) is True
+    assert controller.open_new_tab(url) is True
+    assert _neutralize_webbrowser == [url, url, url]
+
+
+def _isolate_anthropic_credentials(monkeypatch, tmp_path):
+    from agent import anthropic_adapter as aa
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setattr(aa.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(aa.platform, "system", lambda: "Darwin")
+
+    def _real_keychain_reached(*_args, **_kwargs):
+        raise AssertionError("test reached the real macOS Keychain command")
+
+    monkeypatch.setattr(aa.subprocess, "run", _real_keychain_reached)
+    return aa
+
+
+def test_claude_code_credential_read_does_not_touch_macos_keychain(
+    monkeypatch, tmp_path
+):
+    """The real credential reader should be safe under the suite guard."""
+    aa = _isolate_anthropic_credentials(monkeypatch, tmp_path)
+
+    assert aa.read_claude_code_credentials() is None
+
+
+def test_anthropic_token_resolution_does_not_touch_macos_keychain(
+    monkeypatch, tmp_path
+):
+    """Token resolution should be safe under the same suite guard."""
+    aa = _isolate_anthropic_credentials(monkeypatch, tmp_path)
+
+    assert aa.resolve_anthropic_token() is None


### PR DESCRIPTION
## Summary

Fixes #35404.

This makes local test runs hermetic for two desktop credential side effects:

- neutralizes `webbrowser.open`, `open_new`, `open_new_tab`, and `webbrowser.get(...).open*` in pytest so OAuth tests record browser launches instead of opening real windows
- neutralizes Anthropic macOS Keychain credential resolution by default, while letting the dedicated Keychain tests opt in with `@pytest.mark.allow_macos_keychain`
- adds regression tests proving standard browser helpers, direct browser controllers, and Anthropic token resolution stay inside test doubles

## Tests

- `scripts/run_tests.sh tests/test_hermetic_side_effect_guards.py`
- `scripts/run_tests.sh tests/test_hermetic_side_effect_guards.py tests/tools/test_mcp_oauth.py tests/agent/test_anthropic_oauth_pkce.py tests/hermes_cli/test_graphical_browser_detection.py tests/hermes_cli/test_auth_manual_paste.py tests/agent/test_anthropic_adapter.py tests/agent/test_anthropic_keychain.py`

## Safety

- `git diff --cached --check`
- added-line scan for hardcoded secrets, `shell=True`, `eval`/`exec`, and `pickle.loads`: no findings
