### PR TITLE
fix(gateway): detect systemd on older versions (e.g. CentOS 7 systemd 219)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10199,7 +10199,12 @@ class GatewayRunner:
         # us.  The detached subprocess approach (setsid + bash) doesn't work
         # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
         # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # Detect systemd: check /run/systemd/system (works on all systemd versions,
+        # including CentOS 7's systemd 219 which lacks INVOCATION_ID).
+        _under_service = (
+            bool(os.environ.get("INVOCATION_ID"))
+            or os.path.isdir("/run/systemd/system")
+        )
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
         if _under_service or _in_container:
             self.request_restart(detached=False, via_service=True)


### PR DESCRIPTION
## Summary

Fix `/restart` hanging on CentOS 7 (systemd 219) by adding fallback systemd detection.

## Problem

`/restart` command hangs on CentOS 7 because `INVOCATION_ID` environment variable is not available in systemd versions before 225. The gateway exits with code 0 instead of 75, so systemd's `RestartForceExitStatus=75` policy doesn't trigger a restart.

## Root Cause

`INVOCATION_ID` was introduced in systemd 225 (2015). CentOS 7 ships with systemd 219, which lacks this variable.

## Solution

Add `/run/systemd/system` directory check as a fallback. This directory exists in all systemd versions and reliably indicates a systemd-managed environment.

```python
# Before
_under_service = bool(os.environ.get("INVOCATION_ID"))

# After
_under_service = (
    bool(os.environ.get("INVOCATION_ID"))
    or os.path.isdir("/run/systemd/system")
)
```

## Testing

- CentOS 7 (systemd 219): `/restart` now auto-restarts within 21 seconds ✅
- Detection logic: `INVOCATION_ID` empty + `/run/systemd/system` exists = correctly detected ✅
- Backward compatible:保留原有 INVOCATION_ID 检测作为首选