### PR TITLE
feat(skills): project-local skill discovery from the working directory (#4667)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -324,15 +324,109 @@ def get_external_skills_dirs() -> List[Path]:
     return result
 
 
+_PROJECT_LOCAL_SUBDIRS: Tuple[str, ...] = (".claude/skills", ".agents/skills", "skills")
+_PROJECT_LOCAL_FLAG_CACHE: Dict[Tuple[str, int], bool] = {}
+
+
+def _project_local_enabled() -> bool:
+    """True if ``skills.project_local`` is set in config.yaml (default False).
+
+    Cached on config.yaml mtime, mirroring :func:`get_external_skills_dirs`: this
+    is consulted once per skill during banner / tool-registry scans, so the YAML
+    parse must not run on every call.
+    """
+    config_path = get_config_path()
+    if not config_path.exists():
+        return False
+    try:
+        stat = config_path.stat()
+        cache_key: Optional[Tuple[str, int]] = (str(config_path), stat.st_mtime_ns)
+    except OSError:
+        cache_key = None
+    if cache_key is not None:
+        cached = _PROJECT_LOCAL_FLAG_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+    try:
+        parsed = yaml_load(config_path.read_text(encoding="utf-8"))
+        skills_cfg = parsed.get("skills") if isinstance(parsed, dict) else None
+        enabled = bool(isinstance(skills_cfg, dict) and skills_cfg.get("project_local"))
+    except Exception:
+        enabled = False
+    if cache_key is not None:
+        _PROJECT_LOCAL_FLAG_CACHE[cache_key] = enabled
+    return enabled
+
+
+def _find_project_root(start: Path) -> Path:
+    """Nearest ancestor (including ``start``) containing a ``.git``; else ``start``."""
+    try:
+        cur = start.resolve()
+    except Exception:
+        cur = start
+    for _ in range(50):  # bounded walk to the filesystem root
+        if (cur / ".git").exists():
+            return cur
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+    return start
+
+
+def get_project_local_skills_dirs(cwd: Optional[Path] = None) -> List[Path]:
+    """Project-local skill directories for the working repo (issue #4667).
+
+    Discovers ``.claude/skills`` / ``.agents/skills`` / ``skills`` at the
+    *project root* (nearest git root at/above ``cwd``, else ``cwd``) so a repo's
+    own skills load when Hermes works inside it -- without the global
+    ``skills.external_dirs`` pollution of every other project.
+
+    Off by default; enable with ``skills.project_local: true`` in config.yaml
+    (settable per profile).  Returns only existing directories, deduped, and
+    never the local ``~/.hermes/skills/`` dir.
+    """
+    if not _project_local_enabled():
+        return []
+    base = Path(cwd) if cwd is not None else Path(os.getcwd())
+    root = _find_project_root(base)
+    local_skills = get_skills_dir().resolve()
+    seen: Set[Path] = set()
+    result: List[Path] = []
+    for sub in _PROJECT_LOCAL_SUBDIRS:
+        candidate = root / sub
+        try:
+            candidate = candidate.resolve()
+        except Exception:
+            continue
+        if candidate == local_skills or candidate in seen:
+            continue
+        if candidate.is_dir():
+            seen.add(candidate)
+            result.append(candidate)
+    return result
+
+
 def get_all_skills_dirs() -> List[Path]:
     """Return all skill directories: local ``~/.hermes/skills/`` first, then external.
 
     The local dir is always first (and always included even if it doesn't exist
     yet — callers handle that).  External dirs follow in config order.
     """
-    dirs = [get_skills_dir()]
-    dirs.extend(get_external_skills_dirs())
-    return dirs
+    ordered = [get_skills_dir()]
+    ordered.extend(get_project_local_skills_dirs())  # #4667 (opt-in)
+    ordered.extend(get_external_skills_dirs())
+    seen: Set[Path] = set()
+    deduped: List[Path] = []
+    for d in ordered:
+        try:
+            resolved = d.resolve()
+        except Exception:
+            resolved = d
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        deduped.append(d)
+    return deduped
 
 
 # ── Condition extraction ──────────────────────────────────────────────────

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1528,6 +1528,7 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        "project_local": False,  # #4667: discover <project-root>/.claude|.agents/skills
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from agent.skill_utils import (
     extract_skill_conditions,
     iter_skill_index_files,
+    get_project_local_skills_dirs,
     skill_matches_platform,
 )
 
@@ -197,3 +198,46 @@ class TestSkillMatchesPlatformTermux:
             "agent.skill_utils.is_termux", return_value=False
         ):
             assert skill_matches_platform(fm) is True
+
+
+# ── Project-local skill discovery (#4667) ───────────────────────────────────
+
+
+def _make_project(root):
+    """A git repo with a project-local .claude/skills/demo skill."""
+    (root / ".git").mkdir()
+    skill = root / ".claude" / "skills" / "demo"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: demo\ndescription: x\n---\n")
+    return root
+
+
+def test_project_local_disabled_by_default(tmp_path):
+    """With the flag off, nothing is discovered even inside a project."""
+    proj = _make_project(tmp_path)
+    with patch("agent.skill_utils._project_local_enabled", return_value=False):
+        assert get_project_local_skills_dirs(cwd=proj) == []
+
+
+def test_project_local_discovers_claude_skills(tmp_path):
+    """When enabled, <project-root>/.claude/skills is discovered from the cwd."""
+    proj = _make_project(tmp_path)
+    with patch("agent.skill_utils._project_local_enabled", return_value=True):
+        dirs = get_project_local_skills_dirs(cwd=proj)
+    assert (proj / ".claude" / "skills").resolve() in dirs
+
+
+def test_project_local_walks_up_to_git_root(tmp_path):
+    """A nested cwd resolves to the git root's project-local skills."""
+    proj = _make_project(tmp_path)
+    nested = proj / "src" / "deep"
+    nested.mkdir(parents=True)
+    with patch("agent.skill_utils._project_local_enabled", return_value=True):
+        dirs = get_project_local_skills_dirs(cwd=nested)
+    assert (proj / ".claude" / "skills").resolve() in dirs
+
+
+def test_project_local_empty_outside_project(tmp_path):
+    """Outside any project (no .claude/skills above cwd) returns nothing."""
+    with patch("agent.skill_utils._project_local_enabled", return_value=True):
+        assert get_project_local_skills_dirs(cwd=tmp_path) == []


### PR DESCRIPTION
## What

Adds **project-local skill discovery**: Hermes discovers `.claude/skills`, `.agents/skills`, and `skills/` at the **project root** (nearest git root at/above the working directory), so a repository's own skills load when Hermes works inside it.

Implements #4667.

## Why

Today the only way to surface a repo's project-specific skills — e.g. those installed by `npx skills experimental_install` into `.claude/skills/`, or a per-project agent toolkit (BMAD, etc.) — is `skills.external_dirs`, which is **global** and pollutes every other project's context. This is exactly the problem #4667 describes.

## How

- New `get_project_local_skills_dirs(cwd=None)` in `agent/skill_utils.py`: resolves the nearest git root at/above the cwd and returns its existing `.claude/skills` / `.agents/skills` / `skills` directories.
- Folded into `get_all_skills_dirs()` **between** the local dir and `external_dirs`, so project-local skills take precedence over global external dirs, while never shadowing the local `~/.hermes/skills` dir (index 0 is preserved for callers that special-case it).
- **Opt-in** via a new `skills.project_local` flag (default `false`), and **cwd-gated** — it returns nothing when the working directory isn't inside a project that has project-local skills, so it can't affect sessions running outside a project (e.g. the gateway).
- The flag read is cached on `config.yaml` mtime, mirroring `get_external_skills_dirs()`, so it doesn't reintroduce per-skill YAML parsing on cold start.

## Tests

`tests/agent/test_skill_utils.py`: discovery when enabled, walking a nested cwd up to the git root, disabled-by-default, and empty outside a project. All pass.

## Notes

- Default `false` → **no behavior change** for existing users; purely additive.
- Scoped subset of #21686 — this covers the `.claude`/`.agents/skills` discovery; walking `CLAUDE.md`/`AGENTS.md`/`.cursorrules` to the git root is separate and not included here.
