### PR TITLE
fix(agent): optimize dflash stall recovery telemetry

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1098,6 +1098,8 @@ def init_agent(
         )
     except Exception as _tlg_err:
         _ra().logger.warning("Tool loop guardrail config ignored: %s", _tlg_err)
+    _stall_retry_cfg = _agent_cfg.get("stall_retry", {})
+    agent._stall_retry_config = _stall_retry_cfg if isinstance(_stall_retry_cfg, dict) else {}
     # Cache only the derived auxiliary compression context override that is
     # needed later by the startup feasibility check.  Avoid exposing a
     # broad pseudo-public config object on the agent instance.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -458,6 +458,16 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
+    # Agentic stall-retry guard: dflash can stall more than once in a long
+    # tool loop, so allow a bounded number of successful rescues per user turn.
+    # If the cap is exhausted, fail partial rather than accept another
+    # planning-only text response as final. See agent/stall_retry.py.
+    from agent.stall_retry import get_stall_retry_max_per_turn
+
+    _stall_retry_count = 0
+    _stall_retry_max_per_turn = get_stall_retry_max_per_turn(agent)
+    agent._stall_retry_events = []
+
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()
@@ -3494,6 +3504,156 @@ def run_conversation(
                 }
             elif hasattr(agent, "_codex_incomplete_retries"):
                 agent._codex_incomplete_retries = 0
+
+            # ── Agentic stall-retry (opt-in via HERMES_STALL_RETRY_MODEL) ──
+            # dflash Q4 can stop right after an action preamble ("Let me
+            # check X") without producing the promised tool_call. Retry the
+            # configured higher-quality lane before the final-response branch
+            # sees it. The retry request carries a tiny recovery nudge, but
+            # the synthetic nudge is not persisted to the real session. If
+            # the retry returns tool calls, fall through to the normal
+            # executor below in this same loop iteration. If it still returns
+            # no tool call, fail this turn as partial instead of persisting
+            # the planning-only text as a completed assistant message that
+            # poisons future "continue" turns.
+            from agent.stall_retry import (
+                get_stall_retry_max_chars,
+                get_stall_retry_model,
+                looks_like_stall,
+                record_stall_retry_event,
+                retry_on_stall,
+                stall_retry_summary,
+            )
+
+            retry_model = get_stall_retry_model(agent)
+            if (
+                retry_model
+                and getattr(agent, "tools", None)
+                and not getattr(assistant_message, "tool_calls", None)
+            ):
+                max_chars = get_stall_retry_max_chars(agent)
+                try:
+                    stalled_content = assistant_message.content or ""
+                    if looks_like_stall(
+                        stalled_content,
+                        finish_reason,
+                        False,
+                        max_chars,
+                    ):
+                        record_stall_retry_event(
+                            agent,
+                            "detected",
+                            finish_reason=finish_reason,
+                            api_call=api_call_count,
+                            retry_count=_stall_retry_count,
+                            max_per_turn=_stall_retry_max_per_turn,
+                            content=stalled_content,
+                        )
+                        if _stall_retry_count >= _stall_retry_max_per_turn:
+                            _turn_exit_reason = "stall_retry_limit_exhausted"
+                            record_stall_retry_event(
+                                agent,
+                                "limit_exhausted",
+                                finish_reason=finish_reason,
+                                api_call=api_call_count,
+                                retry_count=_stall_retry_count,
+                                max_per_turn=_stall_retry_max_per_turn,
+                                content=stalled_content,
+                            )
+                            agent._mute_post_response = False
+                            agent._vprint(
+                                (
+                                    f"{agent.log_prefix}❌ Stall retry limit "
+                                    f"({_stall_retry_max_per_turn}/turn) exhausted; "
+                                    "saving as partial without storing the "
+                                    "planning-only assistant turn."
+                                ),
+                                force=True,
+                            )
+                            agent._cleanup_task_resources(effective_task_id)
+                            agent._persist_session(messages, conversation_history)
+                            return {
+                                "final_response": None,
+                                "messages": messages,
+                                "api_calls": api_call_count,
+                                "completed": False,
+                                "partial": True,
+                                "failed": True,
+                                "error": (
+                                    "Model repeatedly stopped after an agentic "
+                                    "preamble with no tool call; configured stall "
+                                    "retry limit was exhausted."
+                                ),
+                                "failure_subclass": "stall_retry_limit_exhausted",
+                                "stall_retry": stall_retry_summary(agent),
+                            }
+                        _stall_retry_count += 1
+                        retried = retry_on_stall(
+                            agent,
+                            api_messages,
+                            finish_reason,
+                            stalled_content=stalled_content,
+                            retry_index=_stall_retry_count,
+                        )
+                        if retried is not None and getattr(retried, "tool_calls", None):
+                            assistant_message = retried
+                            finish_reason = getattr(retried, "finish_reason", None) or "tool_calls"
+                            if finish_reason != "tool_calls":
+                                finish_reason = "tool_calls"
+                        else:
+                            _turn_exit_reason = "stall_retry_failed_no_tool_call"
+                            agent._mute_post_response = False
+                            agent._vprint(
+                                (
+                                    f"{agent.log_prefix}❌ Stall retry did not produce "
+                                    "tool calls; saving as partial without storing the "
+                                    "planning-only assistant turn."
+                                ),
+                                force=True,
+                            )
+                            agent._cleanup_task_resources(effective_task_id)
+                            agent._persist_session(messages, conversation_history)
+                            return {
+                                "final_response": None,
+                                "messages": messages,
+                                "api_calls": api_call_count,
+                                "completed": False,
+                                "partial": True,
+                                "failed": True,
+                                "error": (
+                                    "Model stopped after an action preamble with no "
+                                    "tool call; configured stall retry also produced "
+                                    "no tool call."
+                                ),
+                                "failure_subclass": "stall_retry_failed_no_tool_call",
+                                "stall_retry": stall_retry_summary(agent),
+                            }
+                except Exception as exc:
+                    _turn_exit_reason = "stall_retry_exception"
+                    record_stall_retry_event(
+                        agent,
+                        "exception",
+                        error_type=type(exc).__name__,
+                        error=str(exc)[:300],
+                    )
+                    agent._mute_post_response = False
+                    agent._vprint(
+                        f"{agent.log_prefix}❌ Stall retry failed before recovery: {exc}",
+                        force=True,
+                    )
+                    agent._cleanup_task_resources(effective_task_id)
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": None,
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "partial": True,
+                        "failed": True,
+                        "error": f"Stall retry failed before recovery: {exc}",
+                        "failure_subclass": "stall_retry_exception",
+                        "stall_retry": stall_retry_summary(agent),
+                    }
             
             # Check for tool calls
             if assistant_message.tool_calls:
@@ -3830,7 +3990,7 @@ def run_conversation(
             else:
                 # No tool calls - this is the final response
                 final_response = assistant_message.content or ""
-                
+
                 # Fix: unmute output when entering the no-tool-call branch
                 # so the user can see empty-response warnings and recovery
                 # status messages.  _mute_post_response was set during a

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -271,7 +271,17 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
 
 # Model name substrings that trigger tool-use enforcement guidance.
 # Add new patterns here when a model family needs explicit steering.
-TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm", "qwen", "deepseek")
+TOOL_USE_ENFORCEMENT_MODELS = (
+    "gpt",
+    "codex",
+    "gemini",
+    "gemma",
+    "grok",
+    "glm",
+    "qwen",
+    "dflash",
+    "deepseek",
+)
 
 # Universal "finish the job" guidance — applied to ALL models, not gated
 # by model family.  Addresses two cross-model failure modes:

--- a/agent/stall_retry.py
+++ b/agent/stall_retry.py
@@ -1,0 +1,417 @@
+"""
+Agentic stall-retry (dflash Q4 premature-EOS workaround).
+
+dflash (Qwen3.6-27B Q4_K_M, lucebox spec-decode) sometimes emits EOS right
+after a short action preamble ("Let me check X:") on agentic decision turns,
+ending the turn with NO tool_call -> the agent loop treats it as a final
+answer and stops mid-task. Higher-precision weights (the stock Q6 lane on the
+same host) continue to a real tool call on the identical prompt.
+
+This module detects that stall signature on a no-tool-call turn and retries
+the turn against a higher-quality model lane, with a small recovery nudge that
+asks the model to emit the tool call it just promised. If the retry produces
+tool_calls, the loop adopts that response and continues; otherwise the caller
+should fail the turn as partial rather than persist the planning-only text as
+a final assistant message.
+
+Entirely opt-in: does nothing unless ``HERMES_STALL_RETRY_MODEL`` is set
+(e.g. ``qwen3.6-27b-256k``). Default-off => zero change to existing behavior.
+
+Env:
+  HERMES_STALL_RETRY_MODEL  retry lane/model name (required to enable)
+  HERMES_STALL_RETRY_MAX_PER_TURN  max retries per user turn (default 5)
+  HERMES_STALL_RETRY_MAX_CHARS  max content length to still count as a stall
+                                (default 400; real final answers are longer)
+  HERMES_STALL_RETRY_NUDGE  true/false; add a retry-only continuation nudge
+                            (default true)
+  HERMES_STALL_RETRY_TELEMETRY  true/false; append local NDJSON telemetry
+                                (default true)
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+# Action-preamble signature: the turn announced an action but produced no tool
+# call. These end mid-thought, typically with a colon, or open with intent.
+_ACTION_RE = re.compile(
+    r"(let me\b|let's\b|i'?ll\b|i will\b|i'?m going to\b|i am going to\b|"
+    r"now i\b|first,?\s+i\b|next,?\s+i\b|i need to\b|i should\b|"
+    r"going to (check|look|run|start|examine|search|read|list|create|write|edit|use))",
+    re.IGNORECASE,
+)
+# Genuine completion signature: the model declared it is done / nothing to do.
+# These must NOT be retried (they are correct no-tool-call turns).
+_COMPLETION_RE = re.compile(
+    r"(\bdone\b|\bcomplete(d)?\b|nothing to (do|save|change|report|fix)|"
+    r"no changes?\b|no action\b|already (complete|done|finished)|\bfinished\b|"
+    r"all set\b|no further\b|nothing left\b|here('?s| is| are)\b|"
+    r"in summary\b|to summarize\b|the answer is\b)",
+    re.IGNORECASE,
+)
+_NATURAL_END_CHARS = '.!?:)"\']}。！？：）】」』》^'
+_MIN_INCOMPLETE_FINAL_CHARS = 80
+_STALL_RETRY_NUDGE = (
+    "Your previous assistant response ended after describing the next action, "
+    "but it did not include the required tool call. Continue the same task now "
+    "by making the tool call immediately. Do not summarize or apologize; call "
+    "the tool that performs the action you just announced."
+)
+
+
+def _as_positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if lowered in {"0", "false", "no", "off", "disabled"}:
+            return False
+    return default
+
+
+def _stall_retry_config(agent: Any | None = None) -> Mapping[str, Any]:
+    cfg = getattr(agent, "_stall_retry_config", None)
+    if isinstance(cfg, Mapping):
+        return cfg
+    try:
+        from hermes_cli.config import load_config
+
+        loaded = load_config()
+    except Exception:
+        return {}
+    cfg = loaded.get("stall_retry") if isinstance(loaded, Mapping) else None
+    return cfg if isinstance(cfg, Mapping) else {}
+
+
+def get_stall_retry_model(agent: Any | None = None) -> str:
+    """Return the configured retry model, with env taking precedence."""
+    env_model = os.environ.get("HERMES_STALL_RETRY_MODEL", "").strip()
+    if env_model:
+        return env_model
+    cfg_model = _stall_retry_config(agent).get("model")
+    return str(cfg_model or "").strip()
+
+
+def get_stall_retry_max_chars(agent: Any | None = None) -> int:
+    env_value = os.environ.get("HERMES_STALL_RETRY_MAX_CHARS")
+    if env_value is not None:
+        return _as_positive_int(env_value, 400)
+    return _as_positive_int(_stall_retry_config(agent).get("max_chars"), 400)
+
+
+def get_stall_retry_max_per_turn(agent: Any | None = None) -> int:
+    env_value = os.environ.get("HERMES_STALL_RETRY_MAX_PER_TURN")
+    if env_value is not None:
+        try:
+            return max(0, int(env_value))
+        except ValueError:
+            return 5
+    cfg_value = _stall_retry_config(agent).get("max_per_turn")
+    try:
+        return max(0, int(cfg_value))
+    except (TypeError, ValueError):
+        return 5
+
+
+def get_stall_retry_nudge_enabled(agent: Any | None = None) -> bool:
+    env_value = os.environ.get("HERMES_STALL_RETRY_NUDGE")
+    if env_value is not None:
+        return _as_bool(env_value, True)
+    return _as_bool(_stall_retry_config(agent).get("nudge"), True)
+
+
+def get_stall_retry_telemetry_enabled(agent: Any | None = None) -> bool:
+    env_value = os.environ.get("HERMES_STALL_RETRY_TELEMETRY")
+    if env_value is not None:
+        return _as_bool(env_value, True)
+    return _as_bool(_stall_retry_config(agent).get("telemetry"), True)
+
+
+def _has_natural_response_ending(content: str) -> bool:
+    stripped = (content or "").rstrip()
+    if not stripped:
+        return False
+    if stripped.endswith("```"):
+        return True
+    last = stripped[-1]
+    if last in _NATURAL_END_CHARS:
+        return True
+    return ord(last) >= 0x1F300
+
+
+def _safe_preview(value: Any, max_chars: int = 240) -> str:
+    text = value if isinstance(value, str) else str(value or "")
+    text = re.sub(r"^<think>.*?</think>\s*", "", text, flags=re.IGNORECASE | re.DOTALL)
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3].rstrip() + "..."
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    return str(value)
+
+
+def _stall_retry_log_path(agent: Any | None = None) -> Path:
+    cfg_path = _stall_retry_config(agent).get("telemetry_path")
+    if cfg_path:
+        return Path(str(cfg_path)).expanduser()
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = Path(get_hermes_home())
+    except Exception:
+        home = Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser()
+    return home / "logs" / "stall-retry.ndjson"
+
+
+def record_stall_retry_event(agent: Any, event: str, **fields: Any) -> None:
+    """Record local, bounded stall-retry telemetry."""
+    entry: dict[str, Any] = {
+        "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "event": str(event),
+        "session_id": str(getattr(agent, "session_id", "") or ""),
+        "model": str(getattr(agent, "model", "") or ""),
+        "provider": str(getattr(agent, "provider", "") or ""),
+    }
+    content = fields.pop("content", None)
+    if content is not None:
+        text = content if isinstance(content, str) else str(content)
+        entry["content_chars"] = len(text)
+        entry["content_preview"] = _safe_preview(text)
+    entry.update({str(k): _jsonable(v) for k, v in fields.items()})
+
+    events = getattr(agent, "_stall_retry_events", None)
+    if not isinstance(events, list):
+        events = []
+        try:
+            setattr(agent, "_stall_retry_events", events)
+        except Exception:
+            pass
+    events.append(entry)
+
+    if not get_stall_retry_telemetry_enabled(agent):
+        return
+    try:
+        path = _stall_retry_log_path(agent)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, ensure_ascii=False, sort_keys=True) + "\n")
+    except Exception:
+        return
+
+
+def stall_retry_summary(agent: Any) -> dict[str, Any] | None:
+    events = getattr(agent, "_stall_retry_events", None)
+    if not isinstance(events, list) or not events:
+        return None
+    counts = {
+        "detected": 0,
+        "attempted": 0,
+        "recovered": 0,
+        "failed": 0,
+        "limit_exhausted": 0,
+        "exceptions": 0,
+    }
+    for item in events:
+        kind = item.get("event") if isinstance(item, Mapping) else None
+        if kind == "detected":
+            counts["detected"] += 1
+        elif kind == "attempt":
+            counts["attempted"] += 1
+        elif kind == "recovered":
+            counts["recovered"] += 1
+        elif kind in {"failed_no_tool_call", "api_none", "skipped_same_model"}:
+            counts["failed"] += 1
+        elif kind == "limit_exhausted":
+            counts["limit_exhausted"] += 1
+        elif kind == "exception":
+            counts["exceptions"] += 1
+    summary: dict[str, Any] = dict(counts)
+    summary["events"] = len(events)
+    if get_stall_retry_telemetry_enabled(agent):
+        summary["log_path"] = str(_stall_retry_log_path(agent))
+    return summary
+
+
+def _retry_messages_with_nudge(
+    agent: Any,
+    api_messages: list[dict[str, Any]],
+    stalled_content: str,
+) -> list[dict[str, Any]]:
+    if not get_stall_retry_nudge_enabled(agent):
+        return api_messages
+    retry_messages = [msg.copy() if isinstance(msg, dict) else msg for msg in api_messages]
+    visible = (stalled_content or "").strip()
+    if visible:
+        retry_messages.append({"role": "assistant", "content": visible})
+    retry_messages.append({"role": "user", "content": _STALL_RETRY_NUDGE})
+    return retry_messages
+
+
+def looks_like_stall(content: str, finish_reason: str, has_tool_calls: bool,
+                     max_chars: int) -> bool:
+    """True when a no-tool-call turn looks like a premature agentic stall
+    (announced an action, didn't call a tool) rather than a real final answer."""
+    if has_tool_calls:
+        return False
+    if finish_reason not in ("stop", "length"):
+        return False
+    c = (content or "").strip()
+    # Strip a leading <think>...</think> block if present; judge the visible tail.
+    c = re.sub(r"^<think>.*?</think>\s*", "", c, flags=re.IGNORECASE | re.DOTALL).strip()
+    if not c:
+        # Truly empty responses have their own recovery path in the
+        # conversation loop. Do not let stall retry preempt that machinery.
+        return False
+    if len(c) > max_chars:
+        return False  # long => almost certainly a real answer
+    if _COMPLETION_RE.search(c):
+        return False  # model said it's done => respect it
+    if _ACTION_RE.search(c):
+        return True   # announced an action, no tool call => stall
+    # Short prose that doesn't declare completion and isn't an obvious answer:
+    # a trailing colon strongly implies "about to do something".
+    if c.endswith(":"):
+        return True
+    # dflash can also stop after a tool result with ordinary-looking prose that
+    # is simply cut off mid-sentence (for example after a CLI interrupt resumes
+    # the turn). In an agentic tool loop, a short no-tool stop that declares no
+    # completion and lacks a natural ending is safer to retry than to persist as
+    # a final assistant message.
+    if len(c) >= _MIN_INCOMPLETE_FINAL_CHARS and not _has_natural_response_ending(c):
+        return True
+    return False
+
+
+def retry_on_stall(
+    agent,
+    api_messages,
+    finish_reason,
+    stalled_content: str = "",
+    retry_index: int | None = None,
+):
+    """If the just-finished no-tool-call turn looks like a stall and a retry
+    lane is configured, re-issue the turn against that lane (same provider /
+    client / endpoint — only the model name changes). A retry-only nudge is
+    appended by default so the fallback model is told to continue with a tool
+    call instead of repeating the action preamble.
+
+    Returns the normalized assistant_message from the retry IF it produced tool
+    calls (caller should adopt it + its finish_reason='tool_calls'), else None.
+    Never raises into the caller — any failure returns None so the caller can
+    fail closed without storing the stalled assistant message.
+    """
+    retry_model = get_stall_retry_model(agent)
+    if not retry_model:
+        return None
+
+    try:
+        retry_messages = _retry_messages_with_nudge(agent, api_messages, stalled_content)
+        # Build kwargs exactly as the normal turn would, then override only the
+        # model name. Safe when the retry lane is served by the SAME provider/
+        # endpoint as agent.model (e.g. taro serves both dflash and the Q6 lane),
+        # so no client rebuild is needed.
+        api_kwargs = agent._build_api_kwargs(retry_messages)
+        orig_model = api_kwargs.get("model")
+        if retry_model == orig_model:
+            record_stall_retry_event(
+                agent,
+                "skipped_same_model",
+                retry_model=retry_model,
+                finish_reason=finish_reason,
+                retry_index=retry_index,
+            )
+            return None  # nothing to gain retrying the same model
+        api_kwargs = dict(api_kwargs)
+        api_kwargs["model"] = retry_model
+        # Force non-streaming for the retry (simpler, we only inspect the result).
+        api_kwargs.pop("stream", None)
+        api_kwargs["stream"] = False
+
+        try:
+            agent._vprint(
+                f"{getattr(agent, 'log_prefix', '')}↻ stall detected "
+                f"(no tool call) — retrying turn on '{retry_model}'",
+                force=True,
+            )
+        except Exception:
+            pass
+
+        record_stall_retry_event(
+            agent,
+            "attempt",
+            retry_model=retry_model,
+            original_model=orig_model,
+            finish_reason=finish_reason,
+            retry_index=retry_index,
+            nudge=get_stall_retry_nudge_enabled(agent),
+            content=stalled_content,
+        )
+        response = agent._interruptible_api_call(api_kwargs)
+        if response is None:
+            record_stall_retry_event(
+                agent,
+                "api_none",
+                retry_model=retry_model,
+                retry_index=retry_index,
+            )
+            return None
+        transport = agent._get_transport()
+        normalize_kwargs = {}
+        if getattr(agent, "api_mode", None) == "anthropic_messages":
+            normalize_kwargs["strip_tool_prefix"] = getattr(agent, "_is_anthropic_oauth", False)
+        normalized = transport.normalize_response(response, **normalize_kwargs)
+        if getattr(normalized, "tool_calls", None):
+            record_stall_retry_event(
+                agent,
+                "recovered",
+                retry_model=retry_model,
+                retry_index=retry_index,
+                tool_call_count=len(getattr(normalized, "tool_calls", []) or []),
+                content=getattr(normalized, "content", "") or "",
+            )
+            return normalized
+        record_stall_retry_event(
+            agent,
+            "failed_no_tool_call",
+            retry_model=retry_model,
+            retry_index=retry_index,
+            content=getattr(normalized, "content", "") or "",
+        )
+        return None
+    except Exception as exc:
+        record_stall_retry_event(
+            agent,
+            "exception",
+            retry_model=retry_model,
+            retry_index=retry_index,
+            error_type=type(exc).__name__,
+            error=str(exc)[:300],
+        )
+        # Any error => silently fall back to the original response.
+        return None

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
@@ -64,9 +65,10 @@ MUTATING_TOOL_NAMES = frozenset(
 class ToolCallGuardrailConfig:
     """Thresholds for per-turn tool-call loop detection.
 
-    Warnings are enabled by default and never prevent tool execution. Hard stops
-    are explicit opt-in so interactive CLI/TUI sessions get a gentle nudge unless
-    the user enables circuit-breaker behavior in config.yaml.
+    Warnings are enabled by default. Hard stops remain explicit opt-in, but
+    repeated low-information read-only calls may redirect the same tool for one
+    turn so the model has to verify assumptions with a different tool path
+    instead of burning the iteration budget on harmless-looking empty results.
     """
 
     warnings_enabled: bool = True
@@ -77,6 +79,9 @@ class ToolCallGuardrailConfig:
     same_tool_failure_halt_after: int = 8
     no_progress_warn_after: int = 2
     no_progress_block_after: int = 5
+    low_information_warn_after: int = 3
+    low_information_redirect_after: int = 4
+    low_information_halt_after: int = 6
     idempotent_tools: frozenset[str] = field(default_factory=lambda: IDEMPOTENT_TOOL_NAMES)
     mutating_tools: frozenset[str] = field(default_factory=lambda: MUTATING_TOOL_NAMES)
 
@@ -109,6 +114,10 @@ class ToolCallGuardrailConfig:
                 warn_after.get("idempotent_no_progress", data.get("no_progress_warn_after")),
                 defaults.no_progress_warn_after,
             ),
+            low_information_warn_after=_positive_int(
+                warn_after.get("low_information", data.get("low_information_warn_after")),
+                defaults.low_information_warn_after,
+            ),
             exact_failure_block_after=_positive_int(
                 hard_stop_after.get("exact_failure", data.get("exact_failure_block_after")),
                 defaults.exact_failure_block_after,
@@ -120,6 +129,14 @@ class ToolCallGuardrailConfig:
             no_progress_block_after=_positive_int(
                 hard_stop_after.get("idempotent_no_progress", data.get("no_progress_block_after")),
                 defaults.no_progress_block_after,
+            ),
+            low_information_redirect_after=_positive_int(
+                hard_stop_after.get("low_information_redirect", data.get("low_information_redirect_after")),
+                defaults.low_information_redirect_after,
+            ),
+            low_information_halt_after=_positive_int(
+                hard_stop_after.get("low_information", data.get("low_information_halt_after")),
+                defaults.low_information_halt_after,
             ),
         )
 
@@ -145,7 +162,7 @@ class ToolCallSignature:
 class ToolGuardrailDecision:
     """Decision returned by the tool-call guardrail controller."""
 
-    action: str = "allow"  # allow | warn | block | halt
+    action: str = "allow"  # allow | warn | redirect | block | halt
     code: str = "allow"
     message: str = ""
     tool_name: str = ""
@@ -232,6 +249,8 @@ class ToolCallGuardrailController:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._low_information_counts: dict[tuple[str, str], int] = {}
+        self._tool_redirects: dict[str, ToolGuardrailDecision] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
 
     @property
@@ -239,7 +258,38 @@ class ToolCallGuardrailController:
         return self._halt_decision
 
     def before_call(self, tool_name: str, args: Mapping[str, Any] | None) -> ToolGuardrailDecision:
-        signature = ToolCallSignature.from_call(tool_name, _coerce_args(args))
+        args = _coerce_args(args)
+        signature = ToolCallSignature.from_call(tool_name, args)
+        redirect = self._tool_redirects.get(tool_name)
+        if redirect is not None:
+            if tool_name == "terminal" and _terminal_probe_family(args) != "filter_probe":
+                self._clear_low_information_state(tool_name)
+                return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
+            redirected_count = redirect.count + 1
+            action = (
+                "halt"
+                if self.config.hard_stop_enabled
+                and redirected_count >= self.config.low_information_halt_after
+                else "redirect"
+            )
+            code = (
+                "low_information_tool_halt"
+                if action == "halt"
+                else "low_information_tool_redirect"
+            )
+            decision = ToolGuardrailDecision(
+                action=action,
+                code=code,
+                message=_low_information_recovery_hint(tool_name, redirected_count),
+                tool_name=tool_name,
+                count=redirected_count,
+                signature=signature,
+            )
+            self._tool_redirects[tool_name] = decision
+            if decision.should_halt:
+                self._halt_decision = decision
+            return decision
+
         if not self.config.hard_stop_enabled:
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
@@ -260,7 +310,7 @@ class ToolCallGuardrailController:
             self._halt_decision = decision
             return decision
 
-        if self._is_idempotent(tool_name):
+        if self._is_idempotent_call(tool_name, args):
             record = self._no_progress.get(signature)
             if record is not None:
                 _result_hash, repeat_count = record
@@ -302,6 +352,25 @@ class ToolCallGuardrailController:
 
             same_count = self._same_tool_failure_counts.get(tool_name, 0) + 1
             self._same_tool_failure_counts[tool_name] = same_count
+
+            tool_block = _tool_reported_loop_block(tool_name, result)
+            if tool_block:
+                decision = ToolGuardrailDecision(
+                    action="halt",
+                    code="tool_reported_loop_block",
+                    message=(
+                        f"Stopped {tool_name}: the tool reported a repeated-call "
+                        f"loop block after {tool_block['count']} attempts. "
+                        "Use the information already returned, narrow the query, "
+                        "or switch to a different tool path instead of retrying "
+                        "the same call."
+                    ),
+                    tool_name=tool_name,
+                    count=tool_block["count"],
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
 
             if self.config.hard_stop_enabled and same_count >= self.config.same_tool_failure_halt_after:
                 decision = ToolGuardrailDecision(
@@ -347,9 +416,45 @@ class ToolCallGuardrailController:
         self._exact_failure_counts.pop(signature, None)
         self._same_tool_failure_counts.pop(tool_name, None)
 
-        if not self._is_idempotent(tool_name):
+        if not self._is_idempotent_call(tool_name, args):
             self._no_progress.pop(signature, None)
+            self._clear_low_information_state()
             return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
+
+        low_info_kind = _low_information_result(tool_name, args, result)
+        if low_info_kind is not None:
+            key = (tool_name, low_info_kind)
+            low_info_count = self._low_information_counts.get(key, 0) + 1
+            self._low_information_counts[key] = low_info_count
+            if low_info_count >= self.config.low_information_redirect_after:
+                redirect = ToolGuardrailDecision(
+                    action="redirect",
+                    code="low_information_tool_redirect",
+                    message=_low_information_recovery_hint(tool_name, low_info_count),
+                    tool_name=tool_name,
+                    count=low_info_count,
+                    signature=signature,
+                )
+                self._tool_redirects[tool_name] = redirect
+                return ToolGuardrailDecision(
+                    action="warn",
+                    code="low_information_strategy_warning",
+                    message=_low_information_recovery_hint(tool_name, low_info_count),
+                    tool_name=tool_name,
+                    count=low_info_count,
+                    signature=signature,
+                )
+            if self.config.warnings_enabled and low_info_count >= self.config.low_information_warn_after:
+                return ToolGuardrailDecision(
+                    action="warn",
+                    code="low_information_strategy_warning",
+                    message=_low_information_recovery_hint(tool_name, low_info_count),
+                    tool_name=tool_name,
+                    count=low_info_count,
+                    signature=signature,
+                )
+        else:
+            self._clear_low_information_state()
 
         result_hash = _result_hash(result)
         previous = self._no_progress.get(signature)
@@ -379,6 +484,21 @@ class ToolCallGuardrailController:
             return False
         return tool_name in self.config.idempotent_tools
 
+    def _is_idempotent_call(self, tool_name: str, args: Mapping[str, Any]) -> bool:
+        if tool_name == "terminal" and _terminal_probe_family(args) is not None:
+            return True
+        return self._is_idempotent(tool_name)
+
+    def _clear_low_information_state(self, tool_name: str | None = None) -> None:
+        if tool_name is None:
+            self._low_information_counts.clear()
+            self._tool_redirects.clear()
+            return
+        for key in list(self._low_information_counts):
+            if key[0] == tool_name:
+                self._low_information_counts.pop(key, None)
+        self._tool_redirects.pop(tool_name, None)
+
 
 def toolguard_synthetic_result(decision: ToolGuardrailDecision) -> str:
     """Build a synthetic role=tool content string for a blocked tool call."""
@@ -393,9 +513,14 @@ def toolguard_synthetic_result(decision: ToolGuardrailDecision) -> str:
 
 def append_toolguard_guidance(result: str, decision: ToolGuardrailDecision) -> str:
     """Append runtime guidance to the current tool result content."""
-    if decision.action not in {"warn", "halt"} or not decision.message:
+    if decision.action not in {"warn", "redirect", "halt"} or not decision.message:
         return result
-    label = "Tool loop hard stop" if decision.action == "halt" else "Tool loop warning"
+    if decision.action == "halt":
+        label = "Tool loop hard stop"
+    elif decision.action == "redirect":
+        label = "Tool strategy redirect"
+    else:
+        label = "Tool loop warning"
     suffix = (
         f"\n\n[{label}: "
         f"{decision.code}; count={decision.count}; {decision.message}]"
@@ -414,13 +539,181 @@ def _tool_failure_recovery_hint(tool_name: str, count: int) -> str:
         return common + (
             "For terminal failures, run a small diagnostic such as `pwd && ls -la` "
             "in the same tool, then try an absolute path, a simpler command, a different "
-            "working directory, or a different tool such as read_file/write_file/patch."
+            "working directory, or a different tool such as read_file/write_file/patch. "
+            "If a git commit or PR helper fails, verify the commit/PR state before "
+            "claiming it landed; for MeshBoard CLI Python failures, try the repo's "
+            "known Python such as python3.11 instead of repeating filtered probes."
         )
     return common + (
         "Try different arguments, a narrower query/path, an absolute path when relevant, "
         "or a different tool that can make progress. If the blocker is external, report "
         "the blocker after one diagnostic attempt instead of repeating the same failing path."
     )
+
+
+def _low_information_recovery_hint(tool_name: str, count: int) -> str:
+    """Guidance for repeated successful tool calls that returned no usable facts."""
+    common = (
+        f"{tool_name} has returned low-information results {count} times this turn. "
+        "This is no longer an information-gathering phase; change strategy before "
+        "calling the same tool again. "
+    )
+    if tool_name == "search_files":
+        return common + (
+            "Likely causes are the wrong search root, wrong target mode, or a query "
+            "that is too abstract for grep-style search. First verify cwd/path with "
+            "another tool such as terminal (`pwd`, `rg --files`, `rg -n`) or inspect "
+            "a known candidate file with read_file; do not keep varying the same "
+            "empty search."
+        )
+    if tool_name == "read_file":
+        return common + (
+            "The file content already in the conversation is still current. Use it "
+            "to edit/respond, read a different range only if you need new lines, or "
+            "switch to search_files/terminal to locate a different file."
+        )
+    if tool_name == "terminal":
+        return common + (
+            "Stop stacking filtered shell probes that return blank output. Run one "
+            "broad diagnostic such as `pwd && ls -la`, inspect a concrete file, "
+            "create a clean worktree from current main, or report the stale-state "
+            "blocker instead of repeating `grep | head` / `git diff --name-only` "
+            "variants."
+        )
+    return common + "Use a different tool path, make an edit, ask for clarification, or report the blocker."
+
+
+def _low_information_result(tool_name: str, args: Mapping[str, Any], result: str | None) -> str | None:
+    """Classify successful but non-progressing read-only results.
+
+    Exact-repeat detection catches identical calls. This catches the systemic
+    loop class where a model makes small query variations that all produce the
+    same empty/unchanged payload, so exact-signature counters never fire.
+    """
+    parsed = safe_json_loads(result or "")
+    if not isinstance(parsed, dict) or parsed.get("error"):
+        return None
+
+    if tool_name == "search_files":
+        if (
+            parsed.get("total_count") == 0
+            and not parsed.get("matches")
+            and not parsed.get("files")
+            and not parsed.get("counts")
+        ):
+            return "empty_search_result"
+        return None
+
+    if tool_name == "read_file":
+        if (
+            parsed.get("status") == "unchanged"
+            and parsed.get("dedup") is True
+            and parsed.get("content_returned") is False
+        ):
+            return "unchanged_read_stub"
+
+    if tool_name == "terminal":
+        family = _terminal_probe_family(args)
+        if family is None:
+            return None
+        exit_code = parsed.get("exit_code")
+        if exit_code not in (None, 0):
+            return None
+        if not _terminal_result_text(parsed).strip():
+            return f"empty_terminal_{family}"
+        return None
+
+    return None
+
+
+def _terminal_result_text(parsed: Mapping[str, Any]) -> str:
+    parts = []
+    for key in ("stdout", "stderr", "output", "content"):
+        value = parsed.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+    return "\n".join(parts)
+
+
+def _terminal_probe_family(args: Mapping[str, Any]) -> str | None:
+    command = args.get("command", args.get("cmd", ""))
+    if not isinstance(command, str):
+        return None
+    command = _normalize_terminal_command(command)
+    if not command or _has_mutating_shell_signal(command):
+        return None
+    if _is_filtered_terminal_probe(command):
+        return "filter_probe"
+    if _is_read_only_terminal_probe(command):
+        return "read_probe"
+    return None
+
+
+def _normalize_terminal_command(command: str) -> str:
+    command = command.strip()
+    # Common harmless stderr redirections should not make a read probe look
+    # mutating. Keep this conservative so arbitrary file writes still opt out.
+    command = re.sub(r"\s+\d?>\s*/dev/null\b", "", command)
+    command = command.replace(" 2>&1", "")
+    command = re.sub(r"\bcd\s+[^;&|]+&&\s*", "", command)
+    return command.strip()
+
+
+def _has_mutating_shell_signal(command: str) -> bool:
+    lowered = command.lower()
+    mutating_command_re = (
+        r"(^|[;&|]\s*)"
+        r"(rm|mv|cp|mkdir|touch|chmod|chown|"
+        r"git\s+(add|commit|push|checkout|switch|reset|clean|worktree\s+add)|"
+        r"python\d?|python3|node|npm|pnpm|yarn|uv|pip|sed\s+-i|perl\s+-i)\b"
+    )
+    if re.search(mutating_command_re, lowered):
+        return True
+    if re.search(r"(^|[^0-9])>>?", command) and "/dev/null" not in command:
+        return True
+    if re.search(r"\btee\s+", lowered):
+        return True
+    return False
+
+
+def _is_filtered_terminal_probe(command: str) -> bool:
+    lowered = command.lower()
+    if re.search(r"\|\s*(grep|head|tail|wc|sort|uniq)\b", lowered):
+        return True
+    if re.search(r"\bgrep\s+-r\b|\brg\s+.*\|\s*head\b", lowered):
+        return True
+    if "git diff" in lowered and ("--name-only" in lowered or "--stat" in lowered):
+        return True
+    return False
+
+
+def _is_read_only_terminal_probe(command: str) -> bool:
+    readonly_prefixes = (
+        "pwd",
+        "ls",
+        "find",
+        "rg",
+        "grep",
+        "cat",
+        "sed -n",
+        "head",
+        "tail",
+        "wc",
+        "git log",
+        "git show",
+        "git diff",
+        "git status",
+        "git branch",
+        "git remote",
+        "git rev-parse",
+        "git merge-base",
+        "git worktree list",
+        "meshctl task list",
+        "meshctl task show",
+        "meshctl worktree list",
+    )
+    lowered = command.lower().lstrip()
+    return lowered.startswith(readonly_prefixes)
 
 
 def _coerce_args(args: Mapping[str, Any] | None) -> Mapping[str, Any]:
@@ -443,6 +736,37 @@ def _result_hash(result: str | None) -> str:
     else:
         canonical = result or ""
     return _sha256(canonical)
+
+
+def _tool_reported_loop_block(tool_name: str, result: str | None) -> dict[str, int] | None:
+    """Return metadata when a tool already enforced a repeated-call block.
+
+    File/search tools emit explicit ``BLOCKED:`` JSON errors after a model
+    repeats the exact same read/search enough times. Those are stronger than
+    ordinary tool failures: the tool has already proven the next identical call
+    cannot make progress, so the agent loop should halt even when the broader
+    guardrail hard-stop mode is left at its conservative default.
+    """
+    parsed = safe_json_loads(result or "")
+    if not isinstance(parsed, dict):
+        return None
+
+    error = parsed.get("error")
+    if not isinstance(error, str) or not error.startswith("BLOCKED:"):
+        return None
+
+    count = parsed.get("already_searched", parsed.get("already_read"))
+    if not isinstance(count, int) or count < 1:
+        return None
+
+    if (
+        tool_name in {"search_files", "read_file", "mcp_filesystem_read_file"}
+        or "exact search" in error
+        or "exact file region" in error
+        or "exact region" in error
+    ):
+        return {"count": count}
+    return None
 
 
 def _as_bool(value: Any, default: bool) -> bool:

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -354,6 +354,14 @@ def finalize_turn(
     }
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
+    try:
+        from agent.stall_retry import stall_retry_summary
+
+        _stall_retry = stall_retry_summary(agent)
+        if _stall_retry:
+            result["stall_retry"] = _stall_retry
+    except Exception:
+        pass
     # If a /steer landed after the final assistant turn (no more tool
     # batches to drain into), hand it back to the caller so it can be
     # delivered as the next user turn instead of being silently lost.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -349,6 +349,19 @@ tool_loop_guardrails:
     idempotent_no_progress: 5
 
 # =============================================================================
+# Agentic Stall Retry
+# =============================================================================
+# Default-off: set model to a higher-quality lane served by the same endpoint to
+# rescue local models that stop after an action preamble with no tool call. When
+# enabled, Hermes records bounded local telemetry in ~/.hermes/logs/stall-retry.ndjson.
+stall_retry:
+  model: ""                  # Example: qwen3.6-27b-256k
+  max_per_turn: 5
+  max_chars: 400
+  nudge: true                # Retry-only "make the tool call now" continuation
+  telemetry: true            # Local NDJSON only; never logs raw request messages
+
+# =============================================================================
 # Context Compression (Auto-shrinks long conversations)
 # =============================================================================
 # When conversation approaches model's context limit, middle turns are

--- a/cli.py
+++ b/cli.py
@@ -10125,7 +10125,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # by the Enter key binding (routed to the clarify response queue),
             # so we skip interrupt processing to avoid stealing that input.
             interrupt_msg = None
+            interrupt_requested_without_message = False
             while agent_thread.is_alive():
+                if (
+                    self.agent
+                    and getattr(self.agent, "_interrupt_requested", False)
+                    and interrupt_msg is None
+                ):
+                    interrupt_requested_without_message = True
+                    if stop_event is not None:
+                        stop_event.set()
+                    break
                 if hasattr(self, '_interrupt_queue'):
                     try:
                         interrupt_msg = self._interrupt_queue.get(timeout=0.1)
@@ -10168,7 +10178,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # session).  Poll instead of a blocking join so the process_loop
             # stays responsive — if the user sent another interrupt or the
             # agent gets stuck, we can break out instead of freezing forever.
-            if interrupt_msg is not None:
+            interrupt_requested = interrupt_msg is not None or interrupt_requested_without_message
+            if interrupt_requested:
                 # Interrupt path: poll briefly, then move on.  The agent
                 # thread is daemon — it dies on process exit regardless.
                 for _wait_tick in range(50):  # 50 * 0.2s = 10s max
@@ -10190,6 +10201,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 # Normal completion: agent thread should be done already,
                 # but guard against edge cases.
                 agent_thread.join(timeout=30)
+
+            if interrupt_requested and result is None:
+                result = {
+                    "final_response": "Operation interrupted.",
+                    "messages": self.conversation_history,
+                    "api_calls": 0,
+                    "completed": False,
+                    "interrupted": True,
+                    "interrupt_message": interrupt_msg,
+                }
 
             # Freeze per-prompt elapsed timer once the agent thread has
             # exited (or been abandoned as a daemon after interrupt).

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1964,6 +1964,7 @@ class CLICommandsMixin:
             print(f"  Available: {', '.join(sorted(available))}")
             return
 
+        old_skin = get_active_skin_name()
         set_active_skin(new_skin)
         _ACCENT.reset()  # Re-resolve ANSI color for the new skin
         # _DIM is now a fixed dim+italic ANSI escape (terminal-default fg)
@@ -1972,9 +1973,28 @@ class CLICommandsMixin:
             print(f"  Skin set to: {new_skin} (saved)")
         else:
             print(f"  Skin set to: {new_skin}")
-        print("  Note: banner colors will update on next session start.")
         if self._apply_tui_skin_style():
             print("  Prompt + TUI colors updated.")
+        # Reprint the banner with the new skin's colors so the user sees
+        # the full theme change immediately — not just on next session start.
+        self._refresh_banner_after_skin_switch()
+
+    def _refresh_banner_after_skin_switch(self):
+        """Reprint the compact banner with the new skin's colors.
+
+        Inside the TUI, Rich output must go through ChatConsole (prompt_toolkit's
+        native ANSI renderer) instead of self.console (raw stdout, mangled by
+        patch_stdout).  Outside the TUI, self.console works fine.
+        """
+        try:
+            from cli import ChatConsole, _build_compact_banner
+            if self._app:
+                cc = ChatConsole()
+                cc.print(_build_compact_banner())
+            else:
+                self.console.print(_build_compact_banner())
+        except Exception:
+            pass  # banner refresh is cosmetic — never break /skin
 
     def _handle_footer_command(self, cmd_original: str) -> None:
         """Toggle or inspect ``display.runtime_footer.enabled`` from the CLI.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1140,6 +1140,18 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # Agentic stall retry is default-off until a retry model is configured.
+    # It is useful for local models that sometimes stop after an action
+    # preamble with no tool call. When enabled, local bounded telemetry is
+    # appended under ~/.hermes/logs/ so operators can measure recoveries.
+    "stall_retry": {
+        "model": "",
+        "max_per_turn": 5,
+        "max_chars": 400,
+        "nudge": True,
+        "telemetry": True,
+    },
+
     "compression": {
         "enabled": True,
         "threshold": 0.50,            # compress when context usage exceeds this ratio

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -334,7 +334,17 @@ sys.path.insert(0, str(PROJECT_ROOT))
 # Falls back to ~/.hermes/active_profile for sticky default.
 # ---------------------------------------------------------------------------
 def _apply_profile_override() -> None:
-    """Pre-parse --profile/-p and set HERMES_HOME before imports."""
+    """Pre-parse --profile/-p and set HERMES_HOME before module imports."""
+
+    # MeshBoard and other launchers spawn Hermes with a per-dispatch
+    # HERMES_HOME sandbox (e.g. for stream-tap proxy injection).  When
+    # the launcher has already set HERMES_HOME and wants it honoured
+    # verbatim, it passes HERMES_SKIP_PROFILE_OVERRIDE=1 so this
+    # function returns early instead of clobbering the sandbox with the
+    # active profile.  See meshboard task hermes-stream-tap-profile-override.
+    if os.environ.get("HERMES_SKIP_PROFILE_OVERRIDE", "").strip() == "1":
+        return
+
     argv = sys.argv[1:]
     profile_name = None
     consume = 0

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -304,6 +304,18 @@ def _resolve_runtime_from_pool_entry(
     # config.default was still a Claude model.
     effective_model = (target_model or model_cfg.get("default") or "")
     base_url = (getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or "").rstrip("/")
+    # MeshBoard stream-tap launcher sets HERMES_LLM_BASE_URL to a local
+    # loopback proxy URL when the stream-tap is active.  This env var
+    # must override the pool's default base_url so inference traffic
+    # is routed through the proxy and captured as JSONL for the
+    # dashboard.  Without this, Hermes bypasses the tap entirely and
+    # the dashboard shows "model silent" during active dispatches.
+    # However, OAuth providers (qwen-oauth, xai-oauth, etc.) carry
+    # tokens scoped to their own endpoints — do not redirect those.
+    _tap_url = os.getenv("HERMES_LLM_BASE_URL", "").strip().rstrip("/")
+    _oauth_providers = {"qwen-oauth", "xai-oauth", "google-gemini-cli", "minimax-oauth"}
+    if _tap_url and provider not in _oauth_providers:
+        base_url = _tap_url
     api_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
     api_mode = "chat_completions"
     if provider == "openai-codex":
@@ -823,6 +835,11 @@ def _resolve_openrouter_runtime(
 
     env_openrouter_base_url = os.getenv("OPENROUTER_BASE_URL", "").strip()
     env_custom_base_url = os.getenv("CUSTOM_BASE_URL", "").strip()
+    # MeshBoard stream-tap launcher sets HERMES_LLM_BASE_URL to a local
+    # proxy URL.  Honour it when the provider-specific env var is absent
+    # so the tap proxy actually receives inference traffic instead of
+    # being silently bypassed in favour of the default upstream URL.
+    env_hermes_llm_base_url = os.getenv("HERMES_LLM_BASE_URL", "").strip().rstrip("/")
 
     # Use config base_url when available and the provider context matches.
     # OPENAI_BASE_URL env var is no longer consulted — config.yaml is
@@ -842,6 +859,7 @@ def _resolve_openrouter_runtime(
         or env_custom_base_url
         or (cfg_base_url.strip() if use_config_base_url else "")
         or env_openrouter_base_url
+        or env_hermes_llm_base_url
         or OPENROUTER_BASE_URL
     ).rstrip("/")
 
@@ -1207,6 +1225,12 @@ def _resolve_explicit_runtime(
         env_url = ""
         if pconfig.base_url_env_var:
             env_url = os.getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
+        # MeshBoard stream-tap launcher sets HERMES_LLM_BASE_URL to a local
+        # proxy URL.  Honour it when the provider-specific env var is absent
+        # so the tap proxy actually receives inference traffic instead of
+        # being silently bypassed in favour of the default upstream URL.
+        if not env_url:
+            env_url = os.getenv("HERMES_LLM_BASE_URL", "").strip().rstrip("/")
 
         base_url = explicit_base_url
         if not base_url:

--- a/run_agent.py
+++ b/run_agent.py
@@ -201,6 +201,8 @@ from utils import atomic_json_write, base_url_host_matches, base_url_hostname, i
 
 
 _MAX_TOOL_WORKERS = 8
+_TEXT_TOOL_COMPACT_DEFAULT_THRESHOLD = 4_000
+_TEXT_TOOL_COMPACT_DEFAULT_CHARS = 3_000
 
 # Guard so the OpenRouter metadata pre-warm thread is only spawned once per
 # process, not once per AIAgent instantiation.  Without this, long-running
@@ -4434,6 +4436,65 @@ class AIAgent:
             )
         return transformed
 
+    @staticmethod
+    def _env_int(name: str, default: int) -> int:
+        try:
+            value = int(os.environ.get(name, str(default)) or default)
+        except (TypeError, ValueError):
+            return default
+        return value if value > 0 else default
+
+    def _should_compact_text_tool_results_for_active_model(self) -> bool:
+        """Return True when raw text tool outputs should be kept compact.
+
+        The dflash lane is a local llama.cpp/Qwen quant where long raw tool
+        outputs have repeatedly pushed the next decision turn into ordinary
+        text completion instead of structured tool calls. The env override is
+        intentionally generic so operators can opt other local lanes in/out
+        without a code change.
+        """
+        override = os.environ.get("HERMES_COMPACT_TEXT_TOOL_RESULTS", "").strip().lower()
+        if override in {"1", "true", "yes", "on"}:
+            return True
+        if override in {"0", "false", "no", "off"}:
+            return False
+
+        model_lower = (getattr(self, "model", "") or "").strip().lower()
+        if "dflash" in model_lower:
+            return True
+
+        return False
+
+    def _compact_text_tool_result_for_active_model(self, tool_name: str, result: str) -> str:
+        if not self._should_compact_text_tool_results_for_active_model():
+            return result
+
+        threshold = self._env_int(
+            "HERMES_TEXT_TOOL_RESULT_COMPACT_THRESHOLD",
+            _TEXT_TOOL_COMPACT_DEFAULT_THRESHOLD,
+        )
+        if len(result) <= threshold:
+            return result
+
+        keep_chars = self._env_int(
+            "HERMES_TEXT_TOOL_RESULT_COMPACT_CHARS",
+            _TEXT_TOOL_COMPACT_DEFAULT_CHARS,
+        )
+        keep_chars = max(500, min(keep_chars, threshold))
+        head_chars = keep_chars // 2
+        tail_chars = keep_chars - head_chars
+        original_size = len(result)
+
+        head = result[:head_chars].rstrip()
+        tail = result[-tail_chars:].lstrip()
+        return (
+            f"{head}\n\n"
+            f"[Tool output compacted for {getattr(self, 'model', 'the active model')}: "
+            f"original result was {original_size:,} characters. Rerun a narrower "
+            "command or read a specific file/range if more detail is needed.]\n\n"
+            f"{tail}"
+        )
+
     def _tool_result_content_for_active_model(self, tool_name: str, result: Any) -> Any:
         """Return the tool message content that is safe for the active model.
 
@@ -4444,6 +4505,8 @@ class AIAgent:
         the agent has a chance to recover.
         """
         if not _is_multimodal_tool_result(result):
+            if isinstance(result, str):
+                return self._compact_text_tool_result_for_active_model(tool_name, result)
             return result
 
         content = result.get("content") or []
@@ -5134,7 +5197,10 @@ class AIAgent:
             str: Final assistant response
         """
         result = self.run_conversation(message, stream_callback=stream_callback)
-        return result["final_response"]
+        # run_conversation's error/failure return paths (API error after retries,
+        # billing/credits exhaustion, policy halt, etc.) omit "final_response";
+        # surface the error message instead of raising KeyError here.
+        return result.get("final_response") or result.get("error") or ""
 
     def _run_codex_app_server_turn(
         self,
@@ -5327,7 +5393,7 @@ def main(
     print(f"📞 API Calls: {result['api_calls']}")
     print(f"💬 Messages: {len(result['messages'])}")
     
-    if result['final_response']:
+    if result.get('final_response'):
         print("\n🎯 FINAL RESPONSE:")
         print("-" * 30)
         print(result['final_response'])

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -180,6 +180,7 @@ AUTHOR_MAP = {
     "saeed919@pm.me": "falasi",
     "chrisdlc119@outlook.com": "chdlc",
     "omar@techdeveloper.site": "nycomar",
+    "omar@kostudios.io": "OmarB97",
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "mr.aashiz@gmail.com": "aashizpoudel",
     "adityargadgil@gmail.com": "AdityaRajeshGadgil",

--- a/scripts/run_tests_parallel.py
+++ b/scripts/run_tests_parallel.py
@@ -343,6 +343,8 @@ def _run_one_file(
     pytest_args: List[str],
     repo_root: Path,
     file_timeout: float,
+    *,
+    skip_missing: bool = False,
 ) -> Tuple[Path, int, str, dict[str, int], float]:
     """Run ``python -m pytest <file> <pytest_args>`` in a fresh subprocess.
 
@@ -394,6 +396,14 @@ def _run_one_file(
             cmd, repo_root, file_timeout,
             timeout_note=f"per-file timeout on exit-4 retry {attempt}",
         )
+
+    if rc == 4 and skip_missing and not _file_present(file):
+        output = output + (
+            "\n"
+            f"skipping stale discovered test path after exit 4: {file}\n"
+            f"retries_used={attempt}"
+        )
+        rc = 0
 
     if rc == 4:
         # Exit-4 survived the retries (or the file was judged absent).
@@ -873,7 +883,12 @@ def main() -> int:
         for file in files:
             t0 = time.monotonic()
             fut = pool.submit(
-                _run_one_file, file, pytest_passthrough, repo_root, args.file_timeout
+                _run_one_file,
+                file,
+                pytest_passthrough,
+                repo_root,
+                args.file_timeout,
+                skip_missing=True,
             )
             fut.add_done_callback(lambda f, file=file, t0=t0: _on_done(file, t0, f))
             futures.append(fut)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1271,6 +1271,9 @@ class TestToolUseEnforcementGuidance:
     def test_enforcement_models_includes_qwen(self):
         assert "qwen" in TOOL_USE_ENFORCEMENT_MODELS
 
+    def test_enforcement_models_includes_dflash(self):
+        assert "dflash" in TOOL_USE_ENFORCEMENT_MODELS
+
     def test_enforcement_models_includes_deepseek(self):
         assert "deepseek" in TOOL_USE_ENFORCEMENT_MODELS
 

--- a/tests/agent/test_stall_retry.py
+++ b/tests/agent/test_stall_retry.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import inspect
+import json
+from types import SimpleNamespace
+
+from agent import conversation_loop
+from agent.stall_retry import (
+    get_stall_retry_max_chars,
+    get_stall_retry_max_per_turn,
+    get_stall_retry_model,
+    get_stall_retry_nudge_enabled,
+    looks_like_stall,
+    record_stall_retry_event,
+    retry_on_stall,
+    stall_retry_summary,
+)
+
+
+def test_action_preamble_without_tool_call_is_a_stall() -> None:
+    assert looks_like_stall(
+        "Let me check what's on taro and figure out the right approach.",
+        "stop",
+        False,
+        400,
+    )
+
+
+def test_followup_action_preamble_after_successful_retry_is_a_stall() -> None:
+    assert looks_like_stall(
+        "Let me look at open tasks with high priority that I can actually pick up.",
+        "stop",
+        False,
+        400,
+    )
+
+
+def test_completion_text_is_not_a_stall() -> None:
+    assert not looks_like_stall(
+        "Done. The task is complete and no further action is needed.",
+        "stop",
+        False,
+        400,
+    )
+
+
+def test_incomplete_final_fragment_without_action_preamble_is_a_stall() -> None:
+    assert looks_like_stall(
+        (
+            "I'm on main with a clean tree. The fix I made was on Taro "
+            "(remote machine), not locally. The change was on Taro's "
+            "`~/.gitconfig` and the worktree's local git config. These are "
+            "machine-specific runtime"
+        ),
+        "stop",
+        False,
+        400,
+    )
+
+
+def test_empty_visible_response_uses_empty_response_recovery_not_stall_retry() -> None:
+    assert not looks_like_stall("", "stop", False, 400)
+    assert not looks_like_stall("<think>still reasoning</think>", "stop", False, 400)
+
+
+def test_short_status_answer_without_punctuation_is_not_a_stall() -> None:
+    assert not looks_like_stall("main", "stop", False, 400)
+
+
+def test_complete_agentic_answer_without_action_preamble_is_not_a_stall() -> None:
+    assert not looks_like_stall(
+        (
+            "I'm on main with a clean tree. The Taro git identity and SSH "
+            "push configuration are machine-local runtime settings, so there "
+            "is no repository diff to publish."
+        ),
+        "stop",
+        False,
+        400,
+    )
+
+
+def test_retry_on_stall_switches_model_and_returns_tool_calls(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    tool_call = SimpleNamespace(
+        function=SimpleNamespace(name="terminal", arguments='{"cmd":"pwd"}')
+    )
+    normalized = SimpleNamespace(
+        content="",
+        tool_calls=[tool_call],
+        finish_reason="tool_calls",
+    )
+
+    def interruptible_api_call(kwargs: dict[str, object]) -> object:
+        captured["kwargs"] = dict(kwargs)
+        return normalized
+
+    agent = SimpleNamespace(
+        api_mode="openai",
+        _is_anthropic_oauth=False,
+        log_prefix="",
+        _build_api_kwargs=lambda messages: {
+            "model": "dflash",
+            "messages": messages,
+            "stream": True,
+        },
+        _interruptible_api_call=interruptible_api_call,
+        _get_transport=lambda: SimpleNamespace(
+            normalize_response=lambda response, **_kwargs: response
+        ),
+        _vprint=lambda *_args, **_kwargs: None,
+    )
+
+    monkeypatch.setenv("HERMES_STALL_RETRY_MODEL", "qwen3.6-27b-256k")
+    monkeypatch.setenv("HERMES_STALL_RETRY_TELEMETRY", "0")
+    result = retry_on_stall(
+        agent,
+        [{"role": "user", "content": "go"}],
+        "stop",
+        stalled_content="Let me check the repo.",
+        retry_index=1,
+    )
+
+    assert result is normalized
+    kwargs = captured["kwargs"]
+    assert kwargs["model"] == "qwen3.6-27b-256k"
+    assert kwargs["stream"] is False
+    assert kwargs["messages"][-2]["role"] == "assistant"
+    assert kwargs["messages"][-2]["content"] == "Let me check the repo."
+    assert kwargs["messages"][-1]["role"] == "user"
+    assert "required tool call" in kwargs["messages"][-1]["content"]
+    summary = stall_retry_summary(agent)
+    assert summary is not None
+    assert summary["attempted"] == 1
+    assert summary["recovered"] == 1
+
+
+def test_retry_on_stall_uses_agent_config_when_env_is_absent(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    tool_call = SimpleNamespace(
+        function=SimpleNamespace(name="terminal", arguments='{"cmd":"pwd"}')
+    )
+    normalized = SimpleNamespace(
+        content="",
+        tool_calls=[tool_call],
+        finish_reason="tool_calls",
+    )
+
+    def interruptible_api_call(kwargs: dict[str, object]) -> object:
+        captured["kwargs"] = dict(kwargs)
+        return normalized
+
+    agent = SimpleNamespace(
+        api_mode="openai",
+        _is_anthropic_oauth=False,
+        log_prefix="",
+        _stall_retry_config={
+            "model": "qwen3.6-27b-256k",
+            "max_chars": 240,
+            "max_per_turn": 7,
+        },
+        _build_api_kwargs=lambda messages: {
+            "model": "dflash",
+            "messages": messages,
+            "stream": True,
+        },
+        _interruptible_api_call=interruptible_api_call,
+        _get_transport=lambda: SimpleNamespace(
+            normalize_response=lambda response, **_kwargs: response
+        ),
+        _vprint=lambda *_args, **_kwargs: None,
+    )
+
+    monkeypatch.delenv("HERMES_STALL_RETRY_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_STALL_RETRY_MAX_CHARS", raising=False)
+    monkeypatch.delenv("HERMES_STALL_RETRY_MAX_PER_TURN", raising=False)
+    monkeypatch.setenv("HERMES_STALL_RETRY_TELEMETRY", "0")
+
+    assert get_stall_retry_model(agent) == "qwen3.6-27b-256k"
+    assert get_stall_retry_max_chars(agent) == 240
+    assert get_stall_retry_max_per_turn(agent) == 7
+    assert get_stall_retry_nudge_enabled(agent)
+
+    result = retry_on_stall(agent, [{"role": "user", "content": "go"}], "stop")
+
+    assert result is normalized
+    assert captured["kwargs"]["model"] == "qwen3.6-27b-256k"
+    assert captured["kwargs"]["stream"] is False
+
+
+def test_retry_on_stall_can_disable_retry_nudge(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    tool_call = SimpleNamespace(
+        function=SimpleNamespace(name="terminal", arguments='{"cmd":"pwd"}')
+    )
+    normalized = SimpleNamespace(
+        content="",
+        tool_calls=[tool_call],
+        finish_reason="tool_calls",
+    )
+
+    def interruptible_api_call(kwargs: dict[str, object]) -> object:
+        captured["kwargs"] = dict(kwargs)
+        return normalized
+
+    agent = SimpleNamespace(
+        api_mode="openai",
+        _is_anthropic_oauth=False,
+        log_prefix="",
+        _stall_retry_config={
+            "model": "qwen3.6-27b-256k",
+            "nudge": False,
+            "telemetry": False,
+        },
+        _build_api_kwargs=lambda messages: {
+            "model": "dflash",
+            "messages": messages,
+            "stream": True,
+        },
+        _interruptible_api_call=interruptible_api_call,
+        _get_transport=lambda: SimpleNamespace(
+            normalize_response=lambda response, **_kwargs: response
+        ),
+        _vprint=lambda *_args, **_kwargs: None,
+    )
+
+    monkeypatch.delenv("HERMES_STALL_RETRY_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_STALL_RETRY_NUDGE", raising=False)
+    monkeypatch.delenv("HERMES_STALL_RETRY_TELEMETRY", raising=False)
+
+    assert not get_stall_retry_nudge_enabled(agent)
+
+    result = retry_on_stall(
+        agent,
+        [{"role": "user", "content": "go"}],
+        "stop",
+        stalled_content="Let me check.",
+    )
+
+    assert result is normalized
+    assert captured["kwargs"]["messages"] == [{"role": "user", "content": "go"}]
+
+
+def test_stall_retry_telemetry_writes_bounded_local_jsonl(tmp_path) -> None:
+    log_path = tmp_path / "stall-retry.ndjson"
+    agent = SimpleNamespace(
+        session_id="s1",
+        model="dflash",
+        provider="nous",
+        _stall_retry_config={
+            "telemetry": True,
+            "telemetry_path": str(log_path),
+        },
+    )
+
+    record_stall_retry_event(
+        agent,
+        "detected",
+        retry_model="qwen3.6-27b-256k",
+        content="Let me check the repo.\n" * 30,
+    )
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    event = json.loads(lines[0])
+    assert event["event"] == "detected"
+    assert event["session_id"] == "s1"
+    assert event["model"] == "dflash"
+    assert event["provider"] == "nous"
+    assert event["retry_model"] == "qwen3.6-27b-256k"
+    assert event["content_chars"] > len(event["content_preview"])
+    assert len(event["content_preview"]) <= 240
+    assert "messages" not in event
+
+    summary = stall_retry_summary(agent)
+    assert summary is not None
+    assert summary["detected"] == 1
+    assert summary["events"] == 1
+    assert summary["log_path"] == str(log_path)
+
+
+def test_conversation_loop_adopts_retry_before_tool_call_branch() -> None:
+    source = inspect.getsource(conversation_loop.run_conversation)
+    retry_idx = source.index("retried = retry_on_stall")
+    tool_branch_idx = source.index("# Check for tool calls")
+
+    assert retry_idx < tool_branch_idx
+    assert "continue  # re-enter loop top; tool-calls path handles it" not in source
+    assert "stall_retry_failed_no_tool_call" in source
+
+
+def test_conversation_loop_allows_bounded_multiple_stall_retries() -> None:
+    source = inspect.getsource(conversation_loop.run_conversation)
+
+    assert "_stall_retry_used" not in source
+    assert "_stall_retry_count += 1" in source
+    assert "get_stall_retry_max_per_turn" in source
+    assert "stall_retry_limit_exhausted" in source

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -33,7 +33,7 @@ def test_tool_call_signature_hashes_canonical_nested_unicode_args_without_exposi
     assert "☤" not in json.dumps(metadata)
 
 
-def test_default_config_is_soft_warning_only_with_hard_stop_disabled():
+def test_default_config_warns_and_redirects_without_hard_stop():
     cfg = ToolCallGuardrailConfig()
 
     assert cfg.warnings_enabled is True
@@ -41,9 +41,12 @@ def test_default_config_is_soft_warning_only_with_hard_stop_disabled():
     assert cfg.exact_failure_warn_after == 2
     assert cfg.same_tool_failure_warn_after == 3
     assert cfg.no_progress_warn_after == 2
+    assert cfg.low_information_warn_after == 3
     assert cfg.exact_failure_block_after == 5
     assert cfg.same_tool_failure_halt_after == 8
     assert cfg.no_progress_block_after == 5
+    assert cfg.low_information_redirect_after == 4
+    assert cfg.low_information_halt_after == 6
 
 
 def test_config_parses_nested_warn_and_hard_stop_thresholds():
@@ -55,11 +58,14 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
                 "exact_failure": 3,
                 "same_tool_failure": 4,
                 "idempotent_no_progress": 5,
+                "low_information": 6,
             },
             "hard_stop_after": {
                 "exact_failure": 6,
                 "same_tool_failure": 7,
                 "idempotent_no_progress": 8,
+                "low_information_redirect": 9,
+                "low_information": 10,
             },
         }
     )
@@ -69,9 +75,12 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
     assert cfg.exact_failure_warn_after == 3
     assert cfg.same_tool_failure_warn_after == 4
     assert cfg.no_progress_warn_after == 5
+    assert cfg.low_information_warn_after == 6
     assert cfg.exact_failure_block_after == 6
     assert cfg.same_tool_failure_halt_after == 7
     assert cfg.no_progress_block_after == 8
+    assert cfg.low_information_redirect_after == 9
+    assert cfg.low_information_halt_after == 10
 
 
 def test_default_repeated_identical_failed_call_warns_without_blocking():
@@ -90,6 +99,32 @@ def test_default_repeated_identical_failed_call_warns_without_blocking():
     assert {d.code for d in decisions[1:]} == {"repeated_exact_failure_warning"}
     assert controller.before_call("web_search", args).action == "allow"
     assert controller.halt_decision is None
+
+
+def test_tool_reported_loop_block_halts_even_when_hard_stop_disabled():
+    controller = ToolCallGuardrailController()
+    args = {"pattern": "def.*drain", "path": "/repo", "target": "content"}
+    result = json.dumps(
+        {
+            "error": (
+                "BLOCKED: You have run this exact search 4 times in a row. "
+                "The results have NOT changed."
+            ),
+            "already_searched": 4,
+        }
+    )
+
+    decision = controller.after_call(
+        "search_files",
+        args,
+        result,
+        failed=True,
+    )
+
+    assert decision.action == "halt"
+    assert decision.code == "tool_reported_loop_block"
+    assert decision.count == 4
+    assert controller.halt_decision == decision
 
 
 def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution():
@@ -164,6 +199,8 @@ def test_same_tool_varying_args_warns_by_default_without_halting():
     assert "keep using tools" in second.message
     assert "diagnose before retrying" in second.message
     assert "different tool" in second.message
+    assert "verify the commit/PR state" in second.message
+    assert "python3.11" in second.message
     assert controller.halt_decision is None
 
 
@@ -205,6 +242,47 @@ def test_idempotent_no_progress_repeated_result_warns_without_blocking_by_defaul
     assert controller.halt_decision is None
 
 
+def test_low_information_search_variants_redirect_before_exact_repeat_block():
+    controller = ToolCallGuardrailController()
+    empty_search = json.dumps({"total_count": 0})
+
+    decisions = [
+        controller.after_call(
+            "search_files",
+            {"pattern": pattern, "path": "/repo", "target": "content"},
+            empty_search,
+            failed=False,
+        )
+        for pattern in ("def.*drain", "drain_command", "dispatch_command", "select.*task")
+    ]
+
+    assert [decision.action for decision in decisions] == ["allow", "allow", "warn", "warn"]
+    assert decisions[2].code == "low_information_strategy_warning"
+    assert decisions[3].code == "low_information_strategy_warning"
+
+    redirected = controller.before_call(
+        "search_files",
+        {"pattern": "another variation", "path": "/repo", "target": "content"},
+    )
+
+    assert redirected.action == "redirect"
+    assert redirected.code == "low_information_tool_redirect"
+    assert redirected.should_halt is False
+    assert controller.halt_decision is None
+
+    controller.after_call(
+        "terminal",
+        {"command": "pwd && rg --files | head"},
+        json.dumps({"exit_code": 0, "output": "/repo\nrun_agent.py"}),
+        failed=False,
+    )
+
+    assert controller.before_call(
+        "search_files",
+        {"pattern": "run_conversation", "path": "/repo", "target": "content"},
+    ).action == "allow"
+
+
 def test_hard_stop_enabled_blocks_idempotent_no_progress_future_repeat():
     controller = ToolCallGuardrailController(
         ToolCallGuardrailConfig(
@@ -226,6 +304,117 @@ def test_hard_stop_enabled_blocks_idempotent_no_progress_future_repeat():
     blocked = controller.before_call("read_file", args)
     assert blocked.action == "block"
     assert blocked.code == "idempotent_no_progress_block"
+
+
+def test_terminal_filtered_empty_probe_streak_redirects_more_filter_churn():
+    controller = ToolCallGuardrailController()
+    empty_success = json.dumps({"exit_code": 0, "stdout": "", "stderr": ""})
+    commands = [
+        'cd ~/Workspaces/Projects/meshboard && git diff main --name-only 2>/dev/null | head -30',
+        'cd ~/Workspaces/Projects/meshboard && git diff main --name-only 2>/dev/null | grep -v "^tests/" | head -20',
+        'cd ~/Workspaces/Projects/meshboard && grep -r "dispatch.*history" tools/ --include="*.py" -l 2>/dev/null | head -10',
+        'cd ~/Workspaces/Projects/meshboard && rg -n "dispatch history" tools | head -20',
+    ]
+
+    decisions = []
+    for command in commands:
+        assert controller.before_call("terminal", {"command": command}).action == "allow"
+        decisions.append(
+            controller.after_call(
+                "terminal",
+                {"command": command},
+                empty_success,
+                failed=False,
+            )
+        )
+
+    assert decisions[2].code == "low_information_strategy_warning"
+    assert decisions[3].code == "low_information_strategy_warning"
+
+    redirected = controller.before_call(
+        "terminal",
+        {
+            "command": (
+                'cd ~/Workspaces/Projects/meshboard && git diff main --name-only '
+                '2>/dev/null | grep -v "^docs/" | head -20'
+            )
+        },
+    )
+
+    assert redirected.action == "redirect"
+    assert redirected.code == "low_information_tool_redirect"
+    assert "filtered shell probes" in redirected.message
+
+
+def test_terminal_filter_redirect_allows_broad_diagnostic_to_reset():
+    controller = ToolCallGuardrailController()
+    empty_success = json.dumps({"exit_code": 0, "output": ""})
+    for i in range(4):
+        controller.after_call(
+            "terminal",
+            {"command": f'git diff main --name-only | grep -v "path-{i}" | head -20'},
+            empty_success,
+            failed=False,
+        )
+
+    broad = controller.before_call("terminal", {"command": "pwd && ls -la"})
+
+    assert broad.action == "allow"
+    assert controller.before_call(
+        "terminal",
+        {"command": 'git diff main --name-only | grep -v "docs" | head -20'},
+    ).action == "allow"
+
+
+def test_terminal_filter_redirect_does_not_halt_by_default():
+    controller = ToolCallGuardrailController()
+    empty_success = json.dumps({"exit_code": 0, "stdout": "", "stderr": ""})
+    for i in range(4):
+        controller.after_call(
+            "terminal",
+            {"command": f'git diff main --name-only | grep "path-{i}" | head -20'},
+            empty_success,
+            failed=False,
+        )
+
+    last = None
+    for i in range(10):
+        last = controller.before_call(
+            "terminal",
+            {"command": f'git diff main --name-only | grep "again-{i}" | head -20'},
+        )
+
+    assert last is not None
+    assert last.action == "redirect"
+    assert last.code == "low_information_tool_redirect"
+    assert not last.should_halt
+    assert controller.halt_decision is None
+
+
+def test_terminal_filter_redirect_can_halt_when_hard_stop_is_enabled():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True)
+    )
+    empty_success = json.dumps({"exit_code": 0, "stdout": "", "stderr": ""})
+    for i in range(4):
+        controller.after_call(
+            "terminal",
+            {"command": f'git diff main --name-only | grep "path-{i}" | head -20'},
+            empty_success,
+            failed=False,
+        )
+
+    last = None
+    for i in range(2):
+        last = controller.before_call(
+            "terminal",
+            {"command": f'git diff main --name-only | grep "again-{i}" | head -20'},
+        )
+
+    assert last is not None
+    assert last.action == "halt"
+    assert last.code == "low_information_tool_halt"
+    assert controller.halt_decision == last
 
 
 def test_mutating_or_unknown_tools_are_not_blocked_for_repeated_identical_success_output_by_default():

--- a/tests/cli/test_cli_goal_interrupt.py
+++ b/tests/cli/test_cli_goal_interrupt.py
@@ -218,3 +218,16 @@ class TestInterruptFlagLifecycle:
             "runs — otherwise a prior turn's interrupt state leaks into the "
             "next turn's goal hook decision."
         )
+
+    def test_chat_observes_ctrl_c_interrupt_without_queue_message(self, hermes_home):
+        """Ctrl+C sets agent._interrupt_requested without queueing replacement text."""
+        from cli import HermesCLI
+        import inspect
+
+        src = inspect.getsource(HermesCLI.chat)
+
+        assert "interrupt_requested_without_message = False" in src
+        assert 'getattr(self.agent, "_interrupt_requested", False)' in src
+        assert "interrupt_requested = interrupt_msg is not None or interrupt_requested_without_message" in src
+        assert "if interrupt_requested and result is None" in src
+        assert '"interrupted": True' in src

--- a/tests/docker/test_gateway_run_supervised.py
+++ b/tests/docker/test_gateway_run_supervised.py
@@ -37,13 +37,33 @@ def _svstat(container: str, slot: str = "gateway-default") -> str:
 
 def _svstat_wants_up(container: str, slot: str = "gateway-default") -> bool:
     """See test_profile_gateway._svstat_wants_up for the format rules."""
-    state = _svstat(container, slot)
+    return _svstat_state_wants_up(_svstat(container, slot))
+
+
+def _svstat_state_wants_up(state: str) -> bool:
     if not state:
         return False
     head = state.split()[0] if state.split() else ""
     if head == "up":
         return "want down" not in state
     return "want up" in state
+
+
+def _wait_for_svstat_wants_up(
+    container: str,
+    slot: str = "gateway-default",
+    *,
+    timeout: float = 20.0,
+    interval: float = 0.5,
+) -> tuple[bool, str]:
+    deadline = time.monotonic() + timeout
+    last = ""
+    while time.monotonic() < deadline:
+        last = _svstat(container, slot)
+        if _svstat_state_wants_up(last):
+            return True, last
+        time.sleep(interval)
+    return False, last
 
 
 def test_gateway_run_redirects_to_supervised(
@@ -91,9 +111,8 @@ def test_gateway_run_redirects_to_supervised(
     # gateway may or may not be currently up depending on whether the
     # harness profile has a configured model, but the want-intent
     # contract holds either way.
-    assert _svstat_wants_up(container_name), (
-        f"gateway-default slot want-state not up: {_svstat(container_name)!r}"
-    )
+    wants_up, state = _wait_for_svstat_wants_up(container_name)
+    assert wants_up, f"gateway-default slot want-state not up: {state!r}"
 
     # The CMD process (PID under /init that the wrapper exec'd into)
     # should be sleeping, not the gateway. We grep `ps` for the
@@ -392,4 +411,3 @@ def test_supervised_gateway_stdout_reaches_docker_logs(
         "destination may have been dropped by the new s6-log script. "
         f"File contents:\n{file_contents}"
     )
-

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -215,3 +215,29 @@ class TestApplyProfileOverrideHermesHomeGuard:
         assert result is not None
         assert result.endswith("coder")
         assert sys.argv == ["hermes", "--continue"]
+
+    def test_hermes_skip_profile_override_env_var(self, tmp_path, monkeypatch):
+        """HERMES_SKIP_PROFILE_OVERRIDE must skip all profile resolution.
+
+        When HERMES_SKIP_PROFILE_OVERRIDE is set, _apply_profile_override
+        returns immediately without reading active_profile or modifying
+        HERMES_HOME.  This is used by MeshBoard stream-tap launcher to
+        force a specific HERMES_HOME without profile redirection.
+        """
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+        (hermes_root / "active_profile").write_text("coder")
+        profile_dir = hermes_root / "profiles" / "coder"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_root))
+        monkeypatch.setenv("HERMES_SKIP_PROFILE_OVERRIDE", "1")
+        monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "start"])
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        # HERMES_HOME must remain at the root, NOT redirected to profile
+        assert os.environ.get("HERMES_HOME") == str(hermes_root)
+        assert "profiles" not in os.environ.get("HERMES_HOME", "")

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2775,3 +2775,116 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+
+class TestHermesLlmBaseUrl:
+    """Tests for HERMES_LLM_BASE_URL env var override (MeshBoard stream-tap).
+
+    HERMES_LLM_BASE_URL is set by the MeshBoard stream-tap launcher to a local
+    loopback proxy URL.  It must override the resolved base_url so inference
+    traffic is routed through the proxy and captured as JSONL for the dashboard.
+    """
+
+    def test_pool_entry_honors_hermes_llm_base_url(self, monkeypatch):
+        """HERMES_LLM_BASE_URL overrides pool entry base_url."""
+        class _Entry:
+            access_token = "pool-token"
+            source = "manual"
+            base_url = "https://pool.example.com/v1"
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def select(self):
+                return _Entry()
+
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+        monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+        monkeypatch.setenv("HERMES_LLM_BASE_URL", "http://127.0.0.1:9999/v1")
+
+        resolved = rp.resolve_runtime_provider(requested="openai-codex")
+
+        assert resolved["base_url"] == "http://127.0.0.1:9999/v1"
+        assert resolved["api_key"] == "pool-token"
+
+    def test_explicit_path_honors_hermes_llm_base_url(self, monkeypatch):
+        """HERMES_LLM_BASE_URL overrides explicit path when provider env var absent."""
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+        monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setenv("HERMES_LLM_BASE_URL", "http://127.0.0.1:9999/v1")
+
+        resolved = rp.resolve_runtime_provider(
+            requested="openrouter",
+            explicit_api_key="test-key",
+        )
+
+        assert resolved["base_url"] == "http://127.0.0.1:9999/v1"
+        assert resolved["api_key"] == "test-key"
+
+    def test_provider_specific_env_var_wins_over_hermes_llm_base_url(self, monkeypatch):
+        """Provider-specific base_url_env_var takes precedence over HERMES_LLM_BASE_URL."""
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+        monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("CUSTOM_BASE_URL", raising=False)
+        monkeypatch.setenv("OPENROUTER_BASE_URL", "http://provider-specific.example/v1")
+        monkeypatch.setenv("HERMES_LLM_BASE_URL", "http://127.0.0.1:9999/v1")
+
+        resolved = rp.resolve_runtime_provider(
+            requested="openrouter",
+            explicit_api_key="test-key",
+        )
+
+        # Provider-specific env var (OPENROUTER_BASE_URL) takes priority
+        assert resolved["base_url"] == "http://provider-specific.example/v1"
+
+    def test_hermes_llm_base_url_trailing_slash_stripped(self, monkeypatch):
+        """Trailing slashes on HERMES_LLM_BASE_URL are stripped."""
+        class _Entry:
+            access_token = "pool-token"
+            source = "manual"
+            base_url = "https://pool.example.com/v1"
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def select(self):
+                return _Entry()
+
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+        monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+        monkeypatch.setenv("HERMES_LLM_BASE_URL", "http://127.0.0.1:9999/v1/")
+
+        resolved = rp.resolve_runtime_provider(requested="openai-codex")
+
+        assert resolved["base_url"] == "http://127.0.0.1:9999/v1"
+
+    def test_no_hermes_llm_base_url_uses_default(self, monkeypatch):
+        """Without HERMES_LLM_BASE_URL, normal resolution still works."""
+        class _Entry:
+            access_token = "pool-token"
+            source = "manual"
+            base_url = "https://pool.example.com/v1"
+
+        class _Pool:
+            def has_credentials(self):
+                return True
+
+            def select(self):
+                return _Entry()
+
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai-codex")
+        monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+        monkeypatch.delenv("HERMES_LLM_BASE_URL", raising=False)
+
+        resolved = rp.resolve_runtime_provider(requested="openai-codex")
+
+        assert resolved["base_url"] == "https://pool.example.com/v1"
+

--- a/tests/run_agent/test_text_tool_result_compaction.py
+++ b/tests/run_agent/test_text_tool_result_compaction.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from run_agent import AIAgent
+
+
+def _agent(model: str = "dflash", base_url: str = "http://10.10.20.211:8080/v1") -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.model = model
+    agent.provider = "custom"
+    agent.base_url = base_url
+    agent._base_url_lower = base_url.lower()
+    return agent
+
+
+def test_dflash_compacts_large_text_tool_results_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("HERMES_COMPACT_TEXT_TOOL_RESULTS", raising=False)
+    monkeypatch.delenv("HERMES_TEXT_TOOL_RESULT_COMPACT_THRESHOLD", raising=False)
+    monkeypatch.delenv("HERMES_TEXT_TOOL_RESULT_COMPACT_CHARS", raising=False)
+    agent = _agent()
+
+    result = "HEAD\n" + ("A" * 3_000) + "CENTER_MARKER" + ("B" * 3_000) + "\nTAIL\n"
+
+    compacted = agent._tool_result_content_for_active_model("terminal", result)
+
+    assert len(compacted) < len(result)
+    assert "HEAD" in compacted
+    assert "TAIL" in compacted
+    assert "CENTER_MARKER" not in compacted
+    assert "Tool output compacted for dflash" in compacted
+
+
+def test_non_dflash_keeps_large_text_tool_results_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("HERMES_COMPACT_TEXT_TOOL_RESULTS", raising=False)
+    agent = _agent(model="qwen3.6-27b-256k")
+    result = "x" * 20_000
+
+    assert agent._tool_result_content_for_active_model("terminal", result) == result
+
+
+def test_text_tool_result_compaction_can_be_forced(monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_COMPACT_TEXT_TOOL_RESULTS", "1")
+    monkeypatch.setenv("HERMES_TEXT_TOOL_RESULT_COMPACT_THRESHOLD", "1000")
+    monkeypatch.setenv("HERMES_TEXT_TOOL_RESULT_COMPACT_CHARS", "800")
+    agent = _agent(model="qwen3.6-27b-256k")
+    result = "A" * 2_000 + "B" * 2_000
+
+    compacted = agent._tool_result_content_for_active_model("skill_view", result)
+
+    assert len(compacted) < 1_100
+    assert compacted.startswith("A")
+    assert compacted.endswith("B")
+
+
+def test_text_tool_result_compaction_can_be_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("HERMES_COMPACT_TEXT_TOOL_RESULTS", "0")
+    agent = _agent()
+    result = "x" * 20_000
+
+    assert agent._tool_result_content_for_active_model("terminal", result) == result

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -268,6 +268,170 @@ def test_default_run_conversation_warns_without_guardrail_halt():
     assert any("repeated_exact_failure_warning" in content for content in tool_contents)
 
 
+def test_tool_reported_loop_block_run_conversation_halts_with_default_config():
+    agent = _make_agent("search_files", max_iterations=10)
+    args = {"pattern": "def.*drain", "path": "/repo", "target": "content"}
+    blocked_result = json.dumps(
+        {
+            "error": (
+                "BLOCKED: You have run this exact search 4 times in a row. "
+                "The results have NOT changed."
+            ),
+            "already_searched": 4,
+        }
+    )
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="",
+        finish_reason="tool_calls",
+        tool_calls=[_mock_tool_call("search_files", json.dumps(args), "c-search")],
+    )
+
+    with (
+        patch("run_agent.handle_function_call", return_value=blocked_result) as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("find the drain implementation")
+
+    mock_hfc.assert_called_once()
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert result["api_calls"] == 1
+    assert "stopped retrying search_files" in result["final_response"].lower()
+    assert result["guardrail"]["code"] == "tool_reported_loop_block"
+    tool_contents = [m["content"] for m in result["messages"] if m.get("role") == "tool"]
+    assert any("Tool loop hard stop" in content for content in tool_contents)
+
+
+def test_low_information_search_streak_redirects_same_tool_without_halting():
+    agent = _make_agent("search_files", "terminal", max_iterations=10)
+    search_patterns = ["def.*drain", "drain_command", "dispatch_command", "select.*task"]
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call(
+                    "search_files",
+                    json.dumps({"pattern": pattern, "path": "/repo", "target": "content"}),
+                    f"c-search-{i}",
+                )
+            ],
+        )
+        for i, pattern in enumerate(search_patterns, start=1)
+    ]
+    responses.extend(
+        [
+            _mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[
+                    _mock_tool_call(
+                        "search_files",
+                        json.dumps(
+                            {
+                                "pattern": "another search variant",
+                                "path": "/repo",
+                                "target": "content",
+                            }
+                        ),
+                        "c-redirected",
+                    )
+                ],
+            ),
+            _mock_response(
+                content="",
+                finish_reason="tool_calls",
+                tool_calls=[
+                    _mock_tool_call(
+                        "terminal",
+                        json.dumps({"command": "pwd && rg --files | head"}),
+                        "c-terminal",
+                    )
+                ],
+            ),
+            _mock_response(content="done", finish_reason="stop", tool_calls=None),
+        ]
+    )
+    agent.client.chat.completions.create.side_effect = responses
+    executed = []
+
+    def fake_handle(name, args, task_id, **kwargs):
+        executed.append((name, args, kwargs.get("tool_call_id")))
+        if name == "search_files":
+            return json.dumps({"total_count": 0})
+        return json.dumps({"exit_code": 0, "output": "/repo\nrun_agent.py"})
+
+    with (
+        patch("run_agent.handle_function_call", side_effect=fake_handle),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("find the dispatch implementation")
+
+    assert result["turn_exit_reason"].startswith("text_response")
+    assert result["final_response"] == "done"
+    assert "guardrail" not in result
+    assert [name for name, _args, _call_id in executed] == [
+        "search_files",
+        "search_files",
+        "search_files",
+        "search_files",
+        "terminal",
+    ]
+    assert all(call_id != "c-redirected" for _name, _args, call_id in executed)
+    tool_contents = [m["content"] for m in result["messages"] if m.get("role") == "tool"]
+    assert any("low_information_tool_redirect" in content for content in tool_contents)
+    assert any("low_information_strategy_warning" in content for content in tool_contents)
+
+
+def test_low_information_terminal_redirects_without_controlled_halt_by_default():
+    agent = _make_agent("terminal", max_iterations=10)
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[
+                _mock_tool_call(
+                    "terminal",
+                    json.dumps(
+                        {
+                            "command": (
+                                "cd ~/Workspaces/Projects/meshboard && "
+                                f"meshctl task list 2>&1 | grep 'open-{i}' | head -20"
+                            )
+                        }
+                    ),
+                    f"c-terminal-{i}",
+                )
+            ],
+        )
+        for i in range(1, 8)
+    ]
+    responses.append(_mock_response(content="done", finish_reason="stop", tool_calls=None))
+    agent.client.chat.completions.create.side_effect = responses
+
+    with (
+        patch(
+            "run_agent.handle_function_call",
+            return_value=json.dumps({"exit_code": 0, "stdout": "", "stderr": ""}),
+        ) as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("find a MeshBoard task")
+
+    assert mock_hfc.call_count == 4
+    assert result["turn_exit_reason"].startswith("text_response")
+    assert result["final_response"] == "done"
+    assert "guardrail" not in result
+    tool_contents = [m["content"] for m in result["messages"] if m.get("role") == "tool"]
+    assert any("low_information_tool_redirect" in content for content in tool_contents)
+    assert not any("low_information_tool_halt" in content for content in tool_contents)
+
+
 def test_config_enabled_hard_stop_run_conversation_returns_controlled_guardrail_halt_without_top_level_error():
     agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
     same_args = {"query": "same"}

--- a/tests/run_agent/test_vision_tool_messages.py
+++ b/tests/run_agent/test_vision_tool_messages.py
@@ -40,6 +40,7 @@ def _make_agent(provider="openrouter", model="gpt-4o"):
     agent._content_has_image_parts = _real_content_has_image_parts
     agent._model_supports_vision = lambda: AIAgent._model_supports_vision(agent)
     agent._provider_supports_vision_tool_messages = lambda: AIAgent._provider_supports_vision_tool_messages(agent)
+    agent._compact_text_tool_result_for_active_model = lambda _name, result: result
     agent._tool_result_content_for_active_model = (
         lambda name, result: AIAgent._tool_result_content_for_active_model(agent, name, result)
     )

--- a/tests/test_chat_final_response_resilience.py
+++ b/tests/test_chat_final_response_resilience.py
@@ -1,0 +1,41 @@
+"""Regression: AIAgent.chat() must not crash when run_conversation returns an
+error/failure result that omits the 'final_response' key.
+
+Several error/failure return paths in agent.conversation_loop.run_conversation
+(API error after max retries, billing/credits exhaustion, policy halt, etc.)
+return a result dict with keys like {messages, completed, api_calls, error,
+failed} but *no* 'final_response'. chat() previously did
+``return result["final_response"]`` and raised ``KeyError: 'final_response'``
+on those paths instead of surfacing the error.
+"""
+
+
+def _agent_with(result):
+    # Bypass the heavy __init__; chat() only depends on self.run_conversation.
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.run_conversation = lambda *a, **k: result
+    return agent
+
+
+def test_chat_surfaces_error_when_final_response_missing():
+    agent = _agent_with({
+        "messages": [],
+        "completed": False,
+        "api_calls": 1,
+        "error": "API call failed after 3 retries",
+        "failed": True,
+        # no "final_response" key — the regression case
+    })
+    assert agent.chat("hi") == "API call failed after 3 retries"
+
+
+def test_chat_returns_final_response_when_present():
+    agent = _agent_with({"final_response": "hello world", "error": None})
+    assert agent.chat("hi") == "hello world"
+
+
+def test_chat_empty_string_when_neither_final_response_nor_error():
+    agent = _agent_with({"completed": True, "messages": [], "api_calls": 0})
+    assert agent.chat("hi") == ""

--- a/tests/test_run_tests_parallel.py
+++ b/tests/test_run_tests_parallel.py
@@ -255,6 +255,33 @@ def test_exit4_no_retry_when_file_genuinely_missing(tmp_path, monkeypatch):
     assert calls["n"] == 1, f"missing file must NOT be retried, got {calls['n']} calls"
 
 
+def test_exit4_missing_discovered_file_can_be_skipped(tmp_path, monkeypatch):
+    """A discovered shard path that disappears before execution may be skipped."""
+    rtp = _load_runner_module()
+    missing = tmp_path / "test_disappeared.py"  # never created
+
+    calls = {"n": 0}
+
+    def fake_spawn(cmd, repo_root, file_timeout, *, timeout_note="per-file timeout"):
+        calls["n"] += 1
+        return 4, "ERROR: file or directory not found"
+
+    monkeypatch.setattr(rtp, "_spawn_pytest_once", fake_spawn)
+    monkeypatch.setattr(rtp, "_EXIT4_RETRY_BACKOFF_SECONDS", 0.0)
+
+    file, rc, output, summary, _wall = rtp._run_one_file(
+        missing,
+        [],
+        tmp_path,
+        30.0,
+        skip_missing=True,
+    )
+
+    assert rc == 0
+    assert calls["n"] == 1
+    assert "skipping stale discovered test path" in output
+
+
 def test_exit4_retry_gives_up_after_max_attempts(tmp_path, monkeypatch):
     """If the transient never clears, we stop after the bounded attempt count."""
     rtp = _load_runner_module()

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -6,6 +6,7 @@ handling without requiring a running terminal environment.
 
 import json
 import logging
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.file_tools import (
@@ -77,7 +78,9 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(
+            str(Path("/tmp/out.txt").resolve()), "hello world!\n"
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -155,7 +158,9 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            str(Path("/tmp/f.py").resolve()), "foo", "bar", False
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_replace_all_flag(self, mock_get):
@@ -168,7 +173,9 @@ class TestPatchHandler:
         from tools.file_tools import patch_tool
         patch_tool(mode="replace", path="/tmp/f.py",
                    old_string="x", new_string="y", replace_all=True)
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "x", "y", True)
+        mock_ops.patch_replace.assert_called_once_with(
+            str(Path("/tmp/f.py").resolve()), "x", "y", True
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_replace_mode_missing_path_errors(self, mock_get):
@@ -300,6 +307,25 @@ class TestSearchHandler:
         from tools.file_tools import search_tool
         result = json.loads(search_tool(pattern="x"))
         assert "error" in result
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_zero_result_search_includes_root_metadata_and_hint(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.to_dict.return_value = {"total_count": 0}
+        mock_ops.search.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import search_tool
+        result = json.loads(search_tool(pattern="missing_symbol", target="content", path="/src"))
+
+        assert result["total_count"] == 0
+        assert result["pattern"] == "missing_symbol"
+        assert result["target"] == "content"
+        assert result["path"] == "/src"
+        assert result["searched_path"] == "/src"
+        assert "absolute path" in result["_hint"]
+        assert "rg --files" in result["_hint"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1394,6 +1394,21 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 if hasattr(m, 'content') and m.content:
                     m.content = redact_sensitive_text(m.content, code_file=True)
         result_dict = result.to_dict()
+        if _is_empty_search_result(result_dict):
+            searched_path = str(_resolve_path_for_task(path, task_id))
+            result_dict.update({
+                "pattern": pattern,
+                "target": target,
+                "path": path,
+                "searched_path": searched_path,
+            })
+            result_dict["_hint"] = (
+                "No matches were found under searched_path. If this is surprising, "
+                "verify the search root before changing the regex again: pass an "
+                "absolute path, switch target between 'content' and 'files' as "
+                "appropriate, or use terminal (`pwd`, `rg --files`, `rg -n`) to "
+                "confirm the repository layout."
+            )
 
         if count >= 3:
             result_dict["_warning"] = (
@@ -1410,6 +1425,17 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         return result_json
     except Exception as e:
         return tool_error(str(e))
+
+
+def _is_empty_search_result(result_dict: dict) -> bool:
+    return (
+        isinstance(result_dict, dict)
+        and result_dict.get("total_count") == 0
+        and not result_dict.get("matches")
+        and not result_dict.get("files")
+        and not result_dict.get("counts")
+        and not result_dict.get("error")
+    )
 
 
 
@@ -1516,7 +1542,7 @@ SEARCH_FILES_SCHEMA = {
         "properties": {
             "pattern": {"type": "string", "description": "Regex pattern for content search, or glob pattern (e.g., '*.py') for file search"},
             "target": {"type": "string", "enum": ["content", "files"], "description": "'content' searches inside file contents, 'files' searches for files by name", "default": "content"},
-            "path": {"type": "string", "description": "Directory or file to search in (default: current working directory)", "default": "."},
+            "path": {"type": "string", "description": "Directory or file to search in (default: current working directory). Prefer an absolute path after a zero-result search so the search root is unambiguous.", "default": "."},
             "file_glob": {"type": "string", "description": "Filter files by pattern in grep mode (e.g., '*.py' to only search Python files)"},
             "limit": {"type": "integer", "description": "Maximum number of results to return (default: 50)", "default": 50},
             "offset": {"type": "integer", "description": "Skip first N results for pagination (default: 0)", "default": 0},


### PR DESCRIPTION
## What changed

- Enables the existing tool-use enforcement prompt for the `dflash` model alias.
- Adds bounded stall-retry telemetry with per-turn summaries and local NDJSON logging.
- Adds a retry-only continuation nudge so the fallback lane is told to emit the promised tool call instead of repeating the preamble.
- Keeps truly empty responses on the existing empty-response recovery path.
- Makes low-information terminal redirects recoverable by default, while preserving hard halt behavior when `hard_stop_enabled` is explicitly enabled.

## Why

The dflash retry path now recovers most no-tool-call stalls, but live agent sessions still showed avoidable turn churn. A recent trace also showed low-information terminal guardrails ending an interactive turn too aggressively. This patch reduces the initial stall frequency for the local alias, makes retry outcomes measurable, and lets guardrail redirects steer the model without prematurely finalizing the turn.

## How to Review

Review `agent/stall_retry.py` for telemetry and retry nudge behavior, `agent/conversation_loop.py` for result summaries, `agent/prompt_builder.py` for the `dflash` prompt-guidance match, and `agent/tool_guardrails.py` for the hard-stop gate on low-information redirects.

## Evidence

- `scripts/run_tests.sh tests/run_agent/test_run_agent.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/agent/test_stall_retry.py tests/agent/test_tool_guardrails.py tests/agent/test_prompt_builder.py -- -q` passed: 529 tests, 0 failed.
- `git diff --check` passed with rc=0.
- `python -m py_compile agent/stall_retry.py agent/conversation_loop.py agent/prompt_builder.py agent/tool_guardrails.py hermes_cli/config.py` passed with rc=0.

## Verification

```bash
scripts/run_tests.sh tests/run_agent/test_run_agent.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/agent/test_stall_retry.py tests/agent/test_tool_guardrails.py tests/agent/test_prompt_builder.py -- -q
git diff --check
python -m py_compile agent/stall_retry.py agent/conversation_loop.py agent/prompt_builder.py agent/tool_guardrails.py hermes_cli/config.py
```

## Risks / Gaps

- Telemetry writes bounded local JSONL and omits raw request messages; low risk, no follow-up needed.
- This is stacked on the open dflash retry PR series until those upstream reviews land; already tracked by the upstream PR chain.

## Collaborators

Participants: Omar, Codex.

Process: Derived from live Hermes/dflash MeshBoard traces and validated with focused regression coverage plus the broader main-loop test file.

Task context: MeshBoard task `hermes-dflash-stall-optimization-pass`.

Related work: Fork mirror PR https://github.com/OmarB97/hermes-agent/pull/37.
