### PR TITLE
fix(tools): inherit active terminal session virtualenv in execute_code project mode

### DIFF
--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -17,6 +17,7 @@ import os
 import sys
 import unittest
 from contextlib import contextmanager
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -181,6 +182,33 @@ class TestResolveChildPython(unittest.TestCase):
                 result = _resolve_child_python("project")
                 self.assertEqual(result, str(ve / "bin" / "python"))
 
+    def test_project_prefers_live_session_virtualenv_over_parent_env(self):
+        """Project mode should consult the live terminal session before os.environ."""
+        if sys.platform == "win32":
+            pytest.skip(
+                "Creates symlinks and assumes POSIX venv layout (bin/python). "
+                "Windows venvs use Scripts/python.exe and symlink creation "
+                "requires elevated privileges (WinError 1314)."
+            )
+        import pathlib
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as td, tempfile.TemporaryDirectory() as snap_td:
+            fake_venv = pathlib.Path(td)
+            (fake_venv / "bin").mkdir()
+            (fake_venv / "bin" / "python").symlink_to(sys.executable)
+            snapshot = pathlib.Path(snap_td) / "hermes-snap.sh"
+            snapshot.write_text(
+                f'declare -x VIRTUAL_ENV="{fake_venv}"\n',
+                encoding="utf-8",
+            )
+            fake_env = SimpleNamespace(_snapshot_path=str(snapshot), cwd=os.getcwd())
+            with patch("tools.terminal_tool.get_active_env", return_value=fake_env):
+                with patch.dict(os.environ, {"VIRTUAL_ENV": "/broken/parent/venv"}):
+                    _is_usable_python.cache_clear()
+                    result = _resolve_child_python("project", task_id="task-live")
+                    self.assertEqual(result, str(fake_venv / "bin" / "python"))
+
     def test_is_usable_python_rejects_nonexistent(self):
         _is_usable_python.cache_clear()
         self.assertFalse(_is_usable_python("/does/not/exist/python"))
@@ -219,6 +247,18 @@ class TestResolveChildCwd(unittest.TestCase):
         home = str(pathlib.Path.home())
         with patch.dict(os.environ, {"TERMINAL_CWD": "~"}):
             self.assertEqual(_resolve_child_cwd("project", "/tmp/staging"), home)
+
+    def test_project_prefers_live_session_cwd_over_terminal_env(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as session_td, tempfile.TemporaryDirectory() as terminal_td:
+            fake_env = SimpleNamespace(_snapshot_path="", cwd=session_td)
+            with patch("tools.terminal_tool.get_active_env", return_value=fake_env):
+                with patch.dict(os.environ, {"TERMINAL_CWD": terminal_td}):
+                    self.assertEqual(
+                        _resolve_child_cwd("project", "/tmp/staging", task_id="task-live"),
+                        session_td,
+                    )
 
 
 # ---------------------------------------------------------------------------
@@ -350,6 +390,53 @@ class TestExecuteCodeModeIntegration(unittest.TestCase):
             result = self._run(code, mode="project", extra_env={"TERMINAL_CWD": td})
             self.assertEqual(result["status"], "success")
             self.assertIn("mock", result["output"])
+
+    def test_project_mode_prefers_live_session_state_over_parent_env(self):
+        """Project mode should inherit the active terminal session's venv and cwd."""
+        import pathlib
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as venv_td, tempfile.TemporaryDirectory() as session_td, tempfile.TemporaryDirectory() as snap_td, tempfile.TemporaryDirectory() as terminal_td:
+            fake_venv = pathlib.Path(venv_td)
+            (fake_venv / "bin").mkdir()
+            child_python = fake_venv / "bin" / "python"
+            child_python.symlink_to(sys.executable)
+
+            snapshot = pathlib.Path(snap_td) / "hermes-snap.sh"
+            snapshot.write_text(
+                (
+                    f'declare -x VIRTUAL_ENV="{fake_venv}"\n'
+                    f'declare -x PATH="{fake_venv / "bin"}:/usr/bin"\n'
+                ),
+                encoding="utf-8",
+            )
+            fake_env = SimpleNamespace(_snapshot_path=str(snapshot), cwd=session_td)
+            code = (
+                "import os, shutil, sys\n"
+                "print(sys.executable)\n"
+                "print(os.getcwd())\n"
+                "print(os.environ.get('VIRTUAL_ENV', ''))\n"
+                "print(shutil.which('python') or '')\n"
+            )
+
+            with patch("tools.terminal_tool.get_active_env", return_value=fake_env):
+                result = self._run(
+                    code,
+                    mode="project",
+                    extra_env={
+                        "TERMINAL_CWD": terminal_td,
+                        "VIRTUAL_ENV": "",
+                        "CONDA_PREFIX": "",
+                    },
+                )
+
+            self.assertEqual(result["status"], "success")
+            lines = [line.strip() for line in result["output"].splitlines() if line.strip()]
+            self.assertGreaterEqual(len(lines), 4, result["output"])
+            self.assertEqual(os.path.realpath(lines[0]), os.path.realpath(str(child_python)))
+            self.assertEqual(os.path.realpath(lines[1]), os.path.realpath(session_td))
+            self.assertEqual(os.path.realpath(lines[2]), os.path.realpath(str(fake_venv)))
+            self.assertEqual(os.path.realpath(lines[3]), os.path.realpath(str(child_python)))
 
     def test_strict_mode_can_still_import_hermes_tools(self):
         """Regression: strict mode's tmpdir CWD still works for imports."""

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -132,6 +132,8 @@ _WINDOWS_ESSENTIAL_ENV_VARS = frozenset({
     "COMPUTERNAME",
 })
 
+_PROJECT_MODE_SESSION_ENV_KEYS = ("VIRTUAL_ENV", "CONDA_PREFIX", "PATH")
+
 
 def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
     """Produce the scrubbed child-process env for execute_code.
@@ -1220,7 +1222,17 @@ def execute_code(
         # OS-essential allowlist (SYSTEMROOT, WINDIR, COMSPEC, ...) is also
         # passed through — without those, the child can't create a socket
         # or spawn a subprocess.  See ``_scrub_child_env`` for the rules.
-        child_env = _scrub_child_env(os.environ)
+        # In project mode, inherit the live terminal session's activated venv
+        # markers/PATH before scrubbing so child subprocess lookups mirror the
+        # user's current shell more closely.
+        _mode = _get_execution_mode()
+        _session_env, _ = _get_live_project_mode_session_state(task_id)
+        _child_source_env = dict(os.environ)
+        if _mode == "project":
+            for _key, _value in _session_env.items():
+                if _value:
+                    _child_source_env[_key] = _value
+        child_env = _scrub_child_env(_child_source_env)
         child_env["HERMES_RPC_SOCKET"] = rpc_endpoint
         child_env["PYTHONDONTWRITEBYTECODE"] = "1"
         # Force UTF-8 for the child's stdio and default file encoding.
@@ -1273,9 +1285,8 @@ def execute_code(
         #   - project: user's venv python + session's working directory, so
         #              project deps like pandas and user files resolve.
         # Env scrubbing and tool whitelist apply identically in both modes.
-        _mode = _get_execution_mode()
-        _child_python = _resolve_child_python(_mode)
-        _child_cwd = _resolve_child_cwd(_mode, tmpdir)
+        _child_python = _resolve_child_python(_mode, task_id=task_id)
+        _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id)
         _script_path = os.path.join(tmpdir, "script.py")
 
         proc = subprocess.Popen(
@@ -1624,19 +1635,84 @@ def _is_usable_python(python_path: str) -> bool:
         return False
 
 
-def _resolve_child_python(mode: str) -> str:
+def _read_session_snapshot_env(snapshot_path: str,
+                               keys: tuple[str, ...] = _PROJECT_MODE_SESSION_ENV_KEYS) -> Dict[str, str]:
+    """Read selected exported vars from a local terminal snapshot file.
+
+    ``BaseEnvironment.init_session()`` writes ``export -p`` output to a shell
+    snapshot on the host filesystem.  For local project-mode execute_code we
+    consult that live snapshot first so a prior ``source .venv/bin/activate``
+    or ``conda activate`` in the terminal session carries over here too.
+    """
+    if not snapshot_path:
+        return {}
+
+    wanted = set(keys)
+    found: Dict[str, str] = {}
+    try:
+        with open(snapshot_path, encoding="utf-8", errors="replace") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line.startswith("declare -x "):
+                    continue
+                try:
+                    parts = shlex.split(line, posix=True)
+                except ValueError:
+                    continue
+                if len(parts) < 3 or parts[0] != "declare" or parts[1] != "-x":
+                    continue
+                assignment = parts[2]
+                if "=" in assignment:
+                    name, value = assignment.split("=", 1)
+                else:
+                    name, value = assignment, ""
+                if name in wanted:
+                    found[name] = value
+                    if len(found) == len(wanted):
+                        break
+    except OSError:
+        return {}
+    return found
+
+
+def _get_live_project_mode_session_state(task_id: Optional[str]) -> tuple[Dict[str, str], Optional[str]]:
+    """Return live session env vars + cwd for a local terminal task if present."""
+    try:
+        from tools.terminal_tool import get_active_env
+    except Exception:
+        return {}, None
+
+    env = get_active_env(task_id or "default")
+    if env is None:
+        return {}, None
+
+    snapshot_path = getattr(env, "_snapshot_path", "")
+    session_env = _read_session_snapshot_env(snapshot_path)
+
+    session_cwd = getattr(env, "cwd", None)
+    if not isinstance(session_cwd, str) or not session_cwd.strip():
+        session_cwd = None
+
+    return session_env, session_cwd
+
+
+def _resolve_child_python(mode: str, task_id: Optional[str] = None) -> str:
     """Pick the Python interpreter for the execute_code subprocess.
 
     In ``strict`` mode, always ``sys.executable`` — guaranteed to work and
     keeps behavior fully reproducible across sessions.
 
-    In ``project`` mode, prefer the user's active virtualenv/conda env's
-    python so ``import pandas`` etc. work. Falls back to ``sys.executable``
-    if no venv is detected, the candidate binary is missing/not executable,
-    or it fails a Python 3.8+ version check.
+    In ``project`` mode, prefer the live terminal session's active
+    virtualenv/conda env first, then fall back to the parent process env.
+    This keeps ``execute_code`` aligned with the terminal tool after a user
+    activates a venv inside the session. Falls back to ``sys.executable`` if
+    no venv is detected, the candidate binary is missing/not executable, or
+    it fails a Python 3.8+ version check.
     """
     if mode != "project":
         return sys.executable
+
+    session_env, _ = _get_live_project_mode_session_state(task_id)
 
     if _IS_WINDOWS:
         exe_names = ("python.exe", "python3.exe")
@@ -1645,8 +1721,18 @@ def _resolve_child_python(mode: str) -> str:
         exe_names = ("python", "python3")
         subdirs = ("bin",)
 
-    for var in ("VIRTUAL_ENV", "CONDA_PREFIX"):
-        root = os.environ.get(var, "").strip()
+    roots_to_try: list[tuple[str, str]] = []
+    seen_roots: set[tuple[str, str]] = set()
+    for source_env in (session_env, os.environ):
+        for var in ("VIRTUAL_ENV", "CONDA_PREFIX"):
+            root = source_env.get(var, "").strip()
+            key = (var, root)
+            if not root or key in seen_roots:
+                continue
+            seen_roots.add(key)
+            roots_to_try.append(key)
+
+    for var, root in roots_to_try:
         if not root:
             continue
         for subdir in subdirs:
@@ -1667,17 +1753,22 @@ def _resolve_child_python(mode: str) -> str:
     return sys.executable
 
 
-def _resolve_child_cwd(mode: str, staging_dir: str) -> str:
+def _resolve_child_cwd(mode: str, staging_dir: str, task_id: Optional[str] = None) -> str:
     """Resolve the working directory for the execute_code subprocess.
 
     - ``strict``: the staging tmpdir (today's behavior).
-    - ``project``: the session's TERMINAL_CWD (same as the terminal tool), or
-      ``os.getcwd()`` if TERMINAL_CWD is unset or doesn't point at a real dir.
-      Falls back to the staging tmpdir as a last resort so we never invoke
-      Popen with a nonexistent cwd.
+    - ``project``: the live terminal session cwd when available, otherwise
+      ``TERMINAL_CWD`` (same as the terminal tool config), or ``os.getcwd()``
+      if neither points at a real dir. Falls back to the staging tmpdir as a
+      last resort so we never invoke Popen with a nonexistent cwd.
     """
     if mode != "project":
         return staging_dir
+    _, session_cwd = _get_live_project_mode_session_state(task_id)
+    if session_cwd:
+        expanded = os.path.expanduser(session_cwd)
+        if os.path.isdir(expanded):
+            return expanded
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         expanded = os.path.expanduser(raw)


### PR DESCRIPTION
## Summary

Fix `execute_code` project mode so it actually inherits the active terminal session state before falling back to the parent process environment. This makes project mode match its documented contract when a session has already activated a virtual environment.

## Fix

- Updated `execute_code` project-mode resolution to read the live terminal session snapshot first.
- Prefer session `VIRTUAL_ENV` / `CONDA_PREFIX` when choosing the child Python interpreter.
- Prefer the live session working directory when resolving the child process CWD.
- Carry the session-derived `PATH` / venv markers into the scrubbed child environment so Python lookup and imports behave like the active terminal session.
- Kept the previous parent-environment fallback for cases where no live session state exists.
- Added regression coverage for:
  - resolver-level preference of live session venv over parent env
  - resolver-level preference of live session cwd over configured cwd env
  - end-to-end project-mode inheritance of session interpreter, cwd, `VIRTUAL_ENV`, and `PATH`

## Testing

Ran:

- `python -m pytest -o addopts='' -p no:timeout tests\tools\test_code_execution_modes.py -q`
- `python -m pytest -o addopts='' -p no:timeout tests\tools\test_code_execution.py -q`
- `ruff check tools\code_execution_tool.py tests\tools\test_code_execution_modes.py`

Results:

- `tests\tools\test_code_execution_modes.py`: `25 passed, 14 skipped`
- `tests\tools\test_code_execution.py`: `36 passed, 31 skipped`
