### PR TITLE
Fix/systemd restart on failure

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,9 @@
 graft skills
 graft optional-skills
+# Bundled plugin manifests (plugin.yaml / plugin.yml). Without these the
+# PluginManager scan (hermes_cli/plugins.py) finds zero plugins on installs
+# built from the sdist (e.g. Homebrew, downstream packagers). package-data
+# below covers the wheel; this covers the sdist. See #34034 / #28149.
+recursive-include plugins plugin.yaml plugin.yml
 global-exclude __pycache__
 global-exclude *.py[cod]

--- a/acp_registry/agent.json
+++ b/acp_registry/agent.json
@@ -1,16 +1,20 @@
 {
   "id": "hermes-agent",
   "name": "Hermes Agent",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Self-improving open-source AI agent by Nous Research with ACP editor integration, persistent memory, skills, and rich tool support.",
   "repository": "https://github.com/NousResearch/hermes-agent",
   "website": "https://hermes-agent.nousresearch.com/docs/user-guide/features/acp",
-  "authors": ["Nous Research"],
+  "authors": [
+    "Nous Research"
+  ],
   "license": "MIT",
   "distribution": {
     "uvx": {
-      "package": "hermes-agent[acp]==0.15.1",
-      "args": ["hermes-acp"]
+      "package": "hermes-agent[acp]==0.15.2",
+      "args": [
+        "hermes-acp"
+      ]
     }
   }
 }

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,8 +14,8 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.15.1"
-__release_date__ = "2026.5.29"
+__version__ = "0.15.2"
+__release_date__ = "2026.5.29.2"
 
 
 def _ensure_utf8():

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -207,7 +207,7 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
 
     SIGUSR1 is wired in gateway/run.py to ``request_restart(via_service=True)``
     which drains in-flight agent runs (up to ``agent.restart_drain_timeout``
-    seconds), then exits with code 75.  Both systemd (``Restart=always``
+    seconds), then exits with code 75.  Both systemd (``Restart=on-failure``
     + ``RestartForceExitStatus=75``) and launchd (``KeepAlive.SuccessfulExit
     = false``) relaunch the process after the graceful exit.
 
@@ -2217,7 +2217,7 @@ Environment="LOGNAME={username}"
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
-Restart=always
+Restart=on-failure
 RestartSec=5
 RestartMaxDelaySec=300
 RestartSteps=5
@@ -2252,7 +2252,7 @@ WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
-Restart=always
+Restart=on-failure
 RestartSec=5
 RestartMaxDelaySec=300
 RestartSteps=5
@@ -3236,7 +3236,7 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     print()
     
     # Exit with code 1 if gateway fails to connect any platform,
-    # so systemd Restart=always will retry on transient errors
+    # so systemd Restart=on-failure will retry on transient errors
     verbosity = None if quiet else verbose
 
     # ── Exit-path diagnostics ────────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hermes-agent"
-version = "0.15.1"
+version = "0.15.2"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,14 @@ plugins = [
   "*/dashboard/manifest.json",
   "*/dashboard/dist/*",
   "*/dashboard/dist/**/*",
+  # Plugin discovery (hermes_cli/plugins.py) reads a plugin.yaml/plugin.yml
+  # manifest from each bundled plugin directory to register it. Wheels only
+  # carry files declared here, so without this glob the wheel ships every
+  # plugin's Python code but none of its manifests — the scan finds zero
+  # plugins and all gateway platforms fail with "No adapter available for
+  # <platform>" (#34034), web-search providers go missing (#28149), etc.
+  "**/plugin.yaml",
+  "**/plugin.yml",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -20,3 +20,42 @@ def test_manifest_includes_bundled_skills():
 
     assert "graft skills" in manifest
     assert "graft optional-skills" in manifest
+
+
+def test_bundled_plugin_manifests_ship_in_both_wheel_and_sdist():
+    """Regression test for #34034 / #28149.
+
+    Plugin discovery (hermes_cli/plugins.py) registers each bundled plugin by
+    reading its ``plugin.yaml`` / ``plugin.yml`` manifest. Those manifests are
+    data files, not Python modules, so they only reach installed packages when
+    declared explicitly:
+
+    - wheel  -> ``[tool.setuptools.package-data]`` ``plugins`` glob
+    - sdist  -> ``MANIFEST.in`` (Homebrew and other downstream packagers build
+                from the sdist)
+
+    v0.15.0 declared neither, so the wheel shipped every adapter's Python code
+    but none of its manifests, and *every* gateway platform failed with
+    "No adapter available for <platform>". Both channels must cover manifests.
+    """
+    # There must actually be manifests on disk for the globs to match.
+    on_disk = list((REPO_ROOT / "plugins").rglob("plugin.yaml")) + list(
+        (REPO_ROOT / "plugins").rglob("plugin.yml")
+    )
+    assert on_disk, "expected bundled plugin manifests under plugins/"
+
+    # Wheel channel: package-data must declare a glob that matches plugin
+    # manifests anywhere under the plugins package.
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    plugins_pkg_data = data["tool"]["setuptools"]["package-data"].get("plugins", [])
+    assert any(
+        g.endswith("plugin.yaml") or g.endswith("plugin.yml")
+        for g in plugins_pkg_data
+    ), "pyproject package-data 'plugins' must ship plugin.yaml/plugin.yml (wheel)"
+
+    # Sdist channel: MANIFEST.in must recursively include the manifests so
+    # downstream packagers building from the sdist also get them.
+    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    assert "recursive-include plugins" in manifest and "plugin.yaml" in manifest, (
+        "MANIFEST.in must recursive-include plugins plugin.yaml/plugin.yml (sdist)"
+    )


### PR DESCRIPTION
What does this PR do?

Changes Restart=always to Restart=on-failure in the systemd unit templates generated by generate_systemd_unit().

The problem: Restart=always causes systemd to respawn the gateway service immediately after any exit, including the clean SIGTERM exit during system reboot/shutdown. When multiple gateway services are installed (e.g., per-profile gateways), they restart in a loop as fast as systemd can kill them, blocking the shutdown sequence and preventing the system from rebooting.

Why this approach: Restart=on-failure preserves all existing restart behavior for actual failures — crashes (non-zero exit), signal termination, and the existing RestartForceExitStatus=75 mechanism for deliberate graceful restarts via SIGUSR1 — but won't respawn after a clean exit (exit code 0 from SIGTERM during shutdown), so the system can reboot without fighting the service manager.

Related Issue

Fixes # — no existing issue filed. Discovered and fixed while debugging a Debian system with 3 gateway services that couldn't reboot.

Changes Made

- hermes_cli/gateway.py (line 2220): Restart=always → Restart=on-failure in the system-level unit template
- hermes_cli/gateway.py (line 2255): Restart=always → Restart=on-failure in the user-level unit template
- hermes_cli/gateway.py (lines 210, 3239): Updated docstrings/comments referencing Restart=always to match

How to Test

1. Run hermes gateway install — confirm generated unit has Restart=on-failure
2. pytest tests/hermes_cli/test_gateway_service.py -k "systemd" -q — all 40 tests pass
3. pytest tests/hermes_cli/test_gateway.py -q — all 33 tests pass
4. (Manual) On a system with running gateway services: systemctl reboot should complete cleanly