### PR TITLE
fix(tools): respect task and session cwd overrides in execute_code project mode

### DIFF
--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -13,8 +13,11 @@ there is no env-var override. Tests patch ``_load_config`` directly.
 """
 
 import json
+import io
 import os
 import sys
+from types import SimpleNamespace
+import threading
 import unittest
 from contextlib import contextmanager
 from unittest.mock import patch
@@ -220,6 +223,37 @@ class TestResolveChildCwd(unittest.TestCase):
         with patch.dict(os.environ, {"TERMINAL_CWD": "~"}):
             self.assertEqual(_resolve_child_cwd("project", "/tmp/staging"), home)
 
+    def test_project_prefers_task_override_over_terminal_cwd(self):
+        import tempfile
+
+        task_id = "acp-session-1"
+        with tempfile.TemporaryDirectory() as override_cwd, tempfile.TemporaryDirectory() as terminal_cwd:
+            with patch.dict(os.environ, {"TERMINAL_CWD": terminal_cwd}):
+                with patch("tools.terminal_tool._task_env_overrides", {task_id: {"cwd": override_cwd}}):
+                    with patch("tools.terminal_tool._active_environments", {}):
+                        with patch("tools.terminal_tool._env_lock", threading.Lock()):
+                            with patch("tools.terminal_tool._resolve_container_task_id", return_value=task_id):
+                                self.assertEqual(
+                                    _resolve_child_cwd("project", "/tmp/staging", task_id=task_id),
+                                    override_cwd,
+                                )
+
+    def test_project_prefers_live_env_cwd_over_terminal_cwd(self):
+        import tempfile
+
+        task_id = "delegate-1"
+        with tempfile.TemporaryDirectory() as live_cwd, tempfile.TemporaryDirectory() as terminal_cwd:
+            fake_env = SimpleNamespace(cwd=live_cwd)
+            with patch.dict(os.environ, {"TERMINAL_CWD": terminal_cwd}):
+                with patch("tools.terminal_tool._task_env_overrides", {}):
+                    with patch("tools.terminal_tool._active_environments", {"default": fake_env}):
+                        with patch("tools.terminal_tool._env_lock", threading.Lock()):
+                            with patch("tools.terminal_tool._resolve_container_task_id", return_value="default"):
+                                self.assertEqual(
+                                    _resolve_child_cwd("project", "/tmp/staging", task_id=task_id),
+                                    live_cwd,
+                                )
+
 
 # ---------------------------------------------------------------------------
 # Schema description
@@ -361,6 +395,47 @@ class TestExecuteCodeModeIntegration(unittest.TestCase):
         result = self._run(code, mode="strict")
         self.assertEqual(result["status"], "success")
         self.assertIn("mock", result["output"])
+
+
+class TestExecuteCodeProjectCwdSelection(unittest.TestCase):
+    """Focused local-mode regression guards around child cwd selection."""
+
+    def test_execute_code_passes_task_override_cwd_to_local_child(self):
+        task_id = "acp-session-1"
+        captured = {}
+
+        class _FakeProc:
+            def __init__(self, *_args, **kwargs):
+                captured["cwd"] = kwargs["cwd"]
+                self.stdout = io.BytesIO(b"")
+                self.stderr = io.BytesIO(b"")
+                self.returncode = 0
+
+            def poll(self):
+                return 0
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as override_cwd, tempfile.TemporaryDirectory() as terminal_cwd:
+            with _mock_mode("project"):
+                with patch.dict(os.environ, {"TERMINAL_ENV": "local", "TERMINAL_CWD": terminal_cwd}, clear=False):
+                    with patch("tools.code_execution_tool.subprocess.Popen", side_effect=_FakeProc):
+                        with patch("tools.terminal_tool._task_env_overrides", {task_id: {"cwd": override_cwd}}):
+                            with patch("tools.terminal_tool._active_environments", {}):
+                                with patch("tools.terminal_tool._env_lock", threading.Lock()):
+                                    with patch("tools.terminal_tool._resolve_container_task_id", return_value=task_id):
+                                        raw = execute_code(
+                                            code="print('ok')",
+                                            task_id=task_id,
+                                            enabled_tools=list(SANDBOX_ALLOWED_TOOLS),
+                                        )
+
+        result = json.loads(raw)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(
+            os.path.realpath(captured["cwd"]),
+            os.path.realpath(override_cwd),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1275,7 +1275,7 @@ def execute_code(
         # Env scrubbing and tool whitelist apply identically in both modes.
         _mode = _get_execution_mode()
         _child_python = _resolve_child_python(_mode)
-        _child_cwd = _resolve_child_cwd(_mode, tmpdir)
+        _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id)
         _script_path = os.path.join(tmpdir, "script.py")
 
         proc = subprocess.Popen(
@@ -1667,25 +1667,76 @@ def _resolve_child_python(mode: str) -> str:
     return sys.executable
 
 
-def _resolve_child_cwd(mode: str, staging_dir: str) -> str:
+def _normalize_existing_cwd(raw_cwd: str) -> str | None:
+    """Return an existing absolute cwd path, or ``None`` if unusable."""
+    raw_cwd = (raw_cwd or "").strip()
+    if not raw_cwd:
+        return None
+    expanded = os.path.expanduser(raw_cwd)
+    if not os.path.isabs(expanded):
+        expanded = os.path.join(os.getcwd(), expanded)
+    if os.path.isdir(expanded):
+        return expanded
+    return None
+
+
+def _resolve_task_project_cwd(task_id: Optional[str]) -> str | None:
+    """Return a task/session-specific project cwd when terminal state knows it."""
+    try:
+        from tools.terminal_tool import (
+            _active_environments,
+            _env_lock,
+            _resolve_container_task_id,
+            _task_env_overrides,
+        )
+    except Exception:
+        return None
+
+    try:
+        container_key = _resolve_container_task_id(task_id)
+    except Exception:
+        container_key = task_id
+
+    override = _task_env_overrides.get(container_key or "", {}).get("cwd")
+    resolved = _normalize_existing_cwd(override)
+    if resolved:
+        return resolved
+
+    try:
+        with _env_lock:
+            env = _active_environments.get(container_key or "")
+            if env is None and task_id:
+                env = _active_environments.get(task_id)
+            live_cwd = getattr(env, "cwd", None) if env is not None else None
+    except Exception:
+        return None
+
+    return _normalize_existing_cwd(live_cwd)
+
+
+def _resolve_child_cwd(mode: str, staging_dir: str, task_id: Optional[str] = None) -> str:
     """Resolve the working directory for the execute_code subprocess.
 
     - ``strict``: the staging tmpdir (today's behavior).
-    - ``project``: the session's TERMINAL_CWD (same as the terminal tool), or
-      ``os.getcwd()`` if TERMINAL_CWD is unset or doesn't point at a real dir.
-      Falls back to the staging tmpdir as a last resort so we never invoke
-      Popen with a nonexistent cwd.
+    - ``project``: prefer the task/session cwd tracked by terminal state,
+      then ``TERMINAL_CWD``, then ``os.getcwd()``. Falls back to the staging
+      tmpdir as a last resort so we never invoke Popen with a nonexistent cwd.
     """
     if mode != "project":
         return staging_dir
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
-    if raw:
-        expanded = os.path.expanduser(raw)
-        if os.path.isdir(expanded):
-            return expanded
-    here = os.getcwd()
-    if os.path.isdir(here):
+
+    task_cwd = _resolve_task_project_cwd(task_id)
+    if task_cwd:
+        return task_cwd
+
+    env_cwd = _normalize_existing_cwd(os.environ.get("TERMINAL_CWD", ""))
+    if env_cwd:
+        return env_cwd
+
+    here = _normalize_existing_cwd(os.getcwd())
+    if here:
         return here
+
     return staging_dir
 
 


### PR DESCRIPTION
## Summary

This PR fixes `execute_code` project mode so it respects task/session-specific working directory overrides instead of falling back to the process cwd when ACP/editor session context is available.

## Fix

- Passed `task_id` into the local `execute_code` child cwd resolver.
- Added task-aware cwd resolution for project mode with the correct precedence:
  1. task/session cwd override
  2. live terminal environment cwd
  3. `TERMINAL_CWD`
  4. process cwd
  5. staging dir fallback
- Added regression coverage to verify both resolver behavior and the actual `Popen(..., cwd=...)` value used by local project-mode execution.

## Testing

- `tests/tools/test_code_execution_modes.py tests/tools/test_terminal_task_cwd.py tests/acp/test_session.py` -> `70 passed, 12 skipped`
- `tests/tools/test_resolve_path.py` -> `6 passed`