### PR TITLE
fix(gateway): stop system tips from leaking local files as attachments

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -954,11 +954,13 @@ def _media_delivery_denied_paths() -> List[Path]:
     home = Path(os.path.expanduser("~"))
     for sub in _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS:
         denied.append(home / sub)
-    # The Hermes home itself contains credentials (auth.json, .env) — only the
-    # cache subdirectories under it are explicitly allowlisted above.
+    # The Hermes home itself contains credentials (auth.json, .env) and
+    # configuration (config.yaml) — only the cache subdirectories under it
+    # are explicitly allowlisted above.
     denied.append(_HERMES_HOME / ".env")
     denied.append(_HERMES_HOME / "auth.json")
     denied.append(_HERMES_HOME / "credentials")
+    denied.append(_HERMES_HOME / "config.yaml")
     return denied
 
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3736,6 +3736,7 @@ class BasePlatformAdapter(ABC):
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
+            is_ephemeral_response = isinstance(response, EphemeralReply)
 
             # Slash-command handlers may return an EphemeralReply sentinel to
             # request that their reply message auto-delete after a TTL (used
@@ -3793,12 +3794,16 @@ class BasePlatformAdapter(ABC):
                 if images:
                     logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
 
-                # Auto-detect bare local file paths for native media delivery
-                # (helps small models that don't use MEDIA: syntax)
-                local_files, text_content = self.extract_local_files(text_content)
-                local_files = self.filter_local_delivery_paths(local_files)
-                if local_files:
-                    logger.info("[%s] extract_local_files found %d file(s) in response", self.name, len(local_files))
+                local_files = []
+                if not is_ephemeral_response:
+                    # Auto-detect bare local file paths for native media delivery
+                    # (helps small models that don't use MEDIA: syntax). Skip
+                    # system/command notices so config paths stay visible text
+                    # instead of becoming native uploads.
+                    local_files, text_content = self.extract_local_files(text_content)
+                    local_files = self.filter_local_delivery_paths(local_files)
+                    if local_files:
+                        logger.info("[%s] extract_local_files found %d file(s) in response", self.name, len(local_files))
                 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -215,7 +215,7 @@ TIPS = [
     # --- Context & Compression ---
     "Context auto-compresses when it reaches the threshold — memories are flushed and history summarized.",
     "The status bar turns yellow, then orange, then red as context fills up.",
-    "SOUL.md at ~/.hermes/SOUL.md is the agent's primary identity — customize it to shape behavior.",
+    "SOUL.md is the agent's primary identity file — customize it to shape behavior.",
     "Hermes loads project context from .hermes.md, AGENTS.md, CLAUDE.md, or .cursorrules (first match).",
     "Subdirectory AGENTS.md files are discovered progressively as the agent navigates into folders.",
     "Context files are capped at 20,000 characters with smart head/tail truncation.",
@@ -273,7 +273,7 @@ TIPS = [
     "Cron scripts live in ~/.hermes/scripts/ and run before the agent — perfect for data collection pipelines.",
     "prefill_messages_file in config.yaml injects few-shot examples into every API call, never saved to history.",
     "SOUL.md completely replaces the agent's default identity — rewrite it to make Hermes your own.",
-    "SOUL.md is auto-seeded with a default personality on first run. Edit ~/.hermes/SOUL.md to customize.",
+    "SOUL.md is auto-seeded with a default personality on first run. Edit it to customize.",
     "/compress <focus topic> allocates 60-70% of the summary budget to your topic and aggressively trims the rest.",
     "On second+ compression, the compressor updates the previous summary instead of starting from scratch.",
     "Before a gateway session reset, Hermes auto-flushes important facts to memory in the background.",
@@ -430,7 +430,7 @@ TIPS = [
     'hermes -z "<prompt>" is the purest one-shot: final answer on stdout, nothing else — ideal for piping in scripts.',
     'hermes chat --pass-session-id injects the session ID into the system prompt so the agent can self-reference it.',
     'hermes chat --image path/to/pic.png attaches a local image to a single -q query without a separate upload step.',
-    'hermes chat --ignore-user-config skips ~/.hermes/config.yaml — reproducible bug reports and CI runs.',
+    'hermes chat --ignore-user-config skips the active user config — reproducible bug reports and CI runs.',
     "hermes chat --source tool tags programmatic chats so they don't clutter hermes sessions list.",
     'hermes dump --show-keys includes redacted API key fingerprints for deeper support debugging.',
     'hermes sessions rename <ID> "new title" renames any past session; hermes sessions delete <ID> removes one.',
@@ -484,5 +484,4 @@ def get_random_tip(exclude_recent: int = 0) -> str:
             deduplication across sessions.
     """
     return random.choice(TIPS)
-
 

--- a/tests/gateway/test_ephemeral_reply.py
+++ b/tests/gateway/test_ephemeral_reply.py
@@ -269,6 +269,37 @@ async def test_process_message_unwraps_ephemeral_before_send():
 
 
 @pytest.mark.asyncio
+async def test_process_message_ephemeral_reply_does_not_auto_upload_bare_paths(tmp_path):
+    """Tips/system notices may mention local paths; they must remain text."""
+    adapter = _delete_adapter()
+    adapter._send_with_retry = AsyncMock(
+        return_value=SendResult(success=True, message_id="sent-1")
+    )
+    adapter.send_document = AsyncMock(
+        return_value=SendResult(success=True, message_id="doc-1")
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("model:\n  provider: test\n", encoding="utf-8")
+    reply_text = f"Tip: hermes chat --ignore-user-config skips {config_path}"
+
+    async def _handler(evt):
+        return EphemeralReply(reply_text, ttl_seconds=0)
+
+    adapter.set_message_handler(_handler)
+
+    event = _make_event(text="/new")
+    session_key = "agent:main:telegram:private:42"
+    with patch("gateway.platforms.base.asyncio.sleep", AsyncMock()), patch.object(
+        adapter, "_keep_typing", new=AsyncMock()
+    ):
+        await adapter._process_message_background(event, session_key)
+
+    adapter._send_with_retry.assert_called_once()
+    assert adapter._send_with_retry.call_args.kwargs["content"] == reply_text
+    adapter.send_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_process_message_incapable_platform_does_not_schedule_delete():
     adapter = _no_delete_adapter()
     adapter._send_with_retry = AsyncMock(


### PR DESCRIPTION
## Summary
Tips and system notices can no longer leak local files as native attachments. A `/new` tip that mentioned `~/.hermes/config.yaml` was being matched by `extract_local_files()`, which found the file, stripped the path from the text, and uploaded the config as a document.

## Changes
- `gateway/platforms/base.py`: skip bare-path auto-detection (`extract_local_files()`) for `EphemeralReply` system/command responses — the structural fix that covers all current and future tips regardless of wording. MEDIA: tags and image URLs still process normally.
- `gateway/platforms/base.py`: also denylist `~/.hermes/config.yaml` in `_media_delivery_denied_paths()` (defense-in-depth, matches existing `.env`/`auth.json`/`credentials/` protection).
- `hermes_cli/tips.py`: reword the `config.yaml` and `SOUL.md` tips to drop home-relative paths (more accurate for profile/container/custom `HERMES_HOME` installs).
- `tests/gateway/test_ephemeral_reply.py`: regression — an `EphemeralReply` containing an existing `config.yaml` path sends text, never calls `send_document()`.

## Validation
| | Before | After |
|---|---|---|
| `/new` tip with config.yaml path | uploads config.yaml as attachment | text only, no upload |
| `validate_media_delivery_path('~/.hermes/config.yaml')` | returns path | returns None (blocked) |
| legit `cache/documents/*.pdf` delivery | allowed | allowed (unchanged) |
| `tests/gateway/test_ephemeral_reply.py` | — | 14/14 pass |

Salvages #35514 (@helix4u — structural EphemeralReply gate + tip rewording + regression test) with the config.yaml denylist line from #35507 (@JezzaHehn — reported and replicated the bug) added on top. Closes #35507 and #35514.

## Infographic

![stop-tips-leaking-files](https://v3b.fal.media/files/b/0a9c55c2/6KNRfdat7VT9Q9ES6ornE_2DTvub8X.png)
