### PR TITLE
fix(dashboard): require enabled user plugin APIs

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -222,6 +222,22 @@ def _get_enabled_plugins() -> Optional[set]:
         return None
 
 
+def is_plugin_enabled_by_config(name: str, key: Optional[str] = None) -> bool:
+    """Return whether an opt-in plugin may load under ``plugins`` config.
+
+    Explicit ``plugins.disabled`` entries always win. Otherwise, standalone
+    user/entry-point plugins must appear in ``plugins.enabled`` by either their
+    path-derived key or legacy bare manifest name.
+    """
+    lookup_key = key or name
+    disabled = _get_disabled_plugins()
+    if lookup_key in disabled or name in disabled:
+        return False
+
+    enabled = _get_enabled_plugins()
+    return enabled is not None and (lookup_key in enabled or name in enabled)
+
+
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4279,6 +4279,28 @@ def _safe_plugin_api_relpath(api_field: Any, *, dashboard_dir: Path) -> Optional
     return api_field
 
 
+def _dashboard_plugin_config_identity(plugin_dir: Path, dashboard_name: str) -> tuple[str, str]:
+    """Return the PluginManager-compatible config name/key for a dashboard plugin."""
+    manifest_file = plugin_dir / "plugin.yaml"
+    if not manifest_file.exists():
+        manifest_file = plugin_dir / "plugin.yml"
+    if not manifest_file.exists():
+        return dashboard_name, plugin_dir.name
+
+    try:
+        manifest = yaml.safe_load(manifest_file.read_text(encoding="utf-8")) or {}
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("Bad plugin manifest %s: %s", manifest_file, exc)
+        return dashboard_name, plugin_dir.name
+    if not isinstance(manifest, dict):
+        return dashboard_name, plugin_dir.name
+    manifest_name = manifest.get("name")
+    if isinstance(manifest_name, str) and manifest_name.strip():
+        name = manifest_name.strip()
+        return name, name
+    return dashboard_name, plugin_dir.name
+
+
 def _discover_dashboard_plugins() -> list:
     """Scan plugins/*/dashboard/manifest.json for dashboard extensions.
 
@@ -4324,6 +4346,7 @@ def _discover_dashboard_plugins() -> list:
                 if name in seen_names:
                     continue
                 seen_names.add(name)
+                config_name, config_key = _dashboard_plugin_config_identity(child, str(name))
                 # Tab options: ``path`` + ``position`` for a new tab, optional
                 # ``override`` to replace a built-in route, and ``hidden`` to
                 # register the plugin component/slots without adding a tab
@@ -4374,6 +4397,8 @@ def _discover_dashboard_plugins() -> list:
                     "css": data.get("css"),
                     "has_api": bool(safe_api),
                     "source": source,
+                    "_config_name": config_name,
+                    "_key": config_key,
                     "_dir": str(dashboard_dir),
                     "_api_file": safe_api,
                 })
@@ -4777,6 +4802,19 @@ def _mount_plugin_api_routes():
                 plugin["name"], api_file_name,
             )
             continue
+        if plugin.get("source") == "user":
+            from hermes_cli.plugins import is_plugin_enabled_by_config
+
+            if not is_plugin_enabled_by_config(
+                str(plugin.get("_config_name") or plugin["name"]),
+                key=str(plugin.get("_key") or plugin.get("_config_name") or plugin["name"]),
+            ):
+                _log.info(
+                    "Plugin %s: ignoring backend api=%s (plugin is not "
+                    "enabled by plugins.enabled or is disabled)",
+                    plugin["name"], api_file_name,
+                )
+                continue
         dashboard_dir = Path(plugin["_dir"])
         api_path = dashboard_dir / api_file_name
         try:

--- a/tests/hermes_cli/test_project_plugin_rce_bypass.py
+++ b/tests/hermes_cli/test_project_plugin_rce_bypass.py
@@ -266,6 +266,35 @@ class TestMountApiRoutesRefusesUntrusted:
             "_api_file": api_file,
         }
 
+    def _write_user_dashboard_plugin(
+        self,
+        home: Path,
+        name: str = "off",
+        *,
+        dashboard_name: str | None = None,
+        plugin_yaml_name: str | None = None,
+    ) -> Path:
+        dash = _write_plugin_manifest(
+            home / "plugins",
+            name,
+            {
+                "name": dashboard_name or name,
+                "label": (dashboard_name or name).title(),
+                "api": "api.py",
+                "entry": "dist/index.js",
+            },
+        )
+        if plugin_yaml_name:
+            (dash.parent / "plugin.yaml").write_text(
+                f"name: {plugin_yaml_name}\n",
+                encoding="utf-8",
+            )
+        (dash / "api.py").write_text(
+            "from fastapi import APIRouter\nrouter = APIRouter()\n",
+            encoding="utf-8",
+        )
+        return dash
+
     def test_project_source_api_is_not_imported(self, tmp_path):
         plugin = self._payload_plugin(tmp_path, source="project")
         web_server._dashboard_plugins_cache = [plugin]
@@ -288,16 +317,130 @@ class TestMountApiRoutesRefusesUntrusted:
         assert called_path.name == "api.py"
         assert called_path.is_absolute()
 
-    def test_traversal_api_caught_at_mount_time(self, tmp_path):
+    def test_traversal_api_caught_at_mount_time(self, tmp_path, monkeypatch):
         """Defence-in-depth: if discovery is bypassed (e.g. cache
         tampering), mount-time validation still refuses to import a
         file outside the dashboard dir."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (home / "config.yaml").write_text(
+            "plugins:\n  enabled:\n    - synthetic\n",
+            encoding="utf-8",
+        )
         plugin = self._payload_plugin(tmp_path, source="user",
                                        api_file="../../../tmp/evil.py")
         web_server._dashboard_plugins_cache = [plugin]
         with patch("importlib.util.spec_from_file_location") as spec:
             web_server._mount_plugin_api_routes()
         assert spec.call_count == 0
+
+    def test_disabled_user_dashboard_plugin_api_is_not_imported(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        bundled = tmp_path / "bundled"
+        bundled.mkdir()
+        monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+        (home / "config.yaml").write_text(
+            json.dumps({"plugins": {"disabled": ["off"]}}),
+            encoding="utf-8",
+        )
+        self._write_user_dashboard_plugin(home, "off")
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        assert {p["name"] for p in plugins} == {"off"}
+        with patch("importlib.util.spec_from_file_location") as spec, patch.object(
+            web_server.app, "include_router"
+        ) as include_router:
+            web_server._mount_plugin_api_routes()
+
+        assert spec.call_count == 0
+        assert include_router.call_count == 0
+
+    def test_enabled_user_dashboard_plugin_api_imports_normally(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        bundled = tmp_path / "bundled"
+        bundled.mkdir()
+        monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+        (home / "config.yaml").write_text(
+            json.dumps({"plugins": {"enabled": ["on"]}}),
+            encoding="utf-8",
+        )
+        self._write_user_dashboard_plugin(home, "on")
+
+        web_server._get_dashboard_plugins(force_rescan=True)
+        with patch("importlib.util.spec_from_file_location") as spec:
+            spec.return_value = None  # loader is None -> early continue, safe
+            web_server._mount_plugin_api_routes()
+
+        assert spec.call_count == 1
+        called_path = Path(spec.call_args.args[1])
+        assert called_path.name == "api.py"
+
+    def test_user_dashboard_plugin_api_uses_plugin_yaml_name_for_gate(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        bundled = tmp_path / "bundled"
+        bundled.mkdir()
+        monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+        (home / "config.yaml").write_text(
+            json.dumps({"plugins": {"enabled": ["plugin-key"]}}),
+            encoding="utf-8",
+        )
+        self._write_user_dashboard_plugin(
+            home,
+            "directory-key",
+            dashboard_name="dashboard-name",
+            plugin_yaml_name="plugin-key",
+        )
+
+        web_server._get_dashboard_plugins(force_rescan=True)
+        with patch("importlib.util.spec_from_file_location") as spec:
+            spec.return_value = None
+            web_server._mount_plugin_api_routes()
+
+        assert spec.call_count == 1
+        called_path = Path(spec.call_args.args[1])
+        assert called_path.name == "api.py"
+
+    def test_user_dashboard_plugin_api_ignores_dashboard_name_for_gate(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        bundled = tmp_path / "bundled"
+        bundled.mkdir()
+        monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+        (home / "config.yaml").write_text(
+            json.dumps({"plugins": {"enabled": ["dashboard-name"]}}),
+            encoding="utf-8",
+        )
+        self._write_user_dashboard_plugin(
+            home,
+            "directory-key",
+            dashboard_name="dashboard-name",
+            plugin_yaml_name="plugin-key",
+        )
+
+        web_server._get_dashboard_plugins(force_rescan=True)
+        with patch("importlib.util.spec_from_file_location") as spec, patch.object(
+            web_server.app, "include_router"
+        ) as include_router:
+            web_server._mount_plugin_api_routes()
+
+        assert spec.call_count == 0
+        assert include_router.call_count == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add a shared helper for `plugins.enabled` / `plugins.disabled` gating.
- Require user dashboard plugin backend APIs to be explicitly enabled before import/mount.
- Resolve dashboard plugin config identity from `plugin.yaml` when present so API mounting matches PluginManager key/name semantics.
- Preserve the existing project-plugin Python API import block and dashboard UI discovery behavior.

## Security impact
User-installed dashboard plugins are opt-in through the plugin loader, but the dashboard API mount path could still import a user plugin API declared in `dashboard/manifest.json`. This patch applies the same config gate before importing plugin backend code, including the `plugin.yaml` identity used by PluginManager.

## Verification
- `uv run --extra dev ruff check hermes_cli/web_server.py hermes_cli/plugins.py tests/hermes_cli/test_project_plugin_rce_bypass.py`
- `uv run --extra dev python -X utf8 -m pytest tests/hermes_cli/test_project_plugin_rce_bypass.py -q --timeout-method=thread`
- `uv run --extra dev ruff check .`