### PR TITLE
fix: include locales/ i18n catalogs in pip package distribution

### DIFF
--- a/locales/__init__.py
+++ b/locales/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled Hermes translation catalogs."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,7 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]
 gateway = ["assets/**/*"]
+locales = ["*.yaml"]
 plugins = [
   "*/dashboard/manifest.json",
   "*/dashboard/dist/*",
@@ -239,7 +240,7 @@ plugins = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*", "locales"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

The PyPI wheel is missing the top-level `locales/` directory because it is
neither declared as a package in `[tool.setuptools.packages.find]` nor listed
under `[tool.setuptools.package-data]`.  As a result, `agent.i18n.t()` falls
back to returning raw dotted keys in pipx/pip-installed wheels, making all
gateway slash-command output (`/model`, `/reasoning`, etc.) display raw i18n
keys instead of user-facing text.

## Changes

- **locales/__init__.py** (new): marks `locales/` as a Python package so
  setuptools can include it in the wheel
- **pyproject.toml**: added `locales = ["*.yaml"]` under
  `[tool.setuptools.package-data]` to include the YAML translation catalogs
- **pyproject.toml**: added `"locales"` to `[tool.setuptools.packages.find]`
  include list

## Verification

```python
from agent.i18n import _locales_dir, t
assert _locales_dir().exists(), "locales/ must exist in installed package"
val = t("gateway.model.switched", model="TEST_MODEL")
assert val != "gateway.model.switched", "key must be translated, not echoed"
# Expected: "Model switched to `TEST_MODEL`"
```

After the fix the wheel ships all 17 locale files (`af.yaml` through `zh.yaml`)
in addition to `locales/__init__.py`.

Closes #35374