### PR TITLE
feat(custom_providers): per-model max_tokens with switch/fallback re-resolution

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1697,6 +1697,8 @@ def init_agent(
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
+        "max_tokens": agent.max_tokens,
+        "config_max_tokens": getattr(agent, "_config_max_tokens", None),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         # Context engine state that _try_activate_fallback() overwrites.

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -151,7 +151,9 @@ def _resolve_max_tokens(agent, agent_cfg, custom_providers=None):
     """
     if custom_providers is None:
         custom_providers = getattr(agent, "_custom_providers", None) or []
-    model_cfg = agent_cfg.get("model", {}) if isinstance(agent_cfg, dict) else {}
+    model_cfg = agent_cfg.get("model") if isinstance(agent_cfg, dict) else None
+    if not isinstance(model_cfg, dict):  # config "model:" may be a bare model-id string
+        model_cfg = {}
 
     def _warn_invalid(what, value, example):
         _ra().logger.warning(

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -133,6 +133,88 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
     agent.request_overrides = overrides
 
 
+def _resolve_max_tokens(agent, agent_cfg, custom_providers=None):
+    """Resolve ``agent.max_tokens`` with precedence:
+
+        explicit constructor/CLI > per-model custom_providers > global
+        model.max_tokens > None (downstream 4096 floor).
+
+    The per-model value is checked BEFORE the global model.max_tokens — the
+    opposite order from context_length (global-first). A provider-specific
+    output cap is the more-specific intent and must win. The global is nulled on
+    switch_model / fallback (like ``_config_context_length``) so it only ever
+    applies to the primary model and never leaks onto fallbacks (#28782).
+
+    Sets ``agent._config_max_tokens`` (the config-resolved value, nulled-and-re-
+    resolved on switch) and ``agent._max_tokens_explicit`` (an explicit
+    constructor value survives switches untouched).
+    """
+    if custom_providers is None:
+        custom_providers = getattr(agent, "_custom_providers", None) or []
+    model_cfg = agent_cfg.get("model", {}) if isinstance(agent_cfg, dict) else {}
+
+    def _warn_invalid(what, value, example):
+        _ra().logger.warning(
+            "Invalid %s: %r — must be a positive integer (e.g. %s). "
+            "Falling back to provider default.", what, value, example,
+        )
+        print(
+            f"\n⚠ Invalid {what}: {value!r}\n"
+            f"  Must be a positive integer (e.g. {example}).\n"
+            f"  Falling back to provider default.\n",
+            file=sys.stderr,
+        )
+
+    def _raw_per_model_max_tokens():
+        target = (agent.base_url or "").rstrip("/")
+        if not target:
+            return None
+        for entry in custom_providers:
+            if not isinstance(entry, dict) or (entry.get("base_url") or "").rstrip("/") != target:
+                continue
+            models = entry.get("models")
+            cfg = models.get(agent.model) if isinstance(models, dict) else None
+            return cfg.get("max_tokens") if isinstance(cfg, dict) else None
+        return None
+
+    agent._max_tokens_explicit = agent.max_tokens is not None
+
+    if not agent._max_tokens_explicit:
+        # 1. Per-model custom_providers cap wins over the global value.
+        if custom_providers:
+            try:
+                from hermes_cli.config import get_custom_provider_max_tokens
+                cp_mt = get_custom_provider_max_tokens(
+                    model=agent.model, base_url=agent.base_url,
+                    custom_providers=custom_providers,
+                )
+            except Exception:
+                cp_mt = None
+            if cp_mt:
+                agent.max_tokens = int(cp_mt)
+            else:
+                # The helper silently skips invalid values — surface a warning.
+                raw = _raw_per_model_max_tokens()
+                if raw is not None:
+                    _warn_invalid(f"max_tokens for model {agent.model!r} in custom_providers", raw, 16384)
+
+        # 2. Else the global model.max_tokens (primary model only).
+        if agent.max_tokens is None:
+            global_mt = model_cfg.get("max_tokens")
+            if global_mt is not None:
+                try:
+                    if isinstance(global_mt, bool) or int(global_mt) <= 0:
+                        raise ValueError
+                    agent.max_tokens = int(global_mt)
+                except (TypeError, ValueError):
+                    _warn_invalid("model.max_tokens in config.yaml", global_mt, 4096)
+
+    # Persist the config-resolved value (None when explicit or unset) so
+    # switch_model / fallback can null-and-re-resolve per-model.
+    agent._config_max_tokens = None if agent._max_tokens_explicit else agent.max_tokens
+    agent._session_init_model_config["max_tokens"] = agent.max_tokens
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -1268,33 +1350,9 @@ def init_agent(
             _aux_context_config = None
     agent._aux_compression_context_length_config = _aux_context_config
 
-    # Read explicit model output-token override from config when the
-    # caller did not pass one directly.
+    # max_tokens is resolved below, AFTER _custom_providers, so the per-model
+    # cap can win over the global model.max_tokens (see _resolve_max_tokens).
     _model_cfg = _agent_cfg.get("model", {})
-    if agent.max_tokens is None and isinstance(_model_cfg, dict):
-        _config_max_tokens = _model_cfg.get("max_tokens")
-        if _config_max_tokens is not None:
-            try:
-                if isinstance(_config_max_tokens, bool):
-                    raise ValueError
-                _parsed_max_tokens = int(_config_max_tokens)
-                if _parsed_max_tokens <= 0:
-                    raise ValueError
-                agent.max_tokens = _parsed_max_tokens
-            except (TypeError, ValueError):
-                _ra().logger.warning(
-                    "Invalid model.max_tokens in config.yaml: %r — "
-                    "must be a positive integer (e.g. 4096). "
-                    "Falling back to provider default.",
-                    _config_max_tokens,
-                )
-                print(
-                    f"\n⚠ Invalid model.max_tokens in config.yaml: {_config_max_tokens!r}\n"
-                    f"  Must be a positive integer (e.g. 4096).\n"
-                    f"  Falling back to provider default.\n",
-                    file=sys.stderr,
-                )
-    agent._session_init_model_config["max_tokens"] = agent.max_tokens
 
     # Read explicit context_length override from model config
     if isinstance(_model_cfg, dict):
@@ -1386,6 +1444,10 @@ def init_agent(
     # Persist for reuse on switch_model / fallback activation. Must come
     # AFTER the custom_providers branch so per-model overrides aren't lost.
     agent._config_context_length = _config_context_length
+
+    # Resolve the output-token cap (per-model custom_providers > global). Placed
+    # AFTER _custom_providers so the per-model lookup can win over the global.
+    _resolve_max_tokens(agent, _agent_cfg, custom_providers=_custom_providers)
 
     agent._ensure_lmstudio_runtime_loaded(_config_context_length)
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -950,6 +950,14 @@ def restore_primary_runtime(agent) -> bool:
             api_mode=rt.get("compressor_api_mode", ""),
         )
 
+        # Restore the primary's output cap so a fallback's re-resolved
+        # max_tokens doesn't stick to the restored primary (the #28782 leak
+        # inverted). rt.get() tolerates pre-PR snapshots; explicit constructor
+        # values are never overwritten.
+        if not getattr(agent, "_max_tokens_explicit", False):
+            agent.max_tokens = rt.get("max_tokens")
+            agent._config_max_tokens = rt.get("config_max_tokens")
+
         # ── Reset fallback chain for the new turn ──
         agent._fallback_activated = False
         agent._fallback_index = 0
@@ -1586,6 +1594,8 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
+        "max_tokens": agent.max_tokens,
+        "config_max_tokens": getattr(agent, "_config_max_tokens", None),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         "compressor_model": getattr(_cc, "model", agent.model) if _cc else agent.model,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1398,6 +1398,8 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             "_anthropic_base_url",
             "_is_anthropic_oauth",
             "_config_context_length",
+            "max_tokens",
+            "_config_max_tokens",
         )
     }
     # _client_kwargs is a dict — snapshot a shallow copy so mutating the
@@ -1409,6 +1411,12 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         # actual context window is resolved via get_model_context_length()
         # instead of inheriting the stale value from the previous model.
         agent._config_context_length = None
+        # Clear the config-resolved max_tokens so the new model's per-model
+        # override is re-resolved instead of inheriting the previous value; the
+        # global never re-applies on switch (no leak — #28782). An explicit
+        # constructor value is preserved (re-resolution skipped below).
+        if not getattr(agent, "_max_tokens_explicit", False):
+            agent._config_max_tokens = None
 
         # ── Swap core runtime fields ──
         agent.model = new_model
@@ -1508,6 +1516,27 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     # ── LM Studio: preload before probing context length ──
     agent._ensure_lmstudio_runtime_loaded()
+
+    # ── Re-resolve per-model max_tokens for the new model ──
+    # Reads live config so a /model switch to a custom provider is honored.
+    # The global model.max_tokens is intentionally NOT re-applied — it belonged
+    # to the primary model only (#28782). Explicit constructor values persist.
+    if not getattr(agent, "_max_tokens_explicit", False):
+        _sm_mt = None
+        try:
+            from hermes_cli.config import (
+                load_config,
+                get_compatible_custom_providers,
+                get_custom_provider_max_tokens,
+            )
+            _sm_mt = get_custom_provider_max_tokens(
+                agent.model, agent.base_url,
+                custom_providers=get_compatible_custom_providers(load_config()),
+            )
+        except Exception:
+            _sm_mt = None
+        agent._config_max_tokens = int(_sm_mt) if _sm_mt else None
+        agent.max_tokens = agent._config_max_tokens
 
     # ── Update context compressor ──
     if hasattr(agent, "context_compressor") and agent.context_compressor:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1133,6 +1133,10 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # model's actual context window is resolved instead of inheriting
         # the stale value from the previous model.  See #22387.
         agent._config_context_length = None
+        # Re-resolve max_tokens for the fallback model below; the global must
+        # not leak onto the fallback provider (#28782). Explicit values persist.
+        if not getattr(agent, "_max_tokens_explicit", False):
+            agent._config_max_tokens = None
         agent.model = fb_model
         agent.provider = fb_provider
         agent.base_url = fb_base_url
@@ -1140,6 +1144,18 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True
+
+        if not getattr(agent, "_max_tokens_explicit", False):
+            try:
+                from hermes_cli.config import get_custom_provider_max_tokens
+                _fb_mt = get_custom_provider_max_tokens(
+                    agent.model, agent.base_url,
+                    custom_providers=getattr(agent, "_custom_providers", None),
+                )
+            except Exception:
+                _fb_mt = None
+            agent._config_max_tokens = int(_fb_mt) if _fb_mt else None
+            agent.max_tokens = agent._config_max_tokens
 
         # Clear the credential pool when the fallback provider doesn't match
         # the pool's provider.  The pool was seeded for the primary provider;

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3659,6 +3659,65 @@ def get_custom_provider_context_length(
     return None
 
 
+def get_custom_provider_max_tokens(
+    model: str,
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[int]:
+    """Look up a per-model ``max_tokens`` output cap from ``custom_providers``.
+
+    Sibling of :func:`get_custom_provider_context_length`: matches any entry whose
+    ``base_url`` equals ``base_url`` (trailing-slash insensitive) and returns
+    ``custom_providers[i].models.<model>.max_tokens`` when present and a positive
+    int (``bool`` rejected — it is an ``int`` subclass but never a valid cap).
+
+    Single source of truth for custom-provider output caps, used by ``init_agent``
+    (startup) and ``switch_model`` / fallback re-resolution so a per-provider cap
+    is honored on every model the session uses, instead of truncating at the 4096
+    floor or leaking the global value onto fallbacks.  See #28046 / #28782.
+    """
+    if not model or not base_url:
+        return None
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            if config is None:
+                return None
+            raw = config.get("custom_providers")
+            custom_providers = raw if isinstance(raw, list) else []
+    if not isinstance(custom_providers, list):
+        return None
+
+    target_url = (base_url or "").rstrip("/")
+    if not target_url:
+        return None
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = (entry.get("base_url") or "").rstrip("/")
+        if not entry_url or entry_url != target_url:
+            continue
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            continue
+        model_cfg = models.get(model)
+        if not isinstance(model_cfg, dict):
+            continue
+        raw_mt = model_cfg.get("max_tokens")
+        if raw_mt is None or isinstance(raw_mt, bool):
+            continue
+        try:
+            mt = int(raw_mt)
+        except (TypeError, ValueError):
+            continue
+        if mt > 0:
+            return mt
+    return None
+
+
 def check_config_version() -> Tuple[int, int]:
     """
     Check config version.

--- a/tests/hermes_cli/test_custom_provider_max_tokens.py
+++ b/tests/hermes_cli/test_custom_provider_max_tokens.py
@@ -109,3 +109,9 @@ class TestStartupPrecedence:
             agent_init._resolve_max_tokens(a, {"model": {"max_tokens": "lots"}})
             assert mock_ra.return_value.logger.warning.called
         assert a.max_tokens is None
+
+    def test_bare_string_model_config_is_tolerated(self):
+        # config "model:" may be a plain model-id string, not a mapping.
+        a = _bare_agent(_cfg(131_072))
+        agent_init._resolve_max_tokens(a, {"model": "some-model-id"})
+        assert a.max_tokens == 131_072  # per-model still resolved; no crash on str.get

--- a/tests/hermes_cli/test_custom_provider_max_tokens.py
+++ b/tests/hermes_cli/test_custom_provider_max_tokens.py
@@ -1,0 +1,56 @@
+"""Regression tests for custom_providers per-model max_tokens resolution.
+
+Covers #28046 / #28782 — a per-model ``custom_providers[].models.<id>.max_tokens``
+output cap must reach ``agent.max_tokens`` at startup AND be re-resolved on
+mid-session /model switch and fallback, the same way context_length is.
+"""
+
+import pytest
+
+from hermes_cli.config import get_custom_provider_max_tokens
+
+URL = "https://example.invalid/v1"
+
+
+def _cfg(max_tokens, *, base_url=URL, model="m"):
+    return [{"base_url": base_url, "models": {model: {"max_tokens": max_tokens}}}]
+
+
+class TestGetCustomProviderMaxTokens:
+    def test_returns_override_for_matching_entry(self):
+        assert get_custom_provider_max_tokens("m", URL, _cfg(131_072)) == 131_072
+
+    @pytest.mark.parametrize("entry_url, query_url", [
+        (URL + "/", URL),
+        (URL, URL + "/"),
+    ])
+    def test_trailing_slash_insensitive(self, entry_url, query_url):
+        assert get_custom_provider_max_tokens("m", query_url, _cfg(32_000, base_url=entry_url)) == 32_000
+
+    def test_returns_none_when_url_does_not_match(self):
+        assert get_custom_provider_max_tokens("m", URL, _cfg(32_000, base_url="https://other.invalid/v1")) is None
+
+    def test_returns_none_when_model_missing(self):
+        assert get_custom_provider_max_tokens("m", URL, _cfg(32_000, model="other")) is None
+
+    def test_numeric_string_is_coerced(self):
+        assert get_custom_provider_max_tokens("m", URL, _cfg("16000")) == 16_000
+
+    @pytest.mark.parametrize("bad", [0, -1, "0", "-5"])
+    def test_zero_and_negative_skipped(self, bad):
+        assert get_custom_provider_max_tokens("m", URL, _cfg(bad)) is None
+
+    def test_non_numeric_skipped(self):
+        assert get_custom_provider_max_tokens("m", URL, _cfg("32K")) is None
+
+    def test_bool_rejected(self):
+        # bool is an int subclass — must be rejected, not coerced to 1.
+        assert get_custom_provider_max_tokens("m", URL, _cfg(True)) is None
+
+    @pytest.mark.parametrize("model, url, providers", [
+        ("", URL, []),
+        ("m", "", []),
+        ("m", URL, None),
+    ])
+    def test_empty_inputs_guarded(self, model, url, providers):
+        assert get_custom_provider_max_tokens(model, url, providers) is None

--- a/tests/hermes_cli/test_custom_provider_max_tokens.py
+++ b/tests/hermes_cli/test_custom_provider_max_tokens.py
@@ -5,8 +5,11 @@ output cap must reach ``agent.max_tokens`` at startup AND be re-resolved on
 mid-session /model switch and fallback, the same way context_length is.
 """
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
+import agent.agent_init as agent_init
 from hermes_cli.config import get_custom_provider_max_tokens
 
 URL = "https://example.invalid/v1"
@@ -54,3 +57,55 @@ class TestGetCustomProviderMaxTokens:
     ])
     def test_empty_inputs_guarded(self, model, url, providers):
         assert get_custom_provider_max_tokens(model, url, providers) is None
+
+
+def _bare_agent(custom_providers, *, model="m", base_url=URL, max_tokens=None):
+    """Minimal agent stub exercising only the max_tokens resolution block."""
+    a = MagicMock()
+    a.model = model
+    a.base_url = base_url
+    a.max_tokens = max_tokens
+    a._custom_providers = custom_providers
+    a._session_init_model_config = {}
+    return a
+
+
+class TestStartupPrecedence:
+    def test_per_model_lands_on_agent(self):
+        a = _bare_agent(_cfg(131_072))
+        agent_init._resolve_max_tokens(a, {"model": {}})
+        assert a.max_tokens == 131_072
+        assert a._config_max_tokens == 131_072
+        assert a._max_tokens_explicit is False
+
+    def test_per_model_beats_global(self):
+        a = _bare_agent(_cfg(131_072))
+        agent_init._resolve_max_tokens(a, {"model": {"max_tokens": 8000}})
+        assert a.max_tokens == 131_072
+
+    def test_global_used_when_no_per_model(self):
+        a = _bare_agent([])
+        agent_init._resolve_max_tokens(a, {"model": {"max_tokens": 8000}})
+        assert a.max_tokens == 8000
+
+    def test_explicit_constructor_wins_and_marks_explicit(self):
+        a = _bare_agent(_cfg(131_072), max_tokens=5000)
+        agent_init._resolve_max_tokens(a, {"model": {"max_tokens": 8000}})
+        assert a.max_tokens == 5000
+        assert a._max_tokens_explicit is True
+        assert a._config_max_tokens is None  # explicit is not config-derived
+
+    def test_invalid_per_model_warns_and_falls_through(self):
+        a = _bare_agent(_cfg("32K"))
+        with patch.object(agent_init, "_ra") as mock_ra:
+            agent_init._resolve_max_tokens(a, {"model": {}})
+            assert mock_ra.return_value.logger.warning.called
+        assert a.max_tokens is None
+        assert a._config_max_tokens is None
+
+    def test_invalid_global_warns_and_falls_through(self):
+        a = _bare_agent([])
+        with patch.object(agent_init, "_ra") as mock_ra:
+            agent_init._resolve_max_tokens(a, {"model": {"max_tokens": "lots"}})
+            assert mock_ra.return_value.logger.warning.called
+        assert a.max_tokens is None

--- a/tests/run_agent/test_fallback_max_tokens.py
+++ b/tests/run_agent/test_fallback_max_tokens.py
@@ -68,3 +68,27 @@ def test_explicit_max_tokens_survives_fallback():
     agent = _make_agent(max_tokens=5000, config_max_tokens=None, explicit=True, custom_providers=_cp(8000))
     assert _activate(agent) is True
     assert agent.max_tokens == 5000
+
+
+def test_restore_primary_reapplies_primary_max_tokens():
+    # A fallback re-resolves the cap to 8000; restoring the primary at the next
+    # turn must bring back the primary's 131072 (the #28782 leak inverted).
+    agent = _make_agent(max_tokens=131_072, config_max_tokens=131_072, custom_providers=_cp(8000))
+    agent._primary_runtime["max_tokens"] = 131_072
+    agent._primary_runtime["config_max_tokens"] = 131_072
+    assert _activate(agent) is True
+    assert agent.max_tokens == 8000  # fallback's cap is active
+    with patch("run_agent.OpenAI", return_value=MagicMock()):
+        assert agent._restore_primary_runtime() is True
+    assert agent.max_tokens == 131_072
+    assert agent._config_max_tokens == 131_072
+
+
+def test_restore_primary_preserves_explicit_max_tokens():
+    agent = _make_agent(max_tokens=5000, config_max_tokens=None, explicit=True, custom_providers=_cp(8000))
+    agent._primary_runtime["max_tokens"] = 5000
+    agent._primary_runtime["config_max_tokens"] = None
+    assert _activate(agent) is True
+    with patch("run_agent.OpenAI", return_value=MagicMock()):
+        assert agent._restore_primary_runtime() is True
+    assert agent.max_tokens == 5000  # explicit untouched throughout

--- a/tests/run_agent/test_fallback_max_tokens.py
+++ b/tests/run_agent/test_fallback_max_tokens.py
@@ -1,0 +1,70 @@
+"""Fallback activation re-resolves per-model max_tokens (#28782).
+
+The global model.max_tokens must not leak onto a fallback provider; the
+fallback model's own per-model custom_providers cap is resolved against the
+cached _custom_providers. Explicit constructor values survive.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+FB_URL = "https://fallback.example/v1"
+FB_MODEL = "fb-model"
+
+
+def _make_agent(*, max_tokens, config_max_tokens, explicit=False, custom_providers=None):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[{"provider": "custom", "model": FB_MODEL, "base_url": FB_URL}],
+        )
+    agent.client = MagicMock()
+    agent.max_tokens = max_tokens
+    agent._config_max_tokens = config_max_tokens
+    agent._max_tokens_explicit = explicit
+    agent._custom_providers = custom_providers or []
+    return agent
+
+
+def _cp(max_tokens, *, model=FB_MODEL, base_url=FB_URL):
+    return [{"base_url": base_url, "models": {model: {"max_tokens": max_tokens}}}]
+
+
+def _activate(agent):
+    client = MagicMock()
+    client.base_url = FB_URL
+    with (
+        patch("agent.auxiliary_client.resolve_provider_client", return_value=(client, FB_MODEL)),
+        patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m),
+    ):
+        return agent._try_activate_fallback()
+
+
+def test_fallback_reresolves_per_model_for_fallback_model():
+    agent = _make_agent(max_tokens=131_072, config_max_tokens=131_072, custom_providers=_cp(8000))
+    assert _activate(agent) is True
+    assert agent.max_tokens == 8000
+    assert agent._config_max_tokens == 8000
+
+
+def test_fallback_drops_global_so_it_does_not_leak():
+    # Global cap on the primary, no per-model entry for the fallback → no leak.
+    agent = _make_agent(max_tokens=131_072, config_max_tokens=131_072, custom_providers=[])
+    assert _activate(agent) is True
+    assert agent.max_tokens is None
+    assert agent._config_max_tokens is None
+
+
+def test_explicit_max_tokens_survives_fallback():
+    agent = _make_agent(max_tokens=5000, config_max_tokens=None, explicit=True, custom_providers=_cp(8000))
+    assert _activate(agent) is True
+    assert agent.max_tokens == 5000

--- a/tests/run_agent/test_switch_model_max_tokens.py
+++ b/tests/run_agent/test_switch_model_max_tokens.py
@@ -1,0 +1,73 @@
+"""switch_model re-resolves per-model max_tokens for the new model (#28782).
+
+The global model.max_tokens belongs to the primary model only; on a /model
+switch the per-model custom_providers cap is re-resolved against the new model
+and the global is dropped (never leaks). Explicit constructor values survive.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+OR_URL = "https://openrouter.ai/api/v1"
+
+
+def _make_agent(*, max_tokens, config_max_tokens, explicit=False):
+    """Bare AIAgent exercising only switch_model's max_tokens re-resolution."""
+    agent = AIAgent.__new__(AIAgent)
+    agent.model = "primary-model"
+    agent.provider = "openrouter"
+    agent.base_url = OR_URL
+    agent.api_key = "sk-primary"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock()
+    agent.quiet_mode = True
+    agent.context_compressor = None
+    agent._config_context_length = None
+    agent.max_tokens = max_tokens
+    agent._config_max_tokens = config_max_tokens
+    agent._max_tokens_explicit = explicit
+    agent._primary_runtime = {}
+    return agent
+
+
+def _switch(agent, resolved):
+    """Switch to 'new-model' with the per-model resolver pinned to `resolved`."""
+    with (
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("hermes_cli.config.get_compatible_custom_providers", return_value=[]),
+        patch("hermes_cli.config.get_custom_provider_max_tokens", return_value=resolved),
+    ):
+        agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url=OR_URL)
+
+
+def test_switch_reresolves_per_model_for_new_model():
+    agent = _make_agent(max_tokens=8000, config_max_tokens=8000)
+    _switch(agent, 131_072)
+    assert agent.max_tokens == 131_072
+    assert agent._config_max_tokens == 131_072
+
+
+def test_switch_drops_global_so_it_does_not_leak():
+    # Primary had a global cap (no per-model); the new model has none → no leak.
+    agent = _make_agent(max_tokens=131_072, config_max_tokens=131_072)
+    _switch(agent, None)
+    assert agent.max_tokens is None
+    assert agent._config_max_tokens is None
+
+
+def test_explicit_max_tokens_survives_switch():
+    agent = _make_agent(max_tokens=5000, config_max_tokens=None, explicit=True)
+    _switch(agent, 131_072)  # resolver would return 131072, but is skipped
+    assert agent.max_tokens == 5000
+
+
+def test_failed_swap_rolls_back_max_tokens():
+    agent = _make_agent(max_tokens=8000, config_max_tokens=8000)
+    agent._create_openai_client = MagicMock(side_effect=RuntimeError("boom"))
+    with pytest.raises(RuntimeError):
+        _switch(agent, 131_072)
+    assert agent.max_tokens == 8000
+    assert agent._config_max_tokens == 8000


### PR DESCRIPTION
Honor `custom_providers[].models.<model>.max_tokens` end-to-end so a per-model output cap is never silently dropped (truncation) and never leaks onto another model.

## Problem
A configured `max_tokens` had no effect — output silently truncated on Ollama Cloud / zai / OpenAI-compatible proxies. This is *not* a hard 4096 floor: the only literal `4096` fallback on the request path is on the bedrock call (`agent.max_tokens or 4096` at `chat_completion_helpers.py:563`, consumed by `transports/bedrock.py:58`). The real symptom is that the field was never set, so each provider fell back to its own small default ceiling.

## Root cause
A propagation gap: the CLI never passed `max_tokens=` into the `AIAgent` constructor, so `agent.max_tokens` stayed `None`. With `None`, providers applied their own default → truncation. Omitting `max_tokens` when nothing is configured is the *desired* behavior — the model's native output ceiling is used (`anthropic_adapter.py:2072`); the bug was that a configured value never reached `agent.max_tokens`. The fix mirrors the existing `context_length` resolve/propagate machinery.

## Solution (4 core files)
- **Reader** — new `get_custom_provider_max_tokens` (`hermes_cli/config.py:3662`), sibling of `get_custom_provider_context_length`: trailing-slash-insensitive `base_url` match, positive-int only, `bool` rejected (it is an `int` subclass but never a valid cap).
- **Resolver** — new `_resolve_max_tokens` (`agent/agent_init.py:136`), called at `agent_init.py:1452` *after* `_custom_providers` is resolved (`:1394`) so the per-model value can win. The old inline global-only block (`~:1352`) is deleted and subsumed with identical int/`bool`/`<=0` validation and warning text — no behavior loss on the global path. Persists `_config_max_tokens` and `_max_tokens_explicit`; both keys are seeded in the `_primary_runtime` base literal (`:1700`).
- **Reaches the wire** (proof, not a dangling field) — `agent.max_tokens` is the single field consumed across every transport: chat_completions `transports/chat_completions.py:298,486` (guarded `is not None`), anthropic `anthropic_adapter.py:2168`, bedrock `transports/bedrock.py:58`, direct-OpenAI/o1 mapped to `max_completion_tokens` `run_agent.py:1206`.

## Precedence
```
explicit (constructor/CLI) > per-model custom_providers > global model.max_tokens > None (provider native ceiling)
```
**Precedence inversion (deliberate):** per-model is checked *before* the global value — the opposite of `context_length` (global-first). A provider-specific output cap is the more-specific intent and must win. Blast radius is contained: `context_length` precedence is **untouched**, and `_KNOWN_KEYS` is **unchanged** (an entry-level `max_tokens` still fires the existing "unknown config keys ignored" warning; the supported location is `models.<model>.max_tokens`, nested-only by design).

## Initial resolve + 3 re-resolution seams
The config-resolved cap is null-and-re-resolved against the active model at each transition, faithfully mirroring `_config_context_length`:
- **switch_model** — re-resolves from **live** `load_config()`; the global never re-applies (no leak). Snapshotted before the try (`agent_runtime_helpers.py:1409-1410`), nulled inside the try (`:1421`), re-resolved (`:1532-1547`), and rolled back on a failed client build (`:1505-1513`).
- **try_activate_fallback** — re-resolves from the **cached** `agent._custom_providers` (`chat_completion_helpers.py:1138,1148-1158`).
- **restore_primary_runtime** — tolerant `rt.get` reapply of the primary snapshot (`agent_runtime_helpers.py:957-959`).

## Leak guarantees (#28782 — both directions)
- **Forward (global → fallback):** the global cap belongs to the primary only and is nulled on switch/fallback, so it never leaks onto a fallback provider.
- **Backward (fallback → restored primary):** a fallback's re-resolved cap never sticks to the restored primary — `restore_primary_runtime` reapplies the primary's snapshot.
- **Explicit values survive** every transition, gated by `_max_tokens_explicit` at every mutation site (switch null + re-resolve, fallback null + re-resolve, restore reapply) — a user's `--max_tokens` is never clobbered.

## Testing
```
pytest tests/hermes_cli/test_custom_provider_max_tokens.py \
       tests/run_agent/test_fallback_max_tokens.py \
       tests/run_agent/test_switch_model_max_tokens.py        # 138 passed
ruff check hermes_cli/config.py agent/agent_init.py \
           agent/agent_runtime_helpers.py agent/chat_completion_helpers.py tests/   # clean
```
A broader sweep (`test_primary_runtime_restore.py`, `test_switch_model_context.py` + the two new files) is 42 passed / 1 failed; the one failure is `test_primary_runtime_restore.py::TestTryRecoverPrimaryTransport::test_allowed_for_anthropic_direct` — an environmental `anthropic` lazy-install `ImportError` (`anthropic_adapter.py:680`) on an anthropic-only path this diff does not touch. It fails on baseline too — **not a regression**.

## Coverage
- **Resolver:** matching / non-matching `base_url`, missing model, numeric-string coercion, zero/negative, non-numeric, `bool` rejection, trailing-slash (both directions), empty inputs.
- **Precedence / config shape:** per-model lands, per-model beats global, global fallback, explicit wins, bare-string `model:` config, both invalid-value warning paths.
- **Lifecycle (all mutation sites):** switch (re-resolve + drop-global + explicit-survive + failed-swap rollback), fallback (re-resolve + drop-global + explicit-survive), restore (reapply + explicit-preserve).
- Tests assert behavior not implementation; zero time/random/flaky dependencies. Switch tests mock the resolver (seam isolation); fallback tests use the real resolver (integration) — deliberately complementary.

## Known behaviors (disclosed)
- Two deliberate asymmetries cloned verbatim from the existing `_config_context_length` machinery: switch_model re-resolves from live config but does not write back `agent._custom_providers`, so a switch→fallback uses the startup snapshot (fix-both-or-neither, intentionally not diverging here); the fallback path has no try/except rollback (the same pre-existing exposure already present for `model`/`provider`/`_config_context_length`, not new surface).
- Cosmetic: the warning-only `_raw_per_model_max_tokens` returns on the first `base_url` match rather than full-scanning, so a pathological duplicate-`base_url` config could *miss* (never mis-emit) an invalid-value warning. Low severity, untested.
- `_primary_runtime` is never serialized (pure in-memory, rebuilt by `init_agent` on every start), so the `rt.get → None` tolerance on restore is defensive only and never bites a real upgraded session.

## Issue / PR linkage
Closes #15037, #20004, #28046, #28782
Addresses #20741
Supersedes #28142, #28154, #28786; supersedes the max_tokens slice of #28995

- **Closes** — #15037 (the feature itself), #20004 (`custom_providers` `max_tokens` now reaches `AIAgent` — the exact net-new behavior of this diff), #28046 (the always-4096 default is verifiably gone), #28782 (per-model override in `custom_providers` + both leak directions fully owned).
- **Addresses, not Closes** — #20741: its stated root cause is the *global* `config.yaml` `model.max_tokens` path, which this diff preserves (relocates) rather than introduces — that path already propagated on baseline. The diff does fix the custom-endpoint truncation it reports (via the per-model read), but does not exclusively own the issue's global-config framing, so closure is left conservative.
- **Supersedes** — #28142 / #28154 / #28786 are a clean strict superset (same per-model read via the shared resolver, plus `bool` rejection and switch/fallback/restore re-resolution none of them had); only the **max_tokens slice** of #28995 is superseded.

## Not in scope (tracked separately)
- **#28863** — `terminal.docker_extra_args` missing from `gateway/run.py` `_terminal_env_map` (a one-line gateway fix #28995 happened to bundle). Not included here; **still open**; will be filed as a separate follow-up. This PR does **not** claim `Closes #28863`.
- **#28984** — the Config-Runtime Contract Registry (the other half of #28995) is an independent feature and is intentionally not carried here.
