### PR TITLE
fix(send_message): restrict Telegram HTML detection

### DIFF
--- a/tests/tools/test_send_message_telegram_formatting.py
+++ b/tests/tools/test_send_message_telegram_formatting.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from tools.send_message_tool import _message_uses_telegram_html
+
+
+def test_plain_code_like_angle_brackets_are_not_treated_as_html() -> None:
+    assert not _message_uses_telegram_html(
+        "RSS fetch failed in <urlopen>; falling back to cache"
+    )
+
+
+def test_supported_telegram_html_tags_are_treated_as_html() -> None:
+    assert _message_uses_telegram_html(
+        "<b>Important</b> <a href='https://example.com'>link</a>"
+    )
+
+
+def test_supported_opening_tag_with_attributes_is_treated_as_html() -> None:
+    assert _message_uses_telegram_html("<a href='https://example.com'>link")
+
+
+def test_unsupported_html_like_tags_are_not_treated_as_html() -> None:
+    assert not _message_uses_telegram_html("<script>alert('x')</script>")
+
+
+def test_mixed_supported_and_unsupported_tags_fall_back_to_markdown_v2() -> None:
+    # Even one unsupported tag-like token forces MarkdownV2 fallback.
+    # This pins all() semantics: one bad tag → safe mode, no partial HTML.
+    assert not _message_uses_telegram_html("<b>Error</b> parsing <urlopen>")

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -738,6 +738,14 @@ class TestSendTelegramHtmlDetection:
         assert kwargs["parse_mode"] == "HTML"
         assert kwargs["text"] == "<b>Hello</b> world"
 
+    def test_unsupported_html_like_tag_uses_markdown_v2(self, monkeypatch):
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        asyncio.run(_send_telegram("tok", "123", "technical text <urlopen>"))
+
+        kwargs = bot.send_message.await_args.kwargs
+        assert kwargs["parse_mode"] == "MarkdownV2"
 
     def test_transient_bad_gateway_retries_text_send(self, monkeypatch):
         bot = self._make_bot()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -125,6 +125,55 @@ def _media_caption_split(text, media_files, *, max_caption_len):
     if len(stripped) > max_caption_len:
         return None, text
     return stripped, ""
+
+
+_TELEGRAM_HTML_TAG_RE = re.compile(r"</?([A-Za-z][A-Za-z0-9_-]*)(?:\s[^>]*)?/?>")
+# NOTE: ``span`` is only valid as ``<span class="tg-spoiler">`` per the
+# Telegram Bot API spec; a bare ``<span>`` or any other class is rejected
+# by the parser. We accept the tag name here for simplicity — the send
+# path falls back to plain text on parse error, so the worst case is
+# cosmetic (lost formatting), not a hard delivery failure.
+_TELEGRAM_SUPPORTED_HTML_TAGS = frozenset({
+    "a",
+    "b",
+    "blockquote",
+    "code",
+    "del",
+    "em",
+    "i",
+    "ins",
+    "pre",
+    "s",
+    "span",
+    "strike",
+    "strong",
+    "tg-emoji",
+    "tg-spoiler",
+    "u",
+})
+
+
+def _message_uses_telegram_html(message: str) -> bool:
+    """Return True only when tag-like text is valid Telegram HTML.
+
+    Telegram supports a small HTML subset. Treating every ``<word>`` as HTML
+    makes ordinary technical text like ``<urlopen>`` fail parsing before the
+    plain-text fallback. Only opt into HTML mode when every detected tag is in
+    Telegram's supported set.
+
+    Uses ``all()`` (not ``any()``) deliberately: if even one tag-like token is
+    unsupported, the message is routed to MarkdownV2 rather than risk a parse
+    error. Switching to ``any()`` would reintroduce the failures this function
+    exists to prevent.
+    """
+    matches = list(_TELEGRAM_HTML_TAG_RE.finditer(message))
+    if not matches:
+        return False
+    return all(
+        match.group(1).lower() in _TELEGRAM_SUPPORTED_HTML_TAGS for match in matches
+    )
+
+
 _URL_SECRET_QUERY_RE = re.compile(
     r"([?&](?:access_token|api[_-]?key|auth[_-]?token|token|signature|sig)=)([^&#\s]+)",
     re.IGNORECASE,
@@ -1185,9 +1234,9 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         from telegram import Bot
         from telegram.constants import ParseMode
 
-        # Auto-detect HTML tags — if present, skip MarkdownV2 and send as HTML.
-        # Inspired by github.com/ashaney — PR #1568.
-        _has_html = bool(re.search(r'<[a-zA-Z/][^>]*>', message))
+        # Auto-detect supported Telegram HTML tags. Unsupported tag-like text
+        # stays on the MarkdownV2 path instead of triggering a parse error.
+        _has_html = _message_uses_telegram_html(message)
 
         if _has_html:
             formatted = message


### PR DESCRIPTION
## Summary

- restrict standalone Telegram HTML auto-detection to an explicit supported-tag allowlist
- keep technical text such as `<urlopen>` on the MarkdownV2 path instead of misclassifying it as HTML
- preserve HTML mode when every detected tag is supported, including opening tags with attributes
- add focused helper, mixed-tag, and real send-path regression coverage

## Root cause

`_send_telegram` previously treated any `<...>` token beginning with a letter or slash as HTML:

```python
bool(re.search(r"<[a-zA-Z/][^>]*>", message))
```

That sends ordinary technical text such as `<urlopen>` through Telegram's HTML parser. The parse then fails and falls back to plain text, losing the intended MarkdownV2 formatting and adding an avoidable failed request.

## Fix

Add `_message_uses_telegram_html()` with these rules:

- no detected tag → MarkdownV2
- every detected tag is supported → HTML
- any unsupported detected tag → MarkdownV2

The predicate deliberately uses `all()` so a mixed message such as `<b>Error</b> parsing <urlopen>` fails safe as a whole. Existing parse-error fallback, adapter formatting, retry behavior, and transport logic are unchanged.

This refresh preserves the PR's established tag scope; it does not expand Telegram tag support.

## Validation

```text
python -m pytest -o addopts='' tests/tools/test_*send_message*.py tests/gateway/test_telegram_voice_duration.py -q
110 passed, 5 third-party pkg_resources deprecation warnings

ruff check tools/send_message_tool.py tests/tools/test_send_message_tool.py tests/tools/test_send_message_telegram_formatting.py
All checks passed

python -m py_compile tools/send_message_tool.py tests/tools/test_send_message_tool.py tests/tools/test_send_message_telegram_formatting.py
passed

git diff --check
passed
```
