### PR TITLE
feat(discord): add guarded server setup actions

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1626,8 +1626,14 @@ DEFAULT_CONFIG = {
         # or YAML list. Unknown names are dropped with a warning at load time.
         # Actions: list_guilds, server_info, list_channels, channel_info,
         # list_roles, member_info, search_members, fetch_messages, list_pins,
-        # pin_message, unpin_message, create_thread, add_role, remove_role.
+        # pin_message, unpin_message, create_thread, create_channel,
+        # create_category, create_role, add_role, remove_role.
         "server_actions": "",
+        # Safety cap for create_role: privileged permission bits (Administrator,
+        # Manage Roles/Guild/Channels/Webhooks, Ban/Kick, Mention Everyone) are
+        # rejected by default even when create_role is allowed. Set true only if
+        # you explicitly want Hermes to be able to mint privileged Discord roles.
+        "allow_privileged_role_perms": False,
         # Accept arbitrary attachment file types (not just SUPPORTED_DOCUMENT_TYPES).
         # When True, any uploaded file is cached to disk with mime
         # application/octet-stream and the path is surfaced to the agent so it

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -12,6 +12,8 @@ from tools.discord_tool import (
     _ACTIONS,
     _ADMIN_ACTIONS,
     _CORE_ACTIONS,
+    _DANGEROUS_ROLE_PERMISSION_BITS,
+    _allow_privileged_role_perms,
     _available_actions,
     _channel_type_name,
     _detect_capabilities,
@@ -830,6 +832,43 @@ class TestConfigAllowlist:
         assert "unexpected type" in caplog.text
 
 
+class TestPrivilegedRolePermsConfig:
+    def test_missing_key_defaults_false(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {}},
+        )
+        assert _allow_privileged_role_perms() is False
+
+    def test_explicit_false(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"allow_privileged_role_perms": False}},
+        )
+        assert _allow_privileged_role_perms() is False
+
+    def test_explicit_true(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"allow_privileged_role_perms": True}},
+        )
+        assert _allow_privileged_role_perms() is True
+
+    @pytest.mark.parametrize("raw", ["true", "false", "1", "0", "yes", 1])
+    def test_non_boolean_values_do_not_enable_override(self, monkeypatch, raw):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"allow_privileged_role_perms": raw}},
+        )
+        assert _allow_privileged_role_perms() is False
+
+    def test_load_failure_fails_closed(self, monkeypatch):
+        def bad_load():
+            raise RuntimeError("disk gone")
+        monkeypatch.setattr("hermes_cli.config.load_config", bad_load)
+        assert _allow_privileged_role_perms() is False
+
+
 # ---------------------------------------------------------------------------
 # Action filtering combines intents + allowlist
 # ---------------------------------------------------------------------------
@@ -1140,3 +1179,162 @@ class TestModelToolsIntegration:
         assert "discord" not in names
         assert "discord_admin" not in names
         assert "discord_server" not in names
+
+# ---------------------------------------------------------------------------
+# Action: create_channel / create_category / create_role
+# ---------------------------------------------------------------------------
+
+class TestServerSetupActions:
+    @patch("tools.discord_tool._discord_request")
+    def test_create_text_channel(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "333", "name": "ai-lab", "type": 0, "parent_id": "222"}
+        result = json.loads(discord_admin_handler(
+            action="create_channel",
+            guild_id="111",
+            name="ai-lab",
+            channel_type="text",
+            parent_id="222",
+            topic="AI experiments",
+        ))
+        assert result == {"success": True, "channel_id": "333", "name": "ai-lab", "type": "text"}
+        mock_req.assert_called_once_with(
+            "POST",
+            "/guilds/111/channels",
+            "test-token",
+            body={"name": "ai-lab", "type": 0, "parent_id": "222", "topic": "AI experiments"},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_category(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "444", "name": "onboarding", "type": 4}
+        result = json.loads(discord_admin_handler(action="create_category", guild_id="111", name="onboarding"))
+        assert result == {"success": True, "channel_id": "444", "name": "onboarding", "type": "category"}
+        mock_req.assert_called_once_with(
+            "POST",
+            "/guilds/111/channels",
+            "test-token",
+            body={"name": "onboarding", "type": 4},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_role(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {}},
+        )
+        mock_req.return_value = {"id": "555", "name": "Family", "permissions": "1024", "mentionable": False}
+        result = json.loads(discord_admin_handler(
+            action="create_role",
+            guild_id="111",
+            name="Family",
+            permissions="1024",
+            mentionable=False,
+        ))
+        assert result == {"success": True, "role_id": "555", "name": "Family", "permissions": "1024"}
+        mock_req.assert_called_once_with(
+            "POST",
+            "/guilds/111/roles",
+            "test-token",
+            body={"name": "Family", "permissions": "1024", "mentionable": False},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_role_blocks_administrator_by_default(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {}},
+        )
+        result = json.loads(discord_admin_handler(
+            action="create_role",
+            guild_id="111",
+            name="Admin-ish",
+            permissions="8",
+        ))
+        assert "error" in result
+        assert "administrator" in result["error"]
+        assert "allow_privileged_role_perms" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_role_blocks_combined_privileged_bits(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {}},
+        )
+        dangerous = str((1 << 3) | (1 << 28))  # administrator + manage_roles
+        result = json.loads(discord_admin_handler(
+            action="create_role",
+            guild_id="111",
+            name="Privileged",
+            permissions=dangerous,
+        ))
+        assert "error" in result
+        assert "administrator" in result["error"]
+        assert "manage_roles" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    @pytest.mark.parametrize("permission_name, permission_bit", sorted(_DANGEROUS_ROLE_PERMISSION_BITS.items()))
+    def test_create_role_blocks_each_dangerous_permission_by_default(
+        self, mock_req, monkeypatch, permission_name, permission_bit,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {}},
+        )
+        result = json.loads(discord_admin_handler(
+            action="create_role",
+            guild_id="111",
+            name="Privileged",
+            permissions=str(permission_bit),
+        ))
+        assert "error" in result
+        assert permission_name in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_role_invalid_permissions_bitset(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(
+            action="create_role",
+            guild_id="111",
+            name="Bad perms",
+            permissions="not-a-number",
+        ))
+        assert "error" in result
+        assert "Invalid permissions bitset" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_role_override_allows_privileged_permissions(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"allow_privileged_role_perms": True}},
+        )
+        mock_req.return_value = {"id": "777", "name": "Ops", "permissions": "8"}
+        result = json.loads(discord_admin_handler(
+            action="create_role",
+            guild_id="111",
+            name="Ops",
+            permissions="8",
+        ))
+        assert result == {"success": True, "role_id": "777", "name": "Ops", "permissions": "8"}
+        mock_req.assert_called_once_with(
+            "POST",
+            "/guilds/111/roles",
+            "test-token",
+            body={"name": "Ops", "permissions": "8", "mentionable": False},
+        )
+
+    def test_missing_name_for_create_channel(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(action="create_channel", guild_id="111"))
+        assert "error" in result
+        assert "name" in result["error"]

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -833,6 +833,46 @@ class TestConfigAllowlist:
 
 
 class TestPrivilegedRolePermsConfig:
+    def test_real_temp_hermes_home_config_enables_override(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "discord:\n  allow_privileged_role_perms: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert _allow_privileged_role_perms() is True
+
+    @patch("tools.discord_tool._discord_request")
+    def test_real_temp_hermes_home_config_controls_create_role_boundary(
+        self, mock_req, tmp_path, monkeypatch,
+    ):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "discord:\n  allow_privileged_role_perms: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "777", "name": "Ops", "permissions": "8"}
+
+        result = json.loads(discord_admin_handler(
+            action="create_role",
+            guild_id="111",
+            name="Ops",
+            permissions="8",
+        ))
+
+        assert result == {"success": True, "role_id": "777", "name": "Ops", "permissions": "8"}
+        mock_req.assert_called_once_with(
+            "POST",
+            "/guilds/111/roles",
+            "test-token",
+            body={"name": "Ops", "permissions": "8", "mentionable": False},
+        )
+
     def test_missing_key_defaults_false(self, monkeypatch):
         monkeypatch.setattr(
             "hermes_cli.config.load_config",

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -466,6 +466,139 @@ def _remove_role(token: str, guild_id: str, user_id: str, role_id: str, **_kwarg
     return json.dumps({"success": True, "message": f"Role {role_id} removed from user {user_id}."})
 
 
+_CREATE_CHANNEL_TYPES = {
+    "text": 0,
+    "voice": 2,
+    "category": 4,
+    "announcement": 5,
+    "stage": 13,
+    "forum": 15,
+}
+
+# Discord permission bits that can create standing server-level power, expose
+# privileged moderation/server data, or materially affect other users when
+# minted into a new role. ``create_role`` rejects these by default; admins who
+# intentionally want the agent to create privileged roles can opt in via
+# ``discord.allow_privileged_role_perms``.
+_DANGEROUS_ROLE_PERMISSION_BITS = {
+    "kick_members": 1 << 1,
+    "ban_members": 1 << 2,
+    "administrator": 1 << 3,
+    "manage_channels": 1 << 4,
+    "manage_guild": 1 << 5,
+    "view_audit_log": 1 << 7,
+    "priority_speaker": 1 << 8,
+    "manage_messages": 1 << 13,
+    "mention_everyone": 1 << 17,
+    "view_guild_insights": 1 << 19,
+    "mute_members": 1 << 22,
+    "deafen_members": 1 << 23,
+    "move_members": 1 << 24,
+    "manage_nicknames": 1 << 27,
+    "manage_roles": 1 << 28,
+    "manage_webhooks": 1 << 29,
+    "manage_expressions": 1 << 30,
+    "manage_events": 1 << 33,
+    "manage_threads": 1 << 34,
+    "moderate_members": 1 << 40,
+    "view_creator_monetization_analytics": 1 << 41,
+    "pin_messages": 1 << 51,
+    "bypass_slowmode": 1 << 52,
+}
+_DANGEROUS_ROLE_PERMISSION_MASK = 0
+for _permission_bit in _DANGEROUS_ROLE_PERMISSION_BITS.values():
+    _DANGEROUS_ROLE_PERMISSION_MASK |= _permission_bit
+
+
+def _create_channel(
+    token: str,
+    guild_id: str,
+    name: str,
+    channel_type: str = "text",
+    parent_id: str = "",
+    topic: str = "",
+    **_kwargs: Any,
+) -> str:
+    """Create a guild channel."""
+    type_id = _CREATE_CHANNEL_TYPES.get((channel_type or "text").lower())
+    if type_id is None:
+        return json.dumps({
+            "error": (
+                f"Unknown channel_type: {channel_type}. "
+                f"Known: {', '.join(_CREATE_CHANNEL_TYPES)}"
+            )
+        })
+    body: Dict[str, Any] = {"name": name, "type": type_id}
+    if parent_id:
+        body["parent_id"] = parent_id
+    if topic and type_id in {0, 5, 15}:
+        body["topic"] = topic
+    channel = _discord_request("POST", f"/guilds/{guild_id}/channels", token, body=body)
+    return json.dumps({
+        "success": True,
+        "channel_id": channel["id"],
+        "name": channel.get("name"),
+        "type": _channel_type_name(channel.get("type", type_id)),
+    })
+
+
+def _create_category(token: str, guild_id: str, name: str, **_kwargs: Any) -> str:
+    """Create a guild category."""
+    channel = _discord_request(
+        "POST", f"/guilds/{guild_id}/channels", token,
+        body={"name": name, "type": 4},
+    )
+    return json.dumps({
+        "success": True,
+        "channel_id": channel["id"],
+        "name": channel.get("name"),
+        "type": _channel_type_name(channel.get("type", 4)),
+    })
+
+
+def _create_role(
+    token: str,
+    guild_id: str,
+    name: str,
+    permissions: str = "0",
+    mentionable: bool = False,
+    **_kwargs: Any,
+) -> str:
+    """Create a guild role."""
+    try:
+        permissions_int = int(str(permissions or "0"))
+    except (TypeError, ValueError):
+        return json.dumps({"error": f"Invalid permissions bitset for create_role: {permissions!r}"})
+
+    blocked = permissions_int & _DANGEROUS_ROLE_PERMISSION_MASK
+    if blocked and not _allow_privileged_role_perms():
+        blocked_names = sorted(
+            name for name, bit in _DANGEROUS_ROLE_PERMISSION_BITS.items()
+            if blocked & bit
+        )
+        return json.dumps({
+            "error": (
+                "Refusing to create a role with privileged permissions by default: "
+                f"{', '.join(blocked_names)}. Set "
+                "discord.allow_privileged_role_perms: true only if you explicitly "
+                "want Hermes to create privileged Discord roles."
+            )
+        })
+
+    body: Dict[str, Any] = {
+        "name": name,
+        "permissions": str(permissions_int),
+        "mentionable": bool(mentionable),
+    }
+    role = _discord_request("POST", f"/guilds/{guild_id}/roles", token, body=body)
+    return json.dumps({
+        "success": True,
+        "role_id": role["id"],
+        "name": role.get("name"),
+        "permissions": str(role.get("permissions", body["permissions"])),
+    })
+
+
 # ---------------------------------------------------------------------------
 # Action dispatch + metadata
 # ---------------------------------------------------------------------------
@@ -486,6 +619,9 @@ _ACTIONS = {
     "create_thread": _create_thread,
     "add_role": _add_role,
     "remove_role": _remove_role,
+    "create_channel": _create_channel,
+    "create_category": _create_category,
+    "create_role": _create_role,
 }
 
 _CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread"})
@@ -511,6 +647,9 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
     ("delete_message", "(channel_id, message_id)", "delete a message"),
     ("create_thread", "(channel_id, name)", "create a public thread; optional message_id anchor"),
+    ("create_channel", "(guild_id, name)", "create a guild channel; optional channel_type, parent_id, topic"),
+    ("create_category", "(guild_id, name)", "create a channel category"),
+    ("create_role", "(guild_id, name)", "create a server role; optional permissions, mentionable"),
     ("add_role", "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", "(guild_id, user_id, role_id)", "remove a role"),
 ]
@@ -532,6 +671,9 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "unpin_message": ["channel_id", "message_id"],
     "delete_message": ["channel_id", "message_id"],
     "create_thread": ["channel_id", "name"],
+    "create_channel": ["guild_id", "name"],
+    "create_category": ["guild_id", "name"],
+    "create_role": ["guild_id", "name"],
     "add_role": ["guild_id", "user_id", "role_id"],
     "remove_role": ["guild_id", "user_id", "role_id"],
 }
@@ -580,6 +722,34 @@ def _load_allowed_actions_config() -> Optional[List[str]]:
             ", ".join(invalid), ", ".join(_ACTIONS.keys()),
         )
     return valid
+
+
+def _allow_privileged_role_perms() -> bool:
+    """Return whether create_role may mint privileged Discord permissions.
+
+    Fail closed: unlike the action schema allowlist, this guards a
+    privilege-granting mutation, so config read failures should not permit
+    privileged role creation.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception as exc:
+        logger.debug(
+            "discord: could not load config (%s); blocking privileged role perms.",
+            exc,
+        )
+        return False
+    raw = (cfg.get("discord") or {}).get("allow_privileged_role_perms", False)
+    if isinstance(raw, bool):
+        return raw
+    if raw not in (None, "", 0):
+        logger.warning(
+            "discord.allow_privileged_role_perms must be a boolean true to enable; "
+            "got %r (%s), blocking privileged role perms.",
+            raw, type(raw).__name__,
+        )
+    return False
 
 
 def _available_actions(
@@ -691,7 +861,32 @@ def _build_schema(
         },
         "name": {
             "type": "string",
-            "description": "New thread name (create_thread).",
+            "description": "New thread/channel/category/role name.",
+        },
+        "channel_type": {
+            "type": "string",
+            "enum": ["text", "voice", "category", "announcement", "stage", "forum"],
+            "description": "Channel type for create_channel (default text).",
+        },
+        "parent_id": {
+            "type": "string",
+            "description": "Parent category ID for create_channel.",
+        },
+        "topic": {
+            "type": "string",
+            "description": "Topic for create_channel text/announcement/forum channels.",
+        },
+        "permissions": {
+            "type": "string",
+            "description": (
+                "Discord permissions bitset string for create_role. Privileged "
+                "permission bits such as Administrator/Manage Roles are rejected "
+                "by default unless discord.allow_privileged_role_perms is true."
+            ),
+        },
+        "mentionable": {
+            "type": "boolean",
+            "description": "Whether the new role is mentionable (create_role).",
         },
         "limit": {
             "type": "integer",
@@ -835,6 +1030,11 @@ def _run_discord_action(
     message_id: str = "",
     query: str = "",
     name: str = "",
+    channel_type: str = "text",
+    parent_id: str = "",
+    topic: str = "",
+    permissions: str = "0",
+    mentionable: bool = False,
     limit: int = 50,
     before: str = "",
     after: str = "",
@@ -872,6 +1072,11 @@ def _run_discord_action(
         "message_id": message_id,
         "query": query,
         "name": name,
+        "channel_type": channel_type,
+        "parent_id": parent_id,
+        "topic": topic,
+        "permissions": permissions,
+        "mentionable": mentionable,
     }
 
     missing = [p for p in _REQUIRED_PARAMS.get(action, []) if not local_vars.get(p)]
@@ -890,6 +1095,11 @@ def _run_discord_action(
             message_id=message_id,
             query=query,
             name=name,
+            channel_type=channel_type,
+            parent_id=parent_id,
+            topic=topic,
+            permissions=permissions,
+            mentionable=mentionable,
             limit=limit,
             before=before,
             after=after,
@@ -922,6 +1132,8 @@ def discord_admin_handler(action: str, **kwargs) -> str:
 _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
     "role_id": "", "message_id": "", "query": "", "name": "",
+    "channel_type": "text", "parent_id": "", "topic": "",
+    "permissions": "0", "mentionable": False,
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
 }
 


### PR DESCRIPTION
## Summary
- Add guarded Discord server setup actions for creating channels, categories, and roles.
- Keep role creation default-deny for privileged/dangerous Discord permission bits.
- Add explicit opt-in via `discord.allow_privileged_role_perms` for callers that intentionally want privileged role creation.
- Cover additional moderation/server-control permission bits in the dangerous mask.

## Test plan
- `python3 -m pytest tests/tools/test_discord_tool.py -q -o 'addopts='`

## Notes
- This is scoped as a new guarded server-setup capability rather than a fix for an existing `create_role` action on `main`.
- The tests include a temp-`HERMES_HOME` path that exercises real config resolution for `discord.allow_privileged_role_perms` while mocking only the outbound Discord REST request.