### PR TITLE
fix(gateway): raise macOS launchd fd ceiling (8192/16384) + self-heal existing installs

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3516,6 +3516,15 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
             refresh_systemd_unit_if_needed(system=False)
         except Exception:
             pass  # best-effort; don't block gateway startup
+    elif is_macos():
+        # Same rationale for launchd: an exit-75/`/restart` respawn skips
+        # `hermes gateway restart`, so without this the fd-limit bump (and any
+        # future plist change) wouldn't reach existing installs until a manual
+        # restart or `hermes update`.
+        try:
+            refresh_launchd_plist_if_needed()
+        except Exception:
+            pass  # best-effort; don't block gateway startup
 
     from gateway.run import start_gateway
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3126,12 +3126,19 @@ def launchd_plist_is_current() -> bool:
     ) == _normalize_launchd_plist_for_comparison(expected)
 
 
-def refresh_launchd_plist_if_needed() -> bool:
+def refresh_launchd_plist_if_needed(restart: bool = True) -> bool:
     """Rewrite the installed launchd plist when the generated definition has changed.
 
     Unlike systemd, launchd picks up plist changes on the next ``launchctl kill``/
     ``launchctl kickstart`` cycle — no daemon-reload is needed. We still bootout/
     bootstrap to make launchd re-read the updated plist immediately.
+
+    ``restart=False`` is for callers running *inside* the supervised gateway
+    process (``run_gateway``): a ``bootout`` there would SIGTERM this very process
+    mid-startup, and if it died before the ``bootstrap`` line ran the job would be
+    left unloaded. So we mirror systemd's ``daemon-reload`` semantics — refresh the
+    on-disk definition and let the next restart (reboot, ``hermes update``, manual
+    ``hermes gateway restart``) apply it — instead of self-terminating.
     """
     plist_path = get_launchd_plist_path()
     if not plist_path.exists() or launchd_plist_is_current():
@@ -3139,6 +3146,9 @@ def refresh_launchd_plist_if_needed() -> bool:
 
     plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     label = get_launchd_label()
+    if not restart:
+        print("↻ Updated gateway launchd plist on disk; new limits apply on next restart")
+        return True
     # Bootout/bootstrap so launchd picks up the new definition
     subprocess.run(
         ["launchctl", "bootout", f"{_launchd_domain()}/{label}"],
@@ -3520,9 +3530,11 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
         # Same rationale for launchd: an exit-75/`/restart` respawn skips
         # `hermes gateway restart`, so without this the fd-limit bump (and any
         # future plist change) wouldn't reach existing installs until a manual
-        # restart or `hermes update`.
+        # restart or `hermes update`. restart=False: we are the supervised
+        # process — refresh the plist on disk (systemd-parity) but don't
+        # bootout/bootstrap ourselves mid-startup.
         try:
-            refresh_launchd_plist_if_needed()
+            refresh_launchd_plist_if_needed(restart=False)
         except Exception:
             pass  # best-effort; don't block gateway startup
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3090,7 +3090,19 @@ def generate_launchd_plist() -> str:
         <key>SuccessfulExit</key>
         <false/>
     </dict>
-    
+
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>8192</integer>
+    </dict>
+
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>16384</integer>
+    </dict>
+
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
     

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,5 +1,7 @@
 import re
 
+import pytest
+
 from hermes_cli import gateway
 
 
@@ -29,3 +31,22 @@ def test_launchd_plist_without_fd_limits_reads_as_stale(tmp_path, monkeypatch):
     assert old != current
     plist_path.write_text(old, encoding="utf-8")
     assert gateway.launchd_plist_is_current() is False
+
+
+def test_run_gateway_self_heals_launchd_plist_on_macos(monkeypatch):
+    """A code update that ships new plist settings (e.g. the fd-limit bump) must
+    reach macOS on the next boot, not only on an explicit `hermes update`."""
+    monkeypatch.setattr(gateway, "is_macos", lambda: True)
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "_guard_official_docker_root_gateway", lambda: None)
+    healed = []
+    monkeypatch.setattr(gateway, "refresh_launchd_plist_if_needed", lambda: healed.append(True))
+
+    class _Halt(Exception):
+        pass
+
+    monkeypatch.setattr("gateway.run.start_gateway", lambda *a, **k: (_ for _ in ()).throw(_Halt()))
+
+    with pytest.raises(_Halt):
+        gateway.run_gateway()
+    assert healed == [True]

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -40,7 +40,9 @@ def test_run_gateway_self_heals_launchd_plist_on_macos(monkeypatch):
     monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
     monkeypatch.setattr(gateway, "_guard_official_docker_root_gateway", lambda: None)
     healed = []
-    monkeypatch.setattr(gateway, "refresh_launchd_plist_if_needed", lambda: healed.append(True))
+    monkeypatch.setattr(
+        gateway, "refresh_launchd_plist_if_needed", lambda restart=True: healed.append(restart)
+    )
 
     class _Halt(Exception):
         pass
@@ -49,4 +51,56 @@ def test_run_gateway_self_heals_launchd_plist_on_macos(monkeypatch):
 
     with pytest.raises(_Halt):
         gateway.run_gateway()
-    assert healed == [True]
+    # restart=False: in-process self-heal must refresh the plist on disk but
+    # must NOT bootout/bootstrap the gateway it is currently running inside.
+    assert healed == [False]
+
+
+def _stale_plist(tmp_path, monkeypatch):
+    """Install a current plist, then downgrade it to a pre-fd-limit (stale) one."""
+    plist_path = tmp_path / "ai.hermes.gateway.plist"
+    monkeypatch.setattr(gateway, "get_launchd_plist_path", lambda: plist_path)
+    current = gateway.generate_launchd_plist()
+    old = re.sub(
+        r"\s*<key>(Soft|Hard)ResourceLimits</key>\s*<dict>.*?</dict>", "", current, flags=re.S
+    )
+    assert old != current
+    plist_path.write_text(old, encoding="utf-8")
+    return plist_path, current
+
+
+def test_refresh_launchd_no_restart_rewrites_without_bootout(tmp_path, monkeypatch):
+    """In-process refresh (restart=False) must rewrite the stale plist on disk but
+    never shell out to launchctl bootout/bootstrap — that would SIGTERM the running
+    gateway mid-startup (and orphan the job if it died before bootstrap ran)."""
+    plist_path, current = _stale_plist(tmp_path, monkeypatch)
+    calls = []
+    monkeypatch.setattr(gateway.subprocess, "run", lambda *a, **k: calls.append(a[0]))
+
+    assert gateway.refresh_launchd_plist_if_needed(restart=False) is True
+    assert plist_path.read_text(encoding="utf-8") == current  # rewritten to current
+    assert gateway.launchd_plist_is_current() is True
+    assert calls == []  # no launchctl invocation
+
+
+def test_refresh_launchd_with_restart_does_bootout(tmp_path, monkeypatch):
+    """The explicit-CLI path (restart=True, default) still bootout/bootstraps so an
+    operator running `hermes gateway install/start` applies the change immediately."""
+    _stale_plist(tmp_path, monkeypatch)
+    calls = []
+    monkeypatch.setattr(gateway.subprocess, "run", lambda *a, **k: calls.append(a[0][:2]))
+
+    assert gateway.refresh_launchd_plist_if_needed() is True
+    assert ["launchctl", "bootout"] in calls
+    assert ["launchctl", "bootstrap"] in calls
+
+
+def test_refresh_launchd_noop_when_current(tmp_path, monkeypatch):
+    plist_path = tmp_path / "ai.hermes.gateway.plist"
+    monkeypatch.setattr(gateway, "get_launchd_plist_path", lambda: plist_path)
+    plist_path.write_text(gateway.generate_launchd_plist(), encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(gateway.subprocess, "run", lambda *a, **k: calls.append(a[0]))
+
+    assert gateway.refresh_launchd_plist_if_needed(restart=False) is False
+    assert calls == []

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,0 +1,31 @@
+import re
+
+from hermes_cli import gateway
+
+
+def test_launchd_plist_declares_fd_resource_limits():
+    """macOS launchd defaults to a 256 fd soft cap; the dashboard's slash/PTY
+    children exhaust it. The plist must raise it (#24775)."""
+    plist = gateway.generate_launchd_plist()
+    soft = re.search(r"<key>SoftResourceLimits</key>\s*<dict>(.*?)</dict>", plist, re.S)
+    hard = re.search(r"<key>HardResourceLimits</key>\s*<dict>(.*?)</dict>", plist, re.S)
+    assert soft and re.search(r"<key>NumberOfFiles</key>\s*<integer>8192</integer>", soft.group(1))
+    assert hard and re.search(r"<key>NumberOfFiles</key>\s*<integer>16384</integer>", hard.group(1))
+
+
+def test_launchd_plist_without_fd_limits_reads_as_stale(tmp_path, monkeypatch):
+    plist_path = tmp_path / "ai.hermes.gateway.plist"
+    monkeypatch.setattr(gateway, "get_launchd_plist_path", lambda: plist_path)
+
+    current = gateway.generate_launchd_plist()
+    plist_path.write_text(current, encoding="utf-8")
+    assert gateway.launchd_plist_is_current() is True
+
+    # A plist predating the fd-limit bump must be detected as stale so the
+    # boot-time self-heal rewrites it.
+    old = re.sub(
+        r"\s*<key>(Soft|Hard)ResourceLimits</key>\s*<dict>.*?</dict>", "", current, flags=re.S
+    )
+    assert old != current
+    plist_path.write_text(old, encoding="utf-8")
+    assert gateway.launchd_plist_is_current() is False


### PR DESCRIPTION
macOS launchd jobs inherit a **256** file-descriptor soft limit by default (no `*ResourceLimits` keys), so a long-running gateway hits `EMFILE` ("Too many open files") under sustained worker/socket load. This raises the ceiling and delivers the bump to already-installed agents without a manual restart. **This is OS hardening — it does not fix the leak.** The leak *cause* is fixed by the sibling PR `fix/tui-gateway-slash-worker-leak` (`Fixes #24775`); PR1 stops the bleed, PR2 widens the margin.

### What changed

- `hermes_cli/gateway.py` — add `SoftResourceLimits`/`HardResourceLimits` → `NumberOfFiles` **8192 / 16384** to the generated launchd plist; `run_gateway` now calls `refresh_launchd_plist_if_needed(restart=False)` so the bump reaches existing installs on the next gateway boot (an exit-75 / `/restart` respawn skips `hermes gateway restart`, so without this the change wouldn't land until a manual restart or `hermes update`).
- `tests/test_gateway.py` — +6 tests; replaces a test that mocked the refresh function away.

### Self-heal without self-bootout (`restart=False`)

`run_gateway` runs *inside* the launchd-supervised process, so it must not bootout/bootstrap itself. `restart=False` rewrites the plist on disk only and skips `launchctl bootout`/`bootstrap`, mirroring systemd's `daemon-reload` semantics (refresh the unit definition; let the next restart apply it). With `restart=True` here, the `bootout` would send SIGTERM to the live gateway mid-startup — worst case the process dies before the `bootstrap` line runs, leaving the job unloaded. The explicit-CLI callers (`hermes gateway install`/`start`) keep the default `restart=True`; they run in a separate process where bootout/bootstrap is correct and applies the change immediately.

### Scope

Raises the fd *ceiling*; it does not reduce fd consumption or fix the leak. A fast-enough leak still exceeds 16384 — prevention lives in PR1.

- `Refs #24775` — mitigation (higher ceiling), not closure; the leak cause is fixed in the sibling PR.
- `Addresses #32377` — fd headroom softens the blast radius of accumulated half-open-socket leaks; detection + reap live in PR1.

### Tests (6 passing)

`test_launchd_plist_declares_fd_resource_limits` (plist carries 8192/16384) · `test_launchd_plist_without_fd_limits_reads_as_stale` (old plist detected stale) · `test_run_gateway_self_heals_launchd_plist_on_macos` (`run_gateway` passes `restart=False`) · `test_refresh_launchd_no_restart_rewrites_without_bootout` (rewrites file, **no** launchctl call) · `test_refresh_launchd_with_restart_does_bootout` (`restart=True` does bootout + bootstrap) · `test_refresh_launchd_noop_when_current` (current plist → no-op). The self-heal and no-bootout paths were previously untested (the prior test mocked the function away).
