### PR TITLE
feat: add semantic Workit M365 approvals

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -9,6 +9,7 @@ Uses python-telegram-bot library for:
 
 import asyncio
 import dataclasses
+import hashlib
 import json
 import logging
 import os
@@ -2577,6 +2578,52 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_update_prompt failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    def _format_workit_m365_approval_text(self, request: Dict[str, Any]) -> str:
+        def _value(key: str, default: str = "—") -> str:
+            value = request.get(key)
+            if value is None or value == "":
+                return default
+            if isinstance(value, (list, tuple)):
+                return ", ".join(str(v) for v in value) or default
+            return str(value)
+
+        targets = request.get("targets") or request.get("resources") or []
+        if isinstance(targets, (list, tuple)):
+            if len(targets) > 5:
+                payload_hash = str(request.get("payload_hash") or "")
+                digest = payload_hash[:12] or hashlib.sha256(
+                    json.dumps(list(targets), ensure_ascii=False, sort_keys=True).encode("utf-8")
+                ).hexdigest()[:12]
+                targets_text = f"{len(targets)} itens (hash={digest})"
+            else:
+                targets_text = ", ".join(str(t) for t in targets) or "—"
+        else:
+            targets_text = str(targets) if targets else "—"
+
+        ttl_seconds = request.get("ttl_seconds", 1800)
+        try:
+            ttl_minutes = max(1, int(ttl_seconds) // 60)
+        except (TypeError, ValueError):
+            ttl_minutes = 30
+        approval_id = str(request.get("approval_id") or request.get("id") or "")
+        short_id = approval_id[:12] if approval_id else "—"
+
+        lines = [
+            "⚠️ <b>Aprovação necessária — Workit/M365</b>",
+            "",
+            f"Operação: {_html.escape(_value('operation', _value('operation_class')))}",
+            f"Conta: {_html.escape(_value('account'))}",
+            f"Destinatários/recursos: {_html.escape(targets_text)}",
+            f"Assunto/título: {_html.escape(_value('title', _value('subject')))}",
+            f"Efeito: {_html.escape(_value('side_effects'))}",
+            f"Escopos: {_html.escape(_value('required_scopes'))}",
+            f"Validade: {ttl_minutes} min",
+            f"ID: {_html.escape(short_id)}",
+            "",
+            "Aprovar ou negar?",
+        ]
+        return "\n".join(lines)
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
@@ -2591,12 +2638,20 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
-            cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
-            text = (
-                f"⚠️ <b>Command Approval Required</b>\n\n"
-                f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
-                f"Reason: {_html.escape(description)}"
-            )
+            approval_request = (metadata or {}).get("approval_request")
+            if (
+                isinstance(approval_request, dict)
+                and approval_request.get("system") == "khaw-workit"
+                and approval_request.get("provider") == "m365"
+            ):
+                text = self._format_workit_m365_approval_text(approval_request)
+            else:
+                cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
+                text = (
+                    f"⚠️ <b>Command Approval Required</b>\n\n"
+                    f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
+                    f"Reason: {_html.escape(description)}"
+                )
 
             # Resolve thread context for thread replies
             thread_id = self._metadata_thread_id(metadata)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17361,6 +17361,11 @@ class GatewayRunner:
 
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
+                approval_metadata = dict(_status_thread_metadata or {})
+                if approval_data.get("metadata") is not None:
+                    approval_metadata["approval_request"] = approval_data.get("metadata")
+                if approval_data.get("approval_type") is not None:
+                    approval_metadata["approval_type"] = approval_data.get("approval_type")
 
                 # Prefer button-based approval when the adapter supports it.
                 # Check the *class* for the method, not the instance — avoids
@@ -17373,7 +17378,7 @@ class GatewayRunner:
                                 command=cmd,
                                 session_key=_approval_session_key,
                                 description=desc,
-                                metadata=_status_thread_metadata,
+                                metadata=approval_metadata,
                             ),
                             _loop_for_step,
                             logger=logger,
@@ -17407,7 +17412,7 @@ class GatewayRunner:
                         _status_adapter.send(
                             _status_chat_id,
                             msg,
-                            metadata=_status_thread_metadata,
+                            metadata=approval_metadata,
                         ),
                         _loop_for_step,
                         logger=logger,

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -169,6 +169,91 @@ class TestTelegramExecApproval:
         assert "message_thread_id" not in call_log[1] or call_log[1]["message_thread_id"] is None
 
     @pytest.mark.asyncio
+    async def test_workit_semantic_approval_renders_decision_metadata_without_raw_secrets(self):
+        adapter = _make_adapter()
+        sent = {}
+
+        async def mock_send_message(**kwargs):
+            sent.update(kwargs)
+            return SimpleNamespace(message_id=42)
+
+        adapter._bot.send_message = AsyncMock(side_effect=mock_send_message)
+
+        result = await adapter.send_exec_approval(
+            chat_id="12345",
+            command="",
+            session_key="s",
+            description="khaw workit semantic approval",
+            metadata={
+                "approval_request": {
+                    "system": "khaw-workit",
+                    "provider": "m365",
+                    "approval_id": "approval-abcdef123456",
+                    "account": "bernardo@hapvida.example",
+                    "operation": "m365.outlook.send",
+                    "targets": ["a@example.com", "b@example.com"],
+                    "title": "Reunião Hapvida",
+                    "side_effects": "Envia email externo",
+                    "required_scopes": ["Mail.Send"],
+                    "ttl_seconds": 1800,
+                    "body": "SEGREDO corpo bruto do email",
+                    "access_token": "tok-secret-123",
+                    "attachments": [{"name": "plano.pdf", "content": "PDF-RAW"}],
+                }
+            },
+        )
+
+        assert result.success is True
+        text = sent["text"]
+        assert "Aprovação necessária — Workit/M365" in text
+        assert "Operação: m365.outlook.send" in text
+        assert "Conta: bernardo@hapvida.example" in text
+        assert "Destinatários/recursos: a@example.com, b@example.com" in text
+        assert "Assunto/título: Reunião Hapvida" in text
+        assert "Efeito: Envia email externo" in text
+        assert "Escopos: Mail.Send" in text
+        assert "Validade: 30 min" in text
+        assert "ID: approval" in text
+        assert "SEGREDO" not in text
+        assert "tok-secret" not in text
+        assert "PDF-RAW" not in text
+
+    @pytest.mark.asyncio
+    async def test_workit_semantic_approval_summarizes_large_recipient_lists(self):
+        adapter = _make_adapter()
+        sent = {}
+
+        async def mock_send_message(**kwargs):
+            sent.update(kwargs)
+            return SimpleNamespace(message_id=42)
+
+        adapter._bot.send_message = AsyncMock(side_effect=mock_send_message)
+        targets = [f"user{i}@example.com" for i in range(20)]
+
+        result = await adapter.send_exec_approval(
+            chat_id="12345",
+            command="",
+            session_key="s",
+            description="khaw workit semantic approval",
+            metadata={
+                "approval_request": {
+                    "system": "khaw-workit",
+                    "provider": "m365",
+                    "operation": "m365.outlook.send",
+                    "targets": targets,
+                    "ttl_seconds": 1800,
+                    "payload_hash": "payloadhash1234567890",
+                }
+            },
+        )
+
+        assert result.success is True
+        text = sent["text"]
+        assert "20 itens" in text
+        assert "hash=" in text
+        assert "user19@example.com" not in text
+
+    @pytest.mark.asyncio
     async def test_not_connected(self):
         adapter = _make_adapter()
         adapter._bot = None

--- a/tests/tools/test_semantic_gateway_approval.py
+++ b/tests/tools/test_semantic_gateway_approval.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import threading
+
+from tools.approval import (
+    register_gateway_notify,
+    request_gateway_approval,
+    resolve_gateway_approval,
+    unregister_gateway_notify,
+)
+
+
+def test_request_gateway_approval_enqueues_structured_metadata_without_shell_command():
+    session_key = "semantic-session"
+    observed = {}
+
+    def notify(data):
+        observed.update(data)
+        threading.Timer(0.01, lambda: resolve_gateway_approval(session_key, "once")).start()
+
+    register_gateway_notify(session_key, notify)
+    try:
+        result = request_gateway_approval(
+            session_key,
+            description="Workit/M365 write approval",
+            metadata={
+                "system": "khaw-workit",
+                "provider": "m365",
+                "operation": "m365.outlook.send",
+                "payload_hash": "abc123",
+            },
+        )
+    finally:
+        unregister_gateway_notify(session_key)
+
+    assert result["approved"] is True
+    assert observed["approval_type"] == "semantic"
+    assert observed["command"] == ""
+    assert observed["metadata"]["operation"] == "m365.outlook.send"
+    assert observed["metadata"]["payload_hash"] == "abc123"
+
+
+def test_request_gateway_approval_fails_closed_without_gateway_notify():
+    result = request_gateway_approval(
+        "missing-session",
+        description="Workit/M365 write approval",
+        metadata={"system": "khaw-workit"},
+    )
+
+    assert result["approved"] is False
+    assert result["reason"] == "gateway_notify_unavailable"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -586,6 +586,55 @@ def has_blocking_approval(session_key: str) -> bool:
         return bool(_gateway_queues.get(session_key))
 
 
+def request_gateway_approval(
+    session_key: str,
+    *,
+    description: str,
+    metadata: dict,
+    timeout_surface: str = "gateway",
+) -> dict:
+    """Request a structured, non-shell approval through the gateway queue.
+
+    This is for semantic business operations (for example, Workit/M365 writes)
+    that need the same live user approval path as dangerous shell commands
+    without fabricating a command string just to trigger regex-based guards.
+    """
+    with _lock:
+        notify_cb = _gateway_notify_cbs.get(session_key)
+    if not notify_cb:
+        return {
+            "approved": False,
+            "message": "BLOCKED: gateway approval callback unavailable",
+            "reason": "gateway_notify_unavailable",
+        }
+
+    approval_data = {
+        "command": "",
+        "description": description,
+        "pattern_key": "semantic",
+        "pattern_keys": ["semantic"],
+        "approval_type": "semantic",
+        "metadata": dict(metadata or {}),
+    }
+    outcome = _await_gateway_decision(
+        session_key,
+        notify_cb,
+        approval_data,
+        surface=timeout_surface,
+    )
+    choice = outcome.get("choice")
+    if not outcome.get("resolved"):
+        return {
+            "approved": False,
+            "message": "BLOCKED: gateway approval timed out or failed",
+            "reason": "timeout_or_notify_failed",
+            "notify_failed": bool(outcome.get("notify_failed")),
+        }
+    if choice == "deny" or not choice:
+        return {"approved": False, "message": "BLOCKED: User denied approval", "reason": "denied"}
+    return {"approved": True, "choice": choice, "metadata": dict(metadata or {})}
+
+
 def submit_pending(session_key: str, approval: dict):
     """Store a pending approval request for a session."""
     with _lock:


### PR DESCRIPTION
## Summary\n- add structured gateway approval API for semantic non-shell operations\n- pass semantic approval metadata through gateway notification routing\n- render Workit/M365 approval popups in Telegram without raw bodies/tokens/attachments\n\n## Tests\n- python -m pytest tests/tools/test_semantic_gateway_approval.py tests/gateway/test_telegram_approval_buttons.py -q -o 'addopts='