### PR TITLE
fix(line): repair scoped lock, auth escalation, cache prune, edit flag

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -427,6 +427,19 @@ def _allowed_for_source(
 # LINE Reply / Push HTTP client
 # ---------------------------------------------------------------------------
 
+class _LineAuthError(Exception):
+    """Raised when LINE rejects the channel access token (HTTP 401/403).
+
+    Distinguishes a permanent credential failure (revoked/invalid token or
+    missing Messaging API permission) from transient 5xx / offline errors so
+    ``connect()`` can escalate to a non-retryable fatal instead of looping.
+    """
+
+    def __init__(self, status: int) -> None:
+        super().__init__(f"LINE rejected the channel access token (HTTP {status})")
+        self.status = status
+
+
 class _LineClient:
     """Thin async wrapper around the LINE Messaging API.
 
@@ -499,16 +512,26 @@ class _LineClient:
                 return await resp.read()
 
     async def get_bot_user_id(self) -> Optional[str]:
-        """Fetch this channel's own userId so we can filter self-messages."""
+        """Fetch this channel's own userId so we can filter self-messages.
+
+        Raises ``_LineAuthError`` on a 401/403 (the token is invalid, revoked,
+        or lacks Messaging API permission — a permanent failure connect() must
+        escalate). Returns None for any other failure (transient 5xx, timeout,
+        offline tests), where best-effort self-filtering is the right fallback.
+        """
         import aiohttp
         timeout = aiohttp.ClientTimeout(total=10.0)
         try:
             async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
                 async with session.get(LINE_BOT_INFO_URL, headers=self._headers) as resp:
+                    if resp.status in (401, 403):
+                        raise _LineAuthError(resp.status)
                     if resp.status >= 400:
                         return None
                     data = await resp.json()
                     return data.get("userId")
+        except _LineAuthError:
+            raise
         except Exception:
             return None
 
@@ -623,8 +646,16 @@ def _truthy_env(name: str, default: bool = False) -> bool:
 class LineAdapter(BasePlatformAdapter):
     """LINE Messaging API gateway adapter."""
 
-    # LINE has its own message-edit story (none) — we always send fresh
-    # bubbles, never edit, so REQUIRES_EDIT_FINALIZE stays False.
+    # LINE has no message-edit primitive — the reply/push model only ever
+    # appends fresh bubbles. Declaring SUPPORTS_MESSAGE_EDITING = False makes
+    # the gateway disable the live cursor and route streaming as fresh sends
+    # instead of edit_message calls (which the inherited base returns
+    # "Not supported" for). Without it the gateway's getattr default is True,
+    # so the first streamed frame ships with a cursor (█) that every failed
+    # edit then leaves stuck on a permanent partial bubble. Mirrors
+    # signal/wecom/weixin/qqbot/bluebubbles. (REQUIRES_EDIT_FINALIZE is a
+    # separate attribute and stays False by default.)
+    SUPPORTS_MESSAGE_EDITING = False
 
     def __init__(self, config, **kwargs):
         platform = Platform("line")
@@ -710,7 +741,6 @@ class LineAdapter(BasePlatformAdapter):
         self._cache = RequestCache()
         self._dedup = _MessageDeduplicator()
         self._bot_user_id: Optional[str] = None
-        self._lock_key: Optional[str] = None
 
         # Media state
         self._media_tokens: Dict[str, Tuple[str, float]] = {}  # token → (path, expiry)
@@ -735,29 +765,45 @@ class LineAdapter(BasePlatformAdapter):
             return False
 
         # Prevent two profiles from running on the same channel access token.
-        try:
-            from gateway.status import acquire_scoped_lock
-            # Use a hash of the token so we don't write the secret to disk.
-            tok_hash = hashlib.sha256(self.channel_access_token.encode()).hexdigest()[:16]
-            if not acquire_scoped_lock("line", tok_hash):
-                self._set_fatal_error(
-                    "lock_conflict",
-                    "LINE channel already in use by another profile",
-                    retryable=False,
-                )
-                return False
-            self._lock_key = tok_hash
-        except ImportError:
-            self._lock_key = None
+        # _acquire_platform_lock unpacks the (acquired, existing) tuple that
+        # acquire_scoped_lock returns — emitting the owner-PID error message and
+        # a retryable=False fatal on conflict, matching Slack/Telegram/Discord
+        # (acquire_scoped_lock hashes the identity before persisting, so the raw
+        # token is never written to disk). The previous bespoke block called
+        # acquire_scoped_lock as `if not acquire_scoped_lock(...)` and treated
+        # the 2-tuple return as a bool: a non-empty tuple is always truthy, so
+        # `not (...)` was always False and the conflict guard was dead code —
+        # two profiles sharing one channel token both passed it.
+        if not self._acquire_platform_lock(
+            "line-channel-token",
+            self.channel_access_token,
+            "LINE channel access token",
+        ):
+            return False
 
         self._client = _LineClient(self.channel_access_token)
 
-        # Best-effort: fetch our own bot userId for self-message filtering.
-        # If the call fails (offline tests, transient 5xx) we fall back to
-        # not filtering self-events; the cost is minor (LINE doesn't
-        # actually echo our own messages back).
+        # Validate the token via the bot-info probe. A 401/403 means the token
+        # is invalid/revoked or lacks Messaging API permission — a permanent
+        # failure. Since LINE is a webhook receiver, a bad token would otherwise
+        # never surface through connect(): the gateway would report "connected"
+        # while every outbound reply/push 401s forever, and the user silently
+        # receives nothing. Escalate to a non-retryable fatal so the gateway
+        # drops it instead of looping. Any other failure (transient 5xx,
+        # timeout, offline tests) stays best-effort: we skip self-message
+        # filtering, which LINE doesn't require since it never echoes our own
+        # messages back.
         try:
             self._bot_user_id = await self._client.get_bot_user_id()
+        except _LineAuthError as exc:
+            self._set_fatal_error(
+                "auth_failed",
+                "LINE channel access token rejected "
+                f"(HTTP {exc.status}) — check LINE_CHANNEL_ACCESS_TOKEN and "
+                "Messaging API permissions",
+                retryable=False,
+            )
+            return False
         except Exception as exc:
             logger.debug("LINE: get_bot_user_id failed: %s", exc)
             self._bot_user_id = None
@@ -832,13 +878,7 @@ class LineAdapter(BasePlatformAdapter):
         self._media_temp_paths.clear()
         self._media_tokens.clear()
 
-        if self._lock_key:
-            try:
-                from gateway.status import release_scoped_lock
-                release_scoped_lock("line", self._lock_key)
-            except Exception:
-                pass
-            self._lock_key = None
+        self._release_platform_lock()
 
     # ------------------------------------------------------------------
     # Webhook handlers
@@ -880,6 +920,13 @@ class LineAdapter(BasePlatformAdapter):
         return web.Response(status=200, text="ok")
 
     async def _dispatch_event(self, event: Dict[str, Any]) -> None:
+        # Opportunistically reclaim expired postback-cache entries on each
+        # inbound event (eviction-on-touch, the same pattern _register_media
+        # uses for media tokens). Without this, prune() has no callsite and the
+        # cache grows unbounded for the gateway's lifetime — every slow
+        # response and abandoned PENDING entry is retained forever.
+        self._cache.prune()
+
         event_type = event.get("type")
         source = event.get("source") or {}
         webhook_event_id = event.get("webhookEventId", "") or ""

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -45,6 +45,8 @@ validate_config = _line.validate_config
 _standalone_send = _line._standalone_send
 _env_enablement = _line._env_enablement
 _MessageDeduplicator = _line._MessageDeduplicator
+_LineClient = _line._LineClient
+_LineAuthError = _line._LineAuthError
 
 
 # ---------------------------------------------------------------------------
@@ -641,3 +643,225 @@ class TestAdapterInit:
         assert asyncio.run(ad.get_chat_info("U123"))["type"] == "dm"
         assert asyncio.run(ad.get_chat_info("C123"))["type"] == "group"
         assert asyncio.run(ad.get_chat_info("R123"))["type"] == "channel"
+
+
+# ---------------------------------------------------------------------------
+# 9. Scoped-lock conflict detection (acquire_scoped_lock returns a 2-tuple)
+# ---------------------------------------------------------------------------
+
+class TestScopedLockConflict:
+    """connect() must refuse to start when another profile already holds the
+    lock for the same channel access token. The pre-fix code called
+    acquire_scoped_lock as a bare bool — a non-empty tuple is always truthy, so
+    the conflict guard never fired and two gateways ran on one channel."""
+
+    def _adapter(self, monkeypatch):
+        monkeypatch.delenv("LINE_CHANNEL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
+        from gateway.config import PlatformConfig
+        cfg = PlatformConfig(enabled=True, extra={
+            "channel_access_token": "tok",
+            "channel_secret": "sec",
+        })
+        return LineAdapter(cfg)
+
+    def test_connect_refuses_when_lock_held(self, monkeypatch):
+        ad = self._adapter(monkeypatch)
+        import gateway.status as _status
+        # Another profile owns the lock: acquire returns (False, owner_record).
+        monkeypatch.setattr(
+            _status, "acquire_scoped_lock",
+            lambda *a, **kw: (False, {"pid": 4242}),
+        )
+        # If the conflict guard is dead code the adapter proceeds to bind a real
+        # webhook server; assert it short-circuits before that instead.
+        connected = asyncio.run(ad.connect())
+        assert connected is False
+        assert ad.has_fatal_error
+        assert ad.fatal_error_code == "line-channel-token_lock"
+        assert ad.fatal_error_retryable is False
+        # Never created the client / bound the server.
+        assert ad._client is None
+        assert ad._site is None
+
+    def test_connect_acquires_lock_under_channel_token_scope(self, monkeypatch):
+        ad = self._adapter(monkeypatch)
+        import gateway.status as _status
+        seen = {}
+
+        def _acquire(scope, identity, metadata=None):
+            seen["scope"] = scope
+            seen["identity"] = identity
+            return (False, None)  # decline so we don't reach server bind
+
+        monkeypatch.setattr(_status, "acquire_scoped_lock", _acquire)
+        asyncio.run(ad.connect())
+        # Distinct scope per resource (acquire_scoped_lock hashes the identity
+        # internally before persisting, so the raw token never hits disk).
+        assert seen["scope"] == "line-channel-token"
+        assert seen["identity"] == "tok"
+
+
+# ---------------------------------------------------------------------------
+# 10. Invalid/revoked token escalates to a non-retryable fatal
+# ---------------------------------------------------------------------------
+
+class TestAuthEscalation:
+    """A 401/403 from the bot-info probe is a permanent credential failure.
+    connect() must escalate to a non-retryable fatal rather than reporting
+    'connected' while every outbound send 401s forever."""
+
+    def _adapter(self, monkeypatch):
+        monkeypatch.delenv("LINE_CHANNEL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
+        from gateway.config import PlatformConfig
+        cfg = PlatformConfig(enabled=True, extra={
+            "channel_access_token": "tok",
+            "channel_secret": "sec",
+        })
+        ad = LineAdapter(cfg)
+        import gateway.status as _status
+        # Grant the lock so connect() reaches the bot-info probe.
+        monkeypatch.setattr(
+            _status, "acquire_scoped_lock", lambda *a, **kw: (True, None)
+        )
+        return ad
+
+    def test_401_escalates_to_non_retryable_fatal(self, monkeypatch):
+        ad = self._adapter(monkeypatch)
+
+        async def _raise_auth(self):
+            raise _LineAuthError(401)
+
+        monkeypatch.setattr(_LineClient, "get_bot_user_id", _raise_auth)
+        connected = asyncio.run(ad.connect())
+        assert connected is False
+        assert ad.has_fatal_error
+        assert ad.fatal_error_code == "auth_failed"
+        assert ad.fatal_error_retryable is False
+        # Server must NOT have been bound on a permanently-broken credential.
+        assert ad._site is None
+
+    def test_transient_failure_stays_best_effort(self, monkeypatch):
+        # A None return (transient 5xx / offline) must NOT escalate — the
+        # adapter proceeds and self-filtering is simply skipped. We stub the
+        # aiohttp server startup so no socket is bound by the test.
+        ad = self._adapter(monkeypatch)
+
+        async def _return_none(self):
+            return None
+
+        monkeypatch.setattr(_LineClient, "get_bot_user_id", _return_none)
+
+        from aiohttp import web
+
+        class _FakeRunner:
+            def __init__(self, *a, **kw): pass
+            async def setup(self): pass
+            async def cleanup(self): pass
+
+        class _FakeSite:
+            def __init__(self, *a, **kw): pass
+            async def start(self): pass
+            async def stop(self): pass
+
+        monkeypatch.setattr(web, "AppRunner", _FakeRunner)
+        monkeypatch.setattr(web, "TCPSite", _FakeSite)
+
+        connected = asyncio.run(ad.connect())
+        try:
+            assert connected is True
+            assert not ad.has_fatal_error
+            # Transient failure → self-filtering disabled, but no fatal.
+            assert ad._bot_user_id is None
+        finally:
+            asyncio.run(ad.disconnect())
+
+    def test_get_bot_user_id_raises_on_401(self):
+        # Unit-level: a 401 response surfaces as _LineAuthError, not None.
+        client = _LineClient("tok")
+
+        class _Resp:
+            status = 401
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return False
+            async def json(self): return {}
+
+        class _Sess:
+            def __init__(self, *a, **kw): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return False
+            def get(self, *a, **kw): return _Resp()
+
+        import aiohttp
+        orig = aiohttp.ClientSession
+        aiohttp.ClientSession = _Sess
+        try:
+            with pytest.raises(_LineAuthError) as ei:
+                asyncio.run(client.get_bot_user_id())
+            assert ei.value.status == 401
+        finally:
+            aiohttp.ClientSession = orig
+
+
+# ---------------------------------------------------------------------------
+# 11. Postback cache is pruned on inbound events
+# ---------------------------------------------------------------------------
+
+class TestCachePruneOnDispatch:
+    """RequestCache.prune() had no callsite, so the postback cache grew
+    unbounded. _dispatch_event must reclaim expired entries on each event."""
+
+    @pytest.fixture
+    def adapter(self, monkeypatch):
+        monkeypatch.delenv("LINE_CHANNEL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("LINE_CHANNEL_SECRET", raising=False)
+        from gateway.config import PlatformConfig
+        cfg = PlatformConfig(enabled=True, extra={
+            "channel_access_token": "tok",
+            "channel_secret": "sec",
+        })
+        return LineAdapter(cfg)
+
+    def test_dispatch_prunes_expired_entries(self, adapter):
+        import time as _time
+        # A READY entry whose 1h TTL has elapsed.
+        rid = adapter._cache.register_pending("Uold")
+        adapter._cache.set_ready(rid, "stale answer")
+        entry = adapter._cache.get(rid)
+        entry.updated_at = _time.time() - adapter._cache._ttl - 100
+        # Dispatch an unrelated (unauthorized) event — it is rejected by the
+        # allowlist, but prune() at the top of _dispatch_event still runs.
+        asyncio.run(adapter._dispatch_event(
+            {"type": "message", "source": {"type": "user", "userId": "Unobody"}}
+        ))
+        assert adapter._cache.get(rid) is None
+
+    def test_dispatch_keeps_fresh_entries(self, adapter):
+        rid = adapter._cache.register_pending("Ufresh")
+        adapter._cache.set_ready(rid, "recent")
+        asyncio.run(adapter._dispatch_event(
+            {"type": "message", "source": {"type": "user", "userId": "Unobody"}}
+        ))
+        assert adapter._cache.get(rid) is not None
+
+
+# ---------------------------------------------------------------------------
+# 12. SUPPORTS_MESSAGE_EDITING declared False (no LINE edit API)
+# ---------------------------------------------------------------------------
+
+class TestMessageEditingFlag:
+    """LINE has no edit primitive. The attribute must be present and False so
+    the gateway disables the streaming cursor and routes fresh sends instead
+    of failed edit_message calls (which would leave a stuck █ cursor)."""
+
+    def test_class_attribute_is_false(self):
+        assert LineAdapter.SUPPORTS_MESSAGE_EDITING is False
+
+    def test_gateway_getattr_resolves_false(self, monkeypatch):
+        monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+        monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+        from gateway.config import PlatformConfig
+        ad = LineAdapter(PlatformConfig(enabled=True))
+        # This is exactly how gateway/run.py reads it.
+        assert getattr(ad, "SUPPORTS_MESSAGE_EDITING", True) is False


### PR DESCRIPTION
Fixes 4 independently-verified bugs in the LINE plugin adapter, each with a focused red→green regression test. All findings were re-verified against the adapter at the base commit before implementing; every fix fails on the unpatched adapter and passes after. The existing 73-test LINE suite continues to pass (82 total with the new tests).

## 1. Scoped-lock conflict guard was dead code (two gateways on one channel)

**Symptom.** Two profiles configured with the same LINE channel access token could both start, producing duplicate inbound dispatch, a race to consume the single-use reply token, and doubled outbound/push billing — the exact condition the lock exists to prevent.

**Root cause.** `connect()` called `if not acquire_scoped_lock("line", tok_hash):`. `acquire_scoped_lock` returns a 2-tuple `(acquired, existing_record)` (gateway/status.py). A non-empty tuple is always truthy, so `not (...)` was always `False`: the conflict branch (`_set_fatal_error("lock_conflict", ..., retryable=False)`) was unreachable, and `self._lock_key = tok_hash` was set unconditionally — even when the lock was genuinely not acquired.

**Fix.** Replace the bespoke block with the inherited `self._acquire_platform_lock("line-channel-token", self.channel_access_token, "LINE channel access token")`, and `self._release_platform_lock()` in `disconnect()`. This unpacks the tuple correctly, emits the owner-PID error message, and sets the `retryable=False` fatal on conflict — the same path Slack/Telegram/Discord already use. `acquire_scoped_lock` hashes the identity before persisting, so the raw token is never written to disk.

## 2. Invalid/revoked channel token never escalated to a fatal

**Symptom.** With a revoked token or one missing `message:write` permission, the adapter reported `connected`; every outbound reply/push then 401'd forever and the user silently received nothing, with no path to the non-retryable fatal state.

**Root cause.** `connect()` only checked credential *presence*. The one probe that could detect a bad token, `get_bot_user_id()` (hits the bot-info endpoint), collapsed every `status >= 400` and every exception to `None`, making a 401/403 (permanent) indistinguishable from a transient 5xx or an offline test. `connect()` caught that into `_bot_user_id = None` and proceeded to `_mark_connected()`. A revoked token is a permanent failure but was treated as a healthy connection.

**Fix.** Add a typed `_LineAuthError(status)`; `get_bot_user_id()` raises it on 401/403 and still returns `None` for any other failure (transient 5xx, timeout, offline tests). `connect()` catches `_LineAuthError` and calls `_set_fatal_error("auth_failed", ..., retryable=False)` then returns `False`, so the gateway drops the platform instead of looping while reporting connected. The `None`/timeout/5xx path keeps the prior best-effort behaviour (self-filtering is simply skipped — LINE never echoes our own messages back).

## 3. RequestCache.prune() had no callsite (unbounded postback-cache growth)

**Symptom.** Slow-running gateways leaked memory: one retained postback-cache entry per slow response or abandoned PENDING entry, each holding the full response-payload string, accumulating for the process lifetime.

**Root cause.** `RequestCache.prune()` implements the PENDING (24h) and READY/DELIVERED/ERROR (1h) TTLs, but nothing ever called it — `register_pending` only added entries. (`_MessageDeduplicator` has bounded LRU eviction; `RequestCache` had no equivalent reclamation.)

**Fix.** Call `self._cache.prune()` at the top of `_dispatch_event`, the same eviction-on-touch pattern `_register_media` uses for media tokens. Expired entries are reclaimed on each inbound event.

## 4. SUPPORTS_MESSAGE_EDITING was unset, leaving a stuck streaming cursor

**Symptom.** On the common reply-token path, the first streamed frame shipped with the live cursor (█) appended; LINE has no edit API, so every mid-stream `edit_message` failed and the cursor was never stripped — leaving a permanently stuck partial-preview bubble.

**Root cause.** The adapter never declared `SUPPORTS_MESSAGE_EDITING`. The gateway reads it via `getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)`, so the default `True` kept the live cursor enabled and routed mid-stream updates through `adapter.edit_message`, which the inherited base returns `SendResult(success=False, error="Not supported")` for. The in-file comment only referenced `REQUIRES_EDIT_FINALIZE`, conflating the two attributes.

**Fix.** Declare `SUPPORTS_MESSAGE_EDITING = False` on `LineAdapter` (matching signal/wecom/weixin/qqbot/bluebubbles). The gateway then uses an empty cursor and delivers each chunk as a fresh `send()` — exactly what LINE's reply/push model already does cleanly. The comment is updated to reference the correct attribute.

## Overlap

These four fixes are confined to `connect`/`disconnect`, `get_bot_user_id`, `_dispatch_event`, and one class attribute — no core edits. A separate `send_voice`/`send_video` signature fix is intentionally *not* included here: #24091 already owns that work and is more complete, threading `reply_to` through `send_voice`/`send_video`/`_send_messages` (and `send_image_file`) via the reply-token map rather than accepting-and-ignoring it. We defer to #24091 for the media-send signatures.

Two open PRs touch adjacent regions and will need a trivial rebase:

- **#34424** (`feat(line): require_mention and quote-reply for group chats`) edits `get_bot_user_id` and the `connect()` block where `self._bot_user_id = await self._client.get_bot_user_id()` lives — the same region as fix 2. Expect a small conflict there; the resolution is mechanical (keep the `_LineAuthError` escalation around the probe call).
- **#29053** (`feat(line): inline-button approval prompts`) adds an `__init__` field and new postback handlers near fix 1's lock block and fix 3's `_dispatch_event` prune callsite. These are adjacent edits, not the same lines; the hunks coexist after a context-only rebase.

No open PR addresses the lock dead-code, the auth escalation, the prune callsite, or the edit-flag.
