### PR TITLE
feat(google-workspace): add Google Tasks support

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -19,7 +19,7 @@ metadata:
 
 # Google Workspace
 
-Gmail, Calendar, Drive, Contacts, Sheets, and Docs — through Hermes-managed OAuth and a thin CLI wrapper. When `gws` is installed, the skill uses it as the execution backend for broader Google Workspace coverage; otherwise it falls back to the bundled Python client implementation.
+Gmail, Calendar, Tasks, Drive, Contacts, Sheets, and Docs — through Hermes-managed OAuth and a thin CLI wrapper. When `gws` is installed, the skill uses it as the execution backend for broader Google Workspace coverage; otherwise it falls back to the bundled Python client implementation.
 
 ## References
 
@@ -90,7 +90,7 @@ Tell the user:
 > 2. Enable the required APIs from the API Library:
 >    https://console.cloud.google.com/apis/library
 >    Enable: Gmail API, Google Calendar API, Google Drive API,
->    Google Sheets API, Google Docs API, People API
+>    Google Sheets API, Google Docs API, Google Tasks API, People API
 > 3. Create the OAuth client here:
 >    https://console.cloud.google.com/apis/credentials
 >    Credentials → Create Credentials → OAuth 2.0 Client ID
@@ -205,13 +205,24 @@ $GAPI gmail modify MESSAGE_ID --remove-labels UNREAD
 $GAPI calendar list
 $GAPI calendar list --start 2026-03-01T00:00:00Z --end 2026-03-07T23:59:59Z
 
-# Create event (ISO 8601 with timezone required)
+# Create event (naive ISO 8601 datetimes use Hermes' configured timezone)
 $GAPI calendar create --summary "Team Standup" --start 2026-03-01T10:00:00-06:00 --end 2026-03-01T10:30:00-06:00
 $GAPI calendar create --summary "Lunch" --start 2026-03-01T12:00:00Z --end 2026-03-01T13:00:00Z --location "Cafe"
 $GAPI calendar create --summary "Review" --start 2026-03-01T14:00:00Z --end 2026-03-01T15:00:00Z --attendees "alice@co.com,bob@co.com"
 
 # Delete event
 $GAPI calendar delete EVENT_ID
+```
+
+### Tasks
+
+```bash
+# List tasks from the default task list
+$GAPI tasks list --max 20
+
+# Create a task, optionally with a due date
+$GAPI tasks add --title "Pay invoice" --due 2026-03-01
+$GAPI tasks add --title "Inbox zero"
 ```
 
 ### Drive
@@ -295,6 +306,8 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 - **Gmail send/reply**: `{status: "sent", id, threadId}`
 - **Calendar list**: `[{id, summary, start, end, location, description, htmlLink}]`
 - **Calendar create**: `{status: "created", id, summary, htmlLink}`
+- **Tasks list**: `{tasklistId, tasklistTitle, tasks: [{id, title, status, due, updated, webViewLink}]}`
+- **Tasks add**: `{status: "created", tasklistId, tasklistTitle, id, title, due, webViewLink}`
 - **Drive search**: `[{id, name, mimeType, modifiedTime, webViewLink}]`
 - **Drive get**: `{id, name, mimeType, modifiedTime, size, webViewLink, parents, owners}`
 - **Drive upload**: `{status: "uploaded", id, name, mimeType, webViewLink}`
@@ -310,10 +323,10 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 
 ## Rules
 
-1. **Never send email, create/delete calendar events, delete Drive files, share files, or modify Docs/Sheets without confirming with the user first.** Show what will be done (recipients, file IDs, content, share role) and ask for approval. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
+1. **Never send email, create/delete calendar events, create tasks, delete Drive files, share files, or modify Docs/Sheets without confirming with the user first.** Show what will be done (recipients, task title/due date, file IDs, content, share role) and ask for approval. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
 2. **Check auth before first use** — run `setup.py --check`. If it fails, guide the user through setup.
 3. **Use the Gmail search syntax reference** for complex queries — load it with `skill_view("google-workspace", file_path="references/gmail-search-syntax.md")`.
-4. **Calendar times must include timezone** — always use ISO 8601 with offset (e.g., `2026-03-01T10:00:00-06:00`) or UTC (`Z`).
+4. **Calendar times should include timezone when possible** — use ISO 8601 with offset (e.g., `2026-03-01T10:00:00-06:00`) or UTC (`Z`). Naive ISO datetimes are interpreted with Hermes' configured timezone, falling back to the server-local timezone.
 5. **Respect rate limits** — avoid rapid-fire sequential API calls. Batch reads when possible.
 
 ## Troubleshooting

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -51,6 +51,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/contacts.readonly",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/tasks",
 ]
 
 
@@ -70,7 +71,7 @@ def _ensure_authenticated():
 
 def _stored_token_scopes() -> list[str]:
     try:
-        data = json.loads(TOKEN_PATH.read_text(encoding="utf-8"))
+        data = json.loads(TOKEN_PATH.read_text())
     except Exception:
         return list(SCOPES)
     scopes = data.get("scopes")
@@ -108,7 +109,7 @@ def _run_gws(parts: list[str], *, params: dict | None = None, body: dict | None 
     result = subprocess.run(
         cmd,
         capture_output=True,
-        text=True, encoding='utf-8', errors='replace',
+        text=True,
         env=_gws_env(),
     )
     if result.returncode != 0:
@@ -165,6 +166,18 @@ def _extract_doc_text(doc: dict) -> str:
     return "".join(text_parts)
 
 
+def _default_timezone():
+    try:
+        from hermes_time import get_timezone
+
+        configured_tz = get_timezone()
+        if configured_tz is not None:
+            return configured_tz
+    except Exception:
+        pass
+    return datetime.now().astimezone().tzinfo or timezone.utc
+
+
 def _datetime_with_timezone(value: str) -> str:
     if not value:
         return value
@@ -175,7 +188,10 @@ def _datetime_with_timezone(value: str) -> str:
     tail = value[10:]
     if "+" in tail or "-" in tail:
         return value
-    return value + "Z"
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=_default_timezone())
+    return dt.isoformat()
 
 
 def get_credentials():
@@ -192,7 +208,7 @@ def get_credentials():
             json.dumps(
                 _normalize_authorized_user_payload(json.loads(creds.to_json())),
                 indent=2,
-            ), encoding="utf-8"
+            )
         )
     if not creds.valid:
         print("Token is invalid. Re-run setup.", file=sys.stderr)
@@ -518,8 +534,8 @@ def calendar_list(args):
 def calendar_create(args):
     event = {
         "summary": args.summary,
-        "start": {"dateTime": args.start},
-        "end": {"dateTime": args.end},
+        "start": {"dateTime": _datetime_with_timezone(args.start)},
+        "end": {"dateTime": _datetime_with_timezone(args.end)},
     }
     if args.location:
         event["location"] = args.location
@@ -562,6 +578,122 @@ def calendar_delete(args):
     service = build_service("calendar", "v3")
     service.events().delete(calendarId=args.calendar, eventId=args.event_id).execute()
     print(json.dumps({"status": "deleted", "eventId": args.event_id}))
+
+
+# =========================================================================
+# Tasks
+# =========================================================================
+
+
+def _tasks_default_list_id(service, requested: str = "") -> tuple[str, str]:
+    if requested:
+        return requested, requested
+    result = service.tasklists().list(maxResults=10).execute()
+    return _tasks_first_list_from_result(result)
+
+
+def _tasks_default_list_id_gws(requested: str = "") -> tuple[str, str]:
+    if requested:
+        return requested, requested
+    result = _run_gws(["tasks", "tasklists", "list"], params={"maxResults": 10})
+    return _tasks_first_list_from_result(result)
+
+
+def _tasks_first_list_from_result(result: dict) -> tuple[str, str]:
+    items = result.get("items", [])
+    if not items:
+        print("No Google Tasks lists found.", file=sys.stderr)
+        sys.exit(1)
+    first = items[0]
+    return first["id"], first.get("title", "")
+
+
+def _task_summary(item: dict) -> dict:
+    return {
+        "id": item.get("id", ""),
+        "title": item.get("title", ""),
+        "status": item.get("status", ""),
+        "due": item.get("due", ""),
+        "updated": item.get("updated", ""),
+        "webViewLink": item.get("webViewLink", ""),
+    }
+
+
+def _tasks_due_value(raw_due: str) -> str:
+    if not raw_due:
+        return ""
+    if "T" not in raw_due:
+        return raw_due + "T00:00:00Z"
+    return _datetime_with_timezone(raw_due)
+
+
+def tasks_list(args):
+    if _gws_binary():
+        tasklist_id, tasklist_title = _tasks_default_list_id_gws(args.tasklist)
+        result = _run_gws(
+            ["tasks", "tasks", "list"],
+            params={
+                "tasklist": tasklist_id,
+                "maxResults": args.max,
+                "showCompleted": args.show_completed,
+            },
+        )
+        print(json.dumps({
+            "tasklistId": tasklist_id,
+            "tasklistTitle": tasklist_title,
+            "tasks": [_task_summary(item) for item in result.get("items", [])],
+        }, indent=2, ensure_ascii=False))
+        return
+
+    service = build_service("tasks", "v1")
+    tasklist_id, tasklist_title = _tasks_default_list_id(service, args.tasklist)
+    result = service.tasks().list(
+        tasklist=tasklist_id,
+        maxResults=args.max,
+        showCompleted=args.show_completed,
+    ).execute()
+    print(json.dumps({
+        "tasklistId": tasklist_id,
+        "tasklistTitle": tasklist_title,
+        "tasks": [_task_summary(item) for item in result.get("items", [])],
+    }, indent=2, ensure_ascii=False))
+
+
+def tasks_add(args):
+    task_body = {"title": args.title}
+    if args.due:
+        task_body["due"] = _tasks_due_value(args.due)
+
+    if _gws_binary():
+        tasklist_id, tasklist_title = _tasks_default_list_id_gws(args.tasklist)
+        task = _run_gws(
+            ["tasks", "tasks", "insert"],
+            params={"tasklist": tasklist_id},
+            body=task_body,
+        )
+        print(json.dumps({
+            "status": "created",
+            "tasklistId": tasklist_id,
+            "tasklistTitle": tasklist_title,
+            "id": task.get("id", ""),
+            "title": task.get("title", ""),
+            "due": task.get("due", ""),
+            "webViewLink": task.get("webViewLink", ""),
+        }, indent=2, ensure_ascii=False))
+        return
+
+    service = build_service("tasks", "v1")
+    tasklist_id, tasklist_title = _tasks_default_list_id(service, args.tasklist)
+    task = service.tasks().insert(tasklist=tasklist_id, body=task_body).execute()
+    print(json.dumps({
+        "status": "created",
+        "tasklistId": tasklist_id,
+        "tasklistTitle": tasklist_title,
+        "id": task.get("id", ""),
+        "title": task.get("title", ""),
+        "due": task.get("due", ""),
+        "webViewLink": task.get("webViewLink", ""),
+    }, indent=2, ensure_ascii=False))
 
 
 # =========================================================================
@@ -1118,6 +1250,22 @@ def main():
     p.add_argument("event_id")
     p.add_argument("--calendar", default="primary")
     p.set_defaults(func=calendar_delete)
+
+    # --- Tasks ---
+    tasks = sub.add_parser("tasks")
+    tasks_sub = tasks.add_subparsers(dest="action", required=True)
+
+    p = tasks_sub.add_parser("list")
+    p.add_argument("--tasklist", default="", help="Task list ID (defaults to the first available list)")
+    p.add_argument("--max", type=int, default=20)
+    p.add_argument("--show-completed", action="store_true", help="Include completed tasks")
+    p.set_defaults(func=tasks_list)
+
+    p = tasks_sub.add_parser("add")
+    p.add_argument("--title", required=True)
+    p.add_argument("--due", default="", help="Due date YYYY-MM-DD or ISO 8601 datetime")
+    p.add_argument("--tasklist", default="", help="Task list ID (defaults to the first available list)")
+    p.set_defaults(func=tasks_add)
 
     # --- Drive ---
     drv = sub.add_parser("drive")

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -53,6 +53,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/contacts.readonly",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/tasks",
 ]
 
 # Exact pins: keep in sync with pyproject.toml [project.optional-dependencies].google
@@ -70,6 +71,17 @@ REQUIRED_PACKAGES = [
     "pyasn1==0.6.4",
 ]
 
+SERVICE_SCOPES = {
+    "email": SCOPES[0:3],
+    "gmail": SCOPES[0:3],
+    "calendar": ["https://www.googleapis.com/auth/calendar"],
+    "drive": ["https://www.googleapis.com/auth/drive"],
+    "contacts": ["https://www.googleapis.com/auth/contacts.readonly"],
+    "sheets": ["https://www.googleapis.com/auth/spreadsheets"],
+    "docs": ["https://www.googleapis.com/auth/documents"],
+    "tasks": ["https://www.googleapis.com/auth/tasks"],
+}
+
 # OAuth redirect for "out of band" manual code copy flow.
 # Google deprecated OOB, so we use a localhost redirect and tell the user to
 # copy the code from the browser's URL bar (or the page body).
@@ -83,9 +95,29 @@ def _normalize_authorized_user_payload(payload: dict) -> dict:
     return normalized
 
 
+def _resolve_requested_scopes(services: str | None = None) -> list[str]:
+    raw = (services or "all").strip().lower()
+    if not raw or raw == "all":
+        return list(SCOPES)
+
+    requested = [part.strip() for part in raw.replace(",", " ").split() if part.strip()]
+    unknown = sorted(set(requested) - set(SERVICE_SCOPES))
+    if unknown:
+        print(f"ERROR: Unknown Google Workspace service(s): {', '.join(unknown)}")
+        print(f"Known services: all, {', '.join(sorted(SERVICE_SCOPES))}")
+        sys.exit(1)
+
+    scopes: list[str] = []
+    for service in requested:
+        for scope in SERVICE_SCOPES[service]:
+            if scope not in scopes:
+                scopes.append(scope)
+    return scopes
+
+
 def _load_token_payload(path: Path = TOKEN_PATH) -> dict:
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        return json.loads(path.read_text())
     except Exception:
         return {}
 
@@ -178,7 +210,7 @@ def install_deps():
         "On environments without pip (e.g. Nix, or the Hermes Docker image's "
         "uv-managed venv), install the optional extra instead:"
     )
-    print("  hermes setup")
+    print("  pip install 'hermes-agent[google]'")
     print(f"Or manually: {sys.executable} -m pip install {' '.join(REQUIRED_PACKAGES)}")
     return False
 
@@ -253,7 +285,7 @@ def check_auth(quiet: bool = False):
                 json.dumps(
                     _normalize_authorized_user_payload(json.loads(creds.to_json())),
                     indent=2,
-                ), encoding="utf-8"
+                )
             )
             missing_scopes = _missing_scopes_from_payload(_load_token_payload(TOKEN_PATH))
             if missing_scopes:
@@ -293,7 +325,7 @@ def store_client_secret(path: str):
         sys.exit(1)
 
     try:
-        data = json.loads(src.read_text(encoding="utf-8"))
+        data = json.loads(src.read_text())
     except json.JSONDecodeError:
         print("ERROR: File is not valid JSON.")
         sys.exit(1)
@@ -303,11 +335,11 @@ def store_client_secret(path: str):
         print("Download the correct file from: https://console.cloud.google.com/apis/credentials")
         sys.exit(1)
 
-    CLIENT_SECRET_PATH.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    CLIENT_SECRET_PATH.write_text(json.dumps(data, indent=2))
     print(f"OK: Client secret saved to {CLIENT_SECRET_PATH}")
 
 
-def _save_pending_auth(*, state: str, code_verifier: str):
+def _save_pending_auth(*, state: str, code_verifier: str, requested_scopes: list[str]):
     """Persist the OAuth session bits needed for a later token exchange."""
     PENDING_AUTH_PATH.write_text(
         json.dumps(
@@ -315,9 +347,10 @@ def _save_pending_auth(*, state: str, code_verifier: str):
                 "state": state,
                 "code_verifier": code_verifier,
                 "redirect_uri": REDIRECT_URI,
+                "requested_scopes": requested_scopes,
             },
             indent=2,
-        ), encoding="utf-8"
+        )
     )
 
 
@@ -328,7 +361,7 @@ def _load_pending_auth() -> dict:
         sys.exit(1)
 
     try:
-        data = json.loads(PENDING_AUTH_PATH.read_text(encoding="utf-8"))
+        data = json.loads(PENDING_AUTH_PATH.read_text())
     except Exception as e:
         print(f"ERROR: Could not read pending OAuth session: {e}")
         print("Run --auth-url again to start a fresh OAuth session.")
@@ -359,7 +392,7 @@ def _extract_code_and_state(code_or_url: str) -> tuple[str, str | None]:
     return params["code"][0], state
 
 
-def get_auth_url():
+def get_auth_url(services: str | None = None, output_format: str = "text"):
     """Print the OAuth authorization URL. User visits this in a browser."""
     if not CLIENT_SECRET_PATH.exists():
         print("ERROR: No client secret stored. Run --client-secret first.")
@@ -368,9 +401,10 @@ def get_auth_url():
     _ensure_deps()
     from google_auth_oauthlib.flow import Flow
 
+    requested_scopes = _resolve_requested_scopes(services)
     flow = Flow.from_client_secrets_file(
         str(CLIENT_SECRET_PATH),
-        scopes=SCOPES,
+        scopes=requested_scopes,
         redirect_uri=REDIRECT_URI,
         autogenerate_code_verifier=True,
     )
@@ -378,12 +412,24 @@ def get_auth_url():
         access_type="offline",
         prompt="consent",
     )
-    _save_pending_auth(state=state, code_verifier=flow.code_verifier)
-    # Print just the URL so the agent can extract it cleanly
-    print(auth_url)
+    _save_pending_auth(
+        state=state,
+        code_verifier=flow.code_verifier,
+        requested_scopes=requested_scopes,
+    )
+    (HERMES_HOME / "google_oauth_last_url.txt").write_text(auth_url)
+    if output_format == "json":
+        print(json.dumps({
+            "auth_url": auth_url,
+            "scopes": requested_scopes,
+            "last_url_path": str(HERMES_HOME / "google_oauth_last_url.txt"),
+        }, indent=2))
+    else:
+        # Print just the URL so the agent can extract it cleanly.
+        print(auth_url)
 
 
-def exchange_auth_code(code: str):
+def exchange_auth_code(code: str, output_format: str = "text"):
     """Exchange the authorization code for a token and save it."""
     if not CLIENT_SECRET_PATH.exists():
         print("ERROR: No client secret stored. Run --client-secret first.")
@@ -401,7 +447,7 @@ def exchange_auth_code(code: str):
     from urllib.parse import parse_qs, urlparse
 
     # Extract granted scopes from the callback URL if the user pasted the full redirect URL.
-    granted_scopes = list(SCOPES)
+    granted_scopes = list(pending_auth.get("requested_scopes") or SCOPES)
     if isinstance(raw_callback, str) and raw_callback.startswith("http"):
         params = parse_qs(urlparse(raw_callback).query)
         scope_val = (params.get("scope") or [""])[0].strip()
@@ -431,7 +477,8 @@ def exchange_auth_code(code: str):
     # Store only the scopes actually granted by the user, not what was requested.
     # creds.to_json() writes the requested scopes, which causes refresh to fail
     # with invalid_scope if the user only authorized a subset.
-    actually_granted = list(creds.granted_scopes or []) if hasattr(creds, "granted_scopes") and creds.granted_scopes else []
+    granted_scopes_attr = getattr(creds, "granted_scopes", None)
+    actually_granted = list(granted_scopes_attr or [])
     if actually_granted:
         token_payload["scopes"] = actually_granted
     elif granted_scopes != SCOPES:
@@ -443,10 +490,18 @@ def exchange_auth_code(code: str):
         print(f"WARNING: Token missing some Google Workspace scopes: {', '.join(missing_scopes)}")
         print("Some services may not be available.")
 
-    TOKEN_PATH.write_text(json.dumps(token_payload, indent=2), encoding="utf-8")
+    TOKEN_PATH.write_text(json.dumps(token_payload, indent=2))
     PENDING_AUTH_PATH.unlink(missing_ok=True)
-    print(f"OK: Authenticated. Token saved to {TOKEN_PATH}")
-    print(f"Profile-scoped token location: {display_hermes_home()}/google_token.json")
+    if output_format == "json":
+        print(json.dumps({
+            "status": "ok",
+            "token_path": str(TOKEN_PATH),
+            "profile_token_path": f"{display_hermes_home()}/google_token.json",
+            "missing_scopes": missing_scopes,
+        }, indent=2))
+    else:
+        print(f"OK: Authenticated. Token saved to {TOKEN_PATH}")
+        print(f"Profile-scoped token location: {display_hermes_home()}/google_token.json")
 
 
 def revoke():
@@ -492,6 +547,17 @@ def main():
     group.add_argument("--auth-code", metavar="CODE", help="Exchange auth code for token")
     group.add_argument("--revoke", action="store_true", help="Revoke and delete stored token")
     group.add_argument("--install-deps", action="store_true", help="Install Python dependencies")
+    parser.add_argument(
+        "--services",
+        default="all",
+        help="Comma/space-separated services to request during --auth-url (default: all; includes tasks)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for auth-url/auth-code",
+    )
     args = parser.parse_args()
 
     if args.check:
@@ -501,9 +567,9 @@ def main():
     elif args.client_secret:
         store_client_secret(args.client_secret)
     elif args.auth_url:
-        get_auth_url()
+        get_auth_url(args.services, args.format)
     elif args.auth_code:
-        exchange_auth_code(args.auth_code)
+        exchange_auth_code(args.auth_code, args.format)
     elif args.revoke:
         revoke()
     elif args.install_deps:

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -1,0 +1,346 @@
+"""Regression tests for Google Workspace OAuth setup.
+
+These tests cover the headless/manual auth-code flow where the browser step and
+code exchange happen in separate process invocations.
+"""
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/google-workspace/scripts/setup.py"
+)
+
+
+class FakeCredentials:
+    def __init__(self, payload=None):
+        self._payload = payload or {
+            "token": "access-token",
+            "refresh_token": "refresh-token",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "scopes": [
+                "https://www.googleapis.com/auth/gmail.readonly",
+                "https://www.googleapis.com/auth/gmail.send",
+                "https://www.googleapis.com/auth/gmail.modify",
+                "https://www.googleapis.com/auth/calendar",
+                "https://www.googleapis.com/auth/drive.readonly",
+                "https://www.googleapis.com/auth/contacts.readonly",
+                "https://www.googleapis.com/auth/spreadsheets",
+                "https://www.googleapis.com/auth/documents.readonly",
+            ],
+        }
+
+    def to_json(self):
+        return json.dumps(self._payload)
+
+
+class FakeFlow:
+    created = []
+    default_state = "generated-state"
+    default_verifier = "generated-code-verifier"
+    credentials_payload = None
+    fetch_error = None
+
+    def __init__(
+        self,
+        client_secrets_file,
+        scopes,
+        *,
+        redirect_uri=None,
+        state=None,
+        code_verifier=None,
+        autogenerate_code_verifier=False,
+    ):
+        self.client_secrets_file = client_secrets_file
+        self.scopes = scopes
+        self.redirect_uri = redirect_uri
+        self.state = state
+        self.code_verifier = code_verifier
+        self.autogenerate_code_verifier = autogenerate_code_verifier
+        self.authorization_kwargs = None
+        self.fetch_token_calls = []
+        self.credentials = FakeCredentials(self.credentials_payload)
+
+        if autogenerate_code_verifier and not self.code_verifier:
+            self.code_verifier = self.default_verifier
+        if not self.state:
+            self.state = self.default_state
+
+    @classmethod
+    def reset(cls):
+        cls.created = []
+        cls.default_state = "generated-state"
+        cls.default_verifier = "generated-code-verifier"
+        cls.credentials_payload = None
+        cls.fetch_error = None
+
+    @classmethod
+    def from_client_secrets_file(cls, client_secrets_file, scopes, **kwargs):
+        inst = cls(client_secrets_file, scopes, **kwargs)
+        cls.created.append(inst)
+        return inst
+
+    def authorization_url(self, **kwargs):
+        self.authorization_kwargs = kwargs
+        return f"https://auth.example/authorize?state={self.state}", self.state
+
+    def fetch_token(self, **kwargs):
+        self.fetch_token_calls.append(kwargs)
+        if self.fetch_error:
+            raise self.fetch_error
+
+
+@pytest.fixture
+def setup_module(monkeypatch, tmp_path):
+    FakeFlow.reset()
+
+    google_auth_module = types.ModuleType("google_auth_oauthlib")
+    flow_module = types.ModuleType("google_auth_oauthlib.flow")
+    flow_module.Flow = FakeFlow
+    google_auth_module.flow = flow_module
+    monkeypatch.setitem(sys.modules, "google_auth_oauthlib", google_auth_module)
+    monkeypatch.setitem(sys.modules, "google_auth_oauthlib.flow", flow_module)
+
+    spec = importlib.util.spec_from_file_location("google_workspace_setup_test", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    monkeypatch.setattr(module, "_ensure_deps", lambda: None)
+    monkeypatch.setattr(module, "CLIENT_SECRET_PATH", tmp_path / "google_client_secret.json")
+    monkeypatch.setattr(module, "TOKEN_PATH", tmp_path / "google_token.json")
+    monkeypatch.setattr(module, "PENDING_AUTH_PATH", tmp_path / "google_oauth_pending.json", raising=False)
+
+    client_secret = {
+        "installed": {
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+        }
+    }
+    module.CLIENT_SECRET_PATH.write_text(json.dumps(client_secret))
+    return module
+
+
+class TestGetAuthUrl:
+    def test_persists_state_and_code_verifier_for_later_exchange(self, setup_module, capsys):
+        setup_module.get_auth_url()
+
+        out = capsys.readouterr().out.strip()
+        assert out == "https://auth.example/authorize?state=generated-state"
+
+        saved = json.loads(setup_module.PENDING_AUTH_PATH.read_text())
+        assert saved["state"] == "generated-state"
+        assert saved["code_verifier"] == "generated-code-verifier"
+        assert saved["requested_scopes"] == setup_module.SCOPES
+
+        flow = FakeFlow.created[-1]
+        assert flow.autogenerate_code_verifier is True
+        assert flow.authorization_kwargs == {"access_type": "offline", "prompt": "consent"}
+
+    def test_services_option_can_request_tasks_only(self, setup_module):
+        setup_module.get_auth_url("tasks")
+
+        saved = json.loads(setup_module.PENDING_AUTH_PATH.read_text())
+        assert saved["requested_scopes"] == ["https://www.googleapis.com/auth/tasks"]
+        flow = FakeFlow.created[-1]
+        assert flow.scopes == ["https://www.googleapis.com/auth/tasks"]
+
+    def test_services_option_accepts_email_alias_and_json_output(self, setup_module, capsys):
+        setup_module.get_auth_url("email,tasks", output_format="json")
+
+        out = json.loads(capsys.readouterr().out)
+        assert out["auth_url"] == "https://auth.example/authorize?state=generated-state"
+        assert out["scopes"] == [
+            "https://www.googleapis.com/auth/gmail.readonly",
+            "https://www.googleapis.com/auth/gmail.send",
+            "https://www.googleapis.com/auth/gmail.modify",
+            "https://www.googleapis.com/auth/tasks",
+        ]
+        assert (setup_module.HERMES_HOME / "google_oauth_last_url.txt").read_text() == out["auth_url"]
+
+
+class TestExchangeAuthCode:
+    def test_reuses_saved_pkce_material_for_plain_code(self, setup_module):
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+
+        setup_module.exchange_auth_code("4/test-auth-code")
+
+        flow = FakeFlow.created[-1]
+        assert flow.state == "saved-state"
+        assert flow.code_verifier == "saved-verifier"
+        assert flow.fetch_token_calls == [{"code": "4/test-auth-code"}]
+        saved = json.loads(setup_module.TOKEN_PATH.read_text())
+        assert saved["token"] == "access-token"
+        assert saved["type"] == "authorized_user"
+        assert not setup_module.PENDING_AUTH_PATH.exists()
+
+    def test_extracts_code_from_redirect_url_and_checks_state(self, setup_module):
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+
+        setup_module.exchange_auth_code(
+            "http://localhost:1/?code=4/extracted-code&state=saved-state&scope=gmail"
+        )
+
+        flow = FakeFlow.created[-1]
+        assert flow.fetch_token_calls == [{"code": "4/extracted-code"}]
+
+    def test_passes_scopes_from_redirect_url_to_flow(self, setup_module):
+        """Callback URL carries space-delimited scope list; Flow must receive it (not full SCOPES)."""
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+        g1 = "https://www.googleapis.com/auth/gmail.readonly"
+        g2 = "https://www.googleapis.com/auth/calendar"
+        from urllib.parse import quote
+
+        scope_q = quote(f"{g1} {g2}", safe="")
+        setup_module.exchange_auth_code(
+            f"http://localhost:1/?code=4/extracted-code&state=saved-state&scope={scope_q}"
+        )
+        flow = FakeFlow.created[-1]
+        assert flow.scopes == [g1, g2]
+
+    def test_rejects_state_mismatch(self, setup_module, capsys):
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+
+        with pytest.raises(SystemExit):
+            setup_module.exchange_auth_code(
+                "http://localhost:1/?code=4/extracted-code&state=wrong-state"
+            )
+
+        out = capsys.readouterr().out
+        assert "state mismatch" in out.lower()
+        assert not setup_module.TOKEN_PATH.exists()
+
+    def test_requires_pending_auth_session(self, setup_module, capsys):
+        with pytest.raises(SystemExit):
+            setup_module.exchange_auth_code("4/test-auth-code")
+
+        out = capsys.readouterr().out
+        assert "run --auth-url first" in out.lower()
+        assert not setup_module.TOKEN_PATH.exists()
+
+    def test_keeps_pending_auth_session_when_exchange_fails(self, setup_module, capsys):
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+        FakeFlow.fetch_error = Exception("invalid_grant: Missing code verifier")
+
+        with pytest.raises(SystemExit):
+            setup_module.exchange_auth_code("4/test-auth-code")
+
+        out = capsys.readouterr().out
+        assert "token exchange failed" in out.lower()
+        assert setup_module.PENDING_AUTH_PATH.exists()
+        assert not setup_module.TOKEN_PATH.exists()
+
+    def test_accepts_narrower_scopes_with_warning(self, setup_module, capsys):
+        """Partial scopes are accepted with a warning (gws migration: v2.0)."""
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+        setup_module.TOKEN_PATH.write_text(json.dumps({"token": "***", "scopes": setup_module.SCOPES}))
+        FakeFlow.credentials_payload = {
+            "token": "***",
+            "refresh_token": "***",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "scopes": [
+                "https://www.googleapis.com/auth/drive.readonly",
+                "https://www.googleapis.com/auth/spreadsheets",
+            ],
+        }
+
+        setup_module.exchange_auth_code("4/test-auth-code")
+
+        out = capsys.readouterr().out
+        assert "warning" in out.lower()
+        assert "missing" in out.lower()
+        # Token is saved (partial scopes accepted)
+        assert setup_module.TOKEN_PATH.exists()
+        # Pending auth is cleaned up
+        assert not setup_module.PENDING_AUTH_PATH.exists()
+
+
+class TestHermesConstantsFallback:
+    """Tests for _hermes_home.py fallback when hermes_constants is unavailable."""
+
+    HELPER_PATH = (
+        Path(__file__).resolve().parents[2]
+        / "skills/productivity/google-workspace/scripts/_hermes_home.py"
+    )
+
+    def _load_helper(self, monkeypatch):
+        """Load _hermes_home.py with hermes_constants blocked."""
+        monkeypatch.setitem(sys.modules, "hermes_constants", None)
+        spec = importlib.util.spec_from_file_location("_hermes_home_test", self.HELPER_PATH)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+
+    def test_fallback_uses_hermes_home_env_var(self, monkeypatch, tmp_path):
+        """When hermes_constants is missing, HERMES_HOME comes from env var."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "custom-hermes"))
+        module = self._load_helper(monkeypatch)
+        assert module.get_hermes_home() == tmp_path / "custom-hermes"
+
+    def test_fallback_defaults_to_dot_hermes(self, monkeypatch):
+        """When hermes_constants is missing and HERMES_HOME unset, default to ~/.hermes."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        module = self._load_helper(monkeypatch)
+        assert module.get_hermes_home() == Path.home() / ".hermes"
+
+    def test_fallback_ignores_empty_hermes_home(self, monkeypatch):
+        """Empty/whitespace HERMES_HOME is treated as unset."""
+        monkeypatch.setenv("HERMES_HOME", "  ")
+        module = self._load_helper(monkeypatch)
+        assert module.get_hermes_home() == Path.home() / ".hermes"
+
+    def test_fallback_display_hermes_home_shortens_path(self, monkeypatch):
+        """Fallback display_hermes_home() uses ~/ shorthand like the real one."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        module = self._load_helper(monkeypatch)
+        assert module.display_hermes_home() == "~/.hermes"
+
+    def test_fallback_display_hermes_home_profile_path(self, monkeypatch):
+        """Fallback display_hermes_home() handles profile paths under ~/."""
+        monkeypatch.setenv("HERMES_HOME", str(Path.home() / ".hermes/profiles/coder"))
+        module = self._load_helper(monkeypatch)
+        assert module.display_hermes_home() == "~/.hermes/profiles/coder"
+
+    def test_fallback_display_hermes_home_custom_path(self, monkeypatch):
+        """Fallback display_hermes_home() returns full path for non-home locations."""
+        monkeypatch.setenv("HERMES_HOME", "/opt/hermes-custom")
+        module = self._load_helper(monkeypatch)
+        assert module.display_hermes_home() == "/opt/hermes-custom"
+
+    def test_delegates_to_hermes_constants_when_available(self):
+        """When hermes_constants IS importable, _hermes_home delegates to it."""
+        spec = importlib.util.spec_from_file_location(
+            "_hermes_home_happy", self.HELPER_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        import hermes_constants
+        assert module.get_hermes_home is hermes_constants.get_hermes_home
+        assert module.display_hermes_home is hermes_constants.display_hermes_home

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -78,12 +78,79 @@ def test_bridge_returns_valid_token(bridge_module, tmp_path):
     assert result == "ya29.valid"
 
 
+def test_bridge_refreshes_expired_token(bridge_module, tmp_path):
+    """Expired token triggers a refresh via token_uri."""
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    token_path = bridge_module.get_token_path()
+    _write_token(token_path, token="ya29.old", expiry=past)
+
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps({
+        "access_token": "ya29.refreshed",
+        "expires_in": 3600,
+    }).encode()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        result = bridge_module.get_valid_token()
+
+    assert result == "ya29.refreshed"
+    # Verify persisted
+    saved = json.loads(token_path.read_text())
+    assert saved["token"] == "ya29.refreshed"
+    assert saved["type"] == "authorized_user"
 
 
+def test_bridge_refresh_passes_timeout_to_urlopen(bridge_module):
+    """Token refresh must pass an explicit timeout so a hung Google endpoint
+    cannot block the agent turn indefinitely (no `timeout=` defaults to the
+    global socket timeout, which is unset)."""
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    token_path = bridge_module.get_token_path()
+    _write_token(token_path, token="ya29.old", expiry=past)
+
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps({
+        "access_token": "ya29.refreshed",
+        "expires_in": 3600,
+    }).encode()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+
+    with patch("urllib.request.urlopen", return_value=mock_resp) as mocked:
+        bridge_module.get_valid_token()
+
+    assert mocked.call_count == 1
+    _, kwargs = mocked.call_args
+    assert kwargs.get("timeout") is not None, (
+        "urlopen call must pass timeout= to avoid hanging on unreachable upstream"
+    )
 
 
+def test_bridge_refresh_exits_cleanly_on_network_error(bridge_module):
+    """URLError/timeout during refresh exits 1 with a readable message
+    instead of crashing with a raw traceback."""
+    import urllib.error
+
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    token_path = bridge_module.get_token_path()
+    _write_token(token_path, token="ya29.old", expiry=past)
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("timed out"),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            bridge_module.get_valid_token()
+
+    assert exc_info.value.code == 1
 
 
+def test_bridge_exits_on_missing_token(bridge_module):
+    """Missing token file causes exit with code 1."""
+    with pytest.raises(SystemExit):
+        bridge_module.get_valid_token()
 
 
 def test_bridge_main_injects_token_env(bridge_module, tmp_path):
@@ -136,14 +203,312 @@ def test_api_calendar_list_uses_events_list(api_module):
     assert params["calendarId"] == "primary"
 
 
+def test_api_calendar_list_respects_date_range(api_module):
+    """calendar list with --start/--end passes correct time bounds."""
+    captured = {}
+
+    def capture_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return MagicMock(returncode=0, stdout="{}", stderr="")
+
+    args = api_module.argparse.Namespace(
+        start="2026-04-01T00:00:00Z",
+        end="2026-04-07T23:59:59Z",
+        max=25,
+        calendar="primary",
+        func=api_module.calendar_list,
+    )
+
+    with patch.object(api_module.subprocess, "run", side_effect=capture_run):
+        api_module.calendar_list(args)
+
+    cmd = captured["cmd"]
+    params_idx = cmd.index("--params")
+    params = json.loads(cmd[params_idx + 1])
+    assert params["timeMin"] == "2026-04-01T00:00:00Z"
+    assert params["timeMax"] == "2026-04-07T23:59:59Z"
 
 
+def test_api_tasks_list_prefers_gws_and_normalizes_output(api_module, capsys):
+    calls = []
+
+    def fake_run_gws(parts, *, params=None, body=None):
+        calls.append({"parts": parts, "params": params, "body": body})
+        if parts == ["tasks", "tasklists", "list"]:
+            assert params == {"maxResults": 10}
+            return {"items": [{"id": "list-1", "title": "Inbox"}]}
+        assert parts == ["tasks", "tasks", "list"]
+        assert params == {"tasklist": "list-1", "maxResults": 5, "showCompleted": False}
+        return {"items": [{"id": "task-1", "title": "Pay invoice", "status": "needsAction"}]}
+
+    api_module._run_gws = fake_run_gws
+    args = api_module.argparse.Namespace(tasklist="", max=5, show_completed=False)
+
+    api_module.tasks_list(args)
+
+    assert [call["parts"] for call in calls] == [
+        ["tasks", "tasklists", "list"],
+        ["tasks", "tasks", "list"],
+    ]
+    result = json.loads(capsys.readouterr().out)
+    assert result == {
+        "tasklistId": "list-1",
+        "tasklistTitle": "Inbox",
+        "tasks": [
+            {
+                "id": "task-1",
+                "title": "Pay invoice",
+                "status": "needsAction",
+                "due": "",
+                "updated": "",
+                "webViewLink": "",
+            }
+        ],
+    }
 
 
+def test_api_tasks_add_prefers_gws_and_passes_due_body(api_module, capsys):
+    calls = []
+
+    def fake_run_gws(parts, *, params=None, body=None):
+        calls.append({"parts": parts, "params": params, "body": body})
+        if parts == ["tasks", "tasklists", "list"]:
+            return {"items": [{"id": "list-1", "title": "Inbox"}]}
+        assert parts == ["tasks", "tasks", "insert"]
+        assert params == {"tasklist": "list-1"}
+        assert body == {"title": "Pay invoice", "due": "2026-03-01T00:00:00Z"}
+        return {"id": "task-1", "title": "Pay invoice", "due": "2026-03-01T00:00:00Z"}
+
+    api_module._run_gws = fake_run_gws
+    args = api_module.argparse.Namespace(title="Pay invoice", due="2026-03-01", tasklist="")
+
+    api_module.tasks_add(args)
+
+    assert [call["parts"] for call in calls] == [
+        ["tasks", "tasklists", "list"],
+        ["tasks", "tasks", "insert"],
+    ]
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "created"
+    assert result["tasklistId"] == "list-1"
+    assert result["title"] == "Pay invoice"
 
 
+def test_datetime_with_timezone_uses_hermes_configured_timezone(api_module, monkeypatch):
+    class FakeHermesTime(types.SimpleNamespace):
+        @staticmethod
+        def get_timezone():
+            return api_module.timezone(api_module.timedelta(hours=3))
+
+    monkeypatch.setitem(sys.modules, "hermes_time", FakeHermesTime())
+
+    assert api_module._datetime_with_timezone("2026-03-01T10:00:00") == "2026-03-01T10:00:00+03:00"
 
 
+@pytest.mark.parametrize(
+    "header_names",
+    [
+        ("from", "to", "subject", "date"),
+        ("From", "To", "Subject", "Date"),
+    ],
+)
+def test_api_gmail_get_reads_headers_case_insensitively(api_module, capsys, header_names):
+    from_name, to_name, subject_name, date_name = header_names
+
+    def fake_run_gws(parts, *, params=None, body=None):
+        assert parts == ["gmail", "users", "messages", "get"]
+        assert params == {"userId": "me", "id": "msg-1", "format": "full"}
+        return {
+            "id": "msg-1",
+            "threadId": "thread-1",
+            "labelIds": ["INBOX"],
+            "payload": {
+                "headers": [
+                    {"name": from_name, "value": "sender@example.com"},
+                    {"name": to_name, "value": "recipient@example.com"},
+                    {"name": subject_name, "value": "case bug"},
+                    {"name": date_name, "value": "Fri, 29 May 2026 12:00:00 +0000"},
+                ],
+                "body": {},
+            },
+        }
+
+    api_module._run_gws = fake_run_gws
+    args = api_module.argparse.Namespace(message_id="msg-1", func=api_module.gmail_get)
+
+    api_module.gmail_get(args)
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["from"] == "sender@example.com"
+    assert result["to"] == "recipient@example.com"
+    assert result["subject"] == "case bug"
+    assert result["date"] == "Fri, 29 May 2026 12:00:00 +0000"
+
+
+@pytest.mark.parametrize(
+    "header_names",
+    [
+        ("from", "to", "subject", "date"),
+        ("From", "To", "Subject", "Date"),
+    ],
+)
+def test_api_gmail_search_reads_headers_case_insensitively(
+    api_module,
+    capsys,
+    header_names,
+):
+    from_name, to_name, subject_name, date_name = header_names
+    calls = []
+
+    def fake_run_gws(parts, *, params=None, body=None):
+        calls.append({"parts": parts, "params": params, "body": body})
+        if parts == ["gmail", "users", "messages", "list"]:
+            assert params == {"userId": "me", "q": "from:sender", "maxResults": 5}
+            return {"messages": [{"id": "msg-1"}]}
+
+        assert parts == ["gmail", "users", "messages", "get"]
+        assert params == {
+            "userId": "me",
+            "id": "msg-1",
+            "format": "metadata",
+            "metadataHeaders": ["From", "To", "Subject", "Date"],
+        }
+        return {
+            "id": "msg-1",
+            "threadId": "thread-1",
+            "labelIds": ["INBOX"],
+            "snippet": "preview",
+            "payload": {
+                "headers": [
+                    {"name": from_name, "value": "sender@example.com"},
+                    {"name": to_name, "value": "recipient@example.com"},
+                    {"name": subject_name, "value": "case bug"},
+                    {"name": date_name, "value": "Fri, 29 May 2026 12:00:00 +0000"},
+                ],
+            },
+        }
+
+    api_module._run_gws = fake_run_gws
+    args = api_module.argparse.Namespace(
+        query="from:sender",
+        max=5,
+        func=api_module.gmail_search,
+    )
+
+    api_module.gmail_search(args)
+
+    assert len(calls) == 2
+    result = json.loads(capsys.readouterr().out)
+    assert result == [
+        {
+            "id": "msg-1",
+            "threadId": "thread-1",
+            "from": "sender@example.com",
+            "to": "recipient@example.com",
+            "subject": "case bug",
+            "date": "Fri, 29 May 2026 12:00:00 +0000",
+            "snippet": "preview",
+            "labels": ["INBOX"],
+        }
+    ]
+
+
+def test_api_gmail_send_uses_conventional_mime_header_casing(api_module):
+    captured = {}
+
+    def fake_run_gws(parts, *, params=None, body=None):
+        captured["parts"] = parts
+        captured["params"] = params
+        captured["body"] = body
+        return {"id": "sent-1", "threadId": "thread-1"}
+
+    api_module._run_gws = fake_run_gws
+    args = api_module.argparse.Namespace(
+        to="recipient@example.com",
+        subject="hello",
+        body="body",
+        html=False,
+        cc="copy@example.com",
+        from_header="sender@example.com",
+        thread_id="thread-1",
+        func=api_module.gmail_send,
+    )
+
+    api_module.gmail_send(args)
+
+    raw = api_module.base64.urlsafe_b64decode(captured["body"]["raw"])
+    raw_text = raw.decode()
+    assert "To: recipient@example.com" in raw_text
+    assert "Subject: hello" in raw_text
+    assert "Cc: copy@example.com" in raw_text
+    assert "From: sender@example.com" in raw_text
+    assert "\nto: " not in raw_text
+    assert "\nsubject: " not in raw_text
+
+
+@pytest.mark.parametrize(
+    "header_names",
+    [
+        ("from", "subject", "message-id"),
+        ("From", "Subject", "Message-ID"),
+    ],
+)
+def test_api_gmail_reply_reads_headers_case_insensitively_and_uses_conventional_mime_header_casing(
+    api_module,
+    header_names,
+):
+    from_name, subject_name, message_id_name = header_names
+    calls = []
+
+    def fake_run_gws(parts, *, params=None, body=None):
+        calls.append({"parts": parts, "params": params, "body": body})
+        if parts == ["gmail", "users", "messages", "get"]:
+            assert params == {
+                "userId": "me",
+                "id": "msg-1",
+                "format": "metadata",
+                "metadataHeaders": ["From", "Subject", "Message-ID"],
+            }
+            return {
+                "id": "msg-1",
+                "threadId": "thread-1",
+                "payload": {
+                    "headers": [
+                        {"name": from_name, "value": "sender@example.com"},
+                        {"name": subject_name, "value": "case bug"},
+                        {"name": message_id_name, "value": "<msg-1@example.com>"},
+                    ],
+                },
+            }
+
+        assert parts == ["gmail", "users", "messages", "send"]
+        assert params == {"userId": "me"}
+        return {"id": "sent-1", "threadId": "thread-1"}
+
+    api_module._run_gws = fake_run_gws
+    args = api_module.argparse.Namespace(
+        message_id="msg-1",
+        body="reply body",
+        from_header="recipient@example.com",
+        func=api_module.gmail_reply,
+    )
+
+    api_module.gmail_reply(args)
+
+    assert len(calls) == 2
+    body = calls[1]["body"]
+    assert body["threadId"] == "thread-1"
+    raw = api_module.base64.urlsafe_b64decode(body["raw"])
+    raw_text = raw.decode()
+    assert "To: sender@example.com" in raw_text
+    assert "Subject: Re: case bug" in raw_text
+    assert "From: recipient@example.com" in raw_text
+    assert "In-Reply-To: <msg-1@example.com>" in raw_text
+    assert "References: <msg-1@example.com>" in raw_text
+    assert "\nto: " not in raw_text
+    assert "\nsubject: " not in raw_text
+    assert "\nin-reply-to: " not in raw_text
+    assert "\nreferences: " not in raw_text
 
 
 def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, monkeypatch):

--- a/website/docs/user-guide/skills/google-workspace.md
+++ b/website/docs/user-guide/skills/google-workspace.md
@@ -1,13 +1,13 @@
 ---
 sidebar_position: 2
 sidebar_label: "Google Workspace"
-title: "Google Workspace — Gmail, Calendar, Drive, Sheets & Docs"
-description: "Send email, manage calendar events, search Drive, read/write Sheets, and access Docs — all through OAuth2-authenticated Google APIs"
+title: "Google Workspace — Gmail, Calendar, Drive, Tasks, Sheets & Docs"
+description: "Send email, manage calendar events and tasks, search Drive, read/write Sheets, and access Docs — all through OAuth2-authenticated Google APIs"
 ---
 
 # Google Workspace Skill
 
-Gmail, Calendar, Drive, Contacts, Sheets, and Docs integration for Hermes. Uses OAuth2 with automatic token refresh. Prefers the [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli) when available for broader coverage, and falls back to Google's Python client libraries otherwise.
+Gmail, Calendar, Drive, Tasks, Contacts, Sheets, and Docs integration for Hermes. Uses OAuth2 with automatic token refresh. Prefers the [Google Workspace CLI (`gws`)](https://github.com/googleworkspace/cli) when available for broader coverage, and falls back to Google's Python client libraries otherwise.
 
 **Skill path:** `skills/productivity/google-workspace/`
 
@@ -15,7 +15,7 @@ Gmail, Calendar, Drive, Contacts, Sheets, and Docs integration for Hermes. Uses 
 
 The setup is fully agent-driven — ask Hermes to set up Google Workspace and it walks you through each step. The flow:
 
-1. **Create a Google Cloud project** and enable the required APIs (Gmail, Calendar, Drive, Sheets, Docs, People)
+1. **Create a Google Cloud project** and enable the required APIs (Gmail, Calendar, Drive, Tasks, Sheets, Docs, People)
 2. **Create OAuth 2.0 credentials** (Desktop app type) and download the client secret JSON
 3. **Authorize** — Hermes generates an auth URL, you approve in the browser, paste back the redirect URL
 4. **Done** — token auto-refreshes from that point on
@@ -114,7 +114,7 @@ $GAPI gmail modify MESSAGE_ID --remove-labels UNREAD
 $GAPI calendar list
 $GAPI calendar list --start 2026-03-01T00:00:00Z --end 2026-03-07T23:59:59Z
 
-# Create event (timezone required)
+# Create event (timezone recommended; naive datetimes use Hermes' configured timezone)
 $GAPI calendar create --summary "Team Standup" \
   --start 2026-03-01T10:00:00-07:00 --end 2026-03-01T10:30:00-07:00
 
@@ -128,7 +128,22 @@ $GAPI calendar delete EVENT_ID
 ```
 
 :::warning
-Calendar times **must** include a timezone offset (e.g. `-07:00`) or use UTC (`Z`). Bare datetimes like `2026-03-01T10:00:00` are ambiguous and will be treated as UTC.
+Calendar times should include a timezone offset (e.g. `-07:00`) or use UTC (`Z`) when possible. Bare datetimes like `2026-03-01T10:00:00` are interpreted with Hermes' configured timezone, falling back to the server-local timezone.
+:::
+
+## Tasks
+
+```bash
+# List tasks from the default task list
+$GAPI tasks list --max 20
+
+# Create a task, optionally with a due date
+$GAPI tasks add --title "Pay invoice" --due 2026-03-01
+$GAPI tasks add --title "Inbox zero"
+```
+
+:::caution
+Creating a Google Task is a write action. Hermes should show the task title, target task list, and due date (if any) and ask for confirmation before running `tasks add`.
 :::
 
 ## Drive
@@ -176,6 +191,8 @@ All commands return JSON. Key fields per service:
 | `gmail send/reply` | `status`, `id`, `threadId` |
 | `calendar list` | `id`, `summary`, `start`, `end`, `location`, `description`, `htmlLink` |
 | `calendar create` | `status`, `id`, `summary`, `htmlLink` |
+| `tasks list` | `tasklistId`, `tasklistTitle`, `tasks` |
+| `tasks add` | `status`, `tasklistId`, `tasklistTitle`, `id`, `title`, `due`, `webViewLink` |
 | `drive search` | `id`, `name`, `mimeType`, `modifiedTime`, `webViewLink` |
 | `contacts list` | `name`, `emails`, `phones` |
 | `sheets get` | 2D array of cell values |


### PR DESCRIPTION
## Summary
- add Google Tasks OAuth scope and `tasks list` / `tasks add` commands to the google-workspace skill
- document Tasks setup, usage, and JSON output format
- normalize naive Calendar datetimes with `HERMES_GOOGLE_TIMEZONE`, falling back to UTC

## Test Plan
- `/usr/bin/python3 -m py_compile skills/productivity/google-workspace/scripts/google_api.py skills/productivity/google-workspace/scripts/setup.py`
- `/usr/bin/python3 skills/productivity/google-workspace/scripts/google_api.py tasks --help`
- helper assertions for UTC default, `HERMES_GOOGLE_TIMEZONE=Asia/Novosibirsk`, existing `Z`, and explicit offset inputs
- `git diff --check`
- custom changed-file secret scan: no findings

## Notes
- No credential files, migration notes, local auth bridges, or OpenClaw artifacts are included.
- Tasks operations use the existing bundled Python Google API client path, so no extra non-stdlib dependency is added beyond the skill's existing Google client packages.