### PR TITLE
fix: route known gateway env config keys to .env

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5606,22 +5606,16 @@ def set_config_value(key: str, value: str):
     if is_managed():
         managed_error("set configuration values")
         return
-    # Check if it's an API key (goes to .env)
-    api_keys = [
-        'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
-        'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
-        'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
-        'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
-        'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
-        'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
-        'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
-        'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
-        'GITHUB_TOKEN', 'HONCHO_API_KEY',
-    ]
-    
-    if key.upper() in api_keys or key.upper().endswith(('_API_KEY', '_TOKEN')) or key.upper().startswith('TERMINAL_SSH'):
-        save_env_value(key.upper(), value)
-        print(f"✓ Set {key} in {get_env_path()}")
+    env_key = key.upper()
+    known_env_keys = set(OPTIONAL_ENV_VARS.keys()) | _EXTRA_ENV_KEYS
+
+    if (
+        env_key in known_env_keys
+        or env_key.endswith(('_API_KEY', '_TOKEN'))
+        or env_key.startswith('TERMINAL_SSH')
+    ):
+        save_env_value(env_key, value)
+        print(f"✓ Set {env_key} in {get_env_path()}")
         return
     
     # Otherwise it goes to config.yaml

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -124,6 +124,12 @@ class TestConfigYamlRouting:
             or "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=True" in env_content
         )
 
+    def test_known_gateway_env_key_routes_to_env(self, _isolated_hermes_home):
+        set_config_value("DISCORD_ALLOWED_USERS", "123,456")
+        env_content = _read_env(_isolated_hermes_home)
+        assert "DISCORD_ALLOWED_USERS=123,456" in env_content
+        assert "DISCORD_ALLOWED_USERS" not in _read_config(_isolated_hermes_home)
+
 
 # ---------------------------------------------------------------------------
 # Empty / falsy values — regression tests for #4277


### PR DESCRIPTION
Fixes #35231.

## Summary
- route `hermes config set` writes for known env-backed keys through `OPTIONAL_ENV_VARS` instead of a stale hardcoded allowlist
- keep the existing suffix/prefix fallback for `_API_KEY`, `_TOKEN`, and `TERMINAL_SSH*`
- add a regression test proving `DISCORD_ALLOWED_USERS` lands in `.env` rather than `config.yaml`

## Proof
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/hermes_cli/test_set_config_value.py -o 'addopts=' -q`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m ruff check hermes_cli/config.py tests/hermes_cli/test_set_config_value.py`
- `HERMES_HOME=<tmpdir> ... set_config_value('DISCORD_ALLOWED_USERS', 'ID1,ID2')` verified `.env` write and no `config.yaml` write
- `git diff --check`
