### PR TITLE
fix(backup): atomically restore cron/jobs.json via tempfile + rename

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -753,7 +753,21 @@ def restore_cron_jobs_if_emptied(
 
     try:
         live_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(snap_path, live_path)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(live_path.parent), suffix=".tmp", prefix=".cron_restore_"
+        )
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(snap_path.read_bytes())
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, live_path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
     except (OSError, PermissionError) as exc:
         logger.error(
             "Cron jobs were emptied during update but auto-restore failed: %s", exc


### PR DESCRIPTION
## What does this PR do?

`restore_cron_jobs_if_emptied()` in `hermes_cli/backup.py` uses
`shutil.copy2(snap_path, live_path)` to restore `cron/jobs.json` when a
`hermes update` empties it. `shutil.copy2` is **not atomic**: if the process
is killed mid-copy (SIGKILL, OOM, power loss) the live file is left partially
written — corrupt JSON that is *worse* than the empty file the function was
trying to fix.

This PR replaces the copy with the atomic pattern already used by `save_jobs()`
in `cron/jobs.py`: `mkstemp` → `write` + `fsync` → `os.replace`. The temp file
is created in the same directory as the target so the final rename is guaranteed
to be on the same filesystem (atomic). On any failure the temp file is removed
and the live file is left untouched.

## Related Issue

Fixes #34600 (follow-up hardening — the restore path introduced by #34840
inherited the non-atomic copy)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/backup.py`: replace `shutil.copy2(snap_path, live_path)` with
  `mkstemp` + `write` + `fsync` + `os.replace` in `restore_cron_jobs_if_emptied()`

## How to Test

1. Create a few cron jobs (`hermes cron add ...`)
2. Take a quick snapshot: run `hermes update` once so a pre-update snapshot exists
3. Empty `~/.hermes/cron/jobs.json` manually (`echo '{jobs:[]}' > ...`)
4. Call `restore_cron_jobs_if_emptied(snapshot_id)` — confirm jobs are restored
5. To verify atomicity: add a `time.sleep()` after `fdopen` write and kill the
   process mid-sleep — confirm no partial `.cron_restore_*.tmp` file remains and
   `jobs.json` is unchanged

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Same atomic pattern already merged in this repo:
- #30857, #30855, #32233 (`atomic_json_write` migrations)