### PR TITLE
fix(telegram): make gmail-triage callbacks profile-aware

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3550,7 +3550,7 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.error("Failed to write update response from callback: %s", exc)
 
     # Maps `gt:<verb>` -> (script-name, extra-args, success-label, is_state).
-    # Scripts live in ~/.hermes/scripts/gmail-triage/. `arg` from the callback
+    # Scripts live in HERMES_HOME/scripts/gmail-triage/. `arg` from the callback
     # data is always passed as the first positional arg.
     # is_state=True means the verb is a sticky sender-rule change (mute, trust,
     # vip) that should leave the keyboard tappable for follow-on actions.
@@ -3603,7 +3603,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         script_name, extra_args, success_label, is_state_verb = entry
 
-        script_path = _Path.home() / ".hermes" / "scripts" / "gmail-triage" / script_name
+        from hermes_constants import get_hermes_home
+
+        script_path = get_hermes_home() / "scripts" / "gmail-triage" / script_name
         if not script_path.exists():
             await query.answer(text=f"❌ {script_name} missing")
             logger.error("[%s] gmail-triage script missing: %s", self.name, script_path)

--- a/tests/gateway/test_telegram_gmail_triage_profile.py
+++ b/tests/gateway/test_telegram_gmail_triage_profile.py
@@ -1,0 +1,98 @@
+"""Regression tests for profile-aware Telegram gmail-triage callbacks."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from gateway.platforms.telegram import TelegramAdapter
+
+
+def _make_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+class _FakeProc:
+    returncode = 0
+
+    async def communicate(self):
+        return b"", b""
+
+
+class TestTelegramGmailTriageProfile:
+    @pytest.mark.asyncio
+    async def test_uses_profile_local_gmail_triage_script(self, monkeypatch, tmp_path):
+        profile_home = tmp_path / "profiles" / "triage-profile"
+        script_dir = profile_home / "scripts" / "gmail-triage"
+        script_dir.mkdir(parents=True)
+        script_path = script_dir / "send-draft.sh"
+        script_path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        adapter = _make_adapter()
+        adapter._is_callback_user_authorized = MagicMock(return_value=True)
+
+        query = SimpleNamespace(
+            from_user=SimpleNamespace(id="12345", first_name="Tester"),
+            message=SimpleNamespace(text="Original gmail triage message"),
+            answer=AsyncMock(),
+            edit_message_text=AsyncMock(),
+        )
+
+        seen = {}
+
+        async def fake_create_subprocess_exec(*cmd, **kwargs):
+            seen["cmd"] = cmd
+            seen["kwargs"] = kwargs
+            return _FakeProc()
+
+        monkeypatch.setattr(
+            "gateway.platforms.telegram.asyncio.create_subprocess_exec",
+            fake_create_subprocess_exec,
+        )
+
+        await adapter._handle_gmail_triage_callback(
+            query,
+            "gt:send:thread-123",
+            query_chat_id="12345",
+            query_chat_type="private",
+            query_thread_id=None,
+            query_user_name="tester",
+        )
+
+        assert seen["cmd"][0] == str(script_path)
+        assert seen["cmd"][1:] == ("thread-123",)
+        query.answer.assert_awaited_once_with(
+            text=adapter._GT_VERB_DISPATCH["send"][2],
+        )
+        query.edit_message_text.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Route Telegram gmail-triage callbacks through `HERMES_HOME` instead of a hardcoded `~/.hermes` path.
- Fix named-profile behavior so callback actions resolve the profile-local gmail-triage script directory correctly.
- Add regression coverage to verify the callback uses the active profile's script path.

## Testing

- `ruff check gateway/platforms/telegram.py tests/gateway/test_telegram_gmail_triage_profile.py`
- `tests/gateway/test_telegram_gmail_triage_profile.py`
- `tests/gateway/test_telegram_callback_auth_fail_closed.py`

`6 passed, 0 failed`