### PR TITLE
fix(teams): chunk at advertised limit and declare no message editing

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -623,6 +623,12 @@ class TeamsAdapter(BasePlatformAdapter):
     """Microsoft Teams adapter using the microsoft-teams-apps SDK."""
 
     MAX_MESSAGE_LENGTH = 28000  # Teams text message limit (~28 KB)
+    # The microsoft-teams SDK send() returns Bot Framework activity ids that
+    # this adapter cannot edit in place (no edit_message override), so editing
+    # is unsupported.  Declaring this False makes the gateway skip streaming on
+    # the non-editable path instead of sending an un-editable partial preview
+    # followed by a duplicate final message with a stuck cursor.
+    SUPPORTS_MESSAGE_EDITING = False
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform("teams"))
@@ -986,7 +992,11 @@ class TeamsAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Teams app not initialized")
 
         formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted)
+        # Chunk at the advertised Teams limit, not the base 4096 default.
+        # truncate_message is a @staticmethod whose default max_length is
+        # 4096; subclassing does not rebind it to MAX_MESSAGE_LENGTH, so the
+        # limit must be passed explicitly (matching slack/discord/mattermost).
+        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         last_message_id = None
 
         for chunk in chunks:

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -461,6 +461,90 @@ class TestTeamsSend:
         call_args = mock_app.send.call_args
         assert call_args[0][0] == "conv-id"
 
+    @pytest.mark.anyio
+    async def test_send_chunks_at_advertised_limit_not_base_default(self):
+        """Regression: send() must chunk at MAX_MESSAGE_LENGTH (28000), not the
+        base truncate_message default of 4096.  A ~10 KB response that Teams
+        accepts whole was being fragmented into multiple (1/N) messages because
+        the limit was never passed to the @staticmethod."""
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        sent = []
+
+        async def _capture(conversation_id, activity):
+            sent.append(activity)
+            result = MagicMock()
+            result.id = "msg-1"
+            return result
+
+        mock_app = MagicMock()
+        mock_app.send = AsyncMock(side_effect=_capture)
+        adapter._app = mock_app
+
+        # Between the base default (4096) and the Teams limit (28000): fits in
+        # a single Teams message but would split under the wrong default.
+        result = await adapter.send("conv-id", "x" * 10000)
+
+        assert result.success is True
+        # One chunk -> one platform message, no (1/N) continuation tags.
+        assert len(sent) == 1
+        assert mock_app.send.await_count == 1
+        assert "(1/" not in sent[0]
+
+    @pytest.mark.anyio
+    async def test_send_still_chunks_beyond_teams_limit(self):
+        """Content larger than MAX_MESSAGE_LENGTH must still be split, so the
+        explicit limit is honoured (not effectively disabled)."""
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        sent = []
+
+        async def _capture(conversation_id, activity):
+            sent.append(activity)
+            result = MagicMock()
+            result.id = "msg-1"
+            return result
+
+        mock_app = MagicMock()
+        mock_app.send = AsyncMock(side_effect=_capture)
+        adapter._app = mock_app
+
+        result = await adapter.send("conv-id", "y" * 60000)
+
+        assert result.success is True
+        assert len(sent) > 1
+
+
+class TestTeamsStreamingEditSupport:
+    def test_does_not_advertise_message_editing(self):
+        """Regression: TeamsAdapter must declare SUPPORTS_MESSAGE_EDITING=False.
+
+        The adapter implements no edit_message override, so the base returns
+        SendResult(success=False, error='Not supported').  Without this flag the
+        gateway defaults the capability to True, streams an un-editable partial
+        preview, then falls back to a duplicate final message with a stuck
+        cursor.  Declaring it False makes the gateway skip streaming on the
+        non-editable path."""
+        assert TeamsAdapter.SUPPORTS_MESSAGE_EDITING is False
+        # The gateway reads the attribute via getattr(..., True); confirm an
+        # instance resolves it to False rather than the permissive default.
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        assert getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True) is False
+
+    @pytest.mark.anyio
+    async def test_edit_message_is_not_supported(self):
+        """The base edit_message contract still reports unsupported, matching the
+        SUPPORTS_MESSAGE_EDITING=False declaration (no in-place edit override)."""
+        adapter = TeamsAdapter(_make_config(
+            client_id="id", client_secret="secret", tenant_id="tenant",
+        ))
+        result = await adapter.edit_message("conv-id", "msg-1", "updated")
+        assert result.success is False
+
 
 def _make_summary_payload():
     return TeamsMeetingSummaryPayload(


### PR DESCRIPTION
Fixes two independently-verified bugs in the Microsoft Teams plugin adapter (`plugins/platforms/teams/adapter.py`), each covered by a focused regression test. Both are real on the current adapter source: `send()` chunks at the wrong limit, and the adapter never declares its edit capability so the gateway streams an un-editable preview it can never update. The changes are minimal and follow the conventions already used by the slack/discord/mattermost adapters and the no-edit platform adapters (signal/wecom/bluebubbles).

## Fix 1: send() splits long replies at the 4096 default instead of the advertised 28000

Symptom: any Teams reply longer than ~4096 characters is fragmented into several separate platform messages, each tagged with a `(1/N)`/`(2/N)` continuation indicator, even though Teams accepts a single message up to ~28 KB. A ~10 KB answer that should arrive as one bubble is split into ~3 bubbles.

Root cause: `TeamsAdapter` declares `MAX_MESSAGE_LENGTH = 28000` and registers `max_message_length=28000` with the plugin registry, but `send()` calls `self.truncate_message(formatted)` without the `max_length` argument. `truncate_message` is a `@staticmethod` on the base class whose signature defaults `max_length: int = 4096`; subclassing does not rebind that default to the class's `MAX_MESSAGE_LENGTH`, so the splitter runs at 4096. Every sibling adapter passes the limit explicitly (`slack.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)`, `discord` the same, `mattermost.truncate_message(formatted, MAX_POST_LENGTH)`), confirming the omission is the deviation, not the base default.

Fix: pass the class limit explicitly — `chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)` — so chunking matches the registered/advertised 28000 limit and the streaming path (which already reads `MAX_MESSAGE_LENGTH` directly).

Test: `test_send_chunks_at_advertised_limit_not_base_default` sends a 10 KB body and asserts a single platform send with no `(1/N)` tag (fails on base: 3 messages). `test_send_still_chunks_beyond_teams_limit` sends 60 KB and asserts it is still split, proving the explicit limit is honoured rather than disabled.

## Fix 2: adapter does not declare SUPPORTS_MESSAGE_EDITING, so streaming leaves a stuck-cursor partial

Symptom: with streaming enabled, the first delta is sent as a partial preview with the streaming cursor glyph appended. The adapter cannot edit it, so the next delta's edit fails, the cursor freezes on the orphaned partial bubble, and the tail is delivered separately as a fallback continuation.

Root cause: `TeamsAdapter` implements no `edit_message` override, so the base contract returns `SendResult(success=False, error="Not supported")`. The class also never sets `SUPPORTS_MESSAGE_EDITING`, and the gateway reads it via `getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)`, defaulting to `True`. With the default `True`, neither streaming path treats the adapter as non-editable: the cursor is appended, `send()` returns a real activity id, and the next delta routes through the edit path, which fails as a non-flood error and drops into fallback — leaving the partial preview (and its frozen cursor) behind before delivering the tail as a new message. The no-edit sibling adapters (signal/wecom/bluebubbles) all set `SUPPORTS_MESSAGE_EDITING = False` to suppress exactly this.

Fix: add `SUPPORTS_MESSAGE_EDITING = False` to `TeamsAdapter`. The flag is consulted on both gateway streaming paths, with different effects. On the direct-agent path the gateway skips streaming entirely for a non-editable adapter, so no partial is ever sent. On the proxy path the gateway keeps streaming but forces the cursor to empty, so the user no longer sees a frozen cursor on an orphaned partial. Note that on the proxy path the stream consumer's own edit-then-fallback machinery is not keyed off this flag, so a cursorless partial followed by a tail continuation can still occur there; the flag removes the stuck-cursor artifact rather than suppressing intermediate sends entirely. A real in-place `edit_message` against the Bot Framework PUT activities endpoint would be the alternative for true streaming, but the minimal correct fix is the capability flag.

Test: `test_does_not_advertise_message_editing` asserts the class attribute is `False` and that an instance resolves it to `False` via the same `getattr(..., True)` the gateway uses (fails on base: `AttributeError`). `test_edit_message_is_not_supported` documents the matching base contract — `edit_message` reports unsupported, consistent with the declared flag.

## Overlap

These are targeted fixes to the in-tree plugin adapter, not a re-port. PR #26289 ("port #13767 Teams adapter w/ file support to the plugin system") rewrites `plugins/platforms/teams/adapter.py` wholesale as a feature port; if it lands first, the chunking and edit-capability behaviours should be re-confirmed in the rewritten file. PR #18331 touches reply/typing service-url routing, a different code path, and does not conflict. No open PR currently changes the `send()` chunking call or adds the `SUPPORTS_MESSAGE_EDITING` declaration on the existing adapter, so these two fixes do not duplicate in-flight work.
