### PR TITLE
fix(process_registry): keep poll() read-only — do not mark completions consumed

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -168,7 +168,7 @@ class ProcessRegistry:
         self.completion_queue: _queue_mod.Queue = _queue_mod.Queue()
 
         # Track sessions whose completion was already consumed by the agent
-        # via wait/poll/log.  Drain loops skip notifications for these.
+        # via wait/log.  Drain loops skip notifications for these.
         self._completion_consumed: set = set()
 
         # Global watch-match circuit breaker — across all sessions.
@@ -871,14 +871,18 @@ class ProcessRegistry:
     # ----- Query Methods -----
 
     def is_completion_consumed(self, session_id: str) -> bool:
-        """Check if a completion notification was already consumed via wait/poll/log."""
+        """Check if a completion notification was already consumed via wait/log."""
         return session_id in self._completion_consumed
+
+    def mark_completion_consumed(self, session_id: str) -> None:
+        """Explicitly mark a session as consumed (e.g., after TUI notification delivery)."""
+        self._completion_consumed.add(session_id)
 
     def drain_notifications(self) -> "list[tuple[dict, str]]":
         """Pop all pending notification events and return formatted pairs.
 
         Returns a list of (raw_event, formatted_text) tuples.
-        Skips completion events that were already consumed via wait/poll/log.
+        Skips completion events that were already consumed via wait/log.
         """
         results = []
         while not self.completion_queue.empty():
@@ -997,7 +1001,6 @@ class ProcessRegistry:
         }
         if session.exited:
             result["exit_code"] = session.exit_code
-            self._completion_consumed.add(session_id)
         if session.detached:
             result["detached"] = True
             result["note"] = "Process recovered after restart -- output history unavailable"


### PR DESCRIPTION
## What

Removes the `_completion_consumed.add(session_id)` call from `poll()`, making it a pure read operation. Adds explicit `mark_completion_consumed()` method for callers that have actually delivered the notification.

## Why

`poll()` was silently eating completion events, preventing any other consumer from seeing them. The TUI notification bridge needs to poll for events without consuming them — consumption should only happen after successful delivery.

Fixes #10156.

## Changes

- `poll()`: removed `_completion_consumed.add(session_id)` — now read-only
- Added `mark_completion_consumed(session_id)` — explicit consumption after delivery
- Updated comments: "wait/log" instead of "wait/poll/log"