### PR TITLE
fix(skills): check unresolved symlink path in trusted-dir security guard

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1267,3 +1267,104 @@ class TestSkillViewCollisionDetection:
         result = json.loads(raw)
         assert result["success"] is True
         assert "LOCAL BODY" in result["content"]
+
+
+# ---------------------------------------------------------------------------
+# Regression: symlinked skills trigger false "outside trusted skills directory"
+# security warning (#35674)
+# ---------------------------------------------------------------------------
+
+
+def _can_symlink():
+    """Check if we can create symlinks (needs admin/dev-mode on Windows)."""
+    import tempfile
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            src = Path(d) / "src"
+            src.write_text("x")
+            lnk = Path(d) / "lnk"
+            lnk.symlink_to(src)
+            return True
+    except OSError:
+        return False
+
+
+@pytest.mark.skipif(not _can_symlink(), reason="Symlinks need elevated privileges")
+class TestSymlinkSkillSecurityWarning:
+    """Regression test for #35674.
+
+    Skills that are symlinks under the trusted skills directory should NOT
+    trigger the 'outside trusted skills directory' security warning. The
+    check should use the unresolved symlink path, not resolve() which
+    follows the symlink to its target.
+    """
+
+    def test_symlink_inside_trusted_dir_no_warning(self, tmp_path, caplog):
+        """A symlink whose path is inside the trusted directory should not warn."""
+        import logging
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        # Create a real skill directory outside the trusted area
+        external_dir = tmp_path / "external-skills" / "my-skill"
+        external_dir.mkdir(parents=True)
+        (external_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: Test\n---\n# Test Skill\n"
+        )
+
+        # Symlink it INTO the trusted directory
+        symlink_dir = skills_dir / "my-skill"
+        symlink_dir.symlink_to(external_dir, target_is_directory=True)
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            with caplog.at_level(logging.WARNING, logger="tools.skills_tool"):
+                raw = skill_view("my-skill")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+
+        # The security warning should NOT appear
+        outside_warnings = [
+            r.message for r in caplog.records
+            if "outside the trusted skills directory" in r.message
+        ]
+        assert outside_warnings == [], (
+            f"False positive security warning for symlinked skill: {outside_warnings}"
+        )
+
+    def test_symlink_category_dir_no_warning(self, tmp_path, caplog):
+        """A symlinked category directory should not trigger the security warning."""
+        import logging
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        # Create an external skill with a category
+        external_root = tmp_path / "external-repo"
+        external_root.mkdir()
+        external_skill = external_root / "platforms" / "my-platform-skill"
+        external_skill.mkdir(parents=True)
+        (external_skill / "SKILL.md").write_text(
+            "---\nname: my-platform-skill\ndescription: Platform\n---\n# Platform Skill\n"
+        )
+
+        # Symlink the category dir into skills_dir
+        symlink_cat = skills_dir / "platforms"
+        symlink_cat.symlink_to(external_root / "platforms", target_is_directory=True)
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            with caplog.at_level(logging.WARNING, logger="tools.skills_tool"):
+                raw = skill_view("my-platform-skill")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+
+        outside_warnings = [
+            r.message for r in caplog.records
+            if "outside the trusted skills directory" in r.message
+        ]
+        assert outside_warnings == [], (
+            f"False positive for symlinked category: {outside_warnings}"
+        )
+

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1026,11 +1026,21 @@ def skill_view(
             pass
         for _td in _trusted_dirs:
             try:
-                skill_md.resolve().relative_to(_td)
+                # Check the unresolved path first — symlinks inside the
+                # trusted directory should be trusted even when their target
+                # lives elsewhere on the filesystem (e.g. /opt/my-skills/).
+                # Fall back to the resolved path for non-symlink access via
+                # relative paths.
+                (skill_md if skill_md.is_absolute() else skill_md.resolve()).relative_to(_td)
                 _outside_skills_dir = False
                 break
             except ValueError:
-                continue
+                try:
+                    skill_md.resolve().relative_to(_td)
+                    _outside_skills_dir = False
+                    break
+                except ValueError:
+                    continue
 
         # Security: detect common prompt injection patterns
         # (pattern list at module level as _INJECTION_PATTERNS)


### PR DESCRIPTION
## What does this PR do?

Fixes a false "outside trusted skills directory" security warning when skills are symlinks inside `~/.hermes/skills/`. The check was using `Path.resolve()` which follows symlinks to their target — when the target is elsewhere on the filesystem, the resolved path falls outside the trusted directory even though the symlink itself lives inside it.

## Related Issue

Fixes #35674

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_tool.py`: Changed the trusted-directory boundary check to test the unresolved symlink path first (`skill_md` if absolute, `skill_md.resolve()` if relative), then fall back to the fully-resolved path. This ensures symlinks whose path is inside `~/.hermes/skills/` are trusted regardless of where their target resides.
- `tests/tools/test_skills_tool.py`: Added `TestSymlinkSkillSecurityWarning` with two regression tests:
  - `test_symlink_inside_trusted_dir_no_warning`: Symlink inside trusted dir → no warning
  - `test_symlink_category_dir_no_warning`: Symlinked category dir → no warning

## How to Test

1. Create a skill directory outside `~/.hermes/skills/` (e.g., `/opt/my-skills/example-skill/SKILL.md`)
2. Symlink it into the trusted directory: `ln -s /opt/my-skills/example-skill ~/.hermes/skills/example-skill`
3. Load the skill via `skill_view("example-skill")` — should succeed WITHOUT the "outside trusted skills directory" warning
4. Run: `pytest tests/tools/test_skills_tool.py::TestSymlinkSkillSecurityWarning -xvs`
5. Run full skills test suite: `pytest tests/tools/test_skills_tool.py -x`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_skills_tool.py -q` and all 88 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (path logic uses pathlib which handles both)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/skills_tool.py:skill_view` security boundary check (lines 1018-1036)
- Blast radius: LOW — isolated to the security warning check in skill_view; does not affect skill discovery, loading, or content
- Related patterns: `test_skill_view_path_check.py` (path boundary tests), `test_skills_guard.py` (security scanner tests)
