### PR TITLE
fix(gateway): guard rewrite_transcript behind session rotation check

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8814,6 +8814,12 @@ class GatewayRunner:
                                     skip_memory=True,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
+                                    session_db=self.session_store._db,
+                                    platform=(
+                                        "cli"
+                                        if source.platform == Platform.LOCAL
+                                        else source.platform.value
+                                    ),
                                 )
                                 try:
                                     _hyg_agent._print_fn = lambda *a, **kw: None
@@ -12581,6 +12587,12 @@ class GatewayRunner:
                 skip_memory=True,
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
+                session_db=self.session_store._db,
+                platform=(
+                    "cli"
+                    if source.platform == Platform.LOCAL
+                    else source.platform.value
+                ),
             )
             try:
                 tmp_agent._print_fn = lambda *a, **kw: None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8839,12 +8839,11 @@ class GatewayRunner:
                                             source, session_entry,
                                             reason="hygiene-compression",
                                         )
-
-                                    self.session_store.rewrite_transcript(
-                                        session_entry.session_id, _compressed
-                                    )
-                                    # Reset stored token count — transcript was rewritten
-                                    session_entry.last_prompt_tokens = 0
+                                        self.session_store.rewrite_transcript(
+                                            session_entry.session_id, _compressed
+                                        )
+                                        # Reset stored token count — transcript was rewritten
+                                        session_entry.last_prompt_tokens = 0
                                     history = _compressed
                                     _new_count = len(_compressed)
                                     _new_tokens = estimate_messages_tokens_rough(
@@ -12622,12 +12621,11 @@ class GatewayRunner:
                     self._sync_telegram_topic_binding(
                         source, session_entry, reason="compress-command",
                     )
-
-                self.session_store.rewrite_transcript(new_session_id, compressed)
-                # Reset stored token count — transcript changed, old value is stale
-                self.session_store.update_session(
-                    session_entry.session_key, last_prompt_tokens=0
-                )
+                    self.session_store.rewrite_transcript(new_session_id, compressed)
+                    # Reset stored token count — transcript changed, old value is stale
+                    self.session_store.update_session(
+                        session_entry.session_key, last_prompt_tokens=0
+                    )
                 new_tokens = estimate_request_tokens_rough(
                     compressed, system_prompt=_sys_prompt, tools=_tools
                 )


### PR DESCRIPTION
## What does this PR do?

Fixes a data-loss bug in gateway hygiene compression and the `/compress` command caused by two interacting issues:

1. **`rewrite_transcript` called unconditionally after compression**: When compression aborts (e.g. summary generation fails with `abort_on_summary_failure=true`, or lock contention), `_compress_context()` returns without rotating the session ID — but `rewrite_transcript` was still called, hitting the **original** session with a DELETE+INSERT of the stripped message copy. This permanently discarded tool messages, reasoning fields, and other metadata from the state.db transcript.

2. **Temporary agents lack `session_db`, so rotation never happens**: The hygiene and `/compress` paths create temporary AIAgents without `session_db`. Because the session rotation block is gated on `if agent._session_db:` (L498 in `conversation_compression.py`), rotation was always skipped, and the compressed transcript was always written back to the same session.

**The fix (two parts):**

- **Guard `rewrite_transcript`** behind the existing `if new_session_id != old_session_id` check. No rotation → no rewrite.
- **Pass `session_db`** (and correct `platform`) to both temporary agents so that session rotation happens normally when compression succeeds.

Together these ensure: normal compression → rotation occurs → transcript written to new session; abort → no rotation → transcript untouched.

## Related Issue

N/A (discovered during compression code review)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`gateway/run.py`, four changes:

1. **Hygiene temp agent** (~L8817): add `session_db=self.session_store._db` and `platform=("cli" if source.platform == Platform.LOCAL else source.platform.value)`
2. **Hygiene guard** (~L8848): shift `rewrite_transcript()` + `last_prompt_tokens = 0` into the `if _hyg_new_sid != session_entry.session_id:` block
3. **`/compress` temp agent** (~L12590): same `session_db` + `platform` additions
4. **`/compress` guard** (~L12636): shift `rewrite_transcript()` + `update_session(last_prompt_tokens=0)` into the `if new_session_id != session_entry.session_id:` block

## How to Test

1. All compression-related tests pass: `209 passed` across 16 test files (including `test_compress_command.py`, `test_compression_session_id_persistence.py`, `test_hermes_state_compression_locks.py`, `test_compression_persistence.py`, `test_context_compressor.py`, `test_compression_concurrent_fork.py`, `test_compression_boundary.py`, `test_413_compression.py`, `test_compression_feasibility.py` and others).

2. **To reproduce the original bug:** set `compression.abort_on_summary_failure: true`, trigger hygiene compression (>85% context) with aux model failure. Before fix: original transcript replaced with stripped copy. After fix: transcript stays intact.

3. **Normal hygiene compression:** session now properly rotates, compressed transcript written to new session, old transcript preserved in state.db.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run tests and all pass (209 across compression-related files)
- [ ] I've added tests for my changes (existing tests cover the guard logic; the abort + temp-agent interaction is an integration-level race condition)
- [x] I've tested on my platform: Ubuntu 22.04

### Documentation & Housekeeping

- [x] Docs: N/A
- [x] config.yaml.example: N/A
- [x] CONTRIBUTING.md / AGENTS.md: N/A
- [x] Cross-platform impact: N/A (pure logic fix, no platform-specific code)
- [x] Tool descriptions/schemas: N/A