### PR TITLE
fix(simplex): populate inbound message_id from chat item itemId

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -424,6 +424,7 @@ class SimplexAdapter(BasePlatformAdapter):
             media_types=media_types,
             timestamp=timestamp,
             raw_message=wrapper,
+            message_id=str(meta.get("itemId")) if meta.get("itemId") is not None else None,
         )
 
         await self.handle_message(event_obj)

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -264,6 +264,59 @@ async def test_handle_event_filters_own_corr_id():
 
 
 # ---------------------------------------------------------------------------
+# 8b. Inbound: message_id is populated from the chat item's itemId
+# ---------------------------------------------------------------------------
+
+def _inbound_dm_wrapper(item_id, *, text="hi there"):
+    """Build a minimal newChatItem wrapper for a DM, optionally carrying an itemId."""
+    meta: dict = {"itemTs": "2026-05-30T12:00:00Z"}
+    if item_id is not None:
+        meta["itemId"] = item_id
+    return {
+        "chatInfo": {"type": "direct", "contact": {"contactId": 42, "displayName": "Alice"}},
+        "chatItem": {
+            "meta": meta,
+            "content": {"msgContent": {"type": "text", "text": text}},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_inbound_sets_message_id_from_item_id():
+    """An inbound newChatItem with an itemId dispatches message_id == str(itemId)."""
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    captured = AsyncMock()
+    adapter.handle_message = captured  # type: ignore
+
+    await adapter._handle_new_chat_item(_inbound_dm_wrapper(12345))
+
+    captured.assert_called_once()
+    event = captured.call_args[0][0]
+    assert event.message_id == "12345"
+
+
+@pytest.mark.asyncio
+async def test_inbound_missing_item_id_yields_none_not_literal():
+    """A newChatItem with no itemId leaves message_id None (not the string 'None')."""
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    captured = AsyncMock()
+    adapter.handle_message = captured  # type: ignore
+
+    await adapter._handle_new_chat_item(_inbound_dm_wrapper(None))
+
+    captured.assert_called_once()
+    event = captured.call_args[0][0]
+    assert event.message_id is None
+    assert event.message_id != "None"
+
+
+# ---------------------------------------------------------------------------
 # 9. Standalone (out-of-process) send for cron
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Inbound SimpleX messages were never given a `message_id`. The `MessageEvent`
built in `_handle_new_chat_item` omitted the field, so it defaulted to `None`.
As a result, reply-anchoring, the `[Replying to: ...]` disambiguation prefix,
and transcript-id features silently no-op'd on SimpleX, even though the daemon
provides a stable identifier (`itemId`) in the chat item's `meta`.

This sets `message_id` from `meta["itemId"]`, stringified for parity with other
adapters (e.g. Matrix sets `message_id=event_id`). A `None`-guard ensures a
missing id yields `None` rather than the literal string `"None"`:

```python
message_id=str(meta.get("itemId")) if meta.get("itemId") is not None else None
```

`meta` is the same dict already read for `itemStatus` and `itemTs` a few lines
above, so no new parsing is introduced.

## Tests

Added two focused async tests to `tests/gateway/test_simplex_plugin.py`:

- `test_inbound_sets_message_id_from_item_id` — an inbound newChatItem carrying
  `itemId: 12345` dispatches a `MessageEvent` whose `message_id == "12345"`.
- `test_inbound_missing_item_id_yields_none_not_literal` — a newChatItem with no
  `itemId` leaves `message_id` as `None` (and explicitly not the string `"None"`).

Both assert against the event captured from a mocked `handle_message`. The first
test fails on clean main (`None != "12345"`) and passes with this change; the
second guards against a fix that drops the `None`-guard.

## Overlap with other open PRs

This touches the same inbound `MessageEvent` construction site that PR #27978
(groups / native attachments / text batching / auto-accept) rewrites. #27978's
rewritten block still does not set `message_id`, so this is the same latent bug,
not a duplicate. #26433 (polling rewrite) likewise omits `message_id`, and #26480
reads `itemId` only for inbound de-duplication — no open PR actually sets it.

It's a one-line, self-contained change against current `main`; if #27978 lands
first, the rebase here is a single line.
