### PR TITLE
fix: truncate long text in Slack approval card updates to avoid invalid_blocks

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2439,7 +2439,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": original_text or "Confirmation prompt",
+                    "text": (original_text[:2900] + "\u2026") if len(original_text) > 2900 else (original_text or "Confirmation prompt"),
                 },
             },
             {
@@ -2540,7 +2540,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": original_text or "Command approval request",
+                    "text": (original_text[:2900] + "\u2026") if len(original_text) > 2900 else (original_text or "Command approval request"),
                 },
             },
             {


### PR DESCRIPTION
## Problem

Slack's `chat.update` API rejects section blocks with text longer than 3000 characters (`invalid_blocks` / `must be less than 3001 characters`).

When code execution approval cards contain long code previews, the `_handle_approval_action` and `_handle_slash_confirm_action` handlers preserve the original text in `updated_blocks`. This can exceed the 3000-char limit and cause the `chat_update` to fail silently — leaving the approval buttons visible even after the user has successfully clicked them.

## Reproduction

1. Send a code execution approval request with a code preview >3000 chars
2. Click any approval button (approve/deny)
3. The approval is resolved (agent unblocks) but the buttons remain visible
4. Gateway logs show: `Failed to update approval message: invalid_blocks`

## Fix

Truncate `original_text` to 2900 characters + ellipsis when rebuilding the updated blocks in both handlers.

**Changed files:** `gateway/platforms/slack.py` (2 lines)

## Logs

```
WARNING gateway.platforms.slack: [Slack] Failed to update approval message: The request to the Slack API failed. (url: https://slack.com/api/chat.update, status: 200)
The server responded with: {'ok': False, 'error': 'invalid_blocks', '1': 'must be less than 3001 characters [json-pointer:/blocks/0/text/text]'}
```
