### PR TITLE
fix(codex): guard output_text accessor

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -980,6 +980,16 @@ def _extract_responses_reasoning_text(item: Any) -> str:
     return ""
 
 
+def _safe_response_output_text(response: Any) -> str:
+    """Read response.output_text without letting SDK convenience accessors crash."""
+    try:
+        out_text = getattr(response, "output_text", None)
+    except Exception as exc:
+        logger.debug("Codex response.output_text access failed: %s", exc)
+        return ""
+    return out_text.strip() if isinstance(out_text, str) else ""
+
+
 def _format_responses_error(error_obj: Any, response_status: str) -> str:
     """Build a human-readable error string from a Responses ``response.error`` payload.
 
@@ -1043,15 +1053,15 @@ def _normalize_codex_response(
         # The Codex backend can return empty output when the answer was
         # delivered entirely via stream events. Check output_text as a
         # last-resort fallback before raising.
-        out_text = getattr(response, "output_text", None)
-        if isinstance(out_text, str) and out_text.strip():
+        out_text = _safe_response_output_text(response)
+        if out_text:
             logger.debug(
                 "Codex response has empty output but output_text is present (%d chars); "
-                "synthesizing output item.", len(out_text.strip()),
+                "synthesizing output item.", len(out_text),
             )
             output = [SimpleNamespace(
                 type="message", role="assistant", status="completed",
-                content=[SimpleNamespace(type="output_text", text=out_text.strip())],
+                content=[SimpleNamespace(type="output_text", text=out_text)],
             )]
             response.output = output
         else:
@@ -1195,10 +1205,8 @@ def _normalize_codex_response(
             ))
 
     final_text = "\n".join([p for p in content_parts if p]).strip()
-    if not final_text and hasattr(response, "output_text"):
-        out_text = getattr(response, "output_text", "")
-        if isinstance(out_text, str):
-            final_text = out_text.strip()
+    if not final_text:
+        final_text = _safe_response_output_text(response)
 
     # ── Tool-call leak recovery ──────────────────────────────────
     # gpt-5.x on the Codex Responses API sometimes degenerates and emits

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1356,7 +1356,14 @@ def run_conversation(
                             else:
                                 # output_text fallback: stream backfill may have failed
                                 # but normalize can still recover from output_text
-                                _out_text = getattr(response, "output_text", None)
+                                try:
+                                    _out_text = getattr(response, "output_text", None)
+                                except Exception as exc:
+                                    logger.debug(
+                                        "Codex response.output_text access failed during validation: %s",
+                                        exc,
+                                    )
+                                    _out_text = None
                                 _out_text_stripped = _out_text.strip() if isinstance(_out_text, str) else ""
                                 if _out_text_stripped:
                                     logger.debug(

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -398,6 +398,39 @@ class TestCodexNormalizeResponse:
         assert nr.content == "Hello world"
         assert nr.finish_reason == "stop"
 
+    def test_text_fallback_ignores_broken_output_text_accessor(self, transport):
+        """SDK output_text can raise when response.output is malformed."""
+
+        class BrokenOutputTextResponse:
+            output = []
+            status = "completed"
+            incomplete_details = None
+            usage = SimpleNamespace(input_tokens=10, output_tokens=5,
+                                    input_tokens_details=None, output_tokens_details=None)
+
+            @property
+            def output_text(self):
+                raise TypeError("'NoneType' object is not iterable")
+
+        with pytest.raises(RuntimeError, match="Responses API returned no output items"):
+            transport.normalize_response(BrokenOutputTextResponse())
+
+    def test_text_fallback_still_uses_valid_output_text(self, transport):
+        """A valid output_text fallback still synthesizes assistant content."""
+        r = SimpleNamespace(
+            output=None,
+            output_text="  Hello from fallback  ",
+            status="completed",
+            incomplete_details=None,
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5,
+                                  input_tokens_details=None, output_tokens_details=None),
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content == "Hello from fallback"
+        assert nr.finish_reason == "stop"
+
     def test_message_items_preserved_in_provider_data(self, transport):
         """Codex assistant message item ids/phases must survive transport normalization."""
         r = SimpleNamespace(


### PR DESCRIPTION
Summary:
- guard Codex response.output_text access so SDK convenience accessors cannot surface raw TypeError when output is malformed
- preserve output_text fallback behavior for valid text
- add Codex transport regression coverage for broken and valid output_text fallback cases

Tests:
- uv run python -m py_compile agent/codex_responses_adapter.py agent/conversation_loop.py tests/agent/transports/test_codex_transport.py
- uv run --with pytest python -m pytest tests/agent/transports/test_codex_transport.py -q -o addopts=
- uv run --with pytest python -m pytest tests/run_agent/test_codex_xai_oauth_recovery.py -q -o addopts= -k normalize_codex_response
