### PR TITLE
fix: guard fcntl.flock(LOCK_UN) against OSError in cleanup blocks

### DIFF
--- a/agent/google_oauth.py
+++ b/agent/google_oauth.py
@@ -227,7 +227,7 @@ def _credentials_lock(timeout_seconds: float = LOCK_TIMEOUT_SECONDS):
                     import fcntl
 
                     fcntl.flock(fd, fcntl.LOCK_UN)
-                except ImportError:
+                except (ImportError, OSError):
                     try:
                         import msvcrt  # type: ignore[import-not-found]
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1168,7 +1168,10 @@ def _cross_process_init_lock(path: Path):
             else:
                 import fcntl
 
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
         finally:
             handle.close()
 


### PR DESCRIPTION
## Fix: Guard `fcntl.flock(LOCK_UN)` against `OSError` in cleanup blocks

Two locations had unguarded `fcntl.flock(LOCK_UN)` calls that could raise `OSError` (e.g. `EBADF` if the fd was already closed), preventing proper cleanup:

### `agent/google_oauth.py:229`

`OSError` from `flock()` was not caught — the `except` only handled `ImportError` (for platforms without `fcntl`). An `OSError` would skip the `msvcrt` fallback entirely and propagate up.

**Fix:** Added `OSError` to the existing `except ImportError` clause.

### `hermes_cli/kanban_db.py:1171`

`OSError` from `flock()` would skip the `handle.close()` in the outer `finally` block, leaking the file descriptor.

**Fix:** Wrapped in `try/except OSError: pass`.

### Already-guarded locations (no change needed)

5 other `flock(LOCK_UN)` locations already had proper `try/except (OSError, IOError): pass` guards:
- `agent/shell_hooks.py:636`
- `tools/skill_usage.py:91`
- `tools/memory_tool.py:234`
- `tools/environments/file_sync.py:293`
- `hermes_cli/auth.py:1012`