### PR TITLE
fix(gateway): block config.yaml media delivery and fix triggering tip

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -954,11 +954,13 @@ def _media_delivery_denied_paths() -> List[Path]:
     home = Path(os.path.expanduser("~"))
     for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS:
         denied.append(home / sub)
-    # The Hermes home itself contains credentials (auth.json, .env) — only the
-    # cache subdirectories under it are explicitly allowlisted above.
+    # The Hermes home itself contains credentials (auth.json, .env) and
+    # configuration (config.yaml) — only the cache subdirectories under it
+    # are explicitly allowlisted above.
     denied.append(_HERMES_HOME / ".env")
     denied.append(_HERMES_HOME / "auth.json")
     denied.append(_HERMES_HOME / "credentials")
+    denied.append(_HERMES_HOME / "config.yaml")
     return denied
 
 

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -430,7 +430,7 @@ TIPS = [
     'hermes -z "<prompt>" is the purest one-shot: final answer on stdout, nothing else — ideal for piping in scripts.',
     'hermes chat --pass-session-id injects the session ID into the system prompt so the agent can self-reference it.',
     'hermes chat --image path/to/pic.png attaches a local image to a single -q query without a separate upload step.',
-    'hermes chat --ignore-user-config skips ~/.hermes/config.yaml — reproducible bug reports and CI runs.',
+    'hermes chat --ignore-user-config skips user config entirely — reproducible bug reports and CI runs.',
     "hermes chat --source tool tags programmatic chats so they don't clutter hermes sessions list.",
     'hermes dump --show-keys includes redacted API key fingerprints for deeper support debugging.',
     'hermes sessions rename <ID> "new title" renames any past session; hermes sessions delete <ID> removes one.',


### PR DESCRIPTION
## Bug

When running `/new` in a Discord session, config.yaml sometimes gets sent as a native file attachment for no apparent reason.

## Root Cause

Two interacting issues:

1. **The tip** `hermes chat --ignore-user-config skips ~/.hermes/config.yaml — reproducible bug reports and CI runs.` contains a bare home-relative path `~/.hermes/config.yaml`.

2. When this tip is randomly selected during `/new`, `extract_local_files()` in `_process_message_background()` matches `~/.hermes/config.yaml` against its local-file-path regex (line 2527 of `gateway/platforms/base.py`), finds the file actually exists, and sends it as a native Discord document attachment.

## Fix

**Layer 1 — Denylist:** Added `config.yaml` to `_media_delivery_denied_paths()` so even if a path to `~/.hermes/config.yaml` ends up in response text, it can't be delivered as an attachment. Matches the existing protection for `.env`, `auth.json`, and `credentials/`.

**Layer 2 — Trigger:** Reworded the tip to not contain a bare file path.

## Testing

- Verified `validate_media_delivery_path('~/.hermes/config.yaml')` now returns `None` (blocked)
- Verified the old tip regex-matched `~/.hermes/config.yaml` while the new tip does not match any path
- `extract_local_files()` on the old tip would produce `[('/home/agent/.hermes/config.yaml',)]`, on the new tip it produces `[]`