### PR TITLE
feat(email): expose raw message metadata to hooks

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -410,6 +410,7 @@ class EmailAdapter(BasePlatformAdapter):
 
                     results.append({
                         "uid": uid,
+                        "raw_email": raw_email,
                         "sender_addr": sender_addr,
                         "sender_name": sender_name,
                         "subject": subject,
@@ -417,6 +418,7 @@ class EmailAdapter(BasePlatformAdapter):
                         "in_reply_to": in_reply_to,
                         "body": body,
                         "attachments": attachments,
+                        "headers": msg_headers,
                         "date": msg.get("Date", ""),
                     })
             finally:
@@ -491,6 +493,11 @@ class EmailAdapter(BasePlatformAdapter):
             text=text or "(empty email)",
             message_type=msg_type,
             source=source,
+            raw_message={
+                "headers": msg_data.get("headers", {}),
+                "raw_email": msg_data.get("raw_email"),
+                "date": msg_data.get("date", ""),
+            },
             message_id=msg_data["message_id"],
             media_urls=media_urls,
             media_types=media_types,

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -423,6 +423,45 @@ class TestDispatchMessage(unittest.TestCase):
         self.assertEqual(event.source.user_name, "John Doe")
         self.assertEqual(event.source.chat_type, "dm")
 
+    def test_raw_email_metadata_is_attached_to_event(self):
+        """Plugins should be able to inspect raw email metadata.
+
+        Security plugins such as DKIM/alignment checks need access to the
+        original RFC822 bytes and headers.  The gateway still dispatches the
+        normalized text, but keeps the raw email details on ``raw_message`` for
+        hooks that need them.
+        """
+        import asyncio
+        adapter = self._make_adapter()
+        captured_events = []
+
+        async def capture_handle(event):
+            captured_events.append(event)
+
+        adapter.handle_message = capture_handle
+
+        raw_email = b"From: John <john@example.com>\r\nSubject: Hi\r\n\r\nHello"
+        msg_data = {
+            "uid": b"7",
+            "raw_email": raw_email,
+            "sender_addr": "john@example.com",
+            "sender_name": "John",
+            "subject": "Re: hi",
+            "message_id": "<msg7@test.com>",
+            "in_reply_to": "",
+            "body": "Hello",
+            "attachments": [],
+            "headers": {"From": "John <john@example.com>", "Subject": "Hi"},
+            "date": "Mon, 1 Jan 2024 00:00:00 +0000",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+
+        event = captured_events[0]
+        self.assertEqual(event.raw_message["raw_email"], raw_email)
+        self.assertEqual(event.raw_message["headers"]["Subject"], "Hi")
+        self.assertEqual(event.raw_message["date"], "Mon, 1 Jan 2024 00:00:00 +0000")
+
     def test_non_allowlisted_sender_dropped(self):
         """Senders not in EMAIL_ALLOWED_USERS should be dropped before dispatch."""
         import asyncio


### PR DESCRIPTION
## Summary
- attach raw RFC822 bytes and headers to email `MessageEvent.raw_message`
- preserve the normalized text dispatch path while giving hooks/plugins access to message-level metadata
- add a regression test covering the raw metadata on dispatched email events

## Why
Email security plugins such as DKIM/alignment checks need the original raw message bytes and headers. Exposing them on `raw_message` avoids brittle adapter monkeypatching.

## Test plan
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_email.py -q -o 'addopts='`
