### PR TITLE
fix(ntfy): edit-capability flag, fatal escalation, 403 handling, chunking, inbound attachments

### DIFF
--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -66,6 +66,9 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    cache_audio_from_bytes,
+    cache_document_from_bytes,
+    cache_image_from_bytes,
 )
 
 logger = logging.getLogger(__name__)
@@ -158,6 +161,19 @@ class NtfyAdapter(BasePlatformAdapter):
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
 
+    # ntfy has no message-edit API: publishing is POST-only, there is no
+    # PATCH/edit endpoint, and no edit_message override here (so the base
+    # default returns success=False). Declaring this False makes the gateway
+    # treat ntfy as a mirror-line platform: the streaming consumer uses an
+    # empty cursor and routes mid-stream updates as fresh sends instead of
+    # edit_message calls. Left at the default (True), send() always returns a
+    # real message_id, so the consumer stores it and issues edit_message on the
+    # next delta; that fails, trips fallback mode, and tries to strip the
+    # cursor with another failing edit -- the user gets a partial-preview push
+    # ending in a stuck cursor before the real answer. False keeps the preview
+    # from ever leaving a stuck cursor or a failed-edit fallback.
+    SUPPORTS_MESSAGE_EDITING = False
+
     def __init__(self, config: PlatformConfig):
         platform = Platform("ntfy")
         super().__init__(config=config, platform=platform)
@@ -217,7 +233,17 @@ class NtfyAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 return
             except _FatalStreamError:
+                # _set_fatal_error already flipped _running=False and wrote the
+                # fatal runtime status. connect() returned True (the stream is a
+                # background task), so the gateway's startup escalation path was
+                # skipped -- the only way a background failure reaches the
+                # gateway is _notify_fatal_error(), which disconnects/pops this
+                # dead adapter, queues retryable failures for the reconnect
+                # watcher, and cleanly stops the gateway when no platforms
+                # remain. Without it a 401/404/403 silently kills inbound
+                # reception while the adapter lingers reporting stale state.
                 self._running = False
+                await self._notify_fatal_error()
                 return
             except Exception as e:
                 if not self._running:
@@ -268,6 +294,25 @@ class NtfyAdapter(BasePlatformAdapter):
                     retryable=False,
                 )
                 raise _FatalStreamError("404 Not Found")
+            if response.status_code == 403:
+                # ntfy returns 403 (not 401) when a token IS present but lacks
+                # read access to a protected/ACL'd topic. This never succeeds on
+                # retry; without a fatal classification it falls through to
+                # raise_for_status() -> generic except in _run_stream -> reconnect
+                # loop forever at the backoff cap. Mattermost treats 403 the same
+                # way (permanent, stop reconnecting).
+                logger.error(
+                    "[%s] Forbidden (403) for topic %s — stopping reconnect loop. "
+                    "Check NTFY_TOKEN read permissions.",
+                    self.name, self._topic,
+                )
+                self._set_fatal_error(
+                    "ntfy_forbidden",
+                    f"ntfy token lacks read access to topic '{self._topic}' (403). "
+                    "Check NTFY_TOKEN permissions.",
+                    retryable=False,
+                )
+                raise _FatalStreamError("403 Forbidden")
             response.raise_for_status()
 
             async for line in response.aiter_lines():
@@ -319,7 +364,30 @@ class NtfyAdapter(BasePlatformAdapter):
             return
 
         text = (event.get("message") or "").strip()
-        if not text:
+
+        # ntfy can publish a file as an ``attachment`` object
+        # ({"name", "type", "size", "url", "expires"}); the body may be absent.
+        # Download and classify it so the file reaches the agent. Without this
+        # an attachment-only event is dropped at the empty-body guard, and an
+        # attachment-with-body is mistyped as TEXT with its URL discarded — the
+        # gateway only forwards media when message_type is PHOTO/VOICE/DOCUMENT.
+        attachment = event.get("attachment") or {}
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        msg_type = MessageType.TEXT
+        if attachment.get("url"):
+            cached, mime = await self._download_attachment(attachment)
+            if cached:
+                media_urls.append(cached)
+                media_types.append(mime)
+                if mime.startswith("image/"):
+                    msg_type = MessageType.PHOTO
+                elif mime.startswith("audio/"):
+                    msg_type = MessageType.VOICE
+                else:
+                    msg_type = MessageType.DOCUMENT
+
+        if not text and not media_urls:
             logger.debug("[%s] Empty message body, skipping", self.name)
             return
 
@@ -352,15 +420,59 @@ class NtfyAdapter(BasePlatformAdapter):
 
         message_event = MessageEvent(
             text=text,
-            message_type=MessageType.TEXT,
+            message_type=msg_type,
             source=source,
             message_id=msg_id,
             raw_message=event,
             timestamp=timestamp,
+            media_urls=media_urls,
+            media_types=media_types,
         )
 
         logger.debug("[%s] Message on topic %s: %s", self.name, topic, text[:80])
         await self.handle_message(message_event)
+
+    async def _download_attachment(self, attachment: Dict[str, Any]) -> tuple:
+        """Download an ntfy attachment and cache it locally.
+
+        Returns ``(local_path, mime_type)`` on success or ``(None, "")`` on
+        failure. Attachment URLs on protected topics need the same auth headers
+        as the stream, and downstream vision/document tooling reads local file
+        paths — so the bytes are fetched here and cached via the shared
+        ``cache_*_from_bytes`` helpers, mirroring the Mattermost and SimpleX
+        adapters. Failures are logged and degrade gracefully so a bad
+        attachment never crashes the stream consumer.
+        """
+        url = attachment.get("url")
+        if not url or not self._http_client:
+            return None, ""
+        name = attachment.get("name") or "attachment"
+        mime = attachment.get("type") or "application/octet-stream"
+        ext = os.path.splitext(name)[1]
+        try:
+            resp = await self._http_client.get(
+                url, headers=self._auth_headers(), timeout=30.0,
+            )
+            if resp.status_code >= 400:
+                logger.warning(
+                    "[%s] Attachment download failed HTTP %d: %s",
+                    self.name, resp.status_code, url,
+                )
+                return None, ""
+            data = resp.content
+        except Exception as e:
+            logger.warning("[%s] Attachment download error: %s", self.name, e)
+            return None, ""
+
+        try:
+            if mime.startswith("image/"):
+                return cache_image_from_bytes(data, ext or ".jpg"), mime
+            if mime.startswith("audio/"):
+                return cache_audio_from_bytes(data, ext or ".ogg"), mime
+            return cache_document_from_bytes(data, name), mime
+        except Exception as e:
+            logger.warning("[%s] Attachment cache error: %s", self.name, e)
+            return None, ""
 
     # -- Deduplication ------------------------------------------------------
 
@@ -402,27 +514,36 @@ class NtfyAdapter(BasePlatformAdapter):
         if markdown_enabled:
             headers["X-Markdown"] = "true"
 
-        if len(content) > self.MAX_MESSAGE_LENGTH:
-            logger.warning(
-                "[%s] Message truncated from %d to %d chars (ntfy limit)",
-                self.name, len(content), self.MAX_MESSAGE_LENGTH,
-            )
-        body = content[:self.MAX_MESSAGE_LENGTH]
+        # ntfy's 4096-char body limit applies per published notification, so a
+        # long reply must be split across several pushes — a single-slice
+        # ``content[:MAX]`` silently dropped everything past the first chunk
+        # (the gateway hands send() the full response and relies on the adapter
+        # to chunk; it never pre-splits). Loop the base chunker like Mattermost
+        # / IRC and publish each chunk, returning the last message id.
+        chunks = self.truncate_message(content, self.MAX_MESSAGE_LENGTH)
 
         try:
-            resp = await self._http_client.post(
-                url, content=body.encode("utf-8"), headers=headers, timeout=15.0,
-            )
-            if resp.status_code < 300:
+            returned_id: Optional[str] = None
+            for chunk in chunks:
+                resp = await self._http_client.post(
+                    url, content=chunk.encode("utf-8"), headers=headers, timeout=15.0,
+                )
+                if resp.status_code >= 300:
+                    body_text = resp.text
+                    logger.warning(
+                        "[%s] Send failed HTTP %d: %s",
+                        self.name, resp.status_code, body_text[:200],
+                    )
+                    return SendResult(
+                        success=False,
+                        error=f"HTTP {resp.status_code}: {body_text[:200]}",
+                    )
                 try:
                     data = resp.json()
                     returned_id = data.get("id") or uuid.uuid4().hex[:12]
                 except Exception:
                     returned_id = uuid.uuid4().hex[:12]
-                return SendResult(success=True, message_id=returned_id)
-            body_text = resp.text
-            logger.warning("[%s] Send failed HTTP %d: %s", self.name, resp.status_code, body_text[:200])
-            return SendResult(success=False, error=f"HTTP {resp.status_code}: {body_text[:200]}")
+            return SendResult(success=True, message_id=returned_id)
         except httpx.TimeoutException:
             return SendResult(success=False, error="Timeout publishing to ntfy")
         except Exception as e:

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -1019,3 +1019,378 @@ class TestTruncateHelper:
     def test_unicode_message_encoded(self):
         result = _ntfy._truncate_body("héllo 🔔", context="test")
         assert result == "héllo 🔔".encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 13. SUPPORTS_MESSAGE_EDITING — non-editable / mirror-line streaming
+# ---------------------------------------------------------------------------
+
+
+class TestSupportsMessageEditing:
+    """ntfy has no edit API (publishing is POST-only, no edit_message
+    override). It must declare SUPPORTS_MESSAGE_EDITING = False so the gateway
+    reads it via ``getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True)`` and
+    treats ntfy as a mirror-line platform (empty streaming cursor, mid-stream
+    updates routed as fresh sends) instead of issuing edit_message calls that
+    ntfy cannot honor — which would otherwise leave a stuck-cursor preview."""
+
+    def test_flag_is_false_on_class(self):
+        assert NtfyAdapter.SUPPORTS_MESSAGE_EDITING is False
+
+    def test_gateway_getattr_resolves_false(self):
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        # Exactly how gateway/run.py reads the flag.
+        assert getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True) is False
+
+    def test_edit_message_not_supported(self):
+        """No edit_message override -> base default returns success=False.
+        This is why the flag must be False: an edit attempt cannot succeed."""
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        result = _run(adapter.edit_message("t", "mid-1", "updated text"))
+        assert result.success is False
+
+
+# ---------------------------------------------------------------------------
+# 14. Background-stream fatal escalation -> _notify_fatal_error()
+# ---------------------------------------------------------------------------
+
+
+class TestFatalEscalation:
+    """connect() returns True after spawning _run_stream() as a background
+    task, so the gateway's startup escalation (which only runs on connect()
+    == False) is skipped. A background fatal therefore only reaches the
+    gateway through _notify_fatal_error(); _run_stream must call it when the
+    stream dies fatally, otherwise the dead adapter lingers reporting stale
+    state and the gateway never escalates or shuts down."""
+
+    def test_run_stream_notifies_gateway_on_fatal(self):
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        adapter._running = True
+
+        notified = []
+        adapter.set_fatal_error_handler(lambda a: notified.append(a))
+
+        async def _raise_fatal(*_a, **_k):
+            adapter._set_fatal_error("ntfy_unauthorized", "401", retryable=False)
+            raise _ntfy._FatalStreamError("401 Unauthorized")
+
+        with patch.object(adapter, "_consume_stream", side_effect=_raise_fatal):
+            _run(adapter._run_stream())
+
+        assert notified == [adapter]
+        assert adapter._running is False
+
+    def test_run_stream_async_handler_awaited(self):
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        adapter._running = True
+
+        notified = []
+
+        async def _handler(a):
+            notified.append(a)
+
+        adapter.set_fatal_error_handler(_handler)
+
+        async def _raise_fatal(*_a, **_k):
+            adapter._set_fatal_error("ntfy_topic_not_found", "404", retryable=False)
+            raise _ntfy._FatalStreamError("404 Not Found")
+
+        with patch.object(adapter, "_consume_stream", side_effect=_raise_fatal):
+            _run(adapter._run_stream())
+
+        assert notified == [adapter]
+
+
+# ---------------------------------------------------------------------------
+# 15. 403 Forbidden -> permanent fatal (not an infinite reconnect)
+# ---------------------------------------------------------------------------
+
+
+class TestForbiddenFatal:
+    """ntfy returns 403 (not 401) when a token is present but lacks read
+    access to a protected topic. A 403 is permanent and must map to a
+    non-retryable fatal error, otherwise it falls through to
+    raise_for_status() and the reconnect loop busy-loops forever."""
+
+    def test_403_sets_fatal_forbidden(self):
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "locked"}))
+        adapter._http_client = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+        adapter._http_client.stream = MagicMock(return_value=mock_cm)
+
+        fake_httpx = MagicMock()
+        fake_httpx.Timeout = MagicMock()
+        with patch.object(_ntfy, "httpx", fake_httpx):
+            with pytest.raises(_ntfy._FatalStreamError):
+                _run(adapter._consume_stream("https://ntfy.example/locked/json", {}))
+
+        assert adapter.has_fatal_error is True
+        assert adapter._fatal_error_code == "ntfy_forbidden"
+        assert adapter._fatal_error_retryable is False
+        assert "locked" in adapter._fatal_error_message
+
+    def test_403_does_not_call_raise_for_status(self):
+        """403 must be caught before raise_for_status(); otherwise it becomes a
+        generic HTTPStatusError that the reconnect loop retries forever."""
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "locked"}))
+        adapter._http_client = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        mock_response.raise_for_status = MagicMock(
+            side_effect=AssertionError("raise_for_status must not run for 403")
+        )
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+        adapter._http_client.stream = MagicMock(return_value=mock_cm)
+
+        fake_httpx = MagicMock()
+        fake_httpx.Timeout = MagicMock()
+        with patch.object(_ntfy, "httpx", fake_httpx):
+            with pytest.raises(_ntfy._FatalStreamError):
+                _run(adapter._consume_stream("https://ntfy.example/locked/json", {}))
+        mock_response.raise_for_status.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 16. send() chunks long replies instead of dropping the tail
+# ---------------------------------------------------------------------------
+
+
+class TestSendChunking:
+    """The gateway hands send() the full response and relies on the adapter to
+    split it; a single-slice ``content[:MAX]`` silently dropped everything past
+    the first 4096 chars. send() must loop the base chunker and publish every
+    chunk."""
+
+    def _client_capturing_bodies(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"id": "abc"}
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        return mock_client
+
+    def test_long_message_split_into_multiple_posts(self):
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        client = self._client_capturing_bodies()
+        adapter._http_client = client
+
+        long_msg = "x" * (MAX_MESSAGE_LENGTH * 2 + 100)
+        result = _run(adapter.send("t", long_msg))
+
+        assert result.success is True
+        # Multiple chunks -> multiple POSTs (single-slice would post once).
+        assert client.post.call_count >= 2
+
+    def test_tail_not_dropped(self):
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        client = self._client_capturing_bodies()
+        adapter._http_client = client
+
+        # Distinct head/tail so we can prove the tail is actually published.
+        head = "H" * (MAX_MESSAGE_LENGTH - 10)
+        tail = "TAILMARKER"
+        long_msg = head + ("Z" * 20) + tail
+        _run(adapter.send("t", long_msg))
+
+        published = "".join(
+            call.kwargs["content"].decode("utf-8")
+            for call in client.post.call_args_list
+        )
+        assert "TAILMARKER" in published
+
+    def test_each_chunk_within_limit(self):
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        client = self._client_capturing_bodies()
+        adapter._http_client = client
+
+        _run(adapter.send("t", "y" * (MAX_MESSAGE_LENGTH * 2 + 50)))
+        for call in client.post.call_args_list:
+            assert len(call.kwargs["content"].decode("utf-8")) <= MAX_MESSAGE_LENGTH
+
+    def test_short_message_still_single_post(self):
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        client = self._client_capturing_bodies()
+        adapter._http_client = client
+
+        result = _run(adapter.send("t", "short"))
+        assert result.success is True
+        assert client.post.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 17. Inbound attachment download / classification
+# ---------------------------------------------------------------------------
+
+
+class TestInboundAttachments:
+    """ntfy delivers files as an ``attachment`` object on the message event.
+    _on_message must download/classify it (image->PHOTO, audio->VOICE, else
+    DOCUMENT) and populate media_urls/media_types, and must not drop an
+    attachment-only event whose body is empty."""
+
+    def _make_adapter(self):
+        return NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "hermes-in"}))
+
+    def test_image_attachment_promoted_to_photo(self):
+        from gateway.platforms.base import MessageType
+        adapter = self._make_adapter()
+        captured = []
+        adapter.set_message_handler(lambda e: captured.append(e))
+
+        async def _dl(att):
+            return "/cache/img_123.jpg", "image/jpeg"
+
+        with patch.object(adapter, "_download_attachment", side_effect=_dl):
+            _run(adapter._on_message({
+                "id": "att-1",
+                "event": "message",
+                "topic": "hermes-in",
+                "message": "see attached",
+                "attachment": {"name": "pic.jpg", "type": "image/jpeg",
+                               "url": "https://ntfy.example/file/pic.jpg"},
+                "time": None,
+            }))
+
+        assert len(captured) == 1
+        assert captured[0].message_type == MessageType.PHOTO
+        assert captured[0].media_urls == ["/cache/img_123.jpg"]
+        assert captured[0].media_types == ["image/jpeg"]
+
+    def test_document_attachment_promoted_to_document(self):
+        from gateway.platforms.base import MessageType
+        adapter = self._make_adapter()
+        captured = []
+        adapter.set_message_handler(lambda e: captured.append(e))
+
+        async def _dl(att):
+            return "/cache/doc_report.pdf", "application/pdf"
+
+        with patch.object(adapter, "_download_attachment", side_effect=_dl):
+            _run(adapter._on_message({
+                "id": "att-2",
+                "event": "message",
+                "topic": "hermes-in",
+                "message": "report",
+                "attachment": {"name": "report.pdf", "type": "application/pdf",
+                               "url": "https://ntfy.example/file/report.pdf"},
+                "time": None,
+            }))
+
+        assert captured[0].message_type == MessageType.DOCUMENT
+        assert captured[0].media_urls == ["/cache/doc_report.pdf"]
+
+    def test_attachment_only_empty_body_not_dropped(self):
+        """An attachment with no body must still be dispatched — the old
+        ``if not text: return`` guard silently discarded it."""
+        from gateway.platforms.base import MessageType
+        adapter = self._make_adapter()
+        captured = []
+        adapter.set_message_handler(lambda e: captured.append(e))
+
+        async def _dl(att):
+            return "/cache/img_xyz.png", "image/png"
+
+        with patch.object(adapter, "_download_attachment", side_effect=_dl):
+            _run(adapter._on_message({
+                "id": "att-3",
+                "event": "message",
+                "topic": "hermes-in",
+                "attachment": {"name": "shot.png", "type": "image/png",
+                               "url": "https://ntfy.example/file/shot.png"},
+                "time": None,
+            }))
+
+        assert len(captured) == 1
+        assert captured[0].message_type == MessageType.PHOTO
+        assert captured[0].media_urls == ["/cache/img_xyz.png"]
+
+    def test_plain_text_message_stays_text_with_no_media(self):
+        from gateway.platforms.base import MessageType
+        adapter = self._make_adapter()
+        captured = []
+        adapter.set_message_handler(lambda e: captured.append(e))
+
+        _run(adapter._on_message({
+            "id": "txt-1",
+            "event": "message",
+            "topic": "hermes-in",
+            "message": "just text",
+            "time": None,
+        }))
+
+        assert captured[0].message_type == MessageType.TEXT
+        assert captured[0].media_urls == []
+        assert captured[0].media_types == []
+
+    def test_failed_download_degrades_to_text(self):
+        """If the attachment download fails, the message must still be
+        delivered (as text) rather than crashing the stream consumer."""
+        from gateway.platforms.base import MessageType
+        adapter = self._make_adapter()
+        captured = []
+        adapter.set_message_handler(lambda e: captured.append(e))
+
+        async def _dl(att):
+            return None, ""
+
+        with patch.object(adapter, "_download_attachment", side_effect=_dl):
+            _run(adapter._on_message({
+                "id": "att-4",
+                "event": "message",
+                "topic": "hermes-in",
+                "message": "body with broken attachment",
+                "attachment": {"name": "x.bin", "type": "application/octet-stream",
+                               "url": "https://ntfy.example/file/x.bin"},
+                "time": None,
+            }))
+
+        assert len(captured) == 1
+        assert captured[0].message_type == MessageType.TEXT
+        assert captured[0].media_urls == []
+
+    def test_download_attachment_uses_auth_and_caches_image(self):
+        """_download_attachment fetches with auth headers and routes image
+        bytes through cache_image_from_bytes."""
+        adapter = NtfyAdapter(
+            PlatformConfig(enabled=True, extra={"topic": "t", "token": "tk"})
+        )
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = b"\xff\xd8\xff binary"
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        adapter._http_client = mock_client
+
+        with patch.object(_ntfy, "cache_image_from_bytes", return_value="/cache/i.jpg") as m_img:
+            path, mime = _run(adapter._download_attachment(
+                {"name": "p.jpg", "type": "image/jpeg",
+                 "url": "https://ntfy.example/file/p.jpg"}
+            ))
+
+        assert path == "/cache/i.jpg"
+        assert mime == "image/jpeg"
+        m_img.assert_called_once()
+        sent_headers = mock_client.get.call_args.kwargs["headers"]
+        assert sent_headers.get("Authorization") == "Bearer tk"
+
+    def test_download_attachment_http_error_returns_none(self):
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        adapter._http_client = mock_client
+
+        path, mime = _run(adapter._download_attachment(
+            {"name": "x", "type": "image/png", "url": "https://ntfy.example/file/x"}
+        ))
+        assert path is None
+        assert mime == ""


### PR DESCRIPTION
Fixes five independently-verified bugs in the ntfy platform plugin, each with a focused regression test that fails on the current adapter and passes with the change. The fixes span streaming-edit semantics, background fatal escalation, permanent-rejection classification, outbound chunking, and inbound attachment handling — every one verified against the live adapter and cross-checked against the sibling adapters (IRC, Mattermost, SimpleX) that already handle these cases.

## 1. No `SUPPORTS_MESSAGE_EDITING` flag — streamed replies leave a stuck-cursor preview

**Symptom:** When streaming is enabled, a streamed ntfy reply arrives as a partial-preview push notification ending in a streaming cursor that never gets cleaned up, followed separately by the real answer.

**Root cause:** `NtfyAdapter` neither overrides `edit_message` nor declares `SUPPORTS_MESSAGE_EDITING`. The gateway reads the capability with `getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True)`, so ntfy defaults to edit-capable. ntfy has no edit primitive — publishing is POST-only, there is no PATCH/edit endpoint — so `send()` always returns a real message id, the stream consumer stores it, and on the next delta calls `edit_message`, which falls through to the base default `SendResult(success=False, error="Not supported")`. That trips fallback mode and a best-effort cursor-strip edit that also fails, leaving the preview push with a stuck cursor.

**Fix:** Declare `SUPPORTS_MESSAGE_EDITING = False`. The gateway then treats ntfy as a mirror-line platform: it uses an empty streaming cursor and routes mid-stream updates as fresh sends instead of `edit_message` calls. The preview never leaves a stuck cursor or a failed-edit fallback. Mirrors `signal.py`, `wecom.py`, `weixin.py`, `bluebubbles.py`, `qqbot`, and the in-flight SimpleX fix.

## 2. Background stream sets a fatal error but never escalates it to the gateway

**Symptom:** A 401/404 (and, after fix #3, a 403) silently kills inbound reception. The adapter lingers in the gateway's registry reporting stale `is_connected`, runtime status never flips, and if ntfy is the only platform the gateway never shuts down.

**Root cause:** `connect()` returns `True` after spawning `_run_stream()` as a background task, so the gateway registers ntfy as live and the startup fatal-error escalation path — which only runs when `connect()` returns `False` — is skipped. After that, the only channel a background failure has to the gateway is `await self._notify_fatal_error()`, which is what disconnects/pops the dead adapter, queues retryable failures for the reconnect watcher, and cleanly stops the gateway when no platforms remain. `_consume_stream` calls `_set_fatal_error(...)` on 401/404 and raises `_FatalStreamError`; `_run_stream` catches it, sets `_running = False`, and returns — but never calls `_notify_fatal_error()`. On current main `_set_fatal_error` only writes runtime status; it does not auto-notify.

**Fix:** After catching `_FatalStreamError` in `_run_stream`, `await self._notify_fatal_error()` before returning. `_notify_fatal_error` is a no-op when no handler is installed, so it is safe in standalone use. This matches the IRC receive loop, which calls `_set_fatal_error(...)` immediately followed by `await self._notify_fatal_error()`.

## 3. 403 Forbidden is retried forever instead of being treated as permanent

**Symptom:** A token that is present but lacks read access to a protected/ACL'd topic busy-loops reconnecting forever at the backoff cap, with no gateway-visible fatal state.

**Root cause:** `_consume_stream` special-cases only 401 and 404 as fatal. ntfy returns **403** (not 401) when credentials are valid but unauthorized for the topic. 403 falls through to `response.raise_for_status()`, raising `httpx.HTTPStatusError`, which the generic `except Exception` in `_run_stream` logs as a transient stream error and retries forever — backoff is capped at 60s and reset whenever a connection lasts at least 60s, so a fast-failing 403 cycles at the cap indefinitely. This is a permanent authorization failure that never succeeds on retry.

**Fix:** Add a `status_code == 403` branch ahead of `raise_for_status()` that logs, calls `_set_fatal_error("ntfy_forbidden", ..., retryable=False)`, and raises `_FatalStreamError` — the same shape as 401/404. Paired with fix #2, the gateway now escalates instead of looping. Mattermost classifies 403 as a permanent error the same way.

## 4. `send()` drops the tail of long replies instead of chunking

**Symptom:** Any reply longer than 4096 characters (multi-paragraph explanations, code dumps) is silently cut off — the user only receives the first 4096 chars.

**Root cause:** The non-streaming delivery path hands `send()` the full response and relies on each adapter to chunk; the gateway never pre-splits. ntfy's `send()` did `body = content[:MAX_MESSAGE_LENGTH]` after only logging a warning, discarding everything past the limit.

**Fix:** Loop `self.truncate_message(content, self.MAX_MESSAGE_LENGTH)` and POST each chunk, returning the last chunk's message id and failing fast on the first non-2xx. Matches Mattermost (`truncate_message` then send each chunk) and IRC. The base `truncate_message` preserves code-fence boundaries and adds `(1/N)` indicators.

## 5. Inbound attachments are never downloaded or classified

**Symptom:** A user publishing a PDF / image / zip / office file to the topic gets it silently discarded. An attachment with no body is dropped entirely; an attachment with a body is delivered as plain `TEXT` with the file reference lost.

**Root cause:** ntfy delivers files as an `attachment` object (`name`, `type`, `size`, `url`, `expires`) on the message event. `_on_message` only read `event.get("message")` and always built the `MessageEvent` with `message_type=MessageType.TEXT` and empty media. Attachment-only events hit the `if not text: return` guard and were dropped; attachments with a body were mistyped as TEXT. The gateway only forwards inbound media when `message_type` is `DOCUMENT` (documents) or `PHOTO` / `image/*` (images), so neither path ever fired.

**Fix:** Read `event.get("attachment")`; when it carries a `url`, download the bytes (with the same auth headers as the stream) and cache them via the shared `cache_image_from_bytes` / `cache_audio_from_bytes` / `cache_document_from_bytes` helpers, then set `media_urls` / `media_types` and map the MIME type to `PHOTO` (image/*), `VOICE` (audio/*), or `DOCUMENT` (everything else). The empty-body guard now also admits attachment-only events. Download/cache failures are caught, logged, and degrade gracefully to text so a bad attachment never crashes the stream consumer. Mirrors the SimpleX and Mattermost attachment pipelines.

## Overlap

No open or merged PR touches the ntfy adapter for any of these bug classes (the only prior ntfy PRs add the adapter, #30867, and the echo-loop tag fix, #34838, both already in the base). The SimpleX adapter has separate in-flight PRs for the same bug classes — `SUPPORTS_MESSAGE_EDITING = False` (#35522), outbound chunking (#35558), and non-retryable handshake escalation (#35557) — confirming these are recognized platform-adapter defects; this PR brings ntfy to the same baseline. The base PR #28930 proposes auto-notifying from `_set_fatal_error` itself, which would subsume the escalation half of fix #2, but it is unmerged, so the adapter-level `_notify_fatal_error()` call is required on main today.

## Tests

Adds five test classes to `tests/gateway/test_ntfy_plugin.py` (18 new tests). Each fix has at least one red->green regression test verified to fail on the unmodified adapter:

- `TestSupportsMessageEditing` — flag is `False`; gateway `getattr` resolves `False`; `edit_message` returns `success=False`.
- `TestFatalEscalation` — `_run_stream` invokes the installed fatal handler (sync and async) on `_FatalStreamError` and clears `_running`.
- `TestForbiddenFatal` — 403 sets `ntfy_forbidden` non-retryable fatal and never reaches `raise_for_status()`.
- `TestSendChunking` — long replies split across multiple POSTs, the tail is published, each chunk stays within the limit, short replies stay single-POST.
- `TestInboundAttachments` — image->PHOTO, document->DOCUMENT, attachment-only empty body is dispatched, failed download degrades to TEXT, `_download_attachment` sends auth headers and routes through the cache helpers.

Full file: 100 passed. The platform-plugin interface test (`tests/gateway/test_plugin_platform_interface.py`) is environment-skipped (7 skipped) and is unaffected by this change.
