### PR TITLE
feat(wecom): add native reply streaming and markdown chunking

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1488,6 +1488,7 @@ class WeComAdapter(BasePlatformAdapter):
 
         normalized_stream_key = str(stream_key or "").strip()
         content_text = "" if content is None else str(content)
+        thinking_placeholder = content_text == "THINKING_MESSAGE"
         existing_state = self._stream_state(normalized_stream_key)
         reply_req_id = (
             existing_state.get("reply_req_id")
@@ -1496,6 +1497,8 @@ class WeComAdapter(BasePlatformAdapter):
         )
         if not reply_req_id:
             self._clear_stream_state(normalized_stream_key)
+            if thinking_placeholder:
+                return SendResult(success=True)
             return SendResult(success=False, error="WeCom native stream reply context is required")
 
         stream_id = existing_state.get("stream_id") if existing_state else None
@@ -1506,7 +1509,7 @@ class WeComAdapter(BasePlatformAdapter):
         else:
             event = "start"
 
-        native_content = content_text
+        native_content = "" if thinking_placeholder else content_text
         overflow_content = ""
         if finalize and len(content_text) > self.MAX_MESSAGE_LENGTH:
             native_content = content_text[: self.MAX_MESSAGE_LENGTH]

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -139,11 +139,18 @@ def _entry_matches(entries: List[str], target: str) -> bool:
     return False
 
 
+def _iter_markdown_chunks(content: Any, max_length: int) -> List[str]:
+    """Split markdown into bounded chunks while preserving the full tail."""
+    content_text = "" if content is None else str(content)
+    return BasePlatformAdapter.truncate_message(content_text, max_length)
+
+
 class WeComAdapter(BasePlatformAdapter):
     """WeCom AI Bot adapter backed by a persistent WebSocket connection."""
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
     SUPPORTS_MESSAGE_EDITING = False
+    SUPPORTS_NATIVE_STREAMING_REPLIES = True
     # Threshold for detecting WeCom client-side message splits.
     # When a chunk is near the 4000-char limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 3900
@@ -175,6 +182,7 @@ class WeComAdapter(BasePlatformAdapter):
         self._pending_responses: Dict[str, asyncio.Future] = {}
         self._dedup = MessageDeduplicator(max_size=DEDUP_MAX_SIZE)
         self._reply_req_ids: Dict[str, str] = {}
+        self._stream_states: Dict[str, Dict[str, str]] = {}
 
         # Text batching: merge rapid successive messages (Telegram-style).
         # WeCom clients split long messages around 4000 chars.
@@ -915,6 +923,71 @@ class WeComAdapter(BasePlatformAdapter):
             return None
         return self._reply_req_ids.get(normalized)
 
+    @staticmethod
+    def _metadata_reply_req_id(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        if not isinstance(metadata, dict):
+            return None
+        normalized = str(metadata.get("wecom_reply_req_id") or "").strip()
+        return normalized or None
+
+    def _resolve_reply_req_id(
+        self,
+        chat_id: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        metadata_reply_req_id = self._metadata_reply_req_id(metadata)
+        if metadata_reply_req_id:
+            return metadata_reply_req_id
+
+        reply_req_id = self._reply_req_id_for_message(reply_to)
+        if reply_req_id:
+            return reply_req_id
+
+        normalized_chat_id = str(chat_id or "").strip()
+        if normalized_chat_id:
+            return self._last_chat_req_ids.get(normalized_chat_id)
+
+        return None
+
+    @staticmethod
+    def _stream_response_id(response: Dict[str, Any]) -> Optional[str]:
+        body = response.get("body")
+        if isinstance(body, dict):
+            stream = body.get("stream")
+            if isinstance(stream, dict):
+                # We send WeCom's native field name (stream_id), but accept
+                # older/sample response fixtures that report the id as `id`.
+                stream_id = str(stream.get("stream_id") or stream.get("id") or "").strip()
+                if stream_id:
+                    return stream_id
+        return WeComAdapter._payload_req_id(response) or None
+
+    def _remember_stream_state(self, stream_key: str, reply_req_id: str, stream_id: Optional[str]) -> None:
+        normalized_stream_key = str(stream_key or "").strip()
+        normalized_reply_req_id = str(reply_req_id or "").strip()
+        if not normalized_stream_key or not normalized_reply_req_id:
+            return
+
+        state = {"reply_req_id": normalized_reply_req_id}
+        normalized_stream_id = str(stream_id or "").strip()
+        if normalized_stream_id:
+            state["stream_id"] = normalized_stream_id
+        self._stream_states[normalized_stream_key] = state
+        while len(self._stream_states) > DEDUP_MAX_SIZE:
+            self._stream_states.pop(next(iter(self._stream_states)))
+
+    def _clear_stream_state(self, stream_key: Optional[str]) -> None:
+        normalized_stream_key = str(stream_key or "").strip()
+        if normalized_stream_key:
+            self._stream_states.pop(normalized_stream_key, None)
+
+    def _stream_state(self, stream_key: Optional[str]) -> Optional[Dict[str, str]]:
+        normalized_stream_key = str(stream_key or "").strip()
+        if not normalized_stream_key:
+            return None
+        return self._stream_states.get(normalized_stream_key)
+
     # ------------------------------------------------------------------
     # Outbound messaging
     # ------------------------------------------------------------------
@@ -1228,15 +1301,20 @@ class WeComAdapter(BasePlatformAdapter):
         return response
 
     async def _send_reply_markdown(self, reply_req_id: str, content: str) -> Dict[str, Any]:
-        response = await self._send_reply_request(
-            reply_req_id,
-            {
-                "msgtype": "markdown",
-                "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
-            },
-        )
-        self._raise_for_wecom_error(response, "send reply markdown")
+        response: Dict[str, Any] = {}
+        for chunk in self._iter_markdown_chunks(content):
+            response = await self._send_reply_request(
+                reply_req_id,
+                {
+                    "msgtype": "markdown",
+                    "markdown": {"content": chunk},
+                },
+            )
+            self._raise_for_wecom_error(response, "send reply markdown")
         return response
+
+    def _iter_markdown_chunks(self, content: str) -> List[str]:
+        return _iter_markdown_chunks(content, self.MAX_MESSAGE_LENGTH)
 
     async def _send_reply_media_message(
         self,
@@ -1358,28 +1436,27 @@ class WeComAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send markdown to a WeCom chat via proactive ``aibot_send_msg``."""
-        del metadata
 
         if not chat_id:
             return SendResult(success=False, error="chat_id is required")
 
         try:
-            reply_req_id = self._reply_req_id_for_message(reply_to)
-
-            if not reply_req_id and chat_id in self._last_chat_req_ids:
-                reply_req_id = self._last_chat_req_ids[chat_id]
+            reply_req_id = self._resolve_reply_req_id(chat_id=chat_id, reply_to=reply_to, metadata=metadata)
 
             if reply_req_id:
                 response = await self._send_reply_markdown(reply_req_id, content)
             else:
-                response = await self._send_request(
-                    APP_CMD_SEND,
-                    {
-                        "chatid": chat_id,
-                        "msgtype": "markdown",
-                        "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
-                    },
-                )
+                response = {}
+                for chunk in self._iter_markdown_chunks(content):
+                    response = await self._send_request(
+                        APP_CMD_SEND,
+                        {
+                            "chatid": chat_id,
+                            "msgtype": "markdown",
+                            "markdown": {"content": chunk},
+                        },
+                    )
+                    self._raise_for_wecom_error(response, "send markdown")
         except asyncio.TimeoutError:
             return SendResult(success=False, error="Timeout sending message to WeCom")
         except Exception as exc:
@@ -1393,6 +1470,116 @@ class WeComAdapter(BasePlatformAdapter):
         return SendResult(
             success=True,
             message_id=self._payload_req_id(response) or uuid.uuid4().hex[:12],
+            raw_response=response,
+        )
+
+    async def send_stream_chunk(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        stream_key: Optional[str] = None,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if not chat_id:
+            self._clear_stream_state(stream_key)
+            return SendResult(success=False, error="chat_id is required")
+
+        normalized_stream_key = str(stream_key or "").strip()
+        content_text = "" if content is None else str(content)
+        existing_state = self._stream_state(normalized_stream_key)
+        reply_req_id = (
+            existing_state.get("reply_req_id")
+            if existing_state
+            else self._resolve_reply_req_id(chat_id=chat_id, reply_to=reply_to, metadata=metadata)
+        )
+        if not reply_req_id:
+            self._clear_stream_state(normalized_stream_key)
+            return SendResult(success=False, error="WeCom native stream reply context is required")
+
+        stream_id = existing_state.get("stream_id") if existing_state else None
+        if finalize:
+            event = "finish"
+        elif existing_state:
+            event = "continue"
+        else:
+            event = "start"
+
+        native_content = content_text
+        overflow_content = ""
+        if finalize and len(content_text) > self.MAX_MESSAGE_LENGTH:
+            native_content = content_text[: self.MAX_MESSAGE_LENGTH]
+            overflow_content = content_text[self.MAX_MESSAGE_LENGTH :]
+
+        stream_payload: Dict[str, Any] = {
+            "event": event,
+            "content": native_content,
+            "stream_id": stream_id or reply_req_id,
+        }
+
+        body = {
+            "msgtype": "stream",
+            "stream": stream_payload,
+        }
+
+        try:
+            response = await self._send_reply_request(reply_req_id, body)
+            self._raise_for_wecom_error(response, "send stream")
+        except asyncio.TimeoutError:
+            self._clear_stream_state(normalized_stream_key)
+            return SendResult(success=False, error="Timeout sending message to WeCom")
+        except Exception as exc:
+            self._clear_stream_state(normalized_stream_key)
+            logger.error("[%s] Send stream failed: %s", self.name, exc)
+            return SendResult(success=False, error=str(exc))
+
+        response_stream_id = self._stream_response_id(response) or stream_payload.get("stream_id")
+
+        if overflow_content:
+            try:
+                overflow_response = await self._send_reply_markdown(reply_req_id, overflow_content)
+            except asyncio.TimeoutError:
+                self._clear_stream_state(normalized_stream_key)
+                return SendResult(
+                    success=False,
+                    error="Timeout sending message to WeCom",
+                    raw_response={
+                        "confirmed_prefix_len": len(native_content),
+                        "overflow_error": "Timeout sending message to WeCom",
+                        "native_response": response,
+                    },
+                )
+            except Exception as exc:
+                self._clear_stream_state(normalized_stream_key)
+                return SendResult(
+                    success=False,
+                    error=str(exc),
+                    raw_response={
+                        "confirmed_prefix_len": len(native_content),
+                        "overflow_error": str(exc),
+                        "native_response": response,
+                    },
+                )
+            self._clear_stream_state(normalized_stream_key)
+            return SendResult(
+                success=True,
+                message_id=str(response_stream_id or self._payload_req_id(response) or uuid.uuid4().hex[:12]),
+                raw_response={
+                    "native_response": response,
+                    "overflow_response": overflow_response,
+                    "confirmed_prefix_len": len(native_content),
+                },
+            )
+
+        if finalize:
+            self._clear_stream_state(normalized_stream_key)
+        else:
+            self._remember_stream_state(normalized_stream_key, reply_req_id, str(response_stream_id or ""))
+
+        return SendResult(
+            success=True,
+            message_id=str(response_stream_id or self._payload_req_id(response) or uuid.uuid4().hex[:12]),
             raw_response=response,
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -140,6 +140,17 @@ def _gateway_platform_value(platform: Any) -> str:
     return str(getattr(platform, "value", platform) or "").strip().lower()
 
 
+def _adapter_supports_gateway_streaming(adapter: Any) -> bool:
+    """Return True when the adapter can safely own gateway streaming delivery."""
+    if adapter is None:
+        return False
+    if bool(getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True)):
+        return True
+    return bool(getattr(adapter, "SUPPORTS_NATIVE_STREAMING_REPLIES", False)) and callable(
+        getattr(adapter, "send_stream_chunk", None)
+    )
+
+
 def _is_transient_network_error(exc: BaseException) -> bool:
     """Return True for transient network errors safe to log + swallow.
 
@@ -14136,6 +14147,15 @@ class GatewayRunner:
     ) -> Optional[Dict[str, Any]]:
         """Build the metadata dict platforms need for thread-aware replies."""
         thread_id = getattr(source, "thread_id", None)
+        if (
+            getattr(source, "platform", None) == Platform.WECOM
+            and reply_to_message_id is not None
+        ):
+            # WeCom native reply streaming needs the provider reply context in
+            # metadata. Keep this separate from generic thread metadata: it is
+            # only a callback-bound reply anchor, not permission to reroute to
+            # a private/DM fallback target.
+            return {"reply": {"msgid": str(reply_to_message_id)}}
         if thread_id is None:
             return None
         metadata: Dict[str, Any] = {"thread_id": thread_id}
@@ -16063,8 +16083,8 @@ class GatewayRunner:
             try:
                 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
                 _adapter = self.adapters.get(source.platform)
-                if _adapter:
-                    _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
+                if _adapter and _adapter_supports_gateway_streaming(_adapter):
+                    _adapter_supports_edit = bool(getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True))
                     _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
                     _buffer_only = False
                     if source.platform == Platform.MATRIX:
@@ -16892,7 +16912,7 @@ class GatewayRunner:
                 "reply_to_message_id": event_message_id,
             }
         else:
-            _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
+            _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id)
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
@@ -17015,15 +17035,8 @@ class GatewayRunner:
                 try:
                     from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
                     _adapter = self.adapters.get(source.platform)
-                    if _adapter:
-                        # Platforms that don't support editing sent messages
-                        # (e.g. QQ, WeChat) should skip streaming entirely —
-                        # without edit support, the consumer sends a partial
-                        # first message that can never be updated, resulting in
-                        # duplicate messages (partial + final).
-                        _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
-                        if not _adapter_supports_edit:
-                            raise RuntimeError("skip streaming for non-editable platform")
+                    if _adapter and _adapter_supports_gateway_streaming(_adapter):
+                        _adapter_supports_edit = bool(getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True))
                         _effective_cursor = _scfg.cursor
                         # Some Matrix clients render the streaming cursor
                         # as a visible tofu/white-box artifact.  Keep

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -91,6 +91,11 @@ class GatewayStreamConsumer:
         await task         # wait for final edit
     """
 
+    # WeCom's native stream UX shows a client-side "typing / thinking"
+    # indicator when the first stream frame has empty content.  The adapter
+    # maps this sentinel to empty native content; other platforms must not see it.
+    _WECOM_THINKING_PLACEHOLDER = "THINKING_MESSAGE"
+
     # After this many consecutive flood-control failures, permanently disable
     # progressive edits for the remainder of the stream.
     _MAX_FLOOD_STRIKES = 3
@@ -428,6 +433,11 @@ class GatewayStreamConsumer:
             logger.debug(
                 "Stream consumer using native-draft transport (chat=%s draft_id=%s)",
                 self.chat_id, self._draft_id,
+            )
+        if self._use_native_reply_streaming:
+            await self._send_native_reply_chunk(
+                self._WECOM_THINKING_PLACEHOLDER,
+                finalize=False,
             )
 
         try:
@@ -973,6 +983,11 @@ class GatewayStreamConsumer:
             finalize=finalize,
             metadata=self.metadata,
         )
+        if text == self._WECOM_THINKING_PLACEHOLDER:
+            if getattr(result, "success", False):
+                return True
+            self._use_native_reply_streaming = False
+            return False
         delivered, visible = self._apply_native_delivery_result(text, result)
         if delivered:
             self._already_sent = True

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -182,6 +182,10 @@ class GatewayStreamConsumer:
         # first failure we permanently disable drafts for the remainder of
         # this response and route through edit-based for graceful degradation.
         self._draft_failures = 0
+        self._use_native_reply_streaming = False
+        self._native_stream_key = f"stream:{id(self)}"
+        self._native_prefix = ""
+        self._native_ambiguous_failure = False
 
     @property
     def already_sent(self) -> bool:
@@ -261,6 +265,8 @@ class GatewayStreamConsumer:
         self._last_sent_text = ""
         self._fallback_final_send = False
         self._fallback_prefix = ""
+        self._native_prefix = ""
+        self._native_ambiguous_failure = False
         # Native draft streaming: bump the draft_id so the next text segment
         # animates as a fresh preview below the tool-progress bubbles, not
         # over the prior segment's already-finalized draft.  This is how
@@ -415,6 +421,7 @@ class GatewayStreamConsumer:
         # final answer as a regular sendMessage (drafts have no message_id
         # to edit).
         self._use_draft_streaming = self._resolve_draft_streaming()
+        self._use_native_reply_streaming = self._resolve_native_reply_streaming()
         if self._use_draft_streaming:
             type(self)._draft_id_counter += 1
             self._draft_id = type(self)._draft_id_counter
@@ -564,12 +571,26 @@ class GatewayStreamConsumer:
                             current_update_visible
                             and not self._adapter_requires_finalize
                         ):
-                            # Mid-stream edit above already delivered the
-                            # final accumulated content.  Skip the redundant
-                            # final edit — but only for adapters that don't
-                            # need an explicit finalize signal.
+                            # The flush above already delivered the final accumulated
+                            # content.  This includes native-reply transports when
+                            # _send_or_edit(..., finalize=True) sent the finish frame
+                            # in the same tick as _DONE; do not send a duplicate
+                            # finish frame here.
                             self._final_response_sent = True
                             self._final_content_delivered = True
+                        elif self._use_native_reply_streaming and not self._native_ambiguous_failure:
+                            self._final_response_sent = await self._send_native_reply_chunk(
+                                self._accumulated,
+                                finalize=True,
+                            )
+                            if self._native_ambiguous_failure:
+                                return
+                            if self._final_response_sent:
+                                self._final_content_delivered = True
+                            elif self._fallback_final_send:
+                                await self._send_fallback_final(self._accumulated)
+                        elif self._use_native_reply_streaming and self._native_ambiguous_failure:
+                            return
                         elif self._message_id:
                             # Either the mid-stream edit didn't run (no
                             # visible update this tick) OR the adapter needs
@@ -621,6 +642,13 @@ class GatewayStreamConsumer:
                         and self._message_id != "__no_edit__"
                     ):
                         await self._flush_segment_tail_on_edit_failure()
+                    elif (
+                        self._accumulated
+                        and self._use_native_reply_streaming
+                        and self._fallback_final_send
+                        and not self._native_ambiguous_failure
+                    ):
+                        await self._send_fallback_final(self._accumulated)
                     self._reset_segment_state(preserve_no_edit=True)
 
                 await asyncio.sleep(0.05)  # Small yield to not busy-loop
@@ -873,6 +901,91 @@ class GatewayStreamConsumer:
         err = getattr(result, "error", "") or ""
         err_lower = err.lower()
         return "flood" in err_lower or "retry after" in err_lower or "rate" in err_lower
+
+    def _has_native_reply_context(self) -> bool:
+        metadata = self.metadata if isinstance(self.metadata, dict) else {}
+        reply = metadata.get("reply")
+        return isinstance(reply, dict) and bool(reply.get("msgid"))
+
+    def _resolve_native_reply_streaming(self) -> bool:
+        # Native reply streaming is a capability-based branch inside the
+        # gateway's normal streaming modes (not a separate public transport
+        # value). In ``auto`` mode it intentionally takes precedence over
+        # draft/edit streaming when a provider reply context is available.
+        if not self._has_native_reply_context():
+            return False
+        return (
+            getattr(self.adapter, "SUPPORTS_NATIVE_STREAMING_REPLIES", False) is True
+            and callable(getattr(self.adapter, "send_stream_chunk", None))
+        )
+
+    @staticmethod
+    def _confirmed_prefix_len(result: Any) -> int:
+        raw = getattr(result, "raw_response", None)
+        if not isinstance(raw, dict):
+            return 0
+        confirmed = raw.get("confirmed_prefix_len")
+        if confirmed is None:
+            return 0
+        try:
+            return max(0, int(confirmed))
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _delivered_prefix_text(result: Any) -> str:
+        raw = getattr(result, "raw_response", None)
+        if not isinstance(raw, dict):
+            return ""
+        prefix = raw.get("delivered_prefix")
+        return prefix if isinstance(prefix, str) else ""
+
+    def _apply_native_delivery_result(self, content: str, result: Any) -> tuple[bool, bool]:
+        if getattr(result, "success", False):
+            self._native_prefix = content
+            return True, True
+
+        delivered_prefix = self._delivered_prefix_text(result)
+        if delivered_prefix:
+            if content.startswith(delivered_prefix):
+                self._native_prefix = delivered_prefix
+                return False, True
+            self._native_ambiguous_failure = True
+            self._use_native_reply_streaming = False
+            self._fallback_final_send = False
+            self._already_sent = True
+            self._accumulated = ""
+            return False, False
+
+        confirmed_len = self._confirmed_prefix_len(result)
+        if confirmed_len > 0:
+            self._native_prefix = content[:confirmed_len]
+            return False, True
+
+        return False, False
+
+    async def _send_native_reply_chunk(self, text: str, *, finalize: bool = False) -> bool:
+        result = await self.adapter.send_stream_chunk(
+            chat_id=self.chat_id,
+            content=text,
+            reply_to=self._initial_reply_to_id,
+            stream_key=self._native_stream_key,
+            finalize=finalize,
+            metadata=self.metadata,
+        )
+        delivered, visible = self._apply_native_delivery_result(text, result)
+        if delivered:
+            self._already_sent = True
+            self._last_sent_text = text
+            return True
+        if visible:
+            self._already_sent = True
+            self._fallback_final_send = True
+            self._fallback_prefix = self._native_prefix
+            self._edit_supported = False
+            return False
+        self._use_native_reply_streaming = False
+        return False
 
     def _resolve_draft_streaming(self) -> bool:
         """Decide whether this run should use native draft streaming.
@@ -1162,6 +1275,14 @@ class GatewayStreamConsumer:
         #     a tool-boundary segment break where the prior text was finalized
         #     as a real sendMessage and the next text segment continues editing
         #     that one — staying on edit-based for that segment is correct).
+        if (
+            self._use_native_reply_streaming
+            and self._message_id is None
+        ):
+            if text == self._last_sent_text and not finalize:
+                return True
+            return await self._send_native_reply_chunk(text, finalize=finalize)
+
         if (
             self._use_draft_streaming
             and not finalize

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -198,6 +198,21 @@ def test_unknown_adapter_does_not_crash_trust_check(monkeypatch):
     assert runner._is_user_authorized(_source(Platform.WECOM)) is False
 
 
+def test_wecom_adapter_owned_access_policy_remains_honored_with_native_streaming_capability(monkeypatch):
+    """Native reply streaming capability must not bypass adapter-owned auth trust."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={Platform.WECOM: PlatformConfig(enabled=True, extra={"dm_policy": "open"})}
+    )
+    runner, adapter = _make_runner(Platform.WECOM, config, enforces=True)
+    adapter.SUPPORTS_MESSAGE_EDITING = False
+    adapter.SUPPORTS_NATIVE_STREAMING_REPLIES = True
+    adapter.send_stream_chunk = AsyncMock()
+
+    assert runner._adapter_enforces_own_access_policy(Platform.WECOM) is True
+    assert runner._is_user_authorized(_source(Platform.WECOM)) is True
+
+
 # ---------------------------------------------------------------------------
 # Layer 3: unauthorized-DM behavior reads config dm_policy
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -121,6 +121,39 @@ class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
         raise AssertionError("non-editable adapters should not receive edit_message calls")
 
 
+class NativeStreamingProgressAdapter(NonEditingProgressCaptureAdapter):
+    SUPPORTS_NATIVE_STREAMING_REPLIES = True
+
+    def __init__(self, platform=Platform.WECOM):
+        super().__init__(platform=platform)
+        self.stream_chunks = []
+
+    async def send_stream_chunk(
+        self,
+        chat_id,
+        content,
+        *,
+        reply_to=None,
+        stream_key=None,
+        finalize=False,
+        metadata=None,
+    ):
+        if reply_to is None:
+            source = self._pending_messages.get("__last_source__")
+            reply_to = f"native:{getattr(source, 'chat_type', '')}"
+        self.stream_chunks.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "stream_key": stream_key,
+                "finalize": finalize,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=f"stream-{len(self.stream_chunks)}")
+
+
 class FakeAgent:
     def __init__(self, **kwargs):
         # Capture anything passed via kwargs (older code path) but don't
@@ -602,9 +635,12 @@ class PreviewedResponseAgent:
 
 
 class StreamingRefineAgent:
+    instances = []
+
     def __init__(self, **kwargs):
         self.stream_delta_callback = kwargs.get("stream_delta_callback")
         self.tools = []
+        type(self).instances.append(self)
 
     def run_conversation(self, message, conversation_history=None, task_id=None):
         if self.stream_delta_callback:
@@ -685,7 +721,7 @@ async def _run_with_agent(
     platform=Platform.TELEGRAM,
     chat_id="-1001",
     chat_type="group",
-    thread_id="17585",
+    thread_id: str | None = "17585",
     adapter_cls=ProgressCaptureAdapter,
 ):
     if config_data:
@@ -700,8 +736,11 @@ async def _run_with_agent(
     fake_run_agent = types.ModuleType("run_agent")
     fake_run_agent.AIAgent = agent_cls
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    if hasattr(agent_cls, "instances"):
+        agent_cls.instances = []
 
     adapter = adapter_cls(platform=platform)
+    adapter._pending_messages = {}
     runner = _make_runner(adapter)
     gateway_run = importlib.import_module("gateway.run")
     if config_data and "streaming" in config_data:
@@ -714,6 +753,8 @@ async def _run_with_agent(
         chat_type=chat_type,
         thread_id=thread_id,
     )
+    if getattr(adapter, "SUPPORTS_NATIVE_STREAMING_REPLIES", False):
+        adapter._pending_messages["__last_source__"] = source
     session_key = f"agent:main:{platform.value}:{chat_type}:{chat_id}"
     if thread_id:
         session_key = f"{session_key}:{thread_id}"
@@ -732,6 +773,7 @@ async def _run_with_agent(
         source=source,
         session_id=session_id,
         session_key=session_key,
+        event_message_id=("origin-msg-1" if getattr(adapter, "SUPPORTS_NATIVE_STREAMING_REPLIES", False) else None),
     )
     return adapter, result
 
@@ -842,6 +884,110 @@ async def test_run_agent_streaming_does_not_enable_completed_interim_commentary(
 
     assert result.get("already_sent") is True
     assert not any(call["content"] == "I'll inspect the repo first." for call in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_wecom_native_reply_streaming_allowed_for_capable_adapter(monkeypatch, tmp_path):
+    adapter = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingRefineAgent,
+        session_id="sess-wecom-native-stream",
+        config_data={
+            "streaming": {
+                "enabled": True,
+                "transport": "native",
+                "edit_interval": 0.0,
+                "buffer_threshold": 1,
+            },
+            "display": {
+                "interim_assistant_messages": False,
+                "platforms": {"wecom": {"streaming": True}},
+            },
+        },
+        platform=Platform.WECOM,
+        chat_id="wecom-chat-1",
+        chat_type="dm",
+        thread_id=None,
+        adapter_cls=NativeStreamingProgressAdapter,
+    )
+    adapter, result = adapter
+
+    assert result["final_response"] == "Continuing to refine: Final answer."
+    assert StreamingRefineAgent.instances
+    assert StreamingRefineAgent.instances[-1].stream_delta_callback is not None
+    assert adapter.stream_chunks
+    assert any(chunk["content"] for chunk in adapter.stream_chunks)
+    assert {chunk["metadata"]["reply"]["msgid"] for chunk in adapter.stream_chunks} == {"origin-msg-1"}
+    assert adapter.sent == []
+    assert adapter.edits == []
+
+
+@pytest.mark.asyncio
+async def test_non_editing_adapter_without_native_streaming_capability_skips_streaming(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingRefineAgent,
+        session_id="sess-generic-non-edit-no-stream",
+        config_data={
+            "streaming": {
+                "enabled": True,
+                "transport": "native",
+                "edit_interval": 0.0,
+                "buffer_threshold": 1,
+            },
+            "display": {
+                "interim_assistant_messages": False,
+            },
+        },
+        platform=Platform.WEIXIN,
+        chat_id="weixin-chat-1",
+        chat_type="dm",
+        thread_id=None,
+        adapter_cls=NonEditingProgressCaptureAdapter,
+    )
+
+    assert result["final_response"] == "Continuing to refine: Final answer."
+    assert adapter.sent == []
+    assert adapter.edits == []
+
+
+@pytest.mark.asyncio
+async def test_streaming_native_capability_does_not_enable_group_fallback(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingRefineAgent,
+        session_id="sess-wecom-native-group-no-fallback",
+        config_data={
+            "streaming": {
+                "enabled": True,
+                "transport": "native",
+                "edit_interval": 0.0,
+                "buffer_threshold": 1,
+            },
+            "display": {
+                "interim_assistant_messages": False,
+                "platforms": {"wecom": {"streaming": True}},
+            },
+        },
+        platform=Platform.WECOM,
+        chat_id="wecom-group-1",
+        chat_type="group",
+        thread_id=None,
+        adapter_cls=NativeStreamingProgressAdapter,
+    )
+
+    assert result["final_response"] == "Continuing to refine: Final answer."
+    assert adapter.stream_chunks
+    assert {chunk["chat_id"] for chunk in adapter.stream_chunks} == {"wecom-group-1"}
+    assert all(chunk["reply_to"] == "origin-msg-1" for chunk in adapter.stream_chunks)
+    assert {chunk["metadata"]["reply"]["msgid"] for chunk in adapter.stream_chunks} == {"origin-msg-1"}
+    assert adapter.sent == []
+    assert adapter.edits == []
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_stream_consumer_wecom_native.py
+++ b/tests/gateway/test_stream_consumer_wecom_native.py
@@ -15,7 +15,7 @@ class _WeComNativeAdapter:
     MAX_MESSAGE_LENGTH = 4096
     SUPPORTS_NATIVE_STREAMING_REPLIES = True
 
-    def __init__(self, *, native_results=None):
+    def __init__(self, *, native_results=None, thinking_result=None):
         self.send = AsyncMock(
             return_value=SimpleNamespace(success=True, message_id="msg_final")
         )
@@ -26,10 +26,15 @@ class _WeComNativeAdapter:
         self.send_draft = AsyncMock(return_value=SimpleNamespace(success=True))
         self.draft_supported = False
         self._native_results = list(native_results or [])
+        self._thinking_result = thinking_result
         self.native_calls = []
 
     async def send_stream_chunk(self, **kwargs):
         self.native_calls.append(kwargs)
+        if kwargs.get("content") == "THINKING_MESSAGE":
+            if self._thinking_result is not None:
+                return self._thinking_result
+            return SimpleNamespace(success=True)
         if self._native_results:
             return self._native_results.pop(0)
         return SimpleNamespace(success=True)
@@ -286,7 +291,8 @@ async def test_native_failure_before_visible_content_sends_full_final_once():
     consumer.finish()
     await task
 
-    assert len(adapter.native_calls) == 1
+    assert len(adapter.native_calls) == 2
+    assert [call["content"] for call in adapter.native_calls] == ["THINKING_MESSAGE", "Hello world"]
     adapter.send.assert_awaited_once()
     send_await_args = adapter.send.await_args
     assert send_await_args is not None
@@ -355,7 +361,61 @@ async def test_ambiguous_native_delivered_prefix_mismatch_suppresses_blind_full_
     consumer.finish()
     await task
 
-    assert [call["content"] for call in adapter.native_calls] == ["Hello ", "Hello world"]
+    assert [call["content"] for call in adapter.native_calls] == [
+        "THINKING_MESSAGE",
+        "Hello ",
+        "Hello world",
+    ]
     adapter.send.assert_not_awaited()
     assert consumer.final_response_sent is False
     assert consumer.final_content_delivered is False
+
+
+@pytest.mark.asyncio
+async def test_native_reply_stream_sends_empty_start_frame_before_text_delta():
+    adapter = _WeComNativeAdapter(
+        native_results=[SimpleNamespace(success=True), SimpleNamespace(success=True)]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=100, cursor=""),
+        metadata=_reply_metadata(),
+    )
+
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    assert adapter.native_calls, "expected an empty native start frame before visible text"
+    assert adapter.native_calls[0]["content"] == "THINKING_MESSAGE"
+    assert adapter.native_calls[0]["finalize"] is False
+
+    consumer.on_delta("Hello")
+    consumer.finish()
+    await task
+
+    assert [call["finalize"] for call in adapter.native_calls] == [False, True]
+    assert adapter.native_calls[1]["content"] == "Hello"
+    assert adapter.native_calls[0]["stream_key"] == adapter.native_calls[1]["stream_key"]
+
+
+@pytest.mark.asyncio
+async def test_native_thinking_frame_failure_does_not_leak_sentinel_as_visible_text():
+    adapter = _WeComNativeAdapter(
+        thinking_result=SimpleNamespace(success=False, error="reply context expired")
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        metadata=_reply_metadata(),
+    )
+
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.on_delta("Hello")
+    consumer.finish()
+    await task
+
+    sent_contents = [call.kwargs.get("content") for call in adapter.send.await_args_list]
+    assert "THINKING_MESSAGE" not in sent_contents
+    assert sent_contents == ["Hello"]

--- a/tests/gateway/test_stream_consumer_wecom_native.py
+++ b/tests/gateway/test_stream_consumer_wecom_native.py
@@ -1,0 +1,361 @@
+"""Tests for WeCom native reply streaming in GatewayStreamConsumer."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+class _WeComNativeAdapter:
+    MAX_MESSAGE_LENGTH = 4096
+    SUPPORTS_NATIVE_STREAMING_REPLIES = True
+
+    def __init__(self, *, native_results=None):
+        self.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_final")
+        )
+        self.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_edit")
+        )
+        self.draft_calls = []
+        self.send_draft = AsyncMock(return_value=SimpleNamespace(success=True))
+        self.draft_supported = False
+        self._native_results = list(native_results or [])
+        self.native_calls = []
+
+    async def send_stream_chunk(self, **kwargs):
+        self.native_calls.append(kwargs)
+        if self._native_results:
+            return self._native_results.pop(0)
+        return SimpleNamespace(success=True)
+
+    def supports_draft_streaming(self, chat_type=None, metadata=None) -> bool:
+        return bool(self.draft_supported)
+
+
+def _reply_metadata():
+    return {
+        "reply": {
+            "enterprise_id": "ent_1",
+            "chat_type": "dm",
+            "receive_id": "user_1",
+            "msgid": "wecom_msg_1",
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_native_reply_transport_requires_adapter_capability_and_reply_context():
+    adapter = _WeComNativeAdapter()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert adapter.native_calls, "expected native send_stream_chunk calls"
+    adapter.edit_message.assert_not_called()
+    adapter.send.assert_not_awaited()
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_native_reply_transport_not_used_without_reply_context():
+    adapter = _WeComNativeAdapter(
+        native_results=[SimpleNamespace(success=False, error="missing_reply_context")]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=" ▉"),
+        metadata={},
+    )
+
+    consumer.on_delta("Hello")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert adapter.native_calls == []
+    adapter.send.assert_awaited_once()
+    send_await_args = adapter.send.await_args
+    assert send_await_args is not None
+    assert send_await_args.kwargs["content"] == "Hello ▉"
+
+
+@pytest.mark.asyncio
+async def test_native_final_success_sets_final_content_delivered():
+    adapter = _WeComNativeAdapter(
+        native_results=[SimpleNamespace(success=True), SimpleNamespace(success=True)]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+    final_calls = [call for call in adapter.native_calls if call["finalize"] is True]
+    assert len(final_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_native_final_success_sends_single_finish_frame_when_done_arrives_with_first_delta():
+    adapter = _WeComNativeAdapter(
+        native_results=[SimpleNamespace(success=True), SimpleNamespace(success=True)]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=100, cursor=""),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello")
+    consumer.finish()
+    await consumer.run()
+
+    final_calls = [call for call in adapter.native_calls if call["finalize"] is True]
+    assert len(final_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_native_partial_success_falls_back_tail_only():
+    adapter = _WeComNativeAdapter(
+        native_results=[
+            SimpleNamespace(success=True),
+            SimpleNamespace(
+                success=False,
+                error="native_partial",
+                raw_response={"delivered_prefix": "Hello "},
+            ),
+        ]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello ")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.on_delta("world")
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    adapter.send.assert_awaited_once()
+    send_await_args = adapter.send.await_args
+    assert send_await_args is not None
+    assert send_await_args.kwargs["content"] == "world"
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_native_partial_success_confirmed_prefix_len_falls_back_tail_only():
+    adapter = _WeComNativeAdapter(
+        native_results=[
+            SimpleNamespace(success=True),
+            SimpleNamespace(
+                success=False,
+                error="native_partial",
+                raw_response={"confirmed_prefix_len": len("Hello ")},
+            ),
+        ]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello ")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.on_delta("world")
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    adapter.send.assert_awaited_once()
+    send_await_args = adapter.send.await_args
+    assert send_await_args is not None
+    assert send_await_args.kwargs["content"] == "world"
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_native_partial_success_confirmed_prefix_len_larger_than_content_clamps_visible_prefix():
+    adapter = _WeComNativeAdapter(
+        native_results=[
+            SimpleNamespace(success=True),
+            SimpleNamespace(
+                success=False,
+                error="native_partial",
+                raw_response={"confirmed_prefix_len": len("Hello world") + 100},
+            ),
+        ]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello ")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.on_delta("world")
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    adapter.send.assert_not_awaited()
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_native_reply_transport_takes_precedence_over_draft_capability():
+    adapter = _WeComNativeAdapter()
+    adapter.draft_supported = True
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=1, cursor="",
+        ),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert adapter.native_calls
+    adapter.send_draft.assert_not_awaited()
+    adapter.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_native_failure_before_visible_content_sends_full_final_once():
+    adapter = _WeComNativeAdapter(
+        native_results=[SimpleNamespace(success=False, error="native_unavailable")]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello world")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert len(adapter.native_calls) == 1
+    adapter.send.assert_awaited_once()
+    send_await_args = adapter.send.await_args
+    assert send_await_args is not None
+    assert send_await_args.kwargs["content"] == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_segment_break_native_failure_flushes_tail_without_duplicate():
+    adapter = _WeComNativeAdapter(
+        native_results=[
+            SimpleNamespace(success=True),
+            SimpleNamespace(
+                success=False,
+                error="native_partial",
+                raw_response={"delivered_prefix": "Hello "},
+            ),
+        ]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello ")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.on_delta("world")
+    await asyncio.sleep(0.05)
+    consumer.on_segment_break()
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    adapter.send.assert_awaited_once()
+    send_await_args = adapter.send.await_args
+    assert send_await_args is not None
+    assert send_await_args.kwargs["content"] == "world"
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_native_delivered_prefix_mismatch_suppresses_blind_full_resend():
+    adapter = _WeComNativeAdapter(
+        native_results=[
+            SimpleNamespace(success=True),
+            SimpleNamespace(
+                success=False,
+                error="native_partial",
+                raw_response={"delivered_prefix": "Mismatch"},
+            ),
+        ]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=""),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello ")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.on_delta("world")
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert [call["content"] for call in adapter.native_calls] == ["Hello ", "Hello world"]
+    adapter.send.assert_not_awaited()
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is False

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -492,6 +492,59 @@ class TestWeComReplyMode:
         assert "stream-1" not in adapter._stream_states
 
     @pytest.mark.asyncio
+    async def test_send_stream_chunk_thinking_placeholder_maps_to_empty_native_start(self):
+        from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_reply_request = AsyncMock(
+            return_value={
+                "cmd": APP_CMD_RESPONSE,
+                "headers": {"req_id": "metadata-req"},
+                "body": {"stream": {"stream_id": "stream-id-1"}},
+                "errcode": 0,
+            }
+        )
+
+        result = await adapter.send_stream_chunk(
+            chat_id="chat-1",
+            content="THINKING_MESSAGE",
+            finalize=False,
+            stream_key="stream-1",
+            metadata={"wecom_reply_req_id": "metadata-req"},
+        )
+
+        assert result.success is True
+        await_args = adapter._send_reply_request.await_args
+        assert await_args is not None
+        args = await_args.args
+        assert args[0] == "metadata-req"
+        assert args[1]["stream"]["event"] == "start"
+        assert args[1]["stream"]["content"] == ""
+        assert args[1]["stream"]["stream_id"] == "metadata-req"
+        assert adapter._stream_states["stream-1"]["reply_req_id"] == "metadata-req"
+        assert adapter._stream_states["stream-1"]["stream_id"] == "stream-id-1"
+
+    @pytest.mark.asyncio
+    async def test_send_stream_chunk_thinking_placeholder_without_context_does_not_leak(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_reply_request = AsyncMock()
+        adapter._send_request = AsyncMock()
+
+        result = await adapter.send_stream_chunk(
+            chat_id="chat-1",
+            content="THINKING_MESSAGE",
+            finalize=False,
+            stream_key="stream-1",
+        )
+
+        assert result.success is True
+        adapter._send_reply_request.assert_not_awaited()
+        adapter._send_request.assert_not_awaited()
+        assert "stream-1" not in adapter._stream_states
+
+    @pytest.mark.asyncio
     async def test_native_final_overflow_sends_prefix_then_overflow_chunks(self, monkeypatch):
         from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
 

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -5,6 +5,7 @@ import base64
 import os
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -41,6 +42,11 @@ class TestWeComAdapterInit:
         from gateway.platforms.wecom import WeComAdapter
 
         assert WeComAdapter.SUPPORTS_MESSAGE_EDITING is False
+
+    def test_declares_native_streaming_reply_capability(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        assert WeComAdapter.SUPPORTS_NATIVE_STREAMING_REPLIES is True
 
     def test_reads_config_from_extra(self):
         from gateway.platforms.wecom import WeComAdapter
@@ -167,6 +173,440 @@ class TestWeComQrScan:
 
 class TestWeComReplyMode:
     @pytest.mark.asyncio
+    async def test_send_uses_metadata_reply_req_id_first(self):
+        from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["old-msg"] = "legacy-req"
+        adapter._last_chat_req_ids["chat-1"] = "chat-req"
+        adapter._send_reply_request = AsyncMock(
+            return_value={"cmd": APP_CMD_RESPONSE, "headers": {"req_id": "metadata-req"}, "errcode": 0}
+        )
+
+        result = await adapter.send(
+            "chat-1",
+            "hello",
+            reply_to="old-msg",
+            metadata={"wecom_reply_req_id": "metadata-req"},
+        )
+
+        assert result.success is True
+        adapter._send_reply_request.assert_awaited_once()
+        args = adapter._send_reply_request.await_args.args
+        assert args[0] == "metadata-req"
+        assert result.raw_response["cmd"] == APP_CMD_RESPONSE
+        assert result.raw_response["headers"]["req_id"] == "metadata-req"
+
+    @pytest.mark.asyncio
+    async def test_send_falls_back_to_reply_to_then_chat(self):
+        from gateway.platforms.wecom import APP_CMD_SEND, APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["old-msg"] = "legacy-req"
+        adapter._last_chat_req_ids["chat-1"] = "chat-req"
+        adapter._send_reply_request = AsyncMock(
+            side_effect=[
+                {"cmd": APP_CMD_RESPONSE, "headers": {"req_id": "legacy-req"}, "errcode": 0},
+                {"cmd": APP_CMD_RESPONSE, "headers": {"req_id": "chat-req"}, "errcode": 0},
+            ]
+        )
+        adapter._send_request = AsyncMock(
+            return_value={"cmd": APP_CMD_SEND, "headers": {"req_id": "proactive-req"}, "errcode": 0}
+        )
+
+        reply_result = await adapter.send("chat-1", "reply first", reply_to="old-msg")
+        chat_result = await adapter.send("chat-1", "chat fallback")
+        proactive_result = await adapter.send("chat-2", "proactive only")
+
+        assert reply_result.success is True
+        assert chat_result.success is True
+        assert proactive_result.success is True
+        assert adapter._send_reply_request.await_count == 2
+        assert adapter._send_reply_request.await_args_list[0].args[0] == "legacy-req"
+        assert adapter._send_reply_request.await_args_list[1].args[0] == "chat-req"
+        adapter._send_request.assert_awaited_once_with(
+            APP_CMD_SEND,
+            {
+                "chatid": "chat-2",
+                "msgtype": "markdown",
+                "markdown": {"content": "proactive only"},
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_without_reply_context_uses_proactive_send_not_placeholder(self):
+        from gateway.platforms.wecom import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_reply_request = AsyncMock()
+        adapter._send_request = AsyncMock(
+            return_value={"cmd": APP_CMD_SEND, "headers": {"req_id": "proactive-req"}, "errcode": 0}
+        )
+
+        result = await adapter.send("chat-1", "hello")
+
+        assert result.success is True
+        adapter._send_reply_request.assert_not_awaited()
+        adapter._send_request.assert_awaited_once_with(
+            APP_CMD_SEND,
+            {
+                "chatid": "chat-1",
+                "msgtype": "markdown",
+                "markdown": {"content": "hello"},
+            },
+        )
+        assert result.raw_response["cmd"] == APP_CMD_SEND
+
+    @pytest.mark.asyncio
+    async def test_send_ignores_blank_or_non_dict_metadata_reply_req_id(self):
+        from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["old-msg"] = "legacy-req"
+        adapter._send_reply_request = AsyncMock(
+            side_effect=[
+                {"cmd": APP_CMD_RESPONSE, "headers": {"req_id": "legacy-req"}, "errcode": 0},
+                {"cmd": APP_CMD_RESPONSE, "headers": {"req_id": "legacy-req"}, "errcode": 0},
+            ]
+        )
+
+        blank_result = await adapter.send(
+            "chat-1",
+            "blank metadata",
+            reply_to="old-msg",
+            metadata={"wecom_reply_req_id": "   "},
+        )
+        non_dict_result = await adapter.send(
+            "chat-1",
+            "non-dict metadata",
+            reply_to="old-msg",
+            metadata=cast(Any, "metadata-req"),
+        )
+
+        assert blank_result.success is True
+        assert non_dict_result.success is True
+        assert adapter._send_reply_request.await_count == 2
+        assert adapter._send_reply_request.await_args_list[0].args[0] == "legacy-req"
+        assert adapter._send_reply_request.await_args_list[1].args[0] == "legacy-req"
+
+    @pytest.mark.asyncio
+    async def test_send_quote_reply_to_falls_back_to_chat_req_id(self):
+        from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["quote:old-msg"] = "legacy-req"
+        adapter._last_chat_req_ids["chat-1"] = "chat-req"
+        adapter._send_reply_request = AsyncMock(
+            return_value={"cmd": APP_CMD_RESPONSE, "headers": {"req_id": "chat-req"}, "errcode": 0}
+        )
+
+        result = await adapter.send("chat-1", "quoted reply", reply_to="quote:old-msg")
+
+        assert result.success is True
+        adapter._send_reply_request.assert_awaited_once()
+        await_args = adapter._send_reply_request.await_args
+        assert await_args is not None
+        assert await_args.args[0] == "chat-req"
+
+    @pytest.mark.asyncio
+    async def test_send_stream_chunk_requires_reply_context(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_reply_request = AsyncMock()
+        adapter._send_request = AsyncMock()
+
+        result = await adapter.send_stream_chunk(
+            chat_id="chat-1",
+            content="hello",
+            finalize=False,
+            stream_key="stream-1",
+        )
+
+        assert result.success is False
+        assert "reply context" in (result.error or "")
+        adapter._send_reply_request.assert_not_awaited()
+        adapter._send_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_stream_chunk_uses_metadata_req_id(self):
+        from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_reply_request = AsyncMock(
+            return_value={
+                "cmd": APP_CMD_RESPONSE,
+                "headers": {"req_id": "metadata-req"},
+                "body": {"stream": {"id": "stream-id-1"}},
+                "errcode": 0,
+            }
+        )
+
+        result = await adapter.send_stream_chunk(
+            chat_id="chat-1",
+            content="hello",
+            finalize=False,
+            metadata={"wecom_reply_req_id": "metadata-req"},
+            stream_key="stream-1",
+        )
+
+        assert result.success is True
+        adapter._send_reply_request.assert_awaited_once()
+        args = adapter._send_reply_request.await_args.args
+        assert args[0] == "metadata-req"
+        assert args[1]["msgtype"] == "stream"
+        assert args[1]["stream"]["event"] == "start"
+        assert args[1]["stream"]["content"] == "hello"
+        assert args[1]["stream"]["stream_id"] == "metadata-req"
+        assert "id" not in args[1]["stream"]
+
+    @pytest.mark.asyncio
+    async def test_send_stream_chunk_preserves_non_string_falsy_content(self):
+        from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_reply_request = AsyncMock(
+            return_value={
+                "cmd": APP_CMD_RESPONSE,
+                "headers": {"req_id": "metadata-req"},
+                "body": {"stream": {"id": "stream-id-1"}},
+                "errcode": 0,
+            }
+        )
+
+        zero_result = await adapter.send_stream_chunk(
+            chat_id="chat-1",
+            content=cast(Any, 0),
+            finalize=False,
+            metadata={"wecom_reply_req_id": "metadata-req"},
+            stream_key="stream-1",
+        )
+        false_result = await adapter.send_stream_chunk(
+            chat_id="chat-1",
+            content=cast(Any, False),
+            finalize=True,
+            stream_key="stream-1",
+        )
+
+        assert zero_result.success is True
+        assert false_result.success is True
+        sent_contents = [call.args[1]["stream"]["content"] for call in adapter._send_reply_request.await_args_list]
+        assert sent_contents == ["0", "False"]
+
+    @pytest.mark.asyncio
+    async def test_send_stream_chunk_finalize_uses_same_stream_state(self):
+        from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_reply_request = AsyncMock(
+            side_effect=[
+                {
+                    "cmd": APP_CMD_RESPONSE,
+                    "headers": {"req_id": "metadata-req"},
+                    "body": {"stream": {"id": "stream-id-1"}},
+                    "errcode": 0,
+                },
+                {
+                    "cmd": APP_CMD_RESPONSE,
+                    "headers": {"req_id": "metadata-req"},
+                    "body": {"stream": {"id": "stream-id-1"}},
+                    "errcode": 0,
+                },
+                {
+                    "cmd": APP_CMD_RESPONSE,
+                    "headers": {"req_id": "metadata-req"},
+                    "body": {"stream": {"id": "stream-id-1"}},
+                    "errcode": 0,
+                },
+            ]
+        )
+
+        start_result = await adapter.send_stream_chunk(
+            chat_id="chat-1",
+            content="hello",
+            finalize=False,
+            metadata={"wecom_reply_req_id": "metadata-req"},
+            stream_key="stream-1",
+        )
+        continue_result = await adapter.send_stream_chunk(
+            chat_id="chat-1",
+            content="middle",
+            finalize=False,
+            stream_key="stream-1",
+        )
+        finish_result = await adapter.send_stream_chunk(
+            chat_id="chat-1",
+            content="done",
+            finalize=True,
+            stream_key="stream-1",
+        )
+
+        assert start_result.success is True
+        assert continue_result.success is True
+        assert finish_result.success is True
+        assert adapter._send_reply_request.await_count == 3
+        start_args = adapter._send_reply_request.await_args_list[0].args
+        continue_args = adapter._send_reply_request.await_args_list[1].args
+        finish_args = adapter._send_reply_request.await_args_list[2].args
+        assert start_args[0] == "metadata-req"
+        assert continue_args[0] == "metadata-req"
+        assert finish_args[0] == "metadata-req"
+        assert start_args[1]["stream"]["event"] == "start"
+        assert continue_args[1]["stream"]["event"] == "continue"
+        assert finish_args[1]["stream"]["event"] == "finish"
+        assert start_args[1]["stream"]["stream_id"] == "metadata-req"
+        assert continue_args[1]["stream"]["stream_id"] == "stream-id-1"
+        assert finish_args[1]["stream"]["stream_id"] == "stream-id-1"
+        assert "id" not in start_args[1]["stream"]
+        assert "id" not in continue_args[1]["stream"]
+        assert "id" not in finish_args[1]["stream"]
+        assert "stream-1" not in adapter._stream_states
+
+    @pytest.mark.asyncio
+    async def test_send_stream_chunk_error_clears_stream_state(self):
+        from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._stream_states["stream-1"] = {
+            "reply_req_id": "metadata-req",
+            "stream_id": "stream-id-1",
+        }
+        adapter._send_reply_request = AsyncMock(
+            return_value={
+                "cmd": APP_CMD_RESPONSE,
+                "headers": {"req_id": "metadata-req"},
+                "errcode": 846608,
+                "errmsg": "reply context expired",
+            }
+        )
+
+        result = await adapter.send_stream_chunk(
+            chat_id="chat-1",
+            content="continued",
+            finalize=False,
+            stream_key="stream-1",
+        )
+
+        assert result.success is False
+        assert "reply context expired" in (result.error or "")
+        assert "stream-1" not in adapter._stream_states
+
+    @pytest.mark.asyncio
+    async def test_native_final_overflow_sends_prefix_then_overflow_chunks(self, monkeypatch):
+        from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._stream_states["stream-1"] = {
+            "reply_req_id": "metadata-req",
+            "stream_id": "stream-id-1",
+        }
+        monkeypatch.setattr(adapter, "MAX_MESSAGE_LENGTH", 10)
+        overflow_calls: list[str] = []
+
+        async def fake_send_reply_markdown(reply_req_id: str, content: str):
+            overflow_calls.append(content)
+            return {"cmd": APP_CMD_RESPONSE, "headers": {"req_id": reply_req_id}, "errcode": 0}
+
+        adapter._send_reply_request = AsyncMock(
+            return_value={
+                "cmd": APP_CMD_RESPONSE,
+                "headers": {"req_id": "metadata-req"},
+                "body": {"stream": {"id": "stream-id-1"}},
+                "errcode": 0,
+            }
+        )
+        adapter._send_reply_markdown = AsyncMock(side_effect=fake_send_reply_markdown)
+        final_content = "abcdefghijABCDEFGHIJklmnop"
+
+        result = await adapter.send_stream_chunk(
+            chat_id="chat-1",
+            content=final_content,
+            finalize=True,
+            stream_key="stream-1",
+        )
+
+        assert result.success is True
+        adapter._send_reply_request.assert_awaited_once()
+        native_payload = adapter._send_reply_request.await_args.args[1]["stream"]
+        assert native_payload["event"] == "finish"
+        assert len(native_payload["content"]) <= adapter.MAX_MESSAGE_LENGTH
+        adapter._send_reply_markdown.assert_awaited_once_with("metadata-req", final_content[10:])
+        assert native_payload["content"] + "".join(overflow_calls) == final_content
+        assert "stream-1" not in adapter._stream_states
+
+    @pytest.mark.asyncio
+    async def test_overflow_failure_returns_delivered_prefix(self, monkeypatch):
+        from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._stream_states["stream-1"] = {
+            "reply_req_id": "metadata-req",
+            "stream_id": "stream-id-1",
+        }
+        monkeypatch.setattr(adapter, "MAX_MESSAGE_LENGTH", 10)
+        adapter._send_reply_request = AsyncMock(
+            return_value={
+                "cmd": APP_CMD_RESPONSE,
+                "headers": {"req_id": "metadata-req"},
+                "body": {"stream": {"id": "stream-id-1"}},
+                "errcode": 0,
+            }
+        )
+        adapter._send_reply_markdown = AsyncMock(side_effect=RuntimeError("send reply markdown failed: WeCom errcode 500: boom"))
+        final_content = "abcdefghijABCDEFGHIJklmnop"
+
+        result = await adapter.send_stream_chunk(
+            chat_id="chat-1",
+            content=final_content,
+            finalize=True,
+            stream_key="stream-1",
+        )
+
+        assert result.success is False
+        assert "send reply markdown failed" in (result.error or "")
+        assert result.raw_response["confirmed_prefix_len"] == 10
+        assert result.raw_response["overflow_error"] == "send reply markdown failed: WeCom errcode 500: boom"
+        assert result.raw_response["native_response"]["errcode"] == 0
+        assert "stream-1" not in adapter._stream_states
+
+    @pytest.mark.asyncio
+    async def test_expired_req_id_clears_native_state_and_future_call_fails_closed(self):
+        from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._stream_states["stream-1"] = {
+            "reply_req_id": "metadata-req",
+            "stream_id": "stream-id-1",
+        }
+        adapter._send_reply_request = AsyncMock(
+            return_value={
+                "cmd": APP_CMD_RESPONSE,
+                "headers": {"req_id": "metadata-req"},
+                "errcode": 846608,
+                "errmsg": "reply context expired",
+            }
+        )
+        first_result = await adapter.send_stream_chunk(
+            chat_id="chat-1",
+            content="continued",
+            finalize=False,
+            stream_key="stream-1",
+        )
+        second_result = await adapter.send_stream_chunk(
+            chat_id="chat-1",
+            content="continued again",
+            finalize=False,
+            stream_key="stream-1",
+        )
+
+        assert first_result.success is False
+        assert "reply context expired" in (first_result.error or "")
+        assert "stream-1" not in adapter._stream_states
+        assert second_result.success is False
+        assert "reply context" in (second_result.error or "")
+        assert adapter._send_reply_request.await_count == 1
+
+    @pytest.mark.asyncio
     async def test_send_uses_passive_reply_markdown_when_reply_context_exists(self):
         from gateway.platforms.wecom import WeComAdapter
 
@@ -186,6 +626,129 @@ class TestWeComReplyMode:
         # (unsupported type). Markdown renders everywhere.
         assert args[1]["msgtype"] == "markdown"
         assert args[1]["markdown"]["content"] == "hello from reply"
+
+    @pytest.mark.asyncio
+    async def test_send_preserves_non_string_falsy_markdown_content(self):
+        from gateway.platforms.wecom import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._send_request = AsyncMock(
+            return_value={"cmd": APP_CMD_SEND, "headers": {"req_id": "req-final"}, "errcode": 0}
+        )
+
+        zero_result = await adapter.send("chat-1", cast(Any, 0))
+        false_result = await adapter.send("chat-1", cast(Any, False))
+        none_result = await adapter.send("chat-1", cast(Any, None))
+
+        assert zero_result.success is True
+        assert false_result.success is True
+        assert none_result.success is True
+        sent_contents = [call.args[1]["markdown"]["content"] for call in adapter._send_request.await_args_list]
+        assert sent_contents == ["0", "False", ""]
+
+    @pytest.mark.asyncio
+    async def test_send_chunks_long_proactive_markdown_without_dropping_tail(self, monkeypatch):
+        from gateway.platforms.wecom import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "MAX_MESSAGE_LENGTH", 80)
+        adapter._send_request = AsyncMock(
+            return_value={"cmd": APP_CMD_SEND, "headers": {"req_id": "req-final"}, "errcode": 0}
+        )
+        long_content = (
+            "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda "
+            "mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega tail-word"
+        )
+
+        result = await adapter.send("chat-1", long_content)
+
+        assert result.success is True
+        assert adapter._send_request.await_count > 1
+        sent_chunks = [
+            call.args[1]["markdown"]["content"]
+            for call in adapter._send_request.await_args_list
+        ]
+        assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in sent_chunks)
+        total = len(sent_chunks)
+        assert sent_chunks[0].endswith(f"(1/{total})")
+        assert sent_chunks[-1].endswith(f"({total}/{total})")
+        assert "tail-word" in sent_chunks[-1]
+        reconstructed = " ".join(chunk.rsplit(" (", 1)[0] for chunk in sent_chunks)
+        assert reconstructed == long_content
+        assert result.raw_response["headers"]["req_id"] == "req-final"
+
+    @pytest.mark.asyncio
+    async def test_send_stops_on_first_proactive_markdown_chunk_error(self, monkeypatch):
+        from gateway.platforms.wecom import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "MAX_MESSAGE_LENGTH", 80)
+        adapter._send_request = AsyncMock(
+            side_effect=[
+                {"cmd": APP_CMD_SEND, "errcode": 600039, "errmsg": "unsupported type"},
+                {"cmd": APP_CMD_SEND, "headers": {"req_id": "should-not-send"}, "errcode": 0},
+            ]
+        )
+        long_content = " ".join(["chunk-error"] * 30)
+
+        result = await adapter.send("chat-1", long_content)
+
+        assert result.success is False
+        assert "send markdown failed: WeCom errcode 600039: unsupported type" in (result.error or "")
+        assert adapter._send_request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_send_chunks_long_reply_markdown_without_dropping_tail(self, monkeypatch):
+        from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "MAX_MESSAGE_LENGTH", 80)
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter._send_reply_request = AsyncMock(
+            return_value={"cmd": APP_CMD_RESPONSE, "headers": {"req_id": "req-final"}, "errcode": 0}
+        )
+        long_content = (
+            "reply alpha beta gamma delta epsilon zeta eta theta iota kappa "
+            "lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega reply-tail"
+        )
+
+        result = await adapter.send("chat-1", long_content, reply_to="msg-1")
+
+        assert result.success is True
+        assert adapter._send_reply_request.await_count > 1
+        sent_chunks = [
+            call.args[1]["markdown"]["content"]
+            for call in adapter._send_reply_request.await_args_list
+        ]
+        assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in sent_chunks)
+        total = len(sent_chunks)
+        assert sent_chunks[0].endswith(f"(1/{total})")
+        assert sent_chunks[-1].endswith(f"({total}/{total})")
+        assert "reply-tail" in sent_chunks[-1]
+        reconstructed = " ".join(chunk.rsplit(" (", 1)[0] for chunk in sent_chunks)
+        assert reconstructed == long_content
+        assert result.raw_response["headers"]["req_id"] == "req-final"
+
+    @pytest.mark.asyncio
+    async def test_send_stops_on_first_reply_markdown_chunk_error(self, monkeypatch):
+        from gateway.platforms.wecom import APP_CMD_RESPONSE, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "MAX_MESSAGE_LENGTH", 80)
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter._send_reply_request = AsyncMock(
+            side_effect=[
+                {"cmd": APP_CMD_RESPONSE, "errcode": 600039, "errmsg": "unsupported type"},
+                {"cmd": APP_CMD_RESPONSE, "headers": {"req_id": "should-not-send"}, "errcode": 0},
+            ]
+        )
+        long_content = " ".join(["reply-chunk-error"] * 30)
+
+        result = await adapter.send("chat-1", long_content, reply_to="msg-1")
+
+        assert result.success is False
+        assert "send reply markdown failed: WeCom errcode 600039: unsupported type" in (result.error or "")
+        assert adapter._send_reply_request.await_count == 1
 
     @pytest.mark.asyncio
     async def test_send_image_file_uses_passive_reply_media_when_reply_context_exists(self):


### PR DESCRIPTION
## Summary

- Preserve long WeCom markdown replies by chunking passive and proactive markdown sends instead of slicing at `MAX_MESSAGE_LENGTH`.
- Add WeCom native reply streaming support using passive reply context and stream state tracking.
- Wire `GatewayStreamConsumer` and `gateway/run.py` so WeCom can use native reply streaming even though it does not support edit-message streaming.
- Restore WeCom client thinking dots by sending an empty native stream start frame before visible reply text.
- Add regression coverage for metadata-first reply context, chunk error handling, long native replies, no sentinel leakage, run-gate behavior, and access-policy preservation.

## Test plan

```bash
python3 -m pytest -o addopts='' tests/gateway/test_wecom.py tests/gateway/test_stream_consumer_wecom_native.py -q
# 78 passed

python3 -m pytest -o addopts='' \
  tests/gateway/test_stream_consumer.py \
  tests/gateway/test_stream_consumer_draft.py \
  tests/gateway/test_stream_consumer_fresh_final.py \
  tests/gateway/test_stream_consumer_wecom_native.py -q
# 132 passed

python3 -m pytest -o addopts='' tests/gateway/test_run_progress_topics.py tests/gateway/test_config_driven_access_policy.py -q
# 52 passed

git diff --check
# clean
```

## Live validation

- Ran candidate worktree through `hermes-gateway.service` via a temporary systemd drop-in.
- WeCom connected successfully after restart.
- User confirmed the WeCom client shows the native three-dot thinking UI.
- Recent checked live logs did not show new WeCom `846609` errors after restart.

## Known non-blocking runtime issues

- `api_server` is retrying because `API_SERVER_KEY` is missing. This is unrelated to WeCom DM native reply delivery.
- Gateway shutdown/drain timed out during the live restart and required systemd forced handling. This should be tracked as a separate Gateway shutdown reliability follow-up.
