### PR TITLE
fix(mattermost): pass reply_to to send_multiple_images for thread-aware media delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2303,6 +2303,7 @@ class BasePlatformAdapter(ABC):
         images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
+        reply_to: Optional[str] = None,
     ) -> None:
         """Send a batch of images.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11840,7 +11840,8 @@ class GatewayRunner:
             local_files, _ = adapter.extract_local_files(cleaned)
             local_files = BasePlatformAdapter.filter_local_delivery_paths(local_files)
 
-            _thread_meta = self._thread_metadata_for_source(event.source, self._reply_anchor_for_event(event))
+            _reply_anchor = self._reply_anchor_for_event(event)
+            _thread_meta = self._thread_metadata_for_source(event.source, _reply_anchor)
 
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
             _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
@@ -11875,6 +11876,7 @@ class GatewayRunner:
                         chat_id=event.source.chat_id,
                         images=images,
                         metadata=_thread_meta,
+                        reply_to=_reply_anchor,
                     )
                 except Exception as e:
                     logger.warning("[%s] Post-stream image batch delivery failed: %s", adapter.name, e)
@@ -11887,18 +11889,21 @@ class GatewayRunner:
                             chat_id=event.source.chat_id,
                             audio_path=media_path,
                             metadata=_thread_meta,
+                            reply_to=_reply_anchor,
                         )
                     elif ext in _VIDEO_EXTS:
                         await adapter.send_video(
                             chat_id=event.source.chat_id,
                             video_path=media_path,
                             metadata=_thread_meta,
+                            reply_to=_reply_anchor,
                         )
                     else:
                         await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=media_path,
                             metadata=_thread_meta,
+                            reply_to=_reply_anchor,
                         )
                 except Exception as e:
                     logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
@@ -11911,12 +11916,14 @@ class GatewayRunner:
                             chat_id=event.source.chat_id,
                             video_path=file_path,
                             metadata=_thread_meta,
+                            reply_to=_reply_anchor,
                         )
                     else:
                         await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=file_path,
                             metadata=_thread_meta,
+                            reply_to=_reply_anchor,
                         )
                 except Exception as e:
                     logger.warning("[%s] Post-stream file delivery failed: %s", adapter.name, e)

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -523,6 +523,7 @@ class MattermostAdapter(BasePlatformAdapter):
         images: List[Tuple[str, str]],
         metadata: Optional[Dict[str, Any]] = None,
         human_delay: float = 0.0,
+        reply_to: Optional[str] = None,
     ) -> None:
         """Send a batch of images as a single Mattermost post with multiple attachments.
 
@@ -596,6 +597,8 @@ class MattermostAdapter(BasePlatformAdapter):
                     "message": "\n".join(caption_parts),
                     "file_ids": file_ids,
                 }
+                if reply_to and self._reply_mode == "thread":
+                    payload["root_id"] = await self._resolve_root_id(reply_to)
                 logger.info(
                     "Mattermost: sending %d image(s) as single post (chunk %d/%d)",
                     len(file_ids), chunk_idx + 1, len(chunks),

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -396,6 +396,44 @@ class TestMattermostMultiImage:
         _run(adapter.send_multiple_images("channel123", []))
         adapter._api_post.assert_not_called()
 
+    def test_reply_to_sets_root_id_in_thread_mode(self, adapter, tmp_path):
+        """When reply_to is set and reply_mode is 'thread', root_id is included in payload."""
+        adapter._resolve_root_id = AsyncMock(return_value="root_post_456")
+        p = tmp_path / "img.png"
+        p.write_bytes(b"\x89PNG" + b"\x00" * 10)
+        images = [(f"file://{p}", "")]
+
+        _run(adapter.send_multiple_images("channel123", images, reply_to="msg_789"))
+
+        adapter._resolve_root_id.assert_awaited_once_with("msg_789")
+        payload = adapter._api_post.await_args.args[1]
+        assert payload["root_id"] == "root_post_456"
+
+    def test_reply_to_ignored_in_non_thread_mode(self, adapter, tmp_path):
+        """When reply_mode is not 'thread', reply_to is accepted but root_id is not set."""
+        adapter._reply_mode = "off"
+        adapter._resolve_root_id = AsyncMock(return_value="root_post_456")
+        p = tmp_path / "img.png"
+        p.write_bytes(b"\x89PNG" + b"\x00" * 10)
+        images = [(f"file://{p}", "")]
+
+        _run(adapter.send_multiple_images("channel123", images, reply_to="msg_789"))
+
+        adapter._resolve_root_id.assert_not_awaited()
+        payload = adapter._api_post.await_args.args[1]
+        assert "root_id" not in payload
+
+    def test_no_reply_to_no_root_id(self, adapter, tmp_path):
+        """When reply_to is None, root_id is not set even in thread mode."""
+        p = tmp_path / "img.png"
+        p.write_bytes(b"\x89PNG" + b"\x00" * 10)
+        images = [(f"file://{p}", "")]
+
+        _run(adapter.send_multiple_images("channel123", images))
+
+        payload = adapter._api_post.await_args.args[1]
+        assert "root_id" not in payload
+
 
 # ---------------------------------------------------------------------------
 # Email


### PR DESCRIPTION
## What does this PR do?

Fixes media attachments (generated images, files, voice, video) posting to the Mattermost channel root instead of threading under the triggering message. The text reply threaded correctly, but the media delivery path in `_deliver_media_from_response()` did not pass the reply anchor to the send methods.

## Related Issue

Fixes #35844

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/mattermost/adapter.py`: Add `reply_to` parameter to `send_multiple_images()`; set `payload["root_id"]` via `_resolve_root_id(reply_to)` when `reply_mode == "thread"`, matching the existing pattern in `_send_local_file`.
- `gateway/platforms/base.py`: Add `reply_to` parameter to base `send_multiple_images()` signature for interface consistency.
- `gateway/run.py`: In `_deliver_media_from_response()`, extract `_reply_anchor` and pass it as `reply_to` to all media send calls (`send_multiple_images`, `send_voice`, `send_video`, `send_document`).
- `tests/gateway/test_send_multiple_images.py`: Add 3 regression tests — `root_id` set in thread mode, ignored in non-thread mode, absent when `reply_to` is None.

## How to Test

1. Configure Mattermost gateway with `display.platforms.mattermost.reply_mode: thread` (or `MATTERMOST_REPLY_MODE=thread`)
2. In a channel (not an existing thread), mention the bot with an image-generation prompt (e.g. `@bot draw a cat`)
3. Verify the image attachment appears as a reply in the same thread as the text response, not as a separate top-level post
4. Run `pytest tests/gateway/test_send_multiple_images.py::TestMattermostMultiImage -v` — all 6 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `MattermostAdapter.send_multiple_images` (callers: 1 in `_deliver_media_from_response`, 1 fallback in base)
- Analyzed: `_deliver_media_from_response` (callers: 1 in `_process_message_background` post-stream path)
- Blast radius: LOW — changes are additive (`reply_to` parameter with `None` default), no existing callers break
- Related patterns: `_send_local_file` (line 512-513) already implements the same `root_id` resolution pattern; `_send_voice_reply` (line 11776-11793) already passes `reply_to=reply_anchor` to `send_voice`
