### PR TITLE
fix(cli): avoid stale MCP startup banner status

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -682,7 +682,22 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
     if remaining_toolsets > 0:
         right_lines.append(f"[dim {dim}](and {remaining_toolsets} more toolsets...)[/]")
 
-    # MCP Servers section (only if configured)
+    # MCP Servers section (only if configured). MCP discovery runs in a
+    # background thread so CLI startup doesn't freeze on a bad server. The
+    # banner is static, though; if we sample status immediately it can show
+    # healthy-but-still-connecting servers as stale "starting" forever. Give
+    # fast startup discovery a short bounded window to finish before rendering
+    # the one-shot banner state.
+    try:
+        from hermes_cli.mcp_startup import (
+            is_mcp_discovery_in_progress,
+            wait_for_mcp_discovery,
+        )
+
+        wait_for_mcp_discovery(timeout=2.0)
+        mcp_discovery_pending = is_mcp_discovery_in_progress()
+    except Exception:
+        mcp_discovery_pending = False
     try:
         from tools.mcp_tool import get_mcp_status
         mcp_status = get_mcp_status()
@@ -713,6 +728,11 @@ def build_welcome_banner(console: "Console", model: str, cwd: str,
                 right_lines.append(
                     f"[dim {dim}]{srv['name']}[/] [dim]({srv['transport']})[/] "
                     f"[dim {dim}]— configured[/]"
+                )
+            elif mcp_discovery_pending:
+                right_lines.append(
+                    f"[yellow]{srv['name']}[/] [dim]({srv['transport']})[/] "
+                    f"[yellow]— starting[/]"
                 )
             else:
                 right_lines.append(

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -86,3 +86,9 @@ def wait_for_mcp_discovery(timeout: "float | None" = None) -> None:
     if thread is None or not thread.is_alive():
         return
     thread.join(timeout=_resolve_discovery_timeout(timeout))
+
+
+def is_mcp_discovery_in_progress() -> bool:
+    """Return True while background MCP discovery is still connecting servers."""
+    thread = _mcp_discovery_thread
+    return bool(thread is not None and thread.is_alive())

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -200,3 +200,78 @@ def test_build_welcome_banner_configured_mcp_is_not_failed():
     assert "docker-profile" in output
     assert "configured" in output
     assert "failed" not in output
+
+
+def test_build_welcome_banner_waits_for_background_mcp_before_status():
+    """Banner gives fast background MCP discovery a bounded chance to finish."""
+    from unittest.mock import patch as _patch
+    import hermes_cli.banner as _banner
+    import hermes_cli.mcp_startup as _mcp_startup
+    import model_tools as _mt
+    import tools.mcp_tool as _mcp
+
+    wait_calls = []
+    status = [{"name": "context7", "transport": "http", "tools": 0, "connected": False}]
+
+    def _finish_discovery(timeout=0.75):
+        wait_calls.append(timeout)
+        status[0] = {"name": "context7", "transport": "http", "tools": 2, "connected": True}
+
+    with (
+        _patch.object(_mt, "check_tool_availability", return_value=(["web"], [])),
+        _patch.object(_banner, "get_available_skills", return_value={}),
+        _patch.object(_banner, "get_update_result", return_value=None),
+        _patch.object(_mcp_startup, "wait_for_mcp_discovery", side_effect=_finish_discovery),
+        _patch.object(_mcp_startup, "is_mcp_discovery_in_progress", return_value=False),
+        _patch.object(_mcp, "get_mcp_status", side_effect=lambda: list(status)),
+    ):
+        console = Console(record=True, force_terminal=False, color_system=None, width=160)
+        _banner.build_welcome_banner(
+            console=console,
+            model="x",
+            cwd="/tmp",
+            tools=[{"function": {"name": "web_search"}}],
+            get_toolset_for_tool=lambda n: "web",
+        )
+
+    output = console.export_text()
+    assert wait_calls == [2.0]
+    assert "context7 (http) — 2 tool(s)" in output
+    assert "context7 (http) — starting" not in output
+    assert "context7 (http) — failed" not in output
+
+
+def test_build_welcome_banner_marks_mcp_as_starting_during_discovery():
+    """Banner must not call still-connecting MCP servers failed."""
+    from unittest.mock import patch as _patch
+    import hermes_cli.banner as _banner
+    import hermes_cli.mcp_startup as _mcp_startup
+    import model_tools as _mt
+    import tools.mcp_tool as _mcp
+
+    with (
+        _patch.object(_mt, "check_tool_availability", return_value=(["web"], [])),
+        _patch.object(_banner, "get_available_skills", return_value={}),
+        _patch.object(_banner, "get_update_result", return_value=None),
+        _patch.object(
+            _mcp,
+            "get_mcp_status",
+            return_value=[
+                {"name": "github", "transport": "stdio", "tools": 21, "connected": True},
+                {"name": "context7", "transport": "http", "tools": 0, "connected": False},
+            ],
+        ),
+        _patch.object(_mcp_startup, "is_mcp_discovery_in_progress", return_value=True),
+    ):
+        console = Console(record=True, force_terminal=False, color_system=None, width=160)
+        _banner.build_welcome_banner(
+            console=console,
+            model="x",
+            cwd="/tmp",
+            tools=[{"function": {"name": "web_search"}}],
+            get_toolset_for_tool=lambda n: "web",
+        )
+
+    output = console.export_text()
+    assert "context7 (http) — starting" in output
+    assert "context7 (http) — failed" not in output

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -120,6 +120,20 @@ def test_prepare_agent_startup_skips_mcp_bootstrap_for_tui_chat(monkeypatch):
     assert mcp_startup._mcp_discovery_thread is None
 
 
+def test_is_mcp_discovery_in_progress_reflects_live_thread():
+    stop = threading.Event()
+    thread = threading.Thread(target=stop.wait, daemon=True)
+    try:
+        thread.start()
+        mcp_startup._mcp_discovery_thread = thread
+        assert mcp_startup.is_mcp_discovery_in_progress() is True
+    finally:
+        stop.set()
+        thread.join(timeout=1.0)
+
+    assert mcp_startup.is_mcp_discovery_in_progress() is False
+
+
 def test_cli_get_tool_definitions_briefly_waits_for_fast_mcp_thread(monkeypatch):
     thread = threading.Thread(target=lambda: time.sleep(0.05), daemon=True)
     thread.start()


### PR DESCRIPTION
## What does this PR do?

Fixes a welcome banner race when MCP tool discovery is still running in the background.

The banner is a static startup snapshot. Before this change, it could sample MCP status too early and show healthy servers as `failed`, or keep showing `starting` even though discovery finished moments later. This PR gives fast background discovery a short bounded window to finish before sampling status, then still renders `starting` only when discovery is genuinely still active.

## Related Issue

No linked issue. Found during local startup verification.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/mcp_startup.py`
  - Adds `is_mcp_discovery_in_progress()` so UI code can distinguish active discovery from a completed failed connection.
- `hermes_cli/banner.py`
  - Waits up to 2 seconds for background MCP discovery before sampling the one-shot banner status.
  - Renders disconnected MCP entries as `starting` only while discovery is still active.
- `tests/hermes_cli/test_mcp_startup.py`
  - Adds coverage for the discovery-in-progress helper.
- `tests/hermes_cli/test_banner.py`
  - Adds regressions for both states: fast discovery finishing before render, and still-active discovery rendering as `starting` instead of `failed`.

## How to Test

1. Configure multiple MCP servers.
2. Start Hermes and watch the welcome banner.
3. Healthy MCP servers should show their tool counts once fast discovery completes. Servers still being discovered should show `starting`, not `failed`.
4. Run the focused regression tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_banner.py tests/hermes_cli/test_mcp_startup.py -- -q --tb=short
```

## Validation Status

- [x] Focused regression tests passed locally: `13 tests passed, 0 failed`.
- [x] Windows footgun scan passed locally: `python scripts/check-windows-footguns.py`.
- [x] Manually verified on Linux startup: banner now shows all configured MCP servers with real tool counts after relaunch.
- [ ] Full `pytest tests/ -q` not run, focused CLI/MCP regression coverage only.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, kernel 7.0.9

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), N/A, behavior fix covered by tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility), no OS-specific behavior added
- [x] I've updated tool descriptions/schemas if I changed tool behavior, N/A

## Screenshots / Logs

Focused test output:

```text
=== Summary: 2 files, 13 tests passed, 0 failed in 2.2s ===
```

Windows footgun scan:

```text
✓ No Windows footguns found (4 file(s) scanned).
```
