### PR TITLE
feat(webhook): support native Trello board webhooks

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -184,6 +184,7 @@ class WebhookAdapter(BasePlatformAdapter):
 
         app = web.Application()
         app.router.add_get("/health", self._handle_health)
+        app.router.add_head("/webhooks/{route_name}", self._handle_webhook_head)
         app.router.add_post("/webhooks/{route_name}", self._handle_webhook)
 
         # Port conflict detection — fail fast if port is already in use
@@ -281,6 +282,75 @@ class WebhookAdapter(BasePlatformAdapter):
             self._delivery_info.pop(k, None)
             self._delivery_info_created.pop(k, None)
 
+    def _extract_delivery_id(self, request: Any, payload: dict) -> str:
+        """Return a stable provider delivery id for idempotency/session keys.
+
+        Provider retries should map to the same id even when transport-level
+        request headers change.  Precedence keeps existing provider ids for
+        GitHub/Svix, then handles Composio's v3 payload shape before falling
+        back to generic request ids and finally a timestamp.
+        """
+        github_delivery = request.headers.get("X-GitHub-Delivery", "")
+        if github_delivery:
+            return github_delivery
+
+        svix_id = request.headers.get("svix-id", "")
+        if svix_id:
+            return svix_id
+
+        if isinstance(payload, dict):
+            action = payload.get("action")
+            if isinstance(action, dict):
+                action_id = action.get("id")
+                if action_id:
+                    return f"trello-action:{action_id}"
+
+            event_type = payload.get("type") or payload.get("event_type")
+            if event_type == "composio.trigger.message":
+                payload_id = payload.get("id")
+                if payload_id:
+                    return f"composio:{payload_id}"
+
+                metadata = payload.get("metadata")
+                if isinstance(metadata, dict):
+                    log_id = metadata.get("log_id")
+                    if log_id:
+                        return f"composio-log:{log_id}"
+
+        composio_webhook_id = request.headers.get("webhook-id", "")
+        if composio_webhook_id:
+            return f"composio-webhook:{composio_webhook_id}"
+
+        request_id = request.headers.get("X-Request-ID", "")
+        if request_id:
+            return request_id
+
+        return str(int(time.time() * 1000))
+
+    def _extract_trello_action_type(self, payload: dict) -> str:
+        """Return Trello's action type for native board webhooks.
+
+        Trello board webhooks deliver board activity as an ``action`` object.
+        The action ``type`` is the useful event discriminator for route filters
+        (for example ``commentCard``, ``createCard``, ``updateCard``).  List
+        moves are represented as ``updateCard`` actions with ``data.listBefore``
+        and ``data.listAfter``; expose those as ``updateCard:idList`` so routes
+        can subscribe to moves without treating every field edit as equivalent.
+        """
+        if not isinstance(payload, dict):
+            return ""
+        action = payload.get("action")
+        if not isinstance(action, dict):
+            return ""
+        action_type = action.get("type")
+        if not action_type:
+            return ""
+        data = action.get("data")
+        if action_type == "updateCard" and isinstance(data, dict):
+            if "listBefore" in data or "listAfter" in data:
+                return "updateCard:idList"
+        return str(action_type)
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         return {"name": chat_id, "type": "webhook"}
 
@@ -291,6 +361,20 @@ class WebhookAdapter(BasePlatformAdapter):
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
         return web.json_response({"status": "ok", "platform": "webhook"})
+
+    async def _handle_webhook_head(self, request: "web.Request") -> "web.Response":
+        """HEAD /webhooks/{route_name} — provider callback validation.
+
+        Trello validates webhook callback URLs with a HEAD request at
+        registration time.  The validation request has no JSON body and no
+        webhook signature, so only confirm that the route exists; POSTs still
+        require the configured route signature.
+        """
+        self._reload_dynamic_routes()
+        route_name = request.match_info.get("route_name", "")
+        if route_name not in self._routes:
+            return web.Response(status=404)
+        return web.Response(status=200)
 
     def _reload_dynamic_routes(self) -> None:
         """Reload agent-created subscriptions from disk if the file changed."""
@@ -394,7 +478,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 status=403,
             )
         if secret != _INSECURE_NO_AUTH:
-            if not self._validate_signature(request, raw_body, secret):
+            if not self._validate_signature(request, raw_body, secret, route_config):
                 logger.warning(
                     "[webhook] Invalid signature for route %s", route_name
                 )
@@ -434,6 +518,7 @@ class WebhookAdapter(BasePlatformAdapter):
             or request.headers.get("X-GitLab-Event", "")
             or payload.get("event_type", "")
             or payload.get("type", "")
+            or self._extract_trello_action_type(payload)
             or "unknown"
         )
         allowed_events = route_config.get("events", [])
@@ -483,25 +568,24 @@ class WebhookAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
-        # Build a unique delivery ID
-        delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
-            request.headers.get(
-                "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
-            ),
-        )
+        # Build a stable delivery ID before idempotency.  Prefer provider
+        # event identifiers over transport/request fallbacks so webhook retries
+        # don't wake a fresh agent session just because retry headers changed.
+        delivery_id = self._extract_delivery_id(request, payload)
 
         # ── Idempotency ─────────────────────────────────────────
-        # Skip duplicate deliveries (webhook retries).
+        # Skip duplicate deliveries (webhook retries).  Scope cache keys by
+        # route so two unrelated routes can receive the same provider id
+        # without suppressing each other.
         now = time.time()
+        idempotency_key = f"{route_name}:{delivery_id}"
         # Prune expired entries
         self._seen_deliveries = {
             k: v
             for k, v in self._seen_deliveries.items()
             if now - v < self._idempotency_ttl
         }
-        if delivery_id in self._seen_deliveries:
+        if idempotency_key in self._seen_deliveries:
             logger.info(
                 "[webhook] Skipping duplicate delivery %s", delivery_id
             )
@@ -509,7 +593,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"status": "duplicate", "delivery_id": delivery_id},
                 status=200,
             )
-        self._seen_deliveries[delivery_id] = now
+        self._seen_deliveries[idempotency_key] = now
 
         # ── Direct delivery mode (deliver_only) ─────────────────
         # Skip the agent entirely — the rendered prompt IS the message we
@@ -632,15 +716,51 @@ class WebhookAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     def _validate_signature(
-        self, request: "web.Request", body: bytes, secret: str
+        self,
+        request: "web.Request",
+        body: bytes,
+        secret: str,
+        route_config: Optional[dict] = None,
     ) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, generic HMAC-SHA256)."""
+        """Validate webhook signature (GitHub, GitLab, Svix, Trello, generic HMAC-SHA256)."""
         def _header(name: str) -> str:
             return (
                 request.headers.get(name, "")
                 or request.headers.get(name.lower(), "")
                 or request.headers.get(name.upper(), "")
             )
+
+        # Trello: X-Trello-Webhook = base64(HMAC-SHA1(raw_body + callbackURL)).
+        # The callback URL must be byte-for-byte the same string used when the
+        # Trello webhook was registered, so routes that use Trello signatures
+        # must store it explicitly as callback_url/webhook_url.
+        trello_sig = _header("X-Trello-Webhook")
+        if trello_sig:
+            callback_url = ""
+            if isinstance(route_config, dict):
+                callback_url = (
+                    route_config.get("callback_url")
+                    or route_config.get("webhook_url")
+                    or route_config.get("trello_callback_url")
+                    or ""
+                )
+            if not callback_url:
+                logger.debug("[webhook] Trello signature route missing callback_url")
+                return False
+            expected = base64.b64encode(
+                hmac.new(
+                    secret.encode(),
+                    body + str(callback_url).encode(),
+                    hashlib.sha1,
+                ).digest()
+            ).decode()
+            return hmac.compare_digest(trello_sig, expected)
+        if (
+            isinstance(route_config, dict)
+            and str(route_config.get("signature_provider", "")).lower() == "trello"
+        ):
+            logger.debug("[webhook] Trello route missing X-Trello-Webhook signature")
+            return False
 
         # Svix / AgentMail:
         #   svix-id: msg_...

--- a/tests/gateway/test_webhook_trello_native.py
+++ b/tests/gateway/test_webhook_trello_native.py
@@ -1,0 +1,209 @@
+"""Native Trello webhook handling for board activity routes."""
+
+import base64
+import hashlib
+import hmac
+import json
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.webhook import WebhookAdapter
+
+
+def _make_adapter(callback_url="https://webhooks.example.com/webhooks/trello-board-activity"):
+    routes = {
+        "trello-board-activity": {
+            "signature_provider": "trello",
+            "secret": "trello-app-secret",
+            "callback_url": callback_url,
+            "events": ["commentCard", "updateCard:idList", "createCard"],
+            "prompt": "Trello {action.type}: {action.data.card.name}",
+            "deliver": "log",
+        }
+    }
+    return WebhookAdapter(PlatformConfig(enabled=True, extra={"routes": routes}))
+
+
+def _create_app(adapter: WebhookAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_get("/health", adapter._handle_health)
+    app.router.add_head("/webhooks/{route_name}", adapter._handle_webhook_head)
+    app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
+    return app
+
+
+def _trello_signature(body: bytes, secret: str, callback_url: str) -> str:
+    digest = hmac.new(secret.encode(), body + callback_url.encode(), hashlib.sha1).digest()
+    return base64.b64encode(digest).decode()
+
+
+TRELLO_COMMENT_PAYLOAD = {
+    "action": {
+        "id": "6a1800000000000000000001",
+        "type": "commentCard",
+        "date": "2026-05-27T19:50:00.000Z",
+        "data": {
+            "text": "Please wake Charlie",
+            "card": {
+                "id": "6a16b1dc3e938f411c0ad0cb",
+                "name": "Review updated Charlie / Razza Trello operating system",
+                "shortLink": "abc12345",
+            },
+            "board": {"id": "6a16b1d6ab84d89c0f84b58e", "name": "Charlie / Razza Kanban"},
+        },
+        "memberCreator": {"fullName": "Ryan Laubscher", "username": "ryanlaubscher"},
+    },
+    "model": {"id": "6a16b1d6ab84d89c0f84b58e", "name": "Charlie / Razza Kanban"},
+    "webhook": {"id": "6a18000000000000000000ff"},
+}
+
+
+class TestNativeTrelloWebhook:
+    @pytest.mark.asyncio
+    async def test_trello_head_validation_request_returns_ok(self):
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.head("/webhooks/trello-board-activity")
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_signed_trello_comment_event_wakes_agent_with_action_id(self):
+        callback_url = "https://webhooks.example.com/webhooks/trello-board-activity"
+        adapter = _make_adapter(callback_url=callback_url)
+        captured_events = []
+
+        async def _capture(event):
+            captured_events.append(event)
+
+        adapter.handle_message = _capture
+        app = _create_app(adapter)
+        body = json.dumps(TRELLO_COMMENT_PAYLOAD, separators=(",", ":")).encode()
+        signature = _trello_signature(body, "trello-app-secret", callback_url)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/trello-board-activity",
+                data=body,
+                headers={"Content-Type": "application/json", "X-Trello-Webhook": signature},
+            )
+            assert resp.status == 202
+            data = await resp.json()
+            assert data["event"] == "commentCard"
+            assert data["delivery_id"] == "trello-action:6a1800000000000000000001"
+
+        assert len(captured_events) == 1
+        event = captured_events[0]
+        assert event.message_id == "trello-action:6a1800000000000000000001"
+        assert "Trello commentCard" in event.text
+        assert "Review updated Charlie" in event.text
+
+    @pytest.mark.asyncio
+    async def test_trello_signature_uses_exact_registered_callback_url(self):
+        registered_callback = "https://webhooks.example.com/webhooks/trello-board-activity"
+        wrong_callback = "https://webhooks.example.com/webhooks/trello-board-activity/"
+        adapter = _make_adapter(callback_url=registered_callback)
+        app = _create_app(adapter)
+        body = json.dumps(TRELLO_COMMENT_PAYLOAD, separators=(",", ":")).encode()
+        signature_for_wrong_url = _trello_signature(body, "trello-app-secret", wrong_callback)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/trello-board-activity",
+                data=body,
+                headers={"Content-Type": "application/json", "X-Trello-Webhook": signature_for_wrong_url},
+            )
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_trello_duplicate_action_id_is_deduped(self):
+        callback_url = "https://webhooks.example.com/webhooks/trello-board-activity"
+        adapter = _make_adapter(callback_url=callback_url)
+        captured_events = []
+
+        async def _capture(event):
+            captured_events.append(event)
+
+        adapter.handle_message = _capture
+        app = _create_app(adapter)
+        body = json.dumps(TRELLO_COMMENT_PAYLOAD, separators=(",", ":")).encode()
+        signature = _trello_signature(body, "trello-app-secret", callback_url)
+
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post(
+                "/webhooks/trello-board-activity",
+                data=body,
+                headers={"Content-Type": "application/json", "X-Trello-Webhook": signature},
+            )
+            second = await cli.post(
+                "/webhooks/trello-board-activity",
+                data=body,
+                headers={"Content-Type": "application/json", "X-Trello-Webhook": signature},
+            )
+            assert first.status == 202
+            assert second.status == 200
+            assert (await second.json())["status"] == "duplicate"
+
+        assert len(captured_events) == 1
+
+    @pytest.mark.asyncio
+    async def test_trello_route_rejects_generic_signature_even_with_same_secret(self):
+        adapter = _make_adapter()
+        app = _create_app(adapter)
+        body = json.dumps(TRELLO_COMMENT_PAYLOAD, separators=(",", ":")).encode()
+        generic_signature = hmac.new(
+            b"trello-app-secret", body, hashlib.sha256
+        ).hexdigest()
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/trello-board-activity",
+                data=body,
+                headers={"Content-Type": "application/json", "X-Webhook-Signature": generic_signature},
+            )
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_trello_update_card_list_move_maps_to_id_list_event(self):
+        callback_url = "https://webhooks.example.com/webhooks/trello-board-activity"
+        adapter = _make_adapter(callback_url=callback_url)
+        captured_events = []
+
+        async def _capture(event):
+            captured_events.append(event)
+
+        adapter.handle_message = _capture
+        app = _create_app(adapter)
+        payload = {
+            "action": {
+                "id": "6a1800000000000000000002",
+                "type": "updateCard",
+                "date": "2026-05-27T20:15:00.000Z",
+                "data": {
+                    "card": {"id": "card1", "name": "Move me"},
+                    "board": {"id": "board1", "name": "Charlie / Razza Kanban"},
+                    "listBefore": {"id": "list-a", "name": "Inbox / Captured"},
+                    "listAfter": {"id": "list-b", "name": "Ready for Charlie"},
+                },
+                "memberCreator": {"fullName": "Ryan Laubscher"},
+            },
+            "model": {"id": "board1", "name": "Charlie / Razza Kanban"},
+        }
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        signature = _trello_signature(body, "trello-app-secret", callback_url)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/trello-board-activity",
+                data=body,
+                headers={"Content-Type": "application/json", "X-Trello-Webhook": signature},
+            )
+            assert resp.status == 202
+            data = await resp.json()
+            assert data["event"] == "updateCard:idList"
+
+        assert len(captured_events) == 1


### PR DESCRIPTION
## Summary
- Adds native Trello board webhook support: HEAD callback validation, Trello HMAC-SHA1 signature verification, action-id based delivery IDs, and event mapping for list moves.
- Scopes webhook idempotency by route to avoid suppressing unrelated routes that share provider ids.
- Adds regression coverage for Trello HEAD validation, signatures, dedupe, rejected generic signatures, and list-move event mapping.

## Test Plan
- `/usr/local/lib/hermes-agent/venv/bin/python -m py_compile gateway/platforms/webhook.py`
- `/usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/gateway/test_webhook_trello_native.py -q -o addopts=`

## Preservation note
Recovered from Razza's dirty installed Hermes runtime tree and submitted so safe-update cleanup can proceed without losing the feature.