### PR TITLE
feat(gateway/feishu): render markdown tables via interactive card

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1792,16 +1792,28 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    if msg_type == "interactive":
+                        # A rejected card must not drop the message; fall back to
+                        # plain text so the content still reaches the chat.
+                        logger.warning("[Feishu] Interactive card rejected (%s); falling back to plain text", exc)
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type="text",
+                            payload=json.dumps({"text": chunk}, ensure_ascii=False),
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
+                    elif msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
+                    else:
+                        logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type="text",
+                            payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
                 if (
                     msg_type == "post"
                     and not self._response_succeeded(response)
@@ -4312,8 +4324,17 @@ class FeishuAdapter(BasePlatformAdapter):
         # table content as post causes the message to appear blank on the client.
         # Force plain text for anything that looks like a markdown table.
         if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+            # Feishu 'post' / 'lark_md' elements cannot render markdown tables —
+            # such messages arrive blank on the client, so this path used to
+            # downgrade them to plain text. The interactive-card 'markdown'
+            # component (card schema 2.0) DOES render GFM tables, so send the
+            # content as a card instead of losing the table formatting.
+            card = {
+                "schema": "2.0",
+                "config": {"width_mode": "fill"},
+                "body": {"elements": [{"tag": "markdown", "content": content}]},
+            }
+            return "interactive", json.dumps(card, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/gateway/test_feishu_card_rendering.py
+++ b/tests/gateway/test_feishu_card_rendering.py
@@ -1,0 +1,77 @@
+"""Outbound payload routing for the Feishu adapter.
+
+Feishu 'post' / 'lark_md' elements do not render GFM markdown tables (the
+message arrives blank), so table content used to be downgraded to plain text.
+The interactive-card 'markdown' component (card schema 2.0) renders tables, so
+``_build_outbound_payload`` now routes table content to a card. Non-table
+content is unchanged: markdown -> post, plain -> text.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_feishu_mocks():
+    if importlib.util.find_spec("lark_oapi") is None and "lark_oapi" not in sys.modules:
+        mod = MagicMock()
+        for name in ("lark_oapi", "lark_oapi.api.im.v1",
+                     "lark_oapi.event", "lark_oapi.event.callback_type"):
+            sys.modules.setdefault(name, mod)
+    if importlib.util.find_spec("aiohttp") is None and "aiohttp" not in sys.modules:
+        aio = MagicMock()
+        sys.modules.setdefault("aiohttp", aio)
+        sys.modules.setdefault("aiohttp.web", aio.web)
+
+
+_ensure_feishu_mocks()
+
+from gateway.platforms.feishu import FeishuAdapter
+
+_TABLE = (
+    "## GPU usage\n\n"
+    "| host | util | mem |\n"
+    "|---|---|---|\n"
+    "| mx005 | 7.9% | 95.6% |\n"
+    "| mx006 | 11.4% | 96.6% |\n"
+)
+
+
+def _route(content):
+    # _build_outbound_payload does not touch self; call it unbound.
+    return FeishuAdapter._build_outbound_payload(None, content)
+
+
+def test_table_content_routes_to_interactive_card():
+    msg_type, payload = _route(_TABLE)
+    assert msg_type == "interactive"
+    card = json.loads(payload)
+    assert card["schema"] == "2.0"
+    element = card["body"]["elements"][0]
+    assert element["tag"] == "markdown"
+    # The full markdown (table included) is preserved verbatim in the card.
+    assert element["content"] == _TABLE
+    assert "| host |" in element["content"]
+
+
+def test_table_embedded_in_prose_still_routes_to_card():
+    content = "Here is the report:\n\n" + _TABLE + "\nDone."
+    msg_type, payload = _route(content)
+    assert msg_type == "interactive"
+    assert json.loads(payload)["body"]["elements"][0]["content"] == content
+
+
+def test_non_table_markdown_still_routes_to_post():
+    msg_type, _ = _route("**bold** and a list:\n- one\n- two")
+    assert msg_type == "post"
+
+
+def test_plain_text_stays_text():
+    msg_type, payload = _route("just a plain sentence")
+    assert msg_type == "text"
+    assert json.loads(payload) == {"text": "just a plain sentence"}


### PR DESCRIPTION
## Summary

Feishu `post` / `lark_md` elements cannot render GFM markdown tables — the
message arrives **blank** on the client. `_build_outbound_payload` therefore
downgraded any table content to plain text, losing the table formatting.

The interactive-card `markdown` component (card **schema 2.0**) *does* render
tables, so this routes table content to an interactive card instead. Non-table
content is unchanged:

- markdown (headings/bold/lists/code) → `post` (renders fine today)
- plain text → `text`
- **table content → interactive card 2.0 markdown** (new)

`send()` falls back to plain text if a card payload is rejected by the API, so
a malformed card can never drop the message.

## Tests

`tests/gateway/test_feishu_card_rendering.py`:
- table content → interactive card 2.0 markdown (content preserved verbatim)
- a table embedded in surrounding prose still routes to a card
- non-table markdown still routes to `post` (unchanged)
- plain text stays `text` (unchanged)
