### PR TITLE
fix(tui): scope queued prompts to live sessions

### DIFF
--- a/ui-tui/src/__tests__/useQueue.test.ts
+++ b/ui-tui/src/__tests__/useQueue.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { removeAtInPlace } from '../hooks/useQueue.js'
+import { createSessionQueueManager, removeAtInPlace } from '../hooks/useQueue.js'
 
 describe('removeAtInPlace', () => {
   it('removes the item at the given index in place', () => {
@@ -24,5 +24,45 @@ describe('removeAtInPlace', () => {
 
     expect(same).toBe(arr)
     expect(arr).toEqual([])
+  })
+})
+
+describe('createSessionQueueManager', () => {
+  it('keeps queued prompts scoped to their live session', () => {
+    const manager = createSessionQueueManager()
+
+    manager.setSession('session-a')
+    manager.enqueue('follow-up for A')
+    expect(manager.display()).toEqual(['follow-up for A'])
+
+    manager.setSession('session-b')
+    expect(manager.display()).toEqual([])
+
+    manager.enqueue('follow-up for B')
+    expect(manager.display()).toEqual(['follow-up for B'])
+
+    manager.setSession('session-a')
+    expect(manager.display()).toEqual(['follow-up for A'])
+    expect(manager.dequeue()).toBe('follow-up for A')
+    expect(manager.display()).toEqual([])
+
+    manager.setSession('session-b')
+    expect(manager.display()).toEqual(['follow-up for B'])
+  })
+
+  it('preserves in-place queue mutations for the active session only', () => {
+    const manager = createSessionQueueManager()
+
+    manager.setSession('session-a')
+    manager.enqueue('a1')
+    manager.setSession('session-b')
+    manager.enqueue('b1')
+
+    manager.current().unshift('b0')
+    manager.sync()
+    expect(manager.display()).toEqual(['b0', 'b1'])
+
+    manager.setSession('session-a')
+    expect(manager.display()).toEqual(['a1'])
   })
 })

--- a/ui-tui/src/hooks/useQueue.ts
+++ b/ui-tui/src/hooks/useQueue.ts
@@ -1,4 +1,9 @@
-import { useCallback, useRef, useState } from 'react'
+import { useStore } from '@nanostores/react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { $uiSessionId } from '../app/uiStore.js'
+
+const FALLBACK_SESSION_KEY = '__no_session__'
 
 // Mutates `arr` in place; returned reference is the same input array, kept
 // so callers can chain. Use `Array.prototype.toSpliced` if you need a copy.
@@ -12,53 +17,108 @@ export function removeAtInPlace<T>(arr: T[], i: number): T[] {
   return arr
 }
 
+export function createSessionQueueManager() {
+  const queues = new Map<string, string[]>()
+  const currentRef = { current: [] as string[] }
+  let sessionKey = FALLBACK_SESSION_KEY
+
+  const bucketFor = (sid: string | null | undefined): string[] => {
+    const key = sid || FALLBACK_SESSION_KEY
+    let bucket = queues.get(key)
+
+    if (!bucket) {
+      bucket = []
+      queues.set(key, bucket)
+    }
+
+    return bucket
+  }
+
+  const setSession = (sid: string | null | undefined) => {
+    sessionKey = sid || FALLBACK_SESSION_KEY
+    currentRef.current = bucketFor(sessionKey)
+
+    return currentRef.current
+  }
+
+  setSession(sessionKey)
+
+  return {
+    current: () => currentRef.current,
+    currentRef,
+    dequeue: () => currentRef.current.shift(),
+    display: () => [...currentRef.current],
+    enqueue: (text: string) => currentRef.current.push(text),
+    remove: (i: number) => removeAtInPlace(currentRef.current, i),
+    replace: (i: number, text: string) => {
+      currentRef.current[i] = text
+    },
+    setSession,
+    sync: () => [...currentRef.current]
+  }
+}
+
 export function useQueue() {
-  const queueRef = useRef<string[]>([])
-  const [queuedDisplay, setQueuedDisplay] = useState<string[]>([])
+  const sid = useStore($uiSessionId)
+  const managerRef = useRef<ReturnType<typeof createSessionQueueManager> | null>(null)
+
+  if (!managerRef.current) {
+    managerRef.current = createSessionQueueManager()
+  }
+
+  const manager = managerRef.current
+  const queueRef = manager.currentRef
+  const [queuedDisplay, setQueuedDisplay] = useState<string[]>(() => manager.display())
   const queueEditRef = useRef<number | null>(null)
   const [queueEditIdx, setQueueEditIdx] = useState<number | null>(null)
 
-  const syncQueue = useCallback(() => setQueuedDisplay([...queueRef.current]), [])
+  const syncQueue = useCallback(() => setQueuedDisplay(manager.sync()), [manager])
 
   const setQueueEdit = useCallback((idx: number | null) => {
     queueEditRef.current = idx
     setQueueEditIdx(idx)
   }, [])
 
+  useEffect(() => {
+    manager.setSession(sid)
+    setQueueEdit(null)
+    syncQueue()
+  }, [manager, setQueueEdit, sid, syncQueue])
+
   const enqueue = useCallback(
     (text: string) => {
-      queueRef.current.push(text)
+      manager.enqueue(text)
       syncQueue()
     },
-    [syncQueue]
+    [manager, syncQueue]
   )
 
   const dequeue = useCallback(() => {
-    const head = queueRef.current.shift()
+    const head = manager.dequeue()
     syncQueue()
 
     return head
-  }, [syncQueue])
+  }, [manager, syncQueue])
 
   const replaceQ = useCallback(
     (i: number, text: string) => {
-      queueRef.current[i] = text
+      manager.replace(i, text)
       syncQueue()
     },
-    [syncQueue]
+    [manager, syncQueue]
   )
 
   const removeQ = useCallback(
     (i: number) => {
       const before = queueRef.current.length
 
-      removeAtInPlace(queueRef.current, i)
+      manager.remove(i)
 
       if (queueRef.current.length !== before) {
         syncQueue()
       }
     },
-    [syncQueue]
+    [manager, queueRef, syncQueue]
   )
 
   return {


### PR DESCRIPTION
## Summary

- Scope the TUI composer queue by live session id instead of keeping one shared queue for the whole composer.
- Refresh the displayed queued prompts when the active live session changes.
- Add regression coverage showing queued prompts stay with their owner session and direct queue mutations only affect the active session bucket.

Closes #35711

## Test Plan

- [x] `npm test -- --run src/__tests__/useQueue.test.ts`
- [x] `npx eslint --quiet src/hooks/useQueue.ts src/__tests__/useQueue.test.ts`
- [x] `npm run build`
- [x] `npm run build --prefix packages/hermes-ink && npm test` *(suite ran; unrelated existing failures remained in `src/__tests__/virtualHeights.test.ts` and `src/__tests__/cursorDriftRegression.test.ts`; the new `useQueue` regression tests passed)*

## Notes

A full `npm run type-check` currently fails in unrelated `packages/hermes-ink/src/utils/execFileNoThrow.ts` Node typing overloads before reaching this change. The scoped TUI queue tests and targeted lint pass.
