### PR TITLE
fix(tui): gate clampStdoutDimensions behind WSL detection (#35738)

### DIFF
--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -23,7 +23,12 @@ if (!process.stdin.isTTY) {
 // `process.stdout.columns`/`rows` at the source so the Ink renderer, its
 // resize handler, and every component read see sane values. Must run before
 // `ink.render` constructs the renderer.
-clampStdoutDimensions()
+// Only apply in WSL — patching process.stdout via Object.defineProperty breaks
+// some terminals (e.g. Warp) that use non-standard stdout objects.
+// See: https://github.com/NousResearch/hermes-agent/issues/35738
+if (process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP) {
+  clampStdoutDimensions()
+}
 
 // Start from a clean slate. If a previous TUI crashed or was kill -9'd, the
 // terminal tab can still have mouse/focus/paste modes enabled.


### PR DESCRIPTION
## Problem

`clampStdoutDimensions()` (PR #35657) patches `process.stdout` via `Object.defineProperty` to guard against bogus terminal dimensions (e.g. WSL's 131072×1). However, this breaks TUI layout in **Warp terminal** — the status bar and input prompt merge onto one line.

**Root cause:** Warp's `process.stdout` is not a standard Node TTY stream. The `Object.defineProperty` override changes how Ink reads terminal dimensions, causing the FlexBox layout inside `AlternateScreen` to miscalculate vertical space allocation.

**Confirmed:** WezTerm and other standard terminals are unaffected. Commenting out `clampStdoutDimensions()` fixes Warp.

Fixes #35738

## Fix

Gate `clampStdoutDimensions()` behind WSL environment detection so it only runs where needed:

```typescript
if (process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP) {
  clampStdoutDimensions()
}
```

**Why this works:**
- **WSL** (the motivating case): `WSL_DISTRO_NAME` / `WSL_INTEROP` are always set → function runs → bogus 131072×1 is clamped ✅
- **Warp / WezTerm / Terminal.app / tmux**: env vars unset → no patching → `process.stdout` untouched → layout works correctly ✅
- **No Ink core changes** — the function and its behavior are preserved, just conditionally gated
- **No split-brain stdout identity** — `process.stdout` remains the canonical object everywhere

## Testing

| Environment | `WSL_DISTRO_NAME` | `clampStdoutDimensions` | Result |
|---|---|---|---|
| WSL | set | ✅ runs | 131072×1 clamped |
| Warp (macOS) | unset | ❌ skipped | layout correct ✅ (verified by reporter) |
| WezTerm (macOS) | unset | ❌ skipped | layout correct |
| macOS Terminal.app | unset | ❌ skipped | layout correct |
| tmux in WSL | set | ✅ runs | protected |

## Risk assessment

**Minimal.** The change is a 3-line conditional guard around an existing function. The function itself is unchanged. The only behavioral difference is that it no longer runs on non-WSL environments — which is the intended fix.

Cross-validated with Codex (GPT-5.5) which confirmed the approach is sound and identified that alternative approaches (replacing `process.stdout` with a proxy) would break Ink's `instances.get(process.stdout)` identity lookup.