### PR TITLE
feat: digital-brain integration (search-first memory)

### DIFF
--- a/skills/note-taking/digital-brain/SKILL.md
+++ b/skills/note-taking/digital-brain/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: digital-brain
+description: Use when answering any substantive user question or recalling facts/preferences/past decisions — FIRST query the digital brain (the user's personal semantic memory) with brain_search before relying on your own knowledge, then ground and cite the answer in what you retrieved.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [memory, knowledge-base, search-first, brain, semantic-search]
+    related_skills: [obsidian]
+---
+
+# Digital Brain — Search-First Memory
+
+## Overview
+
+The digital brain is the user's external, persistent semantic memory: notes,
+facts, preferences, and past decisions, searchable by text, vector, or hybrid
+similarity. It is reached through three tools — `brain_search`, `brain_get_note`,
+`brain_graph` — which proxy to the user's own isolated memory vault. Your own
+training data is generic and stale; the brain is specific and current. Treat it
+as the source of truth about *this user and their world*.
+
+This skill exists to enforce one habit: **check the brain before you answer.**
+
+## When to Use
+
+Query the brain FIRST, before composing an answer, whenever the user:
+
+- Asks a question about facts, people, projects, configs, or history.
+- Refers to "my", "our", "the", "that" — anything implying shared context
+  ("my server", "our policy", "the deadline we set").
+- Asks you to recall, continue, or build on something from before.
+- Asks for a recommendation or decision that should respect their preferences.
+
+Don't use for: pure small talk, arithmetic, or a self-contained request with no
+reference to the user's world (e.g. "translate this sentence"). When in doubt,
+search — a fast empty result costs little; a confidently wrong answer costs trust.
+
+## Workflow
+
+1. **Search.** Call `brain_search(query=...)` with a focused natural-language
+   query. Prefer the user's own terms. Use `limit` 5–10 for broad recall.
+2. **Assess.** Read the returned excerpts and scores. If results look relevant
+   but thin, pull the full note with `brain_get_note(note_id=...)`.
+3. **Expand (optional).** For "what's related to X" or to map context, call
+   `brain_graph(note_id=...)` to walk the note's links, or `brain_graph()` for
+   the whole vault.
+4. **Ground the answer.** Base your response on what you retrieved. Briefly cite
+   which note(s) informed it (title or id) so the user can verify.
+5. **On empty/irrelevant results.** Say plainly that the brain has nothing on
+   this, then answer from general knowledge — clearly flagged as not from memory.
+   Do not invent a memory.
+
+## Tools Reference
+
+| Tool | Purpose |
+|------|---------|
+| `brain_search(query, mode?, limit?)` | Ranked note search. `mode`: `text` \| `vector` \| `hybrid` (omit for gateway default). Start here. |
+| `brain_get_note(note_id)` | Full content of one note by id (ids come from `brain_search`). |
+| `brain_graph(note_id?)` | Link graph around a note, or the whole vault when `note_id` is omitted. |
+
+This memory is **read-only** from the bot: there is no add/update/learn tool
+here. The user curates the brain through a separate interface. Never tell the
+user you "saved" something to the brain — you cannot.
+
+## Common Pitfalls
+
+1. **Answering from training data first.** The whole point is to search before
+   answering. If you skipped `brain_search`, you used the skill wrong.
+2. **Over-narrow queries.** `brain_search` is semantic; a short conceptual query
+   often beats a long verbatim quote. If empty, retry with broader wording.
+3. **Citing excerpts as if complete.** Excerpts are previews. For anything you
+   rely on heavily, fetch the full note with `brain_get_note`.
+4. **Inventing memories.** If the brain returns nothing, say so. Never fabricate
+   a note or claim the brain "remembers" something it didn't return.
+5. **Claiming you wrote to memory.** The tools are read-only; writing happens
+   elsewhere. Don't promise to remember things via the brain.
+6. **Ignoring "not provisioned yet".** A `503` means the bot's vault is still
+   being set up. Tell the user memory is initializing and answer best-effort.
+
+## Verification Checklist
+
+- [ ] Called `brain_search` BEFORE composing a substantive answer.
+- [ ] Pulled full notes with `brain_get_note` for anything load-bearing.
+- [ ] Grounded the answer in retrieved notes and cited them.
+- [ ] On empty results, said so honestly instead of inventing memory.
+- [ ] Did not claim to have written/saved anything (read-only).

--- a/tools/brain_tools.py
+++ b/tools/brain_tools.py
@@ -1,0 +1,176 @@
+"""Digital-brain tools — read-only access to the bot's personal semantic memory.
+
+The bot reaches the brain through the youself gateway (never the brain
+directly): the gateway resolves this VM to its own isolated tenant+vault and
+forwards the read request. Credentials never live in the VM — these tools only
+need the gateway URL + bearer token that cloud-init already injects:
+
+    YOUSELF_GATEWAY_URL    e.g. https://agent.youself.io/youself-gateway/v1
+    YOUSELF_GATEWAY_TOKEN  per-VM gateway bearer token
+
+The brain read surface is mounted under <YOUSELF_GATEWAY_URL>/brain/...
+
+Pair this with the ``digital-brain`` skill, which enforces the search-first
+workflow ("always check the brain before answering").
+"""
+
+import json
+import logging
+import os
+
+import httpx
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = httpx.Timeout(15.0, connect=5.0)
+
+
+def _base_and_token() -> tuple[str, str]:
+    base = (os.environ.get("YOUSELF_GATEWAY_URL") or "").rstrip("/")
+    token = os.environ.get("YOUSELF_GATEWAY_TOKEN") or ""
+    return base, token
+
+
+def _brain_available() -> bool:
+    base, token = _base_and_token()
+    return bool(base and token)
+
+
+def _request(method: str, path: str, *, params=None, json_body=None) -> str:
+    """Call the gateway brain proxy and return the response body as a string.
+
+    The gateway already returns JSON; we forward it verbatim so the model sees
+    the brain's native shape (results/excerpt/scores, note bodies, graph, ...).
+    """
+    base, token = _base_and_token()
+    if not base or not token:
+        return tool_error("digital brain not configured (missing gateway URL/token)")
+    url = f"{base}/brain{path}"
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        resp = httpx.request(
+            method, url, params=params, json=json_body, headers=headers, timeout=_TIMEOUT
+        )
+    except httpx.HTTPError as e:
+        logger.warning("brain request failed: %s", e)
+        return tool_error(f"brain request failed: {e}")
+
+    if resp.status_code == 503:
+        return tool_error("brain not provisioned for this bot yet; try again shortly")
+    if resp.status_code // 100 != 2:
+        return tool_error(
+            f"brain returned status {resp.status_code}", body=resp.text[:2000]
+        )
+    return resp.text
+
+
+def brain_search(query: str, mode: str = "", limit: int = 5) -> str:
+    """Search the bot's memory. mode: text|vector|hybrid (gateway default if empty)."""
+    if not query or not query.strip():
+        return tool_error("query is required")
+    params = {"q": query, "limit": limit}
+    if mode:
+        params["mode"] = mode
+    return _request("GET", "/search", params=params)
+
+
+def brain_get_note(note_id: str) -> str:
+    """Fetch a single note by id (use ids returned by brain_search)."""
+    if not note_id or not note_id.strip():
+        return tool_error("note_id is required")
+    return _request("GET", f"/notes/{note_id}")
+
+
+def brain_graph(note_id: str = "") -> str:
+    """Link-graph of one note's neighbourhood (note_id set) or the whole vault."""
+    if note_id and note_id.strip():
+        return _request("GET", f"/notes/{note_id}/graph")
+    return _request("GET", "/graph")
+
+
+BRAIN_SEARCH_SCHEMA = {
+    "name": "brain_search",
+    "description": (
+        "Search the user's digital brain (personal semantic memory) for relevant "
+        "notes BEFORE answering. Returns ranked notes with excerpts and ids. "
+        "Always try this first for any substantive question."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Natural-language search query"},
+            "mode": {
+                "type": "string",
+                "enum": ["text", "vector", "hybrid"],
+                "description": "Search mode; leave empty to use the gateway default",
+            },
+            "limit": {"type": "integer", "description": "Max results (default 5)"},
+        },
+        "required": ["query"],
+    },
+}
+
+BRAIN_GET_NOTE_SCHEMA = {
+    "name": "brain_get_note",
+    "description": "Fetch the full content of one note from the digital brain by its id.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "note_id": {"type": "string", "description": "Note id from brain_search results"},
+        },
+        "required": ["note_id"],
+    },
+}
+
+BRAIN_GRAPH_SCHEMA = {
+    "name": "brain_graph",
+    "description": (
+        "Get the link graph around a note (pass note_id) or the whole vault graph "
+        "(omit note_id) to discover related knowledge in the digital brain."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "note_id": {
+                "type": "string",
+                "description": "Optional note id; omit for the full vault graph",
+            },
+        },
+        "required": [],
+    },
+}
+
+registry.register(
+    name="brain_search",
+    toolset="brain",
+    schema=BRAIN_SEARCH_SCHEMA,
+    handler=lambda args, **kw: brain_search(
+        args.get("query", ""), mode=args.get("mode", ""), limit=args.get("limit", 5)
+    ),
+    check_fn=_brain_available,
+    requires_env=["YOUSELF_GATEWAY_URL", "YOUSELF_GATEWAY_TOKEN"],
+    emoji="🧠",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="brain_get_note",
+    toolset="brain",
+    schema=BRAIN_GET_NOTE_SCHEMA,
+    handler=lambda args, **kw: brain_get_note(args.get("note_id", "")),
+    check_fn=_brain_available,
+    requires_env=["YOUSELF_GATEWAY_URL", "YOUSELF_GATEWAY_TOKEN"],
+    emoji="🧠",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="brain_graph",
+    toolset="brain",
+    schema=BRAIN_GRAPH_SCHEMA,
+    handler=lambda args, **kw: brain_graph(args.get("note_id", "")),
+    check_fn=_brain_available,
+    requires_env=["YOUSELF_GATEWAY_URL", "YOUSELF_GATEWAY_TOKEN"],
+    emoji="🧠",
+    max_result_size_chars=100_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -48,6 +48,10 @@ _HERMES_CORE_TOOLS = [
     "text_to_speech",
     # Planning & memory
     "todo", "memory",
+    # Digital brain — external semantic memory (gated on YOUSELF_GATEWAY_URL/
+    # _TOKEN via check_fn; only appears on provisioned youself bots). Pair with
+    # the `digital-brain` skill for search-first behavior.
+    "brain_search", "brain_get_note", "brain_graph",
     # Session history search
     "session_search",
     # Clarifying questions


### PR DESCRIPTION
Add read-only access to the per-bot digital brain (external semantic memory) via the youself gateway:

- tools/brain_tools.py: brain_search / brain_get_note / brain_graph, gated on YOUSELF_GATEWAY_URL + YOUSELF_GATEWAY_TOKEN, hitting the gateway's /v1/brain/* read proxy.
- skills/note-taking/digital-brain: search-first skill — query the brain before answering and ground/cite results.
- toolsets.py: include the brain tools in _HERMES_CORE_TOOLS (they only surface on provisioned youself bots via check_fn).

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

