### PR TITLE
fix(security): convert shell=True to shlex.split in cli.py and mcp_catalog.py

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -359,12 +359,24 @@ def _install_root() -> Path:
 def _run_bootstrap(cwd: Path, commands: List[str]) -> None:
     """Execute bootstrap commands in *cwd*. Raise CatalogError on first failure.
 
-    Each command runs through the shell (so `&&` etc. work). The output is
-    streamed to the user's terminal for visibility.
+    Each command is split via ``shlex`` and run without ``shell=True`` to
+    prevent injection from untrusted YAML catalog entries.  Shell operators
+    (``&&``, ``||``, ``|``) are **not** supported — use separate command
+    entries instead.
+
+    Raises ``CatalogError`` on non-zero exit or malformed commands.
     """
+    import shlex
+
     for cmd in commands:
         print(color(f"  $ {cmd}", Colors.DIM))
-        proc = subprocess.run(cmd, cwd=str(cwd), shell=True)
+        try:
+            args = shlex.split(cmd)
+        except ValueError as exc:
+            raise CatalogError(
+                f"bootstrap command has malformed shell syntax: {cmd!r} ({exc})"
+            ) from exc
+        proc = subprocess.run(args, cwd=str(cwd), shell=False)
         if proc.returncode != 0:
             raise CatalogError(
                 f"bootstrap step failed (exit {proc.returncode}): {cmd}"


### PR DESCRIPTION
## What

Converts `shell=True` subprocess calls to `shlex.split()` + `shell=False` in two config-driven code paths:

| File | Path | Change |
|------|------|--------|
| `hermes_cli/mcp_catalog.py` | MCP catalog bootstrap | `shell=True` → `shlex.split(cmd)` |
| `cli.py` | `quick_commands` | `shell=True` → `shlex.split(cmd)` |

## Why

Fixes #10692. Related: #2743, #16560.

Both paths execute commands from user-editable config (config.yaml `quick_commands` and MCP catalog YAML `external_dependencies.check`). While the user controls the input, `shell=True` is a bad pattern that enables injection if config is shared or sourced from untrusted locations.

## Notes

- Shell operators like `&&` are no longer supported in these paths — use separate command entries instead.
- `tools/environments/docker.py` already uses list argv (upstream fixed this).
- `tui_gateway/server.py` shell injection (#16560) — addressed in a separate branch.