### PR TITLE
fix(anthropic): drop thinking blocks when orphan-strip mutates an assistant turn

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1783,11 +1783,18 @@ def _strip_orphaned_tool_blocks(result: List[Dict[str, Any]]) -> None:
                     tool_result_ids.add(block.get("tool_use_id"))
     for m in result:
         if m["role"] == "assistant" and isinstance(m["content"], list):
-            m["content"] = [
+            kept = [
                 b
                 for b in m["content"]
                 if b.get("type") != "tool_use" or b.get("id") in tool_result_ids
             ]
+            if len(kept) != len(m["content"]):
+                kept = [
+                    b
+                    for b in kept
+                    if not (isinstance(b, dict) and b.get("type") in {"thinking", "redacted_thinking"})
+                ]
+            m["content"] = kept
             if not m["content"]:
                 m["content"] = [{"type": "text", "text": "(tool call removed)"}]
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1757,6 +1757,31 @@ class TestThinkingBlockSignatureManagement:
         assert len(thinking) == 1
         assert thinking[0]["thinking"] == "First thought."
 
+    def test_thinking_dropped_when_orphaned_tool_use_stripped(self):
+        """Stripping an orphaned tool_use invalidates the turn's thinking signature."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_1", "function": {"name": "tool1", "arguments": "{}"}},
+                    {"id": "tc_2", "function": {"name": "tool2", "arguments": "{}"}},
+                ],
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Plan.", "signature": "sig_1"},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_1", "content": "result 1"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+
+        assistant = next(m for m in result if m["role"] == "assistant")
+        types = [b.get("type") for b in assistant["content"]]
+        assert "thinking" not in types
+        assert "redacted_thinking" not in types
+        tool_use_ids = [b["id"] for b in assistant["content"] if b.get("type") == "tool_use"]
+        assert tool_use_ids == ["tc_1"]
+
     def test_empty_content_after_strip_gets_placeholder(self):
         """If stripping thinking leaves an empty message, a placeholder is added."""
         messages = [


### PR DESCRIPTION
## What does this PR do?

Extended-thinking Claude models sign each `thinking` block against the full turn content. When `_strip_orphaned_tool_blocks` removes a `tool_use` whose `tool_result` never arrived (interrupted parallel batch, compression, truncation), the turn's content changes and the signature no longer matches. Replaying it returns a non-retryable HTTP 400:

```
messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest
assistant message cannot be modified. These blocks must remain as they were
in the original response.
```

Since the turn is rebuilt from the store every iteration, the gateway loops on it with no recovery.

`_merge_consecutive_roles` already drops thinking blocks for the same reason when it mutates a turn. This applies the identical treatment to the orphan-strip path: if a turn's `tool_use` set was trimmed, drop its thinking blocks too.

## Related Issue

Fixes #35847

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py` — `_strip_orphaned_tool_blocks`: when a turn's `tool_use` set is trimmed, drop its `thinking`/`redacted_thinking` blocks.
- `tests/agent/test_anthropic_adapter.py` — test covering a partially-answered parallel tool batch.

## How to Test

```
pytest tests/agent/test_anthropic_adapter.py -k "thinking or signature or orphan or merge" -q
```

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] Tests pass
- [x] I've added tests for my changes
- [x] Tested on macOS 26.4, Python 3.11.15

### Documentation & Housekeeping

- [x] N/A — behavior fix, no config/doc/schema changes.
