### PR TITLE
fix(bedrock): batch QoL — raise max_tokens, strip status bar prefix, context table, max_iterations

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -877,7 +877,7 @@ def build_converse_kwargs(
     model: str,
     messages: List[Dict],
     tools: Optional[List[Dict]] = None,
-    max_tokens: int = 4096,
+    max_tokens: int = 16384,
     temperature: Optional[float] = None,
     top_p: Optional[float] = None,
     stop_sequences: Optional[List[str]] = None,
@@ -936,7 +936,7 @@ def call_converse(
     model: str,
     messages: List[Dict],
     tools: Optional[List[Dict]] = None,
-    max_tokens: int = 4096,
+    max_tokens: int = 16384,
     temperature: Optional[float] = None,
     top_p: Optional[float] = None,
     stop_sequences: Optional[List[str]] = None,
@@ -977,7 +977,7 @@ def call_converse_stream(
     model: str,
     messages: List[Dict],
     tools: Optional[List[Dict]] = None,
-    max_tokens: int = 4096,
+    max_tokens: int = 16384,
     temperature: Optional[float] = None,
     top_p: Optional[float] = None,
     stop_sequences: Optional[List[str]] = None,
@@ -1244,7 +1244,12 @@ def classify_bedrock_error(error_message: str) -> str:
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # Anthropic Claude models on Bedrock
+    # Opus 4.6+ and Sonnet 4.5+ support 1M context with entitlement (context-1m beta).
+    # Default to 200K (standard); users with 1M entitlement should set context_length in config.
+    "anthropic.claude-opus-4-8":     200_000,
+    "anthropic.claude-opus-4-7":     200_000,
     "anthropic.claude-opus-4-6":     200_000,
+    "anthropic.claude-opus-4-5":     200_000,
     "anthropic.claude-sonnet-4-6":   200_000,
     "anthropic.claude-sonnet-4-5":   200_000,
     "anthropic.claude-haiku-4-5":    200_000,
@@ -1259,14 +1264,21 @@ BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     "amazon.nova-pro":               300_000,
     "amazon.nova-lite":              300_000,
     "amazon.nova-micro":             128_000,
+    "amazon.nova-premier":           1_000_000,
     # Meta Llama
-    "meta.llama4-maverick":          128_000,
+    "meta.llama4-maverick":          1_000_000,
     "meta.llama4-scout":             128_000,
     "meta.llama3-3-70b-instruct":    128_000,
     # Mistral
     "mistral.mistral-large":         128_000,
+    "mistral.pixtral-large":         128_000,
     # DeepSeek
     "deepseek.v3":                   128_000,
+    "deepseek.r1":                   128_000,
+    # Kimi / GLM / MiniMax (2P models)
+    "moonshotai.kimi-k2":            128_000,
+    "zai.glm-4":                     128_000,
+    "minimax.minimax-m2":            128_000,
 }
 
 # Default for unknown Bedrock models

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -586,7 +586,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             model=agent.model,
             messages=api_messages,
             tools=tools_for_api,
-            max_tokens=agent.max_tokens or 4096,
+            max_tokens=agent.max_tokens or 16384,
             region=region,
             guardrail_config=guardrail,
         )
@@ -1428,6 +1428,22 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                                preserve_dots=agent._anthropic_preserve_dots())
                 summary_response = agent._anthropic_messages_create(_ant_kw)
                 _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=agent._is_anthropic_oauth)
+                final_response = (_summary_result.content or "").strip()
+            elif agent.api_mode == "bedrock_converse":
+                # Route through native Converse API — no OpenAI client needed.
+                from agent.bedrock_adapter import call_converse
+                _br_region = getattr(agent, "_bedrock_region", None) or "us-east-1"
+                _br_guardrail = getattr(agent, "_bedrock_guardrail_config", None)
+                summary_response = call_converse(
+                    region=_br_region,
+                    model=agent.model,
+                    messages=api_messages,
+                    tools=None,
+                    max_tokens=agent.max_tokens or 16384,
+                    guardrail_config=_br_guardrail,
+                )
+                _bt_sum = agent._get_transport()
+                _summary_result = _bt_sum.normalize_response(summary_response)
                 final_response = (_summary_result.content or "").strip()
             else:
                 summary_response = agent._ensure_primary_openai_client(reason="iteration_limit_summary").chat.completions.create(**summary_kwargs)

--- a/agent/transports/bedrock.py
+++ b/agent/transports/bedrock.py
@@ -41,7 +41,7 @@ class BedrockTransport(ProviderTransport):
         Calls convert_messages and convert_tools internally.
 
         params:
-            max_tokens: int — output token limit (default 4096)
+            max_tokens: int — output token limit (default 16384)
             temperature: float | None
             guardrail_config: dict | None — Bedrock guardrails
             region: str — AWS region (default 'us-east-1')
@@ -55,7 +55,7 @@ class BedrockTransport(ProviderTransport):
             model=model,
             messages=messages,
             tools=tools,
-            max_tokens=params.get("max_tokens", 4096),
+            max_tokens=params.get("max_tokens", 16384),
             temperature=params.get("temperature"),
             guardrail_config=guardrail,
         )

--- a/cli.py
+++ b/cli.py
@@ -3476,6 +3476,17 @@ class HermesCLI:
         agent = getattr(self, "agent", None)
         model_name = (getattr(agent, "model", None) or self.model or "unknown")
         model_short = model_name.split("/")[-1] if "/" in model_name else model_name
+        # Strip Bedrock cross-region inference profile prefix (us., global., eu., ap.)
+        # so the status bar shows "claude-sonnet-4-6" instead of "us.anthropic.claude-sonnet-4-6"
+        if "." in model_short:
+            parts = model_short.split(".", 1)
+            if parts[0] in ("us", "eu", "ap", "global", "apac", "jp"):
+                model_short = parts[1]
+            # Also strip the vendor prefix (anthropic., amazon., meta., etc.)
+            if "." in model_short:
+                vendor_parts = model_short.split(".", 1)
+                if vendor_parts[0] in ("anthropic", "amazon", "meta", "mistral", "cohere", "ai21", "deepseek", "moonshotai", "zai", "minimax"):
+                    model_short = vendor_parts[1]
         if model_short.endswith(".gguf"):
             model_short = model_short[:-5]
         if len(model_short) > 26:


### PR DESCRIPTION
Salvage of 4 low-risk community PRs onto current main. Each addresses a real user pain point, all are small and self-contained.

## Changes

### 1. Raise default max_tokens from 4096 to 16384 (ref #20619 by @liorfranko)

The Converse API path hardcoded `max_tokens=4096`. Claude Opus 4.6+ supports 32K output, and even Sonnet regularly produces 8K+ tool-call responses. Users hit silent truncation (`finish_reason='length'`) on any non-trivial agent task.

### 2. Strip Bedrock regional/vendor prefix from status bar (ref #19849 by @mmcclean-aws)

`us.anthropic.claude-sonnet-4-6` is useful as a model ID but ugly in the TUI status bar. Now displays as `claude-sonnet-4-6`. Strips known regional prefixes (`us.`, `global.`, `eu.`, `ap.`) and vendor prefixes (`anthropic.`, `amazon.`, `meta.`, etc.).

### 3. Align context-window table with current Anthropic docs (ref #24059 by @patrick-muller)

Adds missing entries: Opus 4.7/4.8, Nova Premier (1M), Llama 4 Maverick (1M), Pixtral Large, DeepSeek R1, and 2P models (Kimi K2, GLM 4, MiniMax M2). Without correct context lengths, the compression threshold calculates wrong and either compresses too early or too late.

### 4. Add bedrock_converse branch in handle_max_iterations (ref #27544 by @EloquentBrush0x)

`handle_max_iterations()` dispatched `codex_responses` and `anthropic_messages` to their native paths, but `bedrock_converse` fell through to the generic OpenAI-client path (which has no Bedrock credentials). The iteration-limit summary now routes through `call_converse()` directly.

## Testing

118 bedrock_adapter tests passing. All changes are in the Bedrock-specific code path — no impact on other providers.

## Credit

Original authors credited in commit message. This PR rebases their work onto current main (all 4 original PRs are 50-200+ commits stale).