### PR TITLE
fix(qqbot): stop routing file uploads through STT pipeline

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1792,25 +1792,17 @@ class QQAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _is_voice_content_type(content_type: str, filename: str) -> bool:
-        """Check if an attachment is a voice/audio message."""
+        """Check if an attachment is a voice/audio message.
+
+        Only trust ``content_type`` — the QQ Bot API explicitly distinguishes
+        voice messages (``content_type="voice"``) from file uploads
+        (``content_type="file"``).  Filename-extension sniffing is intentionally
+        omitted: files sent via QQ's file-transfer feature can have audio
+        extensions (e.g. ``.wav``, ``.mp3``) but must **not** be routed through
+        the STT pipeline.
+        """
         ct = content_type.strip().lower()
-        fn = filename.strip().lower()
-        if ct == "voice" or ct.startswith("audio/"):
-            return True
-        _VOICE_EXTENSIONS = (
-            ".silk",
-            ".amr",
-            ".mp3",
-            ".wav",
-            ".ogg",
-            ".m4a",
-            ".aac",
-            ".speex",
-            ".flac",
-        )
-        if any(fn.endswith(ext) for ext in _VOICE_EXTENSIONS):
-            return True
-        return False
+        return ct == "voice" or ct.startswith("audio/")
 
     def _qq_media_headers(self) -> Dict[str, str]:
         """Return Authorization headers for QQ multimedia CDN downloads.

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -151,15 +151,6 @@ def _coerce_list(value: Any) -> List[str]:
 # ---------------------------------------------------------------------------
 
 
-def _looks_like_voice(filename: str) -> bool:
-    """Return True if *filename* has a known voice/audio extension."""
-    fn = filename.strip().lower()
-    return any(
-        fn.endswith(ext)
-        for ext in (".silk", ".amr", ".mp3", ".wav", ".ogg", ".m4a", ".aac", ".speex", ".flac")
-    )
-
-
 class QQAdapter(BasePlatformAdapter):
     """QQ Bot adapter backed by the official QQ Bot WebSocket Gateway + REST API."""
 
@@ -1801,27 +1792,22 @@ class QQAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _is_voice_content_type(content_type: str, filename: str) -> bool:
-        """Check if an attachment is a voice/audio message.
-
-        The QQ Bot API explicitly sets ``content_type="voice"`` for voice
-        messages and ``content_type="file"`` for file uploads.  When
-        ``content_type`` is a known non-voice type (``"file"``, ``"image/*"``,
-        ``"video/*"``), we trust it unconditionally and **skip** extension
-        sniffing — files sent via QQ's file-transfer feature can have audio
-        extensions (e.g. ``.wav``, ``.mp3``) but must not be routed through
-        the STT pipeline.
-
-        When ``content_type`` is empty or unrecognised we fall back to
-        filename-extension matching as a defensive measure.
-        """
+        """Check if an attachment is a voice/audio message."""
         ct = content_type.strip().lower()
+        fn = filename.strip().lower()
         if ct == "voice" or ct.startswith("audio/"):
             return True
-        # Explicit non-voice types — never treat as voice regardless of extension.
-        if ct in ("file", "") or ct.startswith("image/") or ct.startswith("video/"):
-            return ct == "" and _looks_like_voice(filename)
-        # Unknown content_type — defensive extension fallback.
-        return _looks_like_voice(filename)
+        # QQ file uploads have content_type="file" — never treat as voice,
+        # even if the filename has an audio extension.
+        if ct == "file":
+            return False
+        _VOICE_EXTENSIONS = (
+            ".silk", ".amr", ".mp3", ".wav", ".ogg",
+            ".m4a", ".aac", ".speex", ".flac",
+        )
+        if any(fn.endswith(ext) for ext in _VOICE_EXTENSIONS):
+            return True
+        return False
 
     def _qq_media_headers(self) -> Dict[str, str]:
         """Return Authorization headers for QQ multimedia CDN downloads.

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -151,6 +151,15 @@ def _coerce_list(value: Any) -> List[str]:
 # ---------------------------------------------------------------------------
 
 
+def _looks_like_voice(filename: str) -> bool:
+    """Return True if *filename* has a known voice/audio extension."""
+    fn = filename.strip().lower()
+    return any(
+        fn.endswith(ext)
+        for ext in (".silk", ".amr", ".mp3", ".wav", ".ogg", ".m4a", ".aac", ".speex", ".flac")
+    )
+
+
 class QQAdapter(BasePlatformAdapter):
     """QQ Bot adapter backed by the official QQ Bot WebSocket Gateway + REST API."""
 
@@ -1794,15 +1803,25 @@ class QQAdapter(BasePlatformAdapter):
     def _is_voice_content_type(content_type: str, filename: str) -> bool:
         """Check if an attachment is a voice/audio message.
 
-        Only trust ``content_type`` — the QQ Bot API explicitly distinguishes
-        voice messages (``content_type="voice"``) from file uploads
-        (``content_type="file"``).  Filename-extension sniffing is intentionally
-        omitted: files sent via QQ's file-transfer feature can have audio
-        extensions (e.g. ``.wav``, ``.mp3``) but must **not** be routed through
+        The QQ Bot API explicitly sets ``content_type="voice"`` for voice
+        messages and ``content_type="file"`` for file uploads.  When
+        ``content_type`` is a known non-voice type (``"file"``, ``"image/*"``,
+        ``"video/*"``), we trust it unconditionally and **skip** extension
+        sniffing — files sent via QQ's file-transfer feature can have audio
+        extensions (e.g. ``.wav``, ``.mp3``) but must not be routed through
         the STT pipeline.
+
+        When ``content_type`` is empty or unrecognised we fall back to
+        filename-extension matching as a defensive measure.
         """
         ct = content_type.strip().lower()
-        return ct == "voice" or ct.startswith("audio/")
+        if ct == "voice" or ct.startswith("audio/"):
+            return True
+        # Explicit non-voice types — never treat as voice regardless of extension.
+        if ct in ("file", "") or ct.startswith("image/") or ct.startswith("video/"):
+            return ct == "" and _looks_like_voice(filename)
+        # Unknown content_type — defensive extension fallback.
+        return _looks_like_voice(filename)
 
     def _qq_media_headers(self) -> Dict[str, str]:
         """Return Authorization headers for QQ multimedia CDN downloads.

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1797,8 +1797,9 @@ class QQAdapter(BasePlatformAdapter):
         fn = filename.strip().lower()
         if ct == "voice" or ct.startswith("audio/"):
             return True
-        # QQ file uploads have content_type="file" — never treat as voice,
-        # even if the filename has an audio extension.
+        # QQ file uploads have content_type="file".  Without this guard,
+        # any uploaded audio file (e.g. .wav, .mp3) would be misrouted into
+        # the STT pipeline and never be received as a normal file attachment.
         if ct == "file":
             return False
         _VOICE_EXTENSIONS = (

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -151,19 +151,11 @@ class TestIsVoiceContentType:
         assert self._fn("", "recording.amr") is True
 
     def test_file_upload_with_audio_extension(self):
-        """File upload with audio extension must NOT be treated as voice."""
+        """content_type='file' is never voice, even with audio extension."""
         assert self._fn("file", "song.mp3") is False
         assert self._fn("file", "audio-30251.instrumental..wav") is False
-
-    def test_file_upload_never_voice(self):
-        """content_type='file' is never voice, regardless of extension."""
         assert self._fn("file", "recording.silk") is False
         assert self._fn("file", "voice.amr") is False
-
-    def test_unknown_content_type_extension_fallback(self):
-        """Unknown content_type falls back to extension matching."""
-        assert self._fn("unknown/type", "voice.ogg") is True
-        assert self._fn("unknown/type", "data.json") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -139,14 +139,21 @@ class TestIsVoiceContentType:
     def test_audio_content_type(self):
         assert self._fn("audio/mp3", "file.mp3") is True
 
-    def test_voice_extension(self):
-        assert self._fn("", "file.silk") is True
+    def test_voice_extension_ignored_when_content_type_empty(self):
+        """content_type='' with audio extension → False (no extension sniffing)."""
+        assert self._fn("", "file.silk") is False
 
     def test_non_voice(self):
         assert self._fn("image/jpeg", "photo.jpg") is False
 
-    def test_audio_extension_amr(self):
-        assert self._fn("", "recording.amr") is True
+    def test_audio_extension_amr_ignored_when_content_type_empty(self):
+        """content_type='' with .amr extension → False (no extension sniffing)."""
+        assert self._fn("", "recording.amr") is False
+
+    def test_file_upload_with_audio_extension(self):
+        """File upload with audio extension must NOT be treated as voice."""
+        assert self._fn("file", "song.mp3") is False
+        assert self._fn("file", "audio-30251.instrumental..wav") is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -139,21 +139,31 @@ class TestIsVoiceContentType:
     def test_audio_content_type(self):
         assert self._fn("audio/mp3", "file.mp3") is True
 
-    def test_voice_extension_ignored_when_content_type_empty(self):
-        """content_type='' with audio extension → False (no extension sniffing)."""
-        assert self._fn("", "file.silk") is False
+    def test_voice_extension_fallback_when_content_type_empty(self):
+        """content_type='' with audio extension → True (extension fallback)."""
+        assert self._fn("", "file.silk") is True
 
     def test_non_voice(self):
         assert self._fn("image/jpeg", "photo.jpg") is False
 
-    def test_audio_extension_amr_ignored_when_content_type_empty(self):
-        """content_type='' with .amr extension → False (no extension sniffing)."""
-        assert self._fn("", "recording.amr") is False
+    def test_audio_extension_amr_fallback_when_content_type_empty(self):
+        """content_type='' with .amr extension → True (extension fallback)."""
+        assert self._fn("", "recording.amr") is True
 
     def test_file_upload_with_audio_extension(self):
         """File upload with audio extension must NOT be treated as voice."""
         assert self._fn("file", "song.mp3") is False
         assert self._fn("file", "audio-30251.instrumental..wav") is False
+
+    def test_file_upload_never_voice(self):
+        """content_type='file' is never voice, regardless of extension."""
+        assert self._fn("file", "recording.silk") is False
+        assert self._fn("file", "voice.amr") is False
+
+    def test_unknown_content_type_extension_fallback(self):
+        """Unknown content_type falls back to extension matching."""
+        assert self._fn("unknown/type", "voice.ogg") is True
+        assert self._fn("unknown/type", "data.json") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #35704

Add a guard clause in `_is_voice_content_type()` to prevent audio file uploads from being misrouted through the STT pipeline.

## Problem

When a user sends an audio file (`.wav`, `.mp3`, `.ogg`, etc.) via QQ's file transfer feature, the `content_type` is `"file"` — but the extension-based heuristic in `_is_voice_content_type()` still matches, causing the file to be consumed by the STT pipeline instead of being saved as a regular attachment.

## Fix

- Added an early return `if ct == "file": return False` before the extension check
- This ensures file uploads (`content_type="file"`) are never matched by the extension heuristic, even if the filename has an audio extension
- Voice messages (`content_type="voice"`) and raw audio types (`audio/*`) continue to work as before

## Before/After

**Before:** File `audio-30251.instrumental..wav` with `content_type="file"` → matched by `.wav` extension → routed to STT → `[Voice] [语音识别失败]` → file lost

**After:** File `audio-30251.instrumental..wav` with `content_type="file"` → early return `False` → saved as regular file attachment ✓

## Testing

Verified with actual QQ Bot message logs:
- Voice message: `content_type=voice, filename=xxx.amr` → still correctly routed to STT ✓
- File upload: `content_type=file, filename=audio-30251.instrumental..wav` → now saved as file ✓