### PR TITLE
chore: sync main version with v0.15.2 release

### DIFF
--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,7 +1,7 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
@@ -9,7 +9,7 @@
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.15.1",
+      "package": "hermes-agent[acp]==0.15.2",
       "args": ["hermes-acp"]
     }
   }

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.15.1"
-__release_date__ = "2026.5.29"
+__version__ = "0.15.2"
+__release_date__ = "2026.5.29.2"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.15.1"
+version = "0.15.2"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- sync `main`'s displayed/package version metadata with the already-published `v2026.5.29.2` / `0.15.2` release
- updates `pyproject.toml`, `hermes_cli.__version__` / release date, and ACP registry metadata

## Why
The latest GitHub release is `v2026.5.29.2` (`0.15.2`), but current `main` still reports `0.15.1` through `hermes --version`. Source installs tracking `main` therefore look stale even when they are up to date.

## Test plan
- `python -m json.tool acp_registry/agent.json`
- `python - <<'PY' ... tomllib load pyproject and assert 0.15.2 ... PY`
- `PYTHONPATH=. python -m hermes_cli.main --version`
- `python -m py_compile hermes_cli/__init__.py hermes_cli/main.py`
- `PYTHONPATH=. python -m pytest -q -o 'addopts=' tests/test_packaging_metadata.py tests/hermes_cli/test_update_check.py`
