### PR TITLE
fix(cli): stabilize prompt elapsed timer

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4026,10 +4026,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         """Format per-prompt elapsed time for the status bar.
 
         Always returns a string — shows 0s on fresh start before first turn.
-        Keeps seconds visible at all scales so it increments smoothly:
-            59s → 1m → 1m 1s → ... → 1m 59s → 2m → 2m 1s → ...
-            59m 59s → 1h → 1h 0m 1s → ...
-            23h 59m 59s → 1d → 1d 0h 1m → ...
+        Keeps seconds visible and zero-padded once minutes are shown so the
+        live footer never shrinks at minute/hour rollovers:
+            59s → 1m00s → 1m01s → ... → 1m59s → 2m00s
+            59m59s → 1h00m00s → 1h00m01s → ...
+            23h59m59s → 1d00h00m00s → ...
 
         Emoji prefix: ⏱ when turn is live, ⏲ when frozen or fresh start.
         Uses width-1 (no variation selector) glyphs so the status bar stays
@@ -4038,23 +4039,20 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if prompt_start_time is None and prompt_duration == 0.0:
             return "⏲ 0s"
         elapsed = time.time() - prompt_start_time if prompt_start_time is not None else prompt_duration
-        elapsed = max(0.0, elapsed)
+        total_seconds = max(0, int(elapsed))
 
-        days = int(elapsed // 86400)
-        remaining = elapsed % 86400
-        hours = int(remaining // 3600)
-        remaining = remaining % 3600
-        minutes = int(remaining // 60)
-        seconds = int(remaining % 60)
+        days, remaining = divmod(total_seconds, 86400)
+        hours, remaining = divmod(remaining, 3600)
+        minutes, seconds = divmod(remaining, 60)
 
         if days > 0:
-            time_str = f"{days}d {hours}h {minutes}m"
+            time_str = f"{days}d{hours:02d}h{minutes:02d}m{seconds:02d}s"
         elif hours > 0:
-            time_str = f"{hours}h {minutes}m {seconds}s" if seconds else f"{hours}h {minutes}m"
+            time_str = f"{hours}h{minutes:02d}m{seconds:02d}s"
         elif minutes > 0:
-            time_str = f"{minutes}m {seconds}s" if seconds else f"{minutes}m"
+            time_str = f"{minutes}m{seconds:02d}s"
         else:
-            time_str = f"{int(elapsed)}s"
+            time_str = f"{total_seconds}s"
 
         emoji = "⏱" if live else "⏲"
         return f"{emoji} {time_str}"

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -428,6 +428,12 @@ class TestCLIStatusBar:
         assert rendered == "⏱ 25m35s"
         assert "351s" not in rendered
 
+    def test_prompt_elapsed_long_turn_does_not_render_raw_seconds(self):
+        rendered = HermesCLI._format_prompt_elapsed(None, 2312, live=True)
+
+        assert rendered == "⏱ 38m32s"
+        assert "2312s" not in rendered
+
     def test_voice_status_bar_compacts_on_narrow_terminals(self):
         cli_obj = _make_cli()
         cli_obj._voice_mode = True

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -414,6 +414,20 @@ class TestCLIStatusBar:
         assert len(short_elapsed) == len(long_elapsed)
         assert "m" in long_elapsed and "s" in long_elapsed
 
+    def test_prompt_elapsed_format_is_rollover_stable(self):
+        before = HermesCLI._format_prompt_elapsed(None, (25 * 60) + 59, live=True)
+        after = HermesCLI._format_prompt_elapsed(None, 26 * 60, live=True)
+
+        assert before == "⏱ 25m59s"
+        assert after == "⏱ 26m00s"
+        assert len(after) == len(before)
+
+    def test_prompt_elapsed_seconds_component_never_exceeds_59(self):
+        rendered = HermesCLI._format_prompt_elapsed(None, (25 * 60) + 35.1, live=True)
+
+        assert rendered == "⏱ 25m35s"
+        assert "351s" not in rendered
+
     def test_voice_status_bar_compacts_on_narrow_terminals(self):
         cli_obj = _make_cli()
         cli_obj._voice_mode = True


### PR DESCRIPTION
## What does this PR do?

Fixes the CLI status/footer prompt elapsed timer so minute, hour, and day rollovers render with normalized, fixed-width time components.

The previous formatter could switch between labels like `25m 59s` and `26m`, which lets stale footer glyphs survive prompt_toolkit redraws. In practice this can show malformed timer text such as `25m351s`.

This changes prompt elapsed labels to stable forms like:

- `25m35s`
- `26m00s`
- `1h00m00s`
- `1d00h00m00s`

## Related Issue

N/A. Reported from a local CLI screenshot.

## Related PRs

- #12948 introduced the per-prompt elapsed stopwatch; this fixes a redraw/formatting artifact in that merged status-bar surface.
- #20683 fixed a related class of status-line jitter by making spinner/TUI ticker elapsed labels width-stable; this applies the same principle to the prompt elapsed footer.
- #32351 is complementary timing correctness work (`time.monotonic()` for duration math); it does not address rendered label rollover width or stale footer glyphs.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`
  - Normalizes prompt elapsed time with `divmod` so the seconds component never exceeds 59.
  - Keeps minutes, hours, and days rollover-stable with zero-padded subcomponents.
- `tests/cli/test_cli_status_bar.py`
  - Adds regression coverage for minute rollover stability.
  - Adds regression coverage for the malformed `25m351s`-style seconds artifact.
  - Adds exact long-turn coverage for `⏱ 2312s` rendering as `⏱ 38m32s`.

## How to Test

1. Run the focused CLI status bar tests:
   `scripts/run_tests.sh tests/cli/test_cli_status_bar.py tests/test_cli_skin_integration.py -- -q --tb=short`
2. Confirm prompt elapsed samples render as normalized labels:
   `25m35s`, `25m59s`, `26m00s`, `38m32s`, `1h00m00s`.
3. In an interactive CLI session, let a prompt timer cross a minute boundary and confirm the footer does not leave stale second digits behind.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python formatting only, no OS-specific terminal APIs changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused validation:

```text
scripts/run_tests.sh tests/cli/test_cli_status_bar.py tests/test_cli_skin_integration.py -- -q --tb=short

=== Summary: 2 files, 52 tests passed, 0 failed (0% complete) in 1.9s (32 workers) ===
```

Local formatter smoke output after the fix:

```text
1535.1: ⏱ 25m35s
1559:   ⏱ 25m59s
1560:   ⏱ 26m00s
2312:   ⏱ 38m32s
3600:   ⏱ 1h00m00s
86400:  ⏱ 1d00h00m00s
```

