### PR TITLE
fix(gateway): guard rewrite_transcript behind session rotation check

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8839,12 +8839,11 @@ class GatewayRunner:
                                             source, session_entry,
                                             reason="hygiene-compression",
                                         )
-
-                                    self.session_store.rewrite_transcript(
-                                        session_entry.session_id, _compressed
-                                    )
-                                    # Reset stored token count — transcript was rewritten
-                                    session_entry.last_prompt_tokens = 0
+                                        self.session_store.rewrite_transcript(
+                                            session_entry.session_id, _compressed
+                                        )
+                                        # Reset stored token count — transcript was rewritten
+                                        session_entry.last_prompt_tokens = 0
                                     history = _compressed
                                     _new_count = len(_compressed)
                                     _new_tokens = estimate_messages_tokens_rough(
@@ -12622,12 +12621,11 @@ class GatewayRunner:
                     self._sync_telegram_topic_binding(
                         source, session_entry, reason="compress-command",
                     )
-
-                self.session_store.rewrite_transcript(new_session_id, compressed)
-                # Reset stored token count — transcript changed, old value is stale
-                self.session_store.update_session(
-                    session_entry.session_key, last_prompt_tokens=0
-                )
+                    self.session_store.rewrite_transcript(new_session_id, compressed)
+                    # Reset stored token count — transcript changed, old value is stale
+                    self.session_store.update_session(
+                        session_entry.session_key, last_prompt_tokens=0
+                    )
                 new_tokens = estimate_request_tokens_rough(
                     compressed, system_prompt=_sys_prompt, tools=_tools
                 )


### PR DESCRIPTION
## What does this PR do?

Fixes a data-loss bug in gateway hygiene compression and the `/compress` command.
When compression aborts (e.g. summary generation fails with `abort_on_summary_failure=true`)
or fails to acquire the compression lock, `_compress_context()` returns without rotating
the session ID — but `rewrite_transcript` was still called unconditionally, hitting the
**original** session with a DELETE+INSERT of the stripped message copy. This permanently
discarded tool messages, reasoning fields, and other metadata from the state.db transcript.

The fix: move `rewrite_transcript` (and the associated token-count reset) inside the
existing `if new_session_id != old_session_id` guard block. No rotation → no rewrite.

## Related Issue

N/A (discovered during compression code review)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` hygiene path (~L8842): shift `rewrite_transcript()` + `last_prompt_tokens = 0` into the `if _hyg_new_sid != session_entry.session_id` block
- `gateway/run.py` `/compress` path (~L12624): shift `rewrite_transcript()` + `update_session(last_prompt_tokens=0)` into the `if new_session_id != session_entry.session_id` block

Both changes are pure indentation shifts. No logic change to compression itself.

## How to Test

1. Run compression-related tests (all pass):
   `pytest tests/gateway/test_compress_command.py tests/gateway/test_compression_session_id_persistence.py tests/test_hermes_state_compression_locks.py tests/run_agent/test_compression_persistence.py tests/agent/test_context_compressor.py tests/agent/test_compression_concurrent_fork.py tests/run_agent/test_compression_boundary.py tests/run_agent/test_413_compression.py tests/run_agent/test_compression_feasibility.py`

2. 159 tests pass across all compression test files.

3. To reproduce the bug: set `compression.abort_on_summary_failure: true`, trigger hygiene compression (>85% context) with aux model failure. Before fix: original transcript replaced with stripped copy. After fix: transcript stays intact.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run tests and all pass (159 across compression-related files)
- [ ] I've added tests for my changes (existing tests cover the guard logic; the bug is triggered by an integration-level race condition)
- [x] I've tested on my platform: Ubuntu 22.04

### Documentation & Housekeeping

- [x] Docs: N/A
- [x] config.yaml.example: N/A
- [x] CONTRIBUTING.md / AGENTS.md: N/A
- [x] Cross-platform impact: N/A (pure logic fix, no platform-specific code)
- [x] Tool descriptions/schemas: N/A