### PR TITLE
fix(docker): discover Playwright headless_shell browser

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -273,9 +273,10 @@ fi
 #   shared libraries (libGLESv2.so, libEGL.so, ...) which inherit the
 #   executable bit from Playwright's tarball but are NOT browser binaries.
 #   We only accept files whose basename is chrome / chromium /
-#   chrome-headless-shell / chromium-browser. Compare PR #18635's earlier
-#   ``find | grep -Ei 'chrome|chromium'`` which would match the path
-#   ``.../chrome-headless-shell-linux64/libGLESv2.so`` and pick a .so.
+#   chrome-headless-shell / headless_shell / chromium-browser. Compare
+#   PR #18635's earlier ``find | grep -Ei 'chrome|chromium'`` which would
+#   match the path ``.../chrome-headless-shell-linux64/libGLESv2.so`` and
+#   pick a .so.
 # - Quietly skipped when $PLAYWRIGHT_BROWSERS_PATH doesn't exist (e.g.
 #   custom builds that strip Playwright).
 if [ -z "${AGENT_BROWSER_EXECUTABLE_PATH:-}" ] && \
@@ -283,7 +284,8 @@ if [ -z "${AGENT_BROWSER_EXECUTABLE_PATH:-}" ] && \
         [ -d "$PLAYWRIGHT_BROWSERS_PATH" ]; then
     browser_bin=$(find "$PLAYWRIGHT_BROWSERS_PATH" -type f -executable \
         \( -name 'chrome' -o -name 'chromium' \
-           -o -name 'chrome-headless-shell' -o -name 'chromium-browser' \) \
+           -o -name 'chrome-headless-shell' -o -name 'headless_shell' \
+           -o -name 'chromium-browser' \) \
         2>/dev/null | head -n 1)
     if [ -n "$browser_bin" ]; then
         echo "[stage2] Found agent-browser Chromium binary: $browser_bin"

--- a/tests/test_docker_stage2_browser_discovery.py
+++ b/tests/test_docker_stage2_browser_discovery.py
@@ -1,0 +1,19 @@
+"""Regression tests for Docker stage2 browser executable discovery."""
+
+from pathlib import Path
+
+
+def test_stage2_discovers_playwright_arm64_headless_shell() -> None:
+    """Playwright's --only-shell layout may use a headless_shell basename."""
+    script = Path("docker/stage2-hook.sh").read_text()
+
+    assert "-name 'headless_shell'" in script
+
+
+def test_stage2_discovery_stays_filename_matched() -> None:
+    """Avoid broad path grep that can pick executable shared libraries."""
+    script = Path("docker/stage2-hook.sh").read_text()
+
+    discovery_block = script.split("browser_bin=$(", 1)[1].split(")\n    if", 1)[0]
+    assert "find \"$PLAYWRIGHT_BROWSERS_PATH\" -type f -executable" in discovery_block
+    assert "grep" not in discovery_block


### PR DESCRIPTION
## Summary
- include Playwright's `headless_shell` executable name in Docker stage2 browser discovery
- add a regression test so the discovery stays filename-matched and does not revert to broad path grep

## Test Plan
- `bash -n docker/stage2-hook.sh`
- `python -m pytest tests/test_docker_stage2_browser_discovery.py tests/test_install_sh_browser_install.py tests/tools/test_browser_chromium_check.py -q`
