### PR TITLE
docs(toolsets): clarify all/* wildcard does not enable kanban

### DIFF
--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -67,7 +67,7 @@ Or in-session:
 | `computer_use` | `computer_use` | Background macOS desktop control via cua-driver — does not steal cursor/focus. Works with any tool-capable model. macOS only; requires `cua-driver` on `$PATH`. |
 | `image_gen` | `image_generate` | Text-to-image generation via FAL.ai (with opt-in OpenAI / xAI backends). |
 | `video_gen` | `video_generate` | Text-to-video and image-to-video via plugin-registered backends (xAI Grok-Imagine, FAL.ai Veo 3.1 / Pixverse v6 / Kling O3). Pass `image_url` to animate an image; omit it for text-to-video. |
-| `kanban` | `kanban_block`, `kanban_comment`, `kanban_complete`, `kanban_create`, `kanban_heartbeat`, `kanban_link`, `kanban_list`, `kanban_show`, `kanban_unblock` | Multi-agent coordination tools. Registered for dispatcher-spawned task workers (`HERMES_KANBAN_TASK`) and for profiles that explicitly enable the `kanban` toolset. Workers mark tasks done, block, heartbeat, comment, and create/link follow-up tasks; orchestrator profiles additionally get board-routing tools like list/unblock. |
+| `kanban` | `kanban_block`, `kanban_comment`, `kanban_complete`, `kanban_create`, `kanban_heartbeat`, `kanban_link`, `kanban_list`, `kanban_show`, `kanban_unblock` | Multi-agent coordination tools. Registered for dispatcher-spawned task workers (`HERMES_KANBAN_TASK`) and for profiles that explicitly list the `kanban` toolset by name (the `all`/`*` wildcard does **not** enable it). Workers mark tasks done, block, heartbeat, comment, and create/link follow-up tasks; orchestrator profiles additionally get board-routing tools like list/unblock. |
 | `memory` | `memory` | Persistent cross-session memory management. |
 | `messaging` | `send_message` | Send messages to other platforms (Telegram, Discord, etc.) from within a session. |
 | `moa` | `mixture_of_agents` | Multi-model consensus via Mixture of Agents. |
@@ -155,6 +155,11 @@ custom_toolsets:
 ### Wildcards
 
 - `all` or `*` — expands to every registered toolset (built-in + dynamic + plugin)
+
+A handful of tools have an additional availability check on top of toolset membership and are **not** turned on by `all`/`*` alone:
+
+- **Capability-gated** tools (browser, `computer_use`, `code_execution`, Feishu, Home Assistant, cronjob) appear only when their backend/credential prerequisite is configured.
+- **Workflow-gated** tools — the `kanban` toolset — are deliberately opt-in. `all`/`*` does **not** enable kanban; you must list `kanban` explicitly (or be a dispatcher-spawned worker with `HERMES_KANBAN_TASK` set). Kanban tools mutate shared board state, so they stay off by default even under `all`.
 
 ## Relationship to `hermes tools`
 


### PR DESCRIPTION
## Summary

`toolsets: ["all"]` does not — and should not — enable the kanban toolset; this clarifies the docs to match.

Kanban tools mutate shared multi-agent board state (close tasks, heartbeat runs, route work). They're gated behind an explicit opt-in (`kanban` in the toolset list, or a dispatcher-spawned worker with `HERMES_KANBAN_TASK`) precisely because they're workflow plumbing, not a general capability. Arming them on every `["all"]` profile would be the riskier default. The behavior is intentional — #35581 was an expectations gap created by the docs saying `all`/`*` expands to "every registered toolset" with no mention of the check_fn carve-out.

## Changes

- `website/docs/reference/toolsets-reference.md`:
  - Wildcards section now notes that `all`/`*` does **not** enable kanban, plus a general note that capability-gated tools (browser, computer_use, code_execution, Feishu, Home Assistant, cronjob) need their prerequisite configured.
  - Kanban row clarified: profiles must list `kanban` **by name** — the wildcard doesn't count.

## Validation

Docs-only content change (no new links/anchors). No code change — current gating is correct.

Closes #35581.

## Infographic

![toolsets-all-not-kanban](https://v3b.fal.media/files/b/0a9c61b0/eUchT4t6M909xCCnj9u3y_1CYzDGXe.png)
