### PR TITLE
feat(bedrock): add Anthropic prompt caching via Converse cachePoint

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -683,6 +683,8 @@ def normalize_converse_response(response: Dict) -> SimpleNamespace:
         total_tokens=(
             usage_data.get("inputTokens", 0) + usage_data.get("outputTokens", 0)
         ),
+        cache_read_input_tokens=usage_data.get("cacheReadInputTokens", 0),
+        cache_creation_input_tokens=usage_data.get("cacheWriteInputTokens", 0),
     )
 
     finish_reason = _converse_stop_reason_to_openai(stop_reason)
@@ -831,6 +833,8 @@ def stream_converse_with_callbacks(
             usage_data = {
                 "inputTokens": meta_usage.get("inputTokens", 0),
                 "outputTokens": meta_usage.get("outputTokens", 0),
+                "cacheReadInputTokens": meta_usage.get("cacheReadInputTokens", 0),
+                "cacheWriteInputTokens": meta_usage.get("cacheWriteInputTokens", 0),
             }
 
     # Flush remaining text
@@ -850,6 +854,8 @@ def stream_converse_with_callbacks(
         total_tokens=(
             usage_data.get("inputTokens", 0) + usage_data.get("outputTokens", 0)
         ),
+        cache_read_input_tokens=usage_data.get("cacheReadInputTokens", 0),
+        cache_creation_input_tokens=usage_data.get("cacheWriteInputTokens", 0),
     )
 
     finish_reason = _converse_stop_reason_to_openai(stop_reason)
@@ -867,6 +873,40 @@ def stream_converse_with_callbacks(
         usage=usage,
         model="",
     )
+
+
+# ---------------------------------------------------------------------------
+# Prompt caching (Anthropic models on Bedrock, via Converse cachePoint)
+# ---------------------------------------------------------------------------
+
+def _bedrock_prompt_cache_enabled() -> bool:
+    """Whether to insert Converse ``cachePoint`` markers for Anthropic models.
+
+    Bedrock supports Anthropic prompt caching natively via ``cachePoint``
+    blocks on the Converse API, but Hermes' generic ``cache_control`` path
+    (agent/prompt_caching.py) never reaches this boto3 adapter — so without
+    this the Bedrock provider re-bills the full prompt every turn. Enabled by
+    default for Anthropic Bedrock models; disable with
+    ``HERMES_BEDROCK_PROMPT_CACHE=0``.
+    """
+    return os.environ.get("HERMES_BEDROCK_PROMPT_CACHE", "1").strip().lower() not in {
+        "0", "false", "no", "off",
+    }
+
+
+def _bedrock_cache_ttl() -> str:
+    """Cache TTL for Bedrock prompt caching. Bedrock Converse accepts ``5m`` or
+    ``1h`` (per the bedrock-runtime ``CacheTTL`` shape). Defaults to ``1h`` for
+    the longest-lived prefix cache; override with ``HERMES_BEDROCK_CACHE_TTL``."""
+    ttl = os.environ.get("HERMES_BEDROCK_CACHE_TTL", "1h").strip().lower()
+    return ttl if ttl in {"5m", "1h"} else "1h"
+
+
+def _cache_point() -> Dict[str, Any]:
+    """A Converse ``cachePoint`` marker. Bedrock caches the entire prefix up to
+    this block; cache hits bill at ~0.1x input cost. Returns a fresh dict so
+    the same marker can be appended to multiple block lists safely."""
+    return {"cachePoint": {"type": "default", "ttl": _bedrock_cache_ttl()}}
 
 
 # ---------------------------------------------------------------------------
@@ -889,6 +929,12 @@ def build_converse_kwargs(
     """
     system_prompt, converse_messages = convert_messages_to_converse(messages)
 
+    # Anthropic models on Bedrock support prompt caching via Converse
+    # ``cachePoint`` markers. We cache the two large, turn-stable prefixes —
+    # the system prompt and the tool schemas — which are re-sent identically
+    # every turn. Cache hits bill at ~0.1x input cost.
+    cache_prefix = is_anthropic_bedrock_model(model) and _bedrock_prompt_cache_enabled()
+
     kwargs: Dict[str, Any] = {
         "modelId": model,
         "messages": converse_messages,
@@ -898,6 +944,9 @@ def build_converse_kwargs(
     }
 
     if system_prompt:
+        if cache_prefix:
+            # Marker goes after all system text so the whole system block is cached.
+            system_prompt = [*system_prompt, _cache_point()]
         kwargs["system"] = system_prompt
 
     if temperature is not None:
@@ -918,6 +967,9 @@ def build_converse_kwargs(
             # Strip tools for known non-tool-calling models and warn the user.
             # Ref: PR #7920 feedback from @ptlally, pattern from PR #4346.
             if _model_supports_tool_use(model):
+                if cache_prefix:
+                    # Cache the tool schemas too — appended after the last tool.
+                    converse_tools = [*converse_tools, _cache_point()]
                 kwargs["toolConfig"] = {"tools": converse_tools}
             else:
                 logger.warning(


### PR DESCRIPTION
## Problem

Hermes' Bedrock provider (`bedrock_converse`) has no prompt caching. The generic `cache_control` path in `agent/prompt_caching.py` never reaches the boto3 Converse adapter, and `anthropic_prompt_cache_policy()` returns `False` for Bedrock. As a result, **every turn re-bills the full prompt** — the system prompt and all tool schemas — even though they are identical across turns.

## Fix

Bedrock natively supports Anthropic prompt caching via Converse `cachePoint` blocks. This PR wires that in with minimal, targeted changes to `agent/bedrock_adapter.py`.

### What changed

**Three new helper functions** (inserted before the high-level API section):

- `_bedrock_prompt_cache_enabled()` — reads `HERMES_BEDROCK_PROMPT_CACHE` env var (default `"1"`, i.e. **on**). Set to `0`/`false`/`no`/`off` to disable.
- `_bedrock_cache_ttl()` — reads `HERMES_BEDROCK_CACHE_TTL` env var (default `"1h"`). Bedrock's `CacheTTL` shape accepts `"5m"` or `"1h"` only; any other value falls back to `"1h"`.
- `_cache_point()` — returns `{"cachePoint": {"type": "default", "ttl": <ttl>}}`, a fresh dict per call so the same marker can safely be appended to multiple block lists.

**`build_converse_kwargs`** — after converting messages, computes `cache_prefix = is_anthropic_bedrock_model(model) and _bedrock_prompt_cache_enabled()`. When true:
- Appends a `cachePoint` after all system content blocks (caches the entire system prompt prefix).
- Appends a `cachePoint` after all tool definitions in `toolConfig` (caches the tool schemas prefix).

These are the two largest, most turn-stable prefixes that Bedrock re-sends every turn.

**`normalize_converse_response`** and **`stream_converse_with_callbacks`** — both SimpleNamespace usage objects now include:
- `cache_read_input_tokens` ← `cacheReadInputTokens` from Bedrock usage
- `cache_creation_input_tokens` ← `cacheWriteInputTokens` from Bedrock usage

This makes cache hit/miss data visible to the existing usage telemetry that already logs these fields for the Anthropic SDK path.

## Environment knobs

| Variable | Default | Effect |
|---|---|---|
| `HERMES_BEDROCK_PROMPT_CACHE` | `1` (on) | Set to `0`/`false`/`no`/`off` to disable caching entirely |
| `HERMES_BEDROCK_CACHE_TTL` | `1h` | Cache TTL: `5m` or `1h` (Bedrock botocore `CacheTTL` enum) |

The feature is opt-out by default for all Anthropic Bedrock models (detected via the existing `is_anthropic_bedrock_model()` check). Non-Anthropic Bedrock models are unaffected — `cachePoint` is only injected when both checks pass.

## Live verification

Tested end-to-end via the Nous gateway on `us.anthropic.claude-sonnet-4-6`. Real Telegram conversation turns showed `cache_read_input_tokens` / total input token ratios of **90–99%** per turn once the cache warmed up (first turn writes, subsequent turns read). Cache write turns billed at standard rates; cache read turns billed at ~0.1× input cost.

The `CachePointBlock` botocore shape accepts the `ttl` enum values `['5m', '1h']` — confirmed against the live Bedrock Runtime API.

## Scope

- Only `agent/bedrock_adapter.py` is modified (+52 lines, 0 deletions).
- No changes to `agent/prompt_caching.py`, the generic cache path, or any other provider.
- `py_compile` passes on the patched file.