### PR TITLE
fix(tui): swallow degraded mouse-burst noise so a stalled loop can't lock the composer

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -133,4 +133,25 @@ describe('fragmented SGR mouse recovery', () => {
 
     expect(key).toMatchObject({ kind: 'key', sequence: '1234;56;78M9;10;11M' })
   })
+
+  it('swallows a fully degraded mouse-burst noise blob without leaking prompt text', () => {
+    // Captured from Windows Terminal during a heavy tool-call render: the event
+    // loop blocked past App's 50ms flush timer, so a long burst of SGR mouse
+    // reports (mode 1003 any-motion) arrived as text with prefixes AND
+    // coordinate digits chewed off across many partial reads. The shards are
+    // too degraded for SGR_MOUSE_FRAGMENT_RE (1- and 2-param remnants, a
+    // stray focus-in [I), so without the whole-text noise fast path the entire
+    // blob types into the composer and locks the user out.
+    const blob =
+      'M6M35;220;56M6M35;218;56M169;48M;157;47M;44M20;43M79;40M78;40M0M7M35;49;41M48;41M;47;40M9;15;32M[I;31M5;211;26M35;211;25M7M;220;1MM0M09;25M24M23M3;22MM18M99;26M32MM38M63;44M47MM1;51M M4M54M'
+    const [events] = parseMultipleKeypresses(INITIAL_STATE, blob)
+
+    expect(events.filter(e => e.kind === 'key' && !(e as { isPasted?: boolean }).isPasted)).toEqual([])
+  })
+
+  it('keeps plain prose that only contains scattered M and m letters', () => {
+    const [[key]] = parseMultipleKeypresses(INITIAL_STATE, 'Mmm MMM mmm yummy')
+
+    expect(key).toMatchObject({ kind: 'key', sequence: 'Mmm MMM mmm yummy' })
+  })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -146,7 +146,7 @@ describe('fragmented SGR mouse recovery', () => {
       'M6M35;220;56M6M35;218;56M169;48M;157;47M;44M20;43M79;40M78;40M0M7M35;49;41M48;41M;47;40M9;15;32M[I;31M5;211;26M35;211;25M7M;220;1MM0M09;25M24M23M3;22MM18M99;26M32MM38M63;44M47MM1;51M M4M54M'
     const [events] = parseMultipleKeypresses(INITIAL_STATE, blob)
 
-    expect(events.filter(e => e.kind === 'key' && !e.isPasted)).toEqual([])
+    expect(events).toEqual([])
   })
 
   it('keeps plain prose that only contains scattered M and m letters', () => {

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -146,12 +146,23 @@ describe('fragmented SGR mouse recovery', () => {
       'M6M35;220;56M6M35;218;56M169;48M;157;47M;44M20;43M79;40M78;40M0M7M35;49;41M48;41M;47;40M9;15;32M[I;31M5;211;26M35;211;25M7M;220;1MM0M09;25M24M23M3;22MM18M99;26M32MM38M63;44M47MM1;51M M4M54M'
     const [events] = parseMultipleKeypresses(INITIAL_STATE, blob)
 
-    expect(events.filter(e => e.kind === 'key' && !(e as { isPasted?: boolean }).isPasted)).toEqual([])
+    expect(events.filter(e => e.kind === 'key' && !e.isPasted)).toEqual([])
   })
 
   it('keeps plain prose that only contains scattered M and m letters', () => {
     const [[key]] = parseMultipleKeypresses(INITIAL_STATE, 'Mmm MMM mmm yummy')
 
     expect(key).toMatchObject({ kind: 'key', sequence: 'Mmm MMM mmm yummy' })
+  })
+
+  it('swallows noise wholesale even when it contains intact recoverable fragments', () => {
+    // A noise blob can carry a few intact `<b;c;r M` fragments amid the chewed
+    // shards. The whole-text noise check must run BEFORE fragment recovery —
+    // otherwise parseTextWithSgrMouseFragments returns non-null and emits a
+    // pile of recovered mouse events instead of dropping the blob wholesale.
+    const blob = '<35;159;11M;44M20;43M0M7M<35;124;26M;47;40M9;15;32M5M2M'
+    const [events] = parseMultipleKeypresses(INITIAL_STATE, blob)
+
+    expect(events).toEqual([])
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.test.ts
@@ -138,9 +138,8 @@ describe('fragmented SGR mouse recovery', () => {
     // Captured from Windows Terminal during a heavy tool-call render: the event
     // loop blocked past App's 50ms flush timer, so a long burst of SGR mouse
     // reports (mode 1003 any-motion) arrived as text with prefixes AND
-    // coordinate digits chewed off across many partial reads. The shards are
     // too degraded for SGR_MOUSE_FRAGMENT_RE (1- and 2-param remnants, a
-    // stray focus-in [I), so without the whole-text noise fast path the entire
+    // stray focus-in `[I`), so without the whole-text noise fast path the entire
     // blob types into the composer and locks the user out.
     const blob =
       'M6M35;220;56M6M35;218;56M169;48M;157;47M;44M20;43M79;40M78;40M0M7M35;49;41M48;41M;47;40M9;15;32M[I;31M5;211;26M35;211;25M7M;220;1MM0M09;25M24M23M3;22MM18M99;26M32MM38M63;44M47MM1;51M M4M54M'

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -65,6 +65,34 @@ const XTVERSION_RE = /^\x1bP>\|(.*?)(?:\x07|\x1b\\)$/s
 const SGR_MOUSE_RE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/
 const SGR_MOUSE_FRAGMENT_RE = /(?<!\d)(?:\[<|<)?(?:[0-9]|[1-9][0-9]|1\d{2}|2[0-4]\d|25[0-5]);\d+;\d+[Mm]/g
 
+// Whole-text mouse-burst noise fast path. When a heavy render blocks the event
+// loop past App's 50ms flush watchdog, a long burst of SGR mouse reports (mode
+// 1003 any-motion / 1006 SGR) can arrive as a single text token with prefixes
+// AND coordinate digits chewed off across many partial reads. The surviving
+// shards (1- and 2-param remnants, stray focus-in `[I`, lone `M`/`m`
+// terminators) are too degraded for SGR_MOUSE_FRAGMENT_RE, so the leftover
+// tail leaks into the composer and locks the user out (they can't type or exit).
+//
+// If the ENTIRE text token is drawn only from the mouse-leak alphabet
+// (`[ ] < ; I M m`, digits, and the stray spaces a burst can carry) AND it
+// carries the structural signature of mouse coordinates — ≥3 `M`/`m`
+// terminators, at least one digit, and at least one `;` separator — swallow it
+// wholesale. All three constraints together preserve real prose: `Mmm MMM mmm`
+// has no digit and no `;`, `see 1;2;3M for details` contains disqualifying
+// letters, and `1234;56;78M9;10;11M` has only two terminators.
+// eslint-disable-next-line no-control-regex
+const MOUSE_BURST_NOISE_RE = /^(?=[^]*\d)(?=[^]*;)(?=(?:[^]*[Mm]){3})[\d;<\[\]IMm \x1b]+$/
+
+// Residual-shard variant for the gaps BETWEEN / AFTER recovered fragments
+// inside parseTextWithSgrMouseFragments. A real recovery run leaves degraded
+// remnants (e.g. `M6M`, `7M;220;1MM0M`, lone `;157;47M`) that are pure
+// mouse-leak alphabet but too short to satisfy the ≥3-terminator whole-text
+// rule. Swallow such a residue only when it is pure alphabet AND carries a
+// digit AND at least one `M`/`m` — a prose gap like ` for details ` contains
+// disqualifying letters and never matches.
+// eslint-disable-next-line no-control-regex
+const MOUSE_BURST_RESIDUE_RE = /^(?=[^]*\d)(?=[^]*[Mm])[\d;<\[\]IMm \x1b]+$/
+
 function createPasteKey(content: string): ParsedKey {
   return {
     kind: 'key',
@@ -273,6 +301,13 @@ export function parseMultipleKeypresses(
 
         if (mouseFragments) {
           keys.push(...mouseFragments)
+        } else if (MOUSE_BURST_NOISE_RE.test(token.value)) {
+          // Fully degraded mouse-burst noise — a heavy render (e.g. a sudo /
+          // secret prompt repaint) blocked the event loop past App's 50ms
+          // flush watchdog, so a long burst of SGR mouse reports arrived as
+          // text with prefixes AND coordinate digits chewed off. The shards are
+          // too mangled for the fragment recovery above; swallow the whole blob
+          // so it never leaks into the composer and locks the user out.
         } else if (/^\[M[\x60-\x7f][\x20-\uffff]{2}$/.test(token.value)) {
           // Orphaned X10 wheel tail (fullscreen only — mouse tracking is off
           // otherwise). A heavy render blocked the event loop past App's 50ms
@@ -674,7 +709,12 @@ function parseTextWithSgrMouseFragments(text: string): ParsedInput[] | null {
     }
 
     if (first.index! > cursor) {
-      parsed.push(parseKeypress(text.slice(cursor, first.index!)))
+      const gap = text.slice(cursor, first.index!)
+      // Skip pure mouse-leak residue between recovered fragments; only emit
+      // real text gaps as keypresses.
+      if (!MOUSE_BURST_RESIDUE_RE.test(gap)) {
+        parsed.push(parseKeypress(gap))
+      }
     }
 
     for (const match of run) {
@@ -690,7 +730,12 @@ function parseTextWithSgrMouseFragments(text: string): ParsedInput[] | null {
   }
 
   if (cursor < text.length) {
-    parsed.push(parseKeypress(text.slice(cursor)))
+    const tail = text.slice(cursor)
+    // Swallow a pure mouse-leak residue tail (the head fragments recovered, but
+    // the burst trailed off into chewed-up shards). Emit only real trailing text.
+    if (!MOUSE_BURST_RESIDUE_RE.test(tail)) {
+      parsed.push(parseKeypress(tail))
+    }
   }
 
   return parsed

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -81,7 +81,7 @@ const SGR_MOUSE_FRAGMENT_RE = /(?<!\d)(?:\[<|<)?(?:[0-9]|[1-9][0-9]|1\d{2}|2[0-4
 // has no digit and no `;`, `see 1;2;3M for details` contains disqualifying
 // letters, and `1234;56;78M9;10;11M` has only two terminators.
 // eslint-disable-next-line no-control-regex
-const MOUSE_BURST_NOISE_RE = /^(?=[^]*\d)(?=[^]*;)(?=(?:[^]*[Mm]){3})[\d;<\[\]IMm \x1b]+$/
+const MOUSE_BURST_NOISE_RE = /^(?=[\s\S]*\d)(?=[\s\S]*;)(?=(?:[^Mm]*[Mm]){3})[\d;<\[\]IMm \x1b]+$/
 
 // Residual-shard variant for the gaps BETWEEN / AFTER recovered fragments
 // inside parseTextWithSgrMouseFragments. A real recovery run leaves degraded

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -91,7 +91,7 @@ const MOUSE_BURST_NOISE_RE = /^(?=[^]*\d)(?=[^]*;)(?=(?:[^]*[Mm]){3})[\d;<\[\]IM
 // digit AND at least one `M`/`m` — a prose gap like ` for details ` contains
 // disqualifying letters and never matches.
 // eslint-disable-next-line no-control-regex
-const MOUSE_BURST_RESIDUE_RE = /^(?=[^]*\d)(?=[^]*[Mm])[\d;<\[\]IMm \x1b]+$/
+const MOUSE_BURST_RESIDUE_RE = /^(?=[^\d]*\d)(?=[^Mm]*[Mm])[\d;<\[\]IMm \x1b]+$/
 
 function createPasteKey(content: string): ParsedKey {
   return {

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -296,18 +296,21 @@ export function parseMultipleKeypresses(
     } else if (token.type === 'text') {
       if (inPaste) {
         pasteBuffer += token.value
+      } else if (MOUSE_BURST_NOISE_RE.test(token.value)) {
+        // Fully degraded mouse-burst noise — a heavy render (e.g. a sudo /
+        // secret prompt repaint) blocked the event loop past App's 50ms flush
+        // watchdog, so a long burst of SGR mouse reports arrived as text with
+        // prefixes AND coordinate digits chewed off. Checked BEFORE fragment
+        // recovery: a noise blob can still contain a few intact `<b;c;r M`
+        // fragments, and parseTextWithSgrMouseFragments would then return
+        // non-null and emit a pile of recovered mouse events instead of
+        // dropping the blob wholesale. Swallow it here so it never leaks into
+        // the composer (and we skip the extra fragment-recovery work mid-stall).
       } else {
         const mouseFragments = parseTextWithSgrMouseFragments(token.value)
 
         if (mouseFragments) {
           keys.push(...mouseFragments)
-        } else if (MOUSE_BURST_NOISE_RE.test(token.value)) {
-          // Fully degraded mouse-burst noise — a heavy render (e.g. a sudo /
-          // secret prompt repaint) blocked the event loop past App's 50ms
-          // flush watchdog, so a long burst of SGR mouse reports arrived as
-          // text with prefixes AND coordinate digits chewed off. The shards are
-          // too mangled for the fragment recovery above; swallow the whole blob
-          // so it never leaks into the composer and locks the user out.
         } else if (/^\[M[\x60-\x7f][\x20-\uffff]{2}$/.test(token.value)) {
           // Orphaned X10 wheel tail (fullscreen only — mouse tracking is off
           // otherwise). A heavy render blocked the event loop past App's 50ms


### PR DESCRIPTION
## Why

User reported the TUI leaking mangled SGR/ANSI mouse sequences into the composer during tool calls — and being unable to type or exit until it cleared. Captured payload (Windows Terminal):

```
M6M35;220;56M6M35;218;56M169;48M;157;47M;44M20;43M79;40M78;40M0M7M35;49;41M48;41M;47;40M9;15;32M[I;31M5;211;26M35;211;25M7M;220;1MM0M09;25M24M23M3;22MM18M99;26M32MM38M63;44M47MM1;51M M4M54M
```

**Root cause of the symptom:** when the Node event loop blocks during a heavy render/tool-call burst, stdin stops being drained. Mode-1003 any-motion mouse reports pile up in the kernel buffer, get partially read, and arrive as text with the `\x1b[<` prefix **and** coordinate digits chewed off across many partial reads. The existing recovery (`SGR_MOUSE_FRAGMENT_RE`) only matches clean `button;col;row[Mm]` triples, so the degraded shards (1-/2-param remnants, lone `M`/`m`, a stray focus-in `[I`) fall through to the text path and get typed into the composer — locking the user out.

## What

Two new recovery layers in `parse-keypress.ts` (extends the existing leak-recovery alphabet rather than rewriting parsing):

- **`MOUSE_BURST_NOISE_RE`** — whole-text fast path. If a text token is drawn only from the mouse-leak alphabet (`[ ] < ; I M m`, digits, spaces) **and** carries the structural signature of mouse coordinates (≥3 `M`/`m` terminators, a digit, and a `;`), swallow it wholesale.
- **`MOUSE_BURST_RESIDUE_RE`** — swallows pure-noise residue in the gaps between and after recovered fragments, so a partially-recovered burst doesn't trail a chewed-up tail into the prompt.

All three constraints together preserve real prose — `Mmm MMM mmm yummy` (no digit/`;`), `see 1;2;3M for details` (disqualifying letters), `1234;56;78M9;10;11M` (only two terminators) are all kept.

This is **defense-in-depth**: it stops the leak/lockout regardless of what blocks the loop.

## Scope / what this does NOT do

The deeper cause — the event loop stalling during streaming/tool render — is a **separate, still-open issue**. I confirmed the stall→leak mechanism but could not faithfully reproduce the streaming-time stall with a synthetic PTY harness (its frame-gaps turned out to be idle-UI artifacts, not real stalls). Root-causing that needs `HERMES_DEV_PERF=1` instrumentation captured during a real model turn. This PR deliberately ships only the input-side hardening that makes a stall non-destructive.

## Tests

```
cd ui-tui
npx vitest run packages/hermes-ink/src/ink/parse-keypress.test.ts   # 18 passed
npm run build                                                        # bundle ships
```

New tests: a regression test using the exact captured leak blob (asserts zero keys leak), plus a `Mmm MMM mmm yummy` prose-preservation guard. Pre-existing unrelated failures (`textInputWrap`/`cursorDrift` — wrap-ansi version mismatch; `execFileNoThrow` TS errors) confirmed present on clean `main` and untouched by this change.
