### PR TITLE
Add 9router image provider and stable dashboard session token

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -511,8 +511,11 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 continue
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
-            # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
+            # Resolve the API key from the env var name stored in key_env.
+            # api_key_env is a documented alias used by some generated configs;
+            # treat it the same way here so providers-dict entries match the
+            # normalizer and the legacy custom_providers path.
+            key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
             resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
@@ -528,6 +531,11 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
                     }
+                    if key_env:
+                        result["key_env"] = key_env
+                    api_key_env = str(entry.get("api_key_env", "") or "").strip()
+                    if api_key_env:
+                        result["api_key_env"] = api_key_env
                     extra_body = entry.get("extra_body")
                     if isinstance(extra_body, dict):
                         result["extra_body"] = dict(extra_body)
@@ -556,6 +564,11 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                             "api_key": resolved_api_key,
                             "model": entry.get("default_model", ""),
                         }
+                        if key_env:
+                            result["key_env"] = key_env
+                        api_key_env = str(entry.get("api_key_env", "") or "").strip()
+                        if api_key_env:
+                            result["api_key_env"] = api_key_env
                         extra_body = entry.get("extra_body")
                         if isinstance(extra_body, dict):
                             result["extra_body"] = dict(extra_body)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -85,7 +85,7 @@ app = FastAPI(title="Hermes Agent", version=__version__)
 # Generated fresh on every server start — dies when the process exits.
 # Injected into the SPA HTML so only the legitimate web UI can use it.
 # ---------------------------------------------------------------------------
-_SESSION_TOKEN = secrets.token_urlsafe(32)
+_SESSION_TOKEN = os.environ.get("CLAUDE_DASHBOARD_TOKEN") or secrets.token_urlsafe(32)
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 
 # In-browser Chat tab (/chat, /api/pty, …).  Off unless ``hermes dashboard --tui``

--- a/plugins/image_gen/9router/__init__.py
+++ b/plugins/image_gen/9router/__init__.py
@@ -1,0 +1,304 @@
+"""9router image generation backend.
+
+Routes Hermes `image_generate` through a local/OpenAI-compatible 9router
+Responses API endpoint and the `image_generation` tool. Supports optional
+reference images by sending them as `input_image` content blocks.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import mimetypes
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_b64_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+API_IMAGE_MODEL = "gpt-image-2"
+DEFAULT_MODEL = "gpt-image-2-high"
+DEFAULT_CHAT_MODEL = "cx/gpt-5.5"
+DEFAULT_BASE_URL = "http://127.0.0.1:20128/v1"
+
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "gpt-image-2-low": {
+        "display": "GPT Image 2 via 9router (Low)",
+        "speed": "~15s",
+        "strengths": "Fast iteration, lowest cost",
+        "quality": "low",
+    },
+    "gpt-image-2-medium": {
+        "display": "GPT Image 2 via 9router (Medium)",
+        "speed": "~40s",
+        "strengths": "Balanced",
+        "quality": "medium",
+    },
+    "gpt-image-2-high": {
+        "display": "GPT Image 2 via 9router (High)",
+        "speed": "~2min",
+        "strengths": "Highest fidelity, strongest prompt adherence",
+        "quality": "high",
+    },
+}
+
+_SIZES = {
+    "landscape": "1536x1024",
+    "square": "1024x1024",
+    "portrait": "1024x1536",
+}
+
+
+def _load_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not load config for 9router image gen: %s", exc)
+        return {}
+
+
+def _image_config() -> Dict[str, Any]:
+    cfg = _load_config()
+    section = cfg.get("image_gen")
+    return section if isinstance(section, dict) else {}
+
+
+def _provider_config() -> Dict[str, Any]:
+    cfg = _load_config()
+    providers = cfg.get("providers")
+    if isinstance(providers, dict):
+        provider = providers.get("9router")
+        if isinstance(provider, dict):
+            return provider
+    return {}
+
+
+def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+    cfg = _image_config()
+    sub = cfg.get("9router") if isinstance(cfg.get("9router"), dict) else {}
+    for candidate in (
+        os.environ.get("ROUTER_IMAGE_MODEL"),
+        sub.get("model") if isinstance(sub, dict) else None,
+        cfg.get("model"),
+    ):
+        if isinstance(candidate, str) and candidate in _MODELS:
+            return candidate, _MODELS[candidate]
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _resolve_base_url() -> str:
+    cfg = _image_config()
+    sub = cfg.get("9router") if isinstance(cfg.get("9router"), dict) else {}
+    candidates = [
+        os.environ.get("ROUTER_BASE_URL"),
+        sub.get("base_url") if isinstance(sub, dict) else None,
+        _provider_config().get("base_url"),
+        (_load_config().get("model") or {}).get("base_url") if isinstance(_load_config().get("model"), dict) else None,
+        DEFAULT_BASE_URL,
+    ]
+    for value in candidates:
+        if isinstance(value, str) and value.strip():
+            return value.strip().rstrip("/")
+    return DEFAULT_BASE_URL
+
+
+def _resolve_chat_model() -> str:
+    cfg = _image_config()
+    sub = cfg.get("9router") if isinstance(cfg.get("9router"), dict) else {}
+    for value in (
+        os.environ.get("ROUTER_RESPONSES_MODEL"),
+        sub.get("responses_model") if isinstance(sub, dict) else None,
+        _provider_config().get("responses_model"),
+        DEFAULT_CHAT_MODEL,
+    ):
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return DEFAULT_CHAT_MODEL
+
+
+def _literal_env(value: str) -> Optional[str]:
+    value = value.strip()
+    if value.startswith("${") and value.endswith("}"):
+        return os.environ.get(value[2:-1])
+    return value or None
+
+
+def _read_key_file(path: Path) -> Optional[str]:
+    try:
+        if path.exists():
+            value = path.read_text(encoding="utf-8").strip()
+            return value or None
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not read 9router key file %s: %s", path, exc)
+    return None
+
+
+def _resolve_api_key() -> Optional[str]:
+    cfg = _image_config()
+    sub = cfg.get("9router") if isinstance(cfg.get("9router"), dict) else {}
+    candidates = [
+        os.environ.get("ROUTER_API_KEY"),
+        os.environ.get("NINE_ROUTER_API_KEY"),
+        sub.get("api_key") if isinstance(sub, dict) else None,
+        _provider_config().get("api_key"),
+        (_load_config().get("model") or {}).get("api_key") if isinstance(_load_config().get("model"), dict) else None,
+    ]
+    for value in candidates:
+        if isinstance(value, str):
+            resolved = _literal_env(value)
+            if resolved:
+                return resolved
+
+    home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))).expanduser()
+    return _read_key_file(home / ".9router-api-key") or _read_key_file(Path("/opt/9router/.client-api-key"))
+
+
+def _image_to_data_url(ref: str) -> str:
+    if ref.startswith("data:image/") or ref.startswith("http://") or ref.startswith("https://"):
+        return ref
+    path = Path(ref).expanduser()
+    raw = path.read_bytes()
+    mime = mimetypes.guess_type(str(path))[0] or "image/png"
+    return f"data:{mime};base64,{base64.b64encode(raw).decode('ascii')}"
+
+
+def _normalize_reference_images(value: Any) -> List[str]:
+    if not value:
+        return []
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, (list, tuple)):
+        values = [v for v in value if isinstance(v, str) and v.strip()]
+    else:
+        values = []
+    return [v.strip() for v in values if v.strip()]
+
+
+def _extract_image_b64(payload: Dict[str, Any]) -> Optional[str]:
+    for item in payload.get("output") or []:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "image_generation_call" and isinstance(item.get("result"), str):
+            return item["result"]
+        for content in item.get("content") or []:
+            if isinstance(content, dict):
+                for key in ("result", "image", "image_b64", "b64_json"):
+                    value = content.get(key)
+                    if isinstance(value, str) and value:
+                        return value
+    return None
+
+
+class NineRouterImageGenProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "9router"
+
+    @property
+    def display_name(self) -> str:
+        return "9router"
+
+    def is_available(self) -> bool:
+        return bool(_resolve_api_key())
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {"id": model_id, "display": meta["display"], "speed": meta["speed"], "strengths": meta["strengths"], "price": "routed"}
+            for model_id, meta in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "9router",
+            "badge": "local",
+            "tag": "GPT Image 2 via local/OpenAI-compatible 9router Responses API",
+            "env_vars": [],
+        }
+
+    def generate(self, prompt: str, aspect_ratio: str = DEFAULT_ASPECT_RATIO, **kwargs: Any) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+        tier_id, meta = _resolve_model()
+        size = _SIZES.get(aspect, _SIZES["square"])
+
+        if not prompt:
+            return error_response(error="Prompt is required", error_type="invalid_argument", provider=self.name, model=tier_id, aspect_ratio=aspect)
+
+        api_key = _resolve_api_key()
+        if not api_key:
+            return error_response(error="No 9router API key available", error_type="auth_required", provider=self.name, model=tier_id, prompt=prompt, aspect_ratio=aspect)
+
+        content: List[Dict[str, str]] = [{"type": "input_text", "text": prompt}]
+        try:
+            for ref in _normalize_reference_images(kwargs.get("reference_images")):
+                content.append({"type": "input_image", "image_url": _image_to_data_url(ref)})
+        except Exception as exc:  # noqa: BLE001
+            return error_response(error=f"Could not load reference image: {exc}", error_type="invalid_reference_image", provider=self.name, model=tier_id, prompt=prompt, aspect_ratio=aspect)
+
+        body = {
+            "model": _resolve_chat_model(),
+            "input": [{"role": "user", "content": content}],
+            "tools": [{
+                "type": "image_generation",
+                "model": API_IMAGE_MODEL,
+                "size": size,
+                "quality": meta["quality"],
+                "output_format": "png",
+                "background": "opaque",
+            }],
+            "tool_choice": {"type": "allowed_tools", "mode": "required", "tools": [{"type": "image_generation"}]},
+        }
+        req = urllib.request.Request(
+            _resolve_base_url() + "/responses",
+            data=json.dumps(body).encode("utf-8"),
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=360) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")[:500]
+            return error_response(error=f"9router HTTP {exc.code}: {detail}", error_type="api_error", provider=self.name, model=tier_id, prompt=prompt, aspect_ratio=aspect)
+        except Exception as exc:  # noqa: BLE001
+            return error_response(error=f"9router image generation failed: {exc}", error_type="api_error", provider=self.name, model=tier_id, prompt=prompt, aspect_ratio=aspect)
+
+        b64 = _extract_image_b64(payload)
+        if not b64:
+            return error_response(error="9router response contained no image_generation_call result", error_type="empty_response", provider=self.name, model=tier_id, prompt=prompt, aspect_ratio=aspect)
+
+        try:
+            saved_path = save_b64_image(b64, prefix=f"9router_{tier_id}")
+        except Exception as exc:  # noqa: BLE001
+            return error_response(error=f"Could not save image to cache: {exc}", error_type="io_error", provider=self.name, model=tier_id, prompt=prompt, aspect_ratio=aspect)
+
+        return success_response(
+            image=str(saved_path),
+            model=tier_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider=self.name,
+            extra={"size": size, "quality": meta["quality"], "reference_images": len(content) - 1},
+        )
+
+
+def register(ctx) -> None:
+    ctx.register_image_gen_provider(NineRouterImageGenProvider())

--- a/plugins/image_gen/9router/__init__.py
+++ b/plugins/image_gen/9router/__init__.py
@@ -138,6 +138,13 @@ def _literal_env(value: str) -> Optional[str]:
     return value or None
 
 
+def _env_from_ref(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    name = value.strip()
+    return os.environ.get(name) if name else None
+
+
 def _read_key_file(path: Path) -> Optional[str]:
     try:
         if path.exists():
@@ -151,11 +158,15 @@ def _read_key_file(path: Path) -> Optional[str]:
 def _resolve_api_key() -> Optional[str]:
     cfg = _image_config()
     sub = cfg.get("9router") if isinstance(cfg.get("9router"), dict) else {}
+    provider = _provider_config()
     candidates = [
         os.environ.get("ROUTER_API_KEY"),
         os.environ.get("NINE_ROUTER_API_KEY"),
+        os.environ.get("NINEROUTER_API_KEY"),
         sub.get("api_key") if isinstance(sub, dict) else None,
-        _provider_config().get("api_key"),
+        _env_from_ref(provider.get("key_env")),
+        _env_from_ref(provider.get("api_key_env")),
+        provider.get("api_key"),
         (_load_config().get("model") or {}).get("api_key") if isinstance(_load_config().get("model"), dict) else None,
     ]
     for value in candidates:

--- a/plugins/image_gen/9router/plugin.yaml
+++ b/plugins/image_gen/9router/plugin.yaml
@@ -1,0 +1,5 @@
+name: 9router
+version: 1.0.0
+description: "9router image generation backend (GPT Image 2 via Responses image_generation tool, with reference-image support). Saves generated images to $HERMES_HOME/cache/images/."
+author: Hermes Agent
+kind: backend

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -793,6 +793,46 @@ def test_named_custom_provider_uses_key_env_from_providers_dict(monkeypatch):
     assert resolved["model"] == "acme-large"
 
 
+def test_named_custom_provider_uses_api_key_env_alias_from_providers_dict(monkeypatch):
+    """providers dict entries with api_key_env should resolve like key_env."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("MYCORP_API_KEY", "env-secret")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "mycorp-proxy": {
+                    "base_url": "https://proxy.example.com/v1",
+                    "default_model": "acme-large",
+                    "api_key_env": "MYCORP_API_KEY",
+                    "name": "MyCorp Proxy",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="mycorp-proxy")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://proxy.example.com/v1"
+    assert resolved["api_key"] == "env-secret"
+    assert resolved["requested_provider"] == "mycorp-proxy"
+    assert resolved["source"] == "custom_provider:MyCorp Proxy"
+    assert resolved["model"] == "acme-large"
+
+
 def test_named_custom_provider_same_url_uses_matching_key_env_and_api_mode(monkeypatch):
     """Named custom providers on one gateway must keep their own credentials and protocol."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/tests/plugins/image_gen/test_9router_provider.py
+++ b/tests/plugins/image_gen/test_9router_provider.py
@@ -55,11 +55,37 @@ class TestAvailability:
     def test_requires_key(self, monkeypatch):
         monkeypatch.delenv("ROUTER_API_KEY", raising=False)
         monkeypatch.delenv("NINE_ROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("NINEROUTER_API_KEY", raising=False)
         monkeypatch.setattr(plugin, "_read_key_file", lambda path: None)
         assert plugin.NineRouterImageGenProvider().is_available() is False
 
     def test_available_with_env_key(self, monkeypatch):
         monkeypatch.setenv("ROUTER_API_KEY", "test-key")
+        assert plugin.NineRouterImageGenProvider().is_available() is True
+
+    def test_available_with_compact_env_key(self, monkeypatch):
+        monkeypatch.delenv("ROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("NINE_ROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("NINEROUTER_API_KEY", "test-key")
+        assert plugin.NineRouterImageGenProvider().is_available() is True
+
+    def test_available_with_provider_api_key_env(self, monkeypatch):
+        monkeypatch.delenv("ROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("NINE_ROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("NINEROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("CUSTOM_ROUTER_KEY", "test-key")
+        monkeypatch.setattr(
+            plugin,
+            "_load_config",
+            lambda: {
+                "providers": {
+                    "9router": {
+                        "base_url": "http://router.local/v1",
+                        "api_key_env": "CUSTOM_ROUTER_KEY",
+                    }
+                }
+            },
+        )
         assert plugin.NineRouterImageGenProvider().is_available() is True
 
 

--- a/tests/plugins/image_gen/test_9router_provider.py
+++ b/tests/plugins/image_gen/test_9router_provider.py
@@ -1,0 +1,103 @@
+"""Tests for the bundled 9router image_gen plugin."""
+
+from __future__ import annotations
+
+import base64
+import importlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+plugin = importlib.import_module("plugins.image_gen.9router")
+
+_PNG_HEX = (
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000d49444154789c6300010000000500010d0a2db40000000049454e44"
+    "ae426082"
+)
+
+
+def _b64_png() -> str:
+    return base64.b64encode(bytes.fromhex(_PNG_HEX)).decode()
+
+
+@pytest.fixture(autouse=True)
+def _tmp_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.setenv("ROUTER_API_KEY", "test-key")
+    monkeypatch.setenv("ROUTER_BASE_URL", "http://router.local/v1")
+    monkeypatch.setenv("ROUTER_IMAGE_MODEL", "gpt-image-2-low")
+    monkeypatch.setenv("ROUTER_RESPONSES_MODEL", "cx/test")
+    return plugin.NineRouterImageGenProvider()
+
+
+class TestMetadata:
+    def test_name(self, provider):
+        assert provider.name == "9router"
+        assert provider.default_model() == "gpt-image-2-high"
+
+    def test_models(self, provider):
+        assert [m["id"] for m in provider.list_models()] == [
+            "gpt-image-2-low",
+            "gpt-image-2-medium",
+            "gpt-image-2-high",
+        ]
+
+
+class TestAvailability:
+    def test_requires_key(self, monkeypatch):
+        monkeypatch.delenv("ROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("NINE_ROUTER_API_KEY", raising=False)
+        monkeypatch.setattr(plugin, "_read_key_file", lambda path: None)
+        assert plugin.NineRouterImageGenProvider().is_available() is False
+
+    def test_available_with_env_key(self, monkeypatch):
+        monkeypatch.setenv("ROUTER_API_KEY", "test-key")
+        assert plugin.NineRouterImageGenProvider().is_available() is True
+
+
+class TestGenerate:
+    def test_sends_reference_image_and_saves_result(self, provider, tmp_path, monkeypatch):
+        ref = tmp_path / "ref.png"
+        ref.write_bytes(bytes.fromhex(_PNG_HEX))
+        captured = {}
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return json.dumps({"output": [{"type": "image_generation_call", "result": _b64_png()}]}).encode()
+
+        def fake_urlopen(req, timeout):
+            captured["url"] = req.full_url
+            captured["headers"] = dict(req.header_items())
+            captured["body"] = json.loads(req.data.decode())
+            captured["timeout"] = timeout
+            return FakeResponse()
+
+        monkeypatch.setattr(plugin.urllib.request, "urlopen", fake_urlopen)
+        result = provider.generate("make it shiny", aspect_ratio="square", reference_images=[str(ref)])
+
+        assert result["success"] is True
+        assert result["provider"] == "9router"
+        assert result["model"] == "gpt-image-2-low"
+        assert Path(result["image"]).exists()
+        assert captured["url"] == "http://router.local/v1/responses"
+        assert captured["body"]["model"] == "cx/test"
+        content = captured["body"]["input"][0]["content"]
+        assert content[0] == {"type": "input_text", "text": "make it shiny"}
+        assert content[1]["type"] == "input_image"
+        assert content[1]["image_url"].startswith("data:image/png;base64,")
+        assert captured["body"]["tools"][0]["type"] == "image_generation"
+        assert captured["body"]["tools"][0]["quality"] == "low"

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -363,11 +363,12 @@ class TestAspectRatioNormalization:
 
 class TestRegistryIntegration:
 
-    def test_schema_exposes_only_prompt_and_aspect_ratio_to_agent(self, image_tool):
-        """The agent-facing schema must stay tight — model selection is a
-        user-level config choice, not an agent-level arg."""
+    def test_schema_exposes_generation_and_reference_inputs_to_agent(self, image_tool):
+        """The agent-facing schema exposes prompt/size plus optional visual
+        references; model selection remains a user-level config choice."""
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
-        assert set(props.keys()) == {"prompt", "aspect_ratio"}
+        assert set(props.keys()) == {"prompt", "aspect_ratio", "reference_image", "reference_images"}
+        assert props["reference_images"]["items"]["type"] == "string"
 
     def test_aspect_ratio_enum_is_three_values(self, image_tool):
         enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["aspect_ratio"]["enum"]

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -906,6 +906,15 @@ IMAGE_GENERATE_SCHEMA = {
                 "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
             },
+            "reference_images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional local image paths or data/image URLs to use as visual references/context for image editing or likeness/style preservation.",
+            },
+            "reference_image": {
+                "type": "string",
+                "description": "Optional single local image path or data/image URL to use as visual reference/context.",
+            },
         },
         "required": ["prompt"],
     },
@@ -951,7 +960,7 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, reference_images=None):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -1006,6 +1015,8 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
 
     try:
         kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
+        if reference_images:
+            kwargs["reference_images"] = reference_images
         if configured_model:
             kwargs["model"] = configured_model
         result = provider.generate(**kwargs)
@@ -1035,10 +1046,16 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    reference_images = args.get("reference_images") or []
+    single_reference = args.get("reference_image")
+    if single_reference:
+        reference_images = [single_reference] + (reference_images if isinstance(reference_images, list) else [])
+    if isinstance(reference_images, str):
+        reference_images = [reference_images]
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio, reference_images=reference_images)
     if dispatched is not None:
         return dispatched
 


### PR DESCRIPTION
## Summary
- add a 9router image generation provider plugin
- allow HERMES_SESSION_TOKEN to override the generated dashboard session token
- update image generation tests for provider routing

## Tests
- python -m pytest -o addopts='' tests/plugins/image_gen/test_9router_provider.py tests/tools/test_image_generation.py