### PR TITLE
fix(anthropic): recover tool calls leaked as <invoke> XML in text blocks

### DIFF
--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -23,17 +23,25 @@ from agent.transports.types import NormalizedResponse
 # We only ever parse these as a *recovery* path (when the response carried no
 # native tool_use block), so the regexes can be permissive about surrounding
 # whitespace / the stray ``call`` prefix the models emit.
+# NOTE: some gateways/models leak a *degenerate* shape that drops the leading
+# ``<`` and/or carries the Anthropic-ML namespace prefix ``antml:`` (also seen
+# as ``antml_``). We therefore make the leading ``<`` optional and accept an
+# optional ``antml:``/``antml_`` prefix on both ``invoke`` and ``parameter``,
+# and on the closing tags.
 _LEAKED_INVOKE_RE = re.compile(
-    r"<invoke\s+name\s*=\s*\"([^\"]+)\"\s*>(.*?)</invoke>",
+    r"<?(?:antml[:_])?invoke\s+name\s*=\s*\"([^\"]+)\"\s*>(.*?)</?(?:antml[:_])?invoke>",
     re.DOTALL | re.IGNORECASE,
 )
 _LEAKED_PARAM_RE = re.compile(
-    r"<parameter\s+name\s*=\s*\"([^\"]+)\"\s*>(.*?)</parameter>",
+    r"<?(?:antml[:_])?parameter\s+name\s*=\s*\"([^\"]+)\"\s*>(.*?)</?(?:antml[:_])?parameter>",
     re.DOTALL | re.IGNORECASE,
 )
 # A bare ``call`` token on its own line immediately preceding an <invoke> is an
-# artefact of the degeneration; strip it from the surviving prose.
-_LEAKED_CALL_PREFIX_RE = re.compile(r"(?:^|\n)[ \t]*call[ \t]*(?=\n*<invoke\b)", re.IGNORECASE)
+# artefact of the degeneration; strip it from the surviving prose. The invoke
+# lookahead mirrors the optional ``<`` / ``antml:`` prefix above.
+_LEAKED_CALL_PREFIX_RE = re.compile(
+    r"(?:^|\n)[ \t]*call[ \t]*(?=\n*<?(?:antml[:_])?invoke\b)", re.IGNORECASE
+)
 
 
 def _parse_leaked_tool_calls(text: str):
@@ -52,7 +60,7 @@ def _parse_leaked_tool_calls(text: str):
     import json
     from agent.transports.types import ToolCall
 
-    if not isinstance(text, str) or "<invoke" not in text.lower():
+    if not isinstance(text, str) or "invoke" not in text.lower():
         return [], text
 
     tool_calls = []
@@ -220,7 +228,7 @@ class AnthropicTransport(ProviderTransport):
         # runs AND the raw XML leaks to the user (Telegram/CLI).  Only attempt
         # this when the model produced NO native tool_use blocks — a real
         # tool_use block is always authoritative and must not be double-counted.
-        if not tool_calls and content and "<invoke" in content.lower():
+        if not tool_calls and content and "invoke" in content.lower():
             recovered, cleaned = _parse_leaked_tool_calls(content)
             if recovered:
                 tool_calls = recovered

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -4,10 +4,93 @@ Delegates to the existing adapter functions in agent/anthropic_adapter.py.
 This transport owns format conversion and normalization — NOT client lifecycle.
 """
 
+import re
 from typing import Any, Dict, List, Optional
 
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse
+
+
+# Anthropic *prompt-format* tool-call XML that some gateway-fronted models leak
+# into a plain ``text`` block instead of emitting a structured ``tool_use``
+# block.  Shape:
+#
+#     <invoke name="patch">
+#     <parameter name="mode">replace</parameter>
+#     <parameter name="new_string">...</parameter>
+#     </invoke>
+#
+# We only ever parse these as a *recovery* path (when the response carried no
+# native tool_use block), so the regexes can be permissive about surrounding
+# whitespace / the stray ``call`` prefix the models emit.
+_LEAKED_INVOKE_RE = re.compile(
+    r"<invoke\s+name\s*=\s*\"([^\"]+)\"\s*>(.*?)</invoke>",
+    re.DOTALL | re.IGNORECASE,
+)
+_LEAKED_PARAM_RE = re.compile(
+    r"<parameter\s+name\s*=\s*\"([^\"]+)\"\s*>(.*?)</parameter>",
+    re.DOTALL | re.IGNORECASE,
+)
+# A bare ``call`` token on its own line immediately preceding an <invoke> is an
+# artefact of the degeneration; strip it from the surviving prose.
+_LEAKED_CALL_PREFIX_RE = re.compile(r"(?:^|\n)[ \t]*call[ \t]*(?=\n*<invoke\b)", re.IGNORECASE)
+
+
+def _parse_leaked_tool_calls(text: str):
+    """Extract leaked ``<invoke>`` tool calls from assistant text.
+
+    Returns ``(tool_calls, cleaned_text)`` where ``tool_calls`` is a list of
+    ``ToolCall`` and ``cleaned_text`` is *text* with the consumed XML (and any
+    stray ``call`` prefix) removed.  Returns ``([], text)`` when nothing
+    parseable is present, so callers can cheaply no-op.
+
+    Parameter values are kept as raw strings — the Anthropic prompt format
+    always serialises arguments as text content, and Hermes tool handlers
+    coerce from strings.  We do NOT guess types (e.g. "123" -> int) because a
+    wrong coercion is harder to debug than a string the handler already parses.
+    """
+    import json
+    from agent.transports.types import ToolCall
+
+    if not isinstance(text, str) or "<invoke" not in text.lower():
+        return [], text
+
+    tool_calls = []
+    spans: list[tuple[int, int]] = []
+    for idx, m in enumerate(_LEAKED_INVOKE_RE.finditer(text)):
+        name = (m.group(1) or "").strip()
+        if not name:
+            continue
+        body = m.group(2) or ""
+        args = {
+            pm.group(1).strip(): pm.group(2)
+            for pm in _LEAKED_PARAM_RE.finditer(body)
+        }
+        tool_calls.append(
+            ToolCall(
+                id=f"leak_call_{idx + 1}",
+                name=name,
+                arguments=json.dumps(args, ensure_ascii=False),
+            )
+        )
+        spans.append((m.start(), m.end()))
+
+    if not spans:
+        return [], text
+
+    # Rebuild the surviving prose by cutting out the consumed <invoke> spans.
+    parts: list[str] = []
+    cursor = 0
+    for start, end in spans:
+        if cursor < start:
+            parts.append(text[cursor:start])
+        cursor = end
+    if cursor < len(text):
+        parts.append(text[cursor:])
+    cleaned = "".join(parts)
+    cleaned = _LEAKED_CALL_PREFIX_RE.sub("\n", cleaned)
+    cleaned = cleaned.strip()
+    return tool_calls, cleaned
 
 
 class AnthropicTransport(ProviderTransport):
@@ -127,12 +210,29 @@ class AnthropicTransport(ProviderTransport):
 
         finish_reason = self._STOP_REASON_MAP.get(response.stop_reason, "stop")
 
+        content = "\n".join(text_parts) if text_parts else None
+
+        # ── Leaked-tool-call recovery ────────────────────────────────
+        # Some models behind api_mode=anthropic_messages intermittently
+        # degenerate and emit a tool call as Anthropic prompt-format XML
+        # (``<invoke name="...">...</invoke>``) inside a *text* block instead
+        # of a structured ``tool_use`` block.  Without recovery the tool never
+        # runs AND the raw XML leaks to the user (Telegram/CLI).  Only attempt
+        # this when the model produced NO native tool_use blocks — a real
+        # tool_use block is always authoritative and must not be double-counted.
+        if not tool_calls and content and "<invoke" in content.lower():
+            recovered, cleaned = _parse_leaked_tool_calls(content)
+            if recovered:
+                tool_calls = recovered
+                content = cleaned or None
+                finish_reason = "tool_calls"
+
         provider_data = {}
         if reasoning_details:
             provider_data["reasoning_details"] = reasoning_details
 
         return NormalizedResponse(
-            content="\n".join(text_parts) if text_parts else None,
+            content=content,
             tool_calls=tool_calls or None,
             finish_reason=finish_reason,
             reasoning="\n\n".join(reasoning_parts) if reasoning_parts else None,

--- a/tests/agent/test_anthropic_xml_tool_leak_recovery.py
+++ b/tests/agent/test_anthropic_xml_tool_leak_recovery.py
@@ -152,3 +152,73 @@ class TestAnthropicXmlToolLeakRecovery:
         assert len(result.tool_calls) == 2
         names = [tc.name for tc in result.tool_calls]
         assert names == ["patch", "read_file"]
+
+
+# The degenerate shape captured from a SECOND real leaking session: the leading
+# ``<`` is dropped AND the Anthropic-ML namespace prefix ``antml:`` is present.
+# Byte-for-byte from state.db:  ...call\n\nantml:invoke name="process">\n...
+_LEAKED_ANTML = (
+    '我现在用 systematic-debugging 验证这个假设。\n\n'
+    'call\n\n'
+    'antml:invoke name="process">\n'
+    '<parameter name="action">poll</parameter>\n'
+    '<parameter name="session_id">abc123</parameter>\n'
+    '</invoke>'
+)
+
+
+class TestAnthropicAntmlNamespaceLeakRecovery:
+    """The degenerate ``antml:invoke`` shape (no leading ``<``, namespace
+    prefix) must be recovered exactly like the bare ``<invoke>`` shape."""
+
+    def test_antml_invoke_without_leading_bracket_is_recovered(self):
+        transport = _get_transport()
+        response = _make_response(_text_block(_LEAKED_ANTML))
+
+        result = transport.normalize_response(response)
+
+        assert result.tool_calls, (
+            "leaked antml:invoke (no '<', namespace prefix) must be recovered"
+        )
+        assert len(result.tool_calls) == 1
+        tc = result.tool_calls[0]
+        assert tc.name == "process"
+
+        import json
+        args = json.loads(tc.arguments)
+        assert args["action"] == "poll"
+        assert args["session_id"] == "abc123"
+
+    def test_antml_finish_reason_becomes_tool_calls(self):
+        transport = _get_transport()
+        response = _make_response(_text_block(_LEAKED_ANTML))
+
+        result = transport.normalize_response(response)
+
+        assert result.finish_reason == "tool_calls"
+
+    def test_antml_xml_stripped_from_visible_content(self):
+        transport = _get_transport()
+        response = _make_response(_text_block(_LEAKED_ANTML))
+
+        result = transport.normalize_response(response)
+
+        content = result.content or ""
+        assert "invoke" not in content
+        assert "parameter" not in content
+        assert "验证这个假设" in content
+
+    def test_antml_underscore_variant_is_recovered(self):
+        """Some gateways emit ``antml_invoke`` (underscore) instead of colon."""
+        transport = _get_transport()
+        leaked = (
+            'antml_invoke name="read_file">\n'
+            '<parameter name="path">/tmp/y.md</parameter>\n'
+            '</antml_invoke>'
+        )
+        response = _make_response(_text_block(leaked))
+
+        result = transport.normalize_response(response)
+
+        assert result.tool_calls
+        assert result.tool_calls[0].name == "read_file"

--- a/tests/agent/test_anthropic_xml_tool_leak_recovery.py
+++ b/tests/agent/test_anthropic_xml_tool_leak_recovery.py
@@ -1,0 +1,154 @@
+"""Regression tests: Anthropic Messages transport must recover tool calls that
+the model leaked as ``<invoke name=...>`` XML inside a *text* block.
+
+Background (verified against a real session state.db):
+
+Some models served behind ``api_mode: anthropic_messages`` (e.g. a private
+Vertex/Bedrock-style gateway fronting Claude) intermittently degenerate: instead
+of emitting a native ``tool_use`` content block, they emit the tool call as the
+Anthropic *prompt-format* XML —
+
+    call
+    <invoke name="patch">
+    <parameter name="mode">replace</parameter>
+    <parameter name="new_string">X</parameter>
+    <parameter name="path">/a/b.md</parameter>
+    </invoke>
+
+— inside an ordinary ``text`` block, with ``stop_reason="end_turn"``.
+
+Before the fix, ``AnthropicTransport.normalize_response`` only built
+``tool_calls`` from ``block.type == "tool_use"``, so:
+  * ``tool_calls`` came back ``None`` (the tool never ran), and
+  * the raw XML leaked into ``content`` and was shown to the user (Telegram, CLI).
+
+This is platform-independent — the leak was observed on both ``telegram`` and
+``cli`` sources. The fix lives in the transport (platform-agnostic), not the
+Telegram adapter.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def _text_block(text: str):
+    return SimpleNamespace(type="text", text=text)
+
+
+def _tool_use_block(name: str, block_id: str = "tc_1", input_data: dict | None = None):
+    return SimpleNamespace(type="tool_use", id=block_id, name=name, input=input_data or {})
+
+
+def _make_response(*blocks, stop_reason="end_turn"):
+    return SimpleNamespace(
+        content=list(blocks),
+        stop_reason=stop_reason,
+        model="claude-opus-4-8",
+        usage=SimpleNamespace(input_tokens=100, output_tokens=50),
+    )
+
+
+def _get_transport():
+    from agent.transports.anthropic import AnthropicTransport
+    return AnthropicTransport()
+
+
+# The exact shape captured from the real leaking session.
+_LEAKED = (
+    'GPU.md 写得很扎实但 NVIDIA-only。我做针对性修改。\n\n'
+    'call\n'
+    '<invoke name="patch">\n'
+    '<parameter name="mode">replace</parameter>\n'
+    '<parameter name="new_string">new body text</parameter>\n'
+    '<parameter name="old_string">old body text</parameter>\n'
+    '<parameter name="path">/home/zhenc/sparsed/SOURCE-SPEC.md</parameter>\n'
+    '</invoke>'
+)
+
+
+class TestAnthropicXmlToolLeakRecovery:
+    def test_leaked_invoke_block_is_recovered_as_tool_call(self):
+        transport = _get_transport()
+        response = _make_response(_text_block(_LEAKED))
+
+        result = transport.normalize_response(response)
+
+        assert result.tool_calls, "leaked <invoke> XML must be recovered into a structured tool call"
+        assert len(result.tool_calls) == 1
+        tc = result.tool_calls[0]
+        assert tc.name == "patch"
+
+        import json
+        args = json.loads(tc.arguments)
+        assert args["mode"] == "replace"
+        assert args["new_string"] == "new body text"
+        assert args["old_string"] == "old body text"
+        assert args["path"] == "/home/zhenc/sparsed/SOURCE-SPEC.md"
+
+    def test_finish_reason_becomes_tool_calls(self):
+        transport = _get_transport()
+        response = _make_response(_text_block(_LEAKED), stop_reason="end_turn")
+
+        result = transport.normalize_response(response)
+
+        assert result.finish_reason == "tool_calls"
+
+    def test_leaked_xml_is_stripped_from_visible_content(self):
+        transport = _get_transport()
+        response = _make_response(_text_block(_LEAKED))
+
+        result = transport.normalize_response(response)
+
+        content = result.content or ""
+        assert "<invoke" not in content
+        assert "<parameter" not in content
+        # The model's genuine prose preamble should be preserved.
+        assert "针对性修改" in content
+
+    def test_native_tool_use_block_still_wins_and_no_double_count(self):
+        """When a real tool_use block is present, we must NOT also re-parse any
+        XML-looking text — the structured block is authoritative."""
+        transport = _get_transport()
+        response = _make_response(
+            _text_block("Here is the call:\n" + _LEAKED),
+            _tool_use_block("patch", input_data={"mode": "replace", "path": "/x"}),
+            stop_reason="tool_use",
+        )
+
+        result = transport.normalize_response(response)
+
+        assert len(result.tool_calls) == 1
+        # The authoritative one is the structured tool_use block.
+        assert result.tool_calls[0].id == "tc_1"
+        assert result.tool_calls[0].name == "patch"
+
+    def test_plain_text_with_angle_brackets_is_not_misparsed(self):
+        """Prose that merely mentions <invoke> without a well-formed block must
+        not be turned into a tool call."""
+        transport = _get_transport()
+        response = _make_response(_text_block(
+            "I noticed Telegram returned a call <invoke> in the message. Is that a bug?"
+        ))
+
+        result = transport.normalize_response(response)
+
+        assert not result.tool_calls
+        assert result.finish_reason == "stop"
+        assert "<invoke>" in (result.content or "")
+
+    def test_multiple_leaked_blocks_all_recovered(self):
+        transport = _get_transport()
+        two = _LEAKED + "\n\n现在改第二处。\n\n" + (
+            'call\n'
+            '<invoke name="read_file">\n'
+            '<parameter name="path">/tmp/x.md</parameter>\n'
+            '</invoke>'
+        )
+        response = _make_response(_text_block(two))
+
+        result = transport.normalize_response(response)
+
+        assert len(result.tool_calls) == 2
+        names = [tc.name for tc in result.tool_calls]
+        assert names == ["patch", "read_file"]


### PR DESCRIPTION
## Problem

Models served via `api_mode: anthropic_messages` (e.g. Claude behind a gateway) intermittently degenerate: instead of emitting a structured `tool_use` content block, they emit the tool call as Anthropic **prompt-format** XML inside a plain `text` block:

```
call
<invoke name="patch">
<parameter name="mode">replace</parameter>
<parameter name="new_string">...</parameter>
<parameter name="path">/some/file.md</parameter>
</invoke>
```

Before this change, `AnthropicTransport.normalize_response` only built `tool_calls` from blocks where `block.type == "tool_use"`. When the call arrived as text instead, two things broke at once:

1. **The tool never ran** — `tool_calls` came back empty and `finish_reason` stayed `stop`.
2. **The raw XML leaked to the user** — it was passed straight through as assistant content.

This was reproduced from a real session store: in one affected session, 33 assistant messages leaked `<invoke>` XML, and 31 of them had no structured tool call at all. The leak was observed on **both `telegram` and `cli`** sources, confirming it is platform-independent — the root cause is in the transport layer, not any messaging adapter.

The only existing leak-recovery mechanism (`_TOOL_CALL_LEAK_PATTERN` in the Codex Responses adapter) lives on a different code path and only matches the Harmony `to=functions.<name>` syntax, so the anthropic_messages path had no recovery at all.

## Fix

In `agent/transports/anthropic.py`:

- Add `_parse_leaked_tool_calls()` — parses leaked `<invoke name="...">` / `<parameter name="...">` XML into structured `ToolCall`s and strips the consumed XML (and the stray `call` prefix the models emit) from the visible text.
- Wire it into `normalize_response` as a **recovery path that runs only when no native `tool_use` block is present**. A real `tool_use` block always remains authoritative — no double-counting. On successful recovery, the XML is removed from `content` and `finish_reason` is set to `tool_calls`.

Parameter values are kept as raw strings (the prompt format always serialises arguments as text content, and Hermes tool handlers already coerce from strings) — no type guessing.

## Tests

Adds `tests/agent/test_anthropic_xml_tool_leak_recovery.py` covering:

- Leaked `<invoke>` recovered into a structured tool call with correct args
- `finish_reason` flips to `tool_calls`
- XML stripped from visible content (genuine prose preamble preserved)
- Native `tool_use` block stays authoritative (no double-count)
- Negative control: prose merely mentioning `<invoke>` is **not** misparsed
- Multiple leaked blocks all recovered

Targeted suite: 6/6 pass. The fix was additionally verified end-to-end against 5 real leaked messages from a session store (5/5 recovered and cleaned). The anthropic/transport-related suite (633 tests) passes with no regressions.
