### PR TITLE
fix(dashboard): require auth for model info endpoint

### DIFF
--- a/hermes_cli/dashboard_auth/public_paths.py
+++ b/hermes_cli/dashboard_auth/public_paths.py
@@ -40,9 +40,8 @@ PUBLIC_API_PATHS: frozenset[str] = frozenset({
     # Read-only config-defaults / schema feeds for the SPA's Config page.
     "/api/config/defaults",
     "/api/config/schema",
-    # Read-only model metadata (context windows, etc.) — same shape as
-    # provider catalogs already exposed on the public internet.
-    "/api/model/info",
+    # Model metadata includes the locally configured provider/model. Keep it
+    # behind dashboard auth; the SPA can load it after login/session bootstrap.
     # Read-only theme + plugin manifests for the dashboard skin engine.
     "/api/dashboard/themes",
     "/api/dashboard/plugins",

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -86,7 +86,6 @@ def test_gated_status_is_public(gated_app):
 @pytest.mark.parametrize("path", [
     "/api/config/defaults",
     "/api/config/schema",
-    "/api/model/info",
     "/api/dashboard/themes",
     "/api/dashboard/plugins",
 ])
@@ -111,6 +110,17 @@ def test_other_public_api_paths_are_public_under_gate(gated_app, path):
             f"{path} redirected to {location} — should be public, "
             "not bounced to /login"
         )
+
+
+def test_gated_model_info_requires_auth(gated_app):
+    """Model metadata includes local provider/model configuration.
+
+    It is read-only, but unlike the public liveness/config-schema endpoints it
+    is not needed for unauthenticated bootstrap. The SPA can fetch it after a
+    dashboard session exists, so keep it behind the auth gate.
+    """
+    r = gated_app.get("/api/model/info", follow_redirects=False)
+    assert r.status_code == 401
 
 
 def test_gated_html_redirects_to_login(gated_app):


### PR DESCRIPTION
## Summary
- remove `/api/model/info` from the unauthenticated dashboard API allowlist
- add a dashboard auth regression test that expects `/api/model/info` to return 401 without a session
- keep existing public bootstrap/liveness endpoints public

## Why
`/api/model/info` exposes the locally configured provider/model metadata. It is read-only, but it is not needed for unauthenticated liveness checks or initial dashboard bootstrap; the SPA can fetch it after a dashboard session exists.

## Test plan
- `uv run --with pytest --with pytest-asyncio --with fastapi --with starlette --with httpx --with python-multipart python -m pytest tests/hermes_cli/test_dashboard_auth_middleware.py -q -o 'addopts='`
  - `22 passed, 2 warnings in 3.85s`
