### PR TITLE
fix(cron): restore cron session env after jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1397,8 +1397,12 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     agent = None
 
     # Mark this as a cron session so the approval system can apply cron_mode.
-    # This env var is process-wide and persists for the lifetime of the
-    # scheduler process — every job this process runs is a cron job.
+    # The gateway may run cron ticks in-process alongside live Telegram/API
+    # conversations, so never leave this process-wide env var set after the
+    # job finishes. Otherwise later live sessions inherit cron approval
+    # semantics and tools such as execute_code are blocked as if no user were
+    # present.
+    _prior_cron_session = os.environ.get("HERMES_CRON_SESSION", "_UNSET_")
     os.environ["HERMES_CRON_SESSION"] = "1"
 
     # Use ContextVars for per-job session/delivery state so parallel jobs
@@ -1821,6 +1825,12 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 os.environ.pop("TERMINAL_CWD", None)
             else:
                 os.environ["TERMINAL_CWD"] = _prior_terminal_cwd
+        # Restore cron approval marker so in-process gateway cron ticks do not
+        # poison subsequent live user sessions.
+        if _prior_cron_session == "_UNSET_":
+            os.environ.pop("HERMES_CRON_SESSION", None)
+        else:
+            os.environ["HERMES_CRON_SESSION"] = _prior_cron_session
         # Clean up ContextVar session/delivery state for this job.
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -912,6 +912,73 @@ class TestRunJobSessionPersistence:
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
 
+    def test_run_job_restores_cron_session_env_after_success(self, tmp_path, monkeypatch):
+        # Regression: gateway runs cron ticks in-process. If a cron job leaves
+        # HERMES_CRON_SESSION=1 behind, later live Telegram sessions inherit
+        # cron approval semantics and execute_code is blocked.
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        job = {
+            "id": "env-restore-job",
+            "name": "env-restore",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, *_ = run_job(job)
+
+        assert success is True
+        assert "HERMES_CRON_SESSION" not in os.environ
+
+    def test_run_job_restores_preexisting_cron_session_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "outer")
+        job = {
+            "id": "env-restore-existing-job",
+            "name": "env-restore-existing",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, *_ = run_job(job)
+
+        assert success is True
+        assert os.environ["HERMES_CRON_SESSION"] == "outer"
+
     def test_run_job_closes_agent_on_failure_to_prevent_fd_leak(self, tmp_path):
         # Regression: if ``run_conversation`` raises, the ephemeral cron
         # agent was previously leaked — over days of ticks this accumulated


### PR DESCRIPTION
## Summary\n- restore HERMES_CRON_SESSION after each cron job instead of leaking it into the gateway process\n- add regression coverage for unset and pre-existing cron session env values\n\n## Why\nGateway cron ticks run in-process. Leaving HERMES_CRON_SESSION=1 set can make later live Telegram/API sessions inherit cron approval behavior, which can incorrectly block interactive tools such as execute_code.\n\n## Tests\n- python -m pytest tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_run_job_restores_cron_session_env_after_success tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_run_job_restores_preexisting_cron_session_env tests/tools/test_cron_approval_mode.py tests/tools/test_execute_code_approval_cluster.py -q\n\n## Cost impact\nNone. Local process env restoration only; no GCP/Cloud Run changes.