### PR TITLE
fix(web): remove deprecated baseUrl from tsconfig.app.json for TS 5.9

### DIFF
--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -17,7 +17,6 @@
     "jsx": "react-jsx",
 
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
## What does this PR do?

Removes the deprecated `baseUrl` option from `web/tsconfig.app.json`, which causes `tsc -b` to fail with TS5101 on TypeScript 5.9.

## Related Issue

Fixes #35685

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/tsconfig.app.json`: Removed `"baseUrl": "."` — with `moduleResolution: "bundler"`, the `paths` configuration resolves correctly without `baseUrl`.

## How to Test

1. `cd web && npm install`
2. `npx tsc -b` — should succeed (currently fails with TS5101)
3. `npm run build` — should complete without errors
4. Verify `@/*` path alias still resolves: `grep -r 'from "@/' src/ | head -5` should import correctly

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `npx tsc -b` and it passes with this change
- [x] I've added tests for my changes — N/A (config-only change, tsc -b success is the test)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (TypeScript version-specific)
- [x] I've updated tool descriptions/schemas — N/A

## Code Intelligence

- Analyzed: `web/tsconfig.app.json` (single config file, no callers)
- Blast radius: LOW — only affects TypeScript compilation of the web UI
- Related patterns: `moduleResolution: "bundler"` resolves `paths` without `baseUrl` since TS 5.0
