### PR TITLE
fix: restore search fallback routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,11 @@ source .venv/bin/activate   # or: source venv/bin/activate
 `$HOME/.hermes/hermes-agent/venv` (for worktrees that share a venv with the
 main checkout).
 
+## Alyosha Runtime Defaults
+
+- Kimi fallback must use `kimi-coding` model `k2p6` with base URL `https://api.kimi.com/coding/v1`. Do not use the retired `kimi-for-coding` or `kimi-k2-turbo-preview` aliases.
+
+
 ## Project Structure
 
 File counts shift constantly — don't treat the tree below as exhaustive.

--- a/docs/hetzner-infrastructure.md
+++ b/docs/hetzner-infrastructure.md
@@ -1,0 +1,129 @@
+# Hetzner Infrastructure — Status & TODO
+
+**Server:** `178.105.246.8` (CX33, `alyosha`)
+**Last updated:** May 30, 2026
+
+## Services
+
+| Service | Port | Process | Status | Auth |
+|---------|------|---------|--------|------|
+| Hermes Gateway | — | systemd `hermes-gateway.service` | ✅ Running | Telegram bot token |
+| OpenClaw | 18789 | nohup (`openclaw gateway`) | ✅ Running | Bot token |
+| Research Substrate v0.7.2 | 4020 (tunnel only) | systemd `research-substrate.service` | ✅ Running | API key + rate limit (demo: 30 req/hr) |
+| Camofox Browser | 9377 | nohup (`camofox-browser`) | ✅ Running | `X-Api-Key` header |
+| SearXNG | 8080 | internal only | ✅ Running | `X-Api-Key` header |
+| LLM Ask Shim | 4010 | uvicorn | ✅ Running | Internal only (127.0.0.1) |
+
+## Firewall
+
+**Hetzner Cloud Firewall** `hermes-fw-v3` (ID 11053687)
+
+| Direction | Protocol | Port | Source |
+|-----------|----------|------|--------|
+| in | tcp | 22 | 0.0.0.0/0, ::/0 |
+| in | tcp | 80 | 0.0.0.0/0, ::/0 |
+| in | tcp | 443 | 0.0.0.0/0, ::/0 |
+| in | icmp | — | 0.0.0.0/0, ::/0 |
+
+**Cloudflare Tunnel:** `research.alyoechosys.dev` → `localhost:4020` (systemd `cloudflared.service`)
+- Tunnel ID: `50d10034-c7ac-4493-9de9-c196e2a29721`
+- Config: `/etc/cloudflared/config.yml` + `/home/alyosha/.cloudflared/config.yml`
+- Credentials: `/etc/cloudflared/50d10034-c7ac-4493-9de9-c196e2a29721.json`
+
+**Notes:**
+- No UFW installed. Hetzner cloud firewall is the only filter.
+- Port 4020 closed externally — only reachable via Cloudflare Tunnel or localhost.
+- Port 9377 (camofox), 18789 (OpenClaw) — blocked at cloud level, safe.
+- **API token:** `HCLOUD_TOKEN` in `.env` on Hetzner — required for firewall management.
+
+## Completed
+
+### May 30, 2026
+
+- [x] **Research substrate patches (v0.5 → v0.6 → v0.7)**
+  - Option-chain auto-fetch nearest expiration date (no `expiration_date` required)
+  - Stock-index auto-reroute (SPX, ^GSPC, DJI, etc. → Yahoo stock-info)
+  - Search fallback chain: MiniMax → Serper → DDG → Brave → SearXNG (triggers on empty results + errors)
+  - 77 search queries stress-tested across 16 categories — 0 unresolved
+  - 39 endpoints tested: 34 working, 3 empty (expected), 1 schema issue
+  - Docs: `docs/research-substrate-endpoints.md`, `docs/web-search-fallback.md`
+
+- [x] **API key auth on substrate** — `X-API-Key` support
+  - `SUBSTRATE_API_KEY` in `/home/alyosha/workspace/research-substrate/.env`
+  - Live public without key: `/docs`, `/openapi.json`, `/healthz`, `/search`, `/providers`, `/v1/models`
+  - Keep private/rate-limited endpoint examples keyed unless live checks prove public access
+
+- [x] **Hetzner cloud firewall** — replaced `hermes-basic-firewall` with `hermes-fw-v3`
+  - Old firewall silently dropped port 4020 on PUT — created new one instead
+  - Applied to server ID 133859693
+
+- [x] **Research substrate service** — running under systemd as `research-substrate.service` behind Cloudflare Tunnel
+
+- [x] **File permissions** — `chmod 600` on all `.env` files and `config.yaml`
+
+- [x] **Serper plugin** — `plugins/web/serper/` (provider.py, plugin.yaml, __init__.py)
+  - Local only (not deployed to Hetzner yet — Hetzner uses SearXNG as fallback)
+
+- [x] **Docs synced** — both doc files on Hetzner at `~/workspace/hermes-agent/docs/`
+
+## TODO
+
+### Cloudflare Tunnel + Domain (priority: ~~high~~ DONE)
+
+- [x] Buy domain (Cloudflare Registrar recommended — at-cost pricing)
+  - `.dev` ~$12/yr, `.com` ~$10/yr
+  - Something neutral, not project-specific
+- [x] Add site to Cloudflare (free plan)
+- [x] Install `cloudflared` on Hetzner
+- [x] Create tunnel: `research.alyoechosys.dev` → `localhost:4020`
+- [x] Configure systemd service for `cloudflared`
+- [x] Close port 4020 on Hetzner firewall
+- [ ] Verify substrate binds to `127.0.0.1` only (belt-and-suspenders behind tunnel)
+- [ ] Optional: Cloudflare Access policy (Zero Trust, email-based, free ≤50 users)
+
+### Service Hardening (priority: medium)
+
+- [ ] Create systemd unit for OpenClaw (currently nohup)
+- [ ] Create systemd unit for camofox (currently nohup)
+- [ ] Bind camofox to `127.0.0.1` instead of `0.0.0.0` (belt-and-suspenders, already firewalled)
+- [ ] Install UFW as second-layer defense
+- [ ] Set up logrotate for substrate logs
+
+### Hermes Agent (priority: medium)
+
+- [ ] Deploy serper plugin to Hetzner
+- [ ] Verify Hermes search fallback chain works end-to-end on Hetzner
+- [ ] Wire substrate API key into Hermes config for internal calls
+
+### Monitoring (priority: low)
+
+- [ ] Health check endpoints for each service
+- [ ] Simple uptime monitoring (cron + curl + Telegram alert?)
+- [ ] Disk/memory alerts (Hetzner CX33 has 8GB RAM)
+
+## Key Paths on Hetzner
+
+```
+/home/alyosha/
+├── .hermes/
+│   ├── config.yaml          # Hermes config (600)
+│   └── .env                 # API keys (600)
+├── workspace/
+│   ├── hermes-agent/        # Hermes repo
+│   │   └── docs/            # This doc + endpoint references
+│   └── research-substrate/  # Substrate code
+│       ├── .env             # SUBSTRATE_API_KEY, SUPADATA_API_KEY, KIMI_API_KEY (600)
+│       └── research_substrate/
+│           └── app.py       # Main app (v0.7.2, ~1400 LOC)
+└── .local/share/hermes-node/  # Camofox browser
+```
+
+## API Token Access
+
+- **Hetzner Cloud API:** token in `.env` on Hetzner as `HCLOUD_TOKEN`
+  - Manage firewall: `curl -H "Authorization: Bearer $HCLOUD_TOKEN" https://api.hetzner.cloud/v1/firewalls`
+  - Server ID: 133859693
+  - Firewall ID: 11053613
+- **Substrate API key:** `SUBSTRATE_API_KEY` in substrate `.env`
+  - Header: `X-API-Key: <key>`
+  - Docs are open: `http://178.105.246.8:4020/docs`

--- a/docs/research-substrate-api.md
+++ b/docs/research-substrate-api.md
@@ -1,0 +1,432 @@
+# Research Substrate API
+
+**Base URL:** `https://research.alyoechosys.dev`
+**Version:** 0.7.2
+**OpenAPI Spec:** `https://research.alyoechosys.dev/openapi.json`
+**Interactive Docs:** `https://research.alyoechosys.dev/docs` (no auth needed)
+
+---
+
+## Authentication
+
+Use an API key when calling private or rate-limited endpoints:
+
+```
+X-API-Key: <SUBSTRATE_API_KEY>
+```
+
+Live check on May 31, 2026: `/docs`, `/openapi.json`, `/healthz`, `/search`, `/providers`, and `/v1/models` returned `200` without a key. Other endpoints may still require `X-API-Key`; keep examples keyed unless you have verified public access.
+
+**Error responses:**
+- `401` — missing or invalid key
+- `429` — rate limit exceeded
+
+---
+
+## Search
+
+### `GET /search`
+
+Web search with multi-provider fallback (MiniMax → Serper → SearXNG).
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `q` | string | ✅ | — | Search query (min 1 char) |
+| `limit` | integer | — | 5 | Max results (1–20) |
+| `provider` | string | — | `auto` | Force: `minimax`, `serper`, `searxng` |
+
+```bash
+curl -s "https://research.alyoechosys.dev/search?q=AI+regulation+2026&limit=5" \
+  -H "X-API-Key: <SUBSTRATE_API_KEY>"
+```
+
+**Response:**
+```json
+{
+  "results": [
+    {
+      "title": "...",
+      "url": "...",
+      "description": "...",
+      "source": "minimax",
+      "position": 1
+    }
+  ],
+  "provider": "minimax",
+  "elapsed_s": 2.1
+}
+```
+
+---
+
+## Read URL
+
+### `POST /read-url`
+
+Extract content from any URL. Returns title + text.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `url` | string | ✅ | — | URL to read |
+| `max_chars` | integer | — | 12000 | Max content length |
+
+```bash
+curl -s -X POST "https://research.alyoechosys.dev/read-url" \
+  -H "X-API-Key: <SUBSTRATE_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://arxiv.org/abs/2401.00001"}'
+```
+
+---
+
+## Research
+
+### `POST /research/ask`
+
+Full research synthesis. Searches web, reads top sources, synthesizes with GLM.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `input` | string | ✅ | — | Research question |
+| `model` | string | — | `glm-5.1` | Synthesis model |
+| `max_sources` | integer | — | 3 | Number of sources to consult |
+| `max_chars_per_source` | integer | — | 6000 | Max chars read per source |
+
+```bash
+curl -s -X POST "https://research.alyoechosys.dev/research/ask" \
+  -H "X-API-Key: <SUBSTRATE_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"input": "Latest quantum computing breakthroughs in 2026?"}'
+```
+
+**Response** (~15–60s):
+```json
+{
+  "output": "## ... (markdown with citations)",
+  "sources": [
+    {"position": 1, "title": "...", "url": "...", "cited": true}
+  ],
+  "conversation_id": "rs_...",
+  "query": "...",
+  "elapsed_s": 13.1,
+  "steps": { ... }
+}
+```
+
+### `POST /research/academic`
+
+Academic paper search (arXiv + Google Scholar via Kimi).
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `query` | string | ✅ | — | Search query |
+| `sources` | string[] | — | `["arxiv","scholar"]` | Sources to search |
+| `max_results` | integer | — | 5 | Max papers |
+| `date_from` | string | — | `2025-01-01` | Filter start date |
+| `synthesize` | boolean | — | `false` | Summarize results |
+
+```bash
+curl -s -X POST "https://research.alyoechosys.dev/research/academic" \
+  -H "X-API-Key: <SUBSTRATE_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "transformer attention mechanism", "max_results": 3}'
+```
+
+---
+
+## Yahoo Finance
+
+US stocks, crypto, ETFs, indices. No suffix needed.
+
+### `POST /yahoo/stock-info`
+
+| Field | Type | Required |
+|-------|------|----------|
+| `ticker` | string | ✅ |
+
+### `POST /yahoo/stock-history`
+
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `ticker` | string | ✅ | — |
+| `period` | string | — | `1mo` |
+| `interval` | string | — | `1d` |
+
+### `POST /yahoo/financials`
+
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `ticker` | string | ✅ | — |
+| `financial_type` | string | — | `income_stmt` |
+
+### `POST /yahoo/holders`
+
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `ticker` | string | ✅ | — |
+| `holder_type` | string | — | `institutional_holders` |
+
+### `POST /yahoo/news`
+
+| Field | Type | Required |
+|-------|------|----------|
+| `ticker` | string | ✅ |
+
+### `POST /yahoo/option-chain`
+
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `ticker` | string | ✅ | — |
+| `expiration_date` | string | — | `""` (auto-fetches nearest) |
+| `option_type` | string | — | `calls` |
+
+`expiration_date` is optional — if omitted, auto-fetches nearest expiry (~60s).
+
+### `POST /yahoo/option-dates`
+
+| Field | Type | Required |
+|-------|------|----------|
+| `ticker` | string | ✅ |
+
+### `POST /yahoo/recommendations`
+
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `ticker` | string | ✅ | — |
+| `recommendation_type` | string | — | `all` |
+| `months_back` | integer | — | `12` |
+
+### `POST /yahoo/stock-actions`
+
+Dividends, splits.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `ticker` | string | ✅ |
+
+```bash
+# Stock info
+curl -s -X POST "https://research.alyoechosys.dev/yahoo/stock-info" \
+  -H "X-API-Key: <SUBSTRATE_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"ticker": "AAPL"}'
+
+# Option chain (auto-expiry)
+curl -s -X POST "https://research.alyoechosys.dev/yahoo/option-chain" \
+  -H "X-API-Key: <SUBSTRATE_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"ticker": "SPY"}'
+```
+
+---
+
+## Finance (Kimi)
+
+Requires exchange suffix for non-US markets.
+
+**Ticker format:**
+- NASDAQ: `.O` → `AAPL.O`, `NVDA.O`
+- NYSE: `.N` → `BRK-B.N`
+- Shanghai: `.SH` → `600519.SH`
+- Shenzhen: `.SZ` → `000001.SZ`
+- HK: `.HK` → `0700.HK`
+
+### `POST /finance/stock-info`
+| Field | Type | Required |
+|-------|------|----------|
+| `ticker` | string | ✅ |
+
+### `POST /finance/stock-price`
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `ticker` | string | ✅ | — |
+| `type` | string | — | `realtime_price` |
+| `time` | string | — | `""` |
+
+### `POST /finance/stock-forecast`
+| Field | Type | Required |
+|-------|------|----------|
+| `ticker` | string | ✅ |
+
+### `POST /finance/stock-financials`
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `ticker` | string | ✅ | — |
+| `statement` | string | — | `all` |
+| `period` | string | — | `20241231` |
+
+### `POST /finance/stock-history`
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `ticker` | string | ✅ | — |
+| `start_date` | string | ✅ | — |
+| `end_date` | string | ✅ | — |
+| `interval` | string | — | `D` |
+| `adjust` | string | — | `forward` |
+
+### `POST /finance/stock-holders`
+| Field | Type | Required |
+|-------|------|----------|
+| `ticker` | string | ✅ |
+
+### `POST /finance/stock-index`
+
+Auto-reroutes index tickers (`SPX`, `^GSPC`, `DJI`, `NDX`, `RUT`) to Yahoo.
+
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `ticker` | string | ✅ | — |
+| `category` | string | — | `profitability` |
+| `period` | string | — | `20241231` |
+
+### `POST /finance/stock-screener`
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `keyword` | string | ✅ | — |
+| `market` | string | — | `stock` |
+
+### `POST /finance/stock-segments`
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `ticker` | string | ✅ | — |
+| `period` | string | — | `20241231` |
+
+### `POST /finance/stock-announcements`
+| Field | Type | Required |
+|-------|------|----------|
+| `ticker` | string | ✅ |
+| `start_date` | string | ✅ |
+| `end_date` | string | ✅ |
+
+```bash
+# Stock index (auto-reroutes to Yahoo for SPX)
+curl -s -X POST "https://research.alyoechosys.dev/finance/stock-index" \
+  -H "X-API-Key: <SUBSTRATE_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"ticker": "SPX"}'
+```
+
+---
+
+## Company (天眼查)
+
+Chinese company data via Tianyancha.
+
+### `POST /company/search`
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `keyword` | string | ✅ | — |
+| `page_size` | integer | — | 20 |
+| `page_num` | integer | — | 1 |
+
+### `POST /company/query`
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `api_name` | string | ✅ | — |
+| `keyword` | string | ✅ | — |
+| `extra_params` | object | — | `{}` |
+
+### `POST /company/search-apis`
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `query` | string | ✅ | — |
+| `limit` | integer | — | 10 |
+
+```bash
+curl -s -X POST "https://research.alyoechosys.dev/company/search" \
+  -H "X-API-Key: <SUBSTRATE_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"keyword": "华为"}'
+```
+
+---
+
+## Macro
+
+### `POST /macro/world-bank-search`
+| Field | Type | Required |
+|-------|------|----------|
+| `query` | string | ✅ |
+
+### `POST /macro/world-bank`
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `country` | string | ✅ | — |
+| `indicator` | string | ✅ | — |
+| `date_range` | string | — | `""` |
+| `most_recent` | integer | — | 0 |
+| `language` | string | — | `en` |
+
+---
+
+## Generate
+
+### `POST /generate/speech`
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `text` | string | ✅ | — |
+| `voice` | string | — | `English_expressive_narrator` |
+| `speed` | number | — | 1.0 |
+| `format` | string | — | `mp3` |
+| `model` | string | — | `speech-2.8-hd` |
+
+### `POST /generate/image`
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `prompt` | string | ✅ | — |
+| `aspect_ratio` | string | — | `1:1` |
+| `n` | integer | — | 1 |
+| `seed` | integer | — | — |
+| `prompt_optimizer` | boolean | — | `false` |
+
+### `POST /generate/music`
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `prompt` | string | ✅ | — |
+| `lyrics` | string | — | — |
+| `lyrics_optimizer` | boolean | — | `false` |
+| `instrumental` | boolean | — | `false` |
+| `vocals` | string | — | — |
+| `genre` | string | — | — |
+| `mood` | string | — | — |
+| `instruments` | string | — | — |
+| `bpm` | integer | — | — |
+| `model` | string | — | `music-2.6` |
+
+---
+
+## Health
+
+### `GET /healthz`
+
+No auth required.
+
+---
+
+## Auto-routes (v0.6.0+)
+
+| Endpoint | Auto-behavior |
+|----------|---------------|
+| `/yahoo/option-chain` | `expiration_date` omitted → auto-fetches nearest from `/yahoo/option-dates` |
+| `/finance/stock-index` | Index tickers (`SPX`, `^GSPC`, `DJI`, `NDX`, `RUT`) → auto-rerouted to `/yahoo/stock-info` |
+
+---
+
+## Rate Limits
+
+| Key type | Limit |
+|----------|-------|
+| Demo (`sub_pub_*`) | 30 requests/hour |
+| Production | Unlimited |
+
+---
+
+## Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `401` | Invalid or missing API key |
+| `405` | Wrong HTTP method |
+| `422` | Validation error (missing/invalid fields) |
+| `429` | Rate limit exceeded |
+| `502` | All upstream providers failed (search only) |

--- a/docs/research-substrate-endpoints.md
+++ b/docs/research-substrate-endpoints.md
@@ -1,0 +1,144 @@
+# Research Substrate v0.7.2 — Endpoint Reference
+
+**Host:** `https://research.alyoechosys.dev` (Cloudflare Tunnel → `localhost:4020`)
+**Auth:** Use `X-API-Key: <SUBSTRATE_API_KEY>` for private/rate-limited calls. Live check on May 31, 2026 found `/docs`, `/openapi.json`, `/healthz`, `/search`, `/providers`, and `/v1/models` public.
+**Tested:** May 30, 2026
+**Datasources:** Kimi Coding Plan (arxiv, scholar, stock_finance_data, yahoo_finance, world_bank, tianyancha)
+**Firewall:** Hetzner cloud `hermes-fw-v3` — ports 22, 80, 443, ICMP. Port 4020 is tunnel-only.
+**Process:** systemd `research-substrate.service`
+
+## Endpoint Status Summary
+
+| Category | Total | ✅ Working | ⚠️ Empty data | 💥 Schema/timeout |
+|----------|-------|-----------|---------------|-------------------|
+| Academic (arxiv + scholar) | 5 | 5 | 0 | 0 |
+|| Finance (Kimi) | 10 | 7 | 2 | 1 |
+|| Yahoo Finance | 11 | 11 | 0 | 0 |
+| Macro (World Bank) | 3 | 3 | 0 | 0 |
+| Company (天眼查) | 5 | 4 | 1 | 0 |
+| Search | 3 | 3 | 0 | 0 |
+| Research/Ask | 2 | 2 | 0 | 0 |
+|| **Total** | **39** | **34** | **3** | **1** |
+
+## Academic (arxiv + scholar)
+
+Both sources working. Queries hit both automatically regardless of `source` param.
+
+| Endpoint | Test | Result |
+|----------|------|--------|
+| `/research/academic` | arxiv: "transformer attention" | ✅ 5 arxiv + 2 scholar results |
+| `/research/academic` | arxiv: "quantum error correction" | ✅ 5 arxiv results |
+| `/research/academic` | arxiv: "CRISPR gene therapy" | ✅ 2 scholar results |
+| `/research/academic` | scholar: "LLM reasoning" | ✅ 4 scholar results |
+| `/research/academic` | scholar: "climate change economics" | ✅ 5 arxiv results |
+
+**Note:** `source` param doesn't fully filter — both arxiv and scholar are queried. Response parsing has some field misalignment (authors/abstract/title fields get shuffled) but titles are correct.
+
+## Finance (Kimi `stock_finance_data`)
+
+**Ticker format:** Must include exchange suffix — `.O` (NASDAQ), `.N` (NYSE), `.SZ` (Shenzhen), `.SH` (Shanghai).
+
+| Endpoint | Ticker | Result |
+|----------|--------|--------|
+| `/finance/stock-info` | AAPL.O | ✅ Full info |
+| `/finance/stock-info` | 000001.SZ | ✅ Chinese A-share |
+| `/finance/stock-forecast` | TSLA.O | ✅ Predicted values |
+| `/finance/stock-forecast` | NVDA.O | ✅ Predicted values |
+| `/finance/stock-financials` | MSFT.O | ✅ Balance sheet |
+| `/finance/stock-holders` | AMZN.O | ✅ Holder info |
+| `/finance/stock-segments` | META.O | ✅ Business segments |
+| `/finance/stock-announcements` | NVDA.O | ⚠️ Empty data (no announcements in range) |
+| `/finance/stock-screener` | keyword "AI" | ⚠️ Empty data |
+|| `/finance/stock-index` | SPX | ✅ Auto-rerouted to Yahoo Finance (index) |
+
+**Working tickers:** `AAPL.O`, `TSLA.O`, `NVDA.O`, `MSFT.O`, `AMZN.O`, `META.O`, `GOOGL.O`, `000001.SZ`
+
+## Yahoo Finance
+
+| Endpoint | Ticker | Result |
+|----------|--------|--------|
+| `/yahoo/stock-info` | BTC-USD | ✅ Crypto |
+| `/yahoo/stock-info` | NVDA | ✅ US stock |
+| `/yahoo/stock-info` | ^GSPC | ✅ Index |
+| `/yahoo/news` | BTC-USD | ✅ |
+|| `/yahoo/news` | NVDA | ✅ (was transient timeout) |
+| `/yahoo/stock-history` | META | ✅ |
+| `/yahoo/stock-history` | ETH-USD | ✅ Crypto |
+| `/yahoo/financials` | AAPL | ✅ |
+| `/yahoo/holders` | TSLA | ✅ |
+|| `/yahoo/recommendations` | NVDA | ✅ (was transient timeout) |
+|| `/yahoo/option-chain` | SPY | ✅ Auto-fetches nearest expiration (~60s) |
+
+**Yahoo tickers** don't need exchange suffixes (unlike Kimi finance).
+
+## Macro (World Bank)
+
+| Endpoint | Test | Result |
+|----------|------|--------|
+| `/macro/world-bank-search` | "GDP per capita" | ✅ Found indicators |
+| `/macro/world-bank-search` | "CO2 emissions" | ✅ Found indicators |
+| `/macro/world-bank` | indicator=SP.POP.TOTL, country=SGP | ✅ Singapore population data |
+
+## Company (天眼查 Tianyancha)
+
+Chinese company data. Works best with Chinese company names.
+
+| Endpoint | Keyword | Result |
+|----------|---------|--------|
+| `/company/search` | 华为 (Huawei) | ✅ |
+| `/company/search` | 腾讯 (Tencent) | ✅ |
+| `/company/search` | 比亚迪 (BYD) | ✅ |
+| `/company/search` | Tesla | ✅ |
+| `/company/query` | api_name=搜索-搜索, keyword=Apple | ⚠️ Empty data |
+
+## Search (MiniMax)
+
+| Endpoint | Query | Result |
+|----------|-------|--------|
+| `/search` (GET) | "OpenAI latest 2026" | ✅ 3 results |
+| `/search` (GET) | "Singapore news today" | ✅ 3 results |
+| `/search` (GET) | "quantum computing breakthrough" | ✅ 3 results |
+
+## Research/Ask (full synthesis)
+
+Search → read → GLM synthesis with citations. ~47s per query.
+
+| Endpoint | Query | Result | Time |
+|----------|-------|--------|------|
+| `/research/ask` | "quantum computing breakthroughs 2026" | ✅ 5726 chars | 47.5s |
+| `/research/ask` | "AI regulation Europe vs US 2026" | ✅ Full report | ~50s |
+
+**Response shape:** `output` (not `answer`), `sources`, `steps`, `conversation_id`, `elapsed_s`
+
+## Auto-routes (v0.6.0)
+
+- **`/yahoo/option-chain`**: `expiration_date` now optional — auto-fetches nearest available date via option-dates API (~60s)
+- **`/finance/stock-index`**: Index tickers (SPX, ^GSPC, DJI, ^DJI, VIX, ^VIX, N225, HSI, etc.) auto-reroute to Yahoo `/yahoo/stock-info`
+
+## Key Schemas (POST body params)
+
+```
+AcademicSearchRequest:     query*, source, limit
+StockPriceRequest:         ticker*
+StockInfoRequest:          ticker*
+StockForecastRequest:      ticker*
+StockFinancialsRequest:    ticker*, statement
+StockHolderRequest:        ticker*
+StockAnnouncementRequest:  ticker*, start_date*, end_date*
+StockScreenerRequest:      keyword*, market
+StockFinancialIndexRequest: ticker*, category, period
+YahooStockInfoRequest:     ticker*
+YahooNewsRequest:          ticker*
+YahooHistoryRequest:       ticker*
+YahooFinancialsRequest:    ticker*
+YahooHolderRequest:        ticker*
+YahooRecommendationsRequest: ticker*
+YahooOptionDatesRequest:   ticker*
+YahooOptionRequest:        ticker*, expiration_date*
+WorldBankSearchRequest:    query*, limit
+WorldBankRequest:          indicator*, country*
+TianyanchaCompanySearchRequest: keyword*
+TianyanchaApiCallRequest:  api_name*, keyword*, extra_params
+ResearchAskRequest:        input*, model, max_sources, max_chars_per_source
+ReadUrlRequest:            url*, max_chars
+```

--- a/docs/web-search-fallback.md
+++ b/docs/web-search-fallback.md
@@ -1,0 +1,142 @@
+# Web Search Fallback Chain
+
+## How It Works
+
+When `web_search` is called, Hermes tries providers in order:
+
+1. **Primary** — configured `search_backend` (MiniMax on both instances)
+2. **Fallback chain** — auto-tried when primary fails or returns **empty results**
+
+Fallback triggers on:
+- API error (`success: false`)
+- Empty results (`success: true` but 0 web hits) — catches **censorship**
+
+Fallback providers must return actual results to be accepted (not just `success: true`).
+
+## Fallback Order
+
+| Priority | Provider | Type | Censored? | Cost |
+|----------|----------|------|-----------|------|
+| 1 | `minimax` | MiniMax Token Plan | **Partial** (see below) | Subscription |
+| 2 | `serper` | Google SERP API | No | Paid |
+| 3 | `ddgs` | DuckDuckGo | No | Free (rate limited) |
+| 4 | `brave-free` | Brave Search | No | Free (2K/mo) |
+| 5 | `searxng` | Self-hosted metasearch | No | Free/self-hosted |
+
+## MiniMax Censorship Profile
+
+Stress-tested 35 queries across 7 categories (May 30, 2026):
+
+### MiniMax censored (returns `success: false`) — 7 queries total:
+
+**English:**
+- `Tiananmen Square 1989 massacre`
+- `Xi Jinping hidden wealth Panama Papers`
+- `Liu Xiaobo Nobel Peace Prize`
+- `1989 student democracy movement China`
+- `Zhao Ziyang purged 1989`
+
+**Chinese (中文):**
+- `六四天安门事件` (June 4th Tiananmen incident)
+- `习近平贪腐` (Xi Jinping corruption)
+
+### MiniMax NOT censored (returns results normally):
+
+Surprisingly these pass through:
+- `Falun Gong persecution China` ✅
+- `Winnie the Pooh Xi Jinping meme` ✅
+- `Great Firewall China censorship` ✅
+- `Hong Kong protests 2019 extradition` ✅
+- `Tibet independence Dalai Lama` ✅
+- `Taiwan independence referendum 2026` ✅
+- `Xinjiang Uyghur genocide UN report` ✅
+- `Charter 08 Liu Xiaobo manifesto` ✅
+- `法轮功迫害` (Falun Gong persecution, Chinese) ✅
+- `新疆集中营` (Xinjiang camps, Chinese) ✅
+
+### Censorship pattern
+
+MiniMax censorship is **narrow and specific** — primarily blocks:
+1. **1989 Tiananmen** — any direct reference to the massacre/protests
+2. **Xi Jinping personal wealth/corruption** — specifically Panama Papers style
+3. **Liu Xiaobo** — the dissident himself (but his manifesto Charter 08 passes!)
+4. **Chinese-language queries about Xi** — `习近平贪腐` blocked but `法轮功迫害` passes
+
+The pattern suggests keyword-level blocking focused on Xi personally and 1989 specifically.
+
+## Full Stress Test (May 30, 2026)
+
+### Round 1: Censorship-focused — 35 queries, 7 categories
+
+| Category | MiniMax OK | Fallback caught | Total resolved |
+|----------|-----------|-----------------|----------------|
+| ROUTINE (5) | 5/5 | 0 | 5/5 |
+| CENSORED (13) | 8/13 | 5 censored | 13/13 |
+| GEOPOLITICS (5) | 5/5 | 0 | 5/5 |
+| ADULT (2) | 2/2 | 0 | 2/2 |
+| TECH (3) | 3/3 | 0 | 3/3 |
+| CN-LANG (5) | 3/5 | 2 censored | 5/5 |
+| EDGE (2) | 1/2 | 0 | 1/2 |
+
+### Round 2: Broad themes — 42 queries, 16 categories
+
+MiniMax resolved 40/42 (95%). Only 2 Tiananmen queries fell back to DDG.
+
+| Category | Queries | MiniMax direct | Fallback |
+|----------|---------|---------------|----------|
+| NEWS | 3 | 3 | 0 |
+| FINANCE | 4 | 4 | 0 |
+| SCIENCE | 3 | 3 | 0 |
+| SPORTS | 3 | 3 | 0 |
+| HEALTH | 3 | 3 | 0 |
+| ENTERTAIN | 3 | 3 | 0 |
+| TRAVEL | 3 | 3 | 0 |
+| FOOD | 2 | 2 | 0 |
+| EDUCATION | 2 | 2 | 0 |
+| ENVIRONMENT | 2 | 2 | 0 |
+| AUTO | 2 | 2 | 0 |
+| PROPERTY | 2 | 2 | 0 |
+| CHINA (non-sensitive) | 3 | 3 | 0 |
+| SEA | 2 | 2 | 0 |
+| CENSORED | 2 | 0 | **2** (DDG) |
+| EDGE | 3 | 3 | 0 |
+
+**Total: 77 queries tested, 0 unresolved. Fallback caught 100% of censored queries.**
+
+## Configuration
+
+### Primary backend
+```yaml
+# ~/.hermes/config.yaml
+web:
+  search_backend: minimax
+```
+
+### Fallback chain (in code)
+File: `tools/web_tools.py` line ~1360
+```python
+_SEARCH_FALLBACK_ORDER = ("minimax", "serper", "ddgs", "brave-free", "searxng")
+```
+
+### Provider availability
+
+| Instance | MiniMax | Serper | DDG | Brave | SearXNG |
+|----------|---------|--------|-----|-------|---------|
+| Local Docker | ✅ | ❌ no key | ✅ | ❌ no key | ❌ |
+| Hetzner VPS | ✅ | ✅ | ✅ | ❌ no key | ✅ :8080 |
+
+## Key Files
+
+- `plugins/web/serper/` — Serper Google SERP plugin
+- `plugins/web/ddgs/` — DuckDuckGo plugin
+- `plugins/web/brave_free/` — Brave Search plugin
+- `plugins/web/minimax/` — MiniMax Token Plan search
+- `tools/web_tools.py` — fallback chain logic (~line 827)
+
+## Adding a New Fallback Provider
+
+1. Create `plugins/web/<name>/` with `provider.py`, `__init__.py`, `plugin.yaml`
+2. Provider must subclass `WebSearchProvider` with `search()` returning `{"success": bool, "data": {"web": [...]}}`
+3. Add to `_fallback_order` in `tools/web_tools.py`
+4. Set env key in `.env`
+5. Restart gateway

--- a/plugins/web/minimax/__init__.py
+++ b/plugins/web/minimax/__init__.py
@@ -1,0 +1,10 @@
+"""MiniMax web search plugin."""
+
+from __future__ import annotations
+
+from plugins.web.minimax.provider import MiniMaxWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the MiniMax provider with the plugin context."""
+    ctx.register_web_search_provider(MiniMaxWebSearchProvider())

--- a/plugins/web/minimax/plugin.yaml
+++ b/plugins/web/minimax/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-minimax
+version: 1.0.0
+description: "MiniMax Coding Plan web search provider. Requires MINIMAX_API_KEY."
+author: Alyosha/Hermes
+kind: backend
+provides_web_providers:
+  - minimax

--- a/plugins/web/minimax/provider.py
+++ b/plugins/web/minimax/provider.py
@@ -1,0 +1,94 @@
+"""MiniMax Token Plan search provider."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+
+class MiniMaxWebSearchProvider(WebSearchProvider):
+    """Search provider backed by MiniMax Coding Plan search API."""
+
+    @property
+    def name(self) -> str:
+        return "minimax"
+
+    @property
+    def display_name(self) -> str:
+        return "MiniMax"
+
+    def is_available(self) -> bool:
+        return bool(os.getenv("MINIMAX_API_KEY", "").strip())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        import httpx
+
+        api_key = os.getenv("MINIMAX_API_KEY", "").strip()
+        api_host = os.getenv("MINIMAX_API_HOST", "https://api.minimax.io").strip().rstrip("/")
+        if not api_key:
+            return {"success": False, "error": "MINIMAX_API_KEY is not set"}
+        if not query.strip():
+            return {"success": False, "error": "query is empty"}
+
+        try:
+            resp = httpx.post(
+                f"{api_host}/v1/coding_plan/search",
+                json={"q": query},
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "MM-API-Source": "Hermes",
+                    "Content-Type": "application/json",
+                },
+                timeout=20,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("MiniMax search HTTP error: %s", exc)
+            return {"success": False, "error": f"MiniMax returned HTTP {exc.response.status_code}"}
+        except httpx.RequestError as exc:
+            logger.warning("MiniMax search request error: %s", exc)
+            return {"success": False, "error": f"Could not reach MiniMax: {exc}"}
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("MiniMax search parse error: %s", exc)
+            return {"success": False, "error": "Could not parse MiniMax response as JSON"}
+
+        base_resp = data.get("base_resp") or {}
+        if base_resp and int(base_resp.get("status_code") or 0) != 0:
+            return {"success": False, "error": f"MiniMax API error {base_resp.get('status_code')}: {base_resp.get('status_msg')}"}
+
+        organic = data.get("organic") or []
+        web_results = []
+        for i, r in enumerate(organic[: max(1, min(int(limit), 20))]):
+            web_results.append({
+                "title": str(r.get("title", "")),
+                "url": str(r.get("link", "")),
+                "description": str(r.get("snippet", "")),
+                "date": str(r.get("date", "")),
+                "position": i + 1,
+            })
+
+        logger.info("MiniMax search '%s': %d results", query, len(web_results))
+        return {"success": True, "data": {"web": web_results}, "provider": "minimax"}
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "MiniMax",
+            "badge": "subscription · Token Plan",
+            "tag": "MiniMax Coding Plan search API. Search only; use a reader/extractor for page content.",
+            "env_vars": [
+                {"key": "MINIMAX_API_KEY", "prompt": "MiniMax Token Plan API key", "url": "https://platform.minimax.io/"},
+                {"key": "MINIMAX_API_HOST", "prompt": "MiniMax API host", "default": "https://api.minimax.io"},
+            ],
+        }

--- a/plugins/web/serper/__init__.py
+++ b/plugins/web/serper/__init__.py
@@ -1,0 +1,10 @@
+"""Serper Google Search API plugin — bundled, auto-loaded."""
+
+from __future__ import annotations
+
+from plugins.web.serper.provider import SerperWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Serper provider with the plugin context."""
+    ctx.register_web_search_provider(SerperWebSearchProvider())

--- a/plugins/web/serper/plugin.yaml
+++ b/plugins/web/serper/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-serper
+version: 1.0.0
+description: "Serper Google SERP web search provider. Requires SERPER_API_KEY."
+author: Alyosha/Hermes
+kind: backend
+provides_web_providers:
+  - serper

--- a/plugins/web/serper/provider.py
+++ b/plugins/web/serper/provider.py
@@ -1,0 +1,86 @@
+"""Serper Google Search API provider."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_SERPER_ENDPOINT = "https://google.serper.dev/search"
+
+
+class SerperWebSearchProvider(WebSearchProvider):
+    """Search-only provider backed by Serper's Google Search API."""
+
+    @property
+    def name(self) -> str:
+        return "serper"
+
+    @property
+    def display_name(self) -> str:
+        return "Serper"
+
+    def is_available(self) -> bool:
+        return bool(os.getenv("SERPER_API_KEY", "").strip())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        import httpx
+
+        api_key = os.getenv("SERPER_API_KEY", "").strip()
+        if not api_key:
+            return {"success": False, "error": "SERPER_API_KEY is not set"}
+
+        num = max(1, min(int(limit), 20))
+        try:
+            resp = httpx.post(
+                _SERPER_ENDPOINT,
+                json={"q": query, "num": num},
+                headers={"X-API-KEY": api_key, "Content-Type": "application/json"},
+                timeout=15,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("Serper HTTP error: %s", exc)
+            return {"success": False, "error": f"Serper returned HTTP {exc.response.status_code}"}
+        except httpx.RequestError as exc:
+            logger.warning("Serper request error: %s", exc)
+            return {"success": False, "error": f"Could not reach Serper: {exc}"}
+
+        try:
+            data = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Serper response parse error: %s", exc)
+            return {"success": False, "error": "Could not parse Serper response as JSON"}
+
+        organic = data.get("organic") or []
+        web_results = []
+        for i, r in enumerate(organic[:limit]):
+            web_results.append({
+                "title": str(r.get("title", "")),
+                "url": str(r.get("link", "")),
+                "description": str(r.get("snippet", "")),
+                "position": int(r.get("position") or i + 1),
+            })
+
+        logger.info("Serper search '%s': %d results", query, len(web_results))
+        return {"success": True, "data": {"web": web_results}}
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Serper",
+            "badge": "paid · Google SERP",
+            "tag": "Google-quality SERP via Serper. Search only; use a reader/extractor for page content.",
+            "env_vars": [
+                {"key": "SERPER_API_KEY", "prompt": "Serper API key", "url": "https://serper.dev/"},
+            ],
+        }

--- a/research-substrate-tools.html
+++ b/research-substrate-tools.html
@@ -1,0 +1,478 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Research Substrate — API Tools</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600&family=Newsreader:ital,wght@0,400;1,400&display=swap" rel="stylesheet">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    background: #faf9f5;
+    color: #3d3929;
+    font-family: 'Hanken Grotesk', ui-sans-serif, -apple-system, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* ── Banner ── */
+  .banner {
+    position: sticky; top: 0; z-index: 50;
+    background: rgba(250, 249, 245, 0.85);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid rgba(0,0,0,0.06);
+    padding: 14px 24px;
+    display: flex; align-items: center; justify-content: space-between;
+  }
+  .banner-left { display: flex; align-items: center; gap: 8px; }
+  .banner-logo {
+    width: 28px; height: 28px; border-radius: 8px;
+    background: linear-gradient(135deg, #3d3929 0%, #6b6550 100%);
+    display: flex; align-items: center; justify-content: center;
+    color: #faf9f5; font-weight: 600; font-size: 14px;
+  }
+  .banner-title { font-weight: 600; font-size: 15px; color: #3d3929; }
+  .banner-links { display: flex; gap: 20px; }
+  .banner-links a {
+    font-size: 14px; color: #83827d; text-decoration: none; font-weight: 500;
+    transition: color 0.15s;
+  }
+  .banner-links a:hover { color: #3d3929; }
+
+  /* ── Hero ── */
+  .hero {
+    max-width: 1344px;
+    margin: 0 auto;
+    padding: 80px 24px 40px;
+    text-align: center;
+  }
+  .hero h1 {
+    font-family: 'Newsreader', 'Iowan Old Style', Georgia, serif;
+    font-size: clamp(36px, 6vw, 60px);
+    font-weight: 400;
+    color: #3d3929;
+    line-height: 1.1;
+    margin-bottom: 16px;
+  }
+  .hero p {
+    font-size: 16px; color: #83827d; max-width: 520px; margin: 0 auto;
+    line-height: 1.6;
+  }
+  .hero .version {
+    display: inline-block; margin-top: 20px;
+    font-size: 12px; font-weight: 500; color: #83827d;
+    background: rgba(0,0,0,0.04); padding: 4px 12px; border-radius: 20px;
+  }
+
+  /* ── Section ── */
+  .section {
+    max-width: 1344px;
+    margin: 0 auto;
+    padding: 0 24px 64px;
+  }
+  .section-label {
+    font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em;
+    color: #a3a29d; margin-bottom: 20px; padding-left: 4px;
+  }
+
+  /* ── Grid ── */
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+  }
+  @media (max-width: 900px) { .grid { grid-template-columns: repeat(2, 1fr); } }
+  @media (max-width: 560px) { .grid { grid-template-columns: 1fr; } }
+
+  /* ── Card ── */
+  .card {
+    display: flex; align-items: flex-start; gap: 14px;
+    padding: 16px;
+    border: 1px solid rgba(0,0,0,0.06);
+    border-radius: 12px;
+    background: #faf9f5;
+    text-decoration: none;
+    transition: border-color 0.15s, box-shadow 0.15s;
+    cursor: pointer;
+  }
+  .card:hover {
+    border-color: rgba(0,0,0,0.12);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  }
+  .card-icon {
+    flex-shrink: 0;
+    width: 40px; height: 40px; border-radius: 10px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 20px;
+  }
+  .card-body { min-width: 0; }
+  .card-title {
+    font-size: 14px; font-weight: 500; color: #3d3929;
+    margin-bottom: 3px; line-height: 1.3;
+  }
+  .card-desc {
+    font-size: 12px; color: #83827d; line-height: 1.5;
+  }
+  .card-method {
+    display: inline-block; font-size: 10px; font-weight: 600;
+    padding: 1px 6px; border-radius: 4px; margin-right: 4px;
+    vertical-align: middle;
+  }
+  .method-get { background: #e8f5e9; color: #2e7d32; }
+  .method-post { background: #e3f2fd; color: #1565c0; }
+
+  /* ── Card icon colors ── */
+  .icon-search { background: #fef3c7; }
+  .icon-research { background: #ede9fe; }
+  .icon-finance { background: #dcfce7; }
+  .icon-yahoo { background: #dbeafe; }
+  .icon-company { background: #fce7f3; }
+  .icon-macro { background: #e0f2fe; }
+  .icon-generate { background: #fef9c3; }
+  .icon-models { background: #f3e8ff; }
+  .icon-health { background: #d1fae5; }
+  .icon-read { background: #ffedd5; }
+
+  /* ── Footer ── */
+  .footer {
+    max-width: 1344px; margin: 0 auto;
+    padding: 24px 24px 48px;
+    border-top: 1px solid rgba(0,0,0,0.06);
+    display: flex; justify-content: space-between; align-items: center;
+    font-size: 13px; color: #a3a29d;
+  }
+  .footer a { color: #83827d; text-decoration: none; }
+  .footer a:hover { color: #3d3929; }
+</style>
+</head>
+<body>
+
+<!-- Banner -->
+<div class="banner">
+  <div class="banner-left">
+    <div class="banner-logo">R</div>
+    <span class="banner-title">Research Substrate</span>
+  </div>
+  <div class="banner-links">
+    <a href="https://research.alyoechosys.dev/docs">API Docs</a>
+    <a href="https://research.alyoechosys.dev/openapi.json">OpenAPI</a>
+  </div>
+</div>
+
+<!-- Hero -->
+<div class="hero">
+  <h1>API Tools</h1>
+  <p>34 endpoints for research, financial data, search, and generation — all behind a single API key.</p>
+  <span class="version">v0.7.2</span>
+</div>
+
+<!-- Model Discovery -->
+<div class="section">
+  <div class="section-label">Model Discovery</div>
+  <div class="grid">
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/v1_models_v1_models_get">
+      <div class="card-icon icon-models">🧠</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-get">GET</span> List models</div>
+        <div class="card-desc">OpenAI-compatible model list — discover available LLMs through LiteLLM</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/providers_providers_get">
+      <div class="card-icon icon-models">🔌</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-get">GET</span> Provider details</div>
+        <div class="card-desc">Detailed provider info with base URLs and parameter counts</div>
+      </div>
+    </a>
+  </div>
+</div>
+
+<!-- Search -->
+<div class="section">
+  <div class="section-label">Search</div>
+  <div class="grid">
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/search_search_get">
+      <div class="card-icon icon-search">🔍</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-get">GET</span> Web search</div>
+        <div class="card-desc">Multi-provider cascade — MiniMax → Serper → SearXNG fallback</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/read_url_read_url_post">
+      <div class="card-icon icon-read">📄</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Read URL</div>
+        <div class="card-desc">Extract readable text from any webpage, PDF, or document URL</div>
+      </div>
+    </a>
+  </div>
+</div>
+
+<!-- Research -->
+<div class="section">
+  <div class="section-label">Research</div>
+  <div class="grid">
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/research_ask_research_ask_post">
+      <div class="card-icon icon-research">🧪</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Research synthesis</div>
+        <div class="card-desc">Full pipeline — search → read sources → GLM synthesis with citations (~15–60s)</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/research_academic_research_academic_post">
+      <div class="card-icon icon-research">📚</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Academic search</div>
+        <div class="card-desc">arXiv + Google Scholar via Kimi — papers, abstracts, citation data</div>
+      </div>
+    </a>
+  </div>
+</div>
+
+<!-- Yahoo Finance -->
+<div class="section">
+  <div class="section-label">Yahoo Finance — US stocks, crypto, ETFs, indices</div>
+  <div class="grid">
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/yahoo_stock_info_yahoo_stock_info_post">
+      <div class="card-icon icon-yahoo">📈</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Stock info</div>
+        <div class="card-desc">Company profile, sector, market cap, key stats</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/yahoo_stock_history_yahoo_stock_history_post">
+      <div class="card-icon icon-yahoo">📊</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Price history</div>
+        <div class="card-desc">OHLCV candle data — configurable period and interval</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/yahoo_financials_yahoo_financials_post">
+      <div class="card-icon icon-yahoo">📋</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Financials</div>
+        <div class="card-desc">Income statement, balance sheet, cash flow</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/yahoo_holders_yahoo_holders_post">
+      <div class="card-icon icon-yahoo">🏦</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Holders</div>
+        <div class="card-desc">Institutional and major holders breakdown</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/yahoo_news_yahoo_news_post">
+      <div class="card-icon icon-yahoo">📰</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> News</div>
+        <div class="card-desc">Latest news articles for any ticker</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/yahoo_option_chain_yahoo_option_chain_post">
+      <div class="card-icon icon-yahoo">🎯</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Option chain</div>
+        <div class="card-desc">Calls/puts with auto-expiry — no date needed</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/yahoo_option_dates_yahoo_option_dates_post">
+      <div class="card-icon icon-yahoo">📅</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Option dates</div>
+        <div class="card-desc">Available expiration dates for a ticker's options</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/yahoo_recommendations_yahoo_recommendations_post">
+      <div class="card-icon icon-yahoo">💡</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Recommendations</div>
+        <div class="card-desc">Analyst upgrades, downgrades, and consensus</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/yahoo_stock_actions_yahoo_stock_actions_post">
+      <div class="card-icon icon-yahoo">💹</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Stock actions</div>
+        <div class="card-desc">Dividend history and stock splits</div>
+      </div>
+    </a>
+  </div>
+</div>
+
+<!-- Finance (Kimi) -->
+<div class="section">
+  <div class="section-label">Finance (Kimi) — Global markets with exchange suffix (.O .SH .SZ .HK)</div>
+  <div class="grid">
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/finance_stock_info_finance_stock_info_post">
+      <div class="card-icon icon-finance">💹</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Stock info</div>
+        <div class="card-desc">Company details for global markets (Kimi datasource)</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/finance_stock_price_finance_stock_price_post">
+      <div class="card-icon icon-finance">💲</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Stock price</div>
+        <div class="card-desc">Real-time and historical price quotes</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/finance_stock_forecast_finance_stock_forecast_post">
+      <div class="card-icon icon-finance">🔮</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Forecast</div>
+        <div class="card-desc">AI-generated price predictions and targets</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/finance_stock_financials_finance_stock_financials_post">
+      <div class="card-icon icon-finance">📑</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Financials</div>
+        <div class="card-desc">Income, balance sheet, cash flow — all periods</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/finance_stock_history_finance_stock_history_post">
+      <div class="card-icon icon-finance">📉</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Price history</div>
+        <div class="card-desc">Historical OHLCV for date range with interval control</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/finance_stock_holders_finance_stock_holders_post">
+      <div class="card-icon icon-finance">🏛️</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Holders</div>
+        <div class="card-desc">Top institutional and mutual fund holders</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/finance_stock_index_finance_stock_index_post">
+      <div class="card-icon icon-finance">🔢</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Stock index</div>
+        <div class="card-desc">Index profitability data — auto-reroutes SPX/DJI/NDX to Yahoo</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/finance_stock_screener_finance_stock_screener_post">
+      <div class="card-icon icon-finance">🔎</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Stock screener</div>
+        <div class="card-desc">Search stocks by keyword across global markets</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/finance_stock_segments_finance_stock_segments_post">
+      <div class="card-icon icon-finance">🧩</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Segments</div>
+        <div class="card-desc">Business segment revenue breakdown</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/finance_stock_announcements_finance_stock_announcements_post">
+      <div class="card-icon icon-finance">📢</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Announcements</div>
+        <div class="card-desc">Corporate announcements within a date range</div>
+      </div>
+    </a>
+  </div>
+</div>
+
+<!-- Company -->
+<div class="section">
+  <div class="section-label">Company (天眼查 Tianyancha)</div>
+  <div class="grid">
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/company_search_company_search_post">
+      <div class="card-icon icon-company">🏢</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Search companies</div>
+        <div class="card-desc">Chinese company data — 华为, 腾讯, 比亚迪, etc.</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/company_query_company_query_post">
+      <div class="card-icon icon-company">🔍</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Query company</div>
+        <div class="card-desc">Targeted API queries — specific datapoints by api_name</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/company_search_apis_company_search_apis_post">
+      <div class="card-icon icon-company">📡</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Search APIs</div>
+        <div class="card-desc">Discover available Tianyancha API endpoints for a query</div>
+      </div>
+    </a>
+  </div>
+</div>
+
+<!-- Macro -->
+<div class="section">
+  <div class="section-label">Macro — World Bank</div>
+  <div class="grid">
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/macro_world_bank_search_macro_world_bank_search_post">
+      <div class="card-icon icon-macro">🌐</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Indicator search</div>
+        <div class="card-desc">Find World Bank indicators — GDP, CO2, population, etc.</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/macro_world_bank_macro_world_bank_post">
+      <div class="card-icon icon-macro">📊</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> World Bank data</div>
+        <div class="card-desc">Time-series data by country and indicator</div>
+      </div>
+    </a>
+  </div>
+</div>
+
+<!-- Generate -->
+<div class="section">
+  <div class="section-label">Generate</div>
+  <div class="grid">
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/generate_speech_generate_speech_post">
+      <div class="card-icon icon-generate">🎙️</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Speech</div>
+        <div class="card-desc">Text-to-speech — MiniMax speech-2.8-hd, multiple voices</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/generate_image_generate_image_post">
+      <div class="card-icon icon-generate">🖼️</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Image</div>
+        <div class="card-desc">Text-to-image with prompt optimization and aspect ratios</div>
+      </div>
+    </a>
+    <a class="card" href="https://research.alyoechosys.dev/docs#/default/generate_music_generate_music_post">
+      <div class="card-icon icon-generate">🎵</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-post">POST</span> Music</div>
+        <div class="card-desc">Text-to-music — lyrics, genre, mood, BPM, instruments</div>
+      </div>
+    </a>
+  </div>
+</div>
+
+<!-- Health -->
+<div class="section">
+  <div class="section-label">System</div>
+  <div class="grid">
+    <a class="card" href="https://research.alyoechosys.dev/healthz">
+      <div class="card-icon icon-health">💓</div>
+      <div class="card-body">
+        <div class="card-title"><span class="card-method method-get">GET</span> Health check</div>
+        <div class="card-desc">Service status — no auth required</div>
+      </div>
+    </a>
+  </div>
+</div>
+
+<!-- Footer -->
+<div class="footer">
+  <span>Research Substrate v0.7.2 — 34 endpoints</span>
+  <a href="https://research.alyoechosys.dev/docs">Interactive API docs →</a>
+</div>
+
+</body>
+</html>

--- a/switch-agent.sh
+++ b/switch-agent.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /home/workspace/hermes-agent
+if [[ -x "./.venv/bin/hermes" ]]; then
+  HERMES="./.venv/bin/hermes"
+elif [[ -x "./venv/bin/hermes" ]]; then
+  HERMES="./venv/bin/hermes"
+else
+  HERMES="$(command -v hermes)"
+fi
+
+STATE_DB="${HERMES_STATE_DB:-/dev/shm/hermes-state.db}"
+HERMES_HOME="$($HERMES config path | python3 -c 'import os,sys; print(os.path.dirname(sys.stdin.read().strip()))')"
+SESSIONS_INDEX="$HERMES_HOME/sessions/sessions.json"
+
+flush_sessions() {
+  echo "Flushing active sessions..."
+  if [[ ! -f "$STATE_DB" ]]; then
+    echo "  No state DB at $STATE_DB"
+    return 0
+  fi
+  python3 - "$STATE_DB" <<'PY'
+import sqlite3, sys, time
+path = sys.argv[1]
+conn = sqlite3.connect(path)
+now = int(time.time())
+rows = conn.execute('SELECT id, source, message_count, input_tokens FROM sessions WHERE ended_at IS NULL').fetchall()
+if not rows:
+    print('  No active sessions to flush')
+else:
+    for r in rows:
+        print(f'  Killing: {r[0]} src={r[1]} msgs={r[2]} tokens={r[3]}')
+    conn.execute('UPDATE sessions SET ended_at = ? WHERE ended_at IS NULL', (now,))
+    conn.commit()
+    print(f'Flushed {len(rows)} session(s)')
+conn.close()
+PY
+
+  python3 - "$SESSIONS_INDEX" <<'PY' 2>/dev/null || true
+import json, os, sys
+idx = sys.argv[1]
+if os.path.exists(idx):
+    with open(idx) as f:
+        data = json.load(f)
+    killed = 0
+    for key in list(data.keys()):
+        s = data[key]
+        if s.get('expires_at') is None or s.get('expires_at', 0) == 0:
+            del data[key]
+            killed += 1
+    with open(idx, 'w') as f:
+        json.dump(data, f, indent=2)
+    print(f'Cleaned sessions index: {killed} removed')
+PY
+}
+
+restart_gateway() {
+  echo "Restarting gateway..."
+  pkill -TERM -f 'hermes gateway run' 2>/dev/null || true
+  sleep 3
+  nohup bash start-gateway.sh >> /dev/shm/hermes-gateway.log 2>> /dev/shm/hermes-gateway_err.log &
+  echo "Gateway restarted (PID: $!)"
+}
+
+case "${1:-status}" in
+  glm)
+    $HERMES config set model.provider zai
+    $HERMES config set model.default glm-5.1
+    echo "Switched to GLM (zai/glm-5.1)"
+    ;;
+  kimi)
+    $HERMES config set model.provider kimi-coding
+    $HERMES config set model.default k2p6
+    echo "Switched to Kimi (kimi-coding/k2p6)"
+    ;;
+  minimax)
+    $HERMES config set model.provider minimax
+    $HERMES config set model.default minimax-m2.7
+    echo "Switched to MiniMax (minimax/minimax-m2.7)"
+    ;;
+  mimo)
+    $HERMES config set model.provider xiaomi
+    $HERMES config set model.default mimo-v2.5-pro
+    echo "Switched to MiMo (xiaomi/mimo-v2.5-pro)"
+    ;;
+  codex)
+    $HERMES config set model.provider openai-codex
+    $HERMES config set model.default gpt-5.5
+    echo "Switched to Codex (openai-codex/gpt-5.5)"
+    ;;
+  flush)
+    flush_sessions
+    ;;
+  restart)
+    restart_gateway
+    ;;
+  status)
+    echo "=== Config ==="
+    $HERMES config | head -12
+    echo ""
+    echo "=== Active sessions ==="
+    if [[ ! -f "$STATE_DB" ]]; then
+      echo "  No state DB at $STATE_DB"
+    else
+      python3 - "$STATE_DB" <<'PY'
+import sqlite3, sys
+conn = sqlite3.connect(sys.argv[1])
+rows = conn.execute('SELECT id, source, message_count, input_tokens FROM sessions WHERE ended_at IS NULL ORDER BY started_at DESC').fetchall()
+if not rows:
+    print('  No active sessions')
+else:
+    for r in rows:
+        print(f'  {r[0][:20]}.. src={r[1]} msgs={r[2]} tokens={r[3]:,}')
+    print(f'  Total: {len(rows)} session(s)')
+conn.close()
+PY
+    fi
+    echo ""
+    echo "=== Gateway process ==="
+    pgrep -fa "hermes gateway run" || echo "  Not running"
+    ;;
+  *)
+    echo "Usage: $0 {glm|kimi|minimax|mimo|codex|flush|restart|status} [--restart]"
+    echo ""
+    echo "Commands:"
+    echo "  glm       Switch to GLM (zai/glm-5.1)"
+    echo "  kimi      Switch to Kimi (kimi-coding/k2p6)"
+    echo "  minimax   Switch to MiniMax (minimax/minimax-m2.7)"
+    echo "  mimo      Switch to MiMo (xiaomi/mimo-v2.5-pro)"
+    echo "  codex     Switch to Codex (openai-codex/gpt-5.5)"
+    echo "  flush     Kill all active sessions (fixes stale model/compression)"
+    echo "  restart   Restart gateway without config change"
+    echo "  status    Show current config, sessions, and process"
+    echo ""
+    echo "Flags:"
+    echo "  --restart   Append to model switch to restart gateway"
+    exit 1
+    ;;
+esac
+
+if [[ "${2:-}" == "--restart" ]]; then
+  flush_sessions
+  restart_gateway
+fi

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -200,6 +200,28 @@ class TestPerCapabilityBackendSelection:
         assert web_tools._get_search_backend() == "tavily"
         assert web_tools._get_extract_backend() == "tavily"
 
+    def test_minimax_search_backend_is_selectable(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+            "search_backend": "minimax",
+        })
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+
+        assert web_tools._is_backend_available("minimax") is True
+        assert web_tools._get_search_backend() == "minimax"
+
+    def test_serper_search_backend_is_selectable(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+            "search_backend": "serper",
+        })
+        monkeypatch.setenv("SERPER_API_KEY", "test-key")
+
+        assert web_tools._is_backend_available("serper") is True
+        assert web_tools._get_search_backend() == "serper"
+
 
 # ---------------------------------------------------------------------------
 # Config key presence in DEFAULT_CONFIG
@@ -256,6 +278,44 @@ class TestWebSearchUsesSearchBackend:
         assert len(called_with) > 0
         assert called_with[0][0] == "search"
 
+    def test_search_tool_falls_back_on_empty_results(self, monkeypatch):
+        import json
+        from tools import web_tools
+        import agent.web_search_registry as registry
+
+        class DummyProvider:
+            def __init__(self, name, response):
+                self.name = name
+                self.display_name = name
+                self._response = response
+
+            def supports_search(self):
+                return True
+
+            def search(self, query, limit=5):
+                return self._response
+
+        providers = {
+            "minimax": DummyProvider("minimax", {"success": True, "data": {"web": []}}),
+            "serper": DummyProvider("serper", {
+                "success": True,
+                "data": {"web": [{"title": "ok", "url": "https://example.com", "description": "fallback"}]},
+            }),
+        }
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"search_backend": "minimax"})
+        monkeypatch.setenv("MINIMAX_API_KEY", "test-key")
+        monkeypatch.setenv("SERPER_API_KEY", "test-key")
+        monkeypatch.setattr(registry, "get_provider", lambda name: providers.get(name))
+        monkeypatch.setattr(registry, "get_active_search_provider", lambda: providers["minimax"])
+
+        result = json.loads(web_tools.web_search_tool("fallback test", 1))
+
+        assert result["success"] is True
+        assert result["provider"] == "serper"
+        assert result["data"]["web"][0]["url"] == "https://example.com"
+        assert result["fallback_errors"][0]["provider"] == "minimax"
+
 
 class TestUnconfiguredErrorEnvelopeParity:
     """Regression tests for PR #25182: the post-migration dispatcher must
@@ -288,6 +348,9 @@ class TestUnconfiguredErrorEnvelopeParity:
             "FIRECRAWL_API_URL",
             "FIRECRAWL_GATEWAY_URL",
             "TOOL_GATEWAY_DOMAIN",
+            "ZO_TOKEN",
+            "MINIMAX_API_KEY",
+            "SERPER_API_KEY",
         ):
             monkeypatch.delenv(k, raising=False)
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -130,7 +130,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in set(_KNOWN_WEB_BACKENDS):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -139,6 +139,9 @@ def _get_backend() -> str:
     # Free-tier backends (searxng / brave-free / ddgs) trail the paid ones so
     # existing paid setups are unaffected.
     backend_candidates = (
+        ("zo-ask", _has_env("ZO_TOKEN")),
+        ("minimax", _has_env("MINIMAX_API_KEY")),
+        ("serper", _has_env("SERPER_API_KEY")),
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL") or _is_tool_gateway_ready()),
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
@@ -218,6 +221,12 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    if backend == "zo-ask":
+        return _has_env("ZO_TOKEN")
+    if backend == "minimax":
+        return _has_env("MINIMAX_API_KEY")
+    if backend == "serper":
+        return _has_env("SERPER_API_KEY")
     return False
 
 
@@ -818,15 +827,27 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Dispatch through the web search registry. All 7 providers
-        # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
-        # now live as plugins; the dispatcher is just a registry lookup +
-        # delegation. Sync only — every provider's search() is sync.
+        # Dispatch through the web search registry. Search providers live as
+        # plugins; the dispatcher is a registry lookup + delegation. Sync only
+        # — every provider's search() is sync.
         _ensure_web_plugins_loaded()
         from agent.web_search_registry import (
             get_active_search_provider,
             get_provider as _wsp_get_provider,
         )
+
+        def _usable_search_response(payload: dict) -> bool:
+            return bool(
+                payload.get("success") is True
+                and payload.get("data", {}).get("web")
+            )
+
+        def _search_with_provider(provider_obj) -> dict:
+            logger.info(
+                "Web search via %s: '%s' (limit: %d)",
+                provider_obj.name, query, limit,
+            )
+            return provider_obj.search(query, limit)
 
         backend = _get_search_backend()
         provider = _wsp_get_provider(backend) if backend else None
@@ -835,7 +856,9 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             # configured backend isn't a registered search provider (typo,
             # uninstalled plugin, or capability mismatch).
             provider = get_active_search_provider()
+            backend = getattr(provider, "name", backend)
 
+        fallback_errors = []
         if provider is None:
             response_data = {
                 "success": False,
@@ -845,11 +868,33 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 ),
             }
         else:
-            logger.info(
-                "Web search via %s: '%s' (limit: %d)",
-                provider.name, query, limit,
-            )
-            response_data = provider.search(query, limit)
+            response_data = _search_with_provider(provider)
+            if not _usable_search_response(response_data):
+                fallback_errors.append({
+                    "provider": provider.name,
+                    "error": response_data.get("error") or "empty results",
+                })
+                for fallback_backend in _SEARCH_FALLBACK_ORDER:
+                    if fallback_backend == provider.name or fallback_backend == backend:
+                        continue
+                    if not _is_backend_available(fallback_backend):
+                        continue
+                    fallback_provider = _wsp_get_provider(fallback_backend)
+                    if fallback_provider is None or not fallback_provider.supports_search():
+                        continue
+                    fallback_response = _search_with_provider(fallback_provider)
+                    if _usable_search_response(fallback_response):
+                        response_data = fallback_response
+                        response_data.setdefault("provider", fallback_provider.name)
+                        response_data["fallback_errors"] = fallback_errors
+                        break
+                    fallback_errors.append({
+                        "provider": fallback_provider.name,
+                        "error": fallback_response.get("error") or "empty results",
+                    })
+                else:
+                    if fallback_errors:
+                        response_data["fallback_errors"] = fallback_errors
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
@@ -1152,14 +1197,18 @@ async def web_extract_tool(
 
 
 # Convenience function to check Firecrawl credentials
+_KNOWN_WEB_BACKENDS = ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai", "zo-ask", "minimax", "serper")
+_SEARCH_FALLBACK_ORDER = ("minimax", "serper", "ddgs", "brave-free", "searxng")
+
+
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"}:
+    if configured in set(_KNOWN_WEB_BACKENDS):
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
+        for backend in _KNOWN_WEB_BACKENDS
     )
 
 


### PR DESCRIPTION
## Summary
- restores Kimi routing guidance to kimi-coding/k2p6
- registers MiniMax and Serper as selectable web search backends
- adds fallback-on-error and fallback-on-empty-results behavior for web_search_tool
- fixes Serper plugin metadata and updates substrate/search docs

## Test Plan
- python -m pytest tests/tools/test_web_providers.py tests/tools/test_web_providers_xai.py tests/integration/test_web_tools.py tests/hermes_cli/test_plugins.py -o 'addopts=' -q
- bash -n switch-agent.sh
- python -m compileall -q plugins/web/minimax plugins/web/serper tools/web_tools.py
- git diff --check