### PR TITLE
fix(browser): guard module-level int() against non-numeric env var

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1178,7 +1178,10 @@ _cleanup_done = False
 # Session inactivity timeout (seconds) - cleanup if no activity for this long
 # Default: 5 minutes. Needs headroom for LLM reasoning between browser commands,
 # especially when subagents are doing multi-step browser tasks.
-BROWSER_SESSION_INACTIVITY_TIMEOUT = int(os.environ.get("BROWSER_INACTIVITY_TIMEOUT", "300"))
+try:
+    BROWSER_SESSION_INACTIVITY_TIMEOUT = int(os.environ.get("BROWSER_INACTIVITY_TIMEOUT", "300"))
+except (ValueError, TypeError):
+    BROWSER_SESSION_INACTIVITY_TIMEOUT = 300
 
 # Track last activity time per session
 _session_last_activity: Dict[str, float] = {}


### PR DESCRIPTION
## Fix: Guard module-level `int()` against non-numeric env var

**File:** `tools/browser_tool.py`, line 1181

**Bug:** `BROWSER_SESSION_INACTIVITY_TIMEOUT` is cast via `int()` at module level without any error handling. If a user sets `BROWSER_INACTIVITY_TIMEOUT` to a non-numeric string (e.g. `"abc"` or an empty string), the entire `browser_tool` module fails to import with an unhandled `ValueError`, **breaking all browser functionality**.

**Fix:** Wrap the module-level `int()` call in `try/except (ValueError, TypeError)` with a fallback to the default value of 300 seconds. This matches the defensive pattern used elsewhere in the codebase (e.g. `_env_float()` helper in `chat_completion_helpers.py`).

**Impact:** High — any misconfigured env var currently causes a complete browser tool outage with no recovery path.