### PR TITLE
fix(kanban): supervise notifier/dispatcher; self-heal notify_subs corruption

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4475,16 +4475,30 @@ class GatewayRunner:
         # Start background session expiry watcher to finalize expired sessions
         asyncio.create_task(self._session_expiry_watcher())
 
-        # Start background kanban notifier — delivers `completed`, `blocked`,
-        # `spawn_auto_blocked`, and `crashed` events to gateway subscribers
-        # so human-in-the-loop workflows hear back without polling.
-        asyncio.create_task(self._kanban_notifier_watcher())
+        # Start background kanban notifier — delivers card-move events to
+        # gateway subscribers so human-in-the-loop workflows hear back
+        # without polling. Wrapped in a supervisor that restarts the
+        # watcher on any exception (including BaseException / GC of the
+        # task handle), so a single transient SQLite "disk I/O error"
+        # or accidental cancellation can't permanently kill the
+        # pipeline. Strong refs held on `self` so the task isn't
+        # garbage-collected.
+        self._kanban_notifier_task = asyncio.create_task(
+            self._supervised_loop(
+                "kanban_notifier", self._kanban_notifier_watcher,
+            )
+        )
 
         # Start background kanban dispatcher — spawns workers for ready
         # tasks. Gated by `kanban.dispatch_in_gateway` (default True).
         # When false, users run `hermes kanban daemon` externally or
-        # simply don't use kanban; this loop becomes a no-op.
-        asyncio.create_task(self._kanban_dispatcher_watcher())
+        # simply don't use kanban; this loop becomes a no-op. Same
+        # supervisor pattern as the notifier.
+        self._kanban_dispatcher_task = asyncio.create_task(
+            self._supervised_loop(
+                "kanban_dispatcher", self._kanban_dispatcher_watcher,
+            )
+        )
 
         # Start background reconnection watcher for platforms that failed at startup
         if self._failed_platforms:
@@ -4893,6 +4907,78 @@ class GatewayRunner:
         except Exception:
             return "default"
 
+    async def _supervised_loop(
+        self,
+        name: str,
+        coro_factory,
+        *,
+        initial_backoff: float = 1.0,
+        max_backoff: float = 60.0,
+    ) -> None:
+        """Run ``coro_factory()`` in a self-restarting supervisor.
+
+        The kanban notifier and dispatcher are long-lived watchers that
+        used to be spawned bare with ``asyncio.create_task(...)`` — a
+        single transient SQLite ``disk I/O error`` between ticks, or
+        garbage collection of the task handle, would silently kill the
+        loop with no restart. Symptom: card moves stop generating
+        Telegram pings even though the dispatcher keeps spawning
+        workers, because they're separate tasks.
+
+        This wrapper:
+          * Catches every ``Exception`` (transient errors → restart
+            with exponential backoff capped at ``max_backoff``).
+          * Catches ``asyncio.CancelledError`` and re-raises only when
+            ``self._running`` is False (clean shutdown). A spurious
+            cancel mid-flight gets logged and the loop is restarted.
+          * Lets ``BaseException`` (e.g. ``SystemExit``,
+            ``KeyboardInterrupt``) propagate so process exit still
+            works.
+
+        Backoff resets to ``initial_backoff`` after the watcher runs
+        for at least 60s without throwing — that way persistent bugs
+        still surface as frequent log entries instead of being hidden
+        by an ever-growing sleep.
+        """
+        backoff = initial_backoff
+        while self._running:
+            started = time.monotonic()
+            try:
+                await coro_factory()
+                # Watcher returned cleanly (e.g. self._running flipped
+                # to False during its own loop). Honor that.
+                if not self._running:
+                    return
+                logger.warning(
+                    "supervised loop %s returned while gateway running; restarting",
+                    name,
+                )
+            except asyncio.CancelledError:
+                if not self._running:
+                    raise
+                logger.warning(
+                    "supervised loop %s was cancelled but gateway is still "
+                    "running; restarting in %.1fs",
+                    name, backoff,
+                )
+            except Exception as exc:
+                logger.error(
+                    "supervised loop %s crashed: %s; restarting in %.1fs",
+                    name, exc, backoff, exc_info=True,
+                )
+            # If the watcher ran for at least a minute before failing,
+            # treat this as an isolated incident and reset backoff.
+            if time.monotonic() - started >= 60.0:
+                backoff = initial_backoff
+            if not self._running:
+                return
+            try:
+                await asyncio.sleep(backoff)
+            except asyncio.CancelledError:
+                if not self._running:
+                    raise
+            backoff = min(backoff * 2, max_backoff)
+
     async def _kanban_notifier_watcher(self, interval: float = 5.0) -> None:
         """Poll ``kanban_notify_subs`` and deliver terminal events to users.
 
@@ -4919,7 +5005,18 @@ class GatewayRunner:
             logger.warning("kanban notifier: kanban_db not importable; notifier disabled")
             return
 
-        TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out")
+        TERMINAL_KINDS = (
+            "completed", "blocked", "gave_up", "crashed", "timed_out",
+            # Lifecycle moves the user wants pings for. Each one is a
+            # visible state transition: card was assigned to a worker
+            # (`claimed`), worker process actually started (`spawned`),
+            # an external action unblocked it (`unblocked`), or the
+            # dispatcher re-queued it for retry (`scheduled` /
+            # `reclaimed`). Decomposition (`decomposed`) is the moment
+            # a triage step splits a card into child tasks.
+            "claimed", "spawned", "unblocked", "scheduled",
+            "reclaimed", "decomposed",
+        )
         # Subscriptions are removed only when the task reaches a truly final
         # status (done / archived). We used to also unsub on any terminal
         # event kind (gave_up / crashed / timed_out / blocked), but that
@@ -5130,6 +5227,45 @@ class GatewayRunner:
                             msg = (
                                 f"⏱ {tag}Kanban {sub['task_id']} timed out "
                                 f"(max_runtime={limit}s); will retry"
+                            )
+                        elif kind == "claimed":
+                            # Worker profile picked the card off the
+                            # queue. Surfaces the assignment so the
+                            # user knows who's driving.
+                            msg = f"🤝 {tag}Kanban {sub['task_id']} claimed — {title}"
+                        elif kind == "spawned":
+                            pid = ev.payload.get("pid") if ev.payload else None
+                            extra = f" (pid {pid})" if pid else ""
+                            msg = (
+                                f"▶ {tag}Kanban {sub['task_id']} worker started"
+                                f"{extra} — {title}"
+                            )
+                        elif kind == "unblocked":
+                            msg = f"▶ {tag}Kanban {sub['task_id']} unblocked — {title}"
+                        elif kind == "scheduled":
+                            reason = ""
+                            if ev.payload and ev.payload.get("reason"):
+                                reason = f": {str(ev.payload['reason'])[:120]}"
+                            msg = (
+                                f"📅 {tag}Kanban {sub['task_id']} re-queued"
+                                f"{reason}"
+                            )
+                        elif kind == "reclaimed":
+                            msg = (
+                                f"🔄 {tag}Kanban {sub['task_id']} reclaimed by "
+                                f"dispatcher — {title}"
+                            )
+                        elif kind == "decomposed":
+                            children = 0
+                            if ev.payload and ev.payload.get("children"):
+                                try:
+                                    children = len(ev.payload["children"])
+                                except Exception:
+                                    children = 0
+                            extra = f" into {children} subtask(s)" if children else ""
+                            msg = (
+                                f"🧩 {tag}Kanban {sub['task_id']} decomposed"
+                                f"{extra} — {title}"
                             )
                         else:
                             continue

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1307,14 +1307,74 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
     if str(resolved) in _INITIALIZED_PATHS:
         return
     reason: Optional[str] = None
+    integrity_rows: list[str] = []
     try:
         probe = _sqlite_connect(resolved)
         try:
-            row = probe.execute("PRAGMA integrity_check").fetchone()
+            # integrity_check returns one row per problem, or a single ('ok',).
+            integrity_rows = [
+                (r[0] or "") for r in probe.execute("PRAGMA integrity_check").fetchall()
+            ]
         finally:
             probe.close()
-        if not row or (row[0] or "").lower() != "ok":
-            reason = f"integrity_check returned {row[0] if row else '<no row>'!r}"
+        if not integrity_rows or (
+            len(integrity_rows) == 1 and integrity_rows[0].lower() == "ok"
+        ):
+            return
+        # If every reported problem is isolated to the ephemeral
+        # ``kanban_notify_subs`` table or its indexes (notification
+        # routing — losing rows is a no-op, subscribers re-register on
+        # next use), try a self-heal: drop+recreate the table, reindex,
+        # and re-check. This avoids taking the whole kanban offline for
+        # a transient routing-state corruption (which has been observed
+        # in the wild when a malformed write path inserts non-conforming
+        # rows).
+        _NOTIFY_TOKENS = ("kanban_notify_subs", "idx_notify_task")
+        if all(any(tok in msg for tok in _NOTIFY_TOKENS) for msg in integrity_rows):
+            try:
+                healed = sqlite3.connect(str(resolved), timeout=5, isolation_level=None)
+                try:
+                    # DROP+recreate is more reliable than DELETE+REINDEX
+                    # when the table's b-tree pages themselves are
+                    # malformed.
+                    healed.execute("DROP TABLE IF EXISTS kanban_notify_subs")
+                    healed.execute(
+                        """
+                        CREATE TABLE kanban_notify_subs (
+                            task_id          TEXT NOT NULL,
+                            platform         TEXT NOT NULL,
+                            chat_id          TEXT NOT NULL,
+                            thread_id        TEXT NOT NULL DEFAULT '',
+                            user_id          TEXT,
+                            notifier_profile TEXT,
+                            created_at       INTEGER NOT NULL,
+                            last_event_id    INTEGER NOT NULL DEFAULT 0,
+                            PRIMARY KEY (task_id, platform, chat_id, thread_id)
+                        )
+                        """
+                    )
+                    healed.execute(
+                        "CREATE INDEX idx_notify_task ON kanban_notify_subs(task_id)"
+                    )
+                    healed.execute("REINDEX")
+                    recheck = [
+                        (r[0] or "")
+                        for r in healed.execute("PRAGMA integrity_check").fetchall()
+                    ]
+                finally:
+                    healed.close()
+                if (
+                    len(recheck) == 1 and recheck[0].lower() == "ok"
+                ):
+                    return  # healed; carry on
+                reason = (
+                    "integrity_check still failing after kanban_notify_subs "
+                    f"self-heal: {recheck!r}"
+                )
+            except sqlite3.DatabaseError as exc:
+                reason = f"self-heal of kanban_notify_subs failed: {exc}"
+        else:
+            reason = f"integrity_check returned {integrity_rows!r}"
     except sqlite3.OperationalError:
         # Lock contention, busy, transient IO — not corruption. Let it propagate.
         raise


### PR DESCRIPTION
## Why

The kanban notifier and dispatcher are spawned as bare `asyncio.create_task(self._kanban_notifier_watcher())`. A single transient SQLite `disk I/O error` between ticks (observed in production: `gateway.log` logged `kanban notifier tick failed: disk I/O error` every 5s for ~80s, then **silent for 35+ minutes**) kills the task with no restart. Symptom: card moves stop generating Telegram pings even though the dispatcher keeps spawning workers — they're separate tasks. Worse, if the task handle is GC'd, the loop dies without even a final log line.

## What

### `gateway/run.py`
- New `_supervised_loop(name, coro_factory)` wrapper:
  - catches `Exception` → log + exponential backoff (1s → 60s, capped)
  - resets backoff after 60s of clean run so persistent bugs still surface as frequent log entries
  - catches spurious `asyncio.CancelledError` (only re-raises when `self._running` is False — i.e. real shutdown)
  - lets `BaseException` propagate so process exit still works
  - strong refs (`self._kanban_notifier_task`, `self._kanban_dispatcher_task`) prevent GC of the task handle
- Both `_kanban_notifier_watcher` and `_kanban_dispatcher_watcher` are now wrapped.
- `TERMINAL_KINDS` extended to include `claimed / spawned / unblocked / scheduled / reclaimed / decomposed` with formatted messages so subscribers see the full card journey, not just final states.

### `hermes_cli/kanban_db.py`
When `_guard_existing_db_is_healthy` sees integrity failures **isolated** to `kanban_notify_subs` / `idx_notify_task` (ephemeral routing state — subscribers re-register on next use), drop+recreate the table and re-check before refusing to open the DB. Avoids taking the whole kanban offline for transient notify-routing corruption.

## Test plan

- `python -c "import ast; ast.parse(open('gateway/run.py').read()); ast.parse(open('hermes_cli/kanban_db.py').read())"` ✓
- Reproduced the failure mode in a local gateway by raising `sqlite3.OperationalError('disk I/O error')` from `claim_unseen_events_for_sub` once. Pre-patch: task dies, no further pings. Post-patch: `supervised loop kanban_notifier crashed: disk I/O error; restarting in 1.0s`, then resumes normally.
- Verified backoff resets after 60s of clean run.
- Verified clean shutdown (Ctrl+C) still propagates `CancelledError`.

## Risk

Low. Both watchers were already best-effort. The supervisor only adds restart behavior; on the success path it's a no-op other than holding a strong ref.

Reported by user: kanban pings silently stopped after a DB I/O blip; gateway restart was required to recover.
