### PR TITLE
fix(dashboard): honor OAuth sessions for plugin endpoints

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -147,7 +147,18 @@ def _has_valid_session_token(request: Request) -> bool:
 
 
 def _require_token(request: Request) -> None:
-    """Validate the ephemeral session token.  Raises 401 on mismatch."""
+    """Validate dashboard API auth. Raises 401 on mismatch.
+
+    Remote/gated dashboards authenticate browser users through the OAuth
+    middleware, which attaches ``request.state.session`` after cookie
+    validation. Local/legacy dashboard callers still use the ephemeral header
+    token checked below.
+    """
+    if (
+        getattr(request.app.state, "auth_required", False)
+        and getattr(request.state, "session", None) is not None
+    ):
+        return
     if not _has_valid_session_token(request):
         raise HTTPException(status_code=401, detail="Unauthorized")
 

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -297,6 +297,41 @@ def test_api_auth_me_requires_auth(gated_app):
     assert r.status_code == 401
 
 
+def test_gated_plugin_hub_accepts_cookie_session_without_legacy_token(gated_app, monkeypatch):
+    def fake_hub():
+        return {"plugins": [{"id": "stub-plugin"}]}
+
+    monkeypatch.setattr(web_server, "_merged_plugins_hub", fake_hub)
+
+    r1 = gated_app.get("/auth/login?provider=stub", follow_redirects=False)
+    state = r1.headers["location"].split("state=")[1]
+    gated_app.get(
+        f"/auth/callback?code=stub_code&state={state}",
+        follow_redirects=False,
+    )
+
+    r = gated_app.get("/api/dashboard/plugins/hub")
+
+    assert r.status_code == 200
+    assert r.json() == {"plugins": [{"id": "stub-plugin"}]}
+
+
+def test_gated_plugin_hub_still_requires_cookie_session(gated_app, monkeypatch):
+    called = False
+
+    def fake_hub():
+        nonlocal called
+        called = True
+        return {"plugins": []}
+
+    monkeypatch.setattr(web_server, "_merged_plugins_hub", fake_hub)
+
+    r = gated_app.get("/api/dashboard/plugins/hub")
+
+    assert r.status_code == 401
+    assert called is False
+
+
 # ---------------------------------------------------------------------------
 # Zero-providers fail-closed
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #35492.

## Summary
- allow dashboard API token checks to accept requests already authenticated by the gated OAuth cookie middleware
- keep the legacy ephemeral dashboard token path for local/non-OAuth callers
- add regression coverage for the plugin hub endpoint accepting a cookie session and still rejecting unauthenticated requests

## Tests
- `uv run --extra dev ruff check .`
- `uv run --extra dev --extra web python -X utf8 -m pytest tests\hermes_cli\test_dashboard_auth_middleware.py -q --timeout-method=thread`