### PR TITLE
feat: add investment review brief helper

### DIFF
--- a/docs/plans/investment-review-brief.md
+++ b/docs/plans/investment-review-brief.md
@@ -1,0 +1,78 @@
+# Investment Review Brief Helper Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a local-first helper script that turns Joe's personal investment position JSON/YAML/CSV files into a concise review brief with risk, stale-review, and missing-thesis flags.
+
+**Architecture:** Create one standalone script under `scripts/` with pure parsing/scoring helpers plus a tiny CLI. Keep data local, deterministic, and reversible. Add focused tests under `tests/scripts/` using temp fixture files.
+
+**Tech Stack:** Python standard library + optional PyYAML when YAML inputs are used; pytest via `scripts/run_tests.sh` or documented direct-pytest fallback if wrapper dependencies are incomplete.
+
+---
+
+## Task 1: Write failing tests for portfolio loading and review brief behavior
+
+**Objective:** Specify the desired script behavior before implementation.
+
+**Files:**
+- Create: `tests/scripts/test_investment_review_brief.py`
+- Create later: `scripts/investment_review_brief.py`
+
+**Step 1: Write failing tests**
+
+Cover:
+- JSON input produces a Traditional Chinese brief with summary, risks, missing thesis, and overdue review sections.
+- `--silent-if-clear` prints exact `[SILENT]` when no positions need attention.
+- CSV input works without third-party dependencies.
+- Invalid / empty input returns a useful non-zero CLI error.
+
+**Step 2: Run test to verify failure**
+
+Run: `python -m pytest tests/scripts/test_investment_review_brief.py -q -o 'addopts='`
+Expected: FAIL because `scripts/investment_review_brief.py` does not exist.
+
+## Task 2: Implement minimal parser, analysis, renderer, and CLI
+
+**Objective:** Make the tests pass with the smallest useful helper.
+
+**Files:**
+- Create: `scripts/investment_review_brief.py`
+
+**Step 1: Implement pure helpers**
+
+- `load_positions(path)` for JSON/YAML/CSV.
+- `analyze_positions(positions, as_of, review_after_days, concentration_threshold)`.
+- `render_brief(analysis, silent_if_clear)`.
+
+**Step 2: Implement CLI**
+
+Arguments:
+- positional `path`
+- `--as-of YYYY-MM-DD`
+- `--review-after-days N`
+- `--concentration-threshold FLOAT`
+- `--silent-if-clear`
+
+**Step 3: Run focused tests**
+
+Run: `python -m pytest tests/scripts/test_investment_review_brief.py -q -o 'addopts='`
+Expected: PASS.
+
+## Task 3: Smoke test CLI and finalize
+
+**Objective:** Verify user-facing CLI behavior and prepare PR.
+
+**Files:**
+- Modify: none beyond script/tests.
+
+**Step 1: Run CLI smoke**
+
+Run a temp JSON fixture through `python scripts/investment_review_brief.py ...` and inspect output.
+
+**Step 2: Run git diff/status**
+
+Ensure only intended files changed.
+
+**Step 3: Commit and open PR**
+
+Commit message: `feat: add investment review brief helper`.

--- a/scripts/investment_review_brief.py
+++ b/scripts/investment_review_brief.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Generate a local-first investment portfolio review brief.
+
+Input files may be JSON, YAML, or CSV. Expected fields per position:
+name, value, cost_basis, category, thesis, last_reviewed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+SILENT_MARKER = "[SILENT]"
+
+
+@dataclass(frozen=True)
+class Position:
+    name: str
+    value: float
+    cost_basis: float | None = None
+    category: str = "uncategorized"
+    thesis: str = ""
+    last_reviewed: date | None = None
+
+
+@dataclass(frozen=True)
+class ReviewAnalysis:
+    as_of: date
+    total_value: float
+    unrealized_pnl: float | None
+    positions: list[dict[str, Any]]
+    concentration_flags: list[dict[str, Any]]
+    missing_thesis: list[dict[str, Any]]
+    stale_reviews: list[dict[str, Any]]
+
+    @property
+    def needs_attention(self) -> bool:
+        return bool(self.concentration_flags or self.missing_thesis or self.stale_reviews)
+
+
+def _parse_date(value: Any) -> date | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, date):
+        return value
+    text = str(value).strip()
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    raise ValueError(f"Invalid date {value!r}; expected YYYY-MM-DD")
+
+
+def _parse_float(value: Any, field: str, name: str) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(str(value).replace(",", ""))
+    except ValueError as exc:
+        raise ValueError(f"Position {name!r} has invalid {field}: {value!r}") from exc
+
+
+def _coerce_position(raw: dict[str, Any], index: int) -> Position:
+    name = str(raw.get("name") or raw.get("asset") or "").strip()
+    if not name:
+        raise ValueError(f"Position #{index} is missing required field: name")
+
+    value = _parse_float(raw.get("value"), "value", name)
+    if value is None:
+        raise ValueError(f"Position {name!r} is missing required field: value")
+    if value < 0:
+        raise ValueError(f"Position {name!r} has negative value: {value}")
+
+    return Position(
+        name=name,
+        value=value,
+        cost_basis=_parse_float(raw.get("cost_basis"), "cost_basis", name),
+        category=str(raw.get("category") or "uncategorized").strip() or "uncategorized",
+        thesis=str(raw.get("thesis") or "").strip(),
+        last_reviewed=_parse_date(raw.get("last_reviewed") or raw.get("reviewed_at")),
+    )
+
+
+def _load_yaml(path: Path) -> Any:
+    try:
+        import yaml  # type: ignore
+    except ImportError as exc:  # pragma: no cover - depends on local environment
+        raise ValueError("YAML input requires PyYAML; use JSON/CSV or install pyyaml") from exc
+    with path.open("r", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def load_positions(path: Path) -> list[Position]:
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    elif suffix in {".yaml", ".yml"}:
+        data = _load_yaml(path)
+    elif suffix == ".csv":
+        with path.open("r", encoding="utf-8", newline="") as fh:
+            data = list(csv.DictReader(fh))
+    else:
+        raise ValueError("Unsupported input format; use .json, .yaml, .yml, or .csv")
+
+    if isinstance(data, dict):
+        data = data.get("positions")
+    if not isinstance(data, list) or not data:
+        raise ValueError("No investment positions found; expected a non-empty list")
+
+    return [_coerce_position(dict(item), index) for index, item in enumerate(data, start=1)]
+
+
+def analyze_positions(
+    positions: list[Position],
+    *,
+    as_of: date,
+    review_after_days: int = 90,
+    concentration_threshold: float = 0.5,
+) -> ReviewAnalysis:
+    total = sum(position.value for position in positions)
+    if total <= 0:
+        raise ValueError("Total portfolio value must be greater than zero")
+
+    total_cost = sum(position.cost_basis for position in positions if position.cost_basis is not None)
+    has_cost_basis = any(position.cost_basis is not None for position in positions)
+    rendered_positions: list[dict[str, Any]] = []
+    concentration_flags: list[dict[str, Any]] = []
+    missing_thesis: list[dict[str, Any]] = []
+    stale_reviews: list[dict[str, Any]] = []
+
+    for position in sorted(positions, key=lambda item: item.value, reverse=True):
+        weight = position.value / total
+        pnl = None if position.cost_basis is None else position.value - position.cost_basis
+        row = {
+            "name": position.name,
+            "category": position.category,
+            "value": position.value,
+            "weight": weight,
+            "pnl": pnl,
+            "thesis": position.thesis,
+            "last_reviewed": position.last_reviewed,
+        }
+        rendered_positions.append(row)
+
+        if weight > concentration_threshold:
+            concentration_flags.append(row)
+        if not position.thesis:
+            missing_thesis.append(row)
+        if position.last_reviewed is None:
+            stale_reviews.append({**row, "days_since_review": None})
+        else:
+            days_since_review = (as_of - position.last_reviewed).days
+            if days_since_review > review_after_days:
+                stale_reviews.append({**row, "days_since_review": days_since_review})
+
+    return ReviewAnalysis(
+        as_of=as_of,
+        total_value=total,
+        unrealized_pnl=(total - total_cost) if has_cost_basis else None,
+        positions=rendered_positions,
+        concentration_flags=concentration_flags,
+        missing_thesis=missing_thesis,
+        stale_reviews=stale_reviews,
+    )
+
+
+def _money(value: float) -> str:
+    return f"{value:,.2f}"
+
+
+def _pct(value: float) -> str:
+    return f"{value * 100:.1f}%"
+
+
+def render_brief(analysis: ReviewAnalysis, *, silent_if_clear: bool = False) -> str:
+    if silent_if_clear and not analysis.needs_attention:
+        return SILENT_MARKER
+
+    lines = [
+        "# 投資組合 Review Brief",
+        "",
+        "## TL;DR",
+        f"- Fact / verified：總資產：{_money(analysis.total_value)}；部位數：{len(analysis.positions)}。",
+    ]
+    if analysis.unrealized_pnl is not None:
+        lines.append(f"- Fact / verified：未實現損益：{_money(analysis.unrealized_pnl)}。")
+    lines.append(
+        f"- Recommendation：優先處理 {len(analysis.concentration_flags)} 個集中風險、"
+        f"{len(analysis.missing_thesis)} 個缺少 thesis、{len(analysis.stale_reviews)} 個過期 review。"
+    )
+
+    lines.extend(["", "## 部位概覽"])
+    for row in analysis.positions:
+        pnl_text = "n/a" if row["pnl"] is None else _money(row["pnl"])
+        lines.append(
+            f"- {row['name']} — {_pct(row['weight'])} / {_money(row['value'])} "
+            f"/ {row['category']} / PnL {pnl_text}"
+        )
+
+    lines.extend(["", "## 需要 Joe review 的事項"])
+    if not analysis.needs_attention:
+        lines.append("- Fact / verified：目前沒有超過門檻的集中風險、缺少 thesis 或過期 review。")
+    for row in analysis.concentration_flags:
+        lines.append(f"- 集中風險：{row['name']} — {_pct(row['weight'])}。")
+    for row in analysis.missing_thesis:
+        lines.append(f"- 缺少 thesis：{row['name']}。")
+    for row in analysis.stale_reviews:
+        days = row.get("days_since_review")
+        if days is None:
+            lines.append(f"- 過期 review：{row['name']}（沒有 last_reviewed）。")
+        else:
+            lines.append(f"- 過期 review：{row['name']}（{days} 天未 review）。")
+
+    lines.extend(
+        [
+            "",
+            "## 建議下一步",
+            "- 補齊缺少 thesis 的部位：一句話 thesis、失效條件、下一次 review 日期。",
+            "- 對集中部位設定可量化 action：加倉、減倉、hedge 或維持，但要寫明條件。",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate a local investment review brief.")
+    parser.add_argument("path", type=Path, help="Portfolio file (.json, .yaml, .yml, .csv)")
+    parser.add_argument("--as-of", default=date.today().isoformat(), help="Review date (YYYY-MM-DD)")
+    parser.add_argument("--review-after-days", type=int, default=90)
+    parser.add_argument("--concentration-threshold", type=float, default=0.5)
+    parser.add_argument("--silent-if-clear", action="store_true", help="Print exact [SILENT] when no flags exist")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        positions = load_positions(args.path)
+        analysis = analyze_positions(
+            positions,
+            as_of=_parse_date(args.as_of) or date.today(),
+            review_after_days=args.review_after_days,
+            concentration_threshold=args.concentration_threshold,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(render_brief(analysis, silent_if_clear=args.silent_if_clear))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_investment_review_brief.py
+++ b/tests/scripts/test_investment_review_brief.py
@@ -1,0 +1,129 @@
+import csv
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "investment_review_brief.py"
+
+
+def run_script(*args):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=SCRIPT.parents[1],
+    )
+
+
+def test_json_input_flags_concentration_missing_thesis_and_stale_reviews(tmp_path):
+    positions = [
+        {
+            "name": "BTC",
+            "category": "crypto",
+            "value": 70000,
+            "cost_basis": 50000,
+            "thesis": "Institutional adoption keeps BTC as portfolio ballast.",
+            "last_reviewed": "2026-01-01",
+        },
+        {
+            "name": "AI Startup Basket",
+            "category": "private",
+            "value": 20000,
+            "cost_basis": 25000,
+            "thesis": "",
+            "last_reviewed": "2026-05-15",
+        },
+        {
+            "name": "Cash",
+            "category": "cash",
+            "value": 10000,
+            "cost_basis": 10000,
+            "thesis": "Dry powder.",
+            "last_reviewed": "2026-05-20",
+        },
+    ]
+    path = tmp_path / "portfolio.json"
+    path.write_text(json.dumps(positions), encoding="utf-8")
+
+    result = run_script(str(path), "--as-of", "2026-05-31", "--review-after-days", "90")
+
+    assert result.returncode == 0, result.stderr
+    assert "# 投資組合 Review Brief" in result.stdout
+    assert "總資產：100,000.00" in result.stdout
+    assert "BTC — 70.0%" in result.stdout
+    assert "AI Startup Basket" in result.stdout
+    assert "缺少 thesis" in result.stdout
+    assert "BTC（150 天未 review）" in result.stdout
+    assert "未實現損益：15,000.00" in result.stdout
+
+
+def test_silent_if_clear_outputs_exact_silent_marker(tmp_path):
+    positions = [
+        {
+            "name": "Index Fund",
+            "value": 5000,
+            "cost_basis": 5000,
+            "thesis": "Long-term diversified equity exposure.",
+            "last_reviewed": "2026-05-01",
+        },
+        {
+            "name": "Cash",
+            "value": 3000,
+            "cost_basis": 3000,
+            "thesis": "Optionality.",
+            "last_reviewed": "2026-05-02",
+        },
+        {
+            "name": "Short Bills",
+            "value": 2000,
+            "cost_basis": 2000,
+            "thesis": "Low-risk carry.",
+            "last_reviewed": "2026-05-03",
+        },
+    ]
+    path = tmp_path / "clear.json"
+    path.write_text(json.dumps(positions), encoding="utf-8")
+
+    result = run_script(str(path), "--as-of", "2026-05-31", "--silent-if-clear")
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "[SILENT]\n"
+
+
+def test_csv_input_is_supported_without_yaml_dependency(tmp_path):
+    path = tmp_path / "portfolio.csv"
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(
+            fh,
+            fieldnames=["name", "category", "value", "cost_basis", "thesis", "last_reviewed"],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "name": "ETH",
+                "category": "crypto",
+                "value": "12000",
+                "cost_basis": "10000",
+                "thesis": "Settlement asset upside.",
+                "last_reviewed": "2026-01-15",
+            }
+        )
+
+    result = run_script(str(path), "--as-of", "2026-05-31", "--review-after-days", "30")
+
+    assert result.returncode == 0, result.stderr
+    assert "ETH" in result.stdout
+    assert "crypto" in result.stdout
+    assert "136 天未 review" in result.stdout
+
+
+def test_invalid_empty_input_exits_nonzero_with_actionable_error(tmp_path):
+    path = tmp_path / "empty.json"
+    path.write_text("[]", encoding="utf-8")
+
+    result = run_script(str(path))
+
+    assert result.returncode == 1
+    assert "No investment positions found" in result.stderr


### PR DESCRIPTION
## Summary
- Add `scripts/investment_review_brief.py`, a local-first helper that turns JSON/YAML/CSV portfolio position files into a Traditional Chinese review brief.
- Flags concentration risk, missing thesis fields, and stale reviews.
- Supports exact `[SILENT]` output with `--silent-if-clear` for cron workflows when no action is needed.
- Add a short implementation plan under `docs/plans/` and focused tests for JSON, CSV, silent, and invalid-input behavior.

## Why
Joe's operating manual calls out personal investment framework / portfolio management as a recurring Hermes collaboration lane. This gives him a deterministic local script for weekly/monthly portfolio hygiene without connecting new private data sources.

## Test Plan
- [x] TDD red check: `python -m pytest tests/scripts/test_investment_review_brief.py -q -o 'addopts='` failed before implementation because the script was missing.
- [x] `python -m pytest tests/scripts/test_investment_review_brief.py -q -o 'addopts='`
- [x] `python -m py_compile scripts/investment_review_brief.py tests/scripts/test_investment_review_brief.py`
- [x] CLI smoke: `python scripts/investment_review_brief.py /tmp/joe-portfolio-sample.json --as-of 2026-05-31 --review-after-days 90`

## Note
`scripts/run_tests.sh tests/scripts/test_investment_review_brief.py` currently cannot start in this local worktree because pytest-timeout is missing from the shared dev venv (`unrecognized arguments: --timeout=30 --timeout-method=signal`). I used the documented direct-pytest fallback with `-o 'addopts='` for the focused test.
