### PR TITLE
fix(skills): accept content/file_content interchangeably in skill_manage (#35736)

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -582,6 +582,34 @@ class TestSkillManageDispatcher:
         assert result["success"] is False
         assert "does not exist" in result["error"]
 
+    def test_write_file_accepts_content_fallback(self, tmp_path):
+        """LLMs sometimes pass 'content' instead of 'file_content' for write_file.
+        The dispatcher should fall back to content rather than erroring."""
+        with _skill_dir(tmp_path):
+            skill_manage(action="create", name="my-skill", content=VALID_SKILL_CONTENT)
+            raw = skill_manage(
+                action="write_file",
+                name="my-skill",
+                file_path="references/api.md",
+                content="# API\nDocs here.",
+            )
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        assert (tmp_path / "my-skill" / "references" / "api.md").read_text() == "# API\nDocs here."
+
+    def test_create_accepts_file_content_fallback(self, tmp_path):
+        """LLMs sometimes pass 'file_content' instead of 'content' for create.
+        The dispatcher should fall back to file_content rather than erroring."""
+        with _skill_dir(tmp_path):
+            raw = skill_manage(
+                action="create",
+                name="my-skill",
+                file_content=VALID_SKILL_CONTENT,
+            )
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        assert (tmp_path / "my-skill" / "SKILL.md").exists()
+
 
 class TestSecurityScanGate:
     """_security_scan_skill is gated by skills.guard_agent_created config flag."""

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -832,10 +832,14 @@ def skill_manage(
     """
     if action == "create":
         if not content:
+            content = file_content
+        if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
         result = _create_skill(name, content, category)
 
     elif action == "edit":
+        if not content:
+            content = file_content
         if not content:
             return tool_error("content is required for 'edit'. Provide the full updated SKILL.md text.", success=False)
         result = _edit_skill(name, content)
@@ -853,6 +857,8 @@ def skill_manage(
     elif action == "write_file":
         if not file_path:
             return tool_error("file_path is required for 'write_file'. Example: 'references/api-guide.md'", success=False)
+        if file_content is None:
+            file_content = content
         if file_content is None:
             return tool_error("file_content is required for 'write_file'.", success=False)
         result = _write_file(name, file_path, file_content)


### PR DESCRIPTION
## What does this PR do?

The `skill_manage` tool exposes both `content` (used by `create` / `edit`) and `file_content` (used by `write_file`). Neither is strictly required in the JSON schema, so the LLM occasionally swaps them. The Python handler then errors out:

```
WARNING agent.tool_executor: Tool skill_manage returned error (0.00s):
  {"error": "file_content is required for 'write_file'.", "success": false}
```

This PR adds a small runtime fallback: if the expected argument is missing, fall back to the sibling argument before erroring. The JSON schema is unchanged.

For `write_file` the fallback specifically guards on `file_content is None` (not falsiness), so legitimately writing an empty file still works.

## Related Issue

Fixes #35736

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_manager_tool.py` in `skill_manage()`:
  - `action == "create"`: fall back to `file_content` when `content` is empty.
  - `action == "edit"`: same fallback.
  - `action == "write_file"`: fall back to `content` when `file_content is None`.
- `tests/tools/test_skill_manager_tool.py`: added two tests in `TestSkillManageDispatcher`:
  - `test_write_file_accepts_content_fallback`
  - `test_create_accepts_file_content_fallback`

## How to Test

1. `source .venv/bin/activate`
2. `pytest tests/tools/test_skill_manager_tool.py -x -q` (88 passed locally)
3. Manually: call `skill_manage(action="write_file", name="x", file_path="references/foo.md", content="hi")` (note `content=`, not `file_content=`) and confirm the file is written.

## Checklist

- [x] Conventional Commit message
- [x] Searched existing PRs, no duplicate
- [x] PR contains only related changes
- [x] Tests added and passing
- [x] Tested on macOS
- [x] No docs/config/architecture changes; tool schema intentionally unchanged
