### PR TITLE
fix: guard json.loads() on user/network input with try/except

### DIFF
--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -868,7 +868,11 @@ def sheets_get(args):
 
 
 def sheets_update(args):
-    values = json.loads(args.values)
+    try:
+        values = json.loads(args.values)
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"Invalid JSON in --values: {e}\n")
+        sys.exit(1)
     body = {"values": values}
 
     if _gws_binary():
@@ -894,7 +898,11 @@ def sheets_update(args):
 
 
 def sheets_append(args):
-    values = json.loads(args.values)
+    try:
+        values = json.loads(args.values)
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"Invalid JSON in --values: {e}\n")
+        sys.exit(1)
     body = {"values": values}
 
     if _gws_binary():

--- a/skills/productivity/google-workspace/scripts/gws_bridge.py
+++ b/skills/productivity/google-workspace/scripts/gws_bridge.py
@@ -81,7 +81,11 @@ def get_valid_token() -> str:
         print("ERROR: No Google token found. Run setup.py --auth-url first.", file=sys.stderr)
         sys.exit(1)
 
-    token_data = json.loads(token_path.read_text())
+    try:
+        token_data = json.loads(token_path.read_text())
+    except json.JSONDecodeError:
+        sys.stderr.write(f"Corrupted token file: {token_path}\n")
+        sys.exit(1)
 
     expiry = token_data.get("expiry", "")
     if expiry:

--- a/skills/productivity/linear/scripts/linear_api.py
+++ b/skills/productivity/linear/scripts/linear_api.py
@@ -95,7 +95,11 @@ def gql(query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
         sys.stderr.write(f"Network error: {e}\n")
         sys.exit(1)
 
-    result = json.loads(body)
+    try:
+        result = json.loads(body)
+    except json.JSONDecodeError:
+        sys.stderr.write(f"Non-JSON response from Linear API:\n{body[:500]}\n")
+        sys.exit(1)
     if "errors" in result and result["errors"]:
         sys.stderr.write(f"GraphQL errors: {json.dumps(result['errors'], indent=2)}\n")
         # Still return data if partial success; let caller decide
@@ -349,7 +353,11 @@ def cmd_search_documents(args: argparse.Namespace) -> None:
 
 
 def cmd_raw(args: argparse.Namespace) -> None:
-    variables = json.loads(args.vars) if args.vars else None
+    try:
+        variables = json.loads(args.vars) if args.vars else None
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"Invalid JSON in --vars: {e}\n")
+        sys.exit(1)
     emit(gql(args.query, variables))
 
 


### PR DESCRIPTION
## Fix: Guard `json.loads()` on user/network/file input

Multiple scripts parse JSON from CLI arguments, HTTP responses, or local files without catching `json.JSONDecodeError`. Malformed input produces a raw Python traceback instead of a user-friendly error message.

### Files changed

| File | Input source | Impact |
|------|-------------|--------|
| `google_api.py` | CLI `--values` arg in `sheets_update()` + `sheets_append()` | User-facing CLI error |
| `linear_api.py` | HTTP response body in `gql()` | Non-JSON API response (e.g. HTML error page) crashes |
| `linear_api.py` | CLI `--vars` arg in `cmd_raw()` | User-facing CLI error |
| `gws_bridge.py` | Token file read | Corrupted token file crashes |

### Pattern

Each `json.loads()` is wrapped in `try/except json.JSONDecodeError` with a descriptive error message to stderr and a clean `sys.exit(1)`. This matches the existing defensive pattern in `setup.py`, `google_api.py:73`, and `maps_client.py`.