### PR TITLE
fix(kanban): honor all toolset aliases

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -117,12 +117,13 @@ def test_worker_with_kanban_toolset_still_hides_board_routing(monkeypatch, tmp_p
     )
 
 
-def test_kanban_tools_visible_with_toolset_config(monkeypatch, tmp_path):
-    """Orchestrator profiles with toolsets: [kanban] see all kanban tools."""
+@pytest.mark.parametrize("toolset_name", ["kanban", "all", "*"])
+def test_kanban_tools_visible_with_toolset_config(monkeypatch, tmp_path, toolset_name):
+    """Orchestrator profiles with kanban-capable toolsets see all kanban tools."""
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
     home = tmp_path / ".hermes"
     home.mkdir()
-    (home / "config.yaml").write_text("toolsets:\n  - kanban\n")
+    (home / "config.yaml").write_text(f"toolsets:\n  - '{toolset_name}'\n")
     monkeypatch.setenv("HERMES_HOME", str(home))
 
     import tools.kanban_tools  # ensure registered

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -54,7 +54,7 @@ def _profile_has_kanban_toolset() -> bool:
         from hermes_cli.config import load_config
         cfg = load_config()
         toolsets = cfg.get("toolsets", [])
-        return "kanban" in toolsets
+        return any(name in {"kanban", "all", "*"} for name in toolsets)
     except Exception:
         return False
 


### PR DESCRIPTION
## Summary
- Fixes the Kanban tool check_fn gate so profiles configured with `toolsets: ["all"]` or `toolsets: ["*"]` expose the same Kanban tools as `toolsets: ["kanban"]`.
- Closes #35581.

## Why
- `toolsets.resolve_toolset()` documents `all`/`*` as aliases for every registered toolset, but `tools/kanban_tools.py` performed a literal `"kanban" in toolsets` check after registry expansion.
- That made Kanban tools silently disappear for non-worker profiles using the aliases, while dispatcher-spawned workers masked the bug via `HERMES_KANBAN_TASK`.

## Changes
- `tools/kanban_tools.py`: treats `kanban`, `all`, and `*` as Kanban-capable profile toolset values in the Kanban gate.
- `tests/tools/test_kanban_tools.py`: parametrizes the orchestrator visibility regression test across `kanban`, `all`, and `*`.

## Validation
- `python -m pytest tests/tools/test_kanban_tools.py -q -o 'addopts='` (83 passed, 1 warning)
- `python -m ruff check tools/kanban_tools.py tests/tools/test_kanban_tools.py`
- `git diff --check`

## Scope
- In scope: the Kanban tool registration check_fn gate for top-level `toolsets` config aliases.
- Out of scope: platform-specific/composite toolset filtering issues such as #35527.
