### PR TITLE
fix(simplex): acquire scoped platform lock to prevent duplicate inbound processing

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -159,22 +159,37 @@ class SimplexAdapter(BasePlatformAdapter):
             logger.error("SimpleX: SIMPLEX_WS_URL is required")
             return False
 
-        # Quick connectivity check — try to open and immediately close
+        # Acquire scoped lock to prevent duplicate SimpleX listeners for the
+        # same daemon URL (two gateways would each dispatch every inbound
+        # message, causing duplicate agent turns).
+        lock_acquired = False
         try:
-            import websockets as _wsclient
-            async with _wsclient.connect(self.ws_url, open_timeout=10):
-                pass
+            if not self._acquire_platform_lock("simplex-ws", self.ws_url, "SimpleX daemon URL"):
+                return False
+            lock_acquired = True
         except Exception as e:
-            logger.error("SimpleX: cannot reach daemon at %s: %s", self.ws_url, e)
-            return False
+            logger.warning("SimpleX: Could not acquire daemon URL lock (non-fatal): %s", e)
 
-        self._running = True
-        self._last_ws_activity = time.time()
-        self._ws_task = asyncio.create_task(self._ws_listener())
-        self._health_task = asyncio.create_task(self._health_monitor())
+        try:
+            # Quick connectivity check — try to open and immediately close
+            try:
+                import websockets as _wsclient
+                async with _wsclient.connect(self.ws_url, open_timeout=10):
+                    pass
+            except Exception as e:
+                logger.error("SimpleX: cannot reach daemon at %s: %s", self.ws_url, e)
+                return False
 
-        logger.info("SimpleX: connected to %s", self.ws_url)
-        return True
+            self._running = True
+            self._last_ws_activity = time.time()
+            self._ws_task = asyncio.create_task(self._ws_listener())
+            self._health_task = asyncio.create_task(self._health_monitor())
+
+            logger.info("SimpleX: connected to %s", self.ws_url)
+            return True
+        finally:
+            if not self._running and lock_acquired:
+                self._release_platform_lock()
 
     async def disconnect(self) -> None:
         """Stop WebSocket listener and clean up."""
@@ -204,6 +219,8 @@ class SimplexAdapter(BasePlatformAdapter):
             except Exception:
                 pass
             self._ws = None
+
+        self._release_platform_lock()
 
         logger.info("SimpleX: disconnected")
 

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -8,7 +8,7 @@ sibling platform-plugin tests on the same xdist worker.
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -344,3 +344,70 @@ def test_register_calls_register_platform():
     assert callable(kwargs["setup_fn"])
     # SimpleX uses opaque IDs only — no PII to redact.
     assert kwargs["pii_safe"] is True
+
+
+# ---------------------------------------------------------------------------
+# 11. Scoped platform lock — prevent duplicate inbound processing
+# ---------------------------------------------------------------------------
+
+def _stub_ws_connect():
+    """Return a stub that mimics ``websockets.connect`` as an async context
+    manager so connect()'s connectivity probe succeeds without a daemon."""
+
+    class _Conn:
+        async def __aenter__(self):
+            return AsyncMock()
+
+        async def __aexit__(self, *exc):
+            return False
+
+    return MagicMock(connect=MagicMock(return_value=_Conn()))
+
+
+@pytest.mark.asyncio
+async def test_connect_acquires_lock_disconnect_releases(monkeypatch):
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    acquire = MagicMock(return_value=True)
+    release = MagicMock()
+    adapter._acquire_platform_lock = acquire  # type: ignore
+    adapter._release_platform_lock = release  # type: ignore
+
+    # Avoid real background tasks and a live daemon.
+    monkeypatch.setattr(adapter, "_ws_listener", AsyncMock())
+    monkeypatch.setattr(adapter, "_health_monitor", AsyncMock())
+
+    with patch.dict("sys.modules", {"websockets": _stub_ws_connect()}):
+        result = await adapter.connect()
+
+    assert result is True
+    acquire.assert_called_once_with("simplex-ws", "ws://localhost:5225", "SimpleX daemon URL")
+    release.assert_not_called()
+
+    await adapter.disconnect()
+    release.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_returns_false_when_lock_unavailable(monkeypatch):
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    # Lock held by another gateway → acquisition fails.
+    adapter._acquire_platform_lock = MagicMock(return_value=False)  # type: ignore
+    release = MagicMock()
+    adapter._release_platform_lock = release  # type: ignore
+
+    # The connectivity probe must never run when the lock is unavailable.
+    probe = _stub_ws_connect()
+    with patch.dict("sys.modules", {"websockets": probe}):
+        result = await adapter.connect()
+
+    assert result is False
+    assert adapter._running is False
+    probe.connect.assert_not_called()
+    # No lock was acquired, so none should be released.
+    release.assert_not_called()


### PR DESCRIPTION
## Problem

The SimpleX adapter's `connect()` and `disconnect()` never acquire the base scoped platform lock. If two gateways are pointed at the same simplex-chat daemon URL, each opens its own persistent WebSocket listener and independently dispatches every inbound message — producing duplicate agent turns for a single user message.

Every other long-lived-listener adapter already guards against this: Signal, Telegram, Slack, and WhatsApp all acquire the scoped lock in `connect()` and release it in `disconnect()`. SimpleX is the lone long-lived-listener adapter missing the guard.

## Fix

Mirror the established Signal pattern (`gateway/platforms/signal.py`) in `plugins/platforms/simplex/adapter.py`:

- `connect()` acquires a lock scoped on the daemon URL via `_acquire_platform_lock("simplex-ws", self.ws_url, "SimpleX daemon URL")`, tracked by a `lock_acquired` flag. If acquisition reports the URL is already in use, `connect()` returns `False`. A status-subsystem error during acquisition is logged as non-fatal (matching Signal), so a transient lock-store hiccup never blocks startup.
- A `try/finally` around the connectivity probe and task startup releases the lock on any connect-failure path (the daemon-unreachable branch), exactly as Signal releases on health-check failure.
- `disconnect()` calls `_release_platform_lock()` after tearing down the listener.

No new imports — `_acquire_platform_lock` / `_release_platform_lock` are provided by `BasePlatformAdapter`.

## Tests

Added to `tests/gateway/test_simplex_plugin.py`:

- `test_connect_acquires_lock_disconnect_releases` — asserts `connect()` acquires the lock with the expected scope/identity/description and that `disconnect()` releases it.
- `test_connect_returns_false_when_lock_unavailable` — asserts that when acquisition fails, `connect()` returns `False`, the adapter stays not-running, and the connectivity probe is never attempted.

Both tests fail on the unmodified adapter and pass with the fix.