### PR TITLE
fix(gateway): add hard-exit watchdog to prevent drain hang on stop/restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6059,6 +6059,30 @@ class GatewayRunner:
             def _phase_elapsed() -> float:
                 return time.monotonic() - _stop_started_at
 
+            # Unconditional hard-exit watchdog: regardless of where the shutdown
+            # sequence gets stuck (drain, interrupt, adapter.disconnect, DB close),
+            # this daemon thread guarantees the process exits within
+            # (drain_timeout + 20s).  This is a belt-and-suspenders guard on top
+            # of the per-zombie watchdog below — the per-zombie guard has a blind
+            # spot when _running_agents is cleared before blocking threads finish.
+            _watchdog_delay = self._restart_drain_timeout + 20.0
+            import threading as _threading_wd
+            def _unconditional_exit_watchdog(delay: float) -> None:
+                import time as _time, os as _os
+                _time.sleep(delay)
+                _os._exit(0)  # noqa: SIM115 — intentional last-resort hard exit
+            _wd_thread = _threading_wd.Thread(
+                target=_unconditional_exit_watchdog,
+                args=(_watchdog_delay,),
+                daemon=True,
+                name="gateway-stop-watchdog",
+            )
+            _wd_thread.start()
+            logger.info(
+                "Shutdown watchdog started: process will os._exit(0) in %.0fs if still alive",
+                _watchdog_delay,
+            )
+
             self._running = False
             self._draining = True
 
@@ -6162,6 +6186,28 @@ class GatewayRunner:
                 while self._running_agents and asyncio.get_running_loop().time() < interrupt_deadline:
                     self._update_runtime_status("draining")
                     await asyncio.sleep(0.1)
+
+                if self._running_agents:
+                    # Zombie sessions whose threads cannot be interrupted.
+                    # Schedule a hard os._exit() 10s from now so launchd /
+                    # systemd does NOT need to SIGKILL us — letting the rest
+                    # of _stop_impl() run for log flushing and DB close, but
+                    # guaranteeing we exit even if an adapter.disconnect() hangs.
+                    _hard_exit_delay = 10.0
+                    logger.warning(
+                        "Gateway drain: %d zombie session(s) remain after interrupt; "
+                        "scheduling os._exit(0) in %.0fs as last-resort watchdog.",
+                        len(self._running_agents),
+                        _hard_exit_delay,
+                    )
+                    import threading as _threading
+                    def _hard_exit_watchdog(delay: float) -> None:
+                        import time as _time
+                        _time.sleep(delay)
+                        import os as _os
+                        _os._exit(0)  # noqa: SIM115 — intentional hard exit after zombie drain
+                    _t = _threading.Thread(target=_hard_exit_watchdog, args=(_hard_exit_delay,), daemon=True)
+                    _t.start()
 
                 # Kill lingering tool subprocesses NOW, before we spend more
                 # budget on adapter disconnect / session DB close.  Under


### PR DESCRIPTION
## Problem

When the gateway receives SIGUSR1 (restart) or is stopped while agent
sessions are active, `_stop_impl()` may hang indefinitely if any session
thread cannot be interrupted ("zombie" sessions — e.g. a blocking
subprocess in `terminal()`, or a synchronous network call that ignores
asyncio cancellation).

On systems managed by **launchd** (macOS) or **systemd** (Linux), the
process is then killed with SIGKILL after `TimeoutStopSec`, which bypasses
log flushing and DB close.

**Reproducing scenario:**
1. Start a gateway session running a long `terminal()` call
2. Send `SIGUSR1` to restart the gateway (`hermes restart`)
3. `_drain_active_agents()` times out; `_interrupt_running_agents()` fires
   but the blocking thread doesn't respond
4. `_stop_impl()` blocks in the 5s interrupt wait loop — or until the
   service manager's SIGKILL

## Fix

Two layered watchdogs in `_stop_impl()`, both using daemon threads:

### Layer 1 — Unconditional stop watchdog

Added at the very start of the shutdown sequence (before drain), fires
after `drain_timeout + 20s` regardless of where the sequence gets stuck:

```python
_watchdog_delay = self._restart_drain_timeout + 20.0
import threading as _threading_wd
def _unconditional_exit_watchdog(delay: float) -> None:
    import time as _time, os as _os
    _time.sleep(delay)
    _os._exit(0)  # noqa: SIM115
_wd_thread = _threading_wd.Thread(
    target=_unconditional_exit_watchdog,
    args=(_watchdog_delay,),
    daemon=True,
    name="gateway-stop-watchdog",
)
_wd_thread.start()
```

This covers the blind spot of Layer 2: when `_running_agents` is cleared
before blocking threads actually finish, the per-zombie check below sees
an empty dict and doesn't fire — but those threads may still be holding
resources. Layer 1 catches this case.

### Layer 2 — Per-zombie watchdog

Triggered only when zombie sessions remain after the interrupt + 5s wait.
Fires after 10s, allowing `_stop_impl()` to continue (log flush, DB
close, adapter disconnect) while guaranteeing exit:

```python
if self._running_agents:
    _hard_exit_delay = 10.0
    import threading as _threading
    def _hard_exit_watchdog(delay: float) -> None:
        import time as _time, os as _os
        _time.sleep(delay)
        _os._exit(0)  # noqa: SIM115
    _t = _threading.Thread(
        target=_hard_exit_watchdog,
        args=(_hard_exit_delay,),
        daemon=True,
    )
    _t.start()
```

### Why `os._exit(0)` not `sys.exit()`

`sys.exit()` raises `SystemExit` which asyncio and Python's `atexit`
machinery may catch or defer — the process might still not exit.
`os._exit(0)` bypasses all cleanup handlers and is the correct
last-resort in a daemon/service process. The `# noqa: SIM115` silences
the linter's preference for `sys.exit()`, which is inappropriate here.

## Behavior

**Normal shutdown (no active sessions):**
Both watchdog threads start but never fire — they are daemon threads and
exit automatically when the main process terminates cleanly.

**Shutdown with interruptible sessions:**
Sessions are cancelled and drained within `drain_timeout`. Process exits
cleanly before either watchdog fires.

**Shutdown with zombie sessions (threads blocked, cannot be interrupted):**
Layer 2 watchdog fires after 10s — process hard-exits via `os._exit(0)`.
Layer 1 was already running but superseded.

**Catastrophic hang (drain loop itself stuck, `_running_agents` cleared early):**
Layer 1 watchdog fires unconditionally at `drain_timeout + 20s`.

## Testing

Reproduced hang by starting a session running `sleep 120` in `terminal()`
tool, then issuing `hermes restart` (SIGUSR1).

- Without this patch: process hangs until SIGKILL from launchd/systemd.
- With this patch: process exits within `drain_timeout + 20s`, log and DB
  close complete normally in the non-zombie path.