### PR TITLE
fix(telegram): preserve command payload after bot target

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4814,7 +4814,21 @@ class TelegramAdapter(BasePlatformAdapter):
         if not text or not self._bot or not getattr(self._bot, "username", None):
             return text
         username = re.escape(self._bot.username)
-        cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", text).strip()
+
+        # Telegram group commands address a specific bot as one bot_command
+        # token, e.g. ``/steer@Charlie_bot Please ...``.  We strip the target
+        # suffix before gateway command dispatch, but must preserve a separator
+        # between the command and its payload.  A plain deletion turns that
+        # example into ``/steerPlease ...``, which the gateway reads as the
+        # unknown command ``/steerplease``.
+        command_target_re = re.compile(rf"(?i)(^|\s)(/[A-Za-z0-9_]+)@{username}\b[,:\-]*\s*")
+
+        def _strip_command_target(match: re.Match) -> str:
+            return f"{match.group(1)}{match.group(2)} "
+
+        cleaned = command_target_re.sub(_strip_command_target, text)
+        cleaned = re.sub(rf"(?i)@{username}\b[,:\-]*\s*", "", cleaned).strip()
+        cleaned = re.sub(r"[ \t]{2,}", " ", cleaned).strip()
         return cleaned or text
 
     def _should_observe_unmentioned_group_message(self, message: Message) -> bool:

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from gateway.config import Platform, PlatformConfig, load_gateway_config
-from gateway.platforms.base import MessageType
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.session import SessionSource
 
 
@@ -468,6 +468,36 @@ def test_group_messages_can_require_direct_trigger_via_config():
     # And commands still pass unconditionally when require_mention is disabled
     adapter_no_mention = _make_adapter(require_mention=False)
     assert adapter_no_mention._should_process_message(_group_message("/status"), is_command=True) is True
+
+
+def test_clean_bot_trigger_text_preserves_space_after_command_target_suffix():
+    adapter = _make_adapter(require_mention=True, bot_username="Charlie_orgo_bot")
+
+    cleaned = adapter._clean_bot_trigger_text(
+        "/steer@Charlie_orgo_bot Please reply with exactly: Aye Aye Captain."
+    )
+
+    assert cleaned == "/steer Please reply with exactly: Aye Aye Captain."
+    event = MessageEvent(text=cleaned, message_type=MessageType.COMMAND)
+    assert event.get_command() == "steer"
+    assert event.get_command_args() == "Please reply with exactly: Aye Aye Captain."
+
+
+def test_clean_bot_trigger_text_preserves_addressed_alias_command_without_payload():
+    adapter = _make_adapter(require_mention=True, bot_username="Charlie_orgo_bot")
+
+    cleaned = adapter._clean_bot_trigger_text("/checkin@Charlie_orgo_bot")
+
+    assert cleaned == "/checkin"
+    event = MessageEvent(text=cleaned, message_type=MessageType.COMMAND)
+    assert event.get_command() == "checkin"
+    assert event.get_command_args() == ""
+
+
+def test_clean_bot_trigger_text_still_strips_plain_bot_mentions():
+    adapter = _make_adapter(require_mention=True, bot_username="Charlie_orgo_bot")
+
+    assert adapter._clean_bot_trigger_text("@Charlie_orgo_bot please reply") == "please reply"
 
 
 def test_explicit_multi_bot_mentions_route_only_to_named_bots():


### PR DESCRIPTION
## Summary
- Preserves the space between a Telegram slash command and its payload when stripping `@botname` command targets.
- Prevents `/steer@bot payload` from becoming `/steerpayload`.
- Adds regression coverage for addressed commands with and without payloads plus plain mentions.

## Test Plan
- `/usr/local/lib/hermes-agent/venv/bin/python -m py_compile gateway/platforms/telegram.py`
- `/usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/gateway/test_telegram_group_gating.py -q -o addopts=`

## Preservation note
Recovered from Razza's dirty installed Hermes runtime tree and submitted so safe-update cleanup can proceed without losing the fix.