### PR TITLE
fix(auxiliary): read task-specific extra_body from config in get_auxiliary_extra_body()

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4131,13 +4131,25 @@ def resolve_vision_provider_client(
     return requested, client, final_model
 
 
-def get_auxiliary_extra_body() -> dict:
+def get_auxiliary_extra_body(task: str = "") -> dict:
     """Return extra_body kwargs for auxiliary API calls.
-    
+
     Includes Nous Portal product tags when the auxiliary client is backed
-    by Nous Portal. Returns empty dict otherwise.
+    by Nous Portal.  When *task* is given, the task-specific
+    ``auxiliary.<task>.extra_body`` from ``config.yaml`` is merged on top
+    so user-configured extras (e.g. ``chat_template_kwargs``) reach the
+    provider.
     """
-    return _nous_extra_body() if auxiliary_is_nous else {}
+    result = _nous_extra_body() if auxiliary_is_nous else {}
+    if task:
+        try:
+            task_cfg = _get_auxiliary_task_config(task)
+            task_extra = task_cfg.get("extra_body", {}) or {}
+            if isinstance(task_extra, dict):
+                result.update(task_extra)
+        except Exception:
+            pass
+    return result
 
 
 def auxiliary_max_tokens_param(value: int) -> dict:

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -446,7 +446,7 @@ def judge_goal(
             temperature=0,
             max_tokens=_goal_judge_max_tokens(),
             timeout=timeout,
-            extra_body=get_auxiliary_extra_body() or None,
+            extra_body=get_auxiliary_extra_body("goal_judge") or None,
         )
     except Exception as exc:
         logger.info("goal judge: API call failed (%s) — falling through to continue", exc)

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -333,7 +333,7 @@ def decompose_task(
             temperature=0.3,
             max_tokens=4000,
             timeout=timeout or 180,
-            extra_body=get_auxiliary_extra_body() or None,
+            extra_body=get_auxiliary_extra_body("kanban_decomposer") or None,
         )
     except Exception as exc:
         logger.info(

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -192,7 +192,7 @@ def specify_task(
             temperature=0.3,
             max_tokens=HERMES_KANBAN_SPECIFY_MAX_TOKENS,
             timeout=timeout or 120,
-            extra_body=get_auxiliary_extra_body() or None,
+            extra_body=get_auxiliary_extra_body("triage_specifier") or None,
         )
     except Exception as exc:
         logger.info(

--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -246,7 +246,7 @@ def describe_profile(
             temperature=0.3,
             max_tokens=400,
             timeout=timeout or 60,
-            extra_body=get_auxiliary_extra_body() or None,
+            extra_body=get_auxiliary_extra_body("profile_describer") or None,
         )
     except Exception as exc:
         logger.info("describe: API call failed for %s (%s)", canon, exc)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2004,6 +2004,77 @@ class TestAuxiliaryTaskExtraBody:
         assert not any("OPENAI_BASE_URL is set" in rec.message for rec in caplog.records), \
             "Should NOT warn when OPENAI_BASE_URL is not set"
 
+    def test_get_auxiliary_extra_body_merges_task_config(self):
+        """get_auxiliary_extra_body(task) merges task-specific extra_body from config."""
+        import agent.auxiliary_client as mod
+
+        config = {
+            "auxiliary": {
+                "profile_describer": {
+                    "extra_body": {
+                        "chat_template_kwargs": {"enable_thinking": False},
+                    }
+                }
+            }
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config), \
+             patch.object(mod, "auxiliary_is_nous", False):
+            result = mod.get_auxiliary_extra_body("profile_describer")
+
+        assert result["chat_template_kwargs"] == {"enable_thinking": False}
+
+    def test_get_auxiliary_extra_body_no_task_returns_base(self):
+        """get_auxiliary_extra_body() without task returns base result only."""
+        import agent.auxiliary_client as mod
+
+        with patch.object(mod, "auxiliary_is_nous", False):
+            result = mod.get_auxiliary_extra_body()
+
+        assert result == {}
+
+    def test_get_auxiliary_extra_body_task_without_extra_body(self):
+        """get_auxiliary_extra_body(task) when task has no extra_body returns base."""
+        import agent.auxiliary_client as mod
+
+        config = {"auxiliary": {"profile_describer": {"model": "qwen3"}}}
+
+        with patch("hermes_cli.config.load_config", return_value=config), \
+             patch.object(mod, "auxiliary_is_nous", False):
+            result = mod.get_auxiliary_extra_body("profile_describer")
+
+        assert result == {}
+
+    def test_get_auxiliary_extra_body_task_config_error_returns_base(self):
+        """get_auxiliary_extra_body(task) returns base result when config load fails."""
+        import agent.auxiliary_client as mod
+
+        with patch("hermes_cli.config.load_config", side_effect=ImportError("no config")), \
+             patch.object(mod, "auxiliary_is_nous", False):
+            result = mod.get_auxiliary_extra_body("profile_describer")
+
+        assert result == {}
+
+    def test_get_auxiliary_extra_body_nous_plus_task_config(self):
+        """get_auxiliary_extra_body(task) merges Nous extras AND task extras."""
+        import agent.auxiliary_client as mod
+
+        config = {
+            "auxiliary": {
+                "web_extract": {
+                    "extra_body": {"custom_param": True},
+                }
+            }
+        }
+
+        with patch("hermes_cli.config.load_config", return_value=config), \
+             patch.object(mod, "auxiliary_is_nous", True), \
+             patch.object(mod, "_nous_extra_body", return_value={"tags": ["test"]}):
+            result = mod.get_auxiliary_extra_body("web_extract")
+
+        assert result["tags"] == ["test"]
+        assert result["custom_param"] is True
+
 # ---------------------------------------------------------------------------
 # Anthropic-compatible image block conversion
 # ---------------------------------------------------------------------------

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -304,7 +304,7 @@ def _resolve_web_extract_auxiliary(model: Optional[str] = None) -> tuple[Optiona
     if client is not None and _is_nous_auxiliary_client(client):
         from agent.auxiliary_client import get_auxiliary_extra_body
         from agent.portal_tags import nous_portal_tags
-        extra_body = get_auxiliary_extra_body() or {"tags": nous_portal_tags()}
+        extra_body = get_auxiliary_extra_body("web_extract") or {"tags": nous_portal_tags()}
 
     return client, effective_model, extra_body
 


### PR DESCRIPTION
## What does this PR do?

Fixes `get_auxiliary_extra_body()` to read task-specific `extra_body` from `auxiliary.<task>.extra_body` in `config.yaml`. Previously, the function only returned Nous Portal tags or `{}` for non-Nous providers, silently ignoring user-configured extras like `chat_template_kwargs: {enable_thinking: false}`.

## Related Issue

Fixes #35566

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: Add optional `task` parameter to `get_auxiliary_extra_body()`. When given, reads `auxiliary.<task>.extra_body` via `_get_auxiliary_task_config()` and merges it into the result.
- `hermes_cli/goals.py`: Pass `"goal_judge"` task name to `get_auxiliary_extra_body()`
- `hermes_cli/kanban_specify.py`: Pass `"triage_specifier"` task name
- `hermes_cli/kanban_decompose.py`: Pass `"kanban_decomposer"` task name
- `hermes_cli/profile_describer.py`: Pass `"profile_describer"` task name
- `tools/web_tools.py`: Pass `"web_extract"` task name
- `tests/agent/test_auxiliary_client.py`: Add 5 regression tests for the new `task` parameter behavior

## How to Test

1. Set `auxiliary.profile_describer.extra_body` in `config.yaml`:
   ```yaml
   auxiliary:
     profile_describer:
       extra_body:
         chat_template_kwargs:
           enable_thinking: false
   ```
2. Run `hermes profile describe researcher --auto`
3. Observe in agent logs (DEBUG level) that the HTTP request now includes `extra_body` with the configured `chat_template_kwargs`
4. Run `pytest tests/agent/test_auxiliary_client.py -k "test_get_auxiliary_extra_body" -v` — all 5 new tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `get_auxiliary_extra_body` in `agent/auxiliary_client.py` (callers: 5 direct call sites across goals, kanban_specify, kanban_decompose, profile_describer, web_tools)
- Blast radius: LOW — optional `task` parameter with empty default preserves backward compatibility for all existing callers
- Related patterns: `_get_task_extra_body()` (internal helper used by `call_llm`) already implements the same config-reading logic; this fix brings `get_auxiliary_extra_body()` to parity
