### PR TITLE
docs(skills): improve GitHub skill routing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -695,6 +695,17 @@ contributor skill PRs.
 
 ---
 
+## Brain operations
+
+Skill resolver rows used by health tooling:
+
+| Trigger | Skill |
+|---|---|
+| Exploratory QA of web apps, dogfood app/site, test website | `skills/dogfood/SKILL.md` |
+| Yuanbao groups, @mention users, query group info/members | `skills/yuanbao/SKILL.md` |
+
+---
+
 ## Toolsets
 
 All toolsets are defined in `toolsets.py` as a single `TOOLSETS` dict.

--- a/skills/dogfood/SKILL.md
+++ b/skills/dogfood/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: dogfood
 description: "Exploratory QA of web apps: find bugs, evidence, reports."
+triggers:
+  - "dogfood this app"
+  - "QA this website"
+  - "test this web app"
+  - "find bugs in this site"
+  - "exploratory web QA"
 version: 1.0.0
 platforms: [linux, macos, windows]
 metadata:

--- a/skills/github/codebase-inspection/SKILL.md
+++ b/skills/github/codebase-inspection/SKILL.md
@@ -24,6 +24,7 @@ Analyze repositories for lines of code, language breakdown, file counts, and cod
 - User asks about codebase size or composition
 - User wants code-vs-comment ratios
 - General "how big is this repo" questions
+- User asks to inventory many GitHub repositories, find repos related to a keyword/model/tool, or distinguish real codebases from lightweight skill/documentation repos
 
 ## Prerequisites
 
@@ -107,6 +108,20 @@ Special pseudo-languages:
 - `__generated__` — auto-generated files (detected heuristically)
 - `__duplicate__` — files with identical content
 - `__unknown__` — unrecognized file types
+
+## 7. Multi-repo GitHub inventory
+
+When the user asks which repositories mention a model/tool/project, or wants a portfolio-wide inventory, use `gh repo list` metadata first, then only clone/inspect likely matches or all repositories if a full audit is requested.
+
+Useful metadata dimensions:
+
+- repository visibility: private/public, archived, fork
+- default branch, primary language, description
+- presence of `SKILL.md`, `README.md`, package manifests, tests, and scripts
+- keyword hits across repository name + description + important top-level docs
+- rough classification: lightweight skill/doc repo vs real application/codebase
+
+For large account inventories, write a machine-readable JSON artifact such as `/tmp/<account>_repo_inventory.json` and summarize counts in the reply. See `references/github-multi-repo-inventory.md` for a compact recipe.
 
 ## Pitfalls
 

--- a/skills/github/codebase-inspection/references/github-multi-repo-inventory.md
+++ b/skills/github/codebase-inspection/references/github-multi-repo-inventory.md
@@ -1,0 +1,69 @@
+# GitHub multi-repo inventory recipe
+
+Use this when asked to search an account or organization for repositories related to a keyword, model family, workflow, or review capability.
+
+## 1. Start with GitHub metadata
+
+```bash
+gh repo list OWNER --limit 1000 --json \
+  name,nameWithOwner,description,isPrivate,isArchived,isFork,primaryLanguage,defaultBranchRef,url
+```
+
+Prefer metadata first; it is fast and avoids cloning everything prematurely.
+
+## 2. Inspect top-level repository shape
+
+For each candidate repository (or all repositories for a full audit), gather:
+
+- top-level files: `README.md`, `SKILL.md`, package manifests
+- directories: `scripts/`, `tests/`, `examples/`, `references/`, `schemas/`
+- file count excluding `.git`, `node_modules`, virtualenvs, build artifacts
+- test count and script count
+- keywords in repository name, description, README, SKILL.md, and package metadata
+
+Classify repositories roughly as:
+
+- **lightweight skill/doc repo**: often just `README.md` + `SKILL.md` and small references/examples
+- **review/eval workflow repo**: scripts + schemas + examples + skill/docs
+- **application/codebase**: package manifests, source dirs, tests, CI, substantial file count
+- **vendor/noisy repo**: large `node_modules`, generated files, or forked dependency
+
+## 3. Save a JSON artifact
+
+Write a durable artifact for the session, e.g.:
+
+```text
+/tmp/OWNER_repo_inventory.json
+```
+
+Suggested fields per repository:
+
+```json
+{
+  "full_name": "OWNER/repo",
+  "description": "...",
+  "private": true,
+  "archived": false,
+  "fork": false,
+  "language": "Python",
+  "file_count": 123,
+  "has_skill": true,
+  "manifests": ["pyproject.toml", "package.json"],
+  "tests_count": 14,
+  "scripts_count": 3,
+  "keyword_hits": ["qwen", "review"]
+}
+```
+
+## 4. Summarize for the user
+
+Report counts first, then the important repositories:
+
+- total repositories, private/public, archived, forks
+- repositories with `SKILL.md`
+- likely lightweight skill/doc repositories
+- real code/app repositories
+- keyword-specific matches
+- recommended next inspection targets
+
+Avoid overclaiming from names alone: mark likely roles and call out when a repository needs deeper inspection.

--- a/skills/github/github-code-review/SKILL.md
+++ b/skills/github/github-code-review/SKILL.md
@@ -97,6 +97,35 @@ git diff main...HEAD | grep -n "<<<<<<\|>>>>>>\|======="
 
 4. **Present structured feedback** to the user.
 
+### Red/Blue documentation workflow review
+
+When the user asks for a Blue Team review of a documentation diff against likely Red Team concerns:
+
+1. First gather the actual diff if available (`gh pr diff`, `git diff`, or changed docs from the remote). If no local checkout or open PR exists, state that limitation and review the provided diff summary plus the current remote/main docs rather than inventing unseen changes.
+2. Evaluate whether the documentation uses the user's requested workflow language, especially ordered process requirements such as `branch -> commit -> scan -> push -> PR`.
+3. Treat omitted explicit steps as a likely Red Team concern even when they are implied by adjacent GitHub workflow prose. Users asking for workflow compliance usually want the sequence auditable in text.
+4. Produce concise bullets with: pass/fail recommendation, Blue Team defense, likely Red Team concerns, mitigations/tests/checks to run, and minimal fixes.
+5. For documentation-only changes, recommended checks include `git diff --check`, markdown/link lint if configured, pre-push leak scanning when GitHub workflow docs or examples are touched, and textual verification that each required workflow token appears in the changed docs.
+
+### Documentation / Policy Diff Red-Team Format
+
+When the user asks for a red-team review of a documentation or policy diff:
+
+1. Inspect the exact diff plus nearby context and any generated templates/scripts that implement the policy.
+2. Check `git status --short --untracked-files=all` and compare it to `git diff --name-only`; untracked files that the prose claims are part of the change are a high-signal next-run failure risk.
+3. If the change adds workflow gates (PR templates, CI workflows, scripts, hooks), inspect whether enforcement artifacts are actually tracked and whether examples invoke/populate them. Treat a checkbox/template-only gate as advisory unless CI/branch protection makes it fail-closed.
+4. For leak-scan workflow claims, challenge scan scope explicitly: staged vs unstaged vs outgoing commits, untracked intended files, scanner command, exit-code behavior, redaction, and remediation when a leak is found. A vague “run a scan” line is not enough evidence for a safe push gate.
+5. Look specifically for concrete failure modes, ambiguities, policy regressions, security/workflow risks, missing preconditions, scanner bypass risk, false confidence, and bypass/misinterpretation paths.
+6. Return concise bullets with severity and evidence. Evidence should include file/line references or exact changed text when available.
+7. Do not propose broad rewrites unless the user asks for fixes. Keep suggestions minimal or omit them entirely when the request is findings-only.
+8. Note verification performed (for example `git diff --check`, leak scan command and scope, frontmatter/metadata parse) and whether any files were modified.
+
+Example bullet:
+
+```
+- **High — Gate can be skipped by generated PRs.** Evidence: docs require the gate, but the PR body generator still emits only the old checklist (`scripts/foo.py:40-48`).
+```
+
 ### Review Output Format
 
 When reviewing local changes, present findings in this structure:

--- a/skills/github/github-repo-management/SKILL.md
+++ b/skills/github/github-repo-management/SKILL.md
@@ -54,6 +54,44 @@ REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
 
 ---
 
+## macOS FileProvider / iCloud Dataless Project Directories
+
+When publishing or inspecting a project under iCloud/FileProvider-backed paths, file reads or git operations may intermittently fail with `Resource deadlock avoided` because files are marked `compressed,dataless`. The durable workaround is to hydrate files before scanning/committing, and if `.git` itself becomes dataless, copy only tracked-worthy source files to a clean staging directory outside iCloud (for example under `/tmp`) and initialize/push from there.
+
+Recommended pattern:
+
+```bash
+# Hydrate project files before tests, scans, git add, or push.
+python3 - <<'PY'
+from pathlib import Path
+import os, subprocess, time
+skip_dirs = {'.git', '.venv', '.pytest_cache', 'state', '__pycache__', 'logs'}
+files = []
+for dirpath, dirnames, filenames in os.walk('.'):
+    dirnames[:] = [d for d in dirnames if d not in skip_dirs]
+    if any(part in skip_dirs for part in Path(dirpath).parts):
+        continue
+    files += [Path(dirpath) / name for name in filenames]
+for p in files:
+    subprocess.run(['/usr/bin/brctl', 'download', str(p)], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+for _ in range(10):
+    bad = []
+    for p in files:
+        try:
+            with p.open('rb') as handle:
+                handle.read(1)
+        except OSError as exc:
+            bad.append((p, exc))
+    if not bad:
+        break
+    time.sleep(1)
+if bad:
+    raise SystemExit(f'unreadable files remain: {bad[:5]}')
+PY
+```
+
+If git metadata is already dataless, avoid repairing it in place during a publish. Create a clean staging copy excluding `.git`, virtualenvs, caches, state, logs, `config.yaml`, and `.env`; then run tests, scans, `git init`, commit, and push from the staging directory.
+
 ## 1. Cloning Repositories
 
 Cloning is pure `git` — works identically either way:

--- a/skills/yuanbao/SKILL.md
+++ b/skills/yuanbao/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: yuanbao
 description: "Yuanbao (元宝) groups: @mention users, query info/members."
+triggers:
+  - "Yuanbao group"
+  - "元宝 group"
+  - "@mention in Yuanbao"
+  - "艾特 someone in 元宝"
+  - "query Yuanbao group members"
 version: 1.0.0
 platforms: [linux, macos, windows]
 metadata:


### PR DESCRIPTION
## Summary
- Adds resolver-visible trigger rows for `dogfood` and `yuanbao`, and adds frontmatter triggers for both skills.
- Improves GitHub skill guidance for multi-repo inventories, documentation/policy reviews, and macOS FileProvider/iCloud dataless repositories.
- Adds a compact `codebase-inspection` reference for GitHub multi-repo inventory workflows.

## Verification
- `python -m pytest tests/tools/test_skill_manager_tool.py tests/agent/test_skill_bundles.py -q -o addopts=` → 119 passed
- Frontmatter parse check for changed SKILL.md files → pass
- Markdown fence balance check for changed docs → pass
- `git diff --check` → pass
- `gbrain skillpack-check` → healthy
- Exact outgoing commit scan: `BASE=$(git merge-base origin/main HEAD); gitleaks detect --source . --log-opts "$BASE..HEAD" --redact=100 --no-banner --exit-code 1` → no leaks found
- Diff pipe scan: `git diff origin/main...HEAD | gitleaks detect --pipe --redact=100 --no-banner --exit-code 1` → no leaks found

## Review notes
- Red Team concerns: docs-only changes can rot if not represented in resolver tables; added `AGENTS.md` table rows and checked `gbrain skillpack-check`.
- Blue Team mitigations: changed SKILL.md frontmatter validates, linked reference file is committed, and gitleaks scans passed before push.
- Final judge status: pass for docs/skill metadata scope.
