### PR TITLE
fix(discord): bridge allow_bots from config.yaml to env + adapter

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -943,6 +943,12 @@ def load_gateway_config() -> GatewayConfig:
                     _, extra = _ensure_platform_extra_dict(platforms_data, entry.name)
                     extra.update(seeded)
 
+            # Discord settings → env vars (env vars take precedence)
+            discord_cfg = yaml_cfg.get("discord", {})
+            if isinstance(discord_cfg, dict):
+                if "allow_bots" in discord_cfg and not os.getenv("DISCORD_ALLOW_BOTS"):
+                    os.environ["DISCORD_ALLOW_BOTS"] = str(discord_cfg["allow_bots"]).lower()
+
             # Slack settings → env vars (env vars take precedence)
             slack_cfg = yaml_cfg.get("slack", {})
             if isinstance(slack_cfg, dict):

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -782,7 +782,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 # permitted by DISCORD_ALLOW_BOTS are not rejected for
                 # not being in DISCORD_ALLOWED_USERS (fixes #4466).
                 if getattr(message.author, "bot", False):
-                    allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
+                    allow_bots = (self.config.extra.get("allow_bots") or os.getenv("DISCORD_ALLOW_BOTS", "none")).lower().strip()
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
@@ -3769,7 +3769,7 @@ class DiscordAdapter(BasePlatformAdapter):
             return ""
 
         # Determine which bot messages to include in context
-        allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
+        allow_bots_raw = (self.config.extra.get("allow_bots") or os.getenv("DISCORD_ALLOW_BOTS", "none")).lower().strip()
         include_other_bots = allow_bots_raw != "none"
 
         # Use the in-memory cache to narrow the fetch window on hot paths.


### PR DESCRIPTION
## Problem

The Discord adapter reads `DISCORD_ALLOW_BOTS` from env vars, but unlike Slack and Feishu, the `gateway/config.py` loader never bridged `discord.allow_bots` from `config.yaml` → `DISCORD_ALLOW_BOTS` env var.

Additionally, the adapter itself only checked `os.getenv()` and never `self.config.extra` (YAML-loaded config), so setting `allow_bots` in config.yaml had no effect through either path.

This meant bot-to-bot communication (e.g. multi-agent setups) only worked when configured via `.env` file, not `config.yaml`.

## Fix

1. **`gateway/config.py`**: Add `discord.allow_bots` → `DISCORD_ALLOW_BOTS` env var bridge (mirrors the existing Slack/Feishu pattern)
2. **`plugins/platforms/discord/adapter.py`**: Check `self.config.extra.get('allow_bots')` first, falling back to env var (mirrors `_discord_require_mention` pattern) — both at message ingress (line 785) and history backfill (line 3772)

## Testing

- Verified Slack/Feishu already have this bridge pattern
- Discord adapter's `_discord_require_mention()` uses the same `config.extra` → env fallback pattern