### PR TITLE
fix(gateway): remove deprecated default_backend() from WeChat AES crypto

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -177,13 +177,13 @@ def _pkcs7_pad(data: bytes, block_size: int = 16) -> bytes:
 
 
 def _aes128_ecb_encrypt(plaintext: bytes, key: bytes) -> bytes:
-    cipher = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())
+    cipher = Cipher(algorithms.AES(key), modes.ECB())
     encryptor = cipher.encryptor()
     return encryptor.update(_pkcs7_pad(plaintext)) + encryptor.finalize()
 
 
 def _aes128_ecb_decrypt(ciphertext: bytes, key: bytes) -> bytes:
-    cipher = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())
+    cipher = Cipher(algorithms.AES(key), modes.ECB())
     decryptor = cipher.decryptor()
     padded = decryptor.update(ciphertext) + decryptor.finalize()
     if not padded:

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -815,6 +815,28 @@ class TestWeixinVoiceSending:
         assert voice_item["bits_per_sample"] == 16
 
 
+class TestWeixinAesCrypto:
+    """Regression tests for #35432: cryptography>=48 compatibility."""
+
+    def test_aes128_ecb_encrypt_decrypt_round_trip(self):
+        from gateway.platforms.weixin import _aes128_ecb_encrypt, _aes128_ecb_decrypt
+
+        key = b"0123456789abcdef"
+        plaintext = b"hello weixin media"
+        ciphertext = _aes128_ecb_encrypt(plaintext, key)
+        assert ciphertext != plaintext
+        assert len(ciphertext) % 16 == 0
+        assert _aes128_ecb_decrypt(ciphertext, key) == plaintext
+
+    def test_aes128_ecb_encrypt_decrypt_round_trip_binary(self):
+        from gateway.platforms.weixin import _aes128_ecb_encrypt, _aes128_ecb_decrypt
+
+        key = bytes(range(16))
+        plaintext = bytes(range(256))
+        ciphertext = _aes128_ecb_encrypt(plaintext, key)
+        assert _aes128_ecb_decrypt(ciphertext, key) == plaintext
+
+
 class TestIsStaleSessionRet:
     """Regression test for #17228: distinguish stale-session ret=-2 from rate-limit ret=-2."""
 


### PR DESCRIPTION
## Summary

Fixes #35432

WeChat image/video/file/voice downloads silently fail with `cryptography >= 48.0.0` because `default_backend()` was removed from the library. The `backend=default_backend()` parameter was deprecated since cryptography 3.x and is now ignored — safe to remove.

## Changes

- Removed `backend=default_backend()` from `Cipher()` construction in `_aes128_ecb_encrypt()` and `_aes128_ecb_decrypt()` in `gateway/platforms/weixin.py`
- Added regression test `TestWeixinAesCrypto` with round-trip encrypt/decrypt verification

## Testing

```
pytest tests/gateway/test_weixin.py::TestWeixinAesCrypto -v
2 passed
```