### PR TITLE
test(agent): add regression tests for Gemini OpenAI-compatible endpoint detection

### DIFF
--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -8,6 +8,45 @@ from types import SimpleNamespace
 import pytest
 
 
+class TestIsNativeGeminiBaseUrl:
+    """Regression tests for bug #35454.
+
+    When base_url ends with /openai (OpenAI-compatible endpoint),
+    is_native_gemini_base_url must return False so the vision module
+    routes through the standard OpenAI chat completions path instead
+    of the native Gemini REST adapter.
+    """
+
+    def test_openai_compatible_endpoint_returns_false(self):
+        from agent.gemini_native_adapter import is_native_gemini_base_url
+
+        assert is_native_gemini_base_url(
+            "https://generativelanguage.googleapis.com/v1beta/openai"
+        ) is False
+
+    def test_openai_compatible_endpoint_trailing_slash(self):
+        from agent.gemini_native_adapter import is_native_gemini_base_url
+
+        assert is_native_gemini_base_url(
+            "https://generativelanguage.googleapis.com/v1beta/openai/"
+        ) is False
+
+    def test_native_gemini_endpoint_returns_true(self):
+        from agent.gemini_native_adapter import is_native_gemini_base_url
+
+        assert (
+            is_native_gemini_base_url(
+                "https://generativelanguage.googleapis.com/v1beta"
+            )
+            is True
+        )
+
+    def test_non_gemini_url_returns_false(self):
+        from agent.gemini_native_adapter import is_native_gemini_base_url
+
+        assert is_native_gemini_base_url("https://api.openai.com/v1") is False
+
+
 class DummyResponse:
     def __init__(self, status_code=200, payload=None, headers=None, text=None):
         self.status_code = status_code


### PR DESCRIPTION
## Summary

Related to #35454

The underlying routing logic in `is_native_gemini_base_url()` already correctly returns `False` when `base_url` ends with `/openai`, preventing the native Gemini adapter from intercepting OpenAI-compatible endpoint calls.

This PR adds explicit regression tests to:
1. Verify `/openai` endpoint returns `False` (skips native adapter)
2. Verify `/openai/` with trailing slash also returns `False`
3. Verify native Gemini endpoint returns `True`
4. Verify non-Gemini URLs return `False`

## Testing

```
pytest tests/agent/test_gemini_native_adapter.py -v
15 passed
```

If the bug is actually elsewhere in the vision resolution path, these tests will still serve as a guard against future regressions.