### PR TITLE
fix(acp): reset token counters on /new to clear stale context usage (#35823)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1790,6 +1790,11 @@ class HermesACPAgent(acp.Agent):
 
     def _cmd_reset(self, args: str, state: SessionState) -> str:
         state.history.clear()
+        # Reset session token counters so the context usage bar shows 0
+        # after /new instead of accumulated stale values (#35823)
+        agent = state.agent
+        if hasattr(agent, "reset_session_state"):
+            agent.reset_session_state()
         self.session_manager.save_session(state.session_id)
         return "Conversation history cleared."
 

--- a/tests/acp_adapter/test_cmd_reset_token_counters.py
+++ b/tests/acp_adapter/test_cmd_reset_token_counters.py
@@ -1,0 +1,69 @@
+"""Tests for ACP adapter _cmd_reset token counter reset (fixes #35823).
+
+After /new or /reset in an ACP session, the agent's session token counters
+must be zeroed so the context usage bar shows a clean slate.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Ensure repo root is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from acp_adapter.session import SessionState
+from acp_adapter.server import HermesACPAgent
+
+
+def _make_state():
+    """Create a minimal SessionState with a mock agent."""
+    agent = MagicMock()
+    agent.reset_session_state = MagicMock()
+    state = SessionState(
+        session_id="test-session",
+        agent=agent,
+        history=[{"role": "user", "content": "hello"}],
+    )
+    return state, agent
+
+
+def _make_server():
+    """Create a minimal HermesACPAgent-like object with _cmd_reset."""
+    server = MagicMock(spec=HermesACPAgent)
+    server.session_manager = MagicMock()
+    server._cmd_reset = lambda args, st: HermesACPAgent._cmd_reset(server, args, st)
+    return server
+
+
+class TestCmdResetTokenCounters:
+    """_cmd_reset must zero session token counters via reset_session_state()."""
+
+    def test_clears_history(self):
+        """History must be empty after reset."""
+        state, agent = _make_state()
+        server = _make_server()
+        result = server._cmd_reset("", state)
+        assert state.history == []
+        assert "cleared" in result.lower()
+
+    def test_calls_reset_session_state(self):
+        """reset_session_state() must be called to zero token counters."""
+        state, agent = _make_state()
+        server = _make_server()
+        server._cmd_reset("", state)
+        agent.reset_session_state.assert_called_once()
+
+    def test_saves_session(self):
+        """Session must be persisted after reset."""
+        state, agent = _make_state()
+        server = _make_server()
+        server._cmd_reset("", state)
+        server.session_manager.save_session.assert_called_once_with("test-session")
+
+    def test_graceful_without_reset_method(self):
+        """If agent lacks reset_session_state, reset still works (no crash)."""
+        state, _ = _make_state()
+        state.agent = MagicMock(spec=[])  # no attributes at all
+        server = _make_server()
+        result = server._cmd_reset("", state)
+        assert state.history == []
+        assert "cleared" in result.lower()


### PR DESCRIPTION
## What does this PR do?

Resets all session token counters when `/new` (or `/reset`) is run in an ACP session, so the context usage bar shows `0 / 1.0M` instead of accumulated stale values from the previous session.

## Related Issue

Fixes #35823

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/server.py`: In `_cmd_reset`, call `agent.reset_session_state()` after clearing history to zero all session-level token counters (input, output, prompt, completion, cache, reasoning, API calls, estimated cost) and reset the context compressor. Uses `hasattr` guard for backward compatibility with agents that lack the method.
- `tests/acp_adapter/test_cmd_reset_token_counters.py`: New test file — verifies history is cleared, `reset_session_state()` is called, session is saved, and graceful degradation when the agent lacks `reset_session_state`.

## How to Test

1. Start an ACP session (VS Code with Hermes extension)
2. Have a long conversation with multiple API calls to accumulate token usage
3. Run `/new` — the context usage bar should reset to `0 / 1.0M`
4. Send a new message — usage should count from 0, not from the previous session's accumulated value
5. Run `pytest tests/acp_adapter/test_cmd_reset_token_counters.py -v` — all 4 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/acp_adapter/test_cmd_reset_token_counters.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `acp_adapter/server.py:_cmd_reset` (callers: 1 via slash command dispatch, flows: 1)
- Blast radius: LOW — single function, self-contained, no downstream effects
- Related patterns: `run_agent.AIAgent.reset_session_state()` (line 566) encapsulates all counter resets + context compressor transition. `tui_gateway/server.py` handles reset by creating a fresh agent — this fix reuses the same `reset_session_state()` for ACP instead.
