### PR TITLE
fix(skills): ignore nested markdown assets in skill_view

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1267,3 +1267,35 @@ class TestSkillViewCollisionDetection:
         result = json.loads(raw)
         assert result["success"] is True
         assert "LOCAL BODY" in result["content"]
+
+    def test_nested_skill_asset_does_not_collide_with_skill_name(self, tmp_path):
+        """Markdown assets inside a skill package are not standalone skills.
+
+        A bundled skill can have references/templates named after another skill
+        (for example ``templates/notion.md``). Those internal assets must not
+        make ``skill_view("notion")`` ambiguous when a real notion skill exists.
+        """
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+
+        _make_skill(local_dir, "notion", category="productivity", body="REAL SKILL")
+        asset_owner = _make_skill(
+            local_dir,
+            "popular-web-designs",
+            category="creative",
+            body="ASSET OWNER",
+        )
+        asset_dir = asset_owner / "templates"
+        asset_dir.mkdir()
+        (asset_dir / "notion.md").write_text("# Notion style reference\n")
+
+        p1, p2 = self._patch_dirs(local_dir, [external_dir])
+        with p1, p2:
+            raw = skill_view("notion")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "REAL SKILL" in result["content"]
+        assert "Ambiguous" not in result.get("error", "")

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -960,9 +960,26 @@ def skill_view(
                 if found_skill_md.parent.name == name:
                     _record(found_skill_md.parent, found_skill_md)
 
+            def _is_inside_skill_package(path: Path) -> bool:
+                """Return True when path is an asset inside another skill dir."""
+                try:
+                    relative_parent = path.parent.relative_to(search_dir)
+                except ValueError:
+                    return False
+
+                current = search_dir
+                for part in relative_parent.parts:
+                    current = current / part
+                    if (current / "SKILL.md").exists():
+                        return True
+                return False
+
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
+            # Do not treat reference/template/assets markdown inside a skill
+            # package as a separate legacy skill; those files are linked files
+            # owned by that skill, not top-level load targets.
             for found_md in search_dir.rglob(f"{name}.md"):
-                if found_md.name != "SKILL.md":
+                if found_md.name != "SKILL.md" and not _is_inside_skill_package(found_md):
                     _record(None, found_md)
 
         if len(candidates) > 1:


### PR DESCRIPTION
## Summary
- Fix `skill_view("<name>")` so nested markdown references/templates/assets inside another skill package are not treated as legacy standalone skills.
- Preserve collision detection for real same-name skills across local/external skill directories.
- Add a regression test covering the bundled-style `templates/notion.md` asset collision scenario.

## Test Plan
- `venv/bin/python -m pytest tests/tools/test_skills_tool.py::TestSkillViewCollisionDetection -q`
- `venv/bin/python -m pytest tests/tools/test_skills_tool.py tests/test_plugin_skills.py -q`
- Manual: `skill_view("notion")` now resolves `productivity/notion/SKILL.md` successfully.

Closes #35743
