### PR TITLE
fix(mcp): tolerate non-200 OAuth token success

### DIFF
--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -7,7 +7,9 @@ cache. See `tools/mcp_oauth_manager.py` for design rationale.
 import json
 import os
 import time
+from types import SimpleNamespace
 
+import httpx
 import pytest
 
 pytest.importorskip(
@@ -139,3 +141,39 @@ def test_manager_builds_hermes_provider_subclass(tmp_path, monkeypatch):
     assert isinstance(provider, _HERMES_PROVIDER_CLS)
     assert provider._hermes_server_name == "srv"
 
+
+@pytest.mark.asyncio
+async def test_hermes_provider_tolerates_created_token_response():
+    """Some providers return 201 Created for OAuth token exchange responses."""
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS
+
+    assert _HERMES_PROVIDER_CLS is not None
+
+    class _Storage:
+        def __init__(self):
+            self.tokens = None
+
+        async def set_tokens(self, tokens):
+            self.tokens = tokens
+
+    storage = _Storage()
+    provider = _HERMES_PROVIDER_CLS.__new__(_HERMES_PROVIDER_CLS)
+    provider.context = SimpleNamespace(
+        current_tokens=None,
+        storage=storage,
+        update_token_expiry=lambda tokens: None,
+    )
+    response = httpx.Response(
+        201,
+        json={
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "expires_in": 86400,
+            "token_type": "Bearer",
+        },
+    )
+
+    await provider._handle_token_response(response)
+
+    assert provider.context.current_tokens.access_token == "access-token"
+    assert storage.tokens is provider.context.current_tokens

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -89,6 +89,7 @@ def _make_hermes_provider_class() -> Optional[type]:
     """
     try:
         from mcp.client.auth.oauth2 import OAuthClientProvider
+        from mcp.client.auth.utils import handle_token_response_scopes
     except ImportError:  # pragma: no cover — SDK required in CI
         return None
 
@@ -110,6 +111,24 @@ def _make_hermes_provider_class() -> Optional[type]:
         def __init__(self, *args: Any, server_name: str = "", **kwargs: Any):
             super().__init__(*args, **kwargs)
             self._hermes_server_name = server_name
+
+        async def _handle_token_response(self, response):  # type: ignore[override]
+            """Tolerate successful non-200 OAuth token responses.
+
+            OAuth token responses are specified as ``200 OK``, but some
+            providers return another successful 2xx status with a valid token
+            payload. Preserve the SDK's handling for the standard path and for
+            non-2xx errors, but parse and persist successful non-200 responses
+            to avoid repeated browser auth loops.
+            """
+            if response.status_code == 200 or not 200 <= response.status_code < 300:
+                await super()._handle_token_response(response)
+                return
+
+            token_response = await handle_token_response_scopes(response)
+            self.context.current_tokens = token_response
+            self.context.update_token_expiry(token_response)
+            await self.context.storage.set_tokens(token_response)
 
         async def _initialize(self) -> None:
             """Load stored tokens + client info AND seed token_expiry_time.


### PR DESCRIPTION
## What does this PR do?

Hermes' MCP OAuth provider wrapper now tolerates successful non-200 token endpoint responses.

OAuth token responses are specified as `200 OK`, but some providers return another successful 2xx status with a valid token payload. Hermes previously delegated all non-200 responses to the MCP SDK error path, which could force repeated browser authorization loops even after the token exchange succeeded.

This keeps the standard path narrow: `200 OK` and non-2xx errors still use the SDK's existing handling, while successful non-200 responses are parsed and persisted through the same token-response helper.

## Related Issue

Related: #29680 and #34274.

#34274 is broader and also handles Supabase client-secret normalization and refresh responses. This PR is intentionally narrower: it only addresses successful non-200 OAuth token exchange responses in `HermesMCPOAuthProvider`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_oauth_manager.py`
  - Import the MCP SDK token-response parsing helper.
  - Override the Hermes OAuth provider's token-response handler for successful non-200 responses.
  - Preserve the SDK path for `200 OK` responses and non-2xx errors.
- `tests/tools/test_mcp_oauth_manager.py`
  - Add regression coverage for a provider returning `201 Created` with a valid token payload.

## How to Test

1. Run `pytest tests/tools/test_mcp_oauth_manager.py -q`.
2. Configure an OAuth MCP provider that returns a successful non-200 token endpoint response.
3. Run `hermes mcp login <server>` and verify the token is persisted instead of re-entering the browser auth loop.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5, Python 3.11.15; targeted test passed

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A: pure Python OAuth response handling, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: N/A

## Screenshots / Logs

N/A. Local validation:

```text
pytest tests/tools/test_mcp_oauth_manager.py -q
8 passed
```
