### PR TITLE
fix(terminal): prefer Scoop MSYS bash over WSL bash on Windows

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -359,27 +359,31 @@ class BaseEnvironment(ABC):
         # Restore configured cwd after login shell profile scripts, which may
         # change the working directory (e.g. bashrc `cd ~`).  Without this,
         # pwd -P captures the profile's directory, not terminal.cwd.
-        _quoted_cwd = shlex.quote(self.cwd)
-        # Quote the snapshot / cwd-file paths so Git Bash on Windows handles
-        # ``C:/Users/...``-shaped paths without glob-splitting the colon or
-        # tripping on drive letters.  On POSIX this is a no-op (no colons /
-        # special chars in a /tmp path).  Previously unquoted interpolation
-        # caused ``C:/Users/.../hermes-snap-*.sh: No such file or directory``
-        # errors on Windows, leaking via stderr (merged into stdout on Linux
-        # backends) into every terminal-tool response.
+        import re as _re
+        _is_windows_cwd = bool(_re.match(r'^[A-Za-z]:[/\\]', self.cwd))
         _quoted_snap = shlex.quote(self._snapshot_path)
         _quoted_cwd_file = shlex.quote(self._cwd_file)
-        bootstrap = (
-            f"export -p > {_quoted_snap}\n"
-            f"declare -f | grep -vE '^_[^_]' >> {_quoted_snap}\n"
-            f"alias -p >> {_quoted_snap}\n"
-            f"echo 'shopt -s expand_aliases' >> {_quoted_snap}\n"
-            f"echo 'set +e' >> {_quoted_snap}\n"
-            f"echo 'set +u' >> {_quoted_snap}\n"
-            f"builtin cd {_quoted_cwd} 2>/dev/null || true\n"
-            f"pwd -P > {_quoted_cwd_file} 2>/dev/null || true\n"
-            f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
-        )
+        bootstrap_parts = [
+            f"export -p > {_quoted_snap}\n",
+            f"declare -f | grep -vE '^_[^_]' >> {_quoted_snap}\n",
+            f"alias -p >> {_quoted_snap}\n",
+            f"echo 'shopt -s expand_aliases' >> {_quoted_snap}\n",
+            f"echo 'set +e' >> {_quoted_snap}\n",
+            f"echo 'set +u' >> {_quoted_snap}\n",
+        ]
+        if _is_windows_cwd:
+            # WSL bash: Popen cwd= already sets /mnt/c/..., skip explicit cd
+            bootstrap_parts.append(
+                f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
+            )
+        else:
+            _quoted_cwd = shlex.quote(self.cwd)
+            bootstrap_parts.append(f"builtin cd {_quoted_cwd} 2>/dev/null || true\n")
+            bootstrap_parts.append(f"pwd -P > {_quoted_cwd_file} 2>/dev/null || true\n")
+            bootstrap_parts.append(
+                f"printf '\\n{self._cwd_marker}%s{self._cwd_marker}\\n' \"$(pwd -P)\"\n"
+            )
+        bootstrap = "".join(bootstrap_parts)
         try:
             proc = self._run_bash(bootstrap, login=True, timeout=self._snapshot_timeout)
             result = self._wait_for_process(proc, timeout=self._snapshot_timeout)
@@ -441,9 +445,23 @@ class BaseEnvironment(ABC):
 
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
         # ``$HOME`` so suffixes with spaces remain a single shell word.
-        quoted_cwd = self._quote_cwd_for_cd(cwd)
-        # ``--`` keeps hyphen-prefixed directory names from being parsed as options.
-        parts.append(f"builtin cd -- {quoted_cwd} || exit 126")
+        # On Windows with WSL bash, subprocess.Popen(cwd=...) already sets the
+        # correct working directory (/mnt/c/...).  A second explicit `builtin cd` to a
+        # Windows-shaped path inside the bash session fails because WSL bash cannot
+        # resolve `C:/...` paths.  We work around this by:
+        #   1. Checking if cwd looks like a Windows absolute path
+        #   2. If so, skip the explicit cd; Popen's cwd= is sufficient
+        #   3. Otherwise use the normal quoted cd as before
+        import re as _re
+        _is_windows_cwd = bool(_re.match(r'^[A-Za-z]:[/\\]', cwd))
+        if _is_windows_cwd:
+            # Skip cd — Popen cwd= already put WSL bash in the right place.
+            # Still emit a cwd marker so _update_cwd can confirm the path.
+            parts.append(f"printf '\n{self._cwd_marker}%s{self._cwd_marker}\n' \"$(pwd -P)\"")
+        else:
+            quoted_cwd = self._quote_cwd_for_cd(cwd)
+            # ``--`` keeps hyphen-prefixed directory names from being parsed as options.
+            parts.append(f"builtin cd -- {quoted_cwd} || exit 126")
 
         # Run the actual command
         parts.append(f"eval '{escaped}'")

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -269,6 +269,14 @@ def _find_bash() -> str:
             if os.path.isfile(candidate):
                 return candidate
 
+    # Scoop-managed Git for Windows — checked before shutil.which to avoid
+    # WSL bash (linux ELF) being picked up from PATH on mixed installs.
+    _userprofile = os.environ.get("USERPROFILE", "")
+    if _userprofile:
+        _scoop_git = os.path.join(_userprofile, "scoop", "apps", "git", "current", "bin", "bash.exe")
+        if os.path.isfile(_scoop_git):
+            return _scoop_git
+
     found = shutil.which("bash")
     if found:
         return found

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -997,6 +997,70 @@ class ShellFileOperations(FileOperations):
         if _is_write_denied(path):
             return WriteResult(error=f"Write denied: '{path}' is a protected system/credential file.")
 
+        # ── Windows absolute path shortcut ─────────────────────────────
+        # On Windows, bash subprocesses inherit a cwd that may not be able to
+        # resolve paths like C:/Users/... (MSYS/bash cwd mismatch).  For
+        # absolute Windows paths, use Python's native open() directly to
+        # bypass the bash cwd problem entirely.  This also means we can skip
+        # the mkdir/wc steps that would also fail without a valid bash cwd.
+        import platform as _platform
+        _IS_WINDOWS = _platform.system() == "Windows"
+        _WINDOWS_DRIVE_LETTER = re.match(r'^[A-Za-z]:[/\\]', path) is not None
+
+        if _IS_WINDOWS and _WINDOWS_DRIVE_LETTER:
+            # Use Python native I/O — bypasses bash cwd entirely
+            parent = os.path.dirname(path)
+            dirs_created = False
+            if parent and not os.path.isdir(parent):
+                try:
+                    os.makedirs(parent, exist_ok=True)
+                    dirs_created = True
+                except OSError as e:
+                    return WriteResult(error=f"Failed to create directory: {e}")
+
+            # Line-ending preservation (same logic as bash path)
+            ext = os.path.splitext(path)[1].lower()
+            pre_content: Optional[str] = None
+            want_pre = ext in LINTERS_INPROC or self._lsp_handles_extension(ext)
+            if want_pre and os.path.isfile(path):
+                try:
+                    with open(path, 'r', encoding='utf-8', errors='replace') as f:
+                        pre_content = f.read()
+                except OSError:
+                    pass
+
+            original_ending = self._detect_file_line_ending(path, pre_content)
+            if original_ending == "\r\n":
+                content = _normalize_line_endings(content, "\r\n")
+
+            self._snapshot_lsp_baseline(path)
+
+            try:
+                mode = 'w'
+                encoding_kw = {'encoding': 'utf-8', 'errors': 'replace'}
+                with open(path, mode, **encoding_kw) as fh:
+                    fh.write(content)
+            except OSError as e:
+                return WriteResult(error=f"Failed to write file: {e}")
+
+            bytes_written = len(content.encode('utf-8'))
+
+            # Post-write lint
+            lint_result = self._check_lint_delta(path, pre_content=pre_content, post_content=content)
+            lsp_diagnostics: Optional[str] = None
+            if lint_result.success or lint_result.skipped:
+                block = self._maybe_lsp_diagnostics(path, pre_content=pre_content, post_content=content)
+                if block:
+                    lsp_diagnostics = block
+
+            return WriteResult(
+                bytes_written=bytes_written,
+                dirs_created=dirs_created,
+                lint=lint_result.to_dict() if lint_result else None,
+                lsp_diagnostics=lsp_diagnostics,
+            )
+        # ── End Windows absolute path shortcut ─────────────────────────
+
         # Capture pre-write content.  Two consumers want it:
         #
         #   1. The lint-delta layer (for in-process linters like ast.parse
@@ -1093,11 +1157,7 @@ class ShellFileOperations(FileOperations):
             lint=lint_result.to_dict() if lint_result else None,
             lsp_diagnostics=lsp_diagnostics,
         )
-    
-    # =========================================================================
-    # PATCH Implementation (Replace Mode)
-    # =========================================================================
-    
+
     def patch_replace(self, path: str, old_string: str, new_string: str,
                       replace_all: bool = False) -> PatchResult:
         """


### PR DESCRIPTION
On Windows hosts with WSL and Scoop Git installed side-by-side, shutil.which('bash') may return /usr/bin/bash (Linux ELF from WSL) which cannot be executed by Python running on the Windows side.

Fixes three related issues:
- _find_bash() now checks Scoop-managed Git before shutil.which
- base.py skips redundant cd for Windows cwd when using WSL bash
- file_operations.py bypasses bash cwd for Windows absolute paths

Health-check job fails with: cd: /c/Users/.../hermes: No such file or directory

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

