### PR TITLE
feat(gateway): add LINE quick reply approvals

### DIFF
--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -22,6 +22,12 @@ gateway:
   no_active_goal:   "Geen aktiewe doelwit nie."
   config_read_failed: "⚠️ Kon nie config.yaml lees nie: {error}"
   config_save_failed: "⚠️ Kon nie konfigurasie stoor nie: {error}"
+  line_quick_reply:
+    allow_once: "Eenmalig toelaat"
+    this_session: "Hierdie sessie"
+    always_allow: "Altyd toelaat"
+    deny: "Weier"
+    cancel: "Kanselleer"
 
   model:
     error_prefix:           "Fout: {error}"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -22,6 +22,12 @@ gateway:
   no_active_goal:   "Kein aktives Ziel."
   config_read_failed: "⚠️ config.yaml konnte nicht gelesen werden: {error}"
   config_save_failed: "⚠️ Konfiguration konnte nicht gespeichert werden: {error}"
+  line_quick_reply:
+    allow_once: "Einmal erlauben"
+    this_session: "Diese Sitzung"
+    always_allow: "Immer erlauben"
+    deny: "Ablehnen"
+    cancel: "Abbrechen"
 
   model:
     error_prefix:           "Fehler: {error}"

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -33,6 +33,12 @@ gateway:
   no_active_goal:   "No active goal."
   config_read_failed: "⚠️ Could not read config.yaml: {error}"
   config_save_failed: "⚠️ Could not save config: {error}"
+  line_quick_reply:
+    allow_once: "Allow Once"
+    this_session: "This Session"
+    always_allow: "Always Allow"
+    deny: "Deny"
+    cancel: "Cancel"
 
   # /model command output -- shown after a model switch or when listing models.
   # Provider names, model IDs, capability strings, and cost figures are NOT

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -22,6 +22,12 @@ gateway:
   no_active_goal:   "No hay objetivo activo."
   config_read_failed: "⚠️ No se pudo leer config.yaml: {error}"
   config_save_failed: "⚠️ No se pudo guardar la configuración: {error}"
+  line_quick_reply:
+    allow_once: "Permitir una vez"
+    this_session: "Esta sesión"
+    always_allow: "Permitir siempre"
+    deny: "Denegar"
+    cancel: "Cancelar"
 
   model:
     error_prefix:           "Error: {error}"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -22,6 +22,12 @@ gateway:
   no_active_goal:   "Aucun objectif actif."
   config_read_failed: "⚠️ Impossible de lire config.yaml : {error}"
   config_save_failed: "⚠️ Impossible de sauvegarder la configuration : {error}"
+  line_quick_reply:
+    allow_once: "Autoriser une fois"
+    this_session: "Cette session"
+    always_allow: "Toujours autoriser"
+    deny: "Refuser"
+    cancel: "Annuler"
 
   model:
     error_prefix:           "Erreur : {error}"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -26,6 +26,12 @@ gateway:
   no_active_goal:   "Níl aon sprioc ghníomhach ann."
   config_read_failed: "⚠️ Níorbh fhéidir config.yaml a léamh: {error}"
   config_save_failed: "⚠️ Níorbh fhéidir an chumraíocht a shábháil: {error}"
+  line_quick_reply:
+    allow_once: "Ceadaigh uair amháin"
+    this_session: "An seisiún seo"
+    always_allow: "Ceadaigh i gcónaí"
+    deny: "Diúltaigh"
+    cancel: "Cealaigh"
 
   model:
     error_prefix:           "Earráid: {error}"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -22,6 +22,12 @@ gateway:
   no_active_goal:   "Nincs aktív cél."
   config_read_failed: "⚠️ Nem sikerült olvasni a config.yaml fájlt: {error}"
   config_save_failed: "⚠️ Nem sikerült menteni a konfigurációt: {error}"
+  line_quick_reply:
+    allow_once: "Egyszer engedélyez"
+    this_session: "Ez a munkamenet"
+    always_allow: "Mindig engedélyez"
+    deny: "Elutasít"
+    cancel: "Mégse"
 
   model:
     error_prefix:           "Hiba: {error}"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -22,6 +22,12 @@ gateway:
   no_active_goal:   "Nessun obiettivo attivo."
   config_read_failed: "⚠️ Impossibile leggere config.yaml: {error}"
   config_save_failed: "⚠️ Impossibile salvare la configurazione: {error}"
+  line_quick_reply:
+    allow_once: "Consenti una volta"
+    this_session: "Questa sessione"
+    always_allow: "Consenti sempre"
+    deny: "Nega"
+    cancel: "Annulla"
 
   model:
     error_prefix:           "Errore: {error}"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -22,6 +22,12 @@ gateway:
   no_active_goal:   "アクティブな目標はありません。"
   config_read_failed: "⚠️ config.yaml を読み込めませんでした: {error}"
   config_save_failed: "⚠️ 設定を保存できませんでした: {error}"
+  line_quick_reply:
+    allow_once: "今回のみ許可"
+    this_session: "このセッション"
+    always_allow: "常に許可"
+    deny: "拒否"
+    cancel: "キャンセル"
 
   model:
     error_prefix:           "エラー: {error}"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -22,6 +22,12 @@ gateway:
   no_active_goal:   "활성 목표가 없습니다."
   config_read_failed: "⚠️ config.yaml을 읽을 수 없습니다: {error}"
   config_save_failed: "⚠️ 설정을 저장할 수 없습니다: {error}"
+  line_quick_reply:
+    allow_once: "한 번 허용"
+    this_session: "이 세션"
+    always_allow: "항상 허용"
+    deny: "거부"
+    cancel: "취소"
 
   model:
     error_prefix:           "오류: {error}"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -22,6 +22,12 @@ gateway:
   no_active_goal:   "Não há objetivo ativo."
   config_read_failed: "⚠️ Não foi possível ler config.yaml: {error}"
   config_save_failed: "⚠️ Não foi possível guardar a configuração: {error}"
+  line_quick_reply:
+    allow_once: "Permitir uma vez"
+    this_session: "Esta sessão"
+    always_allow: "Permitir sempre"
+    deny: "Negar"
+    cancel: "Cancelar"
 
   model:
     error_prefix:           "Erro: {error}"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -22,6 +22,12 @@ gateway:
   no_active_goal:   "Нет активной цели."
   config_read_failed: "⚠️ Не удалось прочитать config.yaml: {error}"
   config_save_failed: "⚠️ Не удалось сохранить конфигурацию: {error}"
+  line_quick_reply:
+    allow_once: "Разрешить раз"
+    this_session: "Этот сеанс"
+    always_allow: "Всегда разрешать"
+    deny: "Отклонить"
+    cancel: "Отмена"
 
   model:
     error_prefix:           "Ошибка: {error}"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -22,6 +22,12 @@ gateway:
   no_active_goal:   "Aktif hedef yok."
   config_read_failed: "⚠️ config.yaml okunamadı: {error}"
   config_save_failed: "⚠️ Yapılandırma kaydedilemedi: {error}"
+  line_quick_reply:
+    allow_once: "Bir kez izin ver"
+    this_session: "Bu oturum"
+    always_allow: "Her zaman izin ver"
+    deny: "Reddet"
+    cancel: "İptal"
 
   model:
     error_prefix:           "Hata: {error}"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -22,6 +22,12 @@ gateway:
   no_active_goal:   "Немає активної цілі."
   config_read_failed: "⚠️ Не вдалося прочитати config.yaml: {error}"
   config_save_failed: "⚠️ Не вдалося зберегти конфігурацію: {error}"
+  line_quick_reply:
+    allow_once: "Дозволити раз"
+    this_session: "Ця сесія"
+    always_allow: "Завжди дозволяти"
+    deny: "Відхилити"
+    cancel: "Скасувати"
 
   model:
     error_prefix:           "Помилка: {error}"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -22,6 +22,12 @@ gateway:
   no_active_goal:   "目前沒有作用中的目標。"
   config_read_failed: "⚠️ 無法讀取 config.yaml：{error}"
   config_save_failed: "⚠️ 無法儲存設定：{error}"
+  line_quick_reply:
+    allow_once: "批准一次"
+    this_session: "本次工作階段"
+    always_allow: "永遠批准"
+    deny: "拒絕"
+    cancel: "取消"
 
   model:
     error_prefix:           "錯誤：{error}"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -22,6 +22,12 @@ gateway:
   no_active_goal:   "当前没有活跃的目标。"
   config_read_failed: "⚠️ 无法读取 config.yaml：{error}"
   config_save_failed: "⚠️ 无法保存配置：{error}"
+  line_quick_reply:
+    allow_once: "批准一次"
+    this_session: "本次会话"
+    always_allow: "始终批准"
+    deny: "拒绝"
+    cancel: "取消"
 
   model:
     error_prefix:           "错误：{error}"

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -95,6 +95,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
 )
 from gateway.config import Platform
+from agent.i18n import t
 
 
 # ---------------------------------------------------------------------------
@@ -581,6 +582,27 @@ def build_postback_button_message(
     }
 
 
+def _attach_quick_reply(
+    message: Dict[str, Any],
+    actions: List[Tuple[str, str]],
+) -> Dict[str, Any]:
+    """Attach LINE quick-reply message actions to an outbound message."""
+    message["quickReply"] = {
+        "items": [
+            {
+                "type": "action",
+                "action": {
+                    "type": "message",
+                    "label": label[:20],
+                    "text": text[:300],
+                },
+            }
+            for label, text in actions
+        ]
+    }
+    return message
+
+
 # Prefixes the gateway uses for system busy-acks (interrupting / queued /
 # steered). When the postback cache has a PENDING entry we *bypass* the
 # cache for these so they reach the user as visible bubbles instead of
@@ -699,6 +721,13 @@ class LineAdapter(BasePlatformAdapter):
         self.interrupted_text = (
             os.getenv("LINE_INTERRUPTED_TEXT")
             or extra.get("interrupted_text", DEFAULT_INTERRUPTED_TEXT)
+        )
+        self.language = (
+            os.getenv("LINE_LANGUAGE")
+            or os.getenv("LINE_LOCALE")
+            or extra.get("language")
+            or extra.get("locale")
+            or None
         )
 
         # Runtime state
@@ -1085,6 +1114,103 @@ class LineAdapter(BasePlatformAdapter):
             return SendResult(success=True, message_id=pending_rid)
 
         return await self._send_text_chunks(chat_id, content, force_push=False)
+
+    async def send_slash_confirm(
+        self,
+        chat_id: str,
+        title: str,
+        message: str,
+        session_key: str,
+        confirm_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a LINE quick-reply prompt for slash-command confirmations."""
+        if not self._client:
+            return SendResult(success=False, error="LINE adapter not connected")
+
+        text = strip_markdown_preserving_urls(message)
+        if len(text) > LINE_SAFE_BUBBLE_CHARS:
+            text = text[: LINE_SAFE_BUBBLE_CHARS - 1].rstrip() + "..."
+
+        line_message = _attach_quick_reply(
+            _text_message(text),
+            [
+                (self._label("allow_once"), "/approve"),
+                (self._label("always_allow"), "/always"),
+                (self._label("cancel"), "/cancel"),
+            ],
+        )
+        return await self._send_message_objects(
+            chat_id,
+            [line_message],
+            purpose="slash confirmation quick-reply",
+        )
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a LINE quick-reply approval prompt for dangerous commands."""
+        if not self._client:
+            return SendResult(success=False, error="LINE adapter not connected")
+
+        cmd_preview = command[:3200] + "..." if len(command) > 3200 else command
+        text = (
+            "Command approval required\n\n"
+            f"{cmd_preview}\n\n"
+            f"Reason: {description}"
+        )
+        text = strip_markdown_preserving_urls(text)
+        if len(text) > LINE_SAFE_BUBBLE_CHARS:
+            text = text[: LINE_SAFE_BUBBLE_CHARS - 1].rstrip() + "..."
+
+        message = _attach_quick_reply(
+            _text_message(text),
+            [
+                (self._label("allow_once"), "/approve"),
+                (self._label("this_session"), "/approve session"),
+                (self._label("always_allow"), "/approve always"),
+                (self._label("deny"), "/deny"),
+            ],
+        )
+        return await self._send_message_objects(
+            chat_id,
+            [message],
+            purpose="approval quick-reply",
+        )
+
+    async def _send_message_objects(
+        self,
+        chat_id: str,
+        messages: List[Dict[str, Any]],
+        *,
+        purpose: str,
+    ) -> SendResult:
+        """Send pre-built LINE message objects, preferring reply token first."""
+        if not self._client:
+            return SendResult(success=False, error="LINE adapter not connected")
+
+        token, used_reply = self._consume_reply_token(chat_id)
+        if used_reply:
+            try:
+                await self._client.reply(token, messages[:LINE_MAX_MESSAGES_PER_CALL])
+                return SendResult(success=True, message_id=token)
+            except Exception as exc:
+                logger.info("LINE: %s reply token rejected (%s); falling back to push", purpose, exc)
+
+        try:
+            await self._client.push(chat_id, messages[:LINE_MAX_MESSAGES_PER_CALL])
+            return SendResult(success=True, message_id=None)
+        except Exception as exc:
+            logger.error("LINE: %s push failed: %s", purpose, exc)
+            return SendResult(success=False, error=str(exc))
+
+    def _label(self, key: str) -> str:
+        return t(f"gateway.line_quick_reply.{key}", lang=self.language)
 
     async def _send_text_chunks(
         self,

--- a/plugins/platforms/line/plugin.yaml
+++ b/plugins/platforms/line/plugin.yaml
@@ -63,3 +63,11 @@ optional_env:
     description: "Seconds before the slow-LLM postback button fires (default: 45; set 0 to disable and always Push-fallback)"
     prompt: "Slow response threshold (seconds)"
     password: false
+  - name: LINE_LANGUAGE
+    description: "Locale for LINE quick-reply labels (defaults to display.language; e.g. en, zh, zh-hant, ja)"
+    prompt: "LINE quick-reply language"
+    password: false
+  - name: LINE_LOCALE
+    description: "Alias for LINE_LANGUAGE for deployments that use locale terminology"
+    prompt: "LINE quick-reply locale"
+    password: false

--- a/tests/gateway/test_line_quick_reply.py
+++ b/tests/gateway/test_line_quick_reply.py
@@ -1,0 +1,144 @@
+"""Tests for the LINE platform adapter."""
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+from plugins.platforms.line.adapter import LineAdapter
+
+
+class FakeLineClient:
+    def __init__(self, *, fail_reply: bool = False):
+        self.fail_reply = fail_reply
+        self.replies = []
+        self.pushes = []
+
+    async def reply(self, reply_token, messages):
+        if self.fail_reply:
+            raise RuntimeError("expired reply token")
+        self.replies.append((reply_token, messages))
+
+    async def push(self, chat_id, messages):
+        self.pushes.append((chat_id, messages))
+
+
+def _make_adapter(client=None, *, language="en"):
+    adapter = object.__new__(LineAdapter)
+    adapter._client = client or FakeLineClient()
+    adapter._reply_tokens = {}
+    adapter.language = language
+    return adapter
+
+
+def _quick_reply_texts(message):
+    return [
+        item["action"]["text"]
+        for item in message["quickReply"]["items"]
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_exec_approval_uses_reply_token_quick_replies():
+    client = FakeLineClient()
+    adapter = _make_adapter(client)
+    adapter._reply_tokens["U123"] = ("reply-token", time.time() + 60)
+
+    result = await adapter.send_exec_approval(
+        chat_id="U123",
+        command="rm -rf /important",
+        session_key="agent:main:line:dm:U123",
+        description="dangerous deletion",
+    )
+
+    assert result.success is True
+    assert result.message_id == "reply-token"
+    assert client.pushes == []
+    assert len(client.replies) == 1
+
+    token, messages = client.replies[0]
+    assert token == "reply-token"
+    message = messages[0]
+    assert "rm -rf /important" in message["text"]
+    assert "dangerous deletion" in message["text"]
+    assert _quick_reply_texts(message) == [
+        "/approve",
+        "/approve session",
+        "/approve always",
+        "/deny",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_slash_confirm_pushes_quick_replies_without_reply_token():
+    client = FakeLineClient()
+    adapter = _make_adapter(client)
+
+    result = await adapter.send_slash_confirm(
+        chat_id="U123",
+        title="Confirm",
+        message="Reset this session?",
+        session_key="agent:main:line:dm:U123",
+        confirm_id="1",
+    )
+
+    assert result.success is True
+    assert client.replies == []
+    assert len(client.pushes) == 1
+
+    chat_id, messages = client.pushes[0]
+    assert chat_id == "U123"
+    assert messages[0]["text"] == "Reset this session?"
+    assert _quick_reply_texts(messages[0]) == ["/approve", "/always", "/cancel"]
+
+
+@pytest.mark.asyncio
+async def test_quick_reply_send_falls_back_to_push_when_reply_token_fails():
+    client = FakeLineClient(fail_reply=True)
+    adapter = _make_adapter(client)
+    adapter._reply_tokens["U123"] = ("expired-token", time.time() + 60)
+
+    result = await adapter.send_slash_confirm(
+        chat_id="U123",
+        title="Confirm",
+        message="Reload MCP servers?",
+        session_key="agent:main:line:dm:U123",
+        confirm_id="2",
+    )
+
+    assert result.success is True
+    assert client.replies == []
+    assert len(client.pushes) == 1
+    assert client.pushes[0][0] == "U123"
+
+
+@pytest.mark.asyncio
+async def test_quick_reply_labels_use_adapter_language():
+    client = FakeLineClient()
+    adapter = _make_adapter(client, language="zh-hant")
+
+    result = await adapter.send_exec_approval(
+        chat_id="U123",
+        command="ls",
+        session_key="agent:main:line:dm:U123",
+    )
+
+    assert result.success is True
+    message = client.pushes[0][1][0]
+    assert [
+        item["action"]["label"]
+        for item in message["quickReply"]["items"]
+    ] == ["批准一次", "本次工作階段", "永遠批准", "拒絕"]
+    assert _quick_reply_texts(message) == [
+        "/approve",
+        "/approve session",
+        "/approve always",
+        "/deny",
+    ]


### PR DESCRIPTION
## What does this PR do?

Adds LINE quick-reply prompts for gateway approval flows, while keeping the actual decision payloads on the existing slash-command path.

LINE users now get quick replies for dangerous command approvals and destructive slash confirmations. The visible labels are localized through Hermes i18n (`display.language`) with LINE-specific overrides via `LINE_LANGUAGE`, `LINE_LOCALE`, `extra.language`, or `extra.locale`. The quick-reply message text remains stable (`/approve`, `/approve session`, `/approve always`, `/deny`, `/always`, `/cancel`) so the gateway's existing approval handlers continue to resolve the flow.

This PR intentionally does not include the LINE media enum fix; that is split into #35681 to keep both PRs focused.

## Related Issue

No issue filed.

Related prior PRs found during duplicate search:

- #23581: closed/unmerged earlier LINE approval button attempt.
- #29053: open/stale earlier LINE approval button attempt using template buttons and postback dispatch.

This PR differs by using LINE Quick Reply message actions that feed the existing slash-command approval path, plus locale-aware labels and focused adapter tests.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/line/adapter.py`
  - Added quick-reply message construction helper.
  - Added LINE `send_exec_approval()` support for dangerous command approvals.
  - Added LINE `send_slash_confirm()` support for destructive slash confirmations.
  - Added shared pre-built LINE message-object send helper with reply-token-first behavior and push fallback.
  - Added LINE locale override resolution.
- `plugins/platforms/line/plugin.yaml`
  - Added optional setup metadata for `LINE_LANGUAGE` and `LINE_LOCALE`.
- `locales/*.yaml`
  - Added `gateway.line_quick_reply.*` labels across all locale catalogs.
- `tests/gateway/test_line_quick_reply.py`
  - Added coverage for reply-token usage, push fallback, quick-reply slash payloads, and Traditional Chinese labels.

## How to Test

1. Run syntax checks:
   - `python3 -m py_compile plugins/platforms/line/adapter.py tests/gateway/test_line_quick_reply.py agent/i18n.py`
2. Run diff hygiene:
   - `git diff --check`
3. Confirm locale/setup coverage:
   - `rg -l "line_quick_reply:" locales`
   - `rg -l "    deny:" locales`
   - `rg -n "LINE_LANGUAGE|LINE_LOCALE" plugins/platforms/line/plugin.yaml`
4. Run the targeted regression test:
   - `scripts/run_tests.sh tests/gateway/test_line_quick_reply.py`
5. Optional broader gateway coverage:
   - `scripts/run_tests.sh tests/gateway`
6. In CI or a complete local dev environment, run the full suite:
   - `pytest tests/ -q`

Note: Full `pytest tests/ -q` was not completed locally. Broader gateway coverage was attempted and has one unrelated local failure in `tests/gateway/test_shutdown_forensics.py::TestSpawnAsyncDiagnostic::test_spawns_subprocess_and_writes_output`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local checkout; targeted LINE quick-reply test passed; gateway suite attempted with one unrelated shutdown-forensics failure

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: updated `plugins/platforms/line/plugin.yaml` setup metadata
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: N/A, LINE plugin setup metadata is in `plugin.yaml`
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A: pure Python adapter/i18n changes, no platform-specific primitives
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: N/A

## Screenshots / Logs

N/A. Local checks run on this branch:

```text
python3 -m py_compile plugins/platforms/line/adapter.py tests/gateway/test_line_quick_reply.py agent/i18n.py: passed
git diff --check: passed
rg locale/setup checks: passed
scripts/run_tests.sh tests/gateway/test_line_quick_reply.py: 4 passed
scripts/run_tests.sh tests/gateway: 6062 passed, 1 unrelated failure

Failure:
tests/gateway/test_shutdown_forensics.py::TestSpawnAsyncDiagnostic::test_spawns_subprocess_and_writes_output
assert pid is not None and pid > 0
```