### PR TITLE
feat(kanban): route assignee notifications to profile lanes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1035,7 +1035,7 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
 )
-from gateway.delivery import DeliveryRouter
+from gateway.delivery import DeliveryRouter, DeliveryTarget
 from gateway.platforms.base import (
     BasePlatformAdapter,
     EphemeralReply,
@@ -4893,6 +4893,204 @@ class GatewayRunner:
         except Exception:
             return "default"
 
+    @staticmethod
+    def _parse_kanban_assignee_notify_target(value: Any) -> Optional[dict]:
+        """Parse one kanban assignee notification target.
+
+        Supported forms:
+        - ``"discord:<channel_id>"``
+        - ``"discord:<channel_id>:<thread_id>"``
+        - ``{"platform": "discord", "chat_id": "...", "thread_id": "..."}``
+
+        Targets must be explicit chat/channel destinations. Bare platform
+        names are intentionally ignored because worker lanes should be
+        profile-specific, not whichever home channel the platform has today.
+        """
+        if isinstance(value, dict):
+            platform = str(value.get("platform") or "").strip().lower()
+            chat_id = value.get("chat_id") or value.get("channel_id")
+            thread_id = value.get("thread_id") or ""
+            if not platform or chat_id in (None, ""):
+                return None
+            chat_id = str(chat_id).strip()
+            thread_id = str(thread_id).strip()
+            if not chat_id:
+                return None
+            try:
+                plat = Platform(platform)
+            except ValueError:
+                return None
+            if plat == Platform.LOCAL:
+                return None
+            return {
+                "platform": plat.value,
+                "chat_id": chat_id,
+                "thread_id": thread_id,
+            }
+
+        if not isinstance(value, str):
+            return None
+        target = DeliveryTarget.parse(value)
+        if target.platform == Platform.LOCAL or not target.chat_id:
+            return None
+        chat_id = str(target.chat_id).strip()
+        thread_id = str(target.thread_id or "").strip()
+        if not chat_id:
+            return None
+        return {
+            "platform": target.platform.value,
+            "chat_id": chat_id,
+            "thread_id": thread_id,
+        }
+
+    def _load_kanban_assignee_notification_routes(self) -> dict[str, dict]:
+        """Load kanban.assignee_notification_channels from config.yaml."""
+        try:
+            from hermes_cli.config import load_config as _load_config
+            from hermes_cli.profiles import normalize_profile_name
+            cfg = _load_config() or {}
+        except Exception as exc:
+            logger.debug("kanban notifier: cannot load assignee notification routes: %s", exc)
+            return {}
+        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        raw = kanban_cfg.get("assignee_notification_channels", {})
+        if not isinstance(raw, dict):
+            if raw not in (None, ""):
+                logger.warning(
+                    "kanban notifier: kanban.assignee_notification_channels must be a mapping; got %s",
+                    type(raw).__name__,
+                )
+            return {}
+        routes: dict[str, dict] = {}
+        for assignee, target in raw.items():
+            if assignee in (None, ""):
+                continue
+            try:
+                key = normalize_profile_name(str(assignee))
+            except Exception:
+                key = str(assignee).strip()
+            if not key:
+                continue
+            parsed = self._parse_kanban_assignee_notify_target(target)
+            if not parsed:
+                logger.warning(
+                    "kanban notifier: invalid assignee notification target for %s: %r",
+                    key, target,
+                )
+                continue
+            routes[key] = parsed
+        return routes
+
+    def _kanban_sync_assignee_notify_subs(
+        self,
+        conn,
+        _kb,
+        routes: dict[str, dict],
+        *,
+        active_platforms: set[str],
+        notifier_profile: str,
+        terminal_kinds: tuple[str, ...],
+        started_at: int,
+        route_first_seen: Optional[dict[tuple[str, str, str, str], int]] = None,
+        board: Optional[str] = None,
+    ) -> int:
+        """Ensure configured assignee lanes have notify rows for future events.
+
+        Origin subscriptions remain authoritative for requester/thread pings.
+        This adds a second subscription for the assigned worker's dedicated
+        channel, scoped to the current notifier profile. Existing terminal
+        events from before the route was first observed by the watcher are
+        skipped so enabling a new channel does not replay historical board
+        noise into that channel.
+        """
+        if not routes:
+            return 0
+        usable = {
+            assignee: route
+            for assignee, route in routes.items()
+            if route.get("platform") in active_platforms
+        }
+        if not usable:
+            return 0
+
+        placeholders = ",".join("?" * len(usable))
+        terminal_placeholders = ",".join("?" * len(terminal_kinds))
+        rows = conn.execute(
+            f"""
+            SELECT
+                t.id AS task_id,
+                t.assignee AS assignee,
+                t.status AS status,
+                COALESCE(MAX(e.id), 0) AS max_event_id,
+                COALESCE(MAX(CASE WHEN e.kind IN ({terminal_placeholders}) THEN e.created_at ELSE 0 END), 0) AS max_terminal_at
+              FROM tasks t
+              LEFT JOIN task_events e ON e.task_id = t.id
+             WHERE t.assignee IN ({placeholders})
+               AND t.status != 'archived'
+             GROUP BY t.id, t.assignee, t.status
+            """,
+            (*terminal_kinds, *usable.keys()),
+        ).fetchall()
+
+        added = 0
+        for row in rows:
+            route = usable.get(row["assignee"])
+            if not route:
+                continue
+            route_thread_id = route.get("thread_id") or ""
+            route_key = (
+                str(row["assignee"]), route["platform"], route["chat_id"], route_thread_id,
+            )
+            first_seen_at = int(
+                (route_first_seen or {}).get(route_key, started_at) or started_at
+            )
+            sub_key = (
+                str(board or ""), str(row["task_id"]), route["platform"],
+                route["chat_id"], route_thread_id,
+            )
+            exists = conn.execute(
+                """
+                SELECT 1 FROM kanban_notify_subs
+                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+                 LIMIT 1
+                """,
+                (row["task_id"], route["platform"], route["chat_id"], route_thread_id),
+            ).fetchone()
+            if exists:
+                continue
+
+            max_event_id = int(row["max_event_id"] or 0)
+            max_terminal_at = int(row["max_terminal_at"] or 0)
+            status = str(row["status"] or "")
+            if status == "done":
+                if sub_key in getattr(self, "_kanban_assignee_notify_terminal_seen", set()):
+                    continue
+                if not max_terminal_at or max_terminal_at <= first_seen_at:
+                    continue
+
+            # If the only terminal event(s) are historical for this route,
+            # start after the current event stream. Future blocks/completions
+            # will still land, but enabling the route will not replay old task
+            # outcomes.
+            initial_cursor = 0
+            if max_terminal_at and max_terminal_at <= first_seen_at:
+                initial_cursor = max_event_id
+
+            _kb.add_notify_sub(
+                conn,
+                task_id=row["task_id"],
+                platform=route["platform"],
+                chat_id=route["chat_id"],
+                thread_id=route_thread_id,
+                user_id=f"assignee:{row['assignee']}",
+                notifier_profile=notifier_profile,
+                last_event_id=initial_cursor,
+            )
+            added += 1
+        if added:
+            logger.debug("kanban notifier: added %d assignee notification subscription(s)", added)
+        return added
+
     async def _kanban_notifier_watcher(self, interval: float = 5.0) -> None:
         """Poll ``kanban_notify_subs`` and deliver terminal events to users.
 
@@ -4945,8 +5143,23 @@ class GatewayRunner:
         if not notifier_profile:
             notifier_profile = self._active_profile_name()
             self._kanban_notifier_profile = notifier_profile
+        assignee_notify_started_at = int(
+            getattr(self, "_kanban_assignee_notify_started_at", 0) or time.time()
+        )
+        self._kanban_assignee_notify_started_at = assignee_notify_started_at
+        assignee_terminal_seen: set[tuple[str, str, str, str, str]] = getattr(
+            self, "_kanban_assignee_notify_terminal_seen", set()
+        )
+        self._kanban_assignee_notify_terminal_seen = assignee_terminal_seen
+        assignee_route_first_seen: dict[tuple[str, str, str, str], int] = getattr(
+            self, "_kanban_assignee_notify_route_first_seen", {}
+        )
+        self._kanban_assignee_notify_route_first_seen = assignee_route_first_seen
+        assignee_known_routes: set[tuple[str, str, str, str]] = getattr(
+            self, "_kanban_assignee_notify_known_routes", set()
+        )
+        self._kanban_assignee_notify_known_routes = assignee_known_routes
 
-        # Initial delay so the gateway can finish wiring adapters.
         await asyncio.sleep(5)
 
         while self._running:
@@ -4960,6 +5173,30 @@ class GatewayRunner:
                     if not active_platforms:
                         logger.debug("kanban notifier: no connected adapters; skipping tick")
                         return deliveries
+                    assignee_routes = self._load_kanban_assignee_notification_routes()
+                    route_keys = {
+                        (
+                            assignee,
+                            route["platform"],
+                            route["chat_id"],
+                            route.get("thread_id") or "",
+                        )
+                        for assignee, route in assignee_routes.items()
+                    }
+                    # Routes present on the first notifier tick are considered
+                    # part of startup config and use the watcher start time as
+                    # their historical cutoff. Routes that appear later should
+                    # not backfill events that happened earlier in this already
+                    # running gateway process.
+                    first_route_observation = not assignee_known_routes and not assignee_route_first_seen
+                    now_ts = int(time.time())
+                    for key in route_keys:
+                        if key not in assignee_route_first_seen:
+                            assignee_route_first_seen[key] = (
+                                assignee_notify_started_at if first_route_observation else now_ts
+                            )
+                    assignee_known_routes.clear()
+                    assignee_known_routes.update(route_keys)
 
                     # Enumerate every board on disk, but poll each resolved DB
                     # path once. Multiple slugs can point at the same DB when
@@ -5003,6 +5240,18 @@ class GatewayRunner:
                             # a legacy DB. `_add_column_if_missing` now
                             # tolerates that race, but we still skip the
                             # redundant call to avoid the wasted work.
+                            if assignee_routes:
+                                self._kanban_sync_assignee_notify_subs(
+                                    conn,
+                                    _kb,
+                                    assignee_routes,
+                                    active_platforms=active_platforms,
+                                    notifier_profile=notifier_profile,
+                                    terminal_kinds=TERMINAL_KINDS,
+                                    started_at=assignee_notify_started_at,
+                                    route_first_seen=assignee_route_first_seen,
+                                    board=slug,
+                                )
                             subs = _kb.list_notify_subs(conn)
                             if not subs:
                                 logger.debug("kanban notifier: board %s has no subscriptions", slug)
@@ -5218,6 +5467,14 @@ class GatewayRunner:
                         # above for the failure mode this prevents.
                         task_terminal = task and task.status in {"done", "archived"}
                         if task_terminal:
+                            if str(sub.get("user_id") or "").startswith("assignee:"):
+                                assignee_terminal_seen.add((
+                                    str(board_slug or ""),
+                                    str(sub["task_id"]),
+                                    str(sub["platform"]),
+                                    str(sub["chat_id"]),
+                                    str(sub.get("thread_id") or ""),
+                                ))
                             await asyncio.to_thread(
                                 self._kanban_unsub, sub, board_slug,
                             )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4954,7 +4954,7 @@ class GatewayRunner:
                 def _collect():
                     deliveries: list[dict] = []
                     active_platforms = {
-                        getattr(platform, "value", str(platform)).lower()
+                        str(getattr(platform, "value", platform)).lower()
                         for platform in self.adapters.keys()
                     }
                     if not active_platforms:
@@ -5014,7 +5014,7 @@ class GatewayRunner:
                                         sub.get("task_id"), owner_profile, notifier_profile,
                                     )
                                     continue
-                                platform = (sub.get("platform") or "").lower()
+                                platform = str(sub.get("platform") or "").lower()
                                 if platform not in active_platforms:
                                     logger.debug(
                                         "kanban notifier: subscription for %s on %s skipped; adapter not connected",
@@ -5053,7 +5053,7 @@ class GatewayRunner:
                     sub = d["sub"]
                     task = d["task"]
                     board_slug = d.get("board")
-                    platform_str = (sub["platform"] or "").lower()
+                    platform_str = str(sub["platform"] or "").lower()
                     try:
                         plat = _Platform(platform_str)
                     except ValueError:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1325,7 +1325,8 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
-    with kb.connect_closing() as conn:
+    current_board = kb.get_current_board()
+    with kb.connect_closing(board=current_board) as conn:
         task_id = kb.create_task(
             conn,
             title=args.title,
@@ -1344,6 +1345,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
             initial_status=getattr(args, "initial_status", "running"),
+            board=current_board,
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7008,13 +7008,20 @@ def repair_notify_subscriptions(conn: sqlite3.Connection) -> int:
     SQLite permits integer values in TEXT-affinity columns. The gateway
     notifier treats platform/chat/thread identifiers as strings, so repair at
     the DB boundary and collapse duplicate rows introduced by type drift.
+
+    Duplicate collapse happens before key-changing updates so legacy rows such
+    as ``platform='Discord'`` and ``platform='discord'`` do not collide with the
+    ``PRIMARY KEY (task_id, platform, chat_id, thread_id)`` during migration.
+    The merged row keeps the highest delivered event cursor so repair never
+    replays events the notifier had already acknowledged.
     """
     try:
         rows = conn.execute("SELECT rowid, * FROM kanban_notify_subs").fetchall()
     except sqlite3.Error:
         return 0
+
     changed = 0
-    seen: set[tuple[str, str, str, str]] = set()
+    groups: dict[tuple[str, str, str, str], list[tuple[sqlite3.Row, dict[str, Any]]]] = {}
     for row in rows:
         norm = _normalize_notify_sub_values(
             task_id=row["task_id"],
@@ -7026,21 +7033,38 @@ def repair_notify_subscriptions(conn: sqlite3.Connection) -> int:
             last_event_id=row["last_event_id"],
         )
         key = (norm["task_id"], norm["platform"], norm["chat_id"], norm["thread_id"])
-        if key in seen:
+        groups.setdefault(key, []).append((row, norm))
+
+    for key, entries in groups.items():
+        keep_row, keep_norm = entries[0]
+        merged = dict(keep_norm)
+        merged["last_event_id"] = max(norm["last_event_id"] for _, norm in entries)
+        for _, norm in entries:
+            if not merged.get("user_id") and norm.get("user_id"):
+                merged["user_id"] = norm["user_id"]
+            if (
+                merged.get("notifier_profile") == "default"
+                and norm.get("notifier_profile")
+                and norm.get("notifier_profile") != "default"
+            ):
+                merged["notifier_profile"] = norm["notifier_profile"]
+
+        # Delete duplicate physical rows first. Otherwise updating the keeper
+        # to its normalized key can violate the notify table primary key.
+        for row, _ in entries[1:]:
             conn.execute("DELETE FROM kanban_notify_subs WHERE rowid = ?", (row["rowid"],))
             changed += 1
-            continue
-        seen.add(key)
+
         original = {
-            "task_id": row["task_id"],
-            "platform": row["platform"],
-            "chat_id": row["chat_id"],
-            "thread_id": row["thread_id"],
-            "user_id": row["user_id"],
-            "notifier_profile": row["notifier_profile"] if "notifier_profile" in row.keys() else None,
-            "last_event_id": row["last_event_id"],
+            "task_id": keep_row["task_id"],
+            "platform": keep_row["platform"],
+            "chat_id": keep_row["chat_id"],
+            "thread_id": keep_row["thread_id"],
+            "user_id": keep_row["user_id"],
+            "notifier_profile": keep_row["notifier_profile"] if "notifier_profile" in keep_row.keys() else None,
+            "last_event_id": keep_row["last_event_id"],
         }
-        if any(original[k] != norm[k] for k in norm):
+        if any(original[k] != merged[k] for k in merged):
             conn.execute(
                 """
                 UPDATE kanban_notify_subs
@@ -7049,9 +7073,9 @@ def repair_notify_subscriptions(conn: sqlite3.Connection) -> int:
                  WHERE rowid = ?
                 """,
                 (
-                    norm["task_id"], norm["platform"], norm["chat_id"],
-                    norm["thread_id"], norm["user_id"], norm["notifier_profile"],
-                    norm["last_event_id"], row["rowid"],
+                    merged["task_id"], merged["platform"], merged["chat_id"],
+                    merged["thread_id"], merged["user_id"], merged["notifier_profile"],
+                    merged["last_event_id"], keep_row["rowid"],
                 ),
             )
             changed += 1
@@ -7067,6 +7091,7 @@ def add_notify_sub(
     thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
     notifier_profile: Optional[str] = None,
+    last_event_id: int = 0,
 ) -> None:
     """Register a gateway source that wants terminal-state notifications
     for ``task_id``. Idempotent on (task, platform, chat, thread)."""
@@ -7078,6 +7103,7 @@ def add_notify_sub(
         thread_id=thread_id,
         user_id=user_id,
         notifier_profile=notifier_profile,
+        last_event_id=last_event_id,
     )
     with write_txn(conn):
         conn.execute(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1367,18 +1367,27 @@ def connect(
         try:
             conn.row_factory = sqlite3.Row
             with _INIT_LOCK:
-                # WAL activation can take an exclusive lock while SQLite creates the
-                # sidecar files for a fresh database. Keep it in the same process-local
-                # critical section as schema initialization so concurrent gateway
-                # startup threads do not race before _INITIALIZED_PATHS is populated.
-                # WAL doesn't work on network filesystems (NFS/SMB/FUSE). Shared helper
-                # falls back to DELETE with one WARNING so kanban stays usable there.
-                # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
-                from hermes_state import apply_wal_with_fallback
-                apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
-                # FULL (was NORMAL): fsync before each checkpoint to narrow the
-                # crash window that can leave a b-tree page header torn.
-                conn.execute("PRAGMA synchronous=FULL")
+                needs_init = resolved not in _INITIALIZED_PATHS
+                if needs_init:
+                    # WAL activation can take an exclusive lock while SQLite creates
+                    # sidecar files. Do it once per process/path with the schema
+                    # init lock held; repeatedly toggling journal mode on every
+                    # short-lived Kanban connection can throw transient SQLite
+                    # disk-I/O errors while gateway notifier/dispatcher threads are
+                    # active. Existing connections keep working with the persisted
+                    # journal mode, so per-open PRAGMA churn is unnecessary.
+                    from hermes_state import apply_wal_with_fallback
+                    apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
+                # FULL: fsync before each checkpoint to narrow the crash window
+                # that can leave a b-tree page header torn. Treat rare EIO here
+                # as advisory so a transient per-connection PRAGMA failure does
+                # not take down gateway notifier/dispatcher loops when the DB
+                # subsequently passes integrity checks.
+                try:
+                    conn.execute("PRAGMA synchronous=FULL")
+                except sqlite3.OperationalError as exc:
+                    if "disk i/o error" not in str(exc).lower():
+                        raise
                 conn.execute("PRAGMA wal_autocheckpoint=100")
                 conn.execute("PRAGMA foreign_keys=ON")
                 # Zero freed pages so a later torn write cannot expose stale
@@ -1387,7 +1396,6 @@ def connect(
                 # Surface corrupt cells as read errors instead of silent
                 # wrong-data returns.
                 conn.execute("PRAGMA cell_size_check=ON")
-                needs_init = resolved not in _INITIALIZED_PATHS
                 if needs_init:
                     # Idempotent: runs CREATE TABLE IF NOT EXISTS + the additive
                     # migrations. Cached so subsequent connect() calls in the same
@@ -1633,6 +1641,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             _add_column_if_missing(
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
             )
+        # SQLite's type affinity is intentionally loose; older gateway and
+        # dashboard paths could persist integer-like platform/chat/thread
+        # fields. Normalize rows during migration so notifier lookups and
+        # platform matching remain type-safe.
+        repair_notify_subscriptions(conn)
 
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.
@@ -1886,21 +1899,21 @@ def write_txn(conn: sqlite3.Connection):
     task + recording an event, etc.).  A claim CAS inside this context is
     atomic -- at most one concurrent writer can succeed.
 
-    The explicit ROLLBACK on exception is wrapped in try/except so that
-    a SQLite auto-rollback (which leaves no active transaction) does not
-    shadow the original exception with a spurious rollback error.
+    Rollback is best-effort: on some SQLite error paths the connection has
+    already left the transaction by the time Python reaches the exception
+    handler. In that case a second ``ROLLBACK`` raises ``OperationalError:
+    cannot rollback - no transaction is active`` and masks the real failure
+    that the caller needs to log. Preserve the original exception instead.
     """
     conn.execute("BEGIN IMMEDIATE")
     try:
         yield conn
     except Exception:
-        try:
-            conn.execute("ROLLBACK")
-        except sqlite3.OperationalError:
-            # SQLite has already auto-rolled-back the transaction (typical
-            # under EIO, lock contention, or corruption). Nothing to undo;
-            # do not let this secondary failure shadow the real one.
-            pass
+        if getattr(conn, "in_transaction", False):
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
         raise
     else:
         conn.execute("COMMIT")
@@ -4263,6 +4276,19 @@ def decompose_triage_task(
         parents_idx = child.get("parents") or []
         if not isinstance(parents_idx, list):
             raise ValueError(f"child[{idx}].parents must be a list")
+        workspace_kind = child.get("workspace_kind", "scratch")
+        if workspace_kind not in VALID_WORKSPACE_KINDS:
+            raise ValueError(
+                f"child[{idx}].workspace_kind must be one of "
+                f"{sorted(VALID_WORKSPACE_KINDS)}, got {workspace_kind!r}"
+            )
+        workspace_path = child.get("workspace_path")
+        if workspace_path is not None and not isinstance(workspace_path, str):
+            raise ValueError(f"child[{idx}].workspace_path must be a string or null")
+        if workspace_path and workspace_kind == "scratch":
+            raise ValueError(
+                f"child[{idx}] cannot set workspace_path with scratch workspace_kind"
+            )
         for p in parents_idx:
             if not isinstance(p, int) or p < 0 or p >= len(children):
                 raise ValueError(
@@ -4322,16 +4348,20 @@ def decompose_triage_task(
             title = child["title"].strip()
             body = child.get("body")
             assignee = _canonical_assignee(child.get("assignee"))
+            workspace_kind = str(child.get("workspace_kind") or "scratch")
+            workspace_path = child.get("workspace_path")
             conn.execute(
                 "INSERT INTO tasks "
-                "(id, title, body, assignee, status, workspace_kind, "
+                "(id, title, body, assignee, status, workspace_kind, workspace_path, "
                 " tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', 'scratch', ?, ?, ?)",
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
                 (
                     new_id,
                     title,
                     body if isinstance(body, str) else None,
                     assignee,
+                    workspace_kind,
+                    workspace_path if isinstance(workspace_path, str) and workspace_path.strip() else None,
                     tenant,
                     now,
                     (author or "decomposer"),
@@ -4342,6 +4372,42 @@ def decompose_triage_task(
                 {"by": author or "decomposer", "from_decompose_of": task_id},
             )
             child_ids.append(new_id)
+
+        # Copy notification subscriptions from the decomposed root to every
+        # child. A user who subscribes to a triage/root card expects to hear
+        # about human gates raised by the workers spawned from that card;
+        # otherwise child ``blocked`` / ``completed`` events are invisible and
+        # review-required tasks can sit unnoticed. Start child cursors at 0:
+        # the notifier only emits terminal event kinds, so already-recorded
+        # child ``created`` events do not produce noisy catch-up messages.
+        root_notify_subs = conn.execute(
+            """
+            SELECT platform, chat_id, thread_id, user_id, notifier_profile
+            FROM kanban_notify_subs
+            WHERE task_id = ?
+            """,
+            (task_id,),
+        ).fetchall()
+        if root_notify_subs:
+            for child_id in child_ids:
+                for sub in root_notify_subs:
+                    conn.execute(
+                        """
+                        INSERT OR IGNORE INTO kanban_notify_subs
+                            (task_id, platform, chat_id, thread_id, user_id,
+                             notifier_profile, created_at, last_event_id)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, 0)
+                        """,
+                        (
+                            child_id,
+                            sub["platform"],
+                            sub["chat_id"],
+                            sub["thread_id"] or "",
+                            sub["user_id"],
+                            sub["notifier_profile"],
+                            now,
+                        ),
+                    )
 
         # Link children to their sibling parents (within the decomposed graph).
         for idx, child in enumerate(children):
@@ -6896,6 +6962,102 @@ def task_age(task: Task) -> dict:
 # Notification subscriptions (used by the gateway kanban-notifier)
 # ---------------------------------------------------------------------------
 
+def _coerce_notify_text(value: Any, *, default: str = "", lower: bool = False) -> str:
+    if value is None:
+        text = default
+    else:
+        text = str(value)
+    text = text.strip()
+    if not text:
+        text = default
+    return text.lower() if lower else text
+
+
+def _coerce_notify_cursor(value: Any) -> int:
+    try:
+        cursor = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(cursor, 0)
+
+
+def _normalize_notify_sub_values(
+    *,
+    task_id: Any,
+    platform: Any,
+    chat_id: Any,
+    thread_id: Any = None,
+    user_id: Any = None,
+    notifier_profile: Any = None,
+    last_event_id: Any = 0,
+) -> dict[str, Any]:
+    return {
+        "task_id": _coerce_notify_text(task_id),
+        "platform": _coerce_notify_text(platform, lower=True),
+        "chat_id": _coerce_notify_text(chat_id),
+        "thread_id": _coerce_notify_text(thread_id),
+        "user_id": None if user_id is None else _coerce_notify_text(user_id),
+        "notifier_profile": _coerce_notify_text(notifier_profile, default="default"),
+        "last_event_id": _coerce_notify_cursor(last_event_id),
+    }
+
+
+def repair_notify_subscriptions(conn: sqlite3.Connection) -> int:
+    """Normalize existing notification rows to the canonical text shape.
+
+    SQLite permits integer values in TEXT-affinity columns. The gateway
+    notifier treats platform/chat/thread identifiers as strings, so repair at
+    the DB boundary and collapse duplicate rows introduced by type drift.
+    """
+    try:
+        rows = conn.execute("SELECT rowid, * FROM kanban_notify_subs").fetchall()
+    except sqlite3.Error:
+        return 0
+    changed = 0
+    seen: set[tuple[str, str, str, str]] = set()
+    for row in rows:
+        norm = _normalize_notify_sub_values(
+            task_id=row["task_id"],
+            platform=row["platform"],
+            chat_id=row["chat_id"],
+            thread_id=row["thread_id"],
+            user_id=row["user_id"],
+            notifier_profile=row["notifier_profile"] if "notifier_profile" in row.keys() else None,
+            last_event_id=row["last_event_id"],
+        )
+        key = (norm["task_id"], norm["platform"], norm["chat_id"], norm["thread_id"])
+        if key in seen:
+            conn.execute("DELETE FROM kanban_notify_subs WHERE rowid = ?", (row["rowid"],))
+            changed += 1
+            continue
+        seen.add(key)
+        original = {
+            "task_id": row["task_id"],
+            "platform": row["platform"],
+            "chat_id": row["chat_id"],
+            "thread_id": row["thread_id"],
+            "user_id": row["user_id"],
+            "notifier_profile": row["notifier_profile"] if "notifier_profile" in row.keys() else None,
+            "last_event_id": row["last_event_id"],
+        }
+        if any(original[k] != norm[k] for k in norm):
+            conn.execute(
+                """
+                UPDATE kanban_notify_subs
+                   SET task_id = ?, platform = ?, chat_id = ?, thread_id = ?,
+                       user_id = ?, notifier_profile = ?, last_event_id = ?
+                 WHERE rowid = ?
+                """,
+                (
+                    norm["task_id"], norm["platform"], norm["chat_id"],
+                    norm["thread_id"], norm["user_id"], norm["notifier_profile"],
+                    norm["last_event_id"], row["rowid"],
+                ),
+            )
+            changed += 1
+    return changed
+
+
 def add_notify_sub(
     conn: sqlite3.Connection,
     *,
@@ -6909,39 +7071,66 @@ def add_notify_sub(
     """Register a gateway source that wants terminal-state notifications
     for ``task_id``. Idempotent on (task, platform, chat, thread)."""
     now = int(time.time())
+    norm = _normalize_notify_sub_values(
+        task_id=task_id,
+        platform=platform,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        user_id=user_id,
+        notifier_profile=notifier_profile,
+    )
     with write_txn(conn):
         conn.execute(
             """
             INSERT OR IGNORE INTO kanban_notify_subs
-                (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+                (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at, last_event_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (task_id, platform, chat_id, thread_id or "", user_id, notifier_profile, now),
+            (
+                norm["task_id"], norm["platform"], norm["chat_id"],
+                norm["thread_id"], norm["user_id"], norm["notifier_profile"],
+                now, norm["last_event_id"],
+            ),
         )
-        if notifier_profile:
-            # Self-heal legacy rows that predate notifier ownership by
-            # backfilling only when the existing value is unset.
-            conn.execute(
-                """
-                UPDATE kanban_notify_subs
-                   SET notifier_profile = ?
-                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
-                   AND (notifier_profile IS NULL OR notifier_profile = '')
-                """,
-                (notifier_profile, task_id, platform, chat_id, thread_id or ""),
-            )
+        # Self-heal legacy rows and keep notifier ownership populated.
+        conn.execute(
+            """
+            UPDATE kanban_notify_subs
+               SET notifier_profile = ?
+             WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+               AND (notifier_profile IS NULL OR notifier_profile = '')
+            """,
+            (
+                norm["notifier_profile"], norm["task_id"], norm["platform"],
+                norm["chat_id"], norm["thread_id"],
+            ),
+        )
 
 
 def list_notify_subs(
     conn: sqlite3.Connection, task_id: Optional[str] = None,
 ) -> list[dict]:
     if task_id is not None:
+        norm_task_id = _coerce_notify_text(task_id)
         rows = conn.execute(
-            "SELECT * FROM kanban_notify_subs WHERE task_id = ?", (task_id,),
+            "SELECT * FROM kanban_notify_subs WHERE task_id = ?", (norm_task_id,),
         ).fetchall()
     else:
         rows = conn.execute("SELECT * FROM kanban_notify_subs").fetchall()
-    return [dict(r) for r in rows]
+    out: list[dict] = []
+    for row in rows:
+        d = dict(row)
+        d.update(_normalize_notify_sub_values(
+            task_id=d.get("task_id"),
+            platform=d.get("platform"),
+            chat_id=d.get("chat_id"),
+            thread_id=d.get("thread_id"),
+            user_id=d.get("user_id"),
+            notifier_profile=d.get("notifier_profile"),
+            last_event_id=d.get("last_event_id"),
+        ))
+        out.append(d)
+    return out
 
 
 def remove_notify_sub(
@@ -6952,11 +7141,14 @@ def remove_notify_sub(
     chat_id: str,
     thread_id: Optional[str] = None,
 ) -> bool:
+    norm = _normalize_notify_sub_values(
+        task_id=task_id, platform=platform, chat_id=chat_id, thread_id=thread_id,
+    )
     with write_txn(conn):
         cur = conn.execute(
             "DELETE FROM kanban_notify_subs WHERE task_id = ? "
             "AND platform = ? AND chat_id = ? AND thread_id = ?",
-            (task_id, platform, chat_id, thread_id or ""),
+            (norm["task_id"], norm["platform"], norm["chat_id"], norm["thread_id"]),
         )
     return cur.rowcount > 0
 
@@ -6976,21 +7168,24 @@ def unseen_events_for_sub(
     cursor is NOT advanced here; call :func:`advance_notify_cursor` after
     the gateway has successfully delivered the notifications.
     """
+    norm = _normalize_notify_sub_values(
+        task_id=task_id, platform=platform, chat_id=chat_id, thread_id=thread_id,
+    )
     row = conn.execute(
         "SELECT last_event_id FROM kanban_notify_subs "
         "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
-        (task_id, platform, chat_id, thread_id or ""),
+        (norm["task_id"], norm["platform"], norm["chat_id"], norm["thread_id"]),
     ).fetchone()
     if row is None:
         return 0, []
-    cursor = int(row["last_event_id"])
+    cursor = _coerce_notify_cursor(row["last_event_id"])
     kind_list = list(kinds) if kinds else None
     q = (
         "SELECT * FROM task_events WHERE task_id = ? AND id > ? "
         + ("AND kind IN (" + ",".join("?" * len(kind_list)) + ") " if kind_list else "")
         + "ORDER BY id ASC"
     )
-    params: list[Any] = [task_id, cursor]
+    params: list[Any] = [norm["task_id"], cursor]
     if kind_list:
         params.extend(kind_list)
     rows = conn.execute(q, params).fetchall()
@@ -7034,20 +7229,23 @@ def claim_unseen_events_for_sub(
     failed before any terminal unsubscribe removed the row.
     """
     with write_txn(conn):
+        norm = _normalize_notify_sub_values(
+            task_id=task_id, platform=platform, chat_id=chat_id, thread_id=thread_id,
+        )
         row = conn.execute(
             "SELECT last_event_id FROM kanban_notify_subs "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
-            (task_id, platform, chat_id, thread_id or ""),
+            (norm["task_id"], norm["platform"], norm["chat_id"], norm["thread_id"]),
         ).fetchone()
         if row is None:
             return 0, 0, []
-        old_cursor = int(row["last_event_id"])
+        old_cursor = _coerce_notify_cursor(row["last_event_id"])
         new_cursor, events = unseen_events_for_sub(
             conn,
-            task_id=task_id,
-            platform=platform,
-            chat_id=chat_id,
-            thread_id=thread_id,
+            task_id=norm["task_id"],
+            platform=norm["platform"],
+            chat_id=norm["chat_id"],
+            thread_id=norm["thread_id"],
             kinds=kinds,
         )
         if not events:
@@ -7056,7 +7254,10 @@ def claim_unseen_events_for_sub(
             "UPDATE kanban_notify_subs SET last_event_id = ? "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
             "AND last_event_id = ?",
-            (int(new_cursor), task_id, platform, chat_id, thread_id or "", int(old_cursor)),
+            (
+                int(new_cursor), norm["task_id"], norm["platform"],
+                norm["chat_id"], norm["thread_id"], int(old_cursor),
+            ),
         )
         return old_cursor, new_cursor, events
 
@@ -7070,11 +7271,17 @@ def advance_notify_cursor(
     thread_id: Optional[str] = None,
     new_cursor: int,
 ) -> None:
+    norm = _normalize_notify_sub_values(
+        task_id=task_id, platform=platform, chat_id=chat_id, thread_id=thread_id,
+    )
     with write_txn(conn):
         conn.execute(
             "UPDATE kanban_notify_subs SET last_event_id = ? "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
-            (int(new_cursor), task_id, platform, chat_id, thread_id or ""),
+            (
+                int(new_cursor), norm["task_id"], norm["platform"],
+                norm["chat_id"], norm["thread_id"],
+            ),
         )
 
 
@@ -7094,14 +7301,17 @@ def rewind_notify_cursor(
     claim. This keeps retry behavior for transient send failures without
     clobbering newer progress.
     """
+    norm = _normalize_notify_sub_values(
+        task_id=task_id, platform=platform, chat_id=chat_id, thread_id=thread_id,
+    )
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE kanban_notify_subs SET last_event_id = ? "
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
             "AND last_event_id = ?",
             (
-                int(old_cursor), task_id, platform, chat_id, thread_id or "",
-                int(claimed_cursor),
+                int(old_cursor), norm["task_id"], norm["platform"],
+                norm["chat_id"], norm["thread_id"], int(claimed_cursor),
             ),
         )
     return cur.rowcount > 0

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -249,6 +249,58 @@ def _format_roster(roster: list[dict]) -> str:
     return "\n".join(lines)
 
 
+def _infer_project_workspace(title: str, body: str) -> Optional[str]:
+    """Infer a repo workspace from board route_keywords for default-board triage.
+
+    Default-board dashboard/CLI triage tasks can mention a repo-backed project
+    even when the root card intentionally stays on the default board. When that
+    happens, decomposed implementation/review children should still run in the
+    project checkout instead of a scratch workspace.
+    """
+    haystack = f"{title}\n{body}".casefold()
+    try:
+        boards = kb.list_boards(include_archived=False)
+    except Exception:
+        return None
+    best: tuple[int, str] | None = None
+    for meta in boards:
+        default_workdir = meta.get("default_workdir")
+        if not default_workdir:
+            continue
+        slug = str(meta.get("slug") or "")
+        keywords = meta.get("route_keywords") or []
+        if not isinstance(keywords, list):
+            keywords = []
+        score = 0
+        for kw in keywords:
+            if not isinstance(kw, str):
+                continue
+            needle = kw.strip().casefold()
+            if needle and needle in haystack:
+                score += max(1, len(needle))
+        if slug and slug.casefold() in haystack:
+            score += max(1, len(slug))
+        if score and (best is None or score > best[0]):
+            best = (score, str(default_workdir))
+    return best[1] if best else None
+
+
+def _child_should_use_project_workspace(child: dict, workspace_path: Optional[str]) -> bool:
+    if not workspace_path:
+        return False
+    text = f"{child.get('title') or ''}\n{child.get('body') or ''}".casefold()
+    # Keep pure final-notification/control-plane tasks scratch. Repo inspection,
+    # implementation, PR creation, and review tasks need the project checkout.
+    if "notification" in text or "gateway" in text:
+        return False
+    repo_terms = (
+        "repo", "repository", "implementation", "implement", "pr",
+        "pull request", "branch", "git", "github", "diff", "file",
+        "files", "validate", "validation", "review", "inspect", "code",
+    )
+    return any(term in text for term in repo_terms)
+
+
 def _normalize_assignee_choice(
     assignee: object,
     *,
@@ -296,6 +348,7 @@ def decompose_task(
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
     auto_promote = bool(kanban_cfg.get("auto_promote_children", True))
     roster, valid_names = _build_roster()
+    inferred_project_workspace = _infer_project_workspace(task.title or "", task.body or "")
 
     try:
         from agent.auxiliary_client import (  # type: ignore
@@ -431,12 +484,16 @@ def decompose_task(
             parents = []
         # Clean parent indices: drop non-int and out-of-range.
         clean_parents = [p for p in parents if isinstance(p, int) and 0 <= p < len(raw_tasks) and p != idx]
-        children.append({
+        child_spec = {
             "title": title.strip()[:200],
             "body": body.strip(),
             "assignee": chosen,
             "parents": clean_parents,
-        })
+        }
+        if _child_should_use_project_workspace(child_spec, inferred_project_workspace):
+            child_spec["workspace_kind"] = "dir"
+            child_spec["workspace_path"] = inferred_project_workspace
+        children.append(child_spec)
 
     try:
         with kb.connect_closing() as conn:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -121,9 +121,114 @@ def _conn(board: Optional[str] = None):
     """
     try:
         kanban_db.init_db(board=board)
+    except kanban_db.KanbanDbCorruptError:
+        raise
     except Exception as exc:
         log.warning("kanban init_db failed: %s", exc)
     return kanban_db.connect(board=board)
+
+
+def _degraded_board_payload(exc: kanban_db.KanbanDbCorruptError, board: Optional[str]) -> dict[str, Any]:
+    """Return a dashboard-safe degraded board response for corrupt DBs."""
+    board_slug = board or kanban_db.get_current_board()
+    return {
+        "status": "degraded",
+        "board": board_slug,
+        "reason": exc.reason,
+        "db_path": str(exc.db_path),
+        "backup_path": str(exc.backup_path) if exc.backup_path else None,
+        "recommended_action": "repair board DB from latest clean backup or restore the preserved corrupt backup manually",
+        "columns": [{"name": name, "tasks": []} for name in BOARD_COLUMNS],
+        "tenants": [],
+        "assignees": [],
+        "latest_event_id": 0,
+        "now": int(time.time()),
+    }
+
+
+def _task_route_text(payload: "CreateTaskBody") -> str:
+    """Compact searchable text used for Josh-local dashboard task routing."""
+    parts = [payload.title or "", payload.body or "", payload.tenant or ""]
+    return "\n".join(str(p).casefold() for p in parts if p)
+
+
+def _route_board_for_create(payload: "CreateTaskBody", board: Optional[str]) -> Optional[str]:
+    """Route dashboard-created default-board tasks to a project board.
+
+    Conservative and metadata-driven: when the browser omits the board query
+    parameter or sends the legacy ``default`` board, a board whose ``board.json``
+    declares matching ``route_keywords`` gets the task instead. Parent links and
+    explicit workspace paths are treated as hard scope signals and are never
+    re-routed.
+    """
+    if board not in (None, "", kanban_db.DEFAULT_BOARD):
+        return board
+    if payload.parents or payload.workspace_path:
+        return board
+
+    text = _task_route_text(payload)
+    if not text:
+        return board
+
+    matches: list[tuple[int, str]] = []
+    for meta in kanban_db.list_boards(include_archived=False):
+        slug = str(meta.get("slug") or "")
+        if not slug or slug == kanban_db.DEFAULT_BOARD:
+            continue
+        keywords = meta.get("route_keywords") or []
+        if isinstance(keywords, str):
+            keywords = [keywords]
+        score = 0
+        for raw in keywords:
+            kw = str(raw).strip().casefold()
+            if kw and kw in text:
+                score += 1
+        if score:
+            matches.append((score, slug))
+    if not matches:
+        return board
+    matches.sort(key=lambda item: (-item[0], item[1]))
+    routed = matches[0][1]
+    log.info("Kanban dashboard routed default-board task %r to board %s", payload.title, routed)
+    return routed
+
+
+def _dashboard_auto_subscribe_enabled() -> bool:
+    """Whether dashboard-created cards should subscribe to home notifications."""
+    try:
+        from hermes_cli.config import get_hermes_home
+        from hermes_cli.env_loader import load_hermes_dotenv
+        load_hermes_dotenv(hermes_home=get_hermes_home())
+    except Exception:
+        pass
+    val = os.environ.get("HERMES_KANBAN_DASHBOARD_AUTO_SUBSCRIBE_HOME", "")
+    return val.strip().casefold() in {"1", "true", "yes", "on"}
+
+
+def _auto_subscribe_home_channels(conn: sqlite3.Connection, task_id: str) -> list[dict]:
+    """Subscribe a new dashboard task to every configured home channel."""
+    if not _dashboard_auto_subscribe_enabled():
+        return []
+    subscribed: list[dict] = []
+    for home in _configured_home_channels():
+        try:
+            kanban_db.add_notify_sub(
+                conn,
+                task_id=task_id,
+                platform=home["platform"],
+                chat_id=home["chat_id"],
+                thread_id=home["thread_id"] or None,
+                notifier_profile=_active_profile_name(),
+            )
+            subscribed.append(home)
+        except Exception as exc:
+            log.warning(
+                "Kanban dashboard auto-subscribe failed for task %s on %s: %s",
+                task_id,
+                home.get("platform"),
+                exc,
+            )
+    return subscribed
 
 
 # ---------------------------------------------------------------------------
@@ -388,7 +493,11 @@ def get_board(
     ``current`` pointer → ``default``).
     """
     board = _resolve_board(board)
-    conn = _conn(board=board)
+    try:
+        conn = _conn(board=board)
+    except kanban_db.KanbanDbCorruptError as exc:
+        log.error("Kanban dashboard board %s is degraded: %s", board or kanban_db.get_current_board(), exc)
+        return _degraded_board_payload(exc, board)
     try:
         tasks = kanban_db.list_tasks(
             conn,
@@ -586,6 +695,7 @@ class CreateTaskBody(BaseModel):
 @router.post("/tasks")
 def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
+    board = _route_board_for_create(payload, board)
     conn = _conn(board=board)
     try:
         task_id = kanban_db.create_task(
@@ -603,9 +713,15 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             idempotency_key=payload.idempotency_key,
             max_runtime_seconds=payload.max_runtime_seconds,
             skills=payload.skills,
+            board=board,
         )
         task = kanban_db.get_task(conn, task_id)
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}
+        subscribed = _auto_subscribe_home_channels(conn, task_id)
+        if subscribed:
+            body["notify_subscriptions"] = subscribed
+        if board:
+            body["board"] = board
         # Surface a dispatcher-presence warning so the UI can show a
         # banner when a `ready` task would otherwise sit idle because no
         # gateway is running (or dispatch_in_gateway=false). Only emit
@@ -1724,6 +1840,12 @@ def _configured_home_channels() -> list[dict]:
     etc.) are honored alongside config.yaml. Returns platforms in a stable
     order and drops platforms without a home.
     """
+    try:
+        from hermes_cli.config import get_hermes_home
+        from hermes_cli.env_loader import load_hermes_dotenv
+        load_hermes_dotenv(hermes_home=get_hermes_home())
+    except Exception:
+        pass
     try:
         from gateway.config import load_gateway_config
     except Exception:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2415,6 +2415,40 @@ def test_repair_notify_subscriptions_normalizes_legacy_rows(kanban_home):
         assert sub["notifier_profile"] == "default"
         assert sub["last_event_id"] == 0
 
+
+def test_repair_notify_subscriptions_merges_normalized_duplicates(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="duplicate notify rows")
+        now = int(time.time())
+        with kb.write_txn(conn):
+            conn.execute(
+                """
+                INSERT INTO kanban_notify_subs
+                    (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at, last_event_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (task_id, "Discord", 12345, 0, None, "default", now, 2),
+            )
+            conn.execute(
+                """
+                INSERT INTO kanban_notify_subs
+                    (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at, last_event_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (task_id, "discord", "12345", "0", "assignee:huginn", "default", now + 1, 7),
+            )
+
+        changed = kb.repair_notify_subscriptions(conn)
+        assert changed >= 1
+        subs = kb.list_notify_subs(conn, task_id)
+        assert len(subs) == 1
+        sub = subs[0]
+        assert sub["platform"] == "discord"
+        assert sub["chat_id"] == "12345"
+        assert sub["thread_id"] == "0"
+        assert sub["user_id"] == "assignee:huginn"
+        assert sub["last_event_id"] == 7
+
 # ---------------------------------------------------------------------------
 # NFS / network-filesystem fallback (see hermes_state.apply_wal_with_fallback)
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2351,9 +2351,122 @@ def test_latest_summaries_batch_omits_tasks_without_summary(kanban_home):
 
 
 
+
+
+def test_notify_subscriptions_are_type_safe_and_lookup_normalized(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="notify typing")
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform=123,
+            chat_id=456,
+            thread_id=789,
+            user_id=101112,
+            notifier_profile=None,
+        )
+        subs = kb.list_notify_subs(conn, task_id)
+        assert subs == [
+            {
+                **subs[0],
+                "task_id": task_id,
+                "platform": "123",
+                "chat_id": "456",
+                "thread_id": "789",
+                "user_id": "101112",
+                "notifier_profile": "default",
+                "last_event_id": 0,
+            }
+        ]
+
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_events (task_id, kind, payload, created_at) VALUES (?, ?, ?, ?)",
+                (task_id, "completed", '{"summary":"done"}', int(time.time())),
+            )
+        old_cursor, new_cursor, events = kb.claim_unseen_events_for_sub(
+            conn, task_id=task_id, platform=123, chat_id=456, thread_id=789, kinds=["completed"],
+        )
+        assert old_cursor == 0
+        assert new_cursor > 0
+        assert [ev.kind for ev in events] == ["completed"]
+        assert kb.remove_notify_sub(conn, task_id=task_id, platform=123, chat_id=456, thread_id=789)
+
+
+def test_repair_notify_subscriptions_normalizes_legacy_rows(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="legacy notify row")
+        with kb.write_txn(conn):
+            conn.execute(
+                """
+                INSERT INTO kanban_notify_subs
+                    (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at, last_event_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (task_id, "Discord", 12345, 0, 999, None, int(time.time()), "not-an-int"),
+            )
+        changed = kb.repair_notify_subscriptions(conn)
+        assert changed == 1
+        sub = kb.list_notify_subs(conn, task_id)[0]
+        assert sub["platform"] == "discord"
+        assert sub["chat_id"] == "12345"
+        assert sub["thread_id"] == "0"
+        assert sub["user_id"] == "999"
+        assert sub["notifier_profile"] == "default"
+        assert sub["last_event_id"] == 0
+
 # ---------------------------------------------------------------------------
 # NFS / network-filesystem fallback (see hermes_state.apply_wal_with_fallback)
 # ---------------------------------------------------------------------------
+
+def test_connect_applies_wal_once_per_process_path(kanban_home, monkeypatch):
+    """Repeated short-lived connects must not churn PRAGMA journal_mode=WAL.
+
+    Gateway notifier/dispatcher loops open frequent Kanban connections. WAL
+    activation can require exclusive sidecar-file work, so doing it on every
+    open can race with other SQLite users and surface as transient disk-I/O
+    errors. Once a process has initialized a DB path, subsequent connects
+    should reuse the persisted journal mode without reapplying WAL.
+    """
+    import hermes_state
+
+    calls = []
+
+    def _fake_apply_wal(conn, *, db_label):
+        calls.append(db_label)
+        conn.execute("PRAGMA journal_mode=WAL")
+
+    monkeypatch.setattr(hermes_state, "apply_wal_with_fallback", _fake_apply_wal)
+    kb._INITIALIZED_PATHS.clear()
+
+    conn1 = kb.connect()
+    conn1.close()
+    conn2 = kb.connect()
+    conn2.close()
+
+    assert len(calls) == 1
+    assert "kanban.db" in calls[0]
+
+
+
+def test_write_txn_preserves_original_error_when_rollback_already_happened(kanban_home):
+    """Rollback cleanup must not mask the SQLite failure that caused it.
+
+    Some SQLite error paths leave autocommit mode before the context manager
+    handles the Python exception. A second ROLLBACK then raises ``cannot
+    rollback - no transaction is active``; callers need the original exception
+    for accurate root-cause logging.
+    """
+    conn = kb.connect()
+    original = RuntimeError("original sqlite failure should be preserved")
+    try:
+        with pytest.raises(RuntimeError, match="original sqlite failure"):
+            with kb.write_txn(conn):
+                conn.execute("ROLLBACK")
+                raise original
+    finally:
+        conn.close()
+
 
 def test_connect_falls_back_to_delete_on_locking_protocol(tmp_path, monkeypatch, caplog):
     """kanban_db.connect() must handle ``locking protocol`` on NFS/SMB.

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -345,3 +345,59 @@ def test_decompose_no_aux_client_configured(kanban_home):
 
     assert outcome.ok is False
     assert "no auxiliary client" in outcome.reason
+
+
+
+def test_decompose_default_board_repo_keywords_assigns_project_workspace(kanban_home, tmp_path):
+    repo = tmp_path / "repos" / "Dow-DevOps" / "k8s"
+    repo.mkdir(parents=True)
+    kb.create_board(
+        "k8s",
+        name="Kubernetes",
+        default_workdir=str(repo),
+    )
+    meta_path = kanban_home / "kanban" / "boards" / "k8s" / "board.json"
+    meta = jsonlib.loads(meta_path.read_text())
+    meta["route_keywords"] = ["Dow-DevOps/k8s", "renovate", "diun"]
+    meta_path.write_text(jsonlib.dumps(meta), encoding="utf-8")
+
+    with kb.connect(board="default") as conn:
+        tid = kb.create_task(
+            conn,
+            title="E2E Renovate + Diun workflow for Dow-DevOps/k8s",
+            body="Create the actual PR and verify gateway notification.",
+            triage=True,
+            board="default",
+        )
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "split repo work from final notification",
+        "tasks": [
+            {"title": "Implement Renovate and Diun PR", "body": "Work in the repo and create a PR.", "assignee": "engineer", "parents": []},
+            {"title": "Verify final gateway notification", "body": "Check gateway notification evidence only.", "assignee": "orchestrator", "parents": [0]},
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value={"kanban": {"orchestrator_profile": "orchestrator", "default_assignee": "orchestrator"}},
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    with kb.connect(board="default") as conn:
+        impl = kb.get_task(conn, outcome.child_ids[0])
+        notify = kb.get_task(conn, outcome.child_ids[1])
+
+    assert impl.workspace_kind == "dir"
+    assert impl.workspace_path == str(repo)
+    assert notify.workspace_kind == "scratch"
+    assert notify.workspace_path is None

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -166,3 +166,40 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
 
     assert any("Decomposed into" in (c.body or "") for c in comments)
     assert any(ev.kind == "decomposed" for ev in events)
+
+
+def test_decompose_copies_notify_subscriptions_to_children(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="discord",
+            chat_id="chat1",
+            thread_id="thread1",
+            user_id="user1",
+            notifier_profile="default",
+        )
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orch",
+            children=[
+                {"title": "task A", "assignee": "researcher"},
+                {"title": "task B", "assignee": "engineer"},
+            ],
+            author="alice",
+        )
+    assert child_ids is not None
+
+    with kb.connect() as conn:
+        for child_id in child_ids:
+            subs = kb.list_notify_subs(conn, child_id)
+            assert len(subs) == 1
+            sub = subs[0]
+            assert sub["platform"] == "discord"
+            assert sub["chat_id"] == "chat1"
+            assert sub["thread_id"] == "thread1"
+            assert sub["user_id"] == "user1"
+            assert sub["notifier_profile"] == "default"
+            assert sub["last_event_id"] == 0

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 import pytest
 
 from pathlib import Path
@@ -24,6 +25,14 @@ def kanban_home(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(tmp_path))
     kb.init_db()
     return home
+
+
+def test_assignee_notify_target_rejects_blank_chat_id():
+    from gateway.run import GatewayRunner
+
+    assert GatewayRunner._parse_kanban_assignee_notify_target(
+        {"platform": "discord", "chat_id": "   "}
+    ) is None
 
 
 @pytest.mark.asyncio
@@ -434,6 +443,220 @@ async def test_notifier_delivers_subscription_owned_by_current_profile(kanban_ho
     finally:
         conn.close()
     assert subs == []
+
+
+@pytest.mark.asyncio
+async def test_notifier_autosubscribes_assignee_channel_from_config(kanban_home):
+    """Configured assignee lanes receive terminal events even without origin subs."""
+    import hermes_cli.kanban_db as kb
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="research thing", assignee="huginn")
+        kb.complete_task(conn, tid, result="found it")
+    finally:
+        conn.close()
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_notifier_profile = "default"
+    runner._kanban_assignee_notify_started_at = 1
+
+    fake_adapter = MagicMock()
+
+    async def _send_and_stop(chat_id, msg, metadata=None):
+        runner._running = False
+
+    fake_adapter.send = AsyncMock(side_effect=_send_and_stop)
+    runner.adapters = {Platform.DISCORD: fake_adapter}
+
+    _orig_sleep = asyncio.sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    cfg = {
+        "kanban": {
+            "assignee_notification_channels": {
+                "huginn": "discord:chan-huginn",
+            }
+        }
+    }
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep), \
+         patch("hermes_cli.config.load_config", return_value=cfg):
+        await asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    fake_adapter.send.assert_called_once()
+    assert fake_adapter.send.call_args[0][0] == "chan-huginn"
+    assert "@huginn" in fake_adapter.send.call_args[0][1]
+    assert tid in fake_adapter.send.call_args[0][1]
+
+
+@pytest.mark.asyncio
+async def test_notifier_assignee_channel_completion_not_redelivered(kanban_home):
+    """Auto assignee lane rows must not reappear forever after done cleanup."""
+    import hermes_cli.kanban_db as kb
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="one shot", assignee="huginn")
+        kb.complete_task(conn, tid, result="done once")
+    finally:
+        conn.close()
+
+    runner = object.__new__(GatewayRunner)
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_notifier_profile = "default"
+    runner._kanban_assignee_notify_started_at = 1
+
+    sent: list[tuple[str, str]] = []
+
+    async def _send(chat_id, msg, metadata=None):
+        sent.append((chat_id, msg))
+        runner._running = False
+
+    fake_adapter = MagicMock()
+    fake_adapter.send = AsyncMock(side_effect=_send)
+    runner.adapters = {Platform.DISCORD: fake_adapter}
+
+    _orig_sleep = asyncio.sleep
+
+    cfg = {"kanban": {"assignee_notification_channels": {"huginn": "discord:chan-huginn"}}}
+
+    for _ in range(2):
+        runner._running = True
+        tick_count = 0
+
+        async def _fast_sleep(_):
+            nonlocal tick_count
+            await _orig_sleep(0)
+            tick_count += 1
+            if tick_count >= 4:
+                runner._running = False
+
+        with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep), \
+             patch("hermes_cli.config.load_config", return_value=cfg):
+            await asyncio.wait_for(
+                runner._kanban_notifier_watcher(interval=1),
+                timeout=10.0,
+            )
+
+    assert len(sent) == 1
+    assert sent[0][0] == "chan-huginn"
+    assert tid in sent[0][1]
+
+
+@pytest.mark.asyncio
+async def test_notifier_autosubscribes_reassigned_assignee_channel(kanban_home):
+    """Reassigned tasks emit to the new assignee's configured profile lane."""
+    import hermes_cli.kanban_db as kb
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="build thing", assignee="brokkr")
+        assert kb.assign_task(conn, tid, "tyr") is True
+        kb.block_task(conn, tid, reason="needs review decision")
+    finally:
+        conn.close()
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_notifier_profile = "default"
+    runner._kanban_assignee_notify_started_at = 1
+
+    fake_adapter = MagicMock()
+
+    async def _send_and_stop(chat_id, msg, metadata=None):
+        runner._running = False
+
+    fake_adapter.send = AsyncMock(side_effect=_send_and_stop)
+    runner.adapters = {Platform.DISCORD: fake_adapter}
+
+    _orig_sleep = asyncio.sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    cfg = {
+        "kanban": {
+            "assignee_notification_channels": {
+                "brokkr": "discord:chan-brokkr",
+                "tyr": "discord:chan-tyr",
+            }
+        }
+    }
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep), \
+         patch("hermes_cli.config.load_config", return_value=cfg):
+        await asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    fake_adapter.send.assert_called_once()
+    assert fake_adapter.send.call_args[0][0] == "chan-tyr"
+    assert "@tyr" in fake_adapter.send.call_args[0][1]
+    assert "blocked" in fake_adapter.send.call_args[0][1]
+
+
+def test_notifier_late_assignee_route_skips_existing_terminal_events(kanban_home):
+    """Adding a worker channel at runtime must not replay old terminal events."""
+    import hermes_cli.kanban_db as kb
+    from gateway.run import GatewayRunner
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="already blocked", assignee="huginn")
+        kb.block_task(conn, tid, reason="blocked before channel existed")
+        max_event_id = conn.execute(
+            "SELECT COALESCE(MAX(id), 0) FROM task_events WHERE task_id = ?",
+            (tid,),
+        ).fetchone()[0]
+
+        runner = object.__new__(GatewayRunner)
+        runner._kanban_assignee_notify_terminal_seen = set()
+        routes = {"huginn": {"platform": "discord", "chat_id": "chan-huginn", "thread_id": ""}}
+        route_first_seen = {("huginn", "discord", "chan-huginn", ""): int(time.time()) + 60}
+
+        added = runner._kanban_sync_assignee_notify_subs(
+            conn,
+            kb,
+            routes,
+            active_platforms={"discord"},
+            notifier_profile="default",
+            terminal_kinds=("blocked",),
+            started_at=0,
+            route_first_seen=route_first_seen,
+            board="default",
+        )
+
+        assert added == 1
+        subs = kb.list_notify_subs(conn, tid)
+        assert len(subs) == 1
+        assert subs[0]["last_event_id"] == max_event_id
+        old_cursor, new_cursor, events = kb.claim_unseen_events_for_sub(
+            conn,
+            task_id=tid,
+            platform="discord",
+            chat_id="chan-huginn",
+            thread_id="",
+            kinds=["blocked"],
+        )
+        assert old_cursor == max_event_id
+        assert new_cursor == max_event_id
+        assert events == []
+    finally:
+        conn.close()
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -47,6 +47,7 @@ def kanban_home(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DASHBOARD_AUTO_SUBSCRIBE_HOME", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home
@@ -78,6 +79,33 @@ def test_board_empty(client):
     assert data["assignees"] == []
     assert data["latest_event_id"] == 0
 
+
+
+
+def test_board_returns_degraded_payload_for_corrupt_board(client, kanban_home):
+    mod = sys.modules["hermes_dashboard_plugin_kanban_test"]
+    db_path = kanban_home / "kanban" / "boards" / "default" / "kanban.db"
+    exc = kb.KanbanDbCorruptError(db_path, db_path.with_suffix(".bak"), "quick_check returned 'malformed'")
+
+    def _raise_corrupt(board=None):
+        raise exc
+
+    original = mod._conn
+    mod._conn = _raise_corrupt
+    try:
+        r = client.get("/api/plugins/kanban/board")
+    finally:
+        mod._conn = original
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "degraded"
+    assert data["board"] == "default"
+    assert "malformed" in data["reason"]
+    assert data["db_path"] == str(db_path)
+    assert data["backup_path"] == str(db_path.with_suffix(".bak"))
+    assert data["columns"]
+    assert all(col["tasks"] == [] for col in data["columns"])
 
 # ---------------------------------------------------------------------------
 # POST /tasks then GET /board sees it

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { GatewayClient } from '../gatewayClient.js'
+import { classifyGatewayExit, GatewayClient } from '../gatewayClient.js'
 
 interface ListenerEntry {
   callback: (event: any) => void
@@ -92,6 +92,24 @@ class FakeWebSocket {
     }
   }
 }
+
+describe('GatewayClient exit classification', () => {
+  it('classifies stdin EOF from the spawned TUI backend as a clean parent-pipe close', () => {
+    expect(classifyGatewayExit(0, 'stdin EOF (TUI closed the command pipe)')).toMatchObject({
+      clean: true,
+      code: 0,
+      kind: 'clean_stdin_eof'
+    })
+  })
+
+  it('keeps non-zero backend exits actionable as errors', () => {
+    expect(classifyGatewayExit(1, 'gateway error: spawn failed')).toMatchObject({
+      clean: false,
+      code: 1,
+      kind: 'error'
+    })
+  })
+})
 
 describe('GatewayClient websocket attach mode', () => {
   const originalWebSocket = globalThis.WebSocket
@@ -301,7 +319,7 @@ describe('GatewayClient websocket attach mode', () => {
     const secretUrl = 'ws://gateway.test/api/ws?token=hunter2&channel=secret'
 
     process.env.HERMES_TUI_GATEWAY_URL = secretUrl
-    ;(globalThis as { WebSocket?: unknown }).WebSocket = class ThrowingWebSocket extends FakeWebSocket {
+    ;(globalThis as { WebSocket?: unknown }).WebSocket = class ThrowingWebSocket {
       constructor(url: string) {
         throw new TypeError(`Invalid URL: ${url}`)
       }
@@ -328,11 +346,10 @@ describe('GatewayClient websocket attach mode', () => {
     process.env.HERMES_TUI_SIDECAR_URL = sidecarUrl
     ;(globalThis as { WebSocket?: unknown }).WebSocket = class ThrowingSidecarWebSocket extends FakeWebSocket {
       constructor(url: string) {
+        super(url)
         if (url.includes('/api/pub')) {
           throw new TypeError(`Invalid URL: ${url}`)
         }
-
-        super(url)
       }
     } as unknown as typeof WebSocket
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -7,7 +7,7 @@ import { MAX_HISTORY, WHEEL_SCROLL_STEP } from '../config/limits.js'
 import { SECTION_NAMES, sectionMode } from '../domain/details.js'
 import { attachedImageNotice, imageTokenMeta } from '../domain/messages.js'
 import { fmtCwdBranch, shortCwd } from '../domain/paths.js'
-import { type GatewayClient } from '../gatewayClient.js'
+import { type GatewayClient, type GatewayExitInfo } from '../gatewayClient.js'
 import type {
   ClarifyRespondResponse,
   ClipboardPasteResponse,
@@ -732,11 +732,22 @@ export function useMainApp(gw: GatewayClient) {
   useEffect(() => {
     const handler = (ev: GatewayEvent) => onEventRef.current(ev)
 
-    const exitHandler = () => {
+    const exitHandler = (_code: null | number, info?: GatewayExitInfo) => {
       turnController.reset()
+
+      if (info?.clean) {
+        const label = info.kind === 'clean_stdin_eof' ? 'TUI backend closed: stdin EOF' : 'TUI backend closed: stdout pipe closed'
+
+        patchUiState({ busy: false, sid: null, status: 'TUI backend closed' })
+        turnController.pushActivity(`${label} · parent TUI/PTY closed the pipe`, 'info')
+        sys(`notice: ${label}; the messaging gateway service is not implied down.`)
+
+        return
+      }
+
       patchUiState({ busy: false, sid: null, status: 'gateway exited' })
       turnController.pushActivity('gateway exited · /logs to inspect', 'error')
-      sys('error: gateway exited')
+      sys(`error: gateway exited${info?.reason ? ` (${info.reason})` : ''}`)
     }
 
     gw.on('event', handler)
@@ -800,6 +811,7 @@ export function useMainApp(gw: GatewayClient) {
       selection,
       send,
       session,
+      setVoiceTts,
       sys
     ]
   )

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -89,6 +89,39 @@ const asWireText = (raw: unknown): string | null => {
   return null
 }
 
+export type GatewayExitKind = 'clean_stdin_eof' | 'clean_broken_pipe' | 'websocket_close' | 'error' | 'unknown'
+
+export interface GatewayExitInfo {
+  code: null | number
+  clean: boolean
+  kind: GatewayExitKind
+  reason: string
+}
+
+export const classifyGatewayExit = (code: null | number, reason?: string): GatewayExitInfo => {
+  const cleanReason = (reason ?? '').trim()
+  const reasonForUser = cleanReason || `gateway exited${code === null ? '' : ` (${code})`}`
+  const lower = cleanReason.toLowerCase()
+
+  if (code === 0 && lower.includes('stdin eof')) {
+    return { clean: true, code, kind: 'clean_stdin_eof', reason: reasonForUser }
+  }
+
+  if (code === 0 && lower.includes('broken stdout pipe')) {
+    return { clean: true, code, kind: 'clean_broken_pipe', reason: reasonForUser }
+  }
+
+  if (lower.includes('websocket closed')) {
+    return { clean: false, code, kind: 'websocket_close', reason: reasonForUser }
+  }
+
+  if (code !== 0) {
+    return { clean: false, code, kind: 'error', reason: reasonForUser }
+  }
+
+  return { clean: false, code, kind: 'unknown', reason: reasonForUser }
+}
+
 // Matches `<scheme>://user:pass@host…` style user-info segments in
 // otherwise-malformed URLs that the WHATWG `URL` parser can't accept.
 // Used by the `redactUrl` fallback so embedded credentials are
@@ -141,11 +174,13 @@ export class GatewayClient extends EventEmitter {
   private pending = new Map<string, Pending>()
   private bufferedEvents = new CircularBuffer<GatewayEvent>(MAX_BUFFERED_EVENTS)
   private pendingExit: number | null | undefined
+  private pendingExitInfo: GatewayExitInfo | undefined
   private ready = false
   private readyTimer: ReturnType<typeof setTimeout> | null = null
   private subscribed = false
   private stdoutRl: ReturnType<typeof createInterface> | null = null
   private stderrRl: ReturnType<typeof createInterface> | null = null
+  private lastGatewayExitReason: string | undefined
 
   constructor() {
     super()
@@ -217,6 +252,8 @@ export class GatewayClient extends EventEmitter {
     this.ready = false
     this.bufferedEvents.clear()
     this.pendingExit = undefined
+    this.pendingExitInfo = undefined
+    this.lastGatewayExitReason = undefined
     this.stdoutRl?.close()
     this.stderrRl?.close()
     this.stdoutRl = null
@@ -248,13 +285,16 @@ export class GatewayClient extends EventEmitter {
   private handleTransportExit(code: null | number, reason?: string) {
     this.clearReadyTimer()
     this.closeSidecarSocket()
-    this.pushLog(`[lifecycle] transport exit code=${code ?? 'null'} reason=${reason ?? 'none'}`)
-    this.rejectPending(new Error(reason || `gateway exited${code === null ? '' : ` (${code})`}`))
+    const info = classifyGatewayExit(code, reason ?? this.lastGatewayExitReason)
+
+    this.pushLog(`[lifecycle] transport exit code=${code ?? 'null'} reason=${info.reason}`)
+    this.rejectPending(new Error(info.reason))
 
     if (this.subscribed) {
-      this.emit('exit', code)
+      this.emit('exit', code, info)
     } else {
       this.pendingExit = code
+      this.pendingExitInfo = info
     }
   }
 
@@ -355,6 +395,10 @@ export class GatewayClient extends EventEmitter {
 
       if (!line) {
         return
+      }
+
+      if (line.startsWith('[gateway-exit] ')) {
+        this.lastGatewayExitReason = line.slice('[gateway-exit] '.length).trim()
       }
 
       this.pushLog(line)
@@ -593,9 +637,11 @@ export class GatewayClient extends EventEmitter {
 
     if (this.pendingExit !== undefined) {
       const code = this.pendingExit
+      const info = this.pendingExitInfo ?? classifyGatewayExit(code)
 
       this.pendingExit = undefined
-      this.emit('exit', code)
+      this.pendingExitInfo = undefined
+      this.emit('exit', code, info)
     }
   }
 


### PR DESCRIPTION
## What

- Hardens Kanban gateway reliability around SQLite/WAL initialization, transaction rollback cleanup, dependency/decomposition routing, and dashboard/task recovery paths.
- Adds `kanban.assignee_notification_channels` support in the gateway notifier so worker/profile lanes can receive terminal task events in dedicated Discord/Gateway channels.
- Seeds assignee notification subscriptions with safe event cursors to avoid replaying historical terminal events when channels are added, and repairs legacy notify subscription rows without cursor loss.

## Why

Mimir hit transient SQLite `disk I/O error` symptoms while the gateway notifier, dispatcher, and live tests were opening frequent short-lived Kanban connections. We also wanted Guild-channel Discord routing where worker/profile lanes act as notification channels without running duplicate Discord gateways.

## How

- Applies WAL setup once per process/path instead of on every Kanban connection, while preserving upstream first-connect locking and integrity checks.
- Makes rollback cleanup best-effort so secondary rollback errors do not mask the original SQLite failure.
- Adds assignee-channel parsing and subscription sync in the gateway notifier, with per-route first-seen cutoffs and terminal-event seen tracking.
- Extends `add_notify_sub()` with an initial `last_event_id` cursor for safe subscription seeding.
- Normalizes/merges legacy notify subscription rows before key-changing updates, preserving the highest delivered cursor.
- Adds regression tests for WAL churn, rollback preservation, assignee lane delivery, late route suppression, duplicate notify repair, and related Kanban routing/dashboard behavior.

## Testing

- `python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_notify.py tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_decompose_db.py tests/plugins/test_kanban_dashboard_plugin.py -q -o 'addopts='`
  - `341 passed, 1 warning`
- `git diff --check origin/main...HEAD`
- Added-lines security-pattern scan for obvious secrets/shell/eval/pickle/SQL-format issues: no matches.
- Independent reviewer pass: no concrete security or logic defects found.

## Review Notes

- `ui-tui` tests were not run because this worktree does not have `ui-tui/node_modules` installed.
- This keeps worker/profile channels as notification lanes only; it does not implement channel-to-profile execution routing.
