### PR TITLE
fix(tui): auto-recover session on unexpected gateway death (+ persist lifecycle breadcrumbs)

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -688,7 +688,9 @@ describe('createGatewayEventHandler', () => {
     const ctx = buildCtx(appended)
 
     ctx.session.newSession = newSession
-    ctx.session.resumeById = resumeById
+    // Mimic resumeById's synchronous status write so the test proves the
+    // "recovering session…" label is applied *after* (and survives) it.
+    ctx.session.resumeById = resumeById.mockImplementation(() => patchUiState({ status: 'resuming…' }))
     ctx.session.STARTUP_RESUME_ID = ''
     ctx.session.recoverSidRef = ref<null | string>('sess-crashed')
 
@@ -701,6 +703,7 @@ describe('createGatewayEventHandler', () => {
     // One-shot: the ref is consumed so a later ordinary restart forges/resumes
     // per config instead of re-resuming the recovered session.
     expect(ctx.session.recoverSidRef.current).toBeNull()
+    expect(getUiState().status).toBe('recovering session…')
   })
 
   it('on gateway.ready with auto_resume on and a recent session, resumes it', async () => {

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -681,6 +681,28 @@ describe('createGatewayEventHandler', () => {
     expect(resumeById).not.toHaveBeenCalled()
   })
 
+  it('on gateway.ready after a crash, resumes the recovered session once and skips forge', async () => {
+    const appended: Msg[] = []
+    const newSession = vi.fn()
+    const resumeById = vi.fn()
+    const ctx = buildCtx(appended)
+
+    ctx.session.newSession = newSession
+    ctx.session.resumeById = resumeById
+    ctx.session.STARTUP_RESUME_ID = ''
+    ctx.session.recoverSidRef = ref<null | string>('sess-crashed')
+
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({ payload: {}, type: 'gateway.ready' } as any)
+
+    await vi.waitFor(() => expect(resumeById).toHaveBeenCalledWith('sess-crashed'))
+    expect(newSession).not.toHaveBeenCalled()
+    // One-shot: the ref is consumed so a later ordinary restart forges/resumes
+    // per config instead of re-resuming the recovered session.
+    expect(ctx.session.recoverSidRef.current).toBeNull()
+  })
+
   it('on gateway.ready with auto_resume on and a recent session, resumes it', async () => {
     const appended: Msg[] = []
     const newSession = vi.fn()

--- a/ui-tui/src/__tests__/gatewayRecovery.test.ts
+++ b/ui-tui/src/__tests__/gatewayRecovery.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { evalRecovery, GATEWAY_RECOVERY_LIMIT, GATEWAY_RECOVERY_WINDOW_MS } from '../app/gatewayRecovery.js'
+
+describe('evalRecovery', () => {
+  it('allows up to the limit within the window, then blocks', () => {
+    let attempts: number[] = []
+    const t0 = 1_000_000
+
+    for (let i = 0; i < GATEWAY_RECOVERY_LIMIT; i++) {
+      const { allowed, recent } = evalRecovery(attempts, t0 + i)
+
+      expect(allowed).toBe(true)
+      attempts = [...recent, t0 + i]
+    }
+
+    // Budget exhausted: the next death within the window falls back to inert.
+    expect(evalRecovery(attempts, t0 + GATEWAY_RECOVERY_LIMIT).allowed).toBe(false)
+  })
+
+  it('prunes attempts older than the window so recovery is allowed again', () => {
+    const old = Array.from({ length: GATEWAY_RECOVERY_LIMIT }, (_, i) => i)
+    const now = GATEWAY_RECOVERY_WINDOW_MS + 100
+
+    const { allowed, recent } = evalRecovery(old, now)
+
+    expect(recent).toEqual([])
+    expect(allowed).toBe(true)
+  })
+})

--- a/ui-tui/src/__tests__/gatewayRecovery.test.ts
+++ b/ui-tui/src/__tests__/gatewayRecovery.test.ts
@@ -1,30 +1,47 @@
 import { describe, expect, it } from 'vitest'
 
-import { evalRecovery, GATEWAY_RECOVERY_LIMIT, GATEWAY_RECOVERY_WINDOW_MS } from '../app/gatewayRecovery.js'
+import { GATEWAY_RECOVERY_LIMIT, GATEWAY_RECOVERY_WINDOW_MS, planGatewayRecovery } from '../app/gatewayRecovery.js'
 
-describe('evalRecovery', () => {
-  it('allows up to the limit within the window, then blocks', () => {
-    let attempts: number[] = []
-    const t0 = 1_000_000
+describe('planGatewayRecovery', () => {
+  it('recovers the live session and records the attempt', () => {
+    const plan = planGatewayRecovery('sess-1', null, [], 1000)
 
-    for (let i = 0; i < GATEWAY_RECOVERY_LIMIT; i++) {
-      const { allowed, recent } = evalRecovery(attempts, t0 + i)
-
-      expect(allowed).toBe(true)
-      attempts = [...recent, t0 + i]
-    }
-
-    // Budget exhausted: the next death within the window falls back to inert.
-    expect(evalRecovery(attempts, t0 + GATEWAY_RECOVERY_LIMIT).allowed).toBe(false)
+    expect(plan).toEqual({ attempts: [1000], recover: true, sid: 'sess-1' })
   })
 
-  it('prunes attempts older than the window so recovery is allowed again', () => {
+  it('does not recover when there is no session to resume', () => {
+    expect(planGatewayRecovery(null, null, [], 1000)).toEqual({ attempts: [], recover: false, sid: null })
+  })
+
+  it('keeps retrying the recovery target through a startup crash-loop, bounded by the budget', () => {
+    // First exit: live sid present.
+    let attempts: number[] = []
+    let plan = planGatewayRecovery('sess-1', null, attempts, 0)
+
+    expect(plan.recover).toBe(true)
+    expect(plan.sid).toBe('sess-1')
+    attempts = plan.attempts
+
+    // Respawn crash-loops before gateway.ready: live sid is now null, but the
+    // recovery target carries it forward so we keep trying up to the budget.
+    for (let i = 1; i < GATEWAY_RECOVERY_LIMIT; i++) {
+      plan = planGatewayRecovery(null, 'sess-1', attempts, i)
+      expect(plan.recover).toBe(true)
+      expect(plan.sid).toBe('sess-1')
+      attempts = plan.attempts
+    }
+
+    // Budget exhausted: fall back to the inert state instead of spawn-storming.
+    plan = planGatewayRecovery(null, 'sess-1', attempts, GATEWAY_RECOVERY_LIMIT)
+    expect(plan.recover).toBe(false)
+    expect(plan.sid).toBe('sess-1')
+  })
+
+  it('prunes attempts older than the window so recovery re-arms', () => {
     const old = Array.from({ length: GATEWAY_RECOVERY_LIMIT }, (_, i) => i)
-    const now = GATEWAY_RECOVERY_WINDOW_MS + 100
+    const plan = planGatewayRecovery('sess-1', null, old, GATEWAY_RECOVERY_WINDOW_MS + 100)
 
-    const { allowed, recent } = evalRecovery(old, now)
-
-    expect(recent).toEqual([])
-    expect(allowed).toBe(true)
+    expect(plan.attempts).toEqual([GATEWAY_RECOVERY_WINDOW_MS + 100])
+    expect(plan.recover).toBe(true)
   })
 })

--- a/ui-tui/src/__tests__/parentLog.test.ts
+++ b/ui-tui/src/__tests__/parentLog.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// parentLog gates itself off under VITEST so unit tests can't pollute a real
+// ~/.hermes. To exercise the real persistence path we clear that gate, point
+// HERMES_HOME at a temp dir, and re-import the module fresh (path + enabled
+// flag are captured at module load).
+const loadFresh = async (home: string) => {
+  vi.resetModules()
+  vi.stubEnv('VITEST', '')
+  vi.stubEnv('HERMES_HOME', home)
+
+  return import('../lib/parentLog.js')
+}
+
+describe('recordParentLifecycle', () => {
+  let home: string
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'hermes-parentlog-'))
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    rmSync(home, { force: true, recursive: true })
+  })
+
+  it('appends a timestamped breadcrumb to logs/tui_gateway_crash.log', async () => {
+    const { recordParentLifecycle } = await loadFresh(home)
+
+    recordParentLifecycle('graceful-exit received signal=SIGHUP → killing gateway')
+
+    const contents = readFileSync(join(home, 'logs', 'tui_gateway_crash.log'), 'utf8')
+
+    expect(contents).toContain('[tui-parent]')
+    expect(contents).toContain('graceful-exit received signal=SIGHUP → killing gateway')
+    expect(contents).toMatch(/\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('is a no-op under VITEST so tests stay hermetic', async () => {
+    vi.resetModules()
+    vi.stubEnv('VITEST', 'true')
+    vi.stubEnv('HERMES_HOME', home)
+
+    const { recordParentLifecycle } = await import('../lib/parentLog.js')
+
+    expect(() => recordParentLifecycle('should not be written')).not.toThrow()
+    expect(() => readFileSync(join(home, 'logs', 'tui_gateway_crash.log'), 'utf8')).toThrow()
+  })
+})

--- a/ui-tui/src/__tests__/parentLog.test.ts
+++ b/ui-tui/src/__tests__/parentLog.test.ts
@@ -40,6 +40,17 @@ describe('recordParentLifecycle', () => {
     expect(contents).toMatch(/\d{4}-\d{2}-\d{2}T/)
   })
 
+  it('collapses embedded newlines so a value stays one breadcrumb', async () => {
+    const { recordParentLifecycle } = await loadFresh(home)
+
+    recordParentLifecycle('uncaughtException: boom\n  at foo()\r\n  at bar()')
+
+    const lines = readFileSync(join(home, 'logs', 'tui_gateway_crash.log'), 'utf8').trimEnd().split('\n')
+
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('boom ↵   at foo() ↵   at bar()')
+  })
+
   it('is a no-op under VITEST so tests stay hermetic', async () => {
     vi.resetModules()
     vi.stubEnv('VITEST', 'true')

--- a/ui-tui/src/__tests__/parentLog.test.ts
+++ b/ui-tui/src/__tests__/parentLog.test.ts
@@ -51,6 +51,17 @@ describe('recordParentLifecycle', () => {
     expect(lines[0]).toContain('boom ↵   at foo() ↵   at bar()')
   })
 
+  it('caps an oversized breadcrumb so it cannot bloat the shared crash log', async () => {
+    const { recordParentLifecycle } = await loadFresh(home)
+
+    recordParentLifecycle('x'.repeat(10_000))
+
+    const line = readFileSync(join(home, 'logs', 'tui_gateway_crash.log'), 'utf8')
+
+    expect(line).toContain('[truncated 10000 chars]')
+    expect(line.length).toBeLessThan(4_500)
+  })
+
   it('is a no-op under VITEST so tests stay hermetic', async () => {
     vi.resetModules()
     vi.stubEnv('VITEST', 'true')

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -311,8 +311,11 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
     if (recoverSid) {
       recoverSidRef!.current = null
-      patchUiState({ status: 'recovering session…' })
       resumeById(recoverSid)
+      // After resumeById: it synchronously sets status to 'resuming…' on entry,
+      // so override it here to keep the distinct "recovering" label visible for
+      // the duration of the resume RPC (which later flips status to 'ready').
+      patchUiState({ status: 'recovering session…' })
 
       return
     }

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -309,8 +309,8 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
     // config. No startup prompt here (this is mid-session, not a cold boot).
     const recoverSid = recoverSidRef?.current
 
-    if (recoverSid) {
-      recoverSidRef!.current = null
+    if (recoverSidRef && recoverSid) {
+      recoverSidRef.current = null
       resumeById(recoverSid)
       // After resumeById: it synchronously sets status to 'resuming…' on entry,
       // so override it here to keep the distinct "recovering" label visible for

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -76,7 +76,7 @@ const normalizeSubagentStatus = (status: unknown, fallback: SubagentStatus): Sub
 
 export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev: GatewayEvent) => void {
   const { rpc } = ctx.gateway
-  const { STARTUP_RESUME_ID, newSession, resumeById, setCatalog } = ctx.session
+  const { STARTUP_RESUME_ID, newSession, recoverSidRef, resumeById, setCatalog } = ctx.session
   const { bellOnComplete, stdout, sys } = ctx.system
   const { appendMessage, panel, setHistoryItems } = ctx.transcript
   const { setInput } = ctx.composer
@@ -302,6 +302,20 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         }
       })
       .catch((e: unknown) => turnController.pushActivity(`command catalog unavailable: ${rpcErrorMessage(e)}`, 'info'))
+
+    // Crash recovery: a respawn triggered by an unexpected gateway death
+    // resumes the session that was live, not a brand-new one. One-shot — the
+    // ref is cleared so an ordinary later restart still forges/resumes per
+    // config. No startup prompt here (this is mid-session, not a cold boot).
+    const recoverSid = recoverSidRef?.current
+
+    if (recoverSid) {
+      recoverSidRef!.current = null
+      patchUiState({ status: 'recovering session…' })
+      resumeById(recoverSid)
+
+      return
+    }
 
     if (STARTUP_RESUME_ID) {
       patchUiState({ status: 'resuming…' })

--- a/ui-tui/src/app/gatewayRecovery.ts
+++ b/ui-tui/src/app/gatewayRecovery.ts
@@ -1,0 +1,16 @@
+// Crash-recovery budget for the gateway exit handler. A gateway that
+// crash-loops on startup must not let the TUI spawn-storm, so respawn+resume
+// attempts are capped to GATEWAY_RECOVERY_LIMIT within a sliding
+// GATEWAY_RECOVERY_WINDOW_MS; past the budget the app falls back to the inert
+// "gateway exited" state. Kept pure (no refs/UI) so the bound is unit-testable.
+export const GATEWAY_RECOVERY_LIMIT = 3
+export const GATEWAY_RECOVERY_WINDOW_MS = 60_000
+
+// Given prior attempt timestamps and the current time, return the timestamps
+// still inside the window plus whether another recovery is allowed. The caller
+// appends `now` to `recent` only when it actually starts a recovery.
+export function evalRecovery(attempts: number[], now: number): { allowed: boolean; recent: number[] } {
+  const recent = attempts.filter(t => now - t < GATEWAY_RECOVERY_WINDOW_MS)
+
+  return { allowed: recent.length < GATEWAY_RECOVERY_LIMIT, recent }
+}

--- a/ui-tui/src/app/gatewayRecovery.ts
+++ b/ui-tui/src/app/gatewayRecovery.ts
@@ -2,15 +2,34 @@
 // crash-loops on startup must not let the TUI spawn-storm, so respawn+resume
 // attempts are capped to GATEWAY_RECOVERY_LIMIT within a sliding
 // GATEWAY_RECOVERY_WINDOW_MS; past the budget the app falls back to the inert
-// "gateway exited" state. Kept pure (no refs/UI) so the bound is unit-testable.
+// "gateway exited" state. Kept pure (no refs/UI) so the bound — including the
+// crash-loop case — is unit-testable.
 export const GATEWAY_RECOVERY_LIMIT = 3
 export const GATEWAY_RECOVERY_WINDOW_MS = 60_000
 
-// Given prior attempt timestamps and the current time, return the timestamps
-// still inside the window plus whether another recovery is allowed. The caller
-// appends `now` to `recent` only when it actually starts a recovery.
-export function evalRecovery(attempts: number[], now: number): { allowed: boolean; recent: number[] } {
-  const recent = attempts.filter(t => now - t < GATEWAY_RECOVERY_WINDOW_MS)
+export interface RecoveryPlan {
+  // Attempt timestamps to persist (the pruned window, plus `now` iff recovering).
+  attempts: number[]
+  recover: boolean
+  // Session to resume — the live sid, or the not-yet-consumed recovery target
+  // when the live sid was already cleared by a prior exit.
+  sid: null | string
+}
 
-  return { allowed: recent.length < GATEWAY_RECOVERY_LIMIT, recent }
+// Decide whether to respawn+resume after a gateway death. `liveSid` is the
+// current session (nulled on the first exit); `recoverSid` is a pending
+// recovery target carried across a respawn that died before gateway.ready —
+// so a startup crash-loop keeps retrying the same session up to the budget
+// instead of stranding it after one attempt.
+export function planGatewayRecovery(
+  liveSid: null | string,
+  recoverSid: null | string,
+  attempts: number[],
+  now: number
+): RecoveryPlan {
+  const sid = liveSid ?? recoverSid
+  const recent = attempts.filter(t => now - t < GATEWAY_RECOVERY_WINDOW_MS)
+  const recover = Boolean(sid) && recent.length < GATEWAY_RECOVERY_LIMIT
+
+  return { attempts: recover ? [...recent, now] : recent, recover, sid }
 }

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -239,6 +239,10 @@ export interface GatewayEventHandlerContext {
     STARTUP_RESUME_ID: string
     colsRef: MutableRefObject<number>
     newSession: (msg?: string, title?: string) => void
+    // Set by useMainApp's exit handler to the session that was live when the
+    // gateway died unexpectedly; consumed once by the next `gateway.ready` so a
+    // respawn resumes that session instead of forging a fresh one.
+    recoverSidRef?: MutableRefObject<null | string>
     resetSession: () => void
     resumeById: (id: string) => void
     setCatalog: StateSetter<null | SlashCatalog>

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -30,7 +30,7 @@ import type { Msg, PanelSection, SlashCatalog } from '../types.js'
 
 import { createGatewayEventHandler } from './createGatewayEventHandler.js'
 import { createSlashHandler } from './createSlashHandler.js'
-import { evalRecovery } from './gatewayRecovery.js'
+import { planGatewayRecovery } from './gatewayRecovery.js'
 import { getInputSelection } from './inputSelectionStore.js'
 import { type GatewayRpc, type TranscriptRow } from './interfaces.js'
 import { $overlayState, patchOverlayState } from './overlayStore.js'
@@ -738,25 +738,26 @@ export function useMainApp(gw: GatewayClient) {
 
     const exitHandler = () => {
       turnController.reset()
-      const deadSid = getUiState().sid
-      // Clear sid immediately: while the gateway is down, sid-guarded effects
-      // (session.active_list poll, queue drain) would otherwise fire RPCs at a
-      // dead/respawning gateway. recoverSidRef carries the session forward, and
-      // resumeById restores sid once the fresh gateway is ready.
-      patchUiState({ busy: false, sid: null, status: 'gateway exited' })
 
       // A still-owned child dying while the TUI is alive is an *unexpected*
       // death — a user /quit exits Node before this fires, and a replaced child
       // is identity-skipped in GatewayClient. Rather than stranding a long
       // session (the user's complaint), respawn the gateway and resume the
       // persisted session via the next gateway.ready, so a single crash / OOM /
-      // signal doesn't lose their work. Bounded so a gateway that crash-loops
-      // on startup can't spawn-storm.
-      const { allowed, recent } = evalRecovery(recoveryAtRef.current, Date.now())
+      // signal doesn't lose their work. planGatewayRecovery bounds the attempts
+      // so a gateway that crash-loops on startup can't spawn-storm, and falls
+      // back to recoverSidRef when sid was already cleared by a prior exit.
+      const plan = planGatewayRecovery(getUiState().sid, recoverSidRef.current, recoveryAtRef.current, Date.now())
 
-      if (deadSid && allowed) {
-        recoveryAtRef.current = [...recent, Date.now()]
-        recoverSidRef.current = deadSid
+      // Clear sid immediately: while the gateway is down, sid-guarded effects
+      // (session.active_list poll, queue drain) would otherwise fire RPCs at a
+      // dead/respawning gateway. recoverSidRef carries the session forward, and
+      // resumeById restores sid once the fresh gateway is ready.
+      recoveryAtRef.current = plan.attempts
+      patchUiState({ busy: false, sid: null, status: 'gateway exited' })
+
+      if (plan.recover && plan.sid) {
+        recoverSidRef.current = plan.sid
         turnController.pushActivity('gateway exited · recovering session…', 'warn')
         sys('gateway exited — recovering your session (the in-flight reply was lost)')
         gw.start()
@@ -764,7 +765,6 @@ export function useMainApp(gw: GatewayClient) {
         return
       }
 
-      recoveryAtRef.current = recent
       recoverSidRef.current = null
       turnController.pushActivity('gateway exited · /logs to inspect', 'error')
       sys('error: gateway exited')

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -759,7 +759,7 @@ export function useMainApp(gw: GatewayClient) {
       if (plan.recover && plan.sid) {
         recoverSidRef.current = plan.sid
         turnController.pushActivity('gateway exited · recovering session…', 'warn')
-        sys('gateway exited — recovering your session (the in-flight reply was lost)')
+        sys('gateway exited — recovering your session (any in-flight reply was lost)')
         gw.start()
 
         return

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -48,6 +48,11 @@ const GOOD_VIBES_RE = /\b(good bot|thanks|thank you|thx|ty|ily|love you)\b/i
 const BRACKET_PASTE_ON = '\x1b[?2004h'
 const BRACKET_PASTE_OFF = '\x1b[?2004l'
 const MAX_HEIGHT_CACHE_BUCKETS = 12
+// Crash-recovery budget: cap respawn+resume attempts so a gateway that
+// crash-loops on startup can't spawn-storm. Past the budget we fall back to
+// the inert "gateway exited" state.
+const GATEWAY_RECOVERY_LIMIT = 3
+const GATEWAY_RECOVERY_WINDOW_MS = 60_000
 
 const capHistory = (items: Msg[]): Msg[] => {
   if (items.length <= MAX_HISTORY) {
@@ -200,6 +205,8 @@ export function useMainApp(gw: GatewayClient) {
   const terminalHintsShownRef = useRef(new Set<string>())
   const historyItemsRef = useRef(historyItems)
   const lastUserMsgRef = useRef(lastUserMsg)
+  const recoverSidRef = useRef<null | string>(null)
+  const recoveryAtRef = useRef<number[]>([])
   const msgIdsRef = useRef(new WeakMap<Msg, string>())
   const msgIdSeqRef = useRef(0)
   const heightCachesRef = useRef(new Map<string, Map<string, number>>())
@@ -694,6 +701,7 @@ export function useMainApp(gw: GatewayClient) {
           STARTUP_RESUME_ID,
           colsRef,
           newSession: session.newSession,
+          recoverSidRef,
           resetSession: session.resetSession,
           resumeById: session.resumeById,
           setCatalog
@@ -734,7 +742,32 @@ export function useMainApp(gw: GatewayClient) {
 
     const exitHandler = () => {
       turnController.reset()
-      patchUiState({ busy: false, sid: null, status: 'gateway exited' })
+      const deadSid = getUiState().sid
+      patchUiState({ busy: false, status: 'gateway exited' })
+
+      // A still-owned child dying while the TUI is alive is an *unexpected*
+      // death — a user /quit exits Node before this fires, and a replaced child
+      // is identity-skipped in GatewayClient. Rather than stranding a long
+      // session (the user's complaint), respawn the gateway and resume the
+      // persisted session via the next gateway.ready, so a single crash / OOM /
+      // signal doesn't lose their work. Bounded so a gateway that crash-loops
+      // on startup can't spawn-storm.
+      const now = Date.now()
+      const recent = recoveryAtRef.current.filter(t => now - t < GATEWAY_RECOVERY_WINDOW_MS)
+
+      if (deadSid && recent.length < GATEWAY_RECOVERY_LIMIT) {
+        recoveryAtRef.current = [...recent, now]
+        recoverSidRef.current = deadSid
+        turnController.pushActivity('gateway exited · recovering session…', 'warn')
+        sys('gateway exited — recovering your session (the in-flight reply was lost)')
+        gw.start()
+
+        return
+      }
+
+      recoveryAtRef.current = recent
+      recoverSidRef.current = null
+      patchUiState({ sid: null })
       turnController.pushActivity('gateway exited · /logs to inspect', 'error')
       sys('error: gateway exited')
     }

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -30,6 +30,7 @@ import type { Msg, PanelSection, SlashCatalog } from '../types.js'
 
 import { createGatewayEventHandler } from './createGatewayEventHandler.js'
 import { createSlashHandler } from './createSlashHandler.js'
+import { evalRecovery } from './gatewayRecovery.js'
 import { getInputSelection } from './inputSelectionStore.js'
 import { type GatewayRpc, type TranscriptRow } from './interfaces.js'
 import { $overlayState, patchOverlayState } from './overlayStore.js'
@@ -48,11 +49,6 @@ const GOOD_VIBES_RE = /\b(good bot|thanks|thank you|thx|ty|ily|love you)\b/i
 const BRACKET_PASTE_ON = '\x1b[?2004h'
 const BRACKET_PASTE_OFF = '\x1b[?2004l'
 const MAX_HEIGHT_CACHE_BUCKETS = 12
-// Crash-recovery budget: cap respawn+resume attempts so a gateway that
-// crash-loops on startup can't spawn-storm. Past the budget we fall back to
-// the inert "gateway exited" state.
-const GATEWAY_RECOVERY_LIMIT = 3
-const GATEWAY_RECOVERY_WINDOW_MS = 60_000
 
 const capHistory = (items: Msg[]): Msg[] => {
   if (items.length <= MAX_HISTORY) {
@@ -743,7 +739,11 @@ export function useMainApp(gw: GatewayClient) {
     const exitHandler = () => {
       turnController.reset()
       const deadSid = getUiState().sid
-      patchUiState({ busy: false, status: 'gateway exited' })
+      // Clear sid immediately: while the gateway is down, sid-guarded effects
+      // (session.active_list poll, queue drain) would otherwise fire RPCs at a
+      // dead/respawning gateway. recoverSidRef carries the session forward, and
+      // resumeById restores sid once the fresh gateway is ready.
+      patchUiState({ busy: false, sid: null, status: 'gateway exited' })
 
       // A still-owned child dying while the TUI is alive is an *unexpected*
       // death — a user /quit exits Node before this fires, and a replaced child
@@ -752,11 +752,10 @@ export function useMainApp(gw: GatewayClient) {
       // persisted session via the next gateway.ready, so a single crash / OOM /
       // signal doesn't lose their work. Bounded so a gateway that crash-loops
       // on startup can't spawn-storm.
-      const now = Date.now()
-      const recent = recoveryAtRef.current.filter(t => now - t < GATEWAY_RECOVERY_WINDOW_MS)
+      const { allowed, recent } = evalRecovery(recoveryAtRef.current, Date.now())
 
-      if (deadSid && recent.length < GATEWAY_RECOVERY_LIMIT) {
-        recoveryAtRef.current = [...recent, now]
+      if (deadSid && allowed) {
+        recoveryAtRef.current = [...recent, Date.now()]
         recoverSidRef.current = deadSid
         turnController.pushActivity('gateway exited · recovering session…', 'warn')
         sys('gateway exited — recovering your session (the in-flight reply was lost)')
@@ -767,7 +766,6 @@ export function useMainApp(gw: GatewayClient) {
 
       recoveryAtRef.current = recent
       recoverSidRef.current = null
-      patchUiState({ sid: null })
       turnController.pushActivity('gateway exited · /logs to inspect', 'error')
       sys('error: gateway exited')
     }

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -11,6 +11,7 @@ import { setupGracefulExit } from './lib/gracefulExit.js'
 import { formatBytes, type HeapDumpResult, performHeapDump } from './lib/memory.js'
 import { type MemorySnapshot, startMemoryMonitor } from './lib/memoryMonitor.js'
 import { openExternalUrl } from './lib/openExternalUrl.js'
+import { recordParentLifecycle } from './lib/parentLog.js'
 import { clampStdoutDimensions } from './lib/terminalDimensions.js'
 import { resetTerminalModes } from './lib/terminalModes.js'
 
@@ -56,9 +57,14 @@ setupGracefulExit({
   onError: (scope, err) => {
     const message = err instanceof Error ? `${err.name}: ${err.message}\n${err.stack ?? ''}` : String(err)
 
+    recordParentLifecycle(`${scope}: ${message.split('\n')[0]?.slice(0, 400) ?? ''}`)
     process.stderr.write(`hermes-tui lifecycle ${scope}: ${message.slice(0, 2000)}\n`)
   },
   onSignal: signal => {
+    // The next line in the crash log is the child's `=== SIGTERM received ===`
+    // (gw.kill forwards SIGTERM regardless of which signal hit us) — this is
+    // what tells SIGHUP (terminal/SSH dropped) apart from a real SIGTERM.
+    recordParentLifecycle(`graceful-exit received signal=${signal} → killing gateway`)
     resetTerminalModes()
     process.stderr.write(`hermes-tui lifecycle: received ${signal}\n`)
   }
@@ -66,6 +72,10 @@ setupGracefulExit({
 
 const stopMemoryMonitor = startMemoryMonitor({
   onCritical: (snap, dump) => {
+    // process.exit(137) closes the child's stdin → the gateway logs a clean
+    // EOF, NOT SIGTERM. Recording it here is the only way a crash report can
+    // attribute a death to Node OOM rather than a signal-driven kill.
+    recordParentLifecycle(`memory-critical process.exit(137) heap=${formatBytes(snap.heapUsed)} rss=${formatBytes(snap.rss)} dump=${dump?.heapPath ?? 'failed'}`)
     resetTerminalModes()
     process.stderr.write(`hermes-tui lifecycle: memory critical exit heap=${formatBytes(snap.heapUsed)} rss=${formatBytes(snap.rss)}\n`)
     process.stderr.write(dumpNotice(snap, dump))

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -6,6 +6,7 @@ import { createInterface } from 'node:readline'
 
 import type { GatewayEvent } from './gatewayTypes.js'
 import { CircularBuffer } from './lib/circularBuffer.js'
+import { recordParentLifecycle } from './lib/parentLog.js'
 
 const MAX_GATEWAY_LOG_LINES = 200
 const MAX_LOG_LINE_BYTES = 4096
@@ -237,7 +238,7 @@ export class GatewayClient extends EventEmitter {
       // readable on slow boots.
       const stderrTail = this.getLogTail(20)
 
-      this.pushLog(`[startup] timed out waiting for gateway.ready (python=${python}, cwd=${cwd})`)
+      this.lifecycle(`[startup] timed out waiting for gateway.ready (python=${python}, cwd=${cwd})`)
       this.publish({
         type: 'gateway.start_timeout',
         payload: { cwd, python, stderr_tail: stderrTail }
@@ -248,7 +249,7 @@ export class GatewayClient extends EventEmitter {
   private handleTransportExit(code: null | number, reason?: string) {
     this.clearReadyTimer()
     this.closeSidecarSocket()
-    this.pushLog(`[lifecycle] transport exit code=${code ?? 'null'} reason=${reason ?? 'none'}`)
+    this.lifecycle(`[lifecycle] transport exit code=${code ?? 'null'} reason=${reason ?? 'none'}`)
     this.rejectPending(new Error(reason || `gateway exited${code === null ? '' : ` (${code})`}`))
 
     if (this.subscribed) {
@@ -335,7 +336,7 @@ export class GatewayClient extends EventEmitter {
     env.PYTHONPATH = pyPath ? `${root}${delimiter}${pyPath}` : root
     this.startReadyTimer(python, cwd)
     this.proc = spawn(python, ['-m', 'tui_gateway.entry'], { cwd, env, stdio: ['pipe', 'pipe', 'pipe'] })
-    this.pushLog(`[lifecycle] spawned gateway child ${describeChild(this.proc)} python=${python} cwd=${cwd}`)
+    this.lifecycle(`[lifecycle] spawned gateway child ${describeChild(this.proc)} python=${python} cwd=${cwd}`)
 
     this.stdoutRl = createInterface({ input: this.proc.stdout! })
     this.stdoutRl.on('line', raw => {
@@ -372,7 +373,7 @@ export class GatewayClient extends EventEmitter {
 
       const line = `[spawn] ${err.message}`
 
-      this.pushLog(`[lifecycle] child error ${describeChild(ownedProc)} message=${err.message}`)
+      this.lifecycle(`[lifecycle] child error ${describeChild(ownedProc)} message=${err.message}`)
       this.pushLog(line)
       this.publish({ type: 'gateway.stderr', payload: { line } })
       // Detach the reference up front so the late `exit` event for
@@ -396,7 +397,7 @@ export class GatewayClient extends EventEmitter {
         return
       }
 
-      this.pushLog(`[lifecycle] child exit ${describeChild(ownedProc)} code=${code ?? 'null'} signal=${signal ?? 'null'}`)
+      this.lifecycle(`[lifecycle] child exit ${describeChild(ownedProc)} code=${code ?? 'null'} signal=${signal ?? 'null'}`)
       this.handleTransportExit(code)
     })
   }
@@ -507,7 +508,7 @@ export class GatewayClient extends EventEmitter {
     this.resetStartupState()
 
     if (this.proc && !this.proc.killed && this.proc.exitCode === null) {
-      this.pushLog(`[lifecycle] replacing live gateway child ${describeChild(this.proc)}`)
+      this.lifecycle(`[lifecycle] replacing live gateway child ${describeChild(this.proc)}`)
       this.proc.kill()
     }
 
@@ -562,6 +563,14 @@ export class GatewayClient extends EventEmitter {
 
   private pushLog(line: string) {
     this.logs.push(truncateLine(line))
+  }
+
+  // Death-explaining breadcrumbs (spawn / exit / kill / replace) — kept in the
+  // in-memory tail for /logs AND persisted to the gateway crash log so the
+  // reason survives a parent exit and lands next to the child's SIGTERM panic.
+  private lifecycle(line: string) {
+    this.pushLog(line)
+    recordParentLifecycle(line)
   }
 
   private rejectPending(err: Error) {
@@ -717,7 +726,7 @@ export class GatewayClient extends EventEmitter {
     const proc = this.proc
     const killed = proc?.kill()
 
-    this.pushLog(`[lifecycle] GatewayClient.kill reason=${reason} ${describeChild(proc)} killResult=${killed ?? 'none'}`)
+    this.lifecycle(`[lifecycle] GatewayClient.kill reason=${reason} ${describeChild(proc)} killResult=${killed ?? 'none'}`)
     this.closeGatewaySocket()
     this.closeSidecarSocket()
     this.clearReadyTimer()

--- a/ui-tui/src/lib/parentLog.ts
+++ b/ui-tui/src/lib/parentLog.ts
@@ -23,9 +23,11 @@ const CRASH_LOG = join(logDir, 'tui_gateway_crash.log')
 // Skipped under vitest so unit tests exercising start()/kill() can't write into
 // a real ~/.hermes (tests must stay hermetic — see AGENTS.md).
 const enabled = !process.env.VITEST
-// Cap a single breadcrumb, matching GatewayClient's in-memory log-line cap, so
-// a pathological value (e.g. a giant error) can't bloat the shared crash log or
-// add noticeable blocking on the synchronous append during a failure path.
+// Slice a single breadcrumb's value to MAX_BREADCRUMB chars (a short
+// "[truncated …]" marker is appended, so the written line is slightly longer)
+// so a pathological value (e.g. a giant error) can't bloat the shared crash log
+// or add noticeable blocking on the synchronous append. Mirrors the spirit of
+// GatewayClient's in-memory log-line cap.
 const MAX_BREADCRUMB = 4096
 let warned = false
 

--- a/ui-tui/src/lib/parentLog.ts
+++ b/ui-tui/src/lib/parentLog.ts
@@ -1,0 +1,38 @@
+import { appendFileSync, mkdirSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+// Mirror the Python gateway's panic log (tui_gateway/server.py::_CRASH_LOG) from
+// the Node parent so lifecycle breadcrumbs interleave, by timestamp, with the
+// child's `=== SIGTERM received ===` / `=== gateway exit ===` entries.
+//
+// A backend SIGTERM is ALWAYS a parent action — `gw.kill()` (graceful-exit on a
+// signal to Node, or an explicit /quit) or `start()` replacing a live child —
+// but #31051 left those breadcrumbs in an in-memory CircularBuffer that dies
+// with the process, so SIGTERM crash reports arrived with no parent context and
+// no way to tell a signal-driven kill from a memory-critical `process.exit(137)`
+// (which closes the child's stdin → clean EOF, not SIGTERM). Persisting the
+// death-explaining events here is what makes those reports diagnosable.
+const logDir = join(process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes'), 'logs')
+const CRASH_LOG = join(logDir, 'tui_gateway_crash.log')
+
+// Skipped under vitest so unit tests exercising start()/kill() can't write into
+// a real ~/.hermes (tests must stay hermetic — see AGENTS.md).
+const enabled = !process.env.VITEST
+let warned = false
+
+export function recordParentLifecycle(line: string): void {
+  if (!enabled) {
+    return
+  }
+
+  try {
+    mkdirSync(logDir, { recursive: true })
+    appendFileSync(CRASH_LOG, `[tui-parent] ${new Date().toISOString()} ${line}\n`)
+  } catch {
+    if (!warned) {
+      warned = true
+      process.stderr.write('hermes-tui: parent lifecycle log unavailable\n')
+    }
+  }
+}

--- a/ui-tui/src/lib/parentLog.ts
+++ b/ui-tui/src/lib/parentLog.ts
@@ -23,6 +23,10 @@ const CRASH_LOG = join(logDir, 'tui_gateway_crash.log')
 // Skipped under vitest so unit tests exercising start()/kill() can't write into
 // a real ~/.hermes (tests must stay hermetic — see AGENTS.md).
 const enabled = !process.env.VITEST
+// Cap a single breadcrumb, matching GatewayClient's in-memory log-line cap, so
+// a pathological value (e.g. a giant error) can't bloat the shared crash log or
+// add noticeable blocking on the synchronous append during a failure path.
+const MAX_BREADCRUMB = 4096
 let warned = false
 
 export function recordParentLifecycle(line: string): void {
@@ -36,8 +40,11 @@ export function recordParentLifecycle(line: string): void {
     // the child's panic output sharing this file.
     const oneLine = line.replace(/[\r\n]+/g, ' ↵ ')
 
+    const capped =
+      oneLine.length > MAX_BREADCRUMB ? `${oneLine.slice(0, MAX_BREADCRUMB)}… [truncated ${oneLine.length} chars]` : oneLine
+
     mkdirSync(logDir, { recursive: true })
-    appendFileSync(CRASH_LOG, `[tui-parent] ${new Date().toISOString()} ${oneLine}\n`)
+    appendFileSync(CRASH_LOG, `[tui-parent] ${new Date().toISOString()} ${capped}\n`)
   } catch {
     if (!warned) {
       warned = true

--- a/ui-tui/src/lib/parentLog.ts
+++ b/ui-tui/src/lib/parentLog.ts
@@ -13,10 +13,11 @@ import { join } from 'node:path'
 // exactly the point: #31051 left these breadcrumbs in an in-memory CircularBuffer
 // that dies with the process, so SIGTERM crash reports arrived with no parent
 // context. A `[tui-parent]` line immediately before the child's panic means a
-// parent kill; its ABSENCE means an external signal. Persisting the
-// death-explaining events here is what makes that distinction (and a
-// memory-critical `process.exit(137)`, which closes stdin → clean EOF, not
-// SIGTERM) diagnosable after the fact.
+// parent kill; its absence *suggests* an external signal — not definitive,
+// since this logger is best-effort (disabled under VITEST, and a failed append
+// is swallowed). Persisting the death-explaining events here is what makes that
+// distinction (and a memory-critical `process.exit(137)`, which closes stdin →
+// clean EOF, not SIGTERM) diagnosable after the fact.
 const logDir = join(process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes'), 'logs')
 const CRASH_LOG = join(logDir, 'tui_gateway_crash.log')
 

--- a/ui-tui/src/lib/parentLog.ts
+++ b/ui-tui/src/lib/parentLog.ts
@@ -6,13 +6,17 @@ import { join } from 'node:path'
 // the Node parent so lifecycle breadcrumbs interleave, by timestamp, with the
 // child's `=== SIGTERM received ===` / `=== gateway exit ===` entries.
 //
-// A backend SIGTERM is ALWAYS a parent action — `gw.kill()` (graceful-exit on a
-// signal to Node, or an explicit /quit) or `start()` replacing a live child —
-// but #31051 left those breadcrumbs in an in-memory CircularBuffer that dies
-// with the process, so SIGTERM crash reports arrived with no parent context and
-// no way to tell a signal-driven kill from a memory-critical `process.exit(137)`
-// (which closes the child's stdin → clean EOF, not SIGTERM). Persisting the
-// death-explaining events here is what makes those reports diagnosable.
+// A backend SIGTERM is *usually* a parent action — `gw.kill()` (graceful-exit on
+// a signal to Node, or an explicit /quit) or `start()` replacing a live child —
+// but it can also come straight from an external supervisor (s6, a cgroup OOM
+// reaper, a stray `kill`) signalling the child directly. Telling those apart is
+// exactly the point: #31051 left these breadcrumbs in an in-memory CircularBuffer
+// that dies with the process, so SIGTERM crash reports arrived with no parent
+// context. A `[tui-parent]` line immediately before the child's panic means a
+// parent kill; its ABSENCE means an external signal. Persisting the
+// death-explaining events here is what makes that distinction (and a
+// memory-critical `process.exit(137)`, which closes stdin → clean EOF, not
+// SIGTERM) diagnosable after the fact.
 const logDir = join(process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes'), 'logs')
 const CRASH_LOG = join(logDir, 'tui_gateway_crash.log')
 
@@ -27,8 +31,13 @@ export function recordParentLifecycle(line: string): void {
   }
 
   try {
+    // Collapse embedded newlines so a multi-line value (e.g. an error message)
+    // stays one breadcrumb and can't masquerade as a separate log entry or as
+    // the child's panic output sharing this file.
+    const oneLine = line.replace(/[\r\n]+/g, ' ↵ ')
+
     mkdirSync(logDir, { recursive: true })
-    appendFileSync(CRASH_LOG, `[tui-parent] ${new Date().toISOString()} ${line}\n`)
+    appendFileSync(CRASH_LOG, `[tui-parent] ${new Date().toISOString()} ${oneLine}\n`)
   } catch {
     if (!warned) {
       warned = true


### PR DESCRIPTION
## Context

Investigating @Bertl's recurring TUI death reports — gateway dies within minutes of heavy work; CLI is fine in the same env. The shared `tui_gateway_crash.log` always shows the Python side's `=== SIGTERM received ===` with the main thread idle on `sys.stdin`, i.e. **the gateway was killed from outside while perfectly healthy.** A backend SIGTERM is always a parent (Node) action: `gw.kill()` (graceful-exit on a signal to Node — e.g. SSH/terminal drop — or `/quit`) or `start()` replacing a live child. `process.exit(137)` from the memory monitor is the other likely death (closes the child's stdin → clean EOF, not SIGTERM).

## The actual fix (commit 2)

The real pain isn't *that* the gateway got a signal — it's that when it dies the TUI nulls the session and drops to an inert `gateway exited` husk, so the user loses a long session and must restart + re-run everything. **That single behavior is most of the "doesn't survive heavy work" complaint, regardless of the killer.**

The `'exit'` event only reaches the app handler on an **unexpected** death (a user `/quit` calls `process.exit` before it fires; a replaced child is identity-skipped in `GatewayClient`). So on exit we now:

1. respawn the gateway, and
2. resume the session that was live (history is persisted in SQLite) via a one-shot `recoverSidRef` the next `gateway.ready` consults **before** forging a new session.

The in-flight reply is lost (it died with the process) but the session survives — the TUI self-heals instead of stranding the user. Bounded to **3 attempts / 60s** so a gateway that crash-loops on startup can't spawn-storm (past the budget it falls back to the old inert state).

## Diagnostics (commit 1)

#31051 added parent-side lifecycle breadcrumbs but left them in an in-memory `CircularBuffer` that dies with the process, so SIGTERM reports arrive with no parent context (`gateway.log` = "file not found") and no way to tell a signal-driven kill from a memory-critical `process.exit(137)`. We persist the death-explaining breadcrumbs (spawn / transport-exit / child-exit / replace-live-child / kill-reason / startup-timeout) + the graceful-exit signal name + the memory-critical exit into the **same crash log the Python side writes**, so they interleave by timestamp next to the child's panic:

```
[tui-parent] 2026-05-28T14:09:25Z graceful-exit received signal=SIGHUP -> killing gateway
=== SIGTERM received . 2026-05-28 14:09:27 ===   (Python side)
```

That pinpoints SIGHUP (SSH/terminal gone) vs real SIGTERM (s6/cgroup) vs `/quit` vs OOM for the next report — so the *trigger* can be fixed at the source too. Gated off under `VITEST` so tests stay hermetic.

## Changes
- `lib/parentLog.ts` (new) — best-effort sync append to the gateway crash log; `VITEST`-gated.
- `gatewayClient.ts` — route death-explaining breadcrumbs through a `lifecycle()` helper (in-memory **and** persisted).
- `entry.tsx` — record graceful-exit signal, memory-critical `process.exit(137)`, uncaught errors.
- `app/useMainApp.ts` — bounded auto-recovery in the gateway exit handler (`recoverSidRef` + retry budget).
- `app/createGatewayEventHandler.ts` — `gateway.ready` resumes a recovered session before forging a new one.
- `app/interfaces.ts` — optional `recoverSidRef` on the handler context.

## Test plan
- [x] `createGatewayEventHandler.test.ts` — new: gateway.ready after a crash resumes the recovered sid once, skips forge, clears the ref. (50 pass)
- [x] `parentLog.test.ts` — new hermetic: writes timestamped breadcrumb when enabled; no-op + no file under VITEST.
- [x] `gatewayClient.test.ts` — existing lifecycle-tail assertions still pass through `lifecycle()`.
- [x] eslint clean on all changed files; no new typecheck errors.
- [x] Full `ui-tui` suite: 907 pass; only pre-existing failures remain (`virtualHeights.test.ts`, `packages/hermes-ink` typecheck — both reproduce on `main`).