### PR TITLE
fix: /title now renames Telegram DM topic threads

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12917,6 +12917,13 @@ class GatewayRunner:
             # Set the title
             try:
                 if self._session_db.set_session_title(session_id, sanitized):
+                    # Also rename the Telegram topic if we're in a DM topic lane
+                    try:
+                        self._schedule_telegram_topic_title_rename(
+                            source, session_id, sanitized,
+                        )
+                    except Exception:
+                        logger.debug("Failed to schedule Telegram topic rename from /title", exc_info=True)
                     return t("gateway.title.set_to", title=sanitized)
                 else:
                     return t("gateway.title.not_found")


### PR DESCRIPTION
## Problem

When `/title <name>` is used inside a Telegram DM topic session, it only renames the Hermes session in SQLite — the actual Telegram topic thread name stays as "New Chat". This leaves the user looking at a sea of unnamed "New Chat" topics with no way to tell which session is which.

## Fix

After setting the session title, also call `_schedule_telegram_topic_title_rename()` to propagate the name change to the Telegram topic thread via `edit_forum_topic`. Falls back gracefully with a debug log if scheduling fails, and the call is a no-op outside Telegram topic sessions (`_is_telegram_topic_lane` guards it).

## Testing

- `/title <name>` in Telegram DM topic → DB title set + Telegram topic renamed
- `/title <name>` in plain DM (no topics) → title set only, no-op on Telegram side (guarded by `_is_telegram_topic_lane`)
- `/title <name>` from CLI/other platforms → title set only, no-op on Telegram side