### PR TITLE
fix(dashboard): validate websocket origin before tickets

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17419,16 +17419,7 @@ async def console_ws(ws: WebSocket) -> None:
         await ws.close(code=4404, reason="embedded chat disabled")
         return
 
-    auth_reason, cred = _ws_auth_reason(ws)
     mode = _ws_auth_mode()
-    if auth_reason is not None:
-        _log.warning(
-            "console auth rejected reason=%s mode=%s cred=%s peer=%s",
-            auth_reason, mode, cred, peer,
-        )
-        await ws.close(code=4401, reason=_ws_close_reason(f"auth: {auth_reason}"))
-        return
-
     host_origin_reason = _ws_host_origin_reason(ws)
     if host_origin_reason is not None:
         _log.warning("console refused: %s peer=%s", host_origin_reason, peer)
@@ -17439,6 +17430,15 @@ async def console_ws(ws: WebSocket) -> None:
     if client_reason is not None:
         _log.warning("console refused: %s", client_reason)
         await ws.close(code=4408, reason=_ws_close_reason(client_reason))
+        return
+
+    auth_reason, cred = _ws_auth_reason(ws)
+    if auth_reason is not None:
+        _log.warning(
+            "console auth rejected reason=%s mode=%s cred=%s peer=%s",
+            auth_reason, mode, cred, peer,
+        )
+        await ws.close(code=4401, reason=_ws_close_reason(f"auth: {auth_reason}"))
         return
 
     await ws.accept()
@@ -17769,22 +17769,13 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.close(code=4404, reason="embedded chat disabled")
         return
 
-    # --- auth + host/origin/peer check (before accept so we can close
+    # --- host/origin/peer + auth check (before accept so we can close
     #     cleanly AND tell the client WHY via the close code + reason).
     #     Each gate maps to a distinct close code so the log and the
     #     browser banner agree on the cause:
     #       4401 bad credential   4403 host/origin mismatch
     #       4408 peer not allowed  4404 chat disabled
-    auth_reason, cred = _ws_auth_reason(ws)
     mode = _ws_auth_mode()
-    if auth_reason is not None:
-        _log.warning(
-            "pty auth rejected reason=%s mode=%s cred=%s peer=%s",
-            auth_reason, mode, cred, peer,
-        )
-        await ws.close(code=4401, reason=_ws_close_reason(f"auth: {auth_reason}"))
-        return
-
     host_origin_reason = _ws_host_origin_reason(ws)
     if host_origin_reason is not None:
         _log.warning("pty refused: %s peer=%s", host_origin_reason, peer)
@@ -17795,6 +17786,15 @@ async def pty_ws(ws: WebSocket) -> None:
     if client_reason is not None:
         _log.warning("pty refused: %s", client_reason)
         await ws.close(code=4408, reason=_ws_close_reason(client_reason))
+        return
+
+    auth_reason, cred = _ws_auth_reason(ws)
+    if auth_reason is not None:
+        _log.warning(
+            "pty auth rejected reason=%s mode=%s cred=%s peer=%s",
+            auth_reason, mode, cred, peer,
+        )
+        await ws.close(code=4401, reason=_ws_close_reason(f"auth: {auth_reason}"))
         return
 
     await ws.accept()
@@ -17953,12 +17953,12 @@ async def gateway_ws(ws: WebSocket) -> None:
         await ws.close(code=4403)
         return
 
-    if not _ws_auth_ok(ws):
-        await ws.close(code=4401)
-        return
-
     if not _ws_request_is_allowed(ws):
         await ws.close(code=4403)
+        return
+
+    if not _ws_auth_ok(ws):
+        await ws.close(code=4401)
         return
 
     from tui_gateway.ws import handle_ws
@@ -17984,12 +17984,12 @@ async def pub_ws(ws: WebSocket) -> None:
         await ws.close(code=4403)
         return
 
-    if not _ws_auth_ok(ws):
-        await ws.close(code=4401)
-        return
-
     if not _ws_request_is_allowed(ws):
         await ws.close(code=4403)
+        return
+
+    if not _ws_auth_ok(ws):
+        await ws.close(code=4401)
         return
 
     channel = _channel_or_close_code(ws)
@@ -18012,12 +18012,12 @@ async def events_ws(ws: WebSocket) -> None:
         await ws.close(code=4403)
         return
 
-    if not _ws_auth_ok(ws):
-        await ws.close(code=4401)
-        return
-
     if not _ws_request_is_allowed(ws):
         await ws.close(code=4403)
+        return
+
+    if not _ws_auth_ok(ws):
+        await ws.close(code=4401)
         return
 
     channel = _channel_or_close_code(ws)

--- a/tests/hermes_cli/test_dashboard_auth_ws_auth.py
+++ b/tests/hermes_cli/test_dashboard_auth_ws_auth.py
@@ -317,7 +317,7 @@ class TestWsRequestIsAllowedGated:
 
     Regression coverage: every WS endpoint (``/api/pty``, ``/api/console``,
     ``/api/ws``, ``/api/pub``, ``/api/events``) calls
-    ``_ws_request_is_allowed`` after ``_ws_auth_ok``. If the peer-IP check
+    ``_ws_request_is_allowed`` before ``_ws_auth_ok``. If the peer-IP check
     rejects gated mode, the chat
     tab + sidebar tool feed silently fail to connect even after a
     successful OAuth login.
@@ -458,12 +458,13 @@ class TestWsHostOriginGuardOrigins:
     ``app://`` scheme). The DNS-rebinding guard only needs to block cross-site
     http(s) origins — a malicious web page can never forge a non-web origin.
 
-    This guard runs only AFTER ``_ws_auth_ok`` has validated the WS credential
-    (session token on loopback / ``--insecure`` binds, single-use ``?ticket=``
-    on OAuth-gated binds), so a non-web origin is trusted in every mode: the
-    credential is the real gate, and a ``file://`` / ``null`` origin cannot
-    originate a DNS-rebinding browser attack. ``http(s)`` origins are still
-    match-checked against the bound host.
+    This non-consuming guard runs before ``_ws_auth_ok`` so a rejected origin
+    cannot burn a single-use ticket. Authentication still follows on every
+    route (session token on loopback / ``--insecure`` binds, single-use
+    ``?ticket=`` on OAuth-gated binds), so a non-web origin is trusted in every
+    mode: the credential remains the real gate, and a ``file://`` / ``null``
+    origin cannot originate a DNS-rebinding browser attack. ``http(s)``
+    origins are still match-checked against the bound host.
     """
 
     def _ws(self, *, origin, host):
@@ -498,8 +499,8 @@ class TestWsHostOriginGuardOrigins:
         """Packaged Hermes Desktop also uses file:// when connecting to a
         Tailscale/LAN dashboard bind.
 
-        The WebSocket route calls _ws_auth_ok before this guard, so in
-        non-gated mode the legacy session token remains the auth boundary.
+        The WebSocket route calls _ws_auth_ok after this guard, so in non-gated
+        mode the legacy session token remains the auth boundary.
         """
         ws = self._ws(origin="file://", host="100.64.0.10:9119")
         assert web_server._ws_host_origin_is_allowed(ws) is True
@@ -516,12 +517,12 @@ class TestWsHostOriginGuardOrigins:
 
     def test_gated_file_origin_allowed(self, gated_app):
         # The packaged desktop app drives a remote OAuth-GATED gateway over a
-        # file:// renderer origin. The WS route validates the single-use
-        # ?ticket= in _ws_auth_ok before this guard runs, and a file:// origin
-        # can't be a DNS-rebinding browser attack, so the Origin guard must let
-        # it through. This is the regression that broke desktop → hosted
-        # gateway connections — every WS upgrade got HTTP 403 even with a valid
-        # ticket.
+        # file:// renderer origin. The WS route validates this non-consuming
+        # guard before the single-use ?ticket= in _ws_auth_ok, and a file://
+        # origin can't be a DNS-rebinding browser attack, so the Origin guard
+        # must let it through. This is the regression that broke desktop →
+        # hosted gateway connections — every WS upgrade got HTTP 403 even with
+        # a valid ticket.
         ws = self._ws(origin="file://", host="fly-app.fly.dev")
         assert web_server._ws_host_origin_is_allowed(ws) is True
 

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -198,17 +198,17 @@ class TestWebSocketHostOriginGuard:
         assert exc.value.code == 4403
 
     @pytest.mark.parametrize(
-        "endpoint",
+        ("endpoint", "expected_reason"),
         [
-            "/api/console",
-            "/api/pty",
-            "/api/ws",
-            "/api/pub?channel=security-test",
-            "/api/events?channel=security-test",
+            ("/api/console", "origin_mismatch"),
+            ("/api/pty", "origin_mismatch"),
+            ("/api/ws", ""),
+            ("/api/pub?channel=security-test", ""),
+            ("/api/events?channel=security-test", ""),
         ],
     )
     def test_rejected_gated_websocket_origin_does_not_consume_ticket(
-        self, monkeypatch, endpoint
+        self, monkeypatch, endpoint, expected_reason
     ):
         from fastapi.testclient import TestClient
         from starlette.websockets import WebSocketDisconnect
@@ -241,6 +241,10 @@ class TestWebSocketHostOriginGuard:
                     pass
 
             assert exc.value.code == 4403
+            if expected_reason:
+                assert exc.value.reason.startswith(expected_reason)
+            else:
+                assert exc.value.reason == ""
             assert consume_ticket(ticket)["user_id"] == "u1"
         finally:
             _reset_for_tests()

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -197,6 +197,54 @@ class TestWebSocketHostOriginGuard:
 
         assert exc.value.code == 4403
 
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "/api/console",
+            "/api/pty",
+            "/api/ws",
+            "/api/pub?channel=security-test",
+            "/api/events?channel=security-test",
+        ],
+    )
+    def test_rejected_gated_websocket_origin_does_not_consume_ticket(
+        self, monkeypatch, endpoint
+    ):
+        from fastapi.testclient import TestClient
+        from starlette.websockets import WebSocketDisconnect
+
+        import hermes_cli.web_server as ws
+        from hermes_cli.dashboard_auth.ws_tickets import (
+            _reset_for_tests,
+            consume_ticket,
+            mint_ticket,
+        )
+
+        _reset_for_tests()
+        monkeypatch.setattr(ws.app.state, "auth_required", True, raising=False)
+        monkeypatch.setattr(ws.app.state, "bound_host", "fly-app.fly.dev", raising=False)
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+
+        ticket = mint_ticket(user_id="u1", provider="stub")
+        client = TestClient(ws.app, base_url="https://fly-app.fly.dev")
+        separator = "&" if "?" in endpoint else "?"
+        url = f"{endpoint}{separator}ticket={ticket}"
+        try:
+            with pytest.raises(WebSocketDisconnect) as exc:
+                with client.websocket_connect(
+                    url,
+                    headers={
+                        "Host": "fly-app.fly.dev",
+                        "Origin": "https://evil.example",
+                    },
+                ):
+                    pass
+
+            assert exc.value.code == 4403
+            assert consume_ticket(ticket)["user_id"] == "u1"
+        finally:
+            _reset_for_tests()
+
     def test_loopback_websocket_host_and_origin_are_accepted(self, monkeypatch):
         from fastapi.testclient import TestClient
 


### PR DESCRIPTION
## Summary
- Validate WebSocket Host/Origin/client boundaries before consuming dashboard auth tickets.
- Apply the order consistently across `/api/pty`, `/api/ws`, `/api/pub`, and `/api/events`.
- Add a regression test proving rejected gated WebSocket origins leave the single-use ticket live across all four WS endpoints.

## Security impact
A cross-origin or rebinding WebSocket attempt should fail at the dashboard boundary before it can burn a short-lived single-use ticket. This keeps the ticket auth path single-use without letting invalid upgrade attempts cause avoidable denial of service for the legitimate browser session.

## Verification
- `uv run --extra dev ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server_host_header.py`
- `uv run --extra dev python -X utf8 -m pytest tests/hermes_cli/test_web_server_host_header.py -q --timeout-method=thread`
- `uv run --extra dev python -X utf8 -m pytest tests/hermes_cli/test_web_server_host_header.py tests/hermes_cli/test_dashboard_auth_ws_auth.py tests/hermes_cli/test_dashboard_auth_ws_tickets.py -q --timeout-method=thread`
- `uv run --extra dev ruff check .`