### PR TITLE
fix(skills): ignore nested assets in skill lookup

### DIFF
--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -221,6 +221,45 @@ class TestSkillViewQualifiedName:
         assert result["success"] is True
         assert result["name"] == "my-local"
 
+    def test_ignores_nested_md_assets_when_resolving_bare_name(self, tmp_path, monkeypatch):
+        from tools.skills_tool import skill_view
+
+        local_skills = tmp_path / "local-skills"
+        notion_skill = local_skills / "productivity" / "notion"
+        notion_skill.mkdir(parents=True)
+        (notion_skill / "SKILL.md").write_text(
+            "---\nname: notion\ndescription: notion skill\n---\nNotion body.\n"
+        )
+        design_skill = local_skills / "creative" / "popular-web-designs"
+        (design_skill / "templates").mkdir(parents=True)
+        (design_skill / "SKILL.md").write_text(
+            "---\nname: popular-web-designs\ndescription: design skill\n---\nDesign body.\n"
+        )
+        (design_skill / "templates" / "notion.md").write_text("asset, not a skill\n")
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", local_skills)
+
+        result = json.loads(skill_view("notion"))
+
+        assert result["success"] is True
+        assert result["name"] == "notion"
+        assert "Notion body." in result["content"]
+
+    def test_keeps_top_level_legacy_flat_md_skill_candidates(self, tmp_path, monkeypatch):
+        from tools.skills_tool import skill_view
+
+        local_skills = tmp_path / "local-skills"
+        local_skills.mkdir()
+        (local_skills / "legacy.md").write_text(
+            "---\nname: legacy\ndescription: flat skill\n---\nLegacy body.\n"
+        )
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", local_skills)
+
+        result = json.loads(skill_view("legacy"))
+
+        assert result["success"] is True
+        assert result["name"] == "legacy"
+        assert "Legacy body." in result["content"]
+
     def test_plugin_exists_but_skill_missing(self, tmp_path):
         from tools.skills_tool import skill_view
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -935,6 +935,27 @@ def skill_view(
             seen_md.add(key)
             candidates.append((sd, smd))
 
+        def _is_nested_skill_asset(candidate: Path, search_dir: Path) -> bool:
+            """Return true when a legacy .md hit lives inside another skill.
+
+            Strategy 3 supports legacy flat ``<name>.md`` skills, but a Markdown
+            file below ``some-skill/{references,templates,...}/`` is an asset of
+            ``some-skill`` rather than an independently loadable skill.  Treating
+            those assets as skill candidates makes bare-name lookup ambiguous
+            whenever an asset happens to share another skill's name.
+            """
+            try:
+                candidate.resolve().relative_to(search_dir.resolve())
+            except Exception:
+                return False
+
+            for ancestor in candidate.parents:
+                if ancestor == search_dir:
+                    break
+                if (ancestor / "SKILL.md").exists():
+                    return True
+            return False
+
         for search_dir in all_dirs:
             # Strategy 1: direct path (e.g., "mlops/axolotl" or bare "axolotl"
             # at the top of the dir).
@@ -962,8 +983,9 @@ def skill_view(
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
             for found_md in search_dir.rglob(f"{name}.md"):
-                if found_md.name != "SKILL.md":
-                    _record(None, found_md)
+                if found_md.name == "SKILL.md" or _is_nested_skill_asset(found_md, search_dir):
+                    continue
+                _record(None, found_md)
 
         if len(candidates) > 1:
             paths = [str(smd) for _, smd in candidates]


### PR DESCRIPTION
## Summary
- Fixes bare `skill_view` resolution so nested Markdown assets inside another skill are not treated as standalone legacy skill candidates.
- Closes #35743.

## Why
- `skill_view notion` could report an ambiguous collision when another skill contained `templates/notion.md` or `references/.../notion.md`.
- Those Markdown files are assets of their parent skill, not loadable skills, so they should not participate in bare-name collision detection.

## Changes
- `tools/skills_tool.py`: skips Strategy 3 legacy `<name>.md` hits when an ancestor directory already contains `SKILL.md`.
- `tests/test_plugin_skills.py`: adds regression coverage for nested asset collisions and preserves top-level legacy flat `.md` skill lookup.

## Validation
- `python -m pytest tests/test_plugin_skills.py -q -o 'addopts='`
- `python -m ruff check tools/skills_tool.py tests/test_plugin_skills.py`
- `git diff --check`

## Scope
- In scope: bare-name `skill_view` candidate discovery for nested Markdown asset files.
- Out of scope: changing explicit categorized skill/file lookup semantics or broader skill index behavior.
