### PR TITLE
feat(cli): inject Portal free-model promotions into the fallback chain

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -934,6 +934,11 @@ DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
     "fallback_providers": [],
+    "fallback_promotions": {
+        "enabled": True,
+        "providers": ["nous"],
+        "position": "prepend",
+    },
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -68,13 +68,126 @@ def _entry_identity(entry: dict[str, Any]) -> tuple[str, str, str]:
     )
 
 
+def _fallback_promotions_config(config: dict[str, Any]) -> dict[str, Any]:
+    raw = config.get("fallback_promotions")
+    if not isinstance(raw, dict):
+        return {}
+    return raw
+
+
+def _fallback_promotions_enabled(config: dict[str, Any]) -> bool:
+    """Return whether dynamic free-promotion fallbacks should be merged.
+
+    The feature is opt-in through DEFAULT_CONFIG's ``fallback_promotions`` key.
+    Tests and callers that pass a small ad-hoc config without that key keep the
+    old static-only behavior.
+    """
+    env_override = os.getenv("HERMES_FALLBACK_PROMOTIONS", "").strip().lower()
+    if env_override in {"0", "false", "no", "off"}:
+        return False
+    if env_override in {"1", "true", "yes", "on"}:
+        return True
+
+    promotions = _fallback_promotions_config(config)
+    return promotions.get("enabled") is True
+
+
+def _provider_promotions_enabled(config: dict[str, Any], provider: str) -> bool:
+    promotions = _fallback_promotions_config(config)
+    providers = promotions.get("providers", ["nous"])
+    if isinstance(providers, str) and providers.strip().lower() in {"*", "all"}:
+        return True
+    if not isinstance(providers, list):
+        return False
+    wanted = {str(p).strip().lower() for p in providers if str(p).strip()}
+    return provider.strip().lower() in wanted
+
+
+def _promotion_position(config: dict[str, Any]) -> str:
+    promotions = _fallback_promotions_config(config)
+    position = str(promotions.get("position") or "prepend").strip().lower()
+    if position not in {"prepend", "append"}:
+        return "prepend"
+    return position
+
+
+def _provider_has_auth(provider: str) -> bool:
+    """Cheap auth gate so startup does not hit remote promo endpoints uselessly."""
+    provider = provider.strip().lower()
+    if provider == "nous":
+        if os.getenv("NOUS_API_KEY", "").strip():
+            return True
+        try:
+            from hermes_cli.auth import get_provider_auth_state
+
+            return bool(get_provider_auth_state("nous"))
+        except Exception:
+            return False
+    return False
+
+
+def _free_nous_promotion_entries() -> list[dict[str, Any]]:
+    """Return free Nous Portal promo models currently advertised by Portal."""
+    try:
+        from hermes_cli.models import (
+            _resolve_nous_portal_url,
+            fetch_nous_recommended_models,
+        )
+    except Exception:
+        return []
+
+    try:
+        payload = fetch_nous_recommended_models(
+            _resolve_nous_portal_url(),
+            timeout=1.5,
+        )
+    except Exception:
+        return []
+
+    free_models = payload.get("freeRecommendedModels") if isinstance(payload, dict) else None
+    if not isinstance(free_models, list):
+        return []
+
+    entries: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in free_models:
+        if not isinstance(item, dict):
+            continue
+        model = str(item.get("modelName") or "").strip()
+        if not model or model.lower() in seen:
+            continue
+        seen.add(model.lower())
+        entries.append(
+            {
+                "provider": "nous",
+                "model": model,
+                "supports_tools": True,
+                "source": "dynamic-free-promotion",
+            }
+        )
+    return entries
+
+
+def _dynamic_free_promotion_entries(config: dict[str, Any]) -> list[dict[str, Any]]:
+    if not _fallback_promotions_enabled(config):
+        return []
+
+    entries: list[dict[str, Any]] = []
+    if _provider_promotions_enabled(config, "nous") and _provider_has_auth("nous"):
+        entries.extend(_free_nous_promotion_entries())
+    return entries
+
+
 def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     """Return the effective fallback chain merged across old and new config keys.
 
     ``fallback_providers`` remains the primary source of truth and keeps its
-    order. Legacy ``fallback_model`` entries are appended afterwards unless
-    they target the same provider/model/base_url route as an earlier entry.
-    The returned list always contains fresh dict copies.
+    relative order. Legacy ``fallback_model`` entries are appended afterwards
+    unless they target the same provider/model/base_url route as an earlier
+    entry. When ``fallback_promotions.enabled`` is true, currently-free
+    provider promotions are merged in memory so short-lived free models do not
+    depend on a static YAML edit. Explicitly configured entries win on
+    duplicates. The returned list always contains fresh dict copies.
     """
 
     config = config or {}
@@ -89,4 +202,16 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
             seen.add(identity)
             chain.append(entry)
 
+    promotion_entries: list[dict[str, Any]] = []
+    for entry in _dynamic_free_promotion_entries(config):
+        identity = _entry_identity(entry)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        promotion_entries.append(entry)
+
+    if promotion_entries and _promotion_position(config) == "prepend":
+        return promotion_entries + chain
+    if promotion_entries:
+        return chain + promotion_entries
     return chain

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -175,6 +175,16 @@ class TestFallbackModelValidation:
         })
         assert any("fallback_model[0]" in i.message and "should be a dict" in i.message for i in issues)
 
+    def test_fallback_promotions_is_known_root_key(self):
+        issues = validate_config_structure({
+            "fallback_promotions": {
+                "enabled": True,
+                "providers": ["nous"],
+                "position": "prepend",
+            },
+        })
+        assert issues == []
+
 
 class TestMissingModelSection:
     """Warn when custom_providers exists but model section is missing."""

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -1,5 +1,7 @@
 """Tests for hermes_cli/fallback_config.py — fallback entry API-key resolution."""
 
+from __future__ import annotations
+
 from hermes_cli.fallback_config import resolve_entry_api_key
 
 
@@ -38,3 +40,173 @@ class TestResolveEntryApiKey:
         monkeypatch.setenv("FB_KEY", "env-key")
         entry = {"api_key": "   ", "key_env": "FB_KEY"}
         assert resolve_entry_api_key(entry) == "env-key"
+
+
+from hermes_cli import fallback_config
+from hermes_cli import models as models_mod
+from hermes_cli.fallback_config import get_fallback_chain
+
+
+def _promotions_config(**overrides):
+    cfg = {
+        "fallback_promotions": {
+            "enabled": True,
+            "providers": ["nous"],
+            "position": "prepend",
+        }
+    }
+    cfg["fallback_promotions"].update(overrides)
+    return cfg
+
+
+def test_missing_promotions_config_preserves_static_only_behavior(monkeypatch):
+    monkeypatch.setattr(fallback_config, "_provider_has_auth", lambda provider: True)
+    monkeypatch.setattr(
+        fallback_config,
+        "_free_nous_promotion_entries",
+        lambda: [
+            {
+                "provider": "nous",
+                "model": "stepfun/step-3.7-flash:free",
+                "supports_tools": True,
+            }
+        ],
+    )
+
+    assert get_fallback_chain({}) == []
+
+
+def test_free_nous_promotion_entries_read_current_portal_recommendations(monkeypatch):
+    calls = []
+
+    def _fake_fetch(portal_base_url, timeout=5.0, **kwargs):
+        calls.append((portal_base_url, timeout, kwargs))
+        return {
+            "freeRecommendedModels": [
+                {"modelName": "stepfun/step-3.7-flash:free"},
+                {"modelName": " stepfun/step-3.7-flash:free "},
+                {"modelName": ""},
+                {},
+            ]
+        }
+
+    monkeypatch.setattr(models_mod, "_resolve_nous_portal_url", lambda: "https://portal.example")
+    monkeypatch.setattr(models_mod, "fetch_nous_recommended_models", _fake_fetch)
+
+    assert fallback_config._free_nous_promotion_entries() == [
+        {
+            "provider": "nous",
+            "model": "stepfun/step-3.7-flash:free",
+            "supports_tools": True,
+            "source": "dynamic-free-promotion",
+        }
+    ]
+    assert calls == [("https://portal.example", 1.5, {})]
+
+
+def test_nous_free_promotions_prepend_to_static_fallbacks(monkeypatch):
+    monkeypatch.setattr(fallback_config, "_provider_has_auth", lambda provider: True)
+    monkeypatch.setattr(
+        fallback_config,
+        "_free_nous_promotion_entries",
+        lambda: [
+            {
+                "provider": "nous",
+                "model": "stepfun/step-3.7-flash:free",
+                "supports_tools": True,
+                "source": "dynamic-free-promotion",
+            }
+        ],
+    )
+
+    cfg = _promotions_config()
+    cfg["fallback_providers"] = [
+        {"provider": "opencode-zen", "model": "deepseek-v4-flash-free"},
+        {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+    ]
+
+    chain = get_fallback_chain(cfg)
+
+    assert chain == [
+        {
+            "provider": "nous",
+            "model": "stepfun/step-3.7-flash:free",
+            "supports_tools": True,
+            "source": "dynamic-free-promotion",
+        },
+        {"provider": "opencode-zen", "model": "deepseek-v4-flash-free"},
+        {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+    ]
+
+
+def test_explicit_fallback_entry_wins_over_dynamic_duplicate(monkeypatch):
+    monkeypatch.setattr(fallback_config, "_provider_has_auth", lambda provider: True)
+    monkeypatch.setattr(
+        fallback_config,
+        "_free_nous_promotion_entries",
+        lambda: [
+            {
+                "provider": "nous",
+                "model": "stepfun/step-3.7-flash:free",
+                "supports_tools": True,
+                "source": "dynamic-free-promotion",
+            }
+        ],
+    )
+
+    cfg = _promotions_config()
+    cfg["fallback_providers"] = [
+        {
+            "provider": "nous",
+            "model": "stepfun/step-3.7-flash:free",
+            "supports_tools": False,
+            "note": "operator override",
+        }
+    ]
+
+    assert get_fallback_chain(cfg) == cfg["fallback_providers"]
+
+
+def test_promotions_can_append_after_static_chain(monkeypatch):
+    monkeypatch.setattr(fallback_config, "_provider_has_auth", lambda provider: True)
+    monkeypatch.setattr(
+        fallback_config,
+        "_free_nous_promotion_entries",
+        lambda: [{"provider": "nous", "model": "stepfun/step-3.7-flash:free"}],
+    )
+
+    cfg = _promotions_config(position="append")
+    cfg["fallback_providers"] = [{"provider": "taro", "model": "qwen3.6-27b-256k"}]
+
+    assert get_fallback_chain(cfg) == [
+        {"provider": "taro", "model": "qwen3.6-27b-256k"},
+        {"provider": "nous", "model": "stepfun/step-3.7-flash:free"},
+    ]
+
+
+def test_promotions_skip_when_provider_is_not_authenticated(monkeypatch):
+    monkeypatch.setattr(fallback_config, "_provider_has_auth", lambda provider: False)
+    monkeypatch.setattr(
+        fallback_config,
+        "_free_nous_promotion_entries",
+        lambda: [{"provider": "nous", "model": "stepfun/step-3.7-flash:free"}],
+    )
+
+    cfg = _promotions_config()
+    cfg["fallback_providers"] = [{"provider": "opencode-zen", "model": "deepseek-v4-flash-free"}]
+
+    assert get_fallback_chain(cfg) == [
+        {"provider": "opencode-zen", "model": "deepseek-v4-flash-free"}
+    ]
+
+
+def test_env_override_can_disable_promotions(monkeypatch):
+    monkeypatch.setenv("HERMES_FALLBACK_PROMOTIONS", "0")
+    monkeypatch.setattr(fallback_config, "_provider_has_auth", lambda provider: True)
+    monkeypatch.setattr(
+        fallback_config,
+        "_free_nous_promotion_entries",
+        lambda: [{"provider": "nous", "model": "stepfun/step-3.7-flash:free"}],
+    )
+
+    assert get_fallback_chain(_promotions_config()) == []


### PR DESCRIPTION
## Summary
- add `fallback_promotions` config enabled by default for dynamic free-provider promos
- inject current Nous Portal `freeRecommendedModels` into the fallback chain at runtime, ahead of static fallbacks unless configured otherwise
- gate remote promo discovery on Nous auth, preserve explicit configured entries, and add an env kill switch via `HERMES_FALLBACK_PROMOTIONS=0`
- cover Portal payload parsing, duplicate handling, auth gating, explicit override precedence, append/prepend behavior, and config validation

## Why
A static fallback ladder misses short-lived free promos that launch after a config sweep. Nous Portal already publishes the current free model list, so Hermes should consume that source of truth instead of waiting for a YAML/template edit.

## Validation
- `python3 -m pytest tests/hermes_cli/test_fallback_config.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_fallback_cmd.py tests/hermes_cli/test_models.py::TestUnionWithPortalFreeRecommendations tests/hermes_cli/test_models.py::TestNousRecommendedModels tests/cli/test_cli_init.py::TestFallbackChainInit -q`
- `python3 -m ruff check hermes_cli/fallback_config.py hermes_cli/config.py tests/hermes_cli/test_fallback_config.py tests/hermes_cli/test_config_validation.py`
- `git diff --check`
- live config smoke confirmed `nous / stepfun/step-3.7-flash:free` is injected before the static fallback chain when Nous auth is available

## Risk
Low. The network fetch uses the existing cached Portal recommended-models helper, has a 1.5s timeout, is skipped when Nous auth is unavailable, and degrades to the static fallback chain on any failure.