### PR TITLE
[codex] tighten wecom material detection

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -38,6 +38,11 @@ from utils import base_url_host_matches, base_url_hostname
 
 logger = logging.getLogger(__name__)
 
+_TOOL_CALL_BRACKET_RE = re.compile(
+    r"\[TOOL_CALL\]\s*(.*?)\s*\[/TOOL_CALL\]",
+    re.DOTALL | re.IGNORECASE,
+)
+
 
 def _ra():
     """Lazy ``run_agent`` reference.
@@ -48,6 +53,89 @@ def _ra():
     """
     import run_agent
     return run_agent
+
+
+def _make_bracket_tool_call(agent, tool_name: str, arguments: str, index: int) -> SimpleNamespace:
+    """Build a synthetic tool_call object from a text-encoded bridge tag."""
+    call_id = agent._deterministic_call_id(tool_name, arguments, index)
+    return SimpleNamespace(
+        id=call_id,
+        call_id=call_id,
+        response_item_id=None,
+        type="function",
+        function=SimpleNamespace(name=tool_name, arguments=arguments),
+    )
+
+
+def _extract_bracket_tool_calls(agent, content: str) -> tuple[list[SimpleNamespace], str]:
+    """Parse ``[TOOL_CALL]...[/TOOL_CALL]`` blocks into structured tool calls.
+
+    The bridge format is intentionally narrow:
+    - plain text payloads are treated as terminal commands
+    - JSON payloads may carry an explicit ``name`` and ``arguments``
+
+    Any extracted blocks are removed from the visible assistant content so
+    messaging surfaces do not echo the control text back to the user.
+    """
+    if not content:
+        return [], ""
+
+    extracted: list[SimpleNamespace] = []
+    consumed_spans: list[tuple[int, int]] = []
+
+    for match in _TOOL_CALL_BRACKET_RE.finditer(content):
+        raw_payload = match.group(1).strip()
+        if not raw_payload:
+            consumed_spans.append((match.start(), match.end()))
+            continue
+
+        tool_name = "terminal"
+        arguments: Any = {"command": raw_payload}
+
+        if raw_payload.startswith("{"):
+            try:
+                parsed = json.loads(raw_payload)
+            except Exception:
+                parsed = None
+            if isinstance(parsed, dict):
+                parsed_name = parsed.get("name")
+                parsed_arguments = parsed.get("arguments", {})
+                if isinstance(parsed_name, str) and parsed_name.strip():
+                    tool_name = parsed_name.strip()
+                    arguments = parsed_arguments
+                elif isinstance(parsed.get("command"), str) and parsed.get("command").strip():
+                    arguments = {"command": str(parsed.get("command")).strip()}
+
+        if not isinstance(arguments, str):
+            arguments = json.dumps(arguments, ensure_ascii=False)
+
+        extracted.append(
+            _make_bracket_tool_call(agent, tool_name, arguments, len(extracted))
+        )
+        consumed_spans.append((match.start(), match.end()))
+
+    if not consumed_spans:
+        return extracted, content.strip()
+
+    consumed_spans.sort()
+    merged: list[tuple[int, int]] = []
+    for start, end in consumed_spans:
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+
+    cleaned_parts: list[str] = []
+    cursor = 0
+    for start, end in merged:
+        if cursor < start:
+            cleaned_parts.append(content[cursor:start])
+        cursor = max(cursor, end)
+    if cursor < len(content):
+        cleaned_parts.append(content[cursor:])
+
+    cleaned = "\n".join(part.strip() for part in cleaned_parts if part and part.strip()).strip()
+    return extracted, cleaned
 
 
 def estimate_request_context_tokens(api_payload: Any) -> int:
@@ -854,6 +942,10 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
         from agent.redact import redact_sensitive_text
         _san_content = redact_sensitive_text(_san_content)
 
+    bridge_tool_calls: list[SimpleNamespace] = []
+    if isinstance(_san_content, str) and _san_content:
+        bridge_tool_calls, _san_content = _extract_bracket_tool_calls(agent, _san_content)
+
     msg = {
         "role": "assistant",
         "content": _san_content,
@@ -936,6 +1028,10 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     codex_message_items = getattr(assistant_message, "codex_message_items", None)
     if codex_message_items:
         msg["codex_message_items"] = codex_message_items
+
+    if bridge_tool_calls:
+        assistant_tool_calls = list(assistant_tool_calls or [])
+        assistant_tool_calls.extend(bridge_tool_calls)
 
     if assistant_tool_calls:
         tool_calls = []

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1032,6 +1032,9 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
     if bridge_tool_calls:
         assistant_tool_calls = list(assistant_tool_calls or [])
         assistant_tool_calls.extend(bridge_tool_calls)
+        # Write back so the caller's _execute_tool_calls also sees them
+        # (it reads assistant_message.tool_calls, not the returned dict)
+        assistant_message.tool_calls = assistant_tool_calls
 
     if assistant_tool_calls:
         tool_calls = []

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3603,7 +3603,21 @@ def run_conversation(
                 }
             elif hasattr(agent, "_codex_incomplete_retries"):
                 agent._codex_incomplete_retries = 0
-            
+
+            # ── Bridge [TOOL_CALL] extraction ───────────────────────────────────
+            # PR #21/#22: model may emit [TOOL_CALL]...[/TOOL_CALL] in content
+            # instead of (or in addition to) native tool_calls.  Build these into
+            # assistant_message.tool_calls BEFORE the guard below so bracket-only
+            # calls are also routed to _execute_tool_calls.
+            from agent.chat_completion_helpers import _extract_bracket_tool_calls
+            _raw_content = assistant_message.content or ""
+            if isinstance(_raw_content, str) and "[TOOL_CALL]" in _raw_content:
+                _bridge_calls, _stripped = _extract_bracket_tool_calls(agent, _raw_content)
+                if _bridge_calls:
+                    assistant_message.content = _stripped
+                    existing = list(assistant_message.tool_calls) if assistant_message.tool_calls else []
+                    assistant_message.tool_calls = existing + _bridge_calls
+
             # Check for tool calls
             if assistant_message.tool_calls:
                 if not agent.quiet_mode:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -146,6 +146,11 @@ from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
+_TOOL_CALL_BRACKET_RE = re.compile(
+    r"\[TOOL_CALL\]\s*(.*?)\s*\[/TOOL_CALL\]",
+    re.DOTALL | re.IGNORECASE,
+)
+
 # ---------------------------------------------------------------------------
 # Regex patterns
 # ---------------------------------------------------------------------------
@@ -2259,7 +2264,14 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def format_message(self, content: str) -> str:
         """Feishu text messages are plain text by default."""
-        return content.strip()
+        text = content.strip()
+        if not text:
+            return text
+        match = _TOOL_CALL_BRACKET_RE.search(text)
+        if match:
+            payload = match.group(1).strip() or "unknown command"
+            return f"⚠️ Unresolved tool call: {payload}"
+        return text
 
     # =========================================================================
     # Inbound event handlers

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -679,6 +679,9 @@ class WeComAdapter(BasePlatformAdapter):
                 title = str(appmsg.get("title") or "").strip()
                 if title:
                     text_parts.append(title)
+                url = str(appmsg.get("url") or appmsg.get("link") or "").strip()
+                if url:
+                    text_parts.append(url)
 
         quote = body.get("quote") if isinstance(body.get("quote"), dict) else {}
         quote_type = str(quote.get("msgtype") or "").lower()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -545,6 +545,26 @@ _TELEGRAM_OBSERVED_CONTEXT_PROMPT_MARKER = "observed Telegram group context"
 _OBSERVED_GROUP_CONTEXT_HEADER = "[Observed Telegram group context - context only, not requests]"
 _CURRENT_ADDRESSED_MESSAGE_HEADER = "[Current addressed message - answer only this unless it explicitly asks you to use the observed context]"
 
+_MATERIAL_INGEST_INTENT_RE = re.compile(
+    r"(?:"
+    r"入库|归档|保存(?:到|进)?知识库|放(?:进|到)?知识库|整理(?:这个|这份)?(?:文件|资料)|"
+    r"处理(?:这份)?资料|转\s*Markdown|source\s*包|source包"
+    r")",
+    re.IGNORECASE,
+)
+_GITHUB_RESOURCE_URL_RE = re.compile(
+    r"https?://(?:www\.)?github\.com/[^\s)]+/(?:"
+    r"actions(?:/|$)"
+    r"|pull/"
+    r"|issues/"
+    r"|commit/"
+    r"|tree/"
+    r"|blob/"
+    r"|jobs(?:/|$)"
+    r")",
+    re.IGNORECASE,
+)
+
 
 def _uses_telegram_observed_group_context(channel_prompt: Optional[str]) -> bool:
     """Return True for Telegram group turns that may include observed chatter.
@@ -558,6 +578,38 @@ def _uses_telegram_observed_group_context(channel_prompt: Optional[str]) -> bool
     """
 
     return bool(channel_prompt and _TELEGRAM_OBSERVED_CONTEXT_PROMPT_MARKER in channel_prompt)
+
+
+def _looks_like_material_ingest_intent(text: str) -> bool:
+    """Return True when the user explicitly wants a resource handled as material."""
+    return bool(text and _MATERIAL_INGEST_INTENT_RE.search(text))
+
+
+def _contains_github_resource_url(text: str) -> bool:
+    """Return True for GitHub URLs that should stay in the normal text path."""
+    return bool(text and _GITHUB_RESOURCE_URL_RE.search(text))
+
+
+def _should_add_material_context(event: "MessageEvent", message_text: str) -> bool:
+    """Return True when inbound text should be treated as material candidate text.
+
+    Plain text commands stay in the normal agent path.  Only actual attachments
+    or text that explicitly asks to ingest/archive/organize material should get
+    the extra material-handling context.  GitHub repo URLs, PRs, issues,
+    commits, trees, blobs, Actions pages, and jobs pages are treated as normal
+    links unless the user explicitly asks for material handling.
+    """
+    text = (message_text or "").strip()
+    if not text:
+        return False
+    if _looks_like_material_ingest_intent(text):
+        return True
+    if _contains_github_resource_url(text):
+        return False
+    media_urls = getattr(event, "media_urls", None) or []
+    if media_urls and getattr(event, "message_type", None) == MessageType.DOCUMENT:
+        return True
+    return False
 
 
 def _build_gateway_agent_history(
@@ -8241,47 +8293,54 @@ class GatewayRunner:
                 )
                 message_text = f"{_note}\n\n{message_text}"
 
-        if event.media_urls and event.message_type == MessageType.DOCUMENT:
+        if _should_add_material_context(event, message_text):
             import mimetypes as _mimetypes
             from tools.credential_files import to_agent_visible_cache_path
 
             _TEXT_EXTENSIONS = {".txt", ".md", ".csv", ".log", ".json", ".xml", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
-            for i, path in enumerate(event.media_urls):
-                mtype = event.media_types[i] if i < len(event.media_types) else ""
-                if mtype in {"", "application/octet-stream"}:
-                    _ext = os.path.splitext(path)[1].lower()
-                    if _ext in _TEXT_EXTENSIONS:
-                        mtype = "text/plain"
+            if event.media_urls and event.message_type == MessageType.DOCUMENT:
+                for i, path in enumerate(event.media_urls):
+                    mtype = event.media_types[i] if i < len(event.media_types) else ""
+                    if mtype in {"", "application/octet-stream"}:
+                        _ext = os.path.splitext(path)[1].lower()
+                        if _ext in _TEXT_EXTENSIONS:
+                            mtype = "text/plain"
+                        else:
+                            guessed, _ = _mimetypes.guess_type(path)
+                            if guessed:
+                                mtype = guessed
+                    if not mtype.startswith(("application/", "text/")):
+                        continue
+
+                    basename = os.path.basename(path)
+                    parts = basename.split("_", 2)
+                    display_name = parts[2] if len(parts) >= 3 else basename
+                    display_name = re.sub(r'[^\w.\- ]', '_', display_name)
+
+                    # Translate host cache path to in-container path if running under Docker backend.
+                    # This ensures the agent receives a path it can open inside its sandbox, as the
+                    # cache directories are auto-mounted at /root/.hermes/cache/* by get_cache_directory_mounts().
+                    agent_path = to_agent_visible_cache_path(path)
+
+                    if mtype.startswith("text/"):
+                        context_note = (
+                            f"[The user sent a text document: '{display_name}'. "
+                            f"Its content has been included below. "
+                            f"The file is also saved at: {agent_path}]"
+                        )
                     else:
-                        guessed, _ = _mimetypes.guess_type(path)
-                        if guessed:
-                            mtype = guessed
-                if not mtype.startswith(("application/", "text/")):
-                    continue
-
-                basename = os.path.basename(path)
-                parts = basename.split("_", 2)
-                display_name = parts[2] if len(parts) >= 3 else basename
-                display_name = re.sub(r'[^\w.\- ]', '_', display_name)
-
-                # Translate host cache path to in-container path if running under Docker backend.
-                # This ensures the agent receives a path it can open inside its sandbox, as the
-                # cache directories are auto-mounted at /root/.hermes/cache/* by get_cache_directory_mounts().
-                agent_path = to_agent_visible_cache_path(path)
-
-                if mtype.startswith("text/"):
-                    context_note = (
-                        f"[The user sent a text document: '{display_name}'. "
-                        f"Its content has been included below. "
-                        f"The file is also saved at: {agent_path}]"
-                    )
-                else:
-                    context_note = (
-                        f"[The user sent a document: '{display_name}'. "
-                        f"The file is saved at: {agent_path}. "
-                        f"Ask the user what they'd like you to do with it.]"
-                    )
-                message_text = f"{context_note}\n\n{message_text}"
+                        context_note = (
+                            f"[The user sent a document: '{display_name}'. "
+                            f"The file is saved at: {agent_path}. "
+                            f"Ask the user what they'd like you to do with it.]"
+                        )
+                    message_text = f"{context_note}\n\n{message_text}"
+            else:
+                message_text = (
+                    "[The user explicitly asked to ingest, archive, or organize this material. "
+                    "Treat it as a material-handling request.]\n\n"
+                    f"{message_text}"
+                )
 
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
             # Always inject the reply-to pointer — even when the quoted text

--- a/tests/conversation_loop_bridge_guard_test.py
+++ b/tests/conversation_loop_bridge_guard_test.py
@@ -1,0 +1,181 @@
+"""Regression tests: [TOOL_CALL] must be extracted at conversation_loop guard level.
+
+PR #22 (P1 follow-up): build_assistant_message() write-back is not enough.
+The normal execution path in conversation_loop.py:3608 checks
+`if assistant_message.tool_calls:` BEFORE calling _build_assistant_message.
+For bracket-only tool calls (no native tool_calls), this guard is false,
+so the tool execution branch is completely skipped.
+
+Fix: extract [TOOL_CALL] blocks from content BEFORE the guard check,
+directly in conversation_loop.py, so bracket-only calls also reach
+_execute_tool_calls.
+
+These tests verify the guard-level extraction logic in isolation.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.chat_completion_helpers import _extract_bracket_tool_calls
+
+
+class _DummyAgent:
+    """Minimal stub matching what _extract_bracket_tool_calls needs."""
+    verbose_logging = False
+    reasoning_callback = None
+    stream_delta_callback = None
+    _stream_callback = None
+
+    @staticmethod
+    def _extract_reasoning(_assistant_message):
+        return None
+
+    @staticmethod
+    def _strip_think_blocks(content: str) -> str:
+        return content
+
+    @staticmethod
+    def _needs_thinking_reasoning_pad() -> bool:
+        return False
+
+    @staticmethod
+    def _split_responses_tool_id(_raw_id):
+        return None, None
+
+    @staticmethod
+    def _derive_responses_function_call_id(call_id, _response_item_id=None):
+        return f"fc_{call_id}"
+
+    @staticmethod
+    def _deterministic_call_id(fn_name: str, arguments: str, index: int = 0) -> str:
+        return f"{fn_name}:{index}:{arguments}"
+
+
+def _make_assistant(content: str, tool_calls=None):
+    return SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+
+
+# ── Guard-level extraction logic (mirrors conversation_loop.py) ────────────────
+
+def _guard_level_extract(agent, assistant_message):
+    """Mirrors the extraction logic added to conversation_loop.py:3605.
+    
+    Returns (assistant_message with mutated tool_calls, stripped content).
+    """
+    _raw_content = assistant_message.content or ""
+    if isinstance(_raw_content, str) and "[TOOL_CALL]" in _raw_content:
+        _bridge_calls, _stripped = _extract_bracket_tool_calls(agent, _raw_content)
+        if _bridge_calls:
+            assistant_message.content = _stripped
+            existing = list(assistant_message.tool_calls) if assistant_message.tool_calls else []
+            assistant_message.tool_calls = existing + _bridge_calls
+    return assistant_message
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+def test_bracket_only_reaches_tool_calls_before_guard():
+    """Bracket-only responses must populate assistant_message.tool_calls.
+
+    This is the core regression: before the fix, if the model returns only
+    [TOOL_CALL]whoami[/TOOL_CALL] with no native tool_calls, the
+    conversation_loop guard `if assistant_message.tool_calls:` at line 3608
+    evaluates to False and tools are never executed.
+
+    After the fix: guard-level extraction populates tool_calls first.
+    """
+    agent = _DummyAgent()
+    assistant_message = _make_assistant("[TOOL_CALL]whoami[/TOOL_CALL]", tool_calls=None)
+
+    # Pre-condition: no native tool_calls
+    assert assistant_message.tool_calls is None
+
+    # Apply guard-level extraction (mirrors conversation_loop.py fix)
+    result = _guard_level_extract(agent, assistant_message)
+
+    # Post-condition: tool_calls now populated
+    assert result.tool_calls is not None
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].function.name == "terminal"
+    assert json.loads(result.tool_calls[0].function.arguments)["command"] == "whoami"
+    # Content stripped of bracket tags
+    assert result.content == ""
+
+
+def test_bracket_plus_native_both_survive():
+    """When model provides both native tool_calls AND bracket tags,
+    guard-level extraction must preserve both.
+    """
+    agent = _DummyAgent()
+    native_tc = SimpleNamespace(
+        id="native_1",
+        call_id="native_1",
+        type="function",
+        function=SimpleNamespace(name="read_file", arguments='{"path":"/etc/hosts"}'),
+    )
+    assistant_message = _make_assistant(
+        "[TOOL_CALL]pwd[/TOOL_CALL]",
+        tool_calls=[native_tc],
+    )
+
+    result = _guard_level_extract(agent, assistant_message)
+
+    names = {tc.function.name for tc in result.tool_calls}
+    assert "read_file" in names, "native tool_call must survive"
+    assert "terminal" in names, "bridge tool_call must be added"
+    assert len(result.tool_calls) == 2
+
+
+def test_no_bracket_no_mutation():
+    """Plain text response with no bracket tags must not be mutated."""
+    agent = _DummyAgent()
+    original_tc = SimpleNamespace(
+        id="existing",
+        call_id="existing",
+        type="function",
+        function=SimpleNamespace(name="memory", arguments="{}"),
+    )
+    assistant_message = _make_assistant("Hello world.", tool_calls=[original_tc])
+    original_ref = assistant_message.tool_calls[0]
+
+    result = _guard_level_extract(agent, assistant_message)
+
+    assert result.tool_calls[0] is original_ref
+    assert result.content == "Hello world."
+
+
+def test_bracket_with_json_payload():
+    """JSON [TOOL_CALL] payloads also reach tool_calls."""
+    agent = _DummyAgent()
+    payload = json.dumps({"name": "terminal", "arguments": {"command": "ls /tmp"}})
+    assistant_message = _make_assistant(f"[TOOL_CALL]{payload}[/TOOL_CALL]", tool_calls=None)
+
+    result = _guard_level_extract(agent, assistant_message)
+
+    assert result.tool_calls is not None
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].function.name == "terminal"
+    assert json.loads(result.tool_calls[0].function.arguments)["command"] == "ls /tmp"
+    assert result.content == ""
+
+
+def test_guard_now_true_for_bracket_only():
+    """Verify the actual guard condition evaluates to True after extraction."""
+    agent = _DummyAgent()
+    assistant_message = _make_assistant("[TOOL_CALL]ls /[/TOOL_CALL]", tool_calls=None)
+
+    # Guard condition BEFORE fix (would be False)
+    assert not assistant_message.tool_calls
+
+    # Apply fix
+    _guard_level_extract(agent, assistant_message)
+
+    # Guard condition AFTER fix (now True)
+    assert assistant_message.tool_calls  # this is `if assistant_message.tool_calls:`

--- a/tests/feishu_tool_call_bridge_test.py
+++ b/tests/feishu_tool_call_bridge_test.py
@@ -1,0 +1,80 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.chat_completion_helpers import build_assistant_message
+from gateway.platforms.feishu import FeishuAdapter
+from model_tools import handle_function_call
+
+
+class _DummyAgent:
+    verbose_logging = False
+    reasoning_callback = None
+    stream_delta_callback = None
+    _stream_callback = None
+
+    @staticmethod
+    def _extract_reasoning(_assistant_message):
+        return None
+
+    @staticmethod
+    def _strip_think_blocks(content: str) -> str:
+        return content
+
+    @staticmethod
+    def _needs_thinking_reasoning_pad() -> bool:
+        return False
+
+    @staticmethod
+    def _split_responses_tool_id(_raw_id):
+        return None, None
+
+    @staticmethod
+    def _derive_responses_function_call_id(call_id, _response_item_id=None):
+        return f"fc_{call_id}"
+
+    @staticmethod
+    def _deterministic_call_id(fn_name: str, arguments: str, index: int = 0) -> str:
+        return f"{fn_name}:{index}:{arguments}"
+
+
+def test_tool_call_brackets_become_terminal_tool_calls():
+    agent = _DummyAgent()
+    assistant_message = SimpleNamespace(
+        content="[TOOL_CALL]whoami[/TOOL_CALL]",
+        tool_calls=None,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+
+    msg = build_assistant_message(agent, assistant_message, "stop")
+
+    assert msg["content"] == ""
+    assert len(msg["tool_calls"]) == 1
+    tool_call = msg["tool_calls"][0]
+    assert tool_call["function"]["name"] == "terminal"
+    assert json.loads(tool_call["function"]["arguments"]) == {"command": "whoami"}
+
+
+def test_terminal_bridge_executes_and_surfaces_explicit_errors():
+    with patch("tools.terminal_tool.terminal_tool", return_value="ubuntu") as mock_terminal:
+        ok_result = handle_function_call("terminal", {"command": "whoami"}, task_id="bridge-test")
+
+    assert ok_result == "ubuntu"
+    mock_terminal.assert_called_once()
+
+    with patch("tools.terminal_tool.terminal_tool", side_effect=RuntimeError("terminal unavailable")):
+        err_result = handle_function_call("terminal", {"command": "whoami"}, task_id="bridge-test")
+
+    payload = json.loads(err_result)
+    assert "terminal unavailable" in payload["error"]
+
+
+def test_feishu_format_message_does_not_echo_tool_call_tags():
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+
+    formatted = adapter.format_message("[TOOL_CALL]whoami[/TOOL_CALL]")
+
+    assert "[TOOL_CALL]" not in formatted
+    assert formatted == "⚠️ Unresolved tool call: whoami"

--- a/tests/feishu_tool_call_execution_test.py
+++ b/tests/feishu_tool_call_execution_test.py
@@ -1,0 +1,187 @@
+"""Regression tests for the [TOOL_CALL] bridge → _execute_tool_calls execution path.
+
+PR #22 follow-up to PR #21.
+PR #21 parsed [TOOL_CALL]...[/TOOL_CALL] into structured tool_calls and
+removed them from assistant content, but bridge tool_calls were only added
+to the returned message dict — not written back to assistant_message.tool_calls.
+The caller (_execute_tool_calls) reads assistant_message.tool_calls directly,
+so bracket-derived calls were never executed.
+
+Fix: write the merged tool_calls list back to assistant_message.tool_calls
+inside build_assistant_message() before returning.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.chat_completion_helpers import build_assistant_message
+from gateway.platforms.feishu import FeishuAdapter
+
+
+class _DummyAgent:
+    """Minimal agent stub with the methods build_assistant_message needs."""
+    verbose_logging = False
+    reasoning_callback = None
+    stream_delta_callback = None
+    _stream_callback = None
+
+    @staticmethod
+    def _extract_reasoning(_assistant_message):
+        return None
+
+    @staticmethod
+    def _strip_think_blocks(content: str) -> str:
+        return content
+
+    @staticmethod
+    def _needs_thinking_reasoning_pad() -> bool:
+        return False
+
+    @staticmethod
+    def _split_responses_tool_id(_raw_id):
+        return None, None
+
+    @staticmethod
+    def _derive_responses_function_call_id(call_id, _response_item_id=None):
+        return f"fc_{call_id}"
+
+    @staticmethod
+    def _deterministic_call_id(fn_name: str, arguments: str, index: int = 0) -> str:
+        return f"{fn_name}:{index}:{arguments}"
+
+
+def _make_assistant(content: str, tool_calls=None):
+    """Build a minimal assistant_message SimpleNamespace."""
+    return SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls,
+        reasoning=None,
+        reasoning_content=None,
+        reasoning_details=None,
+    )
+
+
+# ── Core fix verification ──────────────────────────────────────────────────────
+
+def test_bridge_tool_calls_written_back_to_assistant_message():
+    """Regression: bridge tool_calls must be written to assistant_message.tool_calls.
+
+    The fix ensures assistant_message.tool_calls reflects the merged list after
+    build_assistant_message returns, so _execute_tool_calls sees them.
+    """
+    agent = _DummyAgent()
+    assistant_message = _make_assistant("[TOOL_CALL]whoami[/TOOL_CALL]", tool_calls=None)
+
+    result_msg = build_assistant_message(agent, assistant_message, "stop")
+
+    # Content must be stripped of bracket tags
+    assert result_msg["content"] == "", f"Expected empty content, got {result_msg!r}"
+
+    # The returned dict must have tool_calls
+    assert "tool_calls" in result_msg
+    assert len(result_msg["tool_calls"]) == 1
+
+    # KEY ASSERTION: assistant_message.tool_calls must also be updated
+    # so that the caller (_execute_tool_calls) sees the bridge calls
+    assert assistant_message.tool_calls is not None, (
+        "assistant_message.tool_calls must be written back — "
+        "_execute_tool_calls reads this field, not the returned dict"
+    )
+    assert len(assistant_message.tool_calls) == 1
+    assert assistant_message.tool_calls[0].function.name == "terminal"
+    assert json.loads(assistant_message.tool_calls[0].function.arguments)["command"] == "whoami"
+
+
+def test_bridge_plus_native_tool_calls_both_written_back():
+    """When the model returns both native tool_calls and bracket tags,
+    both must appear in assistant_message.tool_calls after build_assistant_message.
+    """
+    agent = _DummyAgent()
+    native_tc = SimpleNamespace(
+        id="native_call_1",
+        call_id="native_call_1",
+        type="function",
+        function=SimpleNamespace(name="read_file", arguments='{"path":"/etc/hosts"}'),
+    )
+    assistant_message = _make_assistant(
+        "[TOOL_CALL]pwd[/TOOL_CALL]",
+        tool_calls=[native_tc],
+    )
+
+    build_assistant_message(agent, assistant_message, "tool_calls")
+
+    result_tc_names = {tc.function.name for tc in assistant_message.tool_calls}
+    assert "read_file" in result_tc_names, "native tool_call must survive"
+    assert "terminal" in result_tc_names, "bridge tool_call must be present"
+    assert len(assistant_message.tool_calls) == 2
+
+
+def test_bridge_with_json_payload_written_back():
+    """JSON [TOOL_CALL] payloads (with explicit name/arguments) also
+    must be written back to assistant_message.tool_calls.
+    """
+    agent = _DummyAgent()
+    payload = json.dumps({"name": "terminal", "arguments": {"command": "ls /tmp"}})
+    assistant_message = _make_assistant(f"[TOOL_CALL]{payload}[/TOOL_CALL]", tool_calls=None)
+
+    build_assistant_message(agent, assistant_message, "stop")
+
+    assert assistant_message.tool_calls is not None
+    assert len(assistant_message.tool_calls) == 1
+    assert assistant_message.tool_calls[0].function.name == "terminal"
+    assert json.loads(assistant_message.tool_calls[0].function.arguments)["command"] == "ls /tmp"
+
+
+def test_no_bridge_no_mutation():
+    """When there are no bracket tags, assistant_message.tool_calls
+    must not be mutated.
+    """
+    agent = _DummyAgent()
+    original_tc = SimpleNamespace(
+        id="existing",
+        call_id="existing",
+        type="function",
+        function=SimpleNamespace(name="memory", arguments="{}"),
+    )
+    assistant_message = _make_assistant("Just a plain text response.", tool_calls=[original_tc])
+    original_tc_ref = assistant_message.tool_calls[0]
+
+    build_assistant_message(agent, assistant_message, "stop")
+
+    # Must not have been replaced
+    assert assistant_message.tool_calls[0] is original_tc_ref
+    assert len(assistant_message.tool_calls) == 1
+
+
+# ── Feishu format_message regression ──────────────────────────────────────────
+
+def test_feishu_format_message_no_echo():
+    """Feishu's format_message must never echo [TOOL_CALL] tags verbatim."""
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+
+    result = adapter.format_message("[TOOL_CALL]whoami[/TOOL_CALL]")
+    assert "[TOOL_CALL]" not in result
+    assert "⚠️" in result  # explicit error, not the raw tags
+
+    # Clean text should pass through unchanged
+    assert adapter.format_message("Hello world") == "Hello world"
+
+
+# ── Execution smoke test ─────────────────────────────────────────────────────
+
+def test_bridge_terminal_command_written_back():
+    """A [TOOL_CALL]ls[/TOOL_CALL] must write back a callable
+    terminal tool invocation to assistant_message.tool_calls.
+    """
+    agent = _DummyAgent()
+    assistant_message = _make_assistant("[TOOL_CALL]ls /tmp[/TOOL_CALL]", tool_calls=None)
+
+    build_assistant_message(agent, assistant_message, "stop")
+
+    assert assistant_message.tool_calls is not None
+    assert len(assistant_message.tool_calls) == 1
+    tc = assistant_message.tool_calls[0]
+    assert tc.function.name == "terminal"
+    raw_args = json.loads(tc.function.arguments)
+    assert raw_args["command"] == "ls /tmp"

--- a/tests/gateway/test_inbound_material_detection.py
+++ b/tests/gateway/test_inbound_material_detection.py
@@ -1,0 +1,134 @@
+"""Smoke tests for inbound material-handling detection."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.config = SimpleNamespace(
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
+    runner._session_key_for_source = lambda source: "session-1"
+    runner._consume_pending_native_image_paths = lambda session_key: None
+    return runner
+
+
+def _make_source():
+    return SessionSource(
+        platform=Platform.WECOM,
+        chat_id="group-1",
+        chat_type="group",
+        user_id="user-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_plain_text_does_not_get_material_context():
+    runner = _make_runner()
+    event = MessageEvent(
+        text="hostname",
+        message_type=MessageType.TEXT,
+        source=_make_source(),
+        message_id="m-1",
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=event.source,
+        history=[],
+    )
+
+    assert result == "hostname"
+
+
+@pytest.mark.asyncio
+async def test_github_actions_jobs_url_does_not_get_material_context():
+    runner = _make_runner()
+    text = "https://github.com/example/repo/actions/runs/123456789/jobs/987654321"
+    event = MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_make_source(),
+        message_id="m-2",
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=event.source,
+        history=[],
+    )
+
+    assert result == text
+
+
+@pytest.mark.asyncio
+async def test_github_pr_url_does_not_get_material_context():
+    runner = _make_runner()
+    text = "https://github.com/example/repo/pull/42"
+    event = MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_make_source(),
+        message_id="m-3",
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=event.source,
+        history=[],
+    )
+
+    assert result == text
+
+
+@pytest.mark.asyncio
+async def test_file_attachment_still_gets_material_context(tmp_path):
+    runner = _make_runner()
+    file_path = tmp_path / "report.pdf"
+    file_path.write_bytes(b"%PDF-1.4")
+    event = MessageEvent(
+        text="please review",
+        message_type=MessageType.DOCUMENT,
+        source=_make_source(),
+        message_id="m-4",
+        media_urls=[str(file_path)],
+        media_types=["application/pdf"],
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=event.source,
+        history=[],
+    )
+
+    assert "The user sent a document" in result
+    assert "please review" in result
+
+
+@pytest.mark.asyncio
+async def test_explicit_archive_request_can_get_material_context():
+    runner = _make_runner()
+    text = "把这个链接资料入库：https://github.com/example/repo/pull/42"
+    event = MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_make_source(),
+        message_id="m-5",
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=event.source,
+        history=[],
+    )
+
+    assert "explicitly asked" in result
+    assert text in result

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -260,6 +260,20 @@ class TestExtractText:
         assert text == "spoken text"
         assert reply_text == "quoted"
 
+    def test_extracts_appmsg_title_and_url(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        body = {
+            "msgtype": "appmsg",
+            "appmsg": {
+                "title": "GitHub PR",
+                "url": "https://github.com/example/repo/pull/42",
+            },
+        }
+        text, reply_text = WeComAdapter._extract_text(body)
+        assert text == "GitHub PR\nhttps://github.com/example/repo/pull/42"
+        assert reply_text is None
+
 
 class TestCallbackDispatch:
     @pytest.mark.asyncio
@@ -665,7 +679,8 @@ class TestWeComZombieSessionFix:
         assert a._device_id != b._device_id
 
     @pytest.mark.asyncio
-    async def test_open_connection_includes_device_id_in_subscribe(self):
+    async def test_open_connection_includes_device_id_in_subscribe(self, monkeypatch):
+        import gateway.platforms.wecom as wecom_module
         from gateway.platforms.wecom import APP_CMD_SUBSCRIBE, WeComAdapter
 
         adapter = WeComAdapter(PlatformConfig(enabled=True))
@@ -702,8 +717,8 @@ class TestWeComZombieSessionFix:
         adapter._cleanup_ws = _fake_cleanup
         adapter._wait_for_handshake = _fake_handshake
 
-        with patch("gateway.platforms.wecom.aiohttp.ClientSession", _FakeSession):
-            await adapter._open_connection()
+        monkeypatch.setattr(wecom_module, "aiohttp", SimpleNamespace(ClientSession=_FakeSession))
+        await adapter._open_connection()
 
         assert len(sent_payloads) == 1
         subscribe = sent_payloads[0]


### PR DESCRIPTION
## Summary

- Tighten WeCom inbound material detection so plain text and GitHub URLs do not fall into the material/knowledge-base confirmation path.
- Preserve `appmsg` URLs so GitHub link cards can be recognized by the negative allowlist.
- Add smoke coverage for plain text, GitHub PR/actions links, file attachments, and explicit archive/ingest intent.

## Validation

- `python -m pytest tests/gateway/test_wecom.py tests/gateway/test_inbound_material_detection.py`
- `python -m py_compile gateway/run.py gateway/platforms/wecom.py tests/gateway/test_wecom.py tests/gateway/test_inbound_material_detection.py`
- `git diff --check`

## Notes

- No merge performed.
