### PR TITLE
fix(tools): refresh cache when session env changes

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -249,9 +249,19 @@ _LEGACY_TOOLSET_MAP = {
 #
 # Invalidation happens transparently via the registry's _generation counter,
 # which bumps on register() / deregister() / register_toolset_alias(). The
-# inner check_fn TTL cache in registry.py handles environment drift (Docker
-# daemon start/stop, env var changes, etc.) on a 30 s horizon.
+# inner check_fn TTL cache in registry.py handles slow environment drift
+# (Docker daemon start/stop, optional SDK installs, etc.) on a 30 s horizon.
+# Process-local session markers are different: gateway startup and worker
+# dispatch can flip them mid-process, so they are part of this cache key and
+# force the check_fn cache to refresh immediately.
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
+_TOOL_AVAILABILITY_ENV_KEYS = (
+    "HERMES_EXEC_ASK",
+    "HERMES_GATEWAY_SESSION",
+    "HERMES_INTERACTIVE",
+    "HERMES_KANBAN_TASK",
+)
+_last_tool_availability_env_fp: Optional[tuple] = None
 
 
 def _clear_tool_defs_cache() -> None:
@@ -259,6 +269,28 @@ def _clear_tool_defs_cache() -> None:
     schema dependencies change (e.g. discord capability cache reset,
     execute_code sandbox reconfigured)."""
     _tool_defs_cache.clear()
+
+
+def _tool_availability_env_fingerprint() -> tuple:
+    """Return env values that can synchronously change tool availability."""
+    return tuple((key, os.environ.get(key)) for key in _TOOL_AVAILABILITY_ENV_KEYS)
+
+
+def _refresh_check_cache_if_tool_env_changed(env_fp: tuple) -> None:
+    """Drop stale registry check_fn results when session-context env flips."""
+    global _last_tool_availability_env_fp
+    if _last_tool_availability_env_fp is None:
+        _last_tool_availability_env_fp = env_fp
+        return
+    if _last_tool_availability_env_fp == env_fp:
+        return
+    _last_tool_availability_env_fp = env_fp
+    _clear_tool_defs_cache()
+    try:
+        from tools.registry import invalidate_check_fn_cache
+        invalidate_check_fn_cache()
+    except Exception:
+        logger.debug("Could not invalidate registry check_fn cache after env change", exc_info=True)
 
 
 def get_tool_definitions(
@@ -285,6 +317,9 @@ def get_tool_definitions(
     Returns:
         Filtered list of OpenAI-format tool definitions.
     """
+    tool_env_fp = _tool_availability_env_fingerprint()
+    _refresh_check_cache_if_tool_env_changed(tool_env_fp)
+
     # Fast path: memoized result when the caller doesn't need stdout prints.
     # The cache key captures every argument-level input; the registry
     # generation captures registry mutations (MCP refresh, plugin load).
@@ -306,7 +341,7 @@ def get_tool_definitions(
             frozenset(disabled_toolsets) if disabled_toolsets else None,
             registry._generation,
             cfg_fp,
-            bool(os.environ.get("HERMES_KANBAN_TASK")),
+            tool_env_fp,
             bool(skip_tool_search_assembly),
         )
         cached = _tool_defs_cache.get(cache_key)

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -239,6 +239,30 @@ class TestCronjobRequirements:
         monkeypatch.setenv(var_name, false_like_value)
         assert check_cronjob_requirements() is False
 
+    def test_tool_definition_cache_tracks_exec_ask_env(self, monkeypatch):
+        """Cronjob should appear after gateway flips HERMES_EXEC_ASK mid-process."""
+        from model_tools import _clear_tool_defs_cache, get_tool_definitions
+        from tools.registry import invalidate_check_fn_cache
+
+        def cronjob_visible() -> bool:
+            tools = get_tool_definitions(
+                enabled_toolsets=["cronjob"],
+                quiet_mode=True,
+                skip_tool_search_assembly=True,
+            )
+            return any(tool["function"]["name"] == "cronjob" for tool in tools)
+
+        for env_name in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION", "HERMES_EXEC_ASK"):
+            monkeypatch.delenv(env_name, raising=False)
+        _clear_tool_defs_cache()
+        invalidate_check_fn_cache()
+
+        assert cronjob_visible() is False
+
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+
+        assert cronjob_visible() is True
+
 
 class TestUnifiedCronjobTool:
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## What changed

- Tracks process-local tool availability markers (`HERMES_EXEC_ASK`, `HERMES_GATEWAY_SESSION`, `HERMES_INTERACTIVE`, `HERMES_KANBAN_TASK`) in the quiet tool-definition cache key.
- Invalidates the memoized tool definitions and registry `check_fn` cache immediately when those markers change mid-process.
- Adds a regression test for the gateway-style `HERMES_EXEC_ASK` flip that should expose the `cronjob` tool after it was previously hidden.

## Why

Fixes #35561.

`cronjob` availability depends on session/gateway env markers. If `get_tool_definitions(..., quiet_mode=True)` cached the hidden result before `gateway.run` set `HERMES_EXEC_ASK=1`, the later lookup reused stale tool definitions and stale `check_fn` state, so `cronjob` stayed absent until cache expiry or manual invalidation.

## Tests

- `.venv/bin/pytest tests/tools/test_cronjob_tools.py -k 'tool_definition_cache_tracks_exec_ask_env or CronjobRequirements' -q` -> 22 passed, 35 deselected
- `scripts/run_tests.sh tests/tools/test_cronjob_tools.py` -> 57 passed
- `scripts/run_tests.sh tests/tools/test_terminal_tool_requirements.py tests/tools/test_kanban_tools.py` -> 84 passed
- `.venv/bin/ruff check model_tools.py tests/tools/test_cronjob_tools.py` -> All checks passed
- `git diff --check` -> no output
- Manual reproduction script: before env flip `{'pre': []}`, after `HERMES_EXEC_ASK=1` `{'post': ['cronjob']}`

## Compatibility / risk

No public API change. The existing 30s `check_fn` TTL remains for slow external probes like Docker or optional SDK availability. This only treats session-context env markers as synchronous availability inputs, so a gateway or worker transition may do one extra availability recompute and then return to the normal cache path.
