### PR TITLE
fix(gateway/feishu): fall back to chat_id routing on stale thread_id (99992402)

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -5016,6 +5016,26 @@ class FeishuAdapter(BasePlatformAdapter):
                             reply_to=None,
                             metadata=metadata,
                         )
+                # If thread_id routing returned a field-validation error the thread
+                # has been deleted or withdrawn (e.g. stale auto-resume source).
+                # Retry with chat_id routing so the message is not silently dropped.
+                if not self._response_succeeded(response):
+                    code = getattr(response, "code", None)
+                    if code == 99992402 and (metadata or {}).get("thread_id"):
+                        logger.warning(
+                            "[Feishu] thread_id %s routing for chat %s returned 99992402"
+                            " (thread deleted or stale); falling back to chat_id routing",
+                            (metadata or {}).get("thread_id"),
+                            chat_id,
+                        )
+                        stripped_meta = {k: v for k, v in metadata.items() if k != "thread_id"}
+                        response = await self._send_raw_message(
+                            chat_id=chat_id,
+                            msg_type=msg_type,
+                            payload=payload,
+                            reply_to=active_reply_to,
+                            metadata=stripped_meta or None,
+                        )
                 return response
             except Exception as exc:
                 last_error = exc

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2467,3 +2467,80 @@ class TestChatLockEviction(unittest.TestCase):
         self.assertIsInstance(adapter._chat_locks, _collections.OrderedDict)
 
 
+class TestFeishuSendWithRetryThreadIdFallback(unittest.TestCase):
+    """_feishu_send_with_retry must fall back to chat_id routing when a stale
+    thread_id causes Feishu to return error 99992402 (field validation failed)."""
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+        return FeishuAdapter(PlatformConfig())
+
+    @staticmethod
+    def _resp(success, code=None):
+        return SimpleNamespace(success=lambda: success, code=code)
+
+    def test_stale_thread_id_99992402_retries_with_chat_id(self):
+        adapter = self._make_adapter()
+        calls = []
+
+        async def fake_send(*, chat_id, msg_type, payload, reply_to, metadata):
+            calls.append({"metadata": dict(metadata) if metadata else None})
+            if len(calls) == 1:
+                return self._resp(False, code=99992402)
+            return self._resp(True)
+
+        async def run():
+            with patch.object(adapter, "_send_raw_message", side_effect=fake_send):
+                return await adapter._feishu_send_with_retry(
+                    chat_id="oc_chat", msg_type="text",
+                    payload='{"text":"hello"}', reply_to=None,
+                    metadata={"thread_id": "stale_thread", "other": "keep"},
+                )
+
+        result = asyncio.run(run())
+        self.assertTrue(result.success())
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0]["metadata"]["thread_id"], "stale_thread")
+        self.assertNotIn("thread_id", calls[1]["metadata"])
+        self.assertEqual(calls[1]["metadata"].get("other"), "keep")
+
+    def test_99992402_without_thread_id_does_not_retry(self):
+        adapter = self._make_adapter()
+        calls = []
+
+        async def fake_send(*, chat_id, msg_type, payload, reply_to, metadata):
+            calls.append(metadata)
+            return self._resp(False, code=99992402)
+
+        async def run():
+            with patch.object(adapter, "_send_raw_message", side_effect=fake_send):
+                return await adapter._feishu_send_with_retry(
+                    chat_id="oc_chat", msg_type="text",
+                    payload='{"text":"hi"}', reply_to=None,
+                    metadata={"other": "data"},
+                )
+
+        result = asyncio.run(run())
+        self.assertFalse(result.success())
+        self.assertEqual(len(calls), 1)
+
+    def test_other_error_codes_with_thread_id_do_not_trigger_fallback(self):
+        adapter = self._make_adapter()
+        calls = []
+
+        async def fake_send(*, chat_id, msg_type, payload, reply_to, metadata):
+            calls.append(metadata)
+            return self._resp(False, code=230001)
+
+        async def run():
+            with patch.object(adapter, "_send_raw_message", side_effect=fake_send):
+                return await adapter._feishu_send_with_retry(
+                    chat_id="oc_chat", msg_type="text",
+                    payload='{"text":"hi"}', reply_to=None,
+                    metadata={"thread_id": "tid_abc"},
+                )
+
+        result = asyncio.run(run())
+        self.assertFalse(result.success())
+        self.assertEqual(len(calls), 1)


### PR DESCRIPTION
## What does this PR do?

Fixes silent message drops when the gateway auto-resumes a session whose
original Feishu `thread_id` has since been deleted or withdrawn.

`_send_raw_message` routes using `thread_id` as `receive_id` when metadata
contains one. A deleted thread causes Feishu to return `99992402` (field
validation failed). This error was not handled by `_feishu_send_with_retry`,
so both the primary send and the plain-text fallback silently dropped the
message — observed 53 times in production in one reporter's log.

The fix adds a targeted fallback block: on `99992402` with `thread_id` in
metadata, strip the stale `thread_id` and retry with `chat_id` routing.

## Related Issue

Fixes #35576

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/feishu.py` — new fallback block in `_feishu_send_with_retry`
- `tests/gateway/test_feishu.py` — 3 regression tests

## Checklist

- [x] Conventional Commits
- [x] No existing PR for this issue
- [x] Tests added and passing
- [x] Blast radius: LOW — isolated to Feishu send retry path only