### PR TITLE
fix(model-catalog): parse bool-ish config values

### DIFF
--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import time
 import urllib.error
 import urllib.request
@@ -53,7 +54,7 @@ from pathlib import Path
 from typing import Any
 
 from hermes_cli import __version__ as _HERMES_VERSION
-from utils import atomic_replace
+from utils import atomic_replace, is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -104,11 +105,24 @@ def _load_catalog_config() -> dict[str, Any]:
         raw = {}
 
     return {
-        "enabled": bool(raw.get("enabled", True)),
+        "enabled": is_truthy_value(raw.get("enabled"), default=True),
         "url": str(raw.get("url") or DEFAULT_CATALOG_URL),
-        "ttl_hours": float(raw.get("ttl_hours") or DEFAULT_TTL_HOURS),
+        "ttl_hours": _parse_ttl_hours(raw.get("ttl_hours")),
         "providers": raw.get("providers") if isinstance(raw.get("providers"), dict) else {},
     }
+
+
+def _parse_ttl_hours(value: Any) -> float:
+    """Parse ``model_catalog.ttl_hours`` while preserving explicit zero."""
+    if value is None or value == "":
+        return float(DEFAULT_TTL_HOURS)
+    try:
+        ttl = float(value)
+    except (TypeError, ValueError):
+        return float(DEFAULT_TTL_HOURS)
+    if not math.isfinite(ttl):
+        return float(DEFAULT_TTL_HOURS)
+    return ttl
 
 
 def _cache_path() -> Path:

--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -122,7 +122,7 @@ def _parse_ttl_hours(value: Any) -> float:
         return float(DEFAULT_TTL_HOURS)
     if not math.isfinite(ttl):
         return float(DEFAULT_TTL_HOURS)
-    return ttl
+    return max(0.0, ttl)
 
 
 def _cache_path() -> Path:

--- a/tests/hermes_cli/test_model_catalog.py
+++ b/tests/hermes_cli/test_model_catalog.py
@@ -94,6 +94,41 @@ class TestValidation:
         assert _validate_manifest(m) is False
 
 
+class TestConfig:
+    def test_boolish_disabled_string_is_respected(self, isolated_home):
+        from hermes_cli import model_catalog
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"model_catalog": {"enabled": "false"}},
+        ):
+            cfg = model_catalog._load_catalog_config()
+
+        assert cfg["enabled"] is False
+
+    def test_ttl_hours_string_and_zero_are_preserved(self, isolated_home):
+        from hermes_cli import model_catalog
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"model_catalog": {"ttl_hours": "0"}},
+        ):
+            cfg = model_catalog._load_catalog_config()
+
+        assert cfg["ttl_hours"] == 0.0
+
+    def test_invalid_ttl_hours_falls_back_to_default(self, isolated_home):
+        from hermes_cli import model_catalog
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"model_catalog": {"ttl_hours": "not-a-number"}},
+        ):
+            cfg = model_catalog._load_catalog_config()
+
+        assert cfg["ttl_hours"] == float(model_catalog.DEFAULT_TTL_HOURS)
+
+
 class TestFetchSuccess:
     def test_fetch_and_cache_writes_disk(self, isolated_home):
         from hermes_cli import model_catalog

--- a/tests/hermes_cli/test_model_catalog.py
+++ b/tests/hermes_cli/test_model_catalog.py
@@ -128,6 +128,17 @@ class TestConfig:
 
         assert cfg["ttl_hours"] == float(model_catalog.DEFAULT_TTL_HOURS)
 
+    def test_negative_ttl_hours_clamps_to_zero(self, isolated_home):
+        from hermes_cli import model_catalog
+
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"model_catalog": {"ttl_hours": "-5"}},
+        ):
+            cfg = model_catalog._load_catalog_config()
+
+        assert cfg["ttl_hours"] == 0.0
+
 
 class TestFetchSuccess:
     def test_fetch_and_cache_writes_disk(self, isolated_home):


### PR DESCRIPTION
## Summary
- Parse `model_catalog.enabled` with the shared bool-ish config parser so string `"false"` disables the remote catalog.
- Parse `model_catalog.ttl_hours` explicitly so numeric strings work, explicit `0` is preserved, and malformed values fall back safely.

## Problem
`model_catalog` config used raw Python coercion:

- `enabled` used `bool(value)`, so `"false"` was treated as enabled.
- `ttl_hours` used `float(raw.get("ttl_hours") or DEFAULT_TTL_HOURS)`, so explicit zero was replaced with the default TTL.
- malformed TTL values could raise during config loading instead of falling back gracefully.

This made documented config values unreliable, especially when users or UI layers stored scalar values as strings.

## Fix approach
- Parse `enabled` with the existing `is_truthy_value(..., default=True)` helper.
- Add `_parse_ttl_hours()` to handle `None`, empty string, numeric strings, explicit `0`, non-finite values, and malformed values consistently.
- Preserve the existing default of `24` hours when TTL is absent or invalid.
- Add focused tests for `enabled: "false"`, `ttl_hours: "0"`, and invalid TTL fallback.

## Why this is safe
The change only normalizes config inputs before the existing catalog/cache logic runs. Default behavior remains unchanged for absent config, while explicit user intent is respected.

## Test plan
- `uv run python -m pytest -o addopts='' tests/hermes_cli/test_model_catalog.py -q`
- `uv run ruff check hermes_cli/model_catalog.py tests/hermes_cli/test_model_catalog.py`