### PR TITLE
feat(gateway): subscribe chat to tool-created kanban cards (scoped to current turn)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8387,6 +8387,119 @@ class GatewayRunner:
                 pass
         return source
 
+    async def _subscribe_chat_to_kanban_cards(
+        self,
+        source: Any,
+        messages: list[dict],
+        *,
+        turn_start: int = 0,
+    ) -> list[str]:
+        """Subscribe the originating gateway chat to Kanban cards the assistant
+        created via the ``kanban_create`` tool during the current turn.
+
+        Model-issued ``kanban_create`` calls otherwise notify nobody: the
+        ``/kanban create`` slash path subscribes the chat, but a tool call
+        leaves ``kanban_notify_subs`` empty, so the worker's terminal event is
+        delivered to no one. This registers the same subscription the slash
+        path would, using the live gateway ``source``.
+
+        Only messages at/after ``turn_start`` are scanned. Callers pass the
+        agent's ``history_offset`` so we inspect *this* turn's output only: the
+        gateway session transcript is long-lived, and scanning all of it would
+        re-subscribe every previously created card on each new create and
+        replay stale completion notifications.
+        """
+        platform = getattr(source, "platform", None)
+        platform_str = str(getattr(platform, "value", None) or platform or "").lower()
+        chat_id = str(getattr(source, "chat_id", "") or "")
+        if not platform_str or not chat_id:
+            return []
+
+        turn = (messages or [])[turn_start:] if turn_start > 0 else (messages or [])
+
+        # Map each kanban_create tool-call id to the board it targeted (if any).
+        create_boards: dict[str, Optional[str]] = {}
+        for message in turn:
+            if (message or {}).get("role") != "assistant":
+                continue
+            for call in message.get("tool_calls") or []:
+                function = call.get("function") or {}
+                call_id = call.get("id")
+                if function.get("name") != "kanban_create" or not call_id:
+                    continue
+                try:
+                    call_args = json.loads(function.get("arguments") or "{}")
+                except (TypeError, ValueError):
+                    call_args = {}
+                board = call_args.get("board") if isinstance(call_args, dict) else None
+                create_boards[call_id] = str(board) if board else None
+        if not create_boards:
+            return []
+
+        # Collect task ids from the matching successful tool results.
+        pending: list[tuple[str, Optional[str]]] = []
+        for message in turn:
+            if (message or {}).get("role") != "tool":
+                continue
+            call_id = message.get("tool_call_id")
+            if call_id not in create_boards:
+                continue
+            content = message.get("content")
+            try:
+                result = json.loads(content) if isinstance(content, str) else content
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(result, dict) or result.get("error"):
+                continue
+            if not (result.get("ok") is True or result.get("success") is True):
+                continue
+            task_id = result.get("task_id") or result.get("id")
+            if not isinstance(task_id, str) or not task_id.startswith("t_"):
+                continue
+            board = str(result["board"]) if result.get("board") else create_boards[call_id]
+            pending.append((task_id, board))
+
+        pending = list(dict.fromkeys(pending))
+        if not pending:
+            return []
+
+        thread_id = str(getattr(source, "thread_id", "") or "") or None
+        user_id = str(getattr(source, "user_id", "") or "") or None
+        notifier_profile = (
+            getattr(self, "_kanban_notifier_profile", None)
+            or self._active_profile_name()
+        )
+
+        def _persist() -> list[str]:
+            from hermes_cli import kanban_db as _kb
+
+            done: list[str] = []
+            for task_id, board in pending:
+                conn = _kb.connect(board=board)
+                try:
+                    _kb.add_notify_sub(
+                        conn,
+                        task_id=task_id,
+                        platform=platform_str,
+                        chat_id=chat_id,
+                        thread_id=thread_id,
+                        user_id=user_id,
+                        notifier_profile=notifier_profile,
+                    )
+                    done.append(task_id)
+                finally:
+                    conn.close()
+            return done
+
+        subscribed = await asyncio.to_thread(_persist)
+        if subscribed:
+            logger.info(
+                "Auto-subscribed %s chat to %d Kanban card(s) created this "
+                "turn: %s",
+                platform_str, len(subscribed), ", ".join(subscribed),
+            )
+        return subscribed
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -9074,6 +9187,19 @@ class GatewayRunner:
                     "rephrase your question."
                 )
             agent_messages = agent_result.get("messages", [])
+            # Subscribe this chat to Kanban cards the model created THIS turn so
+            # the user is notified when the worker finishes. Scope to the new
+            # messages via history_offset; never re-scan the long-lived session
+            # transcript (that would re-subscribe past cards and replay stale
+            # completions).
+            try:
+                await self._subscribe_chat_to_kanban_cards(
+                    source,
+                    agent_messages,
+                    turn_start=agent_result.get("history_offset", len(history)),
+                )
+            except Exception as _kanban_sub_exc:
+                logger.debug("Kanban auto-subscribe failed: %s", _kanban_sub_exc)
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
             _resp_len = len(response)

--- a/tests/gateway/test_kanban_autosubscribe.py
+++ b/tests/gateway/test_kanban_autosubscribe.py
@@ -1,0 +1,175 @@
+"""Gateway auto-subscription for Kanban cards created via the kanban_create tool.
+
+A model-issued ``kanban_create`` (as opposed to the ``/kanban create`` slash
+command) leaves ``kanban_notify_subs`` empty, so the worker's terminal event is
+delivered to no one. ``GatewayRunner._subscribe_chat_to_kanban_cards`` closes
+that gap, scoped to the current turn so a long-lived session transcript never
+re-subscribes previously created cards.
+"""
+import asyncio
+import json
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+
+
+def _runner():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._kanban_notifier_profile = "main"
+    return runner
+
+
+def _source(platform=Platform.DISCORD, chat_id="chat-1", thread_id="thread-1", user_id="user-1"):
+    return SimpleNamespace(
+        platform=platform, chat_id=chat_id, thread_id=thread_id, user_id=user_id
+    )
+
+
+def _create_msgs(call_id, task_id, *, ok=True, board=None, args=None):
+    result = {"task_id": task_id}
+    result["ok" if ok else "error"] = True if ok else "kanban_create: failed"
+    if board:
+        result["board"] = board
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [{
+                "id": call_id, "type": "function",
+                "function": {"name": "kanban_create",
+                             "arguments": json.dumps(args or {"title": "t", "assignee": "worker"})},
+            }],
+        },
+        {"role": "tool", "tool_call_id": call_id, "content": json.dumps(result)},
+    ]
+
+
+def test_subscribes_card_created_this_turn(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "a.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="tool-created", assignee="worker")
+    finally:
+        conn.close()
+
+    subscribed = asyncio.run(
+        _runner()._subscribe_chat_to_kanban_cards(_source(), _create_msgs("c1", tid))
+    )
+
+    assert subscribed == [tid]
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "discord"
+    assert subs[0]["chat_id"] == "chat-1"
+    assert subs[0]["thread_id"] == "thread-1"
+    assert subs[0]["user_id"] == "user-1"
+    assert subs[0]["notifier_profile"] == "main"
+
+
+def test_turn_start_excludes_prior_turn_cards(tmp_path, monkeypatch):
+    """The key guarantee: cards created in earlier turns of a long-lived
+    session are NOT re-subscribed; only cards at/after ``turn_start`` are."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "b.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        old_tid = kb.create_task(conn, title="old", assignee="worker")
+        new_tid = kb.create_task(conn, title="new", assignee="worker")
+    finally:
+        conn.close()
+
+    # Simulated long-lived transcript: a prior turn that created old_tid, then
+    # this turn (after the second user message) that created new_tid.
+    messages = (
+        [{"role": "user", "content": "first request"}]
+        + _create_msgs("c_old", old_tid)
+        + [{"role": "user", "content": "second request"}]
+        + _create_msgs("c_new", new_tid)
+    )
+    turn_start = 4  # index of the second user message
+
+    subscribed = asyncio.run(
+        _runner()._subscribe_chat_to_kanban_cards(_source(), messages, turn_start=turn_start)
+    )
+
+    assert subscribed == [new_tid]
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, old_tid) == []
+        assert len(kb.list_notify_subs(conn, new_tid)) == 1
+    finally:
+        conn.close()
+
+
+def test_ignores_failed_create(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "c.db"))
+    kb.init_db()
+    subscribed = asyncio.run(
+        _runner()._subscribe_chat_to_kanban_cards(
+            _source(), _create_msgs("c1", "t_deadbeef", ok=False)
+        )
+    )
+    assert subscribed == []
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn) == []
+    finally:
+        conn.close()
+
+
+def test_respects_result_board_field(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    kb._INITIALIZED_PATHS.clear()
+    conn = kb.connect(board="custom-board")
+    try:
+        tid = kb.create_task(conn, title="tool-created", assignee="worker")
+    finally:
+        conn.close()
+
+    subscribed = asyncio.run(
+        _runner()._subscribe_chat_to_kanban_cards(
+            _source(platform=Platform.TELEGRAM, chat_id="tg", thread_id=""),
+            _create_msgs("c1", tid, board="custom-board"),
+        )
+    )
+
+    assert subscribed == [tid]
+    default_conn, custom_conn = kb.connect(), kb.connect(board="custom-board")
+    try:
+        assert kb.list_notify_subs(default_conn) == []
+        subs = kb.list_notify_subs(custom_conn, tid)
+    finally:
+        default_conn.close()
+        custom_conn.close()
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["thread_id"] == ""
+
+
+def test_ignores_malformed_tool_content(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "d.db"))
+    kb.init_db()
+    messages = [
+        {"role": "assistant", "tool_calls": [{
+            "id": "c1", "type": "function",
+            "function": {"name": "kanban_create", "arguments": "{not-json"}}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "{not-json"},
+    ]
+    subscribed = asyncio.run(
+        _runner()._subscribe_chat_to_kanban_cards(_source(), messages)
+    )
+    assert subscribed == []
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn) == []
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

When the assistant creates a Kanban card via the `kanban_create` **tool** (as
opposed to the `/kanban create` slash command), no notification subscription was
registered — `kanban_notify_subs` stayed empty, so the worker's terminal event
was delivered to nobody and the user never heard back.

This subscribes the originating gateway chat to cards created during the
**current turn**, mirroring what the slash-command path already does, using the
live gateway `source` (platform / chat / thread / user / notifier profile).

## Why scope to the current turn?

The gateway session transcript is long-lived. If we scanned the full
`agent_result["messages"]` history on every turn, each new `kanban_create` would
re-subscribe **every previously created card**, and the notifier would replay
their already-delivered terminal events — flooding the chat with stale "done"
notifications on each new request.

`_subscribe_chat_to_kanban_cards` therefore only scans messages at/after
`turn_start`; the caller passes the agent's `history_offset` so we inspect this
turn's output only.

## Relation to #33676

#33676 implements the same feature but scans the entire `messages` list without
a turn boundary, which re-subscribes historical cards in a long-lived gateway
session. This PR is an alternative implementation that adds current-turn scoping
plus regression tests covering it. Happy to fold this into #33676 instead if the
maintainers prefer.

## Tests

`tests/gateway/test_kanban_autosubscribe.py`:
- subscribes a card created this turn (asserts platform/chat/thread/user/profile)
- **does not re-subscribe a card created in a prior turn** (`turn_start`)
- ignores failed `kanban_create` results
- respects the `board` field in the tool result
- ignores malformed tool-call / result JSON
