### PR TITLE
fix(anthropic): honor dotenv API-key auth over parent OAuth

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import random
 import threading
 import time
@@ -1724,6 +1723,34 @@ def _normalize_pool_priorities(provider: str, entries: List[PooledCredential]) -
     return changed
 
 
+def _env_value_prefer_dotenv(env_file: Dict[str, str], key: str) -> str:
+    """Return a stripped dotenv value when present, else a stripped env value."""
+    if key in env_file:
+        return str(env_file.get(key) or "").strip()
+    return str(_get_secret(key, "") or "").strip()
+
+
+def _anthropic_api_key_path_explicit(env_file: Dict[str, str]) -> bool:
+    """Return True when Anthropic API-key auth is explicit and OAuth is absent."""
+    anthropic_api_key = _env_value_prefer_dotenv(env_file, "ANTHROPIC_API_KEY")
+    if not anthropic_api_key:
+        return False
+    if "ANTHROPIC_API_KEY" in env_file:
+        # When ~/.hermes/.env records the API-key path, it is the user's
+        # persisted auth choice.  Do not let inherited OAuth vars from the
+        # parent shell or Claude Code silently undo it.
+        anthropic_oauth_env = (
+            str(env_file.get("ANTHROPIC_TOKEN") or "").strip()
+            or str(env_file.get("CLAUDE_CODE_OAUTH_TOKEN") or "").strip()
+        )
+        return not anthropic_oauth_env
+    anthropic_oauth_env = (
+        _env_value_prefer_dotenv(env_file, "ANTHROPIC_TOKEN")
+        or _env_value_prefer_dotenv(env_file, "CLAUDE_CODE_OAUTH_TOKEN")
+    )
+    return not anthropic_oauth_env
+
+
 def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
     changed = False
     active_sources: Set[str] = set()
@@ -1767,14 +1794,7 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # that `hermes setup` writes.
         _env_file = load_env()
 
-        def _env_val(key: str) -> str:
-            return (_env_file.get(key) or _get_secret(key, "") or "").strip()
-
-        anthropic_api_key = _env_val("ANTHROPIC_API_KEY")
-        anthropic_oauth_env = (
-            _env_val("ANTHROPIC_TOKEN") or _env_val("CLAUDE_CODE_OAUTH_TOKEN")
-        )
-        api_key_path_explicit = bool(anthropic_api_key and not anthropic_oauth_env)
+        api_key_path_explicit = _anthropic_api_key_path_explicit(_env_file)
 
         if api_key_path_explicit:
             # Prune any stale autodiscovered OAuth entries that may have been
@@ -2047,15 +2067,14 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
 def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
     changed = False
     active_sources: Set[str] = set()
+    env_file = load_env()
 
     # Prefer ~/.hermes/.env over os.environ — the user's config file is the
     # authoritative source for Hermes credentials. Stale env vars from parent
     # processes (Codex CLI, test scripts, etc.) should not override deliberate
     # changes to the .env file.
     def _get_env_prefer_dotenv(key: str) -> str:
-        env_file = load_env()
-        val = env_file.get(key) or _get_secret(key, "") or ""
-        return val.strip()
+        return _env_value_prefer_dotenv(env_file, key)
 
     # Honour user suppression — `hermes auth remove <provider> <N>` for an
     # env-seeded credential marks the env:<VAR> source as suppressed so it
@@ -2132,6 +2151,8 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
             "CLAUDE_CODE_OAUTH_TOKEN",
             "ANTHROPIC_API_KEY",
         ]
+        if _anthropic_api_key_path_explicit(env_file):
+            env_vars = ["ANTHROPIC_API_KEY"]
 
     for env_var in env_vars:
         # Prefer ~/.hermes/.env over os.environ

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1715,6 +1715,65 @@ def test_load_pool_api_key_path_skips_oauth_autodiscovery(tmp_path, monkeypatch)
     assert cc_called["n"] == 0
 
 
+def test_load_pool_api_key_path_dotenv_suppresses_parent_oauth_env(tmp_path, monkeypatch):
+    """API-key auth path in .env must suppress parent-process OAuth vars.
+
+    `save_anthropic_api_key()` writes ANTHROPIC_API_KEY and clears
+    ANTHROPIC_TOKEN in ~/.hermes/.env.  A stale parent shell
+    ANTHROPIC_TOKEN or Claude Code's own CLAUDE_CODE_OAUTH_TOKEN must not
+    defeat that persisted choice and reintroduce OAuth entries into the
+    Anthropic pool.
+    """
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-parent-stale-token")
+    monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-parent-cc-token")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    (hermes_home / ".env").write_text(
+        "ANTHROPIC_API_KEY=sk-ant-api03-explicit-user-key\n"
+        "ANTHROPIC_TOKEN=\n",
+        encoding="utf-8",
+    )
+
+    from hermes_cli.config import invalidate_env_cache
+
+    invalidate_env_cache()
+    monkeypatch.setattr("hermes_cli.auth.is_provider_explicitly_configured", lambda pid: True)
+
+    pkce_called = {"n": 0}
+    cc_called = {"n": 0}
+
+    def _fake_pkce():
+        pkce_called["n"] += 1
+        return {
+            "accessToken": "sk-ant-oat01-file-pkce-token",
+            "refreshToken": "pkce-refresh",
+            "expiresAt": int(time.time() * 1000) + 3_600_000,
+        }
+
+    def _fake_cc():
+        cc_called["n"] += 1
+        return {
+            "accessToken": "sk-ant-oat01-file-cc-token",
+            "refreshToken": "cc-refresh",
+            "expiresAt": int(time.time() * 1000) + 3_600_000,
+        }
+
+    monkeypatch.setattr("agent.anthropic_adapter.read_hermes_oauth_credentials", _fake_pkce)
+    monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", _fake_cc)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    sources = {entry.source for entry in pool.entries()}
+
+    assert sources == {"env:ANTHROPIC_API_KEY"}, f"got {sources}"
+    assert pkce_called["n"] == 0
+    assert cc_called["n"] == 0
+
+
 def test_load_pool_api_key_path_prunes_stale_oauth_entries(tmp_path, monkeypatch):
     """Switching OAuth -> API key must prune stale OAuth entries from auth.json.
 


### PR DESCRIPTION
Fixes #29151

## What changed
- Added dotenv-preferred Anthropic auth-path helpers in the credential pool.
- Treat `~/.hermes/.env` `ANTHROPIC_API_KEY` as the persisted API-key auth choice when dotenv OAuth values are absent.
- Prevent inherited parent-process `ANTHROPIC_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN` values from re-seeding OAuth credentials into the Anthropic pool after API-key auth is selected.
- Added regression coverage for the API-key path with stale parent OAuth environment variables.

## Why
`save_anthropic_api_key()` writes `ANTHROPIC_API_KEY` and clears `ANTHROPIC_TOKEN` in `~/.hermes/.env`, but the pool seeder still fell back to parent-process OAuth env vars when dotenv values were empty or absent. That could make the API-key path look non-explicit, reintroduce OAuth entries, and allow credential rotation to cross from API-key auth into OAuth on exhaustion.

The security invariant here is narrow: a persisted Anthropic API-key choice should not be silently overridden by inherited OAuth tokens from the shell or Claude Code. Shell-only OAuth still works when no dotenv API-key choice exists, and explicit dotenv OAuth still wins when configured.

## Prior art
This is a follow-up to e3236e99a40b84709d8bdd255136c1af8fb91aee, which blocked file-backed OAuth autodiscovery for the API-key path but did not cover inherited OAuth env vars.

## Validation
- `scripts/run_tests.sh tests/agent/test_credential_pool.py -- -k 'api_key_path_dotenv_suppresses_parent_oauth_env'`
- `scripts/run_tests.sh tests/agent/test_credential_pool.py`
- `scripts/run_tests.sh tests/tools/test_credential_pool_env_fallback.py`
- `. .venv/bin/activate && python -m py_compile agent/credential_pool.py tests/agent/test_credential_pool.py`
- `git diff --check upstream/main..HEAD`
- `coderabbit review --agent --type committed --base upstream/main` raised 0 issues

---
Created by GPT-5.5 with xhigh reasoning in Codex. Human involvement: general issue selection and resolution guidelines; commit signing; checking notifications.