### PR TITLE
fix: dedupe replayed streaming tool call arguments

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -50,6 +50,25 @@ def _ra():
     return run_agent
 
 
+def _merge_stream_tool_arguments(existing: str, incoming: str) -> str:
+    """Merge tool-call argument chunks without duplicating replayed prefixes.
+
+    Most providers stream only the new JSON fragment for ``arguments``. Some
+    providers instead resend the full accumulated JSON-so-far in later chunks.
+    Preserve normal append semantics for true deltas while treating exact or
+    prefix replays as idempotent updates of the current buffer.
+    """
+    if not incoming:
+        return existing
+    if not existing:
+        return incoming
+    if incoming == existing:
+        return existing
+    if incoming.startswith(existing):
+        return incoming
+    return existing + incoming
+
+
 def estimate_request_context_tokens(api_payload: Any) -> int:
     """Estimate context/load tokens from an API payload, dict or messages list.
 
@@ -1867,7 +1886,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                             # Vercel AI patterns) is immune to this.
                             entry["function"]["name"] = tc_delta.function.name
                         if tc_delta.function.arguments:
-                            entry["function"]["arguments"] += tc_delta.function.arguments
+                            entry["function"]["arguments"] = _merge_stream_tool_arguments(
+                                entry["function"]["arguments"],
+                                tc_delta.function.arguments,
+                            )
                     extra = getattr(tc_delta, "extra_content", None)
                     if extra is None and hasattr(tc_delta, "model_extra"):
                         extra = (tc_delta.model_extra or {}).get("extra_content")

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -186,6 +186,124 @@ class TestStreamingAccumulator:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_tool_arguments_not_duplicated_when_provider_replays_full_prefix(self, mock_close, mock_create):
+        """Some providers resend full arguments-so-far instead of delta fragments."""
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_xml",
+                    name="session_search",
+                    arguments='{"query":"bug","options":{"',
+                )
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_xml",
+                    name="session_search",
+                    arguments='{"query":"bug","options":{"around_message_id":"m_123"',
+                )
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_xml",
+                    name="session_search",
+                    arguments='{"query":"bug","options":{"around_message_id":"m_123","limit":5}}',
+                )
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        tc = response.choices[0].message.tool_calls
+        assert tc is not None
+        assert len(tc) == 1
+        assert tc[0].function.name == "session_search"
+        assert tc[0].function.arguments == (
+            '{"query":"bug","options":{"around_message_id":"m_123","limit":5}}'
+        )
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_tool_arguments_ignore_exact_replay_chunk(self, mock_close, mock_create):
+        """An identical replay chunk must not duplicate the current JSON buffer."""
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_dup",
+                    name="memory",
+                    arguments='{"action":"replace","old_string":"foo"',
+                )
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_dup",
+                    name="memory",
+                    arguments='{"action":"replace","old_string":"foo"',
+                )
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_dup",
+                    name="memory",
+                    arguments='{"action":"replace","old_string":"foo","new_string":"bar"}',
+                )
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        tc = response.choices[0].message.tool_calls
+        assert tc is not None
+        assert len(tc) == 1
+        assert tc[0].function.name == "memory"
+        assert tc[0].function.arguments == (
+            '{"action":"replace","old_string":"foo","new_string":"bar"}'
+        )
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_tool_call_extra_content_preserved(self, mock_close, mock_create):
         """Streamed tool calls preserve provider-specific extra_content metadata."""
         from run_agent import AIAgent


### PR DESCRIPTION
Closes #35592

## Summary
- avoid duplicating streamed tool-call JSON when a provider replays the full arguments-so-far buffer
- keep normal append behavior for true delta fragments
- add regression coverage for both full-prefix replays and exact repeated chunks

## Testing
- uv run --active --frozen --extra dev python -m pytest tests/run_agent/test_streaming.py -o 'addopts=' -q\n- uv run --active --frozen --extra dev python -m ruff check agent/chat_completion_helpers.py tests/run_agent/test_streaming.py\n- git diff --check