### PR TITLE
feat(auth): add RP-initiated OIDC logout via get_end_session_url()

### DIFF
--- a/hermes_cli/dashboard_auth/base.py
+++ b/hermes_cli/dashboard_auth/base.py
@@ -121,6 +121,19 @@ class DashboardAuthProvider(ABC):
     @abstractmethod
     def revoke_session(self, *, refresh_token: str) -> None: ...
 
+    def get_end_session_url(self) -> Optional[str]:
+        """Return the IdP end-session URL for RP-initiated logout, or None.
+
+        Providers that support OIDC ``end_session_endpoint`` override this
+        to return the URL. The ``auth_logout`` handler redirects there
+        after revoking tokens locally, so the IdP session is also terminated.
+
+        The default returns ``None`` — providers that don't support
+        RP-initiated logout (e.g. the bundled Nous provider) skip the
+        redirect and keep the current behaviour.
+        """
+        return None
+
 
 def assert_protocol_compliance(cls: type) -> None:
     """Raise ``TypeError`` if ``cls`` doesn't fully implement the provider protocol.

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 import time
 from typing import Any
+from urllib.parse import urlencode
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
@@ -396,6 +397,17 @@ async def auth_logout(request: Request):
     resp = RedirectResponse(url=f"{prefix}/login", status_code=302)
     clear_session_cookies(resp, prefix=prefix)
     clear_pkce_cookie(resp, prefix=prefix)
+
+    # If any provider supports RP-initiated OIDC logout, redirect the
+    # browser to the IdP's end-session endpoint so the IdP session
+    # cookie is also terminated — not just the dashboard session.
+    for provider in list_providers():
+        end_url = provider.get_end_session_url()
+        if end_url:
+            params = urlencode({"post_logout_redirect_uri": f"{prefix}/login"})
+            resp = RedirectResponse(url=f"{end_url}?{params}", status_code=302)
+            break
+
     return resp
 
 

--- a/plugins/dashboard_auth/nous/__init__.py
+++ b/plugins/dashboard_auth/nous/__init__.py
@@ -290,6 +290,15 @@ class NousDashboardAuthProvider(DashboardAuthProvider):
         _ = refresh_token
         return None
 
+    def get_end_session_url(self) -> Optional[str]:
+        """Nous Portal doesn't currently expose an OIDC end-session endpoint.
+
+        Dashboard logout clears cookies and revokes locally without
+        an IdP redirect. Override this in a subclass when the Portal
+        adds RP-initiated logout support.
+        """
+        return None
+
     # ---- internals --------------------------------------------------------
 
     def _validate_redirect_uri(self, redirect_uri: str) -> None:


### PR DESCRIPTION
Problem
 
When a user logs out of the Hermes dashboard (POST /auth/logout), the IdP
session cookie is not terminated. On the next login, the browser auto-
authenticates via the still-valid IdP session — user never sees a login
prompt again. Logout is effectively incomplete.

Solution

Add get_end_session_url() to DashboardAuthProvider so providers can
expose their OIDC end_session_endpoint. The auth_logout handler now
redirects to the IdP after clearing local cookies when the provider
supports RP-initiated logout.

Changes

- Add get_end_session_url() to DashboardAuthProvider base class
with default return None for backward compatibility
- Modify auth_logout handler to redirect to IdP end-session endpoint
when the provider supports RP-initiated logout
- Add no-op implementation to NousDashboardAuthProvider (Portal
doesn't expose end_session_endpoint yet)

Closes #35410