### PR TITLE
fix(email): suppress explicit no-reply responses

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -508,6 +508,9 @@ class EmailAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an email reply to the given address."""
+        if content.strip() == "__NO_REPLY__":
+            logger.info("[Email] Agent chose not to reply to %s", chat_id)
+            return SendResult(success=True, message_id="")
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -640,6 +640,18 @@ class TestSendMethods(unittest.TestCase):
             mock_server.send_message.assert_called_once()
             mock_server.quit.assert_called_once()
 
+    def test_no_reply_token_suppresses_outbound_email(self):
+        """Exact __NO_REPLY__ means the gateway should not send email."""
+        import asyncio
+        adapter = self._make_adapter()
+
+        with patch.object(adapter, "_send_email") as mock_send_email:
+            result = asyncio.run(adapter.send("user@test.com", "__NO_REPLY__"))
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "")
+        mock_send_email.assert_not_called()
+
     def test_send_failure_returns_error(self):
         """SMTP failure should return SendResult with error."""
         import asyncio


### PR DESCRIPTION
## Summary
- treat an exact `__NO_REPLY__` response as a successful no-op in the email adapter
- add a regression test proving SMTP is not called for the suppression token

## Why
Agents sometimes need to record/handle an inbound email without sending an unnecessary acknowledgement. A literal no-reply token gives the model and prompts a deterministic way to suppress outbound email.

## Test plan
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_email.py -q -o 'addopts='`
