### PR TITLE
fix(file-safety): extend cross-profile guard to cover top-level profile state files

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -421,6 +421,8 @@ def classify_cross_profile_target(path: str) -> Optional[dict]:
         target_profile = parts[1]
         area = parts[2]
 
+    else:
+        return None
     active_profile = _resolve_active_profile_name()
     if target_profile == active_profile:
         # In-profile write — not a cross-profile event.

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -335,6 +335,8 @@ def get_read_block_error(path: str) -> Optional[str]:
 # other code change.
 PROFILE_SCOPED_AREAS = ("skills", "plugins", "cron", "memories")
 
+PROFILE_STATE_FILES = ("SOUL.md", "config.yaml", ".env", "auth.json")
+
 
 def _resolve_active_profile_name() -> str:
     """Return the active profile name derived from HERMES_HOME.
@@ -408,8 +410,16 @@ def classify_cross_profile_target(path: str) -> Optional[dict]:
         # ``<root>/profiles/<name>/<area>/...`` → named profile.
         target_profile = parts[1]
         area = parts[2]
-    else:
-        return None
+    elif parts[0] in PROFILE_STATE_FILES:
+        target_profile = "default"
+        area = parts[0]
+    elif (
+        parts[0] == "profiles"
+        and len(parts) >= 3
+        and parts[2] in PROFILE_STATE_FILES
+    ):
+        target_profile = parts[1]
+        area = parts[2]
 
     active_profile = _resolve_active_profile_name()
     if target_profile == active_profile:
@@ -451,3 +461,4 @@ def get_cross_profile_warning(path: str) -> Optional[str]:
         f"``cross_profile=True``. (Defense-in-depth — not a security "
         f"boundary; the terminal tool can still bypass.)"
     )
+


### PR DESCRIPTION
## What does this PR do?

`classify_cross_profile_target` guarded profile-scoped directories (`skills`, `plugins`, `cron`, `memories`) but not top-level profile state files (`SOUL.md`, `config.yaml`, `.env`, `auth.json`).

This meant an agent running under one profile could silently write to another profile's `SOUL.md` or `config.yaml` without triggering the cross-profile warning — the exact failure mode reported in #32049 (Docker sandbox mirror writes).

**Fix:**
- Add `PROFILE_STATE_FILES = ("SOUL.md", "config.yaml", ".env", "auth.json")` constant
- Extend `classify_cross_profile_target` to detect cross-profile writes targeting these files at both `<root>/SOUL.md` (default profile) and `<root>/profiles/<name>/SOUL.md` (named profile) paths

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## References
Fixes #32049

## Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains **only** changes related to this fix