### PR TITLE
fix(qqbot): align chat_type 'dm' in button interaction authorization

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1086,7 +1086,7 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        if chat_type in {"dm", "c2c"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:


### PR DESCRIPTION
### English (For Maintainers)
Root Cause:
After the recent merge of keyboards.py, the gateway successfully renders approval buttons in QQ private chats. However, clicking any button (Approve/Reject) invariably triggers a 'Rejected unauthorized approval click' error and leads to a 300s timeout.

The gateway structures session keys using the generic "dm" type (e.g., agent:main:qqbot:dm), whereas the interaction authorization function was hardcoded to validate strictly against "c2c".

Fix:
Allowed both "dm" and "c2c" in the chat_type matching block to resolve the generic gateway vs platform-specific naming mismatch without breaking potential fallback logics.

---

### 中文实战批注 (Chinese Context)
【漏洞说明】
5月31日上游合并 keyboards.py 按钮交互后，QQ私聊场景下的命令审批按钮虽能正常弹出，但点击“允许”或“拒绝”时，系统会100%拦截并报错“Rejected unauthorized approval click”，导致300秒超时。

【底层阻断原因】
Gateway 全局分发的 Session Key 统一采用 generic 命名空间的 "dm" 标识（形式如 agent:main:qqbot:dm:...），而回调鉴权函数 _is_authorized_interaction_for_session 内部硬编码强校验了 QQ 原生的 "c2c" 字符串。两端命名空间未对齐，导致合法用户的点击被当成非法越权操作直接丢弃。

【修复动作】
将校验逻辑修正为：if chat_type in {"dm", "c2c"}: 
在完美对齐网关 "dm" 标识的同时，向下兼容原生 "c2c" 回调，无侵入式打通 QQ 通道的按钮交互流。
