### PR TITLE
fix(approval): keep gateway tirith scan under yolo

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1921,3 +1921,195 @@ class TestTirithImportErrorFailOpenPolicy:
                         result = check_all_command_guards("echo hello", "local")
 
         assert result.get("approved") is True
+
+
+class TestGatewayTirithScannerBypassHardening:
+    """Gateway approval bypasses must not bypass the pre-exec scanner."""
+
+    SESSION_KEY = "test-gateway-tirith-bypass"
+
+    def setup_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        mod._session_approved.clear()
+        mod._session_yolo.clear()
+        mod._permanent_approved.clear()
+        mod._pending.clear()
+
+        self._saved_env = {
+            k: os.environ.get(k)
+            for k in ("HERMES_GATEWAY_SESSION", "HERMES_YOLO_MODE",
+                      "HERMES_SESSION_KEY", "HERMES_INTERACTIVE",
+                      "HERMES_EXEC_ASK", "HERMES_CRON_SESSION")
+        }
+        for key in self._saved_env:
+            os.environ.pop(key, None)
+
+    def teardown_method(self):
+        from tools import approval as mod
+        mod._gateway_queues.clear()
+        mod._gateway_notify_cbs.clear()
+        mod._session_approved.clear()
+        mod._session_yolo.clear()
+        mod._permanent_approved.clear()
+        mod._pending.clear()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _run_gateway_guard_and_resolve(self, mod, command, choice="once"):
+        notified = []
+        result_holder = {}
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+
+        def _check():
+            token = mod.set_current_session_key(self.SESSION_KEY)
+            os.environ["HERMES_GATEWAY_SESSION"] = "1"
+            os.environ["HERMES_SESSION_KEY"] = self.SESSION_KEY
+            try:
+                result_holder["result"] = mod.check_all_command_guards(command, "local")
+            finally:
+                os.environ.pop("HERMES_GATEWAY_SESSION", None)
+                os.environ.pop("HERMES_SESSION_KEY", None)
+                mod.reset_current_session_key(token)
+
+        thread = threading.Thread(target=_check)
+        thread.start()
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if notified and mod._gateway_queues.get(self.SESSION_KEY):
+                break
+            time.sleep(0.02)
+
+        assert notified, "gateway approval prompt was not sent"
+        assert mod._gateway_queues.get(self.SESSION_KEY), "gateway approval queue was not created"
+        mod.resolve_gateway_approval(self.SESSION_KEY, choice)
+        thread.join(timeout=5)
+        mod.unregister_gateway_notify(self.SESSION_KEY)
+        assert "result" in result_holder, "approval wait did not finish"
+        return result_holder["result"], notified
+
+    def _run_gateway_guard_expect_no_prompt(self, mod, command):
+        notified = []
+        result_holder = {}
+        mod.register_gateway_notify(self.SESSION_KEY, lambda data: notified.append(data))
+
+        def _check():
+            token = mod.set_current_session_key(self.SESSION_KEY)
+            os.environ["HERMES_GATEWAY_SESSION"] = "1"
+            os.environ["HERMES_SESSION_KEY"] = self.SESSION_KEY
+            try:
+                result_holder["result"] = mod.check_all_command_guards(command, "local")
+            finally:
+                os.environ.pop("HERMES_GATEWAY_SESSION", None)
+                os.environ.pop("HERMES_SESSION_KEY", None)
+                mod.reset_current_session_key(token)
+
+        thread = threading.Thread(target=_check)
+        thread.start()
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if notified or "result" in result_holder:
+                break
+            time.sleep(0.02)
+
+        if notified:
+            mod.resolve_gateway_approval(self.SESSION_KEY, "deny")
+        thread.join(timeout=5)
+        assert not thread.is_alive(), "approval guard did not return without prompting"
+        mod.unregister_gateway_notify(self.SESSION_KEY)
+        assert notified == []
+        assert "result" in result_holder, "approval guard did not return without prompting"
+        return result_holder["result"]
+
+    def _tirith_warn_result(self):
+        return {
+            "action": "warn",
+            "findings": [{
+                "rule_id": "pipe-to-interpreter",
+                "severity": "HIGH",
+                "title": "Pipe to interpreter",
+                "description": "remote script execution",
+            }],
+            "summary": "remote script execution",
+        }
+
+    def test_gateway_yolo_still_prompts_for_tirith_findings(self, monkeypatch):
+        from tools import approval as mod
+        from tools import tirith_security
+
+        monkeypatch.setattr(
+            tirith_security, "check_command_security",
+            lambda command: self._tirith_warn_result(),
+        )
+        mod.enable_session_yolo(self.SESSION_KEY)
+
+        result, notified = self._run_gateway_guard_and_resolve(mod, "echo safe")
+
+        assert result["approved"] is True
+        assert "Security scan" in notified[0]["description"]
+        assert notified[0]["pattern_keys"] == ["tirith:pipe-to-interpreter"]
+
+    def test_gateway_approval_mode_off_still_prompts_for_tirith_findings(self, monkeypatch):
+        from tools import approval as mod
+        from tools import tirith_security
+
+        monkeypatch.setattr(
+            tirith_security, "check_command_security",
+            lambda command: self._tirith_warn_result(),
+        )
+        monkeypatch.setattr(mod, "_get_approval_mode", lambda: "off")
+
+        result, notified = self._run_gateway_guard_and_resolve(mod, "echo safe")
+
+        assert result["approved"] is True
+        assert "Security scan" in notified[0]["description"]
+
+    def test_gateway_permanent_command_allowlist_still_prompts_for_tirith_findings(self, monkeypatch):
+        from tools import approval as mod
+        from tools import tirith_security
+
+        monkeypatch.setattr(
+            tirith_security, "check_command_security",
+            lambda command: self._tirith_warn_result(),
+        )
+        mod.load_permanent({"echo safe"})
+
+        result, notified = self._run_gateway_guard_and_resolve(mod, "echo safe")
+
+        assert result["approved"] is True
+        assert "Security scan" in notified[0]["description"]
+        assert notified[0]["pattern_keys"] == ["tirith:pipe-to-interpreter"]
+
+    def test_gateway_yolo_still_skips_regex_only_dangerous_prompt(self, monkeypatch):
+        from tools import approval as mod
+        from tools import tirith_security
+
+        monkeypatch.setattr(
+            tirith_security,
+            "check_command_security",
+            lambda command: {"action": "allow", "findings": [], "summary": ""},
+        )
+        mod.enable_session_yolo(self.SESSION_KEY)
+
+        result = self._run_gateway_guard_expect_no_prompt(mod, "rm -rf .git")
+
+        assert result["approved"] is True
+
+    def test_gateway_permanent_command_allowlist_skips_regex_only_dangerous_prompt(self, monkeypatch):
+        from tools import approval as mod
+        from tools import tirith_security
+
+        monkeypatch.setattr(
+            tirith_security,
+            "check_command_security",
+            lambda command: {"action": "allow", "findings": [], "summary": ""},
+        )
+        mod.load_permanent({"rm -rf .git"})
+
+        result = self._run_gateway_guard_expect_no_prompt(mod, "rm -rf .git")
+
+        assert result["approved"] is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1557,18 +1557,25 @@ def check_all_command_guards(command: str, env_type: str,
                        sudo_guess_desc, command[:200])
         return _sudo_stdin_block_result(sudo_guess_desc)
 
-    # --yolo or approvals.mode=off: bypass all approval prompts.
-    # Gateway /yolo is session-scoped; CLI --yolo remains process-scoped.
     approval_mode = _get_approval_mode()
-    if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled() or approval_mode == "off":
-        return {"approved": True, "message": None}
-
-    if _command_matches_permanent_allowlist(command):
-        return {"approved": True, "message": None}
-
     is_cli = env_var_enabled("HERMES_INTERACTIVE")
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
+    is_permanently_allowed = _command_matches_permanent_allowlist(command)
+    approval_bypass_enabled = (
+        _YOLO_MODE_FROZEN
+        or is_current_session_yolo_enabled()
+        or approval_mode == "off"
+    )
+
+    # --yolo or approvals.mode=off bypass approval prompts, not the
+    # gateway/API pre-exec scanner. CLI and other legacy non-gateway paths
+    # keep their historical all-approval bypass behavior.
+    if approval_bypass_enabled and not (is_gateway or is_ask):
+        return {"approved": True, "message": None}
+
+    if is_permanently_allowed and not (is_gateway or is_ask):
+        return {"approved": True, "message": None}
 
     # Preserve the existing non-interactive behavior: outside CLI/gateway/ask
     # flows, we do not block on approvals and we skip external guard work.
@@ -1635,8 +1642,13 @@ def check_all_command_guards(command: str, env_type: str,
             }
         # else: tirith_fail_open is True — allow as before (tirith_result stays "allow")
 
-    # Dangerous command check (detection only, no approval)
-    is_dangerous, pattern_key, description = detect_dangerous_command(command)
+    # Dangerous command check (detection only, no approval).  Approval-bypass
+    # modes intentionally skip regex-driven dangerous-command prompts; Tirith
+    # scanner findings above remain active for gateway/API sessions.
+    if approval_bypass_enabled or is_permanently_allowed:
+        is_dangerous, pattern_key, description = False, None, None
+    else:
+        is_dangerous, pattern_key, description = detect_dangerous_command(command)
 
     # --- Phase 2: Decide ---
 


### PR DESCRIPTION
## Summary

Gateway/API sessions can enable session yolo, `approvals.mode=off`, or permanent command allowlist entries to skip manual dangerous-command prompts, but `check_all_command_guards()` returned before running Tirith. That meant the pre-exec scanner could be skipped in the gateway surfaces tracked by #29153.

This PR keeps CLI and other legacy non-gateway bypass behavior intact, including the historical local interactive shortcut for simple `command_allowlist` matches after the hardline and sudo floors have run. In gateway and ask contexts, it runs Tirith before applying bypass shortcuts so scanner block/warn findings still flow through the existing approval path. Bypass modes continue to suppress regex-only dangerous-command prompts, and local allowlisted simple commands still avoid both Tirith and regex prompts.

The regression coverage now checks session yolo, `approvals.mode=off`, and permanent command allowlist entries in gateway execution, and keeps the prompt helpers synchronized with the actual gateway approval queue so the tests do not mask slow or missing prompt registration.

Fixes #29153

## Tests

- `python -m pytest tests/tools/test_command_guards.py -q -p no:cacheprovider`
- `python -m pytest tests/tools/test_approval.py -q -p no:cacheprovider`
- `python -m pytest tests/tools/test_approval.py::TestGatewayTirithScannerBypassHardening -q -p no:cacheprovider`
- CodeRabbit CLI review on the same final tree before the squash: 0 findings

---

Created by GPT-5.5-xhigh in Codex desktop. The account owner loosely reviewed the actions and receives the usual GitHub notifications.
