### PR TITLE
fix(gateway): stop system tips from auto-uploading local files

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3736,6 +3736,7 @@ class BasePlatformAdapter(ABC):
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
+            is_ephemeral_response = isinstance(response, EphemeralReply)
 
             # Slash-command handlers may return an EphemeralReply sentinel to
             # request that their reply message auto-delete after a TTL (used
@@ -3793,12 +3794,16 @@ class BasePlatformAdapter(ABC):
                 if images:
                     logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
 
-                # Auto-detect bare local file paths for native media delivery
-                # (helps small models that don't use MEDIA: syntax)
-                local_files, text_content = self.extract_local_files(text_content)
-                local_files = self.filter_local_delivery_paths(local_files)
-                if local_files:
-                    logger.info("[%s] extract_local_files found %d file(s) in response", self.name, len(local_files))
+                local_files = []
+                if not is_ephemeral_response:
+                    # Auto-detect bare local file paths for native media delivery
+                    # (helps small models that don't use MEDIA: syntax). Skip
+                    # system/command notices so config paths stay visible text
+                    # instead of becoming native uploads.
+                    local_files, text_content = self.extract_local_files(text_content)
+                    local_files = self.filter_local_delivery_paths(local_files)
+                    if local_files:
+                        logger.info("[%s] extract_local_files found %d file(s) in response", self.name, len(local_files))
                 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -215,7 +215,7 @@ TIPS = [
     # --- Context & Compression ---
     "Context auto-compresses when it reaches the threshold — memories are flushed and history summarized.",
     "The status bar turns yellow, then orange, then red as context fills up.",
-    "SOUL.md at ~/.hermes/SOUL.md is the agent's primary identity — customize it to shape behavior.",
+    "SOUL.md is the agent's primary identity file — customize it to shape behavior.",
     "Hermes loads project context from .hermes.md, AGENTS.md, CLAUDE.md, or .cursorrules (first match).",
     "Subdirectory AGENTS.md files are discovered progressively as the agent navigates into folders.",
     "Context files are capped at 20,000 characters with smart head/tail truncation.",
@@ -273,7 +273,7 @@ TIPS = [
     "Cron scripts live in ~/.hermes/scripts/ and run before the agent — perfect for data collection pipelines.",
     "prefill_messages_file in config.yaml injects few-shot examples into every API call, never saved to history.",
     "SOUL.md completely replaces the agent's default identity — rewrite it to make Hermes your own.",
-    "SOUL.md is auto-seeded with a default personality on first run. Edit ~/.hermes/SOUL.md to customize.",
+    "SOUL.md is auto-seeded with a default personality on first run. Edit it to customize.",
     "/compress <focus topic> allocates 60-70% of the summary budget to your topic and aggressively trims the rest.",
     "On second+ compression, the compressor updates the previous summary instead of starting from scratch.",
     "Before a gateway session reset, Hermes auto-flushes important facts to memory in the background.",
@@ -430,7 +430,7 @@ TIPS = [
     'hermes -z "<prompt>" is the purest one-shot: final answer on stdout, nothing else — ideal for piping in scripts.',
     'hermes chat --pass-session-id injects the session ID into the system prompt so the agent can self-reference it.',
     'hermes chat --image path/to/pic.png attaches a local image to a single -q query without a separate upload step.',
-    'hermes chat --ignore-user-config skips ~/.hermes/config.yaml — reproducible bug reports and CI runs.',
+    'hermes chat --ignore-user-config skips the active user config — reproducible bug reports and CI runs.',
     "hermes chat --source tool tags programmatic chats so they don't clutter hermes sessions list.",
     'hermes dump --show-keys includes redacted API key fingerprints for deeper support debugging.',
     'hermes sessions rename <ID> "new title" renames any past session; hermes sessions delete <ID> removes one.',
@@ -484,5 +484,4 @@ def get_random_tip(exclude_recent: int = 0) -> str:
             deduplication across sessions.
     """
     return random.choice(TIPS)
-
 

--- a/tests/gateway/test_ephemeral_reply.py
+++ b/tests/gateway/test_ephemeral_reply.py
@@ -269,6 +269,37 @@ async def test_process_message_unwraps_ephemeral_before_send():
 
 
 @pytest.mark.asyncio
+async def test_process_message_ephemeral_reply_does_not_auto_upload_bare_paths(tmp_path):
+    """Tips/system notices may mention local paths; they must remain text."""
+    adapter = _delete_adapter()
+    adapter._send_with_retry = AsyncMock(
+        return_value=SendResult(success=True, message_id="sent-1")
+    )
+    adapter.send_document = AsyncMock(
+        return_value=SendResult(success=True, message_id="doc-1")
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("model:\n  provider: test\n", encoding="utf-8")
+    reply_text = f"Tip: hermes chat --ignore-user-config skips {config_path}"
+
+    async def _handler(evt):
+        return EphemeralReply(reply_text, ttl_seconds=0)
+
+    adapter.set_message_handler(_handler)
+
+    event = _make_event(text="/new")
+    session_key = "agent:main:telegram:private:42"
+    with patch("gateway.platforms.base.asyncio.sleep", AsyncMock()), patch.object(
+        adapter, "_keep_typing", new=AsyncMock()
+    ):
+        await adapter._process_message_background(event, session_key)
+
+    adapter._send_with_retry.assert_called_once()
+    assert adapter._send_with_retry.call_args.kwargs["content"] == reply_text
+    adapter.send_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_process_message_incapable_platform_does_not_schedule_delete():
     adapter = _no_delete_adapter()
     adapter._send_with_retry = AsyncMock(


### PR DESCRIPTION
## What does this PR do?

Prevents gateway system notices, including `/new` reset tips, from turning bare local paths in their visible text into native file uploads.

The reported leak happened because `/new` returns an `EphemeralReply` that can include a random tip. One tip mentioned `~/.hermes/config.yaml`; the normal gateway delivery path then ran `extract_local_files()` over that text, found the file existed, removed the path from the visible reply, and uploaded the config as a document attachment.

This keeps explicit `MEDIA:` delivery behavior intact while skipping bare-path auto-detection for `EphemeralReply` command/system responses. It also rewords the affected tips so they do not hardcode home-relative install paths, which is more accurate for profile, container, and custom `HERMES_HOME` installs.

## Related Issue

Related to #35507.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py`: skip `extract_local_files()` for `EphemeralReply` system/command responses so tips and command notices remain text instead of becoming uploads.
- `hermes_cli/tips.py`: remove home-specific file paths from the affected `config.yaml` and `SOUL.md` tips.
- `tests/gateway/test_ephemeral_reply.py`: add regression coverage showing an `EphemeralReply` with an existing `config.yaml` path sends the text and does not call `send_document()`.

## How to Test

1. Run `python -m py_compile gateway/platforms/base.py hermes_cli/tips.py tests/gateway/test_ephemeral_reply.py`.
2. Run the targeted async regression helper in the repo venv for `test_process_message_ephemeral_reply_does_not_auto_upload_bare_paths`.
3. Audit the current tip corpus with `BasePlatformAdapter.extract_local_files()` and confirm it reports `hits 0`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 on WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Validation performed locally:

- `python -m py_compile gateway/platforms/base.py hermes_cli/tips.py tests/gateway/test_ephemeral_reply.py` passed.
- Direct venv async regression check for `test_process_message_ephemeral_reply_does_not_auto_upload_bare_paths` passed.
- Tip extractor audit over `hermes_cli.tips.TIPS` reported `hits 0`.

Full pytest was not run locally.
