### PR TITLE
fix(delegate): guard child credential pool binding

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1409,14 +1409,31 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
     def test_same_provider_shares_parent_pool(self):
         parent = _make_mock_parent()
         mock_pool = MagicMock()
+        mock_pool.provider = "openrouter"
         parent._credential_pool = mock_pool
 
         result = _resolve_child_credential_pool("openrouter", parent)
         self.assertIs(result, mock_pool)
 
+    def test_same_parent_provider_rejects_mismatched_parent_pool(self):
+        parent = _make_mock_parent()
+        parent.provider = "openai-codex"
+        mismatched_pool = MagicMock()
+        mismatched_pool.provider = "xiaomi"
+        parent._credential_pool = mismatched_pool
+        own_pool = MagicMock()
+        own_pool.has_credentials.return_value = True
+
+        with patch("agent.credential_pool.load_pool", return_value=own_pool) as mock_load:
+            result = _resolve_child_credential_pool("openai-codex", parent)
+
+        mock_load.assert_called_once_with("openai-codex")
+        self.assertIs(result, own_pool)
+
     def test_no_provider_inherits_parent_pool(self):
         parent = _make_mock_parent()
         mock_pool = MagicMock()
+        mock_pool.provider = "openrouter"
         parent._credential_pool = mock_pool
 
         result = _resolve_child_credential_pool(None, parent)
@@ -1537,7 +1554,10 @@ class TestChildCredentialLeasing(unittest.TestCase):
         leased_entry.id = "cred-b"
 
         child = MagicMock()
+        child.provider = "openrouter"
+        child.base_url = "https://openrouter.ai/api/v1"
         child._credential_pool = MagicMock()
+        child._credential_pool.provider = "openrouter"
         child._credential_pool.acquire_lease.return_value = "cred-b"
         child._credential_pool.current.return_value = leased_entry
         child.run_conversation.return_value = {
@@ -1559,6 +1579,42 @@ class TestChildCredentialLeasing(unittest.TestCase):
         child._credential_pool.acquire_lease.assert_called_once_with()
         child._swap_credential.assert_called_once_with(leased_entry)
         child._credential_pool.release_lease.assert_called_once_with("cred-b")
+
+    def test_run_single_child_skips_cross_provider_leased_credential(self):
+        from tools.delegate_tool import _run_single_child
+
+        leased_entry = MagicMock()
+        leased_entry.id = "xiaomi-cred"
+        leased_entry.provider = "xiaomi"
+        leased_entry.runtime_base_url = "https://token-plan-cn.xiaomimimo.com/v1"
+        leased_entry.base_url = "https://token-plan-cn.xiaomimimo.com/v1"
+
+        child = MagicMock()
+        child.provider = "openai-codex"
+        child.base_url = "https://chatgpt.com/backend-api/codex"
+        child._credential_pool = MagicMock()
+        child._credential_pool.provider = "xiaomi"
+        child._credential_pool.acquire_lease.return_value = "xiaomi-cred"
+        child._credential_pool.current.return_value = leased_entry
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+        result = _run_single_child(
+            task_index=0,
+            goal="Review safely",
+            child=child,
+            parent_agent=_make_mock_parent(),
+        )
+
+        self.assertEqual(result["status"], "completed")
+        child._credential_pool.acquire_lease.assert_called_once_with()
+        child._swap_credential.assert_not_called()
+        child._credential_pool.release_lease.assert_called_once_with("xiaomi-cred")
 
     def test_run_single_child_releases_lease_after_failure(self):
         from tools.delegate_tool import _run_single_child

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1318,6 +1318,67 @@ def _dump_subagent_timeout_diagnostic(
         return None
 
 
+def _normalize_provider_name(value: Any) -> str:
+    """Return a conservative provider identity for runtime safety checks."""
+    if not isinstance(value, str):
+        return ""
+    return value.strip().lower()
+
+
+def _provider_identities_match(candidate: Any, expected: Any) -> bool:
+    """Return True when two provider identifiers can share credentials.
+
+    Most pools use the canonical provider name directly. Named custom-provider
+    pools are keyed as ``custom:<name>`` while the runtime child provider may be
+    the bare configured name; treat those as equivalent, but never collapse two
+    unrelated concrete providers.
+    """
+    candidate_name = _normalize_provider_name(candidate)
+    expected_name = _normalize_provider_name(expected)
+    if not candidate_name or not expected_name:
+        return False
+    if candidate_name == expected_name:
+        return True
+    if (
+        candidate_name.startswith("custom:")
+        and candidate_name.removeprefix("custom:") == expected_name
+    ):
+        return True
+    if (
+        expected_name.startswith("custom:")
+        and expected_name.removeprefix("custom:") == candidate_name
+    ):
+        return True
+    return False
+
+
+def _credential_entry_matches_child_runtime(child: Any, entry: Any) -> bool:
+    """Guard against binding a leased credential to the wrong child runtime."""
+    child_provider = _normalize_provider_name(getattr(child, "provider", None))
+    entry_provider = _normalize_provider_name(getattr(entry, "provider", None))
+    pool_provider = _normalize_provider_name(
+        getattr(getattr(child, "_credential_pool", None), "provider", None)
+    )
+    credential_provider = entry_provider or pool_provider
+    if credential_provider and child_provider and not _provider_identities_match(
+        credential_provider,
+        child_provider,
+    ):
+        return False
+
+    child_base = getattr(child, "base_url", None)
+    entry_base = (
+        getattr(entry, "runtime_base_url", None)
+        or getattr(entry, "base_url", None)
+    )
+    if isinstance(child_base, str) and isinstance(entry_base, str):
+        normalized_child_base = child_base.strip().rstrip("/")
+        normalized_entry_base = entry_base.strip().rstrip("/")
+        if normalized_child_base and normalized_entry_base:
+            return normalized_child_base == normalized_entry_base
+    return True
+
+
 def _run_single_child(
     task_index: int,
     goal: str,
@@ -1349,7 +1410,11 @@ def _run_single_child(
         if leased_cred_id is not None:
             try:
                 leased_entry = child_pool.current()
-                if leased_entry is not None and hasattr(child, "_swap_credential"):
+                if (
+                    leased_entry is not None
+                    and hasattr(child, "_swap_credential")
+                    and _credential_entry_matches_child_runtime(child, leased_entry)
+                ):
                     child._swap_credential(leased_entry)
             except Exception as exc:
                 logger.debug("Failed to bind child to leased credential: %s", exc)
@@ -2325,7 +2390,15 @@ def _resolve_child_credential_pool(effective_provider: Optional[str], parent_age
     parent_provider = getattr(parent_agent, "provider", None) or ""
     parent_pool = getattr(parent_agent, "_credential_pool", None)
     if parent_pool is not None and effective_provider == parent_provider:
-        return parent_pool
+        pool_provider = _normalize_provider_name(getattr(parent_pool, "provider", None))
+        if not pool_provider or _provider_identities_match(pool_provider, effective_provider):
+            return parent_pool
+        logger.debug(
+            "Parent credential pool provider '%s' does not match child provider "
+            "'%s'; loading child pool",
+            getattr(parent_pool, "provider", None),
+            effective_provider,
+        )
 
     try:
         from agent.credential_pool import load_pool


### PR DESCRIPTION
## Summary

This PR hardens `delegate_task` credential-pool handling so a child agent does not bind a leased credential from a different provider/runtime endpoint.

It adds two guards:

- `_run_single_child()` now verifies the leased credential matches the child runtime before calling `_swap_credential()`.
  - Provider identity must match.
  - If both sides expose a concrete base URL, the normalized base URLs must match.
- `_resolve_child_credential_pool()` no longer blindly shares the parent's pool when the parent pool carries explicit provider metadata that differs from the child provider. It falls back to loading the child provider's own pool instead.

This preserves the existing compatibility behavior for old/test pool objects that lack provider metadata, and keeps `custom:<name>` compatible with the bare configured custom-provider name.

## Why

The existing delegation path can accidentally combine a child runtime from one provider with a leased credential/base URL from another provider. One observed shape is an `openai-codex` child using the Codex model/runtime while swapping to a Xiaomi OpenAI-compatible endpoint from the credential pool, producing HTTP 404s.

Related but different prior work:

- #5748 introduced credential-pool sharing for subagents.
- #25369 fixed cross-provider `api_mode` inheritance.
- #20563 discusses broader delegation/provider 404 behavior.

This PR focuses specifically on the credential-pool lease/swap contamination path.

## Tests

```bash
python -m py_compile tools/delegate_tool.py tests/tools/test_delegate.py
python -m pytest -o addopts='' tests/tools/test_delegate.py::TestChildCredentialPoolResolution tests/tools/test_delegate.py::TestChildCredentialLeasing -q
python -m pytest -o addopts='' tests/tools/test_delegate.py -q
git diff --check -- tools/delegate_tool.py tests/tools/test_delegate.py
```

Results:

- `py_compile`: passed
- targeted credential-pool/delegation tests: `12 passed`
- full `tests/tools/test_delegate.py`: `137 passed`
- `git diff --check`: passed

The only warning seen locally is the pre-existing `discord.player` / `audioop` Python 3.13 deprecation warning.
