### PR TITLE
fix(irc): close 7 long-running-adapter gaps (lock, auth/join escalation, send confirmation, channel routing, edit support)

### DIFF
--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -19,7 +19,10 @@ Configuration in config.yaml::
             use_tls: true
             server_password: ""       # optional server password
             nickserv_password: ""     # optional NickServ identification
-            allowed_users: []         # empty = allow all, or list of nicks
+            allowed_users: []         # list of nicks; empty falls through to
+                                      # the gateway default (deny unless
+                                      # IRC_ALLOW_ALL_USERS / a global
+                                      # allowlist is set)
             max_message_length: 450   # IRC line limit (safe default)
 
 Or via environment variables (overrides config.yaml):
@@ -99,6 +102,14 @@ class IRCAdapter(BasePlatformAdapter):
     register_platform().
     """
 
+    # IRC has no message-edit primitive: send() only opens new PRIVMSG lines
+    # and there is no edit_message override. Without this flag the base
+    # default (True) makes the streaming path emit a literal cursor on the
+    # first line, then fail every edit/cursor-strip attempt and re-deliver the
+    # whole answer — leaving a stray cursor plus a duplicate message. Declaring
+    # it False suppresses the cursor and the edit attempts (matches Signal).
+    SUPPORTS_MESSAGE_EDITING = False
+
     def __init__(self, config, **kwargs):
         platform = Platform("irc")
         super().__init__(config=config, platform=platform)
@@ -142,10 +153,36 @@ class IRCAdapter(BasePlatformAdapter):
         self._current_nick = self.nickname
         self._registered = False  # IRC registration complete
         self._registration_event = asyncio.Event()
+        # Set once the configured channel JOIN is confirmed (own JOIN echo or
+        # RPL_ENDOFNAMES) or rejected (a JOIN-failure numeric records the
+        # reason in _join_error). connect() waits on this before reporting a
+        # successful join.
+        self._join_event = asyncio.Event()
+        self._join_error: Optional[str] = None
 
     @property
     def name(self) -> str:
         return "IRC"
+
+    @property
+    def enforces_own_access_policy(self) -> bool:
+        """Honor a config-only ``allowed_users`` allowlist at intake.
+
+        The adapter applies its allowlist inline in ``_handle_line`` before
+        dispatch, but the gateway's ``_is_user_authorized`` only consults the
+        ``IRC_ALLOWED_USERS`` env var — it never reads ``extra.allowed_users``.
+        Without this override, an operator who configures ``allowed_users`` in
+        config.yaml (and sets no env allowlist) would have every message
+        silently default-denied by the gateway even though the nick already
+        passed the adapter's own check.
+
+        This is deliberately gated on a *non-empty* allowlist so the adapter
+        claims to own its access policy only when it actually gated the
+        message. An empty ``allowed_users`` returns ``False`` and falls through
+        to the gateway default-deny — an empty list must never silently allow
+        every IRC user.
+        """
+        return bool(self._allowed_users_lower)
 
     # ── Connection lifecycle ──────────────────────────────────────────────
 
@@ -160,17 +197,22 @@ class IRCAdapter(BasePlatformAdapter):
             )
             return False
 
-        # Prevent two profiles from using the same IRC identity
+        # Prevent two profiles from using the same IRC identity. Route through
+        # the base helper, which unpacks the (acquired, existing) tuple that
+        # acquire_scoped_lock returns, logs the owning PID, and escalates a
+        # non-retryable ``irc_lock`` fatal error on conflict. The previous
+        # inline ``if not acquire_scoped_lock(...)`` tested a 2-tuple for
+        # truthiness — always True — so the conflict branch was dead code and
+        # two profiles sharing one server:nick would both connect.
         try:
-            from gateway.status import acquire_scoped_lock, release_scoped_lock
+            from gateway.status import acquire_scoped_lock  # noqa: F401 — probe availability
             lock_key = f"{self.server}:{self.nickname}"
-            if not acquire_scoped_lock("irc", lock_key):
-                logger.error("IRC: %s@%s already in use by another profile", self.nickname, self.server)
-                self._set_fatal_error("lock_conflict", "IRC identity in use by another profile", retryable=False)
+            if not self._acquire_platform_lock(
+                "irc", lock_key, f"IRC identity {self.nickname}@{self.server}"
+            ):
                 return False
-            self._lock_key = lock_key
         except ImportError:
-            self._lock_key = None  # status module not available (e.g. tests)
+            pass  # status module not available (e.g. tests)
 
         try:
             ssl_ctx = None
@@ -195,7 +237,9 @@ class IRCAdapter(BasePlatformAdapter):
         # Start receive loop
         self._recv_task = asyncio.create_task(self._receive_loop())
 
-        # Wait for registration (001 RPL_WELCOME) with timeout
+        # Wait for registration to resolve: 001 RPL_WELCOME sets the event on
+        # success; 464/465/ERROR set it after recording a non-retryable fatal
+        # error. Either way we stop blocking and inspect the outcome below.
         try:
             await asyncio.wait_for(self._registration_event.wait(), timeout=30.0)
         except asyncio.TimeoutError:
@@ -204,13 +248,40 @@ class IRCAdapter(BasePlatformAdapter):
             self._set_fatal_error("registration_timeout", "IRC server did not send RPL_WELCOME", retryable=True)
             return False
 
+        # A registration-failure numeric (bad password / ban) escalated a
+        # non-retryable fatal error and unblocked the wait above. Preserve that
+        # classification — do not fall through to JOIN and report a bogus
+        # success — so the reconnect watcher drops the platform from the retry
+        # queue instead of retrying unfixable credentials forever.
+        if self.has_fatal_error:
+            logger.error("IRC: registration failed: %s", self.fatal_error_message)
+            await self.disconnect()
+            return False
+
         # NickServ identification
         if self.nickserv_password:
             await self._send_raw(f"PRIVMSG NickServ :IDENTIFY {self.nickserv_password}")
             await asyncio.sleep(2)  # Give NickServ time to process
 
-        # Join channel
+        # Join channel and confirm it. The receive loop sets _join_event on the
+        # own JOIN echo / RPL_ENDOFNAMES (366) or records _join_error on a
+        # JOIN-failure numeric (403/405/471/473/474/475). Reporting a
+        # successful join without this would leave a "connected" adapter that
+        # silently black-holes every channel PRIVMSG on +n networks.
+        self._join_event.clear()
+        self._join_error = None
         await self._send_raw(f"JOIN {self.channel}")
+        try:
+            await asyncio.wait_for(self._join_event.wait(), timeout=10.0)
+        except asyncio.TimeoutError:
+            # No ack within the window. Proceed rather than fail — some servers
+            # are slow and the join may still have succeeded — but log it.
+            logger.warning("IRC: no JOIN confirmation for %s within 10s", self.channel)
+        if self._join_error:
+            logger.error("IRC: %s", self._join_error)
+            await self.disconnect()
+            self._set_fatal_error("join_failed", self._join_error, retryable=False)
+            return False
 
         self._mark_connected()
         logger.info("IRC: connected to %s:%s as %s, joined %s", self.server, self.port, self._current_nick, self.channel)
@@ -219,12 +290,10 @@ class IRCAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Quit and close the connection."""
         # Release the scoped lock so another profile can use this identity
-        if getattr(self, "_lock_key", None):
-            try:
-                from gateway.status import release_scoped_lock
-                release_scoped_lock("irc", self._lock_key)
-            except Exception:
-                pass
+        try:
+            self._release_platform_lock()
+        except Exception:
+            pass
         self._mark_disconnected()
         if self._writer and not self._writer.is_closing():
             try:
@@ -249,6 +318,8 @@ class IRCAdapter(BasePlatformAdapter):
         self._writer = None
         self._registered = False
         self._registration_event.clear()
+        self._join_event.clear()
+        self._join_error = None
 
     # ── Sending ───────────────────────────────────────────────────────────
 
@@ -267,11 +338,21 @@ class IRCAdapter(BasePlatformAdapter):
 
         for line in lines:
             try:
-                await self._send_raw(f"PRIVMSG {target} :{line}")
+                # _send_raw silently drops the line and returns False when the
+                # writer closed mid-send (TCP/TLS drop, or connection_lost
+                # during the rate-limit sleep below). Surface that as a
+                # retryable failure instead of fabricating success for an
+                # unsent line, so the base layer can re-deliver the drop.
+                if not await self._send_raw(f"PRIVMSG {target} :{line}"):
+                    return SendResult(
+                        success=False,
+                        error="connection lost during send",
+                        retryable=True,
+                    )
                 # Basic rate limiting to avoid excess flood
                 await asyncio.sleep(0.3)
             except Exception as e:
-                return SendResult(success=False, error=str(e))
+                return SendResult(success=False, error=str(e), retryable=True)
 
         return SendResult(success=True, message_id=str(int(time.time() * 1000)))
 
@@ -280,7 +361,7 @@ class IRCAdapter(BasePlatformAdapter):
         pass
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
-        is_channel = chat_id.startswith("#") or chat_id.startswith("&")
+        is_channel = _is_irc_channel(chat_id)
         return {
             "name": chat_id,
             "type": "group" if is_channel else "dm",
@@ -353,13 +434,20 @@ class IRCAdapter(BasePlatformAdapter):
 
     # ── Raw IRC I/O ──────────────────────────────────────────────────────
 
-    async def _send_raw(self, line: str) -> None:
-        """Send a raw IRC protocol line."""
+    async def _send_raw(self, line: str) -> bool:
+        """Send a raw IRC protocol line.
+
+        Returns ``True`` if the line was written to the transport, ``False``
+        if the writer is gone or closing (the line is dropped). Delivery-
+        critical callers (``send``) inspect the return value; lifecycle
+        callers (PING/PONG, JOIN, NICK) ignore it.
+        """
         if not self._writer or self._writer.is_closing():
-            return
+            return False
         encoded = (line + "\r\n").encode("utf-8")
         self._writer.write(encoded)
         await self._writer.drain()
+        return True
 
     async def _receive_loop(self) -> None:
         """Main receive loop — reads lines and dispatches them."""
@@ -423,6 +511,52 @@ class IRCAdapter(BasePlatformAdapter):
             await self._send_raw(f"NICK {self._current_nick}")
             return
 
+        # Permanent registration failures. The ircd sends one of these and then
+        # closes the socket, so the connection can never self-resolve. Without
+        # explicit handling the receive loop just hits EOF (before
+        # _mark_connected, so its finally guard sets nothing) while connect()
+        # blocks on the 30s registration timeout and then escalates a
+        # *retryable* timeout — making the gateway reconnect forever on a
+        # credential/ban failure (burning a 30s timeout plus backoff each
+        # cycle, and on a ban escalating the server penalty). Escalate
+        # non-retryable and unblock connect() so the reconnect watcher drops
+        # the platform from the retry queue. The standalone cron path already
+        # rejects 464/465; this closes the same gap in the long-running adapter.
+        if command in {"464", "465"}:
+            code = "auth_rejected" if command == "464" else "banned"
+            detail = params[-1] if params else command
+            self._set_fatal_error(code, f"IRC server rejected registration: {detail}", retryable=False)
+            self._registration_event.set()
+            return
+
+        # Bare ERROR before registration completes — server-side connection
+        # kill (throttled / K-line / G-line). Treat as non-retryable only while
+        # unregistered; a post-registration ERROR is handled as a normal
+        # connection loss by the receive loop's EOF path.
+        if command == "ERROR" and not self._registered:
+            detail = params[-1] if params else "server closed the connection"
+            self._set_fatal_error("server_error", f"IRC server error during registration: {detail}", retryable=False)
+            self._registration_event.set()
+            return
+
+        # JOIN-failure numerics for the configured channel. The standalone cron
+        # path already rejects these; the long-running adapter used to ignore
+        # them, mark itself connected, and then silently black-hole every
+        # PRIVMSG to a channel it never actually joined.
+        if command in {"403", "405", "471", "473", "474", "475"}:
+            chan = params[1] if len(params) >= 2 else self.channel
+            self._join_error = f"JOIN {chan} rejected ({command})"
+            self._join_event.set()
+            return
+
+        # Own JOIN echo or RPL_ENDOFNAMES (366) confirms the channel join.
+        if command == "JOIN" and _extract_nick(msg["prefix"]).lower() == self._current_nick.lower():
+            self._join_event.set()
+            return
+        if command == "366":
+            self._join_event.set()
+            return
+
         # PRIVMSG — incoming message (channel or DM)
         if command == "PRIVMSG" and len(params) >= 2:
             sender_nick = _extract_nick(msg["prefix"])
@@ -441,8 +575,14 @@ class IRCAdapter(BasePlatformAdapter):
             if text.startswith("\x01"):
                 return
 
-            # Determine if this is a channel message or DM
-            is_channel = target.startswith("#") or target.startswith("&")
+            # Determine if this is a channel message or DM. Use the full
+            # RFC 2811 channel-prefix set ("#&+!") via _is_irc_channel so '+'
+            # (no-modes) and '!' (safe) channels are routed as channels and
+            # pass through the require-mention gate below — matching the
+            # outbound JOIN decision in _standalone_send. The narrower
+            # "#"/"&" check misclassified them as DMs, bypassing the gate and
+            # misrouting replies to the sender's nick.
+            is_channel = _is_irc_channel(target)
             chat_id = target if is_channel else sender_nick
             chat_type = "group" if is_channel else "dm"
 

--- a/tests/gateway/test_irc_adapter.py
+++ b/tests/gateway/test_irc_adapter.py
@@ -719,3 +719,329 @@ class TestIRCStandaloneSend:
         assert join_idx is not None, "JOIN must be sent for channel targets"
         assert privmsg_idx is not None
         assert join_idx < privmsg_idx, "JOIN must precede PRIVMSG"
+
+
+# ── Regression tests for the long-running adapter ─────────────────────────
+
+
+def _make_adapter(monkeypatch, **extra):
+    """Construct an IRCAdapter from config.yaml-style extra (no env vars)."""
+    for key in ("IRC_SERVER", "IRC_PORT", "IRC_NICKNAME", "IRC_CHANNEL", "IRC_USE_TLS"):
+        monkeypatch.delenv(key, raising=False)
+    from gateway.config import PlatformConfig
+    base = {
+        "server": "localhost",
+        "port": 6667,
+        "nickname": "hermes",
+        "channel": "#test",
+        "use_tls": False,
+    }
+    base.update(extra)
+    a = IRCAdapter(PlatformConfig(enabled=True, extra=base))
+    a._current_nick = "hermes"
+    a._registered = True
+    return a
+
+
+class TestIRCChannelPrefixRouting:
+    """Inbound '+' and '!' channels must be treated as channels (RFC 2811)."""
+
+    @pytest.mark.asyncio
+    async def test_plus_channel_unaddressed_message_ignored(self, monkeypatch):
+        # A '+' (no-modes) channel message that does NOT address the bot must
+        # hit the require-mention gate and be dropped. The old narrow
+        # "#"/"&" check misclassified '+chan' as a DM, bypassing the gate.
+        adapter = _make_adapter(monkeypatch)
+        dispatched = []
+
+        async def capture(**kwargs):
+            dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        adapter._message_handler = AsyncMock()
+
+        await adapter._handle_line(":user!u@host PRIVMSG +chan :just chatting")
+        assert dispatched == []
+
+    @pytest.mark.asyncio
+    async def test_plus_channel_addressed_routes_to_channel(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        dispatched = []
+
+        async def capture(**kwargs):
+            dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        adapter._message_handler = AsyncMock()
+
+        await adapter._handle_line(":user!u@host PRIVMSG +chan :hermes: hi there")
+        assert len(dispatched) == 1
+        # Reply must go back to the channel, not the sender's nick.
+        assert dispatched[0]["chat_id"] == "+chan"
+        assert dispatched[0]["chat_type"] == "group"
+        assert dispatched[0]["text"] == "hi there"
+
+    @pytest.mark.asyncio
+    async def test_bang_channel_addressed_routes_to_channel(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        dispatched = []
+
+        async def capture(**kwargs):
+            dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture
+        adapter._message_handler = AsyncMock()
+
+        await adapter._handle_line(":user!u@host PRIVMSG !ABCDEchan :hermes: yo")
+        assert len(dispatched) == 1
+        assert dispatched[0]["chat_id"] == "!ABCDEchan"
+        assert dispatched[0]["chat_type"] == "group"
+
+    @pytest.mark.asyncio
+    async def test_get_chat_info_classifies_plus_channel_as_group(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        info = await adapter.get_chat_info("+chan")
+        assert info["type"] == "group"
+
+
+class TestIRCSendDeliveryConfirmation:
+    """send() must not fabricate success for lines dropped mid-send."""
+
+    @pytest.mark.asyncio
+    async def test_send_reports_retryable_failure_when_writer_drops_midsend(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        writer = MagicMock()
+        # False for the top-of-send guard, True afterwards so _send_raw sees a
+        # closing writer and drops the line — simulating a connection_lost mid
+        # send. _send_raw must report the drop instead of swallowing it.
+        writer.is_closing = MagicMock(side_effect=[False, True, True])
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        adapter._writer = writer
+
+        result = await adapter.send("#test", "hello")
+        assert result.success is False
+        assert result.retryable is True
+        assert "connection lost" in result.error
+        # The dropped line was never written to the transport.
+        writer.write.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_raw_returns_true_on_success_false_when_closed(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        writer = MagicMock()
+        writer.is_closing = MagicMock(return_value=False)
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        adapter._writer = writer
+        assert await adapter._send_raw("PING :x") is True
+
+        writer.is_closing = MagicMock(return_value=True)
+        assert await adapter._send_raw("PING :x") is False
+
+
+class TestIRCAccessPolicy:
+    """Config-only allowed_users must bridge to the gateway, fail-open-safe."""
+
+    def test_enforces_own_access_policy_true_with_allowlist(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, allowed_users=["bob"])
+        assert adapter.enforces_own_access_policy is True
+
+    def test_enforces_own_access_policy_false_when_empty(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, allowed_users=[])
+        assert adapter.enforces_own_access_policy is False
+
+    def test_empty_allowlist_no_env_denies_arbitrary_user_at_gateway(self, monkeypatch):
+        """allowed_users=[] + no env allowlist => the gateway DENIES.
+
+        An empty list must NOT silently allow every IRC user: the adapter
+        declines to own the policy (enforces_own_access_policy is False) so the
+        gateway falls through to its default-deny.
+        """
+        for key in (
+            "IRC_ALLOWED_USERS", "IRC_ALLOW_ALL_USERS",
+            "GATEWAY_ALLOWED_USERS", "GATEWAY_ALLOW_ALL_USERS",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.session import SessionSource
+        from gateway.run import GatewayRunner
+
+        irc = Platform("irc")
+        adapter = _make_adapter(monkeypatch, allowed_users=[])
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={irc: PlatformConfig(enabled=True, extra={"allowed_users": []})}
+        )
+        runner.adapters = {irc: adapter}
+        runner.pairing_store = MagicMock()
+        runner.pairing_store.is_approved.return_value = False
+
+        source = SessionSource(
+            platform=irc, user_id="stranger", chat_id="#test",
+            user_name="stranger", chat_type="group",
+        )
+        assert runner._adapter_enforces_own_access_policy(irc) is False
+        assert runner._is_user_authorized(source) is False
+
+    def test_nonempty_allowlist_is_trusted_at_gateway(self, monkeypatch):
+        """A populated config allowlist makes the gateway trust adapter intake."""
+        for key in (
+            "IRC_ALLOWED_USERS", "IRC_ALLOW_ALL_USERS",
+            "GATEWAY_ALLOWED_USERS", "GATEWAY_ALLOW_ALL_USERS",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.session import SessionSource
+        from gateway.run import GatewayRunner
+
+        irc = Platform("irc")
+        adapter = _make_adapter(monkeypatch, allowed_users=["bob"])
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={irc: PlatformConfig(enabled=True, extra={"allowed_users": ["bob"]})}
+        )
+        runner.adapters = {irc: adapter}
+        runner.pairing_store = MagicMock()
+        runner.pairing_store.is_approved.return_value = False
+
+        source = SessionSource(
+            platform=irc, user_id="bob", chat_id="#test",
+            user_name="bob", chat_type="group",
+        )
+        assert runner._adapter_enforces_own_access_policy(irc) is True
+        assert runner._is_user_authorized(source) is True
+
+
+class TestIRCRegistrationEscalation:
+    """Permanent registration failures must escalate non-retryable."""
+
+    @pytest.mark.asyncio
+    async def test_464_passwd_mismatch_non_retryable(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._registered = False
+        adapter._registration_event = asyncio.Event()
+
+        await adapter._handle_line(":server 464 * :Password incorrect")
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        # connect() must be unblocked so it can return the failure.
+        assert adapter._registration_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_465_banned_non_retryable(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._registered = False
+        adapter._registration_event = asyncio.Event()
+
+        await adapter._handle_line(":server 465 * :You are banned from this server")
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter._registration_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_error_before_registration_non_retryable(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._registered = False
+        adapter._registration_event = asyncio.Event()
+
+        await adapter._handle_line("ERROR :Closing link: throttled")
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        assert adapter._registration_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_error_after_registration_not_treated_as_fatal_here(self, monkeypatch):
+        # A post-registration ERROR is left to the receive-loop EOF path; the
+        # registration handler must not hijack it.
+        adapter = _make_adapter(monkeypatch)
+        adapter._registered = True
+
+        await adapter._handle_line("ERROR :server going down")
+        assert adapter.has_fatal_error is False
+
+
+class TestIRCJoinConfirmation:
+    """connect() confirms the channel join instead of assuming success."""
+
+    @pytest.mark.asyncio
+    async def test_join_failure_numeric_records_error(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._join_event = asyncio.Event()
+        adapter._join_error = None
+
+        # 473 = ERR_INVITEONLYCHAN
+        await adapter._handle_line(":server 473 hermes #test :Cannot join channel (+i)")
+        assert adapter._join_event.is_set()
+        assert adapter._join_error is not None
+        assert "473" in adapter._join_error
+
+    @pytest.mark.asyncio
+    async def test_endofnames_confirms_join(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._join_event = asyncio.Event()
+        adapter._join_error = None
+
+        await adapter._handle_line(":server 366 hermes #test :End of /NAMES list.")
+        assert adapter._join_event.is_set()
+        assert adapter._join_error is None
+
+    @pytest.mark.asyncio
+    async def test_own_join_echo_confirms_join(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._join_event = asyncio.Event()
+        adapter._join_error = None
+
+        await adapter._handle_line(":hermes!bot@host JOIN #test")
+        assert adapter._join_event.is_set()
+        assert adapter._join_error is None
+
+
+class TestIRCLockConflict:
+    """The identity lock guard must actually block on conflict (not dead code)."""
+
+    @pytest.mark.asyncio
+    async def test_connect_aborts_non_retryable_on_lock_conflict(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+
+        import gateway.status as status_mod
+        # acquire_scoped_lock returns a (acquired, existing) tuple. The old
+        # `if not acquire_scoped_lock(...)` tested the tuple for truthiness —
+        # always True — so the conflict branch never fired. Simulate a held
+        # lock and assert connect() now bails before opening any socket.
+        monkeypatch.setattr(
+            status_mod, "acquire_scoped_lock",
+            lambda *a, **k: (False, {"pid": 4242, "platform": "irc"}),
+        )
+
+        opened = []
+
+        async def _fail_open(*a, **k):
+            opened.append(True)
+            raise AssertionError("connect() must abort before opening a socket")
+
+        monkeypatch.setattr(_irc_mod.asyncio, "open_connection", _fail_open)
+
+        result = await adapter.connect()
+        assert result is False
+        assert opened == []
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_retryable is False
+        # Base helper escalates a "<scope>_lock" code (irc_lock), not the old
+        # cosmetic "lock_conflict".
+        assert adapter._fatal_error_code == "irc_lock"
+
+
+class TestIRCEditSupport:
+    """IRC has no edit primitive — declare it so streaming suppresses the cursor."""
+
+    def test_supports_message_editing_is_false(self, monkeypatch):
+        assert IRCAdapter.SUPPORTS_MESSAGE_EDITING is False
+        adapter = _make_adapter(monkeypatch)
+        assert getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True) is False


### PR DESCRIPTION
Fixes 7 independently-verified bugs in the long-running IRC adapter, each with a regression test that is red on the base and green after the change. The adapter's out-of-process cron sibling (`_standalone_send`) already handles most of these cases correctly; the live gateway path had drifted from it. Every fix re-verified against current `plugins/platforms/irc/adapter.py` before implementing.

Test file: 19 new tests added; full `tests/gateway/test_irc_adapter.py` passes (63 total, was 44). `tests/gateway/test_config_driven_access_policy.py` still passes (the access-policy change rides the existing `enforces_own_access_policy` contract).

## 1. Identity lock guard was dead code — two profiles could share one IRC nick

Symptom: two gateway profiles configured with the same `server:nickname` both connect, producing dueling bots, 433 nick collisions, and split/double-processed responses on one identity.

Root cause: `connect()` guarded with `if not acquire_scoped_lock("irc", lock_key):`. `acquire_scoped_lock` returns `tuple[bool, Optional[dict]]`, never a bare bool. A non-empty tuple is always truthy, so `not (...)` is always `False` — including the conflict case `(False, {...})`. The conflict branch (log + `_set_fatal_error(... retryable=False)` + `return False`) was unreachable. The lock file was still written as a side effect, so the result looked plausible while silently letting a second instance through.

Fix: route through the inherited `_acquire_platform_lock("irc", lock_key, ...)`, which unpacks `(acquired, existing)`, logs the owning PID, and escalates a non-retryable `irc_lock` fatal error on conflict — matching Telegram/Signal/Discord. Release switched to `_release_platform_lock()`. Note: the base helper escalates the code `<scope>_lock` (i.e. `irc_lock`); the old inline code used a cosmetic `lock_conflict` string that the base never emits — corrected in passing.

## 2. config.yaml `allowed_users` was silently default-denied at the gateway

Symptom: an operator who sets `allowed_users` in config.yaml (with no `IRC_ALLOWED_USERS` env var) has every message dropped, even from a listed nick. The docstring also claimed `allowed_users: []` means "allow all" — false.

Root cause: the adapter reads `extra.allowed_users` and filters inline in `_handle_line`, but the gateway's `_is_user_authorized` only consults the `IRC_ALLOWED_USERS` env var. With no env allowlist, the gateway hits its "no allowlists configured" branch and, because IRC did not override `enforces_own_access_policy` (default `False`), falls through to `GATEWAY_ALLOW_ALL_USERS` (default false) → deny. The two access layers were wired to different config sources.

Fix: override `enforces_own_access_policy` to `return bool(self._allowed_users_lower)`. This is fail-open-safe: the adapter claims to own its access policy only when the allowlist is non-empty (so the gateway trusts the intake check it already passed); an empty `allowed_users` returns `False` and falls through to the gateway default-deny — an empty list must never silently allow every IRC user. The misleading docstring is corrected to describe the deny-by-default behavior. A regression test asserts that with `allowed_users=[]` and no env allowlist an arbitrary user is denied at `_is_user_authorized`, and that a populated list is trusted.

## 3. Permanent auth/ban rejections (464/465/ERROR) retried forever

Symptom: a wrong server password or a server ban causes the gateway to reconnect indefinitely on the 30s→300s backoff, burning a full 30s registration timeout every cycle and, on a ban, escalating the server's penalty.

Root cause: `_handle_line` dispatched only PING, 001, 433, PRIVMSG, NICK. It had no handler for 464 (ERR_PASSWDMISMATCH), 465 (ERR_YOUREBANNEDCREEP), or a bare `ERROR`. On these the server closes the socket; the receive loop hits EOF before `_mark_connected`, so its `finally` guard sets nothing, while `connect()` is still blocked on the registration wait and then escalates a *retryable* `registration_timeout`. `retryable=True` keeps the reconnect watcher retrying unfixable credentials.

Fix: handle 464/465 → `_set_fatal_error("auth_rejected"/"banned", retryable=False)`, and a bare `ERROR` while unregistered → `_set_fatal_error("server_error", retryable=False)`; each sets `_registration_event` to unblock `connect()`. After the wait, `connect()` inspects `has_fatal_error` and returns `False`, preserving the non-retryable classification so the reconnect watcher drops the platform. A post-registration `ERROR` is left to the receive-loop EOF path (normal connection loss). This mirrors the 464/465 handling the standalone cron path already had.

## 4. JOIN was never confirmed — channel-join failures black-holed every send

Symptom: when the configured channel rejects the JOIN (+i invite-only, +k key, +l full, ban, no-such-channel), the adapter still marks itself connected and logs "joined". Subsequent channel sends issue PRIVMSG to a channel the bot is not in; on default `+n` networks the server silently drops them, yet `send()` returns success.

Root cause: `connect()` issued `JOIN` then immediately `_mark_connected()` without reading the response, and `_handle_line` ignored JOIN-result numerics entirely.

Fix: add `_join_event`/`_join_error`; after `JOIN`, wait (10s) for the own JOIN echo / RPL_ENDOFNAMES (366) before `_mark_connected()`, and handle 403/405/471/473/474/475 by recording the rejection and escalating a non-retryable `join_failed`. A missing ack within the window logs a warning and proceeds (some servers are slow); an explicit rejection aborts. Reuses the numeric set the standalone path already rejects.

## 5. send() reported success for lines silently dropped mid-send

Symptom: if the TCP/TLS connection drops after `send()`'s initial guard — e.g. after the first line of a multi-line message, during the 0.3s rate-limit sleep — the remaining lines are discarded but `send()` still returns `success=True` with a fabricated `message_id`, and never sets `retryable`, so the base layer cannot re-deliver.

Root cause: `_send_raw` early-returned silently (no exception) when the writer was gone, and `send()` only checked connection state once at the top.

Fix: `_send_raw` now returns `bool` (`False` when the writer is gone/closing). `send()` checks the return per line and bails with `SendResult(success=False, error="connection lost during send", retryable=True)`; exceptions in the loop are now also marked `retryable=True`. Lifecycle callers (PING/PONG, JOIN, NICK) ignore the return as before.

## 6. Inbound '+' and '!' channels misrouted as DMs, bypassing the require-mention gate

Symptom: messages in RFC 2811 `+` (no-modes) and `!` (safe) channels were treated as DMs — replies went to the *sender's nick* instead of the channel, and every message in those channels was dispatched even when it did not address the bot, defeating the channel require-mention behavior.

Root cause: the inbound path used `target.startswith("#") or target.startswith("&")`, missing `+` and `!`. The adapter's own `_is_irc_channel` helper (used by the outbound JOIN decision) already covers the full `"#&+!"` set, so the two paths were inconsistent.

Fix: use `_is_irc_channel(target)` in `_handle_line` and `_is_irc_channel(chat_id)` in `get_chat_info`, so inbound classification matches the outbound JOIN decision and `+`/`!` channels route as channels and pass through the require-mention gate.

## 7. No edit API, but SUPPORTS_MESSAGE_EDITING defaulted True — broken streaming bubble

Symptom: during streaming the first PRIVMSG line is sent ending in a literal cursor character; the next frame's edit fails (IRC has no edit primitive), the consumer enters fallback and re-delivers the full answer, and the cursor-strip is itself a failing edit — so the user sees a broken first line plus a duplicate message.

Root cause: `SUPPORTS_MESSAGE_EDITING` resolves via `getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True)`, so the IRC adapter (no override, no `edit_message`) defaulted to `True` and the streaming path assumed in-place edits.

Fix: declare `SUPPORTS_MESSAGE_EDITING = False` on `IRCAdapter`, matching Signal. Streaming then suppresses the cursor and the edit attempts and uses the no-edit path.

## Dropped findings

A couple of findings from the audit were scoped out of this PR to keep its surface focused.

## Overlap

These fixes are confined to `connect()`/`disconnect()`, `_handle_line`, `get_chat_info`, `send()`/`_send_raw`, and the `enforces_own_access_policy`/`SUPPORTS_MESSAGE_EDITING` class attributes. The open IRC PRs #4676 (a separate core implementation under `gateway/platforms/`) and #30333 (default-port selection) touch different code and do not overlap.
