### PR TITLE
fix(tools): fall back to .hermes/.env when forwarded secret is empty

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -302,6 +302,40 @@ def test_init_env_args_prefers_shell_env_over_hermes_dotenv(monkeypatch):
     assert "value_from_dotenv" not in args_str
 
 
+def test_init_env_args_uses_hermes_dotenv_for_empty_shell_env(monkeypatch):
+    """A transient empty-string in the live env must fall back to .env, not win.
+
+    Regression: the disk fallback used to fire only on `value is None`, so a
+    present-but-empty `MY_SECRET=""` skipped it and was forwarded as `-e
+    MY_SECRET=`, clobbering the correct value sitting in ~/.hermes/.env.
+    """
+    env = _make_execute_only_env(["MY_SECRET"])
+
+    monkeypatch.setenv("MY_SECRET", "")
+    monkeypatch.setattr(docker_env, "_load_hermes_env_vars", lambda: {"MY_SECRET": "value_from_dotenv"})
+
+    args = env._build_init_env_args()
+
+    # Assert on the resolved value, not the printed -e flag: the disk value
+    # must win and a blank "MY_SECRET=" flag must never be emitted.
+    assert "MY_SECRET=value_from_dotenv" in args
+    assert "MY_SECRET=" not in args
+
+
+def test_init_env_args_never_forwards_blank_secret(monkeypatch):
+    """A legitimately-empty key with no disk value is not forwarded as -e KEY=."""
+    env = _make_execute_only_env(["MY_SECRET"])
+
+    monkeypatch.setenv("MY_SECRET", "")
+    monkeypatch.setattr(docker_env, "_load_hermes_env_vars", lambda: {})
+
+    args = env._build_init_env_args()
+
+    # The key must not appear at all — not even as an empty -e MY_SECRET= flag.
+    assert not any(a.startswith("MY_SECRET=") for a in args)
+    assert "MY_SECRET" not in " ".join(args)
+
+
 # ── docker_env tests ──────────────────────────────────────────────
 
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -814,9 +814,9 @@ class DockerEnvironment(BaseEnvironment):
         hermes_env = _load_hermes_env_vars() if forward_keys else {}
         for key in sorted(forward_keys):
             value = os.getenv(key)
-            if value is None:
+            if not value:
                 value = hermes_env.get(key)
-            if value is not None:
+            if value:
                 exec_env[key] = value
 
         args = []


### PR DESCRIPTION
N.B. Hermes did all the invetigation and work, I'm no python dev

**Expected behaviour:** When a forwarded secret is momentarily empty (`""`) in the gateway's live env, fall back to `/.hermes/.env` (as already happens when unset) and forward the correct value. A transient blank must never override a good on-disk secret, and an empty value must never be forwarded as `-e KEY=`.

**Actual behaviour:** The disk fallback only triggers on `value is None`, not `value == ""`. An empty string skips the fallback and is forwarded as `-e KEY=`. Sandboxed workloads read a zero-length secret and fail auth while the correct value sits in `/.hermes/.env`. Observed as intermittent API 401s (a forwarded `MY_SECRET` arriving with `length: 0`), with no gateway restart and no `.env` rewrite. Hit twice in production 9 days apart. It's invisible for gateway-side secrets (Slack/Telegram) because those never ride a `docker exec -e` into a container; only sandbox-consumed secrets surface it.

**Repro:**
```python
def build_args(forward_keys, live_env, disk_env):
    exec_env, hermes_env = {}, (disk_env if forward_keys else {})
    for key in sorted(forward_keys):
        value = live_env.get(key, None)          # os.getenv(key)
        if value is None:                        # only unset
            value = hermes_env.get(key)
        if value is not None:                    # forwards ""
            exec_env[key] = value
    return [x for k in sorted(exec_env) for x in ("-e", f"{k}={exec_env[k]}")]

args = build_args({"MY_SECRET"}, {"MY_SECRET": ""}, {"MY_SECRET": "x" * 48})
flag = next(a for a in args if a.startswith("MY_SECRET="))
print(flag, "-> length:", len(flag.split("=", 1)[1]))
# Actual:   MY_SECRET= -> length: 0   (disk fallback skipped)
# Expected: MY_SECRET=xxxx... -> length: 48
```

**Fix:** treat empty-string like unset (`if not value:` on the fallback) and never forward a blank (`if value:` on the guard). Robust to whatever produces the transient blank (env mutation during concurrent spawns, partial reload). For strict back-compat, the minimal change is just the fallback line.

```diff
         for key in sorted(forward_keys):
             value = os.getenv(key)
-            if value is None:
+            if not value:
                 value = hermes_env.get(key)
-            if value is not None:
+            if value:
                 exec_env[key] = value
```

**Tests:** two regression tests added to `tests/tools/test_docker_environment.py`, mocking `os.getenv` (via `monkeypatch.setenv`) and the hermes-env loader (`_load_hermes_env_vars`), no real files touched:
- `test_init_env_args_uses_hermes_dotenv_for_empty_shell_env` — live env has `MY_SECRET=""`, disk has the real value; asserts the container receives the disk value and no blank flag. Asserts on the resolved value in the args list, not the printed flag.
- `test_init_env_args_never_forwards_blank_secret` — legitimately empty + no disk value; asserts the key is not forwarded as `-e MY_SECRET=` at all.

Verified RED on old code (both tests fail; old loop emits `['-e', 'MY_SECRET=']`) and GREEN on the fix. Full file passes via the canonical runner:

```
scripts/run_tests.sh tests/tools/test_docker_environment.py
=== Summary: 1 files, 56 tests passed, 0 failed ===
```

**Environment:** Observed in production on Ubuntu (AWS EC2 VPS), Python 3.11. Fix authored and tested on macOS 15.5 (arm64, Darwin 25.5.0), Python 3.11.9, Hermes Agent v0.15.1 (2026.5.29).

Fixes #35580
