### PR TITLE
fix(codex_responses_adapter): drop cross-issuer message ids on replay

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -435,8 +435,30 @@ def _chat_messages_to_responses_input(
                             "status": _normalize_responses_message_status(raw_item.get("status")),
                             "content": normalized_content_parts,
                         }
+                        # Server-issued message ids are sealed to the
+                        # Responses endpoint that minted them (same
+                        # principle as reasoning.encrypted_content).
+                        # Replaying a Copilot-issued ``msg_*``/``fc_*`` id
+                        # against OpenAI's /v1/responses fails with
+                        # HTTP 400 ``Invalid input[N].id: string too long``
+                        # (Copilot ids commonly exceed OpenAI''s 64-char
+                        # cap). Cross-issuer guard: when the active
+                        # endpoint differs from the issuer that minted
+                        # this item, drop the id and let the API assign
+                        # a fresh one. Mirrors the reasoning-item guard
+                        # earlier in this function.
                         item_id = raw_item.get("id")
-                        if isinstance(item_id, str) and item_id.strip():
+                        item_issuer = raw_item.get("_issuer_kind")
+                        cross_issuer = (
+                            current_issuer_kind is not None
+                            and item_issuer is not None
+                            and item_issuer != current_issuer_kind
+                        )
+                        if (
+                            isinstance(item_id, str)
+                            and item_id.strip()
+                            and not cross_issuer
+                        ):
                             replay_item["id"] = item_id.strip()
                         phase = raw_item.get("phase")
                         if isinstance(phase, str) and phase.strip():
@@ -691,7 +713,25 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
             }
             item_id = item.get("id")
             if isinstance(item_id, str) and item_id.strip():
-                normalized_item["id"] = item_id.strip()
+                stripped_id = item_id.strip()
+                # OpenAI Responses API rejects input[N].id strings longer
+                # than 64 chars with HTTP 400 (string_above_max_length).
+                # Copilot/GitHub Responses ids routinely exceed this cap
+                # (200-400+ chars). When a session falls back from
+                # Copilot to OpenAI mid-conversation, replayed message
+                # items carry Copilot ids that would poison every
+                # subsequent turn. Drop oversize ids defensively — the
+                # API will mint a fresh id for this item.
+                if len(stripped_id) <= 64:
+                    normalized_item["id"] = stripped_id
+                else:
+                    logger.debug(
+                        "Dropping oversize input message id (len=%d > 64) "
+                        "— likely a cross-issuer Responses replay "
+                        "(e.g. Copilot -> OpenAI fallback). The API will "
+                        "assign a new id.",
+                        len(stripped_id),
+                    )
             phase = item.get("phase")
             if isinstance(phase, str) and phase.strip():
                 normalized_item["phase"] = phase.strip()
@@ -1107,6 +1147,13 @@ def _normalize_codex_response(
                     "status": _normalize_responses_message_status(item_status),
                     "content": [{"type": "output_text", "text": message_text}],
                 }
+                # Stamp the issuer so a later cross-provider fallback can
+                # detect that this message item (and its server-issued id)
+                # belongs to a different Responses endpoint. Mirrors the
+                # reasoning-item stamping below; consumed by the
+                # cross-issuer guard in _chat_messages_to_responses_input.
+                if issuer_kind:
+                    raw_message_item["_issuer_kind"] = issuer_kind
                 item_id = getattr(item, "id", None)
                 if isinstance(item_id, str) and item_id:
                     raw_message_item["id"] = item_id

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -174,3 +174,218 @@ def test_normalize_codex_response_failed_with_message_only():
     )
     with pytest.raises(RuntimeError, match=r"^model error$"):
         _normalize_codex_response(response)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Regression: cross-issuer message-id replay
+# ─────────────────────────────────────────────────────────────────────
+#
+# Symptom in the wild (May 2026, hermes-gateway production):
+#
+#   provider=openai-api base_url=https://api.openai.com/v1/ model=gpt-5.4-mini
+#   HTTP 400: Invalid 'input[8].id': string too long.
+#   Expected a string with maximum length 64, but got a string with length 408.
+#
+# Root cause: when a session uses Copilot/GitHub Responses primary and
+# falls back to OpenAI Responses mid-conversation, hermes was replaying
+# the persisted ``codex_message_items`` verbatim — including the long
+# Copilot-issued ``id`` field which OpenAI's Responses API rejects with
+# ``string_above_max_length`` (cap is 64). The same root cause already
+# bites reasoning items via the cross-issuer encrypted_content guard.
+#
+# Fix is three-pronged:
+#   1. _normalize_codex_response stamps each message item with an
+#      ``_issuer_kind`` mirroring the existing reasoning-item stamp.
+#   2. _chat_messages_to_responses_input drops the id when the active
+#      endpoint's issuer differs from the stamp (principled fix).
+#   3. _preflight_codex_input_items drops any id > 64 chars as a
+#      defensive backstop (catches legacy unstamped items).
+#
+from agent.codex_responses_adapter import (
+    _chat_messages_to_responses_input,
+    _preflight_codex_input_items,
+)
+
+
+# ── Edit 3: _normalize_codex_response stamps message items ──────────
+
+def test_normalize_codex_response_stamps_message_items_with_issuer():
+    """Each persisted message item should carry an _issuer_kind so a
+    later cross-provider fallback can detect that its id is sealed
+    to a different Responses endpoint."""
+    response = SimpleNamespace(
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="message",
+                id="msg_" + "a" * 400,  # Copilot-style long opaque id
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="hello")],
+            ),
+        ],
+    )
+    assistant_message, _ = _normalize_codex_response(
+        response, issuer_kind="github_responses"
+    )
+    items = assistant_message.codex_message_items
+    assert len(items) == 1
+    assert items[0]["_issuer_kind"] == "github_responses"
+    # id is still captured for local persistence; it's the *replay* path
+    # that filters based on the issuer stamp.
+    assert items[0]["id"].startswith("msg_")
+
+
+def test_normalize_codex_response_omits_issuer_stamp_when_unknown():
+    response = SimpleNamespace(
+        status="completed",
+        output=[
+            SimpleNamespace(
+                type="message",
+                id="msg_short",
+                role="assistant",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text="hi")],
+            ),
+        ],
+    )
+    assistant_message, _ = _normalize_codex_response(response)
+    items = assistant_message.codex_message_items
+    assert "_issuer_kind" not in items[0]
+
+
+# ── Edit 1: converter drops id on cross-issuer replay ────────────────
+
+def _msg_with_codex_item(item_id: str, issuer: str | None = None):
+    item = {
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "content": [{"type": "output_text", "text": "ok"}],
+    }
+    if item_id is not None:
+        item["id"] = item_id
+    if issuer is not None:
+        item["_issuer_kind"] = issuer
+    return {
+        "role": "assistant",
+        "content": "ok",
+        "codex_message_items": [item],
+    }
+
+
+def test_converter_drops_message_id_on_cross_issuer_replay():
+    """Long Copilot-issued id replayed against OpenAI must be dropped."""
+    long_copilot_id = "msg_" + "x" * 400
+    messages = [_msg_with_codex_item(long_copilot_id, issuer="github_responses")]
+    items = _chat_messages_to_responses_input(
+        messages,
+        current_issuer_kind="other:https://api.openai.com/v1/",
+    )
+    msg_items = [i for i in items if i.get("type") == "message"]
+    assert len(msg_items) == 1
+    assert "id" not in msg_items[0], (
+        f"cross-issuer message id should be dropped; got {msg_items[0].get('id')!r}"
+    )
+
+
+def test_converter_keeps_message_id_on_same_issuer_replay():
+    """Same-issuer replay (Copilot -> Copilot) must preserve the id so
+    prefix caching keeps working."""
+    item_id = "msg_short_id_ok"
+    messages = [_msg_with_codex_item(item_id, issuer="github_responses")]
+    items = _chat_messages_to_responses_input(
+        messages,
+        current_issuer_kind="github_responses",
+    )
+    msg_items = [i for i in items if i.get("type") == "message"]
+    assert msg_items[0].get("id") == item_id
+
+
+def test_converter_keeps_message_id_when_no_issuer_context():
+    """Backwards-compat: legacy items without _issuer_kind stamp must
+    pass through unchanged (matches reasoning-item behavior)."""
+    item_id = "msg_legacy_unstamped"
+    messages = [_msg_with_codex_item(item_id, issuer=None)]
+    items = _chat_messages_to_responses_input(
+        messages,
+        current_issuer_kind="other:https://api.openai.com/v1/",
+    )
+    msg_items = [i for i in items if i.get("type") == "message"]
+    assert msg_items[0].get("id") == item_id
+
+
+# ── Edit 2: preflight defensive cap on oversize ids ─────────────────
+
+def test_preflight_drops_oversize_message_id():
+    """Defensive backstop — even if cross-issuer stamping is absent,
+    a >64 char id must be dropped because the OpenAI Responses API
+    rejects it with HTTP 400 string_above_max_length."""
+    long_id = "msg_" + "y" * 200  # 204 chars total
+    raw = [{
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "id": long_id,
+        "content": [{"type": "output_text", "text": "ok"}],
+    }]
+    normalized = _preflight_codex_input_items(raw)
+    assert len(normalized) == 1
+    assert "id" not in normalized[0], (
+        "oversize id (>64) must be dropped to avoid OpenAI 400 string_above_max_length"
+    )
+    # Content + role still intact
+    assert normalized[0]["role"] == "assistant"
+    assert normalized[0]["content"][0]["text"] == "ok"
+
+
+def test_preflight_keeps_within_limit_message_id():
+    """Boundary: exactly 64-char id should pass through (API spec limit)."""
+    sixty_four_char_id = "m" + "a" * 63  # 64 chars
+    assert len(sixty_four_char_id) == 64
+    raw = [{
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "id": sixty_four_char_id,
+        "content": [{"type": "output_text", "text": "ok"}],
+    }]
+    normalized = _preflight_codex_input_items(raw)
+    assert normalized[0]["id"] == sixty_four_char_id
+
+
+def test_preflight_drops_65_char_id():
+    """Boundary: 65-char id (one over) must be dropped."""
+    sixty_five = "m" + "a" * 64  # 65 chars
+    assert len(sixty_five) == 65
+    raw = [{
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "id": sixty_five,
+        "content": [{"type": "output_text", "text": "ok"}],
+    }]
+    normalized = _preflight_codex_input_items(raw)
+    assert "id" not in normalized[0]
+
+
+# ── End-to-end: full Copilot→OpenAI replay shouldn't emit any oversize ids
+def test_end_to_end_copilot_to_openai_fallback_strips_long_ids():
+    """Full pipeline test: an assistant message persisted from Copilot
+    (with a long opaque id and _issuer_kind stamp) goes through the
+    converter and preflight on its way to OpenAI's Responses API.
+    No item in the final input may carry an id >64 chars."""
+    long_copilot_id = "msg_" + "z" * 400
+    messages = [_msg_with_codex_item(long_copilot_id, issuer="github_responses")]
+    converted = _chat_messages_to_responses_input(
+        messages,
+        current_issuer_kind="other:https://api.openai.com/v1/",
+    )
+    normalized = _preflight_codex_input_items(converted)
+    for idx, item in enumerate(normalized):
+        item_id = item.get("id")
+        if isinstance(item_id, str):
+            assert len(item_id) <= 64, (
+                f"input[{idx}].id is {len(item_id)} chars — would trigger "
+                f"OpenAI 400 string_above_max_length"
+            )


### PR DESCRIPTION
## What does this PR do?

In production (`hermes-gateway.service` on hermes-agent v0.15.1) we kept hitting:

```
provider=openai-api base_url=https://api.openai.com/v1/ model=gpt-5.4-mini
HTTP 400: Invalid 'input[8].id': string too long.
Expected a string with maximum length 64, but got a string with length 408.
```

**Root cause.** When a session uses GitHub Copilot Responses as the primary endpoint and falls back to OpenAI Responses mid-conversation, the persisted `codex_message_items` were replayed verbatim — including the long Copilot-issued `id` field. OpenAI's Responses API hard-caps `input[N].id` at 64 chars (`string_above_max_length`); Copilot ids routinely exceed 200–400 chars. Once one such id slipped in, every subsequent fallback turn was poisoned by the same 400 and the session became unusable.

This is the same family of bug as `reasoning.encrypted_content` cross-issuer poisoning, already fixed by #33156 / `9c69204d8` (which superseded #31629 and #32062). Server-issued message ids are sealed to the endpoint that minted them in exactly the same way reasoning content is.

**Why this approach.** Three-pronged fix mirroring the existing reasoning-item architecture so the two cross-issuer-replay code paths stay parallel and easy to reason about:

1. **`_normalize_codex_response`** stamps each persisted message item with `_issuer_kind` so a later cross-provider fallback knows the id belongs to a different endpoint (mirrors lines 1131–1132 for reasoning items).
2. **`_chat_messages_to_responses_input`** drops the `id` when the active endpoint's issuer differs from the stamp (mirrors lines 366–381 for reasoning items).
3. **`_preflight_codex_input_items`** defensively drops any `id` > 64 chars regardless of source. Backstops legacy unstamped items from sessions persisted before the stamping change, and any future code path that bypasses the converter.

## Related Issue

Fixes #27038

Closely related (same family, prior reasoning-item fixes whose architecture this mirrors): #10788, #33156, #31629, #32062.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `agent/codex_responses_adapter.py` — three call sites (+49 / −2):
  - `_normalize_codex_response` (~L1112): stamp `_issuer_kind` on persisted message items
  - `_chat_messages_to_responses_input` (~L435): drop `id` when stamp ≠ current issuer
  - `_preflight_codex_input_items` (~L694): drop `id` when `len(stripped_id) > 64`
- `tests/agent/test_codex_responses_adapter.py` — +9 new regression tests (+215 / −0)

## How to Test

```bash
# 1. The new tests directly
scripts/run_tests.sh tests/agent/test_codex_responses_adapter.py

# 2. Full blast radius (transports, run_agent, provider parity, multimodal, xai recovery)
scripts/run_tests.sh \
  tests/agent/test_codex_responses_adapter.py \
  tests/agent/transports/test_codex_transport.py \
  tests/run_agent/test_run_agent.py \
  tests/run_agent/test_provider_parity.py \
  tests/run_agent/test_run_agent_codex_responses.py \
  tests/run_agent/test_codex_xai_oauth_recovery.py \
  tests/run_agent/test_codex_multimodal_tool_result.py \
  tests/run_agent/test_run_agent_multimodal_prologue.py

# 3. Full CI-equivalent run
scripts/run_tests.sh
```

**Results:** 653 passed across the blast radius (12 pre-existing + 9 new). Full suite: 27,439 passed, 18 failures — **all 18 reproduce identically on unmodified `origin/main`** and none touch `agent/`, `run_agent/`, or any codex/responses path. They live in `acp/` (collection errors from missing optional deps), `tools/test_process_registry.py` (`ptyprocess` missing in env), `honcho_plugin/test_pin_peer_name.py`, `gateway/test_wecom_callback.py`, `hermes_cli/test_*`. Smell-tested by checking out the two modified files at `origin/main` and re-running the failing files — same 5/5 failures reproduce.

### New regression tests

| Test | Layer |
|---|---|
| `test_normalize_codex_response_stamps_message_items_with_issuer` | Edit 3 — stamping |
| `test_normalize_codex_response_omits_issuer_stamp_when_unknown` | Edit 3 — no stamp when source unknown |
| `test_converter_drops_message_id_on_cross_issuer_replay` | Edit 1 — primary fix |
| `test_converter_keeps_message_id_on_same_issuer_replay` | Edit 1 — preserves prefix caching on same-issuer |
| `test_converter_keeps_message_id_when_no_issuer_context` | Edit 1 — backwards compat for legacy unstamped items |
| `test_preflight_drops_oversize_message_id` | Edit 2 — defensive backstop |
| `test_preflight_keeps_within_limit_message_id` | Edit 2 — boundary (exactly 64) |
| `test_preflight_drops_65_char_id` | Edit 2 — boundary (65, one over) |
| `test_end_to_end_copilot_to_openai_fallback_strips_long_ids` | Full pipeline invariant: no id >64 reaches the wire |

### Manual verification

Deployed to a production gateway (`hermes-gateway.service` on hermes-agent v0.15.1, head `5921d6678`). The same Copilot→OpenAI fallback path that was 400'ing pre-patch now completes cleanly; `journalctl -u hermes-gateway.service | grep "string_above_max_length"` returns empty since deployment.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(codex_responses_adapter): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` (the CI-equivalent runner) — all failures observed are pre-existing on `origin/main` and unrelated to the modified code paths; see "How to Test" above
- [x] I've added tests for my changes (9 new regression cases)
- [x] I've tested on my platform: **Linux x86_64 (Arch, kernel 6.x), Python 3.11 (installed venv) + Python 3.14 (dev clone)**

### Documentation & Housekeeping

- [x] N/A — internal data-transform fix; no public API, README, or `docs/` change
- [x] N/A — no new/changed config keys; `cli-config.yaml.example` unaffected
- [x] N/A — no architecture/workflow change; `CONTRIBUTING.md` / `AGENTS.md` unaffected
- [x] Cross-platform considered — pure dict-item transformation, no file I/O / process / terminal handling
- [x] N/A — no tool descriptions or schemas changed

## Screenshots / Logs

**Before** (one failing turn, real production log):
```
ERROR run_agent: Provider call failed (provider=openai-api): 400 Bad Request
{
  "error": {
    "message": "Invalid 'input[8].id': string too long. Expected a string with
                maximum length 64, but got a string with length 408.",
    "type": "invalid_request_error",
    "code": "string_above_max_length"
  }
}
```

**After** (same session, same Copilot→OpenAI fallback path):
```
INFO  run_agent: Provider call complete (provider=openai-api) status=200 ...
```

`grep "string_above_max_length" journalctl-since-deploy.log` → 0 hits.
