### PR TITLE
feat(kanban): auto-subscribe CLI session on task create + --cli flag

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -28,6 +28,11 @@ from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_swarm as ks
 from hermes_cli.profiles import get_active_profile_name, get_profile_dir, seed_profile_skills
 
+# Module-level flag: when True, _cmd_create skips CLI auto-subscribe
+# because the gateway handler (GatewayRunner._handle_kanban_command)
+# will subscribe the originating source channel instead.
+_gateway_kanban_in_progress: bool = False
+
 
 # ---------------------------------------------------------------------------
 # Small formatting helpers
@@ -682,14 +687,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
              "(used by /kanban subscribe in the gateway adapter)",
     )
     p_nsub.add_argument("task_id")
-    p_nsub.add_argument("--platform", required=True)
-    p_nsub.add_argument("--chat-id", required=True)
+    p_nsub.add_argument("--platform", required=False)
+    p_nsub.add_argument("--chat-id", required=False)
     p_nsub.add_argument("--thread-id", default=None)
     p_nsub.add_argument("--user-id", default=None)
     p_nsub.add_argument(
         "--notifier-profile", default=None,
         help="Profile gateway that owns/delivers this subscription (default: active profile)",
     )
+    p_nsub.add_argument("--cli", action="store_true", default=False,
+                        help="Auto-set platform=cli and chat_id=cli-<pid>")
 
     p_nlist = sub.add_parser(
         "notify-list",
@@ -697,6 +704,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_nlist.add_argument("task_id", nargs="?", default=None)
     p_nlist.add_argument("--json", action="store_true")
+    p_nlist.add_argument("--cli-only", action="store_true", default=False,
+                         help="Only show cli platform subscriptions")
 
     p_nrm = sub.add_parser(
         "notify-unsubscribe",
@@ -1348,6 +1357,19 @@ def _cmd_create(args: argparse.Namespace) -> int:
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
+        # Auto-subscribe the current CLI session so the user gets
+        # terminal-state notifications (completed/blocked/crashed/etc.)
+        # when this task finishes. Uses a per-session PID-based chat_id
+        # so multiple concurrent CLI sessions don't stomp each other.
+        # Skip when called from the gateway handler (which manages its
+        # own auto-subscribe via GatewayRunner._handle_kanban_command).
+        if not _gateway_kanban_in_progress:
+            kb.add_notify_sub(
+                conn,
+                task_id=task_id,
+                platform="cli",
+                chat_id=f"cli-{os.getpid()}",
+            )
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
     else:
@@ -1364,7 +1386,36 @@ def _cmd_create(args: argparse.Namespace) -> int:
             running, message = _check_dispatcher_presence()
             if not running and message:
                 print(f"\n⚠  {message}", file=sys.stderr)
+
+        # Auto-subscribe the CLI session so notifications reach the user.
+        # Use platform='cli' with a PID-based chat_id so any future CLI
+        # side-channel (drain thread, TUI FIFO bridge) can pick them up.
+        _auto_subscribe_cli(task_id)
     return 0
+
+
+def _auto_subscribe_cli(task_id: str) -> None:
+    """Subscribe the current CLI process to kanban task events.
+
+    Uses ``platform='cli'`` with ``chat_id=f'cli-{os.getpid()}'`` so that
+    a CLI-side notification drain (or the TUI FIFO bridge) can later claim
+    and deliver terminal-state events to the user.
+    """
+    try:
+        from hermes_cli import kanban_db as _kb
+        import os as _os
+        with _kb.connect() as _conn:
+            _kb.add_notify_sub(
+                _conn, task_id=task_id,
+                platform="cli",
+                chat_id=f"cli-{_os.getpid()}",
+                thread_id=None,
+                user_id=None,
+                notifier_profile=_profile_author(),
+            )
+    except Exception as exc:
+        # Non-fatal — the task was created successfully regardless.
+        print(f"  (auto-subscribe skipped: {exc})", file=sys.stderr)
 
 
 def _cmd_swarm(args: argparse.Namespace) -> int:
@@ -2417,17 +2468,25 @@ def _cmd_stats(args: argparse.Namespace) -> int:
 
 
 def _cmd_notify_subscribe(args: argparse.Namespace) -> int:
+    _platform = args.platform
+    _chat_id = args.chat_id
+    if args.cli:
+        _platform = "cli"
+        _chat_id = f"cli-{os.getpid()}"
+    if not _platform or not _chat_id:
+        print("kanban notify-subscribe: --platform and --chat-id are required (or use --cli)", file=sys.stderr)
+        return 2
     with kb.connect_closing() as conn:
         if kb.get_task(conn, args.task_id) is None:
             print(f"no such task: {args.task_id}", file=sys.stderr)
             return 1
         kb.add_notify_sub(
             conn, task_id=args.task_id,
-            platform=args.platform, chat_id=args.chat_id,
+            platform=_platform, chat_id=_chat_id,
             thread_id=args.thread_id, user_id=args.user_id,
             notifier_profile=args.notifier_profile or _profile_author(),
         )
-    print(f"Subscribed {args.platform}:{args.chat_id}"
+    print(f"Subscribed {_platform}:{_chat_id}"
           + (f":{args.thread_id}" if args.thread_id else "")
           + f" to {args.task_id}")
     return 0
@@ -2436,6 +2495,8 @@ def _cmd_notify_subscribe(args: argparse.Namespace) -> int:
 def _cmd_notify_list(args: argparse.Namespace) -> int:
     with kb.connect_closing() as conn:
         subs = kb.list_notify_subs(conn, args.task_id)
+    if getattr(args, "cli_only", False):
+        subs = [s for s in subs if s.get("platform") == "cli"]
     if getattr(args, "json", False):
         print(json.dumps(subs, indent=2, ensure_ascii=False))
         return 0


### PR DESCRIPTION
## What

Auto-subscribes the current CLI session for terminal-state notifications when a kanban task is created.

**Changes:**
- `kanban create` auto-subscribes with `platform=cli`, `chat_id=cli-{pid}` — per-session, no cross-contamination
- `notify-subscribe` gains `--cli` flag (shortcut for `--platform cli --chat-id cli-{pid}`)
- `notify-subscribe` gains `--cli-only` filter for listing
- Platform/chat_id validation when neither `--cli` nor explicit args given

## Why

Fixes #19479. Without this, CLI users must manually subscribe after every task create. The PID-based chat_id ensures concurrent CLI sessions don't stomp each other.

## Notes

- Non-fatal: auto-subscribe failure doesn't block task creation
- Gateway handler manages its own subscriptions separately — no conflict