### PR TITLE
fix(simplex): avoid AttributeError when an inbound group profile is null

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -336,7 +336,7 @@ class SimplexAdapter(BasePlatformAdapter):
         if is_group:
             group_info = chat_info.get("groupInfo") or chat_info.get("group") or {}
             group_id = str(group_info.get("groupId") or group_info.get("id") or "")
-            group_name = group_info.get("displayName") or group_info.get("groupProfile", {}).get("displayName", "")
+            group_name = group_info.get("displayName") or (group_info.get("groupProfile") or {}).get("displayName", "")
             chat_id = f"group:{group_id}" if group_id else ""
             chat_name = group_name
         else:

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -263,6 +263,50 @@ async def test_handle_event_filters_own_corr_id():
     assert own not in adapter._pending_corr_ids  # discarded
 
 
+@pytest.mark.asyncio
+async def test_handle_group_item_with_null_group_profile_dispatches():
+    """A group newChatItem whose groupProfile is JSON ``null`` must dispatch.
+
+    The daemon can emit ``"groupProfile": null`` rather than omitting the
+    key. With a falsy top-level ``displayName`` the name lookup then has to
+    fall through to ``groupProfile``; a plain ``.get("groupProfile", {})``
+    returns ``None`` there (the default only applies to a missing key) and
+    the subsequent ``.get(...)`` raises ``AttributeError``. That exception is
+    swallowed by the WS-read loop, so the inbound group message is silently
+    dropped. The name lookup must be null-safe and still dispatch.
+    """
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    captured: list = []
+    adapter.handle_message = AsyncMock(side_effect=lambda ev: captured.append(ev))  # type: ignore
+    adapter._fetch_file = AsyncMock(return_value=None)  # type: ignore
+
+    wrapper = {
+        "chatInfo": {
+            "type": "group",
+            "groupInfo": {
+                "groupId": 7,
+                "displayName": "",
+                "groupProfile": None,
+            },
+        },
+        "chatItem": {
+            "content": {"msgContent": {"type": "text", "text": "hi all"}},
+            "meta": {"itemStatus": {"type": "rcvNew"}},
+        },
+    }
+
+    await adapter._handle_new_chat_item(wrapper)
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event.text == "hi all"
+    assert event.source.chat_id == "group:7"
+    assert event.source.chat_name == ""
+
+
 # ---------------------------------------------------------------------------
 # 9. Standalone (out-of-process) send for cron
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

In the SimpleX adapter, resolving a group's display name on an inbound `newChatItem` raises `AttributeError` when `groupProfile` is present-but-`null` and the top-level `displayName` is falsy.

```python
group_name = group_info.get("displayName") or group_info.get("groupProfile", {}).get("displayName", "")
```

## Why it breaks

The `{}` second argument to `dict.get` is only used when the **key is missing**. The simplex-chat daemon can emit `"groupProfile": null` (the key is present with a JSON `null` value), so `.get("groupProfile", {})` returns `None`, and the chained `.get("displayName", "")` then fails with `AttributeError: 'NoneType' object has no attribute 'get'`. This only surfaces when the top-level `displayName` is also falsy, so the lookup has to fall through to `groupProfile`.

`_handle_new_chat_item` runs inside the WebSocket read loop, whose broad `except` swallows the exception — so the inbound **group** message is silently dropped rather than dispatched.

## Fix

Use the `(... or {})` idiom so a `null` value coalesces to an empty dict, exactly mirroring the pattern already used a few lines earlier for `itemStatus`:

```python
group_name = group_info.get("displayName") or (group_info.get("groupProfile") or {}).get("displayName", "")
```

## Test

Adds `test_handle_group_item_with_null_group_profile_dispatches`, which feeds a group `newChatItem` whose `chatInfo.groupInfo.groupProfile` is `None` (with a falsy top-level `displayName`) through `_handle_new_chat_item` with `handle_message`/`_fetch_file` mocked. It asserts the call does not raise and that the message is dispatched (the captured event carries the text and `group:<id>` chat id). The test fails with `AttributeError` on the unmodified adapter and passes with the fix.

## Related

The same null-unsafe `groupProfile`/`profile` `.get(..., {})` pattern also appears in the rewritten adapter code of open PRs #27978 and #4666, so the same `(... or {})` guard is needed wherever this code ends up merging.

Note: #26480 contains an equivalent null-safe `groupProfile` line, but only incidentally within a large unrelated feature PR — this is the minimal standalone fix for the crash.
