### PR TITLE
fix(gateway): map LINE media message types

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -548,6 +548,19 @@ def _video_message(url: str, preview_url: str) -> Dict[str, Any]:
     }
 
 
+def _line_message_type(msg_type: str) -> MessageType:
+    """Map LINE webhook message types to Hermes gateway message types."""
+    return {
+        "text": MessageType.TEXT,
+        "image": MessageType.PHOTO,
+        "audio": MessageType.AUDIO,
+        "video": MessageType.VIDEO,
+        "file": MessageType.DOCUMENT,
+        "sticker": MessageType.STICKER,
+        "location": MessageType.LOCATION,
+    }.get(msg_type, MessageType.TEXT)
+
+
 def build_postback_button_message(
     text: str, button_label: str, request_id: str
 ) -> Dict[str, Any]:
@@ -968,7 +981,7 @@ class LineAdapter(BasePlatformAdapter):
 
         event_obj = MessageEvent(
             text=text,
-            message_type=MessageType.TEXT if msg_type == "text" else MessageType.IMAGE,
+            message_type=_line_message_type(msg_type),
             source=source_obj,
             raw_message=event,
             message_id=message_id,

--- a/tests/gateway/test_line_adapter.py
+++ b/tests/gateway/test_line_adapter.py
@@ -1,0 +1,23 @@
+"""Tests for the LINE platform adapter."""
+
+import sys
+from pathlib import Path
+
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+from gateway.platforms.base import MessageType
+from plugins.platforms.line.adapter import _line_message_type
+
+
+def test_line_message_types_use_gateway_enum_names():
+    assert _line_message_type("text") is MessageType.TEXT
+    assert _line_message_type("image") is MessageType.PHOTO
+    assert _line_message_type("audio") is MessageType.AUDIO
+    assert _line_message_type("video") is MessageType.VIDEO
+    assert _line_message_type("file") is MessageType.DOCUMENT
+    assert _line_message_type("sticker") is MessageType.STICKER
+    assert _line_message_type("location") is MessageType.LOCATION


### PR DESCRIPTION
## What does this PR do?

Fixes LINE inbound media dispatch by mapping LINE webhook message types to Hermes gateway `MessageType` enum values before constructing `MessageEvent`.

The LINE adapter previously used `MessageType.IMAGE` for every non-text message, but the gateway enum defines images as `MessageType.PHOTO`. This could raise before image/media messages reached the gateway processing path. This PR keeps the change narrow by only adding a LINE-specific mapping helper and a focused regression test.

## Related Issue

No issue filed.

Related prior PRs found during duplicate search:

- #23867: open/stale media message-type mapping fix with additional source-factory changes.
- #27142: open/stale broader LINE media normalization and cache routing change.

This PR is intentionally narrower and based on current `main`: it only fixes the LINE webhook message-type enum mapping and adds regression coverage.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/line/adapter.py`
  - Added `_line_message_type()` to map LINE webhook message types to Hermes gateway enum values.
  - Changed inbound LINE `MessageEvent.message_type` construction to use that mapping.
- `tests/gateway/test_line_adapter.py`
  - Added regression coverage for LINE text/image/audio/video/file/sticker/location mappings.

## How to Test

1. Run syntax checks:
   - `python3 -m py_compile plugins/platforms/line/adapter.py tests/gateway/test_line_adapter.py`
2. Run diff hygiene:
   - `git diff --check`
3. Run the targeted regression test:
   - `scripts/run_tests.sh tests/gateway/test_line_adapter.py`
4. Optional broader gateway coverage:
   - `scripts/run_tests.sh tests/gateway`
5. In CI or a complete local dev environment, run the full suite:
   - `pytest tests/ -q`

Note: Full `pytest tests/ -q` was not completed locally. Broader gateway coverage was attempted and has one unrelated local failure in `tests/gateway/test_shutdown_forensics.py::TestSpawnAsyncDiagnostic::test_spawns_subprocess_and_writes_output`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local checkout; targeted LINE test passed; gateway suite attempted with one unrelated shutdown-forensics failure

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A: pure Python enum mapping, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: N/A

## Screenshots / Logs

N/A. Local checks run on this branch:

```text
python3 -m py_compile plugins/platforms/line/adapter.py tests/gateway/test_line_adapter.py: passed
git diff --check: passed
scripts/run_tests.sh tests/gateway/test_line_adapter.py: 1 passed
scripts/run_tests.sh tests/gateway: 6059 passed, 1 unrelated failure

Failure:
tests/gateway/test_shutdown_forensics.py::TestSpawnAsyncDiagnostic::test_spawns_subprocess_and_writes_output
assert pid is not None and pid > 0
```