### PR TITLE
fix(run_agent): return text summary directly for non-vision computer_use captures (fixes #35817)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3889,16 +3889,6 @@ class AIAgent:
             return content
 
         summary = _multimodal_text_summary(result)
-        if tool_name == "computer_use":
-            return json.dumps({
-                "error": (
-                    "computer_use returned screenshot/image content, but the active "
-                    "model/provider does not support image input. Switch to a "
-                    "vision-capable model for desktop computer use, or use browser "
-                    "tools for browser tasks."
-                ),
-                "text_summary": summary,
-            })
 
         logger.warning(
             "Tool %s returned image content for non-vision model %s/%s; "


### PR DESCRIPTION
Non-vision models calling computer_use(action='capture') were getting a JSON object with an error field and the text summary bundled together. The model saw the error, got confused, and complained about not being vision-capable instead of using the summary it already received.

Removed the if tool_name == 'computer_use' block that wrapped the summary in error JSON. Non-vision models now get the text summary (AX tree) directly. The logger.warning on the next line still fires for debugging.

Closes #35817