### PR TITLE
fix: handle Telegram channel media posts

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5399,12 +5399,19 @@ class TelegramAdapter(BasePlatformAdapter):
         self._pending_photo_batch_tasks[batch_key] = asyncio.create_task(self._flush_photo_batch(batch_key))
 
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-        """Handle incoming media messages, downloading images to local cache."""
-        if not update.message:
+        """Handle incoming media messages, downloading file/media attachments to local cache.
+
+        Telegram channel posts arrive as ``update.channel_post`` rather than
+        ``update.message``. Use the same effective-message helper as the text
+        path so channel-uploaded supported files and media are cached and dispatched
+        instead of being dropped before plugins can see them.
+        """
+        msg = self._effective_update_message(update)
+        if not msg:
             return
-        if not self._should_process_message(update.message):
-            if self._should_observe_unmentioned_group_message(update.message):
-                _m = update.message
+        if not self._should_process_message(msg):
+            if self._should_observe_unmentioned_group_message(msg):
+                _m = msg
                 _observe_type = self._media_message_type(_m)
                 _event = self._build_message_event(_m, _observe_type, update_id=update.update_id)
                 if _m.caption:
@@ -5414,8 +5421,6 @@ class TelegramAdapter(BasePlatformAdapter):
                     _m, _event.message_type, update_id=update.update_id, event=_event
                 )
             return
-
-        msg = update.message
 
         msg_type = self._media_message_type(msg)
 

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -1030,7 +1030,7 @@ def _group_photo_message(*, chat_id=-100, caption="Veja esta foto", file_size=10
 def _group_document_message(*, chat_id=-100, caption="Este arquivo", document=None):
     file_obj = SimpleNamespace(
         file_path="documents/report.pdf",
-        download_as_bytearray=AsyncMock(return_value=bytearray(b"%PDF observed bytes")),
+        download_as_bytearray=AsyncMock(return_value=bytearray(b"document observed bytes")),
     )
     document = document or SimpleNamespace(
         file_name="RESULTADO BIOLOGICO - PROTOCOLO 103- URBAN.pdf",
@@ -1160,5 +1160,33 @@ def test_unmentioned_unsupported_document_observed_without_caching(monkeypatch):
         cache_doc.assert_not_called()
         _, message, _ = store.messages[0]
         assert "unsupported" in message["content"].lower()
+
+    asyncio.run(_run())
+
+
+def test_channel_media_post_uses_effective_message():
+    async def _run():
+        adapter = _make_adapter(require_mention=False)
+        adapter.handle_message = AsyncMock()
+        channel_post = _group_voice_message(
+            chat_id=-1001234567890,
+            caption="Channel file upload",
+        )
+        channel_post.chat.type = "channel"
+        channel_post.chat.title = "Example channel"
+        channel_post.from_user = None
+        update = SimpleNamespace(
+            update_id=1001,
+            message=None,
+            effective_message=channel_post,
+        )
+
+        await adapter._handle_media_message(update, SimpleNamespace())
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.call_args[0][0]
+        assert event.source.chat_id == "-1001234567890"
+        assert event.source.chat_type == "channel"
+        assert event.text == "Channel file upload"
 
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- Use the Telegram effective message in media handling, matching the text path.
- Fixes channel media/document posts being dropped when `update.message` is absent.
- Adds regression coverage for channel media posts.

## Why
Telegram channel posts arrive as `update.channel_post` / `effective_message`, not `update.message`. The media handler returned early before plugins could see uploaded documents.

## Test Plan
- [x] `/Users/nick/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_telegram_group_gating.py -q -o 'addopts='`
