### PR TITLE
fix(qqbot): route guild DMs, classify inbound documents, and harden send/connect errors

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -282,12 +282,12 @@ class QQAdapter(BasePlatformAdapter):
         """Authenticate, obtain gateway URL, and open the WebSocket."""
         if not AIOHTTP_AVAILABLE:
             message = "QQ startup failed: aiohttp not installed"
-            self._set_fatal_error("qq_missing_dependency", message, retryable=True)
+            self._set_fatal_error("qq_missing_dependency", message, retryable=False)
             logger.warning("[%s] %s. Run: pip install aiohttp", self._log_tag, message)
             return False
         if not HTTPX_AVAILABLE:
             message = "QQ startup failed: httpx not installed"
-            self._set_fatal_error("qq_missing_dependency", message, retryable=True)
+            self._set_fatal_error("qq_missing_dependency", message, retryable=False)
             logger.warning("[%s] %s. Run: pip install httpx", self._log_tag, message)
             return False
         if not self._app_id or not self._client_secret:
@@ -329,7 +329,13 @@ class QQAdapter(BasePlatformAdapter):
             return True
         except Exception as exc:
             message = f"QQ startup failed: {exc}"
-            self._set_fatal_error("qq_connect_error", message, retryable=True)
+            if self._is_auth_failure(exc):
+                # A 401/403 from the token or gateway-URL fetch means the
+                # app_id/client_secret are wrong; retrying hammers the token
+                # endpoint forever instead of surfacing a fatal config error.
+                self._set_fatal_error("qq_auth_failed", message, retryable=False)
+            else:
+                self._set_fatal_error("qq_connect_error", message, retryable=True)
             logger.error("[%s] %s", self._log_tag, message, exc_info=True)
             await self._cleanup()
             self._release_platform_lock()
@@ -1242,6 +1248,10 @@ class QQAdapter(BasePlatformAdapter):
         image_media_types = att_result["image_media_types"]
         voice_transcripts = att_result["voice_transcripts"]
         attachment_info = att_result["attachment_info"]
+        # Document/file attachments ride the same media_urls list so the event
+        # is classified DOCUMENT and gateway/run.py path-translates them.
+        image_urls = image_urls + att_result["media_urls"]
+        image_media_types = image_media_types + att_result["media_types"]
 
         # Append voice transcripts to the text body
         if voice_transcripts:
@@ -1315,6 +1325,10 @@ class QQAdapter(BasePlatformAdapter):
         image_media_types = att_result["image_media_types"]
         voice_transcripts = att_result["voice_transcripts"]
         attachment_info = att_result["attachment_info"]
+        # Document/file attachments ride the same media_urls list so the event
+        # is classified DOCUMENT and gateway/run.py path-translates them.
+        image_urls = image_urls + att_result["media_urls"]
+        image_media_types = image_media_types + att_result["media_types"]
 
         # Append voice transcripts
         if voice_transcripts:
@@ -1390,6 +1404,10 @@ class QQAdapter(BasePlatformAdapter):
         image_media_types = att_result["image_media_types"]
         voice_transcripts = att_result["voice_transcripts"]
         attachment_info = att_result["attachment_info"]
+        # Document/file attachments ride the same media_urls list so the event
+        # is classified DOCUMENT and gateway/run.py path-translates them.
+        image_urls = image_urls + att_result["media_urls"]
+        image_media_types = image_media_types + att_result["media_types"]
 
         if voice_transcripts:
             voice_block = "\n".join(voice_transcripts)
@@ -1461,6 +1479,10 @@ class QQAdapter(BasePlatformAdapter):
         image_media_types = att_result["image_media_types"]
         voice_transcripts = att_result["voice_transcripts"]
         attachment_info = att_result["attachment_info"]
+        # Document/file attachments ride the same media_urls list so the event
+        # is classified DOCUMENT and gateway/run.py path-translates them.
+        image_urls = image_urls + att_result["media_urls"]
+        image_media_types = image_media_types + att_result["media_types"]
 
         if voice_transcripts:
             voice_block = "\n".join(voice_transcripts)
@@ -1626,6 +1648,13 @@ class QQAdapter(BasePlatformAdapter):
             return MessageType.VIDEO
         if "image" in first_type or "photo" in first_type:
             return MessageType.PHOTO
+        # Generic files (PDFs, spreadsheets, archives, plain text, …) classify
+        # as DOCUMENT so the inbound-document routing in gateway/run.py fires:
+        # it translates the host cache path to the agent-visible path and emits
+        # the "[The user sent a document …]" note. Without this they were only
+        # surfaced as an inline text marker holding the un-translated host path.
+        if first_type.startswith(("application/", "text/")):
+            return MessageType.DOCUMENT
         logger.debug(
             "Unknown media content_type '%s', defaulting to TEXT",
             first_type,
@@ -1653,12 +1682,16 @@ class QQAdapter(BasePlatformAdapter):
                 "image_media_types": [],
                 "voice_transcripts": [],
                 "attachment_info": "",
+                "media_urls": [],
+                "media_types": [],
             }
 
         image_urls: List[str] = []
         image_media_types: List[str] = []
         voice_transcripts: List[str] = []
         other_attachments: List[str] = []
+        media_urls: List[str] = []
+        media_types: List[str] = []
 
         for att in attachments:
             if not isinstance(att, dict):
@@ -1734,6 +1767,14 @@ class QQAdapter(BasePlatformAdapter):
                             other_attachments.append(f"[video: {name} ({cached_path})]")
                         else:
                             other_attachments.append(f"[file: {name} ({cached_path})]")
+                            # Surface generic files (PDFs, docs, archives, …) as
+                            # real media so the event is classified as DOCUMENT
+                            # and gateway/run.py translates the host cache path
+                            # to the agent-visible path. Videos stay text-only:
+                            # the run.py document path only handles
+                            # application/* and text/* MIME types.
+                            media_urls.append(cached_path)
+                            media_types.append(ct or "application/octet-stream")
                 except Exception as exc:
                     logger.debug("[%s] Failed to cache attachment: %s", self._log_tag, exc)
 
@@ -1743,6 +1784,8 @@ class QQAdapter(BasePlatformAdapter):
             "image_media_types": image_media_types,
             "voice_transcripts": voice_transcripts,
             "attachment_info": attachment_info,
+            "media_urls": media_urls,
+            "media_types": media_types,
         }
 
     async def _download_and_cache(
@@ -2338,13 +2381,21 @@ class QQAdapter(BasePlatformAdapter):
                 json=body,
                 timeout=timeout,
             )
-            data = resp.json()
             if resp.status_code >= 400:
+                # Error bodies are not always JSON (CDN/proxy HTML pages,
+                # empty 429s). Read the message defensively so we always
+                # raise the structured RuntimeError downstream callers parse
+                # (e.g. the '40093002' daily-limit biz code in chunked_upload)
+                # instead of leaking a raw JSONDecodeError.
+                try:
+                    err = resp.json()
+                    detail = err.get("message", err) if isinstance(err, dict) else err
+                except Exception:
+                    detail = resp.text[:200]
                 raise RuntimeError(
-                    f"QQ Bot API error [{resp.status_code}] {path}: "
-                    f"{data.get('message', data)}"
+                    f"QQ Bot API error [{resp.status_code}] {path}: {detail}"
                 )
-            return data
+            return resp.json()
         except httpx.TimeoutException as exc:
             raise RuntimeError(f"QQ Bot API timeout [{path}]: {exc}") from exc
 
@@ -2472,18 +2523,19 @@ class QQAdapter(BasePlatformAdapter):
                     return await self._send_group_text(chat_id, content, reply_to)
                 elif chat_type == "guild":
                     return await self._send_guild_text(chat_id, content, reply_to)
+                elif chat_type == "dm":
+                    return await self._send_dm_text(chat_id, content, reply_to)
                 else:
                     return SendResult(
                         success=False, error=f"Unknown chat type for {chat_id}"
                     )
             except Exception as exc:
                 last_exc = exc
-                err = str(exc).lower()
-                # Permanent errors — don't retry
-                if any(
-                        k in err
-                        for k in ("invalid", "forbidden", "not found", "bad request")
-                ):
+                # Permanent errors — don't retry. Classify on the HTTP status
+                # embedded by _api_request ("[<status>]"); QQ returns its
+                # error 'message' in Chinese, so English keyword matching can
+                # never recognize a genuine 4xx.
+                if self._is_permanent_send_error(exc):
                     break
                 # Transient — back off and retry
                 if attempt < 2:
@@ -2499,9 +2551,9 @@ class QQAdapter(BasePlatformAdapter):
 
         error_msg = str(last_exc) if last_exc else "Unknown error"
         logger.error("[%s] Send failed: %s", self._log_tag, error_msg)
-        retryable = not any(
-            k in error_msg.lower() for k in ("invalid", "forbidden", "not found")
-        )
+        # Use the same status-based classifier as the break decision so the
+        # surfaced retryable flag can never disagree with the retry loop.
+        retryable = last_exc is None or not self._is_permanent_send_error(last_exc)
         return SendResult(success=False, error=error_msg, retryable=retryable)
 
     async def _send_c2c_text(
@@ -2559,6 +2611,23 @@ class QQAdapter(BasePlatformAdapter):
             body["msg_id"] = reply_to
 
         data = await self._api_request("POST", f"/channels/{channel_id}/messages", body)
+        msg_id = str(data.get("id", uuid.uuid4().hex[:12]))
+        return SendResult(success=True, message_id=msg_id, raw_response=data)
+
+    async def _send_dm_text(
+            self, guild_id: str, content: str, reply_to: Optional[str] = None
+    ) -> SendResult:
+        """Send text to a guild direct message via REST API.
+
+        Guild DMs target a per-DM guild scope, so the endpoint is
+        ``POST /dms/{guild_id}/messages`` — distinct from the channel send
+        used by :meth:`_send_guild_text` (``/channels/{channel_id}/messages``).
+        """
+        body: Dict[str, Any] = {"content": content[: self.MAX_MESSAGE_LENGTH]}
+        if reply_to:
+            body["msg_id"] = reply_to
+
+        data = await self._api_request("POST", f"/dms/{guild_id}/messages", body)
         msg_id = str(data.get("id", uuid.uuid4().hex[:12]))
         return SendResult(success=True, message_id=msg_id, raw_response=data)
 
@@ -2857,8 +2926,10 @@ class QQAdapter(BasePlatformAdapter):
                 return SendResult(success=False, error="Not connected", retryable=True)
 
         chat_type = self._guess_chat_type(chat_id)
-        if chat_type == "guild":
-            # Guild channels don't support native media upload in the same way.
+        if chat_type in {"guild", "dm"}:
+            # Guild channels and guild DMs don't support the v2 file-upload
+            # path used for C2C/group; routing them through it would POST the
+            # guild_id to the group endpoint and 404.
             return SendResult(
                 success=False,
                 error="Guild media send not supported via this path",
@@ -3120,6 +3191,48 @@ class QQAdapter(BasePlatformAdapter):
     @staticmethod
     def _is_url(source: str) -> bool:
         return urlparse(str(source)).scheme in {"http", "https"}
+
+    @staticmethod
+    def _is_auth_failure(exc: BaseException) -> bool:
+        """Return True if *exc* (or any cause in its chain) is a 401/403.
+
+        Token/gateway fetches wrap ``httpx.HTTPStatusError`` in a generic
+        ``RuntimeError`` via ``from exc``, so the original status survives on
+        ``__cause__``. A 401/403 means bad credentials, which never self-heal.
+        """
+        seen = set()
+        cur: Optional[BaseException] = exc
+        while cur is not None and id(cur) not in seen:
+            seen.add(id(cur))
+            if HTTPX_AVAILABLE and isinstance(cur, httpx.HTTPStatusError):
+                if cur.response is not None and cur.response.status_code in (401, 403):
+                    return True
+            cur = cur.__cause__ or cur.__context__
+        return False
+
+    @staticmethod
+    def _is_permanent_send_error(exc: BaseException) -> bool:
+        """Return True if a send failure is permanent (don't retry).
+
+        ``_api_request`` embeds the HTTP status as ``[<status>]`` in the error
+        message, so classify on the code rather than English keywords (QQ
+        returns its error 'message' field in Chinese). 4xx other than 429 are
+        permanent; 429/5xx/timeouts/transport errors are transient. When no
+        status marker is present (a local error), fall back to keyword match.
+        """
+        import re
+
+        text = str(exc)
+        match = re.search(r"\[(\d{3})\]", text)
+        if match:
+            status = int(match.group(1))
+            if status == 429:
+                return False
+            return 400 <= status < 500
+        return any(
+            k in text.lower()
+            for k in ("invalid", "forbidden", "not found", "bad request")
+        )
 
     def _guess_chat_type(self, chat_id: str) -> str:
         """Determine chat type from stored inbound metadata, fallback to 'c2c'."""

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2041,6 +2041,171 @@ class TestProcessAttachmentsPathExposure:
 
 
 # ---------------------------------------------------------------------------
+# Inbound document classification (DOCUMENT routing in gateway/run.py)
+# ---------------------------------------------------------------------------
+
+class TestInboundDocumentClassification:
+    """File attachments must be surfaced as real media classified DOCUMENT.
+
+    The inbound-document routing in gateway/run.py only fires when
+    event.media_urls is non-empty AND event.message_type == DOCUMENT; it then
+    translates the host cache path to the agent-visible path and emits the
+    "[The user sent a document …]" note. Previously QQ files were emitted only
+    as an inline "[file: name (host_path)]" text marker holding an
+    un-translated host path, so the agent could not open the file under a
+    sandboxed backend.
+    """
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+
+    def test_detect_message_type_document_for_pdf(self):
+        from gateway.platforms.base import MessageType
+        from gateway.platforms.qqbot import QQAdapter
+        assert (
+            QQAdapter._detect_message_type(["doc.pdf"], ["application/pdf"])
+            == MessageType.DOCUMENT
+        )
+
+    def test_detect_message_type_document_for_text(self):
+        from gateway.platforms.base import MessageType
+        from gateway.platforms.qqbot import QQAdapter
+        assert (
+            QQAdapter._detect_message_type(["notes.txt"], ["text/plain"])
+            == MessageType.DOCUMENT
+        )
+
+    def test_leading_image_still_classifies_photo(self):
+        # A document appended after an image must not downgrade the image-led
+        # event away from PHOTO (image stays first in the media list).
+        from gateway.platforms.base import MessageType
+        from gateway.platforms.qqbot import QQAdapter
+        assert (
+            QQAdapter._detect_message_type(
+                ["pic.jpg", "doc.pdf"], ["image/jpeg", "application/pdf"]
+            )
+            == MessageType.PHOTO
+        )
+
+    @pytest.mark.asyncio
+    async def test_file_attachment_enters_media_urls(self):
+        adapter = self._make_adapter()
+
+        async def fake_download(url, ct, original_name=""):
+            return "/cache/doc_abc123_report.pdf"
+
+        adapter._download_and_cache = fake_download  # type: ignore[assignment]
+
+        result = await adapter._process_attachments([
+            {
+                "content_type": "application/pdf",
+                "url": "https://multimedia.example.com/download/file456",
+                "filename": "report.pdf",
+            }
+        ])
+
+        # Routable media so run.py's DOCUMENT path-translation fires …
+        assert result["media_urls"] == ["/cache/doc_abc123_report.pdf"]
+        assert result["media_types"] == ["application/pdf"]
+        # … while the human-readable marker is preserved.
+        assert "[file:" in result["attachment_info"]
+        assert "report.pdf" in result["attachment_info"]
+
+    @pytest.mark.asyncio
+    async def test_video_stays_text_only_not_media(self):
+        # run.py's DOCUMENT routing only handles application/* and text/*;
+        # videos must not be promoted into media_urls.
+        adapter = self._make_adapter()
+
+        async def fake_download(url, ct, original_name=""):
+            return "/cache/video_xyz.mp4"
+
+        adapter._download_and_cache = fake_download  # type: ignore[assignment]
+
+        result = await adapter._process_attachments([
+            {
+                "content_type": "video/mp4",
+                "url": "https://cdn.example.com/vid",
+                "filename": "clip.mp4",
+            }
+        ])
+
+        assert result["media_urls"] == []
+        assert result["media_types"] == []
+        assert "[video:" in result["attachment_info"]
+
+    @pytest.mark.asyncio
+    async def test_handler_emits_document_event_with_media(self):
+        adapter = self._make_adapter()
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+
+        adapter.handle_message = capture  # type: ignore[assignment]
+
+        async def fake_download(url, ct, original_name=""):
+            return "/cache/doc_abc123_report.pdf"
+
+        adapter._download_and_cache = fake_download  # type: ignore[assignment]
+
+        await adapter._handle_c2c_message(
+            {
+                "author": {"user_openid": "user1"},
+                "attachments": [
+                    {
+                        "content_type": "application/pdf",
+                        "url": "https://multimedia.example.com/download/file456",
+                        "filename": "report.pdf",
+                    }
+                ],
+            },
+            "in-1",
+            "",
+            {"user_openid": "user1"},
+            "2026-01-01T00:00:00+00:00",
+        )
+
+        from gateway.platforms.base import MessageType
+        assert len(captured) == 1
+        event = captured[0]
+        assert event.message_type == MessageType.DOCUMENT
+        assert "/cache/doc_abc123_report.pdf" in event.media_urls
+        assert "application/pdf" in event.media_types
+
+    @pytest.mark.asyncio
+    async def test_no_attachment_message_emits_empty_media_lists(self):
+        # The handler reads att_result["media_urls"]/["media_types"]; the
+        # no-attachment early return of _process_attachments must supply those
+        # keys or the text-only path KeyErrors before any event is emitted.
+        adapter = self._make_adapter()
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+
+        adapter.handle_message = capture  # type: ignore[assignment]
+
+        # No "attachments" key → d.get("attachments") is None → the
+        # _process_attachments early-return branch runs.
+        await adapter._handle_c2c_message(
+            {"author": {"user_openid": "user1"}},
+            "in-1",
+            "hello",
+            {"user_openid": "user1"},
+            "2026-01-01T00:00:00+00:00",
+        )
+
+        from gateway.platforms.base import MessageType
+        assert len(captured) == 1
+        event = captured[0]
+        assert event.message_type == MessageType.TEXT
+        assert event.media_urls == []
+        assert event.media_types == []
+
+
+# ---------------------------------------------------------------------------
 # WebSocket op 7 (Server Reconnect) and op 9 (Invalid Session)
 # ---------------------------------------------------------------------------
 
@@ -2197,3 +2362,265 @@ class TestCloseCodeClassification:
         assert 4001 in fatal_codes
         assert 4915 in fatal_codes
 
+
+# ---------------------------------------------------------------------------
+# Guild direct-message (DIRECT_MESSAGE_CREATE) outbound routing
+# ---------------------------------------------------------------------------
+
+class TestGuildDirectMessageRouting:
+    """A guild DM must be routable on the send path, not just inbound.
+
+    _handle_dm_message stamps _chat_type_map[guild_id] = "dm", but the send
+    branches only knew c2c/group/guild, so replies hit the
+    'Unknown chat type' else and media POSTed the guild_id to the group
+    endpoint. These verify the /dms/{guild_id}/messages routing.
+    """
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+
+    @pytest.mark.asyncio
+    async def test_inbound_dm_then_text_reply_routes_to_dms_endpoint(self):
+        adapter = self._make_adapter()
+        adapter._mark_connected()
+        # QQAdapter.is_connected also requires a live (non-closed) socket.
+        adapter._ws = SimpleNamespace(closed=False)
+        adapter.handle_message = mock.AsyncMock()
+
+        calls = []
+
+        async def fake_api_request(method, path, body, **kwargs):
+            calls.append((method, path, body))
+            return {"id": "dm-msg-1"}
+
+        adapter._api_request = fake_api_request  # type: ignore[assignment]
+
+        # Inbound guild DM populates the routing map with "dm".
+        await adapter._handle_dm_message(
+            {"guild_id": "guild123", "attachments": []},
+            "in-1",
+            "hi",
+            {"id": "user1"},
+            "2026-01-01T00:00:00+00:00",
+        )
+        assert adapter._chat_type_map["guild123"] == "dm"
+
+        result = await adapter.send("guild123", "pong")
+
+        assert result.success is True
+        assert len(calls) == 1
+        method, path, _body = calls[0]
+        assert method == "POST"
+        assert path == "/dms/guild123/messages"
+
+    @pytest.mark.asyncio
+    async def test_dm_media_does_not_hit_group_endpoint(self):
+        adapter = self._make_adapter()
+        adapter._mark_connected()
+        adapter._ws = SimpleNamespace(closed=False)
+        adapter._chat_type_map["guild123"] = "dm"
+
+        # Should short-circuit before any upload/API request rather than
+        # POSTing the guild_id to /v2/groups/{id}/messages.
+        adapter._api_request = mock.AsyncMock(
+            side_effect=AssertionError("media must not call the group endpoint")
+        )
+
+        result = await adapter._send_media(
+            "guild123", "https://example.com/x.png", 1, "image"
+        )
+
+        assert result.success is False
+        adapter._api_request.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _api_request: status-before-decode on non-JSON error bodies
+# ---------------------------------------------------------------------------
+
+class TestApiRequestNonJsonError:
+    """A non-JSON 4xx/5xx body must raise the structured RuntimeError, not a
+    raw JSONDecodeError that bypasses daily-limit / permanent-error detection.
+    """
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+
+    @pytest.mark.asyncio
+    async def test_non_json_error_body_raises_runtimeerror_with_status(self):
+        import json as _json
+
+        adapter = self._make_adapter()
+        adapter._ensure_token = mock.AsyncMock(return_value="tok")
+
+        resp = mock.Mock()
+        resp.status_code = 502
+        resp.text = "<html>502 Bad Gateway</html>"
+        resp.json = mock.Mock(
+            side_effect=_json.JSONDecodeError("Expecting value", "", 0)
+        )
+
+        adapter._http_client = mock.AsyncMock()
+        adapter._http_client.request = mock.AsyncMock(return_value=resp)
+
+        with pytest.raises(RuntimeError) as ei:
+            await adapter._api_request("POST", "/v2/users/u/messages", {})
+
+        msg = str(ei.value)
+        assert "[502]" in msg
+        assert "502 Bad Gateway" in msg
+        assert "QQ Bot API error" in msg
+
+    @pytest.mark.asyncio
+    async def test_daily_limit_biz_code_survives_non_dict_message(self):
+        # The daily-limit detection in chunked_upload matches the biz code in
+        # the RuntimeError text; a JSON error body must still surface it.
+        adapter = self._make_adapter()
+        adapter._ensure_token = mock.AsyncMock(return_value="tok")
+
+        resp = mock.Mock()
+        resp.status_code = 400
+        resp.json = mock.Mock(return_value={"code": 40093002, "message": "上传超限"})
+
+        adapter._http_client = mock.AsyncMock()
+        adapter._http_client.request = mock.AsyncMock(return_value=resp)
+
+        with pytest.raises(RuntimeError) as ei:
+            await adapter._api_request("POST", "/v2/groups/g/files", {})
+        assert "上传超限" in str(ei.value)
+        assert "[400]" in str(ei.value)
+
+
+# ---------------------------------------------------------------------------
+# Status-based send classification (QQ returns Chinese error messages)
+# ---------------------------------------------------------------------------
+
+class TestSendErrorClassification:
+    """Permanent 4xx (Chinese message) must not be retried and must be
+    reported retryable=False; the break decision and final flag must agree.
+    """
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+
+    @pytest.mark.asyncio
+    async def test_chinese_403_is_permanent_and_not_retried(self):
+        adapter = self._make_adapter()
+        adapter._mark_connected()
+        adapter._ws = SimpleNamespace(closed=False)
+        adapter._chat_type_map["u1"] = "c2c"
+
+        attempts = {"n": 0}
+
+        async def fail_403(*args, **kwargs):
+            attempts["n"] += 1
+            # Mirrors _api_request's format with a Chinese message.
+            raise RuntimeError("QQ Bot API error [403] /v2/users/u1/messages: 无权限")
+
+        adapter._send_c2c_text = fail_403  # type: ignore[assignment]
+
+        result = await adapter.send("u1", "hi")
+
+        assert result.success is False
+        assert result.retryable is False
+        assert attempts["n"] == 1  # no retries on a permanent error
+
+    @pytest.mark.asyncio
+    async def test_429_is_transient_and_retried(self):
+        adapter = self._make_adapter()
+        adapter._mark_connected()
+        adapter._ws = SimpleNamespace(closed=False)
+        adapter._chat_type_map["u1"] = "c2c"
+
+        attempts = {"n": 0}
+
+        async def fail_429(*args, **kwargs):
+            attempts["n"] += 1
+            raise RuntimeError("QQ Bot API error [429] /v2/users/u1/messages: 频率限制")
+
+        adapter._send_c2c_text = fail_429  # type: ignore[assignment]
+
+        with mock.patch("asyncio.sleep", new=mock.AsyncMock()):
+            result = await adapter.send("u1", "hi")
+
+        assert result.success is False
+        assert result.retryable is True
+        assert attempts["n"] == 3  # retried up to the cap
+
+
+# ---------------------------------------------------------------------------
+# connect() fatal classification for permanent failures
+# ---------------------------------------------------------------------------
+
+class TestConnectFatalClassification:
+    """Missing dependency and bad-credential 401/403 are permanent and must
+    be marked retryable=False so the reconnect watcher stops hammering.
+    """
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
+
+    def test_missing_aiohttp_is_non_retryable(self):
+        from gateway.platforms.qqbot import adapter as qq_adapter
+
+        a = self._make_adapter()
+        with mock.patch.object(qq_adapter, "AIOHTTP_AVAILABLE", False):
+            connected = asyncio.run(a.connect())
+
+        assert connected is False
+        assert a._fatal_error_code == "qq_missing_dependency"
+        assert a._fatal_error_retryable is False
+
+    def test_auth_401_escalates_to_non_retryable(self):
+        from gateway.platforms.qqbot import adapter as qq_adapter
+
+        a = self._make_adapter()
+
+        # Simulate _ensure_token raising the same wrapped error the real path
+        # produces: RuntimeError(...) from httpx.HTTPStatusError(401).
+        request = httpx_request()
+        response = qq_adapter.httpx.Response(401, request=request)
+        status_err = qq_adapter.httpx.HTTPStatusError(
+            "Unauthorized", request=request, response=response
+        )
+
+        async def boom():
+            raise RuntimeError("Failed to get QQ Bot access token") from status_err
+
+        with mock.patch.object(
+            qq_adapter.httpx, "AsyncClient", return_value=mock.AsyncMock()
+        ):
+            a._ensure_token = boom  # type: ignore[assignment]
+            connected = asyncio.run(a.connect())
+
+        assert connected is False
+        assert a._fatal_error_code == "qq_auth_failed"
+        assert a._fatal_error_retryable is False
+
+    def test_network_error_stays_retryable(self):
+        from gateway.platforms.qqbot import adapter as qq_adapter
+
+        a = self._make_adapter()
+
+        async def boom():
+            raise RuntimeError("Failed to get QQ Bot gateway URL: connection reset")
+
+        with mock.patch.object(
+            qq_adapter.httpx, "AsyncClient", return_value=mock.AsyncMock()
+        ):
+            a._ensure_token = boom  # type: ignore[assignment]
+            connected = asyncio.run(a.connect())
+
+        assert connected is False
+        assert a._fatal_error_code == "qq_connect_error"
+        assert a._fatal_error_retryable is True
+
+
+def httpx_request():
+    """Build a minimal httpx.Request for HTTPStatusError construction."""
+    from gateway.platforms.qqbot import adapter as qq_adapter
+    return qq_adapter.httpx.Request("POST", "https://example.com/token")


### PR DESCRIPTION
## fix(qqbot): route guild DMs, classify inbound documents, and harden send/connect error handling

Depth over breadth: this fixes 5 independently-verified bugs in the QQ Bot adapter, each with a focused regression test that is red on the current tree and green after the change. The collapsed findings (7 raw items → 5 distinct bugs; two pairs were duplicates) all reproduce against `gateway/platforms/qqbot/adapter.py` as it stands today.

### 1. Guild direct-message replies are silently dropped (no `dm` send branch)

**Symptom:** A user direct-messages the bot inside a guild; the agent processes the message and generates a reply, but the reply never reaches the user. Media replies hit the wrong endpoint and 404.

**Root cause:** `_handle_dm_message` stamps the routing map `self._chat_type_map[guild_id] = "dm"`, but every outbound path resolves the kind via `_guess_chat_type()` and none understood `"dm"`. `_send_chunk` only branched on `c2c`/`group`/`guild`, so a guild DM fell into the `else` returning `SendResult(success=False, error="Unknown chat type …")`. `_send_media` only short-circuited `chat_type == "guild"`, so a DM fell through and POSTed the `guild_id` to `/v2/groups/{id}/messages` — the wrong endpoint.

**Fix:** Add a `_send_dm_text` helper that POSTs to the correct guild-DM endpoint `POST /dms/{guild_id}/messages` (mirroring the existing `_send_guild_text` pattern), wire a `"dm"` branch into `_send_chunk`, and extend `_send_media`'s guard to short-circuit `{"guild", "dm"}` so a DM media send never reaches the group endpoint.

### 2. Inbound file attachments are never classified `DOCUMENT`

**Symptom:** A user sends a PDF/spreadsheet/generic file. The agent receives an inline text marker `[file: name (<host cache path>)]` and the raw host path embedded in the body. Under a sandboxed agent backend that path is in the wrong namespace and the file cannot be opened.

**Root cause:** Non-image, non-voice attachments were appended only to `attachment_info` text; they never entered `media_urls`/`media_types`, and `_detect_message_type` could only return `VOICE`/`VIDEO`/`PHOTO`/`TEXT` — never `DOCUMENT`. The inbound-document routing in `gateway/run.py` fires only when `event.media_urls` is non-empty AND `event.message_type == MessageType.DOCUMENT`; it then path-translates the host cache path to the agent-visible path and emits the standard "[The user sent a document …]" note. QQ files satisfied neither condition, so that handling never ran.

**Fix:** In `_process_attachments`, also append cached file paths to `media_urls`/`media_types` (real MIME, falling back to `application/octet-stream`) while keeping the human-readable marker. The no-attachment early-return dict carries the same two keys, so the text-only path (every handler reads `att_result["media_urls"]`/`["media_types"]` unconditionally) does not `KeyError`. Extend `_detect_message_type` to return `MessageType.DOCUMENT` for an `application/*` or `text/*` leading type. Videos stay text-only on purpose — the `run.py` document path only handles `application/*` and `text/*`. Images remain first in the media list, so image-led events keep their `PHOTO` classification.

### 3. Send retry/permanent-error classification keyed on English keywords the QQ API never returns

**Symptom:** A permanently-failing send (403 to a user the bot may not message, 404 unknown target) is retried 3× with back-off and then reported `retryable=True`, so the gateway re-queues a doomed send.

**Root cause:** `_send_chunk` decided retry-vs-permanent by substring-matching the lowercased exception against `('invalid','forbidden','not found','bad request')`. The QQ Bot v2 REST API returns its error `message` field in Chinese, so none of those keywords match a genuine 4xx. There was also an internal inconsistency: the break-set included `'bad request'` but the final `retryable` recompute omitted it, so an English `bad request` 400 could break the loop yet still be flagged `retryable=True`.

**Fix:** Classify on the HTTP status `_api_request` already embeds as `[<status>]`. New `_is_permanent_send_error` treats 4xx (except 429) as permanent and 429/5xx/timeouts/transport errors as transient, with a keyword fallback for local (non-HTTP) errors. Both the loop's break decision and the final `retryable` flag now call the same classifier, so they cannot disagree.

### 4. `_api_request` parsed `resp.json()` before checking status

**Symptom:** A 4xx/5xx with a non-JSON body (CDN/proxy HTML page, empty 429) raised a raw `JSONDecodeError` instead of the structured `RuntimeError`. That broke the daily-quota detection in `chunked_upload` (which matches the `40093002` biz code in the message) and left the send classifier with a meaningless decode-error string.

**Root cause:** `data = resp.json()` ran before the `if resp.status_code >= 400` check; only `httpx.TimeoutException` was caught, so the decode error escaped unwrapped.

**Fix:** Check the status first. On `>= 400`, build the message from a guarded body read (`resp.json()` with a fallback to `resp.text[:200]`), then raise the structured `QQ Bot API error [<status>] …`. The success body is parsed only after the status check.

### 5. Permanent `connect()` failures marked `retryable=True` and retried forever

**Symptom:** A missing `aiohttp`/`httpx` install, or a wrong `app_id`/`client_secret`, leaves the operator status stuck on "retrying" while the reconnect watcher hammers the token endpoint at the back-off cap indefinitely.

**Root cause:** The missing-dependency branches set `retryable=True` (a missing pip package cannot self-heal by retrying), and the broad `except Exception` bucketed a 401/403 from `_ensure_token()`/`_get_gateway_url()` into the retryable `qq_connect_error` catch-all.

**Fix:** Set `retryable=False` on the missing-dependency branches. Add `_is_auth_failure`, which walks the exception cause chain for an `httpx.HTTPStatusError` of 401/403 (the token fetch wraps it in a generic `RuntimeError` via `from exc`, so the status survives on `__cause__`). On an auth failure, escalate to a non-retryable `qq_auth_failed` fatal; genuine network/DNS/5xx/timeout errors stay `qq_connect_error`/`retryable=True`. This matches the convention in `weixin.py`/`whatsapp.py`/`telegram.py`.

### Overlap

- **#19891** ("mark WeCom and QQBot missing-credential errors as non-retryable") makes the `qq_missing_credentials` `retryable True→False` edit plus an equivalent test. This PR does not touch the `qq_missing_credentials` line; its connect hardening (fix 5) is a superset that instead covers the missing-dependency branches and escalates 401/403 to `qq_auth_failed` via `_is_auth_failure`. The credential hunk overlaps in spirit (same `connect()` non-retryable direction), but the missing-dependency and auth-failure escalation here are distinct.
- **#26405** ("surface cached file attachments to agents") partially overlaps fix 2: it also passes the cached file path through the media channel. Built on an older base, it routes every non-image attachment (including video) into the media list and does not touch `_detect_message_type`, so the event is never classified `DOCUMENT` and the `gateway/run.py` path-translation + document note still do not fire. Fix 2 here is the superset that actually triggers that routing: it adds the `DOCUMENT` classification and scopes videos out (the run.py document path handles only `application/*` and `text/*`).
- **#32752 / #31593** touch only `_is_authorized_interaction_for_session` (the interaction-approval `dm` chat_type), not the outbound send path; they do not overlap fix 1.
- **#35153** refactors C2C media routing and `tools/send_message_tool.py`; it does not add a guild-DM send branch, the document classification, or the status-based send/connect classifiers. No functional overlap (a textual merge against its adapter rewrite is possible).
