### PR TITLE
[codex] fix(tui): add SIGWINCH resize fallback

### DIFF
--- a/ui-tui/src/__tests__/useMainAppResize.test.ts
+++ b/ui-tui/src/__tests__/useMainAppResize.test.ts
@@ -1,0 +1,67 @@
+import { EventEmitter } from 'node:events'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { subscribeResizeSignals } from '../app/useMainApp.js'
+
+class MockStdout extends EventEmitter {
+  override on(event: 'resize', listener: () => void): this {
+    return super.on(event, listener)
+  }
+
+  override off(event: 'resize', listener: () => void): this {
+    return super.off(event, listener)
+  }
+}
+
+describe('subscribeResizeSignals', () => {
+  it('listens to both stdout resize and SIGWINCH', () => {
+    const stdout = new MockStdout()
+    const signalBus = new EventEmitter()
+    const onResize = vi.fn()
+
+    const dispose = subscribeResizeSignals(stdout, onResize, signalBus)
+
+    stdout.emit('resize')
+    signalBus.emit('SIGWINCH')
+
+    expect(onResize).toHaveBeenCalledTimes(2)
+
+    dispose()
+  })
+
+  it('removes both listeners on cleanup', () => {
+    const stdout = new MockStdout()
+    const signalBus = new EventEmitter()
+    const onResize = vi.fn()
+
+    const dispose = subscribeResizeSignals(stdout, onResize, signalBus)
+    dispose()
+
+    stdout.emit('resize')
+    signalBus.emit('SIGWINCH')
+
+    expect(onResize).not.toHaveBeenCalled()
+  })
+
+  it('ignores unsupported SIGWINCH registration and still tracks stdout resize', () => {
+    const stdout = new MockStdout()
+    const onResize = vi.fn()
+
+    const signalBus = {
+      off: vi.fn(),
+      on: vi.fn(() => {
+        throw new Error('unsupported signal')
+      })
+    }
+
+    const dispose = subscribeResizeSignals(stdout, onResize, signalBus)
+
+    stdout.emit('resize')
+
+    dispose()
+
+    expect(onResize).toHaveBeenCalledTimes(1)
+    expect(signalBus.off).not.toHaveBeenCalled()
+  })
+})

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -49,6 +49,42 @@ const BRACKET_PASTE_ON = '\x1b[?2004h'
 const BRACKET_PASTE_OFF = '\x1b[?2004l'
 const MAX_HEIGHT_CACHE_BUCKETS = 12
 
+type ResizeStdout = Pick<NodeJS.WriteStream, 'off' | 'on'>
+type SignalBus = Pick<NodeJS.Process, 'off' | 'on'>
+
+export function subscribeResizeSignals(
+  stdout: null | ResizeStdout | undefined,
+  onResize: () => void,
+  signalBus: SignalBus = process
+): () => void {
+  if (!stdout) {
+    return () => {}
+  }
+
+  stdout.on('resize', onResize)
+
+  let registeredSigwinch = false
+
+  try {
+    signalBus.on('SIGWINCH', onResize)
+    registeredSigwinch = true
+  } catch {
+    // Some runtimes do not expose SIGWINCH; stdout.resize remains the primary path.
+  }
+
+  return () => {
+    stdout.off('resize', onResize)
+
+    if (registeredSigwinch) {
+      try {
+        signalBus.off('SIGWINCH', onResize)
+      } catch {
+        // Ignore teardown mismatches in runtimes without signal support.
+      }
+    }
+  }
+}
+
 const capHistory = (items: Msg[]): Msg[] => {
   if (items.length <= MAX_HISTORY) {
     return items
@@ -145,14 +181,14 @@ export function useMainApp(gw: GatewayClient) {
 
     const sync = () => setCols(stdout.columns ?? 80)
 
-    stdout.on('resize', sync)
+    const disposeResize = subscribeResizeSignals(stdout, sync)
 
     if (stdout.isTTY) {
       stdout.write(BRACKET_PASTE_ON)
     }
 
     return () => {
-      stdout.off('resize', sync)
+      disposeResize()
 
       if (stdout.isTTY) {
         stdout.write(BRACKET_PASTE_OFF)
@@ -556,11 +592,11 @@ export function useMainApp(gw: GatewayClient) {
       }, 100)
     }
 
-    stdout.on('resize', onResize)
+    const disposeResize = subscribeResizeSignals(stdout, onResize)
 
     return () => {
       clearTimeout(timer)
-      stdout.off('resize', onResize)
+      disposeResize()
     }
   }, [rpc, stdout, ui.sid])
 


### PR DESCRIPTION
## Summary
- add a shared resize subscription helper that listens to both `stdout` resize events and `SIGWINCH`
- use that helper for both local column-state sync and the debounced `terminal.resize` RPC path
- add a focused Vitest regression test covering stdout resize, SIGWINCH fallback, and unsupported-signal cleanup

## Root Cause
Some terminals and PTY environments do not reliably emit Ink's `stdout.on('resize')` event. `useMainApp.ts` depended on that event alone, so the TUI could miss viewport updates and fail to reflow after a resize.

## Validation
- `npm --prefix ui-tui/packages/hermes-ink run build`
- `npm --prefix ui-tui run test -- useMainAppResize`
- `npx eslint src/app/useMainApp.ts src/__tests__/useMainAppResize.test.ts`
- `git diff --check`

Closes #35530.
