### PR TITLE
fix(dashboard): register correct MIME type for .js on Windows

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14,6 +14,7 @@ import hmac
 import importlib.util
 import json
 import logging
+import mimetypes
 import os
 import secrets
 import subprocess
@@ -3725,6 +3726,11 @@ def mount_spa(application: FastAPI):
                 css = css.replace(f"url(\"{asset_dir}", f"url(\"{prefix}{asset_dir}")
                 css = css.replace(f"url('{asset_dir}", f"url('{prefix}{asset_dir}")
         return Response(content=css, media_type="text/css")
+
+    # Windows Python mimetypes maps .js → text/plain instead of
+    # application/javascript, which causes the browser to block the JS
+    # module with "disallowed MIME type". Register the correct mapping.
+    mimetypes.add_type("application/javascript", ".js")
 
     application.mount("/assets", StaticFiles(directory=WEB_DIST / "assets"), name="assets")
 


### PR DESCRIPTION
## Problem
On native Windows, Python mimetypes maps .js to text/plain instead of application/javascript. Browser blocks the Vite entry bundle with disallowed MIME type error, resulting in a blank/green dashboard page.

See upstream tracking: https://github.com/NousResearch/hermes-agent/issues/28987

## Fix
Register the correct mapping before the StaticFiles mount:

import mimetypes
mimetypes.add_type(application/javascript, .js)

Two-line change in hermes_cli/web_server.py.

## Testing
Verified via curl: /assets/index-*.js returns content-type: application/javascript. Dashboard TUI renders correctly after restart on Windows 10.