### PR TITLE
fix(agent): allow bounded repeated stall retries

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -725,6 +725,15 @@ def try_recover_primary_transport(
     if agent._fallback_activated:
         return False
 
+    # The dflash first-chunk watchdog already proved this request was accepted
+    # but produced no SSE data. Rebuilding the same primary client just repeats
+    # the full TTFB wait; route to fallback or fail fast instead.
+    if (
+        getattr(api_error, "_hermes_local_first_chunk_timeout", False)
+        or getattr(api_error, "_hermes_local_dflash_first_chunk_timeout", False)
+    ):
+        return False
+
     # Only for transient transport errors
     error_type = type(api_error).__name__
     if error_type not in _TRANSIENT_TRANSPORT_ERRORS:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -191,20 +191,20 @@ def _local_provider_first_chunk_timeout(api_payload: Any, model: Any) -> float |
 
     timeout = _env_float(
         "HERMES_LOCAL_FIRST_CHUNK_TIMEOUT",
-        _env_float("HERMES_LOCAL_TTFB_TIMEOUT", 180.0),
+        _env_float("HERMES_LOCAL_TTFB_TIMEOUT", 90.0),
     )
     if timeout <= 0:
         return float("inf")
 
     est_tokens = estimate_request_context_tokens(api_payload)
     if est_tokens > 100_000:
-        return max(timeout, 900.0)
-    if est_tokens > 50_000:
         return max(timeout, 600.0)
-    if est_tokens > 25_000:
+    if est_tokens > 50_000:
         return max(timeout, 360.0)
-    if est_tokens > 10_000:
+    if est_tokens > 25_000:
         return max(timeout, 240.0)
+    if est_tokens > 10_000:
+        return max(timeout, 150.0)
     return timeout
 
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -122,6 +122,179 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _is_dflash_like_model(model: Any) -> bool:
+    return "dflash" in str(model or "").lower()
+
+
+def _dflash_local_stale_timeout(api_payload: Any, model: Any) -> float | None:
+    """Return a bounded local-provider stale timeout for dflash models.
+
+    Generic local endpoints still need generous prefill behavior for large
+    self-hosted models, but dflash's failure mode is different: a request can
+    park on an open local socket forever without producing a first chunk. Keep
+    dflash bounded so the normal retry/fallback path gets a chance to run.
+    """
+    if not _is_dflash_like_model(model):
+        return None
+
+    timeout = _env_float(
+        "HERMES_DFLASH_STALE_TIMEOUT",
+        _env_float("HERMES_DFLASH_STREAM_STALE_TIMEOUT", 75.0),
+    )
+    if timeout <= 0:
+        # Preserve the stale-timeout convention that non-positive env values
+        # explicitly disable the watchdog, even for dflash.
+        return float("inf")
+
+    est_tokens = estimate_request_context_tokens(api_payload)
+    if est_tokens > 100_000:
+        return max(timeout, 300.0)
+    if est_tokens > 50_000:
+        return max(timeout, 240.0)
+    if est_tokens > 25_000:
+        return max(timeout, 150.0)
+    if est_tokens > 10_000:
+        return max(timeout, 90.0)
+    return timeout
+
+
+def _dflash_local_first_chunk_timeout(api_payload: Any, model: Any) -> float | None:
+    """Return the dflash no-first-chunk cutoff for local streaming calls.
+
+    This is intentionally separate from the post-first-chunk stale timeout.
+    Long contexts can justify longer gaps between chunks after generation has
+    started, but the 2026-05-31 dflash failure mode was an accepted local
+    request that never emitted its first stream chunk and kept decoding after
+    the client disconnected.
+    """
+    if not _is_dflash_like_model(model):
+        return None
+
+    timeout = _env_float(
+        "HERMES_DFLASH_FIRST_CHUNK_TIMEOUT",
+        _env_float("HERMES_DFLASH_TTFB_TIMEOUT", 75.0),
+    )
+    if timeout <= 0:
+        return float("inf")
+    return timeout
+
+
+def _local_provider_first_chunk_timeout(api_payload: Any, model: Any) -> float | None:
+    """Return the generic local-provider no-first-chunk cutoff.
+
+    Local backends can legitimately spend longer pre-filling than cloud
+    providers, but they still need a finite TTFB watchdog so a fallback model
+    cannot inherit an infinite wait after the primary already stalled.
+    """
+    if _is_dflash_like_model(model):
+        return _dflash_local_first_chunk_timeout(api_payload, model)
+
+    timeout = _env_float(
+        "HERMES_LOCAL_FIRST_CHUNK_TIMEOUT",
+        _env_float("HERMES_LOCAL_TTFB_TIMEOUT", 180.0),
+    )
+    if timeout <= 0:
+        return float("inf")
+
+    est_tokens = estimate_request_context_tokens(api_payload)
+    if est_tokens > 100_000:
+        return max(timeout, 900.0)
+    if est_tokens > 50_000:
+        return max(timeout, 600.0)
+    if est_tokens > 25_000:
+        return max(timeout, 360.0)
+    if est_tokens > 10_000:
+        return max(timeout, 240.0)
+    return timeout
+
+
+def _mark_local_first_chunk_timeout(
+    error: Exception,
+    *,
+    elapsed: float,
+    threshold: float,
+    model: Any,
+    context_tokens: int,
+) -> Exception:
+    """Preserve the local TTFB watchdog reason across SDK transport wrappers."""
+    meta = {
+        "elapsed": int(elapsed),
+        "threshold": int(threshold),
+        "model": str(model or "unknown"),
+        "context_tokens": int(context_tokens or 0),
+    }
+    try:
+        setattr(error, "_hermes_local_first_chunk_timeout", True)
+        setattr(error, "_hermes_local_first_chunk_meta", meta)
+        if _is_dflash_like_model(model):
+            setattr(error, "_hermes_local_dflash_first_chunk_timeout", True)
+            setattr(error, "_hermes_dflash_first_chunk_meta", meta)
+    except Exception:
+        pass
+    return error
+
+
+def _mark_dflash_first_chunk_timeout(
+    error: Exception,
+    *,
+    elapsed: float,
+    threshold: float,
+    model: Any,
+    context_tokens: int,
+) -> Exception:
+    """Backward-compatible wrapper for tests and older call sites."""
+    return _mark_local_first_chunk_timeout(
+        error,
+        elapsed=elapsed,
+        threshold=threshold,
+        model=model,
+        context_tokens=context_tokens,
+    )
+
+
+def resolve_stream_stale_timeout(agent, api_kwargs: dict) -> float:
+    """Resolve the no-chunk timeout for streaming chat completions."""
+    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
+    if _cfg_stale is not None:
+        _stream_stale_timeout_base = _cfg_stale
+        _uses_implicit_default = False
+    else:
+        _env_stale = os.getenv("HERMES_STREAM_STALE_TIMEOUT")
+        if _env_stale is not None:
+            _stream_stale_timeout_base = _env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
+            _uses_implicit_default = False
+        else:
+            _stream_stale_timeout_base = 180.0
+            _uses_implicit_default = True
+
+    _est_tokens = estimate_request_context_tokens(api_kwargs)
+    if (
+        _uses_implicit_default
+        and agent.base_url
+        and is_local_endpoint(agent.base_url)
+    ):
+        _model = api_kwargs.get("model") or agent.model
+        _dflash_timeout = _dflash_local_stale_timeout(api_kwargs, _model)
+        if _dflash_timeout is not None:
+            logger.debug(
+                "Local dflash provider detected (%s) — stream stale timeout set to %.0fs",
+                agent.base_url,
+                _dflash_timeout,
+            )
+            return _dflash_timeout
+        logger.debug(
+            "Local provider detected (%s) — stale stream timeout disabled",
+            agent.base_url,
+        )
+        return float("inf")
+
+    if _est_tokens > 100_000:
+        return max(_stream_stale_timeout_base, 300.0)
+    if _est_tokens > 50_000:
+        return max(_stream_stale_timeout_base, 240.0)
+    return _stream_stale_timeout_base
+
+
 def interruptible_api_call(agent, api_kwargs: dict):
     """
     Run the API call in a background thread so the main conversation loop
@@ -1622,7 +1795,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             raise result["error"]
         return result["response"]
 
-    result = {"response": None, "error": None, "partial_tool_names": []}
+    result = {
+        "response": None,
+        "error": None,
+        "partial_tool_names": [],
+        "local_first_chunk_timeout": None,
+    }
     request_client_holder = {"client": None, "diag": None, "owner_tid": None}
     request_client_lock = threading.Lock()
 
@@ -2287,31 +2465,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         finally:
             _close_request_client_once("stream_request_complete")
 
-    # Provider-configured stale timeout takes priority over env default.
-    _cfg_stale = get_provider_stale_timeout(agent.provider, agent.model)
-    if _cfg_stale is not None:
-        _stream_stale_timeout_base = _cfg_stale
-    else:
-        _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
-    # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
-    # for prefill on large contexts.  Disable the stale detector unless
-    # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.
-    if _stream_stale_timeout_base == 180.0 and agent.base_url and is_local_endpoint(agent.base_url):
-        _stream_stale_timeout = float("inf")
-        logger.debug("Local provider detected (%s) — stale stream timeout disabled", agent.base_url)
-    else:
-        # Scale the stale timeout for large contexts: slow models (like Opus)
-        # can legitimately think for minutes before producing the first token
-        # when the context is large.  Without this, the stale detector kills
-        # healthy connections during the model's thinking phase, producing
-        # spurious RemoteProtocolError ("peer closed connection").
-        _est_tokens = estimate_request_context_tokens(api_kwargs)
-        if _est_tokens > 100_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 300.0)
-        elif _est_tokens > 50_000:
-            _stream_stale_timeout = max(_stream_stale_timeout_base, 240.0)
-        else:
-            _stream_stale_timeout = _stream_stale_timeout_base
+    _stream_stale_timeout = resolve_stream_stale_timeout(agent, api_kwargs)
+    _local_first_chunk_timeout = None
+    _local_first_chunk_model = api_kwargs.get("model") or agent.model
+    if agent.base_url and is_local_endpoint(agent.base_url):
+        _local_first_chunk_timeout = _local_provider_first_chunk_timeout(
+            api_kwargs,
+            _local_first_chunk_model,
+        )
 
     t = threading.Thread(target=_call, daemon=True)
     t.start()
@@ -2335,6 +2496,72 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             agent._touch_activity(
                 f"waiting for stream response ({_waiting_secs}s, no chunks yet)"
             )
+
+        # Local providers have a distinct no-first-chunk failure mode: the HTTP
+        # request is accepted but the server never emits the first SSE chunk.
+        # Do not inherit the larger long-context stale timeout for this phase;
+        # once any chunk arrives, the normal stale detector below takes over.
+        if _local_first_chunk_timeout is not None and not first_chunk_seen["yes"]:
+            _first_elapsed = time.time() - last_chunk_time["t"]
+            if _first_elapsed > _local_first_chunk_timeout:
+                _est_ctx = estimate_request_context_tokens(api_kwargs)
+                _is_dflash_first_chunk = _is_dflash_like_model(_local_first_chunk_model)
+                _local_label = (
+                    "local dflash"
+                    if _is_dflash_first_chunk
+                    else f"local {_local_first_chunk_model or 'model'}"
+                )
+                logger.warning(
+                    "%s stream produced no first chunk for %.0fs "
+                    "(threshold %.0fs). model=%s context=~%s tokens. "
+                    "Killing connection.",
+                    _local_label.capitalize(),
+                    _first_elapsed,
+                    _local_first_chunk_timeout,
+                    api_kwargs.get("model", "unknown"),
+                    f"{_est_ctx:,}",
+                )
+                agent._buffer_status(
+                    f"⚠️ No first stream chunk from {_local_label} for "
+                    f"{int(_first_elapsed)}s "
+                    f"(context: ~{_est_ctx:,} tokens). Switching fallback..."
+                )
+                result["local_first_chunk_timeout"] = {
+                    "elapsed": _first_elapsed,
+                    "threshold": _local_first_chunk_timeout,
+                    "model": _local_first_chunk_model,
+                    "context_tokens": _est_ctx,
+                }
+                try:
+                    _close_request_client_once("local_first_chunk_kill")
+                except Exception:
+                    pass
+                try:
+                    agent._replace_primary_openai_client(
+                        reason="local_first_chunk_pool_cleanup"
+                    )
+                except Exception:
+                    pass
+                t.join(timeout=_env_float("HERMES_STREAM_ABORT_JOIN_TIMEOUT", 2.0))
+                if result["error"] is None and result["response"] is None:
+                    result["error"] = _mark_local_first_chunk_timeout(
+                        TimeoutError(
+                            f"{_local_label.capitalize()} stream produced no first chunk after "
+                            f"{int(_first_elapsed)}s "
+                            f"(threshold: {int(_local_first_chunk_timeout)}s)"
+                        ),
+                        elapsed=_first_elapsed,
+                        threshold=_local_first_chunk_timeout,
+                        model=_local_first_chunk_model,
+                        context_tokens=_est_ctx,
+                    )
+                    break
+                if result["error"] is not None or result["response"] is not None:
+                    break
+                last_chunk_time["t"] = time.time()
+                agent._touch_activity(
+                    f"{_local_label} first-chunk timeout after {int(_first_elapsed)}s"
+                )
 
         # Detect stale streams: connections kept alive by SSE pings
         # but delivering no real chunks.  Kill the client so the
@@ -2382,6 +2609,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 pass
             raise InterruptedError("Agent interrupted during streaming API call")
     if result["error"] is not None:
+        _first_chunk_meta = result.get("local_first_chunk_timeout")
+        if _first_chunk_meta:
+            result["error"] = _mark_local_first_chunk_timeout(
+                result["error"],
+                elapsed=float(_first_chunk_meta.get("elapsed") or 0.0),
+                threshold=float(_first_chunk_meta.get("threshold") or 0.0),
+                model=_first_chunk_meta.get("model"),
+                context_tokens=int(_first_chunk_meta.get("context_tokens") or 0),
+            )
         if deltas_were_sent["yes"]:
             # Streaming failed AFTER some tokens were already delivered to
             # the platform.  Re-raising would let the outer retry loop make

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -208,6 +208,38 @@ def _local_provider_first_chunk_timeout(api_payload: Any, model: Any) -> float |
     return timeout
 
 
+def _local_provider_non_stream_stale_timeout(api_payload: Any, model: Any) -> float:
+    """Return a finite stale timeout for local non-streaming calls.
+
+    Local non-streaming OpenAI-compatible calls are dangerous when left
+    unbounded: the server may accept the request, generate for a very long time,
+    and send no response headers until the entire completion is done.  Keep the
+    default finite so fallback/recovery can run, while still scaling for large
+    prompt prefill.
+    """
+    dflash_timeout = _dflash_local_stale_timeout(api_payload, model)
+    if dflash_timeout is not None:
+        return dflash_timeout
+
+    timeout = _env_float(
+        "HERMES_LOCAL_NON_STREAM_STALE_TIMEOUT",
+        _env_float("HERMES_LOCAL_RESPONSE_TIMEOUT", 120.0),
+    )
+    if timeout <= 0:
+        return float("inf")
+
+    est_tokens = estimate_request_context_tokens(api_payload)
+    if est_tokens > 100_000:
+        return max(timeout, 600.0)
+    if est_tokens > 50_000:
+        return max(timeout, 360.0)
+    if est_tokens > 25_000:
+        return max(timeout, 240.0)
+    if est_tokens > 10_000:
+        return max(timeout, 180.0)
+    return timeout
+
+
 def _mark_local_first_chunk_timeout(
     error: Exception,
     *,
@@ -659,6 +691,21 @@ def interruptible_api_call(agent, api_kwargs: dict):
                     _close_request_client_once("stale_call_kill")
             except Exception:
                 pass
+            if agent.base_url and is_local_endpoint(agent.base_url):
+                try:
+                    from agent.local_backend_recovery import maybe_recover_local_backend
+
+                    maybe_recover_local_backend(
+                        agent,
+                        reason="local_non_stream_stale_timeout",
+                        model=api_kwargs.get("model") or agent.model,
+                        base_url=agent.base_url,
+                        context_tokens=_est_ctx,
+                        elapsed=_elapsed,
+                        threshold=_stale_timeout,
+                    )
+                except Exception:
+                    logger.exception("Local backend recovery hook failed")
             agent._touch_activity(
                 f"stale non-streaming call killed after {int(_elapsed)}s"
             )
@@ -2542,6 +2589,20 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     )
                 except Exception:
                     pass
+                try:
+                    from agent.local_backend_recovery import maybe_recover_local_backend
+
+                    maybe_recover_local_backend(
+                        agent,
+                        reason="local_first_chunk_timeout",
+                        model=_local_first_chunk_model,
+                        base_url=agent.base_url,
+                        context_tokens=_est_ctx,
+                        elapsed=_first_elapsed,
+                        threshold=_local_first_chunk_timeout,
+                    )
+                except Exception:
+                    logger.exception("Local backend recovery hook failed")
                 t.join(timeout=_env_float("HERMES_STREAM_ABORT_JOIN_TIMEOUT", 2.0))
                 if result["error"] is None and result["response"] is None:
                     result["error"] = _mark_local_first_chunk_timeout(
@@ -2591,6 +2652,28 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 agent._replace_primary_openai_client(reason="stale_stream_pool_cleanup")
             except Exception:
                 pass
+            if agent.base_url and is_local_endpoint(agent.base_url):
+                try:
+                    from agent.local_backend_recovery import maybe_recover_local_backend
+
+                    maybe_recover_local_backend(
+                        agent,
+                        reason="local_stream_stale_timeout",
+                        model=api_kwargs.get("model") or agent.model,
+                        base_url=agent.base_url,
+                        context_tokens=_est_ctx,
+                        elapsed=_stale_elapsed,
+                        threshold=_stream_stale_timeout,
+                    )
+                except Exception:
+                    logger.exception("Local backend recovery hook failed")
+            t.join(timeout=_env_float("HERMES_STREAM_ABORT_JOIN_TIMEOUT", 2.0))
+            if result["error"] is None and result["response"] is None:
+                result["error"] = TimeoutError(
+                    f"Streaming API call timed out after {int(_stale_elapsed)}s "
+                    f"with no chunks (threshold: {int(_stream_stale_timeout)}s)"
+                )
+                break
             # Reset the timer so we don't kill repeatedly while
             # the inner thread processes the closure.
             last_chunk_time["t"] = time.time()

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -793,6 +793,11 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
+    # Agentic stall-retry guard: ensures the HERMES_STALL_RETRY_MODEL retry
+    # fires at most once per conversation (avoids loops if the retry lane also
+    # stalls). See agent/stall_retry.py.
+    _stall_retry_used = False
+
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()
@@ -3939,7 +3944,33 @@ def run_conversation(
             else:
                 # No tool calls - this is the final response
                 final_response = assistant_message.content or ""
-                
+
+                # ── Agentic stall-retry (opt-in via HERMES_STALL_RETRY_MODEL) ──
+                # dflash Q4 sometimes emits EOS right after an action preamble
+                # ("Let me check X:") with no tool_call, ending the turn early
+                # and stalling the agent mid-task. If this no-tool-call turn
+                # looks like that stall (not a genuine final answer) and a retry
+                # lane is configured, re-issue the SAME turn once on a
+                # higher-quality model; if it yields tool calls, adopt it and
+                # continue the loop instead of stopping. No-op unless the env is
+                # set, so default behavior is unchanged.
+                if not _stall_retry_used:
+                    try:
+                        from agent.stall_retry import looks_like_stall, retry_on_stall
+                        if looks_like_stall(
+                            final_response, finish_reason,
+                            bool(getattr(assistant_message, "tool_calls", None)),
+                            int(os.environ.get("HERMES_STALL_RETRY_MAX_CHARS", "400") or 400),
+                        ):
+                            _retried = retry_on_stall(agent, api_messages, finish_reason)
+                            if _retried is not None and getattr(_retried, "tool_calls", None):
+                                _stall_retry_used = True
+                                assistant_message = _retried
+                                finish_reason = "tool_calls"
+                                continue  # re-enter loop top; tool-calls path handles it
+                    except Exception:
+                        pass  # any failure: keep the original response
+
                 # Fix: unmute output when entering the no-tool-call branch
                 # so the user can see empty-response warnings and recovery
                 # status messages.  _mute_post_response was set during a

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -801,17 +801,21 @@ def run_conversation(
     _stall_retry_count = 0
     _stall_retry_success_count = 0
     _stall_retry_failed_count = 0
+    _stall_retry_no_tool_recovery_count = 0
     agent._stall_retry_runtime_promoted = False
     try:
         from agent.stall_retry import (
             get_stall_retry_max_per_turn,
+            get_stall_retry_no_tool_recovery_max,
             get_stall_retry_promote_after,
         )
 
         _stall_retry_max_per_turn = get_stall_retry_max_per_turn(agent)
+        _stall_retry_no_tool_recovery_max = get_stall_retry_no_tool_recovery_max(agent)
         _stall_retry_promote_after = get_stall_retry_promote_after(agent)
     except Exception:
         _stall_retry_max_per_turn = 5
+        _stall_retry_no_tool_recovery_max = 2
         _stall_retry_promote_after = 2
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
@@ -3629,12 +3633,10 @@ def run_conversation(
             # dflash Q4 can stop right after an action preamble ("Let me
             # check X") without producing the promised tool_call. Retry the
             # exact same turn on the configured higher-quality lane before
-            # the final-response branch sees it. If the retry returns tool
-            # calls, fall through to the normal executor below in this same
-            # loop iteration. If it still returns no tool call, fail this
-            # turn as partial instead of persisting the planning-only text as
-            # a completed assistant message that poisons future "continue"
-            # turns.
+            # the final-response branch sees it. If it still returns no tool
+            # call, feed a bounded corrective continuation back into the same
+            # turn before finally failing as partial; this prevents one bad
+            # retry-lane sample from killing long mobile sessions.
             try:
                 from agent.stall_retry import get_stall_retry_model
 
@@ -3649,11 +3651,13 @@ def run_conversation(
                 try:
                     from agent.stall_retry import (
                         EMPTY_AFTER_TOOL_RETRY_NUDGE,
+                        FAILED_STALL_RETRY_RECOVERY_NUDGE,
                         activate_stall_retry_runtime,
                         get_stall_retry_max_chars,
                         has_recent_tool_result,
                         looks_like_incomplete_final_fragment,
                         looks_like_stall,
+                        record_stall_retry_event,
                         retry_on_stall,
                     )
 
@@ -3755,11 +3759,13 @@ def run_conversation(
                                 "failure_subclass": "stall_retry_limit_exhausted",
                             }
                         _stall_retry_count += 1
+                        stalled_content = assistant_message.content or ""
                         retried = retry_on_stall(
                             agent,
                             api_messages,
                             finish_reason,
-                            stalled_content=assistant_message.content or "",
+                            stalled_content=stalled_content,
+                            retry_index=_stall_retry_count,
                             accept_content=_retry_accepts_content,
                         )
                         if retried is not None and (
@@ -3788,6 +3794,45 @@ def run_conversation(
                                 )
                         else:
                             _stall_retry_failed_count += 1
+                            if (
+                                _stall_retry_no_tool_recovery_count
+                                < _stall_retry_no_tool_recovery_max
+                            ):
+                                _stall_retry_no_tool_recovery_count += 1
+                                record_stall_retry_event(
+                                    agent,
+                                    "no_tool_recovery_prompt",
+                                    finish_reason=finish_reason,
+                                    api_call=api_call_count,
+                                    retry_count=_stall_retry_count,
+                                    failed_count=_stall_retry_failed_count,
+                                    recovery_count=_stall_retry_no_tool_recovery_count,
+                                    recovery_max=_stall_retry_no_tool_recovery_max,
+                                    content=stalled_content,
+                                )
+                                agent._vprint(
+                                    (
+                                        f"{agent.log_prefix}↻ Stall retry still "
+                                        "returned no tool call; feeding a bounded "
+                                        "same-turn correction back to the model "
+                                        f"({_stall_retry_no_tool_recovery_count}/"
+                                        f"{_stall_retry_no_tool_recovery_max})."
+                                    ),
+                                    force=True,
+                                )
+                                assistant_msg = agent._build_assistant_message(
+                                    assistant_message,
+                                    finish_reason,
+                                )
+                                messages.append(assistant_msg)
+                                messages.append(
+                                    {
+                                        "role": "user",
+                                        "content": FAILED_STALL_RETRY_RECOVERY_NUDGE,
+                                    }
+                                )
+                                agent._session_messages = messages
+                                continue
                             _turn_exit_reason = "stall_retry_failed_no_tool_call"
                             agent._mute_post_response = False
                             agent._vprint(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3262,6 +3262,25 @@ def run_conversation(
                     }
 
                 if retry_count >= max_retries:
+                    if classified.reason == FailoverReason.local_first_chunk_timeout:
+                        if agent._has_pending_fallback():
+                            meta = classified.error_context or {}
+                            waited = meta.get("elapsed")
+                            waited_text = (
+                                f" after {int(waited)}s"
+                                if isinstance(waited, (int, float)) and waited > 0
+                                else ""
+                            )
+                            agent._buffer_status(
+                                "⚠️ Local dflash produced no first chunk"
+                                f"{waited_text} — trying fallback..."
+                            )
+                        if agent._try_activate_fallback(reason=classified.reason):
+                            retry_count = 0
+                            compression_attempts = 0
+                            primary_recovery_attempted = False
+                            continue
+                        primary_recovery_attempted = True
                     # Before falling back, try rebuilding the primary
                     # client once for transient transport errors (stale
                     # connection pool, TCP reset).  Only attempted once

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3608,6 +3608,92 @@ def run_conversation(
                 }
             elif hasattr(agent, "_codex_incomplete_retries"):
                 agent._codex_incomplete_retries = 0
+
+            # ── Agentic stall-retry (opt-in via HERMES_STALL_RETRY_MODEL) ──
+            # dflash Q4 can stop right after an action preamble ("Let me
+            # check X") without producing the promised tool_call. Retry the
+            # exact same turn on the configured higher-quality lane before
+            # the final-response branch sees it. If the retry returns tool
+            # calls, fall through to the normal executor below in this same
+            # loop iteration. If it still returns no tool call, fail this
+            # turn as partial instead of persisting the planning-only text as
+            # a completed assistant message that poisons future "continue"
+            # turns.
+            retry_model = os.environ.get("HERMES_STALL_RETRY_MODEL", "").strip()
+            if (
+                retry_model
+                and not _stall_retry_used
+                and getattr(agent, "tools", None)
+                and not getattr(assistant_message, "tool_calls", None)
+            ):
+                try:
+                    max_chars = int(
+                        os.environ.get("HERMES_STALL_RETRY_MAX_CHARS", "400") or 400
+                    )
+                except ValueError:
+                    max_chars = 400
+                try:
+                    from agent.stall_retry import looks_like_stall, retry_on_stall
+
+                    if looks_like_stall(
+                        assistant_message.content or "",
+                        finish_reason,
+                        False,
+                        max_chars,
+                    ):
+                        _stall_retry_used = True
+                        retried = retry_on_stall(agent, api_messages, finish_reason)
+                        if retried is not None and getattr(retried, "tool_calls", None):
+                            assistant_message = retried
+                            finish_reason = getattr(retried, "finish_reason", None) or "tool_calls"
+                            if finish_reason != "tool_calls":
+                                finish_reason = "tool_calls"
+                        else:
+                            _turn_exit_reason = "stall_retry_failed_no_tool_call"
+                            agent._mute_post_response = False
+                            agent._vprint(
+                                (
+                                    f"{agent.log_prefix}❌ Stall retry did not produce "
+                                    "tool calls; saving as partial without storing the "
+                                    "planning-only assistant turn."
+                                ),
+                                force=True,
+                            )
+                            agent._cleanup_task_resources(effective_task_id)
+                            agent._persist_session(messages, conversation_history)
+                            return {
+                                "final_response": None,
+                                "messages": messages,
+                                "api_calls": api_call_count,
+                                "completed": False,
+                                "partial": True,
+                                "failed": True,
+                                "error": (
+                                    "Model stopped after an action preamble with no "
+                                    "tool call; configured stall retry also produced "
+                                    "no tool call."
+                                ),
+                                "failure_subclass": "stall_retry_failed_no_tool_call",
+                            }
+                except Exception as exc:
+                    _turn_exit_reason = "stall_retry_exception"
+                    agent._mute_post_response = False
+                    agent._vprint(
+                        f"{agent.log_prefix}❌ Stall retry failed before recovery: {exc}",
+                        force=True,
+                    )
+                    agent._cleanup_task_resources(effective_task_id)
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": None,
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "partial": True,
+                        "failed": True,
+                        "error": f"Stall retry failed before recovery: {exc}",
+                        "failure_subclass": "stall_retry_exception",
+                    }
             
             # Check for tool calls
             if assistant_message.tool_calls:
@@ -3944,32 +4030,6 @@ def run_conversation(
             else:
                 # No tool calls - this is the final response
                 final_response = assistant_message.content or ""
-
-                # ── Agentic stall-retry (opt-in via HERMES_STALL_RETRY_MODEL) ──
-                # dflash Q4 sometimes emits EOS right after an action preamble
-                # ("Let me check X:") with no tool_call, ending the turn early
-                # and stalling the agent mid-task. If this no-tool-call turn
-                # looks like that stall (not a genuine final answer) and a retry
-                # lane is configured, re-issue the SAME turn once on a
-                # higher-quality model; if it yields tool calls, adopt it and
-                # continue the loop instead of stopping. No-op unless the env is
-                # set, so default behavior is unchanged.
-                if not _stall_retry_used:
-                    try:
-                        from agent.stall_retry import looks_like_stall, retry_on_stall
-                        if looks_like_stall(
-                            final_response, finish_reason,
-                            bool(getattr(assistant_message, "tool_calls", None)),
-                            int(os.environ.get("HERMES_STALL_RETRY_MAX_CHARS", "400") or 400),
-                        ):
-                            _retried = retry_on_stall(agent, api_messages, finish_reason)
-                            if _retried is not None and getattr(_retried, "tool_calls", None):
-                                _stall_retry_used = True
-                                assistant_message = _retried
-                                finish_reason = "tool_calls"
-                                continue  # re-enter loop top; tool-calls path handles it
-                    except Exception:
-                        pass  # any failure: keep the original response
 
                 # Fix: unmute output when entering the no-tool-call branch
                 # so the user can see empty-response warnings and recovery

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -799,12 +799,11 @@ def run_conversation(
     # planning-only text response as final. See agent/stall_retry.py.
     _stall_retry_count = 0
     try:
-        _stall_retry_max_per_turn = int(
-            os.environ.get("HERMES_STALL_RETRY_MAX_PER_TURN", "5") or 5
-        )
-    except ValueError:
+        from agent.stall_retry import get_stall_retry_max_per_turn
+
+        _stall_retry_max_per_turn = get_stall_retry_max_per_turn(agent)
+    except Exception:
         _stall_retry_max_per_turn = 5
-    _stall_retry_max_per_turn = max(0, _stall_retry_max_per_turn)
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3640,9 +3640,57 @@ def run_conversation(
                 except ValueError:
                     max_chars = 400
                 try:
-                    from agent.stall_retry import looks_like_stall, retry_on_stall
+                    from agent.stall_retry import (
+                        EMPTY_AFTER_TOOL_RETRY_NUDGE,
+                        looks_like_stall,
+                        retry_on_stall,
+                    )
 
-                    if looks_like_stall(
+                    _empty_after_tool_result = (
+                        getattr(agent, "tools", None)
+                        and not getattr(assistant_message, "tool_calls", None)
+                        and not agent._strip_think_blocks(
+                            assistant_message.content or ""
+                        ).strip()
+                        and any(
+                            isinstance(m, dict) and m.get("role") == "tool"
+                            for m in messages[-5:]
+                        )
+                    )
+                    if (
+                        _empty_after_tool_result
+                        and _stall_retry_count < _stall_retry_max_per_turn
+                    ):
+                        _stall_retry_count += 1
+                        retried = retry_on_stall(
+                            agent,
+                            api_messages,
+                            finish_reason,
+                            accept_content=True,
+                            retry_nudge=EMPTY_AFTER_TOOL_RETRY_NUDGE,
+                        )
+                        if retried is not None:
+                            assistant_message = retried
+                            finish_reason = (
+                                getattr(retried, "finish_reason", None)
+                                or (
+                                    "tool_calls"
+                                    if getattr(retried, "tool_calls", None)
+                                    else "stop"
+                                )
+                            )
+                            agent._empty_content_retries = 0
+                            agent._post_tool_empty_retried = False
+                        else:
+                            logging.warning(
+                                "Stall retry lane did not recover empty "
+                                "post-tool response; continuing "
+                                "empty-response recovery (model=%s provider=%s)",
+                                agent.model,
+                                agent.provider,
+                            )
+
+                    if not _empty_after_tool_result and looks_like_stall(
                         assistant_message.content or "",
                         finish_reason,
                         False,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3626,25 +3626,27 @@ def run_conversation(
             # turn as partial instead of persisting the planning-only text as
             # a completed assistant message that poisons future "continue"
             # turns.
-            retry_model = os.environ.get("HERMES_STALL_RETRY_MODEL", "").strip()
+            try:
+                from agent.stall_retry import get_stall_retry_model
+
+                retry_model = get_stall_retry_model(agent)
+            except Exception:
+                retry_model = os.environ.get("HERMES_STALL_RETRY_MODEL", "").strip()
             if (
                 retry_model
                 and getattr(agent, "tools", None)
                 and not getattr(assistant_message, "tool_calls", None)
             ):
                 try:
-                    max_chars = int(
-                        os.environ.get("HERMES_STALL_RETRY_MAX_CHARS", "400") or 400
-                    )
-                except ValueError:
-                    max_chars = 400
-                try:
                     from agent.stall_retry import (
                         EMPTY_AFTER_TOOL_RETRY_NUDGE,
+                        get_stall_retry_max_chars,
+                        looks_like_incomplete_final_fragment,
                         looks_like_stall,
                         retry_on_stall,
                     )
 
+                    max_chars = get_stall_retry_max_chars(agent)
                     _empty_after_tool_result = (
                         getattr(agent, "tools", None)
                         and not getattr(assistant_message, "tool_calls", None)
@@ -3665,6 +3667,7 @@ def run_conversation(
                             agent,
                             api_messages,
                             finish_reason,
+                            stalled_content=assistant_message.content or "",
                             accept_content=True,
                             retry_nudge=EMPTY_AFTER_TOOL_RETRY_NUDGE,
                         )
@@ -3689,6 +3692,12 @@ def run_conversation(
                                 agent.provider,
                             )
 
+                    _retry_accepts_content = looks_like_incomplete_final_fragment(
+                        assistant_message.content or "",
+                        finish_reason,
+                        False,
+                        max_chars,
+                    )
                     if not _empty_after_tool_result and looks_like_stall(
                         assistant_message.content or "",
                         finish_reason,
@@ -3724,11 +3733,23 @@ def run_conversation(
                                 "failure_subclass": "stall_retry_limit_exhausted",
                             }
                         _stall_retry_count += 1
-                        retried = retry_on_stall(agent, api_messages, finish_reason)
-                        if retried is not None and getattr(retried, "tool_calls", None):
+                        retried = retry_on_stall(
+                            agent,
+                            api_messages,
+                            finish_reason,
+                            stalled_content=assistant_message.content or "",
+                            accept_content=_retry_accepts_content,
+                        )
+                        if retried is not None and (
+                            getattr(retried, "tool_calls", None) or _retry_accepts_content
+                        ):
                             assistant_message = retried
-                            finish_reason = getattr(retried, "finish_reason", None) or "tool_calls"
-                            if finish_reason != "tool_calls":
+                            finish_reason = getattr(retried, "finish_reason", None) or (
+                                "tool_calls"
+                                if getattr(retried, "tool_calls", None)
+                                else "stop"
+                            )
+                            if getattr(retried, "tool_calls", None) and finish_reason != "tool_calls":
                                 finish_reason = "tool_calls"
                         else:
                             _turn_exit_reason = "stall_retry_failed_no_tool_call"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -793,10 +793,18 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
-    # Agentic stall-retry guard: ensures the HERMES_STALL_RETRY_MODEL retry
-    # fires at most once per conversation (avoids loops if the retry lane also
-    # stalls). See agent/stall_retry.py.
-    _stall_retry_used = False
+    # Agentic stall-retry guard: dflash can stall more than once in a long
+    # tool loop, so allow a bounded number of successful rescues per user turn.
+    # If the cap is exhausted, fail partial rather than accept another
+    # planning-only text response as final. See agent/stall_retry.py.
+    _stall_retry_count = 0
+    try:
+        _stall_retry_max_per_turn = int(
+            os.environ.get("HERMES_STALL_RETRY_MAX_PER_TURN", "5") or 5
+        )
+    except ValueError:
+        _stall_retry_max_per_turn = 5
+    _stall_retry_max_per_turn = max(0, _stall_retry_max_per_turn)
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
@@ -3622,7 +3630,6 @@ def run_conversation(
             retry_model = os.environ.get("HERMES_STALL_RETRY_MODEL", "").strip()
             if (
                 retry_model
-                and not _stall_retry_used
                 and getattr(agent, "tools", None)
                 and not getattr(assistant_message, "tool_calls", None)
             ):
@@ -3641,7 +3648,35 @@ def run_conversation(
                         False,
                         max_chars,
                     ):
-                        _stall_retry_used = True
+                        if _stall_retry_count >= _stall_retry_max_per_turn:
+                            _turn_exit_reason = "stall_retry_limit_exhausted"
+                            agent._mute_post_response = False
+                            agent._vprint(
+                                (
+                                    f"{agent.log_prefix}❌ Stall retry limit "
+                                    f"({_stall_retry_max_per_turn}/turn) exhausted; "
+                                    "saving as partial without storing the "
+                                    "planning-only assistant turn."
+                                ),
+                                force=True,
+                            )
+                            agent._cleanup_task_resources(effective_task_id)
+                            agent._persist_session(messages, conversation_history)
+                            return {
+                                "final_response": None,
+                                "messages": messages,
+                                "api_calls": api_call_count,
+                                "completed": False,
+                                "partial": True,
+                                "failed": True,
+                                "error": (
+                                    "Model repeatedly stopped after an agentic "
+                                    "preamble with no tool call; configured stall "
+                                    "retry limit was exhausted."
+                                ),
+                                "failure_subclass": "stall_retry_limit_exhausted",
+                            }
+                        _stall_retry_count += 1
                         retried = retry_on_stall(agent, api_messages, finish_reason)
                         if retried is not None and getattr(retried, "tool_calls", None):
                             assistant_message = retried

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -794,16 +794,25 @@ def run_conversation(
         )
 
     # Agentic stall-retry guard: dflash can stall more than once in a long
-    # tool loop, so allow a bounded number of successful rescues per user turn.
-    # If the cap is exhausted, fail partial rather than accept another
-    # planning-only text response as final. See agent/stall_retry.py.
+    # tool loop. Count total attempts for telemetry, but only consume the
+    # terminal budget when the retry lane fails to produce forward progress.
+    # A recovered tool call is work advanced, not a reason to kill the turn.
+    # See agent/stall_retry.py.
     _stall_retry_count = 0
+    _stall_retry_success_count = 0
+    _stall_retry_failed_count = 0
+    agent._stall_retry_runtime_promoted = False
     try:
-        from agent.stall_retry import get_stall_retry_max_per_turn
+        from agent.stall_retry import (
+            get_stall_retry_max_per_turn,
+            get_stall_retry_promote_after,
+        )
 
         _stall_retry_max_per_turn = get_stall_retry_max_per_turn(agent)
+        _stall_retry_promote_after = get_stall_retry_promote_after(agent)
     except Exception:
         _stall_retry_max_per_turn = 5
+        _stall_retry_promote_after = 2
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
@@ -3640,6 +3649,7 @@ def run_conversation(
                 try:
                     from agent.stall_retry import (
                         EMPTY_AFTER_TOOL_RETRY_NUDGE,
+                        activate_stall_retry_runtime,
                         get_stall_retry_max_chars,
                         has_recent_tool_result,
                         looks_like_incomplete_final_fragment,
@@ -3658,7 +3668,7 @@ def run_conversation(
                     )
                     if (
                         _empty_after_tool_result
-                        and _stall_retry_count < _stall_retry_max_per_turn
+                        and _stall_retry_failed_count < _stall_retry_max_per_turn
                     ):
                         _stall_retry_count += 1
                         retried = retry_on_stall(
@@ -3681,7 +3691,21 @@ def run_conversation(
                             )
                             agent._empty_content_retries = 0
                             agent._post_tool_empty_retried = False
+                            _stall_retry_success_count += 1
+                            _stall_retry_failed_count = 0
+                            if (
+                                getattr(retried, "tool_calls", None)
+                                and _stall_retry_promote_after > 0
+                                and _stall_retry_success_count >= _stall_retry_promote_after
+                            ):
+                                activate_stall_retry_runtime(
+                                    agent,
+                                    retry_model,
+                                    promote_after=_stall_retry_promote_after,
+                                    successful_retries=_stall_retry_success_count,
+                                )
                         else:
+                            _stall_retry_failed_count += 1
                             logging.warning(
                                 "Stall retry lane did not recover empty "
                                 "post-tool response; continuing "
@@ -3702,13 +3726,13 @@ def run_conversation(
                         False,
                         max_chars,
                     ):
-                        if _stall_retry_count >= _stall_retry_max_per_turn:
+                        if _stall_retry_max_per_turn <= 0:
                             _turn_exit_reason = "stall_retry_limit_exhausted"
                             agent._mute_post_response = False
                             agent._vprint(
                                 (
                                     f"{agent.log_prefix}❌ Stall retry limit "
-                                    f"({_stall_retry_max_per_turn}/turn) exhausted; "
+                                    f"({_stall_retry_max_per_turn}/turn) disabled; "
                                     "saving as partial without storing the "
                                     "planning-only assistant turn."
                                 ),
@@ -3749,7 +3773,21 @@ def run_conversation(
                             )
                             if getattr(retried, "tool_calls", None) and finish_reason != "tool_calls":
                                 finish_reason = "tool_calls"
+                            _stall_retry_success_count += 1
+                            _stall_retry_failed_count = 0
+                            if (
+                                getattr(retried, "tool_calls", None)
+                                and _stall_retry_promote_after > 0
+                                and _stall_retry_success_count >= _stall_retry_promote_after
+                            ):
+                                activate_stall_retry_runtime(
+                                    agent,
+                                    retry_model,
+                                    promote_after=_stall_retry_promote_after,
+                                    successful_retries=_stall_retry_success_count,
+                                )
                         else:
+                            _stall_retry_failed_count += 1
                             _turn_exit_reason = "stall_retry_failed_no_tool_call"
                             agent._mute_post_response = False
                             agent._vprint(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3641,6 +3641,7 @@ def run_conversation(
                     from agent.stall_retry import (
                         EMPTY_AFTER_TOOL_RETRY_NUDGE,
                         get_stall_retry_max_chars,
+                        has_recent_tool_result,
                         looks_like_incomplete_final_fragment,
                         looks_like_stall,
                         retry_on_stall,
@@ -3653,10 +3654,7 @@ def run_conversation(
                         and not agent._strip_think_blocks(
                             assistant_message.content or ""
                         ).strip()
-                        and any(
-                            isinstance(m, dict) and m.get("role") == "tool"
-                            for m in messages[-5:]
-                        )
+                        and has_recent_tool_result(messages)
                     )
                     if (
                         _empty_after_tool_result

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -38,6 +38,7 @@ class FailoverReason(enum.Enum):
 
     # Transport
     timeout = "timeout"                  # Connection/read timeout — rebuild client + retry
+    local_first_chunk_timeout = "local_first_chunk_timeout"  # Local stream accepted request but emitted no first chunk — fail over immediately
 
     # Context / payload
     context_overflow = "context_overflow"  # Context too large — compress, not failover
@@ -531,6 +532,25 @@ def classify_api_error(
         return ClassifiedError(**defaults)
 
     # ── 1. Provider-specific patterns (highest priority) ────────────
+
+    # The local-provider TTFB watchdog may force-close the SDK stream, which can
+    # surface as a generic APIConnectionError. Honor the marker from the
+    # watchdog so the retry loop fails over instead of rebuilding and waiting
+    # on the same wedged local path again.
+    if (
+        getattr(error, "_hermes_local_first_chunk_timeout", False)
+        or getattr(error, "_hermes_local_dflash_first_chunk_timeout", False)
+    ):
+        return _result(
+            FailoverReason.local_first_chunk_timeout,
+            retryable=False,
+            should_fallback=True,
+            error_context=(
+                getattr(error, "_hermes_local_first_chunk_meta", None)
+                or getattr(error, "_hermes_dflash_first_chunk_meta", {})
+                or {}
+            ),
+        )
 
     # Provider content-policy / safety-filter block. The provider has made a
     # deterministic refusal decision about THIS prompt — retrying unchanged

--- a/agent/local_backend_recovery.py
+++ b/agent/local_backend_recovery.py
@@ -1,0 +1,122 @@
+"""Opt-in recovery hook for wedged local inference backends."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import subprocess
+import time
+from typing import Any
+
+from agent.model_metadata import is_local_endpoint
+
+logger = logging.getLogger(__name__)
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def maybe_recover_local_backend(
+    agent: Any,
+    *,
+    reason: str,
+    model: Any,
+    base_url: Any,
+    context_tokens: int | None = None,
+    elapsed: float | None = None,
+    threshold: float | None = None,
+) -> bool:
+    """Run a configured recovery command after a local backend timeout.
+
+    Hermes cannot safely know how every self-hosted backend should be repaired:
+    llama.cpp may support slot cancellation, llama-swap may need its child
+    process killed, and production deployments may want a service restart.  The
+    durable contract is therefore an opt-in command hook.  The command receives
+    sanitized metadata through environment variables and is rate-limited per
+    agent process so repeated retries do not flap a shared GPU service.
+    """
+    base_url_s = str(base_url or "").strip()
+    if not is_local_endpoint(base_url_s):
+        return False
+
+    command = str(os.getenv("HERMES_LOCAL_BACKEND_RECOVERY_COMMAND") or "").strip()
+    if not command:
+        return False
+
+    cooldown = _env_float("HERMES_LOCAL_BACKEND_RECOVERY_COOLDOWN", 60.0)
+    now = time.monotonic()
+    last_at = float(getattr(agent, "_local_backend_recovery_last_at", 0.0) or 0.0)
+    if cooldown > 0 and last_at and now - last_at < cooldown:
+        logger.info(
+            "Skipping local backend recovery for %s: cooldown %.0fs still active",
+            reason,
+            cooldown,
+        )
+        return False
+    try:
+        setattr(agent, "_local_backend_recovery_last_at", now)
+    except Exception:
+        pass
+
+    timeout = _env_float("HERMES_LOCAL_BACKEND_RECOVERY_TIMEOUT", 20.0)
+    env = os.environ.copy()
+    env.update(
+        {
+            "HERMES_RECOVERY_REASON": str(reason),
+            "HERMES_RECOVERY_MODEL": str(model or ""),
+            "HERMES_RECOVERY_PROVIDER": str(getattr(agent, "provider", "") or ""),
+            "HERMES_RECOVERY_BASE_URL": base_url_s,
+            "HERMES_RECOVERY_CONTEXT_TOKENS": str(int(context_tokens or 0)),
+            "HERMES_RECOVERY_ELAPSED": str(float(elapsed or 0.0)),
+            "HERMES_RECOVERY_THRESHOLD": str(float(threshold or 0.0)),
+            "HERMES_RECOVERY_SESSION_ID": str(getattr(agent, "session_id", "") or ""),
+        }
+    )
+
+    try:
+        argv = shlex.split(command)
+    except ValueError as exc:
+        logger.warning("Invalid local backend recovery command: %s", exc)
+        return False
+    if not argv:
+        return False
+
+    logger.warning(
+        "Running local backend recovery command after %s: model=%s base_url=%s",
+        reason,
+        model or "unknown",
+        base_url_s,
+    )
+    try:
+        completed = subprocess.run(
+            argv,
+            env=env,
+            timeout=timeout if timeout > 0 else None,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "Local backend recovery command timed out after %.0fs",
+            timeout,
+        )
+        return False
+    except Exception as exc:
+        logger.warning("Local backend recovery command failed to start: %s", exc)
+        return False
+
+    if completed.returncode != 0:
+        logger.warning(
+            "Local backend recovery command exited rc=%s",
+            completed.returncode,
+        )
+        return False
+
+    logger.info("Local backend recovery command completed successfully")
+    return True

--- a/agent/stall_retry.py
+++ b/agent/stall_retry.py
@@ -550,6 +550,9 @@ def _retry_api_call(agent: Any, api_kwargs: dict[str, Any], retry_model: str) ->
         retry_kwargs["model"] = resolved_model or retry_model
         return client.chat.completions.create(**retry_kwargs)
 
+    if api_kwargs.get("stream") and hasattr(agent, "_interruptible_streaming_api_call"):
+        return agent._interruptible_streaming_api_call(api_kwargs)
+
     return agent._interruptible_api_call(api_kwargs)
 
 
@@ -870,9 +873,26 @@ def retry_on_stall(
             )
         api_kwargs = dict(api_kwargs)
         api_kwargs["model"] = retry_model
-        # Force non-streaming for the retry (simpler, we only inspect the result).
-        api_kwargs.pop("stream", None)
-        api_kwargs["stream"] = False
+        # Local OpenAI-compatible backends must stay streaming so the
+        # first-chunk watchdog can abort a wedged single-slot server.  For
+        # remote retry lanes, keep the historic non-streaming path because we
+        # only inspect the result.
+        try:
+            from agent.model_metadata import is_local_endpoint
+
+            _retry_should_stream = bool(
+                getattr(agent, "base_url", None)
+                and is_local_endpoint(getattr(agent, "base_url", ""))
+                and not get_stall_retry_provider(agent)
+                and not get_stall_retry_base_url(agent)
+            )
+        except Exception:
+            _retry_should_stream = False
+        if _retry_should_stream:
+            api_kwargs["stream"] = True
+        else:
+            api_kwargs.pop("stream", None)
+            api_kwargs["stream"] = False
 
         try:
             agent._vprint(

--- a/agent/stall_retry.py
+++ b/agent/stall_retry.py
@@ -9,8 +9,9 @@ same host) continue to a real tool call on the identical prompt.
 
 This module detects that stall signature on a no-tool-call turn and retries
 the SAME turn once against a higher-quality model lane. If the retry produces
-tool_calls, the loop adopts that response and continues; otherwise the
-original response stands (no behavior change).
+tool_calls, the loop adopts that response and continues; otherwise the caller
+should fail the turn as partial rather than persist the planning-only text as
+a final assistant message.
 
 Entirely opt-in: does nothing unless ``HERMES_STALL_RETRY_MODEL`` is set
 (e.g. ``qwen3.6-27b-256k``). Default-off => zero change to existing behavior.
@@ -77,7 +78,8 @@ def retry_on_stall(agent, api_messages, finish_reason):
 
     Returns the normalized assistant_message from the retry IF it produced tool
     calls (caller should adopt it + its finish_reason='tool_calls'), else None.
-    Never raises into the caller — any failure returns None (original stands).
+    Never raises into the caller — any failure returns None so the caller can
+    fail closed without storing the stalled assistant message.
     """
     retry_model = os.environ.get("HERMES_STALL_RETRY_MODEL", "").strip()
     if not retry_model:

--- a/agent/stall_retry.py
+++ b/agent/stall_retry.py
@@ -1,0 +1,127 @@
+"""
+Agentic stall-retry (dflash Q4 premature-EOS workaround).
+
+dflash (Qwen3.6-27B Q4_K_M, lucebox spec-decode) sometimes emits EOS right
+after a short action preamble ("Let me check X:") on agentic decision turns,
+ending the turn with NO tool_call -> the agent loop treats it as a final
+answer and stops mid-task. Higher-precision weights (the stock Q6 lane on the
+same host) continue to a real tool call on the identical prompt.
+
+This module detects that stall signature on a no-tool-call turn and retries
+the SAME turn once against a higher-quality model lane. If the retry produces
+tool_calls, the loop adopts that response and continues; otherwise the
+original response stands (no behavior change).
+
+Entirely opt-in: does nothing unless ``HERMES_STALL_RETRY_MODEL`` is set
+(e.g. ``qwen3.6-27b-256k``). Default-off => zero change to existing behavior.
+
+Env:
+  HERMES_STALL_RETRY_MODEL  retry lane/model name (required to enable)
+  HERMES_STALL_RETRY_MAX_CHARS  max content length to still count as a stall
+                                (default 400; real final answers are longer)
+"""
+from __future__ import annotations
+
+import os
+import re
+
+# Action-preamble signature: the turn announced an action but produced no tool
+# call. These end mid-thought, typically with a colon, or open with intent.
+_ACTION_RE = re.compile(
+    r"(let me\b|let's\b|i'?ll\b|i will\b|i'?m going to\b|i am going to\b|"
+    r"now i\b|first,?\s+i\b|next,?\s+i\b|i need to\b|i should\b|"
+    r"going to (check|look|run|start|examine|search|read|list|create|write|edit|use))",
+    re.IGNORECASE,
+)
+# Genuine completion signature: the model declared it is done / nothing to do.
+# These must NOT be retried (they are correct no-tool-call turns).
+_COMPLETION_RE = re.compile(
+    r"(\bdone\b|\bcomplete(d)?\b|nothing to (do|save|change|report|fix)|"
+    r"no changes?\b|no action\b|already (complete|done|finished)|\bfinished\b|"
+    r"all set\b|no further\b|nothing left\b|here('?s| is| are)\b|"
+    r"in summary\b|to summarize\b|the answer is\b)",
+    re.IGNORECASE,
+)
+
+
+def looks_like_stall(content: str, finish_reason: str, has_tool_calls: bool,
+                     max_chars: int) -> bool:
+    """True when a no-tool-call turn looks like a premature agentic stall
+    (announced an action, didn't call a tool) rather than a real final answer."""
+    if has_tool_calls:
+        return False
+    if finish_reason not in ("stop", "length"):
+        return False
+    c = (content or "").strip()
+    # Strip a leading <think>...</think> block if present; judge the visible tail.
+    c = re.sub(r"^<think>.*?</think>\s*", "", c, flags=re.IGNORECASE | re.DOTALL).strip()
+    if not c:
+        return True  # empty visible turn mid-task => stall
+    if len(c) > max_chars:
+        return False  # long => almost certainly a real answer
+    if _COMPLETION_RE.search(c):
+        return False  # model said it's done => respect it
+    if _ACTION_RE.search(c):
+        return True   # announced an action, no tool call => stall
+    # Short prose that doesn't declare completion and isn't an obvious answer:
+    # a trailing colon strongly implies "about to do something".
+    if c.endswith(":"):
+        return True
+    return False
+
+
+def retry_on_stall(agent, api_messages, finish_reason):
+    """If the just-finished no-tool-call turn looks like a stall and a retry
+    lane is configured, re-issue the SAME turn against that lane (same provider
+    / client / endpoint — only the model name changes) ONCE.
+
+    Returns the normalized assistant_message from the retry IF it produced tool
+    calls (caller should adopt it + its finish_reason='tool_calls'), else None.
+    Never raises into the caller — any failure returns None (original stands).
+    """
+    retry_model = os.environ.get("HERMES_STALL_RETRY_MODEL", "").strip()
+    if not retry_model:
+        return None
+    try:
+        max_chars = int(os.environ.get("HERMES_STALL_RETRY_MAX_CHARS", "400"))
+    except ValueError:
+        max_chars = 400
+
+    try:
+        # Build kwargs exactly as the normal turn would, then override only the
+        # model name. Safe when the retry lane is served by the SAME provider/
+        # endpoint as agent.model (e.g. taro serves both dflash and the Q6 lane),
+        # so no client rebuild is needed.
+        api_kwargs = agent._build_api_kwargs(api_messages)
+        orig_model = api_kwargs.get("model")
+        if retry_model == orig_model:
+            return None  # nothing to gain retrying the same model
+        api_kwargs = dict(api_kwargs)
+        api_kwargs["model"] = retry_model
+        # Force non-streaming for the retry (simpler, we only inspect the result).
+        api_kwargs.pop("stream", None)
+        api_kwargs["stream"] = False
+
+        try:
+            agent._vprint(
+                f"{getattr(agent, 'log_prefix', '')}↻ stall detected "
+                f"(no tool call) — retrying turn on '{retry_model}'",
+                force=True,
+            )
+        except Exception:
+            pass
+
+        response = agent._interruptible_api_call(api_kwargs)
+        if response is None:
+            return None
+        transport = agent._get_transport()
+        normalize_kwargs = {}
+        if getattr(agent, "api_mode", None) == "anthropic_messages":
+            normalize_kwargs["strip_tool_prefix"] = getattr(agent, "_is_anthropic_oauth", False)
+        normalized = transport.normalize_response(response, **normalize_kwargs)
+        if getattr(normalized, "tool_calls", None):
+            return normalized
+        return None
+    except Exception:
+        # Any error => silently fall back to the original response.
+        return None

--- a/agent/stall_retry.py
+++ b/agent/stall_retry.py
@@ -43,6 +43,20 @@ _COMPLETION_RE = re.compile(
     r"in summary\b|to summarize\b|the answer is\b)",
     re.IGNORECASE,
 )
+_NATURAL_END_CHARS = '.!?:)"\']}。！？：）】」』》^'
+_MIN_INCOMPLETE_FINAL_CHARS = 80
+
+
+def _has_natural_response_ending(content: str) -> bool:
+    stripped = (content or "").rstrip()
+    if not stripped:
+        return False
+    if stripped.endswith("```"):
+        return True
+    last = stripped[-1]
+    if last in _NATURAL_END_CHARS:
+        return True
+    return ord(last) >= 0x1F300
 
 
 def looks_like_stall(content: str, finish_reason: str, has_tool_calls: bool,
@@ -67,6 +81,13 @@ def looks_like_stall(content: str, finish_reason: str, has_tool_calls: bool,
     # Short prose that doesn't declare completion and isn't an obvious answer:
     # a trailing colon strongly implies "about to do something".
     if c.endswith(":"):
+        return True
+    # dflash can also stop after a tool result with ordinary-looking prose that
+    # is simply cut off mid-sentence (for example after a CLI interrupt resumes
+    # the turn). In an agentic tool loop, a short no-tool stop that declares no
+    # completion and lacks a natural ending is safer to retry than to persist as
+    # a final assistant message.
+    if len(c) >= _MIN_INCOMPLETE_FINAL_CHARS and not _has_natural_response_ending(c):
         return True
     return False
 

--- a/agent/stall_retry.py
+++ b/agent/stall_retry.py
@@ -62,6 +62,14 @@ _COMPLETION_RE = re.compile(
 _NATURAL_END_CHARS = '.!?:)"\']}。！？：）】」』》^'
 _MIN_INCOMPLETE_FINAL_CHARS = 80
 _ACTION_TAIL_CHARS = 500
+_INCOMPLETE_TAIL_RE = re.compile(
+    r"\b("
+    r"and|or|but|so|because|while|with|without|for|to|of|in|on|at|by|from|"
+    r"the|a|an|this|that|these|those|some|any|another|more|other|which|who|"
+    r"where|when|if|then|also"
+    r")\s*$",
+    re.IGNORECASE,
+)
 _STALL_RETRY_NUDGE = (
     "Your previous assistant response ended after describing the next action, "
     "but it did not include the required tool call. Continue the same task now "
@@ -198,6 +206,31 @@ def _has_natural_response_ending(content: str) -> bool:
     if last in _NATURAL_END_CHARS:
         return True
     return ord(last) >= 0x1F300
+
+
+def looks_like_incomplete_final_fragment(
+    content: str,
+    finish_reason: str,
+    has_tool_calls: bool,
+    max_chars: int,
+) -> bool:
+    """True when a short no-tool final looks cut off mid-sentence.
+
+    dflash can occasionally stop with ordinary visible prose after a tool
+    result, e.g. ``"... and some"``. That is not an action preamble, but it is
+    still unsafe to persist as the final answer in a tool loop.
+    """
+    if has_tool_calls or finish_reason not in ("stop", "length"):
+        return False
+    c = (content or "").strip()
+    c = re.sub(r"^<think>.*?</think>\s*", "", c, flags=re.IGNORECASE | re.DOTALL).strip()
+    if not c or len(c) > max_chars:
+        return False
+    if _COMPLETION_RE.search(c) or _has_natural_response_ending(c):
+        return False
+    if len(c) >= _MIN_INCOMPLETE_FINAL_CHARS:
+        return True
+    return len(c) >= 40 and bool(_INCOMPLETE_TAIL_RE.search(c))
 
 
 def _action_after_completion(content: str) -> bool:
@@ -490,7 +523,7 @@ def looks_like_stall(content: str, finish_reason: str, has_tool_calls: bool,
     # the turn). In an agentic tool loop, a short no-tool stop that declares no
     # completion and lacks a natural ending is safer to retry than to persist as
     # a final assistant message.
-    if len(c) >= _MIN_INCOMPLETE_FINAL_CHARS and not _has_natural_response_ending(c):
+    if looks_like_incomplete_final_fragment(c, finish_reason, False, max_chars):
         return True
     return False
 

--- a/agent/stall_retry.py
+++ b/agent/stall_retry.py
@@ -27,6 +27,9 @@ Env:
   HERMES_STALL_RETRY_PROMOTE_AFTER  successful rescues before routing the rest
                                 of the turn through the retry lane (default 2,
                                 0 disables)
+  HERMES_STALL_RETRY_NO_TOOL_RECOVERY_MAX  corrective same-turn continuations
+                                after the retry lane also returns no tool call
+                                (default 2, 0 disables)
   HERMES_STALL_RETRY_MAX_CHARS  max content length to still count as a stall
                                 (default 400; longer open action preambles
                                 ending in ":" get a bounded exception)
@@ -87,6 +90,13 @@ EMPTY_AFTER_TOOL_RETRY_NUDGE = (
     "requires another tool, call it immediately; otherwise provide the next "
     "concise response. Do not summarize or apologize."
 )
+FAILED_STALL_RETRY_RECOVERY_NUDGE = (
+    "The previous assistant response again described an action but did not "
+    "include a tool call. Continue the same task now. If that action requires "
+    "a tool, call it immediately. If no tool is needed because the task is "
+    "complete, state completion explicitly instead of describing another "
+    "future action."
+)
 
 
 def _as_positive_int(value: Any, default: int) -> int:
@@ -95,6 +105,14 @@ def _as_positive_int(value: Any, default: int) -> int:
     except (TypeError, ValueError):
         return default
     return parsed if parsed > 0 else default
+
+
+def _as_nonnegative_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0, parsed)
 
 
 def _as_bool(value: Any, default: bool) -> bool:
@@ -213,15 +231,19 @@ def get_stall_retry_promote_after(agent: Any | None = None) -> int:
     """Return successful retry rescues needed before turn-scoped promotion."""
     env_value = os.environ.get("HERMES_STALL_RETRY_PROMOTE_AFTER")
     if env_value is not None:
-        try:
-            return max(0, int(env_value))
-        except ValueError:
-            return 2
-    cfg_value = _stall_retry_config(agent).get("promote_after")
-    try:
-        return max(0, int(cfg_value))
-    except (TypeError, ValueError):
-        return 2
+        return _as_nonnegative_int(env_value, 2)
+    return _as_nonnegative_int(_stall_retry_config(agent).get("promote_after"), 2)
+
+
+def get_stall_retry_no_tool_recovery_max(agent: Any | None = None) -> int:
+    """Return corrective continuations allowed after retry returns no tools."""
+    env_value = os.environ.get("HERMES_STALL_RETRY_NO_TOOL_RECOVERY_MAX")
+    if env_value is not None:
+        return _as_nonnegative_int(env_value, 2)
+    return _as_nonnegative_int(
+        _stall_retry_config(agent).get("no_tool_recovery_max"),
+        2,
+    )
 
 
 def get_stall_retry_nudge_enabled(agent: Any | None = None) -> bool:
@@ -828,7 +850,8 @@ def retry_on_stall(
         # so no client rebuild is needed.
         api_kwargs = agent._build_api_kwargs(retry_messages)
         orig_model = api_kwargs.get("model")
-        if retry_model == orig_model:
+        same_model_retry = retry_model == orig_model
+        if same_model_retry and not getattr(agent, "_stall_retry_runtime_promoted", False):
             record_stall_retry_event(
                 agent,
                 "skipped_same_model",
@@ -837,6 +860,14 @@ def retry_on_stall(
                 retry_index=retry_index,
             )
             return None  # nothing to gain retrying the same model
+        if same_model_retry:
+            record_stall_retry_event(
+                agent,
+                "same_model_retry_after_promotion",
+                retry_model=retry_model,
+                finish_reason=finish_reason,
+                retry_index=retry_index,
+            )
         api_kwargs = dict(api_kwargs)
         api_kwargs["model"] = retry_model
         # Force non-streaming for the retry (simpler, we only inspect the result).

--- a/agent/stall_retry.py
+++ b/agent/stall_retry.py
@@ -8,7 +8,8 @@ answer and stops mid-task. Higher-precision weights (the stock Q6 lane on the
 same host) continue to a real tool call on the identical prompt.
 
 This module detects that stall signature on a no-tool-call turn and retries
-the SAME turn once against a higher-quality model lane. If the retry produces
+the turn against a higher-quality model lane, with a small recovery nudge that
+asks the model to emit the tool call it just promised. If the retry produces
 tool_calls, the loop adopts that response and continues; otherwise the caller
 should fail the turn as partial rather than persist the planning-only text as
 a final assistant message.
@@ -18,17 +19,30 @@ Entirely opt-in: does nothing unless ``HERMES_STALL_RETRY_MODEL`` is set
 
 Env:
   HERMES_STALL_RETRY_MODEL  retry lane/model name (required to enable)
+  HERMES_STALL_RETRY_PROVIDER  optional provider override for the retry lane
+  HERMES_STALL_RETRY_BASE_URL  optional OpenAI-compatible retry endpoint
   HERMES_STALL_RETRY_MAX_PER_TURN  max retries per user turn (default 5)
   HERMES_STALL_RETRY_MAX_CHARS  max content length to still count as a stall
-                                (default 400; real final answers are longer)
+                                (default 400; longer open action preambles
+                                ending in ":" get a bounded exception)
+  HERMES_STALL_RETRY_NUDGE  true/false; add a retry-only continuation nudge
+                            (default true)
+  HERMES_STALL_RETRY_TELEMETRY  true/false; append local NDJSON telemetry
+                                (default true)
 """
 from __future__ import annotations
 
+import json
 import os
 import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
 
 # Action-preamble signature: the turn announced an action but produced no tool
-# call. These end mid-thought, typically with a colon, or open with intent.
+# call. These English phrases match the observed dflash stall corpus; broader
+# language-agnostic fallbacks below still catch trailing-colon and incomplete
+# final fragments without pretending this regex is multilingual.
 _ACTION_RE = re.compile(
     r"(let me\b|let's\b|i'?ll\b|i will\b|i'?m going to\b|i am going to\b|"
     r"now i\b|first,?\s+i\b|next,?\s+i\b|i need to\b|i should\b|"
@@ -36,7 +50,8 @@ _ACTION_RE = re.compile(
     re.IGNORECASE,
 )
 # Genuine completion signature: the model declared it is done / nothing to do.
-# These must NOT be retried (they are correct no-tool-call turns).
+# These English phrases must NOT be retried (they are correct no-tool-call
+# turns); other languages still rely on the neutral structural checks below.
 _COMPLETION_RE = re.compile(
     r"(\bdone\b|\bcomplete(d)?\b|nothing to (do|save|change|report|fix)|"
     r"no changes?\b|no action\b|already (complete|done|finished)|\bfinished\b|"
@@ -46,12 +61,119 @@ _COMPLETION_RE = re.compile(
 )
 _NATURAL_END_CHARS = '.!?:)"\']}。！？：）】」』》^'
 _MIN_INCOMPLETE_FINAL_CHARS = 80
+_ACTION_TAIL_CHARS = 500
+_STALL_RETRY_NUDGE = (
+    "Your previous assistant response ended after describing the next action, "
+    "but it did not include the required tool call. Continue the same task now "
+    "by making the tool call immediately. Do not summarize or apologize; call "
+    "the tool that performs the action you just announced."
+)
 EMPTY_AFTER_TOOL_RETRY_NUDGE = (
     "Your previous assistant response after the tool results was empty. "
     "Continue the same task using the tool results above. If the next step "
     "requires another tool, call it immediately; otherwise provide the next "
     "concise response. Do not summarize or apologize."
 )
+
+
+def _as_positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if lowered in {"0", "false", "no", "off", "disabled"}:
+            return False
+    return default
+
+
+def _stall_retry_config(agent: Any | None = None) -> Mapping[str, Any]:
+    cfg = getattr(agent, "_stall_retry_config", None)
+    if isinstance(cfg, Mapping):
+        return cfg
+    try:
+        from hermes_cli.config import load_config
+
+        loaded = load_config()
+    except Exception:
+        return {}
+    cfg = loaded.get("stall_retry") if isinstance(loaded, Mapping) else None
+    return cfg if isinstance(cfg, Mapping) else {}
+
+
+def get_stall_retry_model(agent: Any | None = None) -> str:
+    """Return the configured retry model, with env taking precedence."""
+    env_model = os.environ.get("HERMES_STALL_RETRY_MODEL", "").strip()
+    if env_model:
+        return env_model
+    cfg_model = _stall_retry_config(agent).get("model")
+    return str(cfg_model or "").strip()
+
+
+def get_stall_retry_provider(agent: Any | None = None) -> str:
+    """Return an optional provider override for the retry lane."""
+    env_provider = os.environ.get("HERMES_STALL_RETRY_PROVIDER", "").strip()
+    if env_provider:
+        return env_provider
+    cfg_provider = _stall_retry_config(agent).get("provider")
+    return str(cfg_provider or "").strip()
+
+
+def get_stall_retry_base_url(agent: Any | None = None) -> str:
+    """Return an optional base URL override for the retry lane."""
+    env_base_url = os.environ.get("HERMES_STALL_RETRY_BASE_URL", "").strip()
+    if env_base_url:
+        return env_base_url
+    cfg_base_url = _stall_retry_config(agent).get("base_url")
+    return str(cfg_base_url or "").strip()
+
+
+def get_stall_retry_max_chars(agent: Any | None = None) -> int:
+    env_value = os.environ.get("HERMES_STALL_RETRY_MAX_CHARS")
+    if env_value is not None:
+        return _as_positive_int(env_value, 400)
+    return _as_positive_int(_stall_retry_config(agent).get("max_chars"), 400)
+
+
+def get_stall_retry_max_per_turn(agent: Any | None = None) -> int:
+    env_value = os.environ.get("HERMES_STALL_RETRY_MAX_PER_TURN")
+    if env_value is not None:
+        try:
+            return max(0, int(env_value))
+        except ValueError:
+            return 5
+    cfg_value = _stall_retry_config(agent).get("max_per_turn")
+    try:
+        return max(0, int(cfg_value))
+    except (TypeError, ValueError):
+        return 5
+
+
+def get_stall_retry_nudge_enabled(agent: Any | None = None) -> bool:
+    env_value = os.environ.get("HERMES_STALL_RETRY_NUDGE")
+    if env_value is not None:
+        return _as_bool(env_value, True)
+    return _as_bool(_stall_retry_config(agent).get("nudge"), True)
+
+
+def get_stall_retry_telemetry_enabled(agent: Any | None = None) -> bool:
+    env_value = os.environ.get("HERMES_STALL_RETRY_TELEMETRY")
+    if env_value is not None:
+        return _as_bool(env_value, True)
+    return _as_bool(_stall_retry_config(agent).get("telemetry"), True)
 
 
 def _has_natural_response_ending(content: str) -> bool:
@@ -66,6 +188,262 @@ def _has_natural_response_ending(content: str) -> bool:
     return ord(last) >= 0x1F300
 
 
+def _action_after_completion(content: str) -> bool:
+    """True when a response says some step is complete, then promises work.
+
+    The dflash phone failure hit this exact shape:
+    "Onboarding complete. Now let me read the STATUS.md ..."
+
+    The earlier completion word is not a final answer when a later clause is
+    still announcing the next tool step.
+    """
+    action_matches = list(_ACTION_RE.finditer(content or ""))
+    if not action_matches:
+        return False
+    completion_matches = list(_COMPLETION_RE.finditer(content or ""))
+    if not completion_matches:
+        return False
+    return action_matches[-1].start() > completion_matches[-1].end()
+
+
+def _ends_with_action_promise(content: str) -> bool:
+    """True when the visible tail promises immediate work but stops there.
+
+    The generic stall heuristic is intentionally length-capped because long
+    prose is often a real answer. Explicit tail promises are different: a long
+    diagnostic can still end with "Let me check that:" and no tool call, which
+    is the exact dflash premature-stop shape this module exists to recover.
+    """
+    tail = (content or "").strip()[-_ACTION_TAIL_CHARS:]
+    if not tail:
+        return False
+    if not _ACTION_RE.search(tail):
+        return False
+    return tail.rstrip().endswith(":")
+
+
+def _safe_preview(value: Any, max_chars: int = 240) -> str:
+    text = value if isinstance(value, str) else str(value or "")
+    text = re.sub(r"^<think>.*?</think>\s*", "", text, flags=re.IGNORECASE | re.DOTALL)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3].rstrip() + "..."
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    return str(value)
+
+
+def _stall_retry_log_path(agent: Any | None = None) -> Path:
+    cfg_path = _stall_retry_config(agent).get("telemetry_path")
+    if cfg_path:
+        return Path(str(cfg_path)).expanduser()
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = Path(get_hermes_home())
+    except Exception:
+        home = Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser()
+    return home / "logs" / "stall-retry.ndjson"
+
+
+def record_stall_retry_event(agent: Any, event: str, **fields: Any) -> None:
+    """Record local, bounded stall-retry telemetry."""
+    entry: dict[str, Any] = {
+        "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "event": str(event),
+        "session_id": str(getattr(agent, "session_id", "") or ""),
+        "model": str(getattr(agent, "model", "") or ""),
+        "provider": str(getattr(agent, "provider", "") or ""),
+    }
+    content = fields.pop("content", None)
+    if content is not None:
+        text = content if isinstance(content, str) else str(content)
+        entry["content_chars"] = len(text)
+        entry["content_preview"] = _safe_preview(text)
+    entry.update({str(k): _jsonable(v) for k, v in fields.items()})
+
+    events = getattr(agent, "_stall_retry_events", None)
+    if not isinstance(events, list):
+        events = []
+        try:
+            setattr(agent, "_stall_retry_events", events)
+        except Exception:
+            pass
+    events.append(entry)
+
+    if not get_stall_retry_telemetry_enabled(agent):
+        return
+    try:
+        path = _stall_retry_log_path(agent)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, ensure_ascii=False, sort_keys=True) + "\n")
+    except Exception:
+        return
+
+
+def stall_retry_summary(agent: Any) -> dict[str, Any] | None:
+    events = getattr(agent, "_stall_retry_events", None)
+    if not isinstance(events, list) or not events:
+        return None
+    counts = {
+        "detected": 0,
+        "attempted": 0,
+        "recovered": 0,
+        "failed": 0,
+        "limit_exhausted": 0,
+        "exceptions": 0,
+    }
+    for item in events:
+        kind = item.get("event") if isinstance(item, Mapping) else None
+        if kind == "detected":
+            counts["detected"] += 1
+        elif kind == "attempt":
+            counts["attempted"] += 1
+        elif kind == "recovered":
+            counts["recovered"] += 1
+        elif kind in {"failed_no_tool_call", "api_none", "skipped_same_model"}:
+            counts["failed"] += 1
+        elif kind == "limit_exhausted":
+            counts["limit_exhausted"] += 1
+        elif kind == "exception":
+            counts["exceptions"] += 1
+    summary: dict[str, Any] = dict(counts)
+    summary["events"] = len(events)
+    if get_stall_retry_telemetry_enabled(agent):
+        summary["log_path"] = str(_stall_retry_log_path(agent))
+    return summary
+
+
+def _retry_messages_with_nudge(
+    agent: Any,
+    api_messages: list[dict[str, Any]],
+    stalled_content: str,
+    retry_nudge: str | None = None,
+) -> list[dict[str, Any]]:
+    if not get_stall_retry_nudge_enabled(agent):
+        return api_messages
+    retry_messages = [msg.copy() if isinstance(msg, dict) else msg for msg in api_messages]
+    visible = (stalled_content or "").strip()
+    if visible:
+        retry_messages.append({"role": "assistant", "content": visible})
+    retry_messages.append({"role": "user", "content": retry_nudge or _STALL_RETRY_NUDGE})
+    return retry_messages
+
+
+def _load_env_value(name: str) -> str:
+    env_name = str(name or "").strip()
+    if not env_name:
+        return ""
+    value = os.environ.get(env_name, "").strip()
+    if value:
+        return value
+    try:
+        from hermes_cli.env_loader import load_hermes_dotenv
+        from hermes_constants import get_hermes_home
+
+        load_hermes_dotenv(hermes_home=get_hermes_home())
+    except Exception:
+        pass
+    return os.environ.get(env_name, "").strip()
+
+
+def _base_url_keys(value: Any) -> set[str]:
+    raw = str(value or "").strip().lower().rstrip("/")
+    if not raw:
+        return set()
+    keys = {raw}
+    if raw.endswith("/v1"):
+        keys.add(raw[:-3].rstrip("/"))
+    else:
+        keys.add(f"{raw}/v1")
+    return keys
+
+
+def _custom_provider_entry(agent: Any | None, provider: str, base_url: str) -> Mapping[str, Any]:
+    try:
+        from hermes_cli.config import get_compatible_custom_providers, load_config
+
+        entries = get_compatible_custom_providers(load_config())
+    except Exception:
+        entries = getattr(agent, "_custom_providers", []) if agent is not None else []
+    if not isinstance(entries, list):
+        return {}
+
+    provider_name = str(provider or "").strip().lower()
+    target_keys = _base_url_keys(base_url or getattr(agent, "base_url", ""))
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        entry_name = str(entry.get("name") or "").strip().lower()
+        if provider_name and entry_name == provider_name:
+            return entry
+        entry_keys = _base_url_keys(entry.get("base_url"))
+        if target_keys and entry_keys and target_keys.intersection(entry_keys):
+            return entry
+    return {}
+
+
+def _configured_retry_api_key(agent: Any, provider: str, base_url: str) -> str:
+    cfg = _stall_retry_config(agent)
+    explicit = str(cfg.get("api_key") or "").strip()
+    if explicit:
+        return explicit
+    key_env = str(cfg.get("key_env") or cfg.get("api_key_env") or "").strip()
+    if key_env:
+        return _load_env_value(key_env)
+
+    entry = _custom_provider_entry(agent, provider, base_url)
+    explicit = str(entry.get("api_key") or "").strip()
+    if explicit:
+        return explicit
+    key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
+    return _load_env_value(key_env) if key_env else ""
+
+
+def _retry_api_call(agent: Any, api_kwargs: dict[str, Any], retry_model: str) -> Any:
+    """Execute the retry request, optionally through a configured provider.
+
+    The original implementation reused the active client and only changed the
+    model name. That is fine when both models are served anonymously by the
+    same endpoint, but it breaks when the retry lane is a named custom provider
+    whose auth lives in ``key_env``. Resolve that provider explicitly when the
+    retry config names one or supplies endpoint/auth details.
+    """
+    retry_provider = get_stall_retry_provider(agent)
+    retry_base_url = get_stall_retry_base_url(agent)
+    retry_api_key = _configured_retry_api_key(agent, retry_provider, retry_base_url)
+    if not retry_base_url and retry_api_key:
+        retry_base_url = str(getattr(agent, "base_url", "") or "").strip()
+
+    if retry_provider or retry_base_url or retry_api_key:
+        from agent.auxiliary_client import resolve_provider_client
+
+        provider = retry_provider or str(getattr(agent, "provider", "") or "custom")
+        client, resolved_model = resolve_provider_client(
+            provider,
+            model=retry_model,
+            raw_codex=True,
+            explicit_base_url=retry_base_url or None,
+            explicit_api_key=retry_api_key or None,
+        )
+        if client is None:
+            raise RuntimeError(f"Could not resolve stall retry provider {provider!r}")
+        retry_kwargs = dict(api_kwargs)
+        retry_kwargs["model"] = resolved_model or retry_model
+        return client.chat.completions.create(**retry_kwargs)
+
+    return agent._interruptible_api_call(api_kwargs)
+
+
 def looks_like_stall(content: str, finish_reason: str, has_tool_calls: bool,
                      max_chars: int) -> bool:
     """True when a no-tool-call turn looks like a premature agentic stall
@@ -78,11 +456,17 @@ def looks_like_stall(content: str, finish_reason: str, has_tool_calls: bool,
     # Strip a leading <think>...</think> block if present; judge the visible tail.
     c = re.sub(r"^<think>.*?</think>\s*", "", c, flags=re.IGNORECASE | re.DOTALL).strip()
     if not c:
-        return True  # empty visible turn mid-task => stall
-    if len(c) > max_chars:
-        return False  # long => almost certainly a real answer
+        # Truly empty responses have their own recovery path in the
+        # conversation loop. Do not let stall retry preempt that machinery.
+        return False
+    if _action_after_completion(c):
+        return True
     if _COMPLETION_RE.search(c):
         return False  # model said it's done => respect it
+    if _ends_with_action_promise(c):
+        return True
+    if len(c) > max_chars:
+        return False  # long => almost certainly a real answer
     if _ACTION_RE.search(c):
         return True   # announced an action, no tool call => stall
     # Short prose that doesn't declare completion and isn't an obvious answer:
@@ -99,55 +483,52 @@ def looks_like_stall(content: str, finish_reason: str, has_tool_calls: bool,
     return False
 
 
-def _retry_messages_with_nudge(api_messages, stalled_content="", retry_nudge=None):
-    retry_messages = list(api_messages)
-    visible = (stalled_content or "").strip()
-    if visible:
-        retry_messages.append({"role": "assistant", "content": visible})
-    if retry_nudge:
-        retry_messages.append({"role": "user", "content": retry_nudge})
-    return retry_messages
-
-
 def retry_on_stall(
     agent,
     api_messages,
     finish_reason,
-    stalled_content="",
+    stalled_content: str = "",
+    retry_index: int | None = None,
     *,
-    accept_content=False,
-    retry_nudge=None,
+    accept_content: bool = False,
+    retry_nudge: str | None = None,
 ):
     """If the just-finished no-tool-call turn looks like a stall and a retry
-    lane is configured, re-issue the SAME turn against that lane (same provider
-    / client / endpoint — only the model name changes) ONCE.
+    lane is configured, re-issue the turn against that lane (same provider /
+    client / endpoint — only the model name changes). A retry-only nudge is
+    appended by default so the fallback model is told to continue with a tool
+    call instead of repeating the action preamble.
 
     Returns the normalized assistant_message from the retry IF it produced tool
     calls (caller should adopt it + its finish_reason='tool_calls'), else None.
     Never raises into the caller — any failure returns None so the caller can
     fail closed without storing the stalled assistant message.
     """
-    retry_model = os.environ.get("HERMES_STALL_RETRY_MODEL", "").strip()
+    retry_model = get_stall_retry_model(agent)
     if not retry_model:
         return None
-    try:
-        max_chars = int(os.environ.get("HERMES_STALL_RETRY_MAX_CHARS", "400"))
-    except ValueError:
-        max_chars = 400
 
     try:
+        retry_messages = _retry_messages_with_nudge(
+            agent,
+            api_messages,
+            stalled_content,
+            retry_nudge=retry_nudge,
+        )
         # Build kwargs exactly as the normal turn would, then override only the
         # model name. Safe when the retry lane is served by the SAME provider/
         # endpoint as agent.model (e.g. taro serves both dflash and the Q6 lane),
         # so no client rebuild is needed.
-        retry_messages = _retry_messages_with_nudge(
-            api_messages,
-            stalled_content=stalled_content,
-            retry_nudge=retry_nudge,
-        )
         api_kwargs = agent._build_api_kwargs(retry_messages)
         orig_model = api_kwargs.get("model")
         if retry_model == orig_model:
+            record_stall_retry_event(
+                agent,
+                "skipped_same_model",
+                retry_model=retry_model,
+                finish_reason=finish_reason,
+                retry_index=retry_index,
+            )
             return None  # nothing to gain retrying the same model
         api_kwargs = dict(api_kwargs)
         api_kwargs["model"] = retry_model
@@ -164,8 +545,24 @@ def retry_on_stall(
         except Exception:
             pass
 
-        response = agent._interruptible_api_call(api_kwargs)
+        record_stall_retry_event(
+            agent,
+            "attempt",
+            retry_model=retry_model,
+            original_model=orig_model,
+            finish_reason=finish_reason,
+            retry_index=retry_index,
+            nudge=get_stall_retry_nudge_enabled(agent),
+            content=stalled_content,
+        )
+        response = _retry_api_call(agent, api_kwargs, retry_model)
         if response is None:
+            record_stall_retry_event(
+                agent,
+                "api_none",
+                retry_model=retry_model,
+                retry_index=retry_index,
+            )
             return None
         transport = agent._get_transport()
         normalize_kwargs = {}
@@ -175,8 +572,31 @@ def retry_on_stall(
         tool_calls = getattr(normalized, "tool_calls", None)
         content = getattr(normalized, "content", "") or ""
         if tool_calls or (accept_content and content.strip()):
+            record_stall_retry_event(
+                agent,
+                "recovered",
+                retry_model=retry_model,
+                retry_index=retry_index,
+                tool_call_count=len(tool_calls or []),
+                content=content,
+            )
             return normalized
+        record_stall_retry_event(
+            agent,
+            "failed_no_tool_call",
+            retry_model=retry_model,
+            retry_index=retry_index,
+            content=getattr(normalized, "content", "") or "",
+        )
         return None
-    except Exception:
+    except Exception as exc:
+        record_stall_retry_event(
+            agent,
+            "exception",
+            retry_model=retry_model,
+            retry_index=retry_index,
+            error_type=type(exc).__name__,
+            error=str(exc)[:300],
+        )
         # Any error => silently fall back to the original response.
         return None

--- a/agent/stall_retry.py
+++ b/agent/stall_retry.py
@@ -21,7 +21,12 @@ Env:
   HERMES_STALL_RETRY_MODEL  retry lane/model name (required to enable)
   HERMES_STALL_RETRY_PROVIDER  optional provider override for the retry lane
   HERMES_STALL_RETRY_BASE_URL  optional OpenAI-compatible retry endpoint
-  HERMES_STALL_RETRY_MAX_PER_TURN  max retries per user turn (default 5)
+  HERMES_STALL_RETRY_MAX_PER_TURN  max unrecovered retries per user turn
+                                (default 5). Successful retry-lane tool calls
+                                are progress and do not consume this budget.
+  HERMES_STALL_RETRY_PROMOTE_AFTER  successful rescues before routing the rest
+                                of the turn through the retry lane (default 2,
+                                0 disables)
   HERMES_STALL_RETRY_MAX_CHARS  max content length to still count as a stall
                                 (default 400; longer open action preambles
                                 ending in ":" get a bounded exception)
@@ -202,6 +207,21 @@ def get_stall_retry_max_per_turn(agent: Any | None = None) -> int:
         return max(0, int(cfg_value))
     except (TypeError, ValueError):
         return 5
+
+
+def get_stall_retry_promote_after(agent: Any | None = None) -> int:
+    """Return successful retry rescues needed before turn-scoped promotion."""
+    env_value = os.environ.get("HERMES_STALL_RETRY_PROMOTE_AFTER")
+    if env_value is not None:
+        try:
+            return max(0, int(env_value))
+        except ValueError:
+            return 2
+    cfg_value = _stall_retry_config(agent).get("promote_after")
+    try:
+        return max(0, int(cfg_value))
+    except (TypeError, ValueError):
+        return 2
 
 
 def get_stall_retry_nudge_enabled(agent: Any | None = None) -> bool:
@@ -509,6 +529,226 @@ def _retry_api_call(agent: Any, api_kwargs: dict[str, Any], retry_model: str) ->
         return client.chat.completions.create(**retry_kwargs)
 
     return agent._interruptible_api_call(api_kwargs)
+
+
+def activate_stall_retry_runtime(
+    agent: Any,
+    retry_model: str,
+    *,
+    promote_after: int,
+    successful_retries: int,
+) -> bool:
+    """Route the rest of this turn through the retry lane.
+
+    A repeated pattern of primary-model stalls followed by retry-lane tool-call
+    recovery means the primary is no longer reliable for this agentic turn. This
+    helper promotes the already-configured retry lane into the active runtime
+    without updating ``_primary_runtime``; Hermes' normal start-of-turn restore
+    then switches back to the user's selected primary on the next user turn.
+    """
+
+    retry_model = str(retry_model or "").strip()
+    if not retry_model:
+        return False
+    if getattr(agent, "_stall_retry_runtime_promoted", False):
+        return False
+
+    original_model = str(getattr(agent, "model", "") or "")
+    original_provider = str(getattr(agent, "provider", "") or "")
+    original_base_url = str(getattr(agent, "base_url", "") or "")
+    retry_provider = get_stall_retry_provider(agent)
+    retry_base_url = get_stall_retry_base_url(agent)
+    retry_api_key = _configured_retry_api_key(agent, retry_provider, retry_base_url)
+    if not retry_base_url and retry_api_key:
+        retry_base_url = original_base_url
+
+    provider = retry_provider or original_provider
+    base_url = retry_base_url or original_base_url
+    api_key = retry_api_key or getattr(agent, "api_key", "")
+    client = None
+    resolved_model = retry_model
+    client_kwargs: dict[str, Any] = {}
+
+    try:
+        if retry_provider or retry_base_url or retry_api_key:
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, provider_model = resolve_provider_client(
+                provider or "custom",
+                model=retry_model,
+                raw_codex=True,
+                explicit_base_url=retry_base_url or None,
+                explicit_api_key=retry_api_key or None,
+            )
+            if client is None:
+                record_stall_retry_event(
+                    agent,
+                    "promotion_skipped",
+                    retry_model=retry_model,
+                    original_model=original_model,
+                    reason="provider_unavailable",
+                    promote_after=promote_after,
+                    successful_retries=successful_retries,
+                )
+                return False
+            resolved_model = provider_model or retry_model
+            base_url = str(getattr(client, "base_url", base_url) or base_url)
+            api_key = getattr(client, "api_key", api_key)
+            headers = (
+                getattr(client, "_custom_headers", None)
+                or getattr(client, "default_headers", None)
+            )
+            client_kwargs = {
+                "api_key": api_key,
+                "base_url": base_url,
+                **({"default_headers": dict(headers)} if headers else {}),
+            }
+        else:
+            if retry_model == original_model:
+                record_stall_retry_event(
+                    agent,
+                    "promotion_skipped",
+                    retry_model=retry_model,
+                    original_model=original_model,
+                    reason="same_model",
+                    promote_after=promote_after,
+                    successful_retries=successful_retries,
+                )
+                return False
+            client_kwargs = dict(getattr(agent, "_client_kwargs", {}) or {})
+            if not client_kwargs:
+                client_kwargs = {
+                    "api_key": api_key,
+                    "base_url": base_url,
+                }
+
+        try:
+            from hermes_cli.providers import determine_api_mode
+
+            api_mode = determine_api_mode(provider, base_url)
+        except Exception:
+            api_mode = getattr(agent, "api_mode", "") or "chat_completions"
+        if api_mode in {"anthropic_messages", "bedrock_converse", "codex_responses"}:
+            record_stall_retry_event(
+                agent,
+                "promotion_skipped",
+                retry_model=retry_model,
+                original_model=original_model,
+                reason=f"unsupported_api_mode:{api_mode}",
+                promote_after=promote_after,
+                successful_retries=successful_retries,
+            )
+            return False
+
+        try:
+            from hermes_cli.timeouts import get_provider_request_timeout
+
+            timeout = get_provider_request_timeout(provider, resolved_model)
+            if timeout is not None:
+                client_kwargs["timeout"] = timeout
+        except Exception:
+            pass
+
+        agent._config_context_length = None
+        agent.model = resolved_model
+        agent.provider = provider
+        agent.base_url = base_url
+        agent.api_key = api_key
+        agent.api_mode = api_mode or "chat_completions"
+        agent._client_kwargs = client_kwargs
+        if hasattr(agent, "_transport_cache"):
+            agent._transport_cache.clear()
+        if client is not None:
+            agent.client = client
+        elif hasattr(agent, "_create_openai_client"):
+            agent.client = agent._create_openai_client(
+                dict(client_kwargs),
+                reason="stall_retry_runtime_promotion",
+                shared=True,
+            )
+
+        try:
+            agent._use_prompt_caching, agent._use_native_cache_layout = (
+                agent._anthropic_prompt_cache_policy(
+                    provider=provider,
+                    base_url=base_url,
+                    api_mode=agent.api_mode,
+                    model=resolved_model,
+                )
+            )
+        except Exception:
+            pass
+
+        if hasattr(agent, "_ensure_lmstudio_runtime_loaded"):
+            agent._ensure_lmstudio_runtime_loaded()
+
+        context_length = None
+        if getattr(agent, "context_compressor", None):
+            try:
+                from agent.model_metadata import get_model_context_length
+
+                ctx_api_key = api_key if isinstance(api_key, str) else ""
+                context_length = get_model_context_length(
+                    resolved_model,
+                    base_url=base_url,
+                    api_key=ctx_api_key,
+                    provider=provider,
+                    config_context_length=getattr(agent, "_config_context_length", None),
+                    custom_providers=getattr(agent, "_custom_providers", None),
+                )
+                agent.context_compressor.update_model(
+                    model=resolved_model,
+                    context_length=context_length,
+                    base_url=base_url,
+                    api_key=api_key,
+                    provider=provider,
+                    api_mode=agent.api_mode,
+                )
+            except Exception:
+                pass
+
+        agent._fallback_activated = True
+        agent._stall_retry_runtime_promoted = True
+        agent._stall_retry_promoted_from = original_model
+
+        record_stall_retry_event(
+            agent,
+            "runtime_promoted",
+            retry_model=resolved_model,
+            original_model=original_model,
+            original_provider=original_provider,
+            promote_after=promote_after,
+            successful_retries=successful_retries,
+            context_length=context_length,
+        )
+        try:
+            agent._emit_status(
+                "↻ dflash stalled repeatedly; using "
+                f"{resolved_model} for the rest of this turn. "
+                "Primary model will be restored next turn."
+            )
+        except Exception:
+            try:
+                agent._vprint(
+                    f"{getattr(agent, 'log_prefix', '')}↻ dflash stalled "
+                    f"repeatedly; using {resolved_model} for the rest of this turn.",
+                    force=True,
+                )
+            except Exception:
+                pass
+        return True
+    except Exception as exc:
+        record_stall_retry_event(
+            agent,
+            "promotion_exception",
+            retry_model=retry_model,
+            original_model=original_model,
+            error_type=type(exc).__name__,
+            error=str(exc)[:300],
+            promote_after=promote_after,
+            successful_retries=successful_retries,
+        )
+        return False
 
 
 def looks_like_stall(content: str, finish_reason: str, has_tool_calls: bool,

--- a/agent/stall_retry.py
+++ b/agent/stall_retry.py
@@ -101,17 +101,29 @@ def _as_bool(value: Any, default: bool) -> bool:
 
 
 def _stall_retry_config(agent: Any | None = None) -> Mapping[str, Any]:
-    cfg = getattr(agent, "_stall_retry_config", None)
-    if isinstance(cfg, Mapping):
-        return cfg
+    loaded_cfg: Mapping[str, Any] = {}
     try:
         from hermes_cli.config import load_config
 
         loaded = load_config()
     except Exception:
-        return {}
+        loaded = {}
     cfg = loaded.get("stall_retry") if isinstance(loaded, Mapping) else None
-    return cfg if isinstance(cfg, Mapping) else {}
+    if isinstance(cfg, Mapping):
+        loaded_cfg = cfg
+
+    agent_cfg = getattr(agent, "_stall_retry_config", None)
+    if not isinstance(agent_cfg, Mapping):
+        return loaded_cfg
+    if not agent_cfg:
+        return loaded_cfg
+
+    merged = dict(loaded_cfg)
+    for key, value in agent_cfg.items():
+        if value is None or value == "":
+            continue
+        merged[str(key)] = value
+    return merged
 
 
 def get_stall_retry_model(agent: Any | None = None) -> str:

--- a/agent/stall_retry.py
+++ b/agent/stall_retry.py
@@ -37,7 +37,7 @@ import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 # Action-preamble signature: the turn announced an action but produced no tool
 # call. These English phrases match the observed dflash stall corpus; broader
@@ -106,6 +106,28 @@ def _as_bool(value: Any, default: bool) -> bool:
         if lowered in {"0", "false", "no", "off", "disabled"}:
             return False
     return default
+
+
+def has_recent_tool_result(messages: Sequence[Any], *, lookback: int = 24) -> bool:
+    """Return whether the current turn has a recent tool result.
+
+    Stop at the current turn's user message so a tool-heavy previous turn does
+    not make an unrelated empty first response look like post-tool fallout.
+    """
+
+    checked = 0
+    for msg in reversed(messages):
+        if checked >= lookback:
+            return False
+        if not isinstance(msg, Mapping):
+            continue
+        role = msg.get("role")
+        if role == "tool":
+            return True
+        if role == "user":
+            return False
+        checked += 1
+    return False
 
 
 def _stall_retry_config(agent: Any | None = None) -> Mapping[str, Any]:

--- a/agent/stall_retry.py
+++ b/agent/stall_retry.py
@@ -46,6 +46,12 @@ _COMPLETION_RE = re.compile(
 )
 _NATURAL_END_CHARS = '.!?:)"\']}。！？：）】」』》^'
 _MIN_INCOMPLETE_FINAL_CHARS = 80
+EMPTY_AFTER_TOOL_RETRY_NUDGE = (
+    "Your previous assistant response after the tool results was empty. "
+    "Continue the same task using the tool results above. If the next step "
+    "requires another tool, call it immediately; otherwise provide the next "
+    "concise response. Do not summarize or apologize."
+)
 
 
 def _has_natural_response_ending(content: str) -> bool:
@@ -93,7 +99,25 @@ def looks_like_stall(content: str, finish_reason: str, has_tool_calls: bool,
     return False
 
 
-def retry_on_stall(agent, api_messages, finish_reason):
+def _retry_messages_with_nudge(api_messages, stalled_content="", retry_nudge=None):
+    retry_messages = list(api_messages)
+    visible = (stalled_content or "").strip()
+    if visible:
+        retry_messages.append({"role": "assistant", "content": visible})
+    if retry_nudge:
+        retry_messages.append({"role": "user", "content": retry_nudge})
+    return retry_messages
+
+
+def retry_on_stall(
+    agent,
+    api_messages,
+    finish_reason,
+    stalled_content="",
+    *,
+    accept_content=False,
+    retry_nudge=None,
+):
     """If the just-finished no-tool-call turn looks like a stall and a retry
     lane is configured, re-issue the SAME turn against that lane (same provider
     / client / endpoint — only the model name changes) ONCE.
@@ -116,7 +140,12 @@ def retry_on_stall(agent, api_messages, finish_reason):
         # model name. Safe when the retry lane is served by the SAME provider/
         # endpoint as agent.model (e.g. taro serves both dflash and the Q6 lane),
         # so no client rebuild is needed.
-        api_kwargs = agent._build_api_kwargs(api_messages)
+        retry_messages = _retry_messages_with_nudge(
+            api_messages,
+            stalled_content=stalled_content,
+            retry_nudge=retry_nudge,
+        )
+        api_kwargs = agent._build_api_kwargs(retry_messages)
         orig_model = api_kwargs.get("model")
         if retry_model == orig_model:
             return None  # nothing to gain retrying the same model
@@ -143,7 +172,9 @@ def retry_on_stall(agent, api_messages, finish_reason):
         if getattr(agent, "api_mode", None) == "anthropic_messages":
             normalize_kwargs["strip_tool_prefix"] = getattr(agent, "_is_anthropic_oauth", False)
         normalized = transport.normalize_response(response, **normalize_kwargs)
-        if getattr(normalized, "tool_calls", None):
+        tool_calls = getattr(normalized, "tool_calls", None)
+        content = getattr(normalized, "content", "") or ""
+        if tool_calls or (accept_content and content.strip()):
             return normalized
         return None
     except Exception:

--- a/agent/stall_retry.py
+++ b/agent/stall_retry.py
@@ -18,6 +18,7 @@ Entirely opt-in: does nothing unless ``HERMES_STALL_RETRY_MODEL`` is set
 
 Env:
   HERMES_STALL_RETRY_MODEL  retry lane/model name (required to enable)
+  HERMES_STALL_RETRY_MAX_PER_TURN  max retries per user turn (default 5)
   HERMES_STALL_RETRY_MAX_CHARS  max content length to still count as a stall
                                 (default 400; real final answers are longer)
 """

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -10,9 +10,11 @@ reasoning configuration, temperature handling, and extra_body assembly.
 """
 
 import copy
+import os
 from typing import Any, Dict
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
+from agent.model_metadata import is_local_endpoint
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
 from agent.transports.base import ProviderTransport
@@ -97,6 +99,25 @@ def _is_gemini_openai_compat_base_url(base_url: Any) -> bool:
     if "generativelanguage.googleapis.com" not in normalized:
         return False
     return normalized.endswith("/openai")
+
+
+def _local_default_max_tokens(base_url: Any) -> int | None:
+    """Return a finite default output cap for local OpenAI-compatible endpoints."""
+    if not is_local_endpoint(str(base_url or "")):
+        return None
+
+    raw = (
+        os.getenv("HERMES_LOCAL_DEFAULT_MAX_TOKENS")
+        or os.getenv("HERMES_LOCAL_MAX_TOKENS")
+        or "8192"
+    )
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        value = 8192
+    if value <= 0:
+        return None
+    return value
 
 
 class ChatCompletionsTransport(ProviderTransport):
@@ -292,6 +313,7 @@ class ChatCompletionsTransport(ProviderTransport):
         is_kimi = params.get("is_kimi", False)
         is_tokenhub = params.get("is_tokenhub", False)
         reasoning_config = params.get("reasoning_config")
+        local_default = _local_default_max_tokens(params.get("base_url"))
 
         if ephemeral is not None and max_tokens_fn:
             api_kwargs.update(max_tokens_fn(ephemeral))
@@ -299,6 +321,11 @@ class ChatCompletionsTransport(ProviderTransport):
             api_kwargs.update(max_tokens_fn(max_tokens))
         elif anthropic_max_out is not None:
             api_kwargs["max_tokens"] = anthropic_max_out
+        elif local_default is not None:
+            if max_tokens_fn:
+                api_kwargs.update(max_tokens_fn(local_default))
+            else:
+                api_kwargs["max_tokens"] = local_default
 
         # Kimi: top-level reasoning_effort (unless thinking disabled)
         if is_kimi:
@@ -480,6 +507,7 @@ class ChatCompletionsTransport(ProviderTransport):
         # they front several backends with different completion-token limits
         # (e.g. opencode-go: mimo-v2.5-pro = 131072).
         profile_max = profile.get_max_tokens(model)
+        local_default = _local_default_max_tokens(params.get("base_url"))
 
         if ephemeral is not None and max_tokens_fn:
             api_kwargs.update(max_tokens_fn(ephemeral))
@@ -489,6 +517,11 @@ class ChatCompletionsTransport(ProviderTransport):
             api_kwargs.update(max_tokens_fn(profile_max))
         elif anthropic_max is not None:
             api_kwargs["max_tokens"] = anthropic_max
+        elif local_default is not None:
+            if max_tokens_fn:
+                api_kwargs.update(max_tokens_fn(local_default))
+            else:
+                api_kwargs["max_tokens"] = local_default
 
         # Provider-specific api_kwargs extras (reasoning_effort, metadata, etc.)
         reasoning_config = params.get("reasoning_config")

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -23,11 +23,30 @@ from __future__ import annotations
 
 import logging
 import os
+import faulthandler
+import signal
 import sys
 from contextlib import redirect_stderr, redirect_stdout
 from typing import Optional
 
 from hermes_cli.fallback_config import get_fallback_chain
+
+
+def _install_oneshot_timeout_diagnostics() -> None:
+    """Allow canary supervisors to request a Python thread dump before kill."""
+    if os.getenv("HERMES_ONESHOT_FAULTHANDLER", "1").strip().lower() in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }:
+        return
+    try:
+        faulthandler.enable(file=sys.stderr, all_threads=True)
+        if hasattr(signal, "SIGUSR1"):
+            faulthandler.register(signal.SIGUSR1, file=sys.stderr, all_threads=True, chain=False)
+    except Exception:
+        pass
 
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
@@ -175,6 +194,7 @@ def run_oneshot(
     # We'll print the final response to the real stdout at the end.
     real_stdout = sys.stdout
     real_stderr = sys.stderr
+    _install_oneshot_timeout_diagnostics()
     devnull = open(os.devnull, "w", encoding="utf-8")
 
     response: Optional[str] = None

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -159,12 +159,9 @@ def run_oneshot(
 
     Returns the exit code.  Caller should sys.exit() with the return.
     """
-    # Silence every stdlib logger for the duration.  AIAgent, tools, and
-    # provider adapters all log to stderr through the root logger; file
-    # handlers added by setup_logging() keep working (they're attached to
-    # the root logger's handler list, not affected by level), but no
-    # bytes reach the terminal.
-    logging.disable(logging.CRITICAL)
+    # Do not call logging.disable() here.  stdout/stderr are redirected below
+    # so terminal chatter stays hidden, while file handlers keep the provider
+    # watchdog evidence needed by automated hardening loops.
 
     # --provider without --model is ambiguous: carrying the user's configured
     # model across to a different provider is usually wrong (that provider may

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -364,7 +364,10 @@ def _run_agent(
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
 
-    return agent.chat(prompt) or ""
+    result = agent.run_conversation(prompt)
+    if result.get("failed") or (result.get("error") and not result.get("final_response")):
+        raise RuntimeError(result.get("error") or "agent failed without final response")
+    return result.get("final_response") or ""
 
 
 def _oneshot_clarify_callback(question: str, choices=None) -> str:

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -43,8 +43,9 @@ def _install_oneshot_timeout_diagnostics() -> None:
         return
     try:
         faulthandler.enable(file=sys.stderr, all_threads=True)
-        if hasattr(signal, "SIGUSR1"):
-            faulthandler.register(signal.SIGUSR1, file=sys.stderr, all_threads=True, chain=False)
+        sigusr1 = getattr(signal, "SIGUSR1", None)
+        if sigusr1 is not None:
+            faulthandler.register(sigusr1, file=sys.stderr, all_threads=True, chain=False)
     except Exception:
         pass
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1053,9 +1053,9 @@ class AIAgent:
              ``_compute_non_stream_stale_timeout``.
 
         Returns ``(timeout_seconds, uses_implicit_default)`` so the caller can
-        preserve legacy behaviors that only apply when the user has *not*
-        explicitly configured a stale timeout, such as auto-disabling the
-        detector for local endpoints.
+        apply behaviors that only make sense when the user has *not* explicitly
+        configured a stale timeout, such as using local-backend defaults for
+        loopback endpoints.
         """
         cfg = get_provider_stale_timeout(self.provider, self.model)
         if cfg is not None:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1078,6 +1078,10 @@ class AIAgent:
         stale_base, uses_implicit_default = self._resolved_api_call_stale_timeout_base()
         base_url = getattr(self, "_base_url", None) or self.base_url or ""
         if uses_implicit_default and base_url and is_local_endpoint(base_url):
+            from agent.chat_completion_helpers import _dflash_local_stale_timeout
+            dflash_timeout = _dflash_local_stale_timeout(api_payload, self.model)
+            if dflash_timeout is not None:
+                return dflash_timeout
             return float("inf")
 
         from agent.chat_completion_helpers import estimate_request_context_tokens

--- a/run_agent.py
+++ b/run_agent.py
@@ -1078,11 +1078,11 @@ class AIAgent:
         stale_base, uses_implicit_default = self._resolved_api_call_stale_timeout_base()
         base_url = getattr(self, "_base_url", None) or self.base_url or ""
         if uses_implicit_default and base_url and is_local_endpoint(base_url):
-            from agent.chat_completion_helpers import _dflash_local_stale_timeout
-            dflash_timeout = _dflash_local_stale_timeout(api_payload, self.model)
-            if dflash_timeout is not None:
-                return dflash_timeout
-            return float("inf")
+            from agent.chat_completion_helpers import _local_provider_non_stream_stale_timeout
+            model = self.model
+            if isinstance(api_payload, dict):
+                model = api_payload.get("model") or model
+            return _local_provider_non_stream_stale_timeout(api_payload, model)
 
         from agent.chat_completion_helpers import estimate_request_context_tokens
         est_tokens = estimate_request_context_tokens(api_payload)

--- a/scripts/dflash_hardening_loop.py
+++ b/scripts/dflash_hardening_loop.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Run the dflash stability canary as a supervised hardening loop.
+
+The base canary is intentionally finite: it proves a build at one point in
+time.  This wrapper is the ownership layer for iterative hardening.  It keeps
+running bounded canary cycles until a failure appears, records local JSONL
+evidence, and can update a MeshBoard repair task so a worker can pick up the
+next root cause without waiting for a human screenshot.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Sequence
+
+from dflash_stability_canary import (
+    DEFAULT_LOG_DIR,
+    DEFAULT_MODEL,
+    DEFAULT_PROVIDER,
+    DEFAULT_TOOLSETS,
+    iter_cases,
+    record_path,
+    run_case,
+    write_record,
+)
+
+
+TASK_ID_RE = re.compile(r"[^a-z0-9-]+")
+
+
+def slug(value: object) -> str:
+    text = str(value or "unknown").strip().lower().replace("_", "-")
+    text = TASK_ID_RE.sub("-", text)
+    return text.strip("-") or "unknown"
+
+
+def failure_task_id(record: dict, *, prefix: str) -> str:
+    return "-".join(
+        part
+        for part in [
+            slug(prefix),
+            slug(record.get("case")),
+            slug(record.get("failure")),
+        ]
+        if part
+    )
+
+
+def build_meshboard_failure_command(
+    *,
+    meshboard_root: Path,
+    task_id: str,
+    record: dict,
+    log_path: Path,
+    actor: str,
+    parent_task: str,
+) -> list[str]:
+    meshctl = meshboard_root / ".mesh" / "tools" / "meshctl.py"
+    details = (
+        "Automated dflash hardening loop detected a canary failure. "
+        f"case={record.get('case')} failure={record.get('failure')} "
+        f"returncode={record.get('returncode')} elapsed_s={record.get('elapsed_s')}. "
+        "Raw stdout/stderr stay in the local evidence log."
+    )
+    next_step = (
+        "Inspect the evidence log, reproduce the canary failure from the same "
+        "Hermes checkout, fix the root cause, verify with the canary, then "
+        "restart the dflash hardening loop."
+    )
+    cmd = [
+        sys.executable,
+        str(meshctl),
+        "task",
+        "register",
+        task_id,
+        "--update",
+        "--apply",
+        "--state",
+        "open",
+        "--owner",
+        actor,
+        "--priority",
+        "High",
+        "--size",
+        "M",
+        "--risk",
+        "medium",
+        "--requires-human",
+        "false",
+        "--data-policy",
+        "workspace-private",
+        "--title",
+        f"Repair dflash canary failure: {record.get('case')} {record.get('failure')}",
+        "--next",
+        next_step,
+        "--details",
+        details,
+        "--link",
+        str(log_path),
+        "--required-tool",
+        "hermes",
+        "--verification",
+        "Run scripts/dflash_stability_canary.py with the failing case until it passes.",
+    ]
+    if parent_task:
+        cmd.extend(["--parent-task", parent_task])
+    return cmd
+
+
+def register_meshboard_failure(
+    *,
+    meshboard_root: Path,
+    task_id: str,
+    record: dict,
+    log_path: Path,
+    actor: str,
+    parent_task: str,
+) -> dict:
+    cmd = build_meshboard_failure_command(
+        meshboard_root=meshboard_root,
+        task_id=task_id,
+        record=record,
+        log_path=log_path,
+        actor=actor,
+        parent_task=parent_task,
+    )
+    result = subprocess.run(
+        cmd,
+        cwd=str(meshboard_root),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    return {
+        "cmd": [*cmd[:4], "<task-register-args>"],
+        "returncode": result.returncode,
+        "stdout": result.stdout[-2000:],
+        "stderr": result.stderr[-2000:],
+        "task_id": task_id,
+    }
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--max-cycles", type=int, default=0, help="0 means run until failure or interrupt.")
+    parser.add_argument("--cycle-sleep", type=float, default=60.0, help="Seconds between successful cycles.")
+    parser.add_argument("--timeout", type=float, default=180.0, help="Per-case timeout in seconds.")
+    parser.add_argument("--cwd", type=Path, default=Path.cwd(), help="Working directory for hermes -z.")
+    parser.add_argument("--hermes-bin", default="hermes", help="Hermes executable.")
+    parser.add_argument("--provider", default=DEFAULT_PROVIDER, help="Hermes provider override.")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Hermes model override.")
+    parser.add_argument("--toolsets", default=DEFAULT_TOOLSETS, help="Comma-separated toolsets for canary turns.")
+    parser.add_argument("--log-dir", type=Path, default=DEFAULT_LOG_DIR, help="Directory for JSONL evidence logs.")
+    parser.add_argument("--case", action="append", dest="cases", help="Run only this case name; repeatable.")
+    parser.add_argument("--allow-extra-output", action="store_true", help="Allow marker to appear inside extra text.")
+    parser.add_argument("--meshboard-root", type=Path, help="If set, register/update a MeshBoard task on failure.")
+    parser.add_argument("--meshboard-actor", default="dflash-hardening-loop", help="Owner for failure tasks.")
+    parser.add_argument("--meshboard-parent-task", default="", help="Parent MeshBoard task id for failures.")
+    parser.add_argument("--task-prefix", default="hermes-dflash-hardening-loop", help="Failure task id prefix.")
+    parser.add_argument("--continue-after-failure", action="store_true", help="Keep looping after filing a failure.")
+    parser.add_argument("--json", action="store_true", help="Print JSON records to stdout.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    cases = iter_cases(args.cases)
+    strict_marker = not args.allow_extra_output
+    log_path = record_path(args.log_dir)
+    cycle = 0
+
+    while args.max_cycles <= 0 or cycle < args.max_cycles:
+        cycle += 1
+        for case in cases:
+            record = run_case(
+                case,
+                cwd=args.cwd,
+                hermes_bin=args.hermes_bin,
+                model=args.model,
+                provider=args.provider,
+                toolsets=args.toolsets,
+                timeout_s=args.timeout,
+                strict_marker=strict_marker,
+            )
+            record["cycle"] = cycle
+            write_record(log_path, record)
+
+            if args.json:
+                print(json.dumps(record, sort_keys=True), flush=True)
+            else:
+                status = "ok" if record["ok"] else f"fail:{record['failure']}"
+                print(f"cycle={cycle} case={case.name} {status} evidence={log_path}", flush=True)
+
+            if not record["ok"]:
+                if args.meshboard_root:
+                    task_id = failure_task_id(record, prefix=args.task_prefix)
+                    mesh_record = register_meshboard_failure(
+                        meshboard_root=args.meshboard_root,
+                        task_id=task_id,
+                        record=record,
+                        log_path=log_path,
+                        actor=args.meshboard_actor,
+                        parent_task=args.meshboard_parent_task,
+                    )
+                    write_record(log_path, {"cycle": cycle, "meshboard": mesh_record})
+                    if not args.json:
+                        print(
+                            f"registered MeshBoard failure task {task_id} "
+                            f"rc={mesh_record['returncode']}",
+                            flush=True,
+                        )
+                if not args.continue_after_failure:
+                    return 1
+
+        if args.max_cycles > 0 and cycle >= args.max_cycles:
+            break
+        if args.cycle_sleep > 0:
+            time.sleep(args.cycle_sleep)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dflash_hardening_loop.py
+++ b/scripts/dflash_hardening_loop.py
@@ -25,6 +25,7 @@ from dflash_stability_canary import (
     DEFAULT_PROVIDER,
     DEFAULT_TOOLSETS,
     iter_cases,
+    marker_suffix,
     record_path,
     run_case,
     write_record,
@@ -188,6 +189,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 toolsets=args.toolsets,
                 timeout_s=args.timeout,
                 strict_marker=strict_marker,
+                marker_nonce=marker_suffix(log_path.stem, f"c{cycle}", case.name),
             )
             record["cycle"] = cycle
             write_record(log_path, record)

--- a/scripts/dflash_stability_canary.py
+++ b/scripts/dflash_stability_canary.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Run bounded Hermes/dflash stability canaries and write JSONL evidence.
+
+This is intentionally not an endless loop.  It runs a small set of workflow
+prompts through ``hermes -z`` and requires each turn to return an exact success
+marker.  Failures are recorded with enough local evidence to debug the next
+root cause without relying on phone screenshots alone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Iterable, Sequence
+
+
+DEFAULT_LOG_DIR = Path.home() / ".hermes" / "logs" / "dflash-stability-canary"
+DEFAULT_PROVIDER = "taro"
+DEFAULT_MODEL = "dflash"
+DEFAULT_TOOLSETS = "terminal,file"
+MAX_OUTPUT_CHARS = 6000
+
+
+@dataclass(frozen=True)
+class CanaryCase:
+    name: str
+    marker: str
+    prompt: str
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    elapsed_s: float
+    timed_out: bool = False
+
+
+DEFAULT_CASES: tuple[CanaryCase, ...] = (
+    CanaryCase(
+        name="meshboard-onboard",
+        marker="CANARY_ONBOARD_OK",
+        prompt=(
+            "From the current working directory, run "
+            "`python3 .mesh/tools/meshctl.py onboard`. If the command completes "
+            "without a Python traceback, reply exactly CANARY_ONBOARD_OK and "
+            "nothing else. If it fails, do not use the marker; summarize the "
+            "failure briefly."
+        ),
+    ),
+    CanaryCase(
+        name="meshboard-status-read",
+        marker="CANARY_STATUS_OK",
+        prompt=(
+            "From the current working directory, inspect STATUS.md just enough "
+            "to confirm these task ids appear: "
+            "hermes-dflash-phone-cli-sudden-death-root-cause-20260531 and "
+            "hermes-tui-phone-status-bar-readable. Use shell tools if helpful. "
+            "If both appear, reply exactly CANARY_STATUS_OK and nothing else. "
+            "If either is missing, do not use the marker; say which is missing."
+        ),
+    ),
+    CanaryCase(
+        name="short-fragment-detector",
+        marker="CANARY_FRAGMENT_OK",
+        prompt=(
+            "Run a Python check in the current Hermes checkout that imports "
+            "`looks_like_incomplete_final_fragment` from `agent.stall_retry` and "
+            "verifies it returns true for exactly this string: "
+            "`I see a lot of discord-res tasks (digest Discord content) and some`. "
+            "If the check passes, reply exactly CANARY_FRAGMENT_OK and nothing "
+            "else. If it fails, do not use the marker; summarize the failure."
+        ),
+    ),
+)
+
+
+_INCOMPLETE_TAIL_RE = re.compile(
+    r"(?i)(?:^|[\s,;:])("
+    r"and|or|but|then|so|because|with|without|to|for|from|in|on|at|of|by|as|"
+    r"that|which|who|when|where|while|after|before|since|until|if|though|"
+    r"although|some|another"
+    r")\s*[.?!\"')\]]*$"
+)
+
+_ACTION_PROMISE_RE = re.compile(
+    r"(?im)(?:^|\n)\s*(?:let me|now let me|i(?:'ll| will)|i need to)\b.*(?:check|inspect|read|run|look|pick|continue)\b"
+)
+
+_AUTH_RE = re.compile(r"(?i)(?:401|autherror|invalid api key|api key is invalid|unauthorized)")
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def truncate(text: str, max_chars: int = MAX_OUTPUT_CHARS) -> str:
+    if len(text) <= max_chars:
+        return text
+
+    half = max(1, max_chars // 2)
+    return f"{text[:half]}\n...[truncated {len(text) - max_chars} chars]...\n{text[-half:]}"
+
+
+def looks_like_incomplete_tail(text: str) -> bool:
+    stripped = text.strip()
+
+    if not stripped:
+        return False
+
+    if _INCOMPLETE_TAIL_RE.search(stripped):
+        return True
+
+    tail = stripped[-240:]
+
+    return bool(_ACTION_PROMISE_RE.search(tail)) and not re.search(r"[.!?]\s*$", tail)
+
+
+def build_command(
+    hermes_bin: str,
+    case: CanaryCase,
+    *,
+    model: str,
+    provider: str,
+    toolsets: str,
+) -> list[str]:
+    cmd = [hermes_bin]
+
+    if provider:
+        cmd.extend(["--provider", provider])
+
+    if model:
+        cmd.extend(["--model", model])
+
+    if toolsets:
+        cmd.extend(["--toolsets", toolsets])
+
+    cmd.extend(["-z", case.prompt])
+
+    return cmd
+
+
+def run_subprocess(cmd: Sequence[str], *, cwd: Path, timeout_s: float) -> CommandResult:
+    started = time.monotonic()
+
+    try:
+        completed = subprocess.run(
+            list(cmd),
+            cwd=str(cwd),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout_s,
+            check=False,
+        )
+        elapsed_s = time.monotonic() - started
+        return CommandResult(
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+            elapsed_s=elapsed_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        elapsed_s = time.monotonic() - started
+        stdout = exc.stdout if isinstance(exc.stdout, str) else (exc.stdout or b"").decode(errors="replace")
+        stderr = exc.stderr if isinstance(exc.stderr, str) else (exc.stderr or b"").decode(errors="replace")
+        return CommandResult(returncode=124, stdout=stdout, stderr=stderr, elapsed_s=elapsed_s, timed_out=True)
+
+
+def classify_result(result: CommandResult, marker: str, *, strict_marker: bool = True) -> str | None:
+    combined = f"{result.stdout}\n{result.stderr}".strip()
+    stdout = result.stdout.strip()
+
+    if result.timed_out:
+        return "timeout"
+
+    if result.returncode != 0:
+        return "nonzero-exit"
+
+    if not stdout:
+        return "empty-final"
+
+    if _AUTH_RE.search(combined):
+        return "auth-error"
+
+    if marker:
+        if strict_marker and stdout != marker:
+            return "marker-mismatch"
+        if not strict_marker and marker not in stdout:
+            return "marker-missing"
+
+    if looks_like_incomplete_tail(stdout):
+        return "incomplete-tail"
+
+    return None
+
+
+def record_path(log_dir: Path) -> Path:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return log_dir / f"{stamp}.jsonl"
+
+
+def iter_cases(names: Iterable[str] | None = None) -> list[CanaryCase]:
+    cases = list(DEFAULT_CASES)
+
+    if not names:
+        return cases
+
+    selected: list[CanaryCase] = []
+    available = {case.name: case for case in cases}
+
+    for name in names:
+        if name not in available:
+            raise SystemExit(f"Unknown canary case {name!r}; available: {', '.join(sorted(available))}")
+        selected.append(available[name])
+
+    return selected
+
+
+def run_case(
+    case: CanaryCase,
+    *,
+    cwd: Path,
+    hermes_bin: str,
+    model: str,
+    provider: str,
+    toolsets: str,
+    timeout_s: float,
+    strict_marker: bool,
+    runner: Callable[[Sequence[str], Path, float], CommandResult] | None = None,
+) -> dict:
+    cmd = build_command(hermes_bin, case, model=model, provider=provider, toolsets=toolsets)
+
+    if runner is None:
+        result = run_subprocess(cmd, cwd=cwd, timeout_s=timeout_s)
+    else:
+        result = runner(cmd, cwd, timeout_s)
+
+    failure = classify_result(result, case.marker, strict_marker=strict_marker)
+
+    return {
+        "case": case.name,
+        "cmd": cmd[:-1] + ["<prompt>"],
+        "cwd": str(cwd),
+        "elapsed_s": round(result.elapsed_s, 3),
+        "failure": failure,
+        "marker": case.marker,
+        "ok": failure is None,
+        "returncode": result.returncode,
+        "stderr": truncate(result.stderr),
+        "stdout": truncate(result.stdout),
+        "timed_out": result.timed_out,
+        "ts": utc_now(),
+    }
+
+
+def write_record(path: Path, record: dict) -> None:
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rounds", type=int, default=1, help="Number of times to run the selected cases.")
+    parser.add_argument("--sleep", type=float, default=10.0, help="Seconds to sleep between rounds.")
+    parser.add_argument("--timeout", type=float, default=180.0, help="Per-case timeout in seconds.")
+    parser.add_argument("--cwd", type=Path, default=Path.cwd(), help="Working directory for hermes -z.")
+    parser.add_argument("--hermes-bin", default=os.environ.get("HERMES_BIN", "hermes"), help="Hermes executable.")
+    parser.add_argument("--provider", default=DEFAULT_PROVIDER, help="Hermes provider override.")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Hermes model override.")
+    parser.add_argument("--toolsets", default=DEFAULT_TOOLSETS, help="Comma-separated toolsets for canary turns.")
+    parser.add_argument("--log-dir", type=Path, default=DEFAULT_LOG_DIR, help="Directory for JSONL evidence logs.")
+    parser.add_argument("--case", action="append", dest="cases", help="Run only this case name; repeatable.")
+    parser.add_argument("--allow-extra-output", action="store_true", help="Allow marker to appear inside extra text.")
+    parser.add_argument("--dry-run", action="store_true", help="Print the plan without running Hermes.")
+    parser.add_argument("--json", action="store_true", help="Print JSON records to stdout.")
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    cases = iter_cases(args.cases)
+
+    if args.rounds < 1:
+        raise SystemExit("--rounds must be >= 1")
+
+    log_path = record_path(args.log_dir)
+    strict_marker = not args.allow_extra_output
+
+    if args.dry_run:
+        plan = {
+            "cases": [case.name for case in cases],
+            "cwd": str(args.cwd),
+            "hermes_bin": args.hermes_bin,
+            "log_path": str(log_path),
+            "model": args.model,
+            "provider": args.provider,
+            "rounds": args.rounds,
+            "toolsets": args.toolsets,
+        }
+        print(json.dumps(plan, indent=2, sort_keys=True))
+        return 0
+
+    failures = 0
+
+    for round_index in range(args.rounds):
+        for case in cases:
+            record = run_case(
+                case,
+                cwd=args.cwd,
+                hermes_bin=args.hermes_bin,
+                model=args.model,
+                provider=args.provider,
+                toolsets=args.toolsets,
+                timeout_s=args.timeout,
+                strict_marker=strict_marker,
+            )
+            record["round"] = round_index + 1
+            write_record(log_path, record)
+
+            if args.json:
+                print(json.dumps(record, sort_keys=True), flush=True)
+            else:
+                status = "ok" if record["ok"] else f"fail:{record['failure']}"
+                print(f"{record['ts']} round={round_index + 1} case={case.name} {status}", flush=True)
+
+            if not record["ok"]:
+                failures += 1
+                print(f"Evidence: {log_path}", file=sys.stderr)
+                return 1
+
+        if round_index != args.rounds - 1 and args.sleep > 0:
+            time.sleep(args.sleep)
+
+    if not args.json:
+        print(f"All canaries passed. Evidence: {log_path}")
+
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dflash_stability_canary.py
+++ b/scripts/dflash_stability_canary.py
@@ -76,8 +76,9 @@ DEFAULT_CASES: tuple[CanaryCase, ...] = (
         prompt=(
             "Run a Python check from the Hermes checkout at `{source_root}` that imports "
             "`looks_like_incomplete_final_fragment` from `agent.stall_retry` and "
-            "verifies it returns true for exactly this string: "
-            "`I see a lot of discord-res tasks (digest Discord content) and some`. "
+            "verifies `looks_like_incomplete_final_fragment("
+            "\"I see a lot of discord-res tasks (digest Discord content) and some\", "
+            "\"stop\", False, 400)` returns true. "
             "If the check passes, reply exactly CANARY_FRAGMENT_OK and nothing "
             "else. If it fails, do not use the marker; summarize the failure."
         ),

--- a/scripts/dflash_stability_canary.py
+++ b/scripts/dflash_stability_canary.py
@@ -74,7 +74,7 @@ DEFAULT_CASES: tuple[CanaryCase, ...] = (
         name="short-fragment-detector",
         marker="CANARY_FRAGMENT_OK",
         prompt=(
-            "Run a Python check in the current Hermes checkout that imports "
+            "Run a Python check from the Hermes checkout at `{source_root}` that imports "
             "`looks_like_incomplete_final_fragment` from `agent.stall_retry` and "
             "verifies it returns true for exactly this string: "
             "`I see a lot of discord-res tasks (digest Discord content) and some`. "
@@ -155,16 +155,24 @@ def marker_suffix(*parts: object) -> str:
     return re.sub(r"[^A-Za-z0-9_]+", "_", raw).strip("_")
 
 
-def materialize_case_marker(case: CanaryCase, suffix: str = "") -> CanaryCase:
+def materialize_case_marker(
+    case: CanaryCase,
+    suffix: str = "",
+    *,
+    source_root: Path | None = None,
+) -> CanaryCase:
     suffix = marker_suffix(suffix)
+    prompt = case.prompt
+    if source_root is not None:
+        prompt = prompt.replace("{source_root}", str(source_root))
     if not suffix:
-        return case
+        return CanaryCase(name=case.name, marker=case.marker, prompt=prompt)
 
     marker = f"{case.marker}_{suffix}"
     return CanaryCase(
         name=case.name,
         marker=marker,
-        prompt=case.prompt.replace(case.marker, marker),
+        prompt=prompt.replace(case.marker, marker),
     )
 
 
@@ -278,9 +286,14 @@ def run_case(
     timeout_s: float,
     strict_marker: bool,
     marker_nonce: str = "",
+    source_root: Path | None = None,
     runner: Callable[[Sequence[str], Path, float], CommandResult] | None = None,
 ) -> dict:
-    active_case = materialize_case_marker(case, marker_nonce)
+    active_case = materialize_case_marker(
+        case,
+        marker_nonce,
+        source_root=source_root or Path(__file__).resolve().parents[1],
+    )
     cmd = build_command(hermes_bin, active_case, model=model, provider=provider, toolsets=toolsets)
 
     if runner is None:

--- a/scripts/dflash_stability_canary.py
+++ b/scripts/dflash_stability_canary.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 import time
@@ -152,27 +153,46 @@ def build_command(
 def run_subprocess(cmd: Sequence[str], *, cwd: Path, timeout_s: float) -> CommandResult:
     started = time.monotonic()
 
+    env = os.environ.copy()
+    env.setdefault("PYTHONFAULTHANDLER", "1")
+    env.setdefault("HERMES_ONESHOT_FAULTHANDLER", "1")
+    start_new_session = os.name != "nt"
+    proc = subprocess.Popen(
+        list(cmd),
+        cwd=str(cwd),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=start_new_session,
+    )
+
     try:
-        completed = subprocess.run(
-            list(cmd),
-            cwd=str(cwd),
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            timeout=timeout_s,
-            check=False,
-        )
+        stdout, stderr = proc.communicate(timeout=timeout_s)
         elapsed_s = time.monotonic() - started
         return CommandResult(
-            returncode=completed.returncode,
-            stdout=completed.stdout,
-            stderr=completed.stderr,
+            returncode=proc.returncode,
+            stdout=stdout,
+            stderr=stderr,
             elapsed_s=elapsed_s,
         )
-    except subprocess.TimeoutExpired as exc:
+    except subprocess.TimeoutExpired:
+        if start_new_session and hasattr(signal, "SIGUSR1"):
+            try:
+                os.killpg(proc.pid, signal.SIGUSR1)
+                time.sleep(1.0)
+            except Exception:
+                pass
+        try:
+            proc.terminate()
+            stdout, stderr = proc.communicate(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            stdout, stderr = proc.communicate()
         elapsed_s = time.monotonic() - started
-        stdout = exc.stdout if isinstance(exc.stdout, str) else (exc.stdout or b"").decode(errors="replace")
-        stderr = exc.stderr if isinstance(exc.stderr, str) else (exc.stderr or b"").decode(errors="replace")
         return CommandResult(returncode=124, stdout=stdout, stderr=stderr, elapsed_s=elapsed_s, timed_out=True)
 
 

--- a/scripts/dflash_stability_canary.py
+++ b/scripts/dflash_stability_canary.py
@@ -150,6 +150,24 @@ def build_command(
     return cmd
 
 
+def marker_suffix(*parts: object) -> str:
+    raw = "_".join(str(part) for part in parts if str(part or "").strip())
+    return re.sub(r"[^A-Za-z0-9_]+", "_", raw).strip("_")
+
+
+def materialize_case_marker(case: CanaryCase, suffix: str = "") -> CanaryCase:
+    suffix = marker_suffix(suffix)
+    if not suffix:
+        return case
+
+    marker = f"{case.marker}_{suffix}"
+    return CanaryCase(
+        name=case.name,
+        marker=marker,
+        prompt=case.prompt.replace(case.marker, marker),
+    )
+
+
 def run_subprocess(cmd: Sequence[str], *, cwd: Path, timeout_s: float) -> CommandResult:
     started = time.monotonic()
 
@@ -259,16 +277,18 @@ def run_case(
     toolsets: str,
     timeout_s: float,
     strict_marker: bool,
+    marker_nonce: str = "",
     runner: Callable[[Sequence[str], Path, float], CommandResult] | None = None,
 ) -> dict:
-    cmd = build_command(hermes_bin, case, model=model, provider=provider, toolsets=toolsets)
+    active_case = materialize_case_marker(case, marker_nonce)
+    cmd = build_command(hermes_bin, active_case, model=model, provider=provider, toolsets=toolsets)
 
     if runner is None:
         result = run_subprocess(cmd, cwd=cwd, timeout_s=timeout_s)
     else:
         result = runner(cmd, cwd, timeout_s)
 
-    failure = classify_result(result, case.marker, strict_marker=strict_marker)
+    failure = classify_result(result, active_case.marker, strict_marker=strict_marker)
 
     return {
         "case": case.name,
@@ -276,7 +296,8 @@ def run_case(
         "cwd": str(cwd),
         "elapsed_s": round(result.elapsed_s, 3),
         "failure": failure,
-        "marker": case.marker,
+        "marker": active_case.marker,
+        "marker_base": case.marker,
         "ok": failure is None,
         "returncode": result.returncode,
         "stderr": truncate(result.stderr),
@@ -319,6 +340,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     log_path = record_path(args.log_dir)
     strict_marker = not args.allow_extra_output
+    run_stamp = log_path.stem
 
     if args.dry_run:
         plan = {
@@ -347,6 +369,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 toolsets=args.toolsets,
                 timeout_s=args.timeout,
                 strict_marker=strict_marker,
+                marker_nonce=marker_suffix(run_stamp, f"r{round_index + 1}", case.name),
             )
             record["round"] = round_index + 1
             write_record(log_path, record)

--- a/scripts/dflash_stability_canary.py
+++ b/scripts/dflash_stability_canary.py
@@ -177,9 +177,11 @@ def run_subprocess(cmd: Sequence[str], *, cwd: Path, timeout_s: float) -> Comman
             elapsed_s=elapsed_s,
         )
     except subprocess.TimeoutExpired:
-        if start_new_session and hasattr(signal, "SIGUSR1"):
+        sigusr1 = getattr(signal, "SIGUSR1", None)
+        killpg = getattr(os, "killpg", None)
+        if start_new_session and sigusr1 is not None and killpg is not None:
             try:
-                os.killpg(proc.pid, signal.SIGUSR1)
+                killpg(proc.pid, sigusr1)
                 time.sleep(1.0)
             except Exception:
                 pass

--- a/scripts/recover_local_llama_server.py
+++ b/scripts/recover_local_llama_server.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Recover a wedged local llama.cpp server after Hermes abandons a request.
+
+The script first tries the llama.cpp slots cancel action.  Older builds may
+expose `/slots` monitoring but not the cancel action; for those deployments,
+`--kill-listener` can terminate the process listening on the recovered base
+URL's port.  llama-swap deployments normally respawn the child server on the
+next request.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def _request(url: str, *, api_key: str = "", method: str = "GET", timeout: float = 5.0):
+    req = urllib.request.Request(url, method=method)
+    if api_key:
+        req.add_header("Authorization", f"Bearer {api_key}")
+    req.add_header("Accept", "application/json")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read().decode("utf-8", errors="replace")
+    return json.loads(raw) if raw else None
+
+
+def _load_key(path: str) -> str:
+    if not path:
+        return os.getenv("LLAMA_SERVER_API_KEY", "").strip()
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return fh.readline().strip()
+    except OSError:
+        return ""
+
+
+def _active_slot_ids(base_url: str, api_key: str, timeout: float) -> list[int]:
+    data = _request(
+        base_url.rstrip("/") + "/slots",
+        api_key=api_key,
+        timeout=timeout,
+    )
+    if not isinstance(data, list):
+        return []
+    slot_ids: list[int] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        if item.get("is_processing"):
+            try:
+                slot_ids.append(int(item.get("id")))
+            except (TypeError, ValueError):
+                pass
+    return slot_ids
+
+
+def _cancel_slots(base_url: str, api_key: str, slot_ids: list[int], timeout: float) -> bool:
+    cancelled = False
+    for slot_id in slot_ids:
+        url = f"{base_url.rstrip('/')}/slots/{slot_id}?action=cancel"
+        try:
+            _request(url, api_key=api_key, method="POST", timeout=timeout)
+            cancelled = True
+        except urllib.error.HTTPError as exc:
+            if exc.code == 501:
+                return False
+            raise
+    return cancelled
+
+
+def _listener_pids(port: int) -> list[int]:
+    try:
+        result = subprocess.run(
+            ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return []
+    pids: list[int] = []
+    for line in result.stdout.splitlines():
+        try:
+            pids.append(int(line.strip()))
+        except ValueError:
+            pass
+    return pids
+
+
+def _kill_pids(pids: list[int], grace: float) -> bool:
+    if not pids:
+        return False
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+    deadline = time.monotonic() + max(grace, 0.0)
+    while time.monotonic() < deadline:
+        if not any(_pid_exists(pid) for pid in pids):
+            return True
+        time.sleep(0.2)
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    return True
+
+
+def _pid_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base-url",
+        default=os.getenv("HERMES_RECOVERY_BASE_URL", ""),
+        help="llama.cpp base URL; defaults to HERMES_RECOVERY_BASE_URL",
+    )
+    parser.add_argument("--api-key-file", default=os.getenv("LLAMA_SERVER_API_KEY_FILE", ""))
+    parser.add_argument("--timeout", type=float, default=5.0)
+    parser.add_argument("--kill-listener", action="store_true")
+    parser.add_argument("--kill-grace", type=float, default=5.0)
+    args = parser.parse_args(argv)
+
+    parsed = urllib.parse.urlparse(args.base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        print("invalid or missing local base URL", file=sys.stderr)
+        return 2
+    if parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+        print("refusing to kill non-loopback listener", file=sys.stderr)
+        return 2
+
+    api_key = _load_key(args.api_key_file)
+    try:
+        active_slots = _active_slot_ids(args.base_url, api_key, args.timeout)
+    except Exception as exc:
+        print(f"slot probe failed: {type(exc).__name__}", file=sys.stderr)
+        active_slots = []
+
+    if active_slots:
+        try:
+            if _cancel_slots(args.base_url, api_key, active_slots, args.timeout):
+                print(f"cancelled active slots: {len(active_slots)}")
+                return 0
+        except Exception as exc:
+            print(f"slot cancel failed: {type(exc).__name__}", file=sys.stderr)
+
+    if not args.kill_listener:
+        print("no slot cancel performed; listener kill disabled")
+        return 1 if active_slots else 0
+
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    pids = _listener_pids(port)
+    if not pids:
+        print("no listening process found")
+        return 0
+    if _kill_pids(pids, args.kill_grace):
+        print(f"killed listener process count: {len(pids)}")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/recover_local_llama_server.py
+++ b/scripts/recover_local_llama_server.py
@@ -20,6 +20,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from pathlib import Path
 
 
 def _request(url: str, *, api_key: str = "", method: str = "GET", timeout: float = 5.0):
@@ -108,9 +109,10 @@ def _kill_pids(pids: list[int], grace: float) -> bool:
         if not any(_pid_exists(pid) for pid in pids):
             return True
         time.sleep(0.2)
+    sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
     for pid in pids:
         try:
-            os.kill(pid, signal.SIGKILL)
+            os.kill(pid, sigkill)
         except ProcessLookupError:
             pass
     return True
@@ -118,12 +120,11 @@ def _kill_pids(pids: list[int], grace: float) -> bool:
 
 def _pid_exists(pid: int) -> bool:
     try:
-        os.kill(pid, 0)
-        return True
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
+        import psutil
+
+        return bool(psutil.pid_exists(pid))
+    except Exception:
+        return Path(f"/proc/{pid}").exists()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -54,6 +54,7 @@ class TestFailoverReason:
         expected = {
             "auth", "auth_permanent", "billing", "rate_limit",
             "overloaded", "server_error", "timeout",
+            "local_first_chunk_timeout",
             "context_overflow", "payload_too_large", "image_too_large",
             "model_not_found", "format_error",
             "invalid_encrypted_content",
@@ -816,6 +817,23 @@ class TestClassifyApiError:
         e = TimeoutError("timed out")
         result = classify_api_error(e)
         assert result.reason == FailoverReason.timeout
+
+    def test_dflash_first_chunk_timeout_marker_fails_over_without_retry(self):
+        e = ConnectError("Connection error.")
+        e._hermes_local_first_chunk_timeout = True
+        e._hermes_local_first_chunk_meta = {
+            "elapsed": 75,
+            "threshold": 75,
+            "model": "dflash",
+            "context_tokens": 19956,
+        }
+
+        result = classify_api_error(e, provider="taro", model="dflash")
+
+        assert result.reason == FailoverReason.local_first_chunk_timeout
+        assert result.retryable is False
+        assert result.should_fallback is True
+        assert result.error_context["elapsed"] == 75
 
     def test_runtime_error_cli_turn_timed_out_classifies_as_timeout(self):
         # RuntimeError from a local claude-cli shim that wraps a subprocess

--- a/tests/agent/test_local_backend_recovery.py
+++ b/tests/agent/test_local_backend_recovery.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent.local_backend_recovery import maybe_recover_local_backend
+
+
+def test_recovery_hook_skips_remote_endpoint(monkeypatch):
+    monkeypatch.setenv("HERMES_LOCAL_BACKEND_RECOVERY_COMMAND", "echo recover")
+
+    called = {"run": False}
+
+    def fake_run(*_args, **_kwargs):
+        called["run"] = True
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    assert not maybe_recover_local_backend(
+        SimpleNamespace(provider="openai"),
+        reason="stale",
+        model="gpt-5.4",
+        base_url="https://api.openai.com/v1",
+    )
+    assert called["run"] is False
+
+
+def test_recovery_hook_runs_command_with_sanitized_metadata(monkeypatch):
+    monkeypatch.setenv("HERMES_LOCAL_BACKEND_RECOVERY_COMMAND", "recover-local --flag")
+    monkeypatch.setenv("HERMES_LOCAL_BACKEND_RECOVERY_COOLDOWN", "0")
+
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        captured["env"] = kwargs["env"]
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    agent = SimpleNamespace(provider="taro", session_id="s1")
+    assert maybe_recover_local_backend(
+        agent,
+        reason="local_first_chunk_timeout",
+        model="dflash",
+        base_url="http://127.0.0.1:9090/v1",
+        context_tokens=1234,
+        elapsed=75.5,
+        threshold=75.0,
+    )
+
+    assert captured["argv"] == ["recover-local", "--flag"]
+    env = captured["env"]
+    assert env["HERMES_RECOVERY_REASON"] == "local_first_chunk_timeout"
+    assert env["HERMES_RECOVERY_MODEL"] == "dflash"
+    assert env["HERMES_RECOVERY_PROVIDER"] == "taro"
+    assert env["HERMES_RECOVERY_BASE_URL"] == "http://127.0.0.1:9090/v1"
+    assert env["HERMES_RECOVERY_CONTEXT_TOKENS"] == "1234"
+    assert env["HERMES_RECOVERY_SESSION_ID"] == "s1"
+
+
+def test_recovery_hook_enforces_process_cooldown(monkeypatch):
+    monkeypatch.setenv("HERMES_LOCAL_BACKEND_RECOVERY_COMMAND", "recover-local")
+    monkeypatch.setenv("HERMES_LOCAL_BACKEND_RECOVERY_COOLDOWN", "60")
+
+    calls = {"count": 0}
+
+    def fake_run(*_args, **_kwargs):
+        calls["count"] += 1
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    agent = SimpleNamespace(provider="taro")
+    assert maybe_recover_local_backend(
+        agent,
+        reason="first",
+        model="dflash",
+        base_url="http://127.0.0.1:9090/v1",
+    )
+    assert not maybe_recover_local_backend(
+        agent,
+        reason="second",
+        model="dflash",
+        base_url="http://127.0.0.1:9090/v1",
+    )
+    assert calls["count"] == 1

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -144,7 +144,7 @@ class TestLocalDflashStaleTimeout:
             "qwen3.6-27b-256k",
         )
 
-        assert timeout == 180.0
+        assert timeout == 90.0
 
     def test_generic_local_first_chunk_timeout_scales_for_large_context(self, monkeypatch):
         monkeypatch.setenv("HERMES_LOCAL_FIRST_CHUNK_TIMEOUT", "120")
@@ -154,7 +154,7 @@ class TestLocalDflashStaleTimeout:
             "qwen3.6-27b-256k",
         )
 
-        assert timeout == 600.0
+        assert timeout == 360.0
 
     def test_dflash_first_chunk_timeout_marker_preserves_watchdog_metadata(self):
         err = RuntimeError("Connection error.")

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -11,6 +11,14 @@ import pytest
 from unittest.mock import patch
 
 from agent.model_metadata import is_local_endpoint
+from agent.chat_completion_helpers import (
+    _dflash_local_first_chunk_timeout,
+    _dflash_local_stale_timeout,
+    _local_provider_first_chunk_timeout,
+    _mark_local_first_chunk_timeout,
+    _mark_dflash_first_chunk_timeout,
+    resolve_stream_stale_timeout,
+)
 
 
 class TestLocalStreamReadTimeout:
@@ -71,6 +79,197 @@ class TestLocalStreamReadTimeout:
             if _stream_read_timeout == 120.0 and base_url and is_local_endpoint(base_url):
                 _stream_read_timeout = _base_timeout
             assert _stream_read_timeout == 120.0
+
+
+class TestLocalDflashStaleTimeout:
+    """dflash is local, but must not be allowed to wait forever with no chunks."""
+
+    @staticmethod
+    def _payload_for_estimated_tokens(tokens: int) -> dict[str, list[str]]:
+        return {"messages": ["x" * (tokens * 4)]}
+
+    def _make_agent(self, *, model="dflash", base_url="http://10.10.20.211:8080/v1"):
+        from run_agent import AIAgent
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=131072):
+            return AIAgent(
+                api_key="sk-dummy",
+                base_url=base_url,
+                provider="taro",
+                model=model,
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                platform="cli",
+            )
+
+    def test_default_local_dflash_stream_stale_timeout_is_bounded(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        monkeypatch.delenv("HERMES_STREAM_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_STREAM_STALE_TIMEOUT", raising=False)
+
+        agent = self._make_agent(model="dflash")
+
+        timeout = resolve_stream_stale_timeout(
+            agent,
+            {"model": "dflash", "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert timeout == 75.0
+
+    def test_dflash_first_chunk_timeout_does_not_scale_with_context(self, monkeypatch):
+        monkeypatch.delenv("HERMES_DFLASH_FIRST_CHUNK_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_TTFB_TIMEOUT", raising=False)
+
+        timeout = _dflash_local_first_chunk_timeout(
+            self._payload_for_estimated_tokens(66_000),
+            "dflash",
+        )
+
+        assert timeout == 75.0
+
+    def test_dflash_first_chunk_timeout_has_independent_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DFLASH_FIRST_CHUNK_TIMEOUT", "45")
+
+        assert _dflash_local_first_chunk_timeout({"messages": []}, "dflash") == 45.0
+
+    def test_generic_local_first_chunk_timeout_is_finite(self, monkeypatch):
+        monkeypatch.delenv("HERMES_LOCAL_FIRST_CHUNK_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_LOCAL_TTFB_TIMEOUT", raising=False)
+
+        timeout = _local_provider_first_chunk_timeout(
+            self._payload_for_estimated_tokens(6_000),
+            "qwen3.6-27b-256k",
+        )
+
+        assert timeout == 180.0
+
+    def test_generic_local_first_chunk_timeout_scales_for_large_context(self, monkeypatch):
+        monkeypatch.setenv("HERMES_LOCAL_FIRST_CHUNK_TIMEOUT", "120")
+
+        timeout = _local_provider_first_chunk_timeout(
+            self._payload_for_estimated_tokens(66_000),
+            "qwen3.6-27b-256k",
+        )
+
+        assert timeout == 600.0
+
+    def test_dflash_first_chunk_timeout_marker_preserves_watchdog_metadata(self):
+        err = RuntimeError("Connection error.")
+
+        marked = _mark_dflash_first_chunk_timeout(
+            err,
+            elapsed=75.4,
+            threshold=75.0,
+            model="dflash",
+            context_tokens=19956,
+        )
+
+        assert marked is err
+        assert getattr(err, "_hermes_local_dflash_first_chunk_timeout") is True
+        assert getattr(err, "_hermes_dflash_first_chunk_meta") == {
+            "elapsed": 75,
+            "threshold": 75,
+            "model": "dflash",
+            "context_tokens": 19956,
+        }
+
+    def test_generic_local_first_chunk_timeout_marker_is_not_dflash_specific(self):
+        err = RuntimeError("Connection error.")
+
+        marked = _mark_local_first_chunk_timeout(
+            err,
+            elapsed=180.4,
+            threshold=180.0,
+            model="qwen3.6-27b-256k",
+            context_tokens=42000,
+        )
+
+        assert marked is err
+        assert getattr(err, "_hermes_local_first_chunk_timeout") is True
+        assert not getattr(err, "_hermes_local_dflash_first_chunk_timeout", False)
+        assert getattr(err, "_hermes_local_first_chunk_meta") == {
+            "elapsed": 180,
+            "threshold": 180,
+            "model": "qwen3.6-27b-256k",
+            "context_tokens": 42000,
+        }
+
+    def test_generic_local_stream_stale_timeout_still_disables_by_default(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        monkeypatch.delenv("HERMES_STREAM_STALE_TIMEOUT", raising=False)
+
+        agent = self._make_agent(model="qwen3.6-27b")
+
+        timeout = resolve_stream_stale_timeout(
+            agent,
+            {"model": "qwen3.6-27b", "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        assert timeout == float("inf")
+
+    def test_default_local_dflash_non_stream_stale_timeout_is_bounded(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_STREAM_STALE_TIMEOUT", raising=False)
+
+        agent = self._make_agent(model="dflash")
+
+        assert agent._compute_non_stream_stale_timeout({"messages": []}) == 75.0
+
+    def test_explicit_stream_stale_timeout_still_wins_for_dflash(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "12")
+        monkeypatch.setenv("HERMES_DFLASH_STALE_TIMEOUT", "75")
+
+        agent = self._make_agent(model="dflash")
+
+        assert resolve_stream_stale_timeout(agent, {"model": "dflash", "messages": []}) == 12.0
+
+    @pytest.mark.parametrize(
+        ("estimated_tokens", "expected_timeout"),
+        [
+            (10_000, 75.0),
+            (10_001, 90.0),
+            (25_000, 90.0),
+            (25_001, 150.0),
+            (50_000, 150.0),
+            (50_001, 240.0),
+            (100_000, 240.0),
+            (100_001, 300.0),
+        ],
+    )
+    def test_default_dflash_stale_timeout_threshold_boundaries(
+        self,
+        monkeypatch,
+        estimated_tokens,
+        expected_timeout,
+    ):
+        monkeypatch.delenv("HERMES_DFLASH_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_DFLASH_STREAM_STALE_TIMEOUT", raising=False)
+
+        timeout = _dflash_local_stale_timeout(
+            self._payload_for_estimated_tokens(estimated_tokens),
+            "dflash",
+        )
+
+        assert timeout == expected_timeout
+
+    def test_non_positive_dflash_stale_timeout_disables_watchdog(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DFLASH_STALE_TIMEOUT", "0")
+
+        timeout = _dflash_local_stale_timeout(
+            self._payload_for_estimated_tokens(1),
+            "dflash",
+        )
+
+        assert timeout == float("inf")
 
 
 class TestIsLocalEndpoint:

--- a/tests/agent/test_local_stream_timeout.py
+++ b/tests/agent/test_local_stream_timeout.py
@@ -15,6 +15,7 @@ from agent.chat_completion_helpers import (
     _dflash_local_first_chunk_timeout,
     _dflash_local_stale_timeout,
     _local_provider_first_chunk_timeout,
+    _local_provider_non_stream_stale_timeout,
     _mark_local_first_chunk_timeout,
     _mark_dflash_first_chunk_timeout,
     resolve_stream_stale_timeout,
@@ -221,6 +222,27 @@ class TestLocalDflashStaleTimeout:
         agent = self._make_agent(model="dflash")
 
         assert agent._compute_non_stream_stale_timeout({"messages": []}) == 75.0
+
+    def test_generic_local_non_stream_stale_timeout_is_finite(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / ".env").write_text("", encoding="utf-8")
+        monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_LOCAL_NON_STREAM_STALE_TIMEOUT", raising=False)
+        monkeypatch.delenv("HERMES_LOCAL_RESPONSE_TIMEOUT", raising=False)
+
+        agent = self._make_agent(model="qwen3.6-27b-256k")
+
+        assert agent._compute_non_stream_stale_timeout({"messages": []}) == 120.0
+
+    def test_generic_local_non_stream_stale_timeout_scales(self, monkeypatch):
+        monkeypatch.setenv("HERMES_LOCAL_NON_STREAM_STALE_TIMEOUT", "120")
+
+        timeout = _local_provider_non_stream_stale_timeout(
+            self._payload_for_estimated_tokens(66_000),
+            "qwen3.6-27b-256k",
+        )
+
+        assert timeout == 360.0
 
     def test_explicit_stream_stale_timeout_still_wins_for_dflash(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/agent/test_stall_retry.py
+++ b/tests/agent/test_stall_retry.py
@@ -4,7 +4,11 @@ import inspect
 from types import SimpleNamespace
 
 from agent import conversation_loop
-from agent.stall_retry import looks_like_stall, retry_on_stall
+from agent.stall_retry import (
+    EMPTY_AFTER_TOOL_RETRY_NUDGE,
+    looks_like_stall,
+    retry_on_stall,
+)
 
 
 def test_action_preamble_without_tool_call_is_a_stall() -> None:
@@ -105,6 +109,82 @@ def test_retry_on_stall_switches_model_and_returns_tool_calls(monkeypatch) -> No
     assert kwargs["stream"] is False
 
 
+def test_retry_on_stall_can_accept_visible_content(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    normalized = SimpleNamespace(
+        content="I processed the tool result and will continue.",
+        tool_calls=None,
+        finish_reason="stop",
+    )
+
+    def interruptible_api_call(kwargs: dict[str, object]) -> object:
+        captured["kwargs"] = dict(kwargs)
+        return normalized
+
+    agent = SimpleNamespace(
+        api_mode="openai",
+        _is_anthropic_oauth=False,
+        log_prefix="",
+        _build_api_kwargs=lambda messages: {
+            "model": "dflash",
+            "messages": messages,
+            "stream": True,
+        },
+        _interruptible_api_call=interruptible_api_call,
+        _get_transport=lambda: SimpleNamespace(
+            normalize_response=lambda response, **_kwargs: response
+        ),
+        _vprint=lambda *_args, **_kwargs: None,
+    )
+
+    monkeypatch.setenv("HERMES_STALL_RETRY_MODEL", "qwen3.6-27b-256k")
+    result = retry_on_stall(
+        agent,
+        [{"role": "user", "content": "go"}],
+        "stop",
+        accept_content=True,
+        retry_nudge=EMPTY_AFTER_TOOL_RETRY_NUDGE,
+    )
+
+    assert result is normalized
+    kwargs = captured["kwargs"]
+    assert kwargs["model"] == "qwen3.6-27b-256k"
+    assert kwargs["stream"] is False
+    assert kwargs["messages"][-1]["role"] == "user"
+    assert "after the tool results was empty" in kwargs["messages"][-1]["content"]
+
+
+def test_retry_on_stall_still_rejects_content_without_accept_content(monkeypatch) -> None:
+    normalized = SimpleNamespace(
+        content="I processed the tool result and will continue.",
+        tool_calls=None,
+        finish_reason="stop",
+    )
+
+    agent = SimpleNamespace(
+        api_mode="openai",
+        _is_anthropic_oauth=False,
+        log_prefix="",
+        _build_api_kwargs=lambda messages: {
+            "model": "dflash",
+            "messages": messages,
+            "stream": True,
+        },
+        _interruptible_api_call=lambda _kwargs: normalized,
+        _get_transport=lambda: SimpleNamespace(
+            normalize_response=lambda response, **_kwargs: response
+        ),
+        _vprint=lambda *_args, **_kwargs: None,
+    )
+
+    monkeypatch.setenv("HERMES_STALL_RETRY_MODEL", "qwen3.6-27b-256k")
+    assert retry_on_stall(
+        agent,
+        [{"role": "user", "content": "go"}],
+        "stop",
+    ) is None
+
+
 def test_conversation_loop_adopts_retry_before_tool_call_branch() -> None:
     source = inspect.getsource(conversation_loop.run_conversation)
     retry_idx = source.index("retried = retry_on_stall")
@@ -113,6 +193,18 @@ def test_conversation_loop_adopts_retry_before_tool_call_branch() -> None:
     assert retry_idx < tool_branch_idx
     assert "continue  # re-enter loop top; tool-calls path handles it" not in source
     assert "stall_retry_failed_no_tool_call" in source
+
+
+def test_conversation_loop_retries_empty_post_tool_before_generic_stall() -> None:
+    source = inspect.getsource(conversation_loop.run_conversation)
+    empty_retry_idx = source.index("EMPTY_AFTER_TOOL_RETRY_NUDGE")
+    generic_stall_idx = source.index("looks_like_stall(")
+    tool_branch_idx = source.index("# Check for tool calls")
+
+    assert empty_retry_idx < generic_stall_idx
+    assert empty_retry_idx < tool_branch_idx
+    assert "not _empty_after_tool_result and looks_like_stall" in source
+    assert "accept_content=True" in source
 
 
 def test_conversation_loop_allows_bounded_multiple_stall_retries() -> None:

--- a/tests/agent/test_stall_retry.py
+++ b/tests/agent/test_stall_retry.py
@@ -11,6 +11,7 @@ from agent.stall_retry import (
     get_stall_retry_max_per_turn,
     get_stall_retry_model,
     get_stall_retry_nudge_enabled,
+    has_recent_tool_result,
     looks_like_incomplete_final_fragment,
     looks_like_stall,
     record_stall_retry_event,
@@ -122,6 +123,34 @@ def test_short_incomplete_connector_tail_is_a_stall() -> None:
 def test_empty_visible_response_uses_empty_response_recovery_not_stall_retry() -> None:
     assert not looks_like_stall("", "stop", False, 400)
     assert not looks_like_stall("<think>still reasoning</think>", "stop", False, 400)
+
+
+def test_recent_tool_result_detector_spans_status_scaffolding() -> None:
+    messages = [
+        {"role": "user", "content": "do the onboarding"},
+        {"role": "assistant", "tool_calls": [{"id": "call_1"}]},
+        {"role": "tool", "content": "Onboarding complete"},
+        {"role": "assistant", "content": ""},
+        {"role": "assistant", "content": ""},
+        {"role": "assistant", "content": ""},
+        {"role": "system", "content": "status update"},
+        {"role": "assistant", "content": ""},
+    ]
+
+    assert has_recent_tool_result(messages)
+
+
+def test_recent_tool_result_detector_stops_at_current_user() -> None:
+    messages = [
+        {"role": "user", "content": "old task"},
+        {"role": "assistant", "tool_calls": [{"id": "call_1"}]},
+        {"role": "tool", "content": "old result"},
+        {"role": "assistant", "content": "done"},
+        {"role": "user", "content": "new task"},
+        {"role": "assistant", "content": ""},
+    ]
+
+    assert not has_recent_tool_result(messages)
 
 
 def test_short_status_answer_without_punctuation_is_not_a_stall() -> None:

--- a/tests/agent/test_stall_retry.py
+++ b/tests/agent/test_stall_retry.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+from agent import conversation_loop
+from agent.stall_retry import looks_like_stall, retry_on_stall
+
+
+def test_action_preamble_without_tool_call_is_a_stall() -> None:
+    assert looks_like_stall(
+        "Let me check what's on taro and figure out the right approach.",
+        "stop",
+        False,
+        400,
+    )
+
+
+def test_completion_text_is_not_a_stall() -> None:
+    assert not looks_like_stall(
+        "Done. The task is complete and no further action is needed.",
+        "stop",
+        False,
+        400,
+    )
+
+
+def test_retry_on_stall_switches_model_and_returns_tool_calls(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    tool_call = SimpleNamespace(
+        function=SimpleNamespace(name="terminal", arguments='{"cmd":"pwd"}')
+    )
+    normalized = SimpleNamespace(
+        content="",
+        tool_calls=[tool_call],
+        finish_reason="tool_calls",
+    )
+
+    def interruptible_api_call(kwargs: dict[str, object]) -> object:
+        captured["kwargs"] = dict(kwargs)
+        return normalized
+
+    agent = SimpleNamespace(
+        api_mode="openai",
+        _is_anthropic_oauth=False,
+        log_prefix="",
+        _build_api_kwargs=lambda messages: {
+            "model": "dflash",
+            "messages": messages,
+            "stream": True,
+        },
+        _interruptible_api_call=interruptible_api_call,
+        _get_transport=lambda: SimpleNamespace(
+            normalize_response=lambda response, **_kwargs: response
+        ),
+        _vprint=lambda *_args, **_kwargs: None,
+    )
+
+    monkeypatch.setenv("HERMES_STALL_RETRY_MODEL", "qwen3.6-27b-256k")
+    result = retry_on_stall(agent, [{"role": "user", "content": "go"}], "stop")
+
+    assert result is normalized
+    kwargs = captured["kwargs"]
+    assert kwargs["model"] == "qwen3.6-27b-256k"
+    assert kwargs["stream"] is False
+
+
+def test_conversation_loop_adopts_retry_before_tool_call_branch() -> None:
+    source = inspect.getsource(conversation_loop.run_conversation)
+    retry_idx = source.index("retried = retry_on_stall")
+    tool_branch_idx = source.index("# Check for tool calls")
+
+    assert retry_idx < tool_branch_idx
+    assert "continue  # re-enter loop top; tool-calls path handles it" not in source
+    assert "stall_retry_failed_no_tool_call" in source

--- a/tests/agent/test_stall_retry.py
+++ b/tests/agent/test_stall_retry.py
@@ -229,6 +229,57 @@ def test_retry_on_stall_switches_model_and_returns_tool_calls(monkeypatch) -> No
     assert summary["recovered"] == 1
 
 
+def test_retry_on_stall_keeps_local_retry_streaming(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    tool_call = SimpleNamespace(
+        function=SimpleNamespace(name="terminal", arguments='{"cmd":"pwd"}')
+    )
+    normalized = SimpleNamespace(
+        content="",
+        tool_calls=[tool_call],
+        finish_reason="tool_calls",
+    )
+
+    def interruptible_streaming_call(kwargs: dict[str, object]) -> object:
+        captured["kwargs"] = dict(kwargs)
+        return normalized
+
+    agent = SimpleNamespace(
+        api_mode="openai",
+        _is_anthropic_oauth=False,
+        base_url="http://127.0.0.1:9090/v1",
+        log_prefix="",
+        _build_api_kwargs=lambda messages: {
+            "model": "dflash",
+            "messages": messages,
+            "stream": True,
+        },
+        _interruptible_api_call=lambda _kwargs: (_ for _ in ()).throw(
+            AssertionError("local retry should stay streaming")
+        ),
+        _interruptible_streaming_api_call=interruptible_streaming_call,
+        _get_transport=lambda: SimpleNamespace(
+            normalize_response=lambda response, **_kwargs: response
+        ),
+        _vprint=lambda *_args, **_kwargs: None,
+    )
+
+    monkeypatch.setenv("HERMES_STALL_RETRY_MODEL", "qwen3.6-27b-256k")
+    monkeypatch.setenv("HERMES_STALL_RETRY_TELEMETRY", "0")
+
+    result = retry_on_stall(
+        agent,
+        [{"role": "user", "content": "go"}],
+        "stop",
+        stalled_content="Let me check the repo.",
+        retry_index=1,
+    )
+
+    assert result is normalized
+    assert captured["kwargs"]["model"] == "qwen3.6-27b-256k"
+    assert captured["kwargs"]["stream"] is True
+
+
 def test_retry_on_stall_can_accept_visible_content(monkeypatch) -> None:
     captured: dict[str, object] = {}
     normalized = SimpleNamespace(

--- a/tests/agent/test_stall_retry.py
+++ b/tests/agent/test_stall_retry.py
@@ -319,6 +319,33 @@ def test_retry_on_stall_uses_agent_config_when_env_is_absent(monkeypatch) -> Non
     assert captured["kwargs"]["stream"] is False
 
 
+def test_stall_retry_empty_agent_config_falls_back_to_loaded_config(monkeypatch) -> None:
+    import hermes_cli.config as config_mod
+
+    monkeypatch.delenv("HERMES_STALL_RETRY_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_STALL_RETRY_PROVIDER", raising=False)
+    monkeypatch.delenv("HERMES_STALL_RETRY_MAX_PER_TURN", raising=False)
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {
+            "stall_retry": {
+                "max_per_turn": 3,
+                "model": "qwen3.6-27b-256k",
+                "provider": "taro",
+            }
+        },
+    )
+
+    empty_agent = SimpleNamespace(_stall_retry_config={})
+    provider_only_agent = SimpleNamespace(_stall_retry_config={"provider": "ko-mac"})
+
+    assert get_stall_retry_model(empty_agent) == "qwen3.6-27b-256k"
+    assert get_stall_retry_max_per_turn(empty_agent) == 3
+    assert get_stall_retry_model(provider_only_agent) == "qwen3.6-27b-256k"
+    assert get_stall_retry_max_per_turn(provider_only_agent) == 3
+
+
 def test_retry_on_stall_uses_configured_retry_provider(monkeypatch) -> None:
     captured: dict[str, object] = {}
     tool_call = SimpleNamespace(

--- a/tests/agent/test_stall_retry.py
+++ b/tests/agent/test_stall_retry.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
 import inspect
+import json
 from types import SimpleNamespace
 
 from agent import conversation_loop
 from agent.stall_retry import (
     EMPTY_AFTER_TOOL_RETRY_NUDGE,
+    get_stall_retry_max_chars,
+    get_stall_retry_max_per_turn,
+    get_stall_retry_model,
+    get_stall_retry_nudge_enabled,
     looks_like_stall,
+    record_stall_retry_event,
     retry_on_stall,
+    stall_retry_summary,
 )
 
 
@@ -29,9 +36,61 @@ def test_followup_action_preamble_after_successful_retry_is_a_stall() -> None:
     )
 
 
+def test_mixed_explanation_action_preamble_over_default_limit_is_a_stall() -> None:
+    content = (
+        "Now I have a clear picture. The task is to add a pre-dispatch "
+        "executable-state gate in subagent_dispatch_register_command that "
+        "checks if the linked task is in an executable state BEFORE registering "
+        "a dispatch. Currently the stale guard only runs post-dispatch during "
+        "drain and settlement. The goal is to prevent non-executable dispatches "
+        "from being registered in the first place. Let me look at the register "
+        "command's validation section and the _validate_subagent_dispatch_record "
+        "function:"
+    )
+
+    assert len(content) > 400
+    assert looks_like_stall(content, "stop", False, 400)
+
+
+def test_long_diagnostic_ending_with_action_promise_is_a_stall() -> None:
+    content = (
+        "The crash pattern is clear: when the context fills up and llama.cpp "
+        "tries to allocate a new tensor for the KV cache, it runs out of GPU "
+        "memory. The first allocation succeeds, but the subsequent data "
+        "allocation fails and leaves the tensor in an inconsistent state. "
+        * 4
+    )
+    content += "Let me look at the exact crash mechanism more carefully:"
+
+    assert len(content) > 400
+    assert looks_like_stall(content, "stop", False, 400)
+
+
+def test_long_diagnostic_with_completion_text_is_not_a_stall() -> None:
+    content = (
+        "The crash pattern is clear: when the context fills up and llama.cpp "
+        "tries to allocate a new tensor for the KV cache, it runs out of GPU "
+        "memory. "
+        * 5
+    )
+    content += "In summary, the task is complete."
+
+    assert len(content) > 400
+    assert not looks_like_stall(content, "stop", False, 400)
+
+
 def test_completion_text_is_not_a_stall() -> None:
     assert not looks_like_stall(
         "Done. The task is complete and no further action is needed.",
+        "stop",
+        False,
+        400,
+    )
+
+
+def test_completion_then_action_promise_is_still_a_stall() -> None:
+    assert looks_like_stall(
+        "Onboarding complete. Now let me read the STATUS.md to find a task I can pick up.",
         "stop",
         False,
         400,
@@ -50,6 +109,11 @@ def test_incomplete_final_fragment_without_action_preamble_is_a_stall() -> None:
         False,
         400,
     )
+
+
+def test_empty_visible_response_uses_empty_response_recovery_not_stall_retry() -> None:
+    assert not looks_like_stall("", "stop", False, 400)
+    assert not looks_like_stall("<think>still reasoning</think>", "stop", False, 400)
 
 
 def test_short_status_answer_without_punctuation_is_not_a_stall() -> None:
@@ -101,12 +165,27 @@ def test_retry_on_stall_switches_model_and_returns_tool_calls(monkeypatch) -> No
     )
 
     monkeypatch.setenv("HERMES_STALL_RETRY_MODEL", "qwen3.6-27b-256k")
-    result = retry_on_stall(agent, [{"role": "user", "content": "go"}], "stop")
+    monkeypatch.setenv("HERMES_STALL_RETRY_TELEMETRY", "0")
+    result = retry_on_stall(
+        agent,
+        [{"role": "user", "content": "go"}],
+        "stop",
+        stalled_content="Let me check the repo.",
+        retry_index=1,
+    )
 
     assert result is normalized
     kwargs = captured["kwargs"]
     assert kwargs["model"] == "qwen3.6-27b-256k"
     assert kwargs["stream"] is False
+    assert kwargs["messages"][-2]["role"] == "assistant"
+    assert kwargs["messages"][-2]["content"] == "Let me check the repo."
+    assert kwargs["messages"][-1]["role"] == "user"
+    assert "required tool call" in kwargs["messages"][-1]["content"]
+    summary = stall_retry_summary(agent)
+    assert summary is not None
+    assert summary["attempted"] == 1
+    assert summary["recovered"] == 1
 
 
 def test_retry_on_stall_can_accept_visible_content(monkeypatch) -> None:
@@ -138,6 +217,7 @@ def test_retry_on_stall_can_accept_visible_content(monkeypatch) -> None:
     )
 
     monkeypatch.setenv("HERMES_STALL_RETRY_MODEL", "qwen3.6-27b-256k")
+    monkeypatch.setenv("HERMES_STALL_RETRY_TELEMETRY", "0")
     result = retry_on_stall(
         agent,
         [{"role": "user", "content": "go"}],
@@ -178,11 +258,224 @@ def test_retry_on_stall_still_rejects_content_without_accept_content(monkeypatch
     )
 
     monkeypatch.setenv("HERMES_STALL_RETRY_MODEL", "qwen3.6-27b-256k")
+    monkeypatch.setenv("HERMES_STALL_RETRY_TELEMETRY", "0")
     assert retry_on_stall(
         agent,
         [{"role": "user", "content": "go"}],
         "stop",
     ) is None
+
+
+def test_retry_on_stall_uses_agent_config_when_env_is_absent(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    tool_call = SimpleNamespace(
+        function=SimpleNamespace(name="terminal", arguments='{"cmd":"pwd"}')
+    )
+    normalized = SimpleNamespace(
+        content="",
+        tool_calls=[tool_call],
+        finish_reason="tool_calls",
+    )
+
+    def interruptible_api_call(kwargs: dict[str, object]) -> object:
+        captured["kwargs"] = dict(kwargs)
+        return normalized
+
+    agent = SimpleNamespace(
+        api_mode="openai",
+        _is_anthropic_oauth=False,
+        log_prefix="",
+        _stall_retry_config={
+            "model": "qwen3.6-27b-256k",
+            "max_chars": 240,
+            "max_per_turn": 7,
+        },
+        _build_api_kwargs=lambda messages: {
+            "model": "dflash",
+            "messages": messages,
+            "stream": True,
+        },
+        _interruptible_api_call=interruptible_api_call,
+        _get_transport=lambda: SimpleNamespace(
+            normalize_response=lambda response, **_kwargs: response
+        ),
+        _vprint=lambda *_args, **_kwargs: None,
+    )
+
+    monkeypatch.delenv("HERMES_STALL_RETRY_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_STALL_RETRY_MAX_CHARS", raising=False)
+    monkeypatch.delenv("HERMES_STALL_RETRY_MAX_PER_TURN", raising=False)
+    monkeypatch.setenv("HERMES_STALL_RETRY_TELEMETRY", "0")
+
+    assert get_stall_retry_model(agent) == "qwen3.6-27b-256k"
+    assert get_stall_retry_max_chars(agent) == 240
+    assert get_stall_retry_max_per_turn(agent) == 7
+    assert get_stall_retry_nudge_enabled(agent)
+
+    result = retry_on_stall(agent, [{"role": "user", "content": "go"}], "stop")
+
+    assert result is normalized
+    assert captured["kwargs"]["model"] == "qwen3.6-27b-256k"
+    assert captured["kwargs"]["stream"] is False
+
+
+def test_retry_on_stall_uses_configured_retry_provider(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    tool_call = SimpleNamespace(
+        function=SimpleNamespace(name="terminal", arguments='{"cmd":"pwd"}')
+    )
+    normalized = SimpleNamespace(
+        content="",
+        tool_calls=[tool_call],
+        finish_reason="tool_calls",
+    )
+
+    class FakeCompletions:
+        def create(self, **kwargs: object) -> object:
+            captured["kwargs"] = dict(kwargs)
+            return normalized
+
+    fake_client = SimpleNamespace(
+        api_key="retry-key",
+        base_url="http://taro:8080/v1",
+        chat=SimpleNamespace(completions=FakeCompletions()),
+    )
+
+    def fake_resolve_provider_client(**kwargs: object) -> tuple[object, str]:
+        captured["resolve_kwargs"] = dict(kwargs)
+        return fake_client, "qwen3.6-27b-256k"
+
+    agent = SimpleNamespace(
+        api_mode="openai",
+        _is_anthropic_oauth=False,
+        base_url="http://taro:8080/v1",
+        log_prefix="",
+        _stall_retry_config={
+            "model": "qwen3.6-27b-256k",
+            "provider": "taro",
+            "api_key_env": "HERMES_RETRY_TEST_KEY",
+        },
+        _build_api_kwargs=lambda messages: {
+            "model": "dflash",
+            "messages": messages,
+            "stream": True,
+        },
+        _interruptible_api_call=lambda _kwargs: (_ for _ in ()).throw(
+            AssertionError("same-client retry should not be used")
+        ),
+        _get_transport=lambda: SimpleNamespace(
+            normalize_response=lambda response, **_kwargs: response
+        ),
+        _vprint=lambda *_args, **_kwargs: None,
+    )
+
+    monkeypatch.delenv("HERMES_STALL_RETRY_MODEL", raising=False)
+    monkeypatch.setenv("HERMES_RETRY_TEST_KEY", "retry-key")
+    monkeypatch.setenv("HERMES_STALL_RETRY_TELEMETRY", "0")
+    monkeypatch.setattr(
+        "agent.auxiliary_client.resolve_provider_client",
+        lambda provider, **kwargs: fake_resolve_provider_client(provider=provider, **kwargs),
+    )
+
+    result = retry_on_stall(agent, [{"role": "user", "content": "go"}], "stop")
+
+    assert result is normalized
+    assert captured["resolve_kwargs"]["provider"] == "taro"
+    assert captured["resolve_kwargs"]["model"] == "qwen3.6-27b-256k"
+    assert captured["resolve_kwargs"]["explicit_api_key"] == "retry-key"
+    assert captured["kwargs"]["model"] == "qwen3.6-27b-256k"
+    assert captured["kwargs"]["stream"] is False
+
+
+def test_retry_on_stall_can_disable_retry_nudge(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    tool_call = SimpleNamespace(
+        function=SimpleNamespace(name="terminal", arguments='{"cmd":"pwd"}')
+    )
+    normalized = SimpleNamespace(
+        content="",
+        tool_calls=[tool_call],
+        finish_reason="tool_calls",
+    )
+
+    def interruptible_api_call(kwargs: dict[str, object]) -> object:
+        captured["kwargs"] = dict(kwargs)
+        return normalized
+
+    agent = SimpleNamespace(
+        api_mode="openai",
+        _is_anthropic_oauth=False,
+        log_prefix="",
+        _stall_retry_config={
+            "model": "qwen3.6-27b-256k",
+            "nudge": False,
+            "telemetry": False,
+        },
+        _build_api_kwargs=lambda messages: {
+            "model": "dflash",
+            "messages": messages,
+            "stream": True,
+        },
+        _interruptible_api_call=interruptible_api_call,
+        _get_transport=lambda: SimpleNamespace(
+            normalize_response=lambda response, **_kwargs: response
+        ),
+        _vprint=lambda *_args, **_kwargs: None,
+    )
+
+    monkeypatch.delenv("HERMES_STALL_RETRY_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_STALL_RETRY_NUDGE", raising=False)
+    monkeypatch.delenv("HERMES_STALL_RETRY_TELEMETRY", raising=False)
+
+    assert not get_stall_retry_nudge_enabled(agent)
+
+    result = retry_on_stall(
+        agent,
+        [{"role": "user", "content": "go"}],
+        "stop",
+        stalled_content="Let me check.",
+    )
+
+    assert result is normalized
+    assert captured["kwargs"]["messages"] == [{"role": "user", "content": "go"}]
+
+
+def test_stall_retry_telemetry_writes_bounded_local_jsonl(tmp_path) -> None:
+    log_path = tmp_path / "stall-retry.ndjson"
+    agent = SimpleNamespace(
+        session_id="s1",
+        model="dflash",
+        provider="nous",
+        _stall_retry_config={
+            "telemetry": True,
+            "telemetry_path": str(log_path),
+        },
+    )
+
+    record_stall_retry_event(
+        agent,
+        "detected",
+        retry_model="qwen3.6-27b-256k",
+        content="Let me check the repo.\n" * 30,
+    )
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    event = json.loads(lines[0])
+    assert event["event"] == "detected"
+    assert event["session_id"] == "s1"
+    assert event["model"] == "dflash"
+    assert event["provider"] == "nous"
+    assert event["retry_model"] == "qwen3.6-27b-256k"
+    assert event["content_chars"] > len(event["content_preview"])
+    assert len(event["content_preview"]) <= 240
+    assert "messages" not in event
+
+    summary = stall_retry_summary(agent)
+    assert summary is not None
+    assert summary["detected"] == 1
+    assert summary["events"] == 1
+    assert summary["log_path"] == str(log_path)
 
 
 def test_conversation_loop_adopts_retry_before_tool_call_branch() -> None:
@@ -195,15 +488,16 @@ def test_conversation_loop_adopts_retry_before_tool_call_branch() -> None:
     assert "stall_retry_failed_no_tool_call" in source
 
 
-def test_conversation_loop_retries_empty_post_tool_before_generic_stall() -> None:
+def test_conversation_loop_retries_empty_post_tool_before_tool_branch() -> None:
     source = inspect.getsource(conversation_loop.run_conversation)
-    empty_retry_idx = source.index("EMPTY_AFTER_TOOL_RETRY_NUDGE")
+    empty_retry_idx = source.index("empty_after_tool_result")
     generic_stall_idx = source.index("looks_like_stall(")
     tool_branch_idx = source.index("# Check for tool calls")
 
     assert empty_retry_idx < generic_stall_idx
     assert empty_retry_idx < tool_branch_idx
     assert "not _empty_after_tool_result and looks_like_stall" in source
+    assert "EMPTY_AFTER_TOOL_RETRY_NUDGE" in source
     assert "accept_content=True" in source
 
 
@@ -212,5 +506,5 @@ def test_conversation_loop_allows_bounded_multiple_stall_retries() -> None:
 
     assert "_stall_retry_used" not in source
     assert "_stall_retry_count += 1" in source
-    assert "HERMES_STALL_RETRY_MAX_PER_TURN" in source
+    assert "get_stall_retry_max_per_turn" in source
     assert "stall_retry_limit_exhausted" in source

--- a/tests/agent/test_stall_retry.py
+++ b/tests/agent/test_stall_retry.py
@@ -25,6 +25,37 @@ def test_completion_text_is_not_a_stall() -> None:
     )
 
 
+def test_incomplete_final_fragment_without_action_preamble_is_a_stall() -> None:
+    assert looks_like_stall(
+        (
+            "I'm on main with a clean tree. The fix I made was on Taro "
+            "(remote machine), not locally. The change was on Taro's "
+            "`~/.gitconfig` and the worktree's local git config. These are "
+            "machine-specific runtime"
+        ),
+        "stop",
+        False,
+        400,
+    )
+
+
+def test_short_status_answer_without_punctuation_is_not_a_stall() -> None:
+    assert not looks_like_stall("main", "stop", False, 400)
+
+
+def test_complete_agentic_answer_without_action_preamble_is_not_a_stall() -> None:
+    assert not looks_like_stall(
+        (
+            "I'm on main with a clean tree. The Taro git identity and SSH "
+            "push configuration are machine-local runtime settings, so there "
+            "is no repository diff to publish."
+        ),
+        "stop",
+        False,
+        400,
+    )
+
+
 def test_retry_on_stall_switches_model_and_returns_tool_calls(monkeypatch) -> None:
     captured: dict[str, object] = {}
     tool_call = SimpleNamespace(

--- a/tests/agent/test_stall_retry.py
+++ b/tests/agent/test_stall_retry.py
@@ -7,10 +7,12 @@ from types import SimpleNamespace
 from agent import conversation_loop
 from agent.stall_retry import (
     EMPTY_AFTER_TOOL_RETRY_NUDGE,
+    activate_stall_retry_runtime,
     get_stall_retry_max_chars,
     get_stall_retry_max_per_turn,
     get_stall_retry_model,
     get_stall_retry_nudge_enabled,
+    get_stall_retry_promote_after,
     has_recent_tool_result,
     looks_like_incomplete_final_fragment,
     looks_like_stall,
@@ -383,6 +385,83 @@ def test_stall_retry_empty_agent_config_falls_back_to_loaded_config(monkeypatch)
     assert get_stall_retry_max_per_turn(provider_only_agent) == 3
 
 
+def test_stall_retry_promote_after_uses_config_and_env(monkeypatch) -> None:
+    agent = SimpleNamespace(_stall_retry_config={"promote_after": 4})
+
+    monkeypatch.delenv("HERMES_STALL_RETRY_PROMOTE_AFTER", raising=False)
+    assert get_stall_retry_promote_after(agent) == 4
+
+    monkeypatch.setenv("HERMES_STALL_RETRY_PROMOTE_AFTER", "0")
+    assert get_stall_retry_promote_after(agent) == 0
+
+
+def test_activate_stall_retry_runtime_promotes_for_current_turn(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    fake_client = SimpleNamespace(
+        api_key="retry-key",
+        base_url="http://taro:8080/v1",
+        _custom_headers={"X-Test": "1"},
+    )
+
+    def fake_resolve_provider_client(**kwargs: object) -> tuple[object, str]:
+        captured["resolve_kwargs"] = dict(kwargs)
+        return fake_client, "qwen3.6-27b-256k"
+
+    def update_model(**kwargs: object) -> None:
+        captured["context_model"] = dict(kwargs)
+
+    agent = SimpleNamespace(
+        model="dflash",
+        provider="custom",
+        base_url="http://primary:8080/v1",
+        api_key="primary-key",
+        api_mode="chat_completions",
+        _client_kwargs={"api_key": "primary-key", "base_url": "http://primary:8080/v1"},
+        _stall_retry_config={
+            "model": "qwen3.6-27b-256k",
+            "provider": "taro",
+            "base_url": "http://taro:8080/v1",
+        },
+        _transport_cache={"chat": object()},
+        _config_context_length=262144,
+        _custom_providers=[],
+        context_compressor=SimpleNamespace(update_model=update_model),
+        _anthropic_prompt_cache_policy=lambda **_kwargs: (False, False),
+        _ensure_lmstudio_runtime_loaded=lambda: None,
+        _emit_status=lambda message: captured.setdefault("status", message),
+        _fallback_activated=False,
+    )
+
+    monkeypatch.setenv("HERMES_STALL_RETRY_TELEMETRY", "0")
+    monkeypatch.setattr(
+        "agent.auxiliary_client.resolve_provider_client",
+        lambda provider, **kwargs: fake_resolve_provider_client(
+            provider=provider, **kwargs
+        ),
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 262144,
+    )
+
+    assert activate_stall_retry_runtime(
+        agent,
+        "qwen3.6-27b-256k",
+        promote_after=2,
+        successful_retries=2,
+    )
+    assert agent.model == "qwen3.6-27b-256k"
+    assert agent.provider == "taro"
+    assert str(agent.base_url) == "http://taro:8080/v1"
+    assert agent._fallback_activated is True
+    assert agent._stall_retry_runtime_promoted is True
+    assert agent._stall_retry_promoted_from == "dflash"
+    assert agent._transport_cache == {}
+    assert captured["resolve_kwargs"]["provider"] == "taro"
+    assert captured["context_model"]["model"] == "qwen3.6-27b-256k"
+    assert "rest of this turn" in captured["status"]
+
+
 def test_retry_on_stall_uses_configured_retry_provider(monkeypatch) -> None:
     captured: dict[str, object] = {}
     tool_call = SimpleNamespace(
@@ -586,3 +665,20 @@ def test_conversation_loop_allows_bounded_multiple_stall_retries() -> None:
     assert "_stall_retry_count += 1" in source
     assert "get_stall_retry_max_per_turn" in source
     assert "stall_retry_limit_exhausted" in source
+
+
+def test_conversation_loop_does_not_treat_recovered_stalls_as_failures() -> None:
+    source = inspect.getsource(conversation_loop.run_conversation)
+
+    assert "_stall_retry_failed_count" in source
+    assert "if _stall_retry_count >= _stall_retry_max_per_turn" not in source
+    assert "A recovered tool call is work advanced" in source
+
+
+def test_conversation_loop_promotes_retry_lane_after_repeated_rescues() -> None:
+    source = inspect.getsource(conversation_loop.run_conversation)
+
+    assert "get_stall_retry_promote_after" in source
+    assert "_stall_retry_success_count += 1" in source
+    assert "activate_stall_retry_runtime(" in source
+    assert "_stall_retry_success_count >= _stall_retry_promote_after" in source

--- a/tests/agent/test_stall_retry.py
+++ b/tests/agent/test_stall_retry.py
@@ -7,10 +7,12 @@ from types import SimpleNamespace
 from agent import conversation_loop
 from agent.stall_retry import (
     EMPTY_AFTER_TOOL_RETRY_NUDGE,
+    FAILED_STALL_RETRY_RECOVERY_NUDGE,
     activate_stall_retry_runtime,
     get_stall_retry_max_chars,
     get_stall_retry_max_per_turn,
     get_stall_retry_model,
+    get_stall_retry_no_tool_recovery_max,
     get_stall_retry_nudge_enabled,
     get_stall_retry_promote_after,
     has_recent_tool_result,
@@ -305,6 +307,95 @@ def test_retry_on_stall_still_rejects_content_without_accept_content(monkeypatch
     ) is None
 
 
+def test_retry_on_stall_skips_same_model_before_runtime_promotion(monkeypatch) -> None:
+    captured = {"called": False}
+
+    agent = SimpleNamespace(
+        api_mode="openai",
+        _is_anthropic_oauth=False,
+        log_prefix="",
+        _build_api_kwargs=lambda messages: {
+            "model": "qwen3.6-27b-256k",
+            "messages": messages,
+            "stream": True,
+        },
+        _interruptible_api_call=lambda _kwargs: captured.__setitem__("called", True),
+        _get_transport=lambda: SimpleNamespace(
+            normalize_response=lambda response, **_kwargs: response
+        ),
+        _vprint=lambda *_args, **_kwargs: None,
+    )
+
+    monkeypatch.setenv("HERMES_STALL_RETRY_MODEL", "qwen3.6-27b-256k")
+    monkeypatch.setenv("HERMES_STALL_RETRY_TELEMETRY", "0")
+
+    assert retry_on_stall(agent, [{"role": "user", "content": "go"}], "stop") is None
+    assert captured["called"] is False
+    summary = stall_retry_summary(agent)
+    assert summary is not None
+    assert any(
+        event.get("event") == "skipped_same_model"
+        for event in getattr(agent, "_stall_retry_events", [])
+    )
+
+
+def test_retry_on_stall_allows_same_model_after_runtime_promotion(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    tool_call = SimpleNamespace(
+        function=SimpleNamespace(name="terminal", arguments='{"cmd":"pwd"}')
+    )
+    normalized = SimpleNamespace(
+        content="",
+        tool_calls=[tool_call],
+        finish_reason="tool_calls",
+    )
+
+    def interruptible_api_call(kwargs: dict[str, object]) -> object:
+        captured["kwargs"] = dict(kwargs)
+        return normalized
+
+    agent = SimpleNamespace(
+        api_mode="openai",
+        _is_anthropic_oauth=False,
+        log_prefix="",
+        _stall_retry_runtime_promoted=True,
+        _build_api_kwargs=lambda messages: {
+            "model": "qwen3.6-27b-256k",
+            "messages": messages,
+            "stream": True,
+        },
+        _interruptible_api_call=interruptible_api_call,
+        _get_transport=lambda: SimpleNamespace(
+            normalize_response=lambda response, **_kwargs: response
+        ),
+        _vprint=lambda *_args, **_kwargs: None,
+    )
+
+    monkeypatch.setenv("HERMES_STALL_RETRY_MODEL", "qwen3.6-27b-256k")
+    monkeypatch.setenv("HERMES_STALL_RETRY_TELEMETRY", "0")
+
+    result = retry_on_stall(
+        agent,
+        [{"role": "user", "content": "go"}],
+        "stop",
+        stalled_content="Let me check the repo.",
+        retry_index=3,
+    )
+
+    assert result is normalized
+    assert captured["kwargs"]["model"] == "qwen3.6-27b-256k"
+    assert captured["kwargs"]["stream"] is False
+    assert captured["kwargs"]["messages"][-1]["role"] == "user"
+    assert "required tool call" in captured["kwargs"]["messages"][-1]["content"]
+    summary = stall_retry_summary(agent)
+    assert summary is not None
+    assert any(
+        event.get("event") == "same_model_retry_after_promotion"
+        for event in getattr(agent, "_stall_retry_events", [])
+    )
+    assert summary["recovered"] == 1
+
+
 def test_retry_on_stall_uses_agent_config_when_env_is_absent(monkeypatch) -> None:
     captured: dict[str, object] = {}
     tool_call = SimpleNamespace(
@@ -393,6 +484,16 @@ def test_stall_retry_promote_after_uses_config_and_env(monkeypatch) -> None:
 
     monkeypatch.setenv("HERMES_STALL_RETRY_PROMOTE_AFTER", "0")
     assert get_stall_retry_promote_after(agent) == 0
+
+
+def test_stall_retry_no_tool_recovery_max_uses_config_and_env(monkeypatch) -> None:
+    agent = SimpleNamespace(_stall_retry_config={"no_tool_recovery_max": 4})
+
+    monkeypatch.delenv("HERMES_STALL_RETRY_NO_TOOL_RECOVERY_MAX", raising=False)
+    assert get_stall_retry_no_tool_recovery_max(agent) == 4
+
+    monkeypatch.setenv("HERMES_STALL_RETRY_NO_TOOL_RECOVERY_MAX", "0")
+    assert get_stall_retry_no_tool_recovery_max(agent) == 0
 
 
 def test_activate_stall_retry_runtime_promotes_for_current_turn(monkeypatch) -> None:
@@ -629,6 +730,10 @@ def test_conversation_loop_adopts_retry_before_tool_call_branch() -> None:
     assert retry_idx < tool_branch_idx
     assert "continue  # re-enter loop top; tool-calls path handles it" not in source
     assert "stall_retry_failed_no_tool_call" in source
+    assert "FAILED_STALL_RETRY_RECOVERY_NUDGE" in source
+    assert "no_tool_recovery_prompt" in source
+    assert "agent._session_messages = messages" in source
+    assert "continue" in source
 
 
 def test_conversation_loop_retries_empty_post_tool_before_tool_branch() -> None:
@@ -682,3 +787,12 @@ def test_conversation_loop_promotes_retry_lane_after_repeated_rescues() -> None:
     assert "_stall_retry_success_count += 1" in source
     assert "activate_stall_retry_runtime(" in source
     assert "_stall_retry_success_count >= _stall_retry_promote_after" in source
+
+
+def test_conversation_loop_configures_no_tool_recovery_limit() -> None:
+    source = inspect.getsource(conversation_loop.run_conversation)
+
+    assert "get_stall_retry_no_tool_recovery_max(agent)" in source
+    assert "_stall_retry_no_tool_recovery_count" in source
+    assert "_stall_retry_no_tool_recovery_max" in source
+    assert FAILED_STALL_RETRY_RECOVERY_NUDGE

--- a/tests/agent/test_stall_retry.py
+++ b/tests/agent/test_stall_retry.py
@@ -16,6 +16,15 @@ def test_action_preamble_without_tool_call_is_a_stall() -> None:
     )
 
 
+def test_followup_action_preamble_after_successful_retry_is_a_stall() -> None:
+    assert looks_like_stall(
+        "Let me look at open tasks with high priority that I can actually pick up.",
+        "stop",
+        False,
+        400,
+    )
+
+
 def test_completion_text_is_not_a_stall() -> None:
     assert not looks_like_stall(
         "Done. The task is complete and no further action is needed.",
@@ -104,3 +113,12 @@ def test_conversation_loop_adopts_retry_before_tool_call_branch() -> None:
     assert retry_idx < tool_branch_idx
     assert "continue  # re-enter loop top; tool-calls path handles it" not in source
     assert "stall_retry_failed_no_tool_call" in source
+
+
+def test_conversation_loop_allows_bounded_multiple_stall_retries() -> None:
+    source = inspect.getsource(conversation_loop.run_conversation)
+
+    assert "_stall_retry_used" not in source
+    assert "_stall_retry_count += 1" in source
+    assert "HERMES_STALL_RETRY_MAX_PER_TURN" in source
+    assert "stall_retry_limit_exhausted" in source

--- a/tests/agent/test_stall_retry.py
+++ b/tests/agent/test_stall_retry.py
@@ -11,6 +11,7 @@ from agent.stall_retry import (
     get_stall_retry_max_per_turn,
     get_stall_retry_model,
     get_stall_retry_nudge_enabled,
+    looks_like_incomplete_final_fragment,
     looks_like_stall,
     record_stall_retry_event,
     retry_on_stall,
@@ -109,6 +110,13 @@ def test_incomplete_final_fragment_without_action_preamble_is_a_stall() -> None:
         False,
         400,
     )
+
+
+def test_short_incomplete_connector_tail_is_a_stall() -> None:
+    content = "I see a lot of discord-res tasks (digest Discord content) and some"
+
+    assert looks_like_incomplete_final_fragment(content, "stop", False, 400)
+    assert looks_like_stall(content, "stop", False, 400)
 
 
 def test_empty_visible_response_uses_empty_response_recovery_not_stall_retry() -> None:
@@ -526,6 +534,20 @@ def test_conversation_loop_retries_empty_post_tool_before_tool_branch() -> None:
     assert "not _empty_after_tool_result and looks_like_stall" in source
     assert "EMPTY_AFTER_TOOL_RETRY_NUDGE" in source
     assert "accept_content=True" in source
+
+
+def test_conversation_loop_uses_configured_stall_retry_model() -> None:
+    source = inspect.getsource(conversation_loop.run_conversation)
+
+    assert "get_stall_retry_model(agent)" in source
+    assert 'os.environ.get("HERMES_STALL_RETRY_MODEL"' in source
+
+
+def test_conversation_loop_accepts_content_for_incomplete_final_fragment() -> None:
+    source = inspect.getsource(conversation_loop.run_conversation)
+
+    assert "looks_like_incomplete_final_fragment" in source
+    assert "accept_content=_retry_accepts_content" in source
 
 
 def test_conversation_loop_allows_bounded_multiple_stall_retries() -> None:

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -467,6 +467,33 @@ class TestChatCompletionsBuildKwargs:
         # Anthropic Messages API which requires the field.
         assert kw["max_tokens"] == 64000
 
+    def test_local_endpoint_gets_finite_default_max_tokens(self, transport, monkeypatch):
+        monkeypatch.delenv("HERMES_LOCAL_DEFAULT_MAX_TOKENS", raising=False)
+        monkeypatch.delenv("HERMES_LOCAL_MAX_TOKENS", raising=False)
+
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="qwen3.6-27b-256k",
+            messages=msgs,
+            base_url="http://127.0.0.1:9090/v1",
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+
+        assert kw["max_tokens"] == 8192
+
+    def test_local_endpoint_max_tokens_env_override(self, transport, monkeypatch):
+        monkeypatch.setenv("HERMES_LOCAL_DEFAULT_MAX_TOKENS", "4096")
+
+        msgs = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="qwen3.6-27b-256k",
+            messages=msgs,
+            base_url="http://127.0.0.1:9090/v1",
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+
+        assert kw["max_tokens"] == 4096
+
     def test_request_overrides_last(self, transport):
         msgs = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(

--- a/tests/hermes_cli/test_timeouts.py
+++ b/tests/hermes_cli/test_timeouts.py
@@ -268,10 +268,12 @@ def test_resolved_api_call_stale_timeout_priority(monkeypatch, tmp_path):
     assert agent2._resolved_api_call_stale_timeout_base() == (90.0, True)
 
 
-def test_default_non_stream_stale_timeout_auto_disables_for_local_endpoints(monkeypatch, tmp_path):
+def test_default_non_stream_stale_timeout_is_finite_for_local_endpoints(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / ".env").write_text("", encoding="utf-8")
     monkeypatch.delenv("HERMES_API_CALL_STALE_TIMEOUT", raising=False)
+    monkeypatch.delenv("HERMES_LOCAL_NON_STREAM_STALE_TIMEOUT", raising=False)
+    monkeypatch.delenv("HERMES_LOCAL_RESPONSE_TIMEOUT", raising=False)
 
     from run_agent import AIAgent
     agent = AIAgent(
@@ -285,7 +287,7 @@ def test_default_non_stream_stale_timeout_auto_disables_for_local_endpoints(monk
         platform="cli",
     )
 
-    assert agent._compute_non_stream_stale_timeout([]) == float("inf")
+    assert agent._compute_non_stream_stale_timeout([]) == 120.0
 
 
 def test_explicit_non_stream_stale_timeout_is_honored_for_local_endpoints(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -806,9 +806,9 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
             self.stream_delta_callback = object()
             self.tool_gen_callback = object()
 
-        def chat(self, prompt):
+        def run_conversation(self, prompt):
             captured["prompt"] = prompt
-            return "ok"
+            return {"final_response": "ok", "completed": True}
 
     class FakeSessionDB:
         def __new__(cls):
@@ -856,6 +856,61 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     assert captured["session_db"] is sentinel_db
     assert captured["enabled_toolsets"] == ["session_search"]
     assert captured["prompt"] == "recall this"
+
+
+def test_oneshot_run_agent_raises_on_failed_result(monkeypatch):
+    """Oneshot must not print run_conversation errors as successful output."""
+    from hermes_cli.oneshot import _run_agent
+
+    class FakeAgent:
+        def __init__(self, **_kwargs):
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+
+        def run_conversation(self, _prompt):
+            return {"failed": True, "error": "Connection error."}
+
+    def mod(name, **attrs):
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=FakeAgent))
+    monkeypatch.setitem(sys.modules, "hermes_state", mod("hermes_state", SessionDB=lambda: None))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m"}}),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.models",
+        mod("hermes_cli.models", detect_provider_for_model=lambda *_args, **_kwargs: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {
+                "api_key": "k",
+                "base_url": "u",
+                "provider": "p",
+                "api_mode": "chat_completions",
+                "credential_pool": None,
+            },
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: set()),
+    )
+
+    with pytest.raises(RuntimeError, match="Connection error"):
+        _run_agent("hello")
 
 
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5904,6 +5904,18 @@ class TestDeadRetryCode:
             f"but found {occurrences}"
         )
 
+    def test_dflash_first_chunk_timeout_fallback_precedes_primary_recovery(self):
+        import inspect
+        from agent.conversation_loop import run_conversation as _rc
+        source = inspect.getsource(_rc)
+
+        first_chunk_fallback = source.index(
+            "FailoverReason.local_first_chunk_timeout"
+        )
+        primary_recovery = source.index("agent._try_recover_primary_transport")
+
+        assert first_chunk_fallback < primary_recovery
+
 
 class TestSupportsReasoningExtraBody:
     def _make_agent(self):

--- a/tests/scripts/test_dflash_stability_canary.py
+++ b/tests/scripts/test_dflash_stability_canary.py
@@ -12,6 +12,13 @@ canary = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = canary
 SPEC.loader.exec_module(canary)
 
+LOOP_MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "dflash_hardening_loop.py"
+LOOP_SPEC = importlib.util.spec_from_file_location("dflash_hardening_loop", LOOP_MODULE_PATH)
+assert LOOP_SPEC is not None and LOOP_SPEC.loader is not None
+loop = importlib.util.module_from_spec(LOOP_SPEC)
+sys.modules[LOOP_SPEC.name] = loop
+LOOP_SPEC.loader.exec_module(loop)
+
 
 def test_incomplete_tail_classifier_catches_short_connector_fragment():
     assert canary.looks_like_incomplete_tail("I see a lot of discord-res tasks (digest Discord content) and some")
@@ -101,3 +108,39 @@ def test_run_case_uses_runner_and_sanitizes_prompt_from_logged_command(tmp_path)
     assert record["failure"] is None
     assert record["cmd"][-1] == "<prompt>"
     assert record["stdout"] == "OK\n"
+
+
+def test_hardening_loop_failure_task_id_is_stable_and_sanitized():
+    record = {"case": "MeshBoard Onboard", "failure": "nonzero_exit"}
+
+    assert (
+        loop.failure_task_id(record, prefix="Hermes DFlash Hardening Loop")
+        == "hermes-dflash-hardening-loop-meshboard-onboard-nonzero-exit"
+    )
+
+
+def test_hardening_loop_meshboard_command_omits_raw_stdout(tmp_path):
+    record = {
+        "case": "meshboard-onboard",
+        "failure": "auth-error",
+        "returncode": 1,
+        "elapsed_s": 12.3,
+        "stdout": "secret-ish raw model text",
+        "stderr": "raw stderr",
+    }
+
+    cmd = loop.build_meshboard_failure_command(
+        meshboard_root=tmp_path,
+        task_id="hermes-dflash-hardening-loop-meshboard-onboard-auth-error",
+        record=record,
+        log_path=tmp_path / "evidence.jsonl",
+        actor="ko-taro.hermes",
+        parent_task="parent-task",
+    )
+    command_text = "\n".join(cmd)
+
+    assert "secret-ish raw model text" not in command_text
+    assert "raw stderr" not in command_text
+    assert "--parent-task" in cmd
+    assert "parent-task" in cmd
+    assert str(tmp_path / "evidence.jsonl") in cmd

--- a/tests/scripts/test_dflash_stability_canary.py
+++ b/tests/scripts/test_dflash_stability_canary.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "dflash_stability_canary.py"
+SPEC = importlib.util.spec_from_file_location("dflash_stability_canary", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+canary = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = canary
+SPEC.loader.exec_module(canary)
+
+
+def test_incomplete_tail_classifier_catches_short_connector_fragment():
+    assert canary.looks_like_incomplete_tail("I see a lot of discord-res tasks (digest Discord content) and some")
+    assert canary.looks_like_incomplete_tail("Now let me read the STATUS.md to find a task I can pick up")
+    assert not canary.looks_like_incomplete_tail("CANARY_ONBOARD_OK")
+
+
+def test_classify_result_requires_exact_marker():
+    ok = canary.CommandResult(returncode=0, stdout="CANARY_ONBOARD_OK\n", stderr="", elapsed_s=1.0)
+    noisy = canary.CommandResult(returncode=0, stdout="Done. CANARY_ONBOARD_OK\n", stderr="", elapsed_s=1.0)
+
+    assert canary.classify_result(ok, "CANARY_ONBOARD_OK") is None
+    assert canary.classify_result(noisy, "CANARY_ONBOARD_OK") == "marker-mismatch"
+    assert canary.classify_result(noisy, "CANARY_ONBOARD_OK", strict_marker=False) is None
+
+
+def test_classify_result_flags_auth_empty_timeout_and_nonzero():
+    assert (
+        canary.classify_result(
+            canary.CommandResult(returncode=0, stdout="", stderr="", elapsed_s=1.0),
+            "MARKER",
+        )
+        == "empty-final"
+    )
+    assert (
+        canary.classify_result(
+            canary.CommandResult(returncode=0, stdout="MARKER", stderr="Error code: 401 Invalid API key", elapsed_s=1.0),
+            "MARKER",
+        )
+        == "auth-error"
+    )
+    assert (
+        canary.classify_result(
+            canary.CommandResult(returncode=124, stdout="", stderr="", elapsed_s=180.0, timed_out=True),
+            "MARKER",
+        )
+        == "timeout"
+    )
+    assert (
+        canary.classify_result(
+            canary.CommandResult(returncode=2, stdout="MARKER", stderr="", elapsed_s=1.0),
+            "MARKER",
+        )
+        == "nonzero-exit"
+    )
+
+
+def test_build_command_includes_model_provider_toolsets():
+    case = canary.CanaryCase(name="unit", marker="OK", prompt="reply OK")
+    cmd = canary.build_command("hermes", case, model="dflash", provider="taro", toolsets="terminal,file")
+
+    assert cmd == [
+        "hermes",
+        "--provider",
+        "taro",
+        "--model",
+        "dflash",
+        "--toolsets",
+        "terminal,file",
+        "-z",
+        "reply OK",
+    ]
+
+
+def test_run_case_uses_runner_and_sanitizes_prompt_from_logged_command(tmp_path):
+    case = canary.CanaryCase(name="unit", marker="OK", prompt="private prompt")
+
+    def runner(cmd, cwd, timeout_s):
+        assert cmd[-1] == "private prompt"
+        assert cwd == tmp_path
+        assert timeout_s == 5.0
+        return canary.CommandResult(returncode=0, stdout="OK\n", stderr="", elapsed_s=0.25)
+
+    record = canary.run_case(
+        case,
+        cwd=tmp_path,
+        hermes_bin="hermes",
+        model="dflash",
+        provider="taro",
+        toolsets="terminal,file",
+        timeout_s=5.0,
+        strict_marker=True,
+        runner=runner,
+    )
+
+    assert record["ok"] is True
+    assert record["failure"] is None
+    assert record["cmd"][-1] == "<prompt>"
+    assert record["stdout"] == "OK\n"

--- a/tests/scripts/test_dflash_stability_canary.py
+++ b/tests/scripts/test_dflash_stability_canary.py
@@ -110,6 +110,25 @@ def test_run_case_uses_runner_and_sanitizes_prompt_from_logged_command(tmp_path)
     assert record["stdout"] == "OK\n"
 
 
+def test_run_subprocess_timeout_requests_thread_dump(tmp_path):
+    code = (
+        "import faulthandler, signal, sys, time; "
+        "faulthandler.enable(file=sys.stderr, all_threads=True); "
+        "faulthandler.register(signal.SIGUSR1, file=sys.stderr, all_threads=True, chain=False); "
+        "time.sleep(30)"
+    )
+
+    result = canary.run_subprocess(
+        [sys.executable, "-c", code],
+        cwd=tmp_path,
+        timeout_s=0.2,
+    )
+
+    assert result.timed_out is True
+    assert result.returncode == 124
+    assert "Current thread" in result.stderr
+
+
 def test_hardening_loop_failure_task_id_is_stable_and_sanitized():
     record = {"case": "MeshBoard Onboard", "failure": "nonzero_exit"}
 

--- a/tests/scripts/test_dflash_stability_canary.py
+++ b/tests/scripts/test_dflash_stability_canary.py
@@ -92,6 +92,15 @@ def test_materialize_case_marker_replaces_marker_with_nonce():
     assert materialized.prompt == "reply exactly OK_run_1_case"
 
 
+def test_materialize_case_marker_injects_source_root(tmp_path):
+    case = canary.CanaryCase(name="unit", marker="OK", prompt="cd {source_root}; reply OK")
+
+    materialized = canary.materialize_case_marker(case, "n1", source_root=tmp_path)
+
+    assert str(tmp_path) in materialized.prompt
+    assert materialized.prompt.endswith("reply OK_n1")
+
+
 def test_run_case_uses_runner_and_sanitizes_prompt_from_logged_command(tmp_path):
     case = canary.CanaryCase(name="unit", marker="OK", prompt="private prompt")
 

--- a/tests/scripts/test_dflash_stability_canary.py
+++ b/tests/scripts/test_dflash_stability_canary.py
@@ -83,6 +83,15 @@ def test_build_command_includes_model_provider_toolsets():
     ]
 
 
+def test_materialize_case_marker_replaces_marker_with_nonce():
+    case = canary.CanaryCase(name="unit", marker="OK", prompt="reply exactly OK")
+
+    materialized = canary.materialize_case_marker(case, "run-1 case")
+
+    assert materialized.marker == "OK_run_1_case"
+    assert materialized.prompt == "reply exactly OK_run_1_case"
+
+
 def test_run_case_uses_runner_and_sanitizes_prompt_from_logged_command(tmp_path):
     case = canary.CanaryCase(name="unit", marker="OK", prompt="private prompt")
 
@@ -110,11 +119,37 @@ def test_run_case_uses_runner_and_sanitizes_prompt_from_logged_command(tmp_path)
     assert record["stdout"] == "OK\n"
 
 
+def test_run_case_uses_nonce_marker(tmp_path):
+    case = canary.CanaryCase(name="unit", marker="OK", prompt="reply OK")
+
+    def runner(cmd, cwd, timeout_s):
+        assert cmd[-1] == "reply OK_cycle_1"
+        return canary.CommandResult(returncode=0, stdout="OK_cycle_1\n", stderr="", elapsed_s=0.25)
+
+    record = canary.run_case(
+        case,
+        cwd=tmp_path,
+        hermes_bin="hermes",
+        model="dflash",
+        provider="taro",
+        toolsets="terminal,file",
+        timeout_s=5.0,
+        strict_marker=True,
+        marker_nonce="cycle-1",
+        runner=runner,
+    )
+
+    assert record["ok"] is True
+    assert record["marker"] == "OK_cycle_1"
+    assert record["marker_base"] == "OK"
+
+
 def test_run_subprocess_timeout_requests_thread_dump(tmp_path):
     code = (
         "import faulthandler, signal, sys, time; "
         "faulthandler.enable(file=sys.stderr, all_threads=True); "
-        "faulthandler.register(signal.SIGUSR1, file=sys.stderr, all_threads=True, chain=False); "
+        "sig=getattr(signal, 'SIGUSR1', None); "
+        "sig is not None and faulthandler.register(sig, file=sys.stderr, all_threads=True, chain=False); "
         "time.sleep(30)"
     )
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2091,7 +2091,15 @@ def test_session_compress_uses_compress_helper(monkeypatch):
     emit.assert_any_call("session.info", "sid", {"model": "x"})
     # Final status.update clears the pinned "compressing" indicator so the
     # status bar can revert to the neutral state when compaction finishes.
-    emit.assert_any_call("status.update", "sid", {"kind": "status", "text": "ready"})
+    status_updates = [
+        call.args[2]
+        for call in emit.call_args_list
+        if call.args[:2] == ("status.update", "sid")
+    ]
+    assert any(
+        update.get("kind") == "status" and update.get("text") == "ready"
+        for update in status_updates
+    )
 
 
 def test_session_compress_syncs_session_key_after_rotation(monkeypatch):


### PR DESCRIPTION
## Summary
- Replace the one-shot per-turn dflash stall retry guard with a bounded retry counter.
- Add `HERMES_STALL_RETRY_MAX_PER_TURN` with a default of 5 retries per user turn.
- Fail partial when the cap is exhausted instead of persisting another planning-only assistant response as final.
- Add regression coverage for the second action-preamble stall from session `20260530_193349_ae35ee`.

## Root Cause
The previous retry guard used a single `_stall_retry_used` boolean for the whole user turn. In the new repro, the first dflash stall was correctly retried on Q6 and recovered into a real terminal tool call. After that tool result, the next dflash decision stalled again, but the boolean had already disabled recovery, so Hermes accepted `Let me look at open tasks...` as the final answer.

## Stacking Note
This PR is stacked on #35638, which is itself stacked on #35620. The new commit in this stack is `39fcecb16 fix(agent): allow bounded repeated stall retries`; once the earlier dflash retry PRs land, this should collapse to the bounded retry-counter change and tests.

## Validation
- `scripts/run_tests.sh tests/agent/test_stall_retry.py`
- Verified the second repro fragment is retryable while completion text remains non-retryable.

## Impact
Long dflash agentic turns can now recover from multiple independent no-tool-call stalls after tool progress, while still having a finite per-turn cap to prevent retry loops.