### PR TITLE
Add web model routing editor

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -507,6 +507,11 @@ class ModelAssignment(BaseModel):
     task: str = ""
 
 
+class ModelRoutingUpdate(BaseModel):
+    model: dict
+    fallback_providers: list
+
+
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
 try:
     _GATEWAY_HEALTH_TIMEOUT = float(os.getenv("GATEWAY_HEALTH_TIMEOUT", "3"))
@@ -1050,6 +1055,145 @@ def get_model_options():
     except Exception:
         _log.exception("GET /api/model/options failed")
         raise HTTPException(status_code=500, detail="Failed to list model options")
+
+
+_MODEL_ROUTE_OPTIONAL_STRING_KEYS = ("base_url", "api_mode")
+_MODEL_ROUTE_OPTIONAL_INT_KEYS = ("context_length", "max_tokens")
+
+
+def _coerce_model_route(raw: Any, *, require_model: bool) -> Dict[str, Any]:
+    if isinstance(raw, str):
+        route: Dict[str, Any] = {"default": raw}
+    elif isinstance(raw, dict):
+        route = dict(raw)
+    else:
+        route = {}
+
+    model = str(route.get("default", route.get("name", route.get("model", ""))) or "").strip()
+    provider = str(route.get("provider", "") or "").strip()
+
+    if require_model and not model:
+        raise HTTPException(status_code=400, detail="model.default is required")
+
+    if model:
+        route["default"] = model
+    route.pop("name", None)
+    route.pop("model", None)
+    route["provider"] = provider
+
+    for key in _MODEL_ROUTE_OPTIONAL_STRING_KEYS:
+        if key in route:
+            route[key] = str(route.get(key) or "").strip()
+
+    for key in _MODEL_ROUTE_OPTIONAL_INT_KEYS:
+        if key not in route or route.get(key) in (None, ""):
+            route.pop(key, None)
+            continue
+        try:
+            value = int(route[key])
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail=f"{key} must be an integer")
+        if value > 0:
+            route[key] = value
+        else:
+            route.pop(key, None)
+
+    return route
+
+
+def _coerce_fallback_route(raw: Any, index: int) -> Dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise HTTPException(status_code=400, detail=f"fallback_providers[{index}] must be an object")
+
+    route = dict(raw)
+    provider = str(route.get("provider", "") or "").strip()
+    model = str(route.get("model", route.get("default", route.get("name", ""))) or "").strip()
+    if not provider or not model:
+        raise HTTPException(
+            status_code=400,
+            detail=f"fallback_providers[{index}] requires provider and model",
+        )
+
+    route["provider"] = provider
+    route["model"] = model
+    route.pop("default", None)
+    route.pop("name", None)
+
+    for key in _MODEL_ROUTE_OPTIONAL_STRING_KEYS:
+        if key in route:
+            route[key] = str(route.get(key) or "").strip()
+
+    for key in _MODEL_ROUTE_OPTIONAL_INT_KEYS:
+        if key not in route or route.get(key) in (None, ""):
+            route.pop(key, None)
+            continue
+        try:
+            value = int(route[key])
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail=f"fallback_providers[{index}].{key} must be an integer")
+        if value > 0:
+            route[key] = value
+        else:
+            route.pop(key, None)
+
+    return route
+
+
+def _coerce_existing_fallback_routes(raw: Any) -> List[Dict[str, Any]]:
+    if isinstance(raw, dict):
+        candidates = [raw]
+    elif isinstance(raw, list):
+        candidates = raw
+    else:
+        return []
+
+    routes: List[Dict[str, Any]] = []
+    for index, entry in enumerate(candidates):
+        if not isinstance(entry, dict):
+            continue
+        try:
+            routes.append(_coerce_fallback_route(entry, index))
+        except HTTPException:
+            continue
+    return routes
+
+
+@app.get("/api/model/routing")
+def get_model_routing():
+    """Return the editable main model route and fallback provider chain."""
+    try:
+        cfg = load_config()
+        return {
+            "model": _coerce_model_route(cfg.get("model", ""), require_model=False),
+            "fallback_providers": _coerce_existing_fallback_routes(cfg.get("fallback_providers", [])),
+        }
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("GET /api/model/routing failed")
+        raise HTTPException(status_code=500, detail="Failed to read model routing")
+
+
+@app.put("/api/model/routing")
+async def update_model_routing(body: ModelRoutingUpdate):
+    """Persist main model routing and fallback_providers without touching other config."""
+    try:
+        if not isinstance(body.fallback_providers, list):
+            raise HTTPException(status_code=400, detail="fallback_providers must be a list")
+
+        cfg = load_config()
+        cfg["model"] = _coerce_model_route(body.model, require_model=True)
+        cfg["fallback_providers"] = [
+            _coerce_fallback_route(entry, index)
+            for index, entry in enumerate(body.fallback_providers)
+        ]
+        save_config(cfg)
+        return {"ok": True}
+    except HTTPException:
+        raise
+    except Exception:
+        _log.exception("PUT /api/model/routing failed")
+        raise HTTPException(status_code=500, detail="Failed to save model routing")
 
 
 @app.get("/api/model/auxiliary")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -510,6 +510,108 @@ class TestConfigRoundTrip:
         web_config["agent"]["max_turns"] = original_turns
         self.client.put("/api/config", json={"config": web_config})
 
+    def test_model_routing_get_returns_model_and_fallbacks(self):
+        from hermes_cli.config import save_config
+
+        save_config({
+            "model": {
+                "default": "gemini-3.1-pro-preview",
+                "provider": "sub2api",
+                "base_url": "https://sub2api.example/v1",
+                "api_mode": "openai",
+                "context_length": 100000,
+            },
+            "fallback_providers": [
+                {
+                    "provider": "deepseek",
+                    "model": "deepseek-v4-pro",
+                    "base_url": "https://deepseek.example/v1/",
+                    "api_mode": "openai",
+                }
+            ],
+        })
+
+        resp = self.client.get("/api/model/routing")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["model"] == {
+            "default": "gemini-3.1-pro-preview",
+            "provider": "sub2api",
+            "base_url": "https://sub2api.example/v1",
+            "api_mode": "openai",
+            "context_length": 100000,
+        }
+        assert data["fallback_providers"] == [
+            {
+                "provider": "deepseek",
+                "model": "deepseek-v4-pro",
+                "base_url": "https://deepseek.example/v1/",
+                "api_mode": "openai",
+            }
+        ]
+
+    def test_model_routing_put_updates_only_model_and_fallbacks(self):
+        from hermes_cli.config import load_config, save_config
+
+        save_config({
+            "agent": {"max_turns": 7},
+            "model": {
+                "default": "old/model",
+                "provider": "old-provider",
+                "base_url": "https://old.example/v1",
+                "api_mode": "openai",
+            },
+            "fallback_providers": [
+                {"provider": "old-fallback", "model": "old/fallback"},
+            ],
+        })
+
+        resp = self.client.put(
+            "/api/model/routing",
+            json={
+                "model": {
+                    "default": "gemini-3.1-pro-preview",
+                    "provider": "sub2api",
+                    "base_url": "https://sub2api.example/v1",
+                    "api_mode": "openai",
+                    "context_length": "200000",
+                },
+                "fallback_providers": [
+                    {
+                        "provider": "deepseek",
+                        "model": "deepseek-v4-pro",
+                        "base_url": "https://deepseek.example/v1",
+                    }
+                ],
+            },
+        )
+
+        assert resp.status_code == 200
+        after = load_config()
+        assert after["agent"]["max_turns"] == 7
+        assert after["model"]["provider"] == "sub2api"
+        assert after["model"]["default"] == "gemini-3.1-pro-preview"
+        assert after["model"]["context_length"] == 200000
+        assert after["fallback_providers"] == [
+            {
+                "provider": "deepseek",
+                "model": "deepseek-v4-pro",
+                "base_url": "https://deepseek.example/v1",
+            }
+        ]
+
+    def test_model_routing_rejects_invalid_fallbacks(self):
+        resp = self.client.put(
+            "/api/model/routing",
+            json={
+                "model": {"default": "test/model", "provider": "test"},
+                "fallback_providers": [{"provider": "missing-model"}],
+            },
+        )
+
+        assert resp.status_code == 400
+
     def test_schema_types_match_config_values(self):
         """Every schema field should have a matching-type value in the config."""
         config = self.client.get("/api/config").json()

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -255,10 +255,17 @@ export const api = {
   getSchema: () => fetchJSON<{ fields: Record<string, unknown>; category_order: string[] }>("/api/config/schema"),
   getModelInfo: () => fetchJSON<ModelInfoResponse>("/api/model/info"),
   getModelOptions: () => fetchJSON<ModelOptionsResponse>("/api/model/options"),
+  getModelRouting: () => fetchJSON<ModelRoutingResponse>("/api/model/routing"),
   getAuxiliaryModels: () => fetchJSON<AuxiliaryModelsResponse>("/api/model/auxiliary"),
   setModelAssignment: (body: ModelAssignmentRequest) =>
     fetchJSON<ModelAssignmentResponse>("/api/model/set", {
       method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  saveModelRouting: (body: ModelRoutingResponse) =>
+    fetchJSON<{ ok: boolean }>("/api/model/routing", {
+      method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     }),
@@ -832,6 +839,30 @@ export interface ModelOptionsResponse {
   model?: string;
   provider?: string;
   providers?: ModelOptionProvider[];
+}
+
+export interface ModelRouteConfig {
+  provider?: string;
+  default?: string;
+  model?: string;
+  base_url?: string;
+  api_mode?: string;
+  context_length?: number | string;
+  max_tokens?: number | string;
+}
+
+export interface FallbackProviderConfig {
+  provider: string;
+  model: string;
+  base_url?: string;
+  api_mode?: string;
+  context_length?: number | string;
+  max_tokens?: number | string;
+}
+
+export interface ModelRoutingResponse {
+  model: ModelRouteConfig;
+  fallback_providers: FallbackProviderConfig[];
 }
 
 export interface AuxiliaryTaskAssignment {

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -3,8 +3,10 @@ import {
   Code,
   Download,
   FormInput,
+  Plus,
   RotateCcw,
   Search,
+  Trash2,
   Upload,
   X,
   Settings2,
@@ -36,7 +38,12 @@ import {
   FileOutput,
   RefreshCw,
 } from "lucide-react";
-import { api } from "@/lib/api";
+import {
+  api,
+  type FallbackProviderConfig,
+  type ModelRouteConfig,
+  type ModelRoutingResponse,
+} from "@/lib/api";
 import { getNestedValue, setNestedValue } from "@/lib/nested";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { Toast } from "@nous-research/ui/ui/components/toast";
@@ -97,6 +104,204 @@ function CategoryIcon({
   return <Icon className={className ?? "h-4 w-4"} />;
 }
 
+const EMPTY_FALLBACK: FallbackProviderConfig = {
+  provider: "",
+  model: "",
+  base_url: "",
+  api_mode: "",
+  context_length: "",
+};
+
+type EditableRoute = ModelRouteConfig & Partial<FallbackProviderConfig>;
+
+function routeNumberValue(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  return String(value);
+}
+
+function updateRouteField(
+  route: EditableRoute,
+  key: keyof EditableRoute,
+  value: string,
+): EditableRoute {
+  if ((key === "context_length" || key === "max_tokens") && value !== "") {
+    const parsed = Number(value);
+    return { ...route, [key]: Number.isNaN(parsed) ? value : parsed };
+  }
+  return { ...route, [key]: value };
+}
+
+function ModelRouteFields({
+  route,
+  onChange,
+  modelKey,
+}: {
+  route: EditableRoute;
+  onChange: (route: EditableRoute) => void;
+  modelKey: "default" | "model";
+}) {
+  return (
+    <div className="grid gap-2 md:grid-cols-[minmax(0,0.9fr)_minmax(0,1.2fr)_minmax(0,1.4fr)_minmax(0,0.8fr)_minmax(0,0.8fr)]">
+      <Input
+        value={String(route.provider ?? "")}
+        onChange={(e) => onChange(updateRouteField(route, "provider", e.target.value))}
+        placeholder="provider"
+        aria-label="provider"
+      />
+      <Input
+        value={String(route[modelKey] ?? "")}
+        onChange={(e) => onChange(updateRouteField(route, modelKey, e.target.value))}
+        placeholder="model"
+        aria-label="model"
+      />
+      <Input
+        value={String(route.base_url ?? "")}
+        onChange={(e) => onChange(updateRouteField(route, "base_url", e.target.value))}
+        placeholder="base_url"
+        aria-label="base_url"
+      />
+      <Input
+        value={String(route.api_mode ?? "")}
+        onChange={(e) => onChange(updateRouteField(route, "api_mode", e.target.value))}
+        placeholder="api_mode"
+        aria-label="api_mode"
+      />
+      <Input
+        type="number"
+        min={0}
+        value={routeNumberValue(route.context_length)}
+        onChange={(e) => onChange(updateRouteField(route, "context_length", e.target.value))}
+        placeholder="context"
+        aria-label="context_length"
+      />
+    </div>
+  );
+}
+
+function ModelRoutingCard({
+  routing,
+  saving,
+  onChange,
+  onSave,
+}: {
+  routing: ModelRoutingResponse | null;
+  saving: boolean;
+  onChange: (routing: ModelRoutingResponse) => void;
+  onSave: () => void;
+}) {
+  if (!routing) return null;
+
+  const updateFallback = (index: number, route: EditableRoute) => {
+    onChange({
+      ...routing,
+      fallback_providers: routing.fallback_providers.map((entry, i) =>
+        i === index ? (route as FallbackProviderConfig) : entry,
+      ),
+    });
+  };
+
+  const removeFallback = (index: number) => {
+    onChange({
+      ...routing,
+      fallback_providers: routing.fallback_providers.filter((_, i) => i !== index),
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader className="py-3 px-4">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Route className="h-4 w-4" />
+            Model routing
+          </CardTitle>
+          <Button
+            size="sm"
+            className="uppercase"
+            onClick={onSave}
+            disabled={saving}
+            prefix={saving ? <Spinner /> : <Route />}
+          >
+            {saving ? "Saving" : "Save routing"}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="grid gap-4 px-4 pb-4">
+        <div className="grid gap-2">
+          <div className="text-xs font-medium uppercase text-muted-foreground">
+            Main model
+          </div>
+          <ModelRouteFields
+            route={routing.model as EditableRoute}
+            modelKey="default"
+            onChange={(route) =>
+              onChange({ ...routing, model: route as ModelRouteConfig })
+            }
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-xs font-medium uppercase text-muted-foreground">
+              Fallback providers
+            </div>
+            <Button
+              ghost
+              size="sm"
+              prefix={<Plus />}
+              onClick={() =>
+                onChange({
+                  ...routing,
+                  fallback_providers: [
+                    ...routing.fallback_providers,
+                    { ...EMPTY_FALLBACK },
+                  ],
+                })
+              }
+            >
+              Add fallback
+            </Button>
+          </div>
+          <div className="grid gap-2">
+            {routing.fallback_providers.length === 0 ? (
+              <div className="border border-dashed border-border px-3 py-4 text-sm text-muted-foreground">
+                No fallback providers configured.
+              </div>
+            ) : (
+              routing.fallback_providers.map((fallback, index) => (
+                <div
+                  key={index}
+                  className="grid gap-2 border border-border bg-muted/20 p-3"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-xs font-mono text-muted-foreground">
+                      fallback_providers[{index}]
+                    </span>
+                    <Button
+                      ghost
+                      size="icon"
+                      onClick={() => removeFallback(index)}
+                      title="Remove fallback"
+                      aria-label="Remove fallback"
+                    >
+                      <Trash2 />
+                    </Button>
+                  </div>
+                  <ModelRouteFields
+                    route={fallback as EditableRoute}
+                    modelKey="model"
+                    onChange={(route) => updateFallback(index, route)}
+                  />
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 /* ------------------------------------------------------------------ */
 /*  Component                                                          */
 /* ------------------------------------------------------------------ */
@@ -120,6 +325,8 @@ export default function ConfigPage() {
   const [configPath, setConfigPath] = useState<string | null>(null);
   const [activeCategory, setActiveCategory] = useState<string>("");
   const [confirmReset, setConfirmReset] = useState(false);
+  const [modelRouting, setModelRouting] = useState<ModelRoutingResponse | null>(null);
+  const [routingSaving, setRoutingSaving] = useState(false);
   const { toast, showToast } = useToast();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { t } = useI18n();
@@ -180,6 +387,10 @@ export default function ConfigPage() {
     api
       .getStatus()
       .then((resp) => setConfigPath(resp.config_path))
+      .catch(() => {});
+    api
+      .getModelRouting()
+      .then(setModelRouting)
       .catch(() => {});
   }, []);
 
@@ -270,15 +481,36 @@ export default function ConfigPage() {
     }
   };
 
+  const handleRoutingSave = async () => {
+    if (!modelRouting) return;
+    setRoutingSaving(true);
+    try {
+      await api.saveModelRouting(modelRouting);
+      const [nextConfig, nextRouting] = await Promise.all([
+        api.getConfig(),
+        api.getModelRouting(),
+      ]);
+      setConfig(nextConfig);
+      setModelRouting(nextRouting);
+      showToast("Model routing saved", "success");
+    } catch (e) {
+      showToast(`Failed to save model routing: ${e}`, "error");
+    } finally {
+      setRoutingSaving(false);
+    }
+  };
+
   const handleYamlSave = async () => {
     setYamlSaving(true);
     try {
       await api.saveConfigRaw(yamlText);
       showToast(t.config.yamlConfigSaved, "success");
-      api
-        .getConfig()
-        .then(setConfig)
-        .catch(() => {});
+      const [nextConfig, nextRouting] = await Promise.all([
+        api.getConfig(),
+        api.getModelRouting(),
+      ]);
+      setConfig(nextConfig);
+      setModelRouting(nextRouting);
     } catch (e) {
       showToast(`${t.config.failedToSaveYaml}: ${e}`, "error");
     } finally {
@@ -581,7 +813,15 @@ export default function ConfigPage() {
             </div>
           </aside>
 
-          <div className="flex-1 min-w-0">
+          <div className="flex-1 min-w-0 grid gap-4">
+            {!isSearching && (
+              <ModelRoutingCard
+                routing={modelRouting}
+                saving={routingSaving}
+                onChange={setModelRouting}
+                onSave={handleRoutingSave}
+              />
+            )}
             {isSearching ? (
               <Card>
                 <CardHeader className="py-3 px-4">


### PR DESCRIPTION
## Summary
- add a narrow `/api/model/routing` read/write endpoint for main model routing and `fallback_providers`
- add a Config page model routing panel so each fallback provider row can be edited, added, or removed independently
- cover model routing reads, partial saves, and invalid fallback validation in web server tests

## Validation
- `python -m pytest -o addopts="" tests\hermes_cli\test_web_server.py -k "model_routing or round_trip_preserves_model_subkeys or edit_model_name_preserved"` with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`
- `python -m ruff check hermes_cli\web_server.py tests\hermes_cli\test_web_server.py`
- `npm run build`

## Notes
- `npm run lint` currently fails on existing React lint issues across unrelated files such as `web/src/App.tsx`, `web/src/components/ThemeSwitcher.tsx`, `web/src/pages/ModelsPage.tsx`, and `web/src/pages/SessionsPage.tsx`; the targeted build succeeds.
