### PR TITLE
fix(gateway): route /sessions through the resume flow

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7844,6 +7844,9 @@ class GatewayRunner:
         if canonical == "resume":
             return await self._handle_resume_command(event)
 
+        if canonical == "sessions":
+            return await self._handle_sessions_command(event)
+
         if canonical == "branch":
             return await self._handle_branch_command(event)
 
@@ -13362,6 +13365,25 @@ class GatewayRunner:
         if msg_count == 1:
             return t("gateway.resume.resumed_one", title=title, count=msg_count)
         return t("gateway.resume.resumed_many", title=title, count=msg_count)
+
+    async def _handle_sessions_command(self, event: MessageEvent) -> str:
+        """Handle /sessions — gateway alias for browsing/resuming sessions.
+
+        Mirrors the CLI behavior:
+          * ``/sessions`` or ``/sessions list`` shows the recent-session picker
+          * ``/sessions <target>`` behaves exactly like ``/resume <target>``
+
+        Reusing the /resume handler keeps both commands aligned and prevents
+        known slash commands from falling through to the agent loop.
+        """
+        raw_args = event.get_command_args().strip()
+        if not raw_args or raw_args.lower() == "list":
+            resume_text = "/resume"
+        else:
+            resume_text = f"/resume {raw_args}"
+        return await self._handle_resume_command(
+            dataclasses.replace(event, text=resume_text)
+        )
 
     async def _handle_branch_command(self, event: MessageEvent) -> str:
         """Handle /branch [name] — fork the current session into a new independent copy.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -344,6 +344,7 @@ ACTIVE_SESSION_BYPASS_COMMANDS: frozenset[str] = frozenset(
         "profile",
         "queue",
         "restart",
+        "sessions",
         "status",
         "steer",
         "stop",

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -294,6 +294,7 @@ class TestAllResolvableCommandsBypassGuard:
             ("/insights 7", "insights"),
             ("/title my session", "title"),
             ("/resume yesterday", "resume"),
+            ("/sessions", "sessions"),
             ("/retry", "retry"),
             ("/undo", "undo"),
             ("/compress", "compress"),
@@ -325,7 +326,7 @@ class TestAllResolvableCommandsBypassGuard:
 
         for cmd in (
             "model", "reasoning", "personality", "voice", "insights", "title",
-            "resume", "retry", "undo", "compress", "usage",
+            "resume", "sessions", "retry", "undo", "compress", "usage",
             "reload-mcp", "sethome", "reset",
         ):
             assert should_bypass_active_session(cmd) is True, (

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -358,3 +358,68 @@ class TestHandleResumeCommand:
             f"session-id lookup failed: {result!r}"
         )
         db.close()
+
+
+class TestHandleSessionsCommand:
+    """Tests for GatewayRunner._handle_sessions_command."""
+
+    @pytest.mark.asyncio
+    async def test_sessions_lists_recent_sessions(self, tmp_path):
+        """Bare /sessions should reuse the /resume browsing output."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_001", "telegram")
+        db.create_session("sess_002", "telegram")
+        db.set_session_title("sess_001", "Research")
+        db.set_session_title("sess_002", "Coding")
+
+        event = _make_event(text="/sessions")
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_sessions_command(event)
+
+        assert "Named Sessions" in result
+        assert "Research" in result
+        assert "Coding" in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_sessions_list_alias_matches_resume_browse(self, tmp_path):
+        """`/sessions list` should behave the same as bare `/resume`."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_001", "telegram")
+        db.set_session_title("sess_001", "Research")
+
+        event = _make_event(text="/sessions list")
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_sessions_command(event)
+
+        assert "Named Sessions" in result
+        assert "Research" in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_sessions_target_reuses_resume_switch(self, tmp_path):
+        """`/sessions <target>` should switch sessions exactly like `/resume`."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("old_session_abc", "telegram")
+        db.set_session_title("old_session_abc", "My Project")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/sessions My Project")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        result = await runner._handle_sessions_command(event)
+
+        assert "Resumed" in result
+        runner.session_store.switch_session.assert_called_once()
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "old_session_abc"
+        db.close()

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -317,6 +317,8 @@ async def test_group_new_keeps_existing_reset_semantics_when_dm_topic_mode_enabl
 ):
     import gateway.run as gateway_run
 
+    monkeypatch.setattr("hermes_cli.tips.get_random_tip", lambda: "topic reset tip")
+
     session_db = SessionDB(db_path=tmp_path / "state.db")
     session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
     runner = _make_runner(session_db=session_db)
@@ -347,6 +349,8 @@ async def test_group_new_keeps_existing_reset_semantics_when_dm_topic_mode_enabl
 @pytest.mark.asyncio
 async def test_new_inside_telegram_topic_resets_current_topic_with_parallel_tip(monkeypatch):
     import gateway.run as gateway_run
+
+    monkeypatch.setattr("hermes_cli.tips.get_random_tip", lambda: "topic reset tip")
 
     runner = _make_runner()
     runner._telegram_topic_mode_enabled = lambda source: True

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -147,6 +147,34 @@ async def test_known_slash_command_not_flagged_as_unknown(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_known_sessions_command_dispatches_without_leaking_to_agent(monkeypatch, tmp_path):
+    """A registry-known /sessions must hit its handler, not fall through to the LLM."""
+    import gateway.run as gateway_run
+    from hermes_state import SessionDB
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("/sessions leaked through to the agent")
+    )
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("sess-1", "telegram")
+    db.set_session_title("sess-1", "Research")
+    runner._session_db = db
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("/sessions"))
+
+    assert result is not None
+    assert "Named Sessions" in result
+    assert "Research" in result
+    runner._run_agent.assert_not_called()
+    db.close()
+
+
+@pytest.mark.asyncio
 async def test_underscored_alias_for_hyphenated_builtin_not_flagged(monkeypatch):
     """Telegram autocomplete sends /reload_mcp for the /reload-mcp built-in.
     That must NOT be flagged as unknown."""


### PR DESCRIPTION
## Summary

- Fix gateway `/sessions` so the command is successfully intercepted and dispatched instead of falling through to the agent loop as plain text.
- Reuse the existing `/resume` flow so `/sessions`, `/sessions list`, and `/sessions <target>` match standard CLI semantics.
- Add regression coverage for session browsing, session switching, unknown-command leak prevention, active-session bypass behavior, and stabilize Telegram topic-mode reset assertions against random tips.

## Testing

- `tests/gateway/test_telegram_topic_mode.py`
- `tests/gateway/test_resume_command.py`
- `tests/gateway/test_unknown_command.py`
- `tests/gateway/test_command_bypass_active_session.py`
- `tests/gateway/test_slash_access_dispatch.py`

- Result: `132 passed in 6.36s`