### PR TITLE
fix(discord): wrap markdown tables in code fences for readable rendering

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -170,6 +170,75 @@ def _build_allowed_mentions():
     )
 
 
+# --- Markdown table detection for Discord code-fence wrapping ---
+
+_TABLE_SEPARATOR_RE = re.compile(
+    r'^\s*\|?\s*:?-+:?\s*(?:\|\s*:?-+:?\s*){1,}\|?\s*$'
+)
+
+
+def _is_table_row(line: str) -> bool:
+    """Return True if *line* could plausibly be a table data row."""
+    stripped = line.strip()
+    return bool(stripped) and '|' in stripped
+
+
+def _wrap_tables_in_code_fence(text: str) -> str:
+    """Wrap GFM-style pipe tables in fenced code blocks for Discord.
+
+    Discord does not render markdown tables natively — raw pipe characters
+    display as garbage.  Wrapping the table in triple-backtick fences
+    produces a readable monospaced rendering.
+
+    Tables that are already inside fenced code blocks are left alone.
+    """
+    if '|' not in text or '-' not in text:
+        return text
+
+    lines = text.split('\n')
+    out: list[str] = []
+    in_fence = False
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.lstrip()
+
+        # Track existing fenced code blocks — never touch content inside.
+        if stripped.startswith('```'):
+            in_fence = not in_fence
+            out.append(line)
+            i += 1
+            continue
+        if in_fence:
+            out.append(line)
+            i += 1
+            continue
+
+        # Look for a header row (contains '|') immediately followed by a
+        # delimiter row matching the separator regex.
+        if (
+            '|' in line
+            and i + 1 < len(lines)
+            and _TABLE_SEPARATOR_RE.match(lines[i + 1])
+        ):
+            table_block = [line, lines[i + 1]]
+            j = i + 2
+            while j < len(lines) and _is_table_row(lines[j]):
+                table_block.append(lines[j])
+                j += 1
+            # Wrap the detected table in code fences
+            out.append('```')
+            out.extend(table_block)
+            out.append('```')
+            i = j
+            continue
+
+        out.append(line)
+        i += 1
+
+    return '\n'.join(out)
+
+
 class VoiceReceiver:
     """Captures and decodes voice audio from a Discord voice channel.
 
@@ -2908,10 +2977,12 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         Format message for Discord.
 
-        Discord uses its own markdown variant.
+        Discord uses its own markdown variant.  In particular, Discord does
+        not render GFM pipe tables — the raw pipe characters display as
+        garbage.  Detected tables are wrapped in triple-backtick code fences
+        so they render as readable monospaced text.
         """
-        # Discord markdown is fairly standard, no special escaping needed
-        return content
+        return _wrap_tables_in_code_fence(content)
 
     async def _run_simple_slash(
         self,

--- a/tests/gateway/test_discord_table_wrap.py
+++ b/tests/gateway/test_discord_table_wrap.py
@@ -1,0 +1,128 @@
+"""Tests for Discord markdown table code-fence wrapping (issue #21168).
+
+Discord does not render GFM pipe tables — raw pipe characters display as
+garbage.  ``_wrap_tables_in_code_fence`` detects tables and wraps them in
+triple-backtick fences so they render as readable monospaced text.
+"""
+
+import pytest
+
+from plugins.platforms.discord.adapter import _wrap_tables_in_code_fence
+
+
+class TestWrapTablesInCodeFence:
+    """Unit tests for the table-wrapping helper."""
+
+    def test_basic_table_is_wrapped(self):
+        text = (
+            "| Name | Value |\n"
+            "|------|-------|\n"
+            "| foo  | 1     |\n"
+            "| bar  | 2     |"
+        )
+        result = _wrap_tables_in_code_fence(text)
+        assert result.startswith("```\n")
+        assert result.endswith("\n```")
+        # Original table lines are preserved inside the fences
+        assert "| Name | Value |" in result
+        assert "| foo  | 1     |" in result
+
+    def test_table_with_surrounding_text(self):
+        text = (
+            "Here is a comparison:\n"
+            "\n"
+            "| Model | Speed |\n"
+            "|-------|-------|\n"
+            "| A     | fast  |\n"
+            "| B     | slow  |\n"
+            "\n"
+            "Hope that helps!"
+        )
+        result = _wrap_tables_in_code_fence(text)
+        # Surrounding text is untouched
+        assert result.startswith("Here is a comparison:\n")
+        assert result.endswith("\nHope that helps!")
+        # Table is wrapped
+        assert "```\n| Model | Speed |" in result
+        assert "| B     | slow  |\n```" in result
+
+    def test_table_inside_code_fence_is_untouched(self):
+        text = (
+            "```\n"
+            "| A | B |\n"
+            "|---|---|\n"
+            "| 1 | 2 |\n"
+            "```"
+        )
+        result = _wrap_tables_in_code_fence(text)
+        assert result == text  # unchanged
+
+    def test_no_table_passthrough(self):
+        text = "Just a regular message with no pipes or tables."
+        assert _wrap_tables_in_code_fence(text) == text
+
+    def test_pipe_without_separator_is_untouched(self):
+        # A line with '|' but no separator row below is NOT a table
+        text = "Use the | operator in bash for piping."
+        assert _wrap_tables_in_code_fence(text) == text
+
+    def test_empty_input(self):
+        assert _wrap_tables_in_code_fence("") == ""
+
+    def test_table_without_leading_pipe(self):
+        # GFM tables can omit leading/trailing pipes
+        text = (
+            "Name | Value\n"
+            "------|-------\n"
+            "foo  | 1\n"
+            "bar  | 2"
+        )
+        result = _wrap_tables_in_code_fence(text)
+        assert result.startswith("```\n")
+        assert result.endswith("\n```")
+
+    def test_multiple_tables(self):
+        text = (
+            "| A | B |\n"
+            "|---|---|\n"
+            "| 1 | 2 |\n"
+            "\n"
+            "Some text\n"
+            "\n"
+            "| C | D |\n"
+            "|---|---|\n"
+            "| 3 | 4 |"
+        )
+        result = _wrap_tables_in_code_fence(text)
+        # Both tables should be wrapped
+        assert result.count("```") == 4  # 2 opening + 2 closing fences
+
+    def test_table_with_alignment_row(self):
+        text = (
+            "| Left | Center | Right |\n"
+            "|:-----|:------:|------:|\n"
+            "| a    | b      | c     |"
+        )
+        result = _wrap_tables_in_code_fence(text)
+        assert result.startswith("```\n")
+        assert result.endswith("\n```")
+
+    def test_single_column_separator_not_matched(self):
+        # A separator with only one column (no '|') should not match
+        text = "-----\nnot a table"
+        assert _wrap_tables_in_code_fence(text) == text
+
+    def test_format_message_integration(self):
+        """Verify format_message calls the wrapping function."""
+        from plugins.platforms.discord.adapter import DiscordAdapter
+
+        # Create adapter instance bypassing __init__
+        adapter = DiscordAdapter.__new__(DiscordAdapter)
+        text = (
+            "| X | Y |\n"
+            "|---|---|\n"
+            "| 1 | 2 |"
+        )
+        result = adapter.format_message(text)
+        assert result.startswith("```\n")
+        assert result.endswith("\n```")


### PR DESCRIPTION
## What does this PR do?

Wraps GFM-style markdown tables in triple-backtick code fences when sending messages to Discord, so pipe characters render as readable monospaced text instead of garbage.

## Related Issue

Fixes #21168

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/discord/adapter.py`: Added `_wrap_tables_in_code_fence()` helper that detects markdown table patterns (header row + separator row + data rows) and wraps them in ``` fences. Tables already inside code blocks are left untouched. Updated `format_message()` to call this helper instead of being a no-op passthrough.
- `tests/gateway/test_discord_table_wrap.py`: Added 11 tests covering basic wrapping, surrounding text preservation, tables inside existing code fences (untouched), no-table passthrough, pipe-without-separator, empty input, tables without leading pipes, multiple tables, alignment rows, single-column separators, and `format_message` integration.

## How to Test

1. Run `python3 -m pytest tests/gateway/test_discord_table_wrap.py -v` — all 11 tests should pass
2. Run `python3 -m pytest tests/gateway/test_discord_system_messages.py tests/gateway/test_discord_bot_filter.py tests/gateway/test_discord_connect.py -v` — all 32 existing Discord tests should still pass (no regression)
3. Send a message via Discord that produces a markdown table (e.g., "compare models") and verify the table renders as a code block instead of garbage text

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_discord_table_wrap.py tests/gateway/test_discord_system_messages.py tests/gateway/test_discord_bot_filter.py tests/gateway/test_discord_connect.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/platforms/discord/adapter.py` — `format_message()` (callers: 3 in send/send_multiple_images methods), `_wrap_tables_in_code_fence()` (new helper)
- Blast radius: LOW — change is confined to Discord adapter's message formatting; no cross-module impact
- Related patterns: Telegram adapter's `_wrap_markdown_tables()` in `gateway/platforms/telegram.py` (same table detection logic, different output format — Telegram converts to bullet groups, Discord wraps in code fences)
