### PR TITLE
fix(google_chat): 8 independently-verified inbound/outbound correctness bugs

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -38,8 +38,10 @@ CARD_CLICKED is ACK'd only in v1 (follow-up PR implements interactivity).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
+import mimetypes
 import os
 import random
 import re
@@ -887,6 +889,23 @@ class GoogleChatAdapter(BasePlatformAdapter):
             self._set_fatal_error(code="subscription_check", message=msg, retryable=True)
             return False
 
+        # Single-instance guard. Pub/Sub load-balances a subscription's
+        # message stream across every subscriber, so two gateway processes
+        # pulling the same subscription split inbound events and BOTH post
+        # typing cards / replies (the dedup cache and thread-count store are
+        # per-process, so state is split-brained). Mirror the push/poll
+        # siblings (Slack Socket Mode, Telegram long-polling, Discord, QQBot),
+        # which all acquire a single-instance lock on connect. Scope the
+        # identity to the subscription path so two gateways on DIFFERENT
+        # subscriptions can coexist. On conflict, _acquire_platform_lock sets
+        # a non-retryable fatal error.
+        if not self._acquire_platform_lock(
+            "google_chat-subscription",
+            subscription_path,
+            "Google Chat Pub/Sub subscription",
+        ):
+            return False
+
         # Resolve bot user_id (eager): cache first, then members.list.
         self._bot_user_id = self._load_cached_bot_id()
         if not self._bot_user_id:
@@ -935,6 +954,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             except Exception:
                 pass
             self._subscriber = None
+        self._release_platform_lock()
         self._mark_disconnected()
         logger.info("[GoogleChat] Disconnected")
 
@@ -947,6 +967,18 @@ class GoogleChatAdapter(BasePlatformAdapter):
         ``subscribe()`` returns a concurrent.futures.Future that resolves when
         the stream dies. We await ``future.result()`` in a worker thread and
         react to exceptions.
+
+        This task is created at the END of ``connect()``, AFTER
+        ``_mark_connected()`` has already returned True to the gateway, so a
+        permanently-dead stream is invisible to the startup connect path.
+        ``_set_fatal_error`` only flips ``_running`` and writes a status file;
+        it does NOT notify the gateway. The gateway's only post-startup
+        recovery hook is ``_notify_fatal_error()`` ->
+        ``GatewayRunner._handle_adapter_fatal_error()``, which disconnects the
+        dead adapter and requeues retryable failures. Each fatal return path
+        therefore awaits ``_notify_fatal_error()`` so a revoked SA key or
+        sustained outage hands the adapter to that recovery policy instead of
+        silently going dead (mirrors plugins/platforms/irc/adapter.py).
         """
         attempt = 0
         while not self._shutting_down:
@@ -977,6 +1009,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
                     message="Pub/Sub authentication failed (SA key invalid/revoked)",
                     retryable=False,
                 )
+                await self._notify_fatal_error()
                 return
             except gax_exceptions.PermissionDenied:
                 self._set_fatal_error(
@@ -984,6 +1017,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
                     message="SA lacks pubsub.subscriber on the subscription",
                     retryable=False,
                 )
+                await self._notify_fatal_error()
                 return
             except Exception as exc:
                 attempt += 1
@@ -1000,6 +1034,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
                         message=f"Pub/Sub reconnect failed {attempt} times; giving up",
                         retryable=False,
                     )
+                    await self._notify_fatal_error()
                     return
                 delay = min(
                     self._RECONNECT_MAX_DELAY,
@@ -1127,6 +1162,42 @@ class GoogleChatAdapter(BasePlatformAdapter):
 
         return None
 
+    @staticmethod
+    def _relay_dedup_surrogate(
+        msg: Dict[str, Any], space: Dict[str, Any]
+    ) -> str:
+        """Deterministic dedup key for relay events that carry no resource name.
+
+        The native and workspace-addons formats always carry a real Chat
+        resource name; the relay format only forwards ``message_name`` when
+        the relay chooses to. When it is absent, ``msg['name']`` is empty and
+        the caller's dedup guard would be skipped entirely, so a Pub/Sub
+        redelivery re-dispatches the message and the agent processes it twice.
+
+        Hashes the stable parts of the event — sender surrogate, space,
+        thread, and text — so a redelivery of the same relay message produces
+        the same key and is suppressed by the dedup cache. Returns ``""`` when
+        there is nothing identifying to hash.
+
+        Caveat: the relay envelope provides no per-event id or timestamp at
+        this call site, so the key is content-derived. Two genuinely distinct
+        relay messages with identical text from the same sender in the same
+        thread within the dedup TTL window collapse to one. This is the best
+        available surrogate for redelivery suppression on the relay path.
+        """
+        sender = msg.get("sender") or {}
+        thread = msg.get("thread") or {}
+        parts = [
+            sender.get("name") or sender.get("email") or "",
+            space.get("name") or "",
+            thread.get("name") or "",
+            msg.get("text") or msg.get("argumentText") or "",
+        ]
+        if not any(parts):
+            return ""
+        digest = hashlib.sha256("\x00".join(parts).encode("utf-8")).hexdigest()
+        return f"relay-content:{digest}"
+
     def _on_pubsub_message(self, message: Any) -> None:
         """Pub/Sub callback — parse envelope and dispatch to asyncio loop.
 
@@ -1229,8 +1300,17 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 message.ack()
                 return
 
-            # Dedup guard — Pub/Sub is at-least-once.
+            # Dedup guard — Pub/Sub is at-least-once. The native and
+            # workspace-addons formats always carry a real resource name. The
+            # relay format only carries ``message_name`` when the relay
+            # forwards it; when it is absent the dict-level ``name`` is empty
+            # and the guard would be skipped, so a redelivery re-dispatches
+            # the message and the agent processes it twice. Fall back to a
+            # deterministic content-hash surrogate so the relay path still
+            # dedups (see _relay_dedup_surrogate for the surrogate's caveat).
             msg_name = msg.get("name") or ""
+            if not msg_name:
+                msg_name = self._relay_dedup_surrogate(msg, space)
             if msg_name and self._dedup.is_duplicate(msg_name):
                 logger.debug("[GoogleChat] Dedup drop for %s", msg_name)
                 message.ack()
@@ -1566,9 +1646,27 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 continue
             media_urls.append(local_path)
             media_types.append(mime or "application/octet-stream")
-            # Prefer the first-seen type for MessageType if no text present.
-            if message_type == MessageType.TEXT and not text:
-                message_type = _mime_for_message_type(mime or "")
+
+        # Classify the message type from the attachment set, independent of
+        # whether a caption rides along. The gateway's document-forwarding
+        # block (gateway/run.py) is gated strictly on
+        # ``message_type == MessageType.DOCUMENT`` with no MIME fallback, so a
+        # document/PDF/zip attached WITH a caption used to stay TEXT and be
+        # dropped from the agent's view (only the empty-caption case worked).
+        # Images and audio route on their own MIME prefix downstream, so the
+        # message-level type only matters for the DOCUMENT path: prefer
+        # DOCUMENT whenever any attachment is a non-media file (covers the
+        # mixed image+PDF case where the PDF would otherwise be invisible);
+        # otherwise fall back to the first attachment's media type. The
+        # caption flows through unchanged as ``text``.
+        if media_types:
+            attachment_types = [
+                _mime_for_message_type(m or "") for m in media_types
+            ]
+            if MessageType.DOCUMENT in attachment_types:
+                message_type = MessageType.DOCUMENT
+            else:
+                message_type = attachment_types[0]
 
         if is_slash:
             message_type = MessageType.COMMAND
@@ -1665,6 +1763,13 @@ class GoogleChatAdapter(BasePlatformAdapter):
         mime = attachment.get("contentType") or ""
         source = attachment.get("source") or ""
         name = attachment.get("name") or ""
+        # ``name`` is the RESOURCE name (spaces/S/messages/M/attachments/A) —
+        # an opaque id with no extension. ``contentName`` is the
+        # human-readable filename (e.g. report.pdf). Prefer it so the cached
+        # file keeps its real extension; without it cache_document_from_bytes
+        # stores an extensionless blob and gateway/run.py's extension-based
+        # MIME/text classification (and the agent-facing display name) breaks.
+        content_name = (attachment.get("contentName") or "").strip()
         attachment_data_ref = attachment.get("attachmentDataRef") or {}
         resource_name = attachment_data_ref.get("resourceName") or ""
         download_uri = attachment.get("downloadUri") or ""
@@ -1744,7 +1849,12 @@ class GoogleChatAdapter(BasePlatformAdapter):
 
         # Cache based on MIME. Upstream's cache_* helpers expect `ext` for
         # media (image/audio/video) and a positional `filename` for docs.
-        filename = name.split("/")[-1] if name else "attachment"
+        # Prefer the real filename from contentName; fall back to the last
+        # segment of the resource name only when contentName is absent.
+        if content_name:
+            filename = content_name
+        else:
+            filename = name.split("/")[-1] if name else "attachment"
         if "." in filename:
             ext = "." + filename.rsplit(".", 1)[-1].lower()
         else:
@@ -1849,7 +1959,19 @@ class GoogleChatAdapter(BasePlatformAdapter):
                                 "[GoogleChat] Rate limit hit %d times on chat; throttling",
                                 self._rate_limit_hits[chat_id],
                             )
-                        raise
+                        # Return the structured SendResult that every other
+                        # status class returns instead of re-raising a bare
+                        # HttpError out of send(). Callers (gateway/run.py)
+                        # only inspect ``result.success``; an unhandled raise
+                        # here drops the message past the success=False
+                        # handling/logging path. retryable=True lets base.py
+                        # apply its transient-error retry policy
+                        # (SendResult.retryable contract, base.py).
+                        return SendResult(
+                            success=False,
+                            error=_redact_sensitive(str(exc)),
+                            retryable=True,
+                        )
                     raise
             if last_result is None:
                 return SendResult(success=False, error="empty message")
@@ -1968,27 +2090,30 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 .execute(http=self._new_authed_http())
             )
 
-        resp = await asyncio.to_thread(_do_patch)
+        # Route through the bounded-retry helper so a transient 429/5xx on the
+        # typing-card patch path (send()'s first chunk) is retried rather than
+        # surfaced as a single hard failure. _call_with_retry re-raises
+        # non-retryable HttpErrors on the first attempt, so the 403/404/429
+        # handling in send() and edit_message() is preserved.
+        resp = await self._call_with_retry(_do_patch, op_name="messages.patch")
         return SendResult(success=True, message_id=resp.get("name", message_name))
 
     def _chunk_text(self, text: str) -> List[str]:
+        """Split a long message into chunks, preserving code-fence boundaries.
+
+        Delegates to ``BasePlatformAdapter.truncate_message`` (the same helper
+        Discord/Slack/Mattermost use). The previous newline/hard-cut split was
+        fence-unaware: when a triple-backtick block straddled the boundary, the
+        opening ``` landed in chunk N and the closing ``` in chunk N+1, so
+        Google Chat rendered chunk N as an unterminated monospace block (all
+        following text became code) and chunk N+1 as plain text with a stray
+        trailing fence. ``truncate_message`` closes the fence at the end of a
+        chunk and reopens it (with the original language tag) at the start of
+        the next, and appends ``(i/N)`` indicators.
+        """
         if not text:
             return []
-        if len(text) <= _MAX_TEXT_LENGTH:
-            return [text]
-        chunks: List[str] = []
-        remaining = text
-        while remaining:
-            if len(remaining) <= _MAX_TEXT_LENGTH:
-                chunks.append(remaining)
-                break
-            # Try to split on a newline near the cutoff.
-            cut = remaining.rfind("\n", 0, _MAX_TEXT_LENGTH)
-            if cut < _MAX_TEXT_LENGTH // 2:
-                cut = _MAX_TEXT_LENGTH
-            chunks.append(remaining[:cut])
-            remaining = remaining[cut:].lstrip()
-        return chunks
+        return self.truncate_message(text, self.MAX_MESSAGE_LENGTH)
 
     # ------------------------------------------------------------------
     # Outbound formatting
@@ -2504,9 +2629,14 @@ class GoogleChatAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         **kwargs: Any,
     ) -> SendResult:
+        # Pass mime_hint=None and let _send_file resolve a CONCRETE type
+        # (image/png, image/jpeg, …) from the extension. "image/*" is a
+        # wildcard range, not a valid Content-Type; googleapiclient would
+        # forward it verbatim and tag the Chat attachment "image/*", which is
+        # invalid and can block inline rendering / be rejected by media.upload.
         return await self._send_file(
             chat_id, image_path, caption,
-            mime_hint="image/*",
+            mime_hint=None,
             thread_id=self._resolve_thread_id(reply_to, kwargs.get("metadata"), chat_id=chat_id),
         )
 
@@ -2748,7 +2878,16 @@ class GoogleChatAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=f"file not found: {path}")
 
         filename = override_filename or os.path.basename(path) or "upload.bin"
-        mime = mime_hint or "application/octet-stream"
+        # Resolve a CONCRETE MIME. A wildcard range (e.g. "image/*") is not a
+        # valid Content-Type and gets forwarded verbatim by googleapiclient,
+        # tagging the resulting Chat attachment invalidly. When the hint is
+        # missing or a wildcard, guess from the (override) filename so e.g. a
+        # .png uploads as image/png and a .pdf as application/pdf; fall back
+        # to application/octet-stream only when the guess fails.
+        mime = mime_hint or ""
+        if not mime or mime.endswith("/*"):
+            guessed, _ = mimetypes.guess_type(override_filename or path)
+            mime = guessed or "application/octet-stream"
 
         sender_email = self._last_sender_by_chat.get(chat_id)
         chat_api, identity = await self._acquire_user_chat_api(sender_email)

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -407,17 +407,37 @@ class TestChunkText:
         text = "a" * 10000
         chunks = adapter._chunk_text(text)
         assert len(chunks) >= 2
-        assert all(len(c) <= 4000 for c in chunks)
-        assert "".join(chunks) == text
+        # Each chunk (including the appended "(i/N)" indicator) fits the limit.
+        assert all(len(c) <= adapter.MAX_MESSAGE_LENGTH for c in chunks)
+        # All of the original body survives across the chunks.
+        assert "".join(chunks).count("a") == 10000
 
     def test_splits_on_newline_near_boundary(self, adapter):
-        # Build a ~5000-char string with a newline near the 4000 cut.
+        # Build a ~5300-char string with a newline near the 4000 cut.
         text = "a" * 3800 + "\n" + "b" * 1500
         chunks = adapter._chunk_text(text)
         assert len(chunks) == 2
-        # First chunk ends at the newline (3800 a's, no trailing b's)
-        assert chunks[0].endswith("a")
-        assert "\n" not in chunks[0][-5:]  # the split already ate the newline
+        assert all(len(c) <= adapter.MAX_MESSAGE_LENGTH for c in chunks)
+        # The split prefers the newline, so the run of a's lands in chunk 0
+        # and the run of b's in chunk 1 (modulo the "(i/N)" indicator).
+        assert "a" in chunks[0] and "b" not in chunks[0]
+        assert "b" in chunks[1]
+
+    def test_code_fence_is_carried_across_chunks(self, adapter):
+        """Regression: a fenced code block larger than the chunk size must
+        not split with the opening ``` in chunk N and the closing ``` in
+        chunk N+1 (which renders chunk N as an unterminated monospace block
+        in Google Chat). truncate_message closes-and-reopens the fence with
+        the original language tag, so every chunk has balanced fences."""
+        body = "\n".join(f"line_{i:04d} = {i}" for i in range(600))
+        text = f"```python\n{body}\n```"
+        chunks = adapter._chunk_text(text)
+        assert len(chunks) >= 2
+        for chunk in chunks:
+            # Balanced fences in every chunk: even number of ``` markers.
+            assert chunk.count("```") % 2 == 0
+        # The language tag is reopened on the continuation chunk(s).
+        assert "```python" in chunks[1]
 
 
 # ===========================================================================
@@ -550,6 +570,29 @@ class TestOnPubsubMessage:
             adapter._on_pubsub_message(msg)
             submit.assert_called_once()
         msg.ack.assert_called_once()
+
+    def test_relay_redelivery_without_message_name_is_deduped(self, adapter):
+        """Regression: a relay (format 3) event that omits message_name has an
+        empty dict-level ``name``. Pub/Sub is at-least-once, so a redelivery
+        must still be suppressed via the content-hash surrogate — otherwise
+        the agent processes the same message twice."""
+        envelope = {
+            "event_type": "MESSAGE",
+            "sender_email": "alice@example.com",
+            "text": "do the thing",
+            "space_name": "spaces/RELAY",
+            "thread_name": "spaces/RELAY/threads/T",
+            # NOTE: no "message_name" — the dict-level name is empty.
+        }
+        first = _make_pubsub_message(envelope)
+        second = _make_pubsub_message(envelope)
+        with patch.object(adapter, "_submit_on_loop") as submit:
+            adapter._on_pubsub_message(first)
+            adapter._on_pubsub_message(second)
+            # First dispatches; the redelivery is dropped by the surrogate.
+            assert submit.call_count == 1
+        first.ack.assert_called_once()
+        second.ack.assert_called_once()
 
     def test_callback_exception_does_not_escape(self, adapter):
         env = _make_chat_envelope(text="hola")
@@ -884,6 +927,53 @@ class TestBuildMessageEvent:
         # With no text, the message type should reflect the first attachment.
         assert event.message_type == MessageType.PHOTO
 
+    @pytest.mark.asyncio
+    async def test_document_with_caption_is_classified_document(self, adapter):
+        """Regression: a document attached WITH a caption must still classify
+        as MessageType.DOCUMENT. The gateway's document-forwarding block is
+        gated strictly on DOCUMENT with no MIME fallback, so the old
+        ``and not text`` guard left a captioned PDF as TEXT and the agent
+        never learned the file existed."""
+        attachments = [{
+            "name": "spaces/S/messages/M/attachments/A",
+            "contentName": "report.pdf",
+            "contentType": "application/pdf",
+        }]
+        env = _make_chat_envelope(text="here is the report", attachments=attachments)
+        msg = env["chat"]["messagePayload"]["message"]
+        with patch.object(
+            adapter, "_download_attachment",
+            new=AsyncMock(return_value=("/cache/report.pdf", "application/pdf")),
+        ):
+            event = await adapter._build_message_event(msg, env)
+        assert event.media_urls == ["/cache/report.pdf"]
+        assert event.message_type == MessageType.DOCUMENT
+        # The caption still flows through as the message text.
+        assert event.text == "here is the report"
+
+    @pytest.mark.asyncio
+    async def test_mixed_attachments_prefer_document(self, adapter):
+        """Image + PDF in one message: the message type must be DOCUMENT so
+        the PDF reaches the agent (images route on their own MIME prefix
+        downstream regardless of message_type, but the document note keys on
+        message_type == DOCUMENT)."""
+        attachments = [
+            {"name": "a/img", "contentName": "pic.png", "contentType": "image/png"},
+            {"name": "a/doc", "contentName": "report.pdf", "contentType": "application/pdf"},
+        ]
+        env = _make_chat_envelope(text="", attachments=attachments)
+        msg = env["chat"]["messagePayload"]["message"]
+
+        async def _fake_download(att):
+            if att["contentType"].startswith("image/"):
+                return ("/cache/pic.png", "image/png")
+            return ("/cache/report.pdf", "application/pdf")
+
+        with patch.object(adapter, "_download_attachment", new=_fake_download):
+            event = await adapter._build_message_event(msg, env)
+        assert event.media_urls == ["/cache/pic.png", "/cache/report.pdf"]
+        assert event.message_type == MessageType.DOCUMENT
+
 
 # ===========================================================================
 # send() — text, patch-in-place, chunking, error handling
@@ -997,11 +1087,18 @@ class TestSend:
         assert "not found" in (result.error or "")
 
     @pytest.mark.asyncio
-    async def test_429_increments_rate_limit_counter_and_raises(self, adapter):
+    async def test_429_returns_retryable_send_result(self, adapter):
+        """A 429 must return a structured SendResult(success=False,
+        retryable=True) — matching the 403/404 branches — NOT re-raise a bare
+        HttpError out of send(). Callers (gateway/run.py) only inspect
+        result.success; an unhandled raise drops the message past the
+        success=False handling/logging path, and retryable=True lets base.py
+        apply its transient-error retry policy."""
         exc = _FakeHttpError(status=429, reason="Too Many Requests")
         adapter._create_message = AsyncMock(side_effect=exc)
-        with pytest.raises(_FakeHttpError):
-            await adapter.send("spaces/S", "hola")
+        result = await adapter.send("spaces/S", "hola")
+        assert result.success is False
+        assert result.retryable is True
         assert adapter._rate_limit_hits.get("spaces/S") == 1
 
 
@@ -1396,6 +1493,47 @@ class TestNativeAttachmentDelivery:
         assert body_passed["attachment"][0]["attachmentDataRef"] == {
             "resourceName": "ref-abc"
         }
+
+    @pytest.mark.asyncio
+    async def test_send_image_uploads_concrete_mime_not_wildcard(
+        self, adapter, tmp_path, monkeypatch
+    ):
+        """Regression: send_image_file must upload a CONCRETE Content-Type
+        (image/png) resolved from the extension, never the wildcard range
+        ``image/*`` (which googleapiclient forwards verbatim, tagging the
+        Chat attachment invalidly and blocking inline rendering)."""
+        f = tmp_path / "diagram.png"
+        f.write_bytes(b"\x89PNG\r\n")
+
+        captured = {}
+        from plugins.platforms.google_chat import adapter as gc_mod
+
+        def _fake_media_upload(path, mimetype=None, resumable=False):
+            captured["mimetype"] = mimetype
+            return MagicMock()
+
+        monkeypatch.setattr(
+            gc_mod, "MediaFileUpload", _fake_media_upload, raising=False,
+        )
+
+        upload_call = MagicMock()
+        upload_call.return_value.execute = MagicMock(
+            return_value={"attachmentDataRef": {"resourceName": "ref-xyz"}}
+        )
+        create_call = MagicMock()
+        create_call.return_value.execute = MagicMock(
+            return_value={"name": "spaces/S/messages/MID"}
+        )
+        adapter._user_chat_api = MagicMock()
+        adapter._user_chat_api.media.return_value.upload = upload_call
+        adapter._user_chat_api.spaces.return_value.messages.return_value.create = create_call
+        adapter._user_credentials = MagicMock(valid=True)
+        adapter._consume_typing_card_with_text = AsyncMock(return_value=None)
+
+        result = await adapter.send_image_file("spaces/S", str(f), caption=None)
+        assert result.success is True
+        assert captured["mimetype"] == "image/png"
+        assert not (captured["mimetype"] or "").endswith("/*")
 
     @pytest.mark.asyncio
     async def test_send_file_falls_back_to_notice_on_401(self, adapter, tmp_path):
@@ -2162,6 +2300,44 @@ class TestAttachmentSSRFGuard:
         assert mime == "application/pdf"
 
     @pytest.mark.asyncio
+    async def test_document_cached_with_contentName_not_resource_name(
+        self, adapter, tmp_path, monkeypatch
+    ):
+        """Regression: the cached document filename must come from
+        ``contentName`` (the real filename, e.g. report.pdf), NOT the opaque
+        resource ``name``. Caching under the resource name strips the
+        extension, breaking gateway/run.py's extension-based MIME/text
+        classification and the agent-facing display name."""
+        attachment = {
+            "contentType": "application/pdf",
+            "name": "spaces/S/messages/M/attachments/AABBCC",
+            "contentName": "quarterly_report.pdf",
+            "attachmentDataRef": {
+                "resourceName": "spaces/S/messages/M/attachments/AABBCC",
+            },
+        }
+
+        async def _fake_to_thread(fn, *args, **kwargs):
+            return b"%PDF-fake"
+
+        monkeypatch.setattr(asyncio, "to_thread", _fake_to_thread)
+        captured = {}
+        from plugins.platforms.google_chat import adapter as gc_mod
+
+        def _cache_doc(data, filename=None, ext=None):
+            captured["filename"] = filename
+            return str(tmp_path / "out")
+
+        monkeypatch.setattr(
+            gc_mod, "cache_document_from_bytes", _cache_doc, raising=False,
+        )
+
+        path, mime = await adapter._download_attachment(attachment)
+        assert path == str(tmp_path / "out")
+        # Real filename (with extension) used, not the opaque resource id.
+        assert captured["filename"] == "quarterly_report.pdf"
+
+    @pytest.mark.asyncio
     async def test_rejects_non_google_host(self, adapter):
         attachment = {
             "contentType": "image/png",
@@ -2633,6 +2809,44 @@ class TestSupervisorReconnect:
         await adapter._run_supervisor()
         assert adapter.has_fatal_error is True
         assert adapter.fatal_error_code == "pubsub_reconnect_exhausted"
+
+    @pytest.mark.asyncio
+    async def test_reconnect_exhausted_notifies_gateway(self, adapter, monkeypatch):
+        """Regression: a permanently-dead stream must call _notify_fatal_error
+        so GatewayRunner._handle_adapter_fatal_error() can disconnect/requeue
+        the adapter. Without it the adapter stays in the gateway's table with
+        is_connected==False and recovery needs a manual restart."""
+        async def _instant(*args, **kwargs):
+            return None
+        monkeypatch.setattr(
+            "plugins.platforms.google_chat.adapter.asyncio.sleep", _instant
+        )
+        adapter._subscriber.subscribe = MagicMock(
+            side_effect=RuntimeError("stream died")
+        )
+        notified = []
+        adapter.set_fatal_error_handler(lambda a: notified.append(a))
+
+        await adapter._run_supervisor()
+        assert adapter.fatal_error_code == "pubsub_reconnect_exhausted"
+        assert notified == [adapter]
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_notifies_gateway(self, adapter):
+        """A revoked/invalid SA key (Unauthenticated) is non-retryable and
+        must escalate to the gateway via _notify_fatal_error, not just flip
+        the local _running flag."""
+        from plugins.platforms.google_chat import adapter as gc_mod
+
+        adapter._subscriber.subscribe = MagicMock(
+            side_effect=gc_mod.gax_exceptions.Unauthenticated("revoked")
+        )
+        notified = []
+        adapter.set_fatal_error_handler(lambda a: notified.append(a))
+
+        await adapter._run_supervisor()
+        assert adapter.fatal_error_code == "pubsub_auth"
+        assert notified == [adapter]
 
 
 # ===========================================================================


### PR DESCRIPTION
## fix(google_chat): 8 independently-verified inbound/outbound correctness bugs

This fixes **8 independently-verified bugs** in the Google Chat adapter, each with its own red→green regression test. Every bug was re-verified against the current adapter source before implementing. Three findings that all described the same captioned-document misclassification (document+caption stays TEXT, and the mixed multi-attachment variant) were collapsed into a single classification fix — see Overlap.

Touched files: `plugins/platforms/google_chat/adapter.py`, `tests/gateway/test_google_chat.py`.

---

### 1. A permanently-dead Pub/Sub stream silently killed the adapter (no gateway escalation)

**Symptom:** After an SA key revocation or a sustained outage, Google Chat went silently dead — inbound messages stopped being pulled, the platform was never requeued for reconnection, and recovery required a full manual gateway restart.

**Root cause:** `_run_supervisor()` is created at the end of `connect()`, *after* `_mark_connected()` has already returned True to the gateway. On a permanent failure (`gax_exceptions.Unauthenticated`, `gax_exceptions.PermissionDenied`, or transient reconnects exhausted) it called `_set_fatal_error(..., retryable=False)` and returned. `_set_fatal_error` only flips `_running` and writes a status file; it does **not** notify the gateway. The only post-startup recovery hook is `_notify_fatal_error()` → `GatewayRunner._handle_adapter_fatal_error()`, which disconnects the dead adapter and requeues retryable failures. No runtime health poll inspects an already-connected adapter's `_running`/`has_fatal_error`, so once the supervisor returned the adapter sat in the gateway's table with `is_connected == False` forever.

**Fix:** `await self._notify_fatal_error()` after each `_set_fatal_error()` in the supervisor's three fatal return paths, mirroring `plugins/platforms/irc/adapter.py`, which sets the fatal error and then notifies. This hands the dead adapter to the documented gateway-level recovery policy.

---

### 2. `_chunk_text` split code fences mid-block, breaking Google Chat markdown rendering

**Symptom:** Any long code reply rendered broken: chunk N became an unterminated monospace block (everything after the opening fence became code) and chunk N+1 was plain text with a stray trailing ```` ``` ````.

**Root cause:** `send()` runs `format_message()` (which deliberately preserves triple-backtick fenced blocks) and then chunked with the adapter's own `_chunk_text()`, which only split on the last newline before the 4000-char boundary (or hard-cut) and had no awareness of code fences. When a block exceeded the chunk size, the opening ```` ``` ```` landed in one chunk and the closing ```` ``` ```` in the next. Every sibling text adapter (Discord, Mattermost, Slack) instead uses `BasePlatformAdapter.truncate_message()`, which closes-and-reopens the fence with the original language tag.

**Fix:** Delegate `_chunk_text` to `self.truncate_message(text, self.MAX_MESSAGE_LENGTH)`. Each chunk now has balanced fences, the continuation chunk reopens the fence with the original language tag, and multi-chunk responses get `(i/N)` indicators — matching the sibling adapters.

---

### 3. `send()` raised `HttpError` on HTTP 429 instead of returning `SendResult(success=False)`

**Symptom:** A 429 during `send()` raised a bare `HttpError` out to callers (e.g. `gateway/run.py`) that only inspect `result.success` and do not wrap the call in try/except. The message was dropped past the structured `success=False` logging/handling path that 403/404 get.

**Root cause:** Inside `send()`'s per-chunk `except HttpError`, the 403 and 404 branches return `SendResult(success=False, ...)`, but the 429 branch incremented `_rate_limit_hits` and then `raise`d, escaping the for-loop and the whole `send()`. The first-chunk typing-card patch (`_patch_message`) did not go through `_call_with_retry`, so a single transient 429 there propagated immediately and uncaught.

**Fix:** The 429 branch now returns `SendResult(success=False, error=_redact_sensitive(str(exc)), retryable=True)`, matching the 403/404 branches and the `SendResult.retryable` contract so base.py can apply its transient-error retry policy. `_patch_message` now routes its `.execute()` through `_call_with_retry`, so transient 429/5xx on the typing-card patch path are retried instead of surfaced as a single hard failure; `_call_with_retry` re-raises non-retryable `HttpError`s on the first attempt, preserving the existing 403/404/429 handling in `send()` and `edit_message()`.

---

### 4. Documents/PDFs/zips attached *with* a caption stayed `MessageType.TEXT` and were dropped by the gateway

**Symptom:** A common real case — "here is the report" plus an attached PDF — left the agent unaware a file was sent. The file was downloaded and pushed into `media_urls`/`media_types`, but the agent only received the caption. The same failure occurred for the mixed image+PDF case with no caption: the message classified as PHOTO and the PDF stayed invisible.

**Root cause:** `_build_message_event` only promoted `message_type` from TEXT via `_mime_for_message_type()` when `message_type == MessageType.TEXT and not text`, and only from the **first** attachment. With any caption present, `text` was truthy so a non-image/audio/video attachment stayed TEXT; with multiple attachments, only the first classified. The gateway's document-forwarding block (`gateway/run.py`) is gated strictly on `event.message_type == MessageType.DOCUMENT` with no MIME fallback (unlike the image path, which also accepts `mtype.startswith("image/")`), so the `[The user sent ...]` context note and `to_agent_visible_cache_path` injection were skipped.

**Fix:** Classify `message_type` from the full attachment set after the download loop, independent of whether a caption is present: if any attachment maps to `MessageType.DOCUMENT` the message is classified DOCUMENT (documents are the type that needs the gateway note; images/audio route on their own MIME prefix downstream regardless of `message_type`); otherwise the first attachment's media type is used. Slash commands still override to COMMAND. The caption flows through unchanged as `text`. Mirrors the Telegram convention of classifying by attachment kind and assigning the caption afterward. This single change resolves the captioned-document case, the mixed-attachment case, and the duplicate finding describing the same TEXT-vs-DOCUMENT guard.

---

### 5. Inbound attachment filename taken from the resource `name` instead of `contentName`

**Symptom:** Cached documents were stored as extensionless opaque-id blobs, so `gateway/run.py`'s extension-based MIME/text classification could not recover the type and the agent-facing display name was the opaque id rather than e.g. `report.pdf`. Media branches also fell back to generic `.jpg/.ogg/.mp4` defaults.

**Root cause:** `_download_attachment` derived the cached filename from `attachment.get("name")` — which in the Chat REST API is the **resource** name (`spaces/S/messages/M/attachments/A`), an opaque id with no extension. The human-readable filename is the separate `contentName` field.

**Fix:** Read a dedicated `content_name = attachment.get("contentName")` and prefer it when building `filename`, falling back to the last resource-name segment only when `contentName` is absent. This restores the real extension for media MIME defaults and gives `cache_document_from_bytes` a correctly-named file.

---

### 6. Outbound `send_image_file` uploaded with the wildcard MIME `image/*`

**Symptom:** Image attachments were tagged `image/*` on the wire, which is invalid and can prevent inline image rendering or be rejected by `media.upload`.

**Root cause:** `send_image_file` called `_send_file(..., mime_hint="image/*")`. `_send_file` did no MIME resolution (`mime = mime_hint or "application/octet-stream"`) and passed it straight into `MediaFileUpload(path, mimetype=mime, ...)`; googleapiclient forwards a wildcard range verbatim as the upload part's Content-Type.

**Fix:** `_send_file` now resolves a concrete MIME when `mime_hint` is missing or a wildcard (`""`/`*/*`): it guesses from the (override) filename via `mimetypes.guess_type` and falls back to `application/octet-stream` only when the guess fails. `send_image_file` passes `mime_hint=None` so a `.png` uploads as `image/png`. This also mildly improves `send_document` for known doc types.

---

### 7. `connect()` never acquired a scoped platform lock — two gateways split the Pub/Sub stream

**Symptom:** With two gateway processes against the same subscription, Pub/Sub load-balances the message stream across both; the per-process in-memory dedup and per-instance thread-count store become split-brained, and both instances post "Hermes is thinking…" cards and replies — with no gateway-visible fatal lock error.

**Root cause:** `connect()` built the `SubscriberClient` and started the streaming pull without ever calling `self._acquire_platform_lock(...)`. The module docstring states the design parallels Slack Socket Mode and Telegram long-polling — and every one of those push/poll siblings (Slack, Telegram, Discord, QQBot) acquires a single-instance lock on connect. The reference pattern (`_set_fatal_error` with `retryable=False` on lock conflict) is built into `_acquire_platform_lock` and simply was not used here.

**Fix:** After the subscription sanity check passes and before starting the supervisor, `connect()` calls `_acquire_platform_lock("google_chat-subscription", subscription_path, "Google Chat Pub/Sub subscription")` and returns False on conflict (which sets a non-retryable fatal lock error). The identity is scoped to the subscription path so two gateways on *different* subscriptions can coexist. `disconnect()` releases it via `_release_platform_lock()`.

---

### 8. Relay (format 3) events without `message_name` bypassed dedup entirely on Pub/Sub redelivery

**Symptom:** On the relay path, a Pub/Sub redelivery of the same inbound event re-ran dispatch and the agent processed the user's message twice (duplicate agent turns / duplicate replies).

**Root cause:** `_on_pubsub_message`'s dedup guard only fired when a non-empty resource `name` was present (`if msg_name and self._dedup.is_duplicate(msg_name)`). Native (format 2) and workspace-addons (format 1) always carry a real resource name, but the relay (format 3) path synthesizes `msg["name"] = envelope.get("message_name", "")`, which is empty whenever the relay does not forward `message_name`. With an empty key the dedup branch was skipped entirely, and Pub/Sub is at-least-once.

**Fix:** When the dict-level `name` is empty, fall back to a deterministic content-hash surrogate (`_relay_dedup_surrogate`) keyed on `(sender, space, thread, text)`, so a redelivery of the same relay event produces the same dedup key and is suppressed. **Caveat (documented in the method):** the relay envelope provides no per-event id or timestamp at this call site, so two genuinely distinct relay messages with identical text from the same sender in the same thread within the dedup TTL window will collapse to one. This is a redelivery-suppression surrogate — the best available key on the relay path — not a globally-distinct identity.

---

## Overlap

- **Three findings describe the same root cause** — `_build_message_event` classifying `message_type` only when `not text` and only from the first attachment (document+caption stays TEXT; the mixed image+PDF variant; and a duplicate of the document+caption finding). All are resolved by the single post-loop classification block in §4. No separate code paths.
- The 429 contract fix (§3) and the `_patch_message` retry routing both touch the outbound `send()` path but are independent: one converts a raised 429 into a `SendResult`, the other adds bounded retry to the typing-card patch.
- §5 (contentName) and §4 (classification) both touch the inbound attachment path but are orthogonal: §5 fixes the cached filename/extension, §4 fixes the message-level type.

## Tests

9 new regression tests plus 3 updated existing tests in `tests/gateway/test_google_chat.py` (the three updated tests asserted the old/buggy behavior — the fence-unaware chunker and the 429-raises contract — and now pin the corrected behavior). Each is red on the pre-fix code and green after. Full adapter suite: **160 → 168 passed**.
