### PR TITLE
fix: let update cron skip inline gateway restart

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9731,7 +9731,29 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # Auto-restart ALL gateways after update.
         # The code update (git pull) is shared across all profiles, so every
         # running gateway needs restarting to pick up the new code.
+        #
+        # Cron hardening: scheduled auto-update reports may run inside the
+        # gateway-hosted cron scheduler. If `hermes update` restarts the gateway
+        # inline, it kills the cron run before job state/output delivery is
+        # persisted. Let trusted wrapper scripts opt out and schedule a delayed
+        # restart after the report has been delivered.
+        skip_gateway_restart = os.environ.get(
+            "HERMES_UPDATE_SKIP_GATEWAY_RESTART", ""
+        ).strip().lower() in {"1", "true", "yes"}
+
+        class _SkipGatewayRestart(Exception):
+            """Sentinel for wrappers that defer restart until after delivery."""
+
         try:
+            if skip_gateway_restart:
+                print()
+                print(
+                    "ℹ Gateway auto-restart skipped by "
+                    "HERMES_UPDATE_SKIP_GATEWAY_RESTART."
+                )
+                print("  Restart the gateway later to pick up the updated code.")
+                raise _SkipGatewayRestart
+
             from hermes_cli.gateway import (
                 is_macos,
                 supports_systemd_services,
@@ -10249,6 +10271,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
             except Exception as _sweep_exc:
                 logger.debug("Post-restart survivor sweep failed: %s", _sweep_exc)
 
+        except _SkipGatewayRestart:
+            pass
         except Exception as e:
             logger.debug("Gateway restart during update failed: %s", e)
 

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -280,6 +280,38 @@ class TestCmdUpdateBranchFallback:
             assert "applying safe config migrations" in captured.out
             assert "API keys require manual entry" in captured.out
 
+    def test_update_can_skip_gateway_restart_for_cron_wrapper(
+        self, mock_args, capsys, monkeypatch, tmp_path
+    ):
+        """Cron wrappers can defer gateway restart until after delivery persists."""
+        mock_args.gateway = True
+        monkeypatch.setenv("HERMES_UPDATE_SKIP_GATEWAY_RESTART", "1")
+
+        with patch("shutil.which", return_value=None), patch(
+            "subprocess.run"
+        ) as mock_run, patch(
+            "hermes_cli.gateway.find_gateway_pids",
+            side_effect=AssertionError("gateway restart path should be skipped"),
+        ), patch(
+            "hermes_cli.main.get_hermes_home", return_value=tmp_path
+        ), patch(
+            "hermes_cli.main._kill_stale_dashboard_processes"
+        ) as mock_cleanup:
+            mock_run.side_effect = _make_run_side_effect(
+                branch="main", verify_ok=True, commit_count="1"
+            )
+
+            cmd_update(mock_args)
+
+        captured = capsys.readouterr()
+        assert "Gateway auto-restart skipped" in captured.out
+        assert (tmp_path / ".update_exit_code").read_text() == "0"
+        mock_cleanup.assert_called_once()
+        commands = [
+            " ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list
+        ]
+        assert not any("restart" in c and "gateway" in c for c in commands)
+
 
 class TestCmdUpdateMigrationPrompt:
     """The config-migration prompt names what changed and skips the prompt


### PR DESCRIPTION
## Summary
- Add `HERMES_UPDATE_SKIP_GATEWAY_RESTART=1|true|yes` to let update wrappers skip inline gateway restarts.
- Preserve normal update behavior by default.
- Allow gateway-hosted cron update jobs to finish state persistence and delivery before a separately scheduled restart.

## Test plan
- `python -m pytest tests/hermes_cli/test_cmd_update.py::TestCmdUpdateBranchFallback::test_update_can_skip_gateway_restart_for_cron_wrapper tests/hermes_cli/test_cmd_update.py::TestCmdUpdateBranchFallback::test_update_non_interactive_runs_safe_config_migrations -q -o 'addopts='`
