### PR TITLE
feat: expose canonical kanban live statuses

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -33,11 +33,10 @@ from hermes_cli.profiles import get_active_profile_name, get_profile_dir, seed_p
 # ---------------------------------------------------------------------------
 
 _STATUS_ICONS = {
-    "todo":     "◻",
-    "ready":    "▶",
-    "running":  "●",
-    "scheduled":"⏱",
+    "working":  "●",
+    "waiting":  "⏱",
     "blocked":  "⊘",
+    "dormant":  "◌",
     "done":     "✓",
     "archived": "—",
 }
@@ -50,10 +49,12 @@ def _fmt_ts(ts: Optional[int]) -> str:
 
 
 def _fmt_task_line(t: kb.Task) -> str:
-    icon = _STATUS_ICONS.get(t.status, "?")
+    live_status = kb.live_status_for(t.status)
+    icon = _STATUS_ICONS.get(live_status, "?")
     assignee = t.assignee or "(unassigned)"
     tenant = f" [{t.tenant}]" if t.tenant else ""
-    return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}"
+    alias = "" if live_status == t.status else f" ({t.status})"
+    return f"{icon} {t.id}  {live_status:8s}{alias:12s}  {assignee:20s}{tenant}  {t.title}"
 
 
 def _task_to_dict(t: kb.Task) -> dict[str, Any]:
@@ -63,6 +64,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "body": t.body,
         "assignee": t.assignee,
         "status": t.status,
+        "live_status": kb.live_status_for(t.status),
         "priority": t.priority,
         "tenant": t.tenant,
         "workspace_kind": t.workspace_kind,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4492,8 +4492,10 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds) after at least one prior
+        worker run exists for the task.  A prior worker already opened a PR;
+        re-spawning risks a duplicate PR on the same task. Fresh tasks with
+        no runs are not guarded by comment PR URLs alone.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -4524,6 +4526,15 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         return "recent_success"
 
     # 3. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    # Fresh tasks with no worker run can legitimately mention related PRs in
+    # coordinator/reporting comments; do not let those comments suppress the
+    # first worker spawn.
+    if not conn.execute(
+        "SELECT id FROM task_runs WHERE task_id = ? LIMIT 1",
+        (task_id,),
+    ).fetchone():
+        return None
+
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
         "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -97,6 +97,34 @@ _log = logging.getLogger(__name__)
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+
+# User-facing live status vocabulary.  The storage-level task.status column
+# intentionally keeps the legacy workflow aliases above for migration and DB
+# compatibility; UI/API/CLI surfaces can call live_status_for() when presenting
+# active work to humans.
+LIVE_STATUSES = {"working", "waiting", "blocked", "dormant"}
+_LIVE_STATUS_ALIASES = {
+    "ready": "working",
+    "queue": "working",
+    "running": "working",
+    "in_progress": "working",
+    "review": "working",
+    "todo": "waiting",
+    "scheduled": "waiting",
+    "blocked": "blocked",
+    "triage": "dormant",
+}
+
+
+def live_status_for(status: str) -> str:
+    """Return the canonical live status for an internal Kanban status.
+
+    ``done`` and ``archived`` are completion/history states, not live profile
+    availability states, so they pass through unchanged for historical views.
+    """
+    return _LIVE_STATUS_ALIASES.get(status, status)
+
+
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 

--- a/hermes_cli/status_lines.py
+++ b/hermes_cli/status_lines.py
@@ -1,0 +1,188 @@
+"""Deterministic Self/Lineage status-line rendering.
+
+The communication contract for project-structured profiles is deliberately
+small: every Matrix/profile-facing status block should contain exactly these
+canonical lines when a status is needed::
+
+    Self status: WORKING|WAITING|BLOCKED|DORMANT — <specific detail>
+    Lineage status: WORKING|WAITING|BLOCKED|DORMANT — <aggregate descendant detail>
+
+This module is pure and dependency-free so scripts, prompts, diagnostics, and
+future gateway integrations can share the same status vocabulary without asking
+an LLM to recompute semantics from broad context.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class StatusDefinition:
+    """Definition for one canonical live status."""
+
+    status: str
+    default_detail: str
+
+
+STATUS_DEFINITIONS: Mapping[str, StatusDefinition] = {
+    "working": StatusDefinition(
+        "working",
+        "active work is underway or immediately queued/spawnable",
+    ),
+    "waiting": StatusDefinition(
+        "waiting",
+        "active work is waiting on non-human/system continuation",
+    ),
+    "blocked": StatusDefinition(
+        "blocked",
+        "active work is prevented by required human action",
+    ),
+    "dormant": StatusDefinition(
+        "dormant",
+        "no active actionable assignment exists",
+    ),
+}
+
+LIVE_STATUSES: tuple[str, ...] = ("working", "waiting", "blocked", "dormant")
+
+# Storage/workflow aliases accepted at the renderer boundary during migration.
+# ``done`` and ``archived`` are not live availability states; for lineage
+# aggregation they contribute no active work, so they collapse to dormant.
+LIVE_STATUS_ALIASES: Mapping[str, str] = {
+    "working": "working",
+    "ready": "working",
+    "queue": "working",
+    "running": "working",
+    "in_progress": "working",
+    "review": "working",
+    "waiting": "waiting",
+    "todo": "waiting",
+    "scheduled": "waiting",
+    "blocked": "blocked",
+    "dormant": "dormant",
+    "triage": "dormant",
+    "done": "dormant",
+    "archived": "dormant",
+}
+
+# Structural lineage uses the approved aggregate rule: active descendant work
+# wins, then human blockers, then non-human waits, then dormant/no work.
+LINEAGE_PRECEDENCE: tuple[str, ...] = ("working", "blocked", "waiting", "dormant")
+
+
+class StatusLineError(ValueError):
+    """Raised when status-line input is invalid."""
+
+
+def normalize_status(status: str) -> str:
+    """Validate and normalize a canonical live status word."""
+
+    candidate = str(status).strip().lower()
+    if candidate not in STATUS_DEFINITIONS:
+        valid = ", ".join(LIVE_STATUSES)
+        raise StatusLineError(f"unknown status {status!r}; expected one of: {valid}")
+    return candidate
+
+
+def canonical_live_status(status: str, *, fail_unknown_to_blocked: bool = False) -> tuple[str, str | None]:
+    """Map storage/compatibility aliases to canonical live statuses.
+
+    Returns ``(live_status, unknown_marker)``. Unknown lineage inputs can fail
+    closed to ``blocked`` so deterministic aggregate output does not hide a
+    potentially human-actionable status vocabulary drift.
+    """
+
+    candidate = str(status).strip().lower()
+    if candidate in LIVE_STATUS_ALIASES:
+        return LIVE_STATUS_ALIASES[candidate], None
+    if fail_unknown_to_blocked:
+        return "blocked", candidate or "<empty>"
+    return normalize_status(candidate), None
+
+
+def render_line(kind: str, status: str, detail: str = "") -> str:
+    """Render one canonical status line.
+
+    ``kind`` must be ``self`` or ``lineage``. Output status words are uppercase
+    to match profile-prompt contracts; input is case-insensitive.
+    """
+
+    labels = {"self": "Self status", "lineage": "Lineage status"}
+    if kind not in labels:
+        raise StatusLineError("status line kind must be 'self' or 'lineage'")
+    normalized = normalize_status(status)
+    clean_detail = detail.strip() or STATUS_DEFINITIONS[normalized].default_detail
+    return f"{labels[kind]}: {normalized.upper()} — {clean_detail}"
+
+
+def lineage_counts(statuses: Iterable[str]) -> tuple[Counter[str], list[str]]:
+    """Count structural descendant statuses by canonical live state."""
+
+    counts: Counter[str] = Counter({status: 0 for status in LIVE_STATUSES})
+    unknown: list[str] = []
+    for status in statuses:
+        live_status, unknown_marker = canonical_live_status(status, fail_unknown_to_blocked=True)
+        counts[live_status] += 1
+        if unknown_marker is not None:
+            unknown.append(unknown_marker)
+    return counts, unknown
+
+
+def lineage_headline(counts: Mapping[str, int]) -> str:
+    """Choose the aggregate Lineage status from descendant counts."""
+
+    for status in LINEAGE_PRECEDENCE:
+        if counts.get(status, 0) > 0:
+            return status
+    return "dormant"
+
+
+def format_lineage_counts(counts: Mapping[str, int], unknown: Sequence[str] = ()) -> str:
+    """Render concise deterministic lineage evidence in canonical order."""
+
+    detail = "; ".join(f"{status}: {counts.get(status, 0)}" for status in LIVE_STATUSES)
+    if unknown:
+        detail += "; unknown→blocked: " + ", ".join(sorted(set(unknown)))
+    return detail
+
+
+def render_lineage_aggregate(statuses: Iterable[str]) -> str:
+    """Render the aggregate Lineage status line for structural descendants."""
+
+    counts, unknown = lineage_counts(statuses)
+    headline = lineage_headline(counts)
+    return render_line("lineage", headline, format_lineage_counts(counts, unknown))
+
+
+def render_status_pair(
+    self_status: str,
+    self_detail: str,
+    lineage_status: str,
+    lineage_detail: str,
+) -> str:
+    """Render a two-line Self/Lineage status block from scalar inputs."""
+
+    return "\n".join(
+        [
+            render_line("self", self_status, self_detail),
+            render_line("lineage", lineage_status, lineage_detail),
+        ]
+    )
+
+
+def render_status_with_lineage_aggregate(
+    self_status: str,
+    self_detail: str,
+    lineage_statuses: Iterable[str],
+) -> str:
+    """Render Self status plus aggregate descendant Lineage status."""
+
+    return "\n".join(
+        [
+            render_line("self", self_status, self_detail),
+            render_lineage_aggregate(lineage_statuses),
+        ]
+    )

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -69,27 +69,33 @@
     return body || raw;
   }
 
-  // Order matches BOARD_COLUMNS in plugin_api.py.
-  const COLUMN_ORDER = ["triage", "todo", "ready", "running", "blocked", "done"];
+  // Order matches BOARD_COLUMNS in plugin_api.py. Column names remain the
+  // storage-level compatibility aliases; labels/help expose canonical live
+  // statuses (working/waiting/blocked/dormant) plus done history.
+  const COLUMN_ORDER = ["triage", "todo", "scheduled", "ready", "running", "review", "blocked", "done"];
   // English fallback dictionaries — used when the i18n catalog is missing
   // a key, and as defaults for the get*() helpers below so callers running
   // outside any React component (where there's no `t`) still get sane text.
   const FALLBACK_COLUMN_LABEL = {
-    triage: "Triage",
-    todo: "Todo",
-    ready: "Ready",
-    running: "In Progress",
+    triage: "Dormant (triage)",
+    todo: "Waiting (dependencies)",
+    scheduled: "Waiting (scheduled)",
+    ready: "Working (queued)",
+    running: "Working (running)",
+    review: "Working (review)",
     blocked: "Blocked",
-    done: "Done",
+    done: "Done (history)",
     archived: "Archived",
   };
   const FALLBACK_COLUMN_HELP = {
-    triage: "Raw ideas — a specifier will flesh out the spec",
-    todo: "Waiting on dependencies or unassigned",
-    ready: "Dependencies satisfied; assign a profile to dispatch",
-    running: "Claimed by a worker — in-flight",
-    blocked: "Worker asked for human input",
-    done: "Completed",
+    triage: "Dormant: no concrete active spec yet; human/specifier instruction is needed to resume",
+    todo: "Waiting: a concrete task exists but dependencies or assignment are not ready",
+    scheduled: "Waiting: paused on a non-human time/schedule condition",
+    ready: "Working: queued and immediately spawnable by the dispatcher",
+    running: "Working: claimed by a worker and in-flight",
+    review: "Working: reviewer work is claimable",
+    blocked: "Blocked: a specific active task is prevented by required human action",
+    done: "Completion history; not a live availability state",
     archived: "Archived",
   };
   const FALLBACK_DESTRUCTIVE = {
@@ -2985,7 +2991,7 @@
             }, t.title || tx(i18n, "untitled", "(untitled)")),
       ),
       h("div", { className: "hermes-kanban-drawer-meta" },
-        h(MetaRow, { label: tx(i18n, "status", "Status"), value: t.status }),
+        h(MetaRow, { label: tx(i18n, "status", "Status"), value: `${(t.live_status || t.status)}${t.live_status && t.live_status !== t.status ? " (alias: " + t.status + ")" : ""}` }),
         h(AssigneeEditor, { task: t, onPatch: props.onPatch }),
         h(PriorityEditor, { task: t, onPatch: props.onPatch }),
         t.tenant ? h(MetaRow, { label: tx(i18n, "tenant", "Tenant"), value: t.tenant }) : null,

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -69,34 +69,44 @@
     return body || raw;
   }
 
-  // Order matches BOARD_COLUMNS in plugin_api.py. Column names remain the
-  // storage-level compatibility aliases; labels/help expose canonical live
-  // statuses (working/waiting/blocked/dormant) plus done history.
-  const COLUMN_ORDER = ["triage", "todo", "scheduled", "ready", "running", "review", "blocked", "done"];
+  // Order matches BOARD_COLUMNS in plugin_api.py. Columns are canonical
+  // human-facing live statuses; storage workflow aliases stay internal.
+  const COLUMN_ORDER = ["working", "waiting", "blocked", "dormant", "done"];
+  const COLUMN_TARGET_STATUS = {
+    working: "ready",
+    waiting: "todo",
+    blocked: "blocked",
+    dormant: "triage",
+    done: "done",
+    archived: "archived",
+  };
+  function targetStatusForColumn(status) {
+    return COLUMN_TARGET_STATUS[status] || status;
+  }
+  function liveStatusForAlias(status) {
+    if (status === "ready" || status === "queue" || status === "running" || status === "in_progress" || status === "review") return "working";
+    if (status === "todo" || status === "scheduled") return "waiting";
+    if (status === "triage") return "dormant";
+    return status;
+  }
   // English fallback dictionaries — used when the i18n catalog is missing
   // a key, and as defaults for the get*() helpers below so callers running
   // outside any React component (where there's no `t`) still get sane text.
   const FALLBACK_COLUMN_LABEL = {
-    triage: "Dormant (triage)",
-    todo: "Waiting (dependencies)",
-    scheduled: "Waiting (scheduled)",
-    ready: "Working (queued)",
-    running: "Working (running)",
-    review: "Working (review)",
+    working: "Working",
+    waiting: "Waiting",
     blocked: "Blocked",
+    dormant: "Dormant",
     done: "Done (history)",
     archived: "Archived",
   };
   const FALLBACK_COLUMN_HELP = {
-    triage: "Dormant: no concrete active spec yet; human/specifier instruction is needed to resume",
-    todo: "Waiting: a concrete task exists but dependencies or assignment are not ready",
-    scheduled: "Waiting: paused on a non-human time/schedule condition",
-    ready: "Working: queued and immediately spawnable by the dispatcher",
-    running: "Working: claimed by a worker and in-flight",
-    review: "Working: reviewer work is claimable",
-    blocked: "Blocked: a specific active task is prevented by required human action",
-    done: "Completion history; not a live availability state",
-    archived: "Archived",
+    working: "Working: active work is underway or immediately queued/spawnable",
+    waiting: "Waiting: a specific active task/duty/dependency is waiting on non-human/system action",
+    blocked: "Blocked: requires human intervention; non-human pauses should be waiting",
+    dormant: "Dormant: no active actionable assignment exists",
+    done: "Done is completion history, not live availability",
+    archived: "Hidden from normal board views",
   };
   const FALLBACK_DESTRUCTIVE = {
     done: "Mark this task as done? The worker's claim is released and dependent children become ready.",
@@ -141,11 +151,10 @@
   }
 
   const COLUMN_DOT = {
-    triage: "hermes-kanban-dot-triage",
-    todo: "hermes-kanban-dot-todo",
-    ready: "hermes-kanban-dot-ready",
-    running: "hermes-kanban-dot-running",
+    working: "hermes-kanban-dot-ready",
+    waiting: "hermes-kanban-dot-todo",
     blocked: "hermes-kanban-dot-blocked",
+    dormant: "hermes-kanban-dot-triage",
     done: "hermes-kanban-dot-done",
     archived: "hermes-kanban-dot-archived",
   };
@@ -655,14 +664,15 @@
     const moveTask = useCallback(function (taskId, newStatus) {
       const confirmMsg = getDestructiveConfirm(t, newStatus);
       if (confirmMsg && !window.confirm(confirmMsg)) return;
-      const patch = withCompletionSummary({ status: newStatus }, 1, t);
+      const targetStatus = targetStatusForColumn(newStatus);
+      const patch = withCompletionSummary({ status: targetStatus }, 1, t);
       if (!patch) return;
       setBoardData(function (b) {
         if (!b) return b;
         let moved = null;
         const columns = b.columns.map(function (col) {
           const next = col.tasks.filter(function (t) {
-            if (t.id === taskId) { moved = Object.assign({}, t, { status: newStatus }); return false; }
+            if (t.id === taskId) { moved = Object.assign({}, t, { status: targetStatus, live_status: liveStatusForAlias(targetStatus) }); return false; }
             return true;
           });
           return Object.assign({}, col, { tasks: next });
@@ -689,10 +699,11 @@
       setFailedIds(new Set());
     }, []);
     const moveSelected = useCallback(function (newStatus) {
-      const confirmMsg = DESTRUCTIVE_TRANSITIONS[newStatus];
+      const confirmMsg = getDestructiveConfirm(t, newStatus);
       if (confirmMsg && !window.confirm(confirmMsg)) return;
       if (selectedIds.size === 0) return;
-      const patch = withCompletionSummary({ status: newStatus }, selectedIds.size);
+      const targetStatus = targetStatusForColumn(newStatus);
+      const patch = withCompletionSummary({ status: targetStatus }, selectedIds.size);
       if (!patch) return;
       const ids = Array.from(selectedIds);
       // Optimistic UI: remove selected from all columns and prepend to target.
@@ -702,7 +713,7 @@
         const columns = b.columns.map(function (col) {
           const kept = [];
           for (const t of col.tasks) {
-            if (selectedIds.has(t.id)) moved.push(Object.assign({}, t, { status: newStatus }));
+            if (selectedIds.has(t.id)) moved.push(Object.assign({}, t, { status: targetStatus, live_status: liveStatusForAlias(targetStatus) }));
             else kept.push(t);
           }
           return Object.assign({}, col, { tasks: kept });
@@ -829,7 +840,11 @@
     const applyBulk = useCallback(function (patch, confirmMsg) {
       if (selectedIds.size === 0) return;
       if (confirmMsg && !window.confirm(confirmMsg)) return;
-      const finalPatch = withCompletionSummary(patch, selectedIds.size, t);
+      const requestedColumnStatus = patch && patch.status;
+      const normalizedPatch = requestedColumnStatus
+        ? Object.assign({}, patch, { status: targetStatusForColumn(requestedColumnStatus) })
+        : patch;
+      const finalPatch = withCompletionSummary(normalizedPatch, selectedIds.size, t);
       if (!finalPatch) return;
       const body = Object.assign({ ids: Array.from(selectedIds) }, finalPatch);
       // Optimistic UI for status moves (same pattern as moveSelected).
@@ -840,12 +855,12 @@
           const columns = b.columns.map(function (col) {
             const kept = [];
             for (const t of col.tasks) {
-              if (selectedIds.has(t.id)) moved.push(Object.assign({}, t, { status: finalPatch.status }));
+              if (selectedIds.has(t.id)) moved.push(Object.assign({}, t, { status: finalPatch.status, live_status: liveStatusForAlias(finalPatch.status) }));
               else kept.push(t);
             }
             return Object.assign({}, col, { tasks: kept });
           });
-          const dest = columns.find(function (c) { return c.name === finalPatch.status; });
+          const dest = columns.find(function (c) { return c.name === (requestedColumnStatus || liveStatusForAlias(finalPatch.status)); });
           if (dest) dest.tasks = moved.concat(dest.tasks);
           return Object.assign({}, b, { columns });
         });
@@ -2040,15 +2055,15 @@
       h("span", { className: "hermes-kanban-bulk-count" },
         `${props.count} ${tx(t, "selected", "selected")}`),
       h(Button, {
-        onClick: function () { props.onApply({ status: "todo" }); },
+        onClick: function () { props.onApply({ status: "waiting" }); },
         size: "sm",
-        title: "Move selected tasks to Todo.",
-      }, "→ todo"),
+        title: "Move selected tasks to Waiting (stored as todo for dispatcher compatibility).",
+      }, "→ waiting"),
       h(Button, {
-        onClick: function () { props.onApply({ status: "ready" }); },
+        onClick: function () { props.onApply({ status: "working" }); },
         size: "sm",
-        title: "Move selected tasks to Ready. Ready tasks are picked up by the dispatcher on the next tick.",
-      }, "→ ready"),
+        title: "Move selected tasks to Working (stored as ready so the dispatcher can pick them up).",
+      }, "→ working"),
       h(Button, {
         onClick: function () { props.onApply({ status: "blocked" },
           `Block ${props.count} task(s)?`); },
@@ -2056,10 +2071,10 @@
         title: "Block selected tasks. Releases any active claims.",
       }, "Block"),
       h(Button, {
-        onClick: function () { props.onApply({ status: "ready" },
+        onClick: function () { props.onApply({ status: "working" },
           `Unblock ${props.count} task(s)?`); },
         size: "sm",
-        title: "Unblock selected tasks (promote to Ready).",
+        title: "Unblock selected tasks (promote to Working; stored as ready).",
       }, "Unblock"),
       h(Button, {
         onClick: function () {
@@ -2292,7 +2307,7 @@
     };
 
     const lanes = useMemo(function () {
-      if (!props.laneByProfile || props.column.name !== "running") return null;
+      if (!props.laneByProfile || props.column.name !== "working") return null;
       const byProfile = {};
       for (const tk of props.column.tasks) {
         const key = tk.assignee || "(unassigned)";
@@ -2412,7 +2427,7 @@
     const age = task.status === "running"
       ? task.age.started_age_seconds
       : task.age.created_age_seconds;
-    const tier = STALENESS[task.status];
+    const tier = STALENESS[task.live_status || liveStatusForAlias(task.status)];
     if (!tier || age == null) return "";
     if (age >= tier.red)   return "hermes-kanban-card--stale-red";
     if (age >= tier.amber) return "hermes-kanban-card--stale-amber";
@@ -2488,7 +2503,7 @@
       draggable: true,
       tabIndex: 0,
       role: "button",
-      "aria-label": `${t.title || "untitled"} — ${t.id} — ${t.status}`,
+      "aria-label": `${t.title || "untitled"} — ${t.id} — ${t.live_status || liveStatusForAlias(t.status)}`,
       onDragStart: handleDragStart,
       onClick: handleClick,
       onKeyDown: handleKeyDown,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -137,7 +137,7 @@ def _conn(board: Optional[str] = None):
 # tasks into ``todo`` and makes the dashboard look like the Scheduled column
 # disappeared.
 BOARD_COLUMNS: list[str] = [
-    "triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done",
+    "triage", "todo", "scheduled", "ready", "running", "review", "blocked", "done",
 ]
 
 
@@ -161,6 +161,7 @@ def _task_dict(
     # ``task_runs.summary`` (the kanban-worker pattern) instead of
     # ``tasks.result``. ``None`` when no run has produced a summary yet.
     d["latest_summary"] = latest_summary
+    d["live_status"] = kanban_db.live_status_for(task.status)
     # Keep body short on list endpoints; full body comes from /tasks/:id.
     return d
 
@@ -473,7 +474,7 @@ def get_board(
 
         return {
             "columns": [
-                {"name": name, "tasks": columns[name]} for name in columns.keys()
+                {"name": name, "live_status": kanban_db.live_status_for(name), "tasks": columns[name]} for name in columns.keys()
             ],
             "tenants": tenants,
             "assignees": assignees,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -128,17 +128,24 @@ def _conn(board: Optional[str] = None):
 # Serialization helpers
 # ---------------------------------------------------------------------------
 
-# Columns shown by the dashboard, in left-to-right order. "archived" is
-# available via a filter toggle rather than a visible column.
-#
-# Keep this in sync with kanban_db.VALID_STATUSES.  In particular,
-# ``scheduled`` is a first-class waiting column used for time-based follow-ups;
-# if it is omitted here, the board-level fallback below mis-buckets scheduled
-# tasks into ``todo`` and makes the dashboard look like the Scheduled column
-# disappeared.
-BOARD_COLUMNS: list[str] = [
-    "triage", "todo", "scheduled", "ready", "running", "review", "blocked", "done",
-]
+# Columns shown by the dashboard, in left-to-right order.  These are the
+# canonical human-facing live statuses, not storage-level workflow aliases.
+# ``done`` remains visible as completion history; ``archived`` is available via
+# a filter toggle rather than a visible live-status column.
+BOARD_COLUMNS: list[str] = ["working", "waiting", "blocked", "dormant", "done"]
+
+# Moving a card into a canonical live-status column still writes a storage-level
+# workflow status for DB/dispatcher compatibility.  The aliases stay internal;
+# the dashboard groups by live_status so users do not see separate todo vs
+# scheduled or ready vs running lanes as primary semantics.
+COLUMN_TARGET_STATUS: dict[str, str] = {
+    "working": "ready",
+    "waiting": "todo",
+    "blocked": "blocked",
+    "dormant": "triage",
+    "done": "done",
+    "archived": "archived",
+}
 
 
 _CARD_SUMMARY_PREVIEW_CHARS = 200
@@ -450,7 +457,11 @@ def get_board(
                 # needs the summary.
                 d["diagnostics"] = diags
                 d["warnings"] = _warnings_summary_from_diagnostics(diags)
-            col = t.status if t.status in columns else "todo"
+            col = d.get("live_status")
+            if t.status in {"done", "archived"}:
+                col = t.status
+            if col not in columns:
+                col = "waiting"
             columns[col].append(d)
 
         # Stable per-column ordering already applied by list_tasks
@@ -474,7 +485,13 @@ def get_board(
 
         return {
             "columns": [
-                {"name": name, "live_status": kanban_db.live_status_for(name), "tasks": columns[name]} for name in columns.keys()
+                {
+                    "name": name,
+                    "live_status": name if name in kanban_db.LIVE_STATUSES else kanban_db.live_status_for(name),
+                    "target_status": COLUMN_TARGET_STATUS.get(name, name),
+                    "tasks": columns[name],
+                }
+                for name in columns.keys()
             ],
             "tenants": tenants,
             "assignees": assignees,

--- a/scripts/render_status_lines.py
+++ b/scripts/render_status_lines.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Render deterministic Self/Lineage status lines.
+
+This is a lightweight copy-paste helper for profile/Matrix status reporting. It
+uses the canonical live vocabulary (working/waiting/blocked/dormant) and accepts
+legacy Kanban aliases only at the input boundary for migration compatibility.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Allow running directly from a source checkout without installation.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from hermes_cli.status_lines import (  # noqa: E402
+    LIVE_STATUSES,
+    StatusLineError,
+    render_status_pair,
+    render_status_with_lineage_aggregate,
+)
+
+
+def _statuses_from_counts(count_args: list[list[str]] | None) -> list[str]:
+    statuses: list[str] = []
+    for status, raw_count in count_args or []:
+        try:
+            count = int(raw_count)
+        except ValueError as exc:
+            raise StatusLineError(f"invalid count {raw_count!r} for lineage status {status!r}") from exc
+        if count < 0:
+            raise StatusLineError(f"negative count {count} for lineage status {status!r}")
+        statuses.extend([status] * count)
+    return statuses
+
+
+def _statuses_from_json(path: Path) -> list[str]:
+    data = json.loads(path.read_text())
+    if isinstance(data, dict):
+        for key in ("descendants", "profiles", "tasks"):
+            if key in data:
+                data = data[key]
+                break
+    if not isinstance(data, list):
+        raise StatusLineError("lineage JSON must be a list or an object with descendants/profiles/tasks")
+
+    statuses: list[str] = []
+    for idx, item in enumerate(data):
+        if isinstance(item, str):
+            statuses.append(item)
+            continue
+        if isinstance(item, dict):
+            for key in ("live_status", "status", "state", "kanban_status"):
+                if key in item:
+                    statuses.append(str(item[key]))
+                    break
+            else:
+                raise StatusLineError(f"lineage JSON item {idx} lacks live_status/status/state/kanban_status")
+            continue
+        raise StatusLineError(f"lineage JSON item {idx} must be a string or object")
+    return statuses
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Render deterministic Self/Lineage status lines.")
+    parser.add_argument(
+        "--self",
+        nargs=2,
+        metavar=("STATUS", "DETAIL"),
+        required=True,
+        help="self status and specific detail text",
+    )
+    lineage = parser.add_mutually_exclusive_group(required=True)
+    lineage.add_argument(
+        "--lineage",
+        nargs=2,
+        metavar=("STATUS", "DETAIL"),
+        help="explicit lineage status and detail text",
+    )
+    lineage.add_argument(
+        "--lineage-status",
+        action="append",
+        metavar="STATUS",
+        help="one structural descendant status; repeat to aggregate",
+    )
+    lineage.add_argument(
+        "--lineage-count",
+        action="append",
+        nargs=2,
+        metavar=("STATUS", "COUNT"),
+        help="aggregate descendant status count, e.g. --lineage-count working 2",
+    )
+    lineage.add_argument(
+        "--lineage-json",
+        type=Path,
+        metavar="PATH",
+        help="JSON list/object containing descendant statuses",
+    )
+    parser.add_argument(
+        "--list-statuses",
+        action="store_true",
+        help="print the canonical live status vocabulary before the rendered block",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.lineage is not None:
+            rendered = render_status_pair(args.self[0], args.self[1], args.lineage[0], args.lineage[1])
+        elif args.lineage_status is not None:
+            rendered = render_status_with_lineage_aggregate(args.self[0], args.self[1], args.lineage_status)
+        elif args.lineage_count is not None:
+            rendered = render_status_with_lineage_aggregate(args.self[0], args.self[1], _statuses_from_counts(args.lineage_count))
+        else:
+            rendered = render_status_with_lineage_aggregate(args.self[0], args.self[1], _statuses_from_json(args.lineage_json))
+    except (OSError, json.JSONDecodeError, StatusLineError) as exc:
+        parser.error(str(exc))
+
+    if args.list_statuses:
+        print("Canonical live statuses: " + ", ".join(LIVE_STATUSES))
+    print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/devops/kanban-orchestrator/SKILL.md
+++ b/skills/devops/kanban-orchestrator/SKILL.md
@@ -17,7 +17,7 @@ metadata:
 
 Hermes setups vary widely. Some users run a single profile that does everything; some run a small fleet (`docker-worker`, `cron-worker`); some run a curated specialist team they've named themselves. There is **no default specialist roster** — the orchestrator skill does not know what profiles exist on this machine.
 
-Before fanning out, you must ground the decomposition in the profiles that actually exist. The dispatcher silently fails to spawn unknown assignee names — it doesn't autocorrect, doesn't suggest, doesn't fall back. So a card assigned to `researcher` on a setup that only has `docker-worker` just sits in `ready` forever.
+Before fanning out, you must ground the decomposition in the profiles that actually exist. The dispatcher silently fails to spawn unknown assignee names — it doesn't autocorrect, doesn't suggest, doesn't fall back. So a card assigned to `researcher` on a setup that only has `docker-worker` remains `working`/queued (internal alias `ready`) forever.
 
 **Step 0: discover available profiles before planning.**
 
@@ -162,7 +162,7 @@ Tell them what you created in plain prose, naming the actual profiles you used:
 
 ## Pitfalls
 
-**Inventing profile names that don't exist.** The dispatcher silently fails to spawn unknown assignees — the card just sits in `ready` forever. Always assign to a profile from your Step 0 discovery; ask the user if you're unsure.
+**Inventing profile names that don't exist.** The dispatcher silently fails to spawn unknown assignees — the card remains `working`/queued (internal alias `ready`) forever. Always assign to a profile from your Step 0 discovery; ask the user if you're unsure.
 
 **Bundling independent lanes into one card.** If the user asks for two independent outcomes, create two cards. Example: "fix blockers and check model variants" is not one fixer task; create a fixer/engineer card for the fixes and an explorer/researcher card for the variant check, then optionally gate review on both.
 
@@ -182,7 +182,7 @@ Tell them what you created in plain prose, naming the actual profiles you used:
 
 When a worker profile keeps crashing, hallucinating, or getting blocked by its own mistakes (usually: wrong model, missing skill, broken credential), the kanban dashboard flags the task with a ⚠ badge and opens a **Recovery** section in the drawer. Three primary actions:
 
-1. **Reclaim** (or `hermes kanban reclaim <task_id>`) — abort the running worker immediately and reset the task to `ready`. The existing claim TTL is ~15 min; this is the fast path out.
+1. **Reclaim** (or `hermes kanban reclaim <task_id>`) — abort the running worker immediately and reset the task to `working`/queued (internal alias `ready`). The existing claim TTL is ~15 min; this is the fast path out.
 2. **Reassign** (or `hermes kanban reassign <task_id> <new-profile> --reclaim`) — switch the task to a different profile (one that exists on this setup) and let the dispatcher pick it up with a fresh worker.
 3. **Change profile model** — the dashboard prints a copy-paste hint for `hermes -p <profile> model` since profile config lives on disk; edit it in a terminal, then Reclaim to retry with the new model.
 

--- a/skills/devops/kanban-orchestrator/SKILL.md
+++ b/skills/devops/kanban-orchestrator/SKILL.md
@@ -19,6 +19,8 @@ Hermes setups vary widely. Some users run a single profile that does everything;
 
 Before fanning out, you must ground the decomposition in the profiles that actually exist. The dispatcher silently fails to spawn unknown assignee names — it doesn't autocorrect, doesn't suggest, doesn't fall back. So a card assigned to `researcher` on a setup that only has `docker-worker` remains `working`/queued (internal alias `ready`) forever.
 
+For project-structured communication, status reports should use the generic canonical pair `Self status:` and `Lineage status:`. `Lineage status` is structural parent/child responsibility under a profile, not the same as the task dependency graph you create with `parents=[...]`. Do not use legacy `Blocker status:` / `NOT BLOCKED`, and do not replace the generic pair with role-specific labels such as `Coordinator status:`. Prefer deterministic helper output from `python scripts/render_status_lines.py --self ... --lineage-count ...` when available.
+
 **Step 0: discover available profiles before planning.**
 
 Use one of these:

--- a/skills/devops/kanban-worker/SKILL.md
+++ b/skills/devops/kanban-worker/SKILL.md
@@ -13,6 +13,10 @@ metadata:
 
 > You're seeing this skill because the Hermes Kanban dispatcher spawned you as a worker with `--skills kanban-worker` — it's loaded automatically for every dispatched worker. The **lifecycle** (6 steps: orient → work → heartbeat → block/complete) also lives in the `KANBAN_GUIDANCE` block that's auto-injected into your system prompt. This skill is the deeper detail: good handoff shapes, retry diagnostics, edge cases.
 
+## Live status vocabulary
+
+Use canonical live statuses in user-facing prose: `working`, `waiting`, `blocked`, `dormant`. Internal Kanban DB/workflow aliases remain valid during migration: `ready`/`queue`/`running`/`in_progress`/`review` map to `working`; dependency-held `todo` and `scheduled` map to `waiting`; unspecced `triage` maps to `dormant`; `done` is completion history only. Reserve `blocked` for a specific active task/duty/dependency prevented by human action.
+
 ## Workspace handling
 
 Your workspace kind determines how you should behave inside `$HERMES_KANBAN_WORKSPACE`:

--- a/skills/devops/kanban-worker/SKILL.md
+++ b/skills/devops/kanban-worker/SKILL.md
@@ -17,6 +17,8 @@ metadata:
 
 Use canonical live statuses in user-facing prose: `working`, `waiting`, `blocked`, `dormant`. Internal Kanban DB/workflow aliases remain valid during migration: `ready`/`queue`/`running`/`in_progress`/`review` map to `working`; dependency-held `todo` and `scheduled` map to `waiting`; unspecced `triage` maps to `dormant`; `done` is completion history only. Reserve `blocked` for a specific active task/duty/dependency prevented by human action.
 
+For Matrix/profile-facing project communication, use generic `Self status:` and `Lineage status:` lines. Do not introduce role-specific replacements such as `Coordinator status:`, and do not use legacy `Blocker status:` or `NOT BLOCKED` wording in new prompts. `Self status` describes this profile's own active action/wait/human blocker/dormant condition; `Lineage status` aggregates structural descendants and is separate from task dependency links. When deterministic output is needed, prefer the repo helper `python scripts/render_status_lines.py --self ... --lineage-count ...` over recomputing the wording from broad LLM context.
+
 ## Workspace handling
 
 Your workspace kind determines how you should behave inside `$HERMES_KANBAN_WORKSPACE`:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1230,16 +1230,34 @@ def test_respawn_guard_stale_success_not_guarded(kanban_home):
     assert reason is None
 
 
-def test_respawn_guard_active_pr_in_comment(kanban_home):
-    """A GitHub PR URL in a recent comment triggers active_pr."""
+def test_respawn_guard_active_pr_in_comment_after_worker_run(kanban_home):
+    """A GitHub PR URL in a recent comment triggers active_pr after a worker run."""
     with kb.connect() as conn:
         t = kb.create_task(conn, title="has-pr", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'blocked', 'blocked', ?, ?)",
+            (t, now - 300, now - 60),
+        )
         kb.add_comment(
             conn, t, "worker",
             "PR created: https://github.com/totemx-AI/subsidysmart/pull/42",
         )
         reason = kb.check_respawn_guard(conn, t)
     assert reason == "active_pr"
+
+
+def test_respawn_guard_pr_comment_without_worker_run_not_guarded(kanban_home):
+    """A PR URL alone must not block fresh coordinator/readiness tasks."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="readiness-report", assignee="alice")
+        kb.add_comment(
+            conn, t, "coordinator",
+            "Related implementation PR: https://github.com/acme/project/pull/42",
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
 
 
 def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
@@ -1339,6 +1357,12 @@ def test_dispatch_respawn_guard_skips_active_pr(
 
     with kb.connect() as conn:
         t = kb.create_task(conn, title="has-pr", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'blocked', 'blocked', ?, ?)",
+            (t, now - 300, now - 60),
+        )
         kb.add_comment(
             conn, t, "worker",
             "Opened https://github.com/totemx-AI/subsidysmart/pull/99",
@@ -1350,6 +1374,28 @@ def test_dispatch_respawn_guard_skips_active_pr(
     assert t not in res.auto_blocked
     with kb.connect() as conn:
         assert kb.get_task(conn, t).status == "ready"
+
+
+def test_dispatch_respawn_guard_allows_pr_url_comment_without_worker_run(
+    kanban_home, all_assignees_spawnable
+):
+    """dispatch_once spawns fresh tasks even when comments mention PR URLs."""
+    spawned_ids = []
+
+    def fake_spawn(task, workspace):
+        spawned_ids.append(task.id)
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="readiness-report", assignee="alice")
+        kb.add_comment(
+            conn, t, "coordinator",
+            "Related PR for context: https://github.com/acme/project/pull/42",
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert t in spawned_ids
+    assert not res.respawn_guarded
+    assert t not in res.auto_blocked
 
 
 def test_dispatch_respawn_guard_dry_run_no_auto_block(

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -25,6 +25,27 @@ def kanban_home(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Live status aliases
+# ---------------------------------------------------------------------------
+
+
+def test_live_status_for_maps_internal_compatibility_aliases():
+    assert kb.LIVE_STATUSES == {"working", "waiting", "blocked", "dormant"}
+    assert kb.live_status_for("ready") == "working"
+    assert kb.live_status_for("queue") == "working"
+    assert kb.live_status_for("running") == "working"
+    assert kb.live_status_for("in_progress") == "working"
+    assert kb.live_status_for("review") == "working"
+    assert kb.live_status_for("todo") == "waiting"
+    assert kb.live_status_for("scheduled") == "waiting"
+    assert kb.live_status_for("blocked") == "blocked"
+    assert kb.live_status_for("triage") == "dormant"
+    # Completion/history states are not live availability states.
+    assert kb.live_status_for("done") == "done"
+    assert kb.live_status_for("archived") == "archived"
+
+
+# ---------------------------------------------------------------------------
 # Schema / init
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_status_lines.py
+++ b/tests/hermes_cli/test_status_lines.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.status_lines import (
+    StatusLineError,
+    canonical_live_status,
+    lineage_counts,
+    lineage_headline,
+    render_line,
+    render_lineage_aggregate,
+    render_status_pair,
+    render_status_with_lineage_aggregate,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "render_status_lines.py"
+
+
+def test_render_line_uses_canonical_label_and_uppercase_status() -> None:
+    assert render_line("self", "working", "editing status semantics") == (
+        "Self status: WORKING — editing status semantics"
+    )
+    assert render_line("lineage", "dormant", "no descendants") == (
+        "Lineage status: DORMANT — no descendants"
+    )
+
+
+def test_render_status_pair_outputs_two_canonical_lines() -> None:
+    assert render_status_pair(
+        "waiting",
+        "CI is still running",
+        "blocked",
+        "one descendant needs Yunuen review",
+    ) == (
+        "Self status: WAITING — CI is still running\n"
+        "Lineage status: BLOCKED — one descendant needs Yunuen review"
+    )
+
+
+@pytest.mark.parametrize(
+    ("internal", "canonical"),
+    [
+        ("running", "working"),
+        ("ready", "working"),
+        ("queue", "working"),
+        ("in_progress", "working"),
+        ("review", "working"),
+        ("todo", "waiting"),
+        ("scheduled", "waiting"),
+        ("blocked", "blocked"),
+        ("triage", "dormant"),
+        ("done", "dormant"),
+        ("archived", "dormant"),
+    ],
+)
+def test_canonical_live_status_aliases(internal: str, canonical: str) -> None:
+    assert canonical_live_status(internal) == (canonical, None)
+
+
+def test_lineage_aggregate_prefers_working_and_keeps_blocked_counts() -> None:
+    output = render_status_with_lineage_aggregate(
+        "working",
+        "updating status contract",
+        ["running", "blocked", "todo", "done"],
+    )
+    assert output == (
+        "Self status: WORKING — updating status contract\n"
+        "Lineage status: WORKING — working: 1; waiting: 1; blocked: 1; dormant: 1"
+    )
+
+
+def test_lineage_headline_rules() -> None:
+    counts, unknown = lineage_counts(["blocked", "todo"])
+    assert not unknown
+    assert lineage_headline(counts) == "blocked"
+
+    counts, unknown = lineage_counts(["scheduled"])
+    assert not unknown
+    assert lineage_headline(counts) == "waiting"
+
+    counts, unknown = lineage_counts([])
+    assert not unknown
+    assert lineage_headline(counts) == "dormant"
+
+
+def test_unknown_lineage_status_fails_closed_to_blocked() -> None:
+    assert render_lineage_aggregate(["mystery"]) == (
+        "Lineage status: BLOCKED — working: 0; waiting: 0; blocked: 1; dormant: 0; "
+        "unknown→blocked: mystery"
+    )
+
+
+def test_invalid_scalar_status_rejected() -> None:
+    with pytest.raises(StatusLineError):
+        render_line("self", "ready", "ready is a storage alias, not scalar prompt status")
+
+
+def test_script_renders_counts() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--self",
+            "working",
+            "running tests",
+            "--lineage-count",
+            "running",
+            "2",
+            "--lineage-count",
+            "blocked",
+            "1",
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.stdout.strip() == (
+        "Self status: WORKING — running tests\n"
+        "Lineage status: WORKING — working: 2; waiting: 0; blocked: 1; dormant: 0"
+    )
+
+
+def test_script_reads_json_statuses(tmp_path: Path) -> None:
+    data = tmp_path / "lineage.json"
+    data.write_text(json.dumps({"descendants": [{"kanban_status": "scheduled"}, {"status": "done"}]}))
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--self",
+            "dormant",
+            "no direct task",
+            "--lineage-json",
+            str(data),
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    assert proc.stdout.strip() == (
+        "Self status: DORMANT — no direct task\n"
+        "Lineage status: WAITING — working: 0; waiting: 1; blocked: 0; dormant: 1"
+    )

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -99,6 +99,7 @@ def test_create_task_appears_on_board(client):
     assert task["title"] == "Research LLM caching"
     assert task["assignee"] == "researcher"
     assert task["status"] == "ready"  # no parents -> immediately ready
+    assert task["live_status"] == "working"
     assert task["priority"] == 3
     assert task["tenant"] == "acme"
     task_id = task["id"]
@@ -108,8 +109,10 @@ def test_create_task_appears_on_board(client):
     assert r.status_code == 200
     data = r.json()
     ready = next(c for c in data["columns"] if c["name"] == "ready")
+    assert ready["live_status"] == "working"
     assert len(ready["tasks"]) == 1
     assert ready["tasks"][0]["id"] == task_id
+    assert ready["tasks"][0]["live_status"] == "working"
     assert "acme" in data["tenants"]
     assert "researcher" in data["assignees"]
 
@@ -134,9 +137,10 @@ def test_scheduled_tasks_have_their_own_column_not_todo(client):
 
     r = client.get("/api/plugins/kanban/board")
     assert r.status_code == 200
-    columns = {c["name"]: c["tasks"] for c in r.json()["columns"]}
-    assert any(t["id"] == task["id"] for t in columns["scheduled"])
-    assert not any(t["id"] == task["id"] for t in columns["todo"])
+    columns = {c["name"]: c for c in r.json()["columns"]}
+    assert columns["scheduled"]["live_status"] == "waiting"
+    assert any(t["id"] == task["id"] and t["live_status"] == "waiting" for t in columns["scheduled"]["tasks"])
+    assert not any(t["id"] == task["id"] for t in columns["todo"]["tasks"])
 
 
 def test_tenant_filter(client):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -68,11 +68,17 @@ def test_board_empty(client):
     r = client.get("/api/plugins/kanban/board")
     assert r.status_code == 200
     data = r.json()
-    # All canonical columns present (triage + the rest), each empty.
+    # Human-facing dashboard columns are canonical live statuses plus done history.
     names = [c["name"] for c in data["columns"]]
-    assert set(names) == kb.VALID_STATUSES - {"archived"}
-    for expected in ("triage", "todo", "scheduled", "ready", "running", "blocked", "done"):
-        assert expected in names, f"missing column {expected}: {names}"
+    assert names == ["working", "waiting", "blocked", "dormant", "done"]
+    target_status = {c["name"]: c["target_status"] for c in data["columns"]}
+    assert target_status == {
+        "working": "ready",
+        "waiting": "todo",
+        "blocked": "blocked",
+        "dormant": "triage",
+        "done": "done",
+    }
     assert all(len(c["tasks"]) == 0 for c in data["columns"])
     assert data["tenants"] == []
     assert data["assignees"] == []
@@ -104,25 +110,32 @@ def test_create_task_appears_on_board(client):
     assert task["tenant"] == "acme"
     task_id = task["id"]
 
-    # Board now lists it under 'ready'.
+    # Board now lists it under canonical 'working' even though the DB storage
+    # alias remains 'ready' for dispatcher compatibility.
     r = client.get("/api/plugins/kanban/board")
     assert r.status_code == 200
     data = r.json()
-    ready = next(c for c in data["columns"] if c["name"] == "ready")
-    assert ready["live_status"] == "working"
-    assert len(ready["tasks"]) == 1
-    assert ready["tasks"][0]["id"] == task_id
-    assert ready["tasks"][0]["live_status"] == "working"
+    working = next(c for c in data["columns"] if c["name"] == "working")
+    assert working["live_status"] == "working"
+    assert working["target_status"] == "ready"
+    assert len(working["tasks"]) == 1
+    assert working["tasks"][0]["id"] == task_id
+    assert working["tasks"][0]["status"] == "ready"
+    assert working["tasks"][0]["live_status"] == "working"
     assert "acme" in data["tenants"]
     assert "researcher" in data["assignees"]
 
 
-def test_scheduled_tasks_have_their_own_column_not_todo(client):
-    """Scheduled/time-delay tasks must not be silently bucketed into todo."""
+def test_scheduled_and_todo_tasks_share_waiting_column(client):
+    """Waiting aliases must not split into separate primary dashboard lanes."""
 
-    task = client.post(
+    scheduled_task = client.post(
         "/api/plugins/kanban/tasks",
         json={"title": "wait for indexed data", "assignee": "ops"},
+    ).json()["task"]
+    todo_task = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "wait for parent", "assignee": "ops"},
     ).json()["task"]
 
     conn = kb.connect()
@@ -130,7 +143,11 @@ def test_scheduled_tasks_have_their_own_column_not_todo(client):
         with kb.write_txn(conn):
             conn.execute(
                 "UPDATE tasks SET status = 'scheduled' WHERE id = ?",
-                (task["id"],),
+                (scheduled_task["id"],),
+            )
+            conn.execute(
+                "UPDATE tasks SET status = 'todo' WHERE id = ?",
+                (todo_task["id"],),
             )
     finally:
         conn.close()
@@ -138,9 +155,11 @@ def test_scheduled_tasks_have_their_own_column_not_todo(client):
     r = client.get("/api/plugins/kanban/board")
     assert r.status_code == 200
     columns = {c["name"]: c for c in r.json()["columns"]}
-    assert columns["scheduled"]["live_status"] == "waiting"
-    assert any(t["id"] == task["id"] and t["live_status"] == "waiting" for t in columns["scheduled"]["tasks"])
-    assert not any(t["id"] == task["id"] for t in columns["todo"]["tasks"])
+    assert "todo" not in columns
+    assert "scheduled" not in columns
+    waiting_ids = {t["id"] for t in columns["waiting"]["tasks"]}
+    assert {scheduled_task["id"], todo_task["id"]} <= waiting_ids
+    assert all(t["live_status"] == "waiting" for t in columns["waiting"]["tasks"])
 
 
 def test_tenant_filter(client):
@@ -335,9 +354,12 @@ def test_patch_schedule_then_unblock(client):
     assert r.json()["task"]["status"] == "scheduled"
 
     columns = client.get("/api/plugins/kanban/board").json()["columns"]
-    assert "scheduled" in [c["name"] for c in columns]
-    scheduled = next(c for c in columns if c["name"] == "scheduled")
-    assert any(x["id"] == t["id"] for x in scheduled["tasks"])
+    assert "scheduled" not in [c["name"] for c in columns]
+    waiting = next(c for c in columns if c["name"] == "waiting")
+    assert any(
+        x["id"] == t["id"] and x["status"] == "scheduled" and x["live_status"] == "waiting"
+        for x in waiting["tasks"]
+    )
 
     r = client.patch(
         f"/api/plugins/kanban/tasks/{t['id']}",
@@ -612,9 +634,11 @@ def test_create_triage_lands_in_triage_column(client):
     assert task["status"] == "triage"
 
     r = client.get("/api/plugins/kanban/board")
-    triage = next(c for c in r.json()["columns"] if c["name"] == "triage")
-    assert len(triage["tasks"]) == 1
-    assert triage["tasks"][0]["title"] == "rough idea, spec me"
+    dormant = next(c for c in r.json()["columns"] if c["name"] == "dormant")
+    assert len(dormant["tasks"]) == 1
+    assert dormant["tasks"][0]["title"] == "rough idea, spec me"
+    assert dormant["tasks"][0]["status"] == "triage"
+    assert dormant["tasks"][0]["live_status"] == "dormant"
 
 
 def test_triage_task_not_promoted_to_ready(client):
@@ -626,10 +650,10 @@ def test_triage_task_not_promoted_to_ready(client):
     # Run the dispatcher — it should NOT promote the triage task.
     client.post("/api/plugins/kanban/dispatch?dry_run=false&max=4")
     r = client.get("/api/plugins/kanban/board")
-    triage = next(c for c in r.json()["columns"] if c["name"] == "triage")
-    ready = next(c for c in r.json()["columns"] if c["name"] == "ready")
-    assert len(triage["tasks"]) == 1
-    assert len(ready["tasks"]) == 0
+    dormant = next(c for c in r.json()["columns"] if c["name"] == "dormant")
+    working = next(c for c in r.json()["columns"] if c["name"] == "working")
+    assert len(dormant["tasks"]) == 1
+    assert len(working["tasks"]) == 0
 
 
 def test_patch_status_triage_works(client):
@@ -908,10 +932,10 @@ def test_bulk_status_ready(client):
     assert r.status_code == 200
     results = r.json()["results"]
     assert all(r["ok"] for r in results)
-    # All three are now ready.
+    # All three are now in the canonical working column.
     board = client.get("/api/plugins/kanban/board").json()
-    ready = next(col for col in board["columns"] if col["name"] == "ready")
-    ids = {t["id"] for t in ready["tasks"]}
+    working = next(col for col in board["columns"] if col["name"] == "working")
+    ids = {t["id"] for t in working["tasks"]}
     assert {a["id"], b["id"], c2["id"]}.issubset(ids)
 
 
@@ -2128,11 +2152,11 @@ def test_board_endpoint_accepts_explicit_board_default_param(client):
     r = client.get("/api/plugins/kanban/board?board=default")
     assert r.status_code == 200
     data = r.json()
-    ready = next((c for c in data["columns"] if c["name"] == "ready"), None)
-    assert ready is not None, "no 'ready' column in default board response"
-    task_ids = [task["id"] for task in ready["tasks"]]
+    working = next((c for c in data["columns"] if c["name"] == "working"), None)
+    assert working is not None, "no 'working' column in default board response"
+    task_ids = [task["id"] for task in working["tasks"]]
     assert t["id"] in task_ids, (
-        f"task {t['id']} not found in ready column of default board "
+        f"task {t['id']} not found in working column of default board "
         f"(got tasks: {task_ids}). The board=default param was likely ignored."
     )
 
@@ -2165,7 +2189,8 @@ def test_dashboard_bulk_actions_include_reclaim_first():
 
     assert "reclaim_first: reclaimFirst" in dist
     assert "hermes-kanban-bulk-reclaim-first" in dist
-    assert '"→ todo"' in dist
+    assert '"→ waiting"' in dist
+    assert '"→ working"' in dist
     assert '"Block"' in dist
     assert '"Unblock"' in dist
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -59,7 +59,7 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
   (e.g. one per project, repo, or domain); see [Boards (multi-project)](#boards-multi-project)
   below. Single-project users stay on the `default` board and never see the
   word "board" outside this docs section.
-- **Task** — a row with title, optional body, one assignee (a profile name), status (`triage | todo | ready | running | blocked | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation).
+- **Task** — a row with title, optional body, one assignee (a profile name), an internal workflow status (`triage | todo | scheduled | ready | running | blocked | review | done | archived`), optional tenant namespace, optional idempotency key (dedup for retried automation). User-facing live status reports map those workflow aliases to `working | waiting | blocked | dormant`; `done` is completion history, not live availability.
 - **Link** — `task_links` row recording a parent → child dependency. The dispatcher promotes `todo → ready` when all parents are `done`.
 - **Comment** — the inter-agent protocol. Agents and humans append comments; when a worker is (re-)spawned it reads the full comment thread as part of its context.
 - **Workspace** — the directory a worker operates in. Three kinds:
@@ -68,6 +68,19 @@ They coexist: a kanban worker may call `delegate_task` internally during its run
   - `worktree` — a git worktree under `.worktrees/<id>/` for coding tasks. Use `worktree:<path>` to pin the exact target path. Worker-side `git worktree add` creates it, using `--branch` when provided.
 - **Dispatcher** — a long-lived loop that, every N seconds (default 60): reclaims stale claims, reclaims crashed workers (PID gone but TTL not yet expired), promotes ready tasks, atomically claims, spawns assigned profiles. Runs **inside the gateway** by default (`kanban.dispatch_in_gateway: true`). One dispatcher sweeps all boards per tick; workers are spawned with `HERMES_KANBAN_BOARD` pinned so they can't see other boards. After `kanban.failure_limit` consecutive spawn failures on the same task (default: 2) the dispatcher auto-blocks it with the last error as the reason — prevents thrashing on tasks whose profile doesn't exist, workspace can't mount, etc.
 - **Tenant** — optional string namespace *within* a board. One specialist fleet can serve multiple businesses (`--tenant business-a`) with data isolation by workspace path and memory key prefix. Tenants are a soft filter; boards are the hard isolation boundary.
+
+## Live status vocabulary
+
+Kanban keeps the legacy storage-level workflow states for DB and dispatcher compatibility, but new user-facing reports, dashboard labels, and coordinator/profile status lines should use this live vocabulary:
+
+| Live status | Meaning | Compatibility aliases |
+|---|---|---|
+| `working` | Active work is underway or immediately queued/spawnable. | `ready`, `queue`, `running`, `in_progress`, `review` |
+| `waiting` | A specific active task/duty/dependency exists, but progress is paused on a non-human/system condition. | `todo` with unfinished parents, `scheduled` |
+| `blocked` | A specific active task/duty/dependency is prevented until a human acts. | `blocked` only; do not use it for system waits or idle lanes |
+| `dormant` | No active actionable assignment exists. Human instruction is needed to resume, but no specific dependency is currently prevented. | unspecced `triage`, taskless profiles/projects |
+
+`done` remains valid as task completion history. It is not a live profile/project availability state; a profile with no active work is `dormant`, not `done`.
 
 ## Boards (multi-project)
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -82,6 +82,33 @@ Kanban keeps the legacy storage-level workflow states for DB and dispatcher comp
 
 `done` remains valid as task completion history. It is not a live profile/project availability state; a profile with no active work is `dormant`, not `done`.
 
+### Self/Lineage status lines for profile communication
+
+Project-structured profiles that report status in Matrix or other chat surfaces should use two generic lines, not role-specific labels and not legacy `Blocker status` / `NOT BLOCKED` wording:
+
+```text
+Self status: WORKING|WAITING|BLOCKED|DORMANT — <specific status for this profile itself>
+Lineage status: WORKING|WAITING|BLOCKED|DORMANT — <aggregate status for structural descendants>
+```
+
+`Self status` is about the speaker profile's own active action, wait, human blocker, or dormant condition. `Lineage status` is about structurally supervised descendants; it is not the same graph as `task_links` dependencies. A profile with no descendants, or no descendants with active work, reports lineage as `DORMANT`.
+
+Use `scripts/render_status_lines.py` from a source checkout for deterministic copy-paste output instead of recomputing these lines from broad LLM context:
+
+```bash
+python scripts/render_status_lines.py \
+  --self working "updating Kanban status docs" \
+  --lineage-count running 1 \
+  --lineage-count blocked 1
+```
+
+Sample output:
+
+```text
+Self status: WORKING — updating Kanban status docs
+Lineage status: WORKING — working: 1; waiting: 0; blocked: 1; dormant: 0
+```
+
 ## Boards (multi-project)
 
 Boards let you separate unrelated streams of work — one per project, repo,

--- a/website/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator.md
@@ -35,7 +35,7 @@ The following is the complete skill definition that Hermes loads when this skill
 
 Hermes setups vary widely. Some users run a single profile that does everything; some run a small fleet (`docker-worker`, `cron-worker`); some run a curated specialist team they've named themselves. There is **no default specialist roster** — the orchestrator skill does not know what profiles exist on this machine.
 
-Before fanning out, you must ground the decomposition in the profiles that actually exist. The dispatcher silently fails to spawn unknown assignee names — it doesn't autocorrect, doesn't suggest, doesn't fall back. So a card assigned to `researcher` on a setup that only has `docker-worker` just sits in `ready` forever.
+Before fanning out, you must ground the decomposition in the profiles that actually exist. The dispatcher silently fails to spawn unknown assignee names — it doesn't autocorrect, doesn't suggest, doesn't fall back. So a card assigned to `researcher` on a setup that only has `docker-worker` remains `working`/queued (internal alias `ready`) forever.
 
 **Step 0: discover available profiles before planning.**
 
@@ -180,7 +180,7 @@ Tell them what you created in plain prose, naming the actual profiles you used:
 
 ## Pitfalls
 
-**Inventing profile names that don't exist.** The dispatcher silently fails to spawn unknown assignees — the card just sits in `ready` forever. Always assign to a profile from your Step 0 discovery; ask the user if you're unsure.
+**Inventing profile names that don't exist.** The dispatcher silently fails to spawn unknown assignees — the card remains `working`/queued (internal alias `ready`) forever. Always assign to a profile from your Step 0 discovery; ask the user if you're unsure.
 
 **Bundling independent lanes into one card.** If the user asks for two independent outcomes, create two cards. Example: "fix blockers and check model variants" is not one fixer task; create a fixer/engineer card for the fixes and an explorer/researcher card for the variant check, then optionally gate review on both.
 
@@ -200,7 +200,7 @@ Tell them what you created in plain prose, naming the actual profiles you used:
 
 When a worker profile keeps crashing, hallucinating, or getting blocked by its own mistakes (usually: wrong model, missing skill, broken credential), the kanban dashboard flags the task with a ⚠ badge and opens a **Recovery** section in the drawer. Three primary actions:
 
-1. **Reclaim** (or `hermes kanban reclaim <task_id>`) — abort the running worker immediately and reset the task to `ready`. The existing claim TTL is ~15 min; this is the fast path out.
+1. **Reclaim** (or `hermes kanban reclaim <task_id>`) — abort the running worker immediately and reset the task to `working`/queued (internal alias `ready`). The existing claim TTL is ~15 min; this is the fast path out.
 2. **Reassign** (or `hermes kanban reassign <task_id> <new-profile> --reclaim`) — switch the task to a different profile (one that exists on this setup) and let the dispatcher pick it up with a fresh worker.
 3. **Change profile model** — the dashboard prints a copy-paste hint for `hermes -p <profile> model` since profile config lives on disk; edit it in a terminal, then Reclaim to retry with the new model.
 

--- a/website/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator.md
@@ -37,6 +37,8 @@ Hermes setups vary widely. Some users run a single profile that does everything;
 
 Before fanning out, you must ground the decomposition in the profiles that actually exist. The dispatcher silently fails to spawn unknown assignee names — it doesn't autocorrect, doesn't suggest, doesn't fall back. So a card assigned to `researcher` on a setup that only has `docker-worker` remains `working`/queued (internal alias `ready`) forever.
 
+For project-structured communication, status reports should use the generic canonical pair `Self status:` and `Lineage status:`. `Lineage status` is structural parent/child responsibility under a profile, not the same as the task dependency graph you create with `parents=[...]`. Do not use legacy `Blocker status:` / `NOT BLOCKED`, and do not replace the generic pair with role-specific labels such as `Coordinator status:`. Prefer deterministic helper output from `python scripts/render_status_lines.py --self ... --lineage-count ...` when available.
+
 **Step 0: discover available profiles before planning.**
 
 Use one of these:

--- a/website/docs/user-guide/skills/bundled/devops/devops-kanban-worker.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-kanban-worker.md
@@ -31,6 +31,10 @@ The following is the complete skill definition that Hermes loads when this skill
 
 > You're seeing this skill because the Hermes Kanban dispatcher spawned you as a worker with `--skills kanban-worker` — it's loaded automatically for every dispatched worker. The **lifecycle** (6 steps: orient → work → heartbeat → block/complete) also lives in the `KANBAN_GUIDANCE` block that's auto-injected into your system prompt. This skill is the deeper detail: good handoff shapes, retry diagnostics, edge cases.
 
+## Live status vocabulary
+
+Use canonical live statuses in user-facing prose: `working`, `waiting`, `blocked`, `dormant`. Internal Kanban DB/workflow aliases remain valid during migration: `ready`/`queue`/`running`/`in_progress`/`review` map to `working`; dependency-held `todo` and `scheduled` map to `waiting`; unspecced `triage` maps to `dormant`; `done` is completion history only. Reserve `blocked` for a specific active task/duty/dependency prevented by human action.
+
 ## Workspace handling
 
 Your workspace kind determines how you should behave inside `$HERMES_KANBAN_WORKSPACE`:

--- a/website/docs/user-guide/skills/bundled/devops/devops-kanban-worker.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-kanban-worker.md
@@ -35,6 +35,8 @@ The following is the complete skill definition that Hermes loads when this skill
 
 Use canonical live statuses in user-facing prose: `working`, `waiting`, `blocked`, `dormant`. Internal Kanban DB/workflow aliases remain valid during migration: `ready`/`queue`/`running`/`in_progress`/`review` map to `working`; dependency-held `todo` and `scheduled` map to `waiting`; unspecced `triage` maps to `dormant`; `done` is completion history only. Reserve `blocked` for a specific active task/duty/dependency prevented by human action.
 
+For Matrix/profile-facing project communication, use generic `Self status:` and `Lineage status:` lines. Do not introduce role-specific replacements such as `Coordinator status:`, and do not use legacy `Blocker status:` or `NOT BLOCKED` wording in new prompts. `Self status` describes this profile's own active action/wait/human blocker/dormant condition; `Lineage status` aggregates structural descendants and is separate from task dependency links. When deterministic output is needed, prefer the repo helper `python scripts/render_status_lines.py --self ... --lineage-count ...` over recomputing the wording from broad LLM context.
+
 ## Workspace handling
 
 Your workspace kind determines how you should behave inside `$HERMES_KANBAN_WORKSPACE`:


### PR DESCRIPTION
## Summary
- adds canonical Kanban live status mapping for working/waiting/blocked/dormant while preserving storage-level compatibility aliases
- surfaces live_status in CLI JSON and dashboard API/card details, and updates dashboard labels/help text to avoid presenting legacy aliases as primary live states
- documents the live vocabulary in Kanban docs and bundled Kanban skills, including done as completion history only

## Test Plan
- python -m pytest tests/hermes_cli/test_kanban_db.py tests/plugins/test_kanban_dashboard_plugin.py -q -o 'addopts='
- git diff --check

## Coordination note
- Updated /home/engs2272/.hermes/coordination/operating_model.md outside this repo to replace the legacy Blocker status watchdog wording with the canonical four-state Coordinator status line.