### PR TITLE
fix(mcp): keep reconnecting after the retry cap instead of dying permanently

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -535,3 +535,63 @@ class TestMCPInitialConnectionRetry:
                 await task
 
         asyncio.get_event_loop().run_until_complete(_run())
+
+
+# ---------------------------------------------------------------------------
+# Reconnect resilience — a previously-connected server must never be permanently
+# abandoned after the reconnect cap, and only *consecutive* fast failures count
+# toward that cap.
+# ---------------------------------------------------------------------------
+class TestMCPReconnectResilience:
+    """MCPServerTask.run() keeps retrying past the reconnect cap (degraded
+    slow-retry) instead of dying until a full gateway restart."""
+
+    def test_reconnect_streak_reset_constant_exists(self):
+        from tools.mcp_tool import _RECONNECT_STREAK_RESET_SECONDS
+        assert _RECONNECT_STREAK_RESET_SECONDS > 0
+
+    def test_reconnect_does_not_give_up_after_cap(self):
+        """Server that connected once keeps retrying past _MAX_RECONNECT_RETRIES.
+
+        Old behavior: after the cap the _serve loop ``return``ed and the MCP
+        stayed dead forever. A multi-hour egress outage burned all retries then
+        permanently killed the server until a full gateway restart.
+        """
+        import tools.mcp_tool as mcp_mod
+        from tools.mcp_tool import MCPServerTask, _MAX_RECONNECT_RETRIES
+
+        call_count = 0
+        stop_after = _MAX_RECONNECT_RETRIES + 4  # well past the old give-up point
+
+        async def _run():
+            nonlocal call_count
+            server = MCPServerTask("test-degraded")
+
+            async def fake_run_stdio(self_inner, config):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    # First connection succeeds (marks ready), then drops fast
+                    # so subsequent failures take the reconnect (not initial)
+                    # path.
+                    self_inner._ready.set()
+                    raise ConnectionError("egress flap")
+                if call_count >= stop_after:
+                    # Proven it kept retrying past the cap — stop cleanly.
+                    self_inner._shutdown_event.set()
+                    return
+                raise ConnectionError("egress flap")
+
+            # Collapse backoff so the test does not actually wait.
+            with patch.object(mcp_mod, "_MAX_BACKOFF_SECONDS", 0), \
+                 patch.object(MCPServerTask, "_run_stdio", fake_run_stdio):
+                task = asyncio.ensure_future(server.run({"command": "fake"}))
+                await asyncio.wait_for(task, timeout=10)
+
+            # Old code stopped at _MAX_RECONNECT_RETRIES + 1 calls.
+            assert call_count >= stop_after, (
+                f"server gave up early at {call_count} calls; expected to keep "
+                f"retrying past the cap (degraded slow-retry)"
+            )
+
+        asyncio.get_event_loop().run_until_complete(_run())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -262,6 +262,13 @@ _DEFAULT_CONNECT_TIMEOUT = 60    # seconds for initial connection per server
 _MAX_RECONNECT_RETRIES = 5
 _MAX_INITIAL_CONNECT_RETRIES = 3 # retries for the very first connection attempt
 _MAX_BACKOFF_SECONDS = 60
+# A reconnect streak only counts *consecutive* fast failures. If a session
+# stayed healthy at least this long before dropping, the earlier failures were
+# transient (network blip, OAuth token lapse) so the streak resets. Without
+# this, cumulative drops over the process lifetime eventually trip the cap on a
+# perfectly healthy server, and a multi-hour outage permanently kills the MCP
+# until a full gateway restart.
+_RECONNECT_STREAK_RESET_SECONDS = 120
 
 # Environment variables that are safe to pass to stdio subprocesses
 _SAFE_ENV_KEYS = frozenset({
@@ -1703,6 +1710,7 @@ class MCPServerTask:
         backoff = 1.0
 
         while True:
+            conn_start = time.monotonic()
             try:
                 if self._is_http():
                     await self._run_http(config)
@@ -1792,21 +1800,41 @@ class MCPServerTask:
                     )
                     return
 
+                # Only *consecutive* fast failures count toward the cap. A
+                # session that stayed healthy for a meaningful period before
+                # dropping means the prior failures were transient, so reset
+                # the streak — this stops cumulative lifetime drops from ever
+                # tripping the cap on a healthy server.
+                if (time.monotonic() - conn_start) >= _RECONNECT_STREAK_RESET_SECONDS:
+                    retries = 0
+                    backoff = 1.0
+
                 retries += 1
                 if retries > _MAX_RECONNECT_RETRIES:
+                    # Past the streak cap we do NOT abandon the server. A remote
+                    # that connected successfully before is worth retrying: a
+                    # multi-hour egress outage (e.g. a flaky uplink) must not
+                    # require a full gateway restart to recover. Drop to degraded
+                    # slow-retry at max backoff. The tool-call circuit breaker
+                    # already shields the model from spam, and every reconnect
+                    # re-runs the OAuth flow, so a refreshed token is picked up
+                    # automatically once the network heals.
+                    backoff = _MAX_BACKOFF_SECONDS
+                    if retries == _MAX_RECONNECT_RETRIES + 1:
+                        logger.warning(
+                            "MCP server '%s' failed %d consecutive reconnects; "
+                            "entering slow-retry every %ds until it recovers: %s",
+                            self.name, _MAX_RECONNECT_RETRIES,
+                            _MAX_BACKOFF_SECONDS, exc,
+                        )
+                else:
                     logger.warning(
-                        "MCP server '%s' failed after %d reconnection attempts, "
-                        "giving up: %s",
-                        self.name, _MAX_RECONNECT_RETRIES, exc,
+                        "MCP server '%s' connection lost (attempt %d/%d), "
+                        "reconnecting in %.0fs: %s",
+                        self.name, retries, _MAX_RECONNECT_RETRIES,
+                        backoff, exc,
                     )
-                    return
 
-                logger.warning(
-                    "MCP server '%s' connection lost (attempt %d/%d), "
-                    "reconnecting in %.0fs: %s",
-                    self.name, retries, _MAX_RECONNECT_RETRIES,
-                    backoff, exc,
-                )
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, _MAX_BACKOFF_SECONDS)
 


### PR DESCRIPTION
## Problem

A remote MCP server can be permanently disconnected until a full gateway restart. The `MCPServerTask` reconnect loop in `tools/mcp_tool.py` has two compounding issues:

1. **`retries` never resets after a healthy connection.** It is initialized once before the `while True` loop and only ever incremented; the clean-reconnect (OAuth-recovery) path explicitly leaves it untouched. Over a long-lived gateway process, *cumulative* disconnects accumulate and eventually trip the cap on a server that is actually healthy.

2. **Exceeding the cap ends the task.** After `retries > _MAX_RECONNECT_RETRIES` (5) the loop `return`s. The serve task exits, `session` stays `None`, and every subsequent tool call returns `MCP server '<name>' is not connected` until the entire gateway is restarted. With `_MAX_BACKOFF_SECONDS = 60`, the five retries span only ~31s, so any network outage longer than that permanently disables the server.

Observed in practice on a host with a flaky uplink: a multi-hour egress flap burned all five reconnects, the loop gave up, and a remote OAuth MCP stayed `not connected` for hours despite the network (and a valid refreshed token on disk) being available again.

## Fix

- Track per-connection uptime and reset the streak once a session has stayed healthy for `_RECONNECT_STREAK_RESET_SECONDS` (120s). Only **consecutive fast failures** count toward the cap, so transient blips never abandon a server that works most of the time.
- Past the cap, drop to a **degraded slow-retry at max backoff** instead of returning. A remote that connected successfully at least once is always worth retrying, so recovery no longer requires a gateway restart. Each reconnect re-runs the OAuth flow, so a refreshed token is picked up automatically once the network heals. The existing tool-call circuit breaker already prevents the model from spamming an unreachable server.

The initial-connection path (`_MAX_INITIAL_CONNECT_RETRIES`) is unchanged: a server that has *never* connected still fails fast.

## Tests

Adds `TestMCPReconnectResilience` to `tests/tools/test_mcp_stability.py` verifying the server keeps retrying past the cap. Full file passes (22 tests); the broader MCP suite (`test_mcp_reconnect_signal`, `test_mcp_stability`, `test_mcp_tool_session_expired`, `test_mcp_circuit_breaker`, `test_mcp_tool`) passes as well.