### PR TITLE
fix(mcp): replace blocking time.sleep poll in _handle_session_expired_and_retry

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2199,14 +2199,27 @@ def _handle_session_expired_and_retry(
 
     # Trigger the same reconnect mechanism the OAuth recovery path
     # uses, then wait briefly for the new session to come back ready.
+    # The async helper runs on the MCP event loop via _run_on_mcp_loop
+    # so it does NOT block the event loop during the poll interval.
+    # Mirrors the identical pattern in _handle_auth_error_and_retry.
     loop.call_soon_threadsafe(srv._reconnect_event.set)
-    deadline = time.monotonic() + 15
+
+    async def _await_ready() -> bool:
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            if srv.session is not None and srv._ready.is_set():
+                return True
+            await asyncio.sleep(0.25)
+        return False
+
     ready = False
-    while time.monotonic() < deadline:
-        if srv.session is not None and srv._ready.is_set():
-            ready = True
-            break
-        time.sleep(0.25)
+    try:
+        ready = bool(_run_on_mcp_loop(_await_ready(), timeout=15))
+    except Exception as exc:
+        logger.warning(
+            "MCP session-expired '%s': ready poll failed: %s",
+            server_name, exc,
+        )
     if not ready:
         logger.warning(
             "MCP server '%s': reconnect did not ready within 15s after "


### PR DESCRIPTION
## Summary

`_handle_auth_error_and_retry` was already converted to `asyncio.sleep` via `_run_on_mcp_loop` (eb9bfd392), but its sibling `_handle_session_expired_and_retry` kept the identical `time.sleep(0.25)` blocking poll.

On session expiry the 15-second reconnect wait blocked the entire MCP event loop, stalling all concurrent MCP operations (other tool calls, keepalive heartbeats, OAuth token refreshes) for up to 15 seconds.

**Fix:** Apply the same `_await_ready()` async helper pattern used in `_handle_auth_error_and_retry`: schedule the readiness poll as a coroutine on the MCP event loop via `_run_on_mcp_loop` so `asyncio.sleep(0.25)` yields back to the loop instead of blocking it. Exception handling follows the auth-error sibling exactly.

## Test plan

- [x] All 18 existing `tests/tools/test_mcp_tool_session_expired.py` tests pass unchanged — reconnect fires, retry succeeds, `None` fallthrough paths intact
- [x] Only `tools/mcp_tool.py` changed (1 file, 19 insertions, 6 deletions)
- [x] No new `time.sleep` introduced; the surviving `time.sleep(2)` in the SIGTERM/SIGKILL cleanup path is intentional (synchronous process management, not event-loop code)