### PR TITLE
perf(read_file): make compact gutter the only format; drop HERMES_READ_GUTTER

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -356,13 +356,6 @@ class TestShellFileOpsHelpers:
         assert "50|continued" in result
         assert "51|more" in result
 
-    def test_add_line_numbers_padded_env_override(self, file_ops, monkeypatch):
-        # Legacy fixed-width format available via HERMES_READ_GUTTER=padded.
-        monkeypatch.setenv("HERMES_READ_GUTTER", "padded")
-        result = file_ops._add_line_numbers("line one\nline two")
-        assert "     1|line one" in result
-        assert "     2|line two" in result
-
     def test_add_line_numbers_truncates_long_lines(self, file_ops):
         long_line = "x" * (MAX_LINE_LENGTH + 100)
         result = file_ops._add_line_numbers(long_line)

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -714,13 +714,9 @@ class ShellFileOperations(FileOperations):
         line-reference / patch / value-lookup / structure tasks (4/4 both),
         while dropping line numbers entirely regressed line-referencing
         (the model hand-counted and was off-by-one, 3/4) — so we keep the
-        numbers, just not the padding. ``HERMES_READ_GUTTER=padded``
-        restores the legacy fixed-width format for anyone who relied on
-        column alignment.
+        numbers, just not the padding.
         """
-        import os as _os
         from tools.tool_output_limits import get_max_line_length
-        padded = (_os.environ.get("HERMES_READ_GUTTER") or "").lower() == "padded"
         max_line_length = get_max_line_length()
         lines = content.split('\n')
         numbered = []
@@ -728,7 +724,7 @@ class ShellFileOperations(FileOperations):
             # Truncate long lines
             if len(line) > max_line_length:
                 line = line[:max_line_length] + "... [truncated]"
-            numbered.append(f"{i:6d}|{line}" if padded else f"{i}|{line}")
+            numbered.append(f"{i}|{line}")
         return '\n'.join(numbered)
     
     def _expand_path(self, path: str) -> str:


### PR DESCRIPTION
## Summary
`read_file`'s line-number gutter now uses the compact `<n>|content` form as the sole format. Removes the `HERMES_READ_GUTTER=padded` escape hatch introduced in #35368 — there's no legacy fixed-width path to maintain.

The padding was pure token overhead: on dense source the padded gutter cost ~48% more tokens than bare content and ~16% more than the compact form, because the leading spaces tokenize into extra tokens on every single line. The A/B (Sonnet 4.6, 2 passes, 4-task battery) showed compact matches padded on every task (4/4 both), while dropping numbers entirely regressed line-referencing — so the numbers stay, the padding goes, and there's now exactly one format.

## Changes
- `tools/file_operations.py`: `_add_line_numbers()` always emits `f"{i}|{line}"`; dropped the env lookup + `os` import.
- `tests/tools/test_file_operations.py`: removed the padded env-override test; compact assertions retained.

## Validation
| | Format | Tests |
|---|---|---|
| Before (#35368) | compact default + `HERMES_READ_GUTTER=padded` opt-out | env-override test |
| Now | compact only, no toggle | 17 file-tool tests green |

`patch`/`fuzzy_match` never consumed the gutter (they match `old_string` text and compute char offsets internally), so editing is unaffected. No downstream parser keys on the columns.

## Infographic

![compact-gutter](https://v3b.fal.media/files/b/0a9c5523/JcpkSZhdX7yY4Q0CKRnE8_oX26izem.png)
