### PR TITLE
fix: repair kanban dashboard regressions

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6846,11 +6846,12 @@ def board_stats(conn: sqlite3.Connection) -> dict:
     }
 
 
-def _to_epoch(val) -> Optional[int]:
-    """Normalise a timestamp to unix epoch seconds.
+def _safe_int(val) -> Optional[int]:
+    """Best-effort integer coercion for persisted timestamp fields.
 
-    Accepts ints (pass-through), numeric strings, and ISO-8601 strings.
-    Returns ``None`` for ``None`` / empty values.
+    Accepts ints (pass-through), floats (truncated), numeric strings, and
+    ISO-8601 strings. Returns ``None`` for ``None`` / empty / corrupt values
+    instead of letting dashboard serialization crash on legacy bad rows.
     """
     if val is None:
         return None
@@ -6872,6 +6873,11 @@ def _to_epoch(val) -> Optional[int]:
         return int(dt.timestamp())
     except (ValueError, OSError):
         return None
+
+
+def _to_epoch(val) -> Optional[int]:
+    """Normalise a timestamp to unix epoch seconds."""
+    return _safe_int(val)
 
 
 def task_age(task: Task) -> dict:

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -69,9 +69,8 @@
   }
 
   // ``fetchJSON`` throws ``Error("<status>: <raw body>")`` on non-2xx, and
-  // FastAPI bodies look like ``{"detail":"<message>"}``.  Pull the
-  // human-readable message out so banners/toasts don't have to leak HTTP
-  // plumbing at the user (e.g. ``409: {"detail":"…"}``).  See #26744.
+  // FastAPI bodies look like ``{"detail":"<message>"}``. Pull the
+  // human-readable message out so banners/toasts do not leak HTTP plumbing.
   function parseApiErrorMessage(err) {
     const raw = (err && err.message) ? String(err.message) : String(err || "");
     const m = raw.match(/^(\d{3}):\s*(.*)$/s);
@@ -738,7 +737,7 @@
         setLastSelectedId(null);
         loadBoard();
       }).catch(function (err) {
-        setError(`Move failed: ${err.message || err}`);
+        setError(`Move failed: ${parseApiErrorMessage(err)}`);
         setFailedIds(new Set(selectedIds));
         loadBoard();
       });
@@ -2738,7 +2737,7 @@
     // Surface PATCH failures (e.g. 409 "parent not done") right next to
     // the drawer's action row — without it, the drawer's only error
     // surface (``err``) is hidden behind the loaded ``data`` and the
-    // Ready/Block/Complete buttons feel like no-ops.  See #26744.
+    // Ready/Block/Complete buttons feel like no-ops.
     const [patchErr, setPatchErr] = useState(null);
     const [newComment, setNewComment] = useState("");
     const [uploadBusy, setUploadBusy] = useState(false);
@@ -2845,7 +2844,7 @@
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(finalPatch),
-      }).then(function () { load(); props.onRefresh(); })
+      }).then(function () { setPatchErr(null); load(); props.onRefresh(); })
         .catch(function (e) { setPatchErr(parseApiErrorMessage(e)); });
     };
 
@@ -2974,6 +2973,7 @@
         loading ? h("div", { className: "p-4 text-sm text-muted-foreground" },
           tx(t, "loadingDetail", "Loading…")) :
         err ? h("div", { className: "p-4 text-sm text-destructive" }, err) :
+        patchErr ? h("div", { className: "px-4 py-2 text-sm text-destructive" }, patchErr) : null,
         data ? h(TaskDetail, {
           data, editing, setEditing,
           renderMarkdown: props.renderMarkdown,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -847,7 +847,10 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     ok = kanban_db.unblock_task(conn, task_id)
                 else:
                     # Direct status write for drag-drop (todo -> ready etc).
-                    ok = _set_status_direct(conn, task_id, "ready")
+                    try:
+                        ok = _set_status_direct(conn, task_id, "ready")
+                    except RuntimeError as e:
+                        raise HTTPException(status_code=409, detail=str(e))
             elif s == "archived":
                 ok = kanban_db.archive_task(conn, task_id)
             elif s == "running":
@@ -996,10 +999,21 @@ def _set_status_direct(
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
-            if parent_statuses and not all(
-                p["status"] == "done" for p in parent_statuses
-            ):
-                return False
+            blocking = [
+                f"{p['id']} '{p['title']}' status={p['status']}"
+                for p in conn.execute(
+                    "SELECT t.id, t.title, t.status FROM tasks t "
+                    "JOIN task_links l ON l.parent_id = t.id "
+                    "WHERE l.child_id = ? AND t.status != 'done' "
+                    "ORDER BY t.id",
+                    (task_id,),
+                ).fetchall()
+            ]
+            if blocking:
+                raise RuntimeError(
+                    "Cannot move to 'ready': parent dependencies are not done: "
+                    + ", ".join(blocking)
+                )
 
         was_running = prev["status"] == "running"
         reopening_satisfied_parent = (


### PR DESCRIPTION
## Summary
- fixes Kanban dashboard regression around blocked ready transitions with actionable parent dependency errors
- keeps drawer/drag-drop errors visible and human-readable
- keeps corrupt timestamp handling defensive via _safe_int compatibility

## Test plan
- /Users/clawdia/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts="" tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_boards.py tests/plugins/test_kanban_dashboard_plugin.py -q
- result: 355 passed, 1 warning