### PR TITLE
Add compression debounce controls

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1236,6 +1236,12 @@ def init_agent(
         pass
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
+    try:
+        compression_min_interval_seconds = max(
+            0.0, float(_compression_cfg.get("min_interval_seconds", 0) or 0)
+        )
+    except (TypeError, ValueError):
+        compression_min_interval_seconds = 0.0
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
     # protect_first_n is the number of non-system messages to protect at
     # the head, in addition to the system prompt (which is always
@@ -1466,6 +1472,7 @@ def init_agent(
             provider=agent.provider,
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
+            min_interval_seconds=compression_min_interval_seconds,
         )
     agent.compression_enabled = compression_enabled
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -596,6 +596,7 @@ class ContextCompressor(ContextEngine):
         provider: str = "",
         api_mode: str = "",
         abort_on_summary_failure: bool = False,
+        min_interval_seconds: float = 0,
     ):
         self.model = model
         self.base_url = base_url
@@ -607,6 +608,12 @@ class ContextCompressor(ContextEngine):
         self.protect_last_n = protect_last_n
         self.summary_target_ratio = max(0.10, min(summary_target_ratio, 0.80))
         self.quiet_mode = quiet_mode
+        try:
+            self.min_interval_seconds = max(0.0, float(min_interval_seconds or 0))
+        except (TypeError, ValueError):
+            self.min_interval_seconds = 0.0
+        self._last_auto_compression_attempt_at: float = 0.0
+        self._last_compress_deferred_reason: Optional[str] = None
         # When True, summary-generation failure aborts compression entirely
         # (returns messages unchanged, sets _last_compress_aborted=True).
         # When False (default = historical behavior), insert a
@@ -1854,12 +1861,30 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
         self._last_compress_aborted = False
+        self._last_compress_deferred_reason = None
 
         # Manual /compress (force=True) bypasses the failure cooldown so the
         # user can retry immediately after an auto-compress abort.  Without
         # this, /compress would silently no-op for 30-60s after a failure.
         if force and self._summary_failure_cooldown_until > 0.0:
             self._summary_failure_cooldown_until = 0.0
+
+        if not force and self.min_interval_seconds > 0:
+            now = time.monotonic()
+            if (
+                self._last_auto_compression_attempt_at > 0
+                and now - self._last_auto_compression_attempt_at < self.min_interval_seconds
+            ):
+                self._last_compress_deferred_reason = "min_interval"
+                if not self.quiet_mode:
+                    logger.info(
+                        "Context compression deferred by min_interval_seconds "
+                        "(%.0fs remaining)",
+                        self.min_interval_seconds - (now - self._last_auto_compression_attempt_at),
+                    )
+                return messages
+            self._last_auto_compression_attempt_at = now
+
         n_messages = len(messages)
         # Only need head + 3 tail messages minimum (token budget decides the real tail size)
         _min_for_compress = self._protect_head_size(messages) + 3 + 1

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -367,6 +367,11 @@ compression:
   # Range: 0.10 - 0.80
   target_ratio: 0.20
 
+  # Minimum seconds between automatic compression attempts (default: 0 = disabled).
+  # Applies to both in-agent compression and gateway session hygiene. Manual
+  # /compress still bypasses this debounce.
+  min_interval_seconds: 0
+
   # Number of most-recent messages to always preserve (default: 20 ≈ 10 full turns)
   # Higher values keep more recent conversation intact at the cost of more aggressive
   # compression of older turns.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8654,6 +8654,7 @@ class GatewayRunner:
             _hyg_threshold_pct = 0.85
             _hyg_compression_enabled = True
             _hyg_hard_msg_limit = 400
+            _hyg_min_interval_seconds = 0.0
             _hyg_config_context_length = None
             _hyg_provider = None
             _hyg_base_url = None
@@ -8696,6 +8697,13 @@ class GatewayRunner:
                                     _hyg_hard_msg_limit = _parsed
                             except (TypeError, ValueError):
                                 pass
+                        try:
+                            _hyg_min_interval_seconds = max(
+                                0.0,
+                                float(_comp_cfg.get("min_interval_seconds", 0) or 0),
+                            )
+                        except (TypeError, ValueError):
+                            _hyg_min_interval_seconds = 0.0
 
                 try:
                     _hyg_model, _hyg_runtime = self._resolve_session_agent_runtime(
@@ -8786,7 +8794,27 @@ class GatewayRunner:
                     or _msg_count >= _HARD_MSG_LIMIT
                 )
 
+                if _needs_compress and _hyg_min_interval_seconds > 0:
+                    _now = time.time()
+                    _last_hyg_attempt = float(
+                        getattr(session_entry, "last_hygiene_compression_at", 0.0) or 0.0
+                    )
+                    _elapsed = _now - _last_hyg_attempt if _last_hyg_attempt > 0 else None
+                    if _elapsed is not None and _elapsed < _hyg_min_interval_seconds:
+                        _needs_compress = False
+                        logger.info(
+                            "Session hygiene: compression deferred by "
+                            "compression.min_interval_seconds (%.0fs remaining)",
+                            _hyg_min_interval_seconds - _elapsed,
+                        )
+
                 if _needs_compress:
+                    if _hyg_min_interval_seconds > 0:
+                        session_entry.last_hygiene_compression_at = time.time()
+                        try:
+                            self.session_store._save()
+                        except Exception:
+                            pass
                     logger.info(
                         "Session hygiene: %s messages, ~%s tokens (%s) — auto-compressing "
                         "(threshold: %s%% of %s = %s tokens)",

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -452,6 +452,11 @@ class SessionEntry:
     
     # Last API-reported prompt tokens (for accurate compression pre-check)
     last_prompt_tokens: int = 0
+
+    # Wall-clock timestamp of the most recent gateway session-hygiene
+    # compression attempt. Persisted so debounce survives the fresh AIAgent
+    # instance created for each hygiene pass and gateway restarts.
+    last_hygiene_compression_at: float = 0.0
     
     # Set when a session was created because the previous one expired;
     # consumed once by the message handler to inject a notice into context
@@ -506,6 +511,7 @@ class SessionEntry:
             "cache_write_tokens": self.cache_write_tokens,
             "total_tokens": self.total_tokens,
             "last_prompt_tokens": self.last_prompt_tokens,
+            "last_hygiene_compression_at": self.last_hygiene_compression_at,
             "estimated_cost_usd": self.estimated_cost_usd,
             "cost_status": self.cost_status,
             "expiry_finalized": self.expiry_finalized,
@@ -562,6 +568,7 @@ class SessionEntry:
             cache_write_tokens=data.get("cache_write_tokens", 0),
             total_tokens=data.get("total_tokens", 0),
             last_prompt_tokens=data.get("last_prompt_tokens", 0),
+            last_hygiene_compression_at=float(data.get("last_hygiene_compression_at", 0.0) or 0.0),
             estimated_cost_usd=data.get("estimated_cost_usd", 0.0),
             cost_status=data.get("cost_status", "unknown"),
             expiry_finalized=data.get("expiry_finalized", data.get("memory_flushed", False)),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -990,6 +990,7 @@ DEFAULT_CONFIG = {
         "enabled": True,
         "threshold": 0.50,            # compress when context usage exceeds this ratio
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
+        "min_interval_seconds": 0,    # minimum seconds between automatic compression attempts
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 400,  # gateway session-hygiene force-compress threshold by message count
         "protect_first_n": 3,         # non-system head messages always preserved

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -175,6 +175,86 @@ class TestCompress:
         compressor.compress(msgs)
         assert compressor.compression_count == 2
 
+    def test_auto_compress_respects_min_interval_seconds(self):
+        """Automatic compression should debounce repeated summarizer calls."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "## Active Task\nfirst summary"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test/model",
+                protect_first_n=1,
+                protect_last_n=2,
+                min_interval_seconds=300,
+                quiet_mode=True,
+            )
+
+        msgs = [{"role": "system", "content": "System"}] + self._make_messages(12)
+        with (
+            patch("agent.context_compressor.time.monotonic", side_effect=[100.0, 100.0, 200.0]),
+            patch.object(c, "_find_tail_cut_by_tokens", return_value=10),
+            patch("agent.context_compressor.call_llm", return_value=mock_response) as call_llm,
+        ):
+            first = c.compress(msgs)
+            second = c.compress(msgs)
+
+        assert call_llm.call_count == 1
+        assert second == msgs
+        assert c._last_compress_deferred_reason == "min_interval"
+
+    def test_force_compress_bypasses_min_interval_seconds(self):
+        """Manual /compress force=True should retry even during debounce."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "## Active Task\nforced summary"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test/model",
+                protect_first_n=1,
+                protect_last_n=2,
+                min_interval_seconds=300,
+                quiet_mode=True,
+            )
+
+        msgs = [{"role": "system", "content": "System"}] + self._make_messages(12)
+        with (
+            patch("agent.context_compressor.time.monotonic", side_effect=[100.0, 100.0, 200.0, 200.0]),
+            patch.object(c, "_find_tail_cut_by_tokens", return_value=10),
+            patch("agent.context_compressor.call_llm", return_value=mock_response) as call_llm,
+        ):
+            first = c.compress(msgs)
+            second = c.compress(msgs, force=True)
+
+        assert call_llm.call_count == 2
+        assert len(second) <= len(first)
+        assert c._last_compress_deferred_reason is None
+
+    def test_min_interval_default_zero_preserves_existing_behavior(self):
+        """Default debounce of zero should preserve back-to-back auto compression."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "## Active Task\ndefault summary"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test/model",
+                protect_first_n=1,
+                protect_last_n=2,
+                quiet_mode=True,
+            )
+
+        msgs = [{"role": "system", "content": "System"}] + self._make_messages(12)
+        with (
+            patch.object(c, "_find_tail_cut_by_tokens", return_value=10),
+            patch("agent.context_compressor.call_llm", return_value=mock_response) as call_llm,
+        ):
+            c.compress(msgs)
+            c.compress(msgs)
+
+        assert call_llm.call_count == 2
+
     def test_protects_first_and_last(self, compressor):
         msgs = self._make_messages(10)
         result = compressor.compress(msgs)

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -757,6 +757,99 @@ async def test_session_hygiene_honors_configurable_hard_message_limit(
 
 
 @pytest.mark.asyncio
+async def test_session_hygiene_respects_min_interval_across_fresh_agents(
+    monkeypatch, tmp_path
+):
+    """Gateway hygiene should debounce even though it creates a fresh AIAgent.
+
+    The timestamp lives on SessionEntry, not ContextCompressor, so repeated
+    gateway turns cannot hammer the compression summarizer while a session is
+    already above the hard hygiene threshold.
+    """
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FakeCompressAgent:
+        last_instance = None
+
+        def __init__(self, **kwargs):
+            type(self).last_instance = self
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self._print_fn = None
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            self.session_id = f"{self.session_id}_compressed"
+            return ([{"role": "assistant", "content": "compressed"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "compression:\n"
+        "  enabled: true\n"
+        "  hygiene_hard_message_limit: 10\n"
+        "  min_interval_seconds: 300\n"
+    )
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+    monkeypatch.setattr(gateway_run.time, "time", lambda: 1000.0)
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    session_entry = SessionEntry(
+        session_key="agent:main:telegram:private:12345",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="private",
+        last_hygiene_compression_at=900.0,
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = _make_history(12, content_size=40)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(return_value={"final_response": "ok", "messages": [], "tools": [], "history_offset": 0, "last_prompt_tokens": 0})
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", lambda *_args, **_kwargs: 1_000_000)
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="private", user_id="12345"),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert FakeCompressAgent.last_instance is None
+    assert session_entry.last_hygiene_compression_at == 900.0
+    runner.session_store.rewrite_transcript.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_session_hygiene_default_hard_message_limit_does_not_fire_at_12_messages(
     monkeypatch, tmp_path
 ):

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -778,6 +778,12 @@ class TestUserMessagePreviewConfig:
         assert preview["last_lines"] == 2
 
 
+class TestCompressionConfig:
+    def test_default_config_includes_min_interval_seconds(self):
+        compression = DEFAULT_CONFIG["compression"]
+        assert compression["min_interval_seconds"] == 0
+
+
 class TestEnvWriteDenylist:
     """``save_env_value`` refuses to persist env-var names that
     influence how subprocesses execute — ``LD_PRELOAD``, ``PYTHONPATH``,

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -67,6 +67,33 @@ def test_plugin_engine_gets_context_length_on_init():
     assert engine.threshold_tokens == int(204_800 * engine.threshold_percent)
 
 
+def test_builtin_compressor_receives_min_interval_config():
+    """compression.min_interval_seconds should propagate into ContextCompressor."""
+    cfg = {
+        "compression": {"min_interval_seconds": 300},
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.context_compressor.min_interval_seconds == 300.0
+
+
 def test_active_context_engine_tools_survive_explicit_platform_toolsets():
     """LCM-style recovery tools must survive saved `hermes tools` lists."""
     engine = _ToolEngine()

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -61,6 +61,9 @@ grow too large between turns (e.g., overnight accumulation in Telegram/Discord).
 - **Token source**: Prefers actual API-reported tokens from last turn; falls back
   to rough character-based estimate (`estimate_messages_tokens_rough`)
 - **Fires**: Only when `len(history) >= 4` and compression is enabled
+- **Debounce**: Honors `compression.min_interval_seconds` using a persisted
+  per-session timestamp, because hygiene creates a fresh `AIAgent` for each
+  compression attempt
 - **Purpose**: Catch sessions that escaped the agent's own compressor
 
 The gateway hygiene threshold is intentionally higher than the agent's compressor.
@@ -83,6 +86,7 @@ compression:
   enabled: true              # Enable/disable compression (default: true)
   threshold: 0.50            # Fraction of context window (default: 0.50 = 50%)
   target_ratio: 0.20         # How much of threshold to keep as tail (default: 0.20)
+  min_interval_seconds: 0    # Debounce automatic compression attempts (default: disabled)
   protect_last_n: 20         # Minimum protected tail messages (default: 20)
 
 # Summarization model/provider configured under auxiliary:
@@ -99,6 +103,7 @@ auxiliary:
 |-----------|---------|-------|-------------|
 | `threshold` | `0.50` | 0.0-1.0 | Compression triggers when prompt tokens ≥ `threshold × context_length` |
 | `target_ratio` | `0.20` | 0.10-0.80 | Controls tail protection token budget: `threshold_tokens × target_ratio` |
+| `min_interval_seconds` | `0` | ≥0 | Minimum seconds between automatic compression attempts; `0` disables debounce. Manual `/compress` bypasses it. |
 | `protect_last_n` | `20` | ≥1 | Minimum number of recent messages always preserved |
 | `protect_first_n` | `3` | (hardcoded) | System prompt + first exchange always preserved |
 


### PR DESCRIPTION
## Summary

Adds configurable debounce controls for automatic context compression so repeated compression attempts do not hammer the summarizer during long sessions.

- adds `compression.min_interval_seconds` config/default/example/docs
- debounces automatic `ContextCompressor.compress()` calls while preserving default behavior (`0` = disabled)
- keeps manual `/compress` (`force=True`) as an immediate bypass
- persists gateway session-hygiene debounce on `SessionEntry` so it survives the fresh `AIAgent` instance created for each hygiene pass
- adds focused tests for compressor behavior, config propagation, default config, and gateway hygiene debounce

## Test plan

```bash
/home/mike/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/agent/test_context_compressor.py \
  tests/run_agent/test_plugin_context_engine_init.py \
  tests/hermes_cli/test_config.py::TestCompressionConfig \
  tests/gateway/test_session_hygiene.py \
  tests/test_lazy_session_regressions.py \
  -q -o 'addopts='
```

Result: `140 passed in 5.43s`

Additional checks:

```bash
/home/mike/.hermes/hermes-agent/venv/bin/python -m compileall -q \
  agent/context_compressor.py agent/agent_init.py gateway/run.py gateway/session.py \
  tests/agent/test_context_compressor.py tests/gateway/test_session_hygiene.py \
  tests/run_agent/test_plugin_context_engine_init.py tests/hermes_cli/test_config.py
```

## Notes

This is backward compatible: the new debounce defaults to disabled (`0`), and manual compression remains forceable.
