### PR TITLE
fix(kanban): delete partial attachment file on OSError during upload

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -727,6 +727,7 @@ async def upload_task_attachment(
         except HTTPException:
             raise
         except OSError as exc:
+            dest_path.unlink(missing_ok=True)
             raise HTTPException(status_code=500, detail=f"failed to store attachment: {exc}")
 
         att_id = kanban_db.add_attachment(


### PR DESCRIPTION
## What does this PR do?

`upload_task_attachment()` in `plugins/kanban/dashboard/plugin_api.py` writes
the uploaded blob directly to `dest_path`. When an `OSError` occurs mid-write
(disk full, permission denied, etc.) the handler converts it to HTTP 500 but
**does not remove `dest_path`**, leaving a partial file on disk with no matching
row in `task_attachments`.

The size-limit (413) path immediately above already does the right thing:

```python
dest_path.unlink(missing_ok=True)
raise HTTPException(status_code=413, ...)
```

The `OSError` path was missing the same one-line cleanup.

## Related Issue

Fixes #35338 (follow-up — the attachment upload endpoint introduced in #35395
did not clean up on write failure)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/kanban/dashboard/plugin_api.py`: add `dest_path.unlink(missing_ok=True)`
  before re-raising in the `except OSError` handler of `upload_task_attachment()`

## How to Test

1. Upload a file to a kanban task via the dashboard
2. Simulate a disk-full error (e.g. mock `out.write` to raise `OSError`)
3. **Before fix:** a partial file is left under `~/.hermes/kanban/attachments/<task_id>/`
4. **After fix:** no file remains; the HTTP 500 is returned cleanly

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

One-line diff — only the cleanup path changes, happy path is unaffected.