### PR TITLE
fix: auto-truncate tool names exceeding 64 chars for Copilot Opus

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -697,6 +697,35 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     # ── Provider profile path (registered providers) ───────────────────
     # Profiles handle per-provider quirks via hooks. When a profile is
     # found, delegate fully; otherwise fall through to the legacy flag path.
+
+    # GitHub Copilot API enforces a 64-character limit on tool function
+    # names for Opus models (Sonnet is permissive). Exceeding the limit
+    # causes HTTP 400 "Bad Request" with no useful detail. Deep-copy and
+    # truncate before sending; store the reverse map on the agent so
+    # tool_executor can map truncated names back to originals. See #copilot-opus-400.
+    if _is_gh and "opus" in (agent.model or "").lower():
+        _has_long = any(
+            len((t.get("function") or {}).get("name", "")) > 64
+            for t in (tools_for_api or [])
+            if isinstance(t, dict)
+        )
+        if _has_long:
+            try:
+                import copy as _copy
+                from tools.schema_sanitizer import enforce_tool_name_length
+                tools_for_api = _copy.deepcopy(tools_for_api)
+                tools_for_api, _name_map = enforce_tool_name_length(tools_for_api)
+                agent._copilot_tool_name_map = _name_map
+            except Exception as exc:
+                logger.warning(
+                    "%s⚠️ Failed to enforce tool name length for Copilot Opus: %s",
+                    getattr(agent, "log_prefix", ""), exc,
+                )
+        else:
+            agent._copilot_tool_name_map = {}
+    else:
+        agent._copilot_tool_name_map = {}
+
     try:
         from providers import get_provider_profile
         _profile = get_provider_profile(agent.provider)

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -129,8 +129,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
     # ── Parse args + pre-execution bookkeeping ───────────────────────
     parsed_calls = []  # list of (tool_call, function_name, function_args)
+    # Reverse-map for truncated Copilot Opus tool names (see chat_completion_helpers.py)
+    _copilot_name_map = getattr(agent, "_copilot_tool_name_map", None) or {}
     for tool_call in tool_calls:
         function_name = tool_call.function.name
+        # If the model returned a truncated name, restore the original
+        if function_name in _copilot_name_map:
+            function_name = _copilot_name_map[function_name]
 
         # Reset nudge counters
         if function_name == "memory":
@@ -531,6 +536,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
 def execute_tool_calls_sequential(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
     """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools."""
+    # Reverse-map for truncated Copilot Opus tool names (see chat_completion_helpers.py)
+    _copilot_name_map = getattr(agent, "_copilot_tool_name_map", None) or {}
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
         # SAFETY: check interrupt BEFORE starting each tool.
         # If the user sent "stop" during a previous tool's execution,
@@ -551,6 +558,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             break
 
         function_name = tool_call.function.name
+        # If the model returned a truncated name, restore the original
+        if function_name in _copilot_name_map:
+            function_name = _copilot_name_map[function_name]
 
         try:
             function_args = json.loads(tool_call.function.arguments)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2855,18 +2855,22 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
     if not schema:
         return {"type": "object", "properties": {}}
 
-    def _rewrite_local_refs(node):
+    def _rewrite_local_refs(node, *, _is_root=True):
         if isinstance(node, dict):
             normalized = {}
             for key, value in node.items():
-                out_key = "$defs" if key == "definitions" else key
-                normalized[out_key] = _rewrite_local_refs(value)
+                # Only rename "definitions" → "$defs" at the schema root level.
+                # Inside "properties" dicts, "definitions" is a legitimate
+                # property name (e.g. Azure DevOps pipelines_get_builds uses
+                # "definitions" as a parameter for build definition IDs).
+                out_key = "$defs" if key == "definitions" and _is_root else key
+                normalized[out_key] = _rewrite_local_refs(value, _is_root=False)
             ref = normalized.get("$ref")
             if isinstance(ref, str) and ref.startswith("#/definitions/"):
                 normalized["$ref"] = "#/$defs/" + ref[len("#/definitions/"):]
             return normalized
         if isinstance(node, list):
-            return [_rewrite_local_refs(item) for item in node]
+            return [_rewrite_local_refs(item, _is_root=False) for item in node]
         return node
 
     def _strip_nullable_union(node):
@@ -2929,6 +2933,14 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
         return {"type": "object", "properties": {}}
     if normalized.get("type") == "object" and "properties" not in normalized:
         normalized = {**normalized, "properties": {}}
+
+    # Strip $-prefixed meta-keys that aren't needed for tool calling and
+    # violate strict API validators (Anthropic/Copilot reject keys not
+    # matching ^[a-zA-Z0-9_.-]{1,64}$). Common offender: $schema from
+    # @azure-devops/mcp which includes it in every tool inputSchema.
+    _STRIP_DOLLAR_KEYS = {"$schema"}
+    for key in _STRIP_DOLLAR_KEYS:
+        normalized.pop(key, None)
 
     return normalized
 

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -443,3 +443,67 @@ def strip_slash_enum(tools: list[dict]) -> tuple[list[dict], int]:
             stripped,
         )
     return tools, stripped
+
+
+# ── Tool name length enforcement ────────────────────────────────────────
+# GitHub Copilot's /chat/completions endpoint enforces a 64-character limit
+# on tool function names for Opus models (Sonnet does not enforce this).
+# Exceeding the limit causes an opaque HTTP 400 "Bad Request" with no
+# field-level detail. This function truncates long names and returns a
+# mapping to reverse the truncation on tool_call responses.
+
+MAX_TOOL_NAME_LENGTH = 64
+
+
+def enforce_tool_name_length(
+    tools: list[dict],
+    max_length: int = MAX_TOOL_NAME_LENGTH,
+) -> tuple[list[dict], dict[str, str]]:
+    """Truncate tool function names exceeding *max_length* characters.
+
+    Returns ``(tools, name_map)`` where *name_map* maps truncated names
+    back to their originals. Tools list is mutated in place — callers that
+    need to preserve the original should deep-copy first.
+
+    The truncation preserves as much of the original name as possible by
+    simple prefix truncation. A disambiguation suffix is appended when
+    multiple tools collide after truncation.
+    """
+    if not tools:
+        return tools, {}
+
+    name_map: dict[str, str] = {}  # truncated → original
+    seen_truncated: dict[str, int] = {}  # truncated → collision count
+
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function")
+        if not isinstance(fn, dict):
+            continue
+        name = fn.get("name", "")
+        if len(name) <= max_length:
+            continue
+
+        truncated = name[:max_length]
+
+        # Handle collisions: if two different names truncate to the same
+        # string, append a numeric suffix to disambiguate.
+        if truncated in seen_truncated and name_map.get(truncated) != name:
+            seen_truncated[truncated] += 1
+            suffix = str(seen_truncated[truncated])
+            truncated = name[: max_length - len(suffix)] + suffix
+        else:
+            seen_truncated[truncated] = 0
+
+        name_map[truncated] = name
+        fn["name"] = truncated
+
+    if name_map:
+        logger.info(
+            "schema_sanitizer: truncated %d tool name(s) exceeding %d chars "
+            "(Copilot API Opus compatibility)",
+            len(name_map),
+            max_length,
+        )
+    return tools, name_map


### PR DESCRIPTION
## Problem

Copilot API enforces a 64-character limit on `tools[].function.name` for Opus models. MCP servers with long prefixes (e.g., `mcp_azure_devops_varonis_*`) produce names that exceed this limit, causing opaque **Bad Request** errors with no field detail — rendering the agent completely non-operational.

## Solution

Three-layer fix:

1. **`enforce_tool_name_length()`** in `tools/schema_sanitizer.py` — truncates names to 64 chars with collision handling (numeric suffixes) and builds a reverse name map for routing responses back.

2. **Activation gate** in `agent/chat_completion_helpers.py` — only activates for GitHub provider + Opus model (the only known enforcer).

3. **Reverse-map lookup** in `agent/tool_executor.py` — so truncated tool names in LLM responses route back to the correct MCP tool handler.

4. **`mcp_tool.py` fixes** — `_rewrite_local_refs` now handles nested `$defs`/`definitions` correctly, and strips unsupported `$schema` keys that also caused Copilot API rejections.

## Testing

- 234 MCP tools loaded; 3 exceeded 64 chars and were truncated without collision
- Agent fully operational with Opus + Copilot after fix
- No impact on non-Opus models or other providers (gate is model-specific)