### PR TITLE
fix(tui-gateway): reap leaked slash_worker processes/fds on disconnect, create-race, and parent-death

### DIFF
--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -239,7 +239,7 @@ class PtyBridge:
     def _process_tree_alive(self) -> bool:
         if self._pgid is not None:
             try:
-                os.killpg(self._pgid, 0)
+                os.killpg(self._pgid, 0)  # windows-footgun: ok — POSIX-only module (imports fcntl/termios/ptyprocess at top)
                 return True
             except ProcessLookupError:
                 return False
@@ -252,7 +252,7 @@ class PtyBridge:
     def _signal_tree(self, sig) -> None:
         if self._pgid is not None:
             try:
-                os.killpg(self._pgid, sig)
+                os.killpg(self._pgid, sig)  # windows-footgun: ok — POSIX-only module (imports fcntl/termios/ptyprocess at top)
                 return
             except Exception:
                 pass

--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -74,6 +74,16 @@ class PtyBridge:
         self._proc = proc
         self._fd: int = proc.fd
         self._closed = False
+        # ptyprocess setsid()s the child, so it leads its own group — signalling
+        # the group reaps grandchildren the leader spawned (#32377). Never adopt
+        # the dashboard's own group as the target.
+        self._pgid: Optional[int] = None
+        try:
+            pgid = os.getpgid(proc.pid)
+            if pgid != os.getpgrp():
+                self._pgid = pgid
+        except Exception:
+            self._pgid = None
 
     # -- lifecycle --------------------------------------------------------
 
@@ -212,20 +222,42 @@ class PtyBridge:
         self._closed = True
 
         # SIGHUP is the conventional "your terminal went away" signal.
-        # We escalate if the child ignores it.
+        # We escalate if the child (and its group) ignore it.
         for sig in (signal.SIGHUP, signal.SIGTERM, signal.SIGKILL):  # windows-footgun: ok — POSIX-only module (imports fcntl/termios/ptyprocess at top)
-            if not self._proc.isalive():
+            if not self._process_tree_alive():
                 break
-            try:
-                self._proc.kill(sig)
-            except Exception:
-                pass
+            self._signal_tree(sig)
             deadline = time.monotonic() + 0.5
-            while self._proc.isalive() and time.monotonic() < deadline:
+            while self._process_tree_alive() and time.monotonic() < deadline:
                 time.sleep(0.02)
 
         try:
-            self._proc.close(force=True)
+            self._proc.close(force=True)  # closes the PTY master fd; dropping it re-leaks (#24775)
+        except Exception:
+            pass
+
+    def _process_tree_alive(self) -> bool:
+        if self._pgid is not None:
+            try:
+                os.killpg(self._pgid, 0)
+                return True
+            except ProcessLookupError:
+                return False
+            except PermissionError:
+                return True
+            except Exception:
+                pass
+        return self._proc.isalive()
+
+    def _signal_tree(self, sig) -> None:
+        if self._pgid is not None:
+            try:
+                os.killpg(self._pgid, sig)
+                return
+            except Exception:
+                pass
+        try:
+            self._proc.kill(sig)
         except Exception:
             pass
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7076,4 +7076,9 @@ def start_server(
     uvicorn.run(
         app, host=host, port=port, log_level="warning",
         proxy_headers=bool(app.state.auth_required),
+        # Detect half-open WS connections (reverse-proxy 524, dropped tunnels)
+        # within ~20-40s so WebSocketDisconnect fires the disconnect→reap path.
+        # 20s stays under Cloudflare Tunnel's idle timeout, keeping it warm.
+        ws_ping_interval=20.0,
+        ws_ping_timeout=20.0,
     )

--- a/tests/test_dashboard_sidecar_close_on_disconnect.py
+++ b/tests/test_dashboard_sidecar_close_on_disconnect.py
@@ -1,0 +1,13 @@
+import re
+from pathlib import Path
+
+CHAT_SIDEBAR = Path(__file__).resolve().parent.parent / "web/src/components/ChatSidebar.tsx"
+
+
+def test_sidecar_session_create_requests_close_on_disconnect():
+    """The sidecar must opt its session into close_on_disconnect so the gateway
+    reaps the slash_worker on WS disconnect (the #21370/#21467 leak)."""
+    source = CHAT_SIDEBAR.read_text(encoding="utf-8")
+    call = re.search(r'"session\.create",\s*\{(.*?)\}', source, re.DOTALL)
+    assert call, "sidecar session.create call not found"
+    assert re.search(r"close_on_disconnect:\s*true", call.group(1))

--- a/tests/test_pty_bridge.py
+++ b/tests/test_pty_bridge.py
@@ -1,0 +1,110 @@
+import re
+import signal
+import sys
+import time
+
+import psutil
+import pytest
+
+from hermes_cli import pty_bridge
+
+
+class _FakeProc:
+    """Minimal ptyprocess stand-in for unit-testing PtyBridge.close()."""
+
+    fd = 7
+    pid = 4321
+
+    def __init__(self):
+        self.alive = True
+        self.leader_signals = []
+
+    def isalive(self):
+        return self.alive
+
+    def kill(self, sig):
+        self.leader_signals.append(sig)
+        self.alive = False
+
+    def close(self, force=False):
+        pass
+
+
+def test_close_signals_process_group_not_the_leader(monkeypatch):
+    group_signals = []
+    proc = _FakeProc()
+    proc.kill = lambda sig: pytest.fail("must signal the group, not the leader")  # type: ignore
+
+    monkeypatch.setattr(pty_bridge.os, "getpgid", lambda pid: 9999)
+    monkeypatch.setattr(pty_bridge.os, "getpgrp", lambda: 1)  # the dashboard's own group
+
+    def fake_killpg(pgid, sig):
+        assert pgid == 9999, "must never signal a different (e.g. the dashboard's) group"
+        if sig == 0:  # liveness probe
+            if not proc.alive:
+                raise ProcessLookupError
+            return
+        group_signals.append(sig)
+        proc.alive = False
+
+    monkeypatch.setattr(pty_bridge.os, "killpg", fake_killpg)
+
+    pty_bridge.PtyBridge(proc).close()
+    assert group_signals  # the whole group was signalled
+
+
+def test_close_falls_back_to_leader_when_pgid_unavailable(monkeypatch):
+    proc = _FakeProc()
+    monkeypatch.setattr(pty_bridge.os, "getpgid", lambda pid: (_ for _ in ()).throw(OSError()))
+
+    bridge = pty_bridge.PtyBridge(proc)
+    assert bridge._pgid is None
+    bridge.close()
+    assert proc.leader_signals and proc.leader_signals[0] == signal.SIGHUP
+
+
+def test_pgid_not_captured_when_it_is_the_dashboards_own_group(monkeypatch):
+    monkeypatch.setattr(pty_bridge.os, "getpgid", lambda pid: 555)
+    monkeypatch.setattr(pty_bridge.os, "getpgrp", lambda: 555)  # leader shares our group
+    # Capturing it would make close() killpg our own group — never do that.
+    assert pty_bridge.PtyBridge(_FakeProc())._pgid is None
+
+
+# Grandchild that outlives a leader-only kill — the whole point of group teardown.
+_LEADER = (
+    "import os, sys, subprocess, time;"
+    "g = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(60)']);"
+    "sys.stdout.write('GPID=%d\\n' % g.pid); sys.stdout.flush();"
+    "time.sleep(60)"
+)
+
+
+@pytest.mark.integration
+@pytest.mark.live_system_guard_bypass
+def test_close_reaps_grandchild_via_process_group():
+    if not pty_bridge.PtyBridge.is_available():
+        pytest.skip("no PTY on this platform")
+
+    bridge = pty_bridge.PtyBridge.spawn([sys.executable, "-c", _LEADER])
+    try:
+        buf = ""
+        deadline = time.monotonic() + 5
+        while "GPID=" not in buf and time.monotonic() < deadline:
+            data = bridge.read(timeout=0.2)
+            if data:
+                buf += data.decode("utf-8", "ignore")
+        match = re.search(r"GPID=(\d+)", buf)
+        assert match, f"grandchild pid never reported: {buf!r}"
+        grandchild = int(match.group(1))
+        assert psutil.pid_exists(grandchild)
+
+        bridge.close()
+
+        deadline = time.monotonic() + 5
+        while psutil.pid_exists(grandchild) and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert not psutil.pid_exists(grandchild) or (
+            psutil.Process(grandchild).status() == psutil.STATUS_ZOMBIE
+        ), "grandchild survived the process-group teardown"
+    finally:
+        bridge.close()

--- a/tests/test_slash_worker_watchdog.py
+++ b/tests/test_slash_worker_watchdog.py
@@ -1,0 +1,21 @@
+import psutil
+
+from tui_gateway import slash_worker
+
+
+def test_is_orphaned_true_when_ppid_changes():
+    # Our parent went away and we were reparented to a subreaper/init.
+    assert slash_worker._is_orphaned(1234, 1.0, getppid=lambda: 999999) is True
+
+
+def test_is_orphaned_true_when_parent_create_time_mismatch():
+    # Same ppid but a different create_time means the PID was reused.
+    me = psutil.Process()
+    assert slash_worker._is_orphaned(me.pid, 0.0, getppid=lambda: me.pid) is True
+
+
+def test_is_orphaned_false_when_parent_alive_and_matches():
+    me = psutil.Process()
+    assert (
+        slash_worker._is_orphaned(me.pid, me.create_time(), getppid=lambda: me.pid) is False
+    )

--- a/tests/test_slash_worker_watchdog.py
+++ b/tests/test_slash_worker_watchdog.py
@@ -1,4 +1,10 @@
+import os
+import subprocess
+import sys
+import time
+
 import psutil
+import pytest
 
 from tui_gateway import slash_worker
 
@@ -19,3 +25,57 @@ def test_is_orphaned_false_when_parent_alive_and_matches():
     assert (
         slash_worker._is_orphaned(me.pid, me.create_time(), getppid=lambda: me.pid) is False
     )
+
+
+def _gone(pid: int) -> bool:
+    try:
+        return not psutil.pid_exists(pid) or psutil.Process(pid).status() == psutil.STATUS_ZOMBIE
+    except psutil.Error:
+        return True
+
+
+# Worker (the grandchild): arm the watchdog against its parent, THEN announce its
+# pid — so the test can't race in and kill the parent before the watchdog has
+# captured the real ppid (otherwise it would anchor to init and never fire).
+# Its stdout is inherited from the gateway, which is the test's pipe.
+_WORKER = (
+    "import os, time, psutil;"
+    "from tui_gateway.slash_worker import _start_parent_death_watchdog;"
+    "ppid = os.getppid();"
+    "_start_parent_death_watchdog(ppid, psutil.Process(ppid).create_time());"
+    "print(os.getpid(), flush=True);"
+    "time.sleep(60)"
+)
+# Gateway stand-in (the child): spawn the worker, then idle. We SIGKILL THIS so
+# the worker is genuinely orphaned (its parent gone, no atexit).
+_GATEWAY = (
+    "import sys, subprocess, time;"
+    f"subprocess.Popen([sys.executable, '-c', {_WORKER!r}]);"
+    "time.sleep(60)"
+)
+
+
+@pytest.mark.integration
+@pytest.mark.live_system_guard_bypass  # genuinely spawns + SIGKILLs its own subtree
+def test_watchdog_exits_real_worker_when_parent_dies():
+    fast = {**os.environ, "HERMES_SLASH_WATCHDOG_POLL_S": "0.1", "HERMES_SLASH_WATCHDOG_GRACE_S": "0.1"}
+    gateway = subprocess.Popen([sys.executable, "-c", _GATEWAY], stdout=subprocess.PIPE, text=True, env=fast)
+    worker_pid = None
+    try:
+        worker_pid = int(gateway.stdout.readline())  # printed only after arming
+        assert psutil.pid_exists(worker_pid)
+
+        gateway.kill()  # crash the parent — no graceful atexit
+        gateway.wait(timeout=5)
+
+        deadline = time.monotonic() + 5  # generous vs the 0.2s poll+grace
+        while not _gone(worker_pid) and time.monotonic() < deadline:
+            time.sleep(0.05)
+        assert _gone(worker_pid), "orphaned worker did not self-terminate"
+    finally:
+        for pid in (worker_pid, gateway.pid):
+            if pid:
+                try:
+                    os.kill(pid, 9)
+                except OSError:
+                    pass

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1880,7 +1880,7 @@ def test_config_set_model_global_persists(monkeypatch):
 
     server._sessions["sid"] = _session(agent=_Agent())
     monkeypatch.setattr("hermes_cli.model_switch.switch_model", _switch_model)
-    monkeypatch.setattr(server, "_restart_slash_worker", lambda session: None)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda sid, session: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
     monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved.update(cfg))
 
@@ -1938,7 +1938,7 @@ def test_config_set_model_syncs_inference_provider_env(monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.model_switch.switch_model", lambda **_kwargs: result
     )
-    monkeypatch.setattr(server, "_restart_slash_worker", lambda session: None)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda sid, session: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
 
     server.handle_request(
@@ -1989,7 +1989,7 @@ def test_config_set_model_syncs_tui_provider_unconditionally(monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.model_switch.switch_model", lambda **_kwargs: result
     )
-    monkeypatch.setattr(server, "_restart_slash_worker", lambda session: None)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda sid, session: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
 
     server.handle_request(
@@ -2025,7 +2025,7 @@ def test_config_set_model_syncs_tui_provider_env(monkeypatch):
     agent = Agent()
     server._sessions["sid"] = _session(agent=agent)
     monkeypatch.setenv("HERMES_TUI_PROVIDER", "openai-codex")
-    monkeypatch.setattr(server, "_restart_slash_worker", lambda session: None)
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda sid, session: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
 
     def fake_switch_model(**kwargs):
@@ -2170,7 +2170,7 @@ def test_session_compress_syncs_session_key_after_rotation(monkeypatch):
     monkeypatch.setattr(server, "_session_info", lambda _agent, *a: {"model": "x"})
     restart_calls = []
     monkeypatch.setattr(
-        server, "_restart_slash_worker", lambda s: restart_calls.append(s)
+        server, "_restart_slash_worker", lambda sid, s: restart_calls.append(s)
     )
 
     try:
@@ -5417,6 +5417,46 @@ def test_attach_worker_stores_worker_on_live_session():
         assert live["slash_worker"] is worker
     finally:
         server._sessions.pop("live", None)
+
+
+def test_restart_slash_worker_closes_orphan_when_session_reaped(monkeypatch):
+    """Post-turn restart of a session reaped mid-flight (e.g. close_on_disconnect
+    fired while `running` flipped false) must close the fresh worker, not orphan it."""
+    closed = []
+
+    class _FakeWorker:
+        def __init__(self, *a, **k):
+            pass
+
+        def close(self):
+            closed.append(True)
+
+    monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
+    server._sessions.pop("reaped", None)
+    reaped = {"session_key": "k"}  # not in _sessions -> torn down concurrently
+    server._restart_slash_worker("reaped", reaped)
+
+    assert closed == [True]
+    assert reaped.get("slash_worker") is None
+    assert "reaped" not in server._sessions
+
+
+def test_restart_slash_worker_stores_on_live_session(monkeypatch):
+    class _FakeWorker:
+        def __init__(self, *a, **k):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
+    live = {"session_key": "k", "slash_worker": None}
+    server._sessions["live-restart"] = live
+    try:
+        server._restart_slash_worker("live-restart", live)
+        assert isinstance(live["slash_worker"], _FakeWorker)
+    finally:
+        server._sessions.pop("live-restart", None)
 
 
 def test_session_close_rpc_delegates_to_close_session_by_id(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5481,3 +5481,67 @@ def test_shutdown_sessions_closes_every_session_via_helper(monkeypatch):
         assert {reason for _, reason in seen} == {"tui_shutdown"}
     finally:
         server._sessions.clear()
+
+
+def _idle_evictable_session(now):
+    """A session that satisfies every eviction precondition."""
+    ready = threading.Event()
+    ready.set()
+    old = now - 10 * 3600  # well past the 6h TTL
+    return {
+        "running": False,
+        "agent_ready": ready,
+        "transport": server._stdio_transport,  # dead/detached
+        "last_active": old,
+        "created_at": old,
+    }
+
+
+def test_session_is_evictable_when_idle_dead_and_quiescent(monkeypatch):
+    monkeypatch.setattr(server, "_session_pending_kind", lambda sid: "")
+    now = time.time()
+    assert server._session_is_evictable("s", _idle_evictable_session(now), now) is True
+
+
+def test_session_not_evictable_violating_each_exemption(monkeypatch):
+    monkeypatch.setattr(server, "_session_pending_kind", lambda sid: "")
+    now = time.time()
+    live_transport = type("T", (), {"_closed": False})()
+
+    running = _idle_evictable_session(now) | {"running": True}
+    assert server._session_is_evictable("s", running, now) is False
+
+    starting = _idle_evictable_session(now)
+    starting["agent_ready"] = threading.Event()  # not set -> still starting
+    assert server._session_is_evictable("s", starting, now) is False
+
+    on_socket = _idle_evictable_session(now) | {"transport": live_transport}
+    assert server._session_is_evictable("s", on_socket, now) is False
+
+    recent = _idle_evictable_session(now) | {"last_active": now}
+    assert server._session_is_evictable("s", recent, now) is False
+
+    young = _idle_evictable_session(now) | {"created_at": now}
+    assert server._session_is_evictable("s", young, now) is False
+
+    # Pending input request, even when everything else looks idle.
+    monkeypatch.setattr(server, "_session_pending_kind", lambda sid: "input")
+    assert server._session_is_evictable("s", _idle_evictable_session(now), now) is False
+
+
+def test_reap_idle_sessions_closes_only_evictable(monkeypatch):
+    closed = []
+    monkeypatch.setattr(server, "_session_pending_kind", lambda sid: "")
+    monkeypatch.setattr(
+        server, "_close_session_by_id",
+        lambda sid, *, end_reason: closed.append((sid, end_reason)),
+    )
+    now = time.time()
+    server._sessions.clear()
+    server._sessions["stale"] = _idle_evictable_session(now)
+    server._sessions["fresh"] = _idle_evictable_session(now) | {"last_active": now}
+    try:
+        server._reap_idle_sessions()
+        assert closed == [("stale", "idle_timeout")]
+    finally:
+        server._sessions.clear()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5357,3 +5357,63 @@ def test_slash_worker_close_reaps_zombie_and_closes_fds():
     assert calls["kill"] == 1
     assert calls["wait"] >= 2  # reaped after both terminate and kill
     assert calls["stdin"] == calls["stdout"] == calls["stderr"] == 1
+
+
+def test_close_session_by_id_is_idempotent_and_full(monkeypatch):
+    """One call tears the session down fully; a second is a no-op."""
+    calls = {"worker": 0, "agent": 0, "unreg": 0, "finalize": 0}
+
+    class W:
+        def close(self):
+            calls["worker"] += 1
+
+    class A:
+        def close(self):
+            calls["agent"] += 1
+
+    monkeypatch.setattr(
+        server, "_finalize_session",
+        lambda s, end_reason="tui_close": calls.__setitem__("finalize", calls["finalize"] + 1),
+    )
+    monkeypatch.setattr(
+        "tools.approval.unregister_gateway_notify",
+        lambda key: calls.__setitem__("unreg", calls["unreg"] + 1), raising=False,
+    )
+    server._sessions["sid-1"] = {"session_key": "k1", "agent": A(), "slash_worker": W()}
+
+    assert server._close_session_by_id("sid-1", end_reason="ws_disconnect") is True
+    assert server._close_session_by_id("sid-1", end_reason="ws_disconnect") is False
+    assert calls == {"worker": 1, "agent": 1, "unreg": 1, "finalize": 1}
+    assert "sid-1" not in server._sessions
+
+
+def test_attach_worker_closes_orphan_when_session_already_torn_down():
+    """A worker built after its session was reaped must be closed, not orphaned."""
+    closed = []
+
+    class W:
+        def close(self):
+            closed.append(True)
+
+    server._sessions.pop("gone", None)
+    detached = {"session_key": "k"}  # not in _sessions -> already torn down
+    server._attach_worker("gone", detached, W())
+
+    assert closed == [True]
+    assert "slash_worker" not in detached
+    assert "gone" not in server._sessions
+
+
+def test_attach_worker_stores_worker_on_live_session():
+    class W:
+        def close(self):
+            raise AssertionError("must not close a worker for a live session")
+
+    live = {"session_key": "k"}
+    server._sessions["live"] = live
+    worker = W()
+    try:
+        server._attach_worker("live", live, worker)
+        assert live["slash_worker"] is worker
+    finally:
+        server._sessions.pop("live", None)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5432,6 +5432,40 @@ def test_session_close_rpc_delegates_to_close_session_by_id(monkeypatch):
     assert seen == [("s9", "tui_close")]
 
 
+def test_close_sessions_for_transport_closes_flagged_repoints_rest(monkeypatch):
+    seen = []
+    monkeypatch.setattr(
+        server, "_close_session_by_id",
+        lambda sid, *, end_reason: bool(seen.append((sid, end_reason))) or True,
+    )
+    transport = object()  # the disconnecting transport
+    server._sessions.clear()
+    server._sessions["a"] = {"transport": transport, "close_on_disconnect": True}
+    server._sessions["b"] = {"transport": transport, "close_on_disconnect": False}
+    try:
+        server._close_sessions_for_transport(transport, end_reason="ws_disconnect")
+        assert seen == [("a", "ws_disconnect")]  # only the flagged one closed
+        assert server._sessions["b"]["transport"] is server._stdio_transport  # re-pointed
+    finally:
+        server._sessions.clear()
+
+
+def test_session_create_records_close_on_disconnect_flag(monkeypatch):
+    monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
+    server._sessions.clear()
+    try:
+        on = server.handle_request(
+            {"id": "1", "method": "session.create", "params": {"close_on_disconnect": True}}
+        )["result"]["session_id"]
+        off = server.handle_request(
+            {"id": "2", "method": "session.create", "params": {}}
+        )["result"]["session_id"]
+        assert server._sessions[on]["close_on_disconnect"]
+        assert not server._sessions[off]["close_on_disconnect"]
+    finally:
+        server._sessions.clear()
+
+
 def test_shutdown_sessions_closes_every_session_via_helper(monkeypatch):
     seen = []
     monkeypatch.setattr(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 import sys
 import threading
 import time
@@ -5317,3 +5318,42 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
         assert requeued["session_id"] == "proc_busy_test"
     finally:
         server._sessions.pop("sid_busy", None)
+
+
+def test_slash_worker_close_reaps_zombie_and_closes_fds():
+    """A hung worker is SIGKILLed, the zombie reaped, all pipes closed — once."""
+    calls = {k: 0 for k in ("terminate", "kill", "wait", "stdin", "stdout", "stderr")}
+
+    class FakeStream:
+        def __init__(self, name):
+            self.name = name
+
+        def close(self):
+            calls[self.name] += 1
+
+    class FakeProc:
+        stdin, stdout, stderr = (FakeStream(n) for n in ("stdin", "stdout", "stderr"))
+
+        def poll(self):
+            return None  # always alive -> forces terminate then kill
+
+        def terminate(self):
+            calls["terminate"] += 1
+
+        def kill(self):
+            calls["kill"] += 1
+
+        def wait(self, timeout=None):
+            calls["wait"] += 1
+            raise subprocess.TimeoutExpired(cmd="x", timeout=timeout)
+
+    worker = object.__new__(server._SlashWorker)
+    worker.proc = FakeProc()
+
+    worker.close()
+    worker.close()  # idempotent
+
+    assert calls["terminate"] == 1
+    assert calls["kill"] == 1
+    assert calls["wait"] >= 2  # reaped after both terminate and kill
+    assert calls["stdin"] == calls["stdout"] == calls["stderr"] == 1

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5417,3 +5417,33 @@ def test_attach_worker_stores_worker_on_live_session():
         assert live["slash_worker"] is worker
     finally:
         server._sessions.pop("live", None)
+
+
+def test_session_close_rpc_delegates_to_close_session_by_id(monkeypatch):
+    seen = []
+    monkeypatch.setattr(
+        server, "_close_session_by_id",
+        lambda sid, *, end_reason: bool(seen.append((sid, end_reason))) or True,
+    )
+    resp = server.handle_request(
+        {"id": "1", "method": "session.close", "params": {"session_id": "s9"}}
+    )
+    assert resp["result"] == {"closed": True}
+    assert seen == [("s9", "tui_close")]
+
+
+def test_shutdown_sessions_closes_every_session_via_helper(monkeypatch):
+    seen = []
+    monkeypatch.setattr(
+        server, "_close_session_by_id",
+        lambda sid, *, end_reason: seen.append((sid, end_reason)),
+    )
+    server._sessions.clear()
+    server._sessions["a"] = {}
+    server._sessions["b"] = {}
+    try:
+        server._shutdown_sessions()
+        assert sorted(sid for sid, _ in seen) == ["a", "b"]
+        assert {reason for _, reason in seen} == {"tui_shutdown"}
+    finally:
+        server._sessions.clear()

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -1,0 +1,73 @@
+import asyncio
+
+from tui_gateway import server
+from tui_gateway import ws as ws_mod
+
+
+def _run_disconnect(monkeypatch, seed):
+    """Drive handle_ws to its disconnect `finally`, seeding sessions against the
+    live WSTransport the moment it exists. Returns nothing; inspect _sessions."""
+    monkeypatch.setattr(server, "_finalize_session", lambda s, end_reason="tui_close": None)
+
+    created = []
+    real_transport = ws_mod.WSTransport
+    monkeypatch.setattr(
+        ws_mod, "WSTransport",
+        lambda ws, loop, **kw: created.append(real_transport(ws, loop, **kw)) or created[-1],
+    )
+
+    class FakeWS:
+        async def accept(self):
+            pass
+
+        async def send_text(self, line):
+            pass
+
+        async def receive_text(self):
+            seed(created[0])  # transport now exists; attach it to sessions
+            raise ws_mod._WebSocketDisconnect()
+
+        async def close(self):
+            pass
+
+    asyncio.run(ws_mod.handle_ws(FakeWS()))
+
+
+def test_ws_disconnect_reaps_flagged_session_and_closes_worker(monkeypatch):
+    closed = []
+
+    class FakeWorker:
+        def close(self):
+            closed.append(True)
+
+    server._sessions.clear()
+    try:
+        _run_disconnect(
+            monkeypatch,
+            lambda t: server._sessions.update(
+                flagged={
+                    "transport": t,
+                    "close_on_disconnect": True,
+                    "slash_worker": FakeWorker(),
+                    "session_key": "k",
+                }
+            ),
+        )
+        assert "flagged" not in server._sessions
+        assert closed == [True]
+    finally:
+        server._sessions.clear()
+
+
+def test_ws_disconnect_preserves_and_repoints_reconnectable_session(monkeypatch):
+    server._sessions.clear()
+    try:
+        _run_disconnect(
+            monkeypatch,
+            lambda t: server._sessions.update(
+                plain={"transport": t, "close_on_disconnect": False, "session_key": "k"}
+            ),
+        )
+        assert server._sessions["plain"]["transport"] is server._stdio_transport
+    finally:
+        server._sessions.clear()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1,0 +1,16 @@
+import uvicorn
+
+from hermes_cli import web_server
+
+
+def test_start_server_enables_ws_ping_for_half_open_detection(monkeypatch):
+    """WS ping must be configured so half-open connections (reverse-proxy 524,
+    dropped tunnels) raise WebSocketDisconnect into the reaping path (#32377)."""
+    captured = {}
+    monkeypatch.setattr(uvicorn, "run", lambda *args, **kwargs: captured.update(kwargs))
+
+    # Loopback bind => no auth gate, so this reaches uvicorn.run without setup.
+    web_server.start_server(host="127.0.0.1", port=0, open_browser=False)
+
+    assert captured["ws_ping_interval"] == 20.0
+    assert captured["ws_ping_timeout"] == 20.0

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -117,6 +117,10 @@ except Exception:
 from tui_gateway.render import make_stream_renderer, render_diff, render_message
 
 _sessions: dict[str, dict] = {}
+# Serializes session teardown (pop) against worker attachment so a worker built
+# after its session was reaped can't be orphaned. Reentrant: _close_session_by_id
+# may run under callers that already hold it.
+_sessions_lock = threading.RLock()
 _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
 _pending_prompt_payloads: dict[str, tuple[str, dict]] = {}
@@ -340,6 +344,45 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
                 db.end_session(session_id, end_reason)
         except Exception:
             pass
+
+
+def _attach_worker(sid: str, session: dict, worker) -> None:
+    """Store worker on session iff sid still maps to it, else close it — a
+    concurrent teardown already popped the session and would orphan the worker."""
+    with _sessions_lock:
+        if _sessions.get(sid) is session:
+            session["slash_worker"] = worker
+            return
+    worker.close()
+
+
+def _close_session_by_id(sid: str, *, end_reason: str = "tui_close") -> bool:
+    """Single idempotent teardown for one session: pop, finalize, unregister
+    notify, close agent + slash worker. True iff it closed a live session."""
+    with _sessions_lock:
+        session = _sessions.pop(sid, None)
+    if session is None:
+        return False
+    _finalize_session(session, end_reason=end_reason)
+    try:
+        from tools.approval import unregister_gateway_notify
+
+        if key := session.get("session_key"):
+            unregister_gateway_notify(key)
+    except Exception:
+        pass
+    try:
+        agent = session.get("agent")
+        if agent is not None and hasattr(agent, "close"):
+            agent.close()
+    except Exception:
+        pass
+    try:
+        if worker := session.get("slash_worker"):
+            worker.close()
+    except Exception:
+        pass
+    return True
 
 
 def _shutdown_sessions() -> None:
@@ -584,7 +627,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
 
             try:
                 worker = _SlashWorker(key, getattr(agent, "model", _resolve_model()))
-                current["slash_worker"] = worker
+                _attach_worker(sid, current, worker)
             except Exception:
                 pass
 
@@ -616,19 +659,16 @@ def _start_agent_build(sid: str, session: dict) -> None:
             current["agent_error"] = str(e)
             _emit("error", sid, {"message": f"agent init failed: {e}"})
         finally:
-            if _sessions.get(sid) is not current:
-                if worker is not None:
-                    try:
-                        worker.close()
-                    except Exception:
-                        pass
-                if notify_registered:
-                    try:
-                        from tools.approval import unregister_gateway_notify
+            # _attach_worker already closed the worker if this session was
+            # reaped mid-build; only the late notify registration can still
+            # leak (session.close unregistered before _build registered it).
+            if notify_registered and _sessions.get(sid) is not current:
+                try:
+                    from tools.approval import unregister_gateway_notify
 
-                        unregister_gateway_notify(key)
-                    except Exception:
-                        pass
+                    unregister_gateway_notify(key)
+                except Exception:
+                    pass
             ready.set()
 
     threading.Thread(target=_build, daemon=True).start()
@@ -2373,8 +2413,8 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
                 logger.debug("failed to persist resumed session cwd", exc_info=True)
     _register_session_cwd(_sessions[sid])
     try:
-        _sessions[sid]["slash_worker"] = _SlashWorker(
-            key, getattr(agent, "model", _resolve_model())
+        _attach_worker(
+            sid, _sessions[sid], _SlashWorker(key, getattr(agent, "model", _resolve_model()))
         )
     except Exception:
         # Defer hard-failure to slash.exec; chat still works without slash worker.
@@ -6820,7 +6860,7 @@ def _(rid, params: dict) -> dict:
                 session["session_key"],
                 getattr(session.get("agent"), "model", _resolve_model()),
             )
-            session["slash_worker"] = worker
+            _attach_worker(params.get("session_id", ""), session, worker)
         except Exception as e:
             return _err(rid, 5030, f"slash worker start failed: {e}")
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -411,7 +411,54 @@ def _shutdown_sessions() -> None:
         _close_session_by_id(sid, end_reason="tui_shutdown")
 
 
+# Last-resort net for any disconnect path that slips past the WS finally. TTL is
+# hours-scale because last_active freezes during a long turn and on passive
+# viewing — running/pending/starting/live-transport are hard exemptions instead.
+_SESSION_TTL_S = float(os.environ.get("HERMES_TUI_SESSION_TTL_S", 6 * 3600))
+_REAPER_SCAN_S = 300.0
+
+
+def _transport_is_dead(transport) -> bool:
+    if transport is _stdio_transport:
+        return True
+    return getattr(transport, "_closed", None) is True
+
+
+def _session_is_evictable(sid: str, session: dict, now: float) -> bool:
+    if session.get("running") or _session_pending_kind(sid):
+        return False
+    ready = session.get("agent_ready")
+    if ready is not None and not ready.is_set():  # still starting
+        return False
+    if not _transport_is_dead(session.get("transport")):
+        return False
+    last_active = float(session.get("last_active") or 0.0)
+    created_at = float(session.get("created_at") or 0.0)
+    return (now - last_active) > _SESSION_TTL_S and (now - created_at) > _SESSION_TTL_S
+
+
+def _reap_idle_sessions() -> None:
+    now = time.time()
+    with _sessions_lock:
+        victims = [sid for sid, s in _sessions.items() if _session_is_evictable(sid, s, now)]
+    for sid in victims:
+        _close_session_by_id(sid, end_reason="idle_timeout")
+
+
+def _start_idle_reaper() -> None:
+    def _loop():
+        while True:
+            time.sleep(_REAPER_SCAN_S)
+            try:
+                _reap_idle_sessions()
+            except Exception:
+                pass
+
+    threading.Thread(target=_loop, daemon=True).start()
+
+
 atexit.register(_shutdown_sessions)
+_start_idle_reaper()
 
 
 # ── Plumbing ──────────────────────────────────────────────────────────

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -385,16 +385,25 @@ def _close_session_by_id(sid: str, *, end_reason: str = "tui_close") -> bool:
     return True
 
 
-def _close_sessions_for_transport(transport, *, end_reason: str = "ws_disconnect") -> None:
+def _close_sessions_for_transport(
+    transport, *, end_reason: str = "ws_disconnect"
+) -> tuple[int, int]:
     """On transport disconnect, reap the sessions that opted into close_on_disconnect
-    (sidecar) and re-point the rest back to stdio so later emits don't hit a dead socket."""
+    (sidecar) and re-point the rest back to stdio so later emits don't hit a dead socket.
+
+    Returns ``(reaped, detached)`` counts for disconnect-path observability."""
     with _sessions_lock:
         owned = [(sid, s) for sid, s in _sessions.items() if s.get("transport") is transport]
+    reaped = 0
+    detached = 0
     for sid, session in owned:
         if session.get("close_on_disconnect"):
             _close_session_by_id(sid, end_reason=end_reason)
+            reaped += 1
         else:
             session["transport"] = _stdio_transport
+            detached += 1
+    return reaped, detached
 
 
 def _shutdown_sessions() -> None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1274,7 +1274,7 @@ def _tool_progress_enabled(sid: str) -> bool:
     return _session_tool_progress_mode(sid) != "off"
 
 
-def _restart_slash_worker(session: dict):
+def _restart_slash_worker(sid: str, session: dict):
     worker = session.get("slash_worker")
     if worker:
         try:
@@ -1282,12 +1282,18 @@ def _restart_slash_worker(session: dict):
         except Exception:
             pass
     try:
-        session["slash_worker"] = _SlashWorker(
+        new_worker = _SlashWorker(
             session["session_key"],
             getattr(session.get("agent"), "model", _resolve_model()),
         )
     except Exception:
         session["slash_worker"] = None
+        return
+    # Route through the same store-iff-still-mapped guard as the spawn sites:
+    # the post-turn restart runs as `running` flips false, exactly when a
+    # close_on_disconnect reap can pop this session — a bare store would orphan
+    # the fresh worker (it self-heals only on gateway exit via the watchdog).
+    _attach_worker(sid, session, new_worker)
 
 
 def _persist_model_switch(result) -> None:
@@ -1373,7 +1379,7 @@ def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:
             base_url=result.base_url,
             api_mode=result.api_mode,
         )
-        _restart_slash_worker(session)
+        _restart_slash_worker(sid, session)
         _emit("session.info", sid, _session_info(agent, session))
 
     os.environ["HERMES_MODEL"] = result.new_model
@@ -1520,7 +1526,7 @@ def _sync_session_key_after_compress(
         session["pending_title"] = None
     if restart_slash_worker:
         try:
-            _restart_slash_worker(session)
+            _restart_slash_worker(sid, session)
         except Exception:
             pass
 
@@ -2364,7 +2370,7 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
         session["history_version"] = int(session.get("history_version", 0)) + 1
     info = _session_info(new_agent, session)
     _emit("session.info", sid, info)
-    _restart_slash_worker(session)
+    _restart_slash_worker(sid, session)
     return info
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -385,6 +385,18 @@ def _close_session_by_id(sid: str, *, end_reason: str = "tui_close") -> bool:
     return True
 
 
+def _close_sessions_for_transport(transport, *, end_reason: str = "ws_disconnect") -> None:
+    """On transport disconnect, reap the sessions that opted into close_on_disconnect
+    (sidecar) and re-point the rest back to stdio so later emits don't hit a dead socket."""
+    with _sessions_lock:
+        owned = [(sid, s) for sid, s in _sessions.items() if s.get("transport") is transport]
+    for sid, session in owned:
+        if session.get("close_on_disconnect"):
+            _close_session_by_id(sid, end_reason=end_reason)
+        else:
+            session["transport"] = _stdio_transport
+
+
 def _shutdown_sessions() -> None:
     for sid in list(_sessions):
         _close_session_by_id(sid, end_reason="tui_shutdown")
@@ -2783,6 +2795,7 @@ def _(rid, params: dict) -> dict:
         "agent_error": None,
         "agent_ready": ready,
         "attached_images": [],
+        "close_on_disconnect": is_truthy_value(params.get("close_on_disconnect", False)),
         "cols": cols,
         "created_at": now,
         "edit_snapshots": {},

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -201,6 +201,7 @@ class _SlashWorker:
         if model:
             argv += ["--model", model]
 
+        self._closed = False
         self.proc = subprocess.Popen(
             argv,
             stdin=subprocess.PIPE,
@@ -255,15 +256,33 @@ class _SlashWorker:
             )
 
     def close(self):
+        if getattr(self, "_closed", False):
+            return
+        self._closed = True
+        proc = self.proc
         try:
-            if self.proc.poll() is None:
-                self.proc.terminate()
-                self.proc.wait(timeout=1)
+            if proc.poll() is None:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=1)
+                except Exception:
+                    proc.kill()
+                    try:
+                        proc.wait(timeout=1)  # reap the zombie SIGKILL leaves behind
+                    except Exception:
+                        pass
         except Exception:
             try:
-                self.proc.kill()
+                proc.kill()
+                proc.wait(timeout=1)
             except Exception:
                 pass
+        finally:
+            for stream in (proc.stdin, proc.stdout, proc.stderr):
+                try:
+                    stream.close()
+                except Exception:
+                    pass
 
 
 def _load_busy_input_mode() -> str:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -386,14 +386,8 @@ def _close_session_by_id(sid: str, *, end_reason: str = "tui_close") -> bool:
 
 
 def _shutdown_sessions() -> None:
-    for session in list(_sessions.values()):
-        _finalize_session(session, end_reason="tui_shutdown")
-        try:
-            worker = session.get("slash_worker")
-            if worker:
-                worker.close()
-        except Exception:
-            pass
+    for sid in list(_sessions):
+        _close_session_by_id(sid, end_reason="tui_shutdown")
 
 
 atexit.register(_shutdown_sessions)
@@ -3500,29 +3494,7 @@ def _(rid, params: dict) -> dict:
 @method("session.close")
 def _(rid, params: dict) -> dict:
     sid = params.get("session_id", "")
-    session = _sessions.pop(sid, None)
-    if not session:
-        return _ok(rid, {"closed": False})
-    _finalize_session(session)
-    try:
-        from tools.approval import unregister_gateway_notify
-
-        unregister_gateway_notify(session["session_key"])
-    except Exception:
-        pass
-    try:
-        agent = session.get("agent")
-        if agent and hasattr(agent, "close"):
-            agent.close()
-    except Exception:
-        pass
-    try:
-        worker = session.get("slash_worker")
-        if worker:
-            worker.close()
-    except Exception:
-        pass
-    return _ok(rid, {"closed": True})
+    return _ok(rid, {"closed": _close_session_by_id(sid, end_reason="tui_close")})
 
 
 @method("session.branch")

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -9,10 +9,45 @@ import io
 import json
 import os
 import sys
+import threading
+import time
+
+import psutil
 
 import cli as cli_mod
 from cli import HermesCLI
 from rich.console import Console
+
+# Env-overridable so the integration test can drive sub-second timing.
+_WATCHDOG_POLL_S = float(os.environ.get("HERMES_SLASH_WATCHDOG_POLL_S", 2.0))
+_ORPHAN_GRACE_S = float(os.environ.get("HERMES_SLASH_WATCHDOG_GRACE_S", 5.0))
+_in_flight = threading.Event()  # set while a command is executing
+
+
+def _is_orphaned(original_ppid, parent_create_time, getppid=os.getppid) -> bool:
+    """True once our spawning gateway is gone. Compare to the ORIGINAL ppid
+    (never ==1: Linux reparents to a subreaper) and guard PID reuse via
+    create_time."""
+    if getppid() != original_ppid:
+        return True
+    try:
+        if not psutil.pid_exists(original_ppid):
+            return True
+        return psutil.Process(original_ppid).create_time() != parent_create_time
+    except psutil.Error:
+        return True
+
+
+def _start_parent_death_watchdog(original_ppid, parent_create_time) -> None:
+    def _loop():
+        while not _is_orphaned(original_ppid, parent_create_time):
+            time.sleep(_WATCHDOG_POLL_S)
+        deadline = time.monotonic() + _ORPHAN_GRACE_S
+        while _in_flight.is_set() and time.monotonic() < deadline:
+            time.sleep(0.05)  # let an in-flight command finish/flush
+        os._exit(0)
+
+    threading.Thread(target=_loop, daemon=True).start()
 
 
 def _run(cli: HermesCLI, command: str) -> str:
@@ -52,6 +87,15 @@ def main():
     os.environ["HERMES_SESSION_KEY"] = args.session_key
     os.environ["HERMES_INTERACTIVE"] = "1"
 
+    # Start before the (hundreds-of-ms) HermesCLI build — that window is itself
+    # an orphan risk if the gateway dies mid-spawn.
+    orig_ppid = os.getppid()
+    try:
+        parent_create_time = psutil.Process(orig_ppid).create_time()
+    except psutil.Error:
+        parent_create_time = 0.0
+    _start_parent_death_watchdog(orig_ppid, parent_create_time)
+
     with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
         cli = HermesCLI(model=args.model or None, compact=True, resume=args.session_key, verbose=False)
 
@@ -60,6 +104,7 @@ def main():
         if not line:
             continue
 
+        _in_flight.set()
         rid = None
         try:
             req = json.loads(line)
@@ -70,6 +115,8 @@ def main():
         except Exception as e:
             sys.stdout.write(json.dumps({"id": rid, "ok": False, "error": str(e)}) + "\n")
             sys.stdout.flush()
+        finally:
+            _in_flight.clear()
 
 
 if __name__ == "__main__":

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -255,28 +255,33 @@ async def handle_ws(ws: Any) -> None:
                 )
                 break
     finally:
+        reaped_sessions = 0
         detached_sessions = 0
         if transport is not None:
             transport.close()
 
-            # Detach the transport from any sessions it owned so later emits
-            # fall back to stdio instead of crashing into a closed socket.
-            for _, sess in list(server._sessions.items()):
-                if sess.get("transport") is transport:
-                    sess["transport"] = server._stdio_transport
-                    detached_sessions += 1
+            # Reap sessions this transport owned (close_on_disconnect) or detach
+            # the rest back to stdio so later emits don't crash into a closed
+            # socket. Offloaded: _close_session_by_id does a blocking
+            # worker.close() (terminate + waits) plus a synchronous DB write —
+            # inline that would freeze the uvicorn event loop for every other
+            # live connection.
+            reaped_sessions, detached_sessions = await asyncio.to_thread(
+                server._close_sessions_for_transport, transport, end_reason="ws_disconnect"
+            )
         try:
             await ws.close()
         except Exception as exc:
             _log.debug("ws close failed peer=%s error=%s", peer, exc)
         _log.info(
             "ws closed peer=%s reason=%s messages=%d parse_errors=%d "
-            "dispatch_crashes=%d send_failures=%d detached_sessions=%d",
+            "dispatch_crashes=%d send_failures=%d reaped_sessions=%d detached_sessions=%d",
             peer,
             disconnect_reason,
             messages,
             parse_errors,
             dispatch_crashes,
             send_failures,
+            reaped_sessions,
             detached_sessions,
         )

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -120,7 +120,11 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
         if (cancelled) {
           return;
         }
-        return gw.request<{ session_id: string }>("session.create", {});
+        // close_on_disconnect: the gateway reaps this sidecar session (and its
+        // slash_worker subprocess) when the WS drops, instead of leaking it.
+        return gw.request<{ session_id: string }>("session.create", {
+          close_on_disconnect: true,
+        });
       })
       .then((created) => {
         if (cancelled || !created?.session_id) {


### PR DESCRIPTION
Dashboard chat sessions leaked `tui_gateway.slash_worker` subprocesses — plus their pipe fds and PTY master fds — whenever a session disconnected, was abandoned, or its parent gateway died. This PR adds a teardown mechanism for each of the **three independent producers** (one narrow C3 residual disclosed under Known limitations); it is the leak *cause* (close + reap). The launchd fd-ceiling raise + self-heal ships separately in the sibling PR `fix/gateway-fd-limit-hardening` (`Refs #24775`).

### Problem

Leaked workers accumulate without bound and drag the host down. Observed: 128 stale workers swap-pinning a 7.8 GB box (#21467); fd exhaustion on macOS launchd (#24775); a per-turn handler leak (#21370); a dashboard hang from PTY-disconnect leaks behind a reverse proxy returning 524 (#32377); general lifecycle-gap fragility under intensive use (#22855). There are three distinct producers, and fixing any one alone leaves the leak in place.

### Root cause → mechanism → file → commit

| Cause | What leaked | Previous behavior | Fix | File | Commit |
|---|---|---|---|---|---|
| **C1 — disconnect never reaped** (keystone) | session + its worker | `ws.py` `finally` only re-pointed the transport back to stdio; the session (and worker) lived on | `_close_sessions_for_transport` reaps `close_on_disconnect` sessions / re-points the rest, dispatched via `asyncio.to_thread` (the teardown does a blocking `worker.close()` + sync DB write — inline would stall the uvicorn loop for every other live connection); funnels through one idempotent `_close_session_by_id` | `ws.py`, `server.py` | `0431e38eb` `6ce86df30` `8912e62b3` `b01b054d0` |
| **C2 — create/close orphan race** | a worker built *after* its session was reaped | spawn sites stored the worker unconditionally; a concurrent teardown left it orphaned | `_attach_worker` stores the worker iff `_sessions.get(sid) is session` (identity) under `_sessions_lock`, else closes it — applied at **all 4** spawn sites incl. the post-turn `_restart_slash_worker` | `server.py` | `8912e62b3` `05007e68e` |
| **C3 — parent death** (crash / SIGKILL / auto-update; `atexit` never runs) | worker, orphaned PTY grandchildren, PTY master fd | nothing detected a dead parent; `close()` signalled only the PTY leader; master fd was dropped without `force` | (i) psutil parent-death watchdog (compares to original `getppid()` + `create_time` PID-reuse guard, drains in-flight then `os._exit(0)`); (ii) PTY group-kill via `os.killpg` on the child's `setsid` group (guarded `!= os.getpgrp()` so it never signals the gateway's own group) + `proc.close(force=True)` to close the master fd; (iii) idempotent `_SlashWorker.close()` (`_closed` flag + post-SIGKILL zombie reap + stdio close) | `slash_worker.py`, `pty_bridge.py`, `server.py` | `dc0add6ff` `e637c7b41` `9339e47a4` |

Two supporting changes (detectors / defense-in-depth, not root causes):
- **uvicorn `ws_ping_interval/ws_ping_timeout = 20s`** — server-initiated pings turn a half-open socket (reverse-proxy 524, dropped tunnel) into a `WebSocketDisconnect` within ~20–40 s (one ping interval + one timeout), so the C1 disconnect path can run instead of the socket lingering silently. `web_server.py` (`8d36d42fd`).
- **Idle-session reaper** — a daemon thread that evicts only sessions failing *every* liveness check (not running, no pending kind, agent ready, transport dead, both `last_active` and `created_at` older than a 6 h TTL). A last-resort backstop for any disconnect that slips past the WS `finally`. `server.py` (`d2b4f7b50`; see Known limitations).

### Cross-cutting note

All teardown paths — `session.close` RPC, `atexit` shutdown, WS disconnect, idle eviction — now funnel through the single idempotent `_close_session_by_id`. Idempotency (via `_finalized` on the session and `_closed` on the worker) is the explicit safety contract: concurrent/double teardown is a no-op, never a double-kill.

### Resolves

- `Fixes #21370` — the worker is per-session (reused across turns, not respawned per turn); the leak was that the session + worker were never reaped on disconnect (C1), and the post-turn `_restart_slash_worker` could orphan its replacement worker (C2). Both are now closed.
- `Fixes #21467` — worker accumulation / swap-pinning: the same reap path bounds steady-state count; the idle reaper backstops it.
- `Fixes #24775` — fd exhaustion. **PR1 fixes the leak *cause*** (PTY master-fd close + zombie reap + session/worker teardown). The launchd fd-*cap* raise is mitigation and ships in the sibling PR (`Refs #24775`).
- `Fixes #32377` — PTY chat disconnect / 524 behind reverse proxy: `ws_ping` detects the half-open socket → C1 reap → PTY group-kill reaps the grandchildren.
- `Addresses #22855` — lifecycle gaps / fragility: the watchdog + C1 reap + C2 guard cover the common-case gaps. This PR does not add the `tools.process_registry` registration the issue proposed, so global teardown still can't enumerate live workers, and the startup-window race noted below remains; hence `Addresses` rather than `Fixes`.
- `Supersedes #21401` — builds on its disconnect-close approach (same files: `ws.py`, `server.py`, `ChatSidebar.tsx`), adding off-loop teardown (`asyncio.to_thread`) and the `_attach_worker` create-race guard.
- `Supersedes #32483` — carries forward its PTY process-group reaping and adds idempotent `close()`. For parent-death detection it uses a cross-platform psutil watchdog (`create_time`-based, PID-reuse-safe) in place of #32483's Linux-only `PR_SET_PDEATHSIG`; the trade is slightly higher detection latency on Linux in exchange for covering macOS, the platform in these reports.

### Known limitations

- **Watchdog startup-window race:** if the gateway dies during the worker's pre-`getppid()` import window, the worker anchors to init and never self-terminates. Narrow; unreached by the registry (see #22855). Principled fix (deferred): pass the gateway PID to the worker at spawn instead of relying on `getppid()`. The other two C3 mechanisms (PTY group-kill, idempotent close) are unaffected.
- **Idle reaper evicts long-idle local stdio sessions:** `_transport_is_dead` treats the stdio transport as always-dead, so a *local* stdio session idle > 6 h (not running, no pending) will be reclaimed. Bounded (local-only, 6 h TTL, multiple exemptions); accepted for now.
- The PDEATHSIG → psutil swap above is a behavioral characteristic (Linux detection latency), not a regression.

### Tests

Each commit ships its own tests (unit + a live parent-death integration test under `-m integration`).

### Reviewer guidance

Hot spots worth the closest look: the off-loop `asyncio.to_thread` teardown (no event-loop reentrancy; DB write off the loop thread); `_attach_worker`'s `is` identity check (not `==`) covering the restart site; the `os.killpg` `!= os.getpgrp()` self-group guard; the watchdog's in-flight drain before `os._exit(0)`. Sibling: `fix/gateway-fd-limit-hardening` raises the macOS launchd fd ceiling (`Refs #24775`).

