### PR TITLE
fix(providers): preserve Hermes slugs for models.dev aliases

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -214,6 +214,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     ),
 }
 
+MODELS_DEV_PROVIDER_IDS: Dict[str, str] = {
+    "kilocode": "kilo",
+    "opencode-zen": "opencode",
+}
+
 
 # -- Resolved provider -------------------------------------------------------
 # The merged result of models.dev + overlay + user config.
@@ -287,17 +292,16 @@ ALIASES: Dict[str, str] = {
     "github-copilot-acp": "copilot-acp",
 
     # opencode (models.dev ID for OpenCode Zen)
-    "opencode-zen": "opencode",
-    "zen": "opencode",
+    "zen": "opencode-zen",
 
     # opencode-go
     "go": "opencode-go",
     "opencode-go-sub": "opencode-go",
 
     # kilo (models.dev ID for KiloCode)
-    "kilocode": "kilo",
-    "kilo-code": "kilo",
-    "kilo-gateway": "kilo",
+    "kilo": "kilocode",
+    "kilo-code": "kilocode",
+    "kilo-gateway": "kilocode",
 
     # deepseek
     "deep-seek": "deepseek",
@@ -418,15 +422,16 @@ def get_provider(name: str) -> Optional[ProviderDef]:
     Returns a fully-resolved ProviderDef or None.
     """
     canonical = normalize_provider(name)
+    models_dev_id = MODELS_DEV_PROVIDER_IDS.get(canonical, canonical)
 
     # Try to get models.dev data
     try:
         from agent.models_dev import get_provider_info as _mdev_provider
-        mdev_info = _mdev_provider(canonical)
+        mdev_info = _mdev_provider(models_dev_id)
     except Exception:
         mdev_info = None
 
-    overlay = HERMES_OVERLAYS.get(canonical)
+    overlay = HERMES_OVERLAYS.get(canonical) or HERMES_OVERLAYS.get(models_dev_id)
 
     if mdev_info is not None:
         # Merge models.dev + overlay

--- a/tests/hermes_cli/test_overlay_slug_resolution.py
+++ b/tests/hermes_cli/test_overlay_slug_resolution.py
@@ -81,6 +81,17 @@ def test_kilo_overlay_uses_hermes_slug():
     assert kilo_mdev is None, "kilo slug should not appear (resolved to kilocode)"
 
 
+def test_resolve_provider_full_preserves_explicit_hermes_slugs():
+    """Built-in models.dev aliases should not leak into persisted Hermes slugs."""
+    from hermes_cli.providers import normalize_provider, resolve_provider_full
+
+    assert normalize_provider("kilocode") == "kilocode"
+    assert resolve_provider_full("kilocode").id == "kilocode"
+
+    assert normalize_provider("opencode-zen") == "opencode-zen"
+    assert resolve_provider_full("opencode-zen").id == "opencode-zen"
+
+
 
 def test_mapped_provider_credential_pool_visibility(monkeypatch):
     """Mapped providers should appear when credentials live only in auth-store credential_pool."""


### PR DESCRIPTION
## Summary
- Keep explicit Hermes provider slugs like `kilocode` and `opencode-zen` when resolving provider definitions.
- Continue using the corresponding models.dev provider ids (`kilo`, `opencode`) for catalog metadata and Hermes overlays.

## Problem
`hermes_cli.providers` used models.dev ids as canonical aliases for some providers. That meant explicit Hermes-facing slugs could drift during resolution:

- `kilocode` normalized to `kilo`
- `opencode-zen` normalized to `opencode`

Those models.dev ids are useful for catalog lookup, but they should not leak back into Hermes runtime/config slugs. Other parts of Hermes, including model lists and runtime mode logic, use the Hermes slugs.

## Fix approach
- Introduce a small `MODELS_DEV_PROVIDER_IDS` mapping for providers whose Hermes slug differs from the models.dev id.
- Keep `normalize_provider()` canonicalizing to Hermes-facing slugs (`kilocode`, `opencode-zen`).
- In `get_provider()`, query models.dev via the mapped models.dev id while returning `ProviderDef.id` as the Hermes slug.
- Reuse Hermes overlays from either the Hermes slug or mapped models.dev id so transport/auth metadata stays intact.
- Add regression coverage proving `resolve_provider_full()` preserves `kilocode` and `opencode-zen`.

## Why this is safe
This separates display/runtime identity from upstream catalog identity. Callers still get models.dev metadata, but persisted/runtime provider ids remain the slugs already used elsewhere in Hermes.

## Test plan
- `uv run python -m pytest -o addopts='' tests/hermes_cli/test_overlay_slug_resolution.py -q`
- `uv run python -m pytest -o addopts='' tests/run_agent/test_switch_model_rollback.py tests/hermes_cli/test_model_switch_opencode_anthropic.py -q`
- `uv run ruff check hermes_cli/providers.py tests/hermes_cli/test_overlay_slug_resolution.py`