### PR TITLE
fix(simplex): escalate non-retryable WebSocket handshake rejections instead of looping forever

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -108,6 +108,23 @@ def _is_audio_ext(ext: str) -> bool:
     return ext.lower() in {".mp3", ".wav", ".ogg", ".m4a", ".aac"}
 
 
+def _handshake_status_code(exc: Exception) -> Optional[int]:
+    """Extract the HTTP status from a websockets handshake-rejection error.
+
+    websockets >= 14 raises ``InvalidStatus`` carrying ``.response.status_code``;
+    older releases raised ``InvalidStatusCode`` with a flat ``.status_code``.
+    Return the status as an int, or ``None`` if it cannot be determined.
+    """
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if status is None:
+        status = getattr(exc, "status_code", None)
+    try:
+        return int(status) if status is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
 # ---------------------------------------------------------------------------
 # SimpleX Adapter
 # ---------------------------------------------------------------------------
@@ -215,6 +232,17 @@ class SimplexAdapter(BasePlatformAdapter):
         """Maintain a persistent WebSocket connection to the daemon."""
         import websockets as _wsclient
         import websockets as _wsexc
+        # websockets >= 14 raises InvalidStatus on a rejected handshake
+        # (carrying a .response with .status_code). Older releases used
+        # InvalidStatusCode (with a .status_code attribute) and still expose
+        # the name as a deprecated alias; fall back to it so the adapter works
+        # against either version.
+        try:
+            from websockets.exceptions import InvalidStatus as _WSInvalidStatus
+        except ImportError:  # pragma: no cover - very old websockets
+            from websockets.exceptions import (  # type: ignore[attr-defined]
+                InvalidStatusCode as _WSInvalidStatus,
+            )
 
         backoff = WS_RETRY_DELAY_INITIAL
 
@@ -245,6 +273,25 @@ class SimplexAdapter(BasePlatformAdapter):
 
             except asyncio.CancelledError:
                 break
+            except _WSInvalidStatus as e:
+                # The daemon rejected the WebSocket handshake with an HTTP
+                # status. A 4xx is a permanent misconfiguration (bad path,
+                # auth, wrong endpoint) that will never succeed on retry —
+                # escalate to a gateway-visible fatal state instead of
+                # busy-looping forever. 5xx may be transient, so keep
+                # retrying those via the generic path below.
+                status = _handshake_status_code(e)
+                if status is not None and 400 <= status < 500:
+                    message = f"SimpleX daemon rejected WebSocket handshake (HTTP {status})"
+                    logger.error("SimpleX WS: %s — stopping reconnect", message)
+                    self._set_fatal_error("handshake_rejected", message, retryable=False)
+                    break
+                if self._running:
+                    logger.warning(
+                        "SimpleX WS: handshake rejected (HTTP %s) "
+                        "(reconnecting in %.0fs)",
+                        status, backoff,
+                    )
             except _wsexc.WebSocketException as e:
                 if self._running:
                     logger.warning(

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -321,6 +321,116 @@ async def test_standalone_send_missing_url(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# 9b. Reconnect loop escalates a non-retryable handshake rejection
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ws_listener_escalates_4xx_handshake_rejection(monkeypatch):
+    """A 4xx WebSocket-handshake rejection is fatal, not an endless retry.
+
+    A permanently misconfigured daemon answers the handshake with an HTTP
+    4xx. That can never succeed on retry, so the listener must flag a
+    non-retryable fatal error and stop looping instead of busy-reconnecting
+    forever.
+    """
+    import asyncio
+
+    import websockets
+    from gateway.config import PlatformConfig
+
+    # Build a real handshake-rejection exception for the installed
+    # websockets version (InvalidStatus on >= 14, else InvalidStatusCode).
+    try:
+        from websockets.exceptions import InvalidStatus
+        from websockets.datastructures import Headers
+        from websockets.http11 import Response
+
+        rejection = InvalidStatus(Response(403, "Forbidden", Headers()))
+    except ImportError:  # pragma: no cover - very old websockets
+        from websockets.exceptions import InvalidStatusCode
+
+        rejection = InvalidStatusCode(403, Headers())  # type: ignore[call-arg]
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    adapter._running = True
+
+    # Every connect attempt is rejected with the 4xx handshake error.
+    def _raise_rejection(*args, **kwargs):
+        raise rejection
+
+    monkeypatch.setattr(websockets, "connect", _raise_rejection)
+
+    fatal_calls = []
+    monkeypatch.setattr(
+        adapter,
+        "_set_fatal_error",
+        lambda code, message, *, retryable: fatal_calls.append(
+            (code, message, retryable)
+        ),
+    )
+
+    # If the fix is missing the loop busy-retries forever — fail fast rather
+    # than hang the suite.
+    await asyncio.wait_for(adapter._ws_listener(), timeout=5.0)
+
+    assert len(fatal_calls) == 1, "expected exactly one fatal-error escalation"
+    code, _message, retryable = fatal_calls[0]
+    assert retryable is False
+    assert code == "handshake_rejected"
+
+
+@pytest.mark.asyncio
+async def test_ws_listener_retries_5xx_handshake_rejection(monkeypatch):
+    """A 5xx handshake rejection is transient — keep retrying, don't escalate."""
+    import asyncio
+
+    import websockets
+    from gateway.config import PlatformConfig
+
+    try:
+        from websockets.exceptions import InvalidStatus
+        from websockets.datastructures import Headers
+        from websockets.http11 import Response
+
+        rejection = InvalidStatus(Response(503, "Unavailable", Headers()))
+    except ImportError:  # pragma: no cover - very old websockets
+        from websockets.exceptions import InvalidStatusCode
+
+        rejection = InvalidStatusCode(503, Headers())  # type: ignore[call-arg]
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    adapter._running = True
+
+    attempts = 0
+
+    def _raise_rejection(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        # Stop the loop after it has demonstrated a retry rather than escalating.
+        if attempts >= 2:
+            adapter._running = False
+        raise rejection
+
+    monkeypatch.setattr(websockets, "connect", _raise_rejection)
+    # Don't actually sleep through the backoff.
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+    fatal_calls = []
+    monkeypatch.setattr(
+        adapter,
+        "_set_fatal_error",
+        lambda code, message, *, retryable: fatal_calls.append(retryable),
+    )
+
+    await asyncio.wait_for(adapter._ws_listener(), timeout=5.0)
+
+    assert attempts >= 2, "5xx should be retried, not escalated on first hit"
+    assert fatal_calls == [], "5xx must not trigger a fatal escalation"
+
+
+# ---------------------------------------------------------------------------
 # 10. register() — plugin-side metadata
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

When the simplex-chat daemon rejects the WebSocket handshake with an HTTP status (e.g. a permanently misconfigured endpoint, wrong path, or auth failure), the `websockets` client raises `InvalidStatus`. Because `InvalidStatus` is a subclass of `WebSocketException`, the SimpleX adapter's reconnect loop (`_ws_listener`) caught it in the generic reconnect arm and **busy-looped forever** with exponential backoff — never surfacing a gateway-visible fatal state, so operators got no signal that the connection could never succeed.

This adds a specific arm that catches the handshake-rejection exception and inspects the HTTP status:

- **4xx** (permanent misconfiguration that can never succeed on retry) → call `_set_fatal_error("handshake_rejected", ..., retryable=False)` and break out of the reconnect loop, matching the fatal-error convention used by the base adapter and siblings (e.g. IRC, Mattermost's permanent-auth-failure stop).
- **5xx / unknown** → treated as potentially transient and left to the existing reconnect path, so behavior there is unchanged.

Transient errors (`ConnectionClosed`, other `WebSocketException`s) keep retrying exactly as before.

A small helper, `_handshake_status_code`, reads the status from either the newer `InvalidStatus` (`.response.status_code`) or the older `InvalidStatusCode` (`.status_code`), and the import is guarded so the adapter works across `websockets` versions.

## Tests

Added two focused async tests to `tests/gateway/test_simplex_plugin.py`:

- `test_ws_listener_escalates_4xx_handshake_rejection` — patches `websockets.connect` to raise a real `InvalidStatus(403)`, runs `_ws_listener`, and asserts `_set_fatal_error` is called exactly once with `retryable=False` and the loop exits. It wraps the listener in `asyncio.wait_for(..., timeout=5)` so the old busy-loop behavior fails fast instead of hanging.
- `test_ws_listener_retries_5xx_handshake_rejection` — a 503 rejection is retried (loop does not escalate), guarding against over-broad escalation.

The 4xx test is red on current main (the handshake rejection falls into the generic reconnect arm and the loop never exits, tripping the 5s timeout) and green with this change. The 5xx test passes both before and after, confirming transient behavior is preserved.

(One unrelated test in the file, `test_standalone_send_missing_url`, is environment-dependent and is not affected by this change; where it fails, it fails identically on clean `main`.)

## Notes

- Against `websockets` 15.0.1 the rejection class is `InvalidStatus` (exposing `.response.status_code`); the code and tests also handle the older `InvalidStatusCode` alias for portability across versions.
- Overlap with #27978: it edits the same `_ws_listener` region (narrowing the generic catch from `WebSocketException` to `ConnectionClosed` plus a bare `except Exception`), but it adds no handshake-rejection / 4xx fatal handling — so even under #27978 a 4xx `InvalidStatus` would still fall through and loop forever. This fix is not a duplicate; it stands on its own against current `main`, and if #27978 lands first it slots into the restructured loop as a small mechanical rebase. No other open SimpleX PR (#26480, #27120, #27415, #26433, #27628) touches handshake/fatal escalation.
