### PR TITLE
fix(gateway): normalize idle /queue into a regular prompt

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7853,6 +7853,21 @@ class GatewayRunner:
         if canonical == "background":
             return await self._handle_background_command(event)
 
+        if canonical == "queue":
+            # No active agent — /queue should behave like the CLI/TUI and
+            # rewrite into a normal prompt instead of leaking the slash
+            # command text to the model.
+            queue_payload = event.get_command_args().strip()
+            if not queue_payload:
+                return "Usage: /queue <prompt>"
+            try:
+                event.text = queue_payload
+            except Exception:
+                pass
+            # Do NOT return — fall through to _handle_message_with_agent
+            # at the end of this function so the rewritten text is sent
+            # to the agent as a regular user turn.
+
         if canonical == "steer":
             # No active agent — /steer has no tool call to inject into.
             # Strip the prefix so downstream treats it as a normal user

--- a/tests/gateway/test_steer_command.py
+++ b/tests/gateway/test_steer_command.py
@@ -187,5 +187,30 @@ async def test_steer_rejected_payload_returns_rejection_message():
     assert "rejected" in result.lower() or "empty" in result.lower()
 
 
+@pytest.mark.asyncio
+async def test_queue_without_active_agent_strips_prefix_and_runs_as_normal_turn():
+    runner, _adapter = _make_runner(_session_entry())
+    runner._handle_message_with_agent = AsyncMock(return_value="ok")
+
+    result = await runner._handle_message(_make_event("/queue tell me about queues"))
+
+    assert result == "ok"
+    runner._handle_message_with_agent.assert_awaited_once()
+    queued_event = runner._handle_message_with_agent.await_args.args[0]
+    assert queued_event.text == "tell me about queues"
+
+
+@pytest.mark.asyncio
+async def test_queue_without_active_agent_and_without_payload_returns_usage():
+    runner, _adapter = _make_runner(_session_entry())
+    runner._handle_message_with_agent = AsyncMock()
+
+    result = await runner._handle_message(_make_event("/queue"))
+
+    assert result is not None
+    assert "Usage" in result or "usage" in result
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
 if __name__ == "__main__":  # pragma: no cover
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Fix gateway `/queue` so that when no agent is running, only the payload is sent as a normal user turn instead of the literal slash command text.
- Return a usage message for empty `/queue` calls.
- Add regression coverage for idle `/queue` rewrite and empty-argument handling.

## Testing
- `tests/gateway/test_steer_command.py`
- `tests/gateway/test_command_bypass_active_session.py`
- `tests/tui_gateway/test_protocol.py`
- Result: `100 passed in 4.59s`