### PR TITLE
fix(google-workspace): remove unsupported metadataHeaders from gws binary path in gmail_reply

### DIFF
--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -366,7 +366,7 @@ def gmail_reply(args):
                 "userId": "me",
                 "id": args.message_id,
                 "format": "metadata",
-                "metadataHeaders": ["From", "Subject", "Message-ID"],
+                
             },
         )
         headers = _headers_dict(original)


### PR DESCRIPTION
## What does this PR do?

In `gmail_reply`, the `_run_gws` binary path passes `metadataHeaders` inside the `params` dict. The `gws` binary does not recognize this key when serialized as `--params` JSON, so the Gmail API returns no headers — causing `_headers_dict` to return an empty dict and losing the `To` and `Subject` fields in the reply.

The Python client path correctly uses `metadataHeaders` as a keyword argument to `.get()`, which works fine and is left unchanged.

**Fix:** Remove `"metadataHeaders"` from the `params` dict in the `_run_gws` call.

## Type of Change
- [x] 🐛 Bug fix

## References
Fixes #34806

## Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains **only** changes related to this fix