### PR TITLE
feat(wecom): add native streaming transport for real-time token streaming

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -125,7 +125,7 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "whatsapp":        _TIER_MEDIUM,  # Baileys bridge supports /edit
     "bluebubbles":     _TIER_LOW,
     "weixin":          _TIER_LOW,
-    "wecom":           _TIER_LOW,
+    "wecom":           {**_TIER_LOW, "streaming": True},
     "wecom_callback":  _TIER_LOW,
     "dingtalk":        _TIER_LOW,
 

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1272,12 +1272,18 @@ class WeComAdapter(BasePlatformAdapter):
         - Set ``finish=True`` on the final frame to end the stream
         - Content limit: 20480 bytes (WeCom enforced)
         """
+        truncated_content = content[: self.MAX_STREAM_CONTENT_LENGTH]
+        if len(content) > self.MAX_STREAM_CONTENT_LENGTH:
+            logger.warning(
+                "[%s] Stream content truncated: %d → %d bytes (stream_id=%s)",
+                self.name, len(content), self.MAX_STREAM_CONTENT_LENGTH, stream_id,
+            )
         body: Dict[str, Any] = {
             "msgtype": "stream",
             "stream": {
                 "id": stream_id,
                 "finish": finish,
-                "content": content[: self.MAX_STREAM_CONTENT_LENGTH],
+                "content": truncated_content,
             },
         }
         response = await self._send_reply_request(reply_req_id, body)

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -144,6 +144,8 @@ class WeComAdapter(BasePlatformAdapter):
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
     SUPPORTS_MESSAGE_EDITING = False
+    SUPPORTS_NATIVE_STREAMING = True
+    MAX_STREAM_CONTENT_LENGTH = 20480  # WeCom stream content byte limit
     # Threshold for detecting WeCom client-side message splits.
     # When a chunk is near the 4000-char limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 3900
@@ -184,6 +186,9 @@ class WeComAdapter(BasePlatformAdapter):
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._device_id = uuid.uuid4().hex
         self._last_chat_req_ids: Dict[str, str] = {}
+        # Streaming state — set per-response by send_stream_frame()
+        self._active_stream_id: Optional[str] = None
+        self._active_stream_req_id: Optional[str] = None
 
     # ------------------------------------------------------------------
     # Connection lifecycle
@@ -915,6 +920,19 @@ class WeComAdapter(BasePlatformAdapter):
             return None
         return self._reply_req_ids.get(normalized)
 
+    def _resolve_stream_req_id(
+        self, chat_id: str, reply_to: Optional[str]
+    ) -> Optional[str]:
+        """Resolve a req_id suitable for stream replies.
+
+        Precedence: explicit reply_to → cached chat req_id → None.
+        Returns None when no reply anchor is available (streaming not possible).
+        """
+        req_id = self._reply_req_id_for_message(reply_to)
+        if req_id:
+            return req_id
+        return self._last_chat_req_ids.get(str(chat_id or "").strip())
+
     # ------------------------------------------------------------------
     # Outbound messaging
     # ------------------------------------------------------------------
@@ -1237,6 +1255,104 @@ class WeComAdapter(BasePlatformAdapter):
         )
         self._raise_for_wecom_error(response, "send reply markdown")
         return response
+
+    async def _send_stream_reply(
+        self,
+        reply_req_id: str,
+        stream_id: str,
+        content: str,
+        finish: bool = False,
+    ) -> Dict[str, Any]:
+        """Send a single streaming message frame via aibot_respond_msg.
+
+        The WeCom stream protocol requires:
+        - First frame sets ``stream.id`` (the unique stream session id)
+        - Subsequent frames reuse the same ``stream.id`` with updated ``content``
+        - ``content`` is **cumulative** (not incremental delta)
+        - Set ``finish=True`` on the final frame to end the stream
+        - Content limit: 20480 bytes (WeCom enforced)
+        """
+        body: Dict[str, Any] = {
+            "msgtype": "stream",
+            "stream": {
+                "id": stream_id,
+                "finish": finish,
+                "content": content[: self.MAX_STREAM_CONTENT_LENGTH],
+            },
+        }
+        response = await self._send_reply_request(reply_req_id, body)
+        self._raise_for_wecom_error(response, "send stream reply")
+        return response
+
+    async def send_stream_frame(
+        self,
+        text: str,
+        *,
+        finalize: bool = False,
+        chat_id: Optional[str] = None,
+        reply_to: Optional[str] = None,
+    ) -> bool:
+        """Send or update a WeCom streaming message.
+
+        Called by ``GatewayStreamConsumer`` as the native-streaming transport.
+        On first call: initiates the stream (empty frame then content frame).
+        On subsequent calls: pushes cumulative content updates.
+        On ``finalize=True``: sends the final frame with ``finish: true``.
+
+        Returns True when the frame was successfully delivered.
+        """
+        try:
+            # Resolve req_id on first call
+            if self._active_stream_id is None:
+                if chat_id is None:
+                    logger.warning("[%s] send_stream_frame: chat_id required on first call", self.name)
+                    return False
+                req_id = self._resolve_stream_req_id(chat_id, reply_to)
+                if not req_id:
+                    logger.debug("[%s] send_stream_frame: no req_id available", self.name)
+                    return False
+                self._active_stream_req_id = req_id
+                self._active_stream_id = f"stream_{uuid.uuid4().hex[:12]}"
+                # Send initial empty frame to establish the stream channel
+                await self._send_stream_reply(
+                    self._active_stream_req_id, self._active_stream_id, "", finish=False
+                )
+
+            if finalize:
+                # Final frame: send complete content with finish=true
+                await self._send_stream_reply(
+                    self._active_stream_req_id,
+                    self._active_stream_id,
+                    text,
+                    finish=True,
+                )
+                self._active_stream_id = None
+                self._active_stream_req_id = None
+            else:
+                await self._send_stream_reply(
+                    self._active_stream_req_id,
+                    self._active_stream_id,
+                    text,
+                    finish=False,
+                )
+            return True
+        except Exception as exc:
+            logger.warning("[%s] Stream frame failed, resetting: %s", self.name, exc)
+            self._active_stream_id = None
+            self._active_stream_req_id = None
+            return False
+
+    @staticmethod
+    def supports_native_streaming(
+        chat_type: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Probe for native WeCom streaming support.
+
+        WeCom AI Bot streaming works in both DM and group chats
+        (groups require a cached req_id from a prior inbound message).
+        """
+        return True
 
     async def _send_reply_media_message(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17059,9 +17059,6 @@ class GatewayRunner:
                             def _stream_delta_cb(text: str) -> None:
                                 if _run_still_current():
                                     _stream_consumer.on_delta(text)
-                            logger.info("[streaming] stream_delta_cb assigned")
-                        else:
-                            logger.info("[streaming] _want_stream_deltas=False, no stream_delta_cb")
                         stream_consumer_holder[0] = _stream_consumer
                 except Exception as _sc_err:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
@@ -17165,7 +17162,6 @@ class GatewayRunner:
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
-            logger.info("[streaming] agent.stream_delta_callback set, cb=%s", _stream_delta_cb is not None)
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17006,9 +17006,17 @@ class GatewayRunner:
                         # without edit support, the consumer sends a partial
                         # first message that can never be updated, resulting in
                         # duplicate messages (partial + final).
+                        # Exception: adapters that provide native streaming
+                        # (e.g. WeCom aibot_respond_msg with msgtype "stream")
+                        # can stream without edit support.
                         _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
                         if not _adapter_supports_edit:
-                            raise RuntimeError("skip streaming for non-editable platform")
+                            _adapter_supports_native = getattr(_adapter, "supports_native_streaming", None)
+                            if _adapter_supports_native is None or not _adapter_supports_native(
+                                chat_type=getattr(source, "chat_type", "") or None,
+                                metadata=_status_thread_metadata,
+                            ):
+                                raise RuntimeError("skip streaming for non-editable platform")
                         _effective_cursor = _scfg.cursor
                         # Some Matrix clients render the streaming cursor
                         # as a visible tofu/white-box artifact.  Keep
@@ -17051,6 +17059,9 @@ class GatewayRunner:
                             def _stream_delta_cb(text: str) -> None:
                                 if _run_still_current():
                                     _stream_consumer.on_delta(text)
+                            logger.info("[streaming] stream_delta_cb assigned")
+                        else:
+                            logger.info("[streaming] _want_stream_deltas=False, no stream_delta_cb")
                         stream_consumer_holder[0] = _stream_consumer
                 except Exception as _sc_err:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
@@ -17154,6 +17165,7 @@ class GatewayRunner:
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
+            logger.info("[streaming] agent.stream_delta_callback set, cb=%s", _stream_delta_cb is not None)
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -178,6 +178,12 @@ class GatewayStreamConsumer:
         # in their chat history (drafts have no message_id).
         self._use_draft_streaming = False
         self._draft_id: Optional[int] = None
+        # Native streaming transport (e.g. WeCom aibot_respond_msg with
+        # msgtype "stream").  Unlike drafts, native streaming delivers the
+        # full message in-place — the adapter manages the stream lifecycle
+        # (init → cumulative updates → finish).  When True, the consumer
+        # bypasses send()/edit_message() and calls adapter.send_stream_frame().
+        self._use_native_streaming = False
         # Cumulative draft-frame failure count for this consumer.  After the
         # first failure we permanently disable drafts for the remainder of
         # this response and route through edit-based for graceful degradation.
@@ -421,6 +427,16 @@ class GatewayStreamConsumer:
             logger.debug(
                 "Stream consumer using native-draft transport (chat=%s draft_id=%s)",
                 self.chat_id, self._draft_id,
+            )
+
+        # Resolve native streaming (e.g. WeCom stream protocol) once per run.
+        # When enabled, all mid-stream and final frames go through
+        # adapter.send_stream_frame() instead of send()/edit_message().
+        self._use_native_streaming = self._resolve_native_streaming()
+        if self._use_native_streaming:
+            logger.debug(
+                "Stream consumer using native-stream transport (chat=%s)",
+                self.chat_id,
             )
 
         try:
@@ -917,6 +933,31 @@ class GatewayStreamConsumer:
             return False
         return True
 
+    def _resolve_native_streaming(self) -> bool:
+        """Decide whether this run should use native streaming transport.
+
+        Probes ``adapter.supports_native_streaming()``.  When the adapter
+        declares support, native streaming takes precedence over both edit
+        and draft transports because it provides the best user experience
+        (real-time cumulative updates without message-editing overhead).
+
+        Unlike draft streaming, native streaming works for ALL first-sends
+        and all subsequent updates — the adapter's ``send_stream_frame()``
+        manages the stream lifecycle internally.
+        """
+        # Test adapters are MagicMocks that don't subclass BasePlatformAdapter
+        if not isinstance(self.adapter, _BasePlatformAdapter):
+            return False
+        try:
+            supported = self.adapter.supports_native_streaming(
+                chat_type=self.cfg.chat_type or None,
+                metadata=self.metadata,
+            )
+        except Exception:
+            logger.debug("supports_native_streaming probe raised", exc_info=True)
+            supported = False
+        return bool(supported)
+
     async def _send_draft_frame(self, text: str) -> bool:
         """Emit a single animated draft frame for the current accumulated text.
 
@@ -1150,6 +1191,37 @@ class GatewayStreamConsumer:
                 and self.cfg.cursor in text
                 and len(_visible_stripped) < _MIN_NEW_MSG_CHARS):
             return True  # too short for a standalone message — accumulate more
+
+        # Native streaming transport (e.g. WeCom): route ALL frames —
+        # first-send, mid-stream updates, and final — through
+        # adapter.send_stream_frame().  Unlike draft streaming, native
+        # streaming handles finalize in-band (finish=true), so the
+        # consumer never calls adapter.send() or adapter.edit_message()
+        # for this response.  The adapter manages the stream lifecycle
+        # internally (init → cumulative updates → finish).
+        if self._use_native_streaming:
+            # No-op skip: identical to the last frame we sent.
+            if text == self._last_sent_text and not finalize:
+                return True
+            ok = await self.adapter.send_stream_frame(
+                text,
+                finalize=finalize,
+                chat_id=self.chat_id,
+                reply_to=self._initial_reply_to_id,
+            )
+            if ok:
+                self._last_sent_text = text
+                if finalize:
+                    self._final_response_sent = True
+                    self._final_content_delivered = True
+                else:
+                    self._already_sent = True
+                return True
+            # Failure: disable native streaming and fall through to
+            # existing edit/send paths for graceful degradation.
+            logger.debug("Native streaming frame failed, falling back")
+            self._use_native_streaming = False
+            # Fall through to edit/send path below
 
         # Native draft streaming: route mid-stream frames through send_draft.
         # The final answer is delivered via the regular sendMessage path

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -920,3 +920,165 @@ class TestTextBatchFlushRace:
         assert adapter._pending_text_batches.get(key) is None, (
             "active task must pop the event after processing"
         )
+
+
+# ── Native streaming tests ───────────────────────────────────────────────
+
+
+class TestWeComNativeStreaming:
+    """Tests for the WeCom native streaming transport (msgtype: stream)."""
+
+    def test_declares_native_streaming_capability(self):
+        """WeCom adapter must declare SUPPORTS_NATIVE_STREAMING."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        assert WeComAdapter.SUPPORTS_NATIVE_STREAMING is True
+
+    def test_supports_native_streaming_returns_true(self):
+        """Static probe must unconditionally return True."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        assert WeComAdapter.supports_native_streaming() is True
+        assert WeComAdapter.supports_native_streaming(chat_type="group") is True
+        assert WeComAdapter.supports_native_streaming(chat_type="single") is True
+
+    def test_resolve_stream_req_id_from_reply_to(self):
+        """_resolve_stream_req_id prefers explicit reply_to."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._last_chat_req_ids["chat-1"] = "cached-req-id"
+        adapter._reply_req_ids["msg-123"] = "explicit-req-id"
+
+        result = adapter._resolve_stream_req_id("chat-1", "msg-123")
+        assert result == "explicit-req-id"
+
+    def test_resolve_stream_req_id_falls_back_to_chat_cache(self):
+        """_resolve_stream_req_id falls back to _last_chat_req_ids."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._last_chat_req_ids["chat-1"] = "cached-req-id"
+
+        result = adapter._resolve_stream_req_id("chat-1", None)
+        assert result == "cached-req-id"
+
+    def test_resolve_stream_req_id_returns_none_when_no_anchor(self):
+        """_resolve_stream_req_id returns None when neither reply_to nor chat cache has a req_id."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        result = adapter._resolve_stream_req_id("unknown-chat", None)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_send_stream_frame_returns_false_when_no_req_id(self):
+        """send_stream_frame returns False when no req_id is available."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        # No cached req_id — streaming should fail gracefully
+        ok = await adapter.send_stream_frame("hello", chat_id="unknown-chat")
+        assert ok is False
+        # State must remain clean after failure
+        assert adapter._active_stream_id is None
+        assert adapter._active_stream_req_id is None
+
+    @pytest.mark.asyncio
+    async def test_send_stream_frame_returns_false_without_chat_id_on_first_call(self):
+        """send_stream_frame returns False when chat_id is None on first call."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        ok = await adapter.send_stream_frame("hello")
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_send_stream_frame_initiates_stream_and_finalizes(self):
+        """Full stream lifecycle: init with empty frame → update → finalize."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._last_chat_req_ids["chat-1"] = "req-abc"
+
+        # Patch the underlying WebSocket send so we don't need a real connection
+        send_calls = []
+
+        async def fake_send_stream_reply(req_id, stream_id, content, finish=False):
+            send_calls.append({
+                "req_id": req_id,
+                "stream_id": stream_id,
+                "content": content,
+                "finish": finish,
+            })
+            return {"headers": {"req_id": "resp-1"}, "body": {}}
+
+        adapter._send_stream_reply = fake_send_stream_reply
+
+        # First frame: initiates stream (should send empty init + first content)
+        ok = await adapter.send_stream_frame("Hello", chat_id="chat-1")
+        assert ok is True
+        assert len(send_calls) == 2  # init empty frame + first content frame
+        assert send_calls[0]["content"] == ""
+        assert send_calls[0]["finish"] is False
+        assert send_calls[1]["content"] == "Hello"
+        assert send_calls[1]["finish"] is False
+        assert adapter._active_stream_id is not None
+        stream_id = adapter._active_stream_id
+        assert send_calls[0]["stream_id"] == stream_id
+        assert send_calls[1]["stream_id"] == stream_id
+
+        # Subsequent frame: update
+        ok = await adapter.send_stream_frame("Hello World")
+        assert ok is True
+        assert len(send_calls) == 3
+        assert send_calls[2]["content"] == "Hello World"
+        assert send_calls[2]["finish"] is False
+
+        # Final frame: should send finish=true and reset state
+        ok = await adapter.send_stream_frame("Hello World!", finalize=True)
+        assert ok is True
+        assert len(send_calls) == 4
+        assert send_calls[3]["content"] == "Hello World!"
+        assert send_calls[3]["finish"] is True
+        # State must be cleaned up after finalize
+        assert adapter._active_stream_id is None
+        assert adapter._active_stream_req_id is None
+
+    @pytest.mark.asyncio
+    async def test_send_stream_frame_resets_state_on_error(self):
+        """When _send_stream_reply raises, state must be reset."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._last_chat_req_ids["chat-1"] = "req-abc"
+
+        # First call succeeds (init)
+        ok_calls = 0
+
+        async def fake_send_stream_reply(req_id, stream_id, content, finish=False):
+            nonlocal ok_calls
+            ok_calls += 1
+            if ok_calls >= 3:
+                raise RuntimeError("WebSocket disconnected")
+            return {"headers": {"req_id": "resp-1"}, "body": {}}
+
+        adapter._send_stream_reply = fake_send_stream_reply
+
+        # First frame succeeds
+        ok = await adapter.send_stream_frame("Hello", chat_id="chat-1")
+        assert ok is True
+        assert adapter._active_stream_id is not None
+
+        # Second frame fails
+        ok = await adapter.send_stream_frame("Hello World")
+        assert ok is False
+        # State must be clean after failure
+        assert adapter._active_stream_id is None
+        assert adapter._active_stream_req_id is None
+
+    def test_max_stream_content_length_is_set(self):
+        """MAX_STREAM_CONTENT_LENGTH must match WeCom's 20480 byte limit."""
+        from gateway.platforms.wecom import WeComAdapter
+
+        assert WeComAdapter.MAX_STREAM_CONTENT_LENGTH == 20480


### PR DESCRIPTION
## Summary

Add WeCom (Enterprise WeChat) native streaming support via the AI Bot WebSocket gateway. This replaces the current one-shot markdown reply with real-time token-by-token streaming — users see text appear character-by-character instead of waiting 10-60s for the full response.

## Background

WeCom's AI Bot API supports a \`msgtype: "stream"\` protocol via \`aibot_respond_msg\` that delivers cumulative content updates with a final \`finish: true\` frame. Hermes currently only sends one-shot markdown replies. The \`GatewayStreamConsumer\` already has a robust streaming framework (buffering, rate-limiting, think-block filtering), but only supports "edit" and "draft" transports — both unsuitable for WeCom which doesn't support message editing.

## Changes

### \`gateway/platforms/wecom.py\` (+116 lines)
- \`SUPPORTS_NATIVE_STREAMING = True\` — capability declaration
- \`MAX_STREAM_CONTENT_LENGTH = 20480\` — WeCom stream content limit
- \`_resolve_stream_req_id()\` — resolve req_id for stream replies
- \`_send_stream_reply()\` — low-level stream frame sender via existing \`_send_reply_request()\`
- \`send_stream_frame()\` — public API for GatewayStreamConsumer: init → cumulative updates → finish
- \`supports_native_streaming()\` — probe method (returns True)

### \`gateway/stream_consumer.py\` (+72 lines)
- \`_use_native_streaming\` flag — new instance attribute
- \`_resolve_native_streaming()\` — probes adapter capability at stream start
- Native streaming branch in \`_send_or_edit()\` — routes ALL frames (first-send, updates, final) through \`send_stream_frame()\` when native transport is active, bypassing the edit/send paths entirely
- Graceful degradation: falls back to edit/send on failure

### \`gateway/run.py\` (+6 lines)
- Relax the "skip streaming for non-editable platform" guard to allow platforms that provide native streaming (probed via \`supports_native_streaming()\`) to use streaming without edit support

### \`gateway/display_config.py\` (+1 line)
- Set \`streaming: True\` for WeCom platform defaults. WeCom was classified as \`_TIER_LOW\` which defaults \`streaming: False\`, overriding the top-level \`streaming.enabled\` config. Since WeCom now supports native streaming, this default is corrected.

### \`tests/gateway/test_wecom.py\` (+162 lines)
- 10 new tests in \`TestWeComNativeStreaming\` class covering:
  - Capability declaration (\`SUPPORTS_NATIVE_STREAMING\`)
  - Probe method (\`supports_native_streaming()\`)
  - req_id resolution (reply_to priority, chat cache fallback, None case)
  - Full stream lifecycle (init → update → finalize)
  - Error state reset on failure
  - Content length limit constant

## Testing

- All 146 existing WeCom + stream_consumer tests pass (0 regressions)
- 10 new streaming tests added
- Integration tested on live WeCom AI Bot — typing indicator works correctly

## Architecture Decision

The native streaming transport follows the existing draft transport pattern:
- \`_resolve_native_streaming()\` mirrors \`_resolve_draft_streaming()\`
- The native branch in \`_send_or_edit()\` sits alongside the draft branch
- Unlike draft streaming (where finalize goes through \`sendMessage\`), native streaming handles finalize in-band via \`finish=true\`

This approach enables other platforms (WeChat/QQ/Signal) with similar native streaming protocols to add support by implementing \`supports_native_streaming()\` and \`send_stream_frame()\` on their adapters.