### PR TITLE
fix(models): use stale cache before models.dev refresh

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -20,6 +20,7 @@ rather than parsing the raw JSON themselves.
 
 import json
 import logging
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -33,10 +34,13 @@ logger = logging.getLogger(__name__)
 
 MODELS_DEV_URL = "https://models.dev/api.json"
 _MODELS_DEV_CACHE_TTL = 3600  # 1 hour in-memory
+_MODELS_DEV_STALE_GRACE_SECONDS = 300  # Retry background refresh after 5 min
 
 # In-memory cache
 _models_dev_cache: Dict[str, Any] = {}
 _models_dev_cache_time: float = 0
+_models_dev_refresh_lock = threading.Lock()
+_models_dev_refresh_in_flight = False
 
 
 # ---------------------------------------------------------------------------
@@ -237,6 +241,59 @@ def _save_disk_cache(data: Dict[str, Any]) -> None:
         logger.debug("Failed to save models.dev disk cache: %s", e)
 
 
+def _fetch_models_dev_from_network() -> Dict[str, Any]:
+    """Fetch the live models.dev registry without touching local caches."""
+    response = requests.get(MODELS_DEV_URL, timeout=15)
+    response.raise_for_status()
+    data = response.json()
+    if isinstance(data, dict) and data:
+        return data
+    return {}
+
+
+def _mark_stale_cache_grace() -> None:
+    """Give stale cache data a short in-memory grace before retrying refresh."""
+    global _models_dev_cache_time
+    _models_dev_cache_time = (
+        time.time() - _MODELS_DEV_CACHE_TTL + _MODELS_DEV_STALE_GRACE_SECONDS
+    )
+
+
+def _background_refresh_models_dev() -> None:
+    """Best-effort refresh after serving stale cache data."""
+    global _models_dev_cache, _models_dev_cache_time, _models_dev_refresh_in_flight
+    try:
+        data = _fetch_models_dev_from_network()
+        if data:
+            _models_dev_cache = data
+            _models_dev_cache_time = time.time()
+            _save_disk_cache(data)
+            logger.debug(
+                "Refreshed models.dev registry in background: %d providers",
+                len(data),
+            )
+    except Exception as e:
+        logger.debug("Background models.dev refresh failed: %s", e)
+    finally:
+        with _models_dev_refresh_lock:
+            _models_dev_refresh_in_flight = False
+
+
+def _start_background_refresh_models_dev() -> None:
+    """Start one daemon refresh worker if none is already running."""
+    global _models_dev_refresh_in_flight
+    with _models_dev_refresh_lock:
+        if _models_dev_refresh_in_flight:
+            return
+        _models_dev_refresh_in_flight = True
+    thread = threading.Thread(
+        target=_background_refresh_models_dev,
+        name="models-dev-refresh",
+        daemon=True,
+    )
+    thread.start()
+
+
 def fetch_models_dev(force_refresh: bool = False) -> Dict[str, Any]:
     """Fetch models.dev registry. Cache hierarchy: in-mem → disk → network.
 
@@ -244,17 +301,21 @@ def fetch_models_dev(force_refresh: bool = False) -> Dict[str, Any]:
 
     Cache hierarchy (when ``force_refresh=False``):
       1. In-memory cache, populated and < TTL old → return immediately.
-      2. **Disk cache file < TTL old by mtime → load, populate in-mem, return.**
+      2. Stale in-memory cache → return immediately and refresh in background.
+      3. Disk cache file exists → load, populate in-mem, return immediately.
+         Fresh disk caches keep their original TTL. Stale disk caches get a
+         short in-memory grace and refresh in background.
          No network call. Saves ~500 ms per cold-start agent construction;
          ``models.dev`` only changes when providers add new models, so a
-         1 hour staleness window is acceptable (same TTL as in-mem cache).
-      3. Network fetch → on success, save to disk + in-mem and return.
-      4. Network fails → fall back to ANY available disk cache (even stale)
-         with a short 5 min in-mem grace period before retrying network.
+         stale cache is preferable to blocking foreground provider resolution.
+      4. Network fetch (only when no cache is available) → on success, save
+         to disk + in-mem and return.
+      5. Network fails → fall back to ANY available disk cache (even stale)
+         with a short 5 min in-mem grace period before retrying.
 
     When ``force_refresh=True`` (used by ``hermes config refresh``, the
-    \"refresh model catalog\" code path), stages 1 and 2 are skipped. The
-    function always hits the network and only falls back to disk if the
+    \"refresh model catalog\" code path), cache fast paths are skipped. The
+    function always hits the network and only falls back to cache if the
     network call fails.
     """
     global _models_dev_cache, _models_dev_cache_time
@@ -268,32 +329,49 @@ def fetch_models_dev(force_refresh: bool = False) -> Dict[str, Any]:
     ):
         return _models_dev_cache
 
-    # Stage 2: fresh-by-mtime disk cache short-circuits the network call.
+    # Stage 2: stale in-memory cache is still better than blocking provider
+    # resolution on a foreground network timeout. Refresh it in the background.
+    if not force_refresh and _models_dev_cache:
+        _mark_stale_cache_grace()
+        _start_background_refresh_models_dev()
+        logger.warning(
+            "Using stale in-memory models.dev cache; refreshing in background"
+        )
+        return _models_dev_cache
+
+    # Stage 3: disk cache short-circuits the network call.
     # Only kicks in on cold-start processes (in-mem cache is empty or
     # expired) and only when the user hasn't asked for a forced refresh.
-    # Skipped if the disk cache file is missing, unreadable, or older
-    # than _MODELS_DEV_CACHE_TTL.
+    # A stale disk cache is deliberately usable: provider/model resolution
+    # should not hang just because models.dev is unreachable.
     if not force_refresh:
         disk_age = _disk_cache_age_seconds()
-        if disk_age is not None and disk_age < _MODELS_DEV_CACHE_TTL:
+        if disk_age is not None:
             disk_data = _load_disk_cache()
             if disk_data:
                 _models_dev_cache = disk_data
-                # Anchor in-mem TTL to the disk file's age so we don't
-                # extend an already-aging cache by another full hour.
-                _models_dev_cache_time = time.time() - disk_age
-                logger.debug(
-                    "Loaded models.dev from fresh disk cache "
-                    "(%d providers, age=%.0fs)", len(disk_data), disk_age,
-                )
+                if disk_age < _MODELS_DEV_CACHE_TTL:
+                    # Anchor in-mem TTL to the disk file's age so we don't
+                    # extend an already-aging cache by another full hour.
+                    _models_dev_cache_time = time.time() - disk_age
+                    logger.debug(
+                        "Loaded models.dev from fresh disk cache "
+                        "(%d providers, age=%.0fs)", len(disk_data), disk_age,
+                    )
+                else:
+                    _mark_stale_cache_grace()
+                    _start_background_refresh_models_dev()
+                    logger.warning(
+                        "Using stale models.dev disk cache (age=%.0fs); "
+                        "refreshing in background",
+                        disk_age,
+                    )
                 return _models_dev_cache
 
-    # Stage 3: network fetch.
+    # Stage 4: network fetch.
     try:
-        response = requests.get(MODELS_DEV_URL, timeout=15)
-        response.raise_for_status()
-        data = response.json()
-        if isinstance(data, dict) and data:
+        data = _fetch_models_dev_from_network()
+        if data:
             _models_dev_cache = data
             _models_dev_cache_time = time.time()
             _save_disk_cache(data)
@@ -306,13 +384,13 @@ def fetch_models_dev(force_refresh: bool = False) -> Dict[str, Any]:
     except Exception as e:
         logger.debug("Failed to fetch models.dev: %s", e)
 
-    # Stage 4: network failed — fall back to whatever disk cache exists,
+    # Stage 5: network failed — fall back to whatever disk cache exists,
     # even if it's stale. Give it a short 5 min in-mem TTL so we retry
     # the network soon instead of serving stale data for a full hour.
     if not _models_dev_cache:
         _models_dev_cache = _load_disk_cache()
         if _models_dev_cache:
-            _models_dev_cache_time = time.time() - _MODELS_DEV_CACHE_TTL + 300
+            _mark_stale_cache_grace()
             logger.debug("Loaded models.dev from disk cache (%d providers)", len(_models_dev_cache))
 
     return _models_dev_cache

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -208,6 +208,20 @@ class TestFetchModelsDev:
         assert result == SAMPLE_REGISTRY
 
     @patch("agent.models_dev.requests.get")
+    def test_stale_in_memory_cache_returns_without_foreground_network(self, mock_get):
+        """Expired in-memory data should not block foreground resolution."""
+        import agent.models_dev as md
+        md._models_dev_cache = SAMPLE_REGISTRY
+        md._models_dev_cache_time = 0
+
+        with patch.object(md, "_start_background_refresh_models_dev") as mock_refresh:
+            result = fetch_models_dev()
+
+        mock_get.assert_not_called()
+        mock_refresh.assert_called_once()
+        assert result == SAMPLE_REGISTRY
+
+    @patch("agent.models_dev.requests.get")
     def test_fresh_disk_cache_skips_network(self, mock_get):
         """When in-mem cache is empty but disk cache exists and is fresh by
         mtime (< TTL), fetch_models_dev returns disk data without ever
@@ -234,27 +248,20 @@ class TestFetchModelsDev:
         assert md._models_dev_cache == SAMPLE_REGISTRY
 
     @patch("agent.models_dev.requests.get")
-    def test_stale_disk_cache_falls_through_to_network(self, mock_get):
-        """When the disk cache is OLDER than TTL, we must hit the network
-        (and only fall back to the stale disk data if network fails)."""
+    def test_stale_disk_cache_returns_without_foreground_network(self, mock_get):
+        """#35838: stale disk cache should not wait on models.dev timeout."""
         import agent.models_dev as md
         md._models_dev_cache = {}
         md._models_dev_cache_time = 0
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = SAMPLE_REGISTRY
-        mock_resp.raise_for_status = MagicMock()
-        mock_get.return_value = mock_resp
-
-        # Disk cache exists but is older than the TTL — must NOT short-circuit.
         with patch.object(md, "_disk_cache_age_seconds",
                           return_value=md._MODELS_DEV_CACHE_TTL + 60), \
              patch.object(md, "_load_disk_cache", return_value=SAMPLE_REGISTRY), \
-             patch.object(md, "_save_disk_cache"):
+             patch.object(md, "_start_background_refresh_models_dev") as mock_refresh:
             result = fetch_models_dev()
 
-        mock_get.assert_called_once()
+        mock_get.assert_not_called()
+        mock_refresh.assert_called_once()
         assert "anthropic" in result
 
     @patch("agent.models_dev.requests.get")


### PR DESCRIPTION
## Summary
- Return stale in-memory or disk `models.dev` cache immediately for normal metadata lookups instead of waiting on a foreground network timeout.
- Start a single daemon background refresh after serving stale cache data, so live catalog updates can still land without blocking provider/model resolution.
- Keep `force_refresh=True` network-first for explicit refresh flows.

Fixes #35838

## Tests
- `uv run --extra dev python -X utf8 -m pytest tests/agent/test_models_dev.py -q --timeout-method=thread`
- `uv run --extra dev ruff check .`