### PR TITLE
feat(web): add Yandex Cloud Search API web search provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,6 +125,15 @@
 # XIAOMI_BASE_URL=https://api.xiaomimimo.com/v1
 
 # =============================================================================
+# Yandex Cloud Search API (web_search backend: yandex)
+# =============================================================================
+# Paid — requires Yandex Cloud billing account; no free tier.
+# Search API key is separate from YANDEX_API_KEY (LLM / AI Studio).
+# Get credentials at: https://yandex.cloud/en/docs/search-api/quickstart
+# YANDEX_CLOUD_API_KEY=your_search_api_key_here
+# YANDEX_CLOUD_FOLDER_ID=your_folder_id_here
+
+# =============================================================================
 # TOOL API KEYS
 # =============================================================================
 

--- a/plugins/web/yandex/__init__.py
+++ b/plugins/web/yandex/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from plugins.web.yandex.provider import YandexWebSearchProvider
+from .provider import YandexWebSearchProvider
 
 
 def register(ctx) -> None:

--- a/plugins/web/yandex/__init__.py
+++ b/plugins/web/yandex/__init__.py
@@ -1,0 +1,10 @@
+"""Yandex Cloud Search API plugin — bundled web search backend."""
+
+from __future__ import annotations
+
+from plugins.web.yandex.provider import YandexWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Yandex web search provider with the plugin context."""
+    ctx.register_web_search_provider(YandexWebSearchProvider())

--- a/plugins/web/yandex/plugin.yaml
+++ b/plugins/web/yandex/plugin.yaml
@@ -1,0 +1,10 @@
+name: web-yandex
+version: 1.0.0
+description: "Yandex Cloud Search API (paid) — sync /web/search; requires billing account and Search API key (YANDEX_CLOUD_*), separate from YANDEX_API_KEY used for LLM"
+author: pamnard
+kind: backend
+provides_web_providers:
+  - yandex
+requires_env:
+  - YANDEX_CLOUD_API_KEY
+  - YANDEX_CLOUD_FOLDER_ID

--- a/plugins/web/yandex/provider.py
+++ b/plugins/web/yandex/provider.py
@@ -1,0 +1,221 @@
+"""Yandex Cloud Search API — plugin form.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`. Search-only
+backend using Yandex Cloud synchronous ``/web/search`` (single request, XML).
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "yandex"
+      backend: "yandex"
+
+Env vars::
+
+    YANDEX_CLOUD_API_KEY=...     # Yandex Cloud API key (Search API scope)
+    YANDEX_CLOUD_FOLDER_ID=...   # Cloud folder id for billing / routing
+
+Docs: https://yandex.cloud/en/docs/search-api/operations/web-search-sync
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+from typing import Any, Dict, List
+from urllib.parse import urlparse
+from xml.etree import ElementTree as ET
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_API_BASE_URL = "https://searchapi.api.cloud.yandex.net/v2"
+_SEARCH_ENDPOINT = f"{_API_BASE_URL}/web/search"
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise ValueError(f"{name} environment variable is not set")
+    return value
+
+
+def _build_group_spec(num_results: int) -> tuple[int, int]:
+    """Return (groups_on_page, docs_in_group) for the search payload."""
+    count = max(1, min(int(num_results), 20))
+    if count <= 3:
+        return 1, count
+    docs_in_group = 3
+    groups_on_page = min(100, (count + docs_in_group - 1) // docs_in_group)
+    return groups_on_page, docs_in_group
+
+
+def _decode_search_response(data: Dict[str, Any]) -> str:
+    raw_data = data.get("rawData")
+    if not isinstance(raw_data, str) or not raw_data:
+        raise ValueError("Yandex Search response missing rawData")
+
+    try:
+        return base64.b64decode(raw_data).decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise ValueError(f"Failed to decode Yandex Search rawData: {exc}") from exc
+
+
+def parse_yandex_xml_results(xml_response: str, *, limit: int) -> List[Dict[str, str]]:
+    """Parse Yandex Search XML into flat result rows."""
+    if not xml_response:
+        raise ValueError("xml_response cannot be empty")
+
+    root = ET.fromstring(xml_response)
+    docs = root.findall(".//doc")
+    results: List[Dict[str, str]] = []
+
+    for doc in docs:
+        if len(results) >= limit:
+            break
+
+        url_elem = doc.find("url")
+        title_elem = doc.find("title")
+        snippet_elem = doc.find("passages/passage")
+
+        url = url_elem.text if url_elem is not None and url_elem.text else ""
+        title = title_elem.text if title_elem is not None and title_elem.text else ""
+        snippet = snippet_elem.text if snippet_elem is not None and snippet_elem.text else ""
+
+        if not url:
+            continue
+
+        results.append(
+            {
+                "title": title,
+                "url": url,
+                "description": snippet,
+                "domain": urlparse(url).netloc,
+            }
+        )
+
+    return results
+
+
+def yandex_cloud_search(query: str, *, limit: int = 5) -> str:
+    """Run Yandex Cloud synchronous /web/search and return raw XML."""
+    import httpx
+
+    api_key = _require_env("YANDEX_CLOUD_API_KEY")
+    folder_id = _require_env("YANDEX_CLOUD_FOLDER_ID")
+    headers = {
+        "Authorization": f"Api-Key {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    groups_on_page, docs_in_group = _build_group_spec(limit)
+    payload = {
+        "query": {
+            "searchType": "SEARCH_TYPE_RU",
+            "queryText": query,
+            "page": "0",
+        },
+        "groupSpec": {
+            "groupMode": "GROUP_MODE_DEEP",
+            "groupsOnPage": str(groups_on_page),
+            "docsInGroup": str(docs_in_group),
+        },
+        "maxPassages": "3",
+        "region": "ru",
+        "l10N": "LOCALIZATION_RU",
+        "folderId": folder_id,
+        "responseFormat": "FORMAT_XML",
+    }
+
+    with httpx.Client(timeout=60.0) as client:
+        resp = client.post(_SEARCH_ENDPOINT, json=payload, headers=headers)
+        resp.raise_for_status()
+        xml_response = _decode_search_response(resp.json())
+        ET.fromstring(xml_response)
+        return xml_response
+
+
+class YandexWebSearchProvider(WebSearchProvider):
+    """Yandex Cloud Search API — search-only provider."""
+
+    @property
+    def name(self) -> str:
+        return "yandex"
+
+    @property
+    def display_name(self) -> str:
+        return "Yandex Search"
+
+    def is_available(self) -> bool:
+        return bool(os.getenv("YANDEX_CLOUD_API_KEY", "").strip()) and bool(
+            os.getenv("YANDEX_CLOUD_FOLDER_ID", "").strip()
+        )
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        if not query.strip():
+            return {"success": False, "error": "query cannot be empty"}
+
+        if not self.is_available():
+            return {
+                "success": False,
+                "error": (
+                    "YANDEX_CLOUD_API_KEY and YANDEX_CLOUD_FOLDER_ID must be set. "
+                    "See https://yandex.cloud/en/docs/search-api/"
+                ),
+            }
+
+        bounded_limit = max(1, min(int(limit), 20))
+
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return {"success": False, "error": "Interrupted"}
+
+            logger.info("Yandex search: '%s' (limit=%d)", query, bounded_limit)
+            xml_response = yandex_cloud_search(query, limit=bounded_limit)
+            parsed = parse_yandex_xml_results(xml_response, limit=bounded_limit)
+            web_results = [
+                {
+                    "title": row["title"],
+                    "url": row["url"],
+                    "description": row["description"],
+                    "position": idx + 1,
+                }
+                for idx, row in enumerate(parsed)
+            ]
+            return {"success": True, "data": {"web": web_results}}
+        except ValueError as exc:
+            return {"success": False, "error": str(exc)}
+        except Exception as exc:  # noqa: BLE001 — httpx and XML errors
+            logger.warning("Yandex search error: %s", exc)
+            return {"success": False, "error": f"Yandex search failed: {exc}"}
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Yandex Search",
+            "badge": "paid",
+            "tag": (
+                "Yandex Cloud account + active billing required — pay-per-query Search API, "
+                "no free tier. Uses YANDEX_CLOUD_* env vars (separate from YANDEX_API_KEY for LLM)."
+            ),
+            "env_vars": [
+                {
+                    "key": "YANDEX_CLOUD_API_KEY",
+                    "prompt": "Yandex Cloud API key with search-api scope (not the LLM key)",
+                    "url": "https://yandex.cloud/en/docs/search-api/quickstart",
+                },
+                {
+                    "key": "YANDEX_CLOUD_FOLDER_ID",
+                    "prompt": "Yandex Cloud folder ID for Search API billing",
+                    "url": "https://console.cloud.yandex.ru/",
+                },
+            ],
+        }

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -45,6 +45,8 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
         "XAI_API_KEY",
+        "YANDEX_CLOUD_API_KEY",
+        "YANDEX_CLOUD_FOLDER_ID",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -70,7 +72,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestBundledPluginsRegister:
     """All eight bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_nine_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -84,6 +86,7 @@ class TestBundledPluginsRegister:
             "searxng",
             "tavily",
             "xai",
+            "yandex",
         ]
 
     @pytest.mark.parametrize(
@@ -98,6 +101,7 @@ class TestBundledPluginsRegister:
             ("firecrawl", True, True),
             # xai: search-only via Grok's agentic web_search tool.
             ("xai", True, False),
+            ("yandex", True, False),
         ],
     )
     def test_capability_flags_match_spec(
@@ -116,7 +120,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "yandex"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -129,7 +133,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai", "yandex"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -244,6 +248,18 @@ class TestIsAvailable:
         assert p is not None
         assert p.is_available() is False  # no XAI_API_KEY, no auth.json
         monkeypatch.setenv("XAI_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_yandex_requires_cloud_credentials(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("yandex")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("YANDEX_CLOUD_API_KEY", "real")
+        assert p.is_available() is False
+        monkeypatch.setenv("YANDEX_CLOUD_FOLDER_ID", "folder")
         assert p.is_available() is True
 
 
@@ -491,6 +507,17 @@ class TestErrorResponseShapes:
         from agent.web_search_registry import get_provider
 
         p = get_provider("xai")
+        assert p is not None
+        result = p.search("test", limit=5)
+        assert isinstance(result, dict)
+        assert result.get("success") is False
+        assert "error" in result
+
+    def test_yandex_search_returns_error_dict_when_unconfigured(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("yandex")
         assert p is not None
         result = p.search("test", limit=5)
         assert isinstance(result, dict)

--- a/tests/plugins/web/test_yandex_web_search_provider.py
+++ b/tests/plugins/web/test_yandex_web_search_provider.py
@@ -1,0 +1,77 @@
+"""Tests for the Yandex Cloud Search web provider plugin."""
+
+from __future__ import annotations
+
+import pytest
+
+from plugins.web.yandex.provider import (
+    YandexWebSearchProvider,
+    parse_yandex_xml_results,
+)
+
+
+_SAMPLE_XML = """<?xml version="1.0" encoding="utf-8"?>
+<response>
+  <results>
+    <grouping>
+      <group>
+        <doc>
+          <url>https://example.com/a</url>
+          <title>Example A</title>
+          <passages><passage>Snippet A</passage></passages>
+        </doc>
+      </group>
+      <group>
+        <doc>
+          <url>https://example.com/b</url>
+          <title>Example B</title>
+          <passages><passage>Snippet B</passage></passages>
+        </doc>
+      </group>
+    </grouping>
+  </results>
+</response>
+"""
+
+
+class TestParseYandexXmlResults:
+    def test_parses_docs_into_rows(self) -> None:
+        rows = parse_yandex_xml_results(_SAMPLE_XML, limit=5)
+        assert len(rows) == 2
+        assert rows[0]["url"] == "https://example.com/a"
+        assert rows[0]["title"] == "Example A"
+        assert rows[0]["description"] == "Snippet A"
+        assert rows[0]["domain"] == "example.com"
+
+    def test_respects_limit(self) -> None:
+        rows = parse_yandex_xml_results(_SAMPLE_XML, limit=1)
+        assert len(rows) == 1
+        assert rows[0]["url"] == "https://example.com/a"
+
+
+class TestYandexWebSearchProvider:
+    def test_is_available_requires_both_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        provider = YandexWebSearchProvider()
+        monkeypatch.delenv("YANDEX_CLOUD_API_KEY", raising=False)
+        monkeypatch.delenv("YANDEX_CLOUD_FOLDER_ID", raising=False)
+        assert provider.is_available() is False
+
+        monkeypatch.setenv("YANDEX_CLOUD_API_KEY", "key")
+        assert provider.is_available() is False
+
+        monkeypatch.setenv("YANDEX_CLOUD_FOLDER_ID", "folder")
+        assert provider.is_available() is True
+
+    def test_search_returns_error_when_unconfigured(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("YANDEX_CLOUD_API_KEY", raising=False)
+        monkeypatch.delenv("YANDEX_CLOUD_FOLDER_ID", raising=False)
+        provider = YandexWebSearchProvider()
+        result = provider.search("test", limit=5)
+        assert result["success"] is False
+        assert "YANDEX_CLOUD_API_KEY" in result["error"]
+
+    def test_capability_flags(self) -> None:
+        provider = YandexWebSearchProvider()
+        assert provider.name == "yandex"
+        assert provider.supports_search() is True
+        assert provider.supports_extract() is False

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -218,6 +218,21 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    try:
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        from agent.web_search_registry import get_provider
+
+        provider = get_provider(backend)
+        if provider is not None and provider.supports_search():
+            return provider.is_available()
+    except Exception:
+        logger.debug(
+            "Registry availability check failed for backend %r",
+            backend,
+            exc_info=True,
+        )
     return False
 
 
@@ -267,6 +282,8 @@ def _web_requires_env() -> list[str]:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
+        "YANDEX_CLOUD_API_KEY",
+        "YANDEX_CLOUD_FOLDER_ID",
     ]
 
 
@@ -1154,13 +1171,30 @@ async def web_extract_tool(
 # Convenience function to check Firecrawl credentials
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
-    configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"}:
-        return _is_backend_available(configured)
-    return any(
+    cfg = _load_web_config()
+    configured = (cfg.get("backend") or "").lower().strip()
+    search_configured = (cfg.get("search_backend") or "").lower().strip()
+    for backend in (search_configured, configured):
+        if backend and _is_backend_available(backend):
+            return True
+    if any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
-    )
+        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai")
+    ):
+        return True
+    try:
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        from agent.web_search_registry import list_providers
+
+        return any(
+            provider.supports_search() and provider.is_available()
+            for provider in list_providers()
+        )
+    except Exception:
+        logger.debug("Plugin web backend availability scan failed", exc_info=True)
+        return False
 
 
 def check_auxiliary_model() -> bool:


### PR DESCRIPTION
## Summary

Add **Yandex Cloud Search API** as a bundled web-search backend plugin.

- Provider id: `yandex` (search-only)
- API: synchronous `POST /v2/web/search` (XML in `rawData`; no `searchAsync` / operations poll)
- Env: `YANDEX_CLOUD_API_KEY`, `YANDEX_CLOUD_FOLDER_ID` — **separate from** `YANDEX_API_KEY` / `YANDEX_FOLDER_ID` used by LLM providers
- **Paid**: requires Yandex Cloud account with active billing; pay-per-query; no free tier
- Plugs into existing `web_search` tool — no core changes

## Setup

1. Enable [Yandex Cloud Search API](https://yandex.cloud/en/docs/search-api/quickstart) and create an API key with `search-api` scope (not the AI Studio / LLM key).
2. Set env vars in `~/.hermes/.env`:
   - `YANDEX_CLOUD_API_KEY`
   - `YANDEX_CLOUD_FOLDER_ID`
3. Select backend: `web.search_backend: yandex` or `hermes tools` → **Yandex Search [paid]**.

## Test plan

- [ ] `pytest tests/plugins/web/test_yandex_web_search_provider.py -q`
- [ ] `pytest tests/plugins/web/test_web_search_provider_plugins.py -q`
- [ ] `hermes tools` shows Yandex Search with `[paid]` badge and billing note
- [ ] With env vars set, agent `web_search` returns normalized results