### PR TITLE
fix: harden gateway media and email handling

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1443,7 +1443,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     email_pwd = os.getenv("EMAIL_PASSWORD")
     email_imap = os.getenv("EMAIL_IMAP_HOST")
     email_smtp = os.getenv("EMAIL_SMTP_HOST")
-    if all([email_addr, email_pwd, email_imap, email_smtp]):
+    email_enabled = os.getenv("EMAIL_ENABLED", "true").lower() not in {"0", "false", "no", "off"}
+    if email_enabled and all([email_addr, email_pwd, email_imap, email_smtp]):
         if Platform.EMAIL not in config.platforms:
             config.platforms[Platform.EMAIL] = PlatformConfig()
         config.platforms[Platform.EMAIL].enabled = True

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -845,6 +845,7 @@ MEDIA_DELIVERY_SAFE_ROOTS = (
     DOCUMENT_CACHE_DIR,
     SCREENSHOT_CACHE_DIR,
     _HERMES_HOME / "image_cache",
+    _HERMES_HOME / "media_cache",
     _HERMES_HOME / "audio_cache",
     _HERMES_HOME / "video_cache",
     _HERMES_HOME / "document_cache",

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -249,11 +249,15 @@ class EmailAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.EMAIL)
 
         self._address = os.getenv("EMAIL_ADDRESS", "")
+        self._login = os.getenv("EMAIL_LOGIN", self._address)
+        self._from_address = os.getenv("EMAIL_FROM_ADDRESS", self._address)
         self._password = os.getenv("EMAIL_PASSWORD", "")
         self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
         self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
         self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
+        self._smtp_use_ssl = os.getenv("EMAIL_SMTP_USE_SSL", "").lower() in {"1", "true", "yes", "on"}
+        self._smtp_required = os.getenv("EMAIL_SMTP_REQUIRED", "true").lower() not in {"0", "false", "no", "off"}
         self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
 
         # Skip attachments — configured via config.yaml:
@@ -272,6 +276,19 @@ class EmailAdapter(BasePlatformAdapter):
         self._thread_context: Dict[str, Dict[str, str]] = {}
 
         logger.info("[Email] Adapter initialized for %s", self._address)
+
+    def _open_smtp(self) -> smtplib.SMTP:
+        if self._smtp_use_ssl or self._smtp_port == 465:
+            return smtplib.SMTP_SSL(
+                self._smtp_host,
+                self._smtp_port,
+                timeout=30,
+                context=ssl.create_default_context(),
+            )
+
+        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp.starttls(context=ssl.create_default_context())
+        return smtp
 
     def _trim_seen_uids(self) -> None:
         """Keep only the most recent UIDs to prevent unbounded memory growth.
@@ -298,7 +315,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
-            imap.login(self._address, self._password)
+            imap.login(self._login, self._password)
             _send_imap_id(imap)
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
@@ -316,14 +333,15 @@ class EmailAdapter(BasePlatformAdapter):
 
         try:
             # Test SMTP connection
-            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            smtp = self._open_smtp()
+            smtp.login(self._login, self._password)
             smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
             logger.error("[Email] SMTP connection failed: %s", e)
-            return False
+            if self._smtp_required:
+                return False
+            logger.warning("[Email] Continuing without SMTP because EMAIL_SMTP_REQUIRED=false")
 
         self._running = True
         self._poll_task = asyncio.create_task(self._poll_loop())
@@ -367,7 +385,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             try:
-                imap.login(self._address, self._password)
+                imap.login(self._login, self._password)
                 _send_imap_id(imap)
                 imap.select("INBOX")
 
@@ -383,7 +401,9 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    # PEEK reads the message without setting the IMAP \Seen flag,
+                    # so messages that were unread stay unread in the mailbox.
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
                     if status != "OK":
                         continue
 
@@ -433,7 +453,7 @@ class EmailAdapter(BasePlatformAdapter):
         sender_addr = msg_data["sender_addr"]
 
         # Skip self-messages
-        if sender_addr == self._address.lower():
+        if sender_addr in {self._address.lower(), self._from_address.lower()}:
             return
 
         # Never reply to automated senders
@@ -526,7 +546,7 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
-        msg["From"] = self._address
+        msg["From"] = self._from_address
         msg["To"] = to_addr
 
         # Thread context for reply
@@ -543,15 +563,14 @@ class EmailAdapter(BasePlatformAdapter):
             msg["References"] = original_msg_id
 
         msg["Date"] = formatdate(localtime=True)
-        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
+        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._from_address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._open_smtp()
         try:
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            smtp.login(self._login, self._password)
             smtp.send_message(msg)
         finally:
             try:
@@ -637,7 +656,7 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
-        msg["From"] = self._address
+        msg["From"] = self._from_address
         msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})
@@ -652,7 +671,7 @@ class EmailAdapter(BasePlatformAdapter):
             msg["References"] = original_msg_id
 
         msg["Date"] = formatdate(localtime=True)
-        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
+        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._from_address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
 
         if body:
@@ -670,10 +689,9 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[Email] Failed to attach %s: %s", file_path, e)
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._open_smtp()
         try:
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            smtp.login(self._login, self._password)
             smtp.send_message(msg)
         finally:
             try:
@@ -718,7 +736,7 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
-        msg["From"] = self._address
+        msg["From"] = self._from_address
         msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})
@@ -733,7 +751,7 @@ class EmailAdapter(BasePlatformAdapter):
             msg["References"] = original_msg_id
 
         msg["Date"] = formatdate(localtime=True)
-        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
+        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._from_address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
 
         if body:
@@ -749,10 +767,9 @@ class EmailAdapter(BasePlatformAdapter):
             part.add_header("Content-Disposition", f"attachment; filename={fname}")
             msg.attach(part)
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._open_smtp()
         try:
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
+            smtp.login(self._login, self._password)
             smtp.send_message(msg)
         finally:
             try:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3823,6 +3823,25 @@ class TelegramAdapter(BasePlatformAdapter):
         from urllib.parse import unquote as _unquote
         _thread = self._metadata_thread_id(metadata)
 
+        if len(photos) == 1:
+            image_url, alt_text = photos[0]
+            caption = alt_text[:1024] if alt_text else None
+            if image_url.startswith("file://"):
+                await self.send_image_file(
+                    chat_id=chat_id,
+                    image_path=_unquote(image_url[7:]),
+                    caption=caption,
+                    metadata=metadata,
+                )
+            else:
+                await self.send_image(
+                    chat_id=chat_id,
+                    image_url=image_url,
+                    caption=caption,
+                    metadata=metadata,
+                )
+            return
+
         # Chunk into groups of 10 (Telegram's album limit)
         CHUNK = 10
         chunks = [photos[i:i + CHUNK] for i in range(0, len(photos), CHUNK)]
@@ -5384,6 +5403,23 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.info("[Telegram] Cached user audio at %s", cached_path)
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache audio: %s", e, exc_info=True)
+                if "file is too big" in str(e).lower():
+                    size = getattr(msg.audio, "file_size", None)
+                    duration = getattr(msg.audio, "duration", None)
+                    filename = getattr(msg.audio, "file_name", None) or "audio"
+                    details = []
+                    if size:
+                        details.append(f"size={size / (1024 * 1024):.1f} MB")
+                    if duration:
+                        details.append(f"duration={duration // 60}:{duration % 60:02d}")
+                    detail_text = f" ({', '.join(details)})" if details else ""
+                    event.text = (
+                        f"[Telegram audio attachment '{filename}' could not be downloaded by the bot"
+                        f"{detail_text}: Telegram Bot API returned 'File is too big'. "
+                        "Ask the user to split/compress the audio below the bot download limit, "
+                        "send it through another channel, or place the file directly on this machine "
+                        "and provide the local path.]"
+                    )
 
         elif msg.video:
             try:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2090,9 +2090,9 @@ def _run_browser_command(
             result = {"success": False, "error": f"Command timed out after {timeout} seconds"}
             # Fall through to fallback check below
         else:
-            with open(stdout_path, "r", encoding="utf-8") as f:
+            with open(stdout_path, "r", encoding="utf-8", errors="replace") as f:
                 stdout = f.read()
-            with open(stderr_path, "r", encoding="utf-8") as f:
+            with open(stderr_path, "r", encoding="utf-8", errors="replace") as f:
                 stderr = f.read()
             returncode = proc.returncode
 


### PR DESCRIPTION
## Summary
- add email env switches for disabling email auto-enable, SMTP SSL, optional SMTP, login/from overrides, and unread-preserving IMAP BODY.PEEK
- support Hermes media_cache and Windows MEDIA paths in gateway media extraction
- send single Telegram markdown image as a normal photo/file and report oversized Telegram audio attachments clearly
- tolerate non-UTF-8 browser tool output when reading stdout/stderr

## Test plan
- python -m py_compile gateway/config.py gateway/platforms/base.py gateway/platforms/email.py gateway/platforms/telegram.py tools/browser_tool.py
- env -u EMAIL_ENABLED -u EMAIL_SMTP_USE_SSL -u EMAIL_SMTP_REQUIRED -u EMAIL_SMTP_PORT python -m pytest --timeout-method=thread tests/gateway/test_extract_local_files.py tests/gateway/test_media_extraction.py tests/gateway/test_run_tool_media_re.py tests/gateway/test_send_image_file.py tests/gateway/test_send_multiple_images.py tests/gateway/test_tts_media_routing.py tests/tools/test_tts_opus_routing.py
- env -u EMAIL_ENABLED -u EMAIL_SMTP_USE_SSL -u EMAIL_SMTP_REQUIRED -u EMAIL_SMTP_PORT -u EMAIL_LOGIN python -m pytest --timeout-method=thread tests/gateway/test_email.py (59 passed, 1 Windows env-clear home-dir failure)