### PR TITLE
fix(dashboard): skip legacy token check in gated mode for _require_token endpoints

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -147,7 +147,14 @@ def _has_valid_session_token(request: Request) -> bool:
 
 
 def _require_token(request: Request) -> None:
-    """Validate the ephemeral session token.  Raises 401 on mismatch."""
+    """Validate the ephemeral session token.  Raises 401 on mismatch.
+
+    In OAuth gated mode (``app.state.auth_required is True``) the cookie-based
+    gate in ``gated_auth_middleware`` is authoritative — it already verified
+    the session before we reach this point, so skip the legacy token check.
+    """
+    if getattr(request.app.state, "auth_required", False):
+        return
     if not _has_valid_session_token(request):
         raise HTTPException(status_code=401, detail="Unauthorized")
 

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -340,3 +340,39 @@ def test_gated_zero_providers_login_page_renders_help_text():
     finally:
         web_server.app.state.auth_required = prev_required
         web_server.app.state.bound_host = prev_host
+
+
+# ---------------------------------------------------------------------------
+# _require_token under gated mode (regression for #35492)
+# ---------------------------------------------------------------------------
+
+
+def test_gated_plugins_hub_does_not_401_after_login(gated_app):
+    """After a successful OAuth login, ``/api/dashboard/plugins/hub`` must
+    NOT return 401.  The ``_require_token`` guard must defer to the
+    OAuth gate when ``auth_required`` is active.
+
+    Regression test for #35492: the plugins page returned 401 in gated
+    mode because ``_require_token`` unconditionally checked for the legacy
+    session token without consulting ``app.state.auth_required``.
+    """
+    # Walk the full OAuth round trip to get a valid session cookie.
+    r1 = gated_app.get("/auth/login?provider=stub", follow_redirects=False)
+    assert r1.status_code == 302
+    redirect = r1.headers["location"]
+    state = redirect.split("state=")[1]
+
+    r2 = gated_app.get(
+        f"/auth/callback?code=stub_code&state={state}",
+        follow_redirects=False,
+    )
+    assert r2.status_code == 302
+    assert any("hermes_session_at" in c for c in r2.headers.get_list("set-cookie"))
+
+    # Now hit the plugins endpoint — should NOT be 401.
+    r3 = gated_app.get("/api/dashboard/plugins/hub", follow_redirects=False)
+    assert r3.status_code != 401, (
+        "/api/dashboard/plugins/hub returned 401 after successful OAuth "
+        "login — _require_token should skip the legacy token check when "
+        "auth_required is True"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes the dashboard plugins page returning 401 in OAuth gated mode. When `auth_required` is active, the cookie-based `gated_auth_middleware` authenticates requests, but `_require_token()` unconditionally checked for the legacy session token — causing `/api/dashboard/plugins/hub` and 11 other `_require_token`-guarded endpoints to reject authenticated users.

## Related Issue

Fixes #35492

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: Added `auth_required` check to `_require_token()` — when the OAuth gate is active, skip the legacy session token check since `gated_auth_middleware` already authenticated the request
- `tests/hermes_cli/test_dashboard_auth_middleware.py`: Added `test_gated_plugins_hub_does_not_401_after_login` — walks the full OAuth round trip then verifies `/api/dashboard/plugins/hub` returns non-401

## How to Test

1. Configure a `DashboardAuthProvider` (e.g. Nous or stub) and start the gateway with dashboard
2. Log in at `/login` via the OAuth flow
3. Navigate to `/plugins` — should load available plugins instead of showing "No results"
4. Run `pytest tests/hermes_cli/test_dashboard_auth_middleware.py -q` — all 23 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/web_server.py:_require_token` (callers: 13 endpoint handlers)
- Blast radius: LOW — single function, early-return guard, no behavior change in loopback mode
- Related patterns: `auth_middleware` (line 277) uses the same `getattr(request.app.state, "auth_required", False)` check to skip legacy token validation under the OAuth gate. This fix brings `_require_token` into alignment.
