### PR TITLE
test: cover Hermes security regression edges

### DIFF
--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1811,6 +1811,31 @@ def test_dump_api_request_debug_uses_chat_completions_url(monkeypatch, tmp_path)
     assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/chat/completions"
 
 
+def test_dump_api_request_debug_uses_atomic_json_write(monkeypatch, tmp_path):
+    """Request debug dumps should use the shared atomic JSON writer."""
+    import agent.agent_runtime_helpers as helpers
+
+    agent = _build_agent(monkeypatch)
+    agent.base_url = "http://127.0.0.1:9208/v1"
+    agent.logs_dir = tmp_path
+    calls = []
+
+    def fake_atomic_json_write(path, payload, **kwargs):
+        calls.append((path, payload, kwargs))
+        path.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(helpers, "atomic_json_write", fake_atomic_json_write)
+
+    dump_file = agent._dump_api_request_debug(_codex_request_kwargs(), reason="preflight")
+
+    assert dump_file is not None
+    assert calls
+    path, payload, kwargs = calls[0]
+    assert path == dump_file
+    assert payload["reason"] == "preflight"
+    assert kwargs == {"default": str}
+
+
 # --- Reasoning-only response tests (fix for empty content retry loop) ---
 
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -25,6 +25,31 @@ def _reset_signal_scheduler():
     yield
     _reset_scheduler()
 
+
+@pytest.fixture(autouse=True)
+def _reset_cron_auto_delivery_contextvars():
+    """Keep cron-run ContextVars from leaking in from scheduler tests.
+
+    Some scheduler tests call run_job() directly in the pytest task context;
+    run_job() correctly clears cron auto-delivery ContextVars at teardown, but
+    an explicitly cleared ContextVar intentionally suppresses os.environ
+    fallback. send_message tests still exercise the fallback path directly, so
+    each test starts those vars from the never-set sentinel.
+    """
+    from gateway.session_context import _UNSET, _VAR_MAP
+
+    var_names = (
+        "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+        "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+        "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+    )
+    tokens = [_VAR_MAP[name].set(_UNSET) for name in var_names]
+    try:
+        yield
+    finally:
+        for name, token in zip(var_names, tokens):
+            _VAR_MAP[name].reset(token)
+
 from gateway.config import Platform
 from tools.send_message_tool import (
     _is_telegram_thread_not_found,


### PR DESCRIPTION
## Summary
- Adds a regression test that request-debug dumps use the shared atomic JSON writer.
- Resets cron auto-delivery ContextVars in send_message tests so env fallback assertions are isolated from scheduler tests.

## Test Plan
- `/root/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py tests/tools/test_send_message_tool.py -q -o 'addopts='`
- `git diff --check`

## Notes
This is the only still-useful slice from the old security-profile worktree. The implementation changes it originally carried are already represented or superseded on current upstream `main`.
