### PR TITLE
fix(gateway): two fallback-path bugs that 500 / degrade the OpenAI-compatible api_server

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1923,6 +1923,17 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
     if source_msg.get("role") != "assistant":
         return
 
+    # 0. Strict providers (e.g. Mistral) reject a ``reasoning_content`` field
+    # on replayed assistant messages with HTTP 422 (``extra_forbidden``).
+    # ``api_msg`` starts as a copy of the source message, so an inherited
+    # reasoning trace from a prior provider would otherwise leak through and
+    # 422 the request — knocking the fallback out and cascading to a weaker
+    # model. Strip it. Thinking-mode providers (DeepSeek/Kimi/MiMo) require
+    # the echo and are never matched by the detector, so this is safe.
+    if agent._rejects_reasoning_content_echo():
+        api_msg.pop("reasoning_content", None)
+        return
+
     # 1. Explicit reasoning_content already set — preserve it verbatim
     # (includes DeepSeek/Kimi's own space-placeholder written at creation
     # time, and any valid reasoning content from the same provider).

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1155,6 +1155,21 @@ def run_conversation(
         api_kwargs = None  # Guard against UnboundLocalError in except handler
 
         while retry_count < max_retries:
+            # ── Cross-provider reasoning_content guard (fallback) ──
+            # api_messages is built once, above, for the turn's initial
+            # provider. An intra-turn fallback (_try_activate_fallback) swaps
+            # the provider but reuses these messages — so a reasoning trace
+            # copied in for a reasoning-capable provider would now be replayed
+            # to a strict fallback (Mistral 422 / Groq 400 on
+            # reasoning_content), knocking the fallback out and cascading to
+            # the weakest model. Re-strip for the *current* provider each
+            # attempt. Subtractive and idempotent; the fallback chain has no
+            # downstream thinking-mode provider that would need the echo back.
+            if agent._rejects_reasoning_content_echo():
+                for _api_msg in api_messages:
+                    if isinstance(_api_msg, dict) and _api_msg.get("role") == "assistant":
+                        _api_msg.pop("reasoning_content", None)
+
             # ── Nous Portal rate limit guard ──────────────────────
             # If another session already recorded that Nous is rate-
             # limited, skip the API call entirely.  Each attempt

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -986,6 +986,17 @@ class APIServerAdapter(BasePlatformAdapter):
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
 
+        # When the primary provider's auth fails (e.g. expired/429),
+        # _resolve_runtime_agent_kwargs() falls through to the fallback
+        # provider chain, whose runtime dict carries its own `model`. Strip it
+        # and let it override the config model, mirroring the native gateway
+        # path (_resolve_session_agent_runtime in run.py). Otherwise the
+        # explicit `model=model` below collides with the spread
+        # **runtime_kwargs → "got multiple values for keyword argument 'model'".
+        runtime_model = runtime_kwargs.pop("model", None)
+        if runtime_model:
+            model = runtime_model
+
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -4258,6 +4258,25 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "xiaomimimo.com")
         )
 
+    def _rejects_reasoning_content_echo(self) -> bool:
+        """Return True for providers whose Chat Completions API rejects a
+        ``reasoning_content`` field on replayed assistant messages.
+
+        Mistral enforces strict extra-field validation and returns HTTP 422
+        (``extra_forbidden`` on ``messages[].reasoning_content``) when a
+        fallback replays history that carries another provider's reasoning
+        trace. Without stripping, a fallback to Mistral after a reasoning
+        turn (e.g. Gemini/Codex) 422s on every turn and cascades down to the
+        weakest last-resort model — visibly degrading answer quality.
+
+        Mutually exclusive with the thinking-mode providers
+        (DeepSeek/Kimi/MiMo) that *require* the echo: those are never matched
+        here, so this guard cannot strip a field they depend on.
+        """
+        provider = (self.provider or "").strip().lower()
+        base = getattr(self, "_base_url_lower", "") or (self.base_url or "").lower()
+        return provider == "mistral" or "api.mistral.ai" in base
+
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
         """Forwarder — see ``agent.agent_runtime_helpers.copy_reasoning_content_for_api``."""
         from agent.agent_runtime_helpers import copy_reasoning_content_for_api

--- a/run_agent.py
+++ b/run_agent.py
@@ -4272,10 +4272,17 @@ class AIAgent:
         Mutually exclusive with the thinking-mode providers
         (DeepSeek/Kimi/MiMo) that *require* the echo: those are never matched
         here, so this guard cannot strip a field they depend on.
+
+        Known strict providers: Mistral (HTTP 422 ``extra_forbidden``) and
+        Groq (HTTP 400 ``property 'reasoning_content' is unsupported``).
         """
         provider = (self.provider or "").strip().lower()
         base = getattr(self, "_base_url_lower", "") or (self.base_url or "").lower()
-        return provider == "mistral" or "api.mistral.ai" in base
+        return (
+            provider == "mistral"
+            or "api.mistral.ai" in base
+            or "api.groq.com" in base
+        )
 
     def _copy_reasoning_content_for_api(self, source_msg: dict, api_msg: dict) -> None:
         """Forwarder — see ``agent.agent_runtime_helpers.copy_reasoning_content_for_api``."""

--- a/tests/run_agent/test_mistral_reasoning_content_strip.py
+++ b/tests/run_agent/test_mistral_reasoning_content_strip.py
@@ -41,6 +41,16 @@ class TestRejectsReasoningContentDetector:
         )
         assert agent._rejects_reasoning_content_echo() is True
 
+    def test_matches_groq_host_with_custom_provider(self) -> None:
+        # Groq rejects reasoning_content with HTTP 400 'unsupported'; it is
+        # configured as a custom provider, so detection is host-based.
+        agent = _make_agent(
+            provider="custom",
+            model="llama-3.3-70b-versatile",
+            base_url="https://api.groq.com/openai/v1",
+        )
+        assert agent._rejects_reasoning_content_echo() is True
+
     def test_excludes_deepseek(self) -> None:
         agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
         assert agent._rejects_reasoning_content_echo() is False

--- a/tests/run_agent/test_mistral_reasoning_content_strip.py
+++ b/tests/run_agent/test_mistral_reasoning_content_strip.py
@@ -1,0 +1,117 @@
+"""Regression: Mistral rejects ``reasoning_content`` echo on replayed history.
+
+When the agent falls back to Mistral after a reasoning-capable provider
+(e.g. Gemini / Codex) populated assistant turns with ``reasoning_content``,
+Mistral's strict API returns HTTP 422 (``extra_forbidden`` on
+``messages[].reasoning_content``). The turn then cascades down the fallback
+chain to a weaker last-resort model, visibly degrading answer quality.
+
+``copy_reasoning_content_for_api`` must strip ``reasoning_content`` for
+providers that reject it, while leaving DeepSeek/Kimi/MiMo (which *require*
+the echo) and OpenRouter (which may route to a thinking model) untouched.
+"""
+
+from __future__ import annotations
+
+from run_agent import AIAgent
+
+
+def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url  # property setter also populates _base_url_lower
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    return agent
+
+
+class TestRejectsReasoningContentDetector:
+    def test_matches_mistral_provider(self) -> None:
+        agent = _make_agent(provider="mistral", model="mistral-small-latest")
+        assert agent._rejects_reasoning_content_echo() is True
+
+    def test_matches_mistral_host_with_custom_provider(self) -> None:
+        agent = _make_agent(
+            provider="custom",
+            model="mistral-small-latest",
+            base_url="https://api.mistral.ai/v1/",
+        )
+        assert agent._rejects_reasoning_content_echo() is True
+
+    def test_excludes_deepseek(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        assert agent._rejects_reasoning_content_echo() is False
+
+    def test_excludes_openrouter(self) -> None:
+        agent = _make_agent(
+            provider="openrouter",
+            model="anthropic/claude-sonnet-4.6",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert agent._rejects_reasoning_content_echo() is False
+
+
+class TestMistralStripsReasoningContentOnReplay:
+    def test_inherited_reasoning_content_stripped(self) -> None:
+        """``api_msg`` starts as a copy of the source (carrying
+        reasoning_content). The helper must remove it for Mistral so the
+        replayed request does not 422."""
+        agent = _make_agent(provider="mistral", model="mistral-small-latest")
+        source = {
+            "role": "assistant",
+            "content": "ok",
+            "reasoning_content": "prior provider chain of thought",
+        }
+        api_msg = dict(source)  # mirrors `api_msg = msg.copy()` in the loop
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_reasoning_field_not_promoted(self) -> None:
+        """A bare ``reasoning`` field must not be promoted to
+        ``reasoning_content`` for Mistral either."""
+        agent = _make_agent(provider="mistral", model="mistral-small-latest")
+        source = {"role": "assistant", "content": "ok", "reasoning": "thought trace"}
+        api_msg = dict(source)
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_tool_call_turn_reasoning_content_stripped(self) -> None:
+        agent = _make_agent(provider="mistral", model="mistral-small-latest")
+        source = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "type": "function",
+                            "function": {"name": "x", "arguments": "{}"}}],
+            "reasoning_content": "leaked trace",
+        }
+        api_msg = dict(source)
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+
+class TestThinkingProvidersUnaffected:
+    def test_deepseek_still_preserves_reasoning_content(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        source = {
+            "role": "assistant",
+            "content": "ok",
+            "reasoning_content": "<think>real chain of thought</think>",
+        }
+        api_msg = dict(source)
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == "<think>real chain of thought</think>"
+
+    def test_deepseek_poisoned_history_still_padded(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        source = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "type": "function",
+                            "function": {"name": "x", "arguments": "{}"}}],
+        }
+        api_msg = dict(source)
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == " "


### PR DESCRIPTION
Two independent bugs on the **fallback path** that surface together once the primary provider hits an auth failure or usage cap (e.g. Codex 429). Found while the api_server's primary provider was rate-limited; both reproduce on current `main`.

## 1. `api_server._create_agent` 500s on every request when fallback kicks in

`_create_agent` builds the agent with `AIAgent(model=model, **runtime_kwargs)`. When the primary provider's auth fails, `_resolve_runtime_agent_kwargs()` falls through to the fallback provider chain, whose runtime dict carries its own `model` key. The explicit `model=` then collides with the spread:

```
TypeError: run_agent.AIAgent() got multiple values for keyword argument 'model'
```

Result: **every `/v1/chat/completions` returns 500** as soon as the primary provider is unavailable. The native gateway path (`_resolve_session_agent_runtime`) already does `runtime_kwargs.pop("model", ...)` and lets it override the config model — api_server was the one path missing it. This PR mirrors that.

## 2. Mistral fallback 422s on `reasoning_content`, cascading to the weakest model

After a reasoning-capable provider (Gemini, Codex, …) populates assistant turns with `reasoning_content`, falling back to Mistral fails every turn:

```
HTTP 422 extra_forbidden on messages[].assistant.reasoning_content
```

`copy_reasoning_content_for_api` preserved/promoted `reasoning_content` unconditionally (`api_msg` starts as a copy of the source message), so an inherited reasoning trace leaked into the Mistral request. The fallback then cascaded past the trusted mid-tier model down to the weakest last-resort model — a visible quality drop.

Fix: add `AIAgent._rejects_reasoning_content_echo()` (Mistral provider/host) and strip `reasoning_content` for those providers at the top of `copy_reasoning_content_for_api`. This is **mutually exclusive** with the thinking-mode providers (DeepSeek/Kimi/MiMo) that *require* the echo, and leaves the OpenRouter round-trip case untouched.

## Tests

- New `tests/run_agent/test_mistral_reasoning_content_strip.py` (detector + strip-on-replay + thinking-provider-unaffected).
- `tests/run_agent/test_deepseek_reasoning_content_echo.py` still green (no regression to thinking-mode echo).

```
49 passed in 0.92s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)