### PR TITLE
fix(gateway): cross-platform process start-time for scoped-lock PID-reuse guard

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -820,18 +820,15 @@ def _consume_pid_marker_for_self(
 
     our_pid = os.getpid()
     our_start_time = _get_process_start_time(our_pid)
-    # Start-time is a PID-reuse guard. It is only meaningful when both
-    # sides actually have it: ``_get_process_start_time`` returns None on
-    # platforms without ``/proc`` (macOS, native Windows — the very
-    # platform the planned-stop watcher exists for). Requiring a non-None
-    # match there would make every consume return False, so a legitimate
-    # ``hermes gateway stop`` on Windows would be misclassified as an
-    # unexpected ``UNKNOWN`` exit (exit 1) and revived by the service
-    # manager. So: when both start_times are known they must match; when
-    # either is unknown, fall back to PID equality alone (bounded by the
-    # marker's short TTL). This mirrors ``planned_stop_marker_targets_self``
-    # so the watcher's non-destructive probe and this authoritative
-    # consume agree on every platform (issue #34597).
+    # Start-time is a PID-reuse guard, meaningful only when both sides have it.
+    # ``_get_process_start_time`` returns None when psutil cannot read the
+    # process; requiring a non-None match would misclassify a legitimate
+    # ``hermes gateway stop`` as an unexpected ``UNKNOWN`` exit (exit 1) and let
+    # the service manager revive it. So: when both start times are known they
+    # must match; when either is unknown, fall back to PID equality alone
+    # (bounded by the marker's short TTL). Mirrors
+    # ``planned_stop_marker_targets_self`` so the watcher's non-destructive
+    # probe and this authoritative consume agree on every platform (#34597).
     if target_pid != our_pid:
         matches = False
     elif target_start_time is not None and our_start_time is not None:
@@ -859,10 +856,10 @@ def write_takeover_marker(target_pid: int) -> bool:
     is a best-effort signal, not a correctness requirement).
     """
     try:
-        target_start_time = _get_process_start_time(target_pid)
         record = {
             "target_pid": target_pid,
-            "target_start_time": target_start_time,
+            "target_start_time": None,  # tombstone (pre-fix readers)
+            "target_start_time_us": _get_process_start_time(target_pid),
             "replacer_pid": os.getpid(),
             "written_at": _utc_now_iso(),
         }
@@ -886,7 +883,7 @@ def consume_takeover_marker_for_self() -> bool:
     return _consume_pid_marker_for_self(
         _get_takeover_marker_path(),
         pid_field="target_pid",
-        start_time_field="target_start_time",
+        start_time_field="target_start_time_us",
         ttl_s=_TAKEOVER_MARKER_TTL_S,
     )
 
@@ -907,10 +904,10 @@ def write_planned_stop_marker(target_pid: int) -> bool:
     this short-lived marker first to let the target process exit cleanly.
     """
     try:
-        target_start_time = _get_process_start_time(target_pid)
         record = {
             "target_pid": target_pid,
-            "target_start_time": target_start_time,
+            "target_start_time": None,  # tombstone (pre-fix readers)
+            "target_start_time_us": _get_process_start_time(target_pid),
             "stopper_pid": os.getpid(),
             "written_at": _utc_now_iso(),
         }
@@ -925,7 +922,7 @@ def consume_planned_stop_marker_for_self() -> bool:
     return _consume_pid_marker_for_self(
         _get_planned_stop_marker_path(),
         pid_field="target_pid",
-        start_time_field="target_start_time",
+        start_time_field="target_start_time_us",
         ttl_s=_PLANNED_STOP_MARKER_TTL_S,
     )
 
@@ -955,7 +952,7 @@ def planned_stop_marker_targets_self() -> bool:
 
     try:
         target_pid = int(record["target_pid"])
-        target_start_time = record.get("target_start_time")
+        target_start_time = record.get("target_start_time_us")
         written_at = record.get("written_at") or ""
     except (KeyError, TypeError, ValueError):
         # Malformed marker can never match anyone — drop it.
@@ -978,14 +975,12 @@ def planned_stop_marker_targets_self() -> bool:
     if target_pid != our_pid:
         return False
 
-    # Start-time is a PID-reuse guard. It is only meaningful when both
-    # sides actually have it: ``_get_process_start_time`` returns None on
-    # platforms without ``/proc`` (macOS, native Windows — the very
-    # platform this watcher exists for). Requiring a non-None match there
-    # would make the watcher never fire and re-break the #33778 Windows
-    # session-resume path. So: when both start_times are known they must
-    # match; when either is unknown, fall back to PID equality alone
-    # (the marker is short-lived under a 60s TTL, bounding reuse risk).
+    # Start-time is a PID-reuse guard, meaningful only when both sides have it.
+    # ``_get_process_start_time`` returns None when psutil cannot read the
+    # process; requiring a non-None match would make the watcher never fire and
+    # re-break the #33778 session-resume path. So: when both start times are
+    # known they must match; when either is unknown, fall back to PID equality
+    # alone (the marker is short-lived under a 60s TTL, bounding reuse risk).
     our_start_time = _get_process_start_time(our_pid)
     if target_start_time is not None and our_start_time is not None:
         return target_start_time == our_start_time

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -109,12 +109,23 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
 
 
 def _get_process_start_time(pid: int) -> Optional[int]:
-    """Return the kernel start time for a process when available."""
-    stat_path = Path(f"/proc/{pid}/stat")
+    """Return the process creation time in epoch microseconds, or None.
+
+    Uses ``psutil.Process(pid).create_time()``, supported on Linux, macOS and
+    Windows — unlike the historical ``/proc/<pid>/stat`` field-22 read, which
+    returned None on every platform without ``/proc`` and silently disabled the
+    PID-reuse guard there. Microsecond integers are exact-comparable across JSON
+    round-trips and, being epoch-based (not jiffies-since-boot), do not collide
+    across reboots. Returns None on any failure so callers fall back to the
+    cmdline/argv oracle rather than raising.
+    """
     try:
-        # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
-        return int(stat_path.read_text(encoding="utf-8").split()[21])
-    except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
+        import psutil  # hard dependency (pyproject.toml); guarded for safety
+    except ImportError:
+        return None
+    try:
+        return round(psutil.Process(pid).create_time() * 1_000_000)
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess, OSError, ValueError):
         return None
 
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -690,7 +690,7 @@ def release_scoped_lock(scope: str, identity: str) -> None:
         return
     if existing.get("pid") != os.getpid():
         return
-    if existing.get("start_time") != _get_process_start_time(os.getpid()):
+    if existing.get("start_time_us") != _get_process_start_time(os.getpid()):
         return
     try:
         lock_path.unlink(missing_ok=True)
@@ -732,7 +732,7 @@ def release_all_scoped_locks(
                     continue
                 if (
                     owner_start_time is not None
-                    and record.get("start_time") != owner_start_time
+                    and record.get("start_time_us") != owner_start_time
                 ):
                     continue
             try:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -216,7 +216,12 @@ def _build_pid_record() -> dict:
         "pid": os.getpid(),
         "kind": _GATEWAY_KIND,
         "argv": list(sys.argv),
-        "start_time": _get_process_start_time(os.getpid()),
+        # Legacy field, tombstoned: pre-fix binaries read this as /proc jiffies.
+        # Leaving it null (never an int) makes them skip the start-time guard and
+        # fall back to the cmdline/argv oracle instead of false-evicting a live lock.
+        "start_time": None,
+        # Cross-platform process creation time, epoch microseconds.
+        "start_time_us": _get_process_start_time(os.getpid()),
     }
 
 
@@ -526,12 +531,8 @@ def write_runtime_status(
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
     payload = _read_json_file(path) or _build_runtime_status_record()
-    current_record = _build_pid_record()
     payload.setdefault("platforms", {})
-    payload["kind"] = current_record["kind"]
-    payload["pid"] = current_record["pid"]
-    payload["argv"] = current_record["argv"]
-    payload["start_time"] = current_record["start_time"]
+    payload.update(_build_pid_record())  # overwrite stale pid/argv/start_time_us from a prior run
     payload["updated_at"] = _utc_now_iso()
 
     if gateway_state is not _UNSET:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1028,7 +1028,7 @@ def get_running_pid(
         if not _pid_exists(pid):
             continue
 
-        recorded_start = record.get("start_time")
+        recorded_start = record.get("start_time_us")
         current_start = _get_process_start_time(pid)
         if recorded_start is not None and current_start is not None and current_start != recorded_start:
             continue

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -619,7 +619,7 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         except (KeyError, TypeError, ValueError):
             existing_pid = None
 
-        if existing_pid == os.getpid() and existing.get("start_time") == record.get("start_time"):
+        if existing_pid == os.getpid() and existing.get("start_time_us") == record.get("start_time_us"):
             _write_json_file(lock_path, record)
             return True, existing
 
@@ -628,26 +628,18 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
             if not _pid_exists(existing_pid):
                 stale = True
             else:
+                existing_start = existing.get("start_time_us")
                 current_start = _get_process_start_time(existing_pid)
-                if (
-                    existing.get("start_time") is not None
-                    and current_start is not None
-                    and current_start != existing.get("start_time")
-                ):
-                    stale = True
-                # When start_time comparison is unavailable (macOS / Windows
-                # have no /proc, so both sides are None), fall back to
-                # checking the live process command line.  When cmdline is
-                # also unreadable (Windows has no ps), consult the lock
-                # record's own argv — the gateway writes it at startup and
-                # it's the only identity signal on platforms without ps.
-                # Both oracles must indicate "not a gateway" to mark stale.
-                if (
-                    not stale
-                    and existing.get("start_time") is None
-                    and current_start is None
-                    and not _looks_like_gateway_process(existing_pid)
-                ):
+                if existing_start is not None and current_start is not None:
+                    # Both incarnations have a comparable start time: a mismatch
+                    # means the PID was reused by a different process.
+                    stale = current_start != existing_start
+                elif not _looks_like_gateway_process(existing_pid):
+                    # start_time_us unavailable on one/both sides (legacy record
+                    # or psutil could not read the live process). Fall back to the
+                    # cmdline/argv oracle: when cmdline is also unreadable (Windows
+                    # has no ps), consult the record's own argv. Both oracles must
+                    # say "not a gateway" before we mark the lock stale.
                     live_cmdline = _read_process_cmdline(existing_pid)
                     if live_cmdline is not None or not _record_looks_like_gateway(existing):
                         stale = True

--- a/tests/gateway/test_planned_stop_watcher.py
+++ b/tests/gateway/test_planned_stop_watcher.py
@@ -34,7 +34,8 @@ def _write_self_marker(marker, *, stale: bool = False):
     written_at = "2000-01-01T00:00:00+00:00" if stale else status_mod._utc_now_iso()
     record = {
         "target_pid": os.getpid(),
-        "target_start_time": status_mod._get_process_start_time(os.getpid()),
+        "target_start_time": None,
+        "target_start_time_us": status_mod._get_process_start_time(os.getpid()),
         "stopper_pid": os.getpid(),
         "written_at": written_at,
     }

--- a/tests/gateway/test_process_start_time.py
+++ b/tests/gateway/test_process_start_time.py
@@ -37,6 +37,14 @@ def test_returns_epoch_microseconds_int(monkeypatch):
     assert status._get_process_start_time(1234) == 1_748_600_000_123_456
 
 
+def test_sub_microsecond_is_rounded_not_truncated(monkeypatch):
+    # 1.0000007s -> 1_000_000.7us must round to 1_000_001, not truncate to
+    # 1_000_000. Guards against a regression from round() to int()/floor that a
+    # whole-microsecond input could not catch.
+    _install_fake_psutil(monkeypatch, create_time=1.0000007)
+    assert status._get_process_start_time(4321) == 1_000_001
+
+
 @pytest.mark.parametrize(
     "raises",
     ["NoSuchProcess", "AccessDenied", "ZombieProcess", OSError("io"), ValueError("nan")],

--- a/tests/gateway/test_process_start_time.py
+++ b/tests/gateway/test_process_start_time.py
@@ -1,0 +1,51 @@
+import sys
+import types
+
+import pytest
+
+from gateway import status
+
+
+def _install_fake_psutil(monkeypatch, *, create_time=None, raises=None):
+    """Inject a hermetic fake psutil so the test is identical on every CI platform.
+
+    ``raises`` may be a psutil exception class *name* (resolved against the fake,
+    so the instance matches the class the production except clause catches) or any
+    other exception instance.
+    """
+    fake = types.ModuleType("psutil")
+    for name in ("NoSuchProcess", "AccessDenied", "ZombieProcess"):
+        setattr(fake, name, type(name, (Exception,), {}))
+    boom = getattr(fake, raises)("boom") if isinstance(raises, str) else raises
+
+    class _Proc:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def create_time(self):
+            if boom is not None:
+                raise boom
+            return create_time
+
+    fake.Process = _Proc
+    monkeypatch.setitem(sys.modules, "psutil", fake)
+    return fake
+
+
+def test_returns_epoch_microseconds_int(monkeypatch):
+    _install_fake_psutil(monkeypatch, create_time=1_748_600_000.123456)
+    assert status._get_process_start_time(1234) == 1_748_600_000_123_456
+
+
+@pytest.mark.parametrize(
+    "raises",
+    ["NoSuchProcess", "AccessDenied", "ZombieProcess", OSError("io"), ValueError("nan")],
+)
+def test_unreadable_process_returns_none(monkeypatch, raises):
+    _install_fake_psutil(monkeypatch, raises=raises)
+    assert status._get_process_start_time(999999) is None
+
+
+def test_missing_psutil_returns_none(monkeypatch):
+    monkeypatch.setitem(sys.modules, "psutil", None)  # forces ImportError on `import psutil`
+    assert status._get_process_start_time(1234) is None

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -251,7 +251,8 @@ async def test_start_gateway_replace_writes_takeover_marker_before_sigterm(
         from gateway.status import _get_takeover_marker_path, _write_json_file
         _write_json_file(_get_takeover_marker_path(), {
             "target_pid": target_pid,
-            "target_start_time": 0,
+            "target_start_time": None,
+            "target_start_time_us": 0,
             "replacer_pid": 100,
             "written_at": "2026-04-17T00:00:00+00:00",
         })
@@ -322,7 +323,8 @@ async def test_start_gateway_replace_clears_marker_on_permission_denied(
         from gateway.status import _get_takeover_marker_path, _write_json_file
         _write_json_file(_get_takeover_marker_path(), {
             "target_pid": target_pid,
-            "target_start_time": 0,
+            "target_start_time": None,
+            "target_start_time_us": 0,
             "replacer_pid": 100,
             "written_at": "2026-04-17T00:00:00+00:00",
         })

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -734,7 +734,8 @@ class TestTakeoverMarker:
         assert marker.exists()
         payload = json.loads(marker.read_text())
         assert payload["target_pid"] == 12345
-        assert payload["target_start_time"] == 42
+        assert payload["target_start_time_us"] == 42
+        assert payload["target_start_time"] is None  # tombstone
         assert payload["replacer_pid"] == os.getpid()
         assert "written_at" in payload
 
@@ -804,7 +805,7 @@ class TestTakeoverMarker:
         ok = status.write_takeover_marker(target_pid=os.getpid())
         assert ok is True
         payload = json.loads((tmp_path / ".gateway-takeover.json").read_text())
-        assert payload["target_start_time"] is None
+        assert payload["target_start_time_us"] is None
 
         result = status.consume_takeover_marker_for_self()
 
@@ -933,7 +934,8 @@ class TestPlannedStopMarker:
         assert marker.exists()
         payload = json.loads(marker.read_text())
         assert payload["target_pid"] == 12345
-        assert payload["target_start_time"] == 42
+        assert payload["target_start_time_us"] == 42
+        assert payload["target_start_time"] is None  # tombstone
         assert payload["stopper_pid"] == os.getpid()
         assert "written_at" in payload
 
@@ -947,6 +949,22 @@ class TestPlannedStopMarker:
 
         assert result is True
         assert not (tmp_path / ".gateway-planned-stop.json").exists()
+
+    def test_probe_rejects_reused_pid_via_start_time_us(self, tmp_path, monkeypatch):
+        # Non-destructive probe: a marker naming our PID but recording a
+        # different start_time_us means the PID was reused -> must not match.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 111)
+        path = status._get_planned_stop_marker_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({
+            "target_pid": os.getpid(),
+            "target_start_time": None,
+            "target_start_time_us": 999,
+            "stopper_pid": 1,
+            "written_at": status._utc_now_iso(),
+        }), encoding="utf-8")
+        assert status.planned_stop_marker_targets_self() is False
 
     def test_consume_returns_false_for_different_pid(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -1024,9 +1042,10 @@ class TestPlannedStopMarker:
 
         ok = status.write_planned_stop_marker(target_pid=os.getpid())
         assert ok is True
-        # Marker carries a null start_time, exactly as written on Windows.
+        # Marker carries a null start_time_us, exactly as written when psutil
+        # cannot read the process.
         payload = json.loads((tmp_path / ".gateway-planned-stop.json").read_text())
-        assert payload["target_start_time"] is None
+        assert payload["target_start_time_us"] is None
 
         result = status.consume_planned_stop_marker_for_self()
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -636,6 +636,9 @@ class TestScopedLocks:
         assert payload["pid"] == os.getpid()
 
     def test_release_scoped_lock_only_removes_current_owner(self, tmp_path, monkeypatch):
+        # Guards the self-release lock LEAK: release must compare start_time_us,
+        # not the tombstoned legacy start_time (None) — comparing the latter
+        # against this process's live epoch-us value would refuse to unlink.
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
 
         acquired, _ = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
@@ -655,12 +658,14 @@ class TestScopedLocks:
         other_lock = lock_dir / "slack-app-token-other.lock"
         target_lock.write_text(json.dumps({
             "pid": 111,
-            "start_time": 222,
+            "start_time": None,
+            "start_time_us": 222,
             "kind": "hermes-gateway",
         }))
         other_lock.write_text(json.dumps({
             "pid": 999,
-            "start_time": 333,
+            "start_time": None,
+            "start_time_us": 333,
             "kind": "hermes-gateway",
         }))
 
@@ -681,7 +686,8 @@ class TestScopedLocks:
         reused_pid_lock = lock_dir / "telegram-bot-token-reused.lock"
         reused_pid_lock.write_text(json.dumps({
             "pid": 111,
-            "start_time": 999,
+            "start_time": None,
+            "start_time_us": 999,
             "kind": "hermes-gateway",
         }))
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -28,6 +28,29 @@ class TestGatewayPidState:
         # instead of KeyError-ing or misreading microseconds as /proc jiffies.
         assert rec["start_time"] is None
 
+    def test_pre_fix_reader_does_not_false_evict_new_record(self, monkeypatch):
+        # Downgrade safety: replay the pre-fix binary's exact stale predicate
+        # against our NEW record. A pre-fix reader on a later boot sees a
+        # mismatching live start time; it evicts only when the record's
+        # start_time is a non-None int that differs. Because we tombstone
+        # start_time to None, the guard short-circuits and the live lock survives
+        # — the whole reason we tombstone instead of omit.
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 111)
+        record = status._build_pid_record()
+
+        def pre_fix_marks_stale(existing_start_time, current_start):
+            return (
+                existing_start_time is not None
+                and current_start is not None
+                and current_start != existing_start_time
+            )
+
+        current_start = 999  # the live (reused-PID / post-reboot) process
+        assert pre_fix_marks_stale(record.get("start_time"), current_start) is False
+        # Teeth: the tombstone is load-bearing. Had start_time kept a real int,
+        # that same pre-fix predicate WOULD have falsely evicted the live lock.
+        assert pre_fix_marks_stale(30_000_000, current_start) is True
+
     def test_write_pid_file_is_atomic_against_concurrent_writers(self, tmp_path, monkeypatch):
         """Regression: two concurrent --replace invocations must not both win.
 
@@ -303,11 +326,15 @@ class TestGatewayRuntimeStatus:
             "updated_at": "2025-01-01T00:00:00Z",
         }))
 
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 2000)
         status.write_runtime_status(gateway_state="running")
 
         payload = status.read_runtime_status()
         assert payload["pid"] == os.getpid(), "PID should be overwritten, not preserved via setdefault"
-        assert payload["start_time"] != 1000.0, "start_time should be overwritten on restart"
+        # Stale 1000.0 must be gone: the live time now lives in start_time_us and
+        # the legacy field is tombstoned to None.
+        assert payload["start_time_us"] == 2000
+        assert payload["start_time"] is None
 
     def test_write_runtime_status_overwrites_stale_argv_on_restart(self, tmp_path, monkeypatch):
         """Regression: gateway_state.json must not keep the previous launch argv."""
@@ -331,7 +358,8 @@ class TestGatewayRuntimeStatus:
         payload = status.read_runtime_status()
         assert payload["argv"] == ["/new/path/hermes", "gateway", "run"]
         assert payload["pid"] == os.getpid()
-        assert payload["start_time"] == 2000
+        assert payload["start_time_us"] == 2000
+        assert payload["start_time"] is None
 
     def test_write_runtime_status_records_platform_failure(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -501,12 +529,14 @@ class TestScopedLocks:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         lock_path.write_text(json.dumps({
             "pid": 99999,
-            "start_time": 123,
+            "start_time": None,
+            "start_time_us": 123,
             "kind": "hermes-gateway",
         }))
 
         # Post-#21561 the liveness probe routes through
         # ``gateway.status._pid_exists`` (psutil-first, safe on Windows).
+        # Live start_time_us equals the recorded one -> same incarnation -> live.
         monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
         monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -52,6 +52,20 @@ class TestGatewayPidState:
         payload = json.loads((tmp_path / "gateway.pid").read_text())
         assert payload["pid"] == os.getpid()
 
+    def test_get_running_pid_skips_reused_pid_via_start_time_us(self, monkeypatch):
+        record = {
+            "pid": 4321, "kind": status._GATEWAY_KIND,
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": None, "start_time_us": 111,
+        }
+        monkeypatch.setattr(status, "_read_pid_record", lambda p: record)
+        monkeypatch.setattr(status, "_read_gateway_lock_record", lambda p: None)
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda p: True)
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_cleanup_invalid_pid_path", lambda *a, **k: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 999)  # reused -> mismatch
+        assert status.get_running_pid() is None
+
     def test_get_running_pid_rejects_live_non_gateway_pid(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         pid_path = tmp_path / "gateway.pid"

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -20,6 +20,14 @@ class TestGatewayPidState:
         assert isinstance(payload["argv"], list)
         assert payload["argv"]
 
+    def test_pid_record_uses_start_time_us_and_tombstones_legacy(self, monkeypatch):
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 1_748_600_000_123_456)
+        rec = status._build_pid_record()
+        assert rec["start_time_us"] == 1_748_600_000_123_456
+        # Tombstone must be present-but-null so pre-fix readers skip the guard
+        # instead of KeyError-ing or misreading microseconds as /proc jiffies.
+        assert rec["start_time"] is None
+
     def test_write_pid_file_is_atomic_against_concurrent_writers(self, tmp_path, monkeypatch):
         """Regression: two concurrent --replace invocations must not both win.
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -432,6 +432,55 @@ class TestScopedLocks:
         ]
         assert lock_path.read_text(encoding="utf-8") == "\n"
 
+    @staticmethod
+    def _seed_lock(tmp_path, monkeypatch, record, scope="telegram", identity="tok"):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        path = status._get_scope_lock_path(scope, identity)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(record), encoding="utf-8")
+        return path
+
+    def test_acquire_scoped_lock_evicts_reused_pid_via_start_time_us(self, tmp_path, monkeypatch):
+        # Record left by a dead gateway (start_time_us=111); the PID is now a
+        # different LIVE process (start_time_us=999). Differ -> stale -> acquire.
+        path = self._seed_lock(tmp_path, monkeypatch, {
+            "pid": 4321, "kind": status._GATEWAY_KIND,
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": None, "start_time_us": 111,
+        })
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 999)
+        acquired, _ = status.acquire_scoped_lock("telegram", "tok")
+        assert acquired is True
+        assert json.loads(path.read_text())["pid"] == os.getpid()
+
+    def test_acquire_scoped_lock_keeps_lock_for_same_incarnation(self, tmp_path, monkeypatch):
+        self._seed_lock(tmp_path, monkeypatch, {
+            "pid": 4321, "kind": status._GATEWAY_KIND,
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": None, "start_time_us": 555,
+        })
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 555)
+        acquired, existing = status.acquire_scoped_lock("telegram", "tok")
+        assert acquired is False
+        assert existing["pid"] == 4321
+
+    def test_acquire_scoped_lock_legacy_record_uses_oracle_not_false_evict(self, tmp_path, monkeypatch):
+        # Pre-fix record (no start_time_us) + psutil unavailable -> incomparable.
+        # The live PID still looks like a gateway, so the oracle keeps the lock.
+        self._seed_lock(tmp_path, monkeypatch, {
+            "pid": 4321, "kind": status._GATEWAY_KIND,
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": None,
+        })
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: True)
+        acquired, existing = status.acquire_scoped_lock("telegram", "tok")
+        assert acquired is False
+        assert existing["pid"] == 4321
+
     def test_acquire_scoped_lock_rejects_live_other_process(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
         lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"


### PR DESCRIPTION
## Summary

The gateway's scoped-lock PID-reuse guard was effectively Linux-only. `_get_process_start_time` read `/proc/<pid>/stat` and returned `None` on any platform without `/proc`, so locks and markers stored `start_time: null` on macOS and Windows and the PID-reuse check was silently skipped. Once the OS recycled a recorded gateway PID into an unrelated process, the dead lock looked live and the adapter was blocked indefinitely — under launchd/systemd `KeepAlive` this turned into an endless restart-and-fail loop, and `hermes gateway run --replace` could no longer reclaim the token.

This switches the start-time source to `psutil.Process(pid).create_time()`, which works on all three platforms, and stores it as epoch microseconds in a new `start_time_us` field. The only production change is in one file, `gateway/status.py`.

## Root cause

- `_get_process_start_time` read only field 22 of `/proc/<pid>/stat`, so it returned `None` on macOS and Windows (`gateway/status.py:111`).
- With a null start time, the staleness check can only test PID liveness. `os.kill(pid, 0)` succeeds for a recycled PID — it really is alive, just unrelated — so the lock is treated as held forever.
- In practice the recycled PID lands on a launchd system agent (`FamilyControlsAgent`, `CloudDocs`, `TipsWidgetExtension`, `intelligentroutingd`, `TextInputMenuAgent`), and the user sees an error blaming a process that has nothing to do with Hermes.
- Under launchd/systemd `KeepAlive` the blocked adapter restart-fails forever, and `--replace` becomes a no-op.

## The fix

- `psutil.Process(pid).create_time()` rounded to epoch microseconds (`round(... * 1_000_000)`), identical on Linux/macOS/Windows (`gateway/status.py:127`). `psutil` is already a hard dependency; the import is guarded only so a broken environment fails safe to `None` rather than raising.
- The value is stored in a new field, `start_time_us` (`:224`); markers use `target_start_time_us` (`:862`, `:910`).
- The old `start_time` / `target_start_time` fields are written as explicit `null` rather than removed (`:222`, `:861`, `:909`). This is deliberate — see below.
- No `/proc` jiffies fallback and no schema version field. Both are intentional and explained in the next section.

## Why store a new field and null the old one

The hard requirement is that this must never evict a **live** gateway's lock, including when an old and a new binary read each other's records (rollback, a half-finished upgrade, two installs sharing a lock directory). Two choices make that safe:

**Nulling the legacy field (instead of removing it) protects against an old binary reading a new record.** A pre-fix binary only marks a lock stale when its `start_time` is a non-null integer that differs from the live value. A new record writes `start_time: null`, so the old binary skips that branch and falls through to its existing cmdline check, which recognises the live gateway and keeps the lock. If we had left a real integer in that field, an old binary reading a new record after a reboot could wrongly evict it — which is exactly the case the null guards against.

**Routing to the cmdline check whenever `start_time_us` is missing protects against a new binary reading an old record.** An old record has no `start_time_us`, so the new code never compares a Linux jiffies value against a psutil microsecond value (different units, guaranteed mismatch, wrong eviction). When the field is absent on either side, the code uses the cmdline/argv check instead. This same path also covers the case where psutil can't read a live process (e.g. `AccessDenied` on a system PID).

Across every old/new combination, the result is either a correct start-time comparison or the cmdline check — never a wrongful eviction of a live gateway.

## How eviction decides (`acquire_scoped_lock`, `gateway/status.py:616`)

- PID no longer exists → stale.
- Both start times present → stale when they differ (`:636`).
- Either side missing → fall back to the cmdline/argv check; only evict when both the live cmdline and the recorded argv look like something other than a gateway (`:637`).

One behaviour change worth flagging for reviewers: when a record has `start_time_us` but psutil can't read the live process, the old code kept the lock; the new code falls back to the cmdline check. That can only evict a PID whose live identity doesn't look like a gateway, so it's safer, not riskier.

## Where the field is read and written

Every site that previously used `start_time` now uses `start_time_us`:

- `acquire_scoped_lock` — self-owned short-circuit (`:622`) and eviction (`:631`, `:636`).
- `release_scoped_lock` (`:693`) — this one matters: comparing the now-null legacy field against a live microsecond value would refuse to unlink and leak the lock. It now reads `start_time_us`.
- `release_all_scoped_locks` (`:735`).
- `get_running_pid` (`:1026`).
- The takeover and planned-stop markers — write, consume, and probe (`:862`, `:886`, `:910`, `:925`, `:955`).
- `gateway/run.py:18732` is unchanged but stays consistent: it calls the public `get_process_start_time` (which now returns microseconds) and passes the result as `owner_start_time`, compared against the record's `start_time_us` — same units on both sides.

The only remaining write of the old `start_time` field is the intentional `null`.

## A note on the marker fallback

When both a marker and the current process have an unknown start time, the markers (`_consume_pid_marker_for_self`, `planned_stop_marker_targets_self`, `:985`) fall back to matching on PID alone, bounded by the marker's short TTL. This is required so a normal `hermes gateway stop` isn't misread as an unexpected exit and revived by the service manager (#34597, #33778). The migration actually shrinks the window for this fallback, since macOS now usually has a real start time and takes the strict comparison instead.

## Out of scope

- The merged #24610 cmdline/argv check is reused unchanged.
- The Linux-only stopped-process (`T`-state) check is left as-is and not ported to other platforms; the known split-brain edge there is a separate fix for later.

## Testing

```
uv run --extra dev python -m pytest \
  tests/gateway/test_process_start_time.py \
  tests/gateway/test_status.py \
  tests/gateway/test_planned_stop_watcher.py \
  tests/gateway/test_runner_startup_failures.py
```

89 passed with `psutil 7.2.2` installed.

> **Run with `--extra dev`.** Without it, `psutil` isn't installed and `_get_process_start_time` returns `None`, so the suite can pass without ever exercising the fix. The unit tests inject a fake `psutil` and are platform-independent, but the integration assertions need the real dependency.

What's covered:

- microsecond conversion rounds rather than truncates
- psutil errors (`NoSuchProcess`, `AccessDenied`, `ZombieProcess`, `OSError`, `ValueError`) and a missing `psutil` all return `None`
- records write `start_time_us` and null the legacy field
- acquire: same process keeps its lock, a reused PID is evicted, and a legacy record without `start_time_us` falls back to the cmdline check instead of being wrongly evicted
- release: a process unlinks its own lock and refuses to unlink one whose start time doesn't match
- `release_all_scoped_locks` respects the owner start time
- `get_running_pid` skips a reused PID
- markers: write, consume, reject a reused PID, and the both-unknown PID-only fallback
- downgrade safety: a pre-fix reader does not wrongly evict a new record

## Scope

Five files: one production file (`gateway/status.py`, net −1 line) and four test files — `tests/gateway/test_process_start_time.py` (new), plus updates to `test_status.py`, `test_planned_stop_watcher.py`, and `test_runner_startup_failures.py`.

## Compatibility and regressions

- On Linux a live gateway always has a readable start time (psutil reads the same `/proc` data the old code did), so it takes the start-time comparison and never reaches the cmdline fallback. Behaviour is unchanged for live gateways and only changes for dead or reused PIDs.
- Dropping the jiffies value removes a latent issue: jiffies are measured from boot and can repeat across reboots; epoch microseconds can't.
- One caveat on the full `tests/gateway` run: there are ~70 pre-existing failures in `test_ws_auth_retry`, `test_wecom_callback`, and `test_telegram_slash_confirm` caused by a test-isolation problem with a mocked XML parser (`'NoneType' object has no attribute 'fromstring'`). They pass in isolation and share no code with `gateway/status.py`, so they're unrelated to this change.

## Known limitations and follow-ups

- The marker PID-only fallback (above) can still match a reused PID if psutil fails to read a start time within the marker's TTL. This is pre-existing behaviour and is narrower after this change, not wider.
- When given an `owner_start_time`, `release_all_scoped_locks` skips locks written by an older binary (no `start_time_us`). It only ever skips a foreign lock, never the caller's own, and such locks are still reclaimed when the scope is next contended.
- PR #24595 included a `psutil.Process.name()` pre-filter and a `shutil.which("ps")` guard. Neither is needed for correctness (the cmdline match is authoritative), so they were left out; they'd make reasonable follow-ups.
- There's no schema version field, so a future reader can't tell "old record, never had a start time" apart from "new record, psutil returned None." Both fall back to the cmdline check, which is the safe behaviour either way.

## Closes

| Issue | Adapter | Recycled PID | How it's fixed |
|---|---|---|---|
| #16586 | Slack | FamilyControlsAgent | `create_time()` populates `start_time_us` cross-platform, so the PID-reuse guard runs on macOS |
| #18778 | Telegram | intelligentroutingd | the start-time guard was a no-op off-Linux; `start_time_us` makes it fire |
| #21596 | Slack (`--replace` loop) | TipsWidgetExtension | with the guard working, the reused PID is evicted so `--replace` can reclaim the token |
| #21613 | Telegram | start_time=null false positive | `start_time_us` is now non-null on macOS, so PID reuse is detected instead of accepted |
| #24067 | Telegram / Feishu / WeChat | CloudDocs (system process on the same PID) | the start-time mismatch is detected cross-platform; the fix is in the shared `status.py` helper, not `base.py` as the issue guessed |
| #31890 | Weixin | TextInputMenuAgent | `start_time_us` populated cross-platform; a null start time no longer blocks adapters |

## Supersedes

| PR | Approach | Difference here |
|---|---|---|
| #16423 | cmdline check only | doesn't fix the underlying start-time read; this keeps the cmdline check as a fallback and fixes the root cause |
| #22490 | psutil `create_time` but keeps the `/proc` jiffies fallback in the same field | mixing units in one field can misfire; this drops the fallback and nulls the old field |
| #24595 | psutil (ms) + cmdline + `name()` pre-filter + `which("ps")` guard | same core idea at microsecond precision; the pre-filter and guard are optional and noted above as follow-ups |
| #31923 | `ps lstart` string hashed to an int (`Union[int, str]` threaded through, locale-sensitive) | epoch-microsecond `int` is simpler and more robust; keeps the same "trust the live cmdline over the recorded argv" behaviour |

---

Closes #16586, #18778, #21596, #21613, #24067, #31890
Supersedes #16423, #22490, #24595, #31923
