### PR TITLE
perf: batch salvage of 5 verified micro-fixes (cache leaks, per-call waste, blocking sleep, O(n²) drain)

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -61,6 +61,8 @@ _MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
 _PHONE_RE = re.compile(r"\+?\d{7,15}")
 _EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+")
 
+_GUID_CACHE_SIZE = 500  # LRU cap for resolved chat-GUID lookups
+
 
 def _redact(text: str) -> str:
     """Redact phone numbers and emails from log output."""
@@ -130,7 +132,6 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
-        self._GUID_CACHE_MAX = 500
 
     # ------------------------------------------------------------------
     # API helpers
@@ -380,15 +381,13 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 if identifier == target:
                     if guid:
                         self._guid_cache[target] = guid
-                        self._guid_cache.move_to_end(target)
-                        if len(self._guid_cache) > self._GUID_CACHE_MAX:
+                        while len(self._guid_cache) > _GUID_CACHE_SIZE:
                             self._guid_cache.popitem(last=False)
                     return guid
                 for part in chat.get("participants", []) or []:
                     if (part.get("address") or "").strip() == target and guid:
                         self._guid_cache[target] = guid
-                        self._guid_cache.move_to_end(target)
-                        if len(self._guid_cache) > self._GUID_CACHE_MAX:
+                        while len(self._guid_cache) > _GUID_CACHE_SIZE:
                             self._guid_cache.popitem(last=False)
                         return guid
         except Exception:

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -14,6 +14,7 @@ import logging
 import os
 import re
 import uuid
+from collections import OrderedDict
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
@@ -128,7 +129,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._runner = None
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
-        self._guid_cache: Dict[str, str] = {}
+        self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        self._GUID_CACHE_MAX = 500
 
     # ------------------------------------------------------------------
     # API helpers
@@ -365,6 +367,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if ";" in target:
             return target
         if target in self._guid_cache:
+            self._guid_cache.move_to_end(target)
             return self._guid_cache[target]
         try:
             payload = await self._api_post(
@@ -377,10 +380,16 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 if identifier == target:
                     if guid:
                         self._guid_cache[target] = guid
+                        self._guid_cache.move_to_end(target)
+                        if len(self._guid_cache) > self._GUID_CACHE_MAX:
+                            self._guid_cache.popitem(last=False)
                     return guid
                 for part in chat.get("participants", []) or []:
                     if (part.get("address") or "").strip() == target and guid:
                         self._guid_cache[target] = guid
+                        self._guid_cache.move_to_end(target)
+                        if len(self._guid_cache) > self._GUID_CACHE_MAX:
+                            self._guid_cache.popitem(last=False)
                         return guid
         except Exception:
             pass

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -240,6 +240,7 @@ _FEISHU_REACTION_FAILURE = "CrossMark"
 # drain on completion; the cap is a safeguard against unbounded growth from
 # delete-failures, not a capacity plan.
 _FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024
+_FEISHU_MESSAGE_TEXT_CACHE_SIZE = 512       # LRU cap for reply-context message text lookups
 
 # QR onboarding constants
 _ONBOARD_ACCOUNTS_URLS = {
@@ -1452,7 +1453,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
-        self._message_text_cache: Dict[str, Optional[str]] = {}
+        self._message_text_cache: "OrderedDict[str, Optional[str]]" = OrderedDict()
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -3959,6 +3960,7 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client or not message_id:
             return None
         if message_id in self._message_text_cache:
+            self._message_text_cache.move_to_end(message_id)
             return self._message_text_cache[message_id]
         try:
             request = self._build_get_message_request(message_id)
@@ -3980,6 +3982,9 @@ class FeishuAdapter(BasePlatformAdapter):
                 mentions=parent_mentions,
             )
             self._message_text_cache[message_id] = text
+            self._message_text_cache.move_to_end(message_id)
+            while len(self._message_text_cache) > _FEISHU_MESSAGE_TEXT_CACHE_SIZE:
+                self._message_text_cache.popitem(last=False)
             return text
         except Exception:
             logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3982,7 +3982,6 @@ class FeishuAdapter(BasePlatformAdapter):
                 mentions=parent_mentions,
             )
             self._message_text_cache[message_id] = text
-            self._message_text_cache.move_to_end(message_id)
             while len(self._message_text_cache) > _FEISHU_MESSAGE_TEXT_CACHE_SIZE:
                 self._message_text_cache.popitem(last=False)
             return text

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4465,10 +4465,15 @@ class GatewayRunner:
         # Drain any recovered process watchers (from crash recovery checkpoint)
         try:
             from tools.process_registry import process_registry
-            while process_registry.pending_watchers:
-                watcher = process_registry.pending_watchers.pop(0)
+            watchers = process_registry.pending_watchers
+            # Process in batches of 100 with event-loop yield points to avoid
+            # O(n^2) event-loop blocking when recovering thousands of watchers.
+            for i, watcher in enumerate(watchers):
                 asyncio.create_task(self._run_process_watcher(watcher))
                 logger.info("Resumed watcher for recovered process %s", watcher.get("session_id"))
+                if i % 100 == 99:
+                    await asyncio.sleep(0)
+            watchers.clear()
         except Exception as e:
             logger.error("Recovered watcher setup error: %s", e)
 
@@ -7938,7 +7943,7 @@ class GatewayRunner:
                         result = await result
                     return str(result) if result else None
             except Exception as e:
-                logger.debug("Plugin command dispatch failed (non-fatal): %s", e)
+                logger.warning("Plugin command dispatch failed: %s", e)
 
         # Skill slash commands: /skill-name loads the skill and sends to agent.
         # resolve_skill_command_key() handles the Telegram underscore/hyphen
@@ -7970,7 +7975,7 @@ class GatewayRunner:
                             )
                         # Fall through to normal message processing with bundle content
             except Exception as exc:
-                logger.debug("Bundle dispatch failed (non-fatal): %s", exc)
+                logger.warning("Bundle dispatch failed: %s", exc)
 
         if command and not locals().get("_bundle_handled", False):
             try:
@@ -9161,9 +9166,12 @@ class GatewayRunner:
             # Check for pending process watchers (check_interval on background processes)
             try:
                 from tools.process_registry import process_registry
-                while process_registry.pending_watchers:
-                    watcher = process_registry.pending_watchers.pop(0)
+                watchers = process_registry.pending_watchers
+                for i, watcher in enumerate(watchers):
                     asyncio.create_task(self._run_process_watcher(watcher))
+                    if i % 100 == 99:
+                        await asyncio.sleep(0)
+                watchers.clear()
             except Exception as e:
                 logger.error("Process watcher setup error: %s", e)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4465,7 +4465,12 @@ class GatewayRunner:
         # Drain any recovered process watchers (from crash recovery checkpoint)
         try:
             from tools.process_registry import process_registry
+            # Detach the current batch atomically: reassigning to a fresh list
+            # takes ownership of exactly the watchers present now, so any watcher
+            # appended concurrently during the yield below isn't silently dropped
+            # by a clear() on the shared list.
             watchers = process_registry.pending_watchers
+            process_registry.pending_watchers = []
             # Process in batches of 100 with event-loop yield points to avoid
             # O(n^2) event-loop blocking when recovering thousands of watchers.
             for i, watcher in enumerate(watchers):
@@ -4473,7 +4478,6 @@ class GatewayRunner:
                 logger.info("Resumed watcher for recovered process %s", watcher.get("session_id"))
                 if i % 100 == 99:
                     await asyncio.sleep(0)
-            watchers.clear()
         except Exception as e:
             logger.error("Recovered watcher setup error: %s", e)
 
@@ -9166,12 +9170,15 @@ class GatewayRunner:
             # Check for pending process watchers (check_interval on background processes)
             try:
                 from tools.process_registry import process_registry
+                # Detach the current batch atomically (see crash-recovery drain
+                # above): reassign to a fresh list so a watcher appended by a
+                # concurrent session during the yield isn't dropped by clear().
                 watchers = process_registry.pending_watchers
+                process_registry.pending_watchers = []
                 for i, watcher in enumerate(watchers):
                     asyncio.create_task(self._run_process_watcher(watcher))
                     if i % 100 == 99:
                         await asyncio.sleep(0)
-                watchers.clear()
             except Exception as e:
                 logger.error("Process watcher setup error: %s", e)
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1406,6 +1406,9 @@ AUTHOR_MAP = {
     "peter.yuqin@gmail.com": "WuKongAI-CMU",  # PR #10082 (reject symlinked audio inputs)
     "sunil.nitie@gmail.com": "Sunil123135",  # PR #31031 (Windows Docker Desktop compose)
     "weichangyuwcy@gmail.com": "ChyuWei",  # PR #30987 (TUI TTS env var on voice off)
+    # batch salvage PR #35758 (perf micro-fixes)
+    "116212274+amathxbt@users.noreply.github.com": "amathxbt",  # PR #22155 (cache tool_output_limits)
+    "takis312@hotmail.com": "ErnestHysa",  # PRs #32636/#32708 (MCP asyncio.sleep + O(n^2) watcher drain)
 }
 
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import time
 import unittest
+from collections import OrderedDict
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Dict
@@ -4603,7 +4604,7 @@ class TestFeishuFetchMessageText(unittest.TestCase):
         adapter._bot_open_id = "ou_bot"
         adapter._bot_user_id = ""
         adapter._bot_name = "Hermes"
-        adapter._message_text_cache = {}
+        adapter._message_text_cache = OrderedDict()
         adapter._client = Mock()
         adapter._build_get_message_request = Mock(return_value=object())
         return adapter

--- a/tests/tools/test_tool_output_limits.py
+++ b/tests/tools/test_tool_output_limits.py
@@ -22,6 +22,16 @@ import pytest
 from tools import tool_output_limits as tol
 
 
+@pytest.fixture(autouse=True)
+def _reset_limits_cache():
+    """get_tool_output_limits() now memoizes its result for the process
+    lifetime, so each test must start from a clean cache to observe the
+    config value it patches in."""
+    tol._reset_tool_output_limits_cache()
+    yield
+    tol._reset_tool_output_limits_cache()
+
+
 class TestDefaults:
     def test_defaults_match_previous_hardcoded_values(self):
         assert tol.DEFAULT_MAX_BYTES == 50_000

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2040,14 +2040,27 @@ def _handle_auth_error_and_retry(
             loop = _mcp_loop
             if loop is not None and loop.is_running():
                 loop.call_soon_threadsafe(srv._reconnect_event.set)
+
                 # Wait briefly for the session to come back ready. Bounded
                 # so that a stuck reconnect falls through to the error
-                # path rather than hanging the caller.
-                deadline = time.monotonic() + 15
-                while time.monotonic() < deadline:
-                    if srv.session is not None and srv._ready.is_set():
-                        break
-                    time.sleep(0.25)
+                # path rather than hanging the caller.  The async helper
+                # runs on the MCP event loop via _run_on_mcp_loop so it
+                # does NOT block the event loop during the poll interval.
+                async def _await_ready() -> bool:
+                    deadline = time.monotonic() + 15
+                    while time.monotonic() < deadline:
+                        if srv.session is not None and srv._ready.is_set():
+                            return True
+                        await asyncio.sleep(0.25)
+                    return False
+
+                try:
+                    _run_on_mcp_loop(_await_ready(), timeout=15)
+                except Exception as exc:
+                    logger.warning(
+                        "MCP OAuth '%s': ready poll failed: %s",
+                        server_name, exc,
+                    )
 
         # A successful OAuth recovery is independent evidence that the
         # server is viable again, so close the circuit breaker here —

--- a/tools/tool_output_limits.py
+++ b/tools/tool_output_limits.py
@@ -40,6 +40,10 @@ DEFAULT_MAX_BYTES = 50_000       # terminal_tool.MAX_OUTPUT_CHARS
 DEFAULT_MAX_LINES = 2000         # file_operations.MAX_LINES
 DEFAULT_MAX_LINE_LENGTH = 2000   # file_operations.MAX_LINE_LENGTH
 
+# Module-level cache — populated on first call.
+# Avoids repeated config file I/O on every tool call.
+_cached_limits: dict | None = None
+
 
 def _coerce_positive_int(value: Any, default: int) -> int:
     """Return ``value`` as a positive int, or ``default`` on any issue."""
@@ -58,7 +62,14 @@ def get_tool_output_limits() -> Dict[str, int]:
     Keys: ``max_bytes``, ``max_lines``, ``max_line_length``. Missing or
     invalid entries fall through to the ``DEFAULT_*`` constants. This
     function NEVER raises.
+
+    Result is cached for the process lifetime to avoid repeated disk I/O
+    on every tool call. Call ``_reset_tool_output_limits_cache()`` in
+    tests that need a fresh read after config changes.
     """
+    global _cached_limits
+    if _cached_limits is not None:
+        return _cached_limits
     try:
         from hermes_cli.config import load_config
         cfg = load_config() or {}
@@ -68,13 +79,20 @@ def get_tool_output_limits() -> Dict[str, int]:
     except Exception:
         section = {}
 
-    return {
+    _cached_limits = {
         "max_bytes": _coerce_positive_int(section.get("max_bytes"), DEFAULT_MAX_BYTES),
         "max_lines": _coerce_positive_int(section.get("max_lines"), DEFAULT_MAX_LINES),
         "max_line_length": _coerce_positive_int(
             section.get("max_line_length"), DEFAULT_MAX_LINE_LENGTH
         ),
     }
+    return _cached_limits
+
+
+def _reset_tool_output_limits_cache() -> None:
+    """Reset the cached limits — for tests or after config hot-reload."""
+    global _cached_limits
+    _cached_limits = None
 
 
 def get_max_bytes() -> int:


### PR DESCRIPTION
Batch salvage of 5 small, independent, verified `type/perf` fixes (user-requested). Each is a self-contained leak / per-call-waste / blocking-call fix in its own subsystem — non-overlapping files, all ≤38 lines. Original authorship preserved via cherry-pick.

## Included PRs

| Original PR | Author | Fix |
|---|---|---|
| #23706 | @AhmetArif0 | feishu: LRU-cap `_message_text_cache` (was an unbounded plain dict keyed by message_id) |
| #30523 | @dskwe | bluebubbles: LRU-cap `_guid_cache` (was unbounded) |
| #22155 | @amathxbt | `tool_output_limits`: cache limits for process lifetime instead of re-reading config on every tool call |
| #32636 | @ErnestHysa | MCP auth reconnect poll: replace blocking `time.sleep(0.25)` with `await asyncio.sleep(0.25)` on the MCP loop |
| #32708 | @ErnestHysa | gateway: drain `pending_watchers` without `list.pop(0)` (avoids O(n²) on large recovery), add event-loop yield points, upgrade plugin/bundle dispatch failure logs from debug→warning |

## Follow-up commit (mine)

One small test-consistency commit on top, required by two of the changes on current main:
- `test_tool_output_limits.py`: autouse fixture resets the new module-level limits cache between tests (otherwise the first test's read leaks into the rest → 5 failures).
- `test_feishu.py`: hand-built adapter fixture seeded `_message_text_cache` as a plain `dict`; it's now an `OrderedDict` and `_fetch_message_text` calls `.move_to_end()`, so the fixture type had to match.

## Verification

- All 5 diffs verified against current `main` by reading the actual code at each touched site — confirmed each problem still exists (not already fixed / not stale).
- Each cherry-pick applied cleanly; combined diff reviewed for cross-PR / current-main interactions.
- Targeted tests pass: `tests/gateway/test_feishu.py`, `tests/gateway/test_bluebubbles.py`, `tests/tools/test_tool_output_limits.py`, `tests/tools/test_mcp_circuit_breaker.py` — **276 passed**.
- Import smoke check on all touched modules + `gateway.run` passes.

## Deliberately excluded during triage

- **#23383 / #23384** (yuanbao processing-msg + member-cache cleanup) — removed from this batch at the maintainer's request; can be salvaged separately.
- **#32643** (process_registry double-iteration fusion) — would **deadlock**: it moves `_refresh_detached_session()` (which calls `_move_to_finished()` → `with self._lock`) inside `self._lock`, a non-reentrant `threading.Lock`. The original three-phase snapshot pattern exists specifically to avoid this. `git apply` is clean but the fix is semantically wrong.
- **#22166** (rglob-per-terminal-call) — bug is real but the patch no longer applies (`_check_disk_usage_warning` moved from line ~181 → ~123). Needs a rebase.
- **#13701** (batch writes in `_process_batch_worker`) — diff dedents `batch_results_to_write.append(trajectory_entry)` out of the `if success` block, but `trajectory_entry` is only assigned inside it → `UnboundLocalError` on the first failed prompt. Needs a re-roll.
- **#23675** (`malloc_trim(0)` per dispatch) — not platform-gated, runs on the hottest path every tool dispatch, high throughput risk + wasted `CDLL` load on macOS. Should be opt-in + Linux-gated + throttled.
