### PR TITLE
fix: gate Nous auth-refresh message behind verbose mode

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2366,7 +2366,7 @@ def run_conversation(
                 ):
                     nous_auth_retry_attempted = True
                     if agent._try_refresh_nous_client_credentials(force=True):
-                        print(f"{agent.log_prefix}🔐 Nous agent key refreshed after 401. Retrying request...")
+                        agent._buffer_vprint(f"🔐 Nous agent key refreshed after 401. Retrying request...")
                         continue
                     # Credential refresh didn't help — show diagnostic info.
                     # Most common causes: Portal OAuth expired/revoked,


### PR DESCRIPTION
## Problem

The Nous OAuth agent key auto-refreshes roughly every 15 minutes (`expires_in: 899`). On each refresh-after-401, the message:

```
🔐 Nous agent key refreshed after 401. Retrying request...
```

is printed unconditionally via a bare `print()`, so it surfaces in normal (non-verbose) sessions — appearing whenever a request happens to land just after the key expires. It's harmless (the request transparently retries and succeeds) but noisy.

## Fix

The three sibling auth-refresh messages in the same block — xAI OAuth / Codex, Copilot, and Anthropic — all use the verbose-gated `agent._buffer_vprint()`. Only the Nous path used a bare `print()`. This one-line change brings it in line with the others so the routine key refresh no longer prints on every retry, while still being visible under `--verbose`.

```diff
-                        print(f"{agent.log_prefix}🔐 Nous agent key refreshed after 401. Retrying request...")
+                        agent._buffer_vprint(f"🔐 Nous agent key refreshed after 401. Retrying request...")
```

`agent/conversation_loop.py` around line 2369. No behavior change beyond log verbosity — the credential refresh + retry path is untouched.