### PR TITLE
docs(google-workspace): align setup helper flags

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -61,15 +61,16 @@ Calendar/Drive/Sheets/Docs?"**
   Passwords) and takes 2 minutes to set up. No Google Cloud project needed.
   Load the himalaya skill and follow its setup instructions.
 
-- **Email + Calendar** → Continue with this skill, but use
-  `--services email,calendar` during auth so the consent screen only asks for
-  the scopes they actually need.
+- **Email + Calendar** → Continue with this skill. The current setup helper
+  requests the standard Google Workspace scope set; Google may still let the
+  user deselect individual permissions on the consent screen.
 
-- **Calendar/Drive/Sheets/Docs only** → Continue with this skill and use a
-  narrower `--services` set like `calendar,drive,sheets,docs`.
+- **Calendar/Drive/Sheets/Docs only** → Continue with this skill. If the user
+  deselects unused permissions on the Google consent screen, Hermes stores the
+  subset Google actually grants and warns if some services may be unavailable.
 
-- **Full Workspace access** → Continue with this skill and use the default
-  `all` service set.
+- **Full Workspace access** → Continue with this skill and approve the full
+  scope set on the consent screen.
 
 **Question 2: "Does your Google account use Advanced Protection (hardware
 security keys required to sign in)? If you're not sure, you probably don't
@@ -116,19 +117,17 @@ explicit (for example `~/Downloads/hermes-google-client-secret.json`), then run
 
 ### Step 3: Get authorization URL
 
-Use the service set chosen in Step 1. Examples:
+Run:
 
 ```bash
-$GSETUP --auth-url --services email,calendar --format json
-$GSETUP --auth-url --services calendar,drive,sheets,docs --format json
-$GSETUP --auth-url --services all --format json
+$GSETUP --auth-url
 ```
 
-This returns JSON with an `auth_url` field and also saves the exact URL to
-`~/.hermes/google_oauth_last_url.txt`.
+This prints the OAuth URL as plain text and saves the pending PKCE verifier to
+`~/.hermes/google_oauth_pending.json` for the later code exchange.
 
 Agent rules for this step:
-- Extract the `auth_url` field and send that exact URL to the user as a single line.
+- Send the printed URL to the user as a single line.
 - Tell the user that the browser will likely fail on `http://localhost:1` after approval, and that this is expected.
 - Tell them to copy the ENTIRE redirected URL from the browser address bar.
 - If the user gets `Error 403: access_denied`, send them directly to `https://console.cloud.google.com/auth/audience` to add themselves as a test user.
@@ -141,13 +140,13 @@ pending OAuth session locally so `--auth-code` can complete the PKCE exchange
 later, even on headless systems:
 
 ```bash
-$GSETUP --auth-code "THE_URL_OR_CODE_THE_USER_PASTED" --format json
+$GSETUP --auth-code "THE_URL_OR_CODE_THE_USER_PASTED"
 ```
 
-If `--auth-code` fails because the code expired, was already used, or came from
-an older browser tab, it now returns a fresh `fresh_auth_url`. In that case,
-immediately send the new URL to the user and have them retry with the newest
-browser redirect only.
+If `--auth-code` fails because the code expired, was already used, came from
+an older browser tab, or otherwise cannot be exchanged, run `--auth-url` again,
+send the fresh URL to the user, and have them retry with the newest browser
+redirect only.
 
 ### Step 5: Verify
 

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -6,6 +6,8 @@ code exchange happen in separate process invocations.
 
 import importlib.util
 import json
+import re
+import shlex
 import sys
 import types
 from pathlib import Path
@@ -16,6 +18,10 @@ import pytest
 SCRIPT_PATH = (
     Path(__file__).resolve().parents[2]
     / "skills/productivity/google-workspace/scripts/setup.py"
+)
+SKILL_DOC_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/google-workspace/SKILL.md"
 )
 
 
@@ -130,6 +136,28 @@ def setup_module(monkeypatch, tmp_path):
     }
     module.CLIENT_SECRET_PATH.write_text(json.dumps(client_secret))
     return module
+
+
+class TestSkillDocs:
+    def test_setup_examples_use_flags_supported_by_setup_script(self):
+        """Keep SKILL.md's documented setup commands aligned with setup.py argparse."""
+        script_text = SCRIPT_PATH.read_text()
+        supported_flags = set(re.findall(r'add_argument\("(--[\w-]+)"', script_text))
+        assert supported_flags
+
+        doc_text = SKILL_DOC_PATH.read_text()
+        setup_lines = [line.strip() for line in doc_text.splitlines() if "$GSETUP" in line]
+        assert setup_lines
+
+        unsupported = []
+        for line in setup_lines:
+            command_tail = line.split("$GSETUP", 1)[1].replace("`", "")
+            args = shlex.split(command_tail)
+            for arg in args:
+                if arg.startswith("--") and arg not in supported_flags:
+                    unsupported.append((line, arg))
+
+        assert unsupported == []
 
 
 class TestGetAuthUrl:


### PR DESCRIPTION
## Summary
- Aligns the bundled google-workspace skill's OAuth setup examples with the flags that `scripts/setup.py` actually accepts.
- Closes #35560.

## Why
- `SKILL.md` documented `--services` and `--format` flags from an unmerged scoped-OAuth interface, so the documented fresh-auth path failed with `argparse` `unrecognized arguments` errors on current `main`.

## Changes
- `skills/productivity/google-workspace/SKILL.md`: removes unsupported setup flags, documents the current plain-text auth URL output, pending PKCE state file, and retry path.
- `tests/skills/test_google_oauth_setup.py`: adds a regression check that `$GSETUP` examples in the skill doc only use flags declared by `setup.py`.

## Validation
- `python -m pytest tests/skills/test_google_oauth_setup.py tests/skills/test_google_workspace_credential_files.py -q -o 'addopts='`
- `python -m ruff check tests/skills/test_google_oauth_setup.py`
- `git diff --check`

## Scope
- In scope: documentation/test alignment for the setup helper that ships today.
- Out of scope: adding the future scoped `--services` / JSON `--format` interface tracked by #17087.
