### PR TITLE
fix(toolsets): fail closed when explicit toolsets resolve to nothing

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1835,6 +1835,22 @@ def cmd_chat(args):
 
     _pin_kanban_board_env()
 
+    # Fail closed on explicitly-requested toolsets that all resolve to nothing:
+    # catches the `hermes -tui` -> argparse `-t ui` misparse (#32660) before the
+    # agent launches silently tool-less. Covers both the CLI-chat and TUI-launch
+    # branches below. Interactive surface -> exit(2); the shared validator never
+    # calls sys.exit itself (it would escape daemon `except Exception` guards).
+    from hermes_cli.toolset_validation import normalize_toolsets, validate_explicit_toolsets
+
+    requested = normalize_toolsets(getattr(args, "toolsets", None))
+    _, toolset_error = validate_explicit_toolsets(requested, source="hermes")
+    if toolset_error:
+        if requested == ["ui"] and not use_tui:
+            sys.stderr.write("hermes: unknown toolset 'ui'. Did you mean --tui (launch the terminal UI)?\n")
+        else:
+            sys.stderr.write(toolset_error + "\n")
+        sys.exit(2)
+
     if use_tui:
         _launch_tui(
             getattr(args, "resume", None),

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1705,6 +1705,33 @@ def cmd_chat(args):
     """Run interactive chat CLI."""
     use_tui = getattr(args, "tui", False) or os.environ.get("HERMES_TUI") == "1"
 
+    # Fail closed on explicitly-requested toolsets that all resolve to nothing,
+    # BEFORE any session resolution or the first-run provider guard below: this
+    # is a CLI usage error (notably the `hermes -tui` -> argparse `-t ui`
+    # misparse, #32660) and must be reported ahead of "you're not configured
+    # yet" -- otherwise a typo on an unconfigured machine yields a misleading
+    # `hermes setup` prompt instead of the --tui hint. Covers the CLI-chat and
+    # TUI-launch branches alike. Interactive surface -> exit(2); the shared
+    # validator never calls sys.exit itself (that would escape daemon
+    # `except Exception` guards).
+    #
+    # warn=no-op: this is purely the all-unknown exit gate. The partial-invalid
+    # notice is emitted downstream by cli.py / tui_gateway. This gate is
+    # LOAD-BEARING for the CLI-chat surface: cli.py only *warns* on all-unknown
+    # and then runs tool-less (it does not fail closed), so removing it would
+    # reintroduce #32660. The TUI branch is separately protected by
+    # tui_gateway's own validator.
+    from hermes_cli.toolset_validation import normalize_toolsets, validate_explicit_toolsets
+
+    requested = normalize_toolsets(getattr(args, "toolsets", None))
+    _, toolset_error = validate_explicit_toolsets(requested, source="hermes", warn=lambda _: None)
+    if toolset_error:
+        if requested == ["ui"] and not use_tui:
+            sys.stderr.write("hermes: unknown toolset 'ui'. Did you mean --tui (launch the terminal UI)?\n")
+        else:
+            sys.stderr.write(toolset_error + "\n")
+        sys.exit(2)
+
     # Resolve --continue into --resume with the latest session or by name
     continue_val = getattr(args, "continue_last", None)
     if continue_val and not getattr(args, "resume", None):
@@ -1834,28 +1861,6 @@ def cmd_chat(args):
         os.environ["HERMES_SESSION_SOURCE"] = args.source
 
     _pin_kanban_board_env()
-
-    # Fail closed on explicitly-requested toolsets that all resolve to nothing:
-    # catches the `hermes -tui` -> argparse `-t ui` misparse (#32660) before the
-    # agent launches silently tool-less. Covers both the CLI-chat and TUI-launch
-    # branches below. Interactive surface -> exit(2); the shared validator never
-    # calls sys.exit itself (it would escape daemon `except Exception` guards).
-    from hermes_cli.toolset_validation import normalize_toolsets, validate_explicit_toolsets
-
-    # warn=no-op: this is purely the all-unknown exit gate. Don't warn on the
-    # partial-invalid case here -- cli.py / tui_gateway emit that notice. Note
-    # this gate is LOAD-BEARING for the CLI-chat surface: cli.py only *warns* on
-    # all-unknown and then runs tool-less (it does not fail closed), so removing
-    # this gate would reintroduce #32660. The TUI branch is separately protected
-    # by tui_gateway's own validator.
-    requested = normalize_toolsets(getattr(args, "toolsets", None))
-    _, toolset_error = validate_explicit_toolsets(requested, source="hermes", warn=lambda _: None)
-    if toolset_error:
-        if requested == ["ui"] and not use_tui:
-            sys.stderr.write("hermes: unknown toolset 'ui'. Did you mean --tui (launch the terminal UI)?\n")
-        else:
-            sys.stderr.write(toolset_error + "\n")
-        sys.exit(2)
 
     if use_tui:
         _launch_tui(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1842,9 +1842,12 @@ def cmd_chat(args):
     # calls sys.exit itself (it would escape daemon `except Exception` guards).
     from hermes_cli.toolset_validation import normalize_toolsets, validate_explicit_toolsets
 
-    # warn=no-op: this is purely the all-unknown exit gate; the valid/partial
-    # request is re-validated (and any partial-invalid notice emitted) by the
-    # downstream surface (cli.py / tui_gateway), so warning here would double up.
+    # warn=no-op: this is purely the all-unknown exit gate. Don't warn on the
+    # partial-invalid case here -- cli.py / tui_gateway emit that notice. Note
+    # this gate is LOAD-BEARING for the CLI-chat surface: cli.py only *warns* on
+    # all-unknown and then runs tool-less (it does not fail closed), so removing
+    # this gate would reintroduce #32660. The TUI branch is separately protected
+    # by tui_gateway's own validator.
     requested = normalize_toolsets(getattr(args, "toolsets", None))
     _, toolset_error = validate_explicit_toolsets(requested, source="hermes", warn=lambda _: None)
     if toolset_error:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1842,8 +1842,11 @@ def cmd_chat(args):
     # calls sys.exit itself (it would escape daemon `except Exception` guards).
     from hermes_cli.toolset_validation import normalize_toolsets, validate_explicit_toolsets
 
+    # warn=no-op: this is purely the all-unknown exit gate; the valid/partial
+    # request is re-validated (and any partial-invalid notice emitted) by the
+    # downstream surface (cli.py / tui_gateway), so warning here would double up.
     requested = normalize_toolsets(getattr(args, "toolsets", None))
-    _, toolset_error = validate_explicit_toolsets(requested, source="hermes")
+    _, toolset_error = validate_explicit_toolsets(requested, source="hermes", warn=lambda _: None)
     if toolset_error:
         if requested == ["ui"] and not use_tui:
             sys.stderr.write("hermes: unknown toolset 'ui'. Did you mean --tui (launch the terminal UI)?\n")

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -30,96 +30,12 @@ from typing import Optional
 from hermes_cli.fallback_config import get_fallback_chain
 
 
-def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
-    if not toolsets:
-        return None
-
-    raw_items = [toolsets] if isinstance(toolsets, str) else toolsets
-    if not isinstance(raw_items, (list, tuple)):
-        raw_items = [raw_items]
-
-    normalized: list[str] = []
-    for item in raw_items:
-        if isinstance(item, str):
-            normalized.extend(part.strip() for part in item.split(","))
-        else:
-            normalized.append(str(item).strip())
-
-    return [item for item in normalized if item] or None
+from hermes_cli.toolset_validation import normalize_toolsets as _normalize_toolsets
+from hermes_cli.toolset_validation import validate_explicit_toolsets as _validate_shared
 
 
 def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | None, str | None]:
-    normalized = _normalize_toolsets(toolsets)
-    if normalized is None:
-        return None, None
-
-    try:
-        from toolsets import validate_toolset
-    except Exception as exc:
-        return None, f"hermes -z: failed to validate --toolsets: {exc}\n"
-
-    built_in = [name for name in normalized if validate_toolset(name)]
-    unresolved = [name for name in normalized if name not in built_in]
-
-    if unresolved:
-        try:
-            from hermes_cli.plugins import discover_plugins
-
-            discover_plugins()
-            plugin_valid = [name for name in unresolved if validate_toolset(name)]
-        except Exception:
-            plugin_valid = []
-
-        if plugin_valid:
-            built_in.extend(plugin_valid)
-            unresolved = [name for name in unresolved if name not in plugin_valid]
-
-    if any(name in {"all", "*"} for name in built_in):
-        ignored = [name for name in normalized if name not in {"all", "*"}]
-        if ignored:
-            sys.stderr.write(
-                "hermes -z: --toolsets all enables every toolset; "
-                f"ignoring additional entries: {', '.join(ignored)}\n"
-            )
-        return None, None
-
-    mcp_names: set[str] = set()
-    mcp_disabled: set[str] = set()
-    if unresolved:
-        try:
-            from hermes_cli.config import read_raw_config
-            from hermes_cli.tools_config import _parse_enabled_flag
-
-            cfg = read_raw_config()
-            mcp_servers = cfg.get("mcp_servers") if isinstance(cfg.get("mcp_servers"), dict) else {}
-            for name, server_cfg in mcp_servers.items():
-                if not isinstance(server_cfg, dict):
-                    continue
-                if _parse_enabled_flag(server_cfg.get("enabled", True), default=True):
-                    mcp_names.add(str(name))
-                else:
-                    mcp_disabled.add(str(name))
-        except Exception:
-            mcp_names = set()
-            mcp_disabled = set()
-
-    mcp_valid = [name for name in unresolved if name in mcp_names]
-    disabled = [name for name in unresolved if name in mcp_disabled]
-    unknown = [name for name in unresolved if name not in mcp_names and name not in mcp_disabled]
-    valid = built_in + mcp_valid
-
-    if unknown:
-        sys.stderr.write(f"hermes -z: ignoring unknown --toolsets entries: {', '.join(unknown)}\n")
-    if disabled:
-        sys.stderr.write(
-            "hermes -z: ignoring disabled MCP servers (set enabled: true in config.yaml to use): "
-            f"{', '.join(disabled)}\n"
-        )
-
-    if not valid:
-        return None, "hermes -z: --toolsets did not contain any valid toolsets.\n"
-
-    return valid, None
+    return _validate_shared(toolsets, source="hermes -z")
 
 
 def run_oneshot(
@@ -162,7 +78,7 @@ def run_oneshot(
 
     explicit_toolsets, toolsets_error = _validate_explicit_toolsets(toolsets)
     if toolsets_error:
-        sys.stderr.write(toolsets_error)
+        sys.stderr.write(toolsets_error + "\n")
         return 2
     use_config_toolsets = _normalize_toolsets(toolsets) is None
 

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -1,0 +1,134 @@
+"""Shared explicit-toolset validation — single source of truth.
+
+A caller explicitly named toolsets; are they real? Enforces ONE fail-closed
+contract everywhere (CLI, TUI gateway, cron, OpenAI-compatible API server):
+
+    explicit, ALL unknown   -> hard fail   (raise / return error string)
+    explicit, PARTIAL valid -> warn, continue with the valid subset
+    omitted / all / *       -> None        (caller loads the full default set)
+
+CRITICAL: nothing here calls sys.exit(). It returns or raises. SystemExit is a
+BaseException and would escape `except Exception` daemon boundaries (e.g.
+gateway/platforms/base.py:4056), killing a worker task. Only the interactive
+CLI entry frame converts a failure into sys.exit(2).
+
+Lifted from hermes_cli/oneshot.py (which self-discovers plugins + reads MCP
+config), so it is safe to call from any lifecycle position.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Callable
+
+_ALL = {"all", "*"}
+
+
+class InvalidToolsetError(ValueError):
+    """Explicit, non-empty toolset request resolved to nothing valid."""
+
+    def __init__(self, message: str, unknown: list[str] | None = None):
+        super().__init__(message)
+        self.unknown = unknown or []
+
+
+def normalize_toolsets(toolsets: object = None) -> list[str] | None:
+    if not toolsets:
+        return None
+    items = [toolsets] if isinstance(toolsets, str) else toolsets
+    if not isinstance(items, (list, tuple)):
+        items = [items]
+    parts: list[str] = []
+    for item in items:
+        parts.extend(item.split(",") if isinstance(item, str) else [str(item)])
+    return [p for p in (s.strip() for s in parts) if p] or None
+
+
+def _default_warn(message: str) -> None:
+    sys.stderr.write(message if message.endswith("\n") else message + "\n")
+
+
+def validate_explicit_toolsets(
+    toolsets: object = None,
+    *,
+    source: str = "hermes",
+    warn: Callable[[str], None] | None = None,
+) -> tuple[list[str] | None, str | None]:
+    """Return (valid_toolsets, error_message).
+
+    (valid, None) -> use this subset.
+    (None,  None) -> nothing explicit, or `all`/`*` -> caller uses full default set.
+    (None,  error)-> all-unknown; `error` is a ready-to-emit line (caller picks delivery).
+
+    Partial-invalid notices go through `warn` (default: stderr). `source`
+    prefixes every message (e.g. "hermes -z", "[tui]", "cron").
+    """
+    emit = warn or _default_warn
+    normalized = normalize_toolsets(toolsets)
+    if normalized is None:
+        return None, None
+
+    try:
+        from toolsets import validate_toolset
+    except Exception as exc:
+        return None, f"{source}: failed to validate toolsets: {exc}"
+
+    built_in = [name for name in normalized if validate_toolset(name)]
+    unresolved = [name for name in normalized if name not in built_in]
+
+    if unresolved:
+        try:
+            from hermes_cli.plugins import discover_plugins
+
+            discover_plugins()
+        except Exception:
+            pass
+        now_valid = [name for name in unresolved if validate_toolset(name)]
+        built_in.extend(now_valid)
+        unresolved = [name for name in unresolved if name not in now_valid]
+
+    if any(name in _ALL for name in built_in):
+        if ignored := [name for name in normalized if name not in _ALL]:
+            emit(f"{source}: 'all' enables every toolset; ignoring: {', '.join(ignored)}")
+        return None, None
+
+    mcp_names: set[str] = set()
+    mcp_disabled: set[str] = set()
+    if unresolved:
+        try:
+            from hermes_cli.config import read_raw_config
+            from hermes_cli.tools_config import _parse_enabled_flag
+
+            servers = read_raw_config().get("mcp_servers")
+            for name, cfg in (servers if isinstance(servers, dict) else {}).items():
+                if isinstance(cfg, dict):
+                    target = mcp_names if _parse_enabled_flag(cfg.get("enabled", True), default=True) else mcp_disabled
+                    target.add(str(name))
+        except Exception:
+            mcp_names, mcp_disabled = set(), set()
+
+    valid = built_in + [name for name in unresolved if name in mcp_names]
+    disabled = [name for name in unresolved if name in mcp_disabled]
+    unknown = [name for name in unresolved if name not in mcp_names and name not in mcp_disabled]
+
+    if unknown:
+        emit(f"{source}: ignoring unknown toolsets: {', '.join(unknown)}")
+    if disabled:
+        emit(f"{source}: ignoring disabled MCP servers (set enabled: true in config.yaml to use): {', '.join(disabled)}")
+
+    if not valid:
+        return None, f"{source}: no valid toolsets in request (unknown: {', '.join(unknown) or '-'})."
+    return valid, None
+
+
+def validate_explicit_toolsets_or_raise(
+    toolsets: object = None,
+    *,
+    source: str = "hermes",
+    warn: Callable[[str], None] | None = None,
+) -> list[str] | None:
+    """Daemon-side adapter: raise InvalidToolsetError on all-unknown, else return the subset (or None)."""
+    valid, error = validate_explicit_toolsets(toolsets, source=source, warn=warn)
+    if error:
+        raise InvalidToolsetError(error, unknown=normalize_toolsets(toolsets))
+    return valid

--- a/hermes_cli/toolset_validation.py
+++ b/hermes_cli/toolset_validation.py
@@ -130,5 +130,5 @@ def validate_explicit_toolsets_or_raise(
     """Daemon-side adapter: raise InvalidToolsetError on all-unknown, else return the subset (or None)."""
     valid, error = validate_explicit_toolsets(toolsets, source=source, warn=warn)
     if error:
-        raise InvalidToolsetError(error, unknown=normalize_toolsets(toolsets))
+        raise InvalidToolsetError(error)
     return valid

--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -19,6 +19,11 @@ def test_all_alias_means_caller_loads_defaults():
     assert validate_explicit_toolsets("all") == (None, None)
 
 
+def test_single_valid_toolset_is_accepted():
+    # A real toolset must produce no error, so the CLI guard never trips on it.
+    assert validate_explicit_toolsets("web", source="hermes") == (["web"], None)
+
+
 def test_partial_keeps_valid_subset_and_warns():
     warnings = []
     valid, err = validate_explicit_toolsets("web,definitely_not_a_toolset", source="test", warn=warnings.append)

--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -50,6 +50,41 @@ def test_or_raise_never_exits_the_process(monkeypatch):
         validate_explicit_toolsets_or_raise("ui")
 
 
+def test_all_plus_extras_warns_they_are_ignored():
+    warnings = []
+    valid, err = validate_explicit_toolsets("all,web", source="t", warn=warnings.append)
+    assert (valid, err) == (None, None)
+    assert any("web" in w for w in warnings)
+
+
+def test_enabled_mcp_server_resolves_disabled_one_warns(monkeypatch):
+    import hermes_cli.config
+
+    monkeypatch.setattr(
+        hermes_cli.config,
+        "read_raw_config",
+        lambda: {"mcp_servers": {"live_mcp": {"enabled": True}, "off_mcp": {"enabled": False}}},
+    )
+    warnings = []
+    valid, err = validate_explicit_toolsets("web,live_mcp,off_mcp", source="t", warn=warnings.append)
+    assert err is None
+    assert valid == ["web", "live_mcp"]
+    assert any("off_mcp" in w and "enabled: true" in w for w in warnings)
+
+
+def test_unreadable_config_degrades_to_all_unknown(monkeypatch):
+    # A crash reading MCP config must not propagate — names just stay unknown.
+    import hermes_cli.config
+
+    def boom():
+        raise RuntimeError("config exploded")
+
+    monkeypatch.setattr(hermes_cli.config, "read_raw_config", boom)
+    valid, err = validate_explicit_toolsets("not_a_real_mcp", source="t")
+    assert valid is None
+    assert "not_a_real_mcp" in err
+
+
 def test_normalize_splits_and_strips():
     assert normalize_toolsets(" web , search ") == ["web", "search"]
     assert normalize_toolsets(["web", "search"]) == ["web", "search"]

--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -1,0 +1,56 @@
+import sys
+
+import pytest
+
+from hermes_cli.toolset_validation import (
+    InvalidToolsetError,
+    normalize_toolsets,
+    validate_explicit_toolsets,
+    validate_explicit_toolsets_or_raise,
+)
+
+
+def test_omitted_means_caller_loads_defaults():
+    assert validate_explicit_toolsets(None) == (None, None)
+    assert validate_explicit_toolsets("") == (None, None)
+
+
+def test_all_alias_means_caller_loads_defaults():
+    assert validate_explicit_toolsets("all") == (None, None)
+
+
+def test_partial_keeps_valid_subset_and_warns():
+    warnings = []
+    valid, err = validate_explicit_toolsets("web,definitely_not_a_toolset", source="test", warn=warnings.append)
+    assert err is None
+    assert valid == ["web"]
+    assert any("definitely_not_a_toolset" in w for w in warnings)
+
+
+def test_all_unknown_is_an_error():
+    valid, err = validate_explicit_toolsets("ui", source="hermes")
+    assert valid is None
+    assert "ui" in err
+
+
+def test_or_raise_raises_on_all_unknown():
+    with pytest.raises(InvalidToolsetError, match="ui"):
+        validate_explicit_toolsets_or_raise("ui", source="hermes")
+
+
+def test_or_raise_returns_subset_on_partial():
+    assert validate_explicit_toolsets_or_raise("web,bogus", source="t", warn=lambda _: None) == ["web"]
+
+
+def test_or_raise_never_exits_the_process(monkeypatch):
+    # The hard constraint: SystemExit (BaseException) would escape daemon
+    # `except Exception` boundaries and kill a worker task. Shared code raises.
+    monkeypatch.setattr(sys, "exit", lambda *a: pytest.fail("sys.exit called"))
+    with pytest.raises(InvalidToolsetError):
+        validate_explicit_toolsets_or_raise("ui")
+
+
+def test_normalize_splits_and_strips():
+    assert normalize_toolsets(" web , search ") == ["web", "search"]
+    assert normalize_toolsets(["web", "search"]) == ["web", "search"]
+    assert normalize_toolsets(None) is None

--- a/tests/hermes_cli/test_toolset_validation.py
+++ b/tests/hermes_cli/test_toolset_validation.py
@@ -17,6 +17,7 @@ def test_omitted_means_caller_loads_defaults():
 
 def test_all_alias_means_caller_loads_defaults():
     assert validate_explicit_toolsets("all") == (None, None)
+    assert validate_explicit_toolsets("*") == (None, None)
 
 
 def test_single_valid_toolset_is_accepted():
@@ -88,6 +89,15 @@ def test_unreadable_config_degrades_to_all_unknown(monkeypatch):
     valid, err = validate_explicit_toolsets("not_a_real_mcp", source="t")
     assert valid is None
     assert "not_a_real_mcp" in err
+
+
+def test_unimportable_validator_fails_closed(monkeypatch):
+    # If the `toolsets` module itself can't be imported, an explicit request
+    # must fail closed (error), never silently widen to the full set.
+    monkeypatch.setitem(sys.modules, "toolsets", None)
+    valid, err = validate_explicit_toolsets("web", source="t")
+    assert valid is None
+    assert err is not None and "failed to validate toolsets" in err
 
 
 def test_normalize_splits_and_strips():

--- a/tests/hermes_cli/test_toolset_validation_cli.py
+++ b/tests/hermes_cli/test_toolset_validation_cli.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+
+
+def _run(*args):
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "chat", *args],
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+
+
+def test_tui_misparse_exits_with_hint():
+    # `hermes chat -tui` -> argparse `-t ui` -> unknown toolset -> fail with a --tui hint.
+    res = _run("-tui")
+    assert res.returncode == 2
+    assert "--tui" in res.stderr
+    assert "ui" in res.stderr
+
+
+def test_all_unknown_toolsets_exit_2():
+    res = _run("-t", "definitely_not_a_toolset")
+    assert res.returncode == 2
+    assert "definitely_not_a_toolset" in res.stderr

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -635,7 +635,7 @@ def test_oneshot_rejects_invalid_only_toolsets(monkeypatch, capsys):
     assert run_oneshot("hello", toolsets="nope") == 2
     err = capsys.readouterr().err
     assert "nope" in err
-    assert "did not contain any valid toolsets" in err
+    assert "no valid toolsets in request" in err
 
 
 def test_oneshot_fails_closed_on_empty_final_response(monkeypatch, capsys):
@@ -720,7 +720,7 @@ def test_oneshot_all_toolsets_warns_about_ignored_extra_entries(monkeypatch, cap
 
     assert valid is None
     assert error is None
-    assert "ignoring additional entries: nope" in capsys.readouterr().err
+    assert "ignoring: nope" in capsys.readouterr().err
 
 
 def test_oneshot_accepts_plugin_toolset_after_discovery(monkeypatch):
@@ -764,7 +764,7 @@ def test_oneshot_rejects_disabled_mcp_toolset(monkeypatch, capsys):
     valid, error = _validate_explicit_toolsets("mcp-off")
 
     assert valid is None
-    assert error == "hermes -z: --toolsets did not contain any valid toolsets.\n"
+    assert error and "no valid toolsets in request" in error
     err = capsys.readouterr().err
     assert "ignoring disabled MCP servers" in err
     assert "mcp-off" in err
@@ -787,7 +787,7 @@ def test_oneshot_distinguishes_disabled_mcp_from_unknown(monkeypatch, capsys):
     assert valid == ["web"]
     assert error is None
     err = capsys.readouterr().err
-    assert "ignoring unknown --toolsets entries: nope" in err
+    assert "ignoring unknown toolsets: nope" in err
     assert "ignoring disabled MCP servers" in err
     assert "mcp-off" in err
 

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -764,7 +764,7 @@ def test_oneshot_rejects_disabled_mcp_toolset(monkeypatch, capsys):
     valid, error = _validate_explicit_toolsets("mcp-off")
 
     assert valid is None
-    assert error and "no valid toolsets in request" in error
+    assert error and error.startswith("hermes -z:") and "no valid toolsets in request" in error
     err = capsys.readouterr().err
     assert "ignoring disabled MCP servers" in err
     assert "mcp-off" in err

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -487,6 +487,10 @@ def test_tools_list_fails_closed_under_all_unknown_env(monkeypatch):
         types.SimpleNamespace(discover_plugins=lambda: None),
     )
 
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(config_mod, "read_raw_config", lambda: {})
+
     resp = server.dispatch({"id": "1", "method": "tools.list", "params": {}})
 
     assert resp["error"]["code"] == 5031

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7,6 +7,8 @@ import types
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from tui_gateway import server
 
 
@@ -435,7 +437,9 @@ def test_load_enabled_toolsets_accepts_plugin_env_after_discovery(monkeypatch):
     assert server._load_enabled_toolsets() == ["plugin_demo"]
 
 
-def test_load_enabled_toolsets_rejects_disabled_mcp_env(monkeypatch, capsys):
+def test_load_enabled_toolsets_raises_on_disabled_only_mcp_env(monkeypatch, capsys):
+    # A request naming only a disabled MCP server resolves to nothing valid ->
+    # fail closed (raise), not widen to the full configured set.
     monkeypatch.setenv("HERMES_TUI_TOOLSETS", "mcp-off")
     monkeypatch.setitem(
         sys.modules,
@@ -450,27 +454,47 @@ def test_load_enabled_toolsets_rejects_disabled_mcp_env(monkeypatch, capsys):
         "read_raw_config",
         lambda: {"mcp_servers": {"mcp-off": {"enabled": False}}},
     )
-    monkeypatch.setattr(
-        config_mod, "load_config", lambda: {"platform_toolsets": {"cli": ["memory"]}}
-    )
 
-    # Sorted: ["kanban", "memory"]. `kanban` is auto-recovered by
-    # _get_platform_tools because it's a non-configurable platform toolset
-    # whose tools live in hermes-cli's universe (see toolsets.py).
-    assert server._load_enabled_toolsets() == ["kanban", "memory"]
+    with pytest.raises(server.InvalidToolsetError):
+        server._load_enabled_toolsets()
     err = capsys.readouterr().err
     assert "ignoring disabled MCP servers" in err
     assert "mcp-off" in err
-    assert "using configured CLI toolsets" in err
 
 
-def test_load_enabled_toolsets_falls_back_when_tui_env_invalid(monkeypatch, capsys):
+def test_load_enabled_toolsets_raises_when_tui_env_all_unknown(monkeypatch):
+    # Privilege-escalation-by-typo guard: an all-unknown explicit request must
+    # NOT silently widen to every tool. It raises so the daemon refuses it.
     monkeypatch.setenv("HERMES_TUI_TOOLSETS", "nope")
     monkeypatch.setitem(
         sys.modules,
         "hermes_cli.plugins",
         types.SimpleNamespace(discover_plugins=lambda: None),
     )
+
+    with pytest.raises(server.InvalidToolsetError, match="nope"):
+        server._load_enabled_toolsets()
+
+
+def test_tools_list_fails_closed_under_all_unknown_env(monkeypatch):
+    # Documented behavior change: with an all-bogus HERMES_TUI_TOOLSETS and no
+    # live session, the toolset picker surfaces an error rather than silently
+    # listing every toolset as enabled (the old fail-open widening).
+    monkeypatch.setenv("HERMES_TUI_TOOLSETS", "definitely_not_a_toolset")
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(discover_plugins=lambda: None),
+    )
+
+    resp = server.dispatch({"id": "1", "method": "tools.list", "params": {}})
+
+    assert resp["error"]["code"] == 5031
+    assert "definitely_not_a_toolset" in resp["error"]["message"]
+
+
+def test_load_enabled_toolsets_omitted_returns_configured_set(monkeypatch):
+    monkeypatch.delenv("HERMES_TUI_TOOLSETS", raising=False)
 
     import hermes_cli.config as config_mod
 
@@ -478,17 +502,16 @@ def test_load_enabled_toolsets_falls_back_when_tui_env_invalid(monkeypatch, caps
         config_mod, "load_config", lambda: {"platform_toolsets": {"cli": ["memory"]}}
     )
 
+    # Sorted: ["kanban", "memory"]. `kanban` is auto-recovered by
+    # _get_platform_tools as a non-configurable platform toolset (see toolsets.py).
     assert server._load_enabled_toolsets() == ["kanban", "memory"]
-    assert "using configured CLI toolsets" in capsys.readouterr().err
 
 
-def test_load_enabled_toolsets_warns_when_config_fallback_fails(monkeypatch, capsys):
-    monkeypatch.setenv("HERMES_TUI_TOOLSETS", "nope")
-    monkeypatch.setitem(
-        sys.modules,
-        "hermes_cli.plugins",
-        types.SimpleNamespace(discover_plugins=lambda: None),
-    )
+def test_load_enabled_toolsets_fails_closed_when_config_unreadable(monkeypatch, capsys):
+    # No explicit request + config read crash must return [] (no tools), never
+    # None — the agent reads None as "no filter" = every tool, so a crash there
+    # would be a silent all-tools grant.
+    monkeypatch.delenv("HERMES_TUI_TOOLSETS", raising=False)
 
     import hermes_cli.config as config_mod
 
@@ -496,8 +519,8 @@ def test_load_enabled_toolsets_warns_when_config_fallback_fails(monkeypatch, cap
         config_mod, "load_config", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
     )
 
-    assert server._load_enabled_toolsets() is None
-    assert "could not be loaded" in capsys.readouterr().err
+    assert server._load_enabled_toolsets() == []
+    assert "could not load configured CLI toolsets" in capsys.readouterr().err
 
 
 def test_load_enabled_toolsets_honors_builtin_env_if_config_fails(monkeypatch):
@@ -524,7 +547,7 @@ def test_load_enabled_toolsets_all_env_warns_about_ignored_extra_entries(
     monkeypatch.setenv("HERMES_TUI_TOOLSETS", "all,nope")
 
     assert server._load_enabled_toolsets() is None
-    assert "ignoring additional entries: nope" in capsys.readouterr().err
+    assert "ignoring: nope" in capsys.readouterr().err
 
 
 def test_load_enabled_toolsets_reports_disabled_mcp_separately(monkeypatch, capsys):
@@ -545,7 +568,7 @@ def test_load_enabled_toolsets_reports_disabled_mcp_separately(monkeypatch, caps
 
     assert server._load_enabled_toolsets() == ["web"]
     err = capsys.readouterr().err
-    assert "ignoring unknown HERMES_TUI_TOOLSETS entries: nope" in err
+    assert "ignoring unknown toolsets: nope" in err
     assert "ignoring disabled MCP servers" in err
     assert "mcp-off" in err
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -17,6 +17,11 @@ from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_cli.toolset_validation import (
+    InvalidToolsetError,
+    normalize_toolsets,
+    validate_explicit_toolsets_or_raise,
+)
 from utils import is_truthy_value
 from tui_gateway.transport import (
     StdioTransport,
@@ -936,130 +941,41 @@ def _load_tool_progress_mode() -> str:
 
 
 def _load_enabled_toolsets() -> list[str] | None:
-    explicit = [
-        item.strip()
-        for item in os.environ.get("HERMES_TUI_TOOLSETS", "").split(",")
-        if item.strip()
-    ]
-    cfg = None
-    fallback_notice = None
+    def _warn(message: str) -> None:
+        print(message, file=sys.stderr, flush=True)
 
-    try:
-        from toolsets import validate_toolset
-    except Exception:
-        validate_toolset = None
+    # Explicit HERMES_TUI_TOOLSETS -> shared fail-closed validator. An
+    # all-unknown request RAISES (the daemon refuses the session at its
+    # existing `except Exception` boundaries) instead of silently widening a
+    # narrow typo'd request to every tool — privilege-escalation-by-typo.
+    explicit = os.environ.get("HERMES_TUI_TOOLSETS", "")
+    valid = validate_explicit_toolsets_or_raise(explicit, source="[tui]", warn=_warn)
+    if valid is not None:
+        return valid
 
-    if explicit and validate_toolset is not None:
-        built_in = [name for name in explicit if validate_toolset(name)]
-        unresolved = [name for name in explicit if name not in built_in]
+    # valid is None: the validator collapses both `all`/`*` and omitted to None.
+    # An explicit `all`/`*` means every tool (no filter) -> None; only a truly
+    # omitted request falls through to the configured CLI default set.
+    if normalize_toolsets(explicit) is not None:
+        return None
 
-        if unresolved:
-            try:
-                from hermes_cli.plugins import discover_plugins
-
-                discover_plugins()
-                plugin_valid = [name for name in unresolved if validate_toolset(name)]
-            except Exception:
-                plugin_valid = []
-
-            if plugin_valid:
-                built_in.extend(plugin_valid)
-                unresolved = [name for name in unresolved if name not in plugin_valid]
-
-        if any(name in {"all", "*"} for name in built_in):
-            ignored = [name for name in explicit if name not in {"all", "*"}]
-            if ignored:
-                print(
-                    "[tui] HERMES_TUI_TOOLSETS=all enables every toolset; "
-                    f"ignoring additional entries: {', '.join(ignored)}",
-                    file=sys.stderr,
-                    flush=True,
-                )
-            return None
-
-        if not unresolved:
-            return built_in
-
-        mcp_names: set[str] = set()
-        mcp_disabled: set[str] = set()
-        try:
-            from hermes_cli.config import read_raw_config
-            from hermes_cli.tools_config import _parse_enabled_flag
-
-            raw_cfg = read_raw_config()
-            mcp_servers = (
-                raw_cfg.get("mcp_servers")
-                if isinstance(raw_cfg.get("mcp_servers"), dict)
-                else {}
-            )
-            for name, server_cfg in mcp_servers.items():
-                if not isinstance(server_cfg, dict):
-                    continue
-                if _parse_enabled_flag(server_cfg.get("enabled", True), default=True):
-                    mcp_names.add(str(name))
-                else:
-                    mcp_disabled.add(str(name))
-        except Exception:
-            mcp_names = set()
-            mcp_disabled = set()
-
-        mcp_valid = [name for name in unresolved if name in mcp_names]
-        disabled = [name for name in unresolved if name in mcp_disabled]
-        unknown = [
-            name
-            for name in unresolved
-            if name not in mcp_names and name not in mcp_disabled
-        ]
-        valid = built_in + mcp_valid
-
-        if unknown:
-            print(
-                f"[tui] ignoring unknown HERMES_TUI_TOOLSETS entries: {', '.join(unknown)}",
-                file=sys.stderr,
-                flush=True,
-            )
-        if disabled:
-            print(
-                "[tui] ignoring disabled MCP servers in HERMES_TUI_TOOLSETS "
-                "(set enabled: true in config.yaml to use): "
-                f"{', '.join(disabled)}",
-                file=sys.stderr,
-                flush=True,
-            )
-
-        if valid:
-            return valid
-
-        fallback_notice = (
-            "[tui] no valid HERMES_TUI_TOOLSETS entries; using configured CLI toolsets"
-        )
-
+    # Omitted -> the configured CLI toolsets (full default set).
     try:
         from hermes_cli.config import load_config
         from hermes_cli.tools_config import _get_platform_tools
 
-        cfg = cfg if cfg is not None else load_config()
-
-        # Runtime toolset resolution must include default MCP servers so the
-        # agent can actually call them. Passing ``False`` here is the
-        # config-editing variant — used when we need to persist a toolset
-        # list without baking in implicit MCP defaults. Using the wrong
-        # variant at agent creation time makes MCP tools silently missing
-        # from the TUI. See PR #3252 for the original design split.
-        enabled = sorted(
-            _get_platform_tools(cfg, "cli", include_default_mcp_servers=True)
-        )
-        if fallback_notice is not None:
-            print(fallback_notice, file=sys.stderr, flush=True)
+        # include_default_mcp_servers=True: runtime resolution must include
+        # default MCP servers or the agent can't call them. The ``False``
+        # variant is config-editing only; the wrong one makes MCP tools
+        # silently missing from the TUI. See PR #3252 for the design split.
+        enabled = sorted(_get_platform_tools(load_config(), "cli", include_default_mcp_servers=True))
         return enabled or None
     except Exception:
-        if fallback_notice is not None:
-            print(
-                "[tui] no valid HERMES_TUI_TOOLSETS entries and configured CLI toolsets could not be loaded; enabling all toolsets",
-                file=sys.stderr,
-                flush=True,
-            )
-        return None
+        # Config unreadable -> fail closed with NO tools rather than `None`
+        # (which the agent reads as "no filter" = every tool). A read crash
+        # must not become a silent all-tools grant.
+        _warn("[tui] could not load configured CLI toolsets; starting with none")
+        return []
 
 
 def _session_tool_progress_mode(sid: str) -> str:


### PR DESCRIPTION
## fix(toolsets): fail closed when explicit toolsets resolve to nothing

An explicitly-requested toolset that resolves to **nothing valid** now fails loudly (raise / error / exit 2) instead of silently launching a tool-less agent — or worse, silently widening to *every* tool.

## Root cause — `hermes -tui` silently launches tool-less

The reported symptom (#32660: "tools array missing from API calls to a custom Ollama endpoint") is the tail of a quiet chain:

- `-t`/`--toolsets` is value-taking, so `hermes -tui` is tokenized by argparse as `-t ui` → `args.toolsets == ["ui"]` — `hermes_cli/main.py:11211`
- `"ui"` is not a real toolset; the unknown name hits the warn-only branch (and even that print is suppressed under `quiet_mode`), so nothing is added and the include-list stays empty — `model_tools.py:355-368`
- an empty resolution is indistinguishable from "no filter": `enabled_toolsets is None` → "start with everything" — `model_tools.py:347` vs `:369-370`
- a falsy tools list means `if tools:` is False, so the `tools` key is **omitted entirely** from the provider request — exactly the "tools array missing" report — `agent/transports/chat_completions.py:278,469`

Net: the agent runs with no tools and **no error**.

## The fix — one shared validator, three thin adapters

A single source of truth, `hermes_cli/toolset_validation.py` (new), with the resolver behavior lifted from the old oneshot path (plugin self-discovery + MCP config read) so it is safe to call from any lifecycle position.

It **returns or raises — it never calls `sys.exit`**. `SystemExit` is a `BaseException`; it would escape the `except Exception` boundaries that wrap daemon worker tasks and kill the task instead of failing one request. Only the interactive CLI frame converts a failure into `exit(2)`. (Module docstring `toolset_validation.py:10-13`; enforced by `test_or_raise_never_exits_the_process`.)

Return contract (`toolset_validation.py:59-61`):
- `(valid, None)` → use this subset
- `(None, None)` → omitted, or `all`/`*` → caller loads the full default set
- `(None, error)` → all-unknown; `error` is a ready-to-emit line (caller picks delivery)

Three surfaces, each a thin adapter over the same validator:

| Surface | Failure delivery | Anchor |
|---|---|---|
| oneshot (`-z`) | return error string → stderr + `return 2` | `hermes_cli/oneshot.py:33-34, 79-82` |
| tui_gateway (daemon) | `validate_explicit_toolsets_or_raise` → `InvalidToolsetError`, refused at the existing `except Exception` | `tui_gateway/server.py` `_load_enabled_toolsets` |
| main.py (interactive) | the only frame allowed to `sys.exit(2)`; `["ui"]` + not-`--tui` gets a `--tui` hint; runs at the top of `cmd_chat`, before the first-run provider check | `hermes_cli/main.py:1708-1733` |

This consolidation removes 88 lines from `oneshot.py` and 117 from `server.py` (each a net −84 after delegating to the shared module).

## Behavior contract

Same validator on every surface; only the *delivery of failure* differs per column.

| Input | oneshot (`-z`) | tui_gateway (daemon) | main.py (interactive) |
|---|---|---|---|
| omitted | full default set | full default set | full default set |
| `all` / `*` | full set (+ warn ignored extras) | full set | full set |
| explicit, all valid | subset | subset | subset |
| explicit, partial valid | warn + valid subset | warn + valid subset | warn + valid subset |
| **explicit, all unknown** | error + `return 2` | `raise InvalidToolsetError` (session refused) | `sys.exit(2)` (+ `--tui` hint for `["ui"]`) |
| unknown == disabled MCP server | warn "set enabled: true", treated as unknown | same | same |
| config read crash (tui only) | — | `[]` (no tools), never `None` | — |

`all`/`*` is deliberately unchanged: fail-closed targets *unknown* requests, never an intentional widen.

## Behavior change — fail-open → fail-closed

Two distinct flips, called out so they aren't mistaken for incidental churn:

- **Privilege-escalation-by-typo (security):** the old TUI path let an all-unknown `HERMES_TUI_TOOLSETS` fall through to "enable all toolsets" — a typo silently granted every tool. It now raises / refuses. Tests: `test_load_enabled_toolsets_raises_when_tui_env_all_unknown`, `test_tools_list_fails_closed_under_all_unknown_env` (the RPC returns `error.code == 5031`, not a silent enabled-list).
- **Config-read-crash:** now returns `[]` (no tools) instead of `None` (which the agent reads as "no filter" = every tool). A crash reading config must not become a silent all-tools grant. Test: `test_load_enabled_toolsets_fails_closed_when_config_unreadable`.

Error/warning strings were unified across surfaces (`"did not contain any valid toolsets"` → `"no valid toolsets in request"`; `"ignoring additional entries"` → `"ignoring:"`; `"ignoring unknown … entries"` → `"ignoring unknown toolsets"`). The validator returns these lines **without** a trailing newline; the CLI call sites add it on delivery.

## Tests

**247 passed** across the touched suites (one unrelated pre-existing failure excluded — see below):

```
python -m pytest tests/hermes_cli/test_toolset_validation.py \
  tests/hermes_cli/test_toolset_validation_cli.py \
  tests/hermes_cli/test_tui_resume_flow.py \
  tests/test_tui_gateway_server.py \
  --deselect "tests/test_tui_gateway_server.py::test_browser_manage_connect_default_local_reports_launch_hint"
```

- New: `tests/hermes_cli/test_toolset_validation.py` (13 — validator + normalize), `tests/hermes_cli/test_toolset_validation_cli.py` (2 — end-to-end subprocess, exit codes)
- Modified: `test_tui_resume_flow.py` (+4/−4, wording reconciled), `test_tui_gateway_server.py` (+49/−22 — the fail-open→closed flips)
- Named behavioral guards: daemon-safety `test_or_raise_never_exits_the_process` · end-to-end misparse `test_tui_misparse_exits_with_hint` / `test_all_unknown_toolsets_exit_2` · `*`-alias `test_all_alias_means_caller_loads_defaults` · `test_unimportable_validator_fails_closed` · `test_unreadable_config_degrades_to_all_unknown` · partial `test_partial_keeps_valid_subset_and_warns` · MCP `test_enabled_mcp_server_resolves_disabled_one_warns`
- The deselected `test_browser_manage_connect_default_local_reports_launch_hint` is a **pre-existing** failure on `main` (browser-executable detection), unrelated to this change.

## Safety / no-regression

- **Daemon-kill audit:** all 6 `_load_enabled_toolsets` call sites (`server.py:1870, 1977, 4632, 6616, 6647, 6756`) reach an existing `except Exception` boundary — either directly (`4632, 6616, 6647, 6756`) or at the caller of `_make_agent`/`_background_agent_kwargs` (`1977, 1870`). A raise refuses the session; it never crashes the daemon thread.
- **No `sys.exit` in shared code** (only in comments); the sole conversion to `exit(2)` lives in the interactive CLI frame.
- **Hot path untouched:** `model_tools.py` is not in the diff — quiet re-resolution callers pass already-valid names and can't trip the entry-boundary validation.
- **`api_server` is not in the diff.**

## Out of scope

This is the *tools-never-reach-the-model* half of the "tools/function calling not working" cluster. The following are **not addressed here** and this PR makes no claim on them — called out only so the boundary is unambiguous:

- model emitting tool calls as plain content text — a separate root cause, owned by the existing PR #35129
- OpenAI-compatible API tools honoring (#28825) — `api_server` is deliberately untouched; needs net-new validation, not done here
- cron toolset path — untouched

## Manual verification

- `hermes chat -tui` → exit 2 + `--tui` hint
- `hermes chat -t bogus` → exit 2

## Issues & PRs

- Closes https://github.com/NousResearch/hermes-agent/issues/32660 — the `-tui` → `-t ui` misparse → silent zero-tools → omitted tools array; fixed at the resolution boundary.
- Supersedes https://github.com/NousResearch/hermes-agent/pull/33313 — generalizes its narrow `["ui"]`-only misparse check to **all** all-unknown toolset requests, via the shared validator.

Related, but not fixed here:
- #13031 — a distinct root cause (model emits tool calls as plain content text); see PR #35129.
- #28825 — the OpenAI-compatible `api_server` path, which this change does not touch.