### PR TITLE
feat(models): refresh model catalog hourly instead of daily

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1903,7 +1903,7 @@ DEFAULT_CONFIG = {
         # Disk cache TTL in hours.  Beyond this, the CLI refetches on the
         # next /model or `hermes model` invocation; network failures
         # silently fall back to the stale cache.
-        "ttl_hours": 24,
+        "ttl_hours": 1,
         # Optional per-provider override URLs for third parties that want
         # to self-host their own curation list using the same schema.
         # Example:
@@ -2151,7 +2151,7 @@ DEFAULT_CONFIG = {
 
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 24,
+    "_config_version": 25,
 }
 
 # =============================================================================
@@ -4343,6 +4343,22 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                         "  ✓ Seeded auxiliary.curator defaults in config.yaml: "
                         f"{', '.join(added_aux)}"
                     )
+
+    # ── Version 24 → 25: lower model_catalog TTL 24h → 1h ──
+    # The model picker now refreshes its curated list hourly so freshly
+    # published model-catalog.json deploys reach users without a day-long
+    # stale window. Only rewrite the OLD default (24) — never clobber a
+    # value the user deliberately customized.
+    if current_ver < 25:
+        config = read_raw_config()
+        raw_mc = config.get("model_catalog")
+        if isinstance(raw_mc, dict) and raw_mc.get("ttl_hours") == 24:
+            raw_mc["ttl_hours"] = 1
+            config["model_catalog"] = raw_mc
+            save_config(config)
+            results["config_added"].append("model_catalog.ttl_hours 24→1")
+            if not quiet:
+                print("  ✓ Lowered model_catalog.ttl_hours to 1 (hourly picker refresh)")
 
     if current_ver < latest_ver and not quiet:
         print(f"Config version: {current_ver} → {latest_ver}")

--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -73,7 +73,7 @@ DEFAULT_CATALOG_URL = (
 DEFAULT_CATALOG_FALLBACK_URLS: tuple[str, ...] = (
     "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/website/static/api/model-catalog.json",
 )
-DEFAULT_TTL_HOURS = 24
+DEFAULT_TTL_HOURS = 1
 DEFAULT_FETCH_TIMEOUT = 8.0
 SUPPORTED_SCHEMA_VERSION = 1
 


### PR DESCRIPTION
## Summary
The model picker's curated list now refreshes hourly instead of daily, so a freshly published `model-catalog.json` deploy reaches users within an hour instead of up to a day.

## Root cause
The `model_catalog.json` disk cache had a 24h TTL with no user-facing force-refresh. After a catalog deploy, the picker kept serving the stale cached list for up to a day. (`/model --refresh` only busts the per-provider `/v1/models` cache, not the curated-catalog cache.)

## Changes
- `hermes_cli/model_catalog.py`: `DEFAULT_TTL_HOURS` 24 → 1
- `hermes_cli/config.py`: `DEFAULT_CONFIG.model_catalog.ttl_hours` 24 → 1; `_config_version` 24 → 25
- `hermes_cli/config.py`: migration v24→25 rewrites a stale `model_catalog.ttl_hours: 24` → `1`, preserving any value the user deliberately customized

## Behavior
- Cache older than 1h → refetch on next `hermes model` / `/model`
- Cache younger than 1h → serve cache, no network hit
- Network failure → fall back to stale cache (unchanged)

## Validation
| Scenario | Result |
|---|---|
| >1h-old cache | refetches ✓ |
| <1h-old cache | skips refetch ✓ |
| migration stale 24 | → 1 ✓ |
| migration custom 6 | preserved ✓ |
| version bump | 24 → 25 ✓ |

E2E with isolated HERMES_HOME (real config I/O + migration run). `tests/hermes_cli/test_model_catalog.py` + `test_config.py`: 115/115 pass.

## Infographic
![infographic](https://v3b.fal.media/files/b/0a9c6342/FuMdQOEAI02kMPot8ul26_7v9HJLwB.png)
