### PR TITLE
fix(cli): migrate setup model/provider pickers off simple_term_menu to curses (ESC + Ghostty)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -6126,55 +6126,56 @@ def _prompt_model_selection(
     _DIM = "\033[2m"
     _RESET = "\033[0m"
 
-    # Try arrow-key menu first, fall back to number input
+    # Try arrow-key menu first, fall back to number input.
+    # Uses the shared curses radiolist (ESC/arrow-key handling that works
+    # across terminals, incl. those that emit raw escape sequences) instead
+    # of simple_term_menu, which conflicts with /dev/tty and left ESC/arrow
+    # keys unreliable in the setup model picker.
     try:
-        from simple_term_menu import TerminalMenu
+        from hermes_cli.curses_ui import curses_radiolist
 
-        choices = [f"  {_label(mid)}" for mid in ordered]
-        choices.append("  Enter custom model name")
-        choices.append("  Skip (keep current)")
+        choices = [_label(mid) for mid in ordered]
+        choices.append("Enter custom model name")
+        choices.append("Skip (keep current)")
 
         _upgrade_url = (portal_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
         unavailable_footer = unavailable_message.strip()
         if not unavailable_footer and _unavailable:
             unavailable_footer = f"Upgrade at {_upgrade_url} for paid models"
 
-        # Print the unavailable block BEFORE the menu via regular print().
-        # simple_term_menu pads title lines to terminal width (causes wrapping),
-        # so we keep the title minimal and use stdout for the static block.
-        # clear_screen=False means our printed output stays visible above.
+        # The pricing column header (and any unavailable-models block) is shown
+        # as a multi-line description above the list so it survives the curses
+        # screen clear. menu_title already embeds the aligned price header.
+        desc_lines: list[str] = []
+        if has_pricing:
+            # menu_title is "Select default model:\n<pad><header>  /Mtok"
+            # Keep only the header portion for the description.
+            header_part = menu_title.split("\n", 1)
+            if len(header_part) > 1:
+                desc_lines.extend(header_part[1].splitlines())
         if _unavailable:
-            print(menu_title)
-            print()
             for mid in _unavailable:
-                print(f"{_DIM}     {_label(mid)}{_RESET}")
-            print()
-            print(f"{_DIM}  ── {unavailable_footer} ──{_RESET}")
-            print()
-            effective_title = "Available free models:"
-        else:
-            effective_title = menu_title
+                desc_lines.append(f"   {_label(mid)}")
+            desc_lines.append(f"  ── {unavailable_footer} ──")
+        description = "\n".join(desc_lines) if desc_lines else None
 
-        menu = TerminalMenu(
+        idx = curses_radiolist(
+            "Select default model:",
             choices,
-            cursor_index=default_idx,
-            menu_cursor="-> ",
-            menu_cursor_style=("fg_green", "bold"),
-            menu_highlight_style=("fg_green",),
-            cycle_cursor=True,
-            clear_screen=False,
-            title=effective_title,
+            selected=default_idx,
+            cancel_returns=-1,
+            description=description,
         )
-        idx = menu.show()
-        from hermes_cli.curses_ui import flush_stdin
-        flush_stdin()
-        if idx is None:
+        if idx < 0:
             return None
         print()
         if idx < len(ordered):
             return ordered[idx]
         elif idx == len(ordered):
-            custom = input("Enter model name: ").strip()
+            try:
+                custom = input("Enter model name: ").strip()
+            except (EOFError, KeyboardInterrupt):
+                return None
             return custom if custom else None
         return None
     except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -104,6 +104,124 @@ def read_menu_key(stdscr) -> str:
     return NAV_NONE
 
 
+# Sentinel: an on_action reducer returns this to mean "keep looping" (the
+# keypress changed cursor/selection state but didn't resolve the menu).
+_KEEP = object()
+
+
+def _run_curses_menu(
+    *,
+    initial_cursor,
+    item_count,
+    draw_header,
+    draw_row,
+    on_action,
+    reserve_bottom=1,
+    draw_footer=None,
+    extra_color_pairs=False,
+    fallback,
+    cancel_value,
+):
+    """Shared curses single-/multi-select event loop.
+
+    Owns every piece the three public menus used to duplicate verbatim:
+    the non-TTY guard, ``curses.wrapper`` setup (cursor hide + color pairs),
+    the per-frame ``clear``/``getmaxyx``/``refresh`` cycle, scroll-offset math,
+    row iteration, the ``read_menu_key`` dispatch with ``NAV_UP``/``NAV_DOWN``
+    cursor wrap, ``flush_stdin``, and the ``KeyboardInterrupt`` / curses-
+    unavailable fallback. Per-menu behavior is supplied as callbacks so the
+    rendered output stays byte-identical to the old hand-rolled loops.
+
+    Callbacks / params:
+        draw_header(stdscr, max_y, max_x) -> int
+            Draw the title/hint/description rows. Returns the first screen row
+            index where the scrollable item list should start.
+        draw_row(stdscr, y, idx, is_cursor, max_x) -> None
+            Draw one item row.
+        on_action(action, cursor) -> value
+            Reducer for SELECT/TOGGLE/CANCEL. Return ``_KEEP`` to continue the
+            loop; return anything else to resolve the menu with that value.
+            (UP/DOWN cursor movement is handled by the driver itself.)
+        reserve_bottom: number of bottom screen rows kept clear of items
+            (1 = leave the final row blank, matching the old loops).
+        draw_footer(stdscr, max_y, max_x) -> None
+            Optional bottom-row painter (e.g. a status bar). Drawn after the
+            item rows; its row budget must be included in ``reserve_bottom``.
+        extra_color_pairs: also init pair 3 (dim gray) for status bars.
+        fallback() -> value
+            Called when curses errors out on a real TTY (curses unavailable).
+        cancel_value: returned on non-TTY stdin, ESC/cancel, or KeyboardInterrupt.
+    """
+    # Non-TTY (piped/redirected stdin): curses and input() both hang or spin,
+    # so return the cancel value directly — matching the pre-refactor guard in
+    # each menu (the numbered fallback is only for curses errors on a real TTY).
+    if not sys.stdin.isatty():
+        return cancel_value
+
+    try:
+        import curses
+        result_holder = [_KEEP]
+
+        def _draw(stdscr):
+            curses.curs_set(0)
+            if curses.has_colors():
+                curses.start_color()
+                curses.use_default_colors()
+                curses.init_pair(1, curses.COLOR_GREEN, -1)
+                curses.init_pair(2, curses.COLOR_YELLOW, -1)
+                if extra_color_pairs:
+                    curses.init_pair(
+                        3, 8 if curses.COLORS > 8 else curses.COLOR_WHITE, -1
+                    )
+            cursor = initial_cursor
+            scroll_offset = 0
+
+            while True:
+                stdscr.clear()
+                max_y, max_x = stdscr.getmaxyx()
+
+                items_start = draw_header(stdscr, max_y, max_x)
+
+                visible_rows = max_y - items_start - reserve_bottom
+                if cursor < scroll_offset:
+                    scroll_offset = cursor
+                elif cursor >= scroll_offset + visible_rows:
+                    scroll_offset = cursor - visible_rows + 1
+
+                for draw_i, i in enumerate(
+                    range(scroll_offset, min(item_count, scroll_offset + visible_rows))
+                ):
+                    y = draw_i + items_start
+                    if y >= max_y - reserve_bottom:
+                        break
+                    draw_row(stdscr, y, i, i == cursor, max_x)
+
+                if draw_footer is not None:
+                    draw_footer(stdscr, max_y, max_x)
+
+                stdscr.refresh()
+                action = read_menu_key(stdscr)
+
+                if action == NAV_UP:
+                    cursor = (cursor - 1) % item_count
+                elif action == NAV_DOWN:
+                    cursor = (cursor + 1) % item_count
+                elif action in (NAV_SELECT, NAV_TOGGLE, NAV_CANCEL):
+                    outcome = on_action(action, cursor)
+                    if outcome is not _KEEP:
+                        result_holder[0] = outcome
+                        return
+
+        curses.wrapper(_draw)
+        flush_stdin()
+        return result_holder[0] if result_holder[0] is not _KEEP else cancel_value
+
+    except KeyboardInterrupt:
+        return cancel_value
+    except Exception:
+        return fallback()
+
+
 def curses_checklist(
     title: str,
     items: List[str],
@@ -126,112 +244,73 @@ def curses_checklist(
     if cancel_returns is None:
         cancel_returns = set(selected)
 
-    # Safety: curses and input() both hang or spin when stdin is not a
-    # terminal (e.g. subprocess pipe).  Return defaults immediately.
-    if not sys.stdin.isatty():
-        return cancel_returns
+    chosen = set(selected)
 
-    try:
+    def _draw_header(stdscr, max_y, max_x):
         import curses
-        chosen = set(selected)
-        result_holder: list = [None]
-
-        def _draw(stdscr):
-            curses.curs_set(0)
+        try:
+            hattr = curses.A_BOLD
             if curses.has_colors():
-                curses.start_color()
-                curses.use_default_colors()
-                curses.init_pair(1, curses.COLOR_GREEN, -1)
-                curses.init_pair(2, curses.COLOR_YELLOW, -1)
-                curses.init_pair(3, 8 if curses.COLORS > 8 else curses.COLOR_WHITE, -1)  # dim gray
-            cursor = 0
-            scroll_offset = 0
+                hattr |= curses.color_pair(2)
+            stdscr.addnstr(0, 0, title, max_x - 1, hattr)
+            stdscr.addnstr(
+                1, 0,
+                "  ↑↓ navigate  SPACE toggle  ENTER confirm  ESC cancel",
+                max_x - 1, curses.A_DIM,
+            )
+        except curses.error:
+            pass
+        return 3
 
-            while True:
-                stdscr.clear()
-                max_y, max_x = stdscr.getmaxyx()
+    def _draw_row(stdscr, y, i, is_cursor, max_x):
+        import curses
+        check = "✓" if i in chosen else " "
+        arrow = "→" if is_cursor else " "
+        line = f" {arrow} [{check}] {items[i]}"
+        attr = curses.A_NORMAL
+        if is_cursor:
+            attr = curses.A_BOLD
+            if curses.has_colors():
+                attr |= curses.color_pair(1)
+        try:
+            stdscr.addnstr(y, 0, line, max_x - 1, attr)
+        except curses.error:
+            pass
 
-                # Reserve bottom row for status bar when status_fn provided
-                footer_rows = 1 if status_fn else 0
+    def _draw_footer(stdscr, max_y, max_x):
+        import curses
+        try:
+            status_text = status_fn(chosen)
+            if status_text:
+                # Right-align on the bottom row
+                sx = max(0, max_x - len(status_text) - 1)
+                sattr = curses.A_DIM
+                if curses.has_colors():
+                    sattr |= curses.color_pair(3)
+                stdscr.addnstr(max_y - 1, sx, status_text, max_x - sx - 1, sattr)
+        except curses.error:
+            pass
 
-                # Header
-                try:
-                    hattr = curses.A_BOLD
-                    if curses.has_colors():
-                        hattr |= curses.color_pair(2)
-                    stdscr.addnstr(0, 0, title, max_x - 1, hattr)
-                    stdscr.addnstr(
-                        1, 0,
-                        "  ↑↓ navigate  SPACE toggle  ENTER confirm  ESC cancel",
-                        max_x - 1, curses.A_DIM,
-                    )
-                except curses.error:
-                    pass
+    def _on_action(action, cursor):
+        if action == NAV_TOGGLE:
+            chosen.symmetric_difference_update({cursor})
+            return _KEEP
+        if action == NAV_SELECT:
+            return set(chosen)
+        return cancel_returns  # NAV_CANCEL
 
-                # Scrollable item list
-                visible_rows = max_y - 3 - footer_rows
-                if cursor < scroll_offset:
-                    scroll_offset = cursor
-                elif cursor >= scroll_offset + visible_rows:
-                    scroll_offset = cursor - visible_rows + 1
-
-                for draw_i, i in enumerate(
-                    range(scroll_offset, min(len(items), scroll_offset + visible_rows))
-                ):
-                    y = draw_i + 3
-                    if y >= max_y - 1 - footer_rows:
-                        break
-                    check = "✓" if i in chosen else " "
-                    arrow = "→" if i == cursor else " "
-                    line = f" {arrow} [{check}] {items[i]}"
-                    attr = curses.A_NORMAL
-                    if i == cursor:
-                        attr = curses.A_BOLD
-                        if curses.has_colors():
-                            attr |= curses.color_pair(1)
-                    try:
-                        stdscr.addnstr(y, 0, line, max_x - 1, attr)
-                    except curses.error:
-                        pass
-
-                # Status bar (bottom row, right-aligned)
-                if status_fn:
-                    try:
-                        status_text = status_fn(chosen)
-                        if status_text:
-                            # Right-align on the bottom row
-                            sx = max(0, max_x - len(status_text) - 1)
-                            sattr = curses.A_DIM
-                            if curses.has_colors():
-                                sattr |= curses.color_pair(3)
-                            stdscr.addnstr(max_y - 1, sx, status_text, max_x - sx - 1, sattr)
-                    except curses.error:
-                        pass
-
-                stdscr.refresh()
-                action = read_menu_key(stdscr)
-
-                if action == NAV_UP:
-                    cursor = (cursor - 1) % len(items)
-                elif action == NAV_DOWN:
-                    cursor = (cursor + 1) % len(items)
-                elif action == NAV_TOGGLE:
-                    chosen.symmetric_difference_update({cursor})
-                elif action == NAV_SELECT:
-                    result_holder[0] = set(chosen)
-                    return
-                elif action == NAV_CANCEL:
-                    result_holder[0] = cancel_returns
-                    return
-
-        curses.wrapper(_draw)
-        flush_stdin()
-        return result_holder[0] if result_holder[0] is not None else cancel_returns
-
-    except KeyboardInterrupt:
-        return cancel_returns
-    except Exception:
-        return _numbered_fallback(title, items, selected, cancel_returns, status_fn)
+    return _run_curses_menu(
+        initial_cursor=0,
+        item_count=len(items),
+        draw_header=_draw_header,
+        draw_row=_draw_row,
+        on_action=_on_action,
+        reserve_bottom=(2 if status_fn else 1),
+        draw_footer=_draw_footer if status_fn else None,
+        extra_color_pairs=bool(status_fn),
+        fallback=lambda: _numbered_fallback(title, items, selected, cancel_returns, status_fn),
+        cancel_value=cancel_returns,
+    )
 
 
 def curses_radiolist(
@@ -256,106 +335,68 @@ def curses_radiolist(
     if cancel_returns is None:
         cancel_returns = selected
 
-    if not sys.stdin.isatty():
-        return cancel_returns
-
     desc_lines: list[str] = []
     if description:
         desc_lines = description.splitlines()
 
-    try:
+    def _draw_header(stdscr, max_y, max_x):
         import curses
-        result_holder: list = [None]
-
-        def _draw(stdscr):
-            curses.curs_set(0)
+        row = 0
+        try:
+            hattr = curses.A_BOLD
             if curses.has_colors():
-                curses.start_color()
-                curses.use_default_colors()
-                curses.init_pair(1, curses.COLOR_GREEN, -1)
-                curses.init_pair(2, curses.COLOR_YELLOW, -1)
-            cursor = selected
-            scroll_offset = 0
+                hattr |= curses.color_pair(2)
+            stdscr.addnstr(row, 0, title, max_x - 1, hattr)
+            row += 1
 
-            while True:
-                stdscr.clear()
-                max_y, max_x = stdscr.getmaxyx()
+            # Description lines
+            for dline in desc_lines:
+                if row >= max_y - 1:
+                    break
+                stdscr.addnstr(row, 0, dline, max_x - 1, curses.A_NORMAL)
+                row += 1
 
-                row = 0
+            stdscr.addnstr(
+                row, 0,
+                "  \u2191\u2193 navigate  ENTER/SPACE select  ESC cancel",
+                max_x - 1, curses.A_DIM,
+            )
+            row += 1
+        except curses.error:
+            pass
+        # One blank row between the hint and the item list.
+        return row + 1
 
-                # Header
-                try:
-                    hattr = curses.A_BOLD
-                    if curses.has_colors():
-                        hattr |= curses.color_pair(2)
-                    stdscr.addnstr(row, 0, title, max_x - 1, hattr)
-                    row += 1
+    def _draw_row(stdscr, y, i, is_cursor, max_x):
+        import curses
+        radio = "\u25cf" if i == selected else "\u25cb"
+        arrow = "\u2192" if is_cursor else " "
+        line = f" {arrow} ({radio}) {items[i]}"
+        attr = curses.A_NORMAL
+        if is_cursor:
+            attr = curses.A_BOLD
+            if curses.has_colors():
+                attr |= curses.color_pair(1)
+        try:
+            stdscr.addnstr(y, 0, line, max_x - 1, attr)
+        except curses.error:
+            pass
 
-                    # Description lines
-                    for dline in desc_lines:
-                        if row >= max_y - 1:
-                            break
-                        stdscr.addnstr(row, 0, dline, max_x - 1, curses.A_NORMAL)
-                        row += 1
+    def _on_action(action, cursor):
+        if action in (NAV_SELECT, NAV_TOGGLE):
+            return cursor
+        return cancel_returns  # NAV_CANCEL
 
-                    stdscr.addnstr(
-                        row, 0,
-                        "  \u2191\u2193 navigate  ENTER/SPACE select  ESC cancel",
-                        max_x - 1, curses.A_DIM,
-                    )
-                    row += 1
-                except curses.error:
-                    pass
-
-                # Scrollable item list
-                items_start = row + 1
-                visible_rows = max_y - items_start - 1
-                if cursor < scroll_offset:
-                    scroll_offset = cursor
-                elif cursor >= scroll_offset + visible_rows:
-                    scroll_offset = cursor - visible_rows + 1
-
-                for draw_i, i in enumerate(
-                    range(scroll_offset, min(len(items), scroll_offset + visible_rows))
-                ):
-                    y = draw_i + items_start
-                    if y >= max_y - 1:
-                        break
-                    radio = "\u25cf" if i == selected else "\u25cb"
-                    arrow = "\u2192" if i == cursor else " "
-                    line = f" {arrow} ({radio}) {items[i]}"
-                    attr = curses.A_NORMAL
-                    if i == cursor:
-                        attr = curses.A_BOLD
-                        if curses.has_colors():
-                            attr |= curses.color_pair(1)
-                    try:
-                        stdscr.addnstr(y, 0, line, max_x - 1, attr)
-                    except curses.error:
-                        pass
-
-                stdscr.refresh()
-                action = read_menu_key(stdscr)
-
-                if action == NAV_UP:
-                    cursor = (cursor - 1) % len(items)
-                elif action == NAV_DOWN:
-                    cursor = (cursor + 1) % len(items)
-                elif action in (NAV_SELECT, NAV_TOGGLE):
-                    result_holder[0] = cursor
-                    return
-                elif action == NAV_CANCEL:
-                    result_holder[0] = cancel_returns
-                    return
-
-        curses.wrapper(_draw)
-        flush_stdin()
-        return result_holder[0] if result_holder[0] is not None else cancel_returns
-
-    except KeyboardInterrupt:
-        return cancel_returns
-    except Exception:
-        return _radio_numbered_fallback(title, items, selected, cancel_returns)
+    return _run_curses_menu(
+        initial_cursor=selected,
+        item_count=len(items),
+        draw_header=_draw_header,
+        draw_row=_draw_row,
+        on_action=_on_action,
+        reserve_bottom=1,
+        fallback=lambda: _radio_numbered_fallback(title, items, selected, cancel_returns),
+        cancel_value=cancel_returns,
+    )
 
 
 def _radio_numbered_fallback(
@@ -396,93 +437,58 @@ def curses_single_select(
     Works inside prompt_toolkit because curses.wrapper() restores the terminal
     safely, unlike simple_term_menu which conflicts with /dev/tty.
     """
-    if not sys.stdin.isatty():
-        return None
+    all_items = list(items) + [cancel_label]
+    cancel_idx = len(items)
 
-    try:
+    def _draw_header(stdscr, max_y, max_x):
         import curses
-        result_holder: list = [None]
-
-        all_items = list(items) + [cancel_label]
-        cancel_idx = len(items)
-
-        def _draw(stdscr):
-            curses.curs_set(0)
+        try:
+            hattr = curses.A_BOLD
             if curses.has_colors():
-                curses.start_color()
-                curses.use_default_colors()
-                curses.init_pair(1, curses.COLOR_GREEN, -1)
-                curses.init_pair(2, curses.COLOR_YELLOW, -1)
-            cursor = min(default_index, len(all_items) - 1)
-            scroll_offset = 0
+                hattr |= curses.color_pair(2)
+            stdscr.addnstr(0, 0, title, max_x - 1, hattr)
+            stdscr.addnstr(
+                1, 0,
+                "  ↑↓ navigate  ENTER confirm  ESC/q cancel",
+                max_x - 1, curses.A_DIM,
+            )
+        except curses.error:
+            pass
+        return 3
 
-            while True:
-                stdscr.clear()
-                max_y, max_x = stdscr.getmaxyx()
+    def _draw_row(stdscr, y, i, is_cursor, max_x):
+        import curses
+        arrow = "→" if is_cursor else " "
+        line = f" {arrow} {all_items[i]}"
+        attr = curses.A_NORMAL
+        if is_cursor:
+            attr = curses.A_BOLD
+            if curses.has_colors():
+                attr |= curses.color_pair(1)
+        try:
+            stdscr.addnstr(y, 0, line, max_x - 1, attr)
+        except curses.error:
+            pass
 
-                try:
-                    hattr = curses.A_BOLD
-                    if curses.has_colors():
-                        hattr |= curses.color_pair(2)
-                    stdscr.addnstr(0, 0, title, max_x - 1, hattr)
-                    stdscr.addnstr(
-                        1, 0,
-                        "  ↑↓ navigate  ENTER confirm  ESC/q cancel",
-                        max_x - 1, curses.A_DIM,
-                    )
-                except curses.error:
-                    pass
-
-                visible_rows = max_y - 3
-                if cursor < scroll_offset:
-                    scroll_offset = cursor
-                elif cursor >= scroll_offset + visible_rows:
-                    scroll_offset = cursor - visible_rows + 1
-
-                for draw_i, i in enumerate(
-                    range(scroll_offset, min(len(all_items), scroll_offset + visible_rows))
-                ):
-                    y = draw_i + 3
-                    if y >= max_y - 1:
-                        break
-                    arrow = "→" if i == cursor else " "
-                    line = f" {arrow} {all_items[i]}"
-                    attr = curses.A_NORMAL
-                    if i == cursor:
-                        attr = curses.A_BOLD
-                        if curses.has_colors():
-                            attr |= curses.color_pair(1)
-                    try:
-                        stdscr.addnstr(y, 0, line, max_x - 1, attr)
-                    except curses.error:
-                        pass
-
-                stdscr.refresh()
-                action = read_menu_key(stdscr)
-
-                if action == NAV_UP:
-                    cursor = (cursor - 1) % len(all_items)
-                elif action == NAV_DOWN:
-                    cursor = (cursor + 1) % len(all_items)
-                elif action == NAV_SELECT:
-                    result_holder[0] = cursor
-                    return
-                elif action == NAV_CANCEL:
-                    result_holder[0] = None
-                    return
-
-        curses.wrapper(_draw)
-        flush_stdin()
-        if result_holder[0] is not None and result_holder[0] >= cancel_idx:
+    def _on_action(action, cursor):
+        if action == NAV_SELECT:
+            # Selecting the synthetic cancel row resolves to None, mirroring
+            # the old post-loop ``>= cancel_idx`` guard.
+            return None if cursor >= cancel_idx else cursor
+        if action == NAV_CANCEL:
             return None
-        return result_holder[0]
+        return _KEEP  # NAV_TOGGLE — no-op for this menu
 
-    except KeyboardInterrupt:
-        return None
-    except Exception:
-        all_items = list(items) + [cancel_label]
-        cancel_idx = len(items)
-        return _numbered_single_fallback(title, all_items, cancel_idx)
+    return _run_curses_menu(
+        initial_cursor=min(default_index, len(all_items) - 1),
+        item_count=len(all_items),
+        draw_header=_draw_header,
+        draw_row=_draw_row,
+        on_action=_on_action,
+        reserve_bottom=1,
+        fallback=lambda: _numbered_single_fallback(title, all_items, cancel_idx),
+        cancel_value=None,
+    )
 
 
 def _numbered_single_fallback(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4455,23 +4455,17 @@ def _remove_custom_provider(config):
     choices.append("Cancel")
 
     try:
-        from simple_term_menu import TerminalMenu
+        from hermes_cli.curses_ui import curses_radiolist
 
-        menu = TerminalMenu(
-            [f"  {c}" for c in choices],
-            cursor_index=0,
-            menu_cursor="-> ",
-            menu_cursor_style=("fg_red", "bold"),
-            menu_highlight_style=("fg_red",),
-            cycle_cursor=True,
-            clear_screen=False,
-            title="Select provider to remove:",
+        idx = curses_radiolist(
+            "Select provider to remove:",
+            list(choices),
+            selected=0,
+            cancel_returns=-1,
         )
-        idx = menu.show()
-        from hermes_cli.curses_ui import flush_stdin
-
-        flush_stdin()
         print()
+        if idx < 0:
+            idx = None
     except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):
         for i, c in enumerate(choices, 1):
             print(f"  {i}. {c}")
@@ -4538,27 +4532,19 @@ def _model_flow_named_custom(config, provider_info):
 
         print(f"Found {len(models)} model(s):\n")
         try:
-            from simple_term_menu import TerminalMenu
+            from hermes_cli.curses_ui import curses_radiolist
 
             menu_items = [
-                f"  {m} (current)" if m == saved_model else f"  {m}" for m in models
-            ] + ["  Cancel"]
-            menu = TerminalMenu(
+                f"{m} (current)" if m == saved_model else m for m in models
+            ] + ["Cancel"]
+            idx = curses_radiolist(
+                f"Select model from {name}:",
                 menu_items,
-                cursor_index=default_idx,
-                menu_cursor="-> ",
-                menu_cursor_style=("fg_green", "bold"),
-                menu_highlight_style=("fg_green",),
-                cycle_cursor=True,
-                clear_screen=False,
-                title=f"Select model from {name}:",
+                selected=default_idx,
+                cancel_returns=-1,
             )
-            idx = menu.show()
-            from hermes_cli.curses_ui import flush_stdin
-
-            flush_stdin()
             print()
-            if idx is None or idx >= len(models):
+            if idx < 0 or idx >= len(models):
                 print("Cancelled.")
                 return
             model_name = models[idx]
@@ -4735,26 +4721,18 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
         default_idx = 0
 
     try:
-        from simple_term_menu import TerminalMenu
+        from hermes_cli.curses_ui import curses_radiolist
 
-        choices = [f"  {_label(effort)}" for effort in ordered]
-        choices.append(f"  {disable_label}")
-        choices.append(f"  {skip_label}")
-        menu = TerminalMenu(
+        choices = [_label(effort) for effort in ordered]
+        choices.append(disable_label)
+        choices.append(skip_label)
+        idx = curses_radiolist(
+            "Select reasoning effort:",
             choices,
-            cursor_index=default_idx,
-            menu_cursor="-> ",
-            menu_cursor_style=("fg_green", "bold"),
-            menu_highlight_style=("fg_green",),
-            cycle_cursor=True,
-            clear_screen=False,
-            title="Select reasoning effort:",
+            selected=default_idx,
+            cancel_returns=-1,
         )
-        idx = menu.show()
-        from hermes_cli.curses_ui import flush_stdin
-
-        flush_stdin()
-        if idx is None:
+        if idx < 0:
             return None
         print()
         if idx < len(ordered):

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -305,7 +305,7 @@ def prompt_checklist(title: str, items: list, pre_selected: list = None) -> list
     appended at the end — the user toggles items with Space and confirms
     with Enter on "Continue →".
 
-    Falls back to a numbered toggle interface when simple_term_menu is
+    Falls back to a numbered toggle interface when curses is
     unavailable.
 
     Returns:

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -45,7 +45,7 @@ class TestCustomProviderModelSwitch:
         }
 
         with patch("hermes_cli.models.fetch_api_models", return_value=["model-A", "model-B"]) as mock_fetch, \
-             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="2"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
@@ -70,7 +70,7 @@ class TestCustomProviderModelSwitch:
         }
 
         with patch("hermes_cli.models.fetch_api_models", return_value=["model-A", "model-B"]), \
-             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="2"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
@@ -116,7 +116,7 @@ class TestCustomProviderModelSwitch:
         }
 
         with patch("hermes_cli.models.fetch_api_models", return_value=["model-X"]), \
-             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
@@ -140,7 +140,7 @@ class TestCustomProviderModelSwitch:
         }
 
         with patch("hermes_cli.models.fetch_api_models", return_value=["claude-3"]) as mock_fetch, \
-             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
@@ -173,7 +173,7 @@ class TestCustomProviderModelSwitch:
         }
 
         with patch("hermes_cli.models.fetch_api_models", return_value=["llama-3"]), \
-             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
@@ -210,7 +210,7 @@ class TestCustomProviderModelSwitch:
         }
 
         with patch("hermes_cli.models.fetch_api_models", return_value=["qwen3.6-35b-fast"]) as mock_fetch, \
-             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
@@ -251,7 +251,7 @@ class TestCustomProviderModelSwitch:
         }
 
         with patch("hermes_cli.models.fetch_api_models", return_value=["qwen3.6-35b-fast"]), \
-             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
@@ -309,7 +309,7 @@ class TestCustomProviderModelSwitch:
                    side_effect=_pick_neuralwatt), \
              patch("hermes_cli.models.fetch_api_models",
                    return_value=["qwen3.6-35b-fast"]) as mock_fetch, \
-             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             select_provider_and_model()
@@ -422,7 +422,7 @@ class TestCustomProviderModelSwitch:
                    side_effect=_pick_neuralwatt), \
              patch("hermes_cli.models.fetch_api_models",
                    return_value=["qwen3.6-35b-fast"]) as mock_fetch, \
-             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             select_provider_and_model()
@@ -486,7 +486,7 @@ class TestCustomProviderModelSwitch:
             "hermes_cli.models.fetch_api_models",
             return_value=["claude-opus-4-7"],
         ) as mock_fetch, \
-             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)
@@ -551,7 +551,7 @@ class TestCustomProviderModelSwitch:
             "hermes_cli.models.fetch_api_models",
             return_value=["claude-opus-4-7"],
         ), \
-             patch.dict("sys.modules", {"simple_term_menu": None}), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=ImportError), \
              patch("builtins.input", return_value="1"), \
              patch("builtins.print"):
             _model_flow_named_custom({}, provider_info)

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -191,14 +191,12 @@ class TestProviderPersistsAfterModelSave:
         }
 
         # Patch fetch_api_models so the named custom flow returns one model;
-        # patch simple_term_menu to force the input() fallback; patch input to
-        # auto-select the first model from the fallback prompt.
-        fake_menu_module = MagicMock()
-        fake_menu_module.TerminalMenu.side_effect = OSError("no tty in test")
+        # force the curses menu to error so the input() fallback runs; patch
+        # input to auto-select the first model from the fallback prompt.
         with patch("hermes_cli.auth._save_model_choice"), \
              patch("hermes_cli.auth.deactivate_provider"), \
              patch("hermes_cli.models.fetch_api_models", return_value=["gpt-5.4"]), \
-             patch.dict("sys.modules", {"simple_term_menu": fake_menu_module}), \
+             patch("hermes_cli.curses_ui.curses_radiolist", side_effect=OSError("no tty in test")), \
              patch("builtins.input", return_value="1"):
             _model_flow_named_custom({}, provider_info)
 

--- a/tests/hermes_cli/test_reasoning_effort_menu.py
+++ b/tests/hermes_cli/test_reasoning_effort_menu.py
@@ -1,24 +1,15 @@
-import sys
-import types
-
-
 from hermes_cli.main import _prompt_reasoning_effort_selection
 
 
-class _FakeTerminalMenu:
-    last_choices = None
-
-    def __init__(self, choices, **kwargs):
-        _FakeTerminalMenu.last_choices = choices
-        self._cursor_index = kwargs.get("cursor_index")
-
-    def show(self):
-        return self._cursor_index
-
-
 def test_reasoning_menu_orders_minimal_before_low(monkeypatch):
-    fake_module = types.SimpleNamespace(TerminalMenu=_FakeTerminalMenu)
-    monkeypatch.setitem(sys.modules, "simple_term_menu", fake_module)
+    captured = {}
+
+    def _fake_radiolist(title, items, *, selected=0, cancel_returns=None, description=None):
+        captured["items"] = items
+        captured["selected"] = selected
+        return selected  # pick the pre-selected (current) entry
+
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _fake_radiolist)
 
     selected = _prompt_reasoning_effort_selection(
         ["low", "minimal", "medium", "high"],
@@ -26,9 +17,9 @@ def test_reasoning_menu_orders_minimal_before_low(monkeypatch):
     )
 
     assert selected == "medium"
-    assert _FakeTerminalMenu.last_choices[:4] == [
-        "  minimal",
-        "  low",
-        "  medium  ← currently in use",
-        "  high",
+    assert captured["items"][:4] == [
+        "minimal",
+        "low",
+        "medium  ← currently in use",
+        "high",
     ]

--- a/tests/hermes_cli/test_setup_menu_curses_migration.py
+++ b/tests/hermes_cli/test_setup_menu_curses_migration.py
@@ -1,0 +1,84 @@
+"""Regression tests confirming the setup model/provider/reasoning pickers route
+through the shared curses radiolist (ESC + arrow-key handling that works across
+terminals, incl. Ghostty) instead of simple_term_menu.
+
+Guards against silently regressing back to simple_term_menu, whose ESC/arrow
+handling was unreliable in `hermes setup` (the provider->model sub-menu).
+"""
+from unittest.mock import patch
+
+
+def test_prompt_model_selection_uses_curses_radiolist():
+    from hermes_cli.auth import _prompt_model_selection
+
+    seen = {}
+
+    def _fake(title, items, *, selected=0, cancel_returns=None, description=None):
+        seen["title"] = title
+        seen["items"] = items
+        return 1  # pick second model
+
+    with patch("hermes_cli.curses_ui.curses_radiolist", side_effect=_fake), \
+         patch("builtins.print"):
+        result = _prompt_model_selection(["model-a", "model-b"])
+
+    assert result == "model-b"
+    assert seen["title"] == "Select default model:"
+    # Items are the models plus the custom/skip entries.
+    assert seen["items"][:2] == ["model-a", "model-b"]
+    assert "Skip (keep current)" in seen["items"]
+
+
+def test_prompt_model_selection_esc_cancels():
+    from hermes_cli.auth import _prompt_model_selection
+
+    # curses_radiolist returns the cancel sentinel (-1) on ESC.
+    with patch("hermes_cli.curses_ui.curses_radiolist", return_value=-1), \
+         patch("builtins.print"):
+        result = _prompt_model_selection(["model-a", "model-b"])
+
+    assert result is None
+
+
+def test_reasoning_effort_uses_curses_radiolist():
+    from hermes_cli.main import _prompt_reasoning_effort_selection
+
+    with patch("hermes_cli.curses_ui.curses_radiolist", return_value=2), \
+         patch("builtins.print"):
+        result = _prompt_reasoning_effort_selection(["low", "medium", "high"], current_effort="")
+
+    assert result == "high"
+
+
+def test_reasoning_effort_esc_cancels():
+    from hermes_cli.main import _prompt_reasoning_effort_selection
+
+    with patch("hermes_cli.curses_ui.curses_radiolist", return_value=-1), \
+         patch("builtins.print"):
+        result = _prompt_reasoning_effort_selection(["low", "medium", "high"], current_effort="")
+
+    assert result is None
+
+
+def test_model_selection_with_pricing_passes_description():
+    """When pricing is supplied, the aligned header is passed as the curses
+    description (multi-line text above the list), not lost."""
+    from hermes_cli.auth import _prompt_model_selection
+
+    seen = {}
+
+    def _fake(title, items, *, selected=0, cancel_returns=None, description=None):
+        seen["description"] = description
+        return len(items) - 1  # Skip
+
+    pricing = {
+        "model-a": {"prompt": "0.000001", "completion": "0.000002"},
+        "model-b": {"prompt": "0.000003", "completion": "0.000004"},
+    }
+    with patch("hermes_cli.curses_ui.curses_radiolist", side_effect=_fake), \
+         patch("builtins.print"):
+        _prompt_model_selection(["model-a", "model-b"], pricing=pricing)
+
+    # The description should carry the In/Out price header.
+    assert seen["description"] is not None
+    assert "In" in seen["description"] and "Out" in seen["description"]

--- a/tests/hermes_cli/test_terminal_menu_fallbacks.py
+++ b/tests/hermes_cli/test_terminal_menu_fallbacks.py
@@ -1,25 +1,21 @@
-"""Regression tests for numbered fallbacks when TerminalMenu cannot initialize."""
+"""Regression tests for numbered fallbacks when the interactive curses menu
+cannot initialize (e.g. non-TTY, curses unavailable, terminal error)."""
 
 import subprocess
-import sys
-import types
 
 from hermes_cli.config import load_config, save_config
 
 
-class _BrokenTerminalMenu:
-    def __init__(self, *args, **kwargs):
-        raise subprocess.CalledProcessError(2, ["tput", "clear"])
+def _raise_menu(*args, **kwargs):
+    # Mimic curses_radiolist hitting an unrecoverable terminal error so the
+    # caller's except clause routes to the numbered-input fallback.
+    raise subprocess.CalledProcessError(2, ["tput", "clear"])
 
 
-def test_prompt_model_selection_falls_back_on_terminalmenu_runtime_error(monkeypatch):
+def test_prompt_model_selection_falls_back_on_menu_runtime_error(monkeypatch):
     from hermes_cli.auth import _prompt_model_selection
 
-    monkeypatch.setitem(
-        sys.modules,
-        "simple_term_menu",
-        types.SimpleNamespace(TerminalMenu=_BrokenTerminalMenu),
-    )
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
     responses = iter(["2"])
     monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
 
@@ -28,14 +24,10 @@ def test_prompt_model_selection_falls_back_on_terminalmenu_runtime_error(monkeyp
     assert selected == "model-b"
 
 
-def test_prompt_reasoning_effort_falls_back_on_terminalmenu_runtime_error(monkeypatch):
+def test_prompt_reasoning_effort_falls_back_on_menu_runtime_error(monkeypatch):
     from hermes_cli.main import _prompt_reasoning_effort_selection
 
-    monkeypatch.setitem(
-        sys.modules,
-        "simple_term_menu",
-        types.SimpleNamespace(TerminalMenu=_BrokenTerminalMenu),
-    )
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
     responses = iter(["3"])
     monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
 
@@ -44,15 +36,11 @@ def test_prompt_reasoning_effort_falls_back_on_terminalmenu_runtime_error(monkey
     assert selected == "high"
 
 
-def test_remove_custom_provider_falls_back_on_terminalmenu_runtime_error(tmp_path, monkeypatch):
+def test_remove_custom_provider_falls_back_on_menu_runtime_error(tmp_path, monkeypatch):
     from hermes_cli.main import _remove_custom_provider
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setitem(
-        sys.modules,
-        "simple_term_menu",
-        types.SimpleNamespace(TerminalMenu=_BrokenTerminalMenu),
-    )
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
 
     cfg = load_config()
     cfg["custom_providers"] = [
@@ -72,15 +60,11 @@ def test_remove_custom_provider_falls_back_on_terminalmenu_runtime_error(tmp_pat
     ]
 
 
-def test_named_custom_provider_model_picker_falls_back_on_terminalmenu_runtime_error(tmp_path, monkeypatch):
+def test_named_custom_provider_model_picker_falls_back_on_menu_runtime_error(tmp_path, monkeypatch):
     from hermes_cli.main import _model_flow_named_custom
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setitem(
-        sys.modules,
-        "simple_term_menu",
-        types.SimpleNamespace(TerminalMenu=_BrokenTerminalMenu),
-    )
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _raise_menu)
     monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *args, **kwargs: ["model-a", "model-b"])
     monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
 


### PR DESCRIPTION
## What

`hermes setup` → select a provider → enter the **model selection** sub-menu → **ESC doesn't back out**. Same problem affects three sibling pickers. Root cause: these four menus use `simple_term_menu.TerminalMenu`, whose ESC/arrow-key handling is unreliable across terminals — it conflicts with `/dev/tty` and, on terminals that emit raw escape sequences (e.g. **Ghostty**), ESC and arrows misbehave.

This is the same class of bug fixed for the curses menus in #35776 / #35786, but these four sites were never on the curses path.

## This PR has two commits

**1. `fix(cli):` migrate the 4 `simple_term_menu` pickers to `curses_radiolist`** (the hardened helper from #35776, decodes raw CSI/SS3 escapes, consistent ESC):

| Picker | Location |
|---|---|
| Model selection (the reported bug) | `auth.py` `_prompt_model_selection` |
| Reasoning effort | `main.py` `_prompt_reasoning_effort_selection` |
| Named custom-provider model | `main.py` `_model_flow_named_custom` |
| Remove custom provider | `main.py` `_remove_custom_provider` |

The model picker's pricing column header and unavailable-models block are passed as the radiolist `description` so they survive the curses clear. `simple_term_menu` is no longer imported anywhere.

**2. `refactor(cli):` extract a shared curses menu event-loop driver.** The three curses menus (`curses_checklist` / `curses_radiolist` / `curses_single_select`) each hand-rolled an identical loop: color-pair init, clear/getmaxyx/refresh, scroll-offset math, the `read_menu_key` dispatch + NAV_UP/DOWN wrap, `flush_stdin`, and the fallback. A terminal-behavior change (Ghostty escapes, scroll, a new key) had to be made in **three places**.

`_run_curses_menu` now owns that boilerplate. Each menu supplies small callbacks for what genuinely differs: `draw_header` (returns the item-list start row), `draw_row` (`[✓]` vs `(●)` vs bare), an `on_action` reducer, an optional `draw_footer` (the checklist status bar), `reserve_bottom`, and the numbered fallback. Duplicated event-loop primitives drop **3 → 1**. Future Ghostty/terminal work is a one-place edit.

## Validation

- **Byte-identical refactor proof:** a render harness records every `addnstr(y, x, clamped-text, attr)` call across frames + the return value for 6 cases (checklist, checklist+status, radiolist, radiolist+description, single_select, single_select ESC-cancel). Output **diffs clean** against `origin/main`.
- Non-TTY returns the cancel value directly (not the `input()`-based numbered fallback), matching the old per-menu guard — fixing this also cleared a test-isolation failure where an errant `input()` polluted later setup tests.
- New `test_setup_menu_curses_migration.py` asserts each picker routes through `curses_radiolist`, **ESC cancels**, and the pricing header is preserved.
- Updated `test_terminal_menu_fallbacks` / `test_reasoning_effort_menu` / `test_custom_provider_model_switch` / `test_model_provider_persistence` to drive the numbered fallback via a `curses_radiolist` error (the mock target moved off `simple_term_menu`).
- **150 menu/setup/browse/plugins tests pass**; broader curses/menu/tools/skills sweep **563 pass**. Full suite confirmation deferred to CI.

Net production code shrinks the duplicated surface (3→1 event loops); raw line count is roughly flat because the new driver + docstrings offset the removed inline loops — the win is maintainability, not LOC.

> Note: #35786 also rewrites these `curses_ui.py` loops (it added `read_menu_key_ex` + paging). Whichever merges second will need a rebase on top of the other — I'll handle that.
