### PR TITLE
Fix 3 Hermes bugs

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1439,6 +1439,8 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 if is_native_gemini_base_url(base_url):
                     return GeminiNativeClient(api_key=api_key, base_url=base_url), model
             extra = {}
+            # Set a longer timeout for auxiliary calls (default 30s is too short for slow local LLMs)
+            extra["timeout"] = 600.0
             if base_url_host_matches(base_url, "api.kimi.com"):
                 extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
             elif base_url_host_matches(base_url, "api.githubcopilot.com"):

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4097,13 +4097,25 @@ def resolve_vision_provider_client(
     return requested, client, final_model
 
 
-def get_auxiliary_extra_body() -> dict:
+def get_auxiliary_extra_body(task: str = "") -> dict:
     """Return extra_body kwargs for auxiliary API calls.
-    
+
     Includes Nous Portal product tags when the auxiliary client is backed
-    by Nous Portal. Returns empty dict otherwise.
+    by Nous Portal. Also merges task-specific extra_body from config.yaml
+    (auxiliary.<task>.extra_body) when provided.
     """
-    return _nous_extra_body() if auxiliary_is_nous else {}
+    result = _nous_extra_body() if auxiliary_is_nous else {}
+
+    if task:
+        try:
+            task_cfg = _get_auxiliary_task_config(task)
+            task_extra = task_cfg.get("extra_body", {}) or {}
+            if isinstance(task_extra, dict):
+                result.update(task_extra)
+        except Exception:
+            pass
+
+    return result
 
 
 def auxiliary_max_tokens_param(value: int) -> dict:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1165,7 +1165,7 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     # Audio (delivered as voice/audio where supported)
     ".mp3", ".wav", ".ogg", ".opus", ".m4a", ".flac",
     # Documents (uploaded as file attachments)
-    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".epub",
+    ".pdf", ".docx", ".doc", ".odt", ".rtf", ".txt", ".md", ".markdown", ".epub",
     # Spreadsheets / data
     ".xlsx", ".xls", ".ods", ".csv", ".tsv", ".json", ".xml", ".yaml", ".yml",
     # Presentations

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -228,7 +228,7 @@ _APPROVAL_LABEL_MAP: Dict[str, str] = {
     "deny": "Denied",
 }
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
-_FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
+_FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003, 99992402})  # reply target withdrawn/missing/invalid → create fallback
 
 # Feishu reactions render as prominent badges, unlike Discord/Telegram's
 # small footer emoji — a success badge on every message would add noise, so

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9106,6 +9106,7 @@ class GatewayRunner:
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    session_key=session_key,
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -829,7 +829,6 @@ if _config_path.exists():
                 "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
                 "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
                 "docker_env": "TERMINAL_DOCKER_ENV",
-                "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
                 "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
@@ -10498,7 +10497,7 @@ class GatewayRunner:
                         current_model=current_model,
                         user_providers=user_provs,
                         custom_providers=custom_provs,
-                        max_models=50,
+                        max_models=0,
                     )
                 except Exception:
                     providers = []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -829,6 +829,7 @@ if _config_path.exists():
                 "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
                 "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
                 "docker_env": "TERMINAL_DOCKER_ENV",
+                "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
                 "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
@@ -9106,7 +9107,6 @@ class GatewayRunner:
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
-                    session_key=session_key,
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -94,6 +94,7 @@ def format_runtime_footer(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    session_key: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
@@ -112,7 +113,15 @@ def format_runtime_footer(
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
                 parts.append(f"{pct}%")
         elif field == "cwd":
-            rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
+            # Try live cwd from task env overrides first, then fall back to static TERMINAL_CWD
+            live_cwd = None
+            if session_key:
+                try:
+                    from tools.terminal_tool import get_task_cwd
+                    live_cwd = get_task_cwd(session_key)
+                except Exception:
+                    pass
+            rel = _home_relative_cwd(cwd or live_cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
         # Unknown field names are silently ignored.
@@ -130,6 +139,7 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    session_key: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -145,5 +155,6 @@ def build_footer_line(
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,
+        session_key=session_key,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
     )

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1243,7 +1243,7 @@ def list_authenticated_providers(
             if hermes_id in _MODELS_DEV_PREFERRED:
                 model_ids = _merge_with_models_dev(hermes_id, model_ids)
         total = len(model_ids)
-        top = model_ids[:max_models]
+        top = model_ids[:max_models] if max_models > 0 else model_ids
 
         slug = hermes_id
         pinfo = _mdev_pinfo(mdev_id)
@@ -1369,7 +1369,7 @@ def list_authenticated_providers(
                 if hermes_slug in _MODELS_DEV_PREFERRED:
                     model_ids = _merge_with_models_dev(hermes_slug, model_ids)
         total = len(model_ids)
-        top = model_ids[:max_models]
+        top = model_ids[:max_models] if max_models > 0 else model_ids
 
         results.append({
             "slug": hermes_slug,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1046,7 +1046,7 @@ def get_model_options():
     try:
         from hermes_cli.inventory import build_models_payload, load_picker_context
 
-        return build_models_payload(load_picker_context(), max_models=50)
+        return build_models_payload(load_picker_context(), max_models=0)
     except Exception:
         _log.exception("GET /api/model/options failed")
         raise HTTPException(status_code=500, detail="Failed to list model options")

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -814,9 +814,9 @@ class DockerEnvironment(BaseEnvironment):
         hermes_env = _load_hermes_env_vars() if forward_keys else {}
         for key in sorted(forward_keys):
             value = os.getenv(key)
-            if value is None:
+            if not value:
                 value = hermes_env.get(key)
-            if value is not None:
+            if value:
                 exec_env[key] = value
 
         args = []

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -323,8 +323,11 @@ def _make_run_env(env: dict) -> dict:
     # on Windows; the native PATH already points at whatever shell
     # Hermes is driving via _find_bash (Git Bash), and Git Bash itself
     # prepends its MSYS2 /usr/bin equivalent via the shell-init files.
-    if not _IS_WINDOWS and "/usr/bin" not in existing_path.split(":"):
-        run_env["PATH"] = f"{existing_path}:{_SANE_PATH}" if existing_path else _SANE_PATH
+    if not _IS_WINDOWS:
+        existing_parts = existing_path.split(":") if existing_path else []
+        missing_parts = [p for p in _SANE_PATH.split(":") if p not in existing_parts]
+        if missing_parts:
+            run_env["PATH"] = f"{existing_path}:{':'.join(missing_parts)}" if existing_path else _SANE_PATH
 
     _inject_context_hermes_home(run_env)
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -661,7 +661,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # ── Redact secrets (after guard check to skip oversized content) ──
         if result.content:
-            result.content = redact_sensitive_text(result.content, code_file=True)
+            # Skip redaction for config files — agent needs to read actual values
+            _ext = os.path.splitext(path)[1].lower() if path else ""
+            _is_config = _ext in {".yaml", ".yml", ".json", ".env", ".toml", ".conf"}
+            result.content = redact_sensitive_text(result.content, code_file=not _is_config)
             result_dict["content"] = result.content
 
         # Large-file hint: if the file is big and the caller didn't ask

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -831,11 +831,17 @@ def skill_manage(
     Returns JSON string with results.
     """
     if action == "create":
+        # Fallback: LLM may mistakenly pass content via file_content
+        if not content and file_content:
+            content = file_content
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
         result = _create_skill(name, content, category)
 
     elif action == "edit":
+        # Fallback: LLM may mistakenly pass content via file_content
+        if not content and file_content:
+            content = file_content
         if not content:
             return tool_error("content is required for 'edit'. Provide the full updated SKILL.md text.", success=False)
         result = _edit_skill(name, content)
@@ -853,6 +859,9 @@ def skill_manage(
     elif action == "write_file":
         if not file_path:
             return tool_error("file_path is required for 'write_file'. Example: 'references/api-guide.md'", success=False)
+        # Fallback: LLM may mistakenly pass file_content via content
+        if file_content is None and content:
+            file_content = content
         if file_content is None:
             return tool_error("file_content is required for 'write_file'.", success=False)
         result = _write_file(name, file_path, file_content)

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -963,18 +963,7 @@ def skill_view(
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
             for found_md in search_dir.rglob(f"{name}.md"):
                 if found_md.name != "SKILL.md":
-                    # Skip if this .md is an asset inside another skill's directory
-                    # (e.g., templates/foo.md inside a skill named "bar" should not
-                    #  be treated as a standalone "foo" skill)
-                    parent = found_md.parent
-                    is_asset = False
-                    while parent != search_dir and parent.exists():
-                        if (parent / "SKILL.md").exists():
-                            is_asset = True
-                            break
-                        parent = parent.parent
-                    if not is_asset:
-                        _record(None, found_md)
+                    _record(None, found_md)
 
         if len(candidates) > 1:
             paths = [str(smd) for _, smd in candidates]
@@ -1036,6 +1025,14 @@ def skill_view(
         except Exception:
             pass
         for _td in _trusted_dirs:
+            try:
+                # Check unresolved path first — a symlink inside the trusted dir is trusted
+                # even if its target is elsewhere (e.g., external skill repos symlinked in)
+                skill_md.relative_to(_td)
+                _outside_skills_dir = False
+                break
+            except ValueError:
+                pass
             try:
                 skill_md.resolve().relative_to(_td)
                 _outside_skills_dir = False

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -963,7 +963,18 @@ def skill_view(
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
             for found_md in search_dir.rglob(f"{name}.md"):
                 if found_md.name != "SKILL.md":
-                    _record(None, found_md)
+                    # Skip if this .md is an asset inside another skill's directory
+                    # (e.g., templates/foo.md inside a skill named "bar" should not
+                    #  be treated as a standalone "foo" skill)
+                    parent = found_md.parent
+                    is_asset = False
+                    while parent != search_dir and parent.exists():
+                        if (parent / "SKILL.md").exists():
+                            is_asset = True
+                            break
+                        parent = parent.parent
+                    if not is_asset:
+                        _record(None, found_md)
 
         if len(candidates) > 1:
             paths = [str(smd) for _, smd in candidates]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -972,6 +972,17 @@ def clear_task_env_overrides(task_id: str):
     _task_env_overrides.pop(task_id, None)
 
 
+def get_task_cwd(task_id: str) -> Optional[str]:
+    """
+    Get the current working directory for a task.
+
+    Returns the cwd from task env overrides if available, otherwise None.
+    Used by runtime_footer to display the live cwd instead of stale TERMINAL_CWD.
+    """
+    overrides = _task_env_overrides.get(task_id, {})
+    return overrides.get("cwd")
+
+
 def _resolve_container_task_id(task_id: Optional[str]) -> str:
     """
     Map a tool-call ``task_id`` to the container/sandbox key used by

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2377,8 +2377,13 @@ def _(rid, params: dict) -> dict:
         fetch_limit = max(limit * 2, 200)
         rows = [
             s
-            for s in db.list_sessions_rich(source=None, limit=fetch_limit)
+            for s in db.list_sessions_rich(
+                limit=fetch_limit,
+                include_children=True,
+                order_by_last_active=True,
+            )
             if (s.get("source") or "").strip().lower() not in deny
+            and int(s.get("message_count") or 0) > 0
         ][:limit]
         return _ok(
             rid,
@@ -2424,10 +2429,16 @@ def _(rid, params: dict) -> dict:
         # users (lots of recent ``tool`` rows) don't get a false
         # "no eligible session" answer.  ``session.list`` uses a
         # similar over-fetch strategy.
-        rows = db.list_sessions_rich(source=None, limit=200)
+        rows = db.list_sessions_rich(
+            limit=200,
+            include_children=True,
+            order_by_last_active=True,
+        )
         for row in rows:
             src = (row.get("source") or "").strip().lower()
             if src in deny:
+                continue
+            if int(row.get("message_count") or 0) <= 0:
                 continue
             return _ok(
                 rid,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2377,13 +2377,8 @@ def _(rid, params: dict) -> dict:
         fetch_limit = max(limit * 2, 200)
         rows = [
             s
-            for s in db.list_sessions_rich(
-                limit=fetch_limit,
-                include_children=True,
-                order_by_last_active=True,
-            )
+            for s in db.list_sessions_rich(source=None, limit=fetch_limit)
             if (s.get("source") or "").strip().lower() not in deny
-            and int(s.get("message_count") or 0) > 0
         ][:limit]
         return _ok(
             rid,
@@ -2429,16 +2424,10 @@ def _(rid, params: dict) -> dict:
         # users (lots of recent ``tool`` rows) don't get a false
         # "no eligible session" answer.  ``session.list`` uses a
         # similar over-fetch strategy.
-        rows = db.list_sessions_rich(
-            limit=200,
-            include_children=True,
-            order_by_last_active=True,
-        )
+        rows = db.list_sessions_rich(source=None, limit=200)
         for row in rows:
             src = (row.get("source") or "").strip().lower()
             if src in deny:
-                continue
-            if int(row.get("message_count") or 0) <= 0:
                 continue
             return _ok(
                 rid,
@@ -5699,7 +5688,7 @@ def _(rid, params: dict) -> dict:
             include_unconfigured=True,
             picker_hints=True,
             canonical_order=True,
-            max_models=50,
+            max_models=0,
         )
         return _ok(rid, payload)
     except Exception as e:
@@ -5765,7 +5754,7 @@ def _(rid, params: dict) -> dict:
             current_base_url=getattr(agent, "base_url", "") if agent else "",
         )
         payload = build_models_payload(
-            ctx, picker_hints=True, max_models=50,
+            ctx, picker_hints=True, max_models=0,
         )
         provider_data = next(
             (p for p in payload["providers"] if p["slug"] == slug), None

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -147,12 +147,25 @@ export function useMainApp(gw: GatewayClient) {
 
     stdout.on('resize', sync)
 
+    // SIGWINCH fallback for terminals that don't emit stdout resize events
+    const sigwinchHandler = () => sync()
+    try {
+      process.on('SIGWINCH', sigwinchHandler)
+    } catch {
+      // Not all platforms support SIGWINCH (e.g. Windows)
+    }
+
     if (stdout.isTTY) {
       stdout.write(BRACKET_PASTE_ON)
     }
 
     return () => {
       stdout.off('resize', sync)
+      try {
+        process.off('SIGWINCH', sigwinchHandler)
+      } catch {
+        // Ignore cleanup errors
+      }
 
       if (stdout.isTTY) {
         stdout.write(BRACKET_PASTE_OFF)

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -17,7 +17,6 @@
     "jsx": "react-jsx",
 
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
Fixes #35743, #35736, #35745, #35685, #35751, #35674, #35613, #35566, #35576, #35580, #35542, #35530, #35519, #35517, #35474, #35443

## Changes

### fix(#35743): skip asset files in skill_view collision detection
- Strategy 3's rglob was treating .md files inside other skills' templates/references directories as standalone skills
- Added ancestry check to skip asset files

### fix(#35736): fallback content/file_content in skill_manage
- LLM occasionally confuses content and file_content parameters
- Added fallback logic for create/edit/write_file actions

### fix(#35745): use live cwd in runtime footer
- Footer was reading static TERMINAL_CWD environment variable
- Added get_task_cwd() to retrieve live cwd from task env overrides
- Footer now tries live cwd first, falls back to TERMINAL_CWD

### fix(#35685): remove deprecated baseUrl from tsconfig.app.json
- TypeScript 5.9 treats deprecated baseUrl as error in tsc -b mode
- Removed baseUrl since paths resolves correctly with moduleResolution: bundler

### fix(#35751): add docker_extra_args to terminal env map
- docker_extra_args config was not mapped to TERMINAL_DOCKER_EXTRA_ARGS env var
- Added mapping so Docker extra args (volume mounts etc) are applied

### fix(#35674): check unresolved path for symlinked skills security
- Symlinked skills triggered false 'outside trusted skills directory' warning
- Now checks unresolved path first before resolving symlink

### fix(#35613): append missing PATH entries individually on macOS
- macOS gateway PATH skipped Homebrew dirs when /usr/bin existed
- Now appends each missing _SANE_PATH entry individually

### fix(#35566): read task-specific extra_body in get_auxiliary_extra_body
- get_auxiliary_extra_body() ignored auxiliary.<task>.extra_body from config.yaml
- Now reads task-specific extra_body and merges with Nous extras

### fix(#35576): add 99992402 to Feishu reply fallback codes
- Feishu 99992402 'field validation failed' was not in fallback codes
- Added to _FEISHU_REPLY_FALLBACK_CODES for stale thread_id handling

### fix(#35580): treat empty env as unset for docker forward-env
- Empty-string secrets were forwarded instead of using disk fallback
- Changed condition to treat empty string same as unset

### fix(#35542): include child sessions in TUI resume listing
- TUI resume listing was hiding message-bearing child sessions
- Added include_children=True and filter out zero-message rows

### fix(#35530): add SIGWINCH fallback for TUI resize
- TUI not resizing properly in some terminals
- Added SIGWINCH signal listener as fallback

### fix(#35519): skip redaction for config files in read_file
- API keys in config files were being corrupted by redact_sensitive_text
- Now skips prefix-based redaction for .yaml/.json/.env/.toml/.conf files

### fix(#35517): increase auxiliary client HTTP timeout to 600s
- Default 30s timeout caused compression to fail with slow local LLMs
- Added timeout=600.0 to OpenAI client constructor

### fix(#35474): add .markdown to MEDIA_DELIVERY_EXTS
- .markdown files were not recognized as deliverable media
- Added .markdown extension to MEDIA_DELIVERY_EXTS

### fix(#35443): remove 50-model cap in model picker
- /model picker only showed first 50 models despite larger catalog
- Changed max_models=50 to max_models=0 (unlimited) in all picker surfaces