### PR TITLE
fix(transport): generate fallback tool_call_id for tool messages missing the field

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -151,6 +151,9 @@ class ChatCompletionsTransport(ProviderTransport):
             if any(isinstance(k, str) and k.startswith("_") for k in msg):
                 needs_sanitize = True
                 break
+            if msg.get("role") == "tool" and "tool_call_id" not in msg:
+                needs_sanitize = True
+                break
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:
@@ -177,6 +180,10 @@ class ChatCompletionsTransport(ProviderTransport):
             # is safe and future-proofs against new markers being added.
             for key in [k for k in msg if isinstance(k, str) and k.startswith("_")]:
                 msg.pop(key, None)
+            
+            if msg.get("role") == "tool" and "tool_call_id" not in msg:
+                msg["tool_call_id"] = f"call_missing_{id(msg)}"
+
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:


### PR DESCRIPTION
## Summary
- Strict OpenAI-compatible providers (opencode-go, Fireworks, Moonshot/Kimi) reject tool-result messages that lack `tool_call_id` with HTTP 400
- Added detection in the sanitize check loop (`convert_messages`)
- Auto-generates a fallback ID (`call_missing_{id(msg)}`) during message cleanup so strict providers never see a tool message without the required field

## Changes
- `agent/transports/chat_completions.py`: +7 lines (detection + fallback generation)

## Test plan
- [ ] Verify with strict providers (opencode-go, Fireworks, Moonshot/Kimi) that HTTP 400 no longer occurs
- [ ] Run existing `test_background_review_summary.py` tests (covers tool_call_id-missing scenarios)