### PR TITLE
fix(tui): route completion notifications to owner live session

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5158,3 +5158,72 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
         assert requeued["session_id"] == "proc_busy_test"
     finally:
         server._sessions.pop("sid_busy", None)
+
+
+def test_notification_poller_routes_completion_to_owner_live_session(monkeypatch):
+    """Completion notifications route to the live session that owns the process."""
+    from tools.process_registry import ProcessSession, process_registry
+
+    owner_turns = []
+    poller_turns = []
+    emitted = []
+
+    class _OwnerAgent:
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+            owner_turns.append(prompt)
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _PollerAgent:
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+            poller_turns.append(prompt)
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    owner = _session(agent=_OwnerAgent(), session_key="owner-key")
+    poller = _session(agent=_PollerAgent(), session_key="poller-key")
+    server._sessions["sid_owner"] = owner
+    server._sessions["sid_poller"] = poller
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: emitted.append(a))
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+
+    isolated_queue = __import__("queue").Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    process_registry._completion_consumed.discard("proc_owner_test")
+    process_registry._finished["proc_owner_test"] = ProcessSession(
+        id="proc_owner_test",
+        command="echo owner",
+        session_key="owner-key",
+        exited=True,
+        exit_code=0,
+    )
+    isolated_queue.put(
+        {
+            "type": "completion",
+            "session_id": "proc_owner_test",
+            "command": "echo owner",
+            "exit_code": 0,
+            "output": "owner",
+        }
+    )
+
+    stop = threading.Event()
+    stop.set()
+
+    try:
+        server._notification_poller_loop(stop, "sid_poller", poller)
+
+        status_calls = [a for a in emitted if a[0] == "status.update"]
+        assert len(status_calls) >= 1
+        assert status_calls[0][1] == "sid_owner"
+        assert owner_turns and "[IMPORTANT: Background process proc_owner_test completed" in owner_turns[0]
+        assert poller_turns == []
+    finally:
+        server._sessions.pop("sid_owner", None)
+        server._sessions.pop("sid_poller", None)
+        process_registry._finished.pop("proc_owner_test", None)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3399,7 +3399,7 @@ def _notification_poller_loop(
     even if the process was started by a different session. This matches
     CLI/gateway behavior (single session per process).
     """
-    from tools.process_registry import process_registry, format_process_notification
+    from tools.process_registry import process_registry
 
     while not stop_event.is_set() and not session.get("_finalized"):
         try:
@@ -3407,34 +3407,7 @@ def _notification_poller_loop(
         except Exception:
             continue
 
-        _evt_sid = evt.get("session_id", "")
-        if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
-            continue
-
-        text = format_process_notification(evt)
-        if not text:
-            continue
-
-        _emit("status.update", sid, {"kind": "process", "text": text})
-
-        with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                continue
-            session["running"] = True
-
-        rid = f"__notif__{int(time.time() * 1000)}"
-        try:
-            _emit("message.start", sid)
-            _run_prompt_submit(rid, sid, session, text)
-        except Exception as exc:
-            print(
-                f"[tui_gateway] notification poller dispatch failed: "
-                f"{type(exc).__name__}: {exc}",
-                file=sys.stderr,
-            )
-            with session["history_lock"]:
-                session["running"] = False
+        _deliver_notification_event(evt, sid, session, process_registry)
 
     # Drain any remaining events after stop signal (process all pending
     # before exiting so nothing is lost on shutdown).
@@ -3443,33 +3416,74 @@ def _notification_poller_loop(
             evt = process_registry.completion_queue.get_nowait()
         except Exception:
             break
-        _evt_sid = evt.get("session_id", "")
-        if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
+        if _deliver_notification_event(evt, sid, session, process_registry):
             continue
-        text = format_process_notification(evt)
-        if not text:
+        break
+
+
+def _resolve_notification_target(
+    evt: dict, fallback_sid: str, fallback_session: dict, process_registry: Any
+) -> tuple[str, dict]:
+    """Route process notifications to the live session that owns the process."""
+    owner_key = str(evt.get("session_key") or "")
+    if not owner_key:
+        proc_id = str(evt.get("session_id") or "")
+        if proc_id:
+            try:
+                proc_session = process_registry.get(proc_id)
+            except Exception:
+                proc_session = None
+            if proc_session is not None:
+                owner_key = str(getattr(proc_session, "session_key", "") or "")
+
+    if not owner_key:
+        return fallback_sid, fallback_session
+
+    for target_sid, target_session in list(_sessions.items()):
+        if target_session.get("_finalized"):
             continue
+        if str(target_session.get("session_key") or "") == owner_key:
+            return target_sid, target_session
+    return fallback_sid, fallback_session
 
-        _emit("status.update", sid, {"kind": "process", "text": text})
 
-        with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                break
-            session["running"] = True
+def _deliver_notification_event(
+    evt: dict, fallback_sid: str, fallback_session: dict, process_registry: Any
+) -> bool:
+    from tools.process_registry import format_process_notification
 
-        rid = f"__notif__{int(time.time() * 1000)}"
-        try:
-            _emit("message.start", sid)
-            _run_prompt_submit(rid, sid, session, text)
-        except Exception as exc:
-            print(
-                f"[tui_gateway] notification poller dispatch failed: "
-                f"{type(exc).__name__}: {exc}",
-                file=sys.stderr,
-            )
-            with session["history_lock"]:
-                session["running"] = False
+    evt_sid = str(evt.get("session_id") or "")
+    if evt.get("type") == "completion" and process_registry.is_completion_consumed(evt_sid):
+        return True
+
+    text = format_process_notification(evt)
+    if not text:
+        return True
+
+    target_sid, target_session = _resolve_notification_target(
+        evt, fallback_sid, fallback_session, process_registry
+    )
+    _emit("status.update", target_sid, {"kind": "process", "text": text})
+
+    with target_session["history_lock"]:
+        if target_session.get("running"):
+            process_registry.completion_queue.put(evt)
+            return False
+        target_session["running"] = True
+
+    rid = f"__notif__{int(time.time() * 1000)}"
+    try:
+        _emit("message.start", target_sid)
+        _run_prompt_submit(rid, target_sid, target_session, text)
+    except Exception as exc:
+        print(
+            f"[tui_gateway] notification poller dispatch failed: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        with target_session["history_lock"]:
+            target_session["running"] = False
+    return True
 
 
 def _start_notification_poller(sid: str, session: dict) -> threading.Event:


### PR DESCRIPTION
## Summary
- route TUI background-process completion notifications to the live session that owns the process instead of whichever per-session poller drained the global queue first
- factor the poller delivery path so both the steady-state loop and shutdown drain use the same owner-aware routing logic
- add a regression test covering two concurrent live TUI sessions where session B's poller drains session A's completion event

Closes #35652.

## Why
`_notification_poller_loop()` already documents that `completion_queue` is global, but it always emitted the notification and synthetic turn back to the current poller `sid`. In a multi-live-session TUI, that let session B render and ingest session A's `[IMPORTANT: Background process ... completed]` message.

This change keeps the existing queue model but resolves the event back to the owning live session via the tracked process `session_key`, then injects the notification into that owner session.

## Scope
- In scope: owner-scoped routing for TUI completion/watch notifications once an event has been dequeued
- Out of scope: the older core-side spawn/session-id capture family covered by PR #28560; this change only fixes the TUI multi-live-session drain race in `tui_gateway/server.py`

## Validation
- `python -m pytest tests/test_tui_gateway_server.py -k 'notification_poller' -o 'addopts=' -q`
- `python -m ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`
- `git diff --check`
