### PR TITLE
fix(redact): stop masking Discord mention snowflakes

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -150,10 +150,6 @@ _JWT_RE = re.compile(
     r"(?:\.[A-Za-z0-9_=-]{4,}){0,2}"   # Optional payload and/or signature
 )
 
-# Discord user/role mentions: <@123456789012345678> or <@!123456789012345678>
-# Snowflake IDs are 17-20 digit integers that resolve to specific Discord accounts.
-_DISCORD_MENTION_RE = re.compile(r"<@!?(\d{17,20})>")
-
 # E.164 phone numbers: +<country><number>, 7-15 digits
 # Negative lookahead prevents matching hex strings or identifiers
 _SIGNAL_PHONE_RE = re.compile(r"(\+[1-9]\d{6,14})(?![A-Za-z0-9])")
@@ -418,10 +414,6 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     # Form-urlencoded bodies (only triggers on clean k=v&k=v inputs).
     if "&" in text and "=" in text:
         text = _redact_form_body(text)
-
-    # Discord user/role mentions (<@snowflake_id>)
-    if "<@" in text:
-        text = _DISCORD_MENTION_RE.sub(lambda m: f"<@{'!' if '!' in m.group(0) else ''}***>", text)
 
     # E.164 phone numbers (Signal, WhatsApp)
     if "+" in text:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -342,39 +342,33 @@ class TestJWTTokens:
 
 
 class TestDiscordMentions:
-    """Discord snowflake IDs in <@ID> or <@!ID> format."""
+    """Discord mention snowflakes (<@ID> / <@!ID>) are public syntax, not
+    secrets — they must pass through the redactor unchanged so multi-bot
+    @-pings (DISCORD_ALLOW_BOTS=mentions) keep resolving. See issue #35611."""
 
-    def test_normal_mention(self):
-        result = redact_sensitive_text("Hello <@222589316709220353>")
-        assert "222589316709220353" not in result
-        assert "<@***>" in result
+    def test_normal_mention_passes_through(self):
+        text = "Hello <@222589316709220353>"
+        assert redact_sensitive_text(text) == text
 
-    def test_nickname_mention(self):
-        result = redact_sensitive_text("Ping <@!1331549159177846844>")
-        assert "1331549159177846844" not in result
-        assert "<@!***>" in result
+    def test_nickname_mention_passes_through(self):
+        text = "Ping <@!1331549159177846844>"
+        assert redact_sensitive_text(text) == text
 
-    def test_multiple_mentions(self):
+    def test_multiple_mentions_pass_through(self):
         text = "<@111111111111111111> and <@222222222222222222>"
-        result = redact_sensitive_text(text)
-        assert "111111111111111111" not in result
-        assert "222222222222222222" not in result
+        assert redact_sensitive_text(text) == text
 
-    def test_short_id_not_matched(self):
-        """IDs shorter than 17 digits are not Discord snowflakes."""
+    def test_short_id_passes_through(self):
         text = "<@12345>"
         assert redact_sensitive_text(text) == text
 
-    def test_slack_mention_not_matched(self):
-        """Slack mentions use letters, not pure digits."""
+    def test_slack_mention_passes_through(self):
         text = "<@U024BE7LH>"
         assert redact_sensitive_text(text) == text
 
     def test_preserves_surrounding_text(self):
         text = "User <@222589316709220353> said hello"
-        result = redact_sensitive_text(text)
-        assert result.startswith("User ")
-        assert result.endswith(" said hello")
+        assert redact_sensitive_text(text) == text
 
 
 class TestWebUrlsNotRedacted:


### PR DESCRIPTION
## Summary
Discord `<@snowflake>` mentions now survive the secret redactor, so multi-bot @-pings (`DISCORD_ALLOW_BOTS=mentions`) resolve again.

Discord mention IDs are public syntax — every member can right-click any @-mention to see them. They're not credentials or PII. Masking them to `<@***>` served no security purpose and broke inter-agent communication: Bot A's `<@BotB_ID>` reached Discord as literal plaintext, the `mentions` array came back empty, and Bot B's filter correctly dropped a message with no valid mention.

Salvage of #32259 (@JezzaHehn) onto current main. Fixes #35611 (reported by @sstjean).

## Changes
- `agent/redact.py`: remove `_DISCORD_MENTION_RE` and its masking block (plus the orphaned comments/whitespace).
- `tests/agent/test_redact.py`: rewrite `TestDiscordMentions` as negative assertions — mentions pass through unchanged.

## Validation
| input | before | after |
|---|---|---|
| `<@222589316709220353>` | `<@***>` | `<@222589316709220353>` |
| `<@!1331549159177846844>` | `<@!***>` | `<@!1331549159177846844>` |
| `<@id> sk-abc...` | `<@***> sk-abc...7890` | `<@id> sk-abc...7890` (mention kept, secret still masked) |
| `sk-`/`ghp_`/JWT secrets | redacted | redacted (unchanged) |

`scripts/run_tests.sh tests/agent/test_redact.py` → 74/74 pass. E2E verified via real imports: mentions survive, all credential shapes still redacted.

## Infographic

![discord-mentions-unmasked](https://v3b.fal.media/files/b/0a9c5e1b/fkyCXQOHSAjI15gHBFO9l_uoSbbf7r.png)
