### PR TITLE
fix(redact): stop masking Discord mention snowflake IDs at persistence boundary

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -402,7 +402,9 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
         text = _redact_form_body(text)
 
     # Discord user/role mentions (<@snowflake_id>)
-    if "<@" in text:
+    # Default OFF: Discord mention IDs are PUBLIC syntax, not secrets.
+    # Masking them breaks cross-bot @-pings. Opt-in via env var for export use cases.
+    if "<@" in text and os.environ.get("HERMES_REDACT_DISCORD_MENTIONS", "").lower() in {"1", "true", "yes", "on"}:
         text = _DISCORD_MENTION_RE.sub(lambda m: f"<@{'!' if '!' in m.group(0) else ''}***>", text)
 
     # E.164 phone numbers (Signal, WhatsApp)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -345,21 +345,34 @@ class TestJWTTokens:
 class TestDiscordMentions:
     """Discord snowflake IDs in <@ID> or <@!ID> format."""
 
-    def test_normal_mention(self):
-        result = redact_sensitive_text("Hello <@222589316709220353>")
-        assert "222589316709220353" not in result
-        assert "<@***>" in result
-
-    def test_nickname_mention(self):
-        result = redact_sensitive_text("Ping <@!1331549159177846844>")
-        assert "1331549159177846844" not in result
-        assert "<@!***>" in result
-
-    def test_multiple_mentions(self):
-        text = "<@111111111111111111> and <@222222222222222222>"
+    def test_normal_mention_preserved(self):
+        """Discord mention IDs are public syntax, not secrets — preserved by default."""
+        text = "Hello " + "<@" + "222589316709220353" + ">"
         result = redact_sensitive_text(text)
-        assert "111111111111111111" not in result
-        assert "222222222222222222" not in result
+        assert result == text
+        assert "222589316709220353" in result
+
+    def test_nickname_mention_preserved(self):
+        text = "Ping " + "<@!" + "1331549159177846844" + ">"
+        result = redact_sensitive_text(text)
+        assert result == text
+
+    def test_multiple_mentions_preserved(self):
+        text = "<@" + "111111111111111111" + ">" + " and " + "<@" + "222222222222222222" + ">"
+        result = redact_sensitive_text(text)
+        assert "111111111111111111" in result
+        assert "222222222222222222" in result
+
+    def test_opt_in_redaction(self):
+        """When env var is set, mentions ARE redacted (export use case)."""
+        import os
+        os.environ["HERMES_REDACT_DISCORD_MENTIONS"] = "1"
+        try:
+            text = "Hello " + "<@" + "222589316709220353" + ">"
+            result = redact_sensitive_text(text)
+            assert "222589316709220353" not in result
+        finally:
+            del os.environ["HERMES_REDACT_DISCORD_MENTIONS"]
 
     def test_short_id_not_matched(self):
         """IDs shorter than 17 digits are not Discord snowflakes."""


### PR DESCRIPTION
## Summary

`agent/redact.py` unconditionally rewrites Discord `<@snowflake_id>` mentions to `<@***>` inside `redact_sensitive_text()`. This runs at the persistence boundary before messages reach conversation history, session DB, or platform delivery — so even when the model emits a correct mention, the ID is stripped before Discord sees it.

This breaks any multi-bot setup using `DISCORD_ALLOW_BOTS=mentions` (the recommended safe default). Discord renders the literal `<@***>` as plaintext, the `mentions` array is empty, and the recipient bot never processes the message.

Discord mention IDs are public syntax — visible to every channel member by design. They are not credentials, tokens, or PII.

## Changes

- **`agent/redact.py`**: Gate the `_DISCORD_MENTION_RE.sub()` call behind `HERMES_REDACT_DISCORD_MENTIONS` env var (default OFF). Operators who need mention redaction for export/audit can opt in.
- **`tests/agent/test_redact.py`**: Update `TestDiscordMentions` to assert preservation by default. Add opt-in test confirming masking still works when the env var is set.

## Testing

```bash
python -m pytest tests/agent/test_redact.py -v  # 75 passed
```

Verified end-to-end: sent a cross-bot mention via Discord REST API after applying the patch — message delivered with `mentions: [1]` resolved correctly.

## Related

- #34649 (send_message lacks pre-flight mention-lint — downstream compounding issue)
