### PR TITLE
fix(gateway): add .markdown to MEDIA_DELIVERY_EXTS for outbound document delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1165,7 +1165,7 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     # Audio (delivered as voice/audio where supported)
     ".mp3", ".wav", ".ogg", ".opus", ".m4a", ".flac",
     # Documents (uploaded as file attachments)
-    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".epub",
+    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".markdown", ".epub",
     # Spreadsheets / data
     ".xlsx", ".xls", ".ods", ".csv", ".tsv", ".json", ".xml", ".yaml", ".yml",
     # Presentations

--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -57,6 +57,22 @@ class TestExtractMediaImages:
         assert "/audio.ogg" in paths
         assert "/screenshot.png" in paths
 
+    def test_markdown_document_extracted(self):
+        """MEDIA: tags with .markdown extension should be extracted as documents."""
+        content = "MEDIA:/tmp/report.markdown"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "/tmp/report.markdown"
+        assert "MEDIA:" not in cleaned
+
+    def test_md_document_extracted(self):
+        """MEDIA: tags with .md extension should be extracted as documents."""
+        content = "MEDIA:/tmp/notes.md"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0] == "/tmp/notes.md"
+        assert "MEDIA:" not in cleaned
+
 
 # ---------------------------------------------------------------------------
 # Telegram send_image_file tests


### PR DESCRIPTION
## What does this PR do?

Adds `.markdown` to `MEDIA_DELIVERY_EXTS` so that outbound `MEDIA:` tags with `.markdown` extension are correctly extracted and delivered as document attachments instead of appearing as visible text.

## Related Issue

Fixes #35474

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: Added `.markdown` to `MEDIA_DELIVERY_EXTS` tuple (documents section)
- `tests/gateway/test_send_image_file.py`: Added `test_markdown_document_extracted` and `test_md_document_extracted` tests

## How to Test

1. Start a Hermes chat session with any platform delivery available
2. Ask Hermes to create a Markdown file (e.g., `/tmp/test.markdown`)
3. The agent emits `MEDIA:/tmp/test.markdown` in its response
4. Verify the file is delivered as a native document attachment (not as visible text)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `MEDIA_DELIVERY_EXTS` (used by `extract_media()`, `extract_local_files()`, `MEDIA_TAG_CLEANUP_RE`)
- Callers: `extract_media()` — all platform adapters; `extract_local_files()` — all platform adapters
- Blast radius: LOW (adds one extension to existing tuple, no behavioral change for existing extensions)
- Related patterns: `SUPPORTED_DOCUMENT_TYPES` at line 1091 already includes `.md`; this adds the long-form `.markdown` variant
