### PR TITLE
fix(gateway): show live cwd in runtime footer

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10315,14 +10315,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # text, so we fire a separate trailing send below.
             _footer_line = ""
             try:
-                from gateway.runtime_footer import build_footer_line as _bfl
+                from gateway.runtime_footer import (
+                    build_footer_line as _bfl,
+                    resolve_footer_cwd as _rfc,
+                )
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
-                    cwd=os.environ.get("TERMINAL_CWD", ""),
+                    cwd=_rfc(
+                        task_id=getattr(session_entry, "session_id", None),
+                        session_key=session_key,
+                        fallback=os.environ.get("TERMINAL_CWD", ""),
+                    ),
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -53,6 +53,34 @@ def _model_short(model: Optional[str]) -> str:
     return model.rsplit("/", 1)[-1]
 
 
+def resolve_footer_cwd(
+    *,
+    task_id: Optional[str] = None,
+    session_key: Optional[str] = None,
+    fallback: Optional[str] = None,
+) -> str:
+    """Return the live task cwd for footer rendering when the terminal tracks it."""
+    try:
+        from tools.file_tools import _get_live_tracking_cwd
+    except Exception:
+        _get_live_tracking_cwd = None
+
+    if _get_live_tracking_cwd is not None:
+        seen: set[str] = set()
+        for candidate in (task_id, session_key):
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            try:
+                live_cwd = _get_live_tracking_cwd(candidate)
+            except Exception:
+                live_cwd = None
+            if live_cwd:
+                return str(live_cwd)
+
+    return fallback or os.environ.get("TERMINAL_CWD", "")
+
+
 def resolve_footer_config(
     user_config: dict[str, Any] | None,
     platform_key: str | None = None,

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -12,6 +12,7 @@ from gateway.runtime_footer import (
     _model_short,
     build_footer_line,
     format_runtime_footer,
+    resolve_footer_cwd,
     resolve_footer_config,
 )
 
@@ -50,6 +51,56 @@ def test_home_relative_cwd_leaves_abs_path_alone(tmp_path, monkeypatch):
 
 def test_home_relative_cwd_empty_returns_empty():
     assert _home_relative_cwd("") == ""
+
+
+def test_resolve_footer_cwd_prefers_live_task_cwd(monkeypatch):
+    from tools import file_tools
+
+    monkeypatch.setenv("TERMINAL_CWD", "/stale/start")
+    monkeypatch.setattr(
+        file_tools,
+        "_get_live_tracking_cwd",
+        lambda task_id="default": "/live/worktree" if task_id == "session-1" else None,
+    )
+
+    assert (
+        resolve_footer_cwd(
+            task_id="session-1",
+            session_key="telegram:chat",
+            fallback="/stale/start",
+        )
+        == "/live/worktree"
+    )
+
+
+def test_resolve_footer_cwd_falls_back_to_session_key(monkeypatch):
+    from tools import file_tools
+
+    monkeypatch.setattr(
+        file_tools,
+        "_get_live_tracking_cwd",
+        lambda task_id="default": "/live/by-session-key"
+        if task_id == "telegram:chat"
+        else None,
+    )
+
+    assert (
+        resolve_footer_cwd(
+            task_id="missing-task",
+            session_key="telegram:chat",
+            fallback="/stale/start",
+        )
+        == "/live/by-session-key"
+    )
+
+
+def test_resolve_footer_cwd_falls_back_to_static_env(monkeypatch):
+    from tools import file_tools
+
+    monkeypatch.setenv("TERMINAL_CWD", "/static/start")
+    monkeypatch.setattr(file_tools, "_get_live_tracking_cwd", lambda task_id="default": None)
+
+    assert resolve_footer_cwd(task_id="missing-task") == "/static/start"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #35745.

## Summary
- resolve the runtime footer cwd from the live terminal tracking state before falling back to TERMINAL_CWD
- use the gateway session id, with session_key as a secondary lookup, so footer cwd follows active agent directory changes
- keep existing static env fallback for sessions without a live terminal environment

## Tests
- uv run --locked --extra dev python -m pytest tests/gateway/test_runtime_footer.py -q
- uv run --locked --extra dev ruff check gateway/runtime_footer.py gateway/run.py tests/gateway/test_runtime_footer.py