### PR TITLE
fix(qqbot): authorize approval clicks for DM sessions (chat_type='dm')

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1086,7 +1086,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in ("c2c", "dm"):
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -2197,3 +2197,45 @@ class TestCloseCodeClassification:
         assert 4001 in fatal_codes
         assert 4915 in fatal_codes
 
+
+
+# ---------------------------------------------------------------------------
+# _is_authorized_interaction_for_session — DM (chat_type="dm") parity with c2c
+# Regression test for #35760: QQ adapter creates DM sessions with chat_type="dm"
+# but authorization only accepted "c2c", so approval clicks were always rejected.
+# ---------------------------------------------------------------------------
+
+class TestIsAuthorizedInteractionForSession:
+    def _make_adapter(self):
+        from gateway.platforms.qqbot import QQAdapter
+        return QQAdapter(_make_config(app_id="aid", client_secret="sec"))
+
+    def test_dm_chat_type_authorizes_when_operator_matches_chat_id(self):
+        adapter = self._make_adapter()
+        session_key = "agent:main:qqbot:dm:user_open_id_123"
+        event = SimpleNamespace(
+            operator_openid="user_open_id_123",
+            group_openid=None,
+            guild_id=None,
+        )
+        assert adapter._is_authorized_interaction_for_session(event, session_key) is True
+
+    def test_c2c_chat_type_still_authorizes(self):
+        adapter = self._make_adapter()
+        session_key = "agent:main:qqbot:c2c:user_open_id_123"
+        event = SimpleNamespace(
+            operator_openid="user_open_id_123",
+            group_openid=None,
+            guild_id=None,
+        )
+        assert adapter._is_authorized_interaction_for_session(event, session_key) is True
+
+    def test_dm_chat_type_rejects_when_operator_mismatched(self):
+        adapter = self._make_adapter()
+        session_key = "agent:main:qqbot:dm:user_open_id_123"
+        event = SimpleNamespace(
+            operator_openid="someone_else",
+            group_openid=None,
+            guild_id=None,
+        )
+        assert adapter._is_authorized_interaction_for_session(event, session_key) is False


### PR DESCRIPTION
## Summary

Fixes #35760 — QQ bot approval button clicks (e.g. `allow-once`, `allow-always`) were always rejected with `Rejected unauthorized approval click for session ...`, blocking every tool requiring user approval until the ~280s approval timeout fired.

## Root cause

`gateway/platforms/qqbot/adapter.py::_is_authorized_interaction_for_session` only matched `chat_type == "c2c"`. But this adapter creates DM sessions with `chat_type="dm"`:

```python
# adapter.py:1282 (C2C message create handler)
chat_type="dm",
# adapter.py:1492 (friend-add handler)
chat_type="dm",
```

Session keys therefore look like `agent:main:qqbot:dm:<openid>`, which parses to `chat_type="dm"` and never matches `"c2c"`, so every DM approval click falls through to `return False`.

## Fix

One-line: accept both legacy `"c2c"` and current `"dm"` chat_type values.

```diff
-        if chat_type == "c2c":
+        if chat_type in ("c2c", "dm"):
             return bool(chat_id) and operator == chat_id
```

Group/guild branches are unchanged.

## Tests

Adds three regression tests in `tests/gateway/test_qqbot.py::TestIsAuthorizedInteractionForSession`:

- `test_dm_chat_type_authorizes_when_operator_matches_chat_id` — the bug case
- `test_c2c_chat_type_still_authorizes` — backward-compat guard
- `test_dm_chat_type_rejects_when_operator_mismatched` — ensures we still reject impostors

Full file passes: `162 passed`.

## Risk

Minimal. Pure widening of an existing auth predicate. Operator-equality check is unchanged, so security posture is identical to the c2c path.
