### PR TITLE
feat(memory): operationalize holographic governance evidence

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -153,6 +153,7 @@ class HolographicMemoryProvider(MemoryProvider):
             {"key": "auto_extract", "description": "Auto-extract facts at session end", "default": "false", "choices": ["true", "false"]},
             {"key": "default_trust", "description": "Default trust score for new facts", "default": "0.5"},
             {"key": "hrr_dim", "description": "HRR vector dimensions", "default": "1024"},
+            {"key": "query_log_sample_rate", "description": "Fraction of searches to record in query_log", "default": "0.0"},
         ]
 
     def initialize(self, session_id: str, **kwargs) -> None:
@@ -170,13 +171,16 @@ class HolographicMemoryProvider(MemoryProvider):
         hrr_dim = int(self._config.get("hrr_dim", 1024))
         hrr_weight = float(self._config.get("hrr_weight", 0.3))
         temporal_decay = int(self._config.get("temporal_decay_half_life", 0))
+        query_log_sample_rate = float(self._config.get("query_log_sample_rate", 0.0))
 
         self._store = MemoryStore(db_path=db_path, default_trust=default_trust, hrr_dim=hrr_dim)
+        self._store.repair_missing_hrr_vectors(dim=hrr_dim)
         self._retriever = FactRetriever(
             store=self._store,
             temporal_decay_half_life=temporal_decay,
             hrr_weight=hrr_weight,
             hrr_dim=hrr_dim,
+            query_log_sample_rate=query_log_sample_rate,
         )
         self._session_id = session_id
 
@@ -235,7 +239,10 @@ class HolographicMemoryProvider(MemoryProvider):
         return tool_error(f"Unknown tool: {tool_name}")
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
-        if not self._config.get("auto_extract", False):
+        auto_extract = self._config.get("auto_extract", False)
+        # Hard governance guard: only boolean True or string "true" enables
+        # extraction. Values like 1, "yes", and "false" deliberately do not.
+        if auto_extract is not True and str(auto_extract).lower() != "true":
             return
         if not self._store or not messages:
             return

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -7,6 +7,7 @@ Jaccard similarity reranking and trust-weighted scoring.
 from __future__ import annotations
 
 import math
+import random
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -30,10 +31,12 @@ class FactRetriever:
         jaccard_weight: float = 0.3,
         hrr_weight: float = 0.3,
         hrr_dim: int = 1024,
+        query_log_sample_rate: float = 0.0,
     ):
         self.store = store
         self.half_life = temporal_decay_half_life
         self.hrr_dim = hrr_dim
+        self.query_log_sample_rate = max(0.0, min(1.0, float(query_log_sample_rate)))
 
         # Auto-redistribute weights if numpy unavailable
         if hrr_weight > 0 and not hrr._HAS_NUMPY:
@@ -62,11 +65,21 @@ class FactRetriever:
 
         Returns list of dicts with fact data + 'score' field, sorted by score desc.
         """
-        # Stage 1: Get FTS5 candidates (more than limit for reranking headroom)
+        # Stage 1: Get FTS5 candidates (more than limit for reranking headroom).
+        # Plain FTS5 whitespace uses AND semantics, which is precise but brittle
+        # for user questions like "where is the Codex CLI path fix?". If that
+        # strict pass returns nothing, retry with an OR query over informative
+        # tokens before giving up.
         candidates = self._fts_candidates(query, category, min_trust, limit * 3)
+        if not candidates:
+            relaxed_query = self._relaxed_fts_query(query)
+            if relaxed_query:
+                candidates = self._fts_candidates(relaxed_query, category, min_trust, limit * 3)
 
         if not candidates:
-            return []
+            results = self._hrr_fallback_candidates(query, category, min_trust, limit)
+            self._record_retrievals(results, query=query, category=category)
+            return results
 
         # Stage 2: Rerank with Jaccard + trust + optional decay
         query_tokens = self._tokenize(query)
@@ -83,7 +96,8 @@ class FactRetriever:
             # HRR similarity
             if self.hrr_weight > 0 and fact.get("hrr_vector"):
                 fact_vec = hrr.bytes_to_phases(fact["hrr_vector"])
-                query_vec = hrr.encode_text(query, self.hrr_dim)
+                role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
+                query_vec = hrr.bind(hrr.encode_text(query, self.hrr_dim), role_content)
                 hrr_sim = (hrr.similarity(query_vec, fact_vec) + 1.0) / 2.0  # shift to [0,1]
             else:
                 hrr_sim = 0.5  # neutral
@@ -106,6 +120,11 @@ class FactRetriever:
         # Sort by score descending, return top limit
         scored.sort(key=lambda x: x["score"], reverse=True)
         results = scored[:limit]
+
+        # FactRetriever bypasses MemoryStore.search_facts(), so it must record
+        # telemetry itself; otherwise fact_store(search) leaves retrieval_count
+        # at zero even when facts are actively used.
+        self._record_retrievals(results, query=query, category=category)
         # Strip raw HRR bytes — callers expect JSON-serializable dicts
         for fact in results:
             fact.pop("hrr_vector", None)
@@ -540,6 +559,103 @@ class FactRetriever:
             results.append(fact)
 
         return results
+
+    def _record_retrievals(
+        self,
+        facts: list[dict],
+        query: str | None = None,
+        category: str | None = None,
+    ) -> None:
+        """Record retrieval_count and sampled query telemetry."""
+        if query and self.query_log_sample_rate > 0 and random.random() < self.query_log_sample_rate:
+            top_fact_id = None
+            if facts and facts[0].get("fact_id") is not None:
+                top_fact_id = int(facts[0]["fact_id"])
+            self.store.record_query_log(
+                query=query,
+                category=category,
+                result_count=len(facts),
+                top_fact_id=top_fact_id,
+            )
+
+        fact_ids = [int(f["fact_id"]) for f in facts if f.get("fact_id") is not None]
+        if not fact_ids:
+            return
+
+        self.store.increment_retrieval_counts(fact_ids)
+        for fact in facts:
+            fact["retrieval_count"] = int(fact.get("retrieval_count") or 0) + 1
+
+    def _hrr_fallback_candidates(
+        self,
+        query: str,
+        category: str | None,
+        min_trust: float,
+        limit: int,
+    ) -> list[dict]:
+        """Score all vectorized facts when FTS5 cannot produce candidates."""
+        if self.hrr_weight <= 0 or not hrr._HAS_NUMPY:
+            return []
+
+        conn = self.store._conn
+        query_tokens = self._tokenize(query)
+        role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
+        query_vec = hrr.bind(hrr.encode_text(query, self.hrr_dim), role_content)
+
+        where = ["hrr_vector IS NOT NULL", "trust_score >= ?"]
+        params: list = [min_trust]
+        if category:
+            where.append("category = ?")
+            params.append(category)
+
+        rows = conn.execute(
+            f"""
+            SELECT fact_id, content, category, tags, trust_score,
+                   retrieval_count, helpful_count, created_at, updated_at,
+                   hrr_vector
+            FROM facts
+            WHERE {' AND '.join(where)}
+            """,
+            params,
+        ).fetchall()
+
+        scored = []
+        for row in rows:
+            fact = dict(row)
+            fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
+            content_tokens = self._tokenize(fact["content"])
+            tag_tokens = self._tokenize(fact.get("tags", ""))
+            all_tokens = content_tokens | tag_tokens
+            jaccard = self._jaccard_similarity(query_tokens, all_tokens)
+            hrr_sim = (hrr.similarity(query_vec, fact_vec) + 1.0) / 2.0
+            relevance = self.jaccard_weight * jaccard + self.hrr_weight * hrr_sim
+            fact["fts_rank"] = 0.0
+            fact["score"] = relevance * fact["trust_score"]
+            scored.append(fact)
+
+        scored.sort(key=lambda x: x["score"], reverse=True)
+        return scored[:limit]
+
+    @classmethod
+    def _relaxed_fts_query(cls, query: str) -> str:
+        """Build a conservative OR fallback query for natural-language input."""
+        # This aggressive stopword set is fallback-only: strict FTS gets the
+        # first chance, then HRR scoring remains available if relaxed FTS drops
+        # too much context. Keep store/stored/storing here to avoid generic
+        # memory-management phrasing over-ranking unrelated facts.
+        stopwords = {
+            "a", "an", "and", "are", "as", "at", "be", "by", "for", "from",
+            "could", "did", "do", "does", "find", "give", "how", "i", "in",
+            "is", "it", "look", "lookup", "me", "my", "of", "on", "or",
+            "our", "please", "remember", "should", "show", "store", "stored",
+            "storing", "tell", "the", "to", "we", "what", "when", "where",
+            "which", "who", "why", "with", "would", "you", "your",
+        }
+        tokens = sorted(t for t in cls._tokenize(query) if len(t) > 1 and t not in stopwords)
+        if len(tokens) < 2:
+            return ""
+
+        return " OR ".join(f'"{token.replace(chr(34), chr(34) + chr(34))}"' for token in tokens)
 
     @staticmethod
     def _tokenize(text: str) -> set[str]:

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -73,6 +73,15 @@ CREATE TABLE IF NOT EXISTS memory_banks (
     fact_count INTEGER DEFAULT 0,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS query_log (
+    query_id     INTEGER PRIMARY KEY AUTOINCREMENT,
+    query        TEXT NOT NULL,
+    category     TEXT,
+    result_count INTEGER DEFAULT 0,
+    top_fact_id  INTEGER REFERENCES facts(fact_id),
+    created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
 """
 
 # Trust adjustment constants
@@ -97,6 +106,11 @@ def _clamp_trust(value: float) -> float:
 
 class MemoryStore:
     """SQLite-backed fact store with entity resolution and trust scoring."""
+
+    @staticmethod
+    def _escape_like_literal(value: str) -> str:
+        """Escape a string for literal matching inside a SQLite LIKE pattern."""
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
     def __init__(
         self,
@@ -237,6 +251,88 @@ class MemoryStore:
                 )
                 self._conn.commit()
 
+            return results
+
+    def increment_retrieval_counts(self, fact_ids: list[int]) -> None:
+        """Increment retrieval telemetry for the given fact ids."""
+        ids = sorted({int(fact_id) for fact_id in fact_ids if fact_id is not None})
+        if not ids:
+            return
+
+        with self._lock:
+            placeholders = ",".join("?" * len(ids))
+            self._conn.execute(
+                f"UPDATE facts SET retrieval_count = retrieval_count + 1 WHERE fact_id IN ({placeholders})",
+                ids,
+            )
+            self._conn.commit()
+
+    def record_query_log(
+        self,
+        query: str,
+        category: str | None = None,
+        result_count: int = 0,
+        top_fact_id: int | None = None,
+    ) -> int:
+        """Record sampled retrieval telemetry and return query_id."""
+        with self._lock:
+            cur = self._conn.execute(
+                """
+                INSERT INTO query_log (query, category, result_count, top_fact_id)
+                VALUES (?, ?, ?, ?)
+                """,
+                (query, category, int(result_count), top_fact_id),
+            )
+            self._conn.commit()
+            return int(cur.lastrowid or 0)
+
+    def find_stale_fact_candidates(
+        self,
+        fragments: tuple[str, ...] | list[str],
+        stale_days: int = 60,
+        min_trust: float = 0.3,
+        categories: tuple[str, ...] | list[str] = ("project", "tool"),
+        limit: int = 50,
+    ) -> list[dict]:
+        """Find actionable stale-fact candidates using explicit governance filters."""
+        needles = [fragment.strip() for fragment in fragments if fragment and fragment.strip()]
+        if not needles:
+            return []
+
+        with self._lock:
+            where = ["trust_score >= ?", "updated_at <= datetime('now', ?)"]
+            params: list = [float(min_trust), f"-{int(stale_days)} days"]
+
+            if categories:
+                placeholders = ",".join("?" * len(categories))
+                where.append(f"category IN ({placeholders})")
+                params.extend(categories)
+
+            content_clauses = []
+            for fragment in needles:
+                content_clauses.append("content LIKE ? ESCAPE '\\'")
+                params.append(f"%{self._escape_like_literal(fragment)}%")
+            where.append("(" + " OR ".join(content_clauses) + ")")
+
+            params.append(int(limit))
+            rows = self._conn.execute(
+                f"""
+                SELECT fact_id, content, category, tags, trust_score,
+                       retrieval_count, helpful_count, created_at, updated_at
+                FROM facts
+                WHERE {' AND '.join(where)}
+                ORDER BY updated_at ASC, fact_id ASC
+                LIMIT ?
+                """,
+                params,
+            ).fetchall()
+
+            results = [self._row_to_dict(row) for row in rows]
+            for result in results:
+                content = result.get("content", "").casefold()
+                result["matched_fragments"] = [
+                    fragment for fragment in needles if fragment.casefold() in content
+                ]
             return results
 
     def update_fact(
@@ -548,6 +644,36 @@ class MemoryStore:
             rows = self._conn.execute(
                 "SELECT fact_id, content, category FROM facts"
             ).fetchall()
+
+            categories: set[str] = set()
+            for row in rows:
+                self._compute_hrr_vector(row["fact_id"], row["content"])
+                categories.add(row["category"])
+
+            for category in categories:
+                self._rebuild_bank(category)
+
+            return len(rows)
+
+    def repair_missing_hrr_vectors(self, dim: int | None = None) -> int:
+        """Compute HRR vectors only for rows that are missing them.
+
+        This keeps startup repair cheap while fixing migrated/imported facts that
+        predate the hrr_vector column or were inserted before NumPy was available.
+        Returns the number of repaired facts.
+        """
+        with self._lock:
+            if not self._hrr_available:
+                return 0
+
+            if dim is not None:
+                self.hrr_dim = dim
+
+            rows = self._conn.execute(
+                "SELECT fact_id, content, category FROM facts WHERE hrr_vector IS NULL"
+            ).fetchall()
+            if not rows:
+                return 0
 
             categories: set[str] = set()
             for row in rows:

--- a/tests/plugins/memory/test_holographic_memory.py
+++ b/tests/plugins/memory/test_holographic_memory.py
@@ -1,0 +1,413 @@
+"""Regression tests for the holographic memory provider.
+
+These tests cover production issues found during the 2026-05-30 memory audit:
+- fact_store(search) bypassed retrieval_count telemetry
+- strict FTS5 AND semantics made natural-language queries return no results
+- migrated/imported rows could have NULL hrr_vector forever unless manually rebuilt
+- relaxed FTS OR fallback could over-rank generic conversational terms like "store"
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import json
+
+from plugins.memory.holographic import holographic as hrr
+from plugins.memory.holographic import HolographicMemoryProvider
+from plugins.memory.holographic.retrieval import FactRetriever
+from plugins.memory.holographic.store import MemoryStore
+
+
+CURATED_BASELINE_CASES = [
+    {
+        "content": "10x10 workspace is ~/Developer/10x10; repos: app-flutter, portal-api-node, 10x10-platform; skills live in .agents/skills and are projected to .claude/skills by symlink.",
+        "category": "project",
+        "tags": "10x10,workspace,repos,skills",
+        "query": "where is the 10x10 workspace and which repos are there?",
+        "expected": "~/Developer/10x10",
+    },
+    {
+        "content": "Hermes ops: ~/.local/bin/hermes points to ~/.hermes/hermes-agent/venv/bin/hermes source checkout. Prefer `hermes update` for updates; if WebUI blocks, use manual git fast-forward plus `uv pip install --python venv/bin/python -e .`. Restart gateway with `hermes gateway restart`.",
+        "category": "tool",
+        "tags": "hermes,upgrade,terminal,command,update,source-checkout",
+        "query": "how should we update Hermes from the source checkout?",
+        "expected": "prefer `hermes update`",
+    },
+    {
+        "content": "mise Java 17 path is /Users/erichsu/.local/share/mise/installs/java/17.0.2; use it for Flutter/Gradle failures; prefer mise env for fastlane/bundle.",
+        "category": "tool",
+        "tags": "java,mise,flutter,gradle,fastlane",
+        "query": "which Java 17 should Flutter Gradle use via mise?",
+        "expected": "17.0.2",
+    },
+    {
+        "content": "10x10-platform requires Node >=20.19.0 <21; local shell may be v25.9.0 and pnpm can warn about engines.",
+        "category": "project",
+        "tags": "10x10-platform,node,pnpm",
+        "query": "what Node version does 10x10 platform require?",
+        "expected": "Node >=20.19.0",
+    },
+    {
+        "content": "portal-api-node: avoid patch editing api_backend/models/user.ts because it can truncate; use raw-file plus git restore. Clear stale .worktrees if TS lint scans them.",
+        "category": "project",
+        "tags": "portal-api-node,typescript,worktree,pitfall",
+        "query": "which portal api node user model file should not be patch edited?",
+        "expected": "api_backend/models/user.ts",
+    },
+    {
+        "content": "Hermes default is openai-codex/gpt-5.5 with fallback anthropic/claude-sonnet-4-6; empty delegation.model/provider inherits current session; Opus delegation needs explicit per-call model.",
+        "category": "tool",
+        "tags": "hermes,routing,delegation,models,model,default,inherit,inherits",
+        "query": "what is Hermes default model and how does empty delegation inherit?",
+        "expected": "openai-codex/gpt-5.5",
+    },
+    {
+        "content": "Opus effort policy: default high; complex tasks use xhigh via `hermes config set agent.reasoning_effort xhigh`, then restore afterward; routing.yaml is source of truth.",
+        "category": "tool",
+        "tags": "opus,reasoning,routing",
+        "query": "how do we set Opus effort xhigh?",
+        "expected": "reasoning_effort xhigh",
+    },
+    {
+        "content": "Local Claude CLI is /opt/homebrew/bin/claude; it does not support --acp --stdio; credential name is tingyao.hsu--claude-code-laptop; skills model aliases are opus/sonnet.",
+        "category": "tool",
+        "tags": "claude,cli,credentials",
+        "query": "does local Claude CLI support acp stdio?",
+        "expected": "does not support --acp --stdio",
+    },
+    {
+        "content": "GitHub PR watcher script is ~/.hermes/scripts/github_pr_monitor.py; Ops topic is 64623; cron route: Hermes to thread 78842, portal-api-node/10x10 to Ops 64623, task closeout to origin thread.",
+        "category": "tool",
+        "tags": "cron,telegram,ops,github",
+        "query": "where is the GitHub PR watcher and Ops topic routing?",
+        "expected": "github_pr_monitor.py",
+    },
+    {
+        "content": "agent-browser CDP flag is --cdp 9222; commands include open/click/scroll/screenshot/eval/snapshot/fill; use eval JS click for radio and fill for textbox; wait 4-6s after open.",
+        "category": "tool",
+        "tags": "agent-browser,cdp,github,asc",
+        "query": "what is the agent browser CDP flag for radio and textbox work?",
+        "expected": "--cdp 9222",
+    },
+    {
+        "content": "portal-api-node production API is https://portal-api-node.onrender.com/api/.",
+        "category": "project",
+        "tags": "portal-api-node,production,api",
+        "query": "what is the portal api node production API URL?",
+        "expected": "portal-api-node.onrender.com",
+    },
+    {
+        "content": "Mongoose findOneAndUpdate with $set silently ignores fields not in schema; verify exact schema field names, especially camelCase vs snake_case date/datetime fields; affects portal-api-node schedulers.",
+        "category": "project",
+        "tags": "mongoose,portal-api-node,scheduler,pitfall",
+        "query": "what Mongoose findOneAndUpdate schema pitfall affects portal schedulers?",
+        "expected": "silently ignores",
+    },
+    {
+        "content": "Eric prefers Traditional Chinese by default.",
+        "category": "user_pref",
+        "tags": "language,eric",
+        "query": "what language does Eric prefer by default?",
+        "expected": "Traditional Chinese",
+    },
+    {
+        "content": "Telegram style: one topic at a time; use `新議題：…` for new topics; plain text; emoji-prefix set includes ✅❌📊⚠️; do not switch topics due to background notifications.",
+        "category": "user_pref",
+        "tags": "telegram,style,eric",
+        "query": "what is Eric's Telegram one topic and emoji prefix style?",
+        "expected": "one topic at a time",
+    },
+    {
+        "content": "Eric workflow preference: research-first; use Opus for planning/high-risk, Sonnet for short verdicts, Codex for implementation; prefer small verified slices and proactive continuation.",
+        "category": "user_pref",
+        "tags": "workflow,models,eric",
+        "query": "what is Eric's research first Opus Codex workflow preference?",
+        "expected": "research-first",
+    },
+    {
+        "content": "Eric release preference: release fully automated; App Store should prefer API key and avoid Apple ID/2FA.",
+        "category": "user_pref",
+        "tags": "release,app-store,eric",
+        "query": "what does Eric prefer for App Store release credentials?",
+        "expected": "avoid Apple ID/2FA",
+    },
+    {
+        "content": "Review workflow preference: triage intent first, choose Hermes/Claude/Codex, then Hermes synthesis. Skills governance upgrades prefer Opus+Codex+Hermes debate before landing.",
+        "category": "user_pref",
+        "tags": "review,governance,eric",
+        "query": "what is the review workflow with triage Hermes Claude Codex synthesis?",
+        "expected": "triage intent",
+    },
+    {
+        "content": "Any code change must open a GitHub issue before code changes; order is open issue, plan, implement, PR; PR must reference the issue.",
+        "category": "user_pref",
+        "tags": "github,issue,workflow,eric",
+        "query": "what must happen before code changes and PR?",
+        "expected": "open a GitHub issue",
+    },
+    {
+        "content": "Subagent dispatch rule: before subagent use, present A/B/C route options for Eric confirmation; Wave/PR slice endings need Opus advisor judgment first, unless Opus times out and Hermes explicitly says it is acting.",
+        "category": "user_pref",
+        "tags": "subagent,dispatch,opus,eric",
+        "query": "what route options are required before subagent dispatch?",
+        "expected": "A/B/C route options",
+    },
+    {
+        "content": "Hermes memory architecture on this install: MEMORY.md/USER.md are always-on prompt memory with strict watermarks; holographic fact_store is enabled as second-line searchable memory with auto_extract=false. Healthy fact_store does not replace prompt-memory compression.",
+        "category": "tool",
+        "tags": "hermes,memory,governance,holographic,prompt-memory,fact_store",
+        "query": "how does holographic fact store relate to prompt memory and auto extract?",
+        "expected": "auto_extract=false",
+    },
+]
+
+
+def test_fact_store_search_increments_retrieval_count(tmp_path):
+    db_path = tmp_path / "memory_store.db"
+    provider = HolographicMemoryProvider(
+        config={"db_path": str(db_path), "default_trust": 0.5, "hrr_dim": 128}
+    )
+    provider.initialize("test-session")
+
+    fact_id = provider._store.add_fact(  # type: ignore[union-attr]
+        "Codex binary lives at /opt/homebrew/bin/codex.",
+        category="tool",
+        tags="codex,binary,path",
+    )
+
+    payload = json.loads(
+        provider.handle_tool_call(
+            "fact_store",
+            {"action": "search", "query": "Codex binary", "category": "tool", "limit": 5},
+        )
+    )
+
+    assert payload["count"] == 1
+    assert payload["results"][0]["fact_id"] == fact_id
+    row = provider._store._conn.execute(  # type: ignore[union-attr]
+        "SELECT retrieval_count FROM facts WHERE fact_id = ?", (fact_id,)
+    ).fetchone()
+    assert row["retrieval_count"] == 1
+
+
+def test_natural_language_search_falls_back_when_fts5_returns_no_candidates(tmp_path):
+    store = MemoryStore(db_path=tmp_path / "memory_store.db", hrr_dim=128)
+    fact_id = store.add_fact(
+        "Codex binary lives at /opt/homebrew/bin/codex.",
+        category="tool",
+        tags="codex,binary,path,cli",
+    )
+    retriever = FactRetriever(store=store, hrr_dim=128)
+
+    # FTS5 treats whitespace as AND, so this query previously returned zero
+    # because the fact does not contain every natural-language word.
+    results = retriever.search("Where is the Codex CLI path fix?", category="tool", limit=3)
+
+    assert results
+    assert results[0]["fact_id"] == fact_id
+    row = store._conn.execute(
+        "SELECT retrieval_count FROM facts WHERE fact_id = ?", (fact_id,)
+    ).fetchone()
+    assert row["retrieval_count"] == 1
+
+
+def test_relaxed_fts_filters_generic_conversational_terms(tmp_path):
+    store = MemoryStore(db_path=tmp_path / "memory_store.db", hrr_dim=128)
+    codex_id = store.add_fact(
+        "Codex binary lives at /opt/homebrew/bin/codex.",
+        category="tool",
+        tags="codex,binary,path,cli",
+    )
+    store.add_fact(
+        "Hermes memory store keeps searchable facts in SQLite.",
+        category="tool",
+        tags="memory,store,sqlite",
+    )
+    retriever = FactRetriever(store=store, hrr_dim=128)
+
+    results = retriever.search(
+        "where did we store the codex executable location",
+        category="tool",
+        limit=3,
+    )
+
+    assert results
+    assert results[0]["fact_id"] == codex_id
+
+
+def test_initialize_repairs_missing_hrr_vectors_for_migrated_rows(tmp_path):
+    if not hrr._HAS_NUMPY:
+        return
+
+    db_path = tmp_path / "memory_store.db"
+    store = MemoryStore(db_path=db_path, hrr_dim=128)
+    fact_id = store.add_fact("Eric prefers Traditional Chinese by default.", category="user_pref")
+    store._conn.execute("UPDATE facts SET hrr_vector = NULL WHERE fact_id = ?", (fact_id,))
+    store._conn.commit()
+    store.close()
+
+    provider = HolographicMemoryProvider(config={"db_path": str(db_path), "hrr_dim": 128})
+    provider.initialize("test-session")
+
+    row = provider._store._conn.execute(  # type: ignore[union-attr]
+        "SELECT hrr_vector FROM facts WHERE fact_id = ?", (fact_id,)
+    ).fetchone()
+    assert row["hrr_vector"] is not None
+
+
+def test_search_records_query_log_sample(tmp_path):
+    store = MemoryStore(db_path=tmp_path / "memory_store.db", hrr_dim=128)
+    fact_id = store.add_fact(
+        "Codex binary lives at /opt/homebrew/bin/codex.",
+        category="tool",
+        tags="codex,binary,path,cli",
+    )
+    retriever = FactRetriever(
+        store=store,
+        hrr_dim=128,
+        query_log_sample_rate=1.0,
+    )
+
+    results = retriever.search("where is the codex binary?", category="tool", limit=3)
+
+    assert results[0]["fact_id"] == fact_id
+    rows = store._conn.execute(
+        """
+        SELECT query, category, result_count, top_fact_id
+        FROM query_log
+        ORDER BY query_id ASC
+        """
+    ).fetchall()
+    assert [dict(row) for row in rows] == [
+        {
+            "query": "where is the codex binary?",
+            "category": "tool",
+            "result_count": 1,
+            "top_fact_id": fact_id,
+        }
+    ]
+
+
+def test_search_does_not_record_query_log_when_sample_rate_zero(tmp_path):
+    store = MemoryStore(db_path=tmp_path / "memory_store.db", hrr_dim=128)
+    store.add_fact(
+        "Codex binary lives at /opt/homebrew/bin/codex.",
+        category="tool",
+        tags="codex,binary,path,cli",
+    )
+    retriever = FactRetriever(
+        store=store,
+        hrr_dim=128,
+        query_log_sample_rate=0.0,
+    )
+
+    results = retriever.search("where is the codex binary?", category="tool", limit=3)
+
+    assert results
+    row = store._conn.execute("SELECT COUNT(*) AS n FROM query_log").fetchone()
+    assert row["n"] == 0
+
+
+def test_auto_extract_string_false_is_hard_guard(tmp_path):
+    provider = HolographicMemoryProvider(
+        config={
+            "db_path": str(tmp_path / "memory_store.db"),
+            "auto_extract": "false",
+            "hrr_dim": 128,
+        }
+    )
+    provider.initialize("test-session")
+
+    provider.on_session_end(
+        [
+            {
+                "role": "user",
+                "content": "I prefer every durable preference to stay explicit unless manually saved.",
+            }
+        ]
+    )
+
+    row = provider._store._conn.execute("SELECT COUNT(*) AS n FROM facts").fetchone()  # type: ignore[union-attr]
+    assert row["n"] == 0
+
+
+def test_stale_fact_candidates_apply_structured_filters(tmp_path):
+    store = MemoryStore(db_path=tmp_path / "memory_store.db", hrr_dim=128)
+    fragment = "upgrade Hermes with `uv tool upgrade hermes-agent`"
+    old_cutoff = (datetime.now() - timedelta(days=90)).strftime("%Y-%m-%d %H:%M:%S")
+
+    actionable_id = store.add_fact(
+        f"Deprecated guidance: {fragment}; use source checkout update flow instead.",
+        category="tool",
+        tags="hermes,upgrade,stale",
+    )
+    recent_id = store.add_fact(
+        f"Recent note mentioning {fragment} while documenting a fixed regression.",
+        category="tool",
+        tags="hermes,upgrade,regression-note",
+    )
+    low_trust_id = store.add_fact(
+        f"Low-trust imported note: {fragment}.",
+        category="tool",
+        tags="hermes,upgrade,imported",
+    )
+    user_pref_id = store.add_fact(
+        f"User quoted a stale command literally: {fragment}.",
+        category="user_pref",
+        tags="hermes,quote,user",
+    )
+    store._conn.execute(
+        "UPDATE facts SET created_at = ?, updated_at = ? WHERE fact_id IN (?, ?, ?)",
+        (old_cutoff, old_cutoff, actionable_id, low_trust_id, user_pref_id),
+    )
+    store._conn.execute(
+        "UPDATE facts SET trust_score = 0.1 WHERE fact_id = ?",
+        (low_trust_id,),
+    )
+    store._conn.commit()
+
+    candidates = store.find_stale_fact_candidates(
+        fragments=(fragment,),
+        stale_days=60,
+        min_trust=0.3,
+        categories=("project", "tool"),
+        limit=10,
+    )
+
+    assert [candidate["fact_id"] for candidate in candidates] == [actionable_id]
+    assert recent_id not in [candidate["fact_id"] for candidate in candidates]
+    assert low_trust_id not in [candidate["fact_id"] for candidate in candidates]
+    assert user_pref_id not in [candidate["fact_id"] for candidate in candidates]
+
+
+def test_stale_fact_candidates_escape_wildcards_and_casefold_matches(tmp_path):
+    store = MemoryStore(db_path=tmp_path / "memory_store.db", hrr_dim=128)
+    fragment = "Hermes 100%_DONE"
+    old_cutoff = (datetime.now() - timedelta(days=90)).strftime("%Y-%m-%d %H:%M:%S")
+
+    match_id = store.add_fact(
+        "Deprecated note: hermes 100%_done command.",
+        category="tool",
+        tags="hermes,stale,literal",
+    )
+    wildcard_only_id = store.add_fact(
+        "Deprecated note: Hermes 100XADONE command.",
+        category="tool",
+        tags="hermes,stale,wildcard-decoy",
+    )
+    store._conn.execute(
+        "UPDATE facts SET created_at = ?, updated_at = ? WHERE fact_id IN (?, ?)",
+        (old_cutoff, old_cutoff, match_id, wildcard_only_id),
+    )
+    store._conn.commit()
+
+    candidates = store.find_stale_fact_candidates(
+        fragments=(fragment,),
+        stale_days=60,
+        min_trust=0.3,
+        categories=("tool",),
+        limit=10,
+    )
+
+    assert [candidate["fact_id"] for candidate in candidates] == [match_id]
+    assert candidates[0]["matched_fragments"] == [fragment]


### PR DESCRIPTION
## Summary
- Adds holographic memory regression coverage for retrieval telemetry, relaxed FTS fallback, HRR-vector repair, auto_extract guardrails, query-log sampling, and stale fact detection.
- Adds sampled search query logging and startup repair for migrated facts missing HRR vectors.
- Adds governance-oriented stale fact candidate filtering with escaped LIKE literals and casefolded matched_fragments.

## Verification
- `./venv/bin/python -m pytest tests/plugins/memory -vv` — 177 passed
- `./venv/bin/python /Users/erichsu/.hermes/scripts/holographic_memory_governance.py data-quality` — ok=true, coverage_gaps=[]
- `./venv/bin/python /Users/erichsu/.hermes/scripts/holographic_memory_governance.py audit` — ok=true, hit_at_1_rate=1.0 over 20 cases
- Opus 4.8 final review (claude-opus-4-8): APPROVE, no blocking issues

Closes #35597