### PR TITLE
fix(gateway): respect explicit platform enabled:false in YAML config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1252,8 +1252,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
     if telegram_token:
         if Platform.TELEGRAM not in config.platforms:
-            config.platforms[Platform.TELEGRAM] = PlatformConfig()
-        config.platforms[Platform.TELEGRAM].enabled = True
+            # No yaml config — env-only setup, enable it
+            config.platforms[Platform.TELEGRAM] = PlatformConfig(enabled=True)
+        # If YAML config exists, respect its enabled flag (don't override
+        # explicit enabled: false). Token is still stored so skills that
+        # send Telegram messages can use it without activating the gateway
+        # adapter.
         config.platforms[Platform.TELEGRAM].token = telegram_token
     
     # Reply threading mode for Telegram (off/first/all)
@@ -1284,8 +1288,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     discord_token = os.getenv("DISCORD_BOT_TOKEN")
     if discord_token:
         if Platform.DISCORD not in config.platforms:
-            config.platforms[Platform.DISCORD] = PlatformConfig()
-        config.platforms[Platform.DISCORD].enabled = True
+            # No yaml config — env-only setup, enable it
+            config.platforms[Platform.DISCORD] = PlatformConfig(enabled=True)
+        # If YAML config exists, respect its enabled flag (don't override
+        # explicit enabled: false). Token is still stored so skills that
+        # send Discord messages can use it without activating the gateway
+        # adapter.
         config.platforms[Platform.DISCORD].token = discord_token
     
     discord_home = os.getenv("DISCORD_HOME_CHANNEL")
@@ -1880,11 +1888,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                     )
                     seed_for_probe = None
 
-            # Only consult is_connected for platforms that are NOT already
-            # explicitly configured in YAML / env (existing_cfg with
-            # enabled=True means the user wrote it themselves or another
-            # env-var bridge enabled it — keep that decision).
-            if existing_cfg is None or not existing_cfg.enabled:
+            # Only consult is_connected for platforms that have NO existing
+            # config at all.  When YAML explicitly sets enabled: false, the
+            # user has made a deliberate choice — do NOT auto-enable even if
+            # the plugin's env vars are present.  This prevents profile-level
+            # platform disabling from being overridden by shared .env tokens.
+            if existing_cfg is None:
                 if entry.is_connected is not None:
                     try:
                         # Probe with ``enabled=True`` since we're asking
@@ -1930,29 +1939,30 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                             entry.name,
                         )
                         continue
-            if platform not in config.platforms:
-                config.platforms[platform] = PlatformConfig()
-            config.platforms[platform].enabled = True
-            # Commit env-seeded extras onto the now-enabled platform.
-            # We've already called ``env_enablement_fn`` above (for the
-            # probe); reuse that result instead of calling it twice.
-            if isinstance(seed_for_probe, dict) and seed_for_probe:
-                seed = dict(seed_for_probe)
-                # Extract the home_channel dict (if provided) so we wire it
-                # up as a proper HomeChannel dataclass.  Everything else is
-                # merged into ``extra``.
-                home = seed.pop("home_channel", None)
-                config.platforms[platform].extra.update(seed)
-                if isinstance(home, dict) and home.get("chat_id"):
-                    config.platforms[platform].home_channel = HomeChannel(
-                        platform=platform,
-                        chat_id=str(home["chat_id"]),
-                        name=str(home.get("name") or "Home"),
-                        thread_id=(
-                            str(home["thread_id"])
-                            if home.get("thread_id")
-                            else None
-                        ),
-                    )
+            if existing_cfg is None:
+                if platform not in config.platforms:
+                    config.platforms[platform] = PlatformConfig()
+                config.platforms[platform].enabled = True
+                # Commit env-seeded extras onto the now-enabled platform.
+                # We've already called ``env_enablement_fn`` above (for the
+                # probe); reuse that result instead of calling it twice.
+                if isinstance(seed_for_probe, dict) and seed_for_probe:
+                    seed = dict(seed_for_probe)
+                    # Extract the home_channel dict (if provided) so we wire it
+                    # up as a proper HomeChannel dataclass.  Everything else is
+                    # merged into ``extra``.
+                    home = seed.pop("home_channel", None)
+                    config.platforms[platform].extra.update(seed)
+                    if isinstance(home, dict) and home.get("chat_id"):
+                        config.platforms[platform].home_channel = HomeChannel(
+                            platform=platform,
+                            chat_id=str(home["chat_id"]),
+                            name=str(home.get("name") or "Home"),
+                            thread_id=(
+                                str(home["thread_id"])
+                                if home.get("thread_id")
+                                else None
+                            ),
+                        )
     except Exception as e:
         logger.debug("Plugin platform enable pass failed: %s", e)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -815,4 +815,63 @@ class TestHomeChannelEnvOverrides:
 
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
-            assert (home.chat_id, home.name) == expected, platform.value
+            assert home.chat_id == expected[0]
+            assert home.name == expected[1]
+
+
+class TestEnvOverrideRespectsExplicitDisable:
+    """Env token presence must NOT override explicit enabled: false in YAML config.
+
+    Regression tests for #35555: profile config platforms.telegram.enabled: false
+    was ignored when TELEGRAM_BOT_TOKEN was in the environment.
+    """
+
+    def test_telegram_env_token_does_not_override_yaml_disabled(self):
+        """TELEGRAM_BOT_TOKEN in env should NOT auto-enable when YAML says enabled: false."""
+        config = GatewayConfig(platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=False),
+        })
+        with patch.dict(os.environ, {"TELEGRAM_BOT_TOKEN": "bot123"}, clear=False):
+            _apply_env_overrides(config)
+        # YAML's explicit enabled: false must be respected
+        assert config.platforms[Platform.TELEGRAM].enabled is False
+        # Token should still be stored for skills that send Telegram messages
+        assert config.platforms[Platform.TELEGRAM].token == "bot123"
+
+    def test_telegram_env_token_auto_enables_when_no_yaml_config(self):
+        """TELEGRAM_BOT_TOKEN in env should auto-enable when no YAML config exists."""
+        config = GatewayConfig()
+        assert Platform.TELEGRAM not in config.platforms
+        with patch.dict(os.environ, {"TELEGRAM_BOT_TOKEN": "bot123"}, clear=False):
+            _apply_env_overrides(config)
+        assert config.platforms[Platform.TELEGRAM].enabled is True
+        assert config.platforms[Platform.TELEGRAM].token == "bot123"
+
+    def test_telegram_env_token_preserves_yaml_enabled_true(self):
+        """TELEGRAM_BOT_TOKEN should not disable a platform that YAML enabled."""
+        config = GatewayConfig(platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True),
+        })
+        with patch.dict(os.environ, {"TELEGRAM_BOT_TOKEN": "bot123"}, clear=False):
+            _apply_env_overrides(config)
+        assert config.platforms[Platform.TELEGRAM].enabled is True
+        assert config.platforms[Platform.TELEGRAM].token == "bot123"
+
+    def test_discord_env_token_does_not_override_yaml_disabled(self):
+        """DISCORD_BOT_TOKEN in env should NOT auto-enable when YAML says enabled: false."""
+        config = GatewayConfig(platforms={
+            Platform.DISCORD: PlatformConfig(enabled=False),
+        })
+        with patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "discord123"}, clear=False):
+            _apply_env_overrides(config)
+        assert config.platforms[Platform.DISCORD].enabled is False
+        assert config.platforms[Platform.DISCORD].token == "discord123"
+
+    def test_discord_env_token_auto_enables_when_no_yaml_config(self):
+        """DISCORD_BOT_TOKEN in env should auto-enable when no YAML config exists."""
+        config = GatewayConfig()
+        assert Platform.DISCORD not in config.platforms
+        with patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "discord123"}, clear=False):
+            _apply_env_overrides(config)
+        assert config.platforms[Platform.DISCORD].enabled is True
+        assert config.platforms[Platform.DISCORD].token == "discord123"


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `platforms.telegram.enabled: false` (and `platforms.discord.enabled: false`) in profile config.yaml is ignored when `TELEGRAM_BOT_TOKEN` / `DISCORD_BOT_TOKEN` is present in the environment. The gateway would still connect to these platforms despite the explicit disable, breaking multi-profile setups where some profiles should not have certain platforms active.

## Related Issue

Fixes #35555

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/config.py`: Fixed two code paths in `_apply_env_overrides()` that unconditionally set `enabled=True` when env tokens are present:
  - Hardcoded Telegram/Discord token blocks: now only auto-enable when no YAML config exists (env-only setup)
  - Plugin auto-enablement loop: now skips entirely when `existing_cfg` is present (YAML config exists), preventing `is_connected` probes from overriding explicit `enabled: false`
- `tests/gateway/test_config.py`: Added 5 regression tests in `TestEnvOverrideRespectsExplicitDisable` covering Telegram and Discord: explicit disable respected, auto-enable for env-only, and preserve existing enabled state

## How to Test

1. Create a profile config with `platforms.telegram.enabled: false`
2. Have `TELEGRAM_BOT_TOKEN` in `.env` (shared across profiles)
3. Start gateway: `hermes -p <profile> gateway run`
4. Verify: gateway does NOT connect to Telegram (before fix, it would connect)
5. Run tests: `pytest tests/gateway/test_config.py -k "TestEnvOverrideRespectsExplicitDisable" -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/config.py:_apply_env_overrides` (callers: `load_gateway_config`, 1 call site)
- Blast radius: LOW — changes only affect the env-override → platform-enable decision; no schema/API changes
- Related patterns: WhatsApp (lines 1316-1325) and Slack (lines 1337-1347) already implement the correct "respect explicit disable" pattern. This fix aligns Telegram and Discord with that established behavior.
