### PR TITLE
fix(tools): honor explicit composite toolsets for platform-restricted defaults

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1246,8 +1246,28 @@ def _get_platform_tools(
         # keep that toolset enabled on first install.  Skip this dodge for
         # platform-restricted toolsets — those are always opt-in even on
         # their own platform (e.g. `discord` + `discord` should stay OFF).
-        if platform in default_off and platform not in _TOOLSET_PLATFORM_RESTRICTIONS:
+        #
+        # However, when the user has *explicitly* listed toolsets for this
+        # platform in platform_toolsets (even via composite names like
+        # "hermes-discord"), respect their opt-in by also removing
+        # platform-restricted toolsets from default_off.  Without this,
+        # composites fall through to the else-branch (non-explicit-config
+        # path) and the restriction silently strips discord / discord_admin
+        # despite the user's config.  (#35527)
+        if platform in default_off and (
+            platform not in _TOOLSET_PLATFORM_RESTRICTIONS
+            or platform in platform_toolsets
+        ):
             default_off.remove(platform)
+        # When the user explicitly configured this platform's toolsets,
+        # also remove any platform-restricted toolsets (e.g. discord_admin)
+        # from default_off — otherwise they're silently stripped even though
+        # the composite includes them.
+        if platform in platform_toolsets:
+            default_off -= {
+                ts for ts, restricted in _TOOLSET_PLATFORM_RESTRICTIONS.items()
+                if platform in restricted
+            }
         # Home Assistant is already runtime-gated by its check_fn (requires
         # HASS_TOKEN to register any tools). When a user has configured
         # HASS_TOKEN, they've explicitly opted in — don't also strip it via

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1208,6 +1208,31 @@ def test_discord_toolsets_user_enabled_are_honored():
     assert "discord_admin" not in enabled
 
 
+def test_discord_composite_toolset_honors_explicit_config():
+    """Regression: platform_toolsets.discord = ['hermes-discord'] must not
+    silently drop discord / discord_admin due to _TOOLSET_PLATFORM_RESTRICTIONS.
+
+    The composite name "hermes-discord" is not in CONFIGURABLE_TOOLSETS, so it
+    enters the else-branch (non-explicit-config path).  The platform restriction
+    previously blocked the default_off carve-out, stripping the toolsets even
+    though the user explicitly listed them.  (#35527)
+    """
+    config = {"platform_toolsets": {"discord": ["hermes-discord"]}}
+    enabled = _get_platform_tools(config, "discord")
+    assert "discord" in enabled, "discord toolset missing with explicit hermes-discord composite"
+    assert "discord_admin" in enabled, "discord_admin toolset missing with explicit hermes-discord composite"
+
+
+def test_discord_composite_not_auto_enabled_without_config():
+    """discord / discord_admin must stay OFF when no platform_toolsets entry
+    exists (default install).  The platform restriction keeps them opt-in."""
+    enabled = _get_platform_tools({}, "discord")
+    # On a fresh install without explicit config, discord should NOT be
+    # auto-enabled — it's a restricted platform toolset.
+    assert "discord" not in enabled
+    assert "discord_admin" not in enabled
+
+
 def test_save_platform_tools_strips_restricted_toolsets():
     """Hand-edited or all-platforms checklist with `discord` selected for
     Telegram must be stripped at save time."""


### PR DESCRIPTION
## What does this PR do?

Fixes `discord` / `discord_admin` toolsets being silently removed when `platform_toolsets.discord` is set to `["hermes-discord"]` (the composite toolset name). The composite name is not in `CONFIGURABLE_TOOLSETS`, so the code enters the non-explicit-config path where `_TOOLSET_PLATFORM_RESTRICTIONS` blocks the `_DEFAULT_OFF_TOOLSETS` carve-out, silently stripping both toolsets despite the user's explicit configuration.

## Related Issue

Fixes #35527

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/tools_config.py`: When the user has explicitly listed toolsets for a platform in `platform_toolsets` (even via composite names), also remove platform-restricted toolsets from `default_off`. Added guard at line 1256 to check `platform in platform_toolsets` alongside the existing restriction check.
- `tests/hermes_cli/test_tools_config.py`: Added `test_discord_composite_toolset_honors_explicit_config` (regression test for #35527) and `test_discord_composite_not_auto_enabled_without_config` (invariant: default install still keeps discord opt-in).

## How to Test

1. Set `platform_toolsets.discord` to `["hermes-discord"]` in `~/.hermes/config.yaml`
2. Run `hermes gateway restart` and `/reset` in Discord
3. Verify `discord` and `discord_admin` tools are available (e.g. `fetch_messages`, `create_thread`)
4. Remove the `platform_toolsets` entry entirely — verify discord tools are NOT auto-enabled (opt-in preserved)
5. Run `pytest tests/hermes_cli/test_tools_config.py -k discord -v` — all 7 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_tools_config.py -q` and all 86 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/tools_config.py:_get_platform_tools` (callers: 15+ across gateway, CLI, TUI, cron, web_server)
- Blast radius: LOW — change is guarded by `platform in platform_toolsets` (only fires when user has explicit config)
- Related patterns: `_DEFAULT_OFF_TOOLSETS` carve-outs for `homeassistant` (HASS_TOKEN) and `x_search` (xai credentials) follow the same guard-then-remove pattern
