### PR TITLE
fix(whatsapp): make connect timeout configurable

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -27,11 +27,55 @@ import subprocess
 
 _IS_WINDOWS = platform.system() == "Windows"
 from pathlib import Path
-from typing import Dict, Optional, Any
+from typing import Dict, Optional, Any, NamedTuple
 
 from hermes_constants import get_hermes_dir
 
 logger = logging.getLogger(__name__)
+
+_WHATSAPP_CONNECT_TIMEOUT_DEFAULT_SECS = 30.0
+_WHATSAPP_CONNECT_TIMEOUT_GATEWAY_GRACE_SECS = 5.0
+
+
+class ConnectWaitBudget(NamedTuple):
+    total_secs: float
+    http_ready_attempts: int
+    whatsapp_ready_attempts: int
+
+
+def whatsapp_connect_timeout_secs() -> float:
+    """Return the WhatsApp bridge connect timeout budget in seconds."""
+    raw = os.getenv("WHATSAPP_CONNECT_TIMEOUT", "").strip()
+    if raw:
+        try:
+            timeout = float(raw)
+        except ValueError:
+            logger.warning("Ignoring invalid WHATSAPP_CONNECT_TIMEOUT=%r", raw)
+        else:
+            if timeout > 0:
+                return timeout
+            logger.warning("Ignoring non-positive WHATSAPP_CONNECT_TIMEOUT=%r", raw)
+    return _WHATSAPP_CONNECT_TIMEOUT_DEFAULT_SECS
+
+
+def whatsapp_gateway_connect_timeout_secs() -> float:
+    """Return the gateway wait_for timeout for WhatsApp connect()."""
+    return whatsapp_connect_timeout_secs() + _WHATSAPP_CONNECT_TIMEOUT_GATEWAY_GRACE_SECS
+
+
+def _connect_wait_budget() -> ConnectWaitBudget:
+    """Split the WhatsApp connect timeout across bridge and login phases."""
+    total_secs = whatsapp_connect_timeout_secs()
+    per_phase_attempts = max(1, int(round(total_secs / 2)))
+    return ConnectWaitBudget(
+        total_secs=total_secs,
+        http_ready_attempts=per_phase_attempts,
+        whatsapp_ready_attempts=per_phase_attempts,
+    )
+
+
+def _format_timeout_secs(seconds: float) -> str:
+    return f"{seconds:g}s"
 
 
 def _kill_port_process(port: int) -> None:
@@ -670,12 +714,13 @@ class WhatsAppAdapter(BasePlatformAdapter):
             _write_bridge_pidfile(self._session_path, self._bridge_process.pid)
             
             # Wait for the bridge to connect to WhatsApp.
-            # Phase 1: wait for the HTTP server to come up (up to 15s).
-            # Phase 2: wait for WhatsApp status: connected (up to 15s more).
+            # Phase 1: wait for the HTTP server to come up.
+            # Phase 2: wait for WhatsApp status: connected.
+            connect_budget = _connect_wait_budget()
             import aiohttp
             http_ready = False
             data = {}
-            for attempt in range(15):
+            for attempt in range(connect_budget.http_ready_attempts):
                 await asyncio.sleep(1)
                 if self._bridge_process.poll() is not None:
                     print(f"[{self.name}] Bridge process died (exit code {self._bridge_process.returncode})")
@@ -698,7 +743,10 @@ class WhatsAppAdapter(BasePlatformAdapter):
                     continue
 
             if not http_ready:
-                print(f"[{self.name}] Bridge HTTP server did not start in 15s")
+                print(
+                    f"[{self.name}] Bridge HTTP server did not start in "
+                    f"{_format_timeout_secs(connect_budget.http_ready_attempts)}"
+                )
                 print(f"[{self.name}] Check log: {self._bridge_log}")
                 self._close_bridge_log()
                 return False
@@ -707,7 +755,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             # Give it more time to authenticate with saved credentials.
             if data.get("status") != "connected":
                 print(f"[{self.name}] Bridge HTTP ready, waiting for WhatsApp connection...")
-                for attempt in range(15):
+                for attempt in range(connect_budget.whatsapp_ready_attempts):
                     await asyncio.sleep(1)
                     if self._bridge_process.poll() is not None:
                         print(f"[{self.name}] Bridge process died during connection")
@@ -730,7 +778,10 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 else:
                     # Still not connected — warn but proceed (bridge may
                     # auto-reconnect later, e.g. after a code 515 restart).
-                    print(f"[{self.name}] ⚠ WhatsApp not connected after 30s")
+                    print(
+                        f"[{self.name}] ⚠ WhatsApp not connected after "
+                        f"{_format_timeout_secs(connect_budget.total_secs)}"
+                    )
                     print(f"[{self.name}]   Bridge log: {self._bridge_log}")
                     print(f"[{self.name}]   If session expired, re-pair: hermes whatsapp")
             

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2167,8 +2167,13 @@ class GatewayRunner:
                 return max(0.0, timeout)
         return _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT
 
-    def _platform_connect_timeout_secs(self) -> float:
+    def _platform_connect_timeout_secs(self, platform: Optional[Platform] = None) -> float:
         """Return the per-platform connect timeout used during startup/retry."""
+        if platform == Platform.WHATSAPP and os.getenv("WHATSAPP_CONNECT_TIMEOUT", "").strip():
+            from gateway.platforms.whatsapp import whatsapp_gateway_connect_timeout_secs
+
+            return whatsapp_gateway_connect_timeout_secs()
+
         raw = os.getenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "").strip()
         if raw:
             try:
@@ -2184,7 +2189,7 @@ class GatewayRunner:
 
     async def _connect_adapter_with_timeout(self, adapter, platform) -> bool:
         """Connect an adapter without allowing one platform to block others."""
-        timeout = self._platform_connect_timeout_secs()
+        timeout = self._platform_connect_timeout_secs(platform)
         if timeout <= 0:
             return await adapter.connect()
         try:

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -150,6 +150,15 @@ class TestStartupPlatformIsolation:
         with pytest.raises(TimeoutError, match="telegram connect timed out"):
             await runner._connect_adapter_with_timeout(adapter, Platform.TELEGRAM)
 
+    def test_whatsapp_connect_timeout_env_overrides_global_timeout(self, monkeypatch):
+        """WhatsApp can extend cold-start connect timeout without affecting other platforms."""
+        runner = _make_runner()
+        monkeypatch.setenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "30")
+        monkeypatch.setenv("WHATSAPP_CONNECT_TIMEOUT", "60")
+
+        assert runner._platform_connect_timeout_secs(Platform.WHATSAPP) == 65.0
+        assert runner._platform_connect_timeout_secs(Platform.TELEGRAM) == 30.0
+
 
 class TestStartupFailureQueuing:
     """Verify that failed platforms are queued during startup."""

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -104,6 +104,34 @@ def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
 
 
 # ---------------------------------------------------------------------------
+# Configurable connect timeout
+# ---------------------------------------------------------------------------
+
+class TestConnectTimeoutConfig:
+    def test_connect_timeout_default_preserves_15s_per_phase(self, monkeypatch):
+        from gateway.platforms.whatsapp import _connect_wait_budget
+
+        monkeypatch.delenv("WHATSAPP_CONNECT_TIMEOUT", raising=False)
+
+        budget = _connect_wait_budget()
+
+        assert budget.total_secs == 30.0
+        assert budget.http_ready_attempts == 15
+        assert budget.whatsapp_ready_attempts == 15
+
+    def test_connect_timeout_env_extends_each_phase(self, monkeypatch):
+        from gateway.platforms.whatsapp import _connect_wait_budget
+
+        monkeypatch.setenv("WHATSAPP_CONNECT_TIMEOUT", "60")
+
+        budget = _connect_wait_budget()
+
+        assert budget.total_secs == 60.0
+        assert budget.http_ready_attempts == 30
+        assert budget.whatsapp_ready_attempts == 30
+
+
+# ---------------------------------------------------------------------------
 # _close_bridge_log() unit tests
 # ---------------------------------------------------------------------------
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -293,6 +293,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `WHATSAPP_ALLOWED_USERS` | Comma-separated phone numbers (with country code, no `+`), or `*` to allow all senders |
 | `WHATSAPP_ALLOW_ALL_USERS` | Allow all WhatsApp senders without an allowlist (`true`/`false`) |
 | `WHATSAPP_DEBUG` | Log raw message events in the bridge for troubleshooting (`true`/`false`) |
+| `WHATSAPP_CONNECT_TIMEOUT` | WhatsApp bridge cold-start connect budget in seconds (default: `30`); split between bridge HTTP startup and WhatsApp login status polling. |
 | `SIGNAL_HTTP_URL` | signal-cli daemon HTTP endpoint (for example `http://127.0.0.1:8080`) |
 | `SIGNAL_ACCOUNT` | Bot phone number in E.164 format |
 | `SIGNAL_ALLOWED_USERS` | Comma-separated E.164 phone numbers or UUIDs |


### PR DESCRIPTION
## Summary
- Add `WHATSAPP_CONNECT_TIMEOUT` to make the WhatsApp bridge cold-start connect budget configurable.
- Split the configured budget across bridge HTTP startup and WhatsApp login-status polling while preserving the current default 15s + 15s behavior.
- Let the gateway platform connect wrapper honor the WhatsApp-specific timeout with a small grace window so the outer `wait_for()` does not cancel the adapter at the exact internal budget boundary.
- Document the new environment variable.

## Test Plan
- `venv/bin/python -m pytest tests/gateway/test_whatsapp_connect.py tests/gateway/test_platform_reconnect.py -q`
- `venv/bin/python -m ruff check gateway/platforms/whatsapp.py gateway/run.py tests/gateway/test_whatsapp_connect.py tests/gateway/test_platform_reconnect.py`
- `git diff --check`

Closes #35884
