### PR TITLE
fix(tools): use is_managed_tool_gateway_ready in FAL/TTS availability checks

### DIFF
--- a/plugins/video_gen/fal/__init__.py
+++ b/plugins/video_gen/fal/__init__.py
@@ -386,11 +386,12 @@ def _submit_fal_video_request(endpoint: str, arguments: Dict[str, Any]):
 
 def _check_fal_video_available() -> bool:
     """True if the FAL.ai video backend is reachable (direct key or managed gateway)."""
+    from tools.managed_tool_gateway import is_managed_tool_gateway_ready
     from tools.tool_backend_helpers import fal_key_is_configured
 
     if fal_key_is_configured():
         return True
-    return _resolve_managed_fal_video_gateway() is not None
+    return is_managed_tool_gateway_ready("fal-queue")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_fal_tts_availability_skips_oauth_refresh.py
+++ b/tests/tools/test_fal_tts_availability_skips_oauth_refresh.py
@@ -1,0 +1,141 @@
+"""Regression tests — FAL/TTS is_available() must not trigger OAuth refresh.
+
+check_fal_api_key(), _has_openai_audio_backend() (tts_tool), and
+_check_fal_video_available() (video_gen/fal) are called by the tool/model
+picker on every render. Before this fix they called
+resolve_managed_tool_gateway() which defaults to read_nous_access_token
+(a synchronous OAuth refresh POST), burning tokens on every UI paint.
+
+Fix: switch these three read-only availability checks to
+is_managed_tool_gateway_ready(), which defaults to peek_nous_access_token
+and never triggers a refresh. Mirrors the fix applied to BrowserUse and
+Firecrawl in PR #35401.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import tools.managed_tool_gateway as mtg
+
+
+# ---------------------------------------------------------------------------
+# check_fal_api_key — image_generation_tool.py
+# ---------------------------------------------------------------------------
+
+class TestCheckFalApiKeySkipsOAuthRefresh:
+    """check_fal_api_key() must use is_managed_tool_gateway_ready, not
+    resolve_managed_tool_gateway, so no OAuth refresh is triggered."""
+
+    def test_no_refresh_when_gateway_available(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "valid-nous-token")
+
+        import tools.image_generation_tool as igt
+
+        refresh_calls: list = []
+
+        def _record_refresh(**_kw):
+            refresh_calls.append(1)
+            return "fresh-token"
+
+        with (
+            patch("hermes_cli.auth.resolve_nous_access_token", side_effect=_record_refresh),
+            patch.object(igt, "fal_key_is_configured", return_value=False),
+            patch.object(mtg, "managed_nous_tools_enabled", return_value=True),
+        ):
+            result = igt.check_fal_api_key()
+
+        assert refresh_calls == [], (
+            "check_fal_api_key() triggered an OAuth refresh — "
+            "it must use is_managed_tool_gateway_ready instead"
+        )
+        assert result is True
+
+    def test_returns_true_when_fal_key_configured(self, monkeypatch):
+        import tools.image_generation_tool as igt
+        with patch.object(igt, "fal_key_is_configured", return_value=True):
+            assert igt.check_fal_api_key() is True
+
+    def test_returns_false_when_no_key_and_no_gateway(self, monkeypatch):
+        import tools.image_generation_tool as igt
+        with (
+            patch.object(igt, "fal_key_is_configured", return_value=False),
+            patch.object(mtg, "managed_nous_tools_enabled", return_value=False),
+        ):
+            assert igt.check_fal_api_key() is False
+
+
+# ---------------------------------------------------------------------------
+# _has_openai_audio_backend — tts_tool.py
+# ---------------------------------------------------------------------------
+
+class TestHasOpenaiAudioBackendSkipsOAuthRefresh:
+    """_has_openai_audio_backend() must not trigger OAuth refresh on availability
+    check."""
+
+    def test_no_refresh_when_gateway_available(self, monkeypatch):
+        monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "valid-nous-token")
+
+        import tools.tts_tool as tts
+
+        refresh_calls: list = []
+
+        def _record_refresh(**_kw):
+            refresh_calls.append(1)
+            return "fresh-token"
+
+        with (
+            patch("hermes_cli.auth.resolve_nous_access_token", side_effect=_record_refresh),
+            patch.object(tts, "resolve_openai_audio_api_key", return_value=None),
+            patch.object(mtg, "managed_nous_tools_enabled", return_value=True),
+        ):
+            result = tts._has_openai_audio_backend()
+
+        assert refresh_calls == [], (
+            "_has_openai_audio_backend() triggered an OAuth refresh — "
+            "it must use is_managed_tool_gateway_ready instead"
+        )
+        assert result is True
+
+    def test_returns_true_when_direct_api_key_present(self, monkeypatch):
+        import tools.tts_tool as tts
+        with patch.object(tts, "resolve_openai_audio_api_key", return_value="sk-test"):
+            assert tts._has_openai_audio_backend() is True
+
+
+# ---------------------------------------------------------------------------
+# _check_fal_video_available — plugins/video_gen/fal
+# ---------------------------------------------------------------------------
+
+class TestCheckFalVideoAvailableSkipsOAuthRefresh:
+    """_check_fal_video_available() must not trigger OAuth refresh."""
+
+    def test_no_refresh_when_gateway_available(self, monkeypatch):
+        monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "valid-nous-token")
+
+        from plugins.video_gen.fal import _check_fal_video_available
+
+        refresh_calls: list = []
+
+        def _record_refresh(**_kw):
+            refresh_calls.append(1)
+            return "fresh-token"
+
+        with (
+            patch("hermes_cli.auth.resolve_nous_access_token", side_effect=_record_refresh),
+            patch("tools.tool_backend_helpers.fal_key_is_configured", return_value=False),
+            patch.object(mtg, "managed_nous_tools_enabled", return_value=True),
+        ):
+            result = _check_fal_video_available()
+
+        assert refresh_calls == [], (
+            "_check_fal_video_available() triggered an OAuth refresh — "
+            "it must use is_managed_tool_gateway_ready instead"
+        )
+        assert result is True
+
+    def test_returns_true_when_fal_key_configured(self, monkeypatch):
+        from plugins.video_gen.fal import _check_fal_video_available
+        with patch("tools.tool_backend_helpers.fal_key_is_configured", return_value=True):
+            assert _check_fal_video_available() is True

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -62,7 +62,7 @@ from tools.fal_common import (
     _extract_http_status,
     _normalize_fal_queue_url_format,  # noqa: F401 — re-exported for tests
 )
-from tools.managed_tool_gateway import resolve_managed_tool_gateway
+from tools.managed_tool_gateway import is_managed_tool_gateway_ready, resolve_managed_tool_gateway
 from tools.tool_backend_helpers import (
     fal_key_is_configured,
     managed_nous_tools_enabled,
@@ -758,7 +758,7 @@ def image_generate_tool(
 
 def check_fal_api_key() -> bool:
     """True if the FAL.ai API key (direct or managed gateway) is available."""
-    return bool(fal_key_is_configured() or _resolve_managed_fal_gateway())
+    return bool(fal_key_is_configured() or is_managed_tool_gateway_ready("fal-queue"))
 
 
 def _build_no_backend_setup_message() -> str:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -68,7 +68,7 @@ def get_env_value(name, default=None):
         return os.getenv(name, default)
     value = _get_env_value(name)
     return default if value is None else value
-from tools.managed_tool_gateway import resolve_managed_tool_gateway
+from tools.managed_tool_gateway import is_managed_tool_gateway_ready, resolve_managed_tool_gateway
 from tools.tool_backend_helpers import (
     managed_nous_tools_enabled,
     nous_tool_gateway_unavailable_message,
@@ -2235,7 +2235,7 @@ def _resolve_openai_audio_client_config() -> tuple[str, str]:
 
 def _has_openai_audio_backend() -> bool:
     """Return True when OpenAI audio can use direct credentials or the managed gateway."""
-    return bool(resolve_openai_audio_api_key() or resolve_managed_tool_gateway("openai-audio"))
+    return bool(resolve_openai_audio_api_key() or is_managed_tool_gateway_ready("openai-audio"))
 
 
 # ===========================================================================


### PR DESCRIPTION
## What does this PR do?

**Root cause:** `check_fal_api_key()` (`image_generation_tool`), `_has_openai_audio_backend()` (`tts_tool`), and `_check_fal_video_available()` (`video_gen/fal`) are called by the tool/model picker on every UI render. All three called `resolve_managed_tool_gateway()`, which defaults to `read_nous_access_token` — a synchronous OAuth refresh POST (~350 ms) that burns single-use Nous refresh tokens on every availability scan.

**Fix:** Replace the managed-gateway call in each availability path with `is_managed_tool_gateway_ready()`, which defaults to `peek_nous_access_token` (reads cached token from auth.json, no network call). Actual gateway request paths still use `resolve_managed_tool_gateway()` (refresh-aware) unchanged.

Mirrors the identical fix applied to `BrowserUseBrowserProvider` and `FirecrawlWebProvider` in PR #35401 (merged today). The `is_managed_tool_gateway_ready()` docstring explicitly states: *"Defaults to peek_nous_access_token so read-only availability scans avoid synchronous OAuth refresh."*

## Related Issue

Parity fix — same pattern as PR #35401 (browser-use + firecrawl).

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/image_generation_tool.py`: add `is_managed_tool_gateway_ready` to import; `check_fal_api_key()` uses it instead of `_resolve_managed_fal_gateway()` for the managed-gateway check
- `tools/tts_tool.py`: add `is_managed_tool_gateway_ready` to import; `_has_openai_audio_backend()` uses it instead of `resolve_managed_tool_gateway()`
- `plugins/video_gen/fal/__init__.py`: `_check_fal_video_available()` uses `is_managed_tool_gateway_ready("fal-queue")` instead of `_resolve_managed_fal_video_gateway()`
- `tests/tools/test_fal_tts_availability_skips_oauth_refresh.py`: 7 new tests verifying `resolve_nous_access_token` is never called from any of these availability checks

## How to Test

```
pytest tests/tools/test_fal_tts_availability_skips_oauth_refresh.py -v --override-ini="addopts="
pytest tests/tools/test_image_generation_env.py tests/plugins/image_gen/test_fal_provider.py -v --override-ini="addopts="
```

## Checklist

- [x] Contributing Guide read | Conventional Commits | No duplicate PR
- [x] Single logical change | Tests added | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A