### PR TITLE
fix: prune file-mutation verifier false positives from non-mutating tool recovery

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4430,6 +4430,10 @@ def run_conversation(
     # the truth is surfaced on every turn, so over-claiming is
     # structurally impossible past the model.
     #
+    # Before rendering, prune entries whose files were modified by
+    # non-mutating tools (``terminal``, ``git``, etc.) — detected via
+    # mtime change since the failure was recorded.
+    #
     # Gate: only applied when a real text response exists for this
     # turn and the user didn't interrupt.  Empty/interrupted turns
     # already have other surface text that shouldn't be augmented.
@@ -4437,6 +4441,7 @@ def run_conversation(
         try:
             _failed = getattr(agent, "_turn_failed_file_mutations", None) or {}
             if _failed and agent._file_mutation_verifier_enabled():
+                _failed = AIAgent._prune_recovered_file_mutations(_failed)
                 footer = agent._format_file_mutation_failure_footer(_failed)
                 if footer:
                     final_response = final_response.rstrip() + "\n\n" + footer

--- a/run_agent.py
+++ b/run_agent.py
@@ -2049,11 +2049,11 @@ class AIAgent:
     ) -> None:
         """Record a ``write_file`` / ``patch`` outcome for the turn-end verifier.
 
-        On failure, store ``{path: {error_preview, tool}}`` entries.  On
-        success, remove any prior failure entries for the same paths (the
-        model recovered within the turn).  Silently no-ops if the per-turn
-        state dict hasn't been initialised yet (e.g. a tool dispatched
-        outside ``run_conversation``).
+        On failure, store ``{path: {error_preview, tool, snapshot_mtime}}``
+        entries.  On success, remove any prior failure entries for the same
+        paths (the model recovered within the turn).  Silently no-ops if
+        the per-turn state dict hasn't been initialised yet (e.g. a tool
+        dispatched outside ``run_conversation``).
         """
         if tool_name not in _FILE_MUTATING_TOOLS:
             return
@@ -2071,13 +2071,54 @@ class AIAgent:
                 # later see success.  A repeated failure with a different
                 # message shouldn't silently overwrite the original.
                 if path not in state:
-                    state[path] = {
+                    entry: Dict[str, Any] = {
                         "tool": tool_name,
                         "error_preview": preview,
                     }
+                    # Snapshot the file's mtime so we can detect recovery
+                    # via non-mutating tools (e.g. ``terminal`` running
+                    # ``hermes config set``, ``git mv``, ``sed -i``).
+                    try:
+                        import os as _os
+                        entry["snapshot_mtime"] = _os.path.getmtime(path)
+                    except OSError:
+                        entry["snapshot_mtime"] = None
+                    state[path] = entry
         else:
             for path in targets:
                 state.pop(path, None)
+
+    @staticmethod
+    def _prune_recovered_file_mutations(
+        failed: Dict[str, Dict[str, Any]],
+    ) -> Dict[str, Dict[str, Any]]:
+        """Remove entries whose files changed since the failure was recorded.
+
+        When a ``write_file`` / ``patch`` call fails but the agent later
+        recovers via a non-mutating tool (``terminal``, ``git``, etc.),
+        the file's mtime will have changed.  Detect that and drop the
+        stale entry so the verifier doesn't emit a false-positive footer.
+        """
+        if not failed:
+            return failed
+        import os as _os
+        pruned: Dict[str, Dict[str, Any]] = {}
+        for path, info in failed.items():
+            snapshot = info.get("snapshot_mtime")
+            try:
+                current_mtime = _os.path.getmtime(path)
+            except OSError:
+                # File still doesn't exist — keep the entry.
+                pruned[path] = info
+                continue
+            if snapshot is None:
+                # File didn't exist at failure time but does now — recovered.
+                continue
+            if current_mtime != snapshot:
+                # File was modified since the failure — recovered.
+                continue
+            pruned[path] = info
+        return pruned
 
     def _file_mutation_verifier_enabled(self) -> bool:
         """Check whether the per-turn file-mutation verifier footer is on.

--- a/tests/run_agent/test_file_mutation_verifier.py
+++ b/tests/run_agent/test_file_mutation_verifier.py
@@ -1,13 +1,16 @@
 """Tests for the per-turn file-mutation verifier footer.
 
-Covers the three moving pieces:
+Covers the four moving pieces:
 
 1. ``_extract_file_mutation_targets`` — pulls file paths from write_file /
    patch (replace + V4A) tool-call argument dicts.
 2. ``AIAgent._record_file_mutation_result`` — builds the per-turn state
    dict, removing entries when a later success supersedes an earlier
-   failure for the same path.
-3. ``AIAgent._format_file_mutation_failure_footer`` — renders the dict
+   failure for the same path.  Snapshots file mtime at failure time.
+3. ``AIAgent._prune_recovered_file_mutations`` — re-checks mtime at turn
+   end to detect recovery via non-mutating tools (``terminal``, ``git``,
+   etc.) and drops false-positive entries.
+4. ``AIAgent._format_file_mutation_failure_footer`` — renders the dict
    as a user-visible advisory.
 
 Regression target: the "Ben Eng llm-wiki" session where grok-4.1-fast
@@ -299,6 +302,101 @@ class TestFormatFooter:
         lines = out.split("\n")
         bullet_lines = [ln for ln in lines if ln.lstrip().startswith("•")]
         assert len(bullet_lines) == 11  # 10 shown + 1 summary
+
+
+# ---------------------------------------------------------------------------
+# _prune_recovered_file_mutations — mtime-based recovery detection
+# ---------------------------------------------------------------------------
+
+
+class TestPruneRecoveredFileMutations:
+    """Verify that the prune step drops entries whose files were modified
+    by non-mutating tools after the initial failure."""
+
+    def test_empty_dict_returns_empty(self):
+        assert AIAgent._prune_recovered_file_mutations({}) == {}
+
+    def test_unmodified_file_kept(self, tmp_path):
+        """File exists, mtime unchanged → entry stays."""
+        f = tmp_path / "config.yaml"
+        f.write_text("original")
+        mtime = f.stat().st_mtime
+        failed = {
+            str(f): {
+                "tool": "patch",
+                "error_preview": "Write denied",
+                "snapshot_mtime": mtime,
+            }
+        }
+        result = AIAgent._prune_recovered_file_mutations(failed)
+        assert str(f) in result
+
+    def test_modified_file_pruned(self, tmp_path):
+        """File exists, mtime changed → entry removed (recovered)."""
+        import time
+        f = tmp_path / "config.yaml"
+        f.write_text("original")
+        mtime = f.stat().st_mtime
+        failed = {
+            str(f): {
+                "tool": "patch",
+                "error_preview": "Write denied",
+                "snapshot_mtime": mtime,
+            }
+        }
+        # Simulate recovery via terminal (e.g. hermes config set)
+        time.sleep(0.05)
+        f.write_text("updated content")
+        result = AIAgent._prune_recovered_file_mutations(failed)
+        assert str(f) not in result
+
+    def test_file_didnt_exist_at_failure_now_exists(self, tmp_path):
+        """File didn't exist at failure time but does now → pruned."""
+        f = tmp_path / "new_file.txt"
+        failed = {
+            str(f): {
+                "tool": "write_file",
+                "error_preview": "Permission denied",
+                "snapshot_mtime": None,
+            }
+        }
+        # File was created by another tool
+        f.write_text("created")
+        result = AIAgent._prune_recovered_file_mutations(failed)
+        assert str(f) not in result
+
+    def test_file_still_missing_kept(self, tmp_path):
+        """File didn't exist at failure and still doesn't → entry stays."""
+        f = tmp_path / "missing.txt"
+        failed = {
+            str(f): {
+                "tool": "write_file",
+                "error_preview": "No such directory",
+                "snapshot_mtime": None,
+            }
+        }
+        result = AIAgent._prune_recovered_file_mutations(failed)
+        assert str(f) in result
+
+    def test_mixed_recovery(self, tmp_path):
+        """Some files recovered, some didn't — only unrecovered remain."""
+        import time
+        kept = tmp_path / "kept.yaml"
+        pruned = tmp_path / "pruned.yaml"
+        kept.write_text("original")
+        pruned.write_text("original")
+        kept_mtime = kept.stat().st_mtime
+        pruned_mtime = pruned.stat().st_mtime
+        failed = {
+            str(kept): {"tool": "patch", "error_preview": "err", "snapshot_mtime": kept_mtime},
+            str(pruned): {"tool": "patch", "error_preview": "err", "snapshot_mtime": pruned_mtime},
+        }
+        # Only modify pruned
+        time.sleep(0.05)
+        pruned.write_text("recovered via terminal")
+        result = AIAgent._prune_recovered_file_mutations(failed)
+        assert str(kept) in result
+        assert str(pruned) not in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The file-mutation verifier flags paths where `write_file`/`patch` failed and were never succeeded. But when the agent recovers via a non-mutating tool (`terminal` running `hermes config set`, `git mv`, `sed -i`, etc.), the verifier doesn't know the file was actually modified — it only tracks `write_file`/`patch` successes.

This causes false-positive footers like:
```
⚠️ File-mutation verifier: 1 file(s) were NOT modified this turn despite any wording above that may suggest otherwise.
  • /root/.hermes/config.yaml — [patch] Write denied: protected file
```
...even though the agent successfully updated the config via `hermes config set` on the next line.

## Fix

**Snapshot mtime at failure time, re-verify at turn end.**

1. `_record_file_mutation_result` now stores `snapshot_mtime` alongside the error info when a failure is recorded
2. New `_prune_recovered_file_mutations` static method checks each failed path's current mtime against the snapshot — if the file changed, the entry is dropped
3. Called in `conversation_loop.py` just before `_format_file_mutation_failure_footer`

This catches recovery via *any* tool that modifies the file, without needing to enumerate all possible recovery paths.

## Tests

5 new test cases in `TestPruneRecoveredFileMutations`:
- `test_empty_dict_returns_empty`
- `test_unmodified_file_kept` — file unchanged → entry stays (real failure)
- `test_modified_file_pruned` — file changed → entry dropped (recovered)
- `test_file_didnt_exist_at_failure_now_exists` — file created → dropped
- `test_file_still_missing_kept` — still missing → stays
- `test_mixed_recovery` — some recovered, some not → only unrecovered remain

All 39 tests pass (33 existing + 6 new).