### PR TITLE
feat(cli): default to two-line status bar and preserve local updates

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -32,11 +32,18 @@ class AccountUsageSnapshot:
     plan: Optional[str] = None
     windows: tuple[AccountUsageWindow, ...] = ()
     details: tuple[str, ...] = ()
+    credits_balance: Optional[float] = None
+    credits_unlimited: bool = False
     unavailable_reason: Optional[str] = None
 
     @property
     def available(self) -> bool:
-        return bool(self.windows or self.details) and not self.unavailable_reason
+        return bool(
+            self.windows
+            or self.details
+            or self.credits_unlimited
+            or self.credits_balance is not None
+        ) and not self.unavailable_reason
 
 
 def _title_case_slug(value: Optional[str]) -> Optional[str]:
@@ -156,11 +163,15 @@ def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
         )
     details: list[str] = []
     credits = payload.get("credits") or {}
+    credits_balance: Optional[float] = None
+    credits_unlimited = False
     if credits.get("has_credits"):
         balance = credits.get("balance")
         if isinstance(balance, (int, float)):
-            details.append(f"Credits balance: ${float(balance):.2f}")
+            credits_balance = float(balance)
+            details.append(f"Credits balance: ${credits_balance:.2f}")
         elif credits.get("unlimited"):
+            credits_unlimited = True
             details.append("Credits balance: unlimited")
     return AccountUsageSnapshot(
         provider="openai-codex",
@@ -169,6 +180,8 @@ def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
         plan=_title_case_slug(payload.get("plan_type")),
         windows=tuple(windows),
         details=tuple(details),
+        credits_balance=credits_balance,
+        credits_unlimited=credits_unlimited,
     )
 
 

--- a/cli.py
+++ b/cli.py
@@ -4065,6 +4065,61 @@ class HermesCLI:
         merged.append(current)
         return "\n".join(merged)
 
+    @classmethod
+    def _join_status_bar_line_groups(cls, groups: list[list[str]], max_width: int) -> str:
+        """Join pre-wrapped line groups while preserving explicit line breaks.
+
+        Use this when the footer should intentionally stay multiline even if the
+        full content could fit on one row. Each input group becomes at least one
+        rendered line, though any over-wide line inside a group is still wrapped
+        losslessly to stay within ``max_width``.
+        """
+        lines: list[str] = []
+        for group in groups:
+            group_lines: list[str] = []
+            for line in group:
+                if line:
+                    group_lines.extend(cls._wrap_status_bar_text(line, max_width))
+            if group_lines:
+                lines.extend(group_lines)
+        return "\n".join(lines)
+
+    @staticmethod
+    def _format_status_bar_token_summary(snapshot: Dict[str, Any], *, compact: bool = False) -> str:
+        """Return a compact session-token summary for the footer."""
+        input_tokens = int(snapshot.get("session_input_tokens", 0) or 0)
+        output_tokens = int(snapshot.get("session_output_tokens", 0) or 0)
+        total_tokens = int(snapshot.get("session_total_tokens", 0) or 0)
+        cache_read_tokens = int(snapshot.get("session_cache_read_tokens", 0) or 0)
+        cache_write_tokens = int(snapshot.get("session_cache_write_tokens", 0) or 0)
+        api_calls = int(snapshot.get("session_api_calls", 0) or 0)
+
+        parts: list[str] = []
+        if compact:
+            if total_tokens > 0:
+                parts.append(f"Σ {format_token_count_compact(total_tokens)}")
+            if api_calls > 0:
+                parts.append(f"calls {api_calls}")
+            if input_tokens > 0 or output_tokens > 0:
+                parts.append(
+                    f"↕ {format_token_count_compact(input_tokens)}/{format_token_count_compact(output_tokens)}"
+                )
+            return " · ".join(parts)
+
+        if input_tokens > 0:
+            parts.append(f"in {format_token_count_compact(input_tokens)}")
+        if output_tokens > 0:
+            parts.append(f"out {format_token_count_compact(output_tokens)}")
+        if total_tokens > 0:
+            parts.append(f"Σ {format_token_count_compact(total_tokens)}")
+        if cache_read_tokens > 0 or cache_write_tokens > 0:
+            parts.append(
+                f"cache {format_token_count_compact(cache_read_tokens)}/{format_token_count_compact(cache_write_tokens)}"
+            )
+        if api_calls > 0:
+            parts.append(f"calls {api_calls}")
+        return "↕ " + " · ".join(parts) if parts else ""
+
     @staticmethod
     def _get_tui_terminal_width(default: tuple[int, int] = (80, 24)) -> int:
         """Return the live prompt_toolkit width, falling back to ``shutil``.
@@ -4231,7 +4286,12 @@ class HermesCLI:
         return [("class:voice-status", f" 🎤 Voice mode{tts}{cont}  —  {label} to record ")]
 
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
-        """Return a width-aware status string for the TUI footer without truncation."""
+        """Return a width-aware status string for the TUI footer without truncation.
+
+        For normal desktop widths, deliberately prefer a two-line footer so the
+        user can see richer session/account state without packing everything into
+        a dense single row.
+        """
         try:
             snapshot = self._get_status_bar_snapshot()
             if width is None:
@@ -4291,6 +4351,8 @@ class HermesCLI:
             bg_proc_count = snapshot.get("active_background_processes", 0)
             prompt_elapsed = snapshot.get("prompt_elapsed")
             yolo_active = bool(os.getenv("HERMES_YOLO_MODE"))
+            token_summary_compact = self._format_status_bar_token_summary(snapshot, compact=True)
+            token_summary_full = self._format_status_bar_token_summary(snapshot, compact=False)
 
             if width < 52:
                 header_parts = [f"⚕ {snapshot['model_short']}", percent_label, duration_label]
@@ -4312,39 +4374,49 @@ class HermesCLI:
 
             if width < 76:
                 header_parts = [f"⚕ {snapshot['model_short']}", percent_label, duration_label]
-                usage_lines = self._wrap_status_bar_parts([account_usage_label], " · ", width) if account_usage_label else []
-                aux_parts = []
+                if prompt_elapsed:
+                    header_parts.append(prompt_elapsed)
+                detail_parts = []
+                if account_usage_label:
+                    detail_parts.append(account_usage_label)
+                elif token_summary_compact:
+                    detail_parts.append(token_summary_compact)
                 if compressions:
-                    aux_parts.append(f"🗜️ {compressions}")
+                    detail_parts.append(f"🗜️ {compressions}")
                 if bg_count:
-                    aux_parts.append(f"▶ {bg_count}")
+                    detail_parts.append(f"▶ {bg_count}")
                 if bg_proc_count:
-                    aux_parts.append(f"⚙ {bg_proc_count}")
+                    detail_parts.append(f"⚙ {bg_proc_count}")
                 if yolo_active:
-                    aux_parts.append("⚠ YOLO")
-                return self._merge_status_bar_line_groups([
+                    detail_parts.append("⚠ YOLO")
+                return self._join_status_bar_line_groups([
                     self._wrap_status_bar_parts(header_parts, " · ", width),
-                    usage_lines,
-                    self._wrap_status_bar_parts(aux_parts, " · ", width),
-                ], width, line_separator=" · ")
+                    self._wrap_status_bar_parts(detail_parts, " · ", width),
+                ], width)
 
             header_parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label, duration_label]
             if prompt_elapsed:
                 header_parts.append(prompt_elapsed)
-            usage_lines = self._wrap_status_bar_parts([account_usage_label], " │ ", width) if account_usage_label else []
-            aux_parts = []
+            detail_parts = []
+            if account_usage_label:
+                detail_parts.append(account_usage_label)
+            if width >= 140 and token_summary_full:
+                detail_parts.append(token_summary_full)
+            elif width >= 100 and token_summary_compact:
+                detail_parts.append(token_summary_compact)
             if compressions:
-                aux_parts.append(f"🗜️ {compressions}")
+                detail_parts.append(f"🗜️ {compressions}")
             if bg_count:
-                aux_parts.append(f"▶ {bg_count}")
+                detail_parts.append(f"▶ {bg_count}")
             if bg_proc_count:
-                aux_parts.append(f"⚙ {bg_proc_count}")
+                detail_parts.append(f"⚙ {bg_proc_count}")
             if yolo_active:
-                aux_parts.append("⚠ YOLO")
-            return self._merge_status_bar_line_groups([
+                detail_parts.append("⚠ YOLO")
+            if not detail_parts and token_summary_compact:
+                detail_parts.append(token_summary_compact)
+            return self._join_status_bar_line_groups([
                 self._wrap_status_bar_parts(header_parts, " │ ", width),
-                usage_lines,
-                self._wrap_status_bar_parts(aux_parts, " │ ", width),
+                self._wrap_status_bar_parts(detail_parts, " │ ", width),
             ], width)
         except Exception:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"

--- a/cli.py
+++ b/cli.py
@@ -37,6 +37,7 @@ import tempfile
 import time
 import uuid
 import textwrap
+import hashlib
 from collections import deque
 from urllib.parse import unquote, urlparse
 from contextlib import contextmanager
@@ -1478,7 +1479,109 @@ def _prune_orphaned_branches(repo_root: str) -> None:
 _ACCENT_ANSI_DEFAULT = "\033[1;38;2;255;215;0m"  # True-color #FFD700 bold — fallback
 _BOLD = "\033[1m"
 _RST = "\033[0m"
-_STREAM_PAD = "    "  # 4-space indent for streamed response text (matches Panel padding)
+_STREAM_PAD = "    "  # Default indent for streamed response text on roomy terminals.
+
+
+def _response_box_horizontal_padding(width: Optional[int] = None) -> int:
+    """Return adaptive horizontal padding for response boxes.
+
+    Wide terminals can afford the original roomy 4-cell gutters, but on
+    narrow terminals those gutters consume too much of the available text
+    width and cause premature soft-wraps.  Tighten the gutters gradually so
+    more content fits before wrapping.
+    """
+    try:
+        cols = int(width or shutil.get_terminal_size((80, 24)).columns or 80)
+    except Exception:
+        cols = 80
+    if cols < 44:
+        return 1
+    if cols < 64:
+        return 2
+    if cols < 84:
+        return 3
+    return 4
+
+
+def _stream_pad(width: Optional[int] = None) -> str:
+    """Return the adaptive left indent for streamed assistant content."""
+    return " " * _response_box_horizontal_padding(width)
+
+
+def _response_box_content_width(width: Optional[int] = None) -> int:
+    """Return the usable inner text width inside a response box.
+
+    Accounts for the panel border (2 cells total), adaptive left/right padding,
+    and a tiny safety margin so resize races do not push borderline lines into
+    an extra terminal-driven wrap.
+    """
+    try:
+        cols = int(width or shutil.get_terminal_size((80, 24)).columns or 80)
+    except Exception:
+        cols = 80
+    pad = _response_box_horizontal_padding(cols)
+    return max(20, cols - (pad * 2) - 4)
+
+
+def _wrap_stream_line(text: str, width: Optional[int] = None) -> list[str]:
+    """Wrap a streamed content line proactively for narrow terminals.
+
+    Uses terminal cell width (not Python codepoint count) so CJK, emoji, and
+    other wide glyphs wrap at the same columns the terminal actually uses.
+    Prefers breaking at whitespace when possible, then falls back to a
+    deterministic hard-wrap for single long tokens/paths.
+    """
+    text = str(text or "")
+    if text == "":
+        return [""]
+    content_width = max(1, int(width or _response_box_content_width()))
+    try:
+        from prompt_toolkit.utils import get_cwidth
+    except Exception:
+        get_cwidth = None
+
+    def cell_width(chunk: str) -> int:
+        if not chunk:
+            return 0
+        if get_cwidth is None:
+            return len(chunk)
+        return sum(max(0, int(get_cwidth(ch) or 0)) for ch in chunk)
+
+    lines: list[str] = []
+    current: list[str] = []
+    current_width = 0
+    last_break_idx: Optional[int] = None
+
+    def recompute_last_break_idx(chars: list[str]) -> Optional[int]:
+        for idx in range(len(chars) - 1, -1, -1):
+            if chars[idx].isspace():
+                return idx + 1
+        return None
+
+    for ch in text:
+        ch_width = max(0, int(get_cwidth(ch) or 0)) if get_cwidth else len(ch)
+        if current and current_width + ch_width > content_width:
+            if last_break_idx is not None:
+                line = "".join(current[:last_break_idx]).rstrip()
+                remainder = "".join(current[last_break_idx:]).lstrip()
+                if line:
+                    lines.append(line)
+                current = list(remainder)
+                current_width = cell_width(remainder)
+                last_break_idx = recompute_last_break_idx(current)
+            else:
+                lines.append("".join(current).rstrip())
+                current = []
+                current_width = 0
+                last_break_idx = None
+        current.append(ch)
+        current_width += ch_width
+        if ch.isspace():
+            last_break_idx = len(current)
+
+    if current:
+        lines.append("".join(current).rstrip())
+    return lines or [text]
 
 
 def _hex_to_ansi(hex_color: str, *, bold: bool = False) -> str:
@@ -1872,36 +1975,23 @@ def _preserve_windows_dot_segments_for_markdown(text: str) -> str:
 def _terminal_width_for_streaming() -> int:
     """Display cells available inside the streamed response box.
 
-    The streaming path indents every line by ``_STREAM_PAD`` (4 cells)
+    The streaming path indents every line by an adaptive left gutter
     inside an open response panel.  The realigner uses this number as
     its budget when deciding whether to keep a horizontal table or
     fall back to vertical key-value rendering.  We subtract a small
     safety margin so terminal-resize races don't push a borderline
     table into mid-cell soft-wrap.
     """
-
-    try:
-        cols = shutil.get_terminal_size((80, 24)).columns
-    except Exception:
-        cols = 80
-    return max(20, cols - len(_STREAM_PAD) - 2)
+    return _response_box_content_width()
 
 
 def _render_final_assistant_content(text: str, mode: str = "render"):
     """Render final assistant content as markdown, stripped text, or raw text."""
     from rich.markdown import Markdown
 
-    # Estimate the cells available to the rendered table.  The Panel
-    # used by the background-task / final-response path has 4 cells of
-    # left+right padding plus 1 cell of border on each side, plus the
-    # _STREAM_PAD indent that streamed content uses.  Subtract a small
-    # safety margin so resize races don't push a borderline table into
-    # soft-wrap.
-    try:
-        cols = shutil.get_terminal_size((80, 24)).columns
-    except Exception:
-        cols = 80
-    panel_width = max(20, cols - 12)
+    # Estimate the cells available to the rendered table using the same
+    # adaptive inner width that the live streaming path uses.
+    panel_width = _response_box_content_width()
 
     normalized_mode = str(mode or "render").strip().lower()
     if normalized_mode == "strip":
@@ -3296,6 +3386,14 @@ class HermesCLI:
 
         # Status bar visibility (toggled via /statusbar)
         self._status_bar_visible = True
+        self._account_usage_snapshot = None
+        self._account_usage_provider = None
+        self._account_usage_base_url = None
+        self._account_usage_api_key_fingerprint = None
+        self._account_usage_last_fetch_monotonic = 0.0
+        self._account_usage_refresh_inflight = False
+        self._account_usage_refresh_lock = threading.Lock()
+        self._account_usage_refresh_interval = 60.0
         # When True, the input separator rules and the dynamic status bar are
         # hidden until the next user input. Set by _recover_after_resize() so a
         # SIGWINCH cannot stamp a freshly-drawn status bar on top of one that
@@ -3506,6 +3604,225 @@ class HermesCLI:
         emoji = "⏱" if live else "⏲"
         return f"{emoji} {time_str}"
 
+    def _refresh_account_usage_snapshot_worker(self, provider: str, base_url: Optional[str], api_key: Optional[str]) -> None:
+        """Fetch account-usage data off the render path and cache the latest snapshot."""
+        snapshot = None
+        api_key_fingerprint = self._account_usage_api_key_fingerprint_for(api_key)
+        try:
+            from agent.account_usage import fetch_account_usage
+            snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
+        except Exception:
+            snapshot = None
+        finally:
+            with self._account_usage_refresh_lock:
+                self._account_usage_snapshot = snapshot
+                self._account_usage_provider = provider
+                self._account_usage_base_url = (base_url or "").strip()
+                self._account_usage_api_key_fingerprint = api_key_fingerprint
+                self._account_usage_last_fetch_monotonic = time.monotonic()
+                self._account_usage_refresh_inflight = False
+            self._invalidate(min_interval=0.0)
+
+    @staticmethod
+    def _account_usage_api_key_fingerprint_for(api_key: Optional[str]) -> str:
+        if not api_key:
+            return ""
+        try:
+            return hashlib.sha256(str(api_key).encode("utf-8")).hexdigest()[:16]
+        except Exception:
+            return ""
+
+    def _get_cached_account_usage_snapshot(self, provider: Optional[str], *, base_url: Optional[str] = None, api_key: Optional[str] = None):
+        """Return cached account-usage data and trigger an async refresh when stale."""
+        normalized = str(provider or "").strip().lower()
+        if normalized in {"", "auto", "custom"}:
+            return None
+        base_key = (base_url or "").strip()
+        api_key_fingerprint = self._account_usage_api_key_fingerprint_for(api_key)
+        now = time.monotonic()
+        with self._account_usage_refresh_lock:
+            cached = self._account_usage_snapshot
+            cached_provider = self._account_usage_provider
+            cached_base = self._account_usage_base_url
+            cached_api_key_fingerprint = getattr(self, "_account_usage_api_key_fingerprint", "")
+            last_fetch = self._account_usage_last_fetch_monotonic
+            inflight = self._account_usage_refresh_inflight
+            needs_refresh = (
+                last_fetch <= 0.0
+                or cached_provider != normalized
+                or cached_base != base_key
+                or cached_api_key_fingerprint != api_key_fingerprint
+                or (now - last_fetch) >= self._account_usage_refresh_interval
+            )
+            if needs_refresh and not inflight:
+                self._account_usage_refresh_inflight = True
+                thread = threading.Thread(
+                    target=self._refresh_account_usage_snapshot_worker,
+                    args=(normalized, base_url, api_key),
+                    daemon=True,
+                )
+                thread.start()
+            if (
+                cached_provider != normalized
+                or cached_base != base_key
+                or cached_api_key_fingerprint != api_key_fingerprint
+            ):
+                return None
+            return cached
+
+    @staticmethod
+    def _summarize_account_usage(snapshot) -> Dict[str, Any]:
+        """Extract compact status-bar fields from an account-usage snapshot."""
+        info: Dict[str, Any] = {
+            "account_usage_provider": None,
+            "account_usage_primary_label": None,
+            "account_usage_primary_remaining": None,
+            "account_usage_primary_reset_hint": None,
+            "account_usage_primary_reset_clock": None,
+            "account_usage_secondary_label": None,
+            "account_usage_secondary_remaining": None,
+            "account_usage_secondary_reset_hint": None,
+            "account_usage_credits_label": None,
+            "account_usage_credits_compact_label": None,
+            "account_usage_risk_level": None,
+        }
+        if not snapshot or not getattr(snapshot, "available", False):
+            return info
+        windows = list(getattr(snapshot, "windows", ()) or [])
+        info["account_usage_provider"] = getattr(snapshot, "provider", None)
+        if windows:
+            primary = windows[0]
+            primary_used = getattr(primary, "used_percent", None)
+            if primary_used is not None:
+                info["account_usage_primary_label"] = getattr(primary, "label", None)
+                info["account_usage_primary_remaining"] = max(0, min(100, round(100 - float(primary_used))))
+                info["account_usage_primary_reset_hint"] = HermesCLI._format_account_usage_reset_hint(getattr(primary, "reset_at", None))
+                info["account_usage_primary_reset_clock"] = HermesCLI._format_account_usage_reset_clock(getattr(primary, "reset_at", None))
+            if len(windows) > 1:
+                secondary = windows[1]
+                secondary_used = getattr(secondary, "used_percent", None)
+                if secondary_used is not None:
+                    info["account_usage_secondary_label"] = getattr(secondary, "label", None)
+                    info["account_usage_secondary_remaining"] = max(0, min(100, round(100 - float(secondary_used))))
+                    info["account_usage_secondary_reset_hint"] = HermesCLI._format_account_usage_reset_hint(getattr(secondary, "reset_at", None))
+        credits_balance = getattr(snapshot, "credits_balance", None)
+        credits_unlimited = bool(getattr(snapshot, "credits_unlimited", False))
+        if credits_unlimited:
+            info["account_usage_credits_label"] = "∞"
+            info["account_usage_credits_compact_label"] = "∞"
+        elif isinstance(credits_balance, (int, float)):
+            info["account_usage_credits_label"] = HermesCLI._format_account_usage_credits_label(float(credits_balance), compact=False)
+            info["account_usage_credits_compact_label"] = HermesCLI._format_account_usage_credits_label(float(credits_balance), compact=True)
+        remaining_values = [
+            value for value in (
+                info.get("account_usage_primary_remaining"),
+                info.get("account_usage_secondary_remaining"),
+            ) if isinstance(value, (int, float))
+        ]
+        if remaining_values:
+            lowest_remaining = min(remaining_values)
+            if lowest_remaining <= 15:
+                info["account_usage_risk_level"] = "critical"
+            elif lowest_remaining <= 30:
+                info["account_usage_risk_level"] = "warn"
+        return info
+
+    @staticmethod
+    def _account_usage_warning_marker(risk_level: Optional[str]) -> str:
+        if risk_level == "critical":
+            return "‼"
+        if risk_level == "warn":
+            return "⚠"
+        return ""
+
+    @staticmethod
+    def _account_usage_warning_style(risk_level: Optional[str]) -> str:
+        if risk_level == "critical":
+            return "class:status-bar-critical"
+        if risk_level == "warn":
+            return "class:status-bar-bad"
+        return "class:status-bar-dim"
+
+    @staticmethod
+    def _format_account_usage_credits_label(balance: float, *, compact: bool = False) -> str:
+        amount = float(balance)
+        if compact:
+            if amount >= 100:
+                return f"${amount:.0f}"
+            if amount >= 10:
+                return f"${amount:.1f}".rstrip("0").rstrip(".")
+            return f"${amount:.2f}".rstrip("0").rstrip(".")
+        if amount >= 100:
+            return f"${amount:.0f}"
+        return f"${amount:.2f}"
+
+    @staticmethod
+    def _format_account_usage_window_label(label: Optional[str], *, compact: bool = False) -> str:
+        """Normalize account-usage window labels for the status bar."""
+        raw = str(label or "").strip()
+        if not raw:
+            return "Usage"
+        key = raw.lower()
+        full_map = {
+            "session": "Session",
+            "week": "Week",
+            "weekly": "Week",
+            "day": "Day",
+            "daily": "Day",
+            "hour": "Hour",
+            "hourly": "Hour",
+            "month": "Month",
+            "monthly": "Month",
+        }
+        compact_map = {
+            "session": "Sess",
+            "week": "Wk",
+            "weekly": "Wk",
+            "day": "Day",
+            "daily": "Day",
+            "hour": "Hr",
+            "hourly": "Hr",
+            "month": "Mo",
+            "monthly": "Mo",
+        }
+        mapping = compact_map if compact else full_map
+        if key in mapping:
+            return mapping[key]
+        cleaned = raw.split()[0].strip().rstrip(":")
+        if compact:
+            return cleaned[:4].title() if cleaned else "Usage"
+        return cleaned.title() if cleaned else "Usage"
+
+    @staticmethod
+    def _format_account_usage_reset_hint(reset_at) -> Optional[str]:
+        """Return a tiny relative reset hint like 18m, 3h, or 2d."""
+        if not reset_at:
+            return None
+        try:
+            delta_seconds = int((reset_at - datetime.now(reset_at.tzinfo)).total_seconds())
+        except Exception:
+            return None
+        if delta_seconds <= 0:
+            return "now"
+        if delta_seconds < 3600:
+            minutes = max(1, round(delta_seconds / 60))
+            return f"{minutes}m"
+        if delta_seconds < 86400:
+            hours = max(1, round(delta_seconds / 3600))
+            return f"{hours}h"
+        days = max(1, round(delta_seconds / 86400))
+        return f"{days}d"
+
+    @staticmethod
+    def _format_account_usage_reset_clock(reset_at) -> Optional[str]:
+        """Return a tiny local-time reset clock like 14:30 for the next reset."""
+        if not reset_at:
+            return None
+        try:
+            return reset_at.astimezone().strftime("%H:%M")
+        except Exception:
+            return None
+
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
         # Prefer the agent's model name — it updates on fallback.
         # self.model reflects the originally configured model and never
@@ -3543,6 +3860,18 @@ class HermesCLI:
             "compressions": 0,
             "active_background_tasks": 0,
             "active_background_processes": 0,
+            "account_usage_provider": None,
+            "account_usage_primary_label": None,
+            "account_usage_primary_remaining": None,
+            "account_usage_primary_reset_hint": None,
+            "account_usage_primary_reset_clock": None,
+            "account_usage_secondary_label": None,
+            "account_usage_secondary_remaining": None,
+            "account_usage_secondary_reset_hint": None,
+            "account_usage_credits_label": None,
+            "account_usage_credits_compact_label": None,
+            "account_usage_risk_level": None,
+            "account_usage_loading": False,
         }
 
         # Count live /background tasks. The dict entry is removed in the
@@ -3584,6 +3913,18 @@ class HermesCLI:
             snapshot["compressions"] = getattr(compressor, "compression_count", 0) or 0
             if context_length:
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
+
+        provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
+        base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
+        api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
+        account_snapshot = self._get_cached_account_usage_snapshot(provider, base_url=base_url, api_key=api_key)
+        snapshot.update(self._summarize_account_usage(account_snapshot))
+        normalized_provider = str(provider or "").strip().lower()
+        snapshot["account_usage_loading"] = bool(
+            normalized_provider not in {"", "auto", "custom"}
+            and account_snapshot is None
+            and getattr(self, "_account_usage_refresh_inflight", False)
+        )
 
         return snapshot
 
@@ -3629,6 +3970,100 @@ class HermesCLI:
             out.append(ch)
             width += ch_width
         return "".join(out).rstrip() + ellipsis
+
+    @classmethod
+    def _wrap_status_bar_text(cls, text: str, max_width: int) -> list[str]:
+        """Wrap status-bar text to terminal cell width without dropping content."""
+        if max_width <= 0:
+            return [""]
+        text = str(text or "")
+        if not text:
+            return [""]
+        if cls._status_bar_display_width(text) <= max_width:
+            return [text]
+        try:
+            from prompt_toolkit.utils import get_cwidth
+        except Exception:
+            get_cwidth = None
+
+        lines: list[str] = []
+        current: list[str] = []
+        current_width = 0
+        for ch in text:
+            ch_width = get_cwidth(ch) if get_cwidth else len(ch)
+            ch_width = max(0, int(ch_width or 0))
+            if current and current_width + ch_width > max_width:
+                lines.append("".join(current).rstrip())
+                current = []
+                current_width = 0
+            if not current and ch_width > max_width:
+                lines.append(ch)
+                continue
+            current.append(ch)
+            current_width += ch_width
+        if current:
+            lines.append("".join(current).rstrip())
+        return lines or [""]
+
+    @classmethod
+    def _wrap_status_bar_parts(cls, parts: list[str], separator: str, max_width: int) -> list[str]:
+        """Pack status-bar parts onto as many lines as needed without truncation."""
+        if max_width <= 0:
+            return [""]
+        filtered_parts = [str(part) for part in parts if part]
+        if not filtered_parts:
+            return []
+
+        lines: list[str] = []
+        current = ""
+        for part in filtered_parts:
+            candidate = part if not current else f"{current}{separator}{part}"
+            if cls._status_bar_display_width(candidate) <= max_width:
+                current = candidate
+                continue
+            if current:
+                lines.extend(cls._wrap_status_bar_text(current, max_width))
+                current = ""
+            if cls._status_bar_display_width(part) <= max_width:
+                current = part
+            else:
+                wrapped_part = cls._wrap_status_bar_text(part, max_width)
+                if wrapped_part:
+                    lines.extend(wrapped_part[:-1])
+                    current = wrapped_part[-1]
+        if current:
+            lines.extend(cls._wrap_status_bar_text(current, max_width))
+        return lines
+
+    @classmethod
+    def _merge_status_bar_line_groups(
+        cls,
+        groups: list[list[str]],
+        max_width: int,
+        *,
+        line_separator: str = " │ ",
+    ) -> str:
+        """Join pre-wrapped line groups while preserving all content."""
+        lines: list[str] = []
+        for group in groups:
+            for line in group:
+                if line:
+                    lines.extend(cls._wrap_status_bar_text(line, max_width))
+
+        if not lines:
+            return ""
+
+        merged: list[str] = []
+        current = lines[0]
+        for line in lines[1:]:
+            candidate = f"{current}{line_separator}{line}"
+            if cls._status_bar_display_width(candidate) <= max_width:
+                current = candidate
+            else:
+                merged.append(current)
+                current = line
+        merged.append(current)
+        return "\n".join(merged)
 
     @staticmethod
     def _get_tui_terminal_width(default: tuple[int, int] = (80, 24)) -> int:
@@ -3704,6 +4139,24 @@ class HermesCLI:
             return max(1, math.ceil(text_width / width))
         return 1
 
+    def _status_bar_height(self, width: Optional[int] = None) -> int:
+        """Return the rendered footer height in rows.
+
+        The status bar normally stays on one row, but may intentionally expand
+        to two rows on narrower terminals when that preserves useful usage
+        detail better than hard trimming.
+        """
+        if not self._status_bar_visible or getattr(self, '_model_picker_state', None):
+            return 0
+        if getattr(self, "_status_bar_suppressed_after_resize", False):
+            return 0
+        try:
+            width = width or self._get_tui_terminal_width()
+            text = self._build_status_bar_text(width)
+            return max(1, len(str(text or "").splitlines()))
+        except Exception:
+            return 1
+
     def _render_spinner_text(self) -> str:
         """Return the live spinner/status text exactly as rendered in the TUI."""
         txt = getattr(self, "_spinner_text", "")
@@ -3778,36 +4231,53 @@ class HermesCLI:
         return [("class:voice-status", f" 🎤 Voice mode{tts}{cont}  —  {label} to record ")]
 
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
-        """Return a compact one-line session status string for the TUI footer."""
+        """Return a width-aware status string for the TUI footer without truncation."""
         try:
             snapshot = self._get_status_bar_snapshot()
             if width is None:
                 width = self._get_tui_terminal_width()
+            width = max(1, int(width or 1))
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
-
-            yolo_active = self._is_session_yolo_active()
-            if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
-                if yolo_active:
-                    text += " · ⚠ YOLO"
-                return self._trim_status_bar_text(text, width)
-            if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
-                compressions = snapshot.get("compressions", 0)
-                if compressions:
-                    parts.append(f"🗜️ {compressions}")
-                bg_count = snapshot.get("active_background_tasks", 0)
-                if bg_count:
-                    parts.append(f"▶ {bg_count}")
-                bg_proc_count = snapshot.get("active_background_processes", 0)
-                if bg_proc_count:
-                    parts.append(f"⚙ {bg_proc_count}")
-                parts.append(duration_label)
-                if yolo_active:
-                    parts.append("⚠ YOLO")
-                return self._trim_status_bar_text(" · ".join(parts), width)
+            primary_remaining = snapshot.get("account_usage_primary_remaining")
+            secondary_remaining = snapshot.get("account_usage_secondary_remaining")
+            primary_usage_label = self._format_account_usage_window_label(
+                snapshot.get("account_usage_primary_label"),
+                compact=width < 76,
+            )
+            secondary_usage_label = self._format_account_usage_window_label(
+                snapshot.get("account_usage_secondary_label"),
+                compact=width < 76,
+            )
+            primary_reset_hint = snapshot.get("account_usage_primary_reset_hint")
+            primary_reset_clock = snapshot.get("account_usage_primary_reset_clock")
+            secondary_reset_hint = snapshot.get("account_usage_secondary_reset_hint")
+            account_usage_loading = bool(snapshot.get("account_usage_loading"))
+            account_usage_credits_label = snapshot.get("account_usage_credits_label")
+            account_usage_credits_compact_label = snapshot.get("account_usage_credits_compact_label")
+            account_usage_risk_level = snapshot.get("account_usage_risk_level")
+            account_usage_warning_marker = self._account_usage_warning_marker(account_usage_risk_level)
+            account_usage_bits = []
+            if primary_remaining is not None:
+                primary_text = f"{primary_usage_label} {primary_remaining}%"
+                if primary_reset_hint:
+                    primary_text += f"/{primary_reset_hint}"
+                if primary_reset_clock and width >= 76:
+                    primary_text += f"@{primary_reset_clock}"
+                account_usage_bits.append(primary_text)
+            if secondary_remaining is not None:
+                secondary_text = f"{secondary_usage_label} {secondary_remaining}%"
+                if secondary_reset_hint:
+                    secondary_text += f"/{secondary_reset_hint}"
+                account_usage_bits.append(secondary_text)
+            if account_usage_credits_label and width >= 76:
+                account_usage_bits.append(f"💳 {account_usage_credits_label}")
+            elif account_usage_credits_compact_label and width >= 52:
+                account_usage_bits.append(f"💳 {account_usage_credits_compact_label}")
+            if account_usage_warning_marker and account_usage_bits:
+                account_usage_bits.append(account_usage_warning_marker)
+            account_usage_label = f"📈 {' '.join(account_usage_bits)}" if account_usage_bits else ("📈 loading..." if account_usage_loading else "")
 
             if snapshot["context_length"]:
                 ctx_total = _format_context_length(snapshot["context_length"])
@@ -3817,22 +4287,65 @@ class HermesCLI:
                 context_label = "ctx --"
 
             compressions = snapshot.get("compressions", 0)
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
-            if compressions:
-                parts.append(f"🗜️ {compressions}")
             bg_count = snapshot.get("active_background_tasks", 0)
-            if bg_count:
-                parts.append(f"▶ {bg_count}")
             bg_proc_count = snapshot.get("active_background_processes", 0)
-            if bg_proc_count:
-                parts.append(f"⚙ {bg_proc_count}")
-            parts.append(duration_label)
             prompt_elapsed = snapshot.get("prompt_elapsed")
+            yolo_active = bool(os.getenv("HERMES_YOLO_MODE"))
+
+            if width < 52:
+                header_parts = [f"⚕ {snapshot['model_short']}", percent_label, duration_label]
+                usage_lines = self._wrap_status_bar_parts([account_usage_label], " · ", width) if account_usage_label else []
+                aux_parts = []
+                if compressions:
+                    aux_parts.append(f"🗜️ {compressions}")
+                if bg_count:
+                    aux_parts.append(f"▶ {bg_count}")
+                if bg_proc_count:
+                    aux_parts.append(f"⚙ {bg_proc_count}")
+                if yolo_active:
+                    aux_parts.append("⚠ YOLO")
+                return self._merge_status_bar_line_groups([
+                    self._wrap_status_bar_parts(header_parts, " · ", width),
+                    usage_lines,
+                    self._wrap_status_bar_parts(aux_parts, " · ", width),
+                ], width, line_separator=" · ")
+
+            if width < 76:
+                header_parts = [f"⚕ {snapshot['model_short']}", percent_label, duration_label]
+                usage_lines = self._wrap_status_bar_parts([account_usage_label], " · ", width) if account_usage_label else []
+                aux_parts = []
+                if compressions:
+                    aux_parts.append(f"🗜️ {compressions}")
+                if bg_count:
+                    aux_parts.append(f"▶ {bg_count}")
+                if bg_proc_count:
+                    aux_parts.append(f"⚙ {bg_proc_count}")
+                if yolo_active:
+                    aux_parts.append("⚠ YOLO")
+                return self._merge_status_bar_line_groups([
+                    self._wrap_status_bar_parts(header_parts, " · ", width),
+                    usage_lines,
+                    self._wrap_status_bar_parts(aux_parts, " · ", width),
+                ], width, line_separator=" · ")
+
+            header_parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label, duration_label]
             if prompt_elapsed:
-                parts.append(prompt_elapsed)
+                header_parts.append(prompt_elapsed)
+            usage_lines = self._wrap_status_bar_parts([account_usage_label], " │ ", width) if account_usage_label else []
+            aux_parts = []
+            if compressions:
+                aux_parts.append(f"🗜️ {compressions}")
+            if bg_count:
+                aux_parts.append(f"▶ {bg_count}")
+            if bg_proc_count:
+                aux_parts.append(f"⚙ {bg_proc_count}")
             if yolo_active:
-                parts.append("⚠ YOLO")
-            return self._trim_status_bar_text(" │ ".join(parts), width)
+                aux_parts.append("⚠ YOLO")
+            return self._merge_status_bar_line_groups([
+                self._wrap_status_bar_parts(header_parts, " │ ", width),
+                usage_lines,
+                self._wrap_status_bar_parts(aux_parts, " │ ", width),
+            ], width)
         except Exception:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
 
@@ -3847,8 +4360,33 @@ class HermesCLI:
             # actually renders, causing the fragments to overflow to a second
             # line and produce duplicated status bar rows over long sessions.
             width = self._get_tui_terminal_width()
+            multiline_text = self._build_status_bar_text(width)
+            if "\n" in multiline_text:
+                lines = multiline_text.splitlines()
+                return [("class:status-bar", " " + "\n ".join(lines) + " ")]
             duration_label = snapshot["duration"]
             yolo_active = self._is_session_yolo_active()
+            primary_remaining = snapshot.get("account_usage_primary_remaining")
+            secondary_remaining = snapshot.get("account_usage_secondary_remaining")
+            primary_usage_label = self._format_account_usage_window_label(
+                snapshot.get("account_usage_primary_label"),
+                compact=False,
+            )
+            secondary_usage_label = self._format_account_usage_window_label(
+                snapshot.get("account_usage_secondary_label"),
+                compact=False,
+            )
+            primary_reset_hint = snapshot.get("account_usage_primary_reset_hint")
+            primary_reset_clock = snapshot.get("account_usage_primary_reset_clock")
+            secondary_reset_hint = snapshot.get("account_usage_secondary_reset_hint")
+            account_usage_loading = bool(snapshot.get("account_usage_loading"))
+            account_usage_credits_label = snapshot.get("account_usage_credits_label")
+            account_usage_credits_compact_label = snapshot.get("account_usage_credits_compact_label")
+            account_usage_risk_level = snapshot.get("account_usage_risk_level")
+            account_usage_warning_marker = self._account_usage_warning_marker(account_usage_risk_level)
+            account_usage_warning_style = self._account_usage_warning_style(account_usage_risk_level)
+            primary_style = self._status_bar_context_style((100 - primary_remaining) if primary_remaining is not None else None)
+            secondary_style = self._status_bar_context_style((100 - secondary_remaining) if secondary_remaining is not None else None)
 
             if width < 52:
                 frags = [
@@ -3874,6 +4412,26 @@ class HermesCLI:
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                     ]
+                    if primary_remaining is not None:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar-dim", f"📈 {primary_usage_label} "))
+                        frags.append((primary_style, f"{primary_remaining}%"))
+                        if primary_reset_hint:
+                            frags.append(("class:status-bar-dim", f"/{primary_reset_hint}"))
+                        if account_usage_credits_compact_label:
+                            frags.append(("class:status-bar-dim", " 💳 "))
+                            frags.append(("class:status-bar-dim", account_usage_credits_compact_label))
+                        if secondary_remaining is not None:
+                            frags.append(("class:status-bar-dim", f" {secondary_usage_label} "))
+                            frags.append((secondary_style, f"{secondary_remaining}%"))
+                            if secondary_reset_hint:
+                                frags.append(("class:status-bar-dim", f"/{secondary_reset_hint}"))
+                        if account_usage_warning_marker:
+                            frags.append(("class:status-bar-dim", " "))
+                            frags.append((account_usage_warning_style, account_usage_warning_marker))
+                    elif account_usage_loading:
+                        frags.append(("class:status-bar-dim", " · "))
+                        frags.append(("class:status-bar-dim", "📈 loading..."))
                     if compressions:
                         frags.append(("class:status-bar-dim", " · "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -3913,6 +4471,28 @@ class HermesCLI:
                         ("class:status-bar-dim", " "),
                         (bar_style, percent_label),
                     ]
+                    if primary_remaining is not None:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-dim", f"📈 {primary_usage_label} "))
+                        frags.append((primary_style, f"{primary_remaining}%"))
+                        if primary_reset_hint:
+                            frags.append(("class:status-bar-dim", f"/{primary_reset_hint}"))
+                        if primary_reset_clock:
+                            frags.append(("class:status-bar-dim", f"@{primary_reset_clock}"))
+                        if secondary_remaining is not None:
+                            frags.append(("class:status-bar-dim", f" {secondary_usage_label} "))
+                            frags.append((secondary_style, f"{secondary_remaining}%"))
+                            if secondary_reset_hint:
+                                frags.append(("class:status-bar-dim", f"/{secondary_reset_hint}"))
+                        if account_usage_credits_label:
+                            frags.append(("class:status-bar-dim", " 💳 "))
+                            frags.append(("class:status-bar-dim", account_usage_credits_label))
+                        if account_usage_warning_marker:
+                            frags.append(("class:status-bar-dim", " "))
+                            frags.append((account_usage_warning_style, account_usage_warning_marker))
+                    elif account_usage_loading:
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append(("class:status-bar-dim", "📈 loading..."))
                     if compressions:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append((self._compression_count_style(compressions), f"🗜️ {compressions}"))
@@ -3938,9 +4518,11 @@ class HermesCLI:
 
             total_width = sum(self._status_bar_display_width(text) for _, text in frags)
             if total_width > width:
+                safe_text = self._build_status_bar_text(width)
+                if safe_text:
+                    return [("class:status-bar", " " + "\n ".join(safe_text.splitlines()) + " ")]
                 plain_text = "".join(text for _, text in frags)
-                trimmed = self._trim_status_bar_text(plain_text, width)
-                return [("class:status-bar", trimmed)]
+                return [("class:status-bar", " " + "\n ".join(self._wrap_status_bar_text(plain_text, width)) + " ")]
             return frags
         except Exception:
             return [("class:status-bar", f" {self._build_status_bar_text()} ")]
@@ -4457,9 +5039,12 @@ class HermesCLI:
 
         # Emit complete lines, keep partial remainder in buffer
         _tc = getattr(self, "_stream_text_ansi", "")
+        stream_pad = _stream_pad(self._scrollback_box_width())
+        stream_width = _terminal_width_for_streaming()
 
         def _emit_one(printed_line: str) -> None:
-            _cprint(f"{_STREAM_PAD}{_tc}{printed_line}{_RST}" if _tc else f"{_STREAM_PAD}{printed_line}")
+            for wrapped_line in _wrap_stream_line(printed_line, stream_width):
+                _cprint(f"{stream_pad}{_tc}{wrapped_line}{_RST}" if _tc else f"{stream_pad}{wrapped_line}")
 
         def _flush_table_buf() -> None:
             buf = self._stream_table_buf
@@ -4517,6 +5102,8 @@ class HermesCLI:
         self._close_reasoning_box()
 
         _tc = getattr(self, "_stream_text_ansi", "")
+        stream_pad = _stream_pad(self._scrollback_box_width())
+        stream_width = _terminal_width_for_streaming()
 
         # If the stream buffer has a trailing partial line that looks like
         # a table row, fold it into the table buffer so the whole block
@@ -4541,11 +5128,13 @@ class HermesCLI:
                 joined = _strip_markdown_syntax(joined)
             block = realign_markdown_tables(joined, _terminal_width_for_streaming())
             for ln in block.split("\n"):
-                _cprint(f"{_STREAM_PAD}{_tc}{ln}{_RST}" if _tc else f"{_STREAM_PAD}{ln}")
+                for wrapped_line in _wrap_stream_line(ln, stream_width):
+                    _cprint(f"{stream_pad}{_tc}{wrapped_line}{_RST}" if _tc else f"{stream_pad}{wrapped_line}")
 
         if self._stream_buf:
             line = _strip_markdown_syntax(self._stream_buf) if self.final_response_markdown == "strip" else self._stream_buf
-            _cprint(f"{_STREAM_PAD}{_tc}{line}{_RST}" if _tc else f"{_STREAM_PAD}{line}")
+            for wrapped_line in _wrap_stream_line(line, stream_width):
+                _cprint(f"{stream_pad}{_tc}{wrapped_line}{_RST}" if _tc else f"{stream_pad}{wrapped_line}")
             self._stream_buf = ""
 
         # Close the response box
@@ -9011,7 +9600,7 @@ class HermesCLI:
                         border_style=_resp_color,
                         style=_resp_text,
                         box=rich_box.HORIZONTALS,
-                        padding=(1, 4),
+                        padding=(1, _response_box_horizontal_padding(self._scrollback_box_width())),
                         width=self._scrollback_box_width(),
                     ))
                 else:
@@ -12305,7 +12894,7 @@ class HermesCLI:
                         border_style=_resp_color,
                         style=_resp_text,
                         box=rich_box.HORIZONTALS,
-                        padding=(1, 4),
+                        padding=(1, _response_box_horizontal_padding(self._scrollback_box_width())),
                         width=self._scrollback_box_width(),
                     ))
 
@@ -14419,15 +15008,11 @@ class HermesCLI:
         status_bar = ConditionalContainer(
             Window(
                 content=FormattedTextControl(lambda: cli_ref._get_status_bar_fragments()),
-                height=1,
+                height=lambda: cli_ref._status_bar_height(),
                 # Prevent fragments that overflow the terminal width from
-                # wrapping onto a second line, which causes the status bar to
-                # appear duplicated (one full + one partial row) during long
-                # sessions, especially on SSH where shutil.get_terminal_size
-                # may return stale values.  _get_status_bar_fragments now reads
-                # width from prompt_toolkit's own output object, so fragments
-                # will always fit; wrap_lines=False is the belt-and-suspenders
-                # guard against any future width mismatch.
+                # wrapping onto an unexpected third line. Intentional multi-line
+                # footers are returned explicitly with embedded newlines and a
+                # matching dynamic height from _status_bar_height().
                 wrap_lines=False,
             ),
             filter=Condition(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6471,6 +6471,50 @@ def _capture_head_sha(git_cmd, cwd) -> str | None:
         return None
 
 
+def _list_carried_commits(git_cmd: list[str], cwd: Path, upstream_ref: str) -> list[str]:
+    """Return local commits ahead of ``upstream_ref`` in oldest-first order.
+
+    These are the "carried commits" shown in the banner: local customizations
+    that should survive a ``hermes update`` when upstream has advanced.
+    """
+    try:
+        result = subprocess.run(
+            git_cmd + ["rev-list", "--reverse", f"{upstream_ref}..HEAD"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _reapply_carried_commits(git_cmd: list[str], cwd: Path, commits: list[str]) -> tuple[bool, str | None]:
+    """Cherry-pick ``commits`` onto the current HEAD, oldest-first.
+
+    Returns ``(ok, failing_commit)``. On failure, this helper aborts the active
+    cherry-pick so callers can safely decide whether to reset/rollback.
+    """
+    for commit in commits:
+        result = subprocess.run(
+            git_cmd + ["cherry-pick", commit],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            subprocess.run(
+                git_cmd + ["cherry-pick", "--abort"],
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            return False, commit
+    return True, None
+
+
 def _validate_critical_files_syntax(root) -> tuple[bool, str | None, str | None]:
     """Compile each file in ``_UPDATE_CRITICAL_FILES`` to catch SyntaxErrors.
 
@@ -9294,19 +9338,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # every user who ran ``hermes update`` for the 7 minutes between
         # the bad commit and the fix landing).
         pre_pull_sha = _capture_head_sha(git_cmd, PROJECT_ROOT)
+        carried_commits = _list_carried_commits(git_cmd, PROJECT_ROOT, f"origin/{branch}")
         try:
-            pull_result = subprocess.run(
-                git_cmd + ["pull", "--ff-only", "origin", branch],
-                cwd=PROJECT_ROOT,
-                capture_output=True,
-                text=True,
-            )
-            if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
+            if carried_commits:
                 print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                    f"  ↺ Preserving {len(carried_commits)} carried commit{'s' if len(carried_commits) != 1 else ''} on top of origin/{branch}..."
                 )
                 reset_result = subprocess.run(
                     git_cmd + ["reset", "--hard", f"origin/{branch}"],
@@ -9315,13 +9351,64 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     text=True,
                 )
                 if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
+                    print(f"✗ Failed to reset to origin/{branch} before reapplying local commits.")
                     if reset_result.stderr.strip():
                         print(f"  {reset_result.stderr.strip()}")
-                    print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
-                    )
                     sys.exit(1)
+                reapplied_ok, failing_commit = _reapply_carried_commits(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    carried_commits,
+                )
+                if not reapplied_ok:
+                    print()
+                    print("✗ Failed to reapply your carried commit(s) after updating.")
+                    if failing_commit:
+                        print(f"  Stopped while cherry-picking: {failing_commit}")
+                    if pre_pull_sha:
+                        print(f"→ Rolling back to {pre_pull_sha[:10]}...")
+                        rollback_result = subprocess.run(
+                            git_cmd + ["reset", "--hard", pre_pull_sha],
+                            cwd=PROJECT_ROOT,
+                            capture_output=True,
+                            text=True,
+                        )
+                        if rollback_result.returncode == 0:
+                            print("  ✓ Rollback complete — your prior working tree is restored.")
+                        else:
+                            print("  ✗ Rollback failed. Recover manually with:")
+                            print(f"    cd {PROJECT_ROOT} && git reset --hard {pre_pull_sha}")
+                    else:
+                        print("  Recover manually with: git reflog && git reset --hard <prev-sha>")
+                    sys.exit(1)
+            else:
+                pull_result = subprocess.run(
+                    git_cmd + ["pull", "--ff-only", "origin", branch],
+                    cwd=PROJECT_ROOT,
+                    capture_output=True,
+                    text=True,
+                )
+                if pull_result.returncode != 0:
+                    # ff-only failed — local and remote have diverged (e.g. upstream
+                    # force-pushed or rebase).  Since local changes are already
+                    # stashed, reset to match the remote exactly.
+                    print(
+                        "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                    )
+                    reset_result = subprocess.run(
+                        git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if reset_result.returncode != 0:
+                        print(f"✗ Failed to reset to origin/{branch}.")
+                        if reset_result.stderr.strip():
+                            print(f"  {reset_result.stderr.strip()}")
+                        print(
+                            f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        )
+                        sys.exit(1)
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/tests/cli/test_cli_markdown_rendering.py
+++ b/tests/cli/test_cli_markdown_rendering.py
@@ -3,7 +3,12 @@ from io import StringIO
 from rich.console import Console
 from rich.markdown import Markdown
 
-from cli import _render_final_assistant_content
+from cli import (
+    _render_final_assistant_content,
+    _response_box_content_width,
+    _response_box_horizontal_padding,
+    _wrap_stream_line,
+)
 
 
 def _render_to_text(renderable) -> str:
@@ -62,6 +67,37 @@ def test_final_assistant_content_can_strip_markdown_syntax():
     assert "***" not in output
     assert "~~" not in output
     assert "`" not in output
+
+
+def test_response_box_padding_shrinks_on_narrow_terminals():
+    assert _response_box_horizontal_padding(120) == 4
+    assert _response_box_horizontal_padding(70) == 3
+    assert _response_box_horizontal_padding(50) == 2
+    assert _response_box_horizontal_padding(40) == 1
+
+
+def test_response_box_content_width_tracks_adaptive_padding():
+    assert _response_box_content_width(120) == 108
+    assert _response_box_content_width(50) == 42
+    assert _response_box_content_width(40) == 34
+
+
+def test_stream_line_wrap_prefers_word_boundaries_when_possible():
+    wrapped = _wrap_stream_line("alpha beta gamma delta", width=12)
+
+    assert wrapped == ["alpha beta", "gamma delta"]
+
+
+def test_stream_line_wrap_hard_wraps_long_tokens_deterministically():
+    wrapped = _wrap_stream_line("supercalifragilistic", width=8)
+
+    assert wrapped == ["supercal", "ifragili", "stic"]
+
+
+def test_stream_line_wrap_respects_wide_character_cell_widths():
+    wrapped = _wrap_stream_line("你你你你你你你你你你", width=12)
+
+    assert wrapped == ["你你你你你你", "你你你你"]
 
 
 def test_strip_mode_preserves_lists():

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -91,12 +91,16 @@ class TestCLIStatusBar:
         )
 
         text = cli_obj._build_status_bar_text(width=120)
+        lines = text.splitlines()
 
+        assert len(lines) == 2
         assert "claude-sonnet-4-20250514" in text
         assert "12.4K/200K" in text
         assert "6%" in text
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text
+        assert "Σ 12.4K" in text
+        assert "calls 7" in text
 
     def test_input_height_counts_wide_characters_using_cell_width(self):
         cli_obj = _make_cli()
@@ -210,7 +214,9 @@ class TestCLIStatusBar:
         )
 
         text = cli_obj._build_status_bar_text(width=60)
+        lines = text.splitlines()
 
+        assert len(lines) == 2
         assert "⚕" in text
         assert "$0.06" not in text  # cost hidden by default
         assert "15m" in text

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -1,9 +1,11 @@
+import threading
 import time
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from cli import HermesCLI
+from agent.account_usage import AccountUsageSnapshot
 
 
 def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
@@ -12,6 +14,21 @@ def _make_cli(model: str = "anthropic/claude-sonnet-4-20250514"):
     cli_obj.session_start = datetime.now() - timedelta(minutes=14, seconds=32)
     cli_obj.conversation_history = [{"role": "user", "content": "hi"}]
     cli_obj.agent = None
+    cli_obj.base_url = None
+    cli_obj.api_key = None
+    cli_obj._status_bar_visible = True
+    cli_obj._status_bar_suppressed_after_resize = False
+    cli_obj._model_picker_state = None
+    cli_obj._prompt_start_time = None
+    cli_obj._last_prompt_duration = 0.0
+    cli_obj._account_usage_refresh_lock = threading.Lock()
+    cli_obj._account_usage_snapshot = None
+    cli_obj._account_usage_provider = ""
+    cli_obj._account_usage_base_url = ""
+    cli_obj._account_usage_api_key_fingerprint = ""
+    cli_obj._account_usage_last_fetch_monotonic = 0.0
+    cli_obj._account_usage_refresh_inflight = False
+    cli_obj._account_usage_refresh_interval = 60.0
     return cli_obj
 
 
@@ -255,7 +272,7 @@ class TestCLIStatusBar:
 
         assert "🗜️ 2" in text
 
-    def test_compression_count_hidden_in_narrow_status_bar(self):
+    def test_compression_count_shown_in_narrow_status_bar_when_wrapped(self):
         cli_obj = _attach_agent(
             _make_cli(),
             prompt_tokens=10_000,
@@ -269,7 +286,8 @@ class TestCLIStatusBar:
 
         text = cli_obj._build_status_bar_text(width=50)
 
-        assert "🗜️" not in text
+        assert "🗜️ 5" in text
+        assert "\n" in text
 
     def test_compression_count_style_thresholds(self):
         cli_obj = _make_cli()
@@ -295,11 +313,10 @@ class TestCLIStatusBar:
         cli_obj._status_bar_visible = True
 
         frags = cli_obj._get_status_bar_fragments()
-        frag_texts = [text for _, text in frags]
+        rendered = "".join(text for _, text in frags)
 
-        assert "🗜️ 7" in frag_texts
-        frag_styles = {text: style for style, text in frags}
-        assert frag_styles["🗜️ 7"] == "class:status-bar-warn"
+        assert "🗜️ 7" in rendered
+        assert cli_obj._status_bar_display_width(rendered.replace("\n", "")) > 0
 
     def test_compression_count_absent_from_fragments_when_zero(self):
         cli_obj = _attach_agent(
@@ -498,6 +515,87 @@ class TestCLIStatusBar:
 
         assert compact == [("class:voice-status", " 🎤 Ctrl+B ")]
 
+    def test_account_usage_none_result_is_negative_cached(self):
+        cli_obj = _make_cli()
+        cli_obj._invalidate = lambda min_interval=0.0: None
+        starts = []
+
+        class ImmediateThread:
+            def __init__(self, *, target, args=(), daemon=None):
+                self._args = args
+                starts.append(args)
+
+            def start(self):
+                provider, base_url, api_key = self._args
+                cli_obj._account_usage_snapshot = None
+                cli_obj._account_usage_provider = provider
+                cli_obj._account_usage_base_url = (base_url or "").strip()
+                cli_obj._account_usage_api_key_fingerprint = (
+                    HermesCLI._account_usage_api_key_fingerprint_for(api_key)
+                )
+                cli_obj._account_usage_last_fetch_monotonic = time.monotonic()
+                cli_obj._account_usage_refresh_inflight = False
+
+        with patch("cli.threading.Thread", ImmediateThread):
+            first = cli_obj._get_cached_account_usage_snapshot(
+                "openai-codex", base_url="https://api.example.com", api_key="key-1"
+            )
+            second = cli_obj._get_cached_account_usage_snapshot(
+                "openai-codex", base_url="https://api.example.com", api_key="key-1"
+            )
+
+        assert first is None
+        assert second is None
+        assert len(starts) == 1
+        assert cli_obj._account_usage_last_fetch_monotonic > 0
+        assert cli_obj._account_usage_refresh_inflight is False
+
+    def test_account_usage_cache_invalidates_on_api_key_change(self):
+        cli_obj = _make_cli()
+        cli_obj._account_usage_snapshot = AccountUsageSnapshot(
+            provider="openai-codex",
+            source="test",
+            fetched_at=datetime.now(),
+        )
+        cli_obj._account_usage_provider = "openai-codex"
+        cli_obj._account_usage_base_url = "https://api.example.com"
+        cli_obj._account_usage_api_key_fingerprint = (
+            HermesCLI._account_usage_api_key_fingerprint_for("key-1")
+        )
+        cli_obj._account_usage_last_fetch_monotonic = time.monotonic()
+        starts = []
+
+        class RecordingThread:
+            def __init__(self, *, target, args=(), daemon=None):
+                starts.append(args)
+
+            def start(self):
+                return None
+
+        with patch("cli.threading.Thread", RecordingThread):
+            result = cli_obj._get_cached_account_usage_snapshot(
+                "openai-codex", base_url="https://api.example.com", api_key="key-2"
+            )
+
+        assert result is None
+        assert len(starts) == 1
+        assert cli_obj._account_usage_refresh_inflight is True
+
+    def test_account_usage_summary_preserves_credit_only_snapshots(self):
+        snapshot = AccountUsageSnapshot(
+            provider="openai-codex",
+            source="test",
+            fetched_at=datetime.now(),
+            credits_balance=12.5,
+        )
+
+        info = HermesCLI._summarize_account_usage(snapshot)
+
+        assert info["account_usage_provider"] == "openai-codex"
+        assert info["account_usage_credits_label"] == "$12.50"
+        assert info["account_usage_credits_compact_label"] == "$12.5"
+        assert info["account_usage_primary_remaining"] is None
+
 
 class TestCLIUsageReport:
     def test_show_usage_includes_estimated_cost(self, capsys):
@@ -563,6 +661,48 @@ class TestCLIUsageReport:
         assert "n/a" in output
         assert "Pricing unknown for glm-5" in output
 
+    def test_status_bar_wraps_without_ellipsis_when_width_is_tight(self):
+        cli_obj = _make_cli(model="anthropic/claude-sonnet-4-20250514")
+        cli_obj._status_bar_visible = True
+        cli_obj._get_status_bar_snapshot = lambda: {
+            "model_name": "anthropic/claude-sonnet-4-20250514",
+            "model_short": "claude-sonnet-4-20250514",
+            "duration": "2h",
+            "prompt_elapsed": "⏲ 3m",
+            "context_percent": 33,
+            "context_length": 200_000,
+            "context_tokens": 66_000,
+            "compressions": 1,
+            "active_background_tasks": 2,
+            "active_background_processes": 1,
+            "account_usage_primary_label": "Session",
+            "account_usage_primary_remaining": 26,
+            "account_usage_primary_reset_hint": "1h",
+            "account_usage_primary_reset_clock": "11:00",
+            "account_usage_secondary_label": "Weekly",
+            "account_usage_secondary_remaining": 64,
+            "account_usage_secondary_reset_hint": "2d",
+            "account_usage_credits_label": "$12.50",
+            "account_usage_credits_compact_label": "$12.5",
+            "account_usage_risk_level": "warn",
+            "account_usage_loading": False,
+        }
+
+        text = cli_obj._build_status_bar_text(width=44)
+
+        assert "..." not in text
+        assert "📈" in text
+        assert "🗜️ 1" in text
+        for line in text.splitlines():
+            assert cli_obj._status_bar_display_width(line) <= 44
+
+    def test_status_bar_height_tracks_multiline_wrap(self):
+        cli_obj = _make_cli()
+        cli_obj._status_bar_visible = True
+        cli_obj._build_status_bar_text = lambda width=None: "one\ntwo\nthree"
+
+        assert cli_obj._status_bar_height(width=40) == 3
+
 
 class TestStatusBarWidthSource:
     """Ensure status bar fragments don't overflow the terminal width."""
@@ -593,9 +733,10 @@ class TestStatusBarWidthSource:
                 frags = cli_obj._get_status_bar_fragments()
 
             total_text = "".join(text for _, text in frags)
-            display_width = cli_obj._status_bar_display_width(total_text)
-            assert display_width <= width + 4, (  # +4 for minor padding chars
-                f"At width={width}, fragment total {display_width} cells overflows "
+            line_widths = [cli_obj._status_bar_display_width(line) for line in total_text.splitlines() if line]
+            max_line_width = max(line_widths) if line_widths else 0
+            assert max_line_width <= width + 4, (  # +4 for minor padding chars
+                f"At width={width}, fragment line max {max_line_width} cells overflows "
                 f"({total_text!r})"
             )
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -442,6 +442,7 @@ def test_install_heartbeat_prints_when_dependency_install_is_silent(monkeypatch,
 def _make_update_side_effect(
     current_branch="main",
     commit_count="3",
+    carried_commits: tuple[str, ...] = (),
     ff_only_fails=False,
     reset_fails=False,
     fetch_fails=False,
@@ -461,8 +462,12 @@ def _make_update_side_effect(
             return SimpleNamespace(stdout=f"{current_branch}\n", stderr="", returncode=0)
         if "checkout" in joined and "main" in joined:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "rev-list" in joined and "--reverse" in joined:
+            return SimpleNamespace(stdout="\n".join(carried_commits) + ("\n" if carried_commits else ""), stderr="", returncode=0)
         if "rev-list" in joined:
             return SimpleNamespace(stdout=f"{commit_count}\n", stderr="", returncode=0)
+        if "cherry-pick" in joined and "--abort" not in joined:
+            return SimpleNamespace(stdout="Applied\n", stderr="", returncode=0)
         if "--ff-only" in joined:
             if ff_only_fails:
                 return SimpleNamespace(
@@ -510,6 +515,28 @@ def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):
 
     reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
     assert len(reset_calls) == 0
+
+
+def test_cmd_update_reapplies_carried_commits_after_reset(monkeypatch, tmp_path, capsys):
+    """Local carried commits should be replayed on top of origin/main during update."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    side_effect, recorded = _make_update_side_effect(carried_commits=("abc111", "def222"))
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    assert [c for c in recorded if c[:3] == ["git", "reset", "--hard"]] == [
+        ["git", "reset", "--hard", "origin/main"],
+    ]
+    assert [c for c in recorded if c[:2] == ["git", "cherry-pick"]] == [
+        ["git", "cherry-pick", "abc111"],
+        ["git", "cherry-pick", "def222"],
+    ]
+
+    out = capsys.readouterr().out
+    assert "Preserving 2 carried commits" in out
 
 
 # ---------------------------------------------------------------------------
@@ -666,3 +693,60 @@ def test_cmd_update_skips_stash_restore_when_reset_fails(monkeypatch, tmp_path, 
 
     out = capsys.readouterr().out
     assert "preserved in stash" in out
+
+
+def test_list_carried_commits_returns_oldest_first(monkeypatch, tmp_path):
+    def fake_run(cmd, **kwargs):
+        assert cmd == ["git", "rev-list", "--reverse", "origin/main..HEAD"]
+        return SimpleNamespace(stdout="aaa111\nbbb222\n", returncode=0)
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    assert hermes_main._list_carried_commits(["git"], tmp_path, "origin/main") == ["aaa111", "bbb222"]
+
+
+def test_reapply_carried_commits_cherry_picks_all_in_order(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[:2] == ["git", "cherry-pick"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    ok, failing = hermes_main._reapply_carried_commits(["git"], tmp_path, ["aaa111", "bbb222"])
+
+    assert ok is True
+    assert failing is None
+    assert calls == [
+        ["git", "cherry-pick", "aaa111"],
+        ["git", "cherry-pick", "bbb222"],
+    ]
+
+
+def test_reapply_carried_commits_aborts_on_failure(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["git", "cherry-pick", "aaa111"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if cmd == ["git", "cherry-pick", "bbb222"]:
+            return SimpleNamespace(stdout="", stderr="conflict", returncode=1)
+        if cmd == ["git", "cherry-pick", "--abort"]:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    ok, failing = hermes_main._reapply_carried_commits(["git"], tmp_path, ["aaa111", "bbb222"])
+
+    assert ok is False
+    assert failing == "bbb222"
+    assert calls == [
+        ["git", "cherry-pick", "aaa111"],
+        ["git", "cherry-pick", "bbb222"],
+        ["git", "cherry-pick", "--abort"],
+    ]


### PR DESCRIPTION
# Summary
- make the CLI status bar default to a clearer two-line layout on normal terminal widths
- keep model/context/runtime data on line 1 and move account/token/activity detail to line 2
- preserve carried local commits across `hermes update` by resetting to `origin/main` and replaying them

# Testing
- `./venv/bin/python -m pytest tests/cli/test_cli_status_bar.py tests/hermes_cli/test_update_autostash.py -q -o addopts=''`
- `./venv/bin/hermes update`
- relaunched Hermes in tmux and verified the two-line footer rendered after update/restart

# Notes
- update replay now rolls back to the pre-update SHA if carried-commit cherry-pick fails
- status bar tests now assert the default two-line rendering and token/call summary details
