### PR TITLE
fix: guard int()/float() env var casts and unguarded flock(LOCK_UN)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1168,7 +1168,10 @@ def _cross_process_init_lock(path: Path):
             else:
                 import fcntl
 
-                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
         finally:
             handle.close()
 

--- a/mini_swe_runner.py
+++ b/mini_swe_runner.py
@@ -195,11 +195,6 @@ class MiniSWERunner:
         self.cwd = cwd
         
         # Setup logging
-        logging.basicConfig(
-            level=logging.DEBUG if verbose else logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
         
         # Initialize LLM client via centralized provider router.

--- a/plugins/browser/firecrawl/provider.py
+++ b/plugins/browser/firecrawl/provider.py
@@ -78,7 +78,10 @@ class FirecrawlBrowserProvider(BrowserProvider):
         }
 
     def create_session(self, task_id: str) -> Dict[str, object]:
-        ttl = int(os.environ.get("FIRECRAWL_BROWSER_TTL", "300"))
+        try:
+            ttl = int(os.environ.get("FIRECRAWL_BROWSER_TTL", "300"))
+        except (ValueError, TypeError):
+            ttl = 300
 
         body: Dict[str, object] = {"ttl": ttl}
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -588,8 +588,14 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_locks: Dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
         # Text batching: merge rapid successive messages (Telegram-style)
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        try:
+            self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
+        except (ValueError, TypeError):
+            self._text_batch_delay_seconds = 0.6
+        try:
+            self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        except (ValueError, TypeError):
+            self._text_batch_split_delay_seconds = 2.0
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -540,8 +540,14 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # they don't sit in the chat forever as "Hermes is thinking…".
         self._orphan_typing_messages: Dict[str, List[str]] = {}
         # FlowControl knobs (env-configurable).
-        self._max_messages = int(os.getenv("GOOGLE_CHAT_MAX_MESSAGES", "1"))
-        self._max_bytes = int(os.getenv("GOOGLE_CHAT_MAX_BYTES", str(16 * 1024 * 1024)))
+        try:
+            self._max_messages = int(os.getenv("GOOGLE_CHAT_MAX_MESSAGES", "1"))
+        except (ValueError, TypeError):
+            self._max_messages = 1
+        try:
+            self._max_bytes = int(os.getenv("GOOGLE_CHAT_MAX_BYTES", str(16 * 1024 * 1024)))
+        except (ValueError, TypeError):
+            self._max_bytes = 16 * 1024 * 1024
 
     # ------------------------------------------------------------------
     # Configuration loading and validation

--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -107,7 +107,10 @@ class IRCAdapter(BasePlatformAdapter):
 
         # Connection settings (env vars override config.yaml)
         self.server = os.getenv("IRC_SERVER") or extra.get("server", "")
-        self.port = int(os.getenv("IRC_PORT") or extra.get("port", 6697))
+        try:
+            self.port = int(os.getenv("IRC_PORT") or extra.get("port", 6697))
+        except (ValueError, TypeError):
+            self.port = extra.get("port", 6697)
         self.nickname = os.getenv("IRC_NICKNAME") or extra.get("nickname", "hermes-bot")
         self.channel = os.getenv("IRC_CHANNEL") or extra.get("channel", "")
         self.use_tls = (

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1178,7 +1178,10 @@ _cleanup_done = False
 # Session inactivity timeout (seconds) - cleanup if no activity for this long
 # Default: 5 minutes. Needs headroom for LLM reasoning between browser commands,
 # especially when subagents are doing multi-step browser tasks.
-BROWSER_SESSION_INACTIVITY_TIMEOUT = int(os.environ.get("BROWSER_INACTIVITY_TIMEOUT", "300"))
+try:
+    BROWSER_SESSION_INACTIVITY_TIMEOUT: int = int(os.environ.get("BROWSER_INACTIVITY_TIMEOUT", "300"))
+except (ValueError, TypeError):
+    BROWSER_SESSION_INACTIVITY_TIMEOUT = 300
 
 # Track last activity time per session
 _session_last_activity: Dict[str, float] = {}

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -139,7 +139,10 @@ DEFAULT_EXCLUDES = [
 ]
 
 # Git subprocess timeout (seconds).
-_GIT_TIMEOUT: int = max(10, min(60, int(os.getenv("HERMES_CHECKPOINT_TIMEOUT", "30"))))
+try:
+    _GIT_TIMEOUT: int = max(10, min(60, int(os.getenv("HERMES_CHECKPOINT_TIMEOUT", "30"))))
+except (ValueError, TypeError):
+    _GIT_TIMEOUT = 30
 
 # Max files to snapshot — skip huge directories to avoid slowdowns.
 _MAX_FILES = 50_000

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -352,11 +352,6 @@ class TrajectoryCompressor:
         # Initialize OpenRouter client
         self._init_summarizer()
         
-        logging.basicConfig(
-            level=logging.INFO,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            datefmt='%H:%M:%S'
-        )
         self.logger = logging.getLogger(__name__)
     
     def _init_tokenizer(self):


### PR DESCRIPTION
## Summary

Three categories of defensive-coding fixes across 9 files:

### 1. int()/float() env var casts without ValueError guard (6 files)

- `plugins/platforms/irc/adapter.py`: `IRC_PORT`
- `plugins/platforms/discord/adapter.py`: `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS`, `HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS`
- `plugins/platforms/google_chat/adapter.py`: `GOOGLE_CHAT_MAX_MESSAGES`, `GOOGLE_CHAT_MAX_BYTES`
- `plugins/browser/firecrawl/provider.py`: `FIRECRAWL_BROWSER_TTL`
- `tools/browser_tool.py`: `BROWSER_INACTIVITY_TIMEOUT`
- `tools/checkpoint_manager.py`: `HERMES_CHECKPOINT_TIMEOUT`

A non-numeric env var (e.g. typo) crashes the entire gateway on startup. Each cast is wrapped in `try/except (ValueError, TypeError)` with the default as fallback.

This follows the established pattern from prior PRs #29304 and #32458 which fixed the same pattern in core files but missed these plugin/tool locations.

### 2. Unguarded `flock(LOCK_UN)` in `hermes_cli/kanban_db.py`

If `fcntl.flock()` raises `OSError` (e.g. `EBADF`), the exception propagates past the `try/finally`, potentially crashing the caller. Added `try/except OSError: pass` around the unlock call, matching the pattern in all other `flock` locations (8 other files already have this guard).

### 3. `logging.basicConfig()` in library `__init__` (2 files)

- `trajectory_compressor.py`
- `mini_swe_runner.py`

`basicConfig()` hijacks the root logger config. If these classes are instantiated before the main app configures logging, it overrides everything. Removed `basicConfig()`, kept `getLogger(__name__)`. The entry point (`cli.py`, gateway) is responsible for root logger config.

## Testing

- All 9 modified files pass `ast.parse()` syntax validation
- Follows established codebase patterns from prior PRs