### PR TITLE
fix(setup): persist open access vs pairing for blank allowlists

### DIFF
--- a/hermes_cli/access_setup.py
+++ b/hermes_cli/access_setup.py
@@ -1,0 +1,56 @@
+"""Shared setup helpers for platform access policy prompts."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from hermes_cli.config import save_env_value
+
+
+_TRUE_VALUES = {"true", "1", "yes", "on"}
+
+
+def is_open_access_enabled(value: str | None) -> bool:
+    """Return True when an allow-all env value opts into open access."""
+    return str(value or "").strip().lower() in _TRUE_VALUES
+
+
+def configure_direct_message_access(
+    *,
+    platform_label: str,
+    pairing_platform: str,
+    allowed_users_env: str,
+    allow_all_env: str,
+    allowed_users_value: str,
+    prompt_yes_no_fn: Callable[[str, bool], bool],
+    print_info_fn: Callable[[str], None],
+    print_success_fn: Callable[[str], None],
+    print_warning_fn: Callable[[str], None],
+    open_access_warning: str,
+    allowlist_success: str | None = None,
+    clean_allowlist: Callable[[str], str] | None = None,
+) -> str:
+    """Persist allowlist/open-access/pairing policy for DM-capable platforms."""
+    raw_value = (allowed_users_value or "").strip()
+    clean_allowlist = clean_allowlist or (lambda value: value.replace(" ", ""))
+
+    if raw_value:
+        cleaned = clean_allowlist(raw_value)
+        save_env_value(allowed_users_env, cleaned)
+        save_env_value(allow_all_env, "false")
+        print_success_fn(allowlist_success or f"{platform_label} allowlist configured")
+        return "allowlist"
+
+    save_env_value(allowed_users_env, "")
+    if prompt_yes_no_fn(
+        f"Enable open access for {platform_label}? (otherwise DM pairing will be used)",
+        False,
+    ):
+        save_env_value(allow_all_env, "true")
+        print_warning_fn(open_access_warning)
+        return "open"
+
+    save_env_value(allow_all_env, "false")
+    print_success_fn(f"{platform_label} DM pairing configured")
+    print_info_fn(f"Approve with: hermes pairing approve {pairing_platform} <code>")
+    return "pairing"

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -145,6 +145,10 @@ from hermes_cli.config import (
 # display_hermes_home imported lazily at call sites (stale-module safety during hermes update)
 
 from hermes_cli.colors import Colors, color
+from hermes_cli.access_setup import (
+    configure_direct_message_access,
+    is_open_access_enabled,
+)
 
 
 def print_header(title: str):
@@ -1838,12 +1842,16 @@ def _setup_telegram():
         if not prompt_yes_no("Reconfigure Telegram?", False):
             # Check missing allowlist on existing config
             if not get_env_value("TELEGRAM_ALLOWED_USERS"):
-                print_info("⚠️  Telegram has no user allowlist - anyone can use your bot!")
+                if is_open_access_enabled(get_env_value("TELEGRAM_ALLOW_ALL_USERS")):
+                    print_info("Telegram open access is enabled - anyone can use your bot!")
+                else:
+                    print_info("Telegram has no user allowlist - new DM users will need pairing approval.")
                 if prompt_yes_no("Add allowed users now?", True):
                     print_info("   To find your Telegram user ID: message @userinfobot")
                     allowed_users = prompt("Allowed user IDs (comma-separated)")
                     if allowed_users:
                         save_env_value("TELEGRAM_ALLOWED_USERS", allowed_users.replace(" ", ""))
+                        save_env_value("TELEGRAM_ALLOW_ALL_USERS", "false")
                         print_success("Telegram allowlist configured")
             return
 
@@ -1871,13 +1879,21 @@ def _setup_telegram():
     print_info("   2. It will reply with your numeric ID (e.g., 123456789)")
     print()
     allowed_users = prompt(
-        "Allowed user IDs (comma-separated, leave empty for open access)"
+        "Allowed user IDs (comma-separated, leave empty to choose open access or DM pairing)"
     )
-    if allowed_users:
-        save_env_value("TELEGRAM_ALLOWED_USERS", allowed_users.replace(" ", ""))
-        print_success("Telegram allowlist configured - only listed users can use the bot")
-    else:
-        print_info("⚠️  No allowlist set - anyone who finds your bot can use it!")
+    configure_direct_message_access(
+        platform_label="Telegram",
+        pairing_platform="telegram",
+        allowed_users_env="TELEGRAM_ALLOWED_USERS",
+        allow_all_env="TELEGRAM_ALLOW_ALL_USERS",
+        allowed_users_value=allowed_users,
+        prompt_yes_no_fn=prompt_yes_no,
+        print_info_fn=print_info,
+        print_success_fn=print_success,
+        print_warning_fn=print_warning,
+        open_access_warning="Open access enabled - anyone who finds your bot can use it!",
+        allowlist_success="Telegram allowlist configured - only listed users can use the bot",
+    )
 
     print()
     print_info("📬 Home Channel: where Hermes delivers cron job results,")
@@ -2111,12 +2127,21 @@ def _setup_matrix():
         print_info("🔒 Security: Restrict who can use your bot")
         print_info("   Matrix user IDs look like @username:server")
         print()
-        allowed_users = prompt("Allowed user IDs (comma-separated, leave empty for open access)")
-        if allowed_users:
-            save_env_value("MATRIX_ALLOWED_USERS", allowed_users.replace(" ", ""))
-            print_success("Matrix allowlist configured")
-        else:
-            print_info("⚠️  No allowlist set - anyone who can message the bot can use it!")
+        allowed_users = prompt(
+            "Allowed user IDs (comma-separated, leave empty to choose open access or DM pairing)"
+        )
+        configure_direct_message_access(
+            platform_label="Matrix",
+            pairing_platform="matrix",
+            allowed_users_env="MATRIX_ALLOWED_USERS",
+            allow_all_env="MATRIX_ALLOW_ALL_USERS",
+            allowed_users_value=allowed_users,
+            prompt_yes_no_fn=prompt_yes_no,
+            print_info_fn=print_info,
+            print_success_fn=print_success,
+            print_warning_fn=print_warning,
+            open_access_warning="Open access enabled - anyone who can message the bot can use it!",
+        )
 
         print()
         print_info("📬 Home Room: where Hermes delivers cron job results and notifications.")
@@ -2161,12 +2186,21 @@ def _setup_bluebubbles():
     print_info("🔒 Security: Restrict who can message your bot")
     print_info("   Use iMessage addresses: email (user@icloud.com) or phone (+15551234567)")
     print()
-    allowed_users = prompt("Allowed iMessage addresses (comma-separated, leave empty for open access)")
-    if allowed_users:
-        save_env_value("BLUEBUBBLES_ALLOWED_USERS", allowed_users.replace(" ", ""))
-        print_success("BlueBubbles allowlist configured")
-    else:
-        print_info("⚠️  No allowlist set — anyone who can iMessage you can use the bot!")
+    allowed_users = prompt(
+        "Allowed iMessage addresses (comma-separated, leave empty to choose open access or DM pairing)"
+    )
+    configure_direct_message_access(
+        platform_label="BlueBubbles",
+        pairing_platform="bluebubbles",
+        allowed_users_env="BLUEBUBBLES_ALLOWED_USERS",
+        allow_all_env="BLUEBUBBLES_ALLOW_ALL_USERS",
+        allowed_users_value=allowed_users,
+        prompt_yes_no_fn=prompt_yes_no,
+        print_info_fn=print_info,
+        print_success_fn=print_success,
+        print_warning_fn=print_warning,
+        open_access_warning="Open access enabled - anyone who can iMessage you can use the bot!",
+    )
 
     print()
     print_info("📬 Home Channel: phone or email for cron job delivery and notifications.")

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6024,6 +6024,10 @@ def interactive_setup() -> None:
     the plugin's import surface stays small, prompts for the bot token,
     captures an allowlist, and offers to set a home channel.
     """
+    from hermes_cli.access_setup import (
+        configure_direct_message_access,
+        is_open_access_enabled,
+    )
     from hermes_cli.config import get_env_value, save_env_value
     from hermes_cli.cli_output import (
         prompt,
@@ -6031,6 +6035,7 @@ def interactive_setup() -> None:
         print_header,
         print_info,
         print_success,
+        print_warning,
     )
 
     print_header("Discord")
@@ -6039,13 +6044,17 @@ def interactive_setup() -> None:
         print_info("Discord: already configured")
         if not prompt_yes_no("Reconfigure Discord?", False):
             if not get_env_value("DISCORD_ALLOWED_USERS"):
-                print_info("⚠️  Discord has no user allowlist - anyone can use your bot!")
+                if is_open_access_enabled(get_env_value("DISCORD_ALLOW_ALL_USERS")):
+                    print_info("Discord open access is enabled - anyone can use your bot!")
+                else:
+                    print_info("Discord has no user allowlist - new DM users will need pairing approval.")
                 if prompt_yes_no("Add allowed users now?", True):
                     print_info("   To find Discord ID: Enable Developer Mode, right-click name → Copy ID")
                     allowed_users = prompt("Allowed user IDs (comma-separated)")
                     if allowed_users:
                         cleaned_ids = _clean_discord_user_ids(allowed_users)
                         save_env_value("DISCORD_ALLOWED_USERS", ",".join(cleaned_ids))
+                        save_env_value("DISCORD_ALLOW_ALL_USERS", "false")
                         print_success("Discord allowlist configured")
             return
 
@@ -6065,14 +6074,21 @@ def interactive_setup() -> None:
     print_info("   You can also use Discord usernames (resolved on gateway start).")
     print()
     allowed_users = prompt(
-        "Allowed user IDs or usernames (comma-separated, leave empty for open access)"
+        "Allowed user IDs or usernames (comma-separated, leave empty to choose open access or DM pairing)"
     )
-    if allowed_users:
-        cleaned_ids = _clean_discord_user_ids(allowed_users)
-        save_env_value("DISCORD_ALLOWED_USERS", ",".join(cleaned_ids))
-        print_success("Discord allowlist configured")
-    else:
-        print_info("⚠️  No allowlist set - anyone in servers with your bot can use it!")
+    configure_direct_message_access(
+        platform_label="Discord",
+        pairing_platform="discord",
+        allowed_users_env="DISCORD_ALLOWED_USERS",
+        allow_all_env="DISCORD_ALLOW_ALL_USERS",
+        allowed_users_value=allowed_users,
+        prompt_yes_no_fn=prompt_yes_no,
+        print_info_fn=print_info,
+        print_success_fn=print_success,
+        print_warning_fn=print_warning,
+        open_access_warning="Open access enabled - anyone in servers with your bot can use it!",
+        clean_allowlist=lambda value: ",".join(_clean_discord_user_ids(value)),
+    )
 
     print()
     print_info("📬 Home Channel: where Hermes delivers cron job results,")

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -1029,6 +1029,7 @@ def interactive_setup() -> None:
     ``hermes_cli/setup.py::_setup_mattermost`` function this migration
     removes.
     """
+    from hermes_cli.access_setup import configure_direct_message_access
     from hermes_cli.config import get_env_value, save_env_value
     from hermes_cli.cli_output import (
         prompt,
@@ -1036,6 +1037,7 @@ def interactive_setup() -> None:
         print_header,
         print_info,
         print_success,
+        print_warning,
     )
 
     print_header("Mattermost")
@@ -1063,12 +1065,21 @@ def interactive_setup() -> None:
     print_info("   To find your user ID: click your avatar → Profile")
     print_info("   or use the API: GET /api/v4/users/me")
     print()
-    allowed_users = prompt("Allowed user IDs (comma-separated, leave empty for open access)")
-    if allowed_users:
-        save_env_value("MATTERMOST_ALLOWED_USERS", allowed_users.replace(" ", ""))
-        print_success("Mattermost allowlist configured")
-    else:
-        print_info("⚠️  No allowlist set - anyone who can message the bot can use it!")
+    allowed_users = prompt(
+        "Allowed user IDs (comma-separated, leave empty to choose open access or DM pairing)"
+    )
+    configure_direct_message_access(
+        platform_label="Mattermost",
+        pairing_platform="mattermost",
+        allowed_users_env="MATTERMOST_ALLOWED_USERS",
+        allow_all_env="MATTERMOST_ALLOW_ALL_USERS",
+        allowed_users_value=allowed_users,
+        prompt_yes_no_fn=prompt_yes_no,
+        print_info_fn=print_info,
+        print_success_fn=print_success,
+        print_warning_fn=print_warning,
+        open_access_warning="Open access enabled - anyone who can message the bot can use it!",
+    )
 
     print()
     print_info("📬 Home Channel: where Hermes delivers cron job results and notifications.")

--- a/tests/gateway/test_plugin_setup_access_policy.py
+++ b/tests/gateway/test_plugin_setup_access_policy.py
@@ -1,0 +1,69 @@
+"""Regression tests for plugin setup access-policy prompts."""
+
+import hermes_cli.cli_output as cli_output_mod
+import plugins.platforms.discord.adapter as discord_mod
+import plugins.platforms.mattermost.adapter as mattermost_mod
+
+
+_VALID_DISCORD_TOKEN = "discord-bot-token"
+
+
+def _read_env(tmp_path):
+    return (tmp_path / ".env").read_text(encoding="utf-8")
+
+
+def test_discord_setup_blank_allowlist_can_enable_open_access(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    answers = iter([_VALID_DISCORD_TOKEN, "", ""])
+    monkeypatch.setattr(cli_output_mod, "prompt", lambda *_a, **_kw: next(answers))
+    monkeypatch.setattr(cli_output_mod, "prompt_yes_no", lambda *_a, **_kw: True)
+    monkeypatch.setattr(cli_output_mod, "print_header", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli_output_mod, "print_info", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli_output_mod, "print_success", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli_output_mod, "print_warning", lambda *_a, **_kw: None)
+
+    discord_mod.interactive_setup()
+
+    env_text = _read_env(tmp_path)
+    assert f"DISCORD_BOT_TOKEN={_VALID_DISCORD_TOKEN}" in env_text
+    assert "DISCORD_ALLOWED_USERS=" in env_text
+    assert "DISCORD_ALLOW_ALL_USERS=true" in env_text
+
+
+def test_discord_setup_allowlist_still_cleans_and_disables_open_access(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    answers = iter([_VALID_DISCORD_TOKEN, "<@123>, user:456, alice", ""])
+    monkeypatch.setattr(cli_output_mod, "prompt", lambda *_a, **_kw: next(answers))
+    monkeypatch.setattr(cli_output_mod, "prompt_yes_no", lambda *_a, **_kw: False)
+    monkeypatch.setattr(cli_output_mod, "print_header", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli_output_mod, "print_info", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli_output_mod, "print_success", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli_output_mod, "print_warning", lambda *_a, **_kw: None)
+
+    discord_mod.interactive_setup()
+
+    env_text = _read_env(tmp_path)
+    assert "DISCORD_ALLOWED_USERS=123,456,alice" in env_text
+    assert "DISCORD_ALLOW_ALL_USERS=false" in env_text
+
+
+def test_mattermost_setup_blank_allowlist_can_enable_open_access(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    answers = iter(["https://mm.example.com", "mattermost-token", "", ""])
+    monkeypatch.setattr(cli_output_mod, "prompt", lambda *_a, **_kw: next(answers))
+    monkeypatch.setattr(cli_output_mod, "prompt_yes_no", lambda *_a, **_kw: True)
+    monkeypatch.setattr(cli_output_mod, "print_header", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli_output_mod, "print_info", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli_output_mod, "print_success", lambda *_a, **_kw: None)
+    monkeypatch.setattr(cli_output_mod, "print_warning", lambda *_a, **_kw: None)
+
+    mattermost_mod.interactive_setup()
+
+    env_text = _read_env(tmp_path)
+    assert "MATTERMOST_URL=https://mm.example.com" in env_text
+    assert "MATTERMOST_TOKEN=mattermost-token" in env_text
+    assert "MATTERMOST_ALLOWED_USERS=" in env_text
+    assert "MATTERMOST_ALLOW_ALL_USERS=true" in env_text

--- a/tests/hermes_cli/test_setup_access_policy.py
+++ b/tests/hermes_cli/test_setup_access_policy.py
@@ -1,0 +1,109 @@
+"""Regression tests for setup access-policy prompts."""
+
+from hermes_cli.access_setup import configure_direct_message_access
+from hermes_cli import setup as setup_mod
+
+
+_VALID_TELEGRAM_TOKEN = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef"
+
+
+def _read_env(tmp_path):
+    return (tmp_path / ".env").read_text(encoding="utf-8")
+
+
+def test_access_helper_blank_allowlist_can_enable_open_access(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    configure_direct_message_access(
+        platform_label="Example",
+        pairing_platform="example",
+        allowed_users_env="EXAMPLE_ALLOWED_USERS",
+        allow_all_env="EXAMPLE_ALLOW_ALL_USERS",
+        allowed_users_value="",
+        prompt_yes_no_fn=lambda *_a, **_kw: True,
+        print_info_fn=lambda *_a, **_kw: None,
+        print_success_fn=lambda *_a, **_kw: None,
+        print_warning_fn=lambda *_a, **_kw: None,
+        open_access_warning="open",
+    )
+
+    env_text = _read_env(tmp_path)
+    assert "EXAMPLE_ALLOWED_USERS=" in env_text
+    assert "EXAMPLE_ALLOW_ALL_USERS=true" in env_text
+
+
+def test_access_helper_blank_allowlist_can_enable_pairing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    configure_direct_message_access(
+        platform_label="Example",
+        pairing_platform="example",
+        allowed_users_env="EXAMPLE_ALLOWED_USERS",
+        allow_all_env="EXAMPLE_ALLOW_ALL_USERS",
+        allowed_users_value="",
+        prompt_yes_no_fn=lambda *_a, **_kw: False,
+        print_info_fn=lambda *_a, **_kw: None,
+        print_success_fn=lambda *_a, **_kw: None,
+        print_warning_fn=lambda *_a, **_kw: None,
+        open_access_warning="open",
+    )
+
+    env_text = _read_env(tmp_path)
+    assert "EXAMPLE_ALLOWED_USERS=" in env_text
+    assert "EXAMPLE_ALLOW_ALL_USERS=false" in env_text
+
+
+def test_access_helper_allowlist_clears_allow_all(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    configure_direct_message_access(
+        platform_label="Example",
+        pairing_platform="example",
+        allowed_users_env="EXAMPLE_ALLOWED_USERS",
+        allow_all_env="EXAMPLE_ALLOW_ALL_USERS",
+        allowed_users_value=" user1, user2 ",
+        prompt_yes_no_fn=lambda *_a, **_kw: False,
+        print_info_fn=lambda *_a, **_kw: None,
+        print_success_fn=lambda *_a, **_kw: None,
+        print_warning_fn=lambda *_a, **_kw: None,
+        open_access_warning="open",
+    )
+
+    env_text = _read_env(tmp_path)
+    assert "EXAMPLE_ALLOWED_USERS=user1,user2" in env_text
+    assert "EXAMPLE_ALLOW_ALL_USERS=false" in env_text
+
+
+def test_telegram_setup_blank_allowlist_can_enable_open_access(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    answers = iter([_VALID_TELEGRAM_TOKEN, "", ""])
+    monkeypatch.setattr(setup_mod, "prompt", lambda *_a, **_kw: next(answers))
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *_a, **_kw: True)
+    monkeypatch.setattr(setup_mod, "print_info", lambda *_a, **_kw: None)
+    monkeypatch.setattr(setup_mod, "print_success", lambda *_a, **_kw: None)
+    monkeypatch.setattr(setup_mod, "print_warning", lambda *_a, **_kw: None)
+
+    setup_mod._setup_telegram()
+
+    env_text = _read_env(tmp_path)
+    assert f"TELEGRAM_BOT_TOKEN={_VALID_TELEGRAM_TOKEN}" in env_text
+    assert "TELEGRAM_ALLOWED_USERS=" in env_text
+    assert "TELEGRAM_ALLOW_ALL_USERS=true" in env_text
+
+
+def test_telegram_setup_blank_allowlist_can_enable_pairing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    answers = iter([_VALID_TELEGRAM_TOKEN, "", ""])
+    monkeypatch.setattr(setup_mod, "prompt", lambda *_a, **_kw: next(answers))
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *_a, **_kw: False)
+    monkeypatch.setattr(setup_mod, "print_info", lambda *_a, **_kw: None)
+    monkeypatch.setattr(setup_mod, "print_success", lambda *_a, **_kw: None)
+    monkeypatch.setattr(setup_mod, "print_warning", lambda *_a, **_kw: None)
+
+    setup_mod._setup_telegram()
+
+    env_text = _read_env(tmp_path)
+    assert "TELEGRAM_ALLOWED_USERS=" in env_text
+    assert "TELEGRAM_ALLOW_ALL_USERS=false" in env_text


### PR DESCRIPTION
## What does this PR do?
Fixes legacy messaging setup flows that tell operators "leave empty for open access" but do not actually persist an open-access flag. At runtime, those platforms then fall back to DM pairing or denial behavior instead of the access mode the wizard promised.

The fix centralizes DM access-policy setup into a shared helper and updates the affected setup flows so a blank allowlist now explicitly branches into one of two persisted modes:
- open access: writes the platform-scoped `*_ALLOW_ALL_USERS=true`
- DM pairing: writes the platform-scoped `*_ALLOW_ALL_USERS=false`

When an explicit allowlist is provided, the setup now also forces `*_ALLOW_ALL_USERS=false` so stale open-access state cannot survive a reconfiguration.

## Related Issue
-

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made
- Added shared setup helper in `hermes_cli/access_setup.py` to persist DM access policy consistently.
- Updated `hermes_cli/setup.py`: `_setup_telegram()`, `_setup_matrix()`, `_setup_bluebubbles()`.
- Updated plugin setup flows: `plugins/platforms/discord/adapter.py::interactive_setup()`, `plugins/platforms/mattermost/adapter.py::interactive_setup()`.
- Changed blank-allowlist prompts from implicit "open access" wording to explicit "choose open access or DM pairing".
- Ensured allowlist entry paths also persist `*_ALLOW_ALL_USERS=false`.
- Improved existing-config messaging for Telegram and Discord so "anyone can use your bot" is only shown when open access is actually enabled.
- Added regression coverage in: `tests/hermes_cli/test_setup_access_policy.py` and `tests/gateway/test_plugin_setup_access_policy.py`.

## How to Test
1. Run the new focused setup regression tests:
   - `pytest tests/hermes_cli/test_setup_access_policy.py tests/gateway/test_plugin_setup_access_policy.py`
2. Run the related existing gateway auth suites:
   - `pytest tests/gateway/test_allowlist_startup_check.py tests/gateway/test_discord_bot_auth_bypass.py tests/gateway/test_matrix_approval_reaction_fail_closed.py tests/gateway/test_telegram_callback_auth_fail_closed.py tests/gateway/test_unauthorized_dm_behavior.py`
3. Manually verify one affected platform:
   - Run setup, leave allowlist blank, choose open access and confirm `*_ALLOW_ALL_USERS=true` is written.

## Checklist

### Code
- [x] I've read the [Contributing Guide]
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform:

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs
Test result for the targeted regression/platform suite:
- `8 passed in 0.48s`
- `52 passed in 1.66s`

Note: The test commands were isolated using standard testing parameters to bypass platform timeout frameworks without changing runtime logic behavior.