### PR TITLE
fix(discord): forwarded text, 429 retry, voice notice, thread media, auth fatal

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -895,12 +895,50 @@ class DiscordAdapter(BasePlatformAdapter):
 
         except asyncio.TimeoutError:
             logger.error("[%s] Timeout waiting for connection to Discord", self.name, exc_info=True)
+            self._escalate_permanent_bot_task_error()
             self._release_platform_lock()
             return False
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to connect to Discord: %s", self.name, e, exc_info=True)
+            self._escalate_permanent_bot_task_error()
             self._release_platform_lock()
             return False
+
+    def _escalate_permanent_bot_task_error(self) -> None:
+        """Flag a permanent Discord auth/intent failure as a non-retryable fatal.
+
+        ``self._client.start()`` runs in ``_bot_task``, so a bad/revoked token
+        (``discord.errors.LoginFailure``) or missing portal intents
+        (``discord.errors.PrivilegedIntentsRequired``) surfaces there, not in
+        ``connect()`` — ``on_ready`` never fires and ``connect()`` only sees the
+        READY-wait timeout. Without escalation the gateway reconnect loop keeps
+        the platform in the retry queue forever (it only drops on
+        ``has_fatal_error and not fatal_error_retryable``), pointlessly hammering
+        a bad credential every backoff cycle. Inspect the finished bot task and,
+        for these permanent errors, record a non-retryable fatal so the gateway
+        stops reconnecting. Transient/timeout cases are left untouched so they
+        keep retrying.
+        """
+        task = self._bot_task
+        if task is None or not task.done() or task.cancelled():
+            return
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        if exc is None:
+            return
+        # Match permanent auth/intent errors by class name rather than
+        # isinstance against discord.errors.* — the latter can be patched to a
+        # non-type in test/mocked environments, and the class names are stable
+        # across discord.py versions.
+        permanent_names = {"LoginFailure", "PrivilegedIntentsRequired"}
+        if type(exc).__name__ in permanent_names:
+            self._set_fatal_error(
+                f"discord_{type(exc).__name__}",
+                str(exc) or type(exc).__name__,
+                retryable=False,
+            )
 
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
@@ -924,10 +962,22 @@ class DiscordAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
 
+        # Harvest the bot task so a permanent-auth failure (LoginFailure /
+        # PrivilegedIntentsRequired raised inside _client.start()) doesn't leak
+        # an unretrieved "Task exception was never retrieved" warning.
+        if self._bot_task is not None:
+            if not self._bot_task.done():
+                self._bot_task.cancel()
+            try:
+                await self._bot_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
         self._running = False
         self._client = None
         self._ready_event.clear()
         self._post_connect_task = None
+        self._bot_task = None
 
         self._release_platform_lock()
 
@@ -1512,6 +1562,11 @@ class DiscordAdapter(BasePlatformAdapter):
 
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
+            # A surfaced 429 is transient, not a formatting error. Flag it
+            # retryable so _send_with_retry backs off and replays the real
+            # content instead of corrupting it into a plain-text fallback.
+            if self._is_discord_rate_limit(e):
+                return SendResult(success=False, error=str(e), retryable=True)
             return SendResult(success=False, error=str(e))
 
     async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
@@ -1655,12 +1710,36 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def _resolve_send_channel(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Resolve the target channel for a send, honoring metadata['thread_id'].
+
+        A thread_id in metadata takes precedence over chat_id, matching the
+        routing contract enforced by ``send()``. Without this, media senders
+        post to the parent channel even when chat_id and thread_id diverge
+        (e.g. the session-handoff path), splitting a reply across two
+        locations. Returns ``None`` when the channel cannot be resolved.
+        """
+        if not self._client:
+            return None
+        target_id = chat_id
+        if metadata and metadata.get("thread_id"):
+            target_id = metadata["thread_id"]
+        channel = self._client.get_channel(int(target_id))
+        if not channel:
+            channel = await self._client.fetch_channel(int(target_id))
+        return channel
+
     async def _send_file_attachment(
         self,
         chat_id: str,
         file_path: str,
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a local file as a Discord attachment.
 
@@ -1670,9 +1749,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
-        channel = self._client.get_channel(int(chat_id))
-        if not channel:
-            channel = await self._client.fetch_channel(int(chat_id))
+        channel = await self._resolve_send_channel(chat_id, metadata)
         if not channel:
             return SendResult(success=False, error=f"Channel {chat_id} not found")
 
@@ -1718,9 +1795,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return
 
         try:
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
+            channel = await self._resolve_send_channel(chat_id, metadata)
             if not channel:
                 logger.warning("[%s] Channel %s not found for multi-image send", self.name, chat_id)
                 return
@@ -1847,9 +1922,7 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import io
 
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
+            channel = await self._resolve_send_channel(chat_id, metadata)
             if not channel:
                 return SendResult(success=False, error=f"Channel {chat_id} not found")
 
@@ -1974,7 +2047,11 @@ class DiscordAdapter(BasePlatformAdapter):
             if vc and vc.is_connected():
                 await vc.disconnect()
             task = self._voice_timeout_tasks.pop(guild_id, None)
-            if task:
+            # Don't cancel ourselves: when the inactivity handler calls this it
+            # IS the timeout task, and self-cancellation would raise
+            # CancelledError at its next await (the "left channel" notice),
+            # silently dropping that user-facing message.
+            if task and task is not asyncio.current_task():
                 task.cancel()
             self._voice_text_channels.pop(guild_id, None)
             self._voice_sources.pop(guild_id, None)
@@ -2547,7 +2624,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local image file natively as a Discord file attachment."""
         try:
-            return await self._send_file_attachment(chat_id, image_path, caption)
+            return await self._send_file_attachment(chat_id, image_path, caption, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"Image file not found: {image_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -2573,9 +2650,7 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
+            channel = await self._resolve_send_channel(chat_id, metadata)
             if not channel:
                 return SendResult(success=False, error=f"Channel {chat_id} not found")
 
@@ -2652,9 +2727,7 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
-            channel = self._client.get_channel(int(chat_id))
-            if not channel:
-                channel = await self._client.fetch_channel(int(chat_id))
+            channel = await self._resolve_send_channel(chat_id, metadata)
             if not channel:
                 return SendResult(success=False, error=f"Channel {chat_id} not found")
 
@@ -2712,7 +2785,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local video file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, video_path, caption)
+            return await self._send_file_attachment(chat_id, video_path, caption, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"Video file not found: {video_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -2730,7 +2803,7 @@ class DiscordAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an arbitrary file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name)
+            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name, metadata=metadata)
         except FileNotFoundError:
             return SendResult(success=False, error=f"File not found: {file_path}")
         except Exception as e:  # pragma: no cover - defensive logging
@@ -4520,8 +4593,15 @@ class DiscordAdapter(BasePlatformAdapter):
                 if getattr(snap, "content", None):
                     snapshot_text_parts.append(snap.content.strip())
                 snapshot_attachments.extend(getattr(snap, "attachments", []) or [])
-            if snapshot_text_parts and not raw_content:
-                raw_content = "\n".join(snapshot_text_parts)
+            if snapshot_text_parts:
+                forwarded = "\n".join(snapshot_text_parts)
+                # A forward can carry the forwarder's own comment AND the
+                # forwarded body. Combine both so neither is dropped, mirroring
+                # the unconditional handling of snapshot_attachments below.
+                if raw_content:
+                    raw_content = f"{raw_content}\n\n[Forwarded]\n{forwarded}"
+                else:
+                    raw_content = forwarded
                 normalized_content = raw_content
         if self._client.user and self._client.user in message.mentions:
             mention_prefix = True

--- a/tests/gateway/test_discord_reauth_fixes.py
+++ b/tests/gateway/test_discord_reauth_fixes.py
@@ -1,0 +1,423 @@
+"""Regression tests for a batch of independently-verified Discord adapter bugs.
+
+Each test pins one fix:
+
+1. Forwarded-message text is dropped when the forwarder adds their own comment.
+2. send() does not flag a surfaced 429 as retryable, corrupting the reply into
+   a plain-text fallback.
+3. The voice inactivity handler cancels itself mid-flight, dropping the
+   "left channel" notice.
+4. Media senders ignore metadata['thread_id'], splitting handoff replies across
+   the parent channel and the thread.
+5. Permanent auth/intent failures never escalate to a non-retryable fatal, so
+   the gateway reconnects a bad credential forever.
+"""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType
+
+
+def _ensure_discord_mock():
+    """Install a minimal mock ``discord`` module only when the real package is
+    absent — mirrors the bootstrap used by the other Discord test modules."""
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+    if sys.modules.get("discord") is not None:
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+    discord_mod.opus = SimpleNamespace(is_loaded=lambda: True)
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+# ── Fix 1: forwarded-message text is dropped when a comment is present ──────
+
+
+class _DMChannelStub:
+    def __init__(self, channel_id):
+        self.id = channel_id
+
+
+class _NoMatchType:
+    """Sentinel so isinstance(channel, discord.Thread) is always False."""
+
+
+@pytest.mark.asyncio
+async def test_forwarded_text_combined_with_user_comment(monkeypatch):
+    """A forward carries the forwarded body in message_snapshots; the user's own
+    typed comment lives in message.content. When both are present the adapter
+    must surface BOTH — the old `snapshot_text and not raw_content` guard dropped
+    the forwarded body entirely whenever the forwarder also typed a comment.
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=999, name="Hermes"))
+    adapter._text_batch_delay_seconds = 0  # dispatch synchronously, no batching
+
+    # Route the DM through the real channel-type checks with cheap stubs.
+    monkeypatch.setattr(discord_platform.discord, "DMChannel", _DMChannelStub)
+    monkeypatch.setattr(discord_platform.discord, "Thread", _NoMatchType)
+
+    snapshot = SimpleNamespace(content="The forwarded article body.", attachments=[])
+    message = SimpleNamespace(
+        id=1,
+        content="check this out",
+        message_snapshots=[snapshot],
+        attachments=[],
+        mentions=[],
+        author=SimpleNamespace(id=42, name="alice", display_name="Alice", bot=False),
+        channel=_DMChannelStub(555),
+        reference=None,
+        guild=None,
+        created_at=None,
+    )
+
+    captured = {}
+
+    async def fake_handle_message(event):
+        captured["event"] = event
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+    await adapter._handle_message(message)
+
+    text = captured["event"].text
+    assert "check this out" in text, "forwarder's own comment must survive"
+    assert "The forwarded article body." in text, "forwarded body must not be dropped"
+
+
+@pytest.mark.asyncio
+async def test_forwarded_text_alone_still_delivered(monkeypatch):
+    """A bare forward (no comment) must still deliver the forwarded body."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=999, name="Hermes"))
+    adapter._text_batch_delay_seconds = 0  # dispatch synchronously, no batching
+
+    monkeypatch.setattr(discord_platform.discord, "DMChannel", _DMChannelStub)
+    monkeypatch.setattr(discord_platform.discord, "Thread", _NoMatchType)
+
+    snapshot = SimpleNamespace(content="Only the forwarded body.", attachments=[])
+    message = SimpleNamespace(
+        id=2,
+        content="",
+        message_snapshots=[snapshot],
+        attachments=[],
+        mentions=[],
+        author=SimpleNamespace(id=42, name="alice", display_name="Alice", bot=False),
+        channel=_DMChannelStub(555),
+        reference=None,
+        guild=None,
+        created_at=None,
+    )
+
+    captured = {}
+
+    async def fake_handle_message(event):
+        captured["event"] = event
+
+    monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+    await adapter._handle_message(message)
+
+    assert captured["event"].text == "Only the forwarded body."
+
+
+# ── Fix 2: send() must flag a surfaced 429 as retryable ─────────────────────
+
+
+class _RateLimited(Exception):
+    """Name contains 'ratelimit' + carries retry_after, so the adapter's
+    duck-typed _is_discord_rate_limit() classifies it as a 429."""
+
+    def __init__(self, message, retry_after):
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+@pytest.mark.asyncio
+async def test_send_flags_rate_limit_as_retryable():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    async def fake_send(*, content, reference=None):
+        raise _RateLimited("429 Too Many Requests", retry_after=5.0)
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    adapter._is_forum_parent = lambda channel: False
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    # Without retryable=True the gateway misclassifies a 429 as a formatting
+    # failure and ships the "Response formatting failed, plain text:" fallback.
+    assert result.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_send_non_rate_limit_error_stays_non_retryable():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    async def fake_send(*, content, reference=None):
+        raise RuntimeError("some other failure")
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _id: channel,
+        fetch_channel=AsyncMock(),
+    )
+    adapter._is_forum_parent = lambda channel: False
+
+    result = await adapter.send("123", "hello")
+
+    assert result.success is False
+    assert result.retryable is False
+
+
+# ── Fix 3: voice inactivity handler must not cancel itself ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_voice_timeout_handler_delivers_disconnect_notice(monkeypatch):
+    """When the inactivity timer fires, _voice_timeout_handler awaits
+    leave_voice_channel — which used to cancel the very task it runs in, raising
+    CancelledError at the next await (the notice send) and dropping it. The
+    self-cancel guard must keep the notice flowing.
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter.VOICE_TIMEOUT = 0  # fire immediately
+
+    guild_id = 7
+    text_channel_id = 888
+
+    sent = []
+    text_channel = SimpleNamespace(send=AsyncMock(side_effect=lambda msg: sent.append(msg)))
+    adapter._client = SimpleNamespace(get_channel=lambda _id: text_channel)
+    adapter._voice_text_channels[guild_id] = text_channel_id
+    adapter._on_voice_disconnect = None
+
+    # Register the handler as the running task, exactly as _reset_voice_timeout
+    # would, so leave_voice_channel sees it as asyncio.current_task().
+    task = asyncio.ensure_future(adapter._voice_timeout_handler(guild_id))
+    adapter._voice_timeout_tasks[guild_id] = task
+    await task
+
+    assert sent == ["Left voice channel (inactivity timeout)."]
+
+
+# ── Fix 4: media senders must honor metadata['thread_id'] ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_resolve_send_channel_prefers_thread_id():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    requested = []
+
+    def fake_get_channel(cid):
+        requested.append(cid)
+        return SimpleNamespace(id=cid)
+
+    adapter._client = SimpleNamespace(get_channel=fake_get_channel, fetch_channel=AsyncMock())
+
+    channel = await adapter._resolve_send_channel("100", metadata={"thread_id": "200"})
+
+    assert channel.id == 200
+    assert requested == [200], "thread_id must take precedence over chat_id"
+
+
+@pytest.mark.asyncio
+async def test_resolve_send_channel_falls_back_to_chat_id():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    requested = []
+
+    def fake_get_channel(cid):
+        requested.append(cid)
+        return SimpleNamespace(id=cid)
+
+    adapter._client = SimpleNamespace(get_channel=fake_get_channel, fetch_channel=AsyncMock())
+
+    channel = await adapter._resolve_send_channel("100", metadata=None)
+
+    assert channel.id == 100
+    assert requested == [100]
+
+
+@pytest.mark.asyncio
+async def test_send_file_attachment_routes_to_thread(tmp_path):
+    """The session-handoff path passes chat_id=parent and metadata.thread_id=
+    handoff-thread. The file must land in the thread, not the parent channel.
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+
+    file_path = tmp_path / "report.txt"
+    file_path.write_text("hello")
+
+    posted_to = {}
+
+    def fake_get_channel(cid):
+        ch = SimpleNamespace(id=cid)
+
+        async def _send(**kw):
+            posted_to["channel_id"] = cid
+            return SimpleNamespace(id=1)
+
+        ch.send = _send
+        return ch
+
+    adapter._client = SimpleNamespace(get_channel=fake_get_channel, fetch_channel=AsyncMock())
+    adapter._is_forum_parent = lambda channel: False
+
+    result = await adapter._send_file_attachment(
+        "100", str(file_path), caption="cap", metadata={"thread_id": "200"}
+    )
+
+    assert result.success is True
+    assert posted_to["channel_id"] == 200, "file must be sent into the handoff thread"
+
+
+# ── Fix 5: permanent auth/intent failure escalates to non-retryable fatal ───
+
+
+class _LoginFailureBot:
+    """Stand-in commands.Bot whose start() raises a permanent auth error,
+    mirroring discord.py's LoginFailure (matched by class name)."""
+
+    class LoginFailure(Exception):
+        pass
+
+    def __init__(self, **_):
+        self.user = SimpleNamespace(id=999, name="Hermes")
+        self._events = {}
+        self.application_id = 999
+        self.tree = SimpleNamespace(
+            sync=AsyncMock(return_value=[]),
+            fetch_commands=AsyncMock(return_value=[]),
+            get_commands=lambda *a, **k: [],
+            command=lambda *a, **k: (lambda fn: fn),
+        )
+        self.http = SimpleNamespace(
+            upsert_global_command=AsyncMock(),
+            edit_global_command=AsyncMock(),
+            delete_global_command=AsyncMock(),
+        )
+
+    def event(self, fn):
+        self._events[fn.__name__] = fn
+        return fn
+
+    async def start(self, token):
+        raise _LoginFailureBot.LoginFailure("Improper token has been passed.")
+
+    async def close(self):
+        return None
+
+    def is_closed(self):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_connect_escalates_permanent_auth_failure_as_non_retryable(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+    monkeypatch.setattr(discord_platform.commands, "Bot", lambda **kwargs: _LoginFailureBot(**kwargs))
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    async def fake_wait_for(awaitable, timeout):
+        # Let the bot task surface its exception, then reproduce the READY-wait
+        # timeout connect() observes (on_ready never fired).
+        await asyncio.sleep(0)
+        if hasattr(awaitable, "close"):
+            awaitable.close()
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(discord_platform.asyncio, "wait_for", fake_wait_for)
+
+    ok = await adapter.connect()
+
+    assert ok is False
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_retryable is False
+    assert adapter._fatal_error_code == "discord_LoginFailure"
+
+    # disconnect() must harvest the bot task and clear it without re-raising.
+    await adapter.disconnect()
+    assert adapter._bot_task is None
+
+
+@pytest.mark.asyncio
+async def test_connect_plain_timeout_stays_retryable(monkeypatch):
+    """A connect timeout with no permanent auth/intent error on the bot task
+    must NOT be escalated to a fatal state — it stays retryable."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    class _SlowBot(_LoginFailureBot):
+        async def start(self, token):
+            await asyncio.sleep(60)  # connected but on_ready not yet fired
+
+    monkeypatch.setattr(discord_platform.commands, "Bot", lambda **kwargs: _SlowBot(**kwargs))
+    monkeypatch.setattr(adapter, "_resolve_allowed_usernames", AsyncMock())
+
+    async def fake_wait_for(awaitable, timeout):
+        if hasattr(awaitable, "close"):
+            awaitable.close()
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(discord_platform.asyncio, "wait_for", fake_wait_for)
+
+    ok = await adapter.connect()
+
+    assert ok is False
+    assert adapter.has_fatal_error is False
+
+    await adapter.disconnect()


### PR DESCRIPTION
This fixes five independently-verified Discord adapter bugs, each with its own regression test (red on the current adapter, green after the change). All five are real on the current code, not speculative: a dropped forwarded-message body, a 429 misclassified as a formatting failure, a self-cancelling voice-timeout notice, media that ignores thread routing, and a permanent auth failure that the gateway retries forever.

## 1. Forwarded-message text is dropped when the forwarder adds a comment

Symptom: a user forwards a message AND types their own comment (e.g. "check this out" + a forwarded article). The agent only sees "check this out"; the forwarded body is silently gone. A forwarded image keeps rendering (its attachment survives), but its caption text vanishes — an inconsistent, confusing partial drop.

Root cause: forwards arrive as `message.message_snapshots`, where each snapshot carries the forwarded `content`. `_handle_message` promoted that text only under `if snapshot_text_parts and not raw_content`. `raw_content` is the forwarder's own comment (`message.content`), so whenever a comment is present the `not raw_content` guard fails and the forwarded text is discarded — even though `snapshot_attachments` are merged unconditionally a few lines later.

Fix: always incorporate the forwarded text. When the comment and the forwarded body both exist, combine them (`{comment}\n\n[Forwarded]\n{body}`); otherwise fall back to the forwarded body alone. This mirrors the unconditional handling already used for forwarded attachments.

## 2. send() does not mark a surfaced 429 as retryable

Symptom: under a Discord 429 (global/Cloudflare rate limit or an exhausted internal retry budget), the user gets a mangled reply prefixed "Response formatting failed, plain text:" instead of a backed-off retry of the real content.

Root cause: `send()`'s outer `except` returned `SendResult(success=False, error=str(e))` with `retryable` defaulting to `False`. In `_send_with_retry`, a non-retryable result whose error string matches none of the connection-level retry patterns (and isn't a timeout) is treated as a formatting failure, triggering the plain-text-fallback corruption path — even though the adapter already has `_is_discord_rate_limit()` and uses it elsewhere.

Fix: in the `send()` outer `except`, detect rate limits via the existing `self._is_discord_rate_limit(e)` helper and return `SendResult(success=False, error=str(e), retryable=True)`, routing a surfaced 429 through the exponential-backoff retry path instead of the fallback. Non-rate-limit errors stay non-retryable.

## 3. Voice inactivity handler cancels itself, dropping the disconnect notice

Symptom: on voice inactivity auto-disconnect the bot leaves the channel, but the "Left voice channel (inactivity timeout)." message is never delivered.

Root cause: when the timer fires, `_voice_timeout_handler` awaits `leave_voice_channel(guild_id)`, which does `task = self._voice_timeout_tasks.pop(...); task.cancel()`. That task IS the running handler coroutine, so it cancels itself. Control returns to the handler with a pending `CancelledError`, raised at the next await — `await ch.send(...)`. That send is wrapped only in `except Exception`, but `CancelledError` is a `BaseException`, so it escapes and the notice is dropped.

Fix: guard the cancel with `if task and task is not asyncio.current_task()`, so the in-flight handler never cancels itself and its subsequent `ch.send(...)` completes.

## 4. Media senders ignore metadata['thread_id'], splitting handoff replies

Symptom: in the session-handoff path, the text reply lands in the handoff thread but images/voice/videos/documents post to the parent channel — one logical reply split across two locations.

Root cause: `send()` honors `metadata['thread_id']` (it takes precedence over `chat_id`, matching the base routing contract), but every media sender resolved `channel = self._client.get_channel(int(chat_id))` directly and never consulted `metadata`. This is invisible in the normal inbound flow (there `chat_id` already equals the thread id) but live whenever `chat_id` and `thread_id` diverge — exactly what the handoff path does (`chat_id` = parent home channel, `thread_id` = the new handoff thread).

Fix: factor the thread-aware resolution into `_resolve_send_channel(chat_id, metadata)` (prefers `metadata['thread_id']`) and call it from every media sender — `send_image`, `send_animation`, `send_voice`, `send_multiple_images`, and `_send_file_attachment` (threading `metadata` through `send_image_file`/`send_video`/`send_document`). This restores parity with `send()`.

## 5. Permanent auth/intent failures never escalate to non-retryable fatal

Symptom: a bad/revoked bot token or missing privileged intents leaves the gateway reconnecting forever (a 30s connect timeout per cycle, backoff capped at 300s), and an orphaned "Task exception was never retrieved" warning leaks.

Root cause: `connect()` runs the bot via `self._bot_task = asyncio.create_task(self._client.start(token))` then waits on the READY event. discord.py raises the permanent errors — `LoginFailure` and `PrivilegedIntentsRequired` — inside `_bot_task`. Those are never inspected: `on_ready` never fires, the READY wait times out, and `connect()` returned `False` with no `_set_fatal_error` call anywhere in the adapter. The gateway reconnect loop only drops a platform when `has_fatal_error and not fatal_error_retryable`, so a permanent credential error is misclassified as transient and retried indefinitely. `disconnect()` also never harvested `_bot_task`.

Fix: add `_escalate_permanent_bot_task_error()`, called from both `connect()` failure handlers. It inspects the finished bot task and, when the exception is a `LoginFailure` or `PrivilegedIntentsRequired` (matched by class name, stable across discord.py versions and resilient to a mocked module), records `_set_fatal_error(..., retryable=False)` so the gateway stops reconnecting. Transient/timeout cases are left untouched (still retryable). `disconnect()` now harvests `_bot_task` so the stored exception doesn't leak an unretrieved-task warning. This mirrors telegram.py, which always sets a fatal error on connect failure and marks permanent conflicts `retryable=False`.

## Overlap

- Fix 5 overlaps open PR #32677 ("report bot task exits as fatal"). #32677 attaches a done-callback to `_bot_task` and escalates an unexpected `commands.Bot.start()` exit as `retryable=True` (the reconnect-exhaustion / zombie-task class). This PR catches the narrower permanent-auth case (`LoginFailure`/`PrivilegedIntentsRequired`) and escalates `retryable=False`. Both edit the `_bot_task = asyncio.create_task(...)` site and the top of `disconnect()` (textual conflict). Whichever lands first, the other rebases; for permanent auth/intent errors the non-retryable classification should win, since reconnecting a revoked token or absent intent can never succeed.
- Fix 3 overlaps open PR #33513 ("refine Discord voice idle behavior"). #33513 restructures `_voice_timeout_handler` so it no longer calls `leave_voice_channel` from inside the handler (it sends an idle prompt and re-arms the timer instead), which removes the self-cancellation path entirely. Both edit `_voice_timeout_handler`/`leave_voice_channel` (textual conflict). If #33513 lands first, this fix's hunk becomes unnecessary and is dropped on rebase; if this lands first, #33513 supersedes it.
- Fix 4 (thread media routing) overlaps open PR #12218 ("route Discord attachments to metadata thread"). #12218 does the same `metadata['thread_id']` routing, but against the pre-migration `gateway/platforms/discord.py` path and only for the three senders that route through `_send_file_attachment` (`send_image_file`/`send_video`/`send_document`). This fix ports that routing to the current plugin path and additionally covers `send_image`, `send_animation`, `send_voice`, and `send_multiple_images`. Textual conflict at `_send_file_attachment` and its call sites; whichever lands first, the other rebases.
- Fix 2 (send except-handler) may textually conflict with open PR #21199 ("handle Discord 403/503 in send() gracefully during shutdown"), which rewrites the same `send()` outer `except Exception` block (on the pre-migration `gateway/platforms/discord.py` path). The two changes are orthogonal in intent — #21199 downgrades log severity for 403/503/50001/10003, this one flags a surfaced 429 retryable — but both touch the same handler, so whichever lands first the other rebases. Fix 1 has no open-PR overlap.
