### PR TITLE
fix(tools): preserve live session cwd in terminal_tool execution paths

### DIFF
--- a/tests/tools/test_terminal_task_cwd.py
+++ b/tests/tools/test_terminal_task_cwd.py
@@ -1,6 +1,7 @@
 """Regression tests for task/session cwd propagation in terminal_tool."""
 
 import json
+from types import SimpleNamespace
 
 import tools.terminal_tool as terminal_tool
 
@@ -10,6 +11,7 @@ def _minimal_terminal_config(cwd="/default"):
         "env_type": "local",
         "cwd": cwd,
         "timeout": 60,
+        "lifetime_seconds": 3600,
     }
 
 
@@ -72,3 +74,86 @@ def test_explicit_workdir_still_wins_over_registered_task_cwd(monkeypatch):
 
     assert result["exit_code"] == 0
     assert calls == [{"timeout": 60, "cwd": "/explicit/workdir"}]
+
+
+def test_foreground_command_prefers_live_env_cwd_over_init_time_cwd(monkeypatch):
+    """A prior `cd` updates env.cwd; terminal_tool must honor that live cwd."""
+    calls = []
+
+    class FakeEnv:
+        env = {}
+        cwd = "/workspace/live"
+
+        def execute(self, command, **kwargs):
+            calls.append((command, kwargs))
+            return {"output": "ok", "returncode": 0}
+
+    task_id = "session-live-cwd"
+    monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: FakeEnv()})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {task_id: {"cwd": "/workspace/init"}})
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _minimal_terminal_config(cwd="/workspace/init"))
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda value: value or "default")
+    monkeypatch.setattr(
+        terminal_tool,
+        "_check_all_guards",
+        lambda command, env_type: {"approved": True},
+    )
+
+    result = json.loads(terminal_tool.terminal_tool(command="pwd", task_id=task_id))
+
+    assert result["exit_code"] == 0
+    assert calls == [("pwd", {"timeout": 60, "cwd": "/workspace/live"})]
+
+
+def test_background_command_prefers_live_env_cwd_over_init_time_cwd(monkeypatch):
+    """Background process launches must also use the live session cwd."""
+
+    class FakeEnv:
+        env = {}
+        cwd = "/workspace/live"
+
+    class FakeRegistry:
+        def __init__(self):
+            self.calls = []
+            self.pending_watchers = []
+
+        def spawn_local(self, **kwargs):
+            self.calls.append(kwargs)
+            return SimpleNamespace(id="proc_test", pid=1234)
+
+    import tools.process_registry as process_registry_mod
+
+    registry = FakeRegistry()
+    task_id = "session-live-cwd-bg"
+    monkeypatch.setattr(terminal_tool, "_active_environments", {task_id: FakeEnv()})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {task_id: {"cwd": "/workspace/init"}})
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: _minimal_terminal_config(cwd="/workspace/init"))
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool, "_resolve_container_task_id", lambda value: value or "default")
+    monkeypatch.setattr(
+        terminal_tool,
+        "_check_all_guards",
+        lambda command, env_type: {"approved": True},
+    )
+    monkeypatch.setattr(process_registry_mod, "process_registry", registry)
+
+    result = json.loads(
+        terminal_tool.terminal_tool(
+            command="sleep 1",
+            task_id=task_id,
+            background=True,
+        )
+    )
+
+    assert result["exit_code"] == 0
+    assert registry.calls == [{
+        "command": "sleep 1",
+        "cwd": "/workspace/live",
+        "task_id": task_id,
+        "session_key": "",
+        "env_vars": {},
+        "use_pty": False,
+    }]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1718,6 +1718,30 @@ def _resolve_notification_flag_conflict(
     return watch_patterns, ""
 
 
+def _resolve_command_cwd(
+    *,
+    workdir: Optional[str],
+    env: Any,
+    default_cwd: str,
+) -> str:
+    """Return the cwd for a command, preferring the live session cwd.
+
+    ``terminal_tool`` historically re-sent the init-time/config cwd on every
+    call. That broke session-local ``cd`` state: the environment tracked the
+    new directory in ``env.cwd``, but foreground/background calls kept forcing
+    the old cwd back through ``env.execute(..., cwd=...)``. Explicit
+    ``workdir=`` must still override everything.
+    """
+    if workdir:
+        return workdir
+
+    live_cwd = getattr(env, "cwd", None)
+    if isinstance(live_cwd, str) and live_cwd.strip():
+        return live_cwd
+
+    return default_cwd
+
+
 def terminal_tool(
     command: str,
     background: bool = False,
@@ -1990,7 +2014,11 @@ def terminal_tool(
             from tools.process_registry import process_registry
 
             session_key = get_current_session_key(default="")
-            effective_cwd = workdir or cwd
+            effective_cwd = _resolve_command_cwd(
+                workdir=workdir,
+                env=env,
+                default_cwd=cwd,
+            )
             try:
                 if env_type == "local":
                     proc_session = process_registry.spawn_local(
@@ -2207,7 +2235,11 @@ def terminal_tool(
                 try:
                     execute_kwargs = {
                         "timeout": effective_timeout,
-                        "cwd": workdir or cwd,
+                        "cwd": _resolve_command_cwd(
+                            workdir=workdir,
+                            env=env,
+                            default_cwd=cwd,
+                        ),
                     }
                     result = env.execute(command, **execute_kwargs)
                 except Exception as e:


### PR DESCRIPTION
## Summary

This PR fixes a `terminal_tool` cwd regression for existing sessions.

When a session had already changed directories, `terminal_tool()` could still force later commands to run in the init-time/config cwd instead of the live session cwd. That caused both foreground commands and background launches to run in the wrong directory.

## Fix

- Added a small cwd resolver in `tools/terminal_tool.py` with this precedence:
  1. explicit `workdir`
  2. live session `env.cwd`
  3. fallback config/init cwd
- Applied that resolver to:
  - foreground `env.execute(...)`
  - background `process_registry.spawn_local(...)`
  - background `process_registry.spawn_via_env(...)`
- Preserved existing explicit `workdir` behavior.

## Testing

Added regression coverage for:
- existing task cwd override behavior
- explicit `workdir` override behavior
- foreground commands following live `env.cwd`
- background commands following live `env.cwd`

Tests run:

```text
tests/tools/test_terminal_task_cwd.py
4 passed in 0.71s

tests/tools/test_terminal_tool.py
tests/tools/test_terminal_task_cwd.py
18 passed in 0.51s