### PR TITLE
fix: allow disabling prompt caching

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -479,7 +479,10 @@ def init_agent(
         from hermes_cli.config import load_config as _load_pc_cfg
 
         _pc_cfg = _load_pc_cfg().get("prompt_caching", {}) or {}
-        _ttl = _pc_cfg.get("cache_ttl", "5m")
+        if isinstance(_pc_cfg, dict) and _pc_cfg.get("enabled") is False:
+            agent._use_prompt_caching = False
+            agent._use_native_cache_layout = False
+        _ttl = _pc_cfg.get("cache_ttl", "5m") if isinstance(_pc_cfg, dict) else "5m"
         if _ttl in {"5m", "1h"}:
             agent._cache_ttl = _ttl
     except Exception:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1012,8 +1012,11 @@ DEFAULT_CONFIG = {
     },
 
     # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
-    # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
+    # Set enabled: false as an escape hatch for strict providers that reject
+    # cache_control markers; cache_ttl must be "5m" or "1h" (Anthropic-supported
+    # tiers), other values are ignored.
     "prompt_caching": {
+        "enabled": True,
         "cache_ttl": "5m",
     },
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -928,6 +928,30 @@ class TestInit:
             )
             assert a._cache_ttl == "5m"
 
+    def test_prompt_caching_enabled_false_disables_cache_markers(self):
+        """prompt_caching.enabled=false is an escape hatch for strict providers."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter._anthropic_sdk"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"prompt_caching": {"enabled": False}},
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                base_url="https://api.anthropic.com/v1/",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a.api_mode == "anthropic_messages"
+            assert a._use_prompt_caching is False
+            assert a._use_native_cache_layout is False
+
     def test_valid_tool_names_populated(self):
         """valid_tool_names should contain names from loaded tools."""
         tools = _make_tool_defs("web_search", "terminal")


### PR DESCRIPTION
## Summary
- add `prompt_caching.enabled` config support, defaulting to `true`
- allow `prompt_caching.enabled: false` to disable cache marker injection for strict Anthropic-compatible providers
- add regression coverage that the flag disables both prompt-caching flags while preserving existing TTL behavior

## Why
Some strict Anthropic-compatible endpoints can reject Hermes-injected `cache_control` markers with errors like `Unknown parameter: messages[0].content[0].cache_control`. Hermes already supports `prompt_caching.cache_ttl`; this adds a narrow config-gated escape hatch without changing the default behavior for users who benefit from prompt caching.

## Test Plan
- `venv/bin/python -m py_compile agent/agent_init.py hermes_cli/config.py tests/run_agent/test_run_agent.py`
- `venv/bin/python -m pytest tests/run_agent/test_run_agent.py tests/run_agent/test_anthropic_prompt_cache_policy.py tests/agent/test_prompt_caching.py -q -o 'addopts='`

Result: 396 passed, 1 warning.
