### PR TITLE
fix(cron): watchdog supervisor + honest status for the silently-dying in-process ticker

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -163,6 +163,30 @@ def _get_hermes_home() -> Path:
     return _hermes_home or get_hermes_home()
 
 
+def _reload_runtime_env() -> None:
+    """Reload .env + external secret sources fresh for a job run.
+
+    Routes through ``load_hermes_dotenv`` (not bare ``dotenv.load_dotenv``) so
+    BSM/Bitwarden-backed credentials are re-resolved each run instead of leaving
+    the .env placeholder in place — otherwise cron jobs 401 (#33465). It also
+    handles encoding fallbacks and .env sanitization internally.
+
+    ``reset_secret_source_cache()`` first: the gateway applied secrets once at
+    startup, which caches this HERMES_HOME and makes the secret pull a no-op on
+    every subsequent in-process call. Without the reset, this reload re-loads
+    the .env placeholder (override=True) but never re-resolves the real secret —
+    the exact #33465 failure. The Bitwarden value cache (300s TTL) keeps the
+    forced re-pull cheap.
+
+    As at startup, a .env placeholder is only overridden by the resolved secret
+    when the Bitwarden config sets ``override_existing: true`` (the pull runs
+    after the .env load and otherwise skips keys already present in the env).
+    """
+    from hermes_cli.env_loader import load_hermes_dotenv, reset_secret_source_cache
+    reset_secret_source_cache()
+    load_hermes_dotenv(hermes_home=_get_hermes_home())
+
+
 def _get_lock_paths() -> tuple[Path, Path]:
     """Resolve cron lock paths at call time so profile/env changes are honored."""
     hermes_home = _get_hermes_home()
@@ -1465,13 +1489,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
 
     try:
-        # Re-read .env and config.yaml fresh every run so provider/key
-        # changes take effect without a gateway restart.
-        from dotenv import load_dotenv
-        try:
-            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="utf-8")
-        except UnicodeDecodeError:
-            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="latin-1")
+        # Re-read .env and config.yaml fresh every run so provider/key changes
+        # take effect without a gateway restart.
+        _reload_runtime_env()
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18643,6 +18643,25 @@ def _run_planned_stop_watcher(
         stop_event.wait(poll_interval)
 
 
+_cron_last_tick_monotonic: float = 0.0
+_cron_heartbeat_lock = threading.Lock()
+
+
+def _stamp_cron_heartbeat() -> None:
+    """Update the in-process liveness signal (authoritative for the supervisor)."""
+    global _cron_last_tick_monotonic
+    with _cron_heartbeat_lock:
+        _cron_last_tick_monotonic = time.monotonic()
+
+
+def _cron_heartbeat_age() -> Optional[float]:
+    """Seconds since the last tick, or None if the ticker has never stamped."""
+    with _cron_heartbeat_lock:
+        if not _cron_last_tick_monotonic:
+            return None
+        return time.monotonic() - _cron_last_tick_monotonic
+
+
 def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, interval: int = 60):
     """
     Background thread that ticks the cron scheduler at a regular interval.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18643,8 +18643,18 @@ def _run_planned_stop_watcher(
         stop_event.wait(poll_interval)
 
 
+from gateway.status import write_cron_ticker_status, _utc_now_iso
+
 _cron_last_tick_monotonic: float = 0.0
 _cron_heartbeat_lock = threading.Lock()
+
+
+def cron_tick(*args, **kwargs):
+    """Lazy indirection to ``cron.scheduler.tick``: keeps the scheduler import
+    out of gateway-import time (a broken scheduler must not crash the gateway —
+    #20302) while staying patchable in tests."""
+    from cron.scheduler import tick
+    return tick(*args, **kwargs)
 
 
 def _stamp_cron_heartbeat() -> None:
@@ -18676,7 +18686,6 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     image/audio/document cache + expired ``hermes debug share`` pastes
     once per hour.
     """
-    from cron.scheduler import tick as cron_tick
     from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
     from hermes_cli.debug import _sweep_expired_pastes
 
@@ -18687,11 +18696,34 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
 
     logger.info("Cron ticker started (interval=%ds)", interval)
     tick_count = 0
+    consecutive_errors = 0
+    _stamp_cron_heartbeat()
+    try:
+        write_cron_ticker_status(state="running", interval_seconds=interval,
+                                 tick_count=0, last_tick_at=_utc_now_iso(), last_error=None)
+    except Exception:
+        pass
+
     while not stop_event.is_set():
+        last_error = None
         try:
             cron_tick(verbose=False, adapters=adapters, loop=loop)
+            consecutive_errors = 0
         except Exception as e:
-            logger.debug("Cron tick error: %s", e)
+            consecutive_errors += 1
+            last_error = repr(e)
+            logger.warning("Cron tick failed (%d consecutive); continuing",
+                           consecutive_errors, exc_info=True)
+        except BaseException as e:
+            # KeyboardInterrupt cannot reach a non-main thread and SystemExit
+            # kills only this thread; stop_event is our sole shutdown signal.
+            # Honor it, else continue — re-raising a deterministic fatal would
+            # only hot-loop the supervisor's respawn.
+            if stop_event.is_set():
+                break
+            consecutive_errors += 1
+            last_error = repr(e)
+            logger.error("Cron tick hit a non-Exception fault; continuing", exc_info=True)
 
         tick_count += 1
 
@@ -18753,8 +18785,20 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
             except Exception as e:
                 logger.debug("Curator tick error: %s", e)
 
-        stop_event.wait(timeout=interval)
+        _stamp_cron_heartbeat()
+        try:
+            write_cron_ticker_status(state="running", tick_count=tick_count,
+                                     last_tick_at=_utc_now_iso(), last_error=last_error)
+        except Exception:
+            pass
+
+        # Normal cadence is `interval`; on error never hot-loop (min 1s).
+        stop_event.wait(timeout=max(1, interval) if consecutive_errors else interval)
     logger.info("Cron ticker stopped")
+    try:
+        write_cron_ticker_status(state="stopped")
+    except Exception:
+        pass
 
 
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18645,6 +18645,12 @@ def _run_planned_stop_watcher(
 
 from gateway.status import write_cron_ticker_status, _utc_now_iso
 
+CRON_TICK_INTERVAL = 60          # ticker interval (seconds)
+SUPERVISOR_CHECK_INTERVAL = 30   # how often the supervisor checks liveness
+HEARTBEAT_STALE_SECONDS = 1800   # alive but no tick for this long → HUNG (log only)
+_CRON_BACKOFF_BASE = 30          # first respawn delay (seconds)
+_CRON_BACKOFF_CAP = 120          # max respawn delay (≈2 ticks)
+
 _cron_last_tick_monotonic: float = 0.0
 _cron_heartbeat_lock = threading.Lock()
 
@@ -18799,6 +18805,60 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
         write_cron_ticker_status(state="stopped")
     except Exception:
         pass
+
+
+def _spawn_cron_worker(cron_stop, adapters, loop, interval):
+    """Start a fresh cron-ticker worker thread and return it."""
+    thread = threading.Thread(
+        target=_start_cron_ticker,
+        args=(cron_stop,),
+        kwargs={"adapters": adapters, "loop": loop, "interval": interval},
+        daemon=True,
+        name="cron-ticker",
+    )
+    thread.start()
+    return thread
+
+
+def _cron_supervisor_loop(sup_stop, state):
+    """Daemon supervisor: respawn a DEAD worker (retry forever, capped
+    exponential backoff) and surface a HUNG one.
+
+    A hung worker (alive but heartbeat stale) is logged, never killed or
+    respawned — CPython cannot force-kill a thread, and the ``.tick.lock``
+    backstops double-fire. There is deliberately no terminal give-up state:
+    alerting is log-only, so giving up would silently recreate the very
+    indefinite-outage bug this exists to fix. Backoff resets once healthy.
+    """
+    consecutive_deaths = 0
+    while not sup_stop.wait(SUPERVISOR_CHECK_INTERVAL):
+        worker = state["worker"]
+        if not worker.is_alive():
+            consecutive_deaths += 1
+            backoff = min(_CRON_BACKOFF_BASE * 2 ** (consecutive_deaths - 1), _CRON_BACKOFF_CAP)
+            logger.critical("Cron ticker thread is DEAD; jobs are NOT firing. "
+                            "Respawn #%d in %ds.", consecutive_deaths, backoff)
+            try:
+                write_cron_ticker_status(state="stopped",
+                                         last_error=f"thread died; respawn #{consecutive_deaths}")
+            except Exception:
+                pass
+            if sup_stop.wait(backoff):
+                break
+            state["worker"] = _spawn_cron_worker(state["cron_stop"], state["adapters"],
+                                                 state["loop"], state["interval"])
+            continue
+
+        age = _cron_heartbeat_age()
+        if age is not None and age >= HEARTBEAT_STALE_SECONDS:
+            logger.error("Cron ticker alive but no tick for %.0fs (>%ds) — possible "
+                         "hang; jobs may not be firing.", age, HEARTBEAT_STALE_SECONDS)
+            try:
+                write_cron_ticker_status(state="stalled", last_error=f"no tick for {age:.0f}s")
+            except Exception:
+                pass
+        elif age is not None:
+            consecutive_deaths = 0  # healthy → reset backoff
 
 
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18861,6 +18861,29 @@ def _cron_supervisor_loop(sup_stop, state):
             consecutive_deaths = 0  # healthy → reset backoff
 
 
+def _cron_preflight_or_status():
+    """Import ``cron.scheduler`` and confirm ``tick`` is callable BEFORE spawning
+    the ticker. ``import_module`` compiles the module, so a ``SyntaxError`` is
+    caught here (the #20302 silent-death repro). On failure: log CRITICAL, mark
+    ``failed_import``, and return ``(False, reason)`` so the gateway continues
+    WITHOUT cron rather than dying silently."""
+    import importlib
+    try:
+        sched = importlib.import_module("cron.scheduler")
+        if not callable(getattr(sched, "tick", None)):
+            raise ImportError("cron.scheduler.tick is not callable")
+        return True, None
+    except BaseException as e:  # surface ANY import-time fault, incl. SyntaxError
+        reason = f"{type(e).__name__}: {e}"
+        logger.critical("Cron scheduler preflight FAILED — ticker will NOT start; "
+                        "cron jobs will not fire: %s", reason, exc_info=True)
+        try:
+            write_cron_ticker_status(state="failed_import", last_error=reason)
+        except Exception:
+            pass
+        return False, reason
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -19245,18 +19268,29 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             logger.error("Gateway exiting cleanly: %s", runner.exit_reason)
         return True
     
-    # Start background cron ticker so scheduled jobs fire automatically.
-    # Pass the event loop so cron delivery can use live adapters (E2EE support).
+    # Start background cron ticker so scheduled jobs fire automatically, guarded
+    # by a supervisor that respawns it if it dies. Preflight the scheduler import
+    # first so a broken cron.scheduler is reported loudly instead of silently
+    # killing the thread (#20302). On preflight failure the gateway runs on
+    # without cron rather than failing to start.
+    cron_ok, _ = _cron_preflight_or_status()
     cron_stop = threading.Event()
-    cron_thread = threading.Thread(
-        target=_start_cron_ticker,
-        args=(cron_stop,),
-        kwargs={"adapters": runner.adapters, "loop": asyncio.get_running_loop()},
-        daemon=True,
-        name="cron-ticker",
-    )
-    cron_thread.start()
-    
+    sup_stop = threading.Event()
+    cron_thread = None
+    sup_thread = None
+    if cron_ok:
+        loop = asyncio.get_running_loop()
+        cron_thread = _spawn_cron_worker(cron_stop, runner.adapters, loop, CRON_TICK_INTERVAL)
+        sup_thread = threading.Thread(
+            target=_cron_supervisor_loop,
+            args=(sup_stop, {"worker": cron_thread, "cron_stop": cron_stop,
+                             "adapters": runner.adapters, "loop": loop,
+                             "interval": CRON_TICK_INTERVAL}),
+            daemon=True,
+            name="cron-supervisor",
+        )
+        sup_thread.start()
+
     # Wait for shutdown
     await runner.wait_for_shutdown()
 
@@ -19265,9 +19299,13 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
             logger.error("Gateway exiting with failure: %s", runner.exit_reason)
         return False
     
-    # Stop cron ticker cleanly
+    # Stop the supervisor before the worker so it cannot respawn it mid-teardown.
+    sup_stop.set()
+    if sup_thread is not None:
+        sup_thread.join(timeout=5)
     cron_stop.set()
-    cron_thread.join(timeout=5)
+    if cron_thread is not None:
+        cron_thread.join(timeout=5)
 
     # Stop the planned-stop watcher (daemon=True so this is belt-and-suspenders).
     _planned_stop_watcher_stop.set()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18832,33 +18832,42 @@ def _cron_supervisor_loop(sup_stop, state):
     """
     consecutive_deaths = 0
     while not sup_stop.wait(SUPERVISOR_CHECK_INTERVAL):
-        worker = state["worker"]
-        if not worker.is_alive():
-            consecutive_deaths += 1
-            backoff = min(_CRON_BACKOFF_BASE * 2 ** (consecutive_deaths - 1), _CRON_BACKOFF_CAP)
-            logger.critical("Cron ticker thread is DEAD; jobs are NOT firing. "
-                            "Respawn #%d in %ds.", consecutive_deaths, backoff)
-            try:
-                write_cron_ticker_status(state="stopped",
-                                         last_error=f"thread died; respawn #{consecutive_deaths}")
-            except Exception:
-                pass
-            if sup_stop.wait(backoff):
-                break
-            state["worker"] = _spawn_cron_worker(state["cron_stop"], state["adapters"],
-                                                 state["loop"], state["interval"])
-            continue
+        try:
+            worker = state["worker"]
+            if not worker.is_alive():
+                consecutive_deaths += 1
+                backoff = min(_CRON_BACKOFF_BASE * 2 ** (consecutive_deaths - 1), _CRON_BACKOFF_CAP)
+                logger.critical("Cron ticker thread is DEAD; jobs are NOT firing. "
+                                "Respawn #%d in %ds.", consecutive_deaths, backoff)
+                try:
+                    write_cron_ticker_status(state="stopped",
+                                             last_error=f"thread died; respawn #{consecutive_deaths}")
+                except Exception:
+                    pass
+                if sup_stop.wait(backoff):
+                    break
+                state["worker"] = _spawn_cron_worker(state["cron_stop"], state["adapters"],
+                                                     state["loop"], state["interval"])
+                continue
 
-        age = _cron_heartbeat_age()
-        if age is not None and age >= HEARTBEAT_STALE_SECONDS:
-            logger.error("Cron ticker alive but no tick for %.0fs (>%ds) — possible "
-                         "hang; jobs may not be firing.", age, HEARTBEAT_STALE_SECONDS)
-            try:
-                write_cron_ticker_status(state="stalled", last_error=f"no tick for {age:.0f}s")
-            except Exception:
-                pass
-        elif age is not None:
-            consecutive_deaths = 0  # healthy → reset backoff
+            age = _cron_heartbeat_age()
+            if age is not None and age >= HEARTBEAT_STALE_SECONDS:
+                logger.critical("Cron ticker alive but no tick for %.0fs (>%ds) — possible "
+                                "hang; jobs may not be firing.", age, HEARTBEAT_STALE_SECONDS)
+                try:
+                    write_cron_ticker_status(state="stalled", last_error=f"no tick for {age:.0f}s")
+                except Exception:
+                    pass
+            elif age is not None:
+                consecutive_deaths = 0  # healthy → reset backoff
+        except Exception:
+            # The watchdog must outlive a transient fault in its own loop —
+            # e.g. _spawn_cron_worker hitting a thread/fd limit. Dying here
+            # would silently recreate the un-watched dead-ticker bug this
+            # supervisor exists to prevent. Log loudly and retry next cycle;
+            # backoff state is preserved so we don't reset on a spawn failure.
+            logger.critical("Cron supervisor loop iteration failed; "
+                            "retrying next cycle.", exc_info=True)
 
 
 def _cron_preflight_or_status():
@@ -18873,7 +18882,10 @@ def _cron_preflight_or_status():
         if not callable(getattr(sched, "tick", None)):
             raise ImportError("cron.scheduler.tick is not callable")
         return True, None
-    except BaseException as e:  # surface ANY import-time fault, incl. SyntaxError
+    except (Exception, SystemExit) as e:  # surface ANY import-time fault (incl.
+        # SyntaxError, and a module that sys.exit()s at import) — but let a
+        # KeyboardInterrupt during the import propagate so Ctrl-C still aborts
+        # startup instead of silently continuing cron-less.
         reason = f"{type(e).__name__}: {e}"
         logger.critical("Cron scheduler preflight FAILED — ticker will NOT start; "
                         "cron jobs will not fire: %s", reason, exc_info=True)
@@ -19276,16 +19288,19 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     cron_ok, _ = _cron_preflight_or_status()
     cron_stop = threading.Event()
     sup_stop = threading.Event()
-    cron_thread = None
+    cron_state = None
     sup_thread = None
     if cron_ok:
         loop = asyncio.get_running_loop()
-        cron_thread = _spawn_cron_worker(cron_stop, runner.adapters, loop, CRON_TICK_INTERVAL)
+        # Shared with the supervisor; it overwrites cron_state["worker"] on each
+        # respawn, so teardown must join cron_state["worker"] (the live one) —
+        # NOT the original handle, which is dead after any respawn.
+        cron_state = {"worker": _spawn_cron_worker(cron_stop, runner.adapters, loop, CRON_TICK_INTERVAL),
+                      "cron_stop": cron_stop, "adapters": runner.adapters,
+                      "loop": loop, "interval": CRON_TICK_INTERVAL}
         sup_thread = threading.Thread(
             target=_cron_supervisor_loop,
-            args=(sup_stop, {"worker": cron_thread, "cron_stop": cron_stop,
-                             "adapters": runner.adapters, "loop": loop,
-                             "interval": CRON_TICK_INTERVAL}),
+            args=(sup_stop, cron_state),
             daemon=True,
             name="cron-supervisor",
         )
@@ -19304,8 +19319,8 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     if sup_thread is not None:
         sup_thread.join(timeout=5)
     cron_stop.set()
-    if cron_thread is not None:
-        cron_thread.join(timeout=5)
+    if cron_state is not None:
+        cron_state["worker"].join(timeout=5)
 
     # Stop the planned-stop watcher (daemon=True so this is belt-and-suspenders).
     _planned_stop_watcher_stop.set()

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -217,6 +217,7 @@ def _build_runtime_status_record() -> dict[str, Any]:
         "restart_requested": False,
         "active_agents": 0,
         "platforms": {},
+        "cron_ticker": None,
         "updated_at": _utc_now_iso(),
     })
     return payload
@@ -543,6 +544,37 @@ def write_runtime_status(
         platform_payload["updated_at"] = _utc_now_iso()
         payload["platforms"][platform] = platform_payload
 
+    _write_json_file(path, payload)
+
+
+def write_cron_ticker_status(
+    *,
+    state: Any = _UNSET,
+    interval_seconds: Any = _UNSET,
+    tick_count: Any = _UNSET,
+    last_tick_at: Any = _UNSET,
+    last_error: Any = _UNSET,
+) -> None:
+    """Persist cron ticker health into gateway_state.json (best-effort).
+
+    Read-modify-write without a cross-thread lock — the same benign
+    lost-update window every ``write_runtime_status`` caller already
+    accepts. The in-process monotonic heartbeat, not this file, is the
+    authoritative liveness signal, so callers must never rely on this raising.
+    """
+    path = _get_runtime_status_path()
+    payload = _read_json_file(path) or _build_runtime_status_record()
+    block = payload.get("cron_ticker") or {}
+    updates = {
+        "state": state,
+        "interval_seconds": interval_seconds,
+        "tick_count": tick_count,
+        "last_tick_at": last_tick_at,
+        "last_error": last_error,
+    }
+    block.update({k: v for k, v in updates.items() if v is not _UNSET})
+    block["updated_at"] = _utc_now_iso()
+    payload["cron_ticker"] = block
     _write_json_file(path, payload)
 
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -67,7 +67,7 @@ def cron_list(show_all: bool = False):
         repeat_completed = repeat_info.get("completed", 0)
         repeat_str = f"{repeat_completed}/{repeat_times}" if repeat_times else "∞"
 
-        deliver = job.get("deliver", ["local"])
+        deliver = job.get("deliver") or ["local"]
         if isinstance(deliver, str):
             deliver = [deliver]
         deliver_str = ", ".join(deliver)

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -132,6 +132,25 @@ def cron_tick():
     tick(verbose=True)
 
 
+def _read_cron_ticker_health():
+    """Return ``(state, age_seconds | None, last_error | None)`` from
+    gateway_state.json, or ``(None, None, None)`` when unavailable."""
+    try:
+        from datetime import datetime, timezone
+        from gateway.status import read_runtime_status
+
+        block = (read_runtime_status() or {}).get("cron_ticker")
+        if not block:
+            return (None, None, None)
+        age = None
+        if last := block.get("last_tick_at"):
+            ts = datetime.fromisoformat(last.replace("Z", "+00:00"))
+            age = (datetime.now(timezone.utc) - ts).total_seconds()
+        return (block.get("state"), age, block.get("last_error"))
+    except Exception:
+        return (None, None, None)
+
+
 def cron_status():
     """Show cron execution status."""
     from cron.jobs import list_jobs
@@ -141,7 +160,19 @@ def cron_status():
 
     pids = find_gateway_pids()
     if pids:
-        print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
+        state, age, err = _read_cron_ticker_health()
+        if state == "failed_import":
+            print(color(f"✗ Cron ticker failed to start: {err}", Colors.RED))
+            print(color("  Fix cron/scheduler.py, then run: hermes gateway restart", Colors.DIM))
+        elif state is None or age is None:
+            print(color("⚠ Gateway running but cron ticker status unknown", Colors.YELLOW))
+            print(color("  If jobs aren't firing, run: hermes gateway restart", Colors.DIM))
+        elif state in {"stalled", "stopped"} or age >= 1800:  # 1800 == HEARTBEAT_STALE_SECONDS
+            print(color("⚠ Gateway running but cron ticker is NOT alive — jobs are NOT firing", Colors.RED))
+            print(color(f"  Last tick {age:.0f}s ago. Run: hermes gateway restart", Colors.DIM))
+        else:
+            print(color("✓ Cron ticker healthy — jobs will fire automatically", Colors.GREEN))
+            print(color(f"  Last tick {age:.0f}s ago", Colors.DIM))
         print(f"  PID: {', '.join(map(str, pids))}")
     else:
         print(color("✗ Gateway is not running — cron jobs will NOT fire", Colors.RED))

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -132,6 +132,14 @@ def cron_tick():
     tick(verbose=True)
 
 
+# A healthy ticker stamps every CRON_TICK_INTERVAL (60s); 3× gives margin for a
+# slow tick without false alarms. Intentionally distinct from the gateway's
+# HEARTBEAT_STALE_SECONDS (1800s) "alive-but-hung" threshold: this is the
+# liveness backstop for when the supervisor hasn't written state="stopped" yet,
+# so a dead ticker surfaces in ~3 min instead of 30.
+_TICKER_NOT_ALIVE_SECONDS = 180
+
+
 def _read_cron_ticker_health():
     """Return ``(state, age_seconds | None, last_error | None)`` from
     gateway_state.json, or ``(None, None, None)`` when unavailable."""
@@ -167,7 +175,7 @@ def cron_status():
         elif state is None or age is None:
             print(color("⚠ Gateway running but cron ticker status unknown", Colors.YELLOW))
             print(color("  If jobs aren't firing, run: hermes gateway restart", Colors.DIM))
-        elif state in {"stalled", "stopped"} or age >= 1800:  # 1800 == HEARTBEAT_STALE_SECONDS
+        elif state in {"stalled", "stopped"} or age >= _TICKER_NOT_ALIVE_SECONDS:
             print(color("⚠ Gateway running but cron ticker is NOT alive — jobs are NOT firing", Colors.RED))
             print(color(f"  Last tick {age:.0f}s ago. Run: hermes gateway restart", Colors.DIM))
         else:

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -6,7 +6,7 @@ import os
 import sys
 from pathlib import Path
 
-from dotenv import load_dotenv
+import dotenv
 from utils import atomic_replace
 
 
@@ -144,10 +144,14 @@ def _sanitize_loaded_credentials() -> None:
 
 
 def _load_dotenv_with_fallback(path: Path, *, override: bool) -> None:
+    # Call through the ``dotenv`` module (not a ``from dotenv import load_dotenv``
+    # binding) so a ``patch("dotenv.load_dotenv")`` in tests is honored at call
+    # time and cannot be frozen into this module by an import that happens to
+    # occur while the patch is active.
     try:
-        load_dotenv(dotenv_path=path, override=override, encoding="utf-8")
+        dotenv.load_dotenv(dotenv_path=path, override=override, encoding="utf-8")
     except UnicodeDecodeError:
-        load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
+        dotenv.load_dotenv(dotenv_path=path, override=override, encoding="latin-1")
     # Strip non-ASCII characters from credential env vars that were just
     # loaded.  API keys must be pure ASCII since they're sent as HTTP
     # header values (httpx encodes headers as ASCII).  Non-ASCII chars

--- a/tests/cron/test_cron_list.py
+++ b/tests/cron/test_cron_list.py
@@ -1,0 +1,15 @@
+"""Tests for `hermes cron list` rendering (hermes_cli.cron.cron_list)."""
+
+import cron.jobs
+import hermes_cli.cron as c
+
+
+def test_list_renders_job_with_null_deliver(monkeypatch, capsys):
+    """A job whose `deliver` field is present but null must render (falling back
+    to 'local'), not crash with TypeError on ", ".join(None) (#32896)."""
+    job = {"id": "job-1", "name": "nightly", "deliver": None}
+    monkeypatch.setattr(cron.jobs, "list_jobs", lambda include_disabled=False: [job])
+
+    c.cron_list()
+    out = capsys.readouterr().out
+    assert "local" in out  # null deliver falls back to the default channel

--- a/tests/cron/test_cron_profile.py
+++ b/tests/cron/test_cron_profile.py
@@ -222,13 +222,18 @@ class TestRunJobProfileContext:
         monkeypatch.setattr(sched, "_hermes_home", None)
         monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
 
-        import dotenv
+        # The scheduler reloads env via hermes_cli.env_loader.load_hermes_dotenv
+        # (not bare dotenv.load_dotenv) so BSM secrets re-resolve per run.
+        import hermes_cli.env_loader as env_loader
+        from pathlib import Path
 
-        def fake_load_dotenv(path, *_a, **_kw):
-            observed.setdefault("dotenv_paths", []).append(str(path))
-            return True
+        def fake_load_hermes_dotenv(*, hermes_home=None, project_env=None):
+            env_path = Path(hermes_home) / ".env"
+            observed.setdefault("dotenv_paths", []).append(str(env_path))
+            return [env_path]
 
-        monkeypatch.setattr(dotenv, "load_dotenv", fake_load_dotenv)
+        monkeypatch.setattr(env_loader, "load_hermes_dotenv", fake_load_hermes_dotenv)
+        monkeypatch.setattr(env_loader, "reset_secret_source_cache", lambda: None)
 
     def test_run_job_sets_and_restores_profile_home(
         self, isolated_cron_profile_home, monkeypatch
@@ -263,8 +268,9 @@ class TestRunJobProfileContext:
     def test_profile_dotenv_environment_is_restored(
         self, isolated_cron_profile_home, monkeypatch
     ):
-        import dotenv
         import cron.scheduler as sched
+        import hermes_cli.env_loader as env_loader
+        from pathlib import Path
 
         root, profile_home = isolated_cron_profile_home
         observed: dict = {}
@@ -272,14 +278,15 @@ class TestRunJobProfileContext:
         monkeypatch.setenv("HERMES_PROFILE_TEST_SHARED", "outer")
         monkeypatch.delenv("HERMES_PROFILE_TEST_ONLY", raising=False)
 
-        def fake_load_dotenv(path, *_a, **_kw):
-            observed.setdefault("dotenv_paths", []).append(str(path))
+        def fake_load_hermes_dotenv(*, hermes_home=None, project_env=None):
+            env_path = Path(hermes_home) / ".env"
+            observed.setdefault("dotenv_paths", []).append(str(env_path))
             os.environ["HERMES_PROFILE_TEST_SHARED"] = "profile-value"
             os.environ["HERMES_PROFILE_TEST_ONLY"] = "profile-only"
             os.environ["HERMES_CRON_TIMEOUT"] = "123"
-            return True
+            return [env_path]
 
-        monkeypatch.setattr(dotenv, "load_dotenv", fake_load_dotenv)
+        monkeypatch.setattr(env_loader, "load_hermes_dotenv", fake_load_hermes_dotenv)
 
         job = {
             "id": "env-profile",

--- a/tests/cron/test_cron_status.py
+++ b/tests/cron/test_cron_status.py
@@ -1,0 +1,92 @@
+"""Tests for `hermes cron status` ticker-health reporting (hermes_cli.cron)."""
+
+import cron.jobs
+import hermes_cli.cron as c
+import hermes_cli.gateway as gw
+
+
+def _no_jobs(monkeypatch):
+    monkeypatch.setattr(cron.jobs, "list_jobs", lambda include_disabled=False: [])
+
+
+def test_status_healthy_ticker(monkeypatch, capsys):
+    _no_jobs(monkeypatch)
+    monkeypatch.setattr(gw, "find_gateway_pids", lambda: [123])
+    monkeypatch.setattr(c, "_read_cron_ticker_health", lambda: ("running", 5.0, None))
+    c.cron_status()
+    out = capsys.readouterr().out.lower()
+    assert "healthy" in out
+
+
+def test_status_dead_ticker_warns_loudly(monkeypatch, capsys):
+    """Gateway up but ticker hasn't ticked in hours: must NOT claim jobs fire."""
+    _no_jobs(monkeypatch)
+    monkeypatch.setattr(gw, "find_gateway_pids", lambda: [123])
+    monkeypatch.setattr(c, "_read_cron_ticker_health", lambda: ("running", 99999.0, None))
+    c.cron_status()
+    out = capsys.readouterr().out
+    assert "NOT" in out
+    assert "hermes gateway restart" in out
+
+
+def test_status_failed_import(monkeypatch, capsys):
+    _no_jobs(monkeypatch)
+    monkeypatch.setattr(gw, "find_gateway_pids", lambda: [123])
+    monkeypatch.setattr(c, "_read_cron_ticker_health", lambda: ("failed_import", None, "SyntaxError: bad"))
+    c.cron_status()
+    out = capsys.readouterr().out.lower()
+    assert "failed to start" in out
+    assert "syntaxerror" in out
+
+
+def test_status_unknown_health(monkeypatch, capsys):
+    """Gateway up but no ticker block yet (e.g. just started): honest 'unknown'."""
+    _no_jobs(monkeypatch)
+    monkeypatch.setattr(gw, "find_gateway_pids", lambda: [123])
+    monkeypatch.setattr(c, "_read_cron_ticker_health", lambda: (None, None, None))
+    c.cron_status()
+    out = capsys.readouterr().out.lower()
+    assert "unknown" in out
+
+
+def test_status_stopped_ticker_is_not_healthy(monkeypatch, capsys):
+    """A cleanly-stopped ticker (thread gone, gateway up) must not read healthy
+    even when the last tick was recent — jobs are NOT firing."""
+    _no_jobs(monkeypatch)
+    monkeypatch.setattr(gw, "find_gateway_pids", lambda: [123])
+    monkeypatch.setattr(c, "_read_cron_ticker_health", lambda: ("stopped", 3.0, None))
+    c.cron_status()
+    out = capsys.readouterr().out
+    assert "NOT firing" in out
+    assert "healthy" not in out.lower()
+
+
+def test_read_health_parses_real_status_block(tmp_path, monkeypatch):
+    """End-to-end: a real cron_ticker block written by gateway.status round-trips
+    through the reader, yielding a parsed state + finite age."""
+    import gateway.status as status
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    status.write_cron_ticker_status(state="running", last_tick_at=status._utc_now_iso())
+    state, age, err = c._read_cron_ticker_health()
+    assert state == "running"
+    assert age is not None and age < 60
+    assert err is None
+
+
+def test_read_health_degrades_on_bad_timestamp(tmp_path, monkeypatch):
+    """A malformed last_tick_at must degrade to unknown, never crash the CLI."""
+    import gateway.status as status
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    status.write_cron_ticker_status(state="running", last_tick_at="not-a-timestamp")
+    assert c._read_cron_ticker_health() == (None, None, None)
+
+
+def test_status_gateway_not_running(monkeypatch, capsys):
+    _no_jobs(monkeypatch)
+    monkeypatch.setattr(gw, "find_gateway_pids", lambda: [])
+    c.cron_status()
+    out = capsys.readouterr().out
+    assert "not running" in out.lower()
+    assert "NOT fire" in out

--- a/tests/cron/test_cron_status.py
+++ b/tests/cron/test_cron_status.py
@@ -29,6 +29,29 @@ def test_status_dead_ticker_warns_loudly(monkeypatch, capsys):
     assert "hermes gateway restart" in out
 
 
+def test_status_running_but_stale_beyond_liveness_threshold_is_not_healthy(monkeypatch, capsys):
+    """state="running" with an age past the liveness backstop (e.g. the
+    supervisor hasn't yet written "stopped") must read NOT-alive, not green.
+    Pins the 180s threshold: a 300s-stale ticker is dead, not healthy."""
+    _no_jobs(monkeypatch)
+    monkeypatch.setattr(gw, "find_gateway_pids", lambda: [123])
+    monkeypatch.setattr(c, "_read_cron_ticker_health", lambda: ("running", 300.0, None))
+    c.cron_status()
+    out = capsys.readouterr().out
+    assert "NOT" in out
+    assert "healthy" not in out.lower()
+
+
+def test_status_running_within_liveness_threshold_is_healthy(monkeypatch, capsys):
+    """A running ticker just under the threshold stays green — guards against
+    the threshold being set so tight it false-alarms on a slightly slow tick."""
+    _no_jobs(monkeypatch)
+    monkeypatch.setattr(gw, "find_gateway_pids", lambda: [123])
+    monkeypatch.setattr(c, "_read_cron_ticker_health", lambda: ("running", 120.0, None))
+    c.cron_status()
+    assert "healthy" in capsys.readouterr().out.lower()
+
+
 def test_status_failed_import(monkeypatch, capsys):
     _no_jobs(monkeypatch)
     monkeypatch.setattr(gw, "find_gateway_pids", lambda: [123])

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2597,3 +2597,49 @@ class TestSendMediaTimeoutCancelsFuture:
         # 2. Second file still got dispatched — one timeout doesn't abort the batch
         adapter.send_video.assert_called_once()
         assert adapter.send_video.call_args[1]["video_path"] == str(fast.resolve())
+
+
+class TestReloadRuntimeEnv:
+    def test_re_resolves_bsm_secret_over_env_placeholder_each_run(self, monkeypatch, tmp_path):
+        """End-to-end: .env carries a placeholder for a BSM-backed key. Even
+        after the home was already applied once (as the gateway does at startup),
+        a cron reload must RE-pull and override the placeholder with the real
+        secret — otherwise the job 401s (#33465)."""
+        from types import SimpleNamespace
+
+        import agent.secret_sources.bitwarden as bw
+        import cron.scheduler as sched
+        import hermes_cli.env_loader as env_loader
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("API_KEY=placeholder\n", encoding="utf-8")
+        (tmp_path / "config.yaml").write_text(
+            "secrets:\n  bitwarden:\n    enabled: true\n    override_existing: true\n",
+            encoding="utf-8",
+        )
+
+        def fake_apply(**kw):
+            os.environ["API_KEY"] = "real-secret"
+            return SimpleNamespace(applied=["API_KEY"], error=None, warnings=[])
+
+        monkeypatch.setattr(bw, "apply_bitwarden_secrets", fake_apply)
+        # Simulate the gateway having already applied secrets for this home at
+        # startup (which caches the home and would no-op a naive reload).
+        env_loader._apply_external_secret_sources(sched._get_hermes_home())
+        os.environ.pop("API_KEY", None)
+
+        sched._reload_runtime_env()
+        resolved = os.environ.pop("API_KEY", None)
+        assert resolved == "real-secret"  # not the .env placeholder
+
+    def test_does_not_use_bare_dotenv(self, monkeypatch, tmp_path):
+        """Guard against regressing to the bare loader that skips secret sources."""
+        import dotenv
+
+        import cron.scheduler as sched
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        bare_called = {"n": 0}
+        monkeypatch.setattr(dotenv, "load_dotenv", lambda *a, **k: bare_called.__setitem__("n", bare_called["n"] + 1))
+        sched._reload_runtime_env()
+        assert bare_called["n"] == 0

--- a/tests/gateway/test_cron_ticker.py
+++ b/tests/gateway/test_cron_ticker.py
@@ -1,0 +1,97 @@
+"""Tests for the gateway cron ticker worker loop (gateway.run._start_cron_ticker)."""
+
+import logging
+import threading
+
+import gateway.run as run
+
+
+def test_transient_exception_logs_warning_and_continues(monkeypatch, caplog):
+    """A failing tick is logged at WARNING (visible at default level) and the
+    loop survives to tick again — the core #32612/#20302 visibility fix."""
+    calls = {"n": 0}
+    stop = threading.Event()
+
+    def flaky(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ValueError("boom")
+        stop.set()
+
+    monkeypatch.setattr(run, "cron_tick", flaky, raising=False)
+    with caplog.at_level(logging.WARNING, logger=run.logger.name):
+        run._start_cron_ticker(stop, interval=0)
+
+    assert calls["n"] >= 2  # survived the ValueError
+    assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+
+def test_baseexception_honors_stop_and_does_not_propagate(monkeypatch):
+    """A BaseException (e.g. SystemExit) must not escape the worker: when stop
+    is set it breaks cleanly, never re-raising into the thread runner."""
+    stop = threading.Event()
+
+    def fatal(*args, **kwargs):
+        stop.set()
+        raise SystemExit(1)
+
+    monkeypatch.setattr(run, "cron_tick", fatal, raising=False)
+    run._start_cron_ticker(stop, interval=0)  # returns, does not propagate
+
+
+def test_heartbeat_stamped_each_tick(monkeypatch):
+    """The in-process heartbeat advances once the ticker runs (None until then)."""
+    calls = {"n": 0}
+    stop = threading.Event()
+
+    def tick(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            stop.set()
+
+    monkeypatch.setattr(run, "cron_tick", tick, raising=False)
+    monkeypatch.setattr(run, "_cron_last_tick_monotonic", 0.0)
+    assert run._cron_heartbeat_age() is None  # never stamped yet
+
+    run._start_cron_ticker(stop, interval=0)
+    assert run._cron_heartbeat_age() is not None
+
+
+def test_tick_error_recorded_in_status(monkeypatch):
+    """A tick failure surfaces in the persisted cron_ticker block as last_error
+    while state stays "running" (the worker is alive, just erroring)."""
+    writes = []
+    monkeypatch.setattr(run, "write_cron_ticker_status", lambda **kw: writes.append(kw))
+    stop = threading.Event()
+
+    def flaky(*args, **kwargs):
+        stop.set()
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(run, "cron_tick", flaky, raising=False)
+    run._start_cron_ticker(stop, interval=0)
+
+    errored = [w for w in writes if w.get("last_error")]
+    assert errored and "kaboom" in errored[-1]["last_error"]
+    assert errored[-1]["state"] == "running"  # alive, just erroring
+
+
+def test_recovered_tick_clears_last_error(monkeypatch):
+    """A tick that succeeds after a failure must persist last_error=None, so a
+    transient fault does not leave a stale error stuck in the status block."""
+    writes = []
+    monkeypatch.setattr(run, "write_cron_ticker_status", lambda **kw: writes.append(kw))
+    calls = {"n": 0}
+    stop = threading.Event()
+
+    def flaky(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ValueError("boom")
+        stop.set()
+
+    monkeypatch.setattr(run, "cron_tick", flaky, raising=False)
+    run._start_cron_ticker(stop, interval=0)
+
+    per_tick = [w for w in writes if "last_error" in w and "interval_seconds" not in w]
+    assert per_tick[-1]["last_error"] is None  # cleared on the recovering tick

--- a/tests/gateway/test_cron_ticker_supervisor.py
+++ b/tests/gateway/test_cron_ticker_supervisor.py
@@ -1,0 +1,167 @@
+"""Tests for the cron ticker supervisor (gateway.run._cron_supervisor_loop)."""
+
+import threading
+import time
+
+import pytest
+
+import gateway.run as run
+
+
+class _FakeWorker:
+    """Stands in for the worker thread; the supervisor only calls is_alive()."""
+
+    def __init__(self, *alive):
+        self._alive = iter(alive) if alive else iter(())
+
+    def is_alive(self):
+        return next(self._alive, False)
+
+
+def _state(worker):
+    return {
+        "worker": worker,
+        "cron_stop": threading.Event(),
+        "adapters": None,
+        "loop": None,
+        "interval": 60,
+    }
+
+
+def _patch_common(monkeypatch):
+    monkeypatch.setattr(run, "write_cron_ticker_status", lambda **kw: None)
+    monkeypatch.setattr(run, "SUPERVISOR_CHECK_INTERVAL", 0)
+    monkeypatch.setattr(run, "_CRON_BACKOFF_BASE", 0)
+    monkeypatch.setattr(run, "_CRON_BACKOFF_CAP", 0)
+
+
+def test_supervisor_respawns_dead_worker(monkeypatch):
+    spawned = {"n": 0}
+    sup_stop = threading.Event()
+
+    def factory(*args, **kwargs):
+        spawned["n"] += 1
+        sup_stop.set()  # one respawn proves the behavior
+        return _FakeWorker()
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(run, "_spawn_cron_worker", factory)
+    run._cron_supervisor_loop(sup_stop, _state(_FakeWorker()))
+    assert spawned["n"] >= 1
+
+
+def test_supervisor_never_gives_up(monkeypatch):
+    """An always-dead worker is respawned forever — no terminal give-up state."""
+    spawned = {"n": 0}
+    sup_stop = threading.Event()
+
+    def factory(*args, **kwargs):
+        spawned["n"] += 1
+        if spawned["n"] >= 3:
+            sup_stop.set()
+        return _FakeWorker()
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(run, "_spawn_cron_worker", factory)
+    run._cron_supervisor_loop(sup_stop, _state(_FakeWorker()))
+    assert spawned["n"] >= 3
+
+
+def test_supervisor_alerts_but_does_not_respawn_a_hung_worker(monkeypatch):
+    """Alive but stale-heartbeat worker is recorded as stalled, never respawned
+    (CPython cannot force-kill a thread)."""
+    sup_stop = threading.Event()
+    stalled = {"n": 0}
+
+    def on_status(**kw):
+        if kw.get("state") == "stalled":
+            stalled["n"] += 1
+            sup_stop.set()
+
+    monkeypatch.setattr(run, "write_cron_ticker_status", on_status)
+    monkeypatch.setattr(run, "SUPERVISOR_CHECK_INTERVAL", 0)
+    monkeypatch.setattr(run, "HEARTBEAT_STALE_SECONDS", 1)
+    monkeypatch.setattr(run, "_cron_last_tick_monotonic", time.monotonic() - 100)
+    monkeypatch.setattr(run, "_spawn_cron_worker",
+                        lambda *a, **k: pytest.fail("must not respawn a hung worker"))
+
+    run._cron_supervisor_loop(sup_stop, _state(_FakeWorker(True, True)))
+    assert stalled["n"] >= 1
+
+
+def test_supervisor_backoff_escalates_then_caps(monkeypatch):
+    """Consecutive deaths grow the respawn delay exponentially, capped."""
+    backoffs = []
+    sup_stop = threading.Event()
+    real_wait = sup_stop.wait
+
+    def tracking_wait(timeout=None):
+        if timeout:
+            backoffs.append(timeout)
+            if len(backoffs) >= 5:
+                sup_stop.set()
+        return real_wait(0)
+
+    monkeypatch.setattr(run, "write_cron_ticker_status", lambda **kw: None)
+    monkeypatch.setattr(run, "SUPERVISOR_CHECK_INTERVAL", 0)
+    monkeypatch.setattr(run, "_CRON_BACKOFF_BASE", 1)
+    monkeypatch.setattr(run, "_CRON_BACKOFF_CAP", 4)
+    monkeypatch.setattr(run, "_spawn_cron_worker", lambda *a, **k: _FakeWorker())
+    monkeypatch.setattr(sup_stop, "wait", tracking_wait)
+
+    run._cron_supervisor_loop(sup_stop, _state(_FakeWorker()))
+    assert backoffs == [1, 2, 4, 4, 4]
+
+
+def test_supervisor_shutdown_during_backoff_skips_respawn(monkeypatch):
+    """If shutdown arrives while waiting out the backoff, the worker is NOT
+    respawned — teardown stays responsive."""
+    sup_stop = threading.Event()
+    real_wait = sup_stop.wait
+    spawned = {"n": 0}
+
+    def tracking_wait(timeout=None):
+        if timeout:  # the backoff wait — simulate shutdown arriving mid-wait
+            sup_stop.set()
+            return True
+        return real_wait(0)
+
+    monkeypatch.setattr(run, "write_cron_ticker_status", lambda **kw: None)
+    monkeypatch.setattr(run, "SUPERVISOR_CHECK_INTERVAL", 0)
+    monkeypatch.setattr(run, "_CRON_BACKOFF_BASE", 5)
+    monkeypatch.setattr(run, "_CRON_BACKOFF_CAP", 120)
+    monkeypatch.setattr(run, "_spawn_cron_worker",
+                        lambda *a, **k: (spawned.__setitem__("n", spawned["n"] + 1), _FakeWorker())[1])
+    monkeypatch.setattr(sup_stop, "wait", tracking_wait)
+
+    run._cron_supervisor_loop(sup_stop, _state(_FakeWorker()))
+    assert spawned["n"] == 0
+
+
+def test_supervisor_resets_backoff_after_recovery(monkeypatch):
+    """A healthy interval resets the backoff so a transient blip doesn't keep
+    the delay permanently inflated."""
+    backoffs = []
+    sup_stop = threading.Event()
+    real_wait = sup_stop.wait
+    # First spawn comes back alive-then-dead: it recovers (resetting backoff)
+    # before dying again, so its death must use the BASE delay, not an escalated one.
+    respawns = iter([_FakeWorker(True, False), _FakeWorker(), _FakeWorker()])
+
+    def tracking_wait(timeout=None):
+        if timeout:
+            backoffs.append(timeout)
+            if len(backoffs) >= 2:
+                sup_stop.set()
+        return real_wait(0)
+
+    monkeypatch.setattr(run, "write_cron_ticker_status", lambda **kw: None)
+    monkeypatch.setattr(run, "SUPERVISOR_CHECK_INTERVAL", 0)
+    monkeypatch.setattr(run, "_CRON_BACKOFF_BASE", 1)
+    monkeypatch.setattr(run, "_CRON_BACKOFF_CAP", 100)
+    monkeypatch.setattr(run, "_cron_last_tick_monotonic", time.monotonic())  # healthy
+    monkeypatch.setattr(run, "_spawn_cron_worker", lambda *a, **k: next(respawns))
+    monkeypatch.setattr(sup_stop, "wait", tracking_wait)
+
+    run._cron_supervisor_loop(sup_stop, _state(_FakeWorker()))
+    assert backoffs[:2] == [1, 1]  # second death back to base → reset happened

--- a/tests/gateway/test_cron_ticker_supervisor.py
+++ b/tests/gateway/test_cron_ticker_supervisor.py
@@ -67,6 +67,27 @@ def test_supervisor_never_gives_up(monkeypatch):
     assert spawned["n"] >= 3
 
 
+def test_supervisor_survives_spawn_failure(monkeypatch):
+    """A transient _spawn_cron_worker failure (e.g. thread/fd exhaustion) must
+    NOT kill the supervisor — it logs and retries next cycle. Otherwise the
+    watchdog itself dies silently, recreating the un-watched dead-ticker bug
+    the supervisor exists to prevent."""
+    spawned = {"n": 0}
+    sup_stop = threading.Event()
+
+    def factory(*args, **kwargs):
+        spawned["n"] += 1
+        if spawned["n"] == 1:
+            raise RuntimeError("can't start new thread")  # resource limit hit
+        sup_stop.set()  # the retry succeeded → done
+        return _FakeWorker()
+
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(run, "_spawn_cron_worker", factory)
+    run._cron_supervisor_loop(sup_stop, _state(_FakeWorker()))
+    assert spawned["n"] >= 2  # raised once, supervisor survived and retried
+
+
 def test_supervisor_alerts_but_does_not_respawn_a_hung_worker(monkeypatch):
     """Alive but stale-heartbeat worker is recorded as stalled, never respawned
     (CPython cannot force-kill a thread)."""

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -284,3 +284,19 @@ class TestCronPreflight:
         import gateway.run as run
 
         assert run._cron_preflight_or_status() == (True, None)
+
+    def test_preflight_lets_keyboard_interrupt_propagate(self, monkeypatch):
+        """A Ctrl-C landing inside the import must NOT be swallowed as a failed
+        import — it propagates so startup actually aborts instead of silently
+        continuing cron-less."""
+        import importlib
+
+        import gateway.run as run
+        import pytest
+
+        monkeypatch.setattr(
+            importlib, "import_module",
+            lambda name: (_ for _ in ()).throw(KeyboardInterrupt()),
+        )
+        with pytest.raises(KeyboardInterrupt):
+            run._cron_preflight_or_status()

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -245,3 +245,42 @@ async def test_gateway_stop_kills_tool_subprocesses_on_graceful_path(monkeypatch
 
     # Only the final catch-all fires on the graceful path.
     assert kill_count == 1
+
+
+class TestCronPreflight:
+    def test_preflight_failure_marks_failed_import_and_returns_false(self, tmp_path, monkeypatch):
+        """A broken cron.scheduler is reported (status=failed_import) and the
+        caller gets (False, reason) so the gateway continues without cron."""
+        import importlib
+
+        import gateway.run as run
+        import gateway.status as status
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            importlib, "import_module",
+            lambda name: (_ for _ in ()).throw(SyntaxError("broken scheduler")),
+        )
+
+        ok, reason = run._cron_preflight_or_status()
+        assert ok is False
+        assert "broken scheduler" in reason
+        assert status.read_runtime_status()["cron_ticker"]["state"] == "failed_import"
+
+    def test_preflight_rejects_non_callable_tick(self, tmp_path, monkeypatch):
+        import importlib
+        from types import SimpleNamespace
+
+        import gateway.run as run
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(importlib, "import_module", lambda name: SimpleNamespace(tick="nope"))
+        ok, reason = run._cron_preflight_or_status()
+        assert ok is False
+        assert "not callable" in reason
+
+    def test_preflight_succeeds_with_real_scheduler(self):
+        """The real cron.scheduler imports and exposes a callable tick."""
+        import gateway.run as run
+
+        assert run._cron_preflight_or_status() == (True, None)

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1036,3 +1036,40 @@ class TestReadProcessCmdlinePsFallback:
         )
         result = status._read_process_cmdline(12345)
         assert "hermes_cli/main.py" in result
+
+
+class TestCronTickerStatus:
+    def test_cron_ticker_block_roundtrips(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        status.write_runtime_status(gateway_state="running")
+        status.write_cron_ticker_status(
+            state="running", interval_seconds=60, tick_count=7,
+            last_tick_at="2026-05-30T12:00:00Z", last_error=None,
+        )
+        rec = status.read_runtime_status()
+        assert rec["cron_ticker"]["state"] == "running"
+        assert rec["cron_ticker"]["tick_count"] == 7
+        assert rec["cron_ticker"]["interval_seconds"] == 60
+        assert rec["gateway_state"] == "running"  # base fields preserved
+
+    def test_cron_ticker_partial_update_preserves_prior_fields(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        status.write_cron_ticker_status(state="running", interval_seconds=60, tick_count=1)
+        status.write_cron_ticker_status(tick_count=2, last_tick_at="2026-05-30T12:00:01Z")
+        block = status.read_runtime_status()["cron_ticker"]
+        assert block["tick_count"] == 2
+        assert block["interval_seconds"] == 60  # untouched fields survive
+
+    def test_cron_ticker_failed_import_state(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        status.write_cron_ticker_status(state="failed_import", last_error="SyntaxError: bad")
+        block = status.read_runtime_status()["cron_ticker"]
+        assert block["state"] == "failed_import"
+        assert "SyntaxError" in block["last_error"]
+
+    def test_cron_ticker_explicit_none_clears_prior_error(self, tmp_path, monkeypatch):
+        """A recovering tick passes last_error=None to clear a stale error."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        status.write_cron_ticker_status(state="running", last_error="boom")
+        status.write_cron_ticker_status(state="running", last_error=None)
+        assert status.read_runtime_status()["cron_ticker"]["last_error"] is None

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -103,3 +103,32 @@ def test_main_import_applies_user_env_over_shell_values(tmp_path, monkeypatch):
 
     assert os.getenv("OPENAI_BASE_URL") == "https://new.example/v1"
     assert os.getenv("HERMES_INFERENCE_PROVIDER") == "custom"
+
+
+def test_dotenv_load_is_resolved_at_call_time_not_frozen_at_import(tmp_path, monkeypatch):
+    """env_loader must call ``dotenv.load_dotenv`` through the module so a patch
+    applied after import is honored — guarding against the import-order freeze
+    that a ``from dotenv import load_dotenv`` binding would reintroduce (a stale
+    binding silently no-ops real .env loads; see the cron run_job regression)."""
+    import dotenv
+    import hermes_cli.env_loader as env_loader
+
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / ".env").write_text("REGRESSION_SEAM_CHECK=1\n", encoding="utf-8")
+
+    seen_paths = []
+
+    def fake_load_dotenv(*_a, **kw):
+        seen_paths.append(str(kw.get("dotenv_path")))
+        return True
+
+    # Patch AFTER env_loader is already imported. Only call-time resolution
+    # (import dotenv; dotenv.load_dotenv(...)) picks this up.
+    monkeypatch.setattr(dotenv, "load_dotenv", fake_load_dotenv)
+    env_loader.load_hermes_dotenv(hermes_home=home)
+
+    assert seen_paths == [str(home / ".env")], (
+        "env_loader did not resolve dotenv.load_dotenv at call time — the "
+        "from-import binding is frozen and ignores the active patch"
+    )


### PR DESCRIPTION
## Summary

The gateway's in-process cron ticker could die or hang and stay dead **for hours** while the gateway itself kept serving. Three problems compounded: failures were **invisible** (logged at DEBUG, below the default WARNING level), **unrecovered** (a dead thread was never restarted), and **misreported** (`hermes cron status` printed "✓ jobs will fire" while the ticker had been dead 15h). Reported outages ran 15.5h (#32612) and 7.5h after a `cron/scheduler.py` syntax error (#20302).

This PR makes the ticker self-healing and its failures visible and accurately reported, and folds in the two non-ticker fixes that PR #33527 bundled with it: a `cron list` crash and per-run BSM secret resolution.

## Root causes → fix

| # | Root cause | Fix | Issue |
|---|---|---|---|
| RC1 | Tick errors logged at `DEBUG` (invisible at default WARNING) | `WARNING` + `exc_info`, with a consecutive-error counter | #32612, #20302 |
| RC2 | A `BaseException` (e.g. `SystemExit`) killed only the ticker thread, no log | dedicated `except BaseException` that logs + continues unless `stop_event` is set | #32612 |
| RC3 | A broken `cron.scheduler` import killed the thread at import time | lazy `cron_tick` wrapper (scheduler off the gateway-import path) + startup preflight | #20302 |
| RC4 | Nothing restarted a dead ticker | daemon-thread supervisor respawns the worker (capped backoff, retry-forever) | #20302, #32612 |
| RC5 | `cron status` printed green whenever any gateway PID existed | reads true ticker health, 4-way banner | #32612 |
| RC6 | Cron jobs 401'd on BSM/Bitwarden creds (bare `load_dotenv` re-loaded the placeholder) | `_reload_runtime_env` → `reset_secret_source_cache()` + `load_hermes_dotenv` | #33465 |
| RC7 | `cron list` raised `TypeError` on a present-but-null `deliver` | `job.get("deliver") or ["local"]` | #32896 |

## Design decisions

- **DEBUG→WARNING + `exc_info`.** The old level hid the only signal an outage was happening. The consecutive-error count distinguishes a flapping tick from a one-off.
- **Separate `except BaseException` that logs + continues, never re-raises.** `KeyboardInterrupt` can't be delivered to a non-main thread; `SystemExit` would silently kill only this thread; re-raising a deterministic fatal would just hot-loop the supervisor's respawn. `stop_event` is the sole shutdown path.
- **Supervisor is a daemon `threading.Thread`, not asyncio.** The ticker is already a thread, the watchdog must observe `thread.is_alive()` and survive even a wedged event loop. (#32612's outage ran 15.5h under the old in-loop error handling.)
- **Respawn a dead worker with capped exponential backoff 30→120s** (`min(30·2^(deaths−1), 120)`, checked every 30s), reset once a healthy heartbeat is seen.
- **Retry-forever, no terminal give-up state.** Alerting is log-only, so a give-up state would silently recreate the very indefinite-outage bug this exists to fix.
- **The supervisor loop is self-guarded.** A `_spawn_cron_worker` failure (thread/fd exhaustion) inside the loop logs `critical` and retries next cycle instead of silently killing the watchdog; backoff state is preserved across the failure.
- **A hung-but-alive worker is logged at `critical`, never killed or respawned.** CPython can't force-kill a thread; the `.tick.lock` backstops any double-fire. Surfaced at `HEARTBEAT_STALE_SECONDS=1800` (the ~30-min threshold #20302 asks for).
- **Preflight via `importlib.import_module`** compiles the module, so a `SyntaxError` is caught *before* spawn (the #20302 repro). On failure: `critical` log, status `failed_import`, and the gateway runs **without** cron rather than dying. Catches `(Exception, SystemExit)` but lets `KeyboardInterrupt` propagate so Ctrl-C still aborts startup.
- **Two-tier heartbeat.** The in-process monotonic `_cron_last_tick_monotonic` is authoritative for the supervisor (immune to wall-clock jumps); the persisted `gateway_state.json` `cron_ticker` block is best-effort and never raises.
- **Two distinct thresholds.** CLI `_TICKER_NOT_ALIVE_SECONDS=180` (3× the 60s interval) is the liveness backstop for when the supervisor hasn't yet written `state="stopped"` — a dead ticker surfaces in ~3 min, not ~30. It is deliberately separate from the gateway-side `1800` "alive-but-hung" threshold. The two constants live in separate processes (CLI vs gateway) with no shared-import path, so the duplication is intentional.
- **Teardown order.** Stop + join the supervisor *before* signalling the worker, so it can't respawn mid-teardown; then join `cron_state["worker"]` (the live handle the supervisor overwrites on each respawn — the original handle is dead after any respawn).
- **The BSM `reset_secret_source_cache()` is load-bearing.** Startup applies secrets once and caches the home in `_APPLIED_HOMES`, which makes any in-process re-pull a no-op — so a naive `load_hermes_dotenv` re-load would re-apply only the `.env` placeholder and never re-resolve the real secret (exactly #33465). Clearing the cache forces the re-pull; the resolved secret overrides the placeholder only when `secrets.bitwarden.override_existing: true` (mirrors startup), and the 300s Bitwarden value-cache keeps the forced re-pull off the network. A bare swap to `load_hermes_dotenv` without this reset (as in #33527) leaves the placeholder in place, because the process-level dedup no-ops the re-pull — so the reset is required for the fix to take effect in a long-running gateway.

## Files changed (5 core, 9 test)

- **`gateway/run.py`** — ticker constants; monotonic heartbeat + lock; lazy `cron_tick` wrapper; `_stamp_cron_heartbeat`/`_cron_heartbeat_age`; reworked `_start_cron_ticker` (tiered exception policy, per-tick heartbeat + status write); `_spawn_cron_worker`; self-guarded `_cron_supervisor_loop`; `_cron_preflight_or_status`; `start_gateway` rewired to preflight → spawn worker + supervisor via a shared `cron_state` dict → ordered teardown.
- **`gateway/status.py`** — `cron_ticker` added to the runtime-status baseline; `write_cron_ticker_status(*, state/interval_seconds/tick_count/last_tick_at/last_error)` with an `_UNSET`-sentinel partial update.
- **`hermes_cli/cron.py`** — `_TICKER_NOT_ALIVE_SECONDS=180`; `_read_cron_ticker_health` (derives age, fully swallowed on error); `cron_status` 4-way banner (failed_import / unknown / NOT-alive / healthy) replacing the unconditional green print; `cron_list` null-deliver fix.
- **`cron/scheduler.py`** — `_reload_runtime_env`; `_run_job_impl` swaps the inline `load_dotenv` try/except for it.
- **`hermes_cli/env_loader.py`** — call `dotenv.load_dotenv` through the module (`import dotenv`) instead of a `from dotenv import load_dotenv` binding, so the symbol resolves per call. Behavior-identical in production; prevents the binding from being frozen if env_loader is first imported while a test patches `dotenv.load_dotenv` (exposed by the new lazy import in `_reload_runtime_env`).
- **Tests** — `tests/gateway/test_cron_ticker.py` (5), `tests/gateway/test_cron_ticker_supervisor.py` (7), `tests/cron/test_cron_status.py` (10), `tests/cron/test_cron_list.py` (1); additions to `tests/gateway/test_status.py` (+4), `tests/cron/test_scheduler.py` (+2), `tests/gateway/test_gateway_shutdown.py` (+3); `tests/cron/test_cron_profile.py` updated to patch `load_hermes_dotenv` (the seam the scheduler now calls); `tests/hermes_cli/test_env_loader.py` (+1 regression test locking call-time `dotenv.load_dotenv` resolution).

## Also fixed

Two adjacent cron bugs, both also targeted by #33527:

- **#33465** — cron jobs saw the `.env` placeholder instead of the BSM-resolved secret and 401'd. `_reload_runtime_env` (`cron/scheduler.py`) re-resolves secrets on each run.
- **#32896** — `cron list` raised `TypeError` when a job's `deliver` was present but null. Now falls back to the default channel `local` (the issue suggested "auto"/"default"; `local` matches the existing default).

## Testing

```
python -m pytest tests/gateway/test_cron_ticker.py tests/gateway/test_cron_ticker_supervisor.py \
  tests/gateway/test_status.py tests/gateway/test_gateway_shutdown.py \
  tests/cron/test_cron_status.py tests/cron/test_cron_list.py tests/cron/test_scheduler.py -q
ruff check gateway/ cron/ hermes_cli/
```
→ **224 passed** · **ruff: All checks passed**

Coverage by behavior area: **visibility/heartbeat** (worker loop never re-raises, per-tick heartbeat — 5, +4); **supervisor** respawn / capped backoff / hung-detection / spawn-failure-survival (7); **preflight** SyntaxError-caught + `KeyboardInterrupt`-propagates (+3); **status honesty** + the 180s boundary at 300s (NOT-alive) and 120s (healthy) (10); **BSM** re-resolution over the `.env` placeholder (+2); **null-deliver** (1). Worker/supervisor tests run with `interval=0` and are deterministic — the cleanup/curator blocks are gated at ticks ≥5/≥60 and do not fire during these short runs (no sleeps, no timing flakiness).

## Risks / caveats

- **Hung-but-alive worker is detected and logged at `critical`, not auto-killed** — CPython cannot force-interrupt a thread. (New: detection. The previous behavior was no detection at all.)
- **The in-ticker curator's `run_conversation` is not covered by the 600s cron-job inactivity timeout** — a hung curator LLM call can still stall the ticker. **Pre-existing on `main`, not a regression introduced here**; the watchdog now at least surfaces it as "stalled."
- **BSM re-resolution only fires when `secrets.bitwarden.override_existing: true`** (consistent with startup semantics). When the flag is false, an env value already present (including a `.env` placeholder) is left untouched — exactly as at startup; a key absent from the env is still filled.
- **The post-respawn teardown-join (`cron_state["worker"]`) is not unit-tested** — it would need a full async `start_gateway` harness; the underlying respawn/state-dict mechanism is covered indirectly by the supervisor tests.

## Closes

- #20302 — adds the preflight + ~30-min heartbeat monitoring it requests.
- #32612 — fixes the DEBUG-level logging, missing `BaseException` catch, and absent watchdog/misleading status it documents.
- #32895 — ticker ticks reliably, restarts on thread death, and status reflects true health.
- #32896 — null `deliver` no longer crashes `cron list`.
- #33465 — cron jobs resolve BSM secrets instead of 401'ing on the placeholder.

## Supersedes

These open PRs address parts of the same problem; their changes are covered here:

- #32616 — WARNING-level tick visibility.
- #32666 — heartbeat in `gateway_state.json` + stale-status warning.
- #33527 — ticker hardening + null-safe deliver + BSM env loader (its BSM swap omits `reset_secret_source_cache`, so secrets still don't re-resolve in the long-running process; added here).
- #33849 — log/recover + heartbeat file + staleness threshold.
