### PR TITLE
fix: preserve config token prefixes in file reads

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -327,7 +327,13 @@ def _redact_form_body(text: str) -> str:
     return _redact_query_string(text.strip())
 
 
-def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = False) -> str:
+def redact_sensitive_text(
+    text: str,
+    *,
+    force: bool = False,
+    code_file: bool = False,
+    redact_prefixes: bool = True,
+) -> str:
     """Apply all redaction patterns to a block of text.
 
     Safe to call on any string -- non-matching text passes through unchanged.
@@ -339,6 +345,11 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     patterns when the text is known to be source code (e.g. MAX_TOKENS=***
     constants, "apiKey": "test" fixtures). Prefix patterns, auth headers,
     private keys, DB connstrings, JWTs, and URL secrets are still redacted.
+
+    Set redact_prefixes=False for structured configuration reads where masking
+    known vendor token prefixes (``sk-...``, ``ghp_...``) would corrupt the
+    value the agent is intentionally inspecting. Other high-confidence secret
+    forms (private keys, auth headers, DB passwords, JWTs, etc.) still redact.
 
     Performance: each regex pattern is gated behind a cheap substring
     pre-check (e.g. ``"=" in text`` for ENV assignments, ``"://" in text``
@@ -359,7 +370,7 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
         return text
 
     # Known prefixes (sk-, ghp_, etc.) — gate on substring presence
-    if _has_known_prefix_substring(text):
+    if redact_prefixes and _has_known_prefix_substring(text):
         text = _PREFIX_RE.sub(lambda m: _mask_token(m.group(1)), text)
 
     # ENV assignments: OPENAI_API_KEY=***  (skip for code files — false positives)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -32,6 +32,12 @@ class TestKnownPrefixes:
         result = redact_sensitive_text("token: ghp_abc123def456ghi789jkl")
         assert "abc123def456" not in result
 
+    def test_can_skip_vendor_prefix_redaction_for_config_reads(self, monkeypatch):
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+        token = "ghp_abc123def456ghi789jkl"
+        result = redact_sensitive_text(f"token: {token}", redact_prefixes=False)
+        assert token in result
+
     def test_github_pat_fine_grained(self):
         result = redact_sensitive_text("github_pat_abc123def456ghi789jklmno")
         assert "abc123def456" not in result

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -63,6 +64,43 @@ class TestReadFileHandler:
         result = json.loads(read_file_tool("/tmp/test.txt"))
         assert "error" in result
         assert "terminal not available" in result["error"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_config_file_read_preserves_prefixed_token_values(self, mock_get, monkeypatch):
+        """#35519: config reads must not return ghp_abc...1234 impostors."""
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+        token = "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"
+        content = f"github:\n  token: {token}\n"
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = content
+        result_obj.to_dict.return_value = {"content": content, "total_lines": 2}
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import read_file_tool
+        result = json.loads(read_file_tool("/tmp/config.yaml", task_id="config-token-read"))
+
+        assert token in result["content"]
+        assert "..." not in result["content"]
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_source_file_read_still_redacts_prefixed_tokens(self, mock_get, monkeypatch):
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+        token = "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"
+        content = f"TOKEN = '{token}'\n"
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = content
+        result_obj.to_dict.return_value = {"content": content, "total_lines": 1}
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import read_file_tool
+        result = json.loads(read_file_tool("/tmp/app.py", task_id="source-token-read"))
+
+        assert token not in result["content"]
+        assert "ghp_IG...S199" in result["content"]
 
 
 class TestWriteFileHandler:
@@ -300,6 +338,28 @@ class TestSearchHandler:
         from tools.file_tools import search_tool
         result = json.loads(search_tool(pattern="x"))
         assert "error" in result
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_config_search_preserves_prefixed_token_values(self, mock_get, monkeypatch):
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+        token = "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"
+        match = SimpleNamespace(path="/tmp/config.yaml", line_number=2, content=f"  token: {token}")
+        result_obj = SimpleNamespace(
+            matches=[match],
+            to_dict=lambda: {
+                "total_count": 1,
+                "matches": [{"path": match.path, "line": match.line_number, "content": match.content}],
+            },
+        )
+        mock_ops = MagicMock()
+        mock_ops.search.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import search_tool
+        result = json.loads(search_tool(pattern="token", path="/tmp", task_id="config-token-search"))
+
+        assert token in result["matches"][0]["content"]
+        assert "..." not in result["matches"][0]["content"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -62,6 +62,57 @@ def _get_max_read_chars() -> int:
 # range (limit <= 200), we include a hint encouraging targeted reads.
 _LARGE_FILE_HINT_BYTES = 512_000  # 512 KB
 
+_CONFIG_LIKE_EXTENSIONS = {
+    ".cfg",
+    ".conf",
+    ".config",
+    ".env",
+    ".ini",
+    ".json",
+    ".jsonc",
+    ".properties",
+    ".toml",
+    ".yaml",
+    ".yml",
+}
+
+_CONFIG_LIKE_FILENAMES = {
+    ".env",
+    ".env.local",
+    ".npmrc",
+    ".pypirc",
+    "config",
+    "config.yaml",
+    "config.yml",
+    "settings.json",
+    "settings.toml",
+}
+
+
+def _redact_file_content_for_path(content: str, path: str) -> str:
+    """Redact file-tool output without corrupting config token values.
+
+    File tools use ``code_file=True`` to avoid false positives in source code.
+    Config files are a special case: the agent often reads them specifically to
+    discover current credential values. Prefix masking (``ghp_abc...1234``)
+    makes those values look real enough to be written back later, permanently
+    corrupting auth. For config-like paths, skip only the vendor-prefix pass;
+    keep the rest of the redactor active for private keys, auth headers, JWTs,
+    DB URLs, Telegram tokens, phone numbers, etc.
+    """
+    file_path = Path(path)
+    name = file_path.name.lower()
+    suffixes = {s.lower() for s in file_path.suffixes}
+    is_config_like = (
+        name in _CONFIG_LIKE_FILENAMES
+        or bool(suffixes & _CONFIG_LIKE_EXTENSIONS)
+    )
+    return redact_sensitive_text(
+        content,
+        code_file=True,
+        redact_prefixes=not is_config_like,
+    )
+
 # ---------------------------------------------------------------------------
 # Device path blocklist — reading these hangs the process (infinite output
 # or blocking on input).  Checked by path only (no I/O).
@@ -726,7 +777,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # ── Redact secrets (after guard check to skip oversized content) ──
         if result.content:
-            result.content = redact_sensitive_text(result.content, code_file=True)
+            result.content = _redact_file_content_for_path(result.content, path)
             result_dict["content"] = result.content
 
         # Large-file hint: if the file is big and the caller didn't ask
@@ -1245,7 +1296,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         if hasattr(result, 'matches'):
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
-                    m.content = redact_sensitive_text(m.content, code_file=True)
+                    m.content = _redact_file_content_for_path(m.content, m.path)
         result_dict = result.to_dict()
 
         if count >= 3:


### PR DESCRIPTION
## Summary
- add a redact_prefixes switch for file-tool config reads
- skip vendor-prefix masking for config-like file reads/search results so tokens are not returned as corrupt ghp_abc...1234 impostors
- keep prefix redaction enabled for source files and keep other high-confidence redaction patterns active

Fixes #35519

## Test Plan
- python -m pytest tests/agent/test_redact.py tests/tools/test_file_tools.py -q -o 'addopts='