### PR TITLE
fix(kanban): clean up task_links when archiving a task

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4431,6 +4431,15 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
         )
+        # Sever parent→child links so children of the archived task are
+        # no longer blocked.  Without this, ``recompute_ready`` promotes
+        # children (archived ≈ done), but the children's workers may
+        # still try to access the archived parent's scratch workspace,
+        # which was already cleaned up on completion — causing crashes.
+        conn.execute(
+            "DELETE FROM task_links WHERE parent_id = ?",
+            (task_id,),
+        )
         _append_event(conn, task_id, "archived", None, run_id=run_id)
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting


### PR DESCRIPTION
## Problem
When `archive_task()` archives a parent task, it does not remove `task_links` entries where the archived task is a parent. This causes child workers to see the archived parent via `kanban_show()` / `tasks.parents`, exposing a `workspace_path` whose scratch directory was already deleted by `_cleanup_workspace()` during task completion. The worker then crashes with `File not found`.

### Steps to reproduce
1. Create pipeline: parent P → child C via task_links
2. P completes → `_cleanup_workspace()` deletes scratch workspace
3. Archive P → `archive_task()` does NOT delete `task_links WHERE parent_id = P`
4. `recompute_ready()` sees archived P as "dependency satisfied" → promotes C to ready
5. C worker starts → `kanban_show()` returns P with stale `workspace_path` → accessing dead path crashes

### Real case
A 3-task kanban pipeline (T1→T2→T3) had T2 complete and archived while T3 remained linked. T3 worker attempted to access T2 scratch workspace and crashed repeatedly.

## Fix
Add `DELETE FROM task_links WHERE parent_id = ?` inside the `archive_task` write transaction, matching the pattern already used by `delete_archived_task()` which deletes both `parent_id` and `child_id` links.

**Change:** 1 file, +9 lines

## Relation to other PRs
- **#31265**: Previously submitted this fix as part of a broader late-link guard. Closed because the late-link guard had design discussion; this isolates just the archive cleanup.
- **#32529**: Same fix, previously closed under "upstream implemented same" — but git blame confirms upstream/main (355af2c20) does NOT contain `DELETE FROM task_links WHERE parent_id = ?` in `archive_task()` (kanban_db.py:4416-4438). The fix is still missing upstream.

## Verification
- Cross-verified by Codex (GPT-5.4): confirmed upstream/main lacks this fix, bug scenario reproducible, fix correctly breaks the stale link chain
- Hermes Agent orchestrator (DeepSeek v4 Pro): verified same conclusion independently
- CI was previously green on #32529 (identical code)