### PR TITLE
[codex] fix(skills): resolve installed path aliases under symlinked HERMES_HOME

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -655,7 +655,7 @@ def do_install(identifier: str, category: str = "", force: bool = False,
                          bundle.trust_level, "invalid_path", str(exc))
         return
     from tools.skills_hub import SKILLS_DIR
-    c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR)}")
+    c.print(f"[bold green]Installed:[/] {install_dir.relative_to(SKILLS_DIR.resolve())}")
     c.print(f"[dim]Files: {', '.join(bundle.files.keys())}[/]\n")
 
     if invalidate_cache:

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -2201,3 +2201,54 @@ class TestInstallPathSafety:
 
         assert not (skills_dir / "bad-skill" / "leak.txt").exists()
         assert secret.read_text() == "data exfiltration payload\n"
+
+    def test_install_from_quarantine_accepts_symlinked_skills_root_alias(
+        self, tmp_path, patch_lock_file
+    ):
+        """Install bookkeeping should tolerate aliased skills roots like /tmp -> /private/tmp."""
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        real_home = tmp_path / "real-home"
+        real_home.mkdir()
+        alias_home = tmp_path / "alias-home"
+        try:
+            alias_home.symlink_to(real_home, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlink creation unsupported on this platform")
+
+        skills_dir = alias_home / "skills"
+        quarantine_root = skills_dir / ".hub" / "quarantine"
+        quarantine_root.mkdir(parents=True)
+
+        q_dir = quarantine_root / "pending"
+        q_dir.mkdir()
+        skill_text = "---\nname: good-skill\n---\n"
+        (q_dir / "SKILL.md").write_text(skill_text)
+
+        bundle = hub.SkillBundle(
+            name="good-skill",
+            files={"SKILL.md": skill_text},
+            source="community",
+            identifier="skills-sh/example/good-skill",
+            trust_level="community",
+        )
+        scan_result = ScanResult(
+            skill_name="good-skill",
+            source="community",
+            trust_level="community",
+            verdict="safe",
+        )
+        lock_path = tmp_path / "lock.json"
+        patch_lock_file(lock_path)
+
+        with patch.object(hub, "SKILLS_DIR", skills_dir), \
+             patch.object(hub, "QUARANTINE_DIR", quarantine_root), \
+             patch.object(hub, "AUDIT_LOG", tmp_path / "audit.log"):
+            install_dir = hub.install_from_quarantine(
+                q_dir, "good-skill", "note-taking", bundle, scan_result,
+            )
+
+        assert install_dir == (real_home / "skills" / "note-taking" / "good-skill")
+        lock = hub.HubLockFile(path=lock_path)
+        assert lock.get_installed("good-skill")["install_path"] == "note-taking/good-skill"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3255,6 +3255,8 @@ def install_from_quarantine(
     install_dir.parent.mkdir(parents=True, exist_ok=True)
     shutil.move(str(quarantine_path), str(install_dir))
 
+    install_path = str(install_dir.relative_to(SKILLS_DIR.resolve()))
+
     # Record in lock file
     lock = HubLockFile()
     lock.record_install(
@@ -3264,7 +3266,7 @@ def install_from_quarantine(
         trust_level=bundle.trust_level,
         scan_verdict=scan_result.verdict,
         skill_hash=content_hash(install_dir),
-        install_path=str(install_dir.relative_to(SKILLS_DIR)),
+        install_path=install_path,
         files=list(bundle.files.keys()),
         metadata=bundle.metadata,
     )


### PR DESCRIPTION
Closes #35509

## Summary
- normalize installed skill paths against the resolved skills root before recording lock entries or printing the installed path
- keep installs working when `HERMES_HOME` is rooted under an alias such as `/tmp` -> `/private/tmp`
- add a regression test covering a symlinked skills-root alias

## Proof
- `uv run --active --frozen --extra dev python -m pytest tests/tools/test_skills_hub.py -k 'symlinked_skills_root_alias or install_from_quarantine_rejects_symlinks' -o 'addopts=' -q`\n- `uv run --active --frozen --extra dev python -m ruff check tools/skills_hub.py hermes_cli/skills_hub.py tests/tools/test_skills_hub.py`\n- `git diff --check`\n- `HERMES_HOME=$(mktemp -d /tmp/hermes-skillhome-XXXXXX) python -m hermes_cli.main skills install skills-sh/kepano/obsidian-skills/obsidian-bases --category note-taking --yes`