### PR TITLE
fix(image_gen): guard against NoneType iterable in openai-codex SSE parsing

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -175,6 +175,8 @@ def _build_responses_payload(*, prompt: str, size: str, quality: str) -> Dict[st
 def _extract_image_b64(value: Any) -> Optional[str]:
     """Return the newest image b64 embedded in a Responses event payload."""
     found: Optional[str] = None
+    if value is None:
+        return found
     if isinstance(value, dict):
         if value.get("type") == "image_generation_call":
             result = value.get("result")
@@ -222,6 +224,8 @@ def _iter_sse_json(response: Any):
         return payload
 
     for line in response.iter_lines():
+        if line is None:
+            continue
         if isinstance(line, bytes):
             line = line.decode("utf-8", errors="replace")
         line = str(line)
@@ -247,7 +251,7 @@ def _collect_image_b64(token: str, *, prompt: str, size: str, quality: str) -> O
     import httpx
     from agent.auxiliary_client import _codex_cloudflare_headers
 
-    headers = _codex_cloudflare_headers(token)
+    headers = _codex_cloudflare_headers(token) or {}
     headers.update({
         "Accept": "text/event-stream",
         "Authorization": f"Bearer {token}",

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -219,6 +219,40 @@ class TestGenerate:
         assert result["error_type"] == "api_error"
         assert "cloudflare 403" in result["error"]
 
+    def test_extract_image_b64_handles_none_input(self):
+        """_extract_image_b64 must not crash when given None (#35861)."""
+        assert codex_plugin._extract_image_b64(None) is None
+
+    def test_iter_sse_json_skips_none_lines(self):
+        """_iter_sse_json must skip None lines from iter_lines (#35861)."""
+        class _Response:
+            def iter_lines(self):
+                return iter([None, "event: test", 'data: {"a": 1}', "", None, ""])
+
+        events = list(codex_plugin._iter_sse_json(_Response()))
+        assert events == [{"a": 1, "type": "test"}]
+
+    def test_collect_image_b64_handles_none_headers(self, monkeypatch):
+        """_collect_image_b64 must not crash if _codex_cloudflare_headers
+        returns None (#35861)."""
+        from agent import auxiliary_client
+        monkeypatch.setattr(
+            auxiliary_client,
+            "_codex_cloudflare_headers",
+            lambda token: None,
+        )
+        # Should not raise TypeError from dict.update(None)
+        # We can't easily test the full HTTP flow, but we verify the
+        # header guard works by checking that the function doesn't crash
+        # before the HTTP call.
+        import httpx
+        try:
+            codex_plugin._collect_image_b64("fake-token", prompt="test", size="1024x1024", quality="medium")
+        except (httpx.ConnectError, httpx.ConnectTimeout, RuntimeError):
+            pass  # Expected — no real server
+        except TypeError as exc:
+            if "NoneType" in str(exc):
+                pytest.fail(f"NoneType guard failed: {exc}")
 
 # ── Plugin entry point ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

Adds defensive `None` guards to the `openai-codex` image generation plugin's SSE parsing pipeline to prevent `TypeError: 'NoneType' object is not iterable` when the Codex Responses API returns unexpected `None` values in stream lines or event payloads.

## Related Issue

Fixes #35861

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/image_gen/openai-codex/__init__.py`: Added `None` guard in `_extract_image_b64` (early return for `None` input), skip `None` lines in `_iter_sse_json`'s `iter_lines()` loop, and fallback to `{}` if `_codex_cloudflare_headers` returns `None` in `_collect_image_b64`
- `tests/plugins/image_gen/test_openai_codex_provider.py`: Added 3 regression tests — `test_extract_image_b64_handles_none_input`, `test_iter_sse_json_skips_none_lines`, `test_collect_image_b64_handles_none_headers`

## How to Test

1. Run `pytest tests/plugins/image_gen/test_openai_codex_provider.py -v` — all 21 tests should pass
2. The 3 new tests specifically validate that `None` inputs to `_extract_image_b64`, `None` lines from `iter_lines()`, and `None` returns from `_codex_cloudflare_headers` no longer cause `TypeError`
3. Existing tests (metadata, availability, generate flow, SSE parsing) remain green

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/plugins/image_gen/test_openai_codex_provider.py -v` and all 21 tests pass
- [x] I've added tests for my changes (3 regression tests for each None guard)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (internal defensive fix)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A (pure Python, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/image_gen/openai-codex/__init__.py` — `_extract_image_b64`, `_iter_sse_json`, `_collect_image_b64`
- Blast radius: LOW — changes are defensive guards only; no behavior change for normal (non-None) inputs
- Related patterns: Same defensive guard pattern used in `plugins/image_gen/openai/__init__.py` (line 240: `getattr(response, "data", None) or []`)
