### PR TITLE
fix(gateway): clear bloated compression binding on compression-exhaustion auto-reset

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9266,12 +9266,29 @@ class GatewayRunner:
                     "Auto-resetting session %s after compression exhaustion.",
                     session_entry.session_id,
                 )
-                self.session_store.reset_session(session_key)
+                new_entry = self.session_store.reset_session(session_key)
                 self._evict_cached_agent(session_key)
                 self._session_model_overrides.pop(session_key, None)
                 self._set_session_reasoning_override(session_key, None)
                 if hasattr(self, "_pending_model_notes"):
                     self._pending_model_notes.pop(session_key, None)
+                if new_entry is not None:
+                    # Drop the stale reference to the bloated compressed child and
+                    # re-point the Telegram topic binding at the fresh session.
+                    # Compression rotated session_entry.session_id to the oversized
+                    # compressed child earlier this turn (the agent-result sync
+                    # above), and that _sync also rewrote the (chat_id, thread_id)
+                    # -> bloated-child binding. reset_session swaps in a clean,
+                    # parentless session, but without re-syncing the binding the
+                    # next inbound message in this topic gets switch_session'd back
+                    # onto the bloated child by the binding-heal walk, reloads the
+                    # oversized transcript, and re-triggers compression exhaustion
+                    # forever (#35809 — regression of the #9893/#10063 auto-reset).
+                    # No-op on non-topic lanes.
+                    session_entry = new_entry
+                    self._sync_telegram_topic_binding(
+                        source, session_entry, reason="compression-exhausted-reset",
+                    )
                 response = (response or "") + (
                     "\n\n🔄 Session auto-reset — the conversation exceeded the "
                     "maximum context size and could not be compressed further. "

--- a/tests/gateway/test_35809_auto_reset_clean_context.py
+++ b/tests/gateway/test_35809_auto_reset_clean_context.py
@@ -1,0 +1,196 @@
+"""Regression tests for #35809 — compression-exhaustion auto-reset loop.
+
+After compression is exhausted the gateway auto-resets the session so the
+next message starts on a fresh, empty conversation (#9893 / #10063). That
+guarantee regressed once the Telegram topic-binding heal landed
+(#20470 / #29712 / #33414):
+
+    1. Compression rotates ``session_entry.session_id`` to an oversized
+       compressed *child* session mid-turn and the agent-result sync rewrites
+       the ``(chat_id, thread_id) -> child`` topic binding.
+    2. ``reset_session`` swaps in a clean, parentless session — but its return
+       value was discarded and the topic binding was left pointing at the
+       bloated child.
+    3. On the next inbound message in that topic, the binding-heal walk
+       ``switch_session``'d the freshly-reset lane *back* onto the bloated
+       child, ``load_transcript`` reloaded the oversized transcript, and
+       compression exhaustion re-fired — a new session id every loop.
+
+The fix captures the fresh entry from ``reset_session`` and re-syncs the
+topic binding to it (a no-op on non-topic lanes).
+
+Two tests:
+
+* ``TestAutoResetBlockReSyncsBinding`` — an AST invariant on
+  ``gateway/run.py`` (mirrors ``test_compression_session_id_persistence.py``):
+  the compression-exhausted auto-reset block must capture
+  ``reset_session(...)`` and call ``_sync_telegram_topic_binding`` afterward.
+  This is the load-bearing regression pin.
+* ``TestAutoResetLoadsCleanContext`` — a behavioral contract on the real
+  ``SessionStore``: after ``reset_session`` the next turn loads an EMPTY
+  transcript for the new session_id, never the bloated child's transcript.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+from gateway import run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionSource, SessionStore
+from hermes_state import SessionDB
+
+
+# ---------------------------------------------------------------------------
+# AST invariant: the auto-reset block re-syncs the topic binding
+# ---------------------------------------------------------------------------
+def _find_compression_exhausted_reset_block() -> ast.If:
+    """Return the ``if agent_result.get('compression_exhausted') ...`` block."""
+    tree = ast.parse(inspect.getsource(gateway_run))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        consts = [
+            n.value
+            for n in ast.walk(node.test)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)
+        ]
+        # Identify the auto-reset branch by the literal passed to .get(...).
+        if "compression_exhausted" in consts:
+            # Only the branch that actually performs the reset, not the
+            # earlier classifier that merely reads the flag into a bool.
+            calls = {
+                sub.func.attr
+                for sub in ast.walk(node)
+                if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute)
+            }
+            if "reset_session" in calls:
+                return node
+    raise AssertionError(
+        "Could not locate the compression-exhausted auto-reset block "
+        "(if agent_result.get('compression_exhausted') ... reset_session) "
+        "in gateway/run.py — the structure changed or the AST walker is stale."
+    )
+
+
+class TestAutoResetBlockReSyncsBinding:
+    def test_reset_session_return_is_captured(self):
+        """``reset_session`` must be assigned, not called-and-discarded —
+        the fresh entry is needed to re-point the binding and drop the stale
+        reference to the bloated compressed child (#35809)."""
+        block = _find_compression_exhausted_reset_block()
+        captured = False
+        for stmt in ast.walk(block):
+            if isinstance(stmt, ast.Assign):
+                val = stmt.value
+                if (
+                    isinstance(val, ast.Call)
+                    and isinstance(val.func, ast.Attribute)
+                    and val.func.attr == "reset_session"
+                ):
+                    captured = True
+        assert captured, (
+            "gateway/run.py auto-reset block calls reset_session() but discards "
+            "its return value. The fresh SessionEntry must be captured so the "
+            "topic binding can be re-pointed at it; otherwise the next message "
+            "resolves back to the bloated compressed child (#35809)."
+        )
+
+    def test_topic_binding_is_resynced_after_reset(self):
+        """The block must re-sync the topic binding so the next inbound message
+        cannot ``switch_session`` back onto the bloated compressed child."""
+        block = _find_compression_exhausted_reset_block()
+        sync_calls = [
+            sub
+            for sub in ast.walk(block)
+            if isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Attribute)
+            and sub.func.attr == "_sync_telegram_topic_binding"
+        ]
+        assert sync_calls, (
+            "gateway/run.py auto-reset block does not call "
+            "_sync_telegram_topic_binding after reset_session. Without it the "
+            "(chat_id, thread_id) -> bloated-child binding survives the reset "
+            "and the binding-heal walk re-anchors the fresh lane onto the "
+            "oversized compressed transcript, re-triggering the loop (#35809)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Behavioral contract: reset yields a clean next-turn transcript
+# ---------------------------------------------------------------------------
+def _make_store(tmp_path):
+    store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+    # Isolate the SQLite transcript store so we exercise per-session_id
+    # transcripts without touching the developer's real state.db.
+    store._db = SessionDB(db_path=tmp_path / "state.db")
+    return store
+
+
+def _make_source():
+    return SessionSource(platform=Platform.TELEGRAM, chat_id="123", user_id="u1")
+
+
+def _bloat(n):
+    # Stand-in for the oversized, post-compression "child" transcript that
+    # could not be compressed any further (#35809).
+    return [{"role": "user", "content": "x" * 2000} for _ in range(n)]
+
+
+class TestAutoResetLoadsCleanContext:
+    """#35809: after the gateway auto-resets a session because compression
+    was exhausted, the NEXT turn must load an EMPTY transcript for the new
+    session_id — never the bloated compressed-child transcript."""
+
+    def test_next_turn_transcript_is_empty_after_auto_reset(self, tmp_path):
+        store = _make_store(tmp_path)
+        source = _make_source()
+
+        entry = store.get_or_create_session(source)
+        session_key = entry.session_key
+        bloated_sid = entry.session_id
+        store._db.create_session(
+            session_id=bloated_sid, source="telegram", user_id="u1"
+        )
+        store._db.replace_messages(bloated_sid, _bloat(120))
+        assert len(store.load_transcript(bloated_sid)) == 120  # precondition
+
+        new_entry = store.reset_session(session_key)
+        assert new_entry is not None
+        assert new_entry.session_id != bloated_sid
+
+        resolved = store.get_or_create_session(source)
+        assert resolved.session_id == new_entry.session_id
+        loaded = store.load_transcript(resolved.session_id)
+
+        assert loaded == [], (
+            f"Auto-reset must yield an empty context, got {len(loaded)} "
+            f"messages — the bloated compressed child leaked into the new session."
+        )
+        # The old transcript is still searchable, not destroyed.
+        assert len(store.load_transcript(bloated_sid)) == 120
+
+    def test_clean_context_survives_gateway_restart(self, tmp_path):
+        """The fresh, empty session must still be the one loaded after a
+        gateway restart (sessions.json + state.db round-trip)."""
+        store = _make_store(tmp_path)
+        source = _make_source()
+        entry = store.get_or_create_session(source)
+        bloated_sid = entry.session_id
+        store._db.create_session(
+            session_id=bloated_sid, source="telegram", user_id="u1"
+        )
+        store._db.replace_messages(bloated_sid, _bloat(120))
+
+        new_entry = store.reset_session(entry.session_key)
+        new_sid = new_entry.session_id
+
+        # Simulate restart: drop in-memory index, reload from disk.
+        store._loaded = False
+        store._entries.clear()
+
+        reloaded = store.get_or_create_session(source)
+        assert reloaded.session_id == new_sid
+        assert store.load_transcript(reloaded.session_id) == []


### PR DESCRIPTION
## What does this PR do?

Fixes the compression-exhaustion **infinite reset loop** reported in #35809. After compression is exhausted the gateway auto-resets the session so the next message starts on a clean conversation (the #9893 / #10063 fix). That guarantee regressed once the Telegram topic-binding heal landed (#20470 / #29712 / #33414).

During the failing turn, compression rotates `session_entry.session_id` to an oversized compressed *child* session, and the agent-result sync rewrites the `(chat_id, thread_id) -> child` topic binding. `reset_session()` then swaps in a clean, parentless session — **but its return value was discarded and the topic binding was left pointing at the bloated child.** On the next inbound message in that topic, the binding-heal walk (`get_compression_tip` + `switch_session`) re-anchors the freshly-reset lane back onto the bloated child, `load_transcript` reloads the oversized transcript, and compression exhaustion re-fires — producing a new session id on every loop, exactly the reported symptom.

The fix captures the fresh entry returned by `reset_session()`, drops the stale reference to the bloated child, and re-syncs the topic binding to the fresh session so the next message cannot be steered back onto the oversized transcript. `_sync_telegram_topic_binding` early-returns on non-topic lanes, so DMs and non-Telegram platforms are unaffected.

## Related Issue

Fixes #35809

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Addressing maintainer feedback

@alt-glitch (COLLABORATOR) diagnosed this and cross-referenced three PRs; each is accounted for:

- **#10063 — MERGED** (`fix(gateway): break compression-exhaustion infinite loop and auto-reset session`, closed #9893). This is the original auto-reset fix that #35809 regresses. The maintainer is correct: the auto-reset still runs, but it no longer reaches a clean state because the topic binding (added later) re-anchors the lane onto the bloated compressed child. This PR restores #10063's intended "start fresh" guarantee.
- **#26571 — OPEN** (`fix: reset gateway sessions on context overflow`). Touches the same file but only broadens the auto-reset **trigger** (`compression_exhausted` -> any classified context-overflow failure) and reworks the user-facing message; the branch body still calls `reset_session()` and discards its return. It changes *when* reset fires, not *what context is reloaded afterward*, so it does not fix this loop. The two changes are orthogonal and compose cleanly.
- **#33825 — OPEN** (`fix(agent): prevent compression deadlock on high-context models`, closes #31600). A different loop entirely — an in-agent `_compress_context` escape hatch in `agent/conversation_loop.py` for truncated-tool-call JSON. It never touches the gateway, the session store, or the reset path. No overlap.

## Changes Made

- `gateway/run.py`: in `_handle_message_with_agent`, the compression-exhausted auto-reset block now captures the `SessionEntry` returned by `reset_session()`, reassigns the stale local `session_entry`, and calls `_sync_telegram_topic_binding(...)` to re-point the topic binding at the fresh session.
- `tests/gateway/test_35809_auto_reset_clean_context.py`: new regression tests — AST invariants on the reset block (the `reset_session()` return must be captured and the binding re-synced) plus a behavioral `SessionStore` contract test (next-turn transcript is empty after reset, and survives a restart round-trip).

## How to Test

1. `pytest tests/gateway/test_35809_auto_reset_clean_context.py -q` — passes with the fix; the AST tests fail on `main` (verified by stashing the `gateway/run.py` change), proving they pin the regression.
2. `pytest tests/gateway/test_telegram_topic_mode.py tests/gateway/test_fresh_reset_skill_injection.py tests/gateway/test_7100_transient_failure_transcript.py tests/gateway/test_compression_session_id_persistence.py tests/run_agent/test_1630_context_overflow_loop.py -q` — the surrounding auto-reset / binding-heal behavior is unchanged (all pass).
3. Manual repro (Telegram topic lane or any lane that persists a topic binding): drive a session into compression exhaustion, observe the auto-reset, then send a follow-up — the follow-up now starts on the fresh empty session instead of immediately re-failing with context-overflow.

## What platforms tested on

- macOS on darwin-arm64 (local): targeted gateway test suite above green; `ruff check` and `ruff format --check` clean on changed files; `scripts/check-windows-footguns.py` clean on changed files.
- The production change only reassigns a local variable and calls an existing method that already early-returns off the Telegram topic path — no new filesystem, path, signal, or subprocess behavior, so it is platform-agnostic for Linux / native Windows / WSL2.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (#26571, #33825 reviewed — neither covers this reload path)
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran the targeted gateway/run_agent suites above; full suite left to CI)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (darwin-arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A

<!-- autocontrib:worker-id=issue-new-880348fa kind=pr-open -->