### PR TITLE
fix: keep initial blocked kanban tasks inert

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2039,6 +2039,11 @@ def create_task(
     ``kanban-worker``. Use this to pin a task to a specialist skill
     (e.g. ``skills=["translation"]`` so the worker loads the
     translation skill regardless of the profile's default config).
+
+    ``initial_status="blocked"`` is a sticky manual/human-ops block:
+    parent completion will not auto-promote it; an explicit unblock is
+    required to release it. Use parents plus the default status for
+    dependency-only waiting.
     """
     assignee = _canonical_assignee(assignee)
     if not title or not title.strip():
@@ -2223,6 +2228,17 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+                if initial_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": "initial_status=blocked",
+                            "source": "create_task",
+                            "created_by": created_by,
+                        },
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:
@@ -4463,6 +4479,13 @@ def decompose_triage_task(
 
 def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     with write_txn(conn):
+        prev = conn.execute(
+            "SELECT worker_pid, claim_lock FROM tasks "
+            "WHERE id = ? AND status != 'archived'",
+            (task_id,),
+        ).fetchone()
+        if not prev:
+            return False
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
             "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
@@ -4479,7 +4502,37 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
         )
-        _append_event(conn, task_id, "archived", None, run_id=run_id)
+        # Keep the state-change audit event in the same transaction as
+        # the archive itself. Worker termination is best-effort and happens
+        # after commit; a crash between commit and kill must not erase the
+        # archived audit record. The follow-up worker_terminated event below
+        # records the actual termination result.
+        _append_event(
+            conn,
+            task_id,
+            "archived",
+            {
+                "worker_termination": {
+                    "prev_pid": int(prev["worker_pid"]) if prev["worker_pid"] else None,
+                    "prev_claim_lock": prev["claim_lock"],
+                    "pending": bool(prev["worker_pid"] and prev["claim_lock"]),
+                }
+            },
+            run_id=run_id,
+        )
+
+    termination = _terminate_reclaimed_worker(
+        prev["worker_pid"],
+        prev["claim_lock"],
+    )
+    with write_txn(conn):
+        _append_event(
+            conn,
+            task_id,
+            "worker_terminated",
+            {"worker_termination": termination},
+            run_id=run_id,
+        )
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.
@@ -4920,14 +4973,25 @@ def _terminate_reclaimed_worker(
     *,
     signal_fn=None,
 ) -> dict[str, Any]:
-    """Best-effort host-local worker termination for reclaim paths."""
+    """Best-effort host-local worker termination for reclaim paths.
+
+    Safety rule: when using the real OS signal path, only signal a PID
+    that is still a child of this process. That child check is the
+    practical PID-reuse guard available from the stored claim_lock +
+    worker_pid pair: if a PID has exited and been recycled, waitpid()
+    reports it is not our child and we refuse to signal it. Successful
+    termination waits/reaps the child so no zombie remains.
+    """
     import signal
 
     info: dict[str, Any] = {
         "prev_pid": int(pid) if pid else None,
+        "prev_claim_lock": claim_lock,
         "host_local": False,
+        "pid_is_child": False,
         "termination_attempted": False,
         "terminated": False,
+        "reaped": False,
         "sigkill": False,
     }
     if not pid or pid <= 0 or not claim_lock:
@@ -4944,6 +5008,24 @@ def _terminate_reclaimed_worker(
     if kill is None:
         return info
 
+    real_signal_path = signal_fn is None and os.name != "nt"
+    if real_signal_path:
+        try:
+            waited_pid, status = os.waitpid(int(pid), os.WNOHANG)
+        except ChildProcessError:
+            info["refused_reason"] = "pid_not_child_or_already_reaped"
+            return info
+        except OSError as exc:
+            info["refused_reason"] = f"waitpid_probe_failed:{exc.__class__.__name__}"
+            return info
+        if waited_pid == int(pid):
+            _record_worker_exit(int(pid), status)
+            info["pid_is_child"] = True
+            info["terminated"] = True
+            info["reaped"] = True
+            return info
+        info["pid_is_child"] = True
+
     info["termination_attempted"] = True
     try:
         kill(int(pid), signal.SIGTERM)
@@ -4951,12 +5033,25 @@ def _terminate_reclaimed_worker(
         return info
 
     for _ in range(10):
-        if not _pid_alive(pid):
+        if real_signal_path:
+            try:
+                waited_pid, status = os.waitpid(int(pid), os.WNOHANG)
+            except ChildProcessError:
+                info["terminated"] = True
+                info["reaped"] = True
+                return info
+            if waited_pid == int(pid):
+                _record_worker_exit(int(pid), status)
+                info["terminated"] = True
+                info["reaped"] = True
+                return info
+        elif not _pid_alive(pid):
             info["terminated"] = True
             return info
         time.sleep(0.5)
 
-    if _pid_alive(pid):
+    still_alive = True if real_signal_path else _pid_alive(pid)
+    if still_alive:
         try:
             # signal.SIGKILL doesn't exist on Windows; fall back to SIGTERM
             # (which maps to TerminateProcess via the stdlib shim).
@@ -4965,6 +5060,23 @@ def _terminate_reclaimed_worker(
             info["sigkill"] = True
         except (ProcessLookupError, OSError):
             return info
+
+    if real_signal_path:
+        for _ in range(10):
+            try:
+                waited_pid, status = os.waitpid(int(pid), os.WNOHANG)
+            except ChildProcessError:
+                info["terminated"] = True
+                info["reaped"] = True
+                return info
+            if waited_pid == int(pid):
+                _record_worker_exit(int(pid), status)
+                info["terminated"] = True
+                info["reaped"] = True
+                return info
+            time.sleep(0.2)
+        info["terminated"] = not _pid_alive(pid)
+        return info
 
     info["terminated"] = not _pid_alive(pid)
     return info

--- a/tests/hermes_cli/test_kanban_initial_blocked_safety.py
+++ b/tests/hermes_cli/test_kanban_initial_blocked_safety.py
@@ -1,0 +1,238 @@
+"""Regression tests for Kanban initial blocked safety.
+
+Covers the Control Room 2026-05-30 smoke where a card created with
+``initial_status='blocked'`` was auto-promoted, claimed, and spawned.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _event_kinds(conn, task_id: str) -> list[str]:
+    return [
+        row["kind"]
+        for row in conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id",
+            (task_id,),
+        ).fetchall()
+    ]
+
+
+def _event_payloads(conn, task_id: str, kind: str) -> list[dict]:
+    payloads: list[dict] = []
+    for row in conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? AND kind = ? ORDER BY id",
+        (task_id, kind),
+    ).fetchall():
+        payloads.append(json.loads(row["payload"] or "{}"))
+    return payloads
+
+
+def test_initial_status_blocked_without_parents_is_sticky_and_not_promoted(kanban_home: Path) -> None:
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="blocked smoke should remain inert",
+            assignee="kanban-coordenador",
+            initial_status="blocked",
+        )
+
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert "blocked" in _event_kinds(conn, tid)
+
+        for _ in range(3):
+            assert kb.recompute_ready(conn) == 0
+            assert kb.get_task(conn, tid).status == "blocked"
+
+        events = _event_kinds(conn, tid)
+        assert "promoted" not in events
+        assert "claimed" not in events
+        assert "spawned" not in events
+        assert kb.claim_task(conn, tid) is None
+
+
+def test_initial_status_blocked_with_done_parent_waits_for_explicit_unblock(kanban_home: Path) -> None:
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(
+            conn,
+            title="manual blocked child",
+            parents=[parent],
+            initial_status="blocked",
+        )
+        kb.complete_task(conn, parent, result="parent done")
+
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, child).status == "blocked"
+        assert "promoted" not in _event_kinds(conn, child)
+
+        assert kb.unblock_task(conn, child)
+        assert kb.get_task(conn, child).status == "ready"
+
+
+def test_initial_status_blocked_explicit_unblock_releases_parentless_task(kanban_home: Path) -> None:
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="manual block", initial_status="blocked")
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        assert kb.unblock_task(conn, tid)
+
+        assert kb.get_task(conn, tid).status == "ready"
+        events = _event_kinds(conn, tid)
+        assert "unblocked" in events
+        assert "promoted" not in events  # unblock releases directly to ready
+
+
+def test_circuit_breaker_gave_up_without_blocked_event_still_auto_recovers(kanban_home: Path) -> None:
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="circuit breaker recovery")
+        task = kb.claim_task(conn, tid)
+        assert task is not None
+
+        assert kb._record_spawn_failure(conn, tid, "boom", failure_limit=1)
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert "gave_up" in _event_kinds(conn, tid)
+        assert "blocked" not in _event_kinds(conn, tid)
+
+        assert kb.recompute_ready(conn) == 1
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_archive_running_task_records_archived_atomically_then_worker_terminated(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    def fake_terminate(pid, claim_lock, **kwargs):
+        calls.append((pid, claim_lock, kwargs))
+        return {
+            "prev_pid": pid,
+            "prev_claim_lock": claim_lock,
+            "host_local": True,
+            "pid_is_child": True,
+            "termination_attempted": True,
+            "terminated": True,
+            "reaped": True,
+            "sigkill": False,
+        }
+
+    monkeypatch.setattr(kb, "_terminate_reclaimed_worker", fake_terminate)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="archive active worker")
+        task = kb.claim_task(conn, tid, claimer="host:test-claim")
+        assert task is not None
+        conn.execute(
+            "UPDATE tasks SET worker_pid = ? WHERE id = ?",
+            (424242, tid),
+        )
+        conn.commit()
+
+        assert kb.archive_task(conn, tid)
+
+        assert calls == [(424242, "host:test-claim", {})]
+        archived = kb.get_task(conn, tid)
+        assert archived.status == "archived"
+        assert archived.worker_pid is None
+        assert archived.claim_lock is None
+
+        events = _event_kinds(conn, tid)
+        assert events.index("archived") < events.index("worker_terminated")
+        archived_payload = _event_payloads(conn, tid, "archived")[-1]
+        assert archived_payload["worker_termination"]["pending"] is True
+        terminated_payload = _event_payloads(conn, tid, "worker_terminated")[-1]
+        assert terminated_payload["worker_termination"]["terminated"] is True
+
+
+def test_archive_running_real_child_terminates_and_reaps(kanban_home: Path) -> None:
+    if os.name == "nt":
+        pytest.skip("POSIX waitpid/reap test")
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    try:
+        with kb.connect() as conn:
+            tid = kb.create_task(conn, title="archive real child")
+            task = kb.claim_task(conn, tid, claimer=kb._claimer_id())
+            assert task is not None
+            conn.execute("UPDATE tasks SET worker_pid = ? WHERE id = ?", (proc.pid, tid))
+            conn.commit()
+
+            assert kb.archive_task(conn, tid)
+
+            info = _event_payloads(conn, tid, "worker_terminated")[-1]["worker_termination"]
+            assert info["termination_attempted"] is True
+            assert info["terminated"] is True
+            assert info["reaped"] is True
+            assert proc.poll() is not None
+            with pytest.raises(ChildProcessError):
+                os.waitpid(proc.pid, os.WNOHANG)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def test_terminate_reclaimed_worker_refuses_stale_or_recycled_non_child_pid() -> None:
+    if os.name == "nt":
+        pytest.skip("POSIX waitpid/reap test")
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+    try:
+        claim_lock = kb._claimer_id()
+        # Reap first so the PID is no longer our child. This simulates the
+        # safety-relevant stale/recycled case: the stored pid is not a live
+        # child owned by this claim anymore, so the terminator must not signal.
+        proc.terminate()
+        proc.wait(timeout=5)
+        info = kb._terminate_reclaimed_worker(proc.pid, claim_lock)
+        assert info["termination_attempted"] is False
+        assert info["terminated"] is False
+        assert info.get("refused_reason") == "pid_not_child_or_already_reaped"
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def test_archive_with_no_worker_pid_is_noop_and_double_archive_does_not_kill(
+    kanban_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    def fake_terminate(pid, claim_lock, **kwargs):
+        calls.append((pid, claim_lock, kwargs))
+        return {"prev_pid": pid, "terminated": False}
+
+    monkeypatch.setattr(kb, "_terminate_reclaimed_worker", fake_terminate)
+
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="archive no pid")
+        assert kb.archive_task(conn, tid)
+        assert calls == [(None, None, {})]
+        archived_payload = _event_payloads(conn, tid, "archived")[-1]
+        assert archived_payload["worker_termination"]["pending"] is False
+
+        assert kb.archive_task(conn, tid) is False
+        assert calls == [(None, None, {})]
+        assert len(_event_payloads(conn, tid, "archived")) == 1


### PR DESCRIPTION
## Summary

Fixes a Kanban runtime safety bug where tasks created with `initial_status="blocked"` could later be auto-promoted by dependency recomputation because task creation did not emit an explicit `blocked` event.

This also hardens archiving of claimed/running tasks by reclaiming/terminating direct child workers safely and recording archive/termination audit events.

## What changed

- Emit an explicit `blocked` event when a task is created with `initial_status="blocked"`.
- Keep initially blocked tasks inert until an explicit manual unblock event.
- Make archive of claimed/running tasks reclaim the worker lock and terminate only a safe direct-child worker.
- Use `waitpid(..., WNOHANG)` checks before signaling to avoid PID-reuse hazards.
- Record `archived` atomically with the archive state transition.
- Add regression tests for sticky blocked creation, promotion prevention, archive teardown, stale/non-child PID safety, and circuit-breaker behavior.

## Test plan

Local targeted tests:

```text
scripts/run_tests.sh tests/hermes_cli/test_kanban_initial_blocked_safety.py tests/hermes_cli/test_kanban_db.py
# 213 tests passed, 0 failed
```

Expanded Kanban surface:

```text
scripts/run_tests.sh \
  tests/hermes_cli/test_kanban_*.py \
  tests/hermes_cli/test_signal_handler_kanban_worker.py \
  tests/hermes_cli/test_pin_kanban_board_env.py \
  tests/tools/test_kanban_tools.py \
  tests/tools/test_kanban_codex_lane_skill.py \
  tests/plugins/test_kanban_dashboard_plugin.py \
  tests/plugins/test_kanban_worker_runs.py \
  tests/plugins/test_kanban_attachments.py \
  tests/gateway/test_kanban_notifier.py
# 877 tests passed, 0 failed
```

## Safety notes

The worker termination path only signals a PID after successfully reclaiming the task lock and verifying the PID is still a direct child via `waitpid(pid, WNOHANG)`. If the PID is not a child or was already reaped, it refuses to signal, preventing accidental termination of unrelated processes after PID reuse.

The `archived` event is written in the same transaction as the archive state transition, so an audit event is not lost if a crash happens immediately after the state change.
