### PR TITLE
fix(kanban): stop connect() from auto-creating board directories (archived board resurrection)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1353,7 +1353,13 @@ def connect(
         path = db_path
     else:
         path = kanban_db_path(board=board)
-    path.parent.mkdir(parents=True, exist_ok=True)
+    # NOTE: intentionally does NOT auto-create the parent directory.
+    # Directory creation is the responsibility of init_db() and
+    # create_board().  connect() is a read-then-write entry point;
+    # silently creating the directory would resurrect archived boards
+    # (see issue #35211).  Callers that need the directory to exist
+    # must ensure it does before calling connect() -- typically by
+    # calling init_db() first.
     with _cross_process_init_lock(path):
         # Cheap byte-level check first — catches the #29507 TLS-overwrite shape
         # and other invalid-header cases without opening a sqlite connection.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1105,8 +1105,11 @@ def _cross_process_init_lock(path: Path):
     lock keeps header validation, integrity probing, WAL activation, and
     additive migrations single-file/single-writer across the whole host while
     leaving normal post-init DB usage concurrent under SQLite WAL.
+
+    NOTE: does NOT auto-create the parent directory.  Callers must ensure
+    the directory exists before calling connect() — typically via init_db().
+    This prevents archived boards from being resurrected (see issue #35211).
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.with_name(path.name + ".init.lock")
     handle = lock_path.open("a+b")
     try:
@@ -4480,16 +4483,31 @@ def delete_task(conn: sqlite3.Connection, task_id: str) -> bool:
 
     Returns ``True`` if the task existed and was deleted, ``False``
     if the task was not found.
+
+    Refuses to delete a task with an active run or live claim. Operators
+    must reclaim or archive it first so the worker lifecycle stays visible
+    and the in-flight run is closed explicitly.
     """
     with write_txn(conn):
-        cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
-        if cur.rowcount != 1:
+        row = conn.execute(
+            "SELECT status, claim_lock, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if not row:
             return False
+        if row["status"] == "running" or row["claim_lock"] is not None or row["current_run_id"] is not None:
+            raise RuntimeError(
+                f"cannot delete {task_id}: task is currently running or has an active run. "
+                "Reclaim or archive it first."
+            )
         conn.execute("DELETE FROM task_links WHERE parent_id = ? OR child_id = ?", (task_id, task_id))
         conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_events WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM task_runs WHERE task_id = ?", (task_id,))
         conn.execute("DELETE FROM kanban_notify_subs WHERE task_id = ?", (task_id,))
+        cur = conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
+        if cur.rowcount != 1:
+            return False
     recompute_ready(conn)
     return True
 


### PR DESCRIPTION
Closes #35211
Related: #35208 (gateway-level guards — defense-in-depth for dispatcher/notifier)
Related: #27599 (original archive UX — introduced the board lifecycle feature that exposed this bug)

## Problem

Archiving a kanban board appears to not work — the board stays visible in the dashboard immediately after archiving. This is because any code path that calls `connect(board=slug)` silently recreates the archived board's directory via `path.parent.mkdir(parents=True, exist_ok=True)`.

## Root Cause

Two places in `hermes_cli/kanban_db.py` called `path.parent.mkdir(parents=True, exist_ok=True)` on every connection:

1. **`connect()`** — the outer entry point.
2. **`_cross_process_init_lock()`** — the inner lock context manager called by `connect()`.

When a board is archived, its directory is moved to `boards/_archived/<slug>-<ts>/`. But the next call to `connect(board=slug)` immediately recreates the empty directory via either mkdir, resurrecting the board.

## Fix

Remove both `mkdir` calls. Directory creation is now the exclusive responsibility of `init_db()` and `create_board()`, which already have their own `mkdir` calls. `connect()` is a read-then-write entry point and should not create directories.

Removing the inner mkdir from `_cross_process_init_lock()` is safe because `lock_path.open("a+b")` naturally raises `FileNotFoundError` when the parent directory doesn't exist (archived board) — no silent resurrection, no new error-handling code needed.

All existing callers already ensure the directory exists before calling `connect()` — typically via `init_db()` first (fixtures, CLI commands) or by checking `board_dir().exists()` first (gateway notifier/dispatcher paths).

## Additional change

**`delete_task()`** now guards against deleting tasks with an active run or live claim. Operators must reclaim or archive the task first so the worker lifecycle stays visible and the in-flight run is closed explicitly.

## Verification

- All 201 tests in `test_kanban_db.py` pass
- All 278 kanban-related hermes_cli tests pass
- All 128 kanban-related gateway/plugin tests pass
- Manual verification: archived boards stay archived after gateway restart
- Manually tested: default board unaffected, non-default board creation works via `init_db()`, archived board connect correctly raises `FileNotFoundError`