### PR TITLE
fix: use context manager for pymupdf.open() to prevent resource leaks

### DIFF
--- a/skills/productivity/ocr-and-documents/scripts/extract_pymupdf.py
+++ b/skills/productivity/ocr-and-documents/scripts/extract_pymupdf.py
@@ -14,12 +14,12 @@ import json
 
 def extract_text(path, pages=None):
     import pymupdf
-    doc = pymupdf.open(path)
-    page_range = range(len(doc)) if pages is None else pages
-    for i in page_range:
-        if i < len(doc):
-            print(f"\n--- Page {i+1}/{len(doc)} ---\n")
-            print(doc[i].get_text())
+    with pymupdf.open(path) as doc:
+        page_range = range(len(doc)) if pages is None else pages
+        for i in page_range:
+            if i < len(doc):
+                print(f"\n--- Page {i+1}/{len(doc)} ---\n")
+                print(doc[i].get_text())
 
 def extract_markdown(path, pages=None):
     import pymupdf4llm
@@ -28,43 +28,43 @@ def extract_markdown(path, pages=None):
 
 def extract_tables(path):
     import pymupdf
-    doc = pymupdf.open(path)
-    for i, page in enumerate(doc):
-        tables = page.find_tables()
-        for j, table in enumerate(tables.tables):
-            print(f"\n--- Page {i+1}, Table {j+1} ---\n")
-            df = table.to_pandas()
-            print(df.to_markdown(index=False))
+    with pymupdf.open(path) as doc:
+        for i, page in enumerate(doc):
+            tables = page.find_tables()
+            for j, table in enumerate(tables.tables):
+                print(f"\n--- Page {i+1}, Table {j+1} ---\n")
+                df = table.to_pandas()
+                print(df.to_markdown(index=False))
 
 def extract_images(path, output_dir):
     import pymupdf
     from pathlib import Path
     Path(output_dir).mkdir(parents=True, exist_ok=True)
-    doc = pymupdf.open(path)
     count = 0
-    for i, page in enumerate(doc):
-        for img_idx, img in enumerate(page.get_images(full=True)):
-            xref = img[0]
-            pix = pymupdf.Pixmap(doc, xref)
-            if pix.n >= 5:
-                pix = pymupdf.Pixmap(pymupdf.csRGB, pix)
-            out_path = f"{output_dir}/page{i+1}_img{img_idx+1}.png"
-            pix.save(out_path)
-            count += 1
+    with pymupdf.open(path) as doc:
+        for i, page in enumerate(doc):
+            for img_idx, img in enumerate(page.get_images(full=True)):
+                xref = img[0]
+                pix = pymupdf.Pixmap(doc, xref)
+                if pix.n >= 5:
+                    pix = pymupdf.Pixmap(pymupdf.csRGB, pix)
+                out_path = f"{output_dir}/page{i+1}_img{img_idx+1}.png"
+                pix.save(out_path)
+                count += 1
     print(f"Extracted {count} images to {output_dir}/")
 
 def show_metadata(path):
     import pymupdf
-    doc = pymupdf.open(path)
-    print(json.dumps({
-        "pages": len(doc),
-        "title": doc.metadata.get("title", ""),
-        "author": doc.metadata.get("author", ""),
-        "subject": doc.metadata.get("subject", ""),
-        "creator": doc.metadata.get("creator", ""),
-        "producer": doc.metadata.get("producer", ""),
-        "format": doc.metadata.get("format", ""),
-    }, indent=2))
+    with pymupdf.open(path) as doc:
+        print(json.dumps({
+            "pages": len(doc),
+            "title": doc.metadata.get("title", ""),
+            "author": doc.metadata.get("author", ""),
+            "subject": doc.metadata.get("subject", ""),
+            "creator": doc.metadata.get("creator", ""),
+            "producer": doc.metadata.get("producer", ""),
+            "format": doc.metadata.get("format", ""),
+        }, indent=2))
 
 if __name__ == "__main__":
     args = sys.argv[1:]


### PR DESCRIPTION
## What does this PR do?
Fixes resource leaks in `skills/productivity/ocr-and-documents/scripts/extract_pymupdf.py` by replacing bare `pymupdf.open(path)` calls with context managers (`with pymupdf.open(path) as doc:`) in all four functions.

## Type of Change
- [x] Bug fix

## Changes Made
- `extract_text()`: wrapped doc in context manager
- `extract_tables()`: wrapped doc in context manager
- `extract_images()`: wrapped doc in context manager, moved `count = 0` before `with` block
- `show_metadata()`: wrapped doc in context manager

## How to Test
Run any of the CLI modes against a PDF file and verify no file handle leaks occur, especially when exceptions are raised mid-execution.

## Checklist
- [x] Single commit
- [x] No secrets or API keys
- [x] Follows existing code style