### PR TITLE
fix(tui): route process notifications to owner session

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5063,6 +5063,74 @@ def test_notification_poller_delivers_completion(monkeypatch):
             process_registry.completion_queue.get_nowait()
 
 
+def test_notification_poller_routes_events_to_owner_session(monkeypatch):
+    """A poller that wakes first must dispatch to the event's owning TUI session."""
+    import queue as _queue_mod
+
+    from tools.process_registry import process_registry
+
+    turns = []
+    emitted = []
+
+    class _Agent:
+        def __init__(self, label):
+            self.label = label
+
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+            turns.append((self.label, prompt))
+            return {
+                "final_response": f"ok {self.label}",
+                "messages": [{"role": "assistant", "content": f"ok {self.label}"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    owner = _session(agent=_Agent("owner"), session_key="owner-session-key")
+    thief = _session(agent=_Agent("thief"), session_key="thief-session-key")
+    server._sessions["sid_owner"] = owner
+    server._sessions["sid_thief"] = thief
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: emitted.append(a))
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+
+    isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
+    process_registry._completion_consumed.discard("proc_owner_test")
+    isolated_queue.put({
+        "type": "completion",
+        "session_id": "proc_owner_test",
+        "session_key": "owner-session-key",
+        "command": "echo owner",
+        "exit_code": 0,
+        "output": "owner",
+    })
+
+    stop = threading.Event()
+    stop.set()
+
+    try:
+        # Simulate the non-owner session's poller winning the global queue race.
+        server._notification_poller_loop(stop, "sid_thief", thief)
+
+        assert len(turns) == 1
+        assert turns[0][0] == "owner"
+        assert "[IMPORTANT: Background process proc_owner_test completed" in turns[0][1]
+        status_calls = [a for a in emitted if a[0] == "status.update"]
+        assert status_calls
+        assert status_calls[0][1] == "sid_owner"
+    finally:
+        server._sessions.pop("sid_owner", None)
+        server._sessions.pop("sid_thief", None)
+        while not isolated_queue.empty():
+            isolated_queue.get_nowait()
+
+
 def test_notification_poller_skips_consumed(monkeypatch):
     """Already-consumed completions are not dispatched by the poller."""
     from tools.process_registry import process_registry

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -863,6 +863,7 @@ class ProcessRegistry:
             self.completion_queue.put({
                 "type": "completion",
                 "session_id": session.id,
+                "session_key": session.session_key,
                 "command": session.command,
                 "exit_code": session.exit_code,
                 "output": output_tail,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3385,6 +3385,91 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"status": "streaming"})
 
 
+def _resolve_notification_target(
+    evt: dict,
+    fallback_sid: str,
+    fallback_session: dict,
+    process_registry: Any,
+) -> tuple[str, dict]:
+    """Resolve the live TUI session that owns a process notification event.
+
+    The process registry notification queue is global, so any live TUI session's
+    poller can win the ``get()`` race.  Route owner-scoped events back to the
+    session that launched the process instead of the poller that happened to wake
+    up first.  Events without owner metadata keep the legacy fallback behavior.
+    """
+    owner_key = str(evt.get("session_key") or "")
+    proc_id = str(evt.get("session_id") or "")
+
+    if not owner_key and proc_id:
+        try:
+            proc_session = process_registry.get(proc_id)
+            owner_key = str(getattr(proc_session, "session_key", "") or "")
+        except Exception:
+            owner_key = ""
+
+    if not owner_key:
+        return fallback_sid, fallback_session
+
+    for candidate_sid, candidate_session in list(_sessions.items()):
+        if candidate_session.get("_finalized"):
+            continue
+        if str(candidate_session.get("session_key") or "") == owner_key:
+            return candidate_sid, candidate_session
+        agent_session_id = getattr(candidate_session.get("agent"), "session_id", None)
+        if str(agent_session_id or "") == owner_key:
+            return candidate_sid, candidate_session
+
+    return fallback_sid, fallback_session
+
+
+def _dispatch_notification_event(
+    evt: dict,
+    fallback_sid: str,
+    fallback_session: dict,
+    process_registry: Any,
+    format_process_notification: Any,
+) -> bool:
+    """Dispatch one queued process notification.
+
+    Returns False when the event was requeued because the owning session is busy;
+    drain callers should stop in that case to avoid spin-requeueing.
+    """
+    _evt_sid = evt.get("session_id", "")
+    if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
+        return True
+
+    target_sid, target_session = _resolve_notification_target(
+        evt, fallback_sid, fallback_session, process_registry
+    )
+
+    text = format_process_notification(evt)
+    if not text:
+        return True
+
+    _emit("status.update", target_sid, {"kind": "process", "text": text})
+
+    with target_session["history_lock"]:
+        if target_session.get("running"):
+            process_registry.completion_queue.put(evt)
+            return False
+        target_session["running"] = True
+
+    rid = f"__notif__{int(time.time() * 1000)}"
+    try:
+        _emit("message.start", target_sid)
+        _run_prompt_submit(rid, target_sid, target_session, text)
+    except Exception as exc:
+        print(
+            f"[tui_gateway] notification poller dispatch failed: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        with target_session["history_lock"]:
+            target_session["running"] = False
+    return True
+
+
 def _notification_poller_loop(
     stop_event: threading.Event, sid: str, session: dict
 ) -> None:
@@ -3392,12 +3477,7 @@ def _notification_poller_loop(
 
     Runs in a daemon thread started by _init_session(). Emits a
     status.update (kind=process) for user visibility, then chains an
-    agent turn via _run_prompt_submit if the session is idle.
-
-    NOTE: The completion_queue is global (one per process). If multiple
-    TUI sessions coexist, whichever poller wakes first grabs the event,
-    even if the process was started by a different session. This matches
-    CLI/gateway behavior (single session per process).
+    agent turn via _run_prompt_submit if the owning session is idle.
     """
     from tools.process_registry import process_registry, format_process_notification
 
@@ -3406,35 +3486,7 @@ def _notification_poller_loop(
             evt = process_registry.completion_queue.get(timeout=0.5)
         except Exception:
             continue
-
-        _evt_sid = evt.get("session_id", "")
-        if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
-            continue
-
-        text = format_process_notification(evt)
-        if not text:
-            continue
-
-        _emit("status.update", sid, {"kind": "process", "text": text})
-
-        with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                continue
-            session["running"] = True
-
-        rid = f"__notif__{int(time.time() * 1000)}"
-        try:
-            _emit("message.start", sid)
-            _run_prompt_submit(rid, sid, session, text)
-        except Exception as exc:
-            print(
-                f"[tui_gateway] notification poller dispatch failed: "
-                f"{type(exc).__name__}: {exc}",
-                file=sys.stderr,
-            )
-            with session["history_lock"]:
-                session["running"] = False
+        _dispatch_notification_event(evt, sid, session, process_registry, format_process_notification)
 
     # Drain any remaining events after stop signal (process all pending
     # before exiting so nothing is lost on shutdown).
@@ -3443,33 +3495,10 @@ def _notification_poller_loop(
             evt = process_registry.completion_queue.get_nowait()
         except Exception:
             break
-        _evt_sid = evt.get("session_id", "")
-        if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
-            continue
-        text = format_process_notification(evt)
-        if not text:
-            continue
-
-        _emit("status.update", sid, {"kind": "process", "text": text})
-
-        with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                break
-            session["running"] = True
-
-        rid = f"__notif__{int(time.time() * 1000)}"
-        try:
-            _emit("message.start", sid)
-            _run_prompt_submit(rid, sid, session, text)
-        except Exception as exc:
-            print(
-                f"[tui_gateway] notification poller dispatch failed: "
-                f"{type(exc).__name__}: {exc}",
-                file=sys.stderr,
-            )
-            with session["history_lock"]:
-                session["running"] = False
+        if not _dispatch_notification_event(
+            evt, sid, session, process_registry, format_process_notification
+        ):
+            break
 
 
 def _start_notification_poller(sid: str, session: dict) -> threading.Event:


### PR DESCRIPTION
## Summary
- Route TUI background process notifications to the live session that owns the process instead of whichever per-session poller wins the global queue race.
- Include `session_key` on `notify_on_complete` completion events so TUI routing has stable owner metadata.
- Add a regression test where a non-owner poller drains the queue first and must still dispatch to the owner session.

Fixes #35652.

## Test plan
- `PYTEST_ADDOPTS='' /home/zebra/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/test_tui_gateway_server.py::test_notification_poller_routes_events_to_owner_session tests/test_tui_gateway_server.py::test_notification_poller_delivers_completion tests/test_tui_gateway_server.py::test_notification_poller_requeues_when_busy -q`
- `PYTEST_ADDOPTS='' /home/zebra/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/test_tui_gateway_server.py -q`
- `PYTEST_ADDOPTS='' /home/zebra/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/tools/test_process_registry.py -q` *(one PTY stdin EOF test was flaky locally; reran that single test successfully)*
- `/home/zebra/.hermes/hermes-agent/venv/bin/python -m py_compile tui_gateway/server.py tools/process_registry.py tests/test_tui_gateway_server.py`
- `/home/zebra/.hermes/hermes-agent/venv/bin/ruff check tui_gateway/server.py tools/process_registry.py tests/test_tui_gateway_server.py`
- `git diff --check`
