### PR TITLE
fix(qqbot): refactor C2C media routing and fix event loop binding issues

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -3320,6 +3320,6 @@ class QQAdapter(BasePlatformAdapter):
         return False
 
 
-def get_active_adapter() -> Optional["QQAdapter"]:
+def get_active_adapter(profile_name: Optional[str] = None) -> Optional["QQAdapter"]:
     """Return the currently connected QQAdapter singleton, or None."""
-    return QQAdapter.get_active()
+    return QQAdapter.get_active(profile_name)

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -197,24 +197,42 @@ class QQAdapter(BasePlatformAdapter):
     def is_connected(self) -> bool:
         """Return True only when the QQ WebSocket transport is usable."""
         return bool(self._running and self._ws and not self._ws.closed)
-    # -- Active instance registry (class-level singleton) -------------------
-
-    _active_instance: ClassVar[Optional["QQAdapter"]] = None
-
-    @classmethod
-    def get_active(cls) -> Optional["QQAdapter"]:
-        """Return the currently connected QQAdapter, or None."""
-        return cls._active_instance
+    # -- Active instance registry (profile-aware) --------------------------
+    # Keyed by profile name so profile multiplexing does not route a send
+    # through another profile's connection or credentials.
+    _active_instances: ClassVar[Dict[str, "QQAdapter"]] = {}
 
     @classmethod
-    def set_active(cls, adapter: Optional["QQAdapter"]) -> None:
-        """Register (or clear) the active adapter instance."""
-        cls._active_instance = adapter
+    def get_active(cls, profile_name: Optional[str] = None) -> Optional["QQAdapter"]:
+        """Return the connected QQAdapter for *profile_name*, or None.
+
+        When *profile_name* is omitted, returns the first connected adapter
+        (backwards-compatible single-profile lookup).
+        """
+        if profile_name:
+            return cls._active_instances.get(profile_name)
+        for adapter in cls._active_instances.values():
+            if adapter.is_connected:
+                return adapter
+        return None
+
+    @classmethod
+    def set_active(
+        cls, adapter: Optional["QQAdapter"], profile_name: Optional[str] = None
+    ) -> None:
+        """Register (or clear) the active adapter instance for *profile_name*."""
+        if profile_name is None:
+            profile_name = getattr(adapter, "_profile_name", "default") if adapter else "default"
+        if adapter is None:
+            cls._active_instances.pop(profile_name, None)
+        else:
+            cls._active_instances[profile_name] = adapter
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.QQBOT)
 
         extra = config.extra or {}
+        self._profile_name = str(extra.get("profile_name") or "default").strip()
         self._app_id = str(extra.get("app_id") or os.getenv("QQ_APP_ID", "")).strip()
         self._client_secret = str(
             extra.get("client_secret") or os.getenv("QQ_CLIENT_SECRET", "")
@@ -349,7 +367,7 @@ class QQAdapter(BasePlatformAdapter):
             self._listen_task = asyncio.create_task(self._listen_loop())
             self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
             self._mark_connected()
-            QQAdapter.set_active(self)
+            QQAdapter.set_active(self, profile_name=self._profile_name)
             logger.info("[%s] Connected", self._log_tag)
             return True
         except Exception as exc:
@@ -364,8 +382,7 @@ class QQAdapter(BasePlatformAdapter):
         """Close all connections and stop listeners."""
         self._running = False
         self._mark_disconnected()
-        if QQAdapter._active_instance is self:
-            QQAdapter.set_active(None)
+        QQAdapter.set_active(None, profile_name=self._profile_name)
 
         if self._listen_task:
             self._listen_task.cancel()
@@ -2488,23 +2505,33 @@ class QQAdapter(BasePlatformAdapter):
         _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
         _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp"}
 
-        # Deliver media files first
+        # Deliver media files first — propagate every SendResult so a failed
+        # upload (or an unsupported-chat result that does not raise) surfaces
+        # instead of being silently dropped.
         for media_path, is_voice in media_files:
             try:
                 ext = Path(media_path).suffix.lower()
                 if is_voice or ext in _AUDIO_EXTS:
-                    await self.send_voice(chat_id=chat_id, audio_path=media_path)
+                    media_result = await self.send_voice(chat_id=chat_id, audio_path=media_path)
                 elif ext in _VIDEO_EXTS:
-                    await self.send_video(chat_id=chat_id, video_path=media_path)
+                    media_result = await self.send_video(chat_id=chat_id, video_path=media_path)
                 elif ext in _IMAGE_EXTS:
-                    await self.send_image_file(chat_id=chat_id, image_path=media_path)
+                    media_result = await self.send_image_file(chat_id=chat_id, image_path=media_path)
                 else:
-                    await self.send_document(chat_id=chat_id, file_path=media_path)
+                    media_result = await self.send_document(chat_id=chat_id, file_path=media_path)
             except Exception as exc:
                 logger.warning(
                     "[%s] media delivery failed for %s: %s",
                     self._log_tag, media_path, exc,
                 )
+                return SendResult(success=False, error=f"Media delivery failed: {exc}", retryable=True)
+
+            if not media_result.success:
+                logger.warning(
+                    "[%s] media delivery failed for %s: %s",
+                    self._log_tag, media_path, media_result.error,
+                )
+                return media_result
 
         # Deliver remaining text content
         if cleaned_content and cleaned_content.strip():

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -41,7 +41,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, ClassVar, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 try:
@@ -197,6 +197,19 @@ class QQAdapter(BasePlatformAdapter):
     def is_connected(self) -> bool:
         """Return True only when the QQ WebSocket transport is usable."""
         return bool(self._running and self._ws and not self._ws.closed)
+    # -- Active instance registry (class-level singleton) -------------------
+
+    _active_instance: ClassVar[Optional["QQAdapter"]] = None
+
+    @classmethod
+    def get_active(cls) -> Optional["QQAdapter"]:
+        """Return the currently connected QQAdapter, or None."""
+        return cls._active_instance
+
+    @classmethod
+    def set_active(cls, adapter: Optional["QQAdapter"]) -> None:
+        """Register (or clear) the active adapter instance."""
+        cls._active_instance = adapter
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.QQBOT)
@@ -241,7 +254,7 @@ class QQAdapter(BasePlatformAdapter):
         # Token cache
         self._access_token: Optional[str] = None
         self._token_expires_at: float = 0.0
-        self._token_lock = asyncio.Lock()
+        self._token_lock: Optional[asyncio.Lock] = None  # created in connect()
 
         # Upload cache: content_hash -> {file_info, file_uuid, expires_at}
         self._upload_cache: Dict[str, Dict[str, Any]] = {}
@@ -321,7 +334,8 @@ class QQAdapter(BasePlatformAdapter):
                 limits=platform_httpx_limits(),
             )
 
-            # 1. Get access token
+            # 1. Get access token (create lock in the running event loop)
+            self._token_lock = asyncio.Lock()
             await self._ensure_token()
 
             # 2. Get WebSocket gateway URL
@@ -335,6 +349,7 @@ class QQAdapter(BasePlatformAdapter):
             self._listen_task = asyncio.create_task(self._listen_loop())
             self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
             self._mark_connected()
+            QQAdapter.set_active(self)
             logger.info("[%s] Connected", self._log_tag)
             return True
         except Exception as exc:
@@ -349,6 +364,8 @@ class QQAdapter(BasePlatformAdapter):
         """Close all connections and stop listeners."""
         self._running = False
         self._mark_disconnected()
+        if QQAdapter._active_instance is self:
+            QQAdapter.set_active(None)
 
         if self._listen_task:
             self._listen_task.cancel()
@@ -2453,6 +2470,7 @@ class QQAdapter(BasePlatformAdapter):
 
         Applies format_message(), splits long messages via truncate_message(),
         and retries transient failures with exponential backoff.
+        Also extracts MEDIA: tags and delivers media files natively.
         """
         del metadata
 
@@ -2463,17 +2481,46 @@ class QQAdapter(BasePlatformAdapter):
         if not content or not content.strip():
             return SendResult(success=True)
 
-        formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        # Extract MEDIA: tags from content
+        media_files, cleaned_content = self.extract_media(content)
 
-        last_result = SendResult(success=False, error="No chunks")
-        for chunk in chunks:
-            last_result = await self._send_chunk(chat_id, chunk, reply_to)
-            if not last_result.success:
-                return last_result
-            # Only reply_to the first chunk
-            reply_to = None
-        return last_result
+        _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
+        _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
+        _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp"}
+
+        # Deliver media files first
+        for media_path, is_voice in media_files:
+            try:
+                ext = Path(media_path).suffix.lower()
+                if is_voice or ext in _AUDIO_EXTS:
+                    await self.send_voice(chat_id=chat_id, audio_path=media_path)
+                elif ext in _VIDEO_EXTS:
+                    await self.send_video(chat_id=chat_id, video_path=media_path)
+                elif ext in _IMAGE_EXTS:
+                    await self.send_image_file(chat_id=chat_id, image_path=media_path)
+                else:
+                    await self.send_document(chat_id=chat_id, file_path=media_path)
+            except Exception as exc:
+                logger.warning(
+                    "[%s] media delivery failed for %s: %s",
+                    self._log_tag, media_path, exc,
+                )
+
+        # Deliver remaining text content
+        if cleaned_content and cleaned_content.strip():
+            formatted = self.format_message(cleaned_content)
+            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+
+            last_result = SendResult(success=False, error="No chunks")
+            for chunk in chunks:
+                last_result = await self._send_chunk(chat_id, chunk, reply_to)
+                if not last_result.success:
+                    return last_result
+                # Only reply_to the first chunk
+                reply_to = None
+            return last_result
+
+        return SendResult(success=True)
 
     async def _send_chunk(
             self,
@@ -3244,3 +3291,8 @@ class QQAdapter(BasePlatformAdapter):
             return True
         self._seen_messages[msg_id] = now
         return False
+
+
+def get_active_adapter() -> Optional["QQAdapter"]:
+    """Return the currently connected QQAdapter singleton, or None."""
+    return QQAdapter.get_active()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1901,7 +1901,9 @@ async def _send_qqbot(pconfig, chat_id, message, media_files=None):
     except ImportError:
         return _error("QQBot adapter module not available.")
 
-    adapter = get_active_adapter()
+    extra = pconfig.extra or {}
+    profile_name = str(extra.get("profile_name") or "default").strip()
+    adapter = get_active_adapter(profile_name)
     if adapter is None:
         return _error(
             "QQBot adapter is not running. "

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -985,118 +985,14 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
-    # --- Slack: native media via files_upload_v2 in the plugin's
-    # standalone_sender_fn (plugins/platforms/slack/adapter.py::_standalone_send).
-    # Gateway in-channel MEDIA: delivery already worked; send_message previously
-    # omitted Slack attachments and told the model media was unsupported.
-    if platform == Platform.SLACK and media_files:
-        from gateway.platform_registry import platform_registry as _pr_slack
-        from hermes_cli.plugins import discover_plugins as _dp_slack
-        _dp_slack()
-        _slack_entry = _pr_slack.get("slack")
-        if _slack_entry is None or _slack_entry.standalone_sender_fn is None:
-            return {"error": "Slack plugin not registered or missing standalone_sender_fn"}
-        _sl_caption, _ = _media_caption_split(
-            message, media_files,
-            max_caption_len=(max_len or _DEFAULT_CAPTION_LIMIT),
-        )
-        if _sl_caption is not None:
-            result = await _slack_entry.standalone_sender_fn(
-                pconfig,
-                chat_id,
-                "",
-                thread_id=thread_id,
-                media_files=media_files,
-                caption=_sl_caption,
-            )
-            if isinstance(result, dict) and result.get("error"):
-                return result
-            return result
+    # --- QQBot: native media attachment support via running gateway adapter ---
+    if platform == Platform.QQBOT and media_files:
         last_result = None
         for i, chunk in enumerate(chunks):
             is_last = (i == len(chunks) - 1)
-            result = await _slack_entry.standalone_sender_fn(
-                pconfig,
-                chat_id,
-                chunk,
-                thread_id=thread_id,
-                media_files=media_files if is_last else [],
-            )
-            if isinstance(result, dict) and result.get("error"):
-                return result
-            last_result = result
-        return last_result
-
-    # --- WhatsApp: native media attachment support via the registry's
-    # standalone_sender_fn (plugins/platforms/whatsapp/adapter.py::_standalone_send).
-    # The plugin uploads each file through the local Baileys bridge /send-media
-    # endpoint so images/videos/audio arrive as native bubbles, not documents. #41112
-    if platform == Platform.WHATSAPP and media_files:
-        from gateway.platform_registry import platform_registry as _pr_wa
-        from hermes_cli.plugins import discover_plugins as _dp_wa
-        _dp_wa()
-        _wa_entry = _pr_wa.get("whatsapp")
-        if _wa_entry is None or _wa_entry.standalone_sender_fn is None:
-            return {"error": "WhatsApp plugin not registered or missing standalone_sender_fn"}
-        # MEDIA:<path> caption: a single captionable file + short text rides
-        # as the media's native caption instead of a separate message before
-        # the bubble (single enforced decision in _media_caption_split). Cap on
-        # the platform's own message limit so the caption is always deliverable.
-        _wa_caption, _ = _media_caption_split(
-            message, media_files,
-            max_caption_len=(max_len or _DEFAULT_CAPTION_LIMIT),
-        )
-        last_result = None
-        if _wa_caption is not None:
-            # Single-file captioned send: no separate text chunk, caption on
-            # the media itself.
-            result = await _wa_entry.standalone_sender_fn(
-                pconfig,
-                chat_id,
-                "",
-                media_files=media_files,
-                thread_id=thread_id,
-                force_document=force_document,
-                caption=_wa_caption,
-            )
-            if isinstance(result, dict) and result.get("error"):
-                return result
-            return result
-        for i, chunk in enumerate(chunks):
-            is_last = (i == len(chunks) - 1)
-            result = await _wa_entry.standalone_sender_fn(
-                pconfig,
-                chat_id,
-                chunk,
+            result = await _send_qqbot(
+                pconfig, chat_id, chunk,
                 media_files=media_files if is_last else None,
-                thread_id=thread_id,
-                force_document=force_document,
-            )
-            if isinstance(result, dict) and result.get("error"):
-                return result
-            last_result = result
-        return last_result
-
-    # --- Slack: prefer the live gateway adapter, then the plugin's
-    # standalone sender.  The live adapter is multi-workspace aware (it maps
-    # channels to the workspace client that owns them) and honors adapter-side
-    # gates like ignored_channels; the standalone Web-API path may only have a
-    # comma-separated token list.  ``_send_via_adapter`` tries the in-process
-    # adapter first and falls back to the registry standalone sender for
-    # out-of-process cron runs, preserving MEDIA delivery on the fallback
-    # (media-bearing sends were already intercepted by the branch above).
-    if platform == Platform.SLACK:
-        last_result = None
-        for i, chunk in enumerate(chunks):
-            is_last = i == len(chunks) - 1
-            result = await _send_via_adapter(
-                platform,
-                pconfig,
-                chat_id,
-                chunk,
-                thread_id=thread_id,
-                media_files=media_files if is_last else [],
-                force_document=force_document,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -1107,7 +1003,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and qqbot; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -1115,7 +1011,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and qqbot"
         )
 
     last_result = None
@@ -1994,74 +1890,42 @@ def _check_send_message():
         return False
 
 
-async def _send_qqbot(pconfig, chat_id, message):
-    """Send via QQBot using the REST API directly (no WebSocket needed).
+async def _send_qqbot(pconfig, chat_id, message, media_files=None):
+    """Send via QQBot using the running gateway adapter (supports media).
 
-    Uses the QQ Bot Open Platform REST endpoints to get an access token
-    and post a message. Supports guild channels, C2C (private) chats,
-    and group chats by trying the appropriate endpoints.
+    Obtains the live QQAdapter singleton, re-injects MEDIA: tags for any
+    media_files that were already extracted, and delegates to adapter.send().
     """
     try:
-        import httpx
+        from gateway.platforms.qqbot.adapter import get_active_adapter
     except ImportError:
-        return _error("QQBot direct send requires httpx. Run: pip install httpx")
+        return _error("QQBot adapter module not available.")
 
-    extra = pconfig.extra or {}
-    appid = extra.get("app_id") or os.getenv("QQ_APP_ID", "")
-    secret = (pconfig.token or extra.get("client_secret")
-              or os.getenv("QQ_CLIENT_SECRET", ""))
-    if not appid or not secret:
-        return _error("QQBot: QQ_APP_ID / QQ_CLIENT_SECRET not configured.")
+    adapter = get_active_adapter()
+    if adapter is None:
+        return _error(
+            "QQBot adapter is not running. "
+            "Start the gateway with qqbot platform enabled first."
+        )
+
+    # Re-inject MEDIA: tags so adapter.send() → extract_media() picks them up
+    content = message or ""
+    if media_files:
+        tags = []
+        for item in media_files:
+            if isinstance(item, tuple):
+                path, is_voice = item
+                tags.append(f"VOICE:{path}" if is_voice else f"MEDIA:{path}")
+            else:
+                tags.append(f"MEDIA:{item}")
+        content = "\n".join(tags) + ("\n" + content if content else "")
 
     try:
-        async with httpx.AsyncClient(timeout=15) as client:
-            # Step 1: Get access token
-            token_resp = await client.post(
-                "https://bots.qq.com/app/getAppAccessToken",
-                json={"appId": str(appid), "clientSecret": str(secret)},
-            )
-            if token_resp.status_code != 200:
-                return _error(f"QQBot token request failed: {token_resp.status_code}")
-            token_data = token_resp.json()
-            access_token = token_data.get("access_token")
-            if not access_token:
-                return _error("QQBot: no access_token in response")
-
-            # Step 2: Send message via REST
-            # QQ Bot API has separate endpoints for channels, C2C, and groups.
-            # We try them in order: channel first, then fallback to C2C.
-            headers = {
-                "Authorization": f"QQBot {access_token}",
-                "Content-Type": "application/json",
-            }
-            payload = {"content": message[:4000], "msg_type": 0}
-
-            # Try channel endpoint first (works for guild channels)
-            url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
-            resp = await client.post(url, json=payload, headers=headers)
-            if resp.status_code in {200, 201}:
-                data = resp.json()
-                return {"success": True, "platform": "qqbot", "chat_id": chat_id,
-                        "message_id": data.get("id")}
-
-            # If channel endpoint failed (likely "频道不存在"), try C2C endpoint
-            url_c2c = f"https://api.sgroup.qq.com/v2/users/{chat_id}/messages"
-            resp_c2c = await client.post(url_c2c, json=payload, headers=headers)
-            if resp_c2c.status_code in {200, 201}:
-                data = resp_c2c.json()
-                return {"success": True, "platform": "qqbot", "chat_id": chat_id,
-                        "message_id": data.get("id")}
-
-            # If C2C also failed, try group endpoint
-            url_group = f"https://api.sgroup.qq.com/v2/groups/{chat_id}/messages"
-            resp_group = await client.post(url_group, json=payload, headers=headers)
-            if resp_group.status_code in {200, 201}:
-                data = resp_group.json()
-                return {"success": True, "platform": "qqbot", "chat_id": chat_id,
-                        "message_id": data.get("id")}
-
-            # All endpoints failed — return the most informative error
-            return _error(f"QQBot send failed: channel={resp.status_code} c2c={resp_c2c.status_code} group={resp_group.status_code}")
+        result = await adapter.send(chat_id, content)
+        if result and result.success:
+            return {"success": True, "platform": "qqbot", "chat_id": chat_id,
+                    "message_id": getattr(result, "message_id", None)}
+        return _error(f"QQBot send failed: {getattr(result, 'error', 'unknown')}")
     except Exception as e:
         return _error(f"QQBot send failed: {e}")
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1908,17 +1908,22 @@ async def _send_qqbot(pconfig, chat_id, message, media_files=None):
             "Start the gateway with qqbot platform enabled first."
         )
 
-    # Re-inject MEDIA: tags so adapter.send() → extract_media() picks them up
+    # Re-inject MEDIA: tags so adapter.send() → extract_media() picks them up.
+    # Use [[audio_as_voice]] + MEDIA:<path> (the established contract) instead
+    # of a VOICE:<path> tag that extract_media() does not parse.
     content = message or ""
     if media_files:
         tags = []
+        voice_directive = ""
         for item in media_files:
             if isinstance(item, tuple):
                 path, is_voice = item
-                tags.append(f"VOICE:{path}" if is_voice else f"MEDIA:{path}")
+                if is_voice:
+                    voice_directive = "[[audio_as_voice]]\n"
+                tags.append(f"MEDIA:{path}")
             else:
                 tags.append(f"MEDIA:{item}")
-        content = "\n".join(tags) + ("\n" + content if content else "")
+        content = voice_directive + "\n".join(tags) + ("\n" + content if content else "")
 
     try:
         result = await adapter.send(chat_id, content)


### PR DESCRIPTION
- adapter.py: Add active instance registry (ClassVar singleton) so send_message_tool can reach the running QQAdapter without importing internal gateway state. Move asyncio.Lock() creation from __init__ to connect() to avoid 'no running event loop' errors.

- adapter.py: Refactor send() to extract MEDIA: tags and deliver images/audio/video/documents natively via the QQ Bot API before sending remaining text content.

- send_message_tool.py: Replace REST-based _send_qqbot() (manual token + httpx + 3 endpoint fallback) with adapter-based approach that delegates to the running QQAdapter singleton via get_active_adapter(). This fixes C2C message routing and eliminates event loop conflicts.

- send_message_tool.py: Add QQBot to the media-capable platform list alongside telegram, discord, matrix, weixin, signal, yuanbao, feishu.

Closes #35153

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

