### PR TITLE
fix: improve Slack mrkdwn rendering

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -480,6 +480,7 @@ class SlackAdapter(BasePlatformAdapter):
             "response_type": "ephemeral",
             "replace_original": True,
             "text": text,
+            "blocks": self._mrkdwn_blocks(text),
         }
         try:
             async with aiohttp.ClientSession(trust_env=True) as session:
@@ -796,6 +797,7 @@ class SlackAdapter(BasePlatformAdapter):
                     "channel": chat_id,
                     "text": chunk,
                     "mrkdwn": True,
+                    "blocks": self._mrkdwn_blocks(chunk),
                 }
                 if thread_ts:
                     kwargs["thread_ts"] = thread_ts
@@ -854,6 +856,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "user": user_id,
                 "text": formatted,
                 "mrkdwn": True,
+                "blocks": self._mrkdwn_blocks(formatted),
             }
             if thread_ts:
                 kwargs["thread_ts"] = thread_ts
@@ -885,6 +888,7 @@ class SlackAdapter(BasePlatformAdapter):
                 channel=chat_id,
                 ts=message_id,
                 text=formatted,
+                blocks=self._mrkdwn_blocks(formatted),
             )
             if finalize:
                 await self.stop_typing(chat_id)
@@ -1174,6 +1178,50 @@ class SlackAdapter(BasePlatformAdapter):
 
     # ----- Markdown → mrkdwn conversion -----
 
+    def _mrkdwn_blocks(self, text: str) -> List[Dict[str, Any]]:
+        """Build Block Kit mrkdwn sections for reliable Slack rendering.
+
+        Slack clients render top-level ``text`` inconsistently, especially for
+        edited/updated messages.  Supplying matching mrkdwn section blocks makes
+        bold, quotes, lists, and links render predictably while keeping ``text``
+        as a notification/accessibility fallback.
+        """
+        if not text:
+            return []
+
+        max_section = 3000
+        blocks: List[Dict[str, Any]] = []
+
+        def _append(chunk: str) -> None:
+            chunk = chunk.strip("\n")
+            if not chunk:
+                return
+            blocks.append({
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": chunk},
+            })
+
+        current = ""
+        for line in text.splitlines(keepends=True):
+            if len(line) > max_section:
+                if current:
+                    _append(current)
+                    current = ""
+                for i in range(0, len(line), max_section):
+                    _append(line[i:i + max_section])
+                continue
+
+            if current and len(current) + len(line) > max_section:
+                _append(current)
+                current = line
+            else:
+                current += line
+
+        if current:
+            _append(current)
+
+        return blocks[:50]
+
     def format_message(self, content: str) -> str:
         """Convert standard markdown to Slack mrkdwn format.
 
@@ -1196,10 +1244,23 @@ class SlackAdapter(BasePlatformAdapter):
 
         text = content
 
-        # 1) Protect fenced code blocks (``` ... ```)
+        # 1) Protect fenced code blocks (``` ... ```). Slack code blocks do
+        # not support language info strings; if we send ```python, Slack
+        # renders "python" as the first code line. Strip the info string while
+        # preserving the code body untouched.
+        def _normalize_fenced_code_block(m):
+            block = m.group(0)
+            info_match = re.match(r'```([^`\n]*)\n([\s\S]*?)```$', block)
+            if not info_match:
+                return _ph(block)
+            info = info_match.group(1).strip()
+            if not info:
+                return _ph(block)
+            return _ph(f'```\n{info_match.group(2)}```')
+
         text = re.sub(
             r'(```(?:[^\n]*\n)?[\s\S]*?```)',
-            lambda m: _ph(m.group(0)),
+            _normalize_fenced_code_block,
             text,
         )
 
@@ -1236,6 +1297,54 @@ class SlackAdapter(BasePlatformAdapter):
         text = text.replace('&amp;', '&').replace('&lt;', '<').replace('&gt;', '>')
         text = text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
 
+        # 6.5) Convert Markdown pipe tables to Slack-readable bullet rows.
+        # Slack mrkdwn has no table syntax, so leaving the pipe table intact
+        # renders the separator row (|---|---|) as ugly raw text.
+        def _split_table_row(line: str) -> List[str]:
+            stripped = line.strip()
+            if stripped.startswith('|'):
+                stripped = stripped[1:]
+            if stripped.endswith('|'):
+                stripped = stripped[:-1]
+            return [cell.strip() for cell in stripped.split('|')]
+
+        def _is_table_sep(line: str) -> bool:
+            return bool(re.match(
+                r'^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)+\|?\s*$',
+                line,
+            ))
+
+        def _convert_pipe_tables(src: str) -> str:
+            lines = src.split('\n')
+            out: List[str] = []
+            i = 0
+            while i < len(lines):
+                if (
+                    i + 1 < len(lines)
+                    and lines[i].lstrip().startswith('|')
+                    and '|' in lines[i].strip()[1:]
+                    and _is_table_sep(lines[i + 1])
+                ):
+                    headers = _split_table_row(lines[i])
+                    rendered: List[str] = []
+                    i += 2
+                    while i < len(lines) and lines[i].lstrip().startswith('|'):
+                        cells = _split_table_row(lines[i])
+                        pairs = []
+                        for header, cell in zip(headers, cells):
+                            if header or cell:
+                                pairs.append(f'*{header}*: {cell}' if header else cell)
+                        if pairs:
+                            rendered.append('• ' + ' / '.join(pairs))
+                        i += 1
+                    out.append(_ph('\n'.join(rendered)))
+                    continue
+                out.append(lines[i])
+                i += 1
+            return '\n'.join(out)
+
+        text = _convert_pipe_tables(text)
+
         # 7) Convert headers (## Title) → *Title* (bold)
         def _convert_header(m):
             inner = m.group(1).strip()
@@ -1247,29 +1356,37 @@ class SlackAdapter(BasePlatformAdapter):
             r'^#{1,6}\s+(.+)$', _convert_header, text, flags=re.MULTILINE
         )
 
+        # 7.5) Horizontal rules and markdown list bullets.
+        text = re.sub(r'^\s{0,3}(?:---|\*\*\*|___)\s*$', '────────', text, flags=re.MULTILINE)
+        text = re.sub(r'^(\s*)[-*]\s+', lambda m: m.group(1) + '• ', text, flags=re.MULTILINE)
+
         # 8) Convert bold+italic: ***text*** → *_text_* (Slack bold wrapping italic)
         text = re.sub(
-            r'\*\*\*(.+?)\*\*\*',
+            r'\*\*\*([\s\S]+?)\*\*\*',
             lambda m: _ph(f'*_{m.group(1)}_*'),
             text,
         )
 
-        # 9) Convert bold: **text** → *text* (Slack bold)
+        # 9) Convert bold: **text** → *text* (Slack bold).
+        # When bold wraps paired Japanese/paren punctuation, move the Slack
+        # emphasis markers inside the punctuation; Slack often fails to render
+        # `*「text」*` but renders `「*text*」` reliably.
         text = re.sub(
-            r'\*\*(.+?)\*\*',
+            r'\*\*([「『（(\[])([\s\S]+?)([」』）)\]])\*\*',
+            lambda m: _ph(f'{m.group(1)}*{m.group(2)}*{m.group(3)}'),
+            text,
+        )
+        text = re.sub(
+            r'\*\*([\s\S]+?)\*\*',
             lambda m: _ph(f'*{m.group(1)}*'),
             text,
         )
 
-        # 10) Convert italic: _text_ stays as _text_ (already Slack italic)
-        #     Single *text* → _text_ (Slack italic), but only when the
-        #     emphasized text touches non-whitespace on both sides so literal
-        #     delimiters like "a * b * c" are preserved.
-        text = re.sub(
-            r'(?<!\*)\*(\S(?:[^*\n]*?\S)?)\*(?!\*)',
-            lambda m: _ph(f'_{m.group(1)}_'),
-            text,
-        )
+        # 10) Preserve single-star spans. In Slack mrkdwn, *text* means bold
+        #     (not italic), and users often ask for Slack-native single-star
+        #     emphasis. Earlier versions converted *text* → _text_, which made
+        #     assistant output like *do-not-change* fail to render as bold. Leave
+        #     single-star spans untouched; _text_ remains Slack italic.
 
         # 11) Convert strikethrough: ~~text~~ → ~text~
         text = re.sub(

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -620,13 +620,13 @@ class TestSendPrivateNotice:
         )
 
         assert result.success
-        adapter._app.client.chat_postEphemeral.assert_called_once_with(
-            channel="C123",
-            user="U123",
-            text="private hello",
-            mrkdwn=True,
-            thread_ts="1234567890.123456",
-        )
+        kwargs = adapter._app.client.chat_postEphemeral.call_args.kwargs
+        assert kwargs["channel"] == "C123"
+        assert kwargs["user"] == "U123"
+        assert kwargs["text"] == "private hello"
+        assert kwargs["mrkdwn"] is True
+        assert kwargs["thread_ts"] == "1234567890.123456"
+        assert kwargs["blocks"][0]["text"] == {"type": "mrkdwn", "text": "private hello"}
 
 
 # ---------------------------------------------------------------------------
@@ -1359,11 +1359,11 @@ class TestSendTyping:
         )
 
         assert result.success
-        adapter._app.client.chat_update.assert_called_once_with(
-            channel="C123",
-            ts="reply_ts",
-            text="done",
-        )
+        kwargs = adapter._app.client.chat_update.call_args.kwargs
+        assert kwargs["channel"] == "C123"
+        assert kwargs["ts"] == "reply_ts"
+        assert kwargs["text"] == "done"
+        assert kwargs["blocks"][0]["text"] == {"type": "mrkdwn", "text": "done"}
         adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
             channel_id="C123",
             thread_ts="parent_ts",
@@ -1400,8 +1400,15 @@ class TestFormatMessage:
     def test_bold_conversion(self, adapter):
         assert adapter.format_message("**hello**") == "*hello*"
 
-    def test_italic_asterisk_conversion(self, adapter):
-        assert adapter.format_message("*hello*") == "_hello_"
+    def test_multiline_bold_conversion(self, adapter):
+        text = "**Use Byteflare as the first customer,\nthen market it as an AI-automated company.**"
+        assert adapter.format_message(text) == "*Use Byteflare as the first customer,\nthen market it as an AI-automated company.*"
+
+    def test_single_asterisk_preserved_as_slack_bold(self, adapter):
+        assert adapter.format_message("*hello*") == "*hello*"
+
+    def test_single_asterisk_phrase_preserved_as_slack_bold(self, adapter):
+        assert adapter.format_message("Please *do not change* this") == "Please *do not change* this"
 
     def test_italic_underscore_preserved(self, adapter):
         assert adapter.format_message("_hello_") == "_hello_"
@@ -1432,9 +1439,17 @@ class TestFormatMessage:
     def test_strikethrough(self, adapter):
         assert adapter.format_message("~~deleted~~") == "~deleted~"
 
-    def test_code_block_preserved(self, adapter):
+    def test_code_block_strips_language_info_string(self, adapter):
         code = "```python\nx = **not bold**\n```"
+        assert adapter.format_message(code) == "```\nx = **not bold**\n```"
+
+    def test_code_block_without_language_preserved(self, adapter):
+        code = "```\nx = **not bold**\n```"
         assert adapter.format_message(code) == code
+
+    def test_code_block_strips_language_for_slack_inline_close(self, adapter):
+        code = "```py\ndef test()...```"
+        assert adapter.format_message(code) == "```\ndef test()...```"
 
     def test_inline_code_preserved(self, adapter):
         text = "Use `**raw**` syntax"
@@ -1444,7 +1459,7 @@ class TestFormatMessage:
         text = "**Bold** and *italic* with `code`"
         result = adapter.format_message(text)
         assert "*Bold*" in result
-        assert "_italic_" in result
+        assert "*italic*" in result
         assert "`code`" in result
 
     def test_empty_string(self, adapter):
@@ -1500,9 +1515,9 @@ class TestFormatMessage:
         """**bold** still works after adding ***bold italic*** support."""
         assert adapter.format_message("**bold**") == "*bold*"
 
-    def test_bold_italic_does_not_break_plain_italic(self, adapter):
-        """*italic* still works after adding ***bold italic*** support."""
-        assert adapter.format_message("*italic*") == "_italic_"
+    def test_bold_italic_does_not_break_single_star_slack_bold(self, adapter):
+        """*bold* stays Slack bold after adding ***bold italic*** support."""
+        assert adapter.format_message("*bold*") == "*bold*"
 
     def test_bold_italic_mixed_with_bold(self, adapter):
         """Both ***bold italic*** and **bold** in the same message."""
@@ -1580,9 +1595,9 @@ class TestFormatMessage:
     # --- Additional edge cases ---
 
     def test_message_only_code_block(self, adapter):
-        """Entire message is a fenced code block — no conversion."""
+        """Entire message is a fenced code block — language info is stripped for Slack."""
         code = "```python\nx = 1\n```"
-        assert adapter.format_message(code) == code
+        assert adapter.format_message(code) == "```\nx = 1\n```"
 
     def test_multiline_mixed_formatting(self, adapter):
         """Multi-line message with headers, bold, links, code, and blockquotes."""
@@ -1625,6 +1640,24 @@ class TestFormatMessage:
     def test_emoji_shortcodes_passthrough(self, adapter):
         """Emoji shortcodes like :smile: pass through unchanged."""
         assert adapter.format_message(":smile: hello :wave:") == ":smile: hello :wave:"
+
+    def test_horizontal_rule_conversion(self, adapter):
+        assert adapter.format_message("before\n---\nafter") == "before\n────────\nafter"
+
+    def test_markdown_pipe_table_converts_to_bullets(self, adapter):
+        text = "| Type | Market price |\n|---|---|\n| Lightweight setup | $2,000-$5,000 |"
+        assert adapter.format_message(text) == "• *Type*: Lightweight setup / *Market price*: $2,000-$5,000"
+
+    def test_separatorless_pipe_lines_are_preserved(self, adapter):
+        text = "| a | b |\n| c | d |"
+        assert adapter.format_message(text) == text
+
+    def test_mrkdwn_blocks_split_and_mark_sections(self, adapter):
+        blocks = adapter._mrkdwn_blocks("*bold*\n" + "x" * 3100)
+        assert blocks
+        assert all(block["type"] == "section" for block in blocks)
+        assert all(block["text"]["type"] == "mrkdwn" for block in blocks)
+        assert all(len(block["text"]["text"]) <= 3000 for block in blocks)
 
 
 # ---------------------------------------------------------------------------
@@ -1710,7 +1743,7 @@ class TestEditMessageStreamingPipeline:
         assert result.success is True
         kwargs = adapter._app.client.chat_update.call_args.kwargs
         assert kwargs["text"].startswith("*Result:*")
-        assert "```python\nprint('hello')\n```" in kwargs["text"]
+        assert "```\nprint('hello')\n```" in kwargs["text"]
 
     @pytest.mark.asyncio
     async def test_edit_message_formats_blockquote_in_stream(self, adapter):


### PR DESCRIPTION
## Summary
- send Slack replies/updates with Block Kit `mrkdwn` section blocks in addition to fallback text
- normalize fenced code blocks for Slack by stripping unsupported language info strings from opening fences
- preserve single-star spans (`*text*`) as Slack-native bold instead of converting them to underscore italics
- add Slack adapter tests covering mrkdwn blocks, code fence language stripping, and single-star preservation

## Test Plan
- `source venv/bin/activate && python -m pytest tests/gateway/test_slack.py -q -o 'addopts='`
