### PR TITLE
fix(banner): don't render PyPI version delta as '1 commit behind' (#35857)

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -195,7 +195,12 @@ def _fetch_pypi_latest(package: str = "hermes-agent") -> Optional[str]:
 def check_via_pypi() -> Optional[int]:
     """Compare installed version against PyPI latest.
 
-    Returns 0 if up-to-date, 1 if behind, None on failure.
+    Returns 0 if up-to-date, UPDATE_AVAILABLE_NO_COUNT if behind,
+    or None on failure. We deliberately do NOT return a positive
+    integer here: the banner renderer treats positive values as a
+    literal commit count ("N commits behind"), but a PyPI version
+    delta is not a commit count. Using the sentinel routes us through
+    the "update available" branch instead (see #35857).
     """
     latest = _fetch_pypi_latest()
     if latest is None:
@@ -204,10 +209,10 @@ def check_via_pypi() -> Optional[int]:
         return 0
     try:
         if _version_tuple(latest) > _version_tuple(VERSION):
-            return 1
+            return UPDATE_AVAILABLE_NO_COUNT
         return 0
     except Exception:
-        return 1 if latest != VERSION else 0
+        return UPDATE_AVAILABLE_NO_COUNT if latest != VERSION else 0
 
 
 def check_for_updates() -> Optional[int]:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6371,6 +6371,12 @@ def _print_version_info(*, check_updates: bool = True) -> None:
                 f"Update available: {behind} {commits_word} behind — "
                 f"run '{recommended_update_command()}'"
             )
+        elif behind is not None and behind < 0:
+            # UPDATE_AVAILABLE_NO_COUNT sentinel (e.g. PyPI fallback inside
+            # Docker has no commit count to report). See #35857.
+            print(
+                f"Update available — run '{recommended_update_command()}'"
+            )
         elif behind == 0:
             print("Up to date")
     except Exception:

--- a/tests/hermes_cli/test_banner_pip_update.py
+++ b/tests/hermes_cli/test_banner_pip_update.py
@@ -2,12 +2,16 @@ from unittest.mock import patch
 
 
 def testcheck_via_pypi_detects_update():
-    """check_via_pypi returns 1 when PyPI has newer version."""
-    from hermes_cli.banner import check_via_pypi
+    """check_via_pypi returns UPDATE_AVAILABLE_NO_COUNT when PyPI has newer version.
+
+    A PyPI version delta is not a commit count, so the banner must not
+    render it as "N commits behind" (see #35857).
+    """
+    from hermes_cli.banner import check_via_pypi, UPDATE_AVAILABLE_NO_COUNT
     with patch("hermes_cli.banner.VERSION", "0.12.0"):
         with patch("hermes_cli.banner._fetch_pypi_latest", return_value="0.13.0"):
             result = check_via_pypi()
-            assert result == 1
+            assert result == UPDATE_AVAILABLE_NO_COUNT
 
 
 def testcheck_via_pypi_up_to_date():


### PR DESCRIPTION
## Summary

Fixes #35857. Inside a Docker container built from a git clone, `.dockerignore` excludes `.git`, so `check_for_updates()` falls back to `check_via_pypi()`. That function used to return `1` whenever an update was available, and the banner renderer then formatted the literal `1` as `"1 commit behind"` — even though no commit was ever counted (the comparison was version-to-version against PyPI, not HEAD-to-origin).

## Fix

- `hermes_cli/banner.py`: `check_via_pypi()` now returns the existing `UPDATE_AVAILABLE_NO_COUNT` sentinel (`-1`) instead of `1`. The banner renderer already has a branch for negative values that prints `⚠ update available` (no fabricated commit count).
- `hermes_cli/main.py`: `_print_version_info()` (called by `hermes --version`) only handled `behind > 0` and `behind == 0`. Added a branch for the sentinel so the "update available" signal isn't silently dropped on PyPI installs.
- Updated `tests/hermes_cli/test_banner_pip_update.py` to assert the sentinel.

## Test plan

```
pytest tests/hermes_cli/test_banner_pip_update.py \
       tests/hermes_cli/test_update_check.py \
       tests/hermes_cli/test_cmd_update_docker.py
# 20 passed
```

## Notes

- No change to git-checkout path: `_check_via_local_git()` still returns a real commit count, which still renders as "N commits behind".
- No change to nix-build path: `HERMES_REVISION` path already used `UPDATE_AVAILABLE_NO_COUNT`.
- Cache schema unchanged; existing `.update_check` entries with stale `behind: 1` will be re-validated and overwritten on the next 6h cycle (or sooner if `VERSION` bumps).

Closes #35857
