### PR TITLE
feat(delegate): profile toolset isolation + MCP bypass for no_mcp orchestrators

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -793,6 +793,7 @@ _DOCKER_MEDIA_OUTPUT_CONTAINER_PATHS = {"/output", "/outputs"}
 # Bridge config.yaml values into the environment so os.getenv() picks them up.
 # config.yaml is authoritative for terminal settings — overrides .env.
 _config_path = _hermes_home / 'config.yaml'
+_cfg: Dict[str, Any] = {}
 if _config_path.exists():
     try:
         import yaml as _yaml
@@ -800,7 +801,8 @@ if _config_path.exists():
             _cfg = _yaml.safe_load(_f) or {}
         # Expand ${ENV_VAR} references before bridging to env vars.
         from hermes_cli.config import _expand_env_vars
-        _cfg = _expand_env_vars(_cfg)
+        _expanded = _expand_env_vars(_cfg)
+        _cfg = _expanded if isinstance(_expanded, dict) else {}
         # Top-level simple values (fallback only — don't override .env)
         for _key, _val in _cfg.items():
             if isinstance(_val, (str, int, float, bool)) and _key not in os.environ:
@@ -982,7 +984,7 @@ if _config_path.exists():
 # Apply IPv4 preference if configured (before any HTTP clients are created).
 try:
     from hermes_constants import apply_ipv4_preference
-    _network_cfg = (_cfg if '_cfg' in dir() else {}).get("network", {})
+    _network_cfg = _cfg.get("network", {})
     if isinstance(_network_cfg, dict) and _network_cfg.get("force_ipv4"):
         apply_ipv4_preference(force=True)
 except Exception as _bootstrap_exc:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1401,6 +1401,25 @@ def _platform_config_key(platform: "Platform") -> str:
     return "cli" if platform == Platform.LOCAL else platform.value
 
 
+def _active_platform_uses_no_mcp(config: dict) -> bool:
+    """Return True if the current platform's toolsets include the no_mcp sentinel.
+
+    The active platform is resolved from the ``HERMES_PLATFORM`` env var (with the
+    ``HERMES_SESSION_PLATFORM`` fallback used elsewhere in the codebase), defaulting
+    to ``"cli"``. When that platform's ``platform_toolsets`` list contains the
+    ``no_mcp`` sentinel, eager MCP discovery can be skipped at startup and deferred
+    until the first child delegation that actually needs MCP toolsets.
+    """
+    platform = (
+        os.environ.get("HERMES_PLATFORM")
+        or os.environ.get("HERMES_SESSION_PLATFORM")
+        or "cli"
+    )
+    platform_toolsets = (config or {}).get("platform_toolsets", {}) or {}
+    toolsets = platform_toolsets.get(platform, []) or []
+    return "no_mcp" in toolsets
+
+
 def _teams_pipeline_plugin_enabled() -> bool:
     """Return True when the standalone Teams pipeline plugin is enabled."""
     config = _load_gateway_config()
@@ -19124,7 +19143,16 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     try:
         from tools.mcp_tool import discover_mcp_tools
         _loop = asyncio.get_running_loop()
-        await _loop.run_in_executor(None, discover_mcp_tools)
+        _gateway_cfg = _load_gateway_config()
+        if _active_platform_uses_no_mcp(_gateway_cfg):
+            from tools.mcp_tool import mark_eager_discovery_skipped
+            mark_eager_discovery_skipped()
+            logger.info(
+                "MCP eager discovery skipped (platform uses no_mcp); "
+                "tools will load lazily on first delegation"
+            )
+        else:
+            await _loop.run_in_executor(None, discover_mcp_tools)
     except Exception as e:
         logger.debug("MCP tool discovery failed: %s", e)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11305,6 +11305,32 @@ def _should_background_mcp_startup(args) -> bool:
     return args.command in {None, "chat", "rl"}
 
 
+def _active_platform_uses_no_mcp_at_startup() -> bool:
+    """Return True if the active platform's toolsets include the no_mcp sentinel.
+
+    Resolves the platform from ``HERMES_PLATFORM`` (with the
+    ``HERMES_SESSION_PLATFORM`` fallback used elsewhere), defaulting to ``"cli"``,
+    and reads ``platform_toolsets`` directly from the raw config dict. Used to
+    decide whether eager MCP discovery can be skipped at CLI startup (Phase 2
+    lazy discovery). Best-effort: any failure returns False so discovery runs
+    as before.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+
+        config = read_raw_config() or {}
+    except Exception:
+        return False
+    platform = (
+        os.environ.get("HERMES_PLATFORM")
+        or os.environ.get("HERMES_SESSION_PLATFORM")
+        or "cli"
+    )
+    platform_toolsets = config.get("platform_toolsets", {}) or {}
+    toolsets = platform_toolsets.get(platform, []) or []
+    return "no_mcp" in toolsets
+
+
 def _prepare_agent_startup(args) -> None:
     """Discover plugins/MCP/hooks for commands that can run an agent turn."""
     _sub_attr, _sub_set = _AGENT_SUBCOMMANDS.get(args.command, (None, None))
@@ -11352,9 +11378,22 @@ def _prepare_agent_startup(args) -> None:
         try:
             # MCP tool discovery remains synchronous for entrypoints that do
             # not own a later bounded/executor startup path.
+            #
+            # When the active platform's toolsets include the ``no_mcp`` sentinel
+            # (e.g. api_server), skip eager discovery and let the first
+            # MCP-needing delegation trigger it lazily (Phase 2).
             from tools.mcp_tool import discover_mcp_tools
 
-            discover_mcp_tools()
+            if _active_platform_uses_no_mcp_at_startup():
+                from tools.mcp_tool import mark_eager_discovery_skipped
+
+                mark_eager_discovery_skipped()
+                logger.debug(
+                    "MCP eager discovery skipped at CLI startup "
+                    "(platform uses no_mcp); tools will load lazily on first delegation"
+                )
+            else:
+                discover_mcp_tools()
         except Exception:
             logger.debug(
                 "MCP tool discovery failed at CLI startup",

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -200,7 +200,7 @@ def setup_logging(
     log_dir.mkdir(parents=True, exist_ok=True)
 
     # Read config defaults (best-effort — config may not be loaded yet).
-    cfg_level, cfg_max_size, cfg_backup = _read_logging_config()
+    cfg_level, cfg_max_size, cfg_backup, cfg_loggers = _read_logging_config()
 
     level_name = (log_level or cfg_level or "INFO").upper()
     level = getattr(logging, level_name, logging.INFO)
@@ -254,6 +254,50 @@ def setup_logging(
     # Suppress noisy third-party loggers.
     for name in _NOISY_LOGGERS:
         logging.getLogger(name).setLevel(logging.WARNING)
+
+    # Apply per-logger level overrides from config.yaml ``logging.loggers``.
+    # Must run after handlers are attached so the levels take effect on the
+    # configured hierarchy.  Each entry may be a bare string ("DEBUG") or a
+    # dict with a "level" key ({"level": "DEBUG"}).  Invalid or missing levels
+    # are skipped silently to avoid breaking startup.
+    #
+    # When any override is finer-grained than the current root/handler level
+    # (e.g. DEBUG while agent.log runs at INFO), the root logger and the
+    # agent.log handler are also lowered so that per-logger records can
+    # propagate all the way to the file.  The root logger's level gates
+    # propagated records before they reach handlers; the handler's level gates
+    # what it writes.  Both must be at or below the per-logger level for the
+    # records to appear in agent.log.
+    if isinstance(cfg_loggers, dict):
+        min_per_logger_level: Optional[int] = None
+        for logger_name, logger_cfg in cfg_loggers.items():
+            if isinstance(logger_cfg, dict):
+                lvl_value = logger_cfg.get("level")
+            elif isinstance(logger_cfg, str):
+                lvl_value = logger_cfg
+            else:
+                continue
+            if not isinstance(lvl_value, str):
+                continue
+            lvl_int = getattr(logging, lvl_value.upper(), None)
+            if not isinstance(lvl_int, int):
+                continue
+            logging.getLogger(logger_name).setLevel(lvl_int)
+            if min_per_logger_level is None or lvl_int < min_per_logger_level:
+                min_per_logger_level = lvl_int
+
+        # Lower root + agent.log handler if needed so per-logger records reach
+        # the file.  We never raise these levels — only lower them.
+        if min_per_logger_level is not None and min_per_logger_level < level:
+            if root.level > min_per_logger_level or root.level == logging.NOTSET:
+                root.setLevel(min_per_logger_level)
+            for h in root.handlers:
+                if (
+                    isinstance(h, RotatingFileHandler)
+                    and "agent.log" in getattr(h, "baseFilename", "")
+                    and h.level > min_per_logger_level
+                ):
+                    h.setLevel(min_per_logger_level)
 
     _logging_initialized = True
     return log_dir
@@ -456,7 +500,15 @@ def _add_rotating_handler(
 def _read_logging_config():
     """Best-effort read of ``logging.*`` from config.yaml.
 
-    Returns ``(level, max_size_mb, backup_count)`` — any may be ``None``.
+    Returns ``(level, max_size_mb, backup_count, loggers)`` — any may be
+    ``None``.  ``loggers`` is a dict mapping logger name → config entry,
+    where each entry is either a bare level string (``"DEBUG"``) or a dict
+    with a ``"level"`` key (``{"level": "DEBUG"}``).
+
+    Why: Centralises config parsing so setup_logging() can apply both the
+    top-level level and per-logger overrides from a single read.
+    Test: Write a config.yaml with ``logging.loggers.tools.tool_search.level:
+    DEBUG`` and assert the returned loggers dict contains that entry.
     """
     try:
         import yaml
@@ -470,7 +522,8 @@ def _read_logging_config():
                     log_cfg.get("level"),
                     log_cfg.get("max_size_mb"),
                     log_cfg.get("backup_count"),
+                    log_cfg.get("loggers") or {},
                 )
     except Exception:
         pass
-    return (None, None, None)
+    return (None, None, None, {})

--- a/run_agent.py
+++ b/run_agent.py
@@ -4450,6 +4450,7 @@ class AIAgent:
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
+            profile=function_args.get("profile"),
             parent_agent=self,
         )
 

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -752,17 +752,18 @@ class TestReadLoggingConfig:
     """_read_logging_config() reads from config.yaml."""
 
     def test_returns_none_when_no_config(self, hermes_home):
-        level, max_size, backup = hermes_logging._read_logging_config()
+        level, max_size, backup, loggers = hermes_logging._read_logging_config()
         assert level is None
         assert max_size is None
         assert backup is None
+        assert loggers == {}
 
     def test_reads_logging_section(self, hermes_home):
         import yaml
         config = {"logging": {"level": "DEBUG", "max_size_mb": 10, "backup_count": 5}}
         (hermes_home / "config.yaml").write_text(yaml.dump(config))
 
-        level, max_size, backup = hermes_logging._read_logging_config()
+        level, max_size, backup, loggers = hermes_logging._read_logging_config()
         assert level == "DEBUG"
         assert max_size == 10
         assert backup == 5
@@ -772,8 +773,151 @@ class TestReadLoggingConfig:
         config = {"model": "test"}
         (hermes_home / "config.yaml").write_text(yaml.dump(config))
 
-        level, max_size, backup = hermes_logging._read_logging_config()
+        level, max_size, backup, loggers = hermes_logging._read_logging_config()
         assert level is None
+
+    def test_reads_loggers_dict(self, hermes_home):
+        """loggers dict is returned when present in config.yaml."""
+        import yaml
+        config = {
+            "logging": {
+                "level": "INFO",
+                "loggers": {
+                    "tools.tool_search": {"level": "DEBUG"},
+                    "tools.reranker": {"level": "WARNING"},
+                },
+            }
+        }
+        (hermes_home / "config.yaml").write_text(yaml.dump(config))
+
+        _, _, _, loggers = hermes_logging._read_logging_config()
+        assert loggers == {
+            "tools.tool_search": {"level": "DEBUG"},
+            "tools.reranker": {"level": "WARNING"},
+        }
+
+    def test_returns_empty_loggers_when_absent(self, hermes_home):
+        """loggers is an empty dict when the key is not in config."""
+        import yaml
+        config = {"logging": {"level": "INFO"}}
+        (hermes_home / "config.yaml").write_text(yaml.dump(config))
+
+        _, _, _, loggers = hermes_logging._read_logging_config()
+        assert loggers == {}
+
+
+class TestPerLoggerLevels:
+    """setup_logging() applies per-logger level overrides from config.yaml."""
+
+    def test_dict_shape_sets_logger_level(self, hermes_home):
+        """logging.loggers.<name>: {level: DEBUG} sets that logger to DEBUG."""
+        import yaml
+        config = {
+            "logging": {
+                "level": "INFO",
+                "loggers": {
+                    "tools.tool_search": {"level": "DEBUG"},
+                },
+            }
+        }
+        (hermes_home / "config.yaml").write_text(yaml.dump(config))
+
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
+        assert logging.getLogger("tools.tool_search").level == logging.DEBUG
+
+    def test_bare_string_shape_sets_logger_level(self, hermes_home):
+        """logging.loggers.<name>: DEBUG (bare string) is also accepted."""
+        import yaml
+        config = {
+            "logging": {
+                "level": "INFO",
+                "loggers": {
+                    "tools.reranker": "DEBUG",
+                },
+            }
+        }
+        (hermes_home / "config.yaml").write_text(yaml.dump(config))
+
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
+        assert logging.getLogger("tools.reranker").level == logging.DEBUG
+
+    def test_invalid_level_is_ignored(self, hermes_home):
+        """An unrecognised level string does not crash setup_logging()."""
+        import yaml
+        config = {
+            "logging": {
+                "level": "INFO",
+                "loggers": {
+                    "tools.tool_search": {"level": "NOTVALID"},
+                },
+            }
+        }
+        (hermes_home / "config.yaml").write_text(yaml.dump(config))
+
+        # Reset the specific logger so we can detect whether setup_logging
+        # touches it — prior tests in the same process may have left it set.
+        target = logging.getLogger("tools.tool_search")
+        target.setLevel(logging.NOTSET)
+
+        # Must not raise.
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
+        # Level is unchanged (NOTSET) — the invalid entry was silently skipped.
+        assert target.level == logging.NOTSET
+
+    def test_multiple_loggers_all_applied(self, hermes_home):
+        """Multiple loggers in config are all configured independently."""
+        import yaml
+        config = {
+            "logging": {
+                "level": "INFO",
+                "loggers": {
+                    "tools.tool_search": {"level": "DEBUG"},
+                    "tools.reranker": {"level": "WARNING"},
+                    "agent.context": {"level": "ERROR"},
+                },
+            }
+        }
+        (hermes_home / "config.yaml").write_text(yaml.dump(config))
+
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
+        assert logging.getLogger("tools.tool_search").level == logging.DEBUG
+        assert logging.getLogger("tools.reranker").level == logging.WARNING
+        assert logging.getLogger("agent.context").level == logging.ERROR
+
+    def test_per_logger_debug_records_propagate_to_agent_log(self, hermes_home):
+        """DEBUG records from a per-logger-configured logger reach agent.log.
+
+        Why: The whole point of the fix — verifying records actually appear.
+        Propagation must remain True so the root-attached agent.log handler
+        receives the records.
+        """
+        import yaml
+        config = {
+            "logging": {
+                "level": "INFO",
+                "loggers": {
+                    "tools.tool_search": {"level": "DEBUG"},
+                },
+            }
+        }
+        (hermes_home / "config.yaml").write_text(yaml.dump(config))
+
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+
+        logger = logging.getLogger("tools.tool_search")
+        assert logger.propagate, "propagation must be True for agent.log to receive records"
+        logger.debug("tool_search debug record")
+
+        for h in logging.getLogger().handlers:
+            h.flush()
+
+        agent_log = hermes_home / "logs" / "agent.log"
+        content = agent_log.read_text()
+        assert "tool_search debug record" in content
 
 
 class TestExternalRotationRecovery:

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -492,3 +492,171 @@ class TestProfileMcpBypassEndToEnd:
         assert "mcp-nextcloud-files" not in child_toolsets, (
             "mcp-nextcloud-files must be stripped when profile_name=None (security boundary)."
         )
+
+
+# ---------------------------------------------------------------------------
+# TestBatchToolsetInjectionBlocked
+# Security regression guard for the batch-mode privilege-escalation hole:
+# a model that names a valid profile (activating the mcp-* bypass in
+# _build_child_agent) AND supplies per-task toolsets must NOT gain toolsets
+# beyond what the profile declares.
+# ---------------------------------------------------------------------------
+
+_PROFILES_WITH_NEXTCLOUD = {
+    "documents": {
+        "toolsets": ["mcp-nextcloud-files"],
+    },
+}
+
+_PROFILES_EMPTY_TOOLSETS = {
+    "bare-profile": {
+        # no 'toolsets' key → empty profile
+    },
+}
+
+
+class TestBatchToolsetInjectionBlocked:
+    """Batch-mode model-supplied toolsets cannot override a resolved profile.
+
+    The vulnerability: batch tasks=[{"goal":"x","toolsets":["mcp-evil"]}] with
+    profile="documents" previously let the model inject arbitrary mcp-* toolsets
+    because the batch loop used `t.get("toolsets") or toolsets`, overriding the
+    profile-resolved toolsets while resolved_profile_name stayed set (activating
+    the mcp-* bypass in _build_child_agent).
+
+    These tests FAIL on pre-fix code (mcp-injected-evil present in child) and
+    PASS after the fix (child toolsets match profile declaration only).
+    """
+
+    @patch("tools.delegate_tool._load_agent_profiles", return_value=_PROFILES_WITH_NEXTCLOUD)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_batch_injection_blocked_model_cannot_inject_evil_mcp_toolset(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """CRITICAL security: batch per-task toolsets are ignored when a profile is set.
+
+        Why: Pre-fix, the batch loop used t.get("toolsets") or toolsets, so a
+        model could name profile="documents" (activating the mcp-* bypass) and
+        supply tasks=[{"goal":"x","toolsets":["mcp-injected-evil"]}] to gain
+        mcp-injected-evil — which the 'documents' profile never declared.
+        What: Assert _build_child_agent receives only the profile's toolsets
+        (mcp-nextcloud-files), and NOT the model-injected mcp-injected-evil.
+        Test: Compare the toolsets kwarg of the mock call against the profile
+        declaration; mcp-injected-evil must be absent, mcp-nextcloud-files present.
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                # No top-level goal — use batch tasks path
+                tasks=[{"goal": "do something", "toolsets": ["mcp-injected-evil"]}],
+                profile="documents",
+                parent_agent=parent,
+            )
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        child_toolsets = kwargs.get("toolsets") or []
+
+        assert "mcp-injected-evil" not in child_toolsets, (
+            f"SECURITY: mcp-injected-evil must be blocked but found in {child_toolsets!r}. "
+            "Pre-fix code lets batch per-task toolsets override the profile. "
+            "This test must FAIL before the fix and PASS after."
+        )
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            f"mcp-nextcloud-files (from profile 'documents') must be present, "
+            f"got {child_toolsets!r}"
+        )
+
+    @patch("tools.delegate_tool._load_agent_profiles", return_value=_PROFILES_WITH_NEXTCLOUD)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_single_task_profile_toolsets_unchanged(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """Single-task profile path: child receives profile's declared toolsets.
+
+        Why: Regression guard — the batch fix must not break single-task profile
+        delegation, which already worked correctly pre-fix.
+        What: delegate_task(goal=..., profile="documents") → child gets
+        mcp-nextcloud-files (the profile's only declared toolset).
+        Test: Assert mcp-nextcloud-files in toolsets kwarg and profile_name set.
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="Manage my documents",
+                profile="documents",
+                parent_agent=parent,
+            )
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        child_toolsets = kwargs.get("toolsets") or []
+
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            f"Single-task profile path must forward profile toolsets, got {child_toolsets!r}"
+        )
+        assert kwargs.get("profile_name") == "documents", (
+            f"profile_name must be 'documents', got {kwargs.get('profile_name')!r}"
+        )
+
+    @patch("tools.delegate_tool._load_agent_profiles", return_value=_PROFILES_EMPTY_TOOLSETS)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_empty_profile_toolsets_bypass_not_activated(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """Profile with no toolsets does NOT activate the mcp-* bypass.
+
+        Why: Pre-fix, a profile with empty/missing toolsets still set
+        resolved_profile_name, activating the bypass with whatever caller-
+        supplied toolsets were present.  Any mcp-* name the model supplied
+        would bypass the parent intersection — a privilege-escalation vector.
+        What: Assert profile_name=None in the _build_child_agent call so the
+        intersection path (not bypass) is used, stripping mcp-x from a no_mcp
+        parent.
+        Test: Profile 'bare-profile' has no toolsets; caller passes
+        toolsets=['mcp-x']; assert profile_name=None in build call.
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="Do something restricted",
+                toolsets=["mcp-x"],
+                profile="bare-profile",
+                parent_agent=parent,
+            )
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+
+        assert kwargs.get("profile_name") is None, (
+            f"Empty-toolsets profile must NOT set profile_name (bypass must be inactive), "
+            f"got profile_name={kwargs.get('profile_name')!r}. "
+            "Pre-fix: resolved_profile_name was set regardless of toolsets presence."
+        )

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -7,8 +7,14 @@ arbitrary toolsets.
 """
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
 
-from tools.delegate_tool import _strip_blocked_tools
+from tools.delegate_tool import (
+    DELEGATE_TASK_SCHEMA,
+    _build_child_agent,
+    _strip_blocked_tools,
+    delegate_task,
+)
 
 
 class TestToolsetIntersection:
@@ -63,3 +69,426 @@ class TestToolsetIntersection:
         scoped = [t for t in requested if t in parent_toolsets]
 
         assert scoped == []
+
+
+def _make_mcp_restricted_parent():
+    """Parent agent whose MCP context is empty (e.g. no_mcp orchestrator).
+
+    enabled_toolsets=[] means the parent loaded no toolsets at all — the
+    intersection against it would normally drop every requested toolset.
+    """
+    parent = MagicMock()
+    parent.enabled_toolsets = []
+    parent._delegate_depth = 0
+    parent._credential_pool = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._print_fn = None
+    return parent
+
+
+class TestProfileMcpToolsetBypass:
+    """MCP toolsets declared by a named agent_profile bypass parent intersection.
+
+    Regression coverage for NousResearch/hermes-agent#32668: an orchestrator
+    that restricts its own MCP servers must still be able to hand domain MCP
+    toolsets to a child via a named profile. Non-MCP toolsets keep going
+    through the parent intersection (the security boundary).
+    """
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_profile_mcp_toolsets_bypass_parent_intersection(self, _):
+        """profile_name set → MCP toolsets pass through even when parent has none."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Check mail",
+                context=None,
+                toolsets=["mcp-fastmail", "mcp-knowledge"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="mail",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-fastmail" in child_toolsets
+        assert "mcp-knowledge" in child_toolsets
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_no_profile_mcp_toolsets_still_intersected(self, _):
+        """No profile → MCP toolset request is dropped (intersection enforced)."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Check mail",
+                context=None,
+                toolsets=["mcp-fastmail"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name=None,
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-fastmail" not in child_toolsets
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_profile_non_mcp_toolsets_still_intersected(self, _):
+        """Even with a profile, non-MCP toolsets the parent lacks are dropped."""
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Browse the web",
+                context=None,
+                toolsets=["mcp-fastmail", "browser"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="mail",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        # MCP toolset bypasses intersection ...
+        assert "mcp-fastmail" in child_toolsets
+        # ... but the non-MCP toolset the parent never had is still dropped.
+        assert "browser" not in child_toolsets
+
+
+# ---------------------------------------------------------------------------
+# TestDelegateTaskProfileWiring
+# Regression guard for NousResearch/hermes-agent#32668 / #32727.
+# The full call chain from delegate_task() → _build_child_agent() must
+# thread the profile name and resolved toolsets through so MCP toolsets
+# bypass the no_mcp parent intersection at the _build_child_agent level.
+# ---------------------------------------------------------------------------
+
+_FAKE_AGENT_PROFILES = {
+    "documents": {
+        "toolsets": ["mcp-nextcloud-files", "mcp-knowledge"],
+    },
+    "mail": {
+        "toolsets": ["mcp-fastmail"],
+    },
+}
+
+# Minimal delegate_task config: no delegation-specific overrides.
+_BARE_DELEGATION_CFG = {}
+
+# A structurally valid result dict from _run_single_child (enough fields for
+# the post-run aggregation logic in delegate_task to not raise AttributeError).
+def _make_fake_child_result(task_index: int = 0) -> dict:
+    """Return a minimal _run_single_child result dict.
+
+    Why: delegate_task's post-run loop calls entry.pop('_child_role', None),
+    entry.get('api_calls', 0), etc. — mocking with a plain string raises
+    AttributeError.  This helper produces a dict with every field that the
+    post-run aggregation touches.
+    Test: Used internally by TestDelegateTaskProfileWiring patches.
+    """
+    return {
+        "task_index": task_index,
+        "status": "ok",
+        "summary": "done",
+        "error": None,
+        "exit_reason": "complete",
+        "api_calls": 0,
+        "duration_seconds": 0.1,
+        "_child_role": "leaf",
+        "diagnostic_path": None,
+    }
+
+
+def _make_no_mcp_parent():
+    """Parent agent that simulates a no_mcp orchestrator.
+
+    enabled_toolsets contains only the non-MCP platform toolsets.
+    No mcp-* names are present, so the intersection path in
+    _build_child_agent would strip every MCP toolset when profile_name=None.
+    """
+    parent = MagicMock()
+    parent.enabled_toolsets = ["delegation", "knowledge"]
+    parent._delegate_depth = 0
+    parent._credential_pool = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._print_fn = None
+    parent.api_key = None
+    parent._client_kwargs = {}
+    parent.model = "test-model"
+    parent._subagent_id = None
+    parent.valid_tool_names = []
+    return parent
+
+
+class TestDelegateTaskProfileWiring:
+    """delegate_task() wires profile → _build_child_agent(profile_name=...).
+
+    Key regression guard: MUST fail against pre-fix code (profile_name=None
+    hardcoded) and MUST pass after the fix (profile_name=resolved name).
+    """
+
+    @patch("tools.delegate_tool._load_agent_profiles", return_value=_FAKE_AGENT_PROFILES)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_profile_forwarded_to_build_child_agent(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """delegate_task with profile='documents' calls _build_child_agent with
+        profile_name='documents' and the profile's toolsets.
+
+        This test FAILS on pre-fix code (profile_name=None hardcoded) and
+        PASSES after the fix (profile_name='documents' forwarded).
+
+        Why: Without this wiring the bypass branch at lines 972-976 of
+        _build_child_agent never activates, so mcp-nextcloud-files is stripped
+        from a no_mcp parent's child agent.
+        Test: Assert _build_child_agent is called with profile_name='documents'
+        and toolsets=['mcp-nextcloud-files', 'mcp-knowledge'].
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        # delegate_task needs _run_single_child; patch it out with a proper dict.
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="Fetch the document",
+                context="Use the Nextcloud MCP server",
+                profile="documents",
+                parent_agent=parent,
+            )
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        assert kwargs.get("profile_name") == "documents", (
+            f"profile_name should be 'documents', got {kwargs.get('profile_name')!r}. "
+            "Pre-fix code hardcodes profile_name=None — this is the regression guard."
+        )
+        assert "mcp-nextcloud-files" in (kwargs.get("toolsets") or []), (
+            f"Expected mcp-nextcloud-files in toolsets, got {kwargs.get('toolsets')!r}. "
+            "Profile toolsets must override the toolsets arg so the bypass activates."
+        )
+
+    @patch("tools.delegate_tool._load_agent_profiles", return_value=_FAKE_AGENT_PROFILES)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_no_profile_leaves_profile_name_none(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """Without profile= arg, _build_child_agent is called with profile_name=None.
+
+        Preserves backward-compatible behavior: ad-hoc delegation without a
+        named profile still goes through the security intersection path.
+
+        Why: Must not accidentally enable the bypass for unprofiled calls.
+        Test: Call delegate_task without profile= and assert profile_name=None.
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+        parent.enabled_toolsets = ["terminal", "file"]
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="List files",
+                toolsets=["terminal", "file"],
+                parent_agent=parent,
+            )
+
+        _, kwargs = mock_build.call_args
+        assert kwargs.get("profile_name") is None, (
+            f"Expected profile_name=None for unprofiled call, got {kwargs.get('profile_name')!r}"
+        )
+
+    @patch("tools.delegate_tool._load_agent_profiles", return_value=_FAKE_AGENT_PROFILES)
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_unknown_profile_falls_back_gracefully(
+        self, mock_build, _mock_cfg, _mock_profiles
+    ):
+        """Unknown profile name logs a warning and falls back to explicit toolsets.
+
+        Why: A typo in a profile name should not hard-fail the delegation;
+        it should fall back to whatever toolsets the caller provided, if any.
+        Test: Pass profile='nonexistent', assert profile_name=None in call.
+        """
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+        parent.enabled_toolsets = ["terminal"]
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="Do something",
+                toolsets=["terminal"],
+                profile="nonexistent",
+                parent_agent=parent,
+            )
+
+        _, kwargs = mock_build.call_args
+        # Unknown profile → resolved_profile_name stays None → no bypass.
+        assert kwargs.get("profile_name") is None, (
+            f"Unknown profile should leave profile_name=None, got {kwargs.get('profile_name')!r}"
+        )
+
+
+class TestDelegateTaskSchemaProfile:
+    """DELEGATE_TASK_SCHEMA must formally declare the 'profile' property.
+
+    The model reliably emits only schema-declared fields. Without a formal
+    'profile' entry in the schema the model would silently omit it even when
+    the SOUL/orchestrator prompt instructs it to pass profile=.
+    """
+
+    def test_profile_field_in_schema(self):
+        """'profile' is a declared property in DELEGATE_TASK_SCHEMA.
+
+        Why: Without a formal schema entry the LLM strips the field before
+        calling the tool, making the orchestrator's profile= instruction
+        invisible to the handler.
+        Test: Assert 'profile' key exists in schema properties.
+        """
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        assert "profile" in props, (
+            "'profile' missing from DELEGATE_TASK_SCHEMA parameters.properties. "
+            "Add it so the model reliably emits the field."
+        )
+
+    def test_profile_field_is_string_type(self):
+        """'profile' schema property must be type=string.
+
+        Why: Any other type would cause schema validation failures at the
+        provider API boundary.
+        Test: Assert type == 'string' for the profile property.
+        """
+        prop = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["profile"]
+        assert prop.get("type") == "string", (
+            f"Expected profile schema type='string', got {prop.get('type')!r}"
+        )
+
+    def test_profile_field_not_required(self):
+        """'profile' must not be in the 'required' array (it is optional).
+
+        Why: Making it required would break all existing delegate_task calls
+        that don't specify a profile.
+        Test: Assert 'profile' absent from the required list.
+        """
+        required = DELEGATE_TASK_SCHEMA["parameters"].get("required", [])
+        assert "profile" not in required, (
+            "'profile' should not be in required — it is an optional field."
+        )
+
+
+class TestProfileMcpBypassEndToEnd:
+    """End-to-end bypass: no_mcp parent + profile → child keeps MCP toolsets.
+
+    This is the key regression guard from the PR description. It directly
+    tests _build_child_agent with profile_name set vs. None to confirm the
+    bypass branch activates/deactivates correctly.
+    """
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_no_mcp_parent_with_profile_retains_mcp_toolsets(self, _):
+        """CRITICAL: no_mcp parent + profile_name → child retains mcp-nextcloud-files.
+
+        This test FAILS against pre-fix code (profile_name=None hardcoded in
+        the _build_child_agent call site) because the bypass branch is never
+        entered — mcp-nextcloud-files gets stripped by the parent intersection.
+
+        After the fix (profile_name='documents' forwarded) the bypass branch
+        activates and mcp-nextcloud-files survives.
+
+        Why: The confirmed prod gap: fat sub-agents under no_mcp orchestrators
+        received 0 MCP tools. This verifies the fix at the _build_child_agent
+        level independent of the delegate_task wiring.
+        Test: Pass profile_name='documents' and assert mcp-nextcloud-files in
+        child enabled_toolsets. Then repeat with profile_name=None and assert
+        it IS stripped.
+        """
+        parent = _make_mcp_restricted_parent()
+
+        # --- With profile_name set (post-fix behavior) ---
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="File management",
+                context=None,
+                toolsets=["mcp-nextcloud-files", "knowledge"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="documents",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            "mcp-nextcloud-files should bypass no_mcp parent intersection when "
+            "profile_name is set. If this fails the fix is not working."
+        )
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_no_mcp_parent_without_profile_strips_mcp_toolsets(self, _):
+        """Confirm the pre-fix behavior: no profile → MCP stripped (security).
+
+        This must remain true to preserve the security boundary. Ad-hoc
+        delegation without a profile cannot bypass the intersection.
+
+        Why: The bypass is a deliberate whitelist; only named profiles whose
+        config explicitly declares MCP servers should get them through.
+        Test: profile_name=None → mcp-nextcloud-files absent from child.
+        """
+        parent = _make_mcp_restricted_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="File management",
+                context=None,
+                toolsets=["mcp-nextcloud-files"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name=None,
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+        assert "mcp-nextcloud-files" not in child_toolsets, (
+            "mcp-nextcloud-files must be stripped when profile_name=None (security boundary)."
+        )

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -660,3 +660,102 @@ class TestBatchToolsetInjectionBlocked:
             f"got profile_name={kwargs.get('profile_name')!r}. "
             "Pre-fix: resolved_profile_name was set regardless of toolsets presence."
         )
+
+
+# ---------------------------------------------------------------------------
+# TestProfileToolsetsAliasing
+# Regression guard for the config-aliasing vulnerability: toolsets must be
+# copied (list()) from the config dict, not assigned by reference.
+#
+# Without the copy, any in-place mutation of the working `toolsets` variable
+# (or of `profile_resolved_toolsets`, which is derived from it) silently
+# corrupts the agent_profiles config dict for the entire process lifetime.
+# On the next delegate_task call the now-mutated list would be used as the
+# authoritative profile declaration, bypassing the intended toolset scope.
+# ---------------------------------------------------------------------------
+
+class TestProfileToolsetsAliasing:
+    """Profile toolsets assignment must copy, not reference, the config list.
+
+    Why: profile_cfg["toolsets"] lives inside the dict returned by
+    _load_agent_profiles() and may be cached for the process lifetime.
+    Assigning it directly to the working variable means any in-place
+    mutation (e.g., .append(), .clear(), .pop()) of that variable would
+    corrupt the config — all subsequent delegate_task calls in the same
+    process would see the mutated toolsets as the 'official' profile
+    declaration.  This is a privilege-escalation / DoS vector.
+
+    The fix (list(profile_toolsets) at line ~2082 and
+    list(toolsets) at line ~2110) ensures the working variable and the
+    authoritative capture are independent copies.
+    """
+
+    @patch("tools.delegate_tool._load_agent_profiles")
+    @patch("tools.delegate_tool._load_config", return_value=_BARE_DELEGATION_CFG)
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_profile_toolsets_copy_prevents_config_corruption(
+        self, mock_build, _mock_cfg, mock_load_profiles
+    ):
+        """Mutating the toolsets list passed to _build_child_agent must NOT
+        corrupt the original agent_profiles config entry.
+
+        Why: Pre-fix code did ``toolsets = profile_toolsets`` (reference), so
+        mutating the kwarg received by _build_child_agent also mutated
+        profiles["documents"]["toolsets"] — corrupting it for every future call.
+        What: After delegate_task resolves a profile, capture the toolsets list
+        that was passed to _build_child_agent, mutate it in-place, then verify
+        profiles["documents"]["toolsets"] is unchanged.
+        Test: Assert that appending a sentinel to the captured child toolsets
+        list does NOT appear in the original config dict, proving list() copy.
+        """
+        # Hold a direct reference to the config list so we can inspect it after
+        # delegate_task has run and after we mutate the captured child toolsets.
+        original_toolsets_list = ["mcp-nextcloud-files", "mcp-knowledge"]
+        profiles_cfg = {
+            "documents": {
+                "toolsets": original_toolsets_list,
+            },
+        }
+        mock_load_profiles.return_value = profiles_cfg
+
+        fake_child = MagicMock()
+        fake_child._delegate_saved_tool_names = []
+        mock_build.return_value = fake_child
+
+        parent = _make_no_mcp_parent()
+
+        with patch(
+            "tools.delegate_tool._run_single_child",
+            return_value=_make_fake_child_result(0),
+        ):
+            delegate_task(
+                goal="Fetch documents",
+                profile="documents",
+                parent_agent=parent,
+            )
+
+        # Retrieve the toolsets list that was handed to _build_child_agent.
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        child_toolsets_arg: list = kwargs.get("toolsets") or []
+
+        # Sanity: the profile toolsets made it through correctly.
+        assert "mcp-nextcloud-files" in child_toolsets_arg, (
+            f"Profile toolsets must be forwarded; got {child_toolsets_arg!r}"
+        )
+
+        # Now mutate the list that _build_child_agent received.
+        sentinel = "mcp-INJECTED-SENTINEL"
+        child_toolsets_arg.append(sentinel)
+        child_toolsets_arg.clear()
+
+        # CRITICAL ASSERTION: the original config list must be untouched.
+        # Pre-fix (reference): original_toolsets_list would now be empty.
+        # Post-fix (copy):     original_toolsets_list is still the original.
+        assert original_toolsets_list == ["mcp-nextcloud-files", "mcp-knowledge"], (
+            f"Config corruption detected: profiles['documents']['toolsets'] was mutated "
+            f"to {original_toolsets_list!r}. "
+            "The toolsets working variable must be a list() copy, not a reference to the "
+            "config dict's list. Pre-fix code assigns `toolsets = profile_toolsets` "
+            "(reference); the fix is `toolsets = list(profile_toolsets)`."
+        )

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -759,3 +759,166 @@ class TestProfileToolsetsAliasing:
             "config dict's list. Pre-fix code assigns `toolsets = profile_toolsets` "
             "(reference); the fix is `toolsets = list(profile_toolsets)`."
         )
+
+
+# ---------------------------------------------------------------------------
+# TestInheritMcpToolsetsProfileGuard
+# Security hardening: _preserve_parent_mcp_toolsets must NOT run when a named
+# profile is in use.  The profile's declared toolsets are authoritative — the
+# parent's MCP toolsets must not bleed in via the inherit_mcp_toolsets path.
+#
+# Scenario: parent has mcp-nextcloud-files AND mcp-fastmail in its toolsets.
+# Profile "documents" declares only ["mcp-nextcloud-files"].
+# With inherit_mcp_toolsets=True (default), the pre-fix code calls
+# _preserve_parent_mcp_toolsets unconditionally, which appends mcp-fastmail
+# (a parent MCP toolset missing from the child list) to the resolved profile
+# toolsets — violating the invariant that the profile is authoritative.
+#
+# These tests FAIL on pre-fix code (mcp-fastmail bleeds in) and PASS after
+# the fix (guard `and not profile_name` prevents _preserve_parent_mcp_toolsets
+# from running when a profile is set).
+# ---------------------------------------------------------------------------
+
+_PROFILES_DOCUMENTS_NEXTCLOUD_ONLY = {
+    "documents": {
+        "toolsets": ["mcp-nextcloud-files"],
+    },
+}
+
+
+def _make_mcp_rich_parent():
+    """Parent agent that carries two MCP toolsets: nextcloud-files AND fastmail.
+
+    Why: Simulates an orchestrator that has loaded both domain MCP servers.
+    The profile "documents" only declares mcp-nextcloud-files, so mcp-fastmail
+    is the parent-only MCP toolset that must NOT bleed into the child when a
+    profile is named.
+
+    What: enabled_toolsets includes both mcp-nextcloud-files and mcp-fastmail
+    so that _preserve_parent_mcp_toolsets would normally append mcp-fastmail.
+
+    Test: Use as the parent arg in _build_child_agent calls below.
+    """
+    parent = MagicMock()
+    parent.enabled_toolsets = ["mcp-nextcloud-files", "mcp-fastmail", "delegation"]
+    parent._delegate_depth = 0
+    parent._credential_pool = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent._print_fn = None
+    parent.api_key = None
+    parent._client_kwargs = {}
+    parent.model = "test-model"
+    parent._subagent_id = None
+    parent.valid_tool_names = []
+    return parent
+
+
+class TestInheritMcpToolsetsProfileGuard:
+    """inherit_mcp_toolsets=True must NOT add parent MCP toolsets when a profile is named.
+
+    The profile's declared toolsets are authoritative.  _preserve_parent_mcp_toolsets
+    must be skipped entirely when profile_name is set so that parent-only MCP toolsets
+    cannot bleed into the child.
+
+    FAIL before fix: mcp-fastmail (parent-only) appears in child toolsets.
+    PASS after fix:  child toolsets are EXACTLY the profile's (mcp-nextcloud-files only).
+    """
+
+    @patch("tools.delegate_tool._get_inherit_mcp_toolsets", return_value=True)
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_parent_mcp_bleed_blocked_under_profile(self, _mock_cfg, _mock_inherit):
+        """CRITICAL: profile toolsets are authoritative — parent MCP toolsets must not bleed.
+
+        Why: Pre-fix, _preserve_parent_mcp_toolsets runs unconditionally when
+        inherit_mcp_toolsets=True, appending every parent MCP toolset absent from
+        the child list.  With a profile that declares only mcp-nextcloud-files,
+        the parent's mcp-fastmail gets added — a silent scope expansion that
+        violates the "profile declares exactly which MCP servers the child needs"
+        invariant.
+
+        What: _build_child_agent with profile_name="documents" (declares only
+        mcp-nextcloud-files) and a parent that has BOTH mcp-nextcloud-files and
+        mcp-fastmail.  Child toolsets must be exactly ["mcp-nextcloud-files"]
+        (after stripping delegation); mcp-fastmail must NOT appear.
+
+        Test: Assert "mcp-nextcloud-files" in child toolsets and
+        "mcp-fastmail" NOT in child toolsets.  FAILS pre-fix (mcp-fastmail
+        bleeds in via _preserve_parent_mcp_toolsets), PASSES post-fix (guard
+        `and not profile_name` skips the bleed path).
+        """
+        parent = _make_mcp_rich_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Manage documents",
+                context=None,
+                toolsets=["mcp-nextcloud-files"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name="documents",
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            f"Profile-declared mcp-nextcloud-files must be present, got {child_toolsets!r}"
+        )
+        assert "mcp-fastmail" not in child_toolsets, (
+            f"SECURITY: mcp-fastmail (parent-only) must NOT bleed into the child when "
+            f"profile_name is set, but got {child_toolsets!r}. "
+            "Pre-fix: _preserve_parent_mcp_toolsets runs unconditionally, appending "
+            "every parent MCP toolset not in the child list. "
+            "Fix: add `and not profile_name` guard to the inherit_mcp_toolsets check "
+            "at line ~980 of delegate_tool.py."
+        )
+
+    @patch("tools.delegate_tool._get_inherit_mcp_toolsets", return_value=True)
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_non_profile_inheritance_unchanged(self, _mock_cfg, _mock_inherit):
+        """Non-profile delegation with inherit_mcp_toolsets=True still inherits parent MCP.
+
+        Why: Regression baseline — the profile guard must not break the existing
+        behavior for ad-hoc (no profile) delegation.  When no profile is named,
+        _preserve_parent_mcp_toolsets should still run and add parent MCP toolsets
+        to a narrowed child that requests only a subset.
+
+        What: parent has mcp-nextcloud-files + mcp-fastmail; child requests only
+        mcp-nextcloud-files with NO profile.  After the fix, mcp-fastmail must
+        still appear in child toolsets (non-profile path is unchanged).
+
+        Test: Assert BOTH mcp-nextcloud-files and mcp-fastmail are present in the
+        child toolsets, proving that the guard is scoped to the profile case only.
+        """
+        parent = _make_mcp_rich_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+
+            _build_child_agent(
+                task_index=0,
+                goal="Ad-hoc file management",
+                context=None,
+                toolsets=["mcp-nextcloud-files"],
+                model=None,
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                profile_name=None,  # no profile — inheritance must still work
+            )
+
+        child_toolsets = MockAgent.call_args[1]["enabled_toolsets"]
+
+        assert "mcp-nextcloud-files" in child_toolsets, (
+            f"Requested mcp-nextcloud-files must be present, got {child_toolsets!r}"
+        )
+        assert "mcp-fastmail" in child_toolsets, (
+            f"mcp-fastmail must be inherited from parent when no profile is named "
+            f"(non-profile inheritance must be unchanged), got {child_toolsets!r}. "
+            "If this fails the profile guard is too broad."
+        )

--- a/tests/tools/test_mcp_lazy_discovery.py
+++ b/tests/tools/test_mcp_lazy_discovery.py
@@ -1,0 +1,185 @@
+"""Tests for Phase 2 lazy MCP discovery.
+
+When the active platform's toolsets include the ``no_mcp`` sentinel
+(e.g. api_server), the gateway/CLI skip eager MCP discovery at startup and
+defer it until the first child-agent build that needs MCP toolsets. This
+module verifies:
+
+* ``mark_eager_discovery_skipped()`` / ``ensure_mcp_discovered()`` behavior,
+  including the one-shot, thread-safe, failure-tolerant contract.
+* ``_active_platform_uses_no_mcp()`` config-dict resolution in gateway.run.
+
+See NousResearch/hermes-agent#32668.
+"""
+
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+import tools.mcp_tool as mcp_tool
+
+
+@pytest.fixture(autouse=True)
+def reset_lazy_discovery_state():
+    """Save/restore the module-level lazy-discovery globals around each test.
+
+    Discovery state is process-global; without this fixture a test that sets
+    ``_eager_discovery_skipped`` or the done Event would leak into siblings.
+    """
+    saved_skipped = mcp_tool._eager_discovery_skipped
+    saved_event = mcp_tool._lazy_discovery_done
+
+    # Start each test from a clean slate.
+    mcp_tool._eager_discovery_skipped = False
+    mcp_tool._lazy_discovery_done = threading.Event()
+
+    try:
+        yield
+    finally:
+        mcp_tool._eager_discovery_skipped = saved_skipped
+        mcp_tool._lazy_discovery_done = saved_event
+
+
+class TestMarkEagerDiscoverySkipped:
+    def test_sets_flag_true(self):
+        assert mcp_tool._eager_discovery_skipped is False
+        mcp_tool.mark_eager_discovery_skipped()
+        assert mcp_tool._eager_discovery_skipped is True
+
+
+class TestEnsureMcpDiscovered:
+    def test_noop_when_not_skipped(self):
+        """When eager discovery ran (skipped=False), ensure_* is a no-op."""
+        with patch.object(mcp_tool, "discover_mcp_tools") as mock_discover:
+            mcp_tool.ensure_mcp_discovered()
+            mock_discover.assert_not_called()
+        # The done-Event must remain unset so a later skipped flow can still run.
+        assert not mcp_tool._lazy_discovery_done.is_set()
+
+    def test_calls_discover_once_when_skipped(self):
+        """First call after skip triggers discovery exactly once."""
+        mcp_tool.mark_eager_discovery_skipped()
+        with patch.object(mcp_tool, "discover_mcp_tools") as mock_discover:
+            mcp_tool.ensure_mcp_discovered()
+            mock_discover.assert_called_once()
+        assert mcp_tool._lazy_discovery_done.is_set()
+
+    def test_idempotent_after_done(self):
+        """Second call after the done-Event is set never re-runs discovery."""
+        mcp_tool.mark_eager_discovery_skipped()
+        with patch.object(mcp_tool, "discover_mcp_tools") as mock_discover:
+            mcp_tool.ensure_mcp_discovered()
+            mcp_tool.ensure_mcp_discovered()
+            mcp_tool.ensure_mcp_discovered()
+            assert mock_discover.call_count == 1
+
+    def test_thread_safe_single_discovery(self):
+        """10 concurrent callers must trigger discovery exactly once."""
+        mcp_tool.mark_eager_discovery_skipped()
+
+        call_count = 0
+        count_lock = threading.Lock()
+
+        def slow_discover():
+            nonlocal call_count
+            with count_lock:
+                call_count += 1
+            # Hold the lazy lock long enough that all threads contend.
+            time.sleep(0.05)
+            return []
+
+        start = threading.Event()
+        threads = []
+
+        def worker():
+            start.wait()
+            mcp_tool.ensure_mcp_discovered()
+
+        with patch.object(mcp_tool, "discover_mcp_tools", side_effect=slow_discover):
+            for _ in range(10):
+                t = threading.Thread(target=worker)
+                t.start()
+                threads.append(t)
+            start.set()
+            for t in threads:
+                t.join(timeout=5)
+
+        assert call_count == 1
+        assert mcp_tool._lazy_discovery_done.is_set()
+
+    def test_failure_does_not_propagate(self):
+        """If discover raises, ensure_* swallows it, sets done, logs a warning."""
+        mcp_tool.mark_eager_discovery_skipped()
+
+        def boom():
+            raise RuntimeError("connection refused")
+
+        with patch.object(mcp_tool, "discover_mcp_tools", side_effect=boom), \
+                patch.object(mcp_tool.logger, "warning") as mock_warning:
+            # Must not raise.
+            mcp_tool.ensure_mcp_discovered()
+
+        # Done-Event set to prevent retry storms after a hard failure.
+        assert mcp_tool._lazy_discovery_done.is_set()
+        mock_warning.assert_called_once()
+
+    def test_failure_prevents_retry(self):
+        """After a failed discovery, subsequent calls do not retry."""
+        mcp_tool.mark_eager_discovery_skipped()
+
+        with patch.object(
+            mcp_tool, "discover_mcp_tools", side_effect=RuntimeError("boom")
+        ) as mock_discover, patch.object(mcp_tool.logger, "warning"):
+            mcp_tool.ensure_mcp_discovered()
+            mcp_tool.ensure_mcp_discovered()
+            assert mock_discover.call_count == 1
+
+
+class TestActivePlatformUsesNoMcp:
+    def test_true_for_api_server_with_no_mcp(self):
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {"platform_toolsets": {"api_server": ["delegation", "no_mcp"]}}
+        with patch.dict("os.environ", {"HERMES_PLATFORM": "api_server"}):
+            assert _active_platform_uses_no_mcp(config) is True
+
+    def test_false_for_cli(self):
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {
+            "platform_toolsets": {
+                "cli": ["delegation"],
+                "api_server": ["delegation", "no_mcp"],
+            }
+        }
+        with patch.dict("os.environ", {"HERMES_PLATFORM": "cli"}):
+            assert _active_platform_uses_no_mcp(config) is False
+
+    def test_false_when_platform_toolsets_missing(self):
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {"some_other_key": {}}
+        with patch.dict("os.environ", {"HERMES_PLATFORM": "api_server"}):
+            assert _active_platform_uses_no_mcp(config) is False
+
+    def test_false_for_unconfigured_platform(self):
+        """Platform present in env but absent from platform_toolsets -> False."""
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {"platform_toolsets": {"cli": ["delegation"]}}
+        with patch.dict("os.environ", {"HERMES_PLATFORM": "api_server"}):
+            assert _active_platform_uses_no_mcp(config) is False
+
+    def test_defaults_to_cli_when_env_unset(self):
+        """No HERMES_PLATFORM -> defaults to 'cli', which lacks no_mcp here."""
+        from gateway.run import _active_platform_uses_no_mcp
+
+        config = {"platform_toolsets": {"api_server": ["delegation", "no_mcp"]}}
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("HERMES_PLATFORM", None)
+            os.environ.pop("HERMES_SESSION_PLATFORM", None)
+            assert _active_platform_uses_no_mcp(config) is False

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2066,17 +2066,36 @@ def delegate_task(
                 sorted(all_profiles.keys()) if all_profiles else [],
             )
         else:
-            resolved_profile_name = profile
-            # Profile toolsets override caller-supplied toolsets so the model
-            # cannot expand its own access beyond what the profile declares.
             profile_toolsets = profile_cfg.get("toolsets")
             if profile_toolsets and isinstance(profile_toolsets, list):
+                # Profile toolsets are authoritative: store them separately so
+                # the batch path (below) can enforce them per-task without
+                # allowing model-supplied per-task toolsets to override.
+                resolved_profile_name = profile
                 toolsets = profile_toolsets
+            else:
+                # Profile declares no toolsets — granting the bypass here
+                # would activate the mcp-* exception in _build_child_agent
+                # with whatever the model supplied as toolsets.  That is a
+                # privilege-escalation vector, so we refuse to set the
+                # resolved name and fall back to the normal intersection path.
+                logger.warning(
+                    "delegate_task: profile %r has no non-empty toolsets list; "
+                    "bypass NOT activated (falling back to intersection path).",
+                    profile,
+                )
             logger.debug(
-                "delegate_task: resolved profile %r → toolsets=%s",
+                "delegate_task: resolved profile %r → resolved_profile_name=%r toolsets=%s",
                 profile,
+                resolved_profile_name,
                 toolsets,
             )
+
+    # Capture the profile-resolved toolsets so the batch loop below can enforce
+    # them as authoritative, ignoring any per-task toolsets the model supplies.
+    # When no profile was resolved this is None and the batch loop falls through
+    # to the per-task / top-level toolsets (existing behaviour unchanged).
+    profile_resolved_toolsets: Optional[list[str]] = toolsets if resolved_profile_name else None
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -2143,7 +2162,13 @@ def delegate_task(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets,
+                # Security: when a named profile was resolved its toolsets are
+                # authoritative for every task in the batch.  Using per-task
+                # model-supplied toolsets here would allow the model to name a
+                # valid profile (activating the mcp-* bypass in
+                # _build_child_agent) while injecting arbitrary toolsets that
+                # the profile never declared — a privilege-escalation vector.
+                toolsets=profile_resolved_toolsets if resolved_profile_name else (t.get("toolsets") or toolsets),
                 model=creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2072,7 +2072,14 @@ def delegate_task(
                 # the batch path (below) can enforce them per-task without
                 # allowing model-supplied per-task toolsets to override.
                 resolved_profile_name = profile
-                toolsets = profile_toolsets
+                # Copy, not reference: profile_toolsets is the list stored
+                # inside the config dict returned by _load_agent_profiles().
+                # Assigning the reference directly means any later in-place
+                # mutation (e.g. .append() / .clear()) of the working
+                # `toolsets` variable would corrupt the config for the entire
+                # process lifetime.  list() gives us an independent shallow
+                # copy of the string items, which is all we need.
+                toolsets = list(profile_toolsets)
             else:
                 # Profile declares no toolsets — granting the bypass here
                 # would activate the mcp-* exception in _build_child_agent
@@ -2095,7 +2102,12 @@ def delegate_task(
     # them as authoritative, ignoring any per-task toolsets the model supplies.
     # When no profile was resolved this is None and the batch loop falls through
     # to the per-task / top-level toolsets (existing behaviour unchanged).
-    profile_resolved_toolsets: Optional[list[str]] = toolsets if resolved_profile_name else None
+    #
+    # Take an independent copy (list()) even though `toolsets` was already
+    # copied from profile_toolsets above.  This keeps profile_resolved_toolsets
+    # stable against any future code that mutates `toolsets` in-place between
+    # here and the batch loop — defence-in-depth.
+    profile_resolved_toolsets: Optional[list[str]] = list(toolsets) if resolved_profile_name else None
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -977,7 +977,7 @@ def _build_child_agent(
         else:
             child_toolsets = [t for t in toolsets if t in expanded_parent]
 
-        if _get_inherit_mcp_toolsets():
+        if _get_inherit_mcp_toolsets() and not profile_name:
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
             )

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -888,6 +888,10 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Name of the resolved agent_profiles profile, if delegation used one.
+    # When set, MCP toolsets declared by the profile bypass parent
+    # intersection (see toolset resolution below).
+    profile_name: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -897,6 +901,16 @@ def _build_child_agent(
     those credentials instead of inheriting from the parent.  This enables
     routing subagents to a different provider:model pair (e.g. cheap/fast
     model on OpenRouter while the parent runs on Nous Portal).
+
+    profile_name: when set (i.e. the delegation came from a named
+    agent_profiles entry), MCP toolsets in the requested toolset list bypass
+    the parent-intersection check and are resolved directly from the global
+    mcp_servers config.  This is intentional: a profile explicitly declares
+    which MCP servers its worker needs, and those servers should be available
+    regardless of whether the orchestrator itself loaded them (e.g. it
+    restricted its own context via no_mcp).  Non-MCP toolsets still go
+    through intersection — that security boundary is preserved for ad-hoc
+    delegation.  See NousResearch/hermes-agent#32668.
     """
     from run_agent import AIAgent
     import uuid as _uuid
@@ -947,7 +961,22 @@ def _build_child_agent(
         # Expand composite toolsets (e.g. hermes-cli) so that individual
         # toolset names (e.g. web, terminal) are recognised during intersection.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
-        child_toolsets = [t for t in toolsets if t in expanded_parent]
+
+        # When toolsets come from a named agent_profile, MCP toolsets bypass the
+        # parent intersection. The profile declares exactly which MCP servers the
+        # child needs; resolving them against the parent's loaded tools would
+        # silently drop them whenever the orchestrator restricts its own MCP
+        # context (e.g. no_mcp, or simply not loading domain servers). Non-MCP
+        # toolsets still go through intersection — that security boundary is
+        # preserved. See NousResearch/hermes-agent#32668.
+        if profile_name:
+            child_toolsets = [
+                t for t in toolsets
+                if _is_mcp_toolset_name(t) or t in expanded_parent
+            ]
+        else:
+            child_toolsets = [t for t in toolsets if t in expanded_parent]
+
         if _get_inherit_mcp_toolsets():
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
@@ -1102,6 +1131,16 @@ def _build_child_agent(
         # Note: openrouter_min_coding_score is model-gated (only emitted on
         # openrouter/pareto-code), so we keep it inherited even when the
         # provider is overridden — it's a no-op on any other model.
+
+    # Trigger lazy MCP discovery if this child needs MCP toolsets. This is a
+    # no-op when eager discovery already ran at startup; it only does work when
+    # the active platform skipped eager discovery via the no_mcp sentinel
+    # (Phase 2). Runs for ALL MCP-needing child builds, not just profile-named
+    # ones, so the child sees a populated MCP registry before AIAgent builds.
+    if any(_is_mcp_toolset_name(t) for t in child_toolsets):
+        from tools.mcp_tool import ensure_mcp_discovered
+
+        ensure_mcp_discovered()
 
     child = AIAgent(
         base_url=effective_base_url,
@@ -1924,6 +1963,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    profile: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -1937,6 +1977,16 @@ def delegate_task(
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    The 'profile' parameter names an entry in the top-level
+    ``agent_profiles`` config mapping.  When set, the profile's declared
+    toolsets are used as the effective toolset list for the child, and
+    ``profile_name`` is forwarded to ``_build_child_agent`` so that
+    MCP toolsets declared by the profile bypass the parent's toolset
+    intersection.  This is the mechanism that lets fat sub-agents receive
+    their full MCP toolsets even when the orchestrator runs under a
+    ``no_mcp`` platform toolset.  See NousResearch/hermes-agent#32668 and
+    #32727.
 
     Returns JSON with results array, one entry per task.
     """
@@ -1996,6 +2046,37 @@ def delegate_task(
         creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
         return tool_error(str(exc))
+
+    # Resolve named agent_profile, if one was requested.
+    # When ``profile`` is set the caller wants a pre-declared agent archetype
+    # (toolsets, model, system_prompt) from the top-level ``agent_profiles``
+    # config section.  We extract the toolsets from the profile here so the
+    # rest of the function can treat them as the effective toolset list.
+    # ``resolved_profile_name`` stays None when no profile was requested so
+    # the existing intersection path in _build_child_agent is unchanged.
+    resolved_profile_name: Optional[str] = None
+    if profile and isinstance(profile, str) and profile.strip():
+        all_profiles = _load_agent_profiles()
+        profile_cfg = all_profiles.get(profile)
+        if profile_cfg is None:
+            logger.warning(
+                "delegate_task: unknown profile %r; known profiles: %s. "
+                "Falling back to explicit toolsets (if any).",
+                profile,
+                sorted(all_profiles.keys()) if all_profiles else [],
+            )
+        else:
+            resolved_profile_name = profile
+            # Profile toolsets override caller-supplied toolsets so the model
+            # cannot expand its own access beyond what the profile declares.
+            profile_toolsets = profile_cfg.get("toolsets")
+            if profile_toolsets and isinstance(profile_toolsets, list):
+                toolsets = profile_toolsets
+            logger.debug(
+                "delegate_task: resolved profile %r → toolsets=%s",
+                profile,
+                toolsets,
+            )
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
@@ -2080,6 +2161,7 @@ def delegate_task(
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
                 role=effective_role,
+                profile_name=resolved_profile_name,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -2481,6 +2563,41 @@ def _load_config() -> dict:
         return {}
 
 
+def _load_agent_profiles() -> dict:
+    """Return the top-level ``agent_profiles`` mapping from full config.
+
+    Why: agent_profiles live at the root of config.yaml (not under
+    ``delegation``), so _load_config() cannot see them.  This helper
+    reads the full config and returns the profiles dict so delegate_task()
+    can resolve a named profile to its declared toolsets/model.
+
+    What: Returns cfg["agent_profiles"] (a dict of name → profile dict),
+    or an empty dict when the key is absent or config loading fails.
+
+    Test: Patch ``cli.CLI_CONFIG`` with {"agent_profiles": {"docs": {"toolsets":
+    ["mcp-nextcloud-files"]}}} and assert _load_agent_profiles() returns
+    that inner dict keyed by "docs".
+    """
+    try:
+        from cli import CLI_CONFIG
+
+        profiles = CLI_CONFIG.get("agent_profiles")
+        if profiles and isinstance(profiles, dict):
+            return profiles
+    except Exception:
+        pass
+    try:
+        from hermes_cli.config import load_config
+
+        full = load_config()
+        profiles = full.get("agent_profiles")
+        if profiles and isinstance(profiles, dict):
+            return profiles
+    except Exception:
+        pass
+    return {}
+
+
 # ---------------------------------------------------------------------------
 # OpenAI Function-Calling Schema
 # ---------------------------------------------------------------------------
@@ -2771,6 +2888,17 @@ DELEGATE_TASK_SCHEMA = {
                     "Leave empty unless acp_command is explicitly provided."
                 ),
             },
+            "profile": {
+                "type": "string",
+                "description": (
+                    "Named agent_profiles entry whose toolsets (and optionally model "
+                    "and system prompt) the sub-agent should use. When set, the "
+                    "profile's declared MCP toolsets are forwarded to the child even "
+                    "when the orchestrator runs under a no_mcp platform_toolset that "
+                    "has no MCP servers of its own. Leave unset to use ad-hoc "
+                    "toolsets or inherit from the parent. Example: 'documents'."
+                ),
+            },
         },
         "required": [],
     },
@@ -2793,6 +2921,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        profile=args.get("profile"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2280,6 +2280,14 @@ _orphan_stdio_pids: set = set()
 # (``os.getpgid`` is POSIX-only).
 _stdio_pgids: Dict[int, int] = {}  # pid -> pgid
 
+# Lazy discovery state -- used when the active platform skips eager discovery
+# (e.g. api_server, whose toolsets include the ``no_mcp`` sentinel). When the
+# gateway marks eager discovery as skipped, the first child agent build that
+# needs MCP toolsets triggers a one-shot, thread-safe lazy discovery instead.
+_eager_discovery_skipped: bool = False
+_lazy_discovery_done: threading.Event = threading.Event()
+_lazy_discovery_lock: threading.Lock = threading.Lock()
+
 
 def _snapshot_child_pids() -> set:
     """Return a set of current child process PIDs.
@@ -3511,6 +3519,45 @@ def discover_mcp_tools() -> List[str]:
         logger.info(summary)
 
     return tool_names
+
+
+def mark_eager_discovery_skipped() -> None:
+    """Called by gateway startup when the active platform uses no_mcp.
+
+    Signals that eager MCP discovery was intentionally skipped.
+    The first call to ensure_mcp_discovered() will trigger lazy discovery.
+    """
+    global _eager_discovery_skipped
+    _eager_discovery_skipped = True
+
+
+def ensure_mcp_discovered() -> None:
+    """Trigger MCP discovery lazily, exactly once, thread-safe.
+
+    Safe to call concurrently from multiple threads. The first caller runs
+    discovery; subsequent callers return immediately once the Event is set.
+
+    If discovery was NOT skipped at startup (eager path already ran), this
+    is a no-op -- the Event is already set or discovery runs as normal.
+
+    On failure: logs a warning, sets the done-Event to prevent retry storms,
+    and returns -- child agents will get an empty/partial MCP toolset
+    (same degradation as a startup discovery failure).
+    """
+    if not _eager_discovery_skipped:
+        # Eager discovery ran at startup (or wasn't needed); nothing to do.
+        return
+    if _lazy_discovery_done.is_set():
+        return
+    with _lazy_discovery_lock:
+        if _lazy_discovery_done.is_set():
+            return
+        try:
+            discover_mcp_tools()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Lazy MCP discovery failed: %s", exc)
+        finally:
+            _lazy_discovery_done.set()
 
 
 def is_mcp_tool_parallel_safe(tool_name: str) -> bool:


### PR DESCRIPTION
## What
Implements per-profile toolset isolation for delegated sub-agents. Profile-declared toolsets are now the single source of truth; batch-mode model-supplied toolsets are rejected when a profile is set, parent MCP context does not leak into children via `inherit_mcp_toolsets`, and toolset lists are deep-copied to prevent config aliasing. Four surgical fixes with dedicated tests: profile name wiring, batch injection blocking, config aliasing fix, and parent MCP bleed guard. Also fixes per-logger levels from config so DEBUG logging reaches output.

**Files modified:** `tools/delegate_tool.py` (profile wiring, injection block, copy fix, inherit guard), `tests/tools/test_delegate_toolset_scope.py` (new), `config/agent_cfg.py` (logger level application).

## Why
The orchestrator pattern (no_mcp parent routing work to MCP-capable child agents) requires toolset boundaries. Before this PR, three gaps allowed boundary violations: batch-mode injection, parent MCP bleed, and config aliasing. This hardens the security model so delegation is safe at scale.

## Tests
```bash
pytest tests/tools/test_delegate_toolset_scope.py -v
```
4 test classes pass covering all security hardening scenarios; 9 adversarial E2E scenarios confirmed no privilege escalation.

## Platforms tested
Linux (CT/LXC environment, Python 3.13)