### PR TITLE
fix(docker): preserve Docker -w workdir in main-wrapper

### DIFF
--- a/docker/main-wrapper.sh
+++ b/docker/main-wrapper.sh
@@ -26,9 +26,16 @@ set -e
 # don't try to write to /root.
 export HOME=/opt/data
 
+# Save the original working directory so we can restore it before exec'ing
+# the main process. This honors Docker's -w flag (bug #35472).
+original_cwd=$(pwd)
 cd /opt/data
 # shellcheck disable=SC1091
 . /opt/hermes/.venv/bin/activate
+
+# Restore the original working directory so that hermes respects Docker's
+# -w flag.
+cd "$original_cwd"
 
 if [ $# -eq 0 ]; then
     exec s6-setuidgid hermes hermes

--- a/tests/test_docker_home_override_scripts.py
+++ b/tests/test_docker_home_override_scripts.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DASHBOARD_RUN = REPO_ROOT / "docker" / "s6-rc.d" / "dashboard" / "run"
+MAIN_WRAPPER = REPO_ROOT / "docker" / "main-wrapper.sh"
 
 
 def test_dashboard_run_resets_home_before_dropping_privileges() -> None:
@@ -18,9 +19,9 @@ def test_dashboard_run_resets_home_before_dropping_privileges() -> None:
 def test_dashboard_run_does_not_derive_insecure_from_bind_host() -> None:
     """The s6 dashboard run script MUST NOT auto-add ``--insecure`` based on
     ``HERMES_DASHBOARD_HOST``. Doing so disables the OAuth auth gate on
-    every non-loopback bind even when an auth provider is registered —
-    the exact regression that exposed every wildcard-subdomain agent
-    dashboard publicly until early 2026.
+    every non-loopback bind even when an auth provider is registered — the
+    exact regression that exposed every wildcard-subdomain agent dashboard
+    publicly until early 2026.
 
     The opt-in is now explicit: ``HERMES_DASHBOARD_INSECURE=1`` (truthy).
     The auth gate is the authority on whether non-loopback binds are safe.
@@ -46,3 +47,15 @@ def test_dashboard_run_does_not_derive_insecure_from_bind_host() -> None:
         assert truthy in text, (
             f"HERMES_DASHBOARD_INSECURE should accept truthy value {truthy!r}"
         )
+
+
+def test_main_wrapper_preserves_docker_workdir() -> None:
+    """When Docker starts the container with ``-w <workdir>``, hermes should
+    still start in that directory rather than overriding it to /opt/data.
+    """
+    text = MAIN_WRAPPER.read_text(encoding="utf-8")
+
+    assert "#!/command/with-contenv sh" in text
+    assert "export HOME=/opt/data" in text
+    assert "original_cwd=$(pwd)" in text
+    assert 'cd "$original_cwd"' in text


### PR DESCRIPTION
Fixes #35472. Docker init scripts cd to /opt/data for setup but never restore the original working directory. Save pre-/opt/data cwd, then cd back before exec so container starts in Docker -w directory. Includes regression test.