### PR TITLE
fix(tui): show child transcript sessions in resume

### DIFF
--- a/tests/gateway/test_session_list_allowed_sources.py
+++ b/tests/gateway/test_session_list_allowed_sources.py
@@ -25,7 +25,7 @@ class _StubDB:
 
     def list_sessions_rich(self, **kwargs):
         self.calls.append(kwargs)
-        return list(self.rows)
+        return [{"message_count": 1, **row} for row in self.rows]
 
 
 def _call(limit: int | None = None):
@@ -86,6 +86,26 @@ def test_session_list_respects_explicit_limit(monkeypatch):
     _call(limit=10)
     # fetch_limit = max(limit * 2, 200) = 200 when limit is small.
     assert db.calls[0].get("limit") == 200, db.calls[0]
+
+
+def test_session_list_asks_for_child_message_rows_without_projection(monkeypatch):
+    """Child transcripts should be visible while empty shell rows stay hidden."""
+    db = _StubDB([
+        {"id": "empty-parent", "source": "tui", "message_count": 0, "started_at": 3},
+        {"id": "child-transcript", "source": "tui", "message_count": 4, "started_at": 2},
+        {"id": "tool-child", "source": "tool", "message_count": 3, "started_at": 1},
+    ])
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+
+    resp = _call(limit=10)
+
+    assert db.calls[0] == {
+        "limit": 200,
+        "include_children": True,
+        "project_compression_tips": False,
+        "order_by_last_active": True,
+    }
+    assert [s["id"] for s in resp["result"]["sessions"]] == ["child-transcript"]
 
 
 def test_session_list_preserves_ordering_after_filter(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4077,13 +4077,19 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
     """Drops `tool` rows like session.list does, returns the first hit."""
 
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200):
+        def __init__(self):
+            self.calls: list[dict] = []
+
+        def list_sessions_rich(self, **kwargs):
+            self.calls.append(kwargs)
             return [
-                {"id": "tool-1", "source": "tool", "title": "noise", "started_at": 100},
-                {"id": "tui-1", "source": "tui", "title": "real", "started_at": 99},
+                {"id": "tool-1", "source": "tool", "title": "noise", "started_at": 100, "message_count": 1},
+                {"id": "empty-parent", "source": "tui", "title": "shell", "started_at": 100, "message_count": 0},
+                {"id": "tui-1", "source": "tui", "title": "real", "started_at": 99, "message_count": 3},
             ]
 
-    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    db = _DB()
+    monkeypatch.setattr(server, "_get_db", lambda: db)
 
     resp = server.handle_request(
         {"id": "1", "method": "session.most_recent", "params": {}}
@@ -4092,12 +4098,18 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
     assert resp["result"]["session_id"] == "tui-1"
     assert resp["result"]["title"] == "real"
     assert resp["result"]["source"] == "tui"
+    assert db.calls[0] == {
+        "limit": 200,
+        "include_children": True,
+        "project_compression_tips": False,
+        "order_by_last_active": True,
+    }
 
 
 def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200):
-            return [{"id": "tool-1", "source": "tool", "started_at": 1}]
+        def list_sessions_rich(self, **kwargs):
+            return [{"id": "tool-1", "source": "tool", "started_at": 1, "message_count": 1}]
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 
@@ -4114,7 +4126,7 @@ def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):
     'no answer' (Copilot review on #17130)."""
 
     class _BrokenDB:
-        def list_sessions_rich(self, *, source=None, limit=200):
+        def list_sessions_rich(self, **kwargs):
             raise RuntimeError("db locked")
 
     monkeypatch.setattr(server, "_get_db", lambda: _BrokenDB())

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2385,13 +2385,21 @@ def _(rid, params: dict) -> dict:
 
         limit = int(params.get("limit", 200) or 200)
         # Over-fetch modestly so per-source filtering doesn't leave us
-        # short; the compression-tip projection in ``list_sessions_rich``
-        # can also merge rows.
+        # short.  Include child rows because resumable transcripts may live
+        # under a parent shell session after compression/delegation; disable
+        # compression-tip projection here so the raw picker can choose the
+        # message-bearing row rather than an empty shell.
         fetch_limit = max(limit * 2, 200)
         rows = [
             s
-            for s in db.list_sessions_rich(source=None, limit=fetch_limit)
+            for s in db.list_sessions_rich(
+                limit=fetch_limit,
+                include_children=True,
+                project_compression_tips=False,
+                order_by_last_active=True,
+            )
             if (s.get("source") or "").strip().lower() not in deny
+            and int(s.get("message_count") or 0) > 0
         ][:limit]
         return _ok(
             rid,
@@ -2437,10 +2445,17 @@ def _(rid, params: dict) -> dict:
         # users (lots of recent ``tool`` rows) don't get a false
         # "no eligible session" answer.  ``session.list`` uses a
         # similar over-fetch strategy.
-        rows = db.list_sessions_rich(source=None, limit=200)
+        rows = db.list_sessions_rich(
+            limit=200,
+            include_children=True,
+            project_compression_tips=False,
+            order_by_last_active=True,
+        )
         for row in rows:
             src = (row.get("source") or "").strip().lower()
             if src in deny:
+                continue
+            if int(row.get("message_count") or 0) <= 0:
                 continue
             return _ok(
                 rid,


### PR DESCRIPTION
## Summary
- Makes the TUI historical session picker and most-recent resume path include child session rows that contain the actual transcript.
- Filters out zero-message shell rows and internal `tool` rows so empty compression/coordination parents do not hide resumable sessions.

Closes #35542

## Why
- `session.list` and `session.most_recent` queried `list_sessions_rich(...)` without `include_children=True`, so transcript-bearing child rows could be hidden while empty parent shell rows were surfaced.
- This made historical sessions look empty even though their messages still existed in `state.db`.

## Changes
- `tui_gateway/server.py`: request child rows, raw last-active ordering, and no compression-tip projection for TUI resume/list queries; require positive `message_count` after source filtering.
- `tests/gateway/test_session_list_allowed_sources.py`: cover the child transcript / empty shell filtering behavior and query kwargs.
- `tests/test_tui_gateway_server.py`: cover the same behavior for `session.most_recent`.

## Validation
- `python -m pytest tests/test_tui_gateway_server.py tests/gateway/test_session_list_allowed_sources.py -q -o 'addopts='` (191 passed)
- `python -m ruff check tui_gateway/server.py tests/test_tui_gateway_server.py tests/gateway/test_session_list_allowed_sources.py`
- `git diff --check`

## Scope
- In scope: TUI historical session listing and most-recent resume selection.
- Out of scope: broader `/sessions` vs `/resume` product semantics or gateway resume scoping changes.