### PR TITLE
fix(simplex): declare SUPPORTS_MESSAGE_EDITING = False

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -119,6 +119,13 @@ class SimplexAdapter(BasePlatformAdapter):
     ``ctx.register_platform()`` in :func:`register`.
     """
 
+    # SimpleX cannot edit already-sent messages: ``send()`` returns no
+    # message_id and there is no edit_message implementation. Mark it
+    # explicitly so streaming suppresses the visible cursor instead of
+    # falling back to a partial-preview plus a separate final message
+    # (a duplicate bubble with a stuck cursor in the chat client).
+    SUPPORTS_MESSAGE_EDITING = False
+
     def __init__(self, config: PlatformConfig, **kwargs):
         platform = Platform("simplex")
         super().__init__(config=config, platform=platform)

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -141,6 +141,14 @@ def test_adapter_platform_identity():
     assert adapter.platform is Platform("simplex")
 
 
+def test_message_editing_disabled():
+    """SimpleX has no edit API (send() returns no message_id), so the
+    adapter must declare SUPPORTS_MESSAGE_EDITING = False to keep the
+    streaming consumer from emitting a partial-preview + separate final
+    message (a duplicate bubble with a stuck cursor)."""
+    assert SimplexAdapter.SUPPORTS_MESSAGE_EDITING is False
+
+
 # ---------------------------------------------------------------------------
 # 5. Helper functions (magic-byte detection)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Declare `SUPPORTS_MESSAGE_EDITING = False` on `SimplexAdapter`.

## Why

`SimplexAdapter` never declares `SUPPORTS_MESSAGE_EDITING`, so it inherits the default `True` (the streaming consumer reads it via `getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True)`). But SimpleX cannot edit an already-sent message: `send()` returns `message_id=None` and the adapter implements no `edit_message`. With editing assumed available but unusable, the streaming consumer falls back to a partial-preview message followed by a separate final message — a duplicate bubble with a stuck/visible cursor in the chat client.

Declaring the attribute `False` makes streaming suppress the visible cursor and emit a single final message instead.

## Convention

Five sibling adapters with identical send semantics (no edit API) already declare `SUPPORTS_MESSAGE_EDITING = False` as a class attribute: Signal, WeCom, QQ, BlueBubbles, and Weixin. This brings SimpleX in line with that convention; the placement and explanatory comment mirror `gateway/platforms/signal.py`.

## Test

Adds `test_message_editing_disabled` asserting `SimplexAdapter.SUPPORTS_MESSAGE_EDITING is False`. On the unmodified adapter the attribute is absent, so the test fails with `AttributeError`; with the fix it passes.