### PR TITLE
feat(email): restrict default email toolsets

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -52,6 +52,18 @@ from hermes_cli.cli_output import (  # noqa: E402 — late import block
 # Toolsets shown in the configurator, grouped for display.
 # Each entry: (toolset_name, label, description)
 # These map to keys in toolsets.py TOOLSETS dict.
+EMAIL_SAFE_TOOLSETS = {
+    "messaging",
+    "memory",
+    "session_search",
+    "todo",
+    "clarify",
+    "search",
+    "vision",
+    "skills",
+}
+
+
 CONFIGURABLE_TOOLSETS = [
     ("web",             "🔍 Web Search & Scraping",    "web_search, web_extract"),
     ("browser",         "🌐 Browser Automation",       "navigate, click, type, scroll"),
@@ -1381,6 +1393,13 @@ def _get_platform_tools(
     if disabled_toolsets:
         disabled_set = {str(ts) for ts in disabled_toolsets}
         enabled_toolsets -= disabled_set
+
+    # Email can be triggered by third-party message bodies, so keep its tool
+    # surface narrow by default. Operators can opt out with
+    # EMAIL_RESTRICT_TOOLS=0 if they intentionally want full email-triggered
+    # sessions.
+    if platform == "email" and os.getenv("EMAIL_RESTRICT_TOOLS", "1").lower() not in {"0", "false", "no", "off"}:
+        enabled_toolsets &= EMAIL_SAFE_TOOLSETS
 
     return enabled_toolsets
 

--- a/tests/hermes_cli/test_email_tool_restriction.py
+++ b/tests/hermes_cli/test_email_tool_restriction.py
@@ -1,0 +1,49 @@
+"""Email platform toolset hardening tests."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from hermes_cli.tools_config import _get_platform_tools
+
+
+def test_email_toolsets_restricted_by_default():
+    config = {
+        "platform_toolsets": {
+            "email": [
+                "terminal",
+                "browser",
+                "web",
+                "memory",
+                "session_search",
+                "todo",
+                "clarify",
+                "search",
+                "vision",
+                "skills",
+                "messaging",
+            ]
+        }
+    }
+
+    enabled = _get_platform_tools(config, "email")
+
+    assert "memory" in enabled
+    assert "session_search" in enabled
+    assert "terminal" not in enabled
+    assert "browser" not in enabled
+    assert "web" not in enabled
+
+
+def test_email_toolset_restriction_can_be_disabled():
+    config = {
+        "platform_toolsets": {
+            "email": ["terminal", "memory", "search"]
+        }
+    }
+
+    with patch.dict("os.environ", {"EMAIL_RESTRICT_TOOLS": "0"}):
+        enabled = _get_platform_tools(config, "email")
+
+    assert "terminal" in enabled
+    assert "memory" in enabled
+    assert "search" in enabled


### PR DESCRIPTION
## Summary
- restrict email-triggered sessions to a small safe toolset surface by default
- allow operators to opt out with `EMAIL_RESTRICT_TOOLS=0`
- add regression tests for default restriction and opt-out behavior

## Why
Email messages are third-party input and a common prompt-injection vector. Narrowing the default tool surface for email sessions reduces the impact of malicious inbound content while preserving an explicit operator escape hatch.

## Test plan
- `uv run --with pytest python -m pytest tests/hermes_cli/test_email_tool_restriction.py -q -o 'addopts='`
