### PR TITLE
fix(gateway): attach MEDIA log documents

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1165,7 +1165,7 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     # Audio (delivered as voice/audio where supported)
     ".mp3", ".wav", ".ogg", ".opus", ".m4a", ".flac",
     # Documents (uploaded as file attachments)
-    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".epub",
+    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".log", ".epub",
     # Spreadsheets / data
     ".xlsx", ".xls", ".ods", ".csv", ".tsv", ".json", ".xml", ".yaml", ".yml",
     # Presentations

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -757,6 +757,19 @@ class TestSignalMediaExtraction:
         assert media[0][0] == "/tmp/reply.ogg"
         assert media[0][1] is True  # is_voice flag
 
+    @pytest.mark.parametrize("extension", ["md", "json", "yaml", "html", "log"])
+    def test_extract_media_finds_common_document_tags(self, extension):
+        """BasePlatformAdapter.extract_media should find generated document paths."""
+        from gateway.platforms.base import BasePlatformAdapter
+
+        media, cleaned = BasePlatformAdapter.extract_media(
+            f"Here's the generated report.\nMEDIA:/tmp/report.{extension}"
+        )
+
+        assert media == [(f"/tmp/report.{extension}", False)]
+        assert "MEDIA:" not in cleaned
+        assert f"report.{extension}" not in cleaned
+
     def test_signal_has_all_media_methods(self, monkeypatch):
         """SignalAdapter must override all media send methods used by gateway."""
         adapter = _make_signal_adapter(monkeypatch)

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -228,6 +228,37 @@ class TestSendMessageTool:
             force_document=False,
         )
 
+    def test_media_markdown_document_tag_is_extracted_for_attachment(self, tmp_path):
+        doc = tmp_path / "report.md"
+        doc.write_text("# Report\n", encoding="utf-8")
+        config, telegram_cfg = _make_config()
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:-1001",
+                        "message": f"Here is the report.\nMEDIA:{doc}",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            Platform.TELEGRAM,
+            telegram_cfg,
+            "-1001",
+            "Here is the report.",
+            thread_id=None,
+            media_files=[(str(doc.resolve()), False)],
+            force_document=False,
+        )
+
     def test_display_label_target_resolves_via_channel_directory(self, tmp_path):
         config, telegram_cfg = _make_config()
         cache_file = tmp_path / "channel_directory.json"


### PR DESCRIPTION
## Summary
- add `.log` to shared MEDIA delivery extensions so generated log files are extracted as attachments
- add regression coverage for generated document MEDIA tags (`.md`, `.json`, `.yaml`, `.html`, `.log`)
- add send_message coverage proving `MEDIA:/path/report.md` is stripped from visible text and passed as a native attachment

## Context
Upstream already has the shared MEDIA extension architecture and covers most generated document types. This closes the remaining `.log` gap and adds explicit regression tests for document-style MEDIA tags.

## Tests
- `python -m pytest tests/gateway/test_signal.py::TestSignalMediaExtraction::test_extract_media_finds_common_document_tags tests/tools/test_send_message_tool.py::TestSendMessageTool::test_media_markdown_document_tag_is_extracted_for_attachment -q -o 'addopts='` → 6 passed\n\n## Note\nA broader focused class run currently has an unrelated existing failure in `TestSendMessageTool.test_cron_duplicate_target_is_skipped_and_explained` (`KeyError: skipped`); the targeted regression tests above pass.\n