### PR TITLE
fix(gateway): log accepted webhook dispatch failures

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3292,6 +3292,67 @@ class BasePlatformAdapter(ABC):
         self._discard_text_debounce(session_key)
         return True
 
+    def _log_background_task_result(
+        self,
+        task: asyncio.Task,
+        session_key: str,
+        *,
+        task_label: str = "message-processing",
+    ) -> None:
+        """Retrieve/log background task results so async handoff failures are visible.
+
+        Fire-and-forget tasks can otherwise fail after an HTTP 202 / platform
+        ACK with little more than a late event-loop warning.  This callback is
+        intentionally side-effect-light: it only observes task state and logs
+        the failure with session context while leaving lifecycle cleanup to the
+        task's own finally block.
+        """
+        try:
+            if task.cancelled():
+                logger.debug(
+                    "[%s] Background %s task cancelled for session %s",
+                    self.name,
+                    task_label,
+                    session_key,
+                )
+                return
+            exc = task.exception()
+        except asyncio.CancelledError:
+            logger.debug(
+                "[%s] Background %s task cancelled for session %s",
+                self.name,
+                task_label,
+                session_key,
+            )
+            return
+        except Exception as callback_err:
+            logger.debug(
+                "[%s] Could not inspect background %s task for session %s: %s",
+                self.name,
+                task_label,
+                session_key,
+                callback_err,
+                exc_info=True,
+            )
+            return
+
+        if exc is not None:
+            logger.error(
+                "[%s] Background %s task failed for session %s: %s",
+                self.name,
+                task_label,
+                session_key,
+                exc,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+        else:
+            logger.debug(
+                "[%s] Background %s task completed for session %s",
+                self.name,
+                task_label,
+                session_key,
+            )
+
     def _start_session_processing(
         self,
         event: MessageEvent,
@@ -3322,6 +3383,12 @@ class BasePlatformAdapter(ABC):
         if hasattr(task, "add_done_callback"):
             task.add_done_callback(self._background_tasks.discard)
             task.add_done_callback(self._expected_cancelled_tasks.discard)
+            task.add_done_callback(
+                lambda done_task, _session_key=session_key: self._log_background_task_result(
+                    done_task,
+                    _session_key,
+                )
+            )
         return True
 
     async def cancel_session_processing(
@@ -3660,7 +3727,15 @@ class BasePlatformAdapter(ABC):
         # pattern — set the guard synchronously, not inside the task.)
         # _start_session_processing installs the guard AND the owner-task
         # mapping atomically so stale-lock detection works.
-        self._start_session_processing(event, session_key)
+        started = self._start_session_processing(event, session_key)
+        if not started:
+            logger.error(
+                "[%s] Failed to start background processing for session %s; "
+                "falling back to inline processing in dispatch task",
+                self.name,
+                session_key,
+            )
+            await self._process_message_background(event, session_key)
     
     @staticmethod
     def _get_human_delay() -> float:

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -612,10 +612,21 @@ class WebhookAdapter(BasePlatformAdapter):
             delivery_id,
         )
 
-        # Non-blocking — return 202 Accepted immediately
+        # Non-blocking — return 202 Accepted immediately.  Track the short
+        # dispatch task separately from the longer message-processing task it
+        # spawns so accepted webhooks cannot fail silently before the session
+        # guard/transcript path is reached.
         task = asyncio.create_task(self.handle_message(event))
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
+        task.add_done_callback(
+            lambda done_task, _delivery_id=delivery_id, _session_chat_id=session_chat_id: self._log_webhook_dispatch_result(
+                done_task,
+                route_name=route_name,
+                delivery_id=_delivery_id,
+                session_chat_id=_session_chat_id,
+            )
+        )
 
         return web.json_response(
             {
@@ -626,6 +637,67 @@ class WebhookAdapter(BasePlatformAdapter):
             },
             status=202,
         )
+
+    def _log_webhook_dispatch_result(
+        self,
+        task: asyncio.Task,
+        *,
+        route_name: str,
+        delivery_id: str,
+        session_chat_id: str,
+    ) -> None:
+        """Log failures in the accepted-webhook → adapter-dispatch handoff.
+
+        The HTTP handler returns 202 before the agent turn begins.  If the
+        intermediate ``handle_message`` task fails before BasePlatformAdapter
+        can install the per-session processing guard, the user otherwise sees
+        an accepted webhook with no obvious transcript evidence.  Retrieve the
+        task result here to surface that boundary explicitly.
+        """
+        try:
+            if task.cancelled():
+                logger.warning(
+                    "[webhook] agent dispatch cancelled route=%s delivery=%s chat=%s",
+                    route_name,
+                    delivery_id,
+                    session_chat_id,
+                )
+                return
+            exc = task.exception()
+        except asyncio.CancelledError:
+            logger.warning(
+                "[webhook] agent dispatch cancelled route=%s delivery=%s chat=%s",
+                route_name,
+                delivery_id,
+                session_chat_id,
+            )
+            return
+        except Exception as callback_err:
+            logger.debug(
+                "[webhook] could not inspect dispatch task route=%s delivery=%s: %s",
+                route_name,
+                delivery_id,
+                callback_err,
+                exc_info=True,
+            )
+            return
+
+        if exc is not None:
+            logger.error(
+                "[webhook] agent dispatch failed route=%s delivery=%s chat=%s: %s",
+                route_name,
+                delivery_id,
+                session_chat_id,
+                exc,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+        else:
+            logger.debug(
+                "[webhook] agent dispatch enqueued route=%s delivery=%s chat=%s",
+                route_name,
+                delivery_id,
+                session_chat_id,
+            )
 
     # ------------------------------------------------------------------
     # Signature validation

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1,5 +1,7 @@
 """Tests for gateway/platforms/base.py — MessageEvent, media extraction, message truncation."""
 
+import asyncio
+import logging
 import os
 import time
 from unittest.mock import patch
@@ -10,6 +12,8 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
+    MessageType,
+    SendResult,
     safe_url_for_log,
     utf16_len,
     _log_safe_path,
@@ -869,10 +873,10 @@ class TestTruncateMessage:
             async def disconnect(self):
                 pass
 
-            async def send(self, *a, **kw):
-                pass
+            async def send(self, chat_id, content, reply_to=None, metadata=None):
+                return SendResult(success=True)
 
-            async def get_chat_info(self, *a):
+            async def get_chat_info(self, chat_id):
                 return {}
 
         from gateway.config import Platform, PlatformConfig
@@ -950,6 +954,48 @@ class TestTruncateMessage:
             assert len(chunk) <= max_len + 20, (
                 f"Chunk {i} too long: {len(chunk)} > {max_len}"
             )
+
+
+# ---------------------------------------------------------------------------
+# background task observability
+# ---------------------------------------------------------------------------
+
+
+class TestBackgroundTaskObservability:
+    def _adapter(self):
+        class StubAdapter(BasePlatformAdapter):
+            async def connect(self):
+                return True
+
+            async def disconnect(self):
+                pass
+
+            async def send(self, chat_id, content, reply_to=None, metadata=None):
+                return SendResult(success=True)
+
+            async def get_chat_info(self, chat_id):
+                return {}
+
+        from gateway.config import Platform, PlatformConfig
+
+        config = PlatformConfig(enabled=True, token="test")
+        return StubAdapter(config=config, platform=Platform.TELEGRAM)
+
+    @pytest.mark.asyncio
+    async def test_background_task_failure_is_logged_with_session_context(self, caplog):
+        adapter = self._adapter()
+
+        async def _boom():
+            raise RuntimeError("synthetic background boom")
+
+        caplog.set_level(logging.ERROR, logger="gateway.platforms.base")
+        task = asyncio.create_task(_boom())
+        await asyncio.sleep(0)
+
+        adapter._log_background_task_result(task, "session-123")
+
+        assert "Background message-processing task failed for session session-123" in caplog.text
+        assert "synthetic background boom" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -19,6 +19,7 @@ import base64
 import hashlib
 import hmac
 import json
+import logging
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -499,6 +500,34 @@ class TestHTTPHandling:
             assert data["route"] == "test"
 
     @pytest.mark.asyncio
+    async def test_accepted_webhook_dispatch_failure_is_logged(self, caplog):
+        """Failures after the 202 ACK must be retrieved and logged with context."""
+        routes = {"test": {"secret": _INSECURE_NO_AUTH, "prompt": "hi"}}
+        adapter = _make_adapter(routes=routes)
+
+        async def _boom(event):
+            raise RuntimeError("synthetic dispatch boom")
+
+        adapter.handle_message = _boom
+        caplog.set_level(logging.ERROR, logger="gateway.platforms.webhook")
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/test",
+                json={"data": "value"},
+                headers={"X-GitHub-Delivery": "dispatch-123"},
+            )
+            assert resp.status == 202
+
+        await asyncio.sleep(0.05)
+
+        assert "agent dispatch failed route=test" in caplog.text
+        assert "delivery=dispatch-123" in caplog.text
+        assert "chat=webhook:test:dispatch-123" in caplog.text
+        assert "synthetic dispatch boom" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_route_without_secret_rejects_unsigned_request(self):
         """Missing HMAC secret must fail closed even if connect() was bypassed."""
         routes = {"test": {"prompt": "hi"}}
@@ -604,8 +633,8 @@ class TestIdempotency:
             resp1 = await cli.post("/webhooks/idem", json={"x": 1}, headers=headers)
             assert resp1.status == 202
 
-            # Backdate the cache entry so it appears expired
-            adapter._seen_deliveries["delivery-456"] = time.time() - 3700
+            # Backdate the scoped cache entry so it appears expired
+            adapter._seen_deliveries["idem:delivery-456"] = time.time() - 3700
 
             resp2 = await cli.post("/webhooks/idem", json={"x": 1}, headers=headers)
             assert resp2.status == 202  # re-accepted


### PR DESCRIPTION
## Summary
- Logs failures from fire-and-forget gateway/webhook dispatch tasks so accepted HTTP 202 webhooks cannot fail silently.
- Adds background-task result logging with session/delivery context.
- Fixes idempotency test setup to use scoped delivery cache keys.

## Test Plan
- `/usr/local/lib/hermes-agent/venv/bin/python -m py_compile gateway/platforms/base.py gateway/platforms/webhook.py`
- `/usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/gateway/test_platform_base.py::TestBackgroundTaskObservability tests/gateway/test_webhook_adapter.py::TestHTTPHandling::test_accepted_webhook_dispatch_failure_is_logged -q -o addopts=`

## Preservation note
Recovered from Razza's dirty installed Hermes runtime tree and submitted so safe-update cleanup can proceed without losing the fix.