### PR TITLE
fix: allow ZWJ (U+200D) in legitimate emoji sequences

### DIFF
--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -298,6 +298,95 @@ class TestInvisibleUnicode:
         # shared set.
         assert isinstance(INVISIBLE_CHARS, frozenset)
 
+    # ── ZWJ emoji context (U+200D) — regression for #18581 ──────────
+
+    def test_zwj_in_emoji_context_not_flagged(self):
+        """U+200D inside an emoji ZWJ sequence (e.g. 🤸‍♀️ cartwheel
+        gymnast) must NOT trigger the invisible-unicode detector."""
+        # Cartwheel gymnast: 🤸 + ZWJ + ♀ + VS16
+        content = "Maintain your tension \U0001F938\u200d\u2640\ufe0f."
+        findings = scan_for_threats(content, scope="context")
+        assert not any("200D" in f for f in findings), (
+            f"ZWJ should NOT be flagged in emoji context: {findings}"
+        )
+
+    def test_zwj_between_ascii_still_blocked(self):
+        """U+200D between ASCII characters is the injection signal —
+        must still be flagged."""
+        content = "hel\u200dlo world"
+        findings = scan_for_threats(content, scope="context")
+        assert any("200D" in f for f in findings), (
+            f"ZWJ between ASCII chars MUST be flagged: {findings}"
+        )
+
+    def test_zwj_at_edges_still_blocked(self):
+        """U+200D at the start or end of text cannot be emoji context."""
+        findings = scan_for_threats("\u200dhello", scope="context")
+        assert any("200D" in f for f in findings)
+        findings = scan_for_threats("hello\u200d", scope="context")
+        assert any("200D" in f for f in findings)
+
+    def test_mixed_emoji_and_malicious_zwj(self):
+        """When content has both legitimate emoji ZWJ and malicious ZWJ
+        between ASCII, the malicious one must still be caught."""
+        content = "okay \U0001F938\u200d\u2640\ufe0f but hel\u200dlo is bad"
+        findings = scan_for_threats(content, scope="context")
+        assert any("200D" in f for f in findings), (
+            f"Malicious ZWJ must be flagged even with emoji present: {findings}"
+        )
+
+    def test_family_emoji_with_multiple_zwj(self):
+        """Family emoji uses multiple ZWJs — all should be allowed."""
+        # 👨 + ZWJ + 👩 + ZWJ + 👧
+        content = "Family \U0001F468\u200d\U0001F469\u200d\U0001F467 portrait"
+        findings = scan_for_threats(content, scope="context")
+        assert not any("200D" in f for f in findings), (
+            f"Multi-ZWJ family emoji should pass: {findings}"
+        )
+
+    def test_zwj_between_cjk_blocked(self):
+        """ZWJ between Chinese characters is NOT an emoji sequence —
+        must be flagged as potential injection."""
+        content = "\u5ffd\u7565\u200d\u6307\u4ee4"  # 忽略‍指令
+        findings = scan_for_threats(content, scope="context")
+        assert any("200D" in f for f in findings), (
+            f"ZWJ between CJK chars MUST be flagged: {findings}"
+        )
+
+    def test_zwj_between_non_ascii_latin_blocked(self):
+        """ZWJ between non-ASCII Latin characters (e.g. accented French)
+        is NOT an emoji sequence and must be flagged."""
+        content = "caf\u00e9\u200d\u00efgnore"  # café‍ïgnore
+        findings = scan_for_threats(content, scope="context")
+        assert any("200D" in f for f in findings), (
+            f"ZWJ between non-ASCII Latin MUST be flagged: {findings}"
+        )
+
+    def test_skin_tone_emoji_zwj_allowed(self):
+        """Person + skin tone + ZWJ + laptop (👩🏽‍💻) must pass."""
+        content = "coding \U0001F469\U0001F3FD\u200d\U0001F4BB"
+        findings = scan_for_threats(content, scope="context")
+        assert not any("200D" in f for f in findings), (
+            f"Skin-tone emoji ZWJ should be allowed: {findings}"
+        )
+
+    def test_heart_on_fire_emoji_allowed(self):
+        """Heart-on-fire (❤️‍🔥) is a common ZWJ emoji — must pass."""
+        content = "love \u2764\ufe0f\u200d\U0001F525"
+        findings = scan_for_threats(content, scope="context")
+        assert not any("200D" in f for f in findings), (
+            f"Heart-on-fire emoji should be allowed: {findings}"
+        )
+
+    def test_zwj_between_emoji_and_cjk_blocked(self):
+        """ZWJ between an emoji and a CJK character is not a valid
+        emoji sequence — must be flagged."""
+        content = "\U0001F938\u200d\u5ffd\u7565"  # 🤸‍忽略
+        findings = scan_for_threats(content, scope="context")
+        assert any("200D" in f for f in findings), (
+            f"ZWJ between emoji and CJK MUST be flagged: {findings}"
+        )
+
 
 # =========================================================================
 # first_threat_message helper

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -184,6 +184,91 @@ def _compile() -> None:
 _compile()
 
 
+# ---------------------------------------------------------------------------
+# ZWJ (U+200D) emoji-aware scanning
+#
+# U+200D (Zero Width Joiner) is a legitimate Unicode mechanism for
+# constructing emoji sequences (gender, family, skin-tone combinations per
+# Unicode TR#51).  It must be allowed inside emoji grapheme clusters but
+# still blocked when used to hide invisible text between plain characters.
+#
+# The approach mirrors ``cronjob_tools._zwj_has_emoji_neighbour`` and
+# ``cronjob_tools._strip_legitimate_emoji_zwj``: inspect the codepoints
+# adjacent to each ZWJ (skipping over U+FE0F variation selectors) and check
+# whether they fall inside known emoji Unicode ranges.
+# ---------------------------------------------------------------------------
+
+# Codepoint ranges that contain emoji base characters.  Covers the SMP
+# pictographic ranges, Miscellaneous Symbols, Dingbats, Enclosed
+# Alphanumerics Supplement, and regional indicators — sufficient for all
+# ZWJ sequences defined in emoji-sequences.txt as of Unicode 16.0.
+_EMOJI_CP_RANGES: tuple[tuple[int, int], ...] = (
+    (0x1F000, 0x1FFFF),   # SMP pictographic ranges (faces, activities, objects…)
+    (0x2600,  0x27BF),    # Miscellaneous Symbols + Dingbats (⚕✈✳✴ etc.)
+    (0x2300,  0x23FF),    # Miscellaneous Technical (⌛⏳⏰⏱ etc.)
+    (0x1F1E6, 0x1F1FF),   # Regional indicator symbols (flag sequences)
+    (0x20E3,  0x20E3),    # Combining enclosing keycap
+    (0x2702,  0x27B0),    # Dingbats subset used in emoji
+    (0x25AA,  0x25FE),    # Small squares / geometric shapes used as emoji
+    (0x2B05,  0x2B55),    # Arrows & shapes used as emoji
+    (0x200D,  0x200D),    # ZWJ itself (when chained: emoji+ZWJ+ZWJ…)
+    (0xFE0F,  0xFE0F),    # VS16 (variation selector — presentational)
+    (0xFE0E,  0xFE0E),    # VS15 (variation selector — text)
+    # Skin tone modifiers — always appear adjacent to ZWJ in sequences.
+    (0x1F3FB, 0x1F3FF),
+    # Gender signs used in ZWJ sequences.
+    (0x2640,  0x2642),
+)
+
+_VS16 = 0xFE0F   # Variation Selector-16 (presentational emoji selector)
+
+
+def _is_emoji_cp(cp: int) -> bool:
+    """Return True if *cp* falls inside a known emoji codepoint range."""
+    return any(lo <= cp <= hi for lo, hi in _EMOJI_CP_RANGES)
+
+
+def _zwj_in_emoji_sequence(text: str, idx: int) -> bool:
+    """Return True when the ZWJ at *text[idx]* appears inside an emoji
+    grapheme cluster.
+
+    Scans left and right from *idx*, skipping over U+FE0F variation
+    selectors, then checks whether the nearest non-VS16 neighbours on
+    both sides are emoji codepoints.  This mirrors the approach already
+    proven in ``cronjob_tools._zwj_has_emoji_neighbour``.
+    """
+    # Walk left past any VS16 characters.
+    left = idx - 1
+    while left >= 0 and ord(text[left]) == _VS16:
+        left -= 1
+    # Walk right past any VS16 characters.
+    right = idx + 1
+    while right < len(text) and ord(text[right]) == _VS16:
+        right += 1
+    return (
+        left >= 0
+        and right < len(text)
+        and _is_emoji_cp(ord(text[left]))
+        and _is_emoji_cp(ord(text[right]))
+    )
+
+
+def _strip_legitimate_emoji_zwj(content: str) -> str:
+    """Remove ZWJ characters that are part of legitimate emoji sequences.
+
+    After stripping, any remaining ZWJ in the output is *not* part of an
+    emoji sequence and should be treated as suspicious invisible unicode.
+    """
+    if '\u200d' not in content:
+        return content
+    cleaned: list[str] = []
+    for idx, ch in enumerate(content):
+        if ch == '\u200d' and _zwj_in_emoji_sequence(content, idx):
+            continue
+        cleaned.append(ch)
+    return ''.join(cleaned)
+
+
 def scan_for_threats(content: str, scope: str = "context") -> List[str]:
     """Return a list of matched pattern IDs in ``content`` at the given scope.
 
@@ -207,8 +292,12 @@ def scan_for_threats(content: str, scope: str = "context") -> List[str]:
     findings: List[str] = []
 
     # Invisible unicode — single pass through the content set, not 17
-    # ``in`` lookups.
-    char_set = set(content)
+    # ``in`` lookups.  Before checking, strip ZWJ characters that are
+    # part of legitimate emoji sequences so they don't produce false
+    # positives (e.g. 🤸‍♀️, 👨‍👩‍👧).  Any ZWJ remaining after stripping
+    # is suspicious and should be reported.
+    content_for_invisible_scan = _strip_legitimate_emoji_zwj(content)
+    char_set = set(content_for_invisible_scan)
     invisible_hits = char_set & INVISIBLE_CHARS
     for ch in invisible_hits:
         findings.append(f"invisible_unicode_U+{ord(ch):04X}")


### PR DESCRIPTION
Closes #18581

## Problem

The invisible-unicode scanner in `threat_patterns.py` flags **all** U+200D (Zero Width Joiner) occurrences as potential prompt injection. This silently blocks SOUL.md and other context files that contain standard emoji sequences like 🤸‍♀️, 👨‍👩‍👧, or ❤️‍🔥, replacing them with `[BLOCKED: SOUL.md contained potential prompt injection (invisible unicode U+200D)]`.

ZWJ is the standard Unicode mechanism (TR#51) for constructing gendered, family, and skin-tone emoji — not an injection vector when used in emoji sequences.

## Root Cause

`INVISIBLE_CHARS` includes U+200D, and `scan_for_threats()` performs a simple `char_set & INVISIBLE_CHARS` intersection without considering whether the ZWJ sits inside a legitimate emoji grapheme cluster.

## Fix

Mirror the proven approach already used in `cronjob_tools.py` — define emoji codepoint ranges, skip VS16 variation selectors, and check whether each ZWJ sits between emoji codepoints. Strip legitimate emoji ZWJ before the invisible-char scan so that only suspicious ZWJ (between ASCII / CJK / Latin etc.) is flagged.

### Key design decisions

- **Emoji range table** (`_EMOJI_CP_RANGES`): covers SMP pictographic ranges, Miscellaneous Symbols, Dingbats, regional indicators, skin tone modifiers, and gender symbols — sufficient for all ZWJ sequences defined in `emoji-sequences.txt` as of Unicode 16.0.
- **VS16 skip**: `_zwj_in_emoji_sequence()` walks past U+FE0F variation selectors before checking neighbours, matching real emoji encoding (e.g. `🏳️‍🌈` is `🏳 + FE0F + 200D + 🌈`).
- **Strip-then-scan**: `_strip_legitimate_emoji_zwj()` removes legitimate ZWJ from a copy of the content, so the existing `INVISIBLE_CHARS` intersection logic works unchanged.

### Security preserved

| Input | Result |
|-------|--------|
| 🤸‍♀️ emoji | ✅ allowed |
| 👨‍👩‍👧 family emoji | ✅ allowed |
| ❤️‍🔥 heart-on-fire | ✅ allowed |
| 👩🏽‍💻 skin-tone emoji | ✅ allowed |
| `hel\u200dlo` (ASCII injection) | 🚫 flagged |
| `忽略\u200d指令` (CJK injection) | 🚫 flagged |
| `café\u200dïgnore` (Latin injection) | 🚫 flagged |
| ZWJ at text edges | 🚫 flagged |
| U+200B, U+2066 etc. | 🚫 still flagged |

## Changes

- `tools/threat_patterns.py`: add `_EMOJI_CP_RANGES`, `_is_emoji_cp()`, `_zwj_in_emoji_sequence()`, `_strip_legitimate_emoji_zwj()`; update `scan_for_threats()` to strip emoji ZWJ before scanning
- `tests/tools/test_threat_patterns.py`: add 10 new test cases (47 total, all passing)
