### PR TITLE
fix(anthropic): demote dead thinking signature when orphan-strip mutates the latest turn

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1783,11 +1783,25 @@ def _strip_orphaned_tool_blocks(result: List[Dict[str, Any]]) -> None:
                     tool_result_ids.add(block.get("tool_use_id"))
     for m in result:
         if m["role"] == "assistant" and isinstance(m["content"], list):
-            m["content"] = [
+            kept = [
                 b
                 for b in m["content"]
                 if b.get("type") != "tool_use" or b.get("id") in tool_result_ids
             ]
+            # If stripping an orphaned tool_use mutated a turn that also carries a
+            # signed thinking block, that block's Anthropic signature was computed
+            # against the ORIGINAL (un-stripped) turn content and is now invalid.
+            # Anthropic rejects the replayed turn with HTTP 400 "thinking blocks in
+            # the latest assistant message cannot be modified".  Flag the turn so
+            # _manage_thinking_signatures can demote the dead signature instead of
+            # replaying it verbatim.  See hermes-agent: extended-thinking + parallel
+            # tool batch interrupted mid-flight → non-retryable 400 crash-loop.
+            if len(kept) != len(m["content"]) and any(
+                isinstance(b, dict) and b.get("type") in {"thinking", "redacted_thinking"}
+                for b in m["content"]
+            ):
+                m["_thinking_signature_invalidated"] = True
+            m["content"] = kept
             if not m["content"]:
                 m["content"] = [{"type": "text", "text": "(tool call removed)"}]
 
@@ -1832,6 +1846,10 @@ def _merge_consecutive_roles(result: List[Dict[str, Any]]) -> List[Dict[str, Any
                     fixed[-1]["content"] = prev_content + curr_content
             else:
                 # Consecutive assistant messages — merge text content.
+                # Propagate the orphan-strip signature-invalidation flag onto the
+                # surviving (prev) dict so _manage_thinking_signatures still sees it.
+                if m.get("_thinking_signature_invalidated"):
+                    fixed[-1]["_thinking_signature_invalidated"] = True
                 # Drop thinking blocks from the *second* message: their
                 # signature was computed against a different turn boundary
                 # and becomes invalid once merged.
@@ -1920,10 +1938,25 @@ def _manage_thinking_signatures(
         else:
             # Latest assistant on direct Anthropic: keep signed, downgrade unsigned
             # to text so the reasoning isn't lost.
+            #
+            # Exception: if orphan-stripping (or another structural mutation) removed
+            # a tool_use block from THIS turn, every thinking signature on it was
+            # computed against the original turn content and is now dead.  Anthropic
+            # rejects the turn either way — replaying the signed block 400s with
+            # "thinking blocks in the latest assistant message cannot be modified",
+            # and a bare signed block with no following tool_use is also invalid.
+            # Demote ALL thinking blocks on this turn to text so the turn replays
+            # cleanly and the model can re-plan from the surviving tool results.
+            signature_dead = bool(m.get("_thinking_signature_invalidated"))
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
                     new_content.append(b)
+                    continue
+                if signature_dead:
+                    thinking_text = b.get("thinking", "")
+                    if thinking_text:
+                        new_content.append({"type": "text", "text": thinking_text})
                     continue
                 if b.get("type") == "redacted_thinking":
                     # Redacted blocks use 'data' for the signature payload —
@@ -1943,6 +1976,9 @@ def _manage_thinking_signatures(
         for b in m["content"]:
             if isinstance(b, dict) and b.get("type") in _THINKING_TYPES:
                 b.pop("cache_control", None)
+
+        # Drop the internal bookkeeping flag — it must never reach the API payload.
+        m.pop("_thinking_signature_invalidated", None)
 
 
 def _evict_old_screenshots(result: List[Dict[str, Any]]) -> None:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1827,6 +1827,79 @@ class TestThinkingBlockSignatureManagement:
         assert len(last_thinking) == 1
         assert last_thinking[0]["signature"] == "sig_3"
 
+    def test_orphan_stripped_tool_use_demotes_dead_signed_thinking(self):
+        """Regression: extended-thinking + interrupted parallel tool batch.
+
+        An assistant turn with a signed thinking block fires several parallel
+        tool_use blocks, but the batch is interrupted before every tool_result
+        comes back. On replay, the orphaned tool_use is stripped — which mutates
+        the turn and invalidates the thinking-block signature (it was computed
+        against the original, un-stripped content). Anthropic then rejects the
+        turn with HTTP 400 "thinking blocks in the latest assistant message
+        cannot be modified", a non-retryable error that crash-loops the gateway.
+
+        The signed thinking block on the mutated latest turn must be demoted to
+        a plain text block so the turn replays cleanly.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_kept", "function": {"name": "tool_a", "arguments": "{}"}},
+                    {"id": "tc_orphan", "function": {"name": "tool_b", "arguments": "{}"}},
+                ],
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Plan: call A and B.", "signature": "sig_dead"},
+                ],
+            },
+            # Only one of the two parallel tool_use blocks got a result back.
+            {"role": "tool", "tool_call_id": "tc_kept", "content": "result A"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        assistant = next(m for m in result if m["role"] == "assistant")
+        blocks = assistant["content"]
+
+        # No signed thinking block survives — the signature is dead.
+        assert not any(
+            isinstance(b, dict) and b.get("type") in {"thinking", "redacted_thinking"}
+            for b in blocks
+        )
+        # The reasoning text is preserved as a text block (not silently lost).
+        text_contents = [b.get("text", "") for b in blocks if b.get("type") == "text"]
+        assert "Plan: call A and B." in text_contents
+        # The orphaned tool_use is gone; the answered one survives.
+        tool_use_ids = [b.get("id") for b in blocks if b.get("type") == "tool_use"]
+        assert tool_use_ids == ["tc_kept"]
+        # Internal bookkeeping flag must never leak into the API payload.
+        assert "_thinking_signature_invalidated" not in assistant
+
+    def test_signed_thinking_preserved_when_no_tool_use_stripped(self):
+        """Control: an intact latest turn keeps its signed thinking verbatim.
+
+        This guards against the orphan-strip fix over-firing — when no tool_use
+        is removed, the signature is still valid and must be replayed as-is.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_1", "function": {"name": "tool_a", "arguments": "{}"}},
+                ],
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Valid plan.", "signature": "sig_live"},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result A"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        assistant = next(m for m in result if m["role"] == "assistant")
+        thinking = [b for b in assistant["content"] if b.get("type") == "thinking"]
+        assert len(thinking) == 1
+        assert thinking[0]["signature"] == "sig_live"
+        assert "_thinking_signature_invalidated" not in assistant
+
 
 # ---------------------------------------------------------------------------
 # Tool choice


### PR DESCRIPTION
## What does this PR do?

Fixes a non-retryable HTTP 400 crash-loop that occurs with extended-thinking Claude models (4.6+, e.g. Opus 4.8) when a parallel tool batch is interrupted before every tool result returns.

Extended-thinking models emit a **signed `thinking` block** on assistant turns that also fire `tool_use` blocks. Anthropic signs that block against the *full, original* turn content. When the next request replays that turn, the signed block must be passed back byte-for-byte — if the turn was modified, Anthropic rejects it:

```
messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest
assistant message cannot be modified. These blocks must remain as they were
in the original response.
```

`_strip_orphaned_tool_blocks()` legitimately removes a `tool_use` whose matching `tool_result` never arrived (parallel batch interrupted, context compression, session truncation). But that **mutates the latest assistant turn**, and `_manage_thinking_signatures()` then replays the now-stale signed thinking block verbatim → HTTP 400. The error is classified non-retryable, so the gateway falls back / retries and reloads the same poisoned transcript from the persisted store **every turn** — an infinite crash-loop with no self-recovery (a soft session reset does not clear it, because history is rebuilt from the store). The drifting `content` index in the error message is simply the changing count of stripped `tool_use` blocks across rebuilds.

This is a clean reproduction: turn = `[thinking(signed), tool_use_A, tool_use_B]`, only `tool_result_A` comes back → `tool_use_B` is stripped → signature over the original 3-block turn is now dead.

## Related Issue

Fixes #35847
Related (separate bug, also filed): #35848 — the fallback path raises `'NoneType' object is not iterable` downstream of this 400.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`agent/anthropic_adapter.py`**
  - `_strip_orphaned_tool_blocks()`: when stripping an orphaned `tool_use` mutates a turn that also carries a `thinking`/`redacted_thinking` block, set an internal `_thinking_signature_invalidated` flag on that message (its signature is now computed against content that no longer exists).
  - `_merge_consecutive_roles()`: propagate the flag onto the surviving (prev) dict when consecutive assistant messages are merged, so it isn't lost before signature management runs.
  - `_manage_thinking_signatures()`: in the latest-assistant branch, when the flag is set, **demote all thinking blocks on that turn to plain text blocks** (preserving the reasoning text) instead of replaying a dead signature. An intact turn is unaffected — its signed thinking is still replayed verbatim. The internal flag is stripped before the payload is sent.
- **`tests/agent/test_anthropic_adapter.py`**
  - `test_orphan_stripped_tool_use_demotes_dead_signed_thinking` — regression for the crash-loop: orphaned parallel `tool_use` stripped → signed thinking demoted to text, reasoning preserved, answered tool_use survives, internal flag never leaks.
  - `test_signed_thinking_preserved_when_no_tool_use_stripped` — control: an intact latest turn keeps its signed thinking verbatim (guards against the fix over-firing).

## How to Test

1. `pytest tests/agent/test_anthropic_adapter.py -k "thinking or signature or orphan or merge or preserved or redacted" -q` → 27 passed.
2. Targeted: `pytest tests/agent/test_anthropic_adapter.py -k "orphan_stripped or no_tool_use_stripped" -q` → 2 passed.
3. Repro (pre-fix): build an assistant turn with one signed thinking block + two `tool_use` blocks, supply only one `tool_result`, and call `convert_messages_to_anthropic`. Before the fix, the latest turn keeps the signed `thinking` block whose signature no longer matches the stripped content (Anthropic 400s on replay). After the fix, the block is demoted to text and the turn replays cleanly.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(anthropic): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant suite and tests pass (3 unrelated `TestRunOauthSetupToken` failures are pre-existing on the base commit — a MagicMock/subprocess mock issue, not touched by this PR)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4 (Apple Silicon), Python 3.11.15

### Documentation & Housekeeping

- [x] N/A — no documentation/config/tool-schema changes; behavior fix only, fully covered by existing docstrings updated inline.
