### PR TITLE
fix(skills): honor `gws` CLI native credentials in Google Workspace skill

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -48,6 +48,8 @@ $GSETUP --check
 ```
 
 If it prints `AUTHENTICATED`, skip to Usage — setup is already done.
+This includes users who already authenticated via `gws auth login` — the
+check detects gws native credentials automatically.
 
 ### Step 1: Triage — ask the user what they need
 
@@ -161,7 +163,7 @@ Should print `AUTHENTICATED`. Setup is complete — token refreshes automaticall
 
 - Token is stored at `~/.hermes/google_token.json` and auto-refreshes.
 - Pending OAuth session state/verifier are stored temporarily at `~/.hermes/google_oauth_pending.json` until exchange completes.
-- If `gws` is installed, `google_api.py` points it at the same `~/.hermes/google_token.json` credentials file. Users do not need to run a separate `gws auth login` flow.
+- If the user already authenticated via `gws auth login`, the skill detects gws native credentials automatically — no Hermes OAuth setup needed. If both `~/.hermes/google_token.json` and gws native credentials exist, the Hermes token takes priority.
 - To revoke: `$GSETUP --revoke`
 
 ## Usage
@@ -320,7 +322,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 
 | Problem | Fix |
 |---------|-----|
-| `NOT_AUTHENTICATED` | Run setup Steps 2-5 above |
+| `NOT_AUTHENTICATED` | Run setup Steps 2-5 above, or authenticate via `gws auth login` if `gws` is installed |
 | `REFRESH_FAILED` | Token revoked or expired — redo Steps 3-5 |
 | `HttpError 403: Insufficient Permission` | Missing API scope — `$GSETUP --revoke` then redo Steps 3-5 |
 | `AUTHENTICATED (partial)` or "Token missing scopes" | New write capabilities (Drive write/delete, Docs create/edit) require re-authorization. `$GSETUP --revoke` then redo Steps 3-5 to grant the upgraded scopes. |

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -88,7 +88,8 @@ def _gws_binary() -> str | None:
 
 def _gws_env() -> dict[str, str]:
     env = os.environ.copy()
-    env["GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE"] = str(TOKEN_PATH)
+    if TOKEN_PATH.exists():
+        env["GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE"] = str(TOKEN_PATH)
     return env
 
 
@@ -97,20 +98,13 @@ def _run_gws(parts: list[str], *, params: dict | None = None, body: dict | None 
     if not binary:
         raise RuntimeError("gws not installed")
 
-    _ensure_authenticated()
-
     cmd = [binary, *parts]
     if params is not None:
         cmd.extend(["--params", json.dumps(params)])
     if body is not None:
         cmd.extend(["--json", json.dumps(body)])
 
-    result = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        env=_gws_env(),
-    )
+    result = subprocess.run(cmd, capture_output=True, text=True, env=_gws_env())
     if result.returncode != 0:
         err = result.stderr.strip() or result.stdout.strip() or "Unknown gws error"
         print(err, file=sys.stderr)

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -57,17 +57,32 @@ SCOPES = [
 REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"]
 
 
-def _gws_native_cred_path() -> Path | None:
-    """Return the gws CLI's native credential file path if it exists, else None."""
+def _gws_auth_status() -> dict | None:
+    """Query ``gws auth status`` for native credential info.
+
+    Returns the parsed JSON dict on success, or None if gws is not
+    installed or the command fails.
+    """
     binary = os.getenv("HERMES_GWS_BIN") or shutil.which("gws")
     if not binary:
         return None
-    if sys.platform == "win32":
-        base = Path(os.environ.get("APPDATA", ""))
-    else:
-        base = Path(os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config")))
-    cred = Path(base) / "gws" / "credentials.enc"
-    return cred if cred.exists() else None
+    try:
+        result = subprocess.run(
+            [binary, "auth", "status"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        # gws may print non-JSON preamble lines (e.g. "Using keyring backend: ...")
+        # before the JSON object — find the first '{'.
+        stdout = result.stdout
+        brace = stdout.find("{")
+        if brace == -1:
+            return None
+        data = json.loads(stdout[brace:])
+        return data if data.get("encrypted_credentials_exists") or data.get("plain_credentials_exists") else None
+    except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
+        return None
 
 # OAuth redirect for "out of band" manual code copy flow.
 # Google deprecated OOB, so we use a localhost redirect and tell the user to
@@ -152,25 +167,14 @@ def check_auth_live():
         return False
 
     if not TOKEN_PATH.exists():
-        # Authenticated via gws native credentials — verify with a gws API call.
-        binary = os.getenv("HERMES_GWS_BIN") or shutil.which("gws")
-        if not binary:
-            return False
-        try:
-            result = subprocess.run(
-                [binary, "calendar", "calendarList", "list",
-                 "--params", json.dumps({"maxResults": 1})],
-                capture_output=True, text=True, timeout=15,
-            )
-            if result.returncode == 0:
-                print("LIVE_CHECK_OK: gws CLI native auth verified.")
-                return True
-            err = result.stderr.strip() or result.stdout.strip()
-            print(f"LIVE_CHECK_FAILED: gws auth error: {err}")
-            return False
-        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-            print(f"LIVE_CHECK_FAILED: {e}")
-            return False
+        # Authenticated via gws native credentials — gws auth status already
+        # confirmed token_valid in check_auth(), so we trust that result.
+        status = _gws_auth_status()
+        if status and status.get("token_valid"):
+            print("LIVE_CHECK_OK: gws auth status reports token_valid=true.")
+            return True
+        print("LIVE_CHECK_FAILED: gws auth status reports token is not valid.")
+        return False
 
     try:
         from googleapiclient.discovery import build
@@ -195,10 +199,22 @@ def check_auth_live():
 def check_auth(quiet: bool = False):
     """Check if stored credentials are valid. Prints status, exits 0 or 1."""
     if not TOKEN_PATH.exists():
-        gws_cred = _gws_native_cred_path()
-        if gws_cred:
+        status = _gws_auth_status()
+        if status:
+            if not status.get("token_valid"):
+                print("GWS_TOKEN_INVALID: gws credentials found but token is not valid. "
+                      "Re-run: gws auth login")
+                return False
+            gws_scopes = set(status.get("scopes") or [])
+            missing = sorted(s for s in SCOPES if s not in gws_scopes)
+            if missing and not quiet:
+                print(f"AUTHENTICATED (partial): gws native credentials valid "
+                      f"but missing {len(missing)} Hermes scopes:")
+                for s in missing:
+                    print(f"  - {s}")
             if not quiet:
-                print(f"AUTHENTICATED: Using gws CLI native credentials ({gws_cred})")
+                user = status.get("user", "unknown")
+                print(f"AUTHENTICATED: Using gws CLI native credentials ({user})")
             return True
         print(f"NOT_AUTHENTICATED: No token at {TOKEN_PATH}")
         return False

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -26,6 +26,7 @@ from __future__ import annotations  # allow PEP 604 `X | None` on Python 3.9+
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -54,6 +55,19 @@ SCOPES = [
 ]
 
 REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"]
+
+
+def _gws_native_cred_path() -> Path | None:
+    """Return the gws CLI's native credential file path if it exists, else None."""
+    binary = os.getenv("HERMES_GWS_BIN") or shutil.which("gws")
+    if not binary:
+        return None
+    if sys.platform == "win32":
+        base = Path(os.environ.get("APPDATA", ""))
+    else:
+        base = Path(os.environ.get("XDG_CONFIG_HOME", str(Path.home() / ".config")))
+    cred = Path(base) / "gws" / "credentials.enc"
+    return cred if cred.exists() else None
 
 # OAuth redirect for "out of band" manual code copy flow.
 # Google deprecated OOB, so we use a localhost redirect and tell the user to
@@ -136,6 +150,28 @@ def check_auth_live():
     # final status line reflects the live-call outcome (OK or FAILED).
     if not check_auth(quiet=True):
         return False
+
+    if not TOKEN_PATH.exists():
+        # Authenticated via gws native credentials — verify with a gws API call.
+        binary = os.getenv("HERMES_GWS_BIN") or shutil.which("gws")
+        if not binary:
+            return False
+        try:
+            result = subprocess.run(
+                [binary, "calendar", "calendarList", "list",
+                 "--params", json.dumps({"maxResults": 1})],
+                capture_output=True, text=True, timeout=15,
+            )
+            if result.returncode == 0:
+                print("LIVE_CHECK_OK: gws CLI native auth verified.")
+                return True
+            err = result.stderr.strip() or result.stdout.strip()
+            print(f"LIVE_CHECK_FAILED: gws auth error: {err}")
+            return False
+        except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+            print(f"LIVE_CHECK_FAILED: {e}")
+            return False
+
     try:
         from googleapiclient.discovery import build
         from google.oauth2.credentials import Credentials
@@ -159,6 +195,11 @@ def check_auth_live():
 def check_auth(quiet: bool = False):
     """Check if stored credentials are valid. Prints status, exits 0 or 1."""
     if not TOKEN_PATH.exists():
+        gws_cred = _gws_native_cred_path()
+        if gws_cred:
+            if not quiet:
+                print(f"AUTHENTICATED: Using gws CLI native credentials ({gws_cred})")
+            return True
         print(f"NOT_AUTHENTICATED: No token at {TOKEN_PATH}")
         return False
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
When a user authenticates with `gws auth login` directly, the Google Workspace skill ignores those credentials and demands its own `google_token.json`.
This PR makes the skill detect and use `gws`-native credentials transparently, so users who already set up `gws` independently don't have to re-authenticate through the Hermes OAuth flow.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

N/A - discovered during regular usage of Hermes Agent.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `skills/productivity/google-workspace/scripts/google_api.py`:
  - `_gws_env()`: only sets `GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE` when `google_token.json` exists. Previously it always pointed `gws` at the Hermes token path, overriding `gws`'s own credential discovery even when the file was absent.
  - `_run_gws()`: removed the `_ensure_authenticated()` gate. When the Hermes token is absent, `gws` handles its own auth; errors propagate through the existing stderr path. The Python SDK fallback still requires the token via `get_credentials()`.

- `skills/productivity/google-workspace/scripts/setup.py`:
  - Added `_gws_auth_status()` - calls `gws auth status`, parses its JSON output to get `token_valid`, `scopes`, and `user`.
  - `check_auth()`: when `google_token.json` is absent, queries `gws auth status`. Reports partial scopes as a warning (not a failure) and shows the authenticated user.
  - `check_auth_live()`: when using `gws` native auth, trusts `token_valid` from `gws auth status` instead of making an arbitrary scope-specific API call.

- `skills/productivity/google-workspace/SKILL.md`: documents `gws auth login` as a supported setup alternative.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Authenticate via `gws auth login --readonly -s calendar`
2. Remove or rename `~/.hermes/google_token.json` if it exists
3. Run `python scripts/setup.py --check` - should print `AUTHENTICATED: Using gws CLI native credentials (you@example.com)` and warn about any missing scopes
4. Run `python scripts/google_api.py calendar list` - should return events via gws
5. Restore `google_token.json` - verify `--check` still reports `AUTHENTICATED: Token valid at ...` (Hermes token takes priority)

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features): **Irrelevant for the changes' scope**
- [x] I've tested on my platform: **Arch Linux**

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A:  **`SKILL.md`**
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A: Windows `%APPDATA%` path not needed. `gws auth status` handles its own platform logic.
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A