### PR TITLE
fix(api_server): fallback to final response for empty chat streams

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2022,6 +2022,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             last_activity = time.monotonic()
+            streamed_content_parts: list[str] = []
 
             # Role chunk
             role_chunk = {
@@ -2049,6 +2050,8 @@ class APIServerAdapter(BasePlatformAdapter):
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
                     )
                 else:
+                    if isinstance(item, str) and item:
+                        streamed_content_parts.append(item)
                     content_chunk = {
                         "id": completion_id, "object": "chat.completion.chunk",
                         "created": created, "model": model,
@@ -2086,11 +2089,17 @@ class APIServerAdapter(BasePlatformAdapter):
 
             # Get usage from completed agent
             usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            result = {}
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
             except Exception as exc:
                 logger.warning("Agent task %s failed, usage data lost: %s", completion_id, exc)
+
+            final_response = str(result.get("final_response") or "")
+            streamed_content = "".join(streamed_content_parts)
+            if final_response and not streamed_content:
+                last_activity = await _emit(final_response)
 
             # Finish chunk
             finish_chunk = {

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -894,6 +894,88 @@ class TestChatCompletionsEndpoint:
                 assert "Hello!" in body
 
     @pytest.mark.asyncio
+    async def test_stream_falls_back_to_final_response_when_no_deltas(self, adapter):
+        """Regression: streaming clients must receive content even if no deltas fire."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                return (
+                    {"final_response": "pong", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "ping"}],
+                        "stream": True,
+                    },
+                )
+
+            assert resp.status == 200
+            body = await resp.text()
+            assert "[DONE]" in body
+
+            content_chunks = []
+            finish_chunks = []
+            for line in body.splitlines():
+                if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+                    continue
+                chunk = json.loads(line[len("data: "):])
+                choice = chunk["choices"][0]
+                content = choice.get("delta", {}).get("content")
+                if content:
+                    content_chunks.append(content)
+                if choice.get("finish_reason") == "stop":
+                    finish_chunks.append(chunk)
+
+            assert content_chunks == ["pong"]
+            assert finish_chunks[-1]["usage"] == {
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "total_tokens": 12,
+            }
+
+    @pytest.mark.asyncio
+    async def test_stream_final_response_fallback_does_not_duplicate_deltas(self, adapter):
+        """If live content streamed, final_response is not emitted again."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("Hello!")
+                return (
+                    {"final_response": "Hello!", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                )
+
+            assert resp.status == 200
+            body = await resp.text()
+            content_chunks = []
+            for line in body.splitlines():
+                if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+                    continue
+                chunk = json.loads(line[len("data: "):])
+                content = chunk["choices"][0].get("delta", {}).get("content")
+                if content:
+                    content_chunks.append(content)
+
+            assert content_chunks == ["Hello!"]
+
+    @pytest.mark.asyncio
     async def test_stream_string_false_returns_json_completion(self, adapter):
         """Quoted false must not route chat completions into SSE mode."""
         mock_result = {


### PR DESCRIPTION
## What does this PR do?

  Fixes a `/v1/chat/completions` streaming edge case where the API server could return a valid SSE response with only the initial assistant
  role chunk and `[DONE]`, but no assistant `delta.content`, even though the agent produced a final response.

  This affects OpenAI-compatible streaming clients such as Open WebUI, which render that as a blank/no-response assistant message.

  The fix preserves live token streaming when deltas are emitted. It only falls back to sending `final_response` as a final `delta.content`
  chunk when no assistant content was streamed.

  ## Related Issue

  Fixes #

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✅ Tests (adding or improving test coverage)

  ## Changes Made

  - Track assistant content emitted by the chat completions SSE writer.
  - Emit `final_response` before the finish chunk only when no assistant content was streamed.
  - Add regression coverage for no-delta streams.
  - Add coverage that already-streamed deltas are not duplicated by the fallback.

  ## How to Test

  1. Reproduce old behavior against baseline `5921d6678`:
     - streaming request returns `status=200` and `[DONE]`
     - no assistant content chunks are emitted: `content_chunks=[]`

  2. Verify new behavior on this branch:
     - same streaming request returns `content_chunks=['pong']`

  3. Run tests:
     - `./scripts/run_tests.sh tests/gateway/test_api_server.py -- -k 'stream'`
     - `./scripts/run_tests.sh tests/gateway/test_api_server.py`

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide
  - [x] My commit messages follow Conventional Commits
  - [x] My PR contains only changes related to this fix
  - [x] I've run focused tests and the touched test file
  - [x] I've added tests for my changes
  - [x] I've tested on Ubuntu/Linux

  ### Documentation & Housekeeping

  - [x] Documentation update N/A
  - [x] `cli-config.yaml.example` update N/A
  - [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
  - [x] Tool descriptions/schemas update N/A
