### PR TITLE
fix(browser): escape cmd metacharacters when invoking .cmd shim on Windows

### DIFF
--- a/tests/tools/test_browser_cmd_arg_escape.py
+++ b/tests/tools/test_browser_cmd_arg_escape.py
@@ -1,0 +1,139 @@
+"""Tests for cmd.exe-safe argument quoting when invoking the agent-browser
+.cmd shim on Windows. Regression coverage for issue #35654.
+
+The bug: on Windows, npm-installed `agent-browser` resolves to a `.cmd`
+wrapper that re-evaluates `%*` through cmd.exe. Args containing cmd
+metacharacters (`&`, `|`, `<`, `>`) — common in URL query strings — get
+interpreted as shell tokens and the URL is split mid-flight.
+
+CPython 3.11.9+ / 3.12.3+ fix this automatically (CVE-2024-1874), but
+older patch levels of supported Pythons remain vulnerable. The fix
+here is a portable backport: render the argv as a cmd.exe-safe string
+and hand that to subprocess.Popen instead of a list.
+"""
+
+import os
+import subprocess
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import tools.browser_tool as _bt
+from tools.browser_tool import (
+    _build_bat_cmdline,
+    _is_windows_bat_target,
+    _quote_arg_for_cmd,
+)
+
+
+class TestQuoteArgForCmd:
+    """Unit tests for the per-argument quoting helper."""
+
+    def test_plain_arg_unchanged(self):
+        assert _quote_arg_for_cmd("plain") == "plain"
+
+    def test_url_with_ampersand_gets_quoted(self):
+        assert (
+            _quote_arg_for_cmd("https://x.example.com/?a=1&b=2")
+            == '"https://x.example.com/?a=1&b=2"'
+        )
+
+    def test_arg_with_pipe_gets_quoted(self):
+        assert _quote_arg_for_cmd("a|b") == '"a|b"'
+
+    def test_arg_with_redirect_gets_quoted(self):
+        assert _quote_arg_for_cmd("a<b") == '"a<b"'
+        assert _quote_arg_for_cmd("a>b") == '"a>b"'
+
+    def test_arg_with_caret_gets_quoted(self):
+        assert _quote_arg_for_cmd("a^b") == '"a^b"'
+
+    def test_arg_with_space_gets_quoted(self):
+        assert _quote_arg_for_cmd("hello world") == '"hello world"'
+
+    def test_arg_with_internal_quote_doubled(self):
+        # cmd.exe convention: doubled quotes inside a quoted region.
+        assert _quote_arg_for_cmd('a"b&c') == '"a""b&c"'
+
+    def test_empty_arg_quoted(self):
+        # An empty positional arg must survive as `""` so it isn't dropped.
+        assert _quote_arg_for_cmd("") == '""'
+
+    def test_arg_with_percent_quoted(self):
+        # `%FOO%` would expand inside a .cmd; quoting blocks expansion.
+        assert _quote_arg_for_cmd("%PATH%") == '"%PATH%"'
+
+
+class TestBuildBatCmdline:
+    """Unit tests for the full cmdline string builder."""
+
+    def test_empty_parts(self):
+        assert _build_bat_cmdline([]) == ""
+
+    def test_executable_only(self):
+        assert _build_bat_cmdline(["agent-browser.cmd"]) == "agent-browser.cmd"
+
+    def test_simple_args_unchanged(self):
+        out = _build_bat_cmdline(["agent-browser.cmd", "--json", "open"])
+        assert out == "agent-browser.cmd --json open"
+
+    def test_url_with_ampersand_protected(self):
+        # The original bug: this URL gets split on `&` inside the .cmd shim.
+        out = _build_bat_cmdline([
+            "agent-browser.cmd",
+            "--json",
+            "open",
+            "https://example.com/search?q=test&page=2",
+        ])
+        # The URL is one quoted token; cmd.exe and the .cmd's %* see it whole.
+        assert '"https://example.com/search?q=test&page=2"' in out
+        # And nothing outside the quotes contains a bare `&`.
+        unquoted = out.replace('"https://example.com/search?q=test&page=2"', "")
+        assert "&" not in unquoted
+
+    def test_executable_path_with_spaces_quoted(self):
+        out = _build_bat_cmdline([
+            r"C:\Program Files\nodejs\agent-browser.cmd",
+            "--json",
+        ])
+        assert out.startswith('"C:\\Program Files\\nodejs\\agent-browser.cmd"')
+
+    def test_executable_path_without_spaces_unquoted(self):
+        out = _build_bat_cmdline([r"C:\nodejs\agent-browser.cmd", "--json"])
+        assert out == r"C:\nodejs\agent-browser.cmd --json"
+
+    def test_javascript_with_pipe_protected(self):
+        # `evaluate` payloads can carry `|` as a logical-OR operator.
+        out = _build_bat_cmdline([
+            "agent-browser.cmd",
+            "evaluate",
+            "x || y",
+        ])
+        assert '"x || y"' in out
+
+
+class TestIsWindowsBatTarget:
+    """Detection of .cmd / .bat shims, gated on os.name == 'nt'."""
+
+    def test_cmd_extension_on_windows(self):
+        with patch.object(_bt.os, "name", "nt"):
+            assert _is_windows_bat_target(r"C:\foo\agent-browser.cmd") is True
+
+    def test_bat_extension_on_windows(self):
+        with patch.object(_bt.os, "name", "nt"):
+            assert _is_windows_bat_target(r"C:\foo\thing.bat") is True
+
+    def test_uppercase_extension_on_windows(self):
+        # PATHEXT on Windows is case-insensitive.
+        with patch.object(_bt.os, "name", "nt"):
+            assert _is_windows_bat_target(r"C:\foo\AGENT-BROWSER.CMD") is True
+
+    def test_no_extension_on_windows(self):
+        with patch.object(_bt.os, "name", "nt"):
+            assert _is_windows_bat_target(r"C:\foo\agent-browser") is False
+
+    def test_cmd_extension_on_posix_returns_false(self):
+        # A path that happens to end in `.cmd` on POSIX must NOT be routed
+        # through the cmd.exe quoter — there's no cmd.exe involved.
+        with patch.object(_bt.os, "name", "posix"):
+            assert _is_windows_bat_target("/tmp/agent-browser.cmd") is False

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -865,6 +865,10 @@ def _run_chrome_fallback_command(
 
     def _run_tmp(cmd: str, cmd_args: List[str]) -> Dict[str, Any]:
         full = base_args + [cmd] + cmd_args
+        # Same Windows .cmd/.bat shim escaping as _run_browser_command — see #35654.
+        popen_target: Union[List[str], str] = (
+            _build_bat_cmdline(full) if _is_windows_bat_target(full[0]) else full
+        )
         # Use temp-file stdout/stderr pattern (same as _run_browser_command)
         # to avoid pipe hang from agent-browser daemon inheriting fds.
         stdout_path = os.path.join(task_socket_dir, f"_stdout_{cmd}")
@@ -908,7 +912,7 @@ def _run_chrome_fallback_command(
                 _si.dwFlags |= subprocess.STARTF_USESTDHANDLES
                 _popen_extra["startupinfo"] = _si
             proc = subprocess.Popen(
-                full, stdout=stdout_fd, stderr=stderr_fd,
+                popen_target, stdout=stdout_fd, stderr=stderr_fd,
                 stdin=subprocess.DEVNULL, env=browser_env,
                 **_popen_extra,
             )
@@ -1748,6 +1752,53 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, str]:
 
 
 
+# Cmd.exe metacharacters that, if unquoted, get interpreted by the .cmd/.bat
+# wrapper's `%*` re-evaluation pass. `&` splits a URL, `|` pipes the rest, etc.
+# CPython 3.11.9+ / 3.12.3+ / 3.13+ auto-escape these for .bat/.cmd targets
+# (CVE-2024-1874); the helper below backports the same protection so older
+# patch levels of supported Pythons (3.11.0–3.11.8) don't drop URL query
+# strings on the floor.  See issue #35654.
+_CMD_METACHARS = frozenset('&|<>^"%!()')
+
+
+def _quote_arg_for_cmd(arg: str) -> str:
+    """Wrap *arg* in cmd.exe-safe double quotes if it contains any cmd
+    metacharacter or whitespace; otherwise return it unchanged.
+
+    Internal `"` are doubled (`""`) per cmd.exe convention so the .cmd shim's
+    `%*` expansion preserves them.
+    """
+    if not arg:
+        return '""'
+    if any(c in _CMD_METACHARS or c.isspace() for c in arg):
+        return '"' + arg.replace('"', '""') + '"'
+    return arg
+
+
+def _build_bat_cmdline(parts: List[str]) -> str:
+    """Render argv as a single command-line string with cmd.exe-safe quoting.
+
+    Used when the executable is a `.cmd` / `.bat` shim on Windows: passing a
+    list to `subprocess.Popen` would route through `subprocess.list2cmdline`,
+    whose backslash-quote escaping is incompatible with the cmd.exe parser
+    that runs inside the shim's `%*` expansion.
+    """
+    if not parts:
+        return ""
+    # Quote the executable path itself if it contains spaces (typical for
+    # `C:\Program Files\…\agent-browser.cmd`).  Internal quotes shouldn't
+    # appear in a real path; if they do, this fails closed by quoting them.
+    head = parts[0]
+    if any(c.isspace() or c == '"' for c in head):
+        head = '"' + head.replace('"', '""') + '"'
+    return " ".join([head, *(_quote_arg_for_cmd(a) for a in parts[1:])])
+
+
+def _is_windows_bat_target(executable: str) -> bool:
+    """True iff *executable* will be dispatched through the cmd.exe shim layer."""
+    return os.name == "nt" and executable.lower().endswith((".cmd", ".bat"))
+
+
 def _find_agent_browser() -> str:
     """
     Find the agent-browser CLI executable.
@@ -1976,6 +2027,15 @@ def _run_browser_command(
         command
     ] + args
 
+    # Windows .cmd/.bat shim: render argv as a cmd.exe-safe string so URLs
+    # containing `&` / `|` / `<` / `>` aren't split by the wrapper's `%*`
+    # re-evaluation pass.  See _build_bat_cmdline for the rationale; #35654.
+    popen_target: Union[List[str], str] = (
+        _build_bat_cmdline(cmd_parts)
+        if _is_windows_bat_target(cmd_parts[0])
+        else cmd_parts
+    )
+
     try:
         # Give each task its own socket directory to prevent concurrency conflicts.
         # Without this, parallel workers fight over the same default socket path,
@@ -2069,7 +2129,7 @@ def _run_browser_command(
                 _si.dwFlags |= subprocess.STARTF_USESTDHANDLES
                 _popen_extra["startupinfo"] = _si
             proc = subprocess.Popen(
-                cmd_parts,
+                popen_target,
                 stdout=stdout_fd,
                 stderr=stderr_fd,
                 stdin=subprocess.DEVNULL,


### PR DESCRIPTION
## What

When `agent-browser` resolves to a `.cmd` shim on Windows (npm install layout — `node_modules/.bin/agent-browser.cmd`), `cmd.exe` re-evaluates the shim's `%*` expansion and interprets cmd metacharacters (`&`, `|`, `<`, `>`) in our argv as shell tokens. URL query strings split mid-flight: `https://example.com/search?q=test&page=2` becomes `https://example.com/search?q=test` plus a stray `page=2` invocation.

## Why

CPython 3.11.9+ / 3.12.3+ auto-escape these for `.bat`/`.cmd` targets (CVE-2024-1874). Hermes pins `python>=3.11`, so users on patch levels **3.11.0–3.11.8** remain vulnerable. The reporter (#35654) is on Python 3.11 + Windows + Hermes 0.14.

## How

Backport the protection at the two `subprocess.Popen` sites in `tools/browser_tool.py`:
- `_run_browser_command` — main code path
- `_run_chrome_fallback_command._run_tmp` — Lightpanda → Chrome fallback

When the resolved executable is a `.cmd`/`.bat` on Windows, render argv as a cmd.exe-safe command-line **string** (quote any arg containing cmd metachars or whitespace; double internal `"`) and pass that to `Popen` instead of a list. This bypasses `subprocess.list2cmdline`'s backslash-quote escaping, which is incompatible with cmd.exe's parser inside the `.cmd` shim's `%*` expansion.

Three new module-level helpers, all private:
- `_quote_arg_for_cmd(arg)` — per-arg cmd.exe quoting
- `_build_bat_cmdline(parts)` — full cmdline string builder
- `_is_windows_bat_target(exe)` — `os.name == 'nt'` AND `.cmd`/`.bat` extension

POSIX hosts and non-`.cmd` targets are unaffected (still pass an argv list).

## Test

`tests/tools/test_browser_cmd_arg_escape.py` — 21 cases:
- `_quote_arg_for_cmd`: plain / `&` / `|` / `<` / `>` / `^` / space / internal `"` / empty / `%`
- `_build_bat_cmdline`: empty / exe-only / simple / URL with `&` (the bug repro) / exe path with spaces / exe path no spaces / JS with `||`
- `_is_windows_bat_target`: `.cmd` and `.bat` on Windows / uppercase / no-extension / POSIX path that happens to end `.cmd`

```
$ pytest tests/tools/test_browser_cmd_arg_escape.py -q
21 passed in 1.81s
```

Neighboring `test_browser_homebrew_paths.py`, `test_browser_cleanup.py`, `test_browser_hardening.py` — 48/48 still pass.

## Platform

Windows-only fix path; behavior unchanged on macOS/Linux/WSL2 (still pass argv list, never hit the helper). Verified by `_is_windows_bat_target`'s `os.name == 'nt'` gate.

## Issue

Closes #35654

🤖 Generated with [Claude Code](https://claude.com/claude-code)