### PR TITLE
[codex] fix Feishu tool-call bridge

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -38,6 +38,11 @@ from utils import base_url_host_matches, base_url_hostname
 
 logger = logging.getLogger(__name__)
 
+_TOOL_CALL_BRACKET_RE = re.compile(
+    r"\[TOOL_CALL\]\s*(.*?)\s*\[/TOOL_CALL\]",
+    re.DOTALL | re.IGNORECASE,
+)
+
 
 def _ra():
     """Lazy ``run_agent`` reference.
@@ -48,6 +53,89 @@ def _ra():
     """
     import run_agent
     return run_agent
+
+
+def _make_bracket_tool_call(agent, tool_name: str, arguments: str, index: int) -> SimpleNamespace:
+    """Build a synthetic tool_call object from a text-encoded bridge tag."""
+    call_id = agent._deterministic_call_id(tool_name, arguments, index)
+    return SimpleNamespace(
+        id=call_id,
+        call_id=call_id,
+        response_item_id=None,
+        type="function",
+        function=SimpleNamespace(name=tool_name, arguments=arguments),
+    )
+
+
+def _extract_bracket_tool_calls(agent, content: str) -> tuple[list[SimpleNamespace], str]:
+    """Parse ``[TOOL_CALL]...[/TOOL_CALL]`` blocks into structured tool calls.
+
+    The bridge format is intentionally narrow:
+    - plain text payloads are treated as terminal commands
+    - JSON payloads may carry an explicit ``name`` and ``arguments``
+
+    Any extracted blocks are removed from the visible assistant content so
+    messaging surfaces do not echo the control text back to the user.
+    """
+    if not content:
+        return [], ""
+
+    extracted: list[SimpleNamespace] = []
+    consumed_spans: list[tuple[int, int]] = []
+
+    for match in _TOOL_CALL_BRACKET_RE.finditer(content):
+        raw_payload = match.group(1).strip()
+        if not raw_payload:
+            consumed_spans.append((match.start(), match.end()))
+            continue
+
+        tool_name = "terminal"
+        arguments: Any = {"command": raw_payload}
+
+        if raw_payload.startswith("{"):
+            try:
+                parsed = json.loads(raw_payload)
+            except Exception:
+                parsed = None
+            if isinstance(parsed, dict):
+                parsed_name = parsed.get("name")
+                parsed_arguments = parsed.get("arguments", {})
+                if isinstance(parsed_name, str) and parsed_name.strip():
+                    tool_name = parsed_name.strip()
+                    arguments = parsed_arguments
+                elif isinstance(parsed.get("command"), str) and parsed.get("command").strip():
+                    arguments = {"command": str(parsed.get("command")).strip()}
+
+        if not isinstance(arguments, str):
+            arguments = json.dumps(arguments, ensure_ascii=False)
+
+        extracted.append(
+            _make_bracket_tool_call(agent, tool_name, arguments, len(extracted))
+        )
+        consumed_spans.append((match.start(), match.end()))
+
+    if not consumed_spans:
+        return extracted, content.strip()
+
+    consumed_spans.sort()
+    merged: list[tuple[int, int]] = []
+    for start, end in consumed_spans:
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+
+    cleaned_parts: list[str] = []
+    cursor = 0
+    for start, end in merged:
+        if cursor < start:
+            cleaned_parts.append(content[cursor:start])
+        cursor = max(cursor, end)
+    if cursor < len(content):
+        cleaned_parts.append(content[cursor:])
+
+    cleaned = "\n".join(part.strip() for part in cleaned_parts if part and part.strip()).strip()
+    return extracted, cleaned
 
 
 def estimate_request_context_tokens(api_payload: Any) -> int:
@@ -854,6 +942,10 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
         from agent.redact import redact_sensitive_text
         _san_content = redact_sensitive_text(_san_content)
 
+    bridge_tool_calls: list[SimpleNamespace] = []
+    if isinstance(_san_content, str) and _san_content:
+        bridge_tool_calls, _san_content = _extract_bracket_tool_calls(agent, _san_content)
+
     msg = {
         "role": "assistant",
         "content": _san_content,
@@ -936,6 +1028,10 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     codex_message_items = getattr(assistant_message, "codex_message_items", None)
     if codex_message_items:
         msg["codex_message_items"] = codex_message_items
+
+    if bridge_tool_calls:
+        assistant_tool_calls = list(assistant_tool_calls or [])
+        assistant_tool_calls.extend(bridge_tool_calls)
 
     if assistant_tool_calls:
         tool_calls = []

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -146,6 +146,11 @@ from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
+_TOOL_CALL_BRACKET_RE = re.compile(
+    r"\[TOOL_CALL\]\s*(.*?)\s*\[/TOOL_CALL\]",
+    re.DOTALL | re.IGNORECASE,
+)
+
 # ---------------------------------------------------------------------------
 # Regex patterns
 # ---------------------------------------------------------------------------
@@ -2259,7 +2264,14 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def format_message(self, content: str) -> str:
         """Feishu text messages are plain text by default."""
-        return content.strip()
+        text = content.strip()
+        if not text:
+            return text
+        match = _TOOL_CALL_BRACKET_RE.search(text)
+        if match:
+            payload = match.group(1).strip() or "unknown command"
+            return f"⚠️ Unresolved tool call: {payload}"
+        return text
 
     # =========================================================================
     # Inbound event handlers

--- a/tests/feishu_tool_call_bridge_test.py
+++ b/tests/feishu_tool_call_bridge_test.py
@@ -1,0 +1,80 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.chat_completion_helpers import build_assistant_message
+from gateway.platforms.feishu import FeishuAdapter
+from model_tools import handle_function_call
+
+
+class _DummyAgent:
+    verbose_logging = False
+    reasoning_callback = None
+    stream_delta_callback = None
+    _stream_callback = None
+
+    @staticmethod
+    def _extract_reasoning(_assistant_message):
+        return None
+
+    @staticmethod
+    def _strip_think_blocks(content: str) -> str:
+        return content
+
+    @staticmethod
+    def _needs_thinking_reasoning_pad() -> bool:
+        return False
+
+    @staticmethod
+    def _split_responses_tool_id(_raw_id):
+        return None, None
+
+    @staticmethod
+    def _derive_responses_function_call_id(call_id, _response_item_id=None):
+        return f"fc_{call_id}"
+
+    @staticmethod
+    def _deterministic_call_id(fn_name: str, arguments: str, index: int = 0) -> str:
+        return f"{fn_name}:{index}:{arguments}"
+
+
+def test_tool_call_brackets_become_terminal_tool_calls():
+    agent = _DummyAgent()
+    assistant_message = SimpleNamespace(
+        content="[TOOL_CALL]whoami[/TOOL_CALL]",
+        tool_calls=None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+
+    msg = build_assistant_message(agent, assistant_message, "stop")
+
+    assert msg["content"] == ""
+    assert len(msg["tool_calls"]) == 1
+    tool_call = msg["tool_calls"][0]
+    assert tool_call["function"]["name"] == "terminal"
+    assert json.loads(tool_call["function"]["arguments"]) == {"command": "whoami"}
+
+
+def test_terminal_bridge_executes_and_surfaces_explicit_errors():
+    with patch("tools.terminal_tool.terminal_tool", return_value="ubuntu") as mock_terminal:
+        ok_result = handle_function_call("terminal", {"command": "whoami"}, task_id="bridge-test")
+
+    assert ok_result == "ubuntu"
+    mock_terminal.assert_called_once()
+
+    with patch("tools.terminal_tool.terminal_tool", side_effect=RuntimeError("terminal unavailable")):
+        err_result = handle_function_call("terminal", {"command": "whoami"}, task_id="bridge-test")
+
+    payload = json.loads(err_result)
+    assert "terminal unavailable" in payload["error"]
+
+
+def test_feishu_format_message_does_not_echo_tool_call_tags():
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+
+    formatted = adapter.format_message("[TOOL_CALL]whoami[/TOOL_CALL]")
+
+    assert "[TOOL_CALL]" not in formatted
+    assert formatted == "⚠️ Unresolved tool call: whoami"


### PR DESCRIPTION
## What changed
- Parse `[TOOL_CALL]...[/TOOL_CALL]` blocks into structured tool calls during assistant-message normalization.
- Add a Feishu fallback that replaces any leaked tool-call tags with an explicit unresolved-tool-call error instead of echoing raw tags.
- Add a regression test covering terminal execution, explicit tool errors, and Feishu formatting.

## Why
- Feishu was showing the bridge text verbatim instead of executing terminal commands.
- The existing terminal bridge already dispatches through `handle_function_call`, so the missing piece was parsing the bracketed tool-call text before final response delivery.

## Validation
- `pytest -q tests/feishu_tool_call_bridge_test.py` → **3 passed in 0.83s**
- `python -m py_compile` on all three changed files → **OK (no syntax errors)**
- `git diff --check` → **OK (no whitespace errors)**
