### PR TITLE
fix(anthropic): preserve interleaved thinking/tool_use block order on replay

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1632,6 +1632,29 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
     reasoning_content injection for Kimi/DeepSeek endpoints.
     """
     content = m.get("content", "")
+    # Anthropic interleaved-thinking fast path: when this turn carries a
+    # verbatim, order-preserving block list (set by normalize_response only
+    # for turns that interleave SIGNED thinking with tool_use), replay it
+    # unchanged. Reconstructing from the parallel reasoning_details +
+    # tool_calls fields front-loads thinking and reorders signed blocks,
+    # which Anthropic rejects with HTTP 400 ("thinking ... blocks in the
+    # latest assistant message cannot be modified"). Block order — and thus
+    # each thinking block's signature — must survive verbatim. tool_use IDs
+    # are sanitized to match the tool_result IDs produced elsewhere; the
+    # downstream mcp_ prefixing pass handles tool names on these blocks.
+    ordered_blocks = m.get("anthropic_content_blocks")
+    if isinstance(ordered_blocks, list) and ordered_blocks:
+        replayed: List[Dict[str, Any]] = []
+        for b in ordered_blocks:
+            if not isinstance(b, dict):
+                continue
+            blk = copy.deepcopy(b)
+            if blk.get("type") == "tool_use" and "id" in blk:
+                blk["id"] = _sanitize_tool_id(blk.get("id", ""))
+            replayed.append(blk)
+        if replayed:
+            return {"role": "assistant", "content": replayed}
+
     blocks = _extract_preserved_thinking_blocks(m)
     if content:
         if isinstance(content, list):

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1704,11 +1704,41 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
     # dropped, leaving thinking signatures and tool_use id/name/input intact.
     ordered_blocks = m.get("anthropic_content_blocks")
     if isinstance(ordered_blocks, list) and ordered_blocks:
+        # Re-source each tool_use input from the stored tool_calls map rather
+        # than the captured block. The ordered-blocks list captures tool_use
+        # input from the RAW API response (normalize_response), which is NOT
+        # credential-redacted; tool_calls[].function.arguments IS redacted at
+        # storage time (build_assistant_message, #19798). Replaying the raw
+        # block input would resurrect a secret the model inlined into a tool
+        # call (e.g. terminal(command="curl -H 'Authorization: Bearer sk-...'")
+        # onto the wire, even though the same value is redacted everywhere else
+        # in history. Keying by sanitized tool id preserves interleave order
+        # (the reason this channel exists) while swapping in the redacted
+        # input. Adapted from #36071 (replay-time tool-input re-sourcing).
+        redacted_input_by_id: Dict[str, Any] = {}
+        for tc in m.get("tool_calls", []) or []:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function", {}) or {}
+            raw_args = fn.get("arguments", "{}")
+            try:
+                parsed_args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+            except (json.JSONDecodeError, ValueError):
+                parsed_args = {}
+            redacted_input_by_id[_sanitize_tool_id(tc.get("id", ""))] = parsed_args
         replayed: List[Dict[str, Any]] = []
         for b in ordered_blocks:
             clean = _sanitize_replay_block(b)
-            if clean is not None:
-                replayed.append(clean)
+            if clean is None:
+                continue
+            if clean.get("type") == "tool_use":
+                # Override raw (un-redacted) input with the redacted copy when
+                # we have one for this id; fall back to the sanitized block
+                # input only if the tool_call is missing (shape mismatch).
+                redacted = redacted_input_by_id.get(clean.get("id", ""))
+                if redacted is not None:
+                    clean["input"] = redacted
+            replayed.append(clean)
         if replayed:
             return {"role": "assistant", "content": replayed}
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1511,6 +1511,15 @@ def _convert_content_part_to_anthropic(part: Any) -> Optional[Dict[str, Any]]:
 
     if ptype == "input_text":
         block: Dict[str, Any] = {"type": "text", "text": part.get("text", "")}
+    elif ptype == "text":
+        # A stored Anthropic text block. Rebuild from whitelisted fields only —
+        # SDK response text blocks carry output-only siblings (parsed_output,
+        # citations=None) that the Messages INPUT schema rejects with HTTP 400
+        # "Extra inputs are not permitted". Do NOT dict(part) it verbatim.
+        block = {"type": "text", "text": part.get("text", "")}
+        cits = part.get("citations")
+        if isinstance(cits, list) and cits:
+            block["citations"] = cits
     elif ptype in {"image_url", "input_image"}:
         image_value = part.get("image_url", {})
         url = image_value.get("url", "") if isinstance(image_value, dict) else str(image_value or "")
@@ -1625,6 +1634,58 @@ def _content_parts_to_anthropic_blocks(parts: Any) -> List[Dict[str, Any]]:
     return out
 
 
+def _sanitize_replay_block(b: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Strip output-only fields from a stored Anthropic content block so it is
+    valid as REQUEST input on replay.
+
+    The SDK response objects carry output-only attributes that the Messages
+    *input* schema forbids ("Extra inputs are not permitted"): text blocks get
+    ``parsed_output``/``citations`` (when null), tool_use blocks get ``caller``,
+    etc. ``normalize_response`` captured blocks verbatim via ``_to_plain_data``,
+    so these leak back as input on the next turn → HTTP 400.
+
+    Whitelist per type (NOT a blacklist) so future SDK output-only fields can't
+    reintroduce the bug. Returns a clean block, or None to drop it.
+    """
+    if not isinstance(b, dict):
+        return None
+    btype = b.get("type")
+    if btype == "text":
+        out: Dict[str, Any] = {"type": "text", "text": b.get("text", "")}
+        # citations is input-valid ONLY when it's a non-empty list; the SDK
+        # emits citations=None on responses, which the input schema rejects.
+        cits = b.get("citations")
+        if isinstance(cits, list) and cits:
+            out["citations"] = cits
+        if isinstance(b.get("cache_control"), dict):
+            out["cache_control"] = b["cache_control"]
+        return out
+    if btype == "thinking":
+        out = {"type": "thinking", "thinking": b.get("thinking", "")}
+        if b.get("signature"):
+            out["signature"] = b["signature"]
+        return out
+    if btype == "redacted_thinking":
+        # Only valid with its data payload; drop if missing.
+        return {"type": "redacted_thinking", "data": b["data"]} if b.get("data") else None
+    if btype == "tool_use":
+        out = {
+            "type": "tool_use",
+            "id": _sanitize_tool_id(b.get("id", "")),
+            "name": b.get("name", ""),
+            "input": b.get("input", {}),
+        }
+        if isinstance(b.get("cache_control"), dict):
+            out["cache_control"] = b["cache_control"]
+        return out
+    if btype == "image":
+        src = b.get("source")
+        return {"type": "image", "source": src} if isinstance(src, dict) else None
+    # Unknown/unsupported block type on the input path — drop rather than risk
+    # another "Extra inputs are not permitted".
+    return None
+
+
 def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
     """Convert an assistant message to Anthropic content blocks.
 
@@ -1634,24 +1695,20 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
     content = m.get("content", "")
     # Anthropic interleaved-thinking fast path: when this turn carries a
     # verbatim, order-preserving block list (set by normalize_response only
-    # for turns that interleave SIGNED thinking with tool_use), replay it
-    # unchanged. Reconstructing from the parallel reasoning_details +
-    # tool_calls fields front-loads thinking and reorders signed blocks,
-    # which Anthropic rejects with HTTP 400 ("thinking ... blocks in the
-    # latest assistant message cannot be modified"). Block order — and thus
-    # each thinking block's signature — must survive verbatim. tool_use IDs
-    # are sanitized to match the tool_result IDs produced elsewhere; the
-    # downstream mcp_ prefixing pass handles tool names on these blocks.
+    # for turns that interleave SIGNED thinking with tool_use), replay it.
+    # Each block is run through _sanitize_replay_block to strip output-only
+    # SDK fields (parsed_output, caller, citations=None, …) that the Messages
+    # INPUT schema forbids — replaying them verbatim caused HTTP 400 "Extra
+    # inputs are not permitted" (text.parsed_output). Block ORDER is preserved
+    # (the reason this channel exists); only forbidden sibling fields are
+    # dropped, leaving thinking signatures and tool_use id/name/input intact.
     ordered_blocks = m.get("anthropic_content_blocks")
     if isinstance(ordered_blocks, list) and ordered_blocks:
         replayed: List[Dict[str, Any]] = []
         for b in ordered_blocks:
-            if not isinstance(b, dict):
-                continue
-            blk = copy.deepcopy(b)
-            if blk.get("type") == "tool_use" and "id" in blk:
-                blk["id"] = _sanitize_tool_id(blk.get("id", ""))
-            replayed.append(blk)
+            clean = _sanitize_replay_block(b)
+            if clean is not None:
+                replayed.append(clean)
         if replayed:
             return {"role": "assistant", "content": replayed}
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -924,6 +924,18 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
         if preserved:
             msg["reasoning_details"] = preserved
 
+    # Anthropic interleaved-thinking replay: when a turn interleaves signed
+    # thinking blocks with tool_use, the parallel reasoning_details +
+    # tool_calls fields lose the cross-type ordering, and reconstruction
+    # front-loads thinking — reordering signed blocks and triggering HTTP 400
+    # ("thinking ... blocks in the latest assistant message cannot be
+    # modified"). Carry the verbatim ordered block list so the adapter can
+    # replay the latest assistant message unchanged. See
+    # agent/transports/anthropic.py and agent/anthropic_adapter.py.
+    ordered_blocks = getattr(assistant_message, "anthropic_content_blocks", None)
+    if ordered_blocks:
+        msg["anthropic_content_blocks"] = ordered_blocks
+
     # Codex Responses API: preserve encrypted reasoning items for
     # multi-turn continuity. These get replayed as input on the next turn.
     codex_items = getattr(assistant_message, "codex_reasoning_items", None)

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -546,14 +546,32 @@ def classify_api_error(
             should_fallback=True,
         )
 
-    # Anthropic thinking block signature invalid (400).
+    # Anthropic thinking block replay rejected (400). Two distinct upstream
+    # messages, same root meaning ("the thinking block we replayed no longer
+    # matches what Anthropic originally returned") and same recovery (strip
+    # reasoning_details and retry):
+    #   1. "Invalid signature in thinking block ..."  (signature mismatch)
+    #   2. "thinking ... blocks in the latest assistant message cannot be
+    #      modified. These blocks must remain as they were in the original
+    #      response."  (content/order mismatch — interleaved thinking blocks
+    #      reordered relative to tool_use on rebuild)
+    # Variant 2 carries no "signature" token, so the original pattern missed it
+    # and the turn hard-aborted as a non-retryable client error instead of
+    # self-healing. This is defense-in-depth: the anthropic_content_blocks
+    # channel prevents the reorder at the source, but if any future mutator
+    # reintroduces it, the turn still recovers instead of crash-looping.
+    # Adapted from #36087 / #36071 (classifier broadening).
     # Don't gate on provider — OpenRouter proxies Anthropic errors, so the
     # provider may be "openrouter" even though the error is Anthropic-specific.
-    # The message pattern ("signature" + "thinking") is unique enough.
+    # The "thinking" token plus any one of these signals is unique enough.
     if (
         status_code == 400
-        and "signature" in error_msg
         and "thinking" in error_msg
+        and (
+            "signature" in error_msg
+            or "cannot be modified" in error_msg
+            or "must remain as they were" in error_msg
+        )
     ):
         return _result(
             FailoverReason.thinking_signature,

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -94,13 +94,27 @@ class AnthropicTransport(ProviderTransport):
         reasoning_parts = []
         reasoning_details = []
         tool_calls = []
+        # Verbatim, order-preserving copy of every content block in the turn.
+        # Anthropic signs each thinking block against the turn content that
+        # PRECEDES it at its position; when a turn interleaves thinking and
+        # tool_use (adaptive/interleaved thinking, Claude 4.6+), the parallel
+        # reasoning_details + tool_calls lists below lose that cross-type
+        # ordering. Replaying the latest assistant message in the wrong order
+        # invalidates the signatures -> HTTP 400 "thinking ... blocks in the
+        # latest assistant message cannot be modified". Preserve the exact
+        # block sequence here so the adapter can replay it unchanged. See
+        # tests/agent/test_anthropic_thinking_block_order.py.
+        ordered_blocks = []
 
         for block in response.content:
+            block_dict = _to_plain_data(block)
+            if isinstance(block_dict, dict):
+                ordered_blocks.append(block_dict)
             if block.type == "text":
                 text_parts.append(block.text)
-            elif block.type == "thinking":
-                reasoning_parts.append(block.thinking)
-                block_dict = _to_plain_data(block)
+            elif block.type in ("thinking", "redacted_thinking"):
+                if block.type == "thinking":
+                    reasoning_parts.append(block.thinking)
                 if isinstance(block_dict, dict):
                     reasoning_details.append(block_dict)
             elif block.type == "tool_use":
@@ -130,6 +144,23 @@ class AnthropicTransport(ProviderTransport):
         provider_data = {}
         if reasoning_details:
             provider_data["reasoning_details"] = reasoning_details
+        # Only worth carrying the ordered-blocks channel when the turn
+        # actually interleaves signed thinking with tool_use — that's the
+        # only shape the parallel lists reconstruct incorrectly. A turn that
+        # is purely text, or thinking-then-tools with a single leading
+        # thinking block, replays correctly without it.
+        _has_signed_thinking = any(
+            isinstance(b, dict)
+            and b.get("type") in ("thinking", "redacted_thinking")
+            and (b.get("signature") or b.get("data"))
+            for b in ordered_blocks
+        )
+        _has_tool_use = any(
+            isinstance(b, dict) and b.get("type") == "tool_use"
+            for b in ordered_blocks
+        )
+        if _has_signed_thinking and _has_tool_use:
+            provider_data["anthropic_content_blocks"] = ordered_blocks
 
         return NormalizedResponse(
             content="\n".join(text_parts) if text_parts else None,

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -84,7 +84,7 @@ class AnthropicTransport(ProviderTransport):
         to OpenAI finish_reason, and collects reasoning_details in provider_data.
         """
         import json
-        from agent.anthropic_adapter import _to_plain_data
+        from agent.anthropic_adapter import _to_plain_data, _sanitize_replay_block
         from agent.transports.types import ToolCall
 
         strip_tool_prefix = kwargs.get("strip_tool_prefix", False)
@@ -108,14 +108,26 @@ class AnthropicTransport(ProviderTransport):
 
         for block in response.content:
             block_dict = _to_plain_data(block)
+            clean_block = None
             if isinstance(block_dict, dict):
-                ordered_blocks.append(block_dict)
+                # Sanitize at capture so output-only SDK fields (parsed_output,
+                # caller, citations=None, …) never persist to state.db and leak
+                # back as request input on replay → HTTP 400 "Extra inputs are
+                # not permitted". Defence-in-depth with the replay-side sanitize.
+                clean_block = _sanitize_replay_block(block_dict)
+                if clean_block is not None:
+                    ordered_blocks.append(clean_block)
             if block.type == "text":
                 text_parts.append(block.text)
             elif block.type in ("thinking", "redacted_thinking"):
                 if block.type == "thinking":
                     reasoning_parts.append(block.thinking)
-                if isinstance(block_dict, dict):
+                # Use the sanitized block (clean_block) for reasoning_details too,
+                # since _extract_preserved_thinking_blocks replays these on the
+                # non-ordered path. Falls back to raw only if sanitize dropped it.
+                if isinstance(clean_block, dict):
+                    reasoning_details.append(clean_block)
+                elif isinstance(block_dict, dict):
                     reasoning_details.append(block_dict)
             elif block.type == "tool_use":
                 name = block.name

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -122,6 +122,18 @@ class NormalizedResponse:
         return pd.get("reasoning_details")
 
     @property
+    def anthropic_content_blocks(self):
+        """Verbatim, order-preserving Anthropic content blocks for a turn.
+
+        Present only when an Anthropic turn interleaves signed thinking with
+        tool_use — the one shape the parallel reasoning_details + tool_calls
+        lists reconstruct in the wrong order, invalidating thinking-block
+        signatures on replay. See agent/transports/anthropic.py.
+        """
+        pd = self.provider_data or {}
+        return pd.get("anthropic_content_blocks")
+
+    @property
     def codex_reasoning_items(self):
         pd = self.provider_data or {}
         return pd.get("codex_reasoning_items")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -270,6 +270,7 @@ CREATE TABLE IF NOT EXISTS messages (
     reasoning TEXT,
     reasoning_content TEXT,
     reasoning_details TEXT,
+    anthropic_content_blocks TEXT,
     codex_reasoning_items TEXT,
     codex_message_items TEXT,
     platform_message_id TEXT,
@@ -1672,6 +1673,7 @@ class SessionDB:
         reasoning: str = None,
         reasoning_content: str = None,
         reasoning_details: Any = None,
+        anthropic_content_blocks: Any = None,
         codex_reasoning_items: Any = None,
         codex_message_items: Any = None,
         platform_message_id: str = None,
@@ -1693,6 +1695,10 @@ class SessionDB:
         reasoning_details_json = (
             json.dumps(reasoning_details)
             if reasoning_details else None
+        )
+        anthropic_content_blocks_json = (
+            json.dumps(anthropic_content_blocks)
+            if anthropic_content_blocks else None
         )
         codex_items_json = (
             json.dumps(codex_reasoning_items)
@@ -1716,9 +1722,10 @@ class SessionDB:
             cursor = conn.execute(
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
-                   reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
+                   reasoning, reasoning_content, reasoning_details, anthropic_content_blocks,
+                   codex_reasoning_items,
                    codex_message_items, platform_message_id, observed)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -1732,6 +1739,7 @@ class SessionDB:
                     reasoning,
                     reasoning_content,
                     reasoning_details_json,
+                    anthropic_content_blocks_json,
                     codex_items_json,
                     codex_message_items_json,
                     platform_message_id,
@@ -1780,6 +1788,9 @@ class SessionDB:
                 role = msg.get("role", "unknown")
                 tool_calls = msg.get("tool_calls")
                 reasoning_details = msg.get("reasoning_details") if role == "assistant" else None
+                anthropic_content_blocks = (
+                    msg.get("anthropic_content_blocks") if role == "assistant" else None
+                )
                 codex_reasoning_items = (
                     msg.get("codex_reasoning_items") if role == "assistant" else None
                 )
@@ -1789,6 +1800,9 @@ class SessionDB:
 
                 reasoning_details_json = (
                     json.dumps(reasoning_details) if reasoning_details else None
+                )
+                anthropic_content_blocks_json = (
+                    json.dumps(anthropic_content_blocks) if anthropic_content_blocks else None
                 )
                 codex_items_json = (
                     json.dumps(codex_reasoning_items) if codex_reasoning_items else None
@@ -1806,9 +1820,10 @@ class SessionDB:
                 conn.execute(
                     """INSERT INTO messages (session_id, role, content, tool_call_id,
                        tool_calls, tool_name, timestamp, token_count, finish_reason,
-                       reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
+                       reasoning, reasoning_content, reasoning_details, anthropic_content_blocks,
+                       codex_reasoning_items,
                        codex_message_items, platform_message_id, observed)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         session_id,
                         role,
@@ -1822,6 +1837,7 @@ class SessionDB:
                         msg.get("reasoning") if role == "assistant" else None,
                         msg.get("reasoning_content") if role == "assistant" else None,
                         reasoning_details_json,
+                        anthropic_content_blocks_json,
                         codex_items_json,
                         codex_message_items_json,
                         platform_msg_id,
@@ -2143,6 +2159,7 @@ class SessionDB:
             rows = self._conn.execute(
                 "SELECT role, content, tool_call_id, tool_calls, tool_name, "
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
+                "anthropic_content_blocks, "
                 "codex_reasoning_items, codex_message_items, platform_message_id, observed "
                 f"FROM messages WHERE session_id IN ({placeholders}) ORDER BY id",
                 tuple(session_ids),
@@ -2189,6 +2206,12 @@ class SessionDB:
                     except (json.JSONDecodeError, TypeError):
                         logger.warning("Failed to deserialize reasoning_details, falling back to None")
                         msg["reasoning_details"] = None
+                if row["anthropic_content_blocks"]:
+                    try:
+                        msg["anthropic_content_blocks"] = json.loads(row["anthropic_content_blocks"])
+                    except (json.JSONDecodeError, TypeError):
+                        logger.warning("Failed to deserialize anthropic_content_blocks, falling back to None")
+                        msg["anthropic_content_blocks"] = None
                 if row["codex_reasoning_items"]:
                     try:
                         msg["codex_reasoning_items"] = json.loads(row["codex_reasoning_items"])

--- a/run_agent.py
+++ b/run_agent.py
@@ -1514,6 +1514,7 @@ class AIAgent:
                     reasoning=msg.get("reasoning") if role == "assistant" else None,
                     reasoning_content=msg.get("reasoning_content") if role == "assistant" else None,
                     reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
+                    anthropic_content_blocks=msg.get("anthropic_content_blocks") if role == "assistant" else None,
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
                 )

--- a/tests/agent/test_anthropic_output_field_leak.py
+++ b/tests/agent/test_anthropic_output_field_leak.py
@@ -1,0 +1,96 @@
+"""Regression: output-only SDK fields must not leak into Anthropic request input.
+
+Reproduces HTTP 400 `messages.N.content.M.text.parsed_output: Extra inputs are
+not permitted`. Anthropic SDK response blocks carry output-only attributes
+(text blocks: `parsed_output`, `citations=None`; tool_use blocks: `caller`)
+that the Messages *input* schema forbids. normalize_response captured blocks
+verbatim via _to_plain_data and replayed them as input → 400.
+
+Fix: whitelist input-permitted fields per block type at three points —
+normalize_response capture, _sanitize_replay_block (ordered-blocks replay), and
+_convert_content_part_to_anthropic (content-list replay).
+"""
+import sys, os
+sys.path.insert(0, os.path.expanduser("~/.hermes/hermes-agent"))
+
+import pytest
+from agent.anthropic_adapter import (
+    _sanitize_replay_block,
+    _convert_content_part_to_anthropic,
+    _convert_assistant_message,
+)
+
+FORBIDDEN = {"parsed_output", "caller"}
+
+
+def _assert_clean(block):
+    """No forbidden output-only key, and no null citations, anywhere."""
+    assert isinstance(block, dict)
+    for k in FORBIDDEN:
+        assert k not in block, f"forbidden field {k!r} survived: {block}"
+    if "citations" in block:
+        assert isinstance(block["citations"], list) and block["citations"], \
+            "citations must be a non-empty list if present (None/[] is input-invalid)"
+
+
+class TestSanitizeReplayBlock:
+    def test_text_block_strips_parsed_output_and_null_citations(self):
+        poisoned = {"type": "text", "text": "hi", "parsed_output": None, "citations": None}
+        out = _sanitize_replay_block(poisoned)
+        _assert_clean(out)
+        assert out == {"type": "text", "text": "hi"}
+
+    def test_tool_use_strips_caller(self):
+        poisoned = {"type": "tool_use", "id": "toolu_1", "name": "read_file",
+                    "input": {"path": "a"}, "caller": {"type": "agent"}}
+        out = _sanitize_replay_block(poisoned)
+        _assert_clean(out)
+        assert out["name"] == "read_file" and out["input"] == {"path": "a"}
+
+    def test_thinking_preserves_signature(self):
+        b = {"type": "thinking", "thinking": "x", "signature": "sig-AAA"}
+        out = _sanitize_replay_block(b)
+        assert out == {"type": "thinking", "thinking": "x", "signature": "sig-AAA"}
+
+    def test_text_keeps_real_citations(self):
+        real = [{"type": "char_location", "cited_text": "q"}]
+        out = _sanitize_replay_block({"type": "text", "text": "t", "citations": real})
+        assert out["citations"] == real
+
+    def test_unknown_type_dropped(self):
+        assert _sanitize_replay_block({"type": "server_tool_use", "foo": 1}) is None
+
+
+class TestContentPartConversion:
+    def test_stored_text_block_with_parsed_output_cleaned(self):
+        # The exact content.N.text.parsed_output failure shape.
+        part = {"type": "text", "text": "hello", "parsed_output": None, "citations": None}
+        out = _convert_content_part_to_anthropic(part)
+        _assert_clean(out)
+
+
+class TestAssistantReplay:
+    def test_interleaved_blocks_replayed_clean_and_ordered(self):
+        m = {
+            "role": "assistant",
+            "anthropic_content_blocks": [
+                {"type": "thinking", "thinking": "plan", "signature": "s1"},
+                {"type": "text", "text": "doing it", "parsed_output": None, "citations": None},
+                {"type": "tool_use", "id": "toolu_1", "name": "read_file",
+                 "input": {"path": "a"}, "caller": {"type": "agent"}},
+            ],
+        }
+        out = _convert_assistant_message(m)
+        blocks = out["content"]
+        # order preserved
+        assert [b["type"] for b in blocks] == ["thinking", "text", "tool_use"]
+        # every block clean
+        for b in blocks:
+            _assert_clean(b)
+        # signature + tool fields intact
+        assert blocks[0]["signature"] == "s1"
+        assert blocks[2]["name"] == "read_file"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/agent/test_anthropic_thinking_block_order.py
+++ b/tests/agent/test_anthropic_thinking_block_order.py
@@ -1,0 +1,235 @@
+"""Regression test for the Anthropic interleaved thinking-block 400.
+
+Reproduces: HTTP 400 ``messages.N.content.M: thinking or redacted_thinking
+blocks in the latest assistant message cannot be modified. These blocks must
+remain as they were in the original response.``
+
+Root cause under test
+----------------------
+With adaptive / interleaved thinking (Claude 4.6+, e.g. Opus 4.8), a single
+assistant turn can emit content blocks in an interleaved order::
+
+    thinking_1 (signed) · tool_use_1 · thinking_2 (signed) · tool_use_2
+
+Anthropic signs each thinking block against the turn content that precedes it
+at its position.  ``thinking_2`` is signed with ``tool_use_1`` before it.
+
+``AnthropicTransport.normalize_response`` (agent/transports/anthropic.py)
+splits the turn into two *parallel* lists — ``reasoning_details`` (thinking
+blocks) and ``tool_calls`` (tool_use blocks) — discarding the cross-type
+ordering.  ``run_agent`` stores those as separate fields on the assistant
+message.  On replay, ``_convert_assistant_message`` (agent/anthropic_adapter.py)
+rebuilds the content as ``[all thinking][text][all tool_use]``, which reorders
+``thinking_2`` ahead of ``tool_use_1``.  The signature no longer matches its
+original position, so Anthropic rejects the latest assistant message with the
+400 above.
+
+This test asserts that an interleaved turn round-trips through
+normalize_response -> stored message -> convert_messages_to_anthropic with its
+block order preserved.  It FAILS on the current code (documenting the bug) and
+should PASS once block ordering is preserved on replay.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.transports import get_transport
+from agent.anthropic_adapter import convert_messages_to_anthropic
+
+
+def _thinking_block(text: str, signature: str) -> SimpleNamespace:
+    """A signed Anthropic thinking block, shaped like the SDK object."""
+    return SimpleNamespace(type="thinking", thinking=text, signature=signature)
+
+
+def _tool_use_block(block_id: str, name: str, payload: dict) -> SimpleNamespace:
+    return SimpleNamespace(type="tool_use", id=block_id, name=name, input=payload)
+
+
+def _interleaved_response() -> SimpleNamespace:
+    """An assistant turn with thinking interleaved between two tool_use blocks."""
+    return SimpleNamespace(
+        content=[
+            _thinking_block("Plan: inspect file A first.", "sig-AAA"),
+            _tool_use_block("toolu_1", "read_file", {"path": "a.py"}),
+            _thinking_block("A looked fine; now inspect B.", "sig-BBB"),
+            _tool_use_block("toolu_2", "read_file", {"path": "b.py"}),
+        ],
+        stop_reason="tool_use",
+        usage=None,
+    )
+
+
+def _stored_assistant_message(normalized) -> dict:
+    """Reconstruct the OpenAI-style assistant message the way run_agent stores it.
+
+    run_agent.py persists assistant turns as separate fields: content,
+    reasoning_details (from provider_data), and tool_calls.  See
+    run_agent.py L1513-1516 and hermes_state.py.
+    """
+    provider_data = normalized.provider_data or {}
+    tool_calls = []
+    for tc in (normalized.tool_calls or []):
+        tool_calls.append({
+            "id": tc.id,
+            "type": "function",
+            "function": {"name": tc.name, "arguments": tc.arguments},
+        })
+    msg = {
+        "role": "assistant",
+        "content": normalized.content or "",
+        "reasoning_details": provider_data.get("reasoning_details"),
+        "tool_calls": tool_calls,
+    }
+    # build_assistant_message lifts the verbatim ordered-block channel onto
+    # the stored message; mirror that here.
+    blocks = provider_data.get("anthropic_content_blocks")
+    if blocks:
+        msg["anthropic_content_blocks"] = blocks
+    return msg
+
+
+def _original_block_order(response) -> list:
+    """The (type, key) sequence of the original interleaved response."""
+    order = []
+    for b in response.content:
+        if b.type == "thinking":
+            order.append(("thinking", b.signature))
+        elif b.type == "tool_use":
+            order.append(("tool_use", b.id))
+    return order
+
+
+def _replayed_block_order(assistant_content) -> list:
+    order = []
+    for b in assistant_content:
+        if not isinstance(b, dict):
+            continue
+        if b.get("type") in ("thinking", "redacted_thinking"):
+            order.append(("thinking", b.get("signature")))
+        elif b.get("type") == "tool_use":
+            order.append(("tool_use", b.get("id")))
+    return order
+
+
+class TestInterleavedThinkingBlockOrder:
+    def test_normalize_response_loses_interleaving(self):
+        """Confirm the lossy split: normalize_response stores thinking and
+        tool_use in independent fields with no positional linkage."""
+        transport = get_transport("anthropic_messages")
+        normalized = transport.normalize_response(_interleaved_response())
+
+        # Both thinking blocks are captured...
+        details = (normalized.provider_data or {}).get("reasoning_details")
+        assert details is not None and len(details) == 2
+        # ...and both tool calls...
+        assert normalized.tool_calls is not None and len(normalized.tool_calls) == 2
+        # ...but they live in separate fields. There is no single ordered
+        # structure recording that thinking_2 sat between the two tool calls.
+        # (This is the structural precondition for the reorder bug.)
+
+    def test_interleaved_order_preserved_on_replay(self):
+        """The latest assistant message must replay blocks in their ORIGINAL
+        order, or Anthropic rejects the signed thinking blocks with a 400.
+
+        FAILS on current code: _convert_assistant_message front-loads all
+        thinking blocks, producing
+            thinking_1 · thinking_2 · tool_use_1 · tool_use_2
+        instead of the original
+            thinking_1 · tool_use_1 · thinking_2 · tool_use_2
+        """
+        response = _interleaved_response()
+        original_order = _original_block_order(response)
+
+        transport = get_transport("anthropic_messages")
+        normalized = transport.normalize_response(response)
+        assistant_msg = _stored_assistant_message(normalized)
+
+        # Build a minimal conversation where this assistant turn is the LATEST
+        # assistant message (the one whose signed blocks are sent verbatim).
+        messages = [
+            {"role": "user", "content": "Inspect a.py and b.py."},
+            assistant_msg,
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "a.py: ok"},
+            {"role": "tool", "tool_call_id": "toolu_2", "content": "b.py: ok"},
+        ]
+
+        _system, anthropic_messages = convert_messages_to_anthropic(
+            messages,
+            base_url=None,             # direct Anthropic
+            model="claude-opus-4-8",   # adaptive thinking family
+        )
+
+        # Find the (latest) assistant message in the converted output.
+        assistant_out = [m for m in anthropic_messages if m.get("role") == "assistant"]
+        assert assistant_out, "no assistant message in converted output"
+        replayed_order = _replayed_block_order(assistant_out[-1]["content"])
+
+        assert replayed_order == original_order, (
+            "Interleaved thinking/tool_use order was not preserved on replay.\n"
+            f"  original: {original_order}\n"
+            f"  replayed: {replayed_order}\n"
+            "Anthropic signs thinking blocks against their original position; "
+            "reordering invalidates the signature -> HTTP 400 'thinking blocks "
+            "in the latest assistant message cannot be modified'."
+        )
+
+    def test_interleaved_order_survives_db_roundtrip(self, tmp_path):
+        """The ordered-block channel must survive SQLite persistence + reload.
+
+        This is the exact path that fails after a gateway crash: the session
+        is reloaded from state.db via get_messages_as_conversation, then
+        replayed. If the verbatim block list is dropped or not deserialized,
+        the reconstruction reorders signed thinking blocks -> HTTP 400.
+        """
+        import hermes_state
+
+        response = _interleaved_response()
+        original_order = _original_block_order(response)
+
+        transport = get_transport("anthropic_messages")
+        normalized = transport.normalize_response(response)
+        assistant_msg = _stored_assistant_message(normalized)
+
+        db = hermes_state.SessionDB(tmp_path / "state.db")
+        sid = "sess_roundtrip"
+        db.create_session(sid, source="test")
+        db.append_message(
+            session_id=sid,
+            role="assistant",
+            content=assistant_msg["content"],
+            tool_calls=assistant_msg["tool_calls"],
+            reasoning_details=assistant_msg.get("reasoning_details"),
+            anthropic_content_blocks=assistant_msg.get("anthropic_content_blocks"),
+        )
+        db.append_message(session_id=sid, role="tool", tool_call_id="toolu_1", content="a ok")
+        db.append_message(session_id=sid, role="tool", tool_call_id="toolu_2", content="b ok")
+
+        # Reload via the conversation-restore path used on resume / crash recovery.
+        loaded = db.get_messages_as_conversation(sid)
+        reloaded_assistant = [m for m in loaded if m.get("role") == "assistant"]
+        assert reloaded_assistant, "no assistant message after DB reload"
+        # The ordered-block channel must come back as a deserialized list.
+        blocks = reloaded_assistant[0].get("anthropic_content_blocks")
+        assert isinstance(blocks, list) and len(blocks) == 4, (
+            "anthropic_content_blocks was not persisted/deserialized correctly"
+        )
+
+        _system, anthropic_messages = convert_messages_to_anthropic(
+            loaded, base_url=None, model="claude-opus-4-8",
+        )
+        assistant_out = [m for m in anthropic_messages if m.get("role") == "assistant"]
+        assert assistant_out, "no assistant message in converted output"
+        replayed_order = _replayed_block_order(assistant_out[-1]["content"])
+
+        assert replayed_order == original_order, (
+            "Interleaved block order was lost across the SQLite round-trip.\n"
+            f"  original: {original_order}\n"
+            f"  replayed: {replayed_order}"
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/agent/test_anthropic_thinking_block_order.py
+++ b/tests/agent/test_anthropic_thinking_block_order.py
@@ -231,5 +231,104 @@ class TestInterleavedThinkingBlockOrder:
         )
 
 
+class TestInterleavedReplayCredentialRedaction:
+    """The verbatim-replay fast path must not leak un-redacted secrets.
+
+    anthropic_content_blocks captures each tool_use ``input`` from the RAW API
+    response (normalize_response), which is NOT credential-redacted. The
+    parallel tool_calls[].function.arguments IS redacted at storage time
+    (build_assistant_message, #19798). If the fast path replays the block's raw
+    input verbatim, a secret the model inlined into a tool call rides back onto
+    the wire — even though it is redacted everywhere else in history. The fix
+    re-sources tool_use input from the redacted tool_calls map by id.
+    """
+
+    def test_tool_use_input_resourced_from_redacted_tool_calls(self):
+        REDACTED = "[REDACTED_SECRET]"
+        # Ordered channel: raw input carries the live secret (as captured from
+        # the unredacted API response).
+        ordered = [
+            {"type": "thinking", "thinking": "Call the API.", "signature": "sig-AAA"},
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "terminal",
+                "input": {"command": "curl -H 'Authorization: Bearer sk-LIVE-SECRET-123'"},
+            },
+            {"type": "thinking", "thinking": "Now the second call.", "signature": "sig-BBB"},
+            {
+                "type": "tool_use",
+                "id": "toolu_2",
+                "name": "terminal",
+                "input": {"command": "echo done"},
+            },
+        ]
+        # Stored tool_calls: arguments already redacted (the #19798 path).
+        assistant_msg = {
+            "role": "assistant",
+            "content": "",
+            "reasoning_details": [b for b in ordered if b["type"] == "thinking"],
+            "tool_calls": [
+                {
+                    "id": "toolu_1",
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": json.dumps(
+                            {"command": f"curl -H 'Authorization: Bearer {REDACTED}'"}
+                        ),
+                    },
+                },
+                {
+                    "id": "toolu_2",
+                    "type": "function",
+                    "function": {
+                        "name": "terminal",
+                        "arguments": json.dumps({"command": "echo done"}),
+                    },
+                },
+            ],
+            "anthropic_content_blocks": ordered,
+        }
+        messages = [
+            {"role": "user", "content": "Hit the API twice."},
+            assistant_msg,
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "200 OK"},
+            {"role": "tool", "tool_call_id": "toolu_2", "content": "done"},
+        ]
+
+        _system, anthropic_messages = convert_messages_to_anthropic(
+            messages, base_url=None, model="claude-opus-4-8",
+        )
+        assistant_out = [m for m in anthropic_messages if m.get("role") == "assistant"]
+        assert assistant_out, "no assistant message in converted output"
+        blocks = assistant_out[-1]["content"]
+
+        tool_uses = {b["id"]: b for b in blocks if b.get("type") == "tool_use"}
+        assert set(tool_uses) == {"toolu_1", "toolu_2"}, "tool_use blocks missing/renamed"
+
+        # The replayed input must be the REDACTED value, not the live secret.
+        replayed_cmd = tool_uses["toolu_1"]["input"]["command"]
+        assert "sk-LIVE-SECRET-123" not in replayed_cmd, (
+            "Un-redacted secret leaked onto the wire via the verbatim-replay "
+            "fast path. tool_use input must be re-sourced from the redacted "
+            "tool_calls map, not the raw captured block."
+        )
+        assert REDACTED in replayed_cmd
+
+        # Interleave order is still preserved (the reason the channel exists).
+        order = [
+            ("thinking", b.get("signature")) if b.get("type") == "thinking"
+            else ("tool_use", b.get("id"))
+            for b in blocks if b.get("type") in ("thinking", "tool_use")
+        ]
+        assert order == [
+            ("thinking", "sig-AAA"),
+            ("tool_use", "toolu_1"),
+            ("thinking", "sig-BBB"),
+            ("tool_use", "toolu_2"),
+        ]
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -661,6 +661,42 @@ class TestClassifyApiError:
         # Without "thinking" in the message, it shouldn't be thinking_signature
         assert result.reason != FailoverReason.thinking_signature
 
+    def test_anthropic_thinking_blocks_cannot_be_modified(self):
+        """Frozen-block mutation 400 (no 'signature' token) routes to
+        thinking_signature recovery instead of hard-aborting. Regression for
+        the interleaved-thinking reorder: latest-assistant thinking blocks
+        'cannot be modified' after the turn is rebuilt out of order."""
+        e = MockAPIError(
+            "messages.73.content.10: `thinking` or `redacted_thinking` blocks "
+            "in the latest assistant message cannot be modified. These blocks "
+            "must remain as they were in the original response.",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="anthropic")
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_anthropic_thinking_cannot_be_modified_via_openrouter(self):
+        """Same frozen-block error proxied through OpenRouter must also be
+        caught — the classifier does not gate on provider."""
+        e = MockAPIError(
+            "`thinking` or `redacted_thinking` blocks in the latest assistant "
+            "message cannot be modified.",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="openrouter")
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_400_cannot_be_modified_without_thinking_not_classified(self):
+        """A 400 'cannot be modified' unrelated to thinking blocks must NOT be
+        swept into thinking_signature recovery (negative case)."""
+        e = MockAPIError(
+            "this field cannot be modified after creation", status_code=400,
+        )
+        result = classify_api_error(e, provider="anthropic", approx_tokens=0)
+        assert result.reason != FailoverReason.thinking_signature
+
     def test_invalid_encrypted_content_classified_as_retryable_replay_failure(self):
         body = {
             "error": {


### PR DESCRIPTION
## What does this PR do?

Fixes an intermittent HTTP 400 from Anthropic on multi-step agentic turns:

```
messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest
assistant message cannot be modified. These blocks must remain as they were
in the original response.
```

**Root cause.** With adaptive/interleaved thinking (Claude 4.6+, e.g. Opus 4.8), a single assistant turn interleaves signed `thinking` blocks with `tool_use` blocks. Anthropic signs each thinking block against the turn content *preceding it at its position*. `AnthropicTransport.normalize_response` split the turn into two parallel lists — `reasoning_details` (thinking) and `tool_calls` (tool_use) — discarding cross-type ordering, and `_convert_assistant_message` rebuilt the turn as `[all thinking][text][all tool_use]`. This front-loads thinking, moving `thinking_2` (signed with `tool_use_1` before it) ahead of `tool_use_1`. The signature no longer matches its position, and the API rejects the latest assistant message.

It recurs only on turns with multiple thinking blocks interleaved with tool calls (high/xhigh-effort agentic work), which is why it is intermittent. Confirmed in local logs as `agent.conversation_loop` failures against `api.anthropic.com` / `claude-opus-4-8`, at block indices `content.6/.7/.8/.10/.13`.

**Fix (preserve original order).** Carry a verbatim, order-preserving copy of the turn's content blocks (`anthropic_content_blocks`) end-to-end and replay it unchanged for the latest assistant message, instead of reconstructing from the parallel lists. The channel is **gated** — populated only when a turn actually interleaves *signed* thinking with `tool_use`, so pure-text and single-leading-thinking turns are untouched (near-zero overhead).

## Related Issue

No existing issue — root cause analysis and reproduction are documented inline.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/anthropic.py` — `normalize_response` captures ordered blocks; gated to interleaved signed-thinking + tool_use turns.
- `agent/transports/types.py` — `anthropic_content_blocks` property on `NormalizedResponse`.
- `agent/chat_completion_helpers.py` — `build_assistant_message` lifts the channel onto the stored message.
- `agent/anthropic_adapter.py` — `_convert_assistant_message` replays verbatim blocks when present.
- `hermes_state.py` — new `anthropic_content_blocks` column (auto-migrates via `_ensure_columns`), wired through both insert paths and the conversation-restore deserialize.
- `run_agent.py` — passes the field through to `append_message`.
- `tests/agent/test_anthropic_thinking_block_order.py` — 3 regression tests.

## How to Test

1. `pytest tests/agent/test_anthropic_thinking_block_order.py -v` — 3 tests: lossy-split confirmation, replay-order preservation, and a SQLite round-trip mirroring crash-recovery reload. All fail on `main`, pass with this change.
2. Broader suites green: `pytest tests/agent/test_anthropic_adapter.py tests/agent/transports/ -q` → 496 passed.
3. Old sessions without the column degrade gracefully to the existing reconstruction path; the new column is added automatically on startup.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(anthropic):`)
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/` and tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Linux (Solus 7.0.10)
- [x] Documentation & config: N/A (no config keys; internal adapter behavior)
- [x] Cross-platform: pure stdlib + SQLite, no POSIX-only calls
