### PR TITLE
fix(auxiliary): preserve auto-resolved runtime model

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3261,7 +3261,13 @@ def resolve_provider_client(
     # main_model also empty), the branches still hit their own
     # missing-credentials returns and ``_resolve_auto`` falls through to
     # the Step-2 chain as before.
-    if not model:
+    # Do not apply the generic config.model fallback before the auto branch.
+    # _resolve_auto() already has the live main_runtime and returns the model
+    # paired with the provider it actually selected.  If we pre-fill from
+    # config.yaml here, a fallback/Codex session can resolve the Codex client
+    # correctly, then overwrite its resolved model with the normal Anthropic
+    # config model and fail at request time.
+    if not model and provider != "auto":
         model = _get_aux_model_for_provider(provider) or _read_main_model() or model
 
     def _needs_codex_wrap(client_obj, base_url_str: str, model_str: str) -> bool:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -639,6 +639,42 @@ class TestResolveProviderClientUniversalModelFallback:
         mock_read_main.assert_not_called()
         assert mock_build.call_args.args[0] == "grok-4.20-multi-agent"
 
+    def test_auto_resolution_uses_resolved_model_not_config_fallback(self):
+        """Regression: auto aux routing must not overwrite the resolved
+        runtime model with config.model.default.
+
+        Cron and fallback sessions can run with provider=openai-codex and a
+        live runtime model such as gpt-5.5 while config.yaml still names the
+        normal Anthropic chat model.  Compression previously resolved the
+        Codex client correctly, then replaced its resolved model with the
+        configured Anthropic model, causing a ChatGPT-account 400.
+        """
+        from agent.auxiliary_client import resolve_provider_client
+
+        codex_client = MagicMock(name="codex-client")
+        with (
+            patch("agent.auxiliary_client._read_main_provider", return_value="anthropic"),
+            patch("agent.auxiliary_client._read_main_model", return_value="claude-opus-4-8"),
+            patch("agent.auxiliary_client.resolve_provider_client") as mock_resolve,
+        ):
+            mock_resolve.side_effect = [
+                (codex_client, "gpt-5.5"),
+            ]
+            client, model = resolve_provider_client(
+                "auto",
+                model=None,  # type: ignore[arg-type]  # None means "auto-resolve"
+                main_runtime={
+                    "provider": "openai-codex",
+                    "model": "gpt-5.5",
+                    "base_url": "https://chatgpt.com/backend-api/codex",
+                    "api_key": "token",
+                    "api_mode": "codex_responses",
+                },
+            )
+
+        assert client is codex_client
+        assert model == "gpt-5.5"
+
 
 class TestExpiredCodexFallback:
     """Test that expired Codex tokens don't block the auto chain."""


### PR DESCRIPTION
## What does this PR do?

Fixes an auxiliary auto-routing bug where `resolve_provider_client("auto", model=None, main_runtime=...)` can pair the *resolved* runtime provider with the wrong model from config.

In mixed provider setups, config can legitimately say something like:

```yaml
model:
  provider: anthropic
  default: claude-opus-4-8
```

while the live session has resolved to a different runtime provider/model, for example `openai-codex` / `gpt-5.5` after fallback or runtime selection.

Before this PR, `resolve_provider_client()` pre-filled `model` from config before the `provider == "auto"` branch ran. `_resolve_auto()` correctly returned the live runtime provider/model, but the auto branch then preferred the already-populated config model. The result was a Codex auxiliary client being asked to run an Anthropic model id, producing errors like:

```text
Compression summary failed: Error code: 400 - {'detail': "The 'claude-opus-4-8' model is not supported when using Codex with a ChatGPT account."}
```

This PR skips the generic config-model fallback before the auto branch, so `provider: auto` can preserve the provider/model pair returned by `_resolve_auto()`.

Non-auto explicit provider paths keep the existing generic fallback behavior.

## Related issue / prior search

I searched existing issues and PRs before opening this. The closest related items I found were adjacent but not the same fix:

- #30065 fixes primary runtime provider/model mismatches in gateway/cron runtime resolution.
- #14306 covers `auxiliary.provider=main` inheriting the live session model for compression.
- #15714 covers auxiliary compression fallback behavior after main-model usage limits.
- #34482 hardens Codex compression calls and timeout behavior.

This PR is narrower: it fixes `auxiliary.*.provider: auto` overwriting `_resolve_auto()`'s live runtime model with config `model.default`.

## Changes made

- `agent/auxiliary_client.py`
  - Do not apply the generic config `model.default` fallback before the `provider == "auto"` branch.
  - Add a comment explaining why auto mode must preserve the resolved provider/model pair.

- `tests/agent/test_auxiliary_client.py`
  - Add a regression test where config default is `claude-opus-4-8` but live runtime is `openai-codex` / `gpt-5.5`.
  - Assert that auto resolution returns `gpt-5.5`, not the stale config model.

## How to test

Focused regression suite:

```bash
./venv/bin/python -m pytest tests/agent/test_auxiliary_client.py::TestResolveProviderClientUniversalModelFallback -q
```

Result:

```text
5 passed in 0.25s
```

Related compression/auxiliary suite:

```bash
./venv/bin/python -m pytest \
  tests/agent/test_auxiliary_main_first.py \
  tests/agent/test_set_runtime_main_custom_provider.py \
  tests/run_agent/test_compression_feasibility.py \
  tests/agent/test_context_compressor.py \
  -q
```

Result:

```text
129 passed, 1 warning in 4.55s
```

Static diff check:

```bash
git diff --check origin/main...HEAD
```

Result: passed.

## Checklist

### Code

- [x] I searched for existing issues and PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added regression coverage
- [x] I've run the affected test suite
- [x] I've tested on my platform: macOS, Python 3.11 virtualenv

### Documentation and housekeeping

- [x] Documentation update: N/A, no user-facing config key added
- [x] `cli-config.yaml.example` update: N/A
- [x] Cross-platform impact considered: pure Python logic/test change
