### PR TITLE
fix(email): handle unknown-8bit charset from QQ Mail in IMAP fetch

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -16,6 +16,7 @@ Environment variables:
 """
 
 import asyncio
+import codecs
 import email as email_lib
 import imaplib
 import logging
@@ -110,15 +111,46 @@ def check_email_requirements() -> bool:
     return True
 
 
-def _decode_header_value(raw: str) -> str:
-    """Decode an RFC 2047 encoded email header into a plain string."""
-    parts = decode_header(raw)
+def _resolve_charset(charset: str | None) -> str:
+    """Normalise a charset name, falling back to utf-8 for unrecognised values.
+
+    Some mail servers (notably QQ Mail) report ``unknown-8bit`` as the charset,
+    which Python's codec registry does not recognise.  We fall back to
+    ``utf-8`` with ``errors="replace"`` so the message is still usable.
+    """
+    if not charset:
+        return "utf-8"
+    charset = charset.strip().lower()
+    # Common non-standard / unrecognised charset names seen in the wild
+    if charset in ("unknown-8bit", "unknown", "x-unknown", "default"):
+        return "utf-8"
+    try:
+        codecs.lookup(charset)
+    except LookupError:
+        return "utf-8"
+    return charset
+
+
+def _decode_header_value(raw) -> str:
+    """Decode an RFC 2047 encoded email header into a plain string.
+
+    *raw* may be a :class:`str`, :class:`bytes`, or an
+    :class:`email.header.Header` object.  The latter can appear when a
+    non-ASCII sender name is encoded by the composing MUA and is not yet
+    decoded by :func:`email.message_from_bytes`.
+    """
+    try:
+        parts = decode_header(raw)
+    except Exception:
+        # If decode_header itself fails (e.g. malformed encoding), return raw
+        return str(raw)
     decoded = []
     for part, charset in parts:
         if isinstance(part, bytes):
-            decoded.append(part.decode(charset or "utf-8", errors="replace"))
+            decoded.append(part.decode(_resolve_charset(charset), errors="replace"))
         else:
-            decoded.append(part)
+            # part may be str or email.header.Header
+            decoded.append(str(part))
     return " ".join(decoded)
 
 
@@ -134,7 +166,7 @@ def _extract_text_body(msg: email_lib.message.Message) -> str:
             if content_type == "text/plain":
                 payload = part.get_payload(decode=True)
                 if payload:
-                    charset = part.get_content_charset() or "utf-8"
+                    charset = _resolve_charset(part.get_content_charset())
                     return payload.decode(charset, errors="replace")
         # Fallback: try text/html and strip tags
         for part in msg.walk():
@@ -145,14 +177,14 @@ def _extract_text_body(msg: email_lib.message.Message) -> str:
             if content_type == "text/html":
                 payload = part.get_payload(decode=True)
                 if payload:
-                    charset = part.get_content_charset() or "utf-8"
+                    charset = _resolve_charset(part.get_content_charset())
                     html = payload.decode(charset, errors="replace")
                     return _strip_html(html)
         return ""
     else:
         payload = msg.get_payload(decode=True)
         if payload:
-            charset = msg.get_content_charset() or "utf-8"
+            charset = _resolve_charset(msg.get_content_charset())
             text = payload.decode(charset, errors="replace")
             if msg.get_content_type() == "text/html":
                 return _strip_html(text)

--- a/tests/gateway/test_email_encoding.py
+++ b/tests/gateway/test_email_encoding.py
@@ -1,0 +1,173 @@
+"""Regression tests for _resolve_charset and _decode_header_value with non-standard charsets.
+
+Covers: #35901 — QQ Mail sends ``unknown-8bit`` charset which crashes IMAP fetch.
+"""
+import codecs
+import email
+from email.header import decode_header
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+import importlib
+import sys
+
+# Ensure the gateway package is importable (it may lack an __init__ in some
+# checkouts, so we add the repo root to sys.path).
+_REPO_ROOT = str(__import__("pathlib").Path(__file__).resolve().parents[2])
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+# The email adapter lives at gateway/platforms/email.py — import via importlib
+# to avoid triggering the full gateway package __init__ (which pulls in heavy
+# deps like aiohttp).
+_mod = importlib.import_module("gateway.platforms.email")
+
+_resolve_charset = _mod._resolve_charset
+_decode_header_value = _mod._decode_header_value
+_extract_text_body = _mod._extract_text_body
+
+
+# ===================================================================
+# _resolve_charset
+# ===================================================================
+class TestResolveCharset:
+    """Unit tests for charset normalisation."""
+
+    def test_none_returns_utf8(self):
+        assert _resolve_charset(None) == "utf-8"
+
+    def test_empty_returns_utf8(self):
+        assert _resolve_charset("") == "utf-8"
+
+    def test_whitespace_only_returns_utf8(self):
+        assert _resolve_charset("   ") == "utf-8"
+
+    def test_unknown_8bit_returns_utf8(self):
+        """The primary fix: QQ Mail's ``unknown-8bit`` charset."""
+        assert _resolve_charset("unknown-8bit") == "utf-8"
+
+    def test_unknown_returns_utf8(self):
+        assert _resolve_charset("unknown") == "utf-8"
+
+    def test_x_unknown_returns_utf8(self):
+        assert _resolve_charset("x-unknown") == "utf-8"
+
+    def test_default_returns_utf8(self):
+        assert _resolve_charset("default") == "utf-8"
+
+    def test_case_insensitive(self):
+        assert _resolve_charset("UNKNOWN-8BIT") == "utf-8"
+        assert _resolve_charset("Unknown-8bit") == "utf-8"
+
+    def test_valid_charset_preserved(self):
+        assert _resolve_charset("utf-8") == "utf-8"
+        assert _resolve_charset("iso-8859-1") == "iso-8859-1"
+        assert _resolve_charset("gbk") == "gbk"
+        assert _resolve_charset("gb2312") == "gb2312"
+
+    def test_arbitrary_invalid_charset_falls_back(self):
+        """Any charset not in codecs registry falls back to utf-8."""
+        assert _resolve_charset("totally-bogus-charset-xyz") == "utf-8"
+
+    def test_codecs_lookup_called(self):
+        """Verify the codecs.lookup path is exercised for non-blocklisted names."""
+        with patch.object(codecs, "lookup", wraps=codecs.lookup) as mock:
+            _resolve_charset("iso-8859-1")
+            mock.assert_called_once_with("iso-8859-1")
+
+
+# ===================================================================
+# _decode_header_value
+# ===================================================================
+class TestDecodeHeaderValue:
+    """Regression tests for header decoding with unusual charsets."""
+
+    def test_plain_ascii(self):
+        assert _decode_header_value("Hello World") == "Hello World"
+
+    def test_rfc2047_utf8(self):
+        raw = "=?utf-8?b?SGVsbG8gV29ybGQ=?="
+        assert _decode_header_value(raw) == "Hello World"
+
+    def test_rfc2047_unknown_8bit(self):
+        """QQ Mail may encode headers with ``unknown-8bit`` charset.
+
+        The raw bytes should still be decoded (via utf-8 fallback) without
+        raising ``LookupError: unknown encoding: unknown-8bit``.
+        """
+        # Construct a header that decode_header() would parse as
+        # (bytes, "unknown-8bit") — simulate QQ Mail behaviour.
+        raw_bytes = "测试"
+        encoded = f"=?unknown-8bit?b?{__import__('base64').b64encode(raw_bytes.encode('utf-8')).decode('ascii')}?="
+        # Should NOT raise
+        result = _decode_header_value(encoded)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_header_object_input(self):
+        """_decode_header_value must accept email.header.Header objects."""
+        h = email.header.Header("测试邮件", charset="utf-8")
+        result = _decode_header_value(h)
+        assert "测试" in result or isinstance(result, str)
+
+    def test_bytes_input(self):
+        """Bytes input triggers TypeError in decode_header; function returns str(raw)."""
+        result = _decode_header_value(b"raw bytes")
+        # str(b"raw bytes") == "b'raw bytes'" — bytes are not a normal input
+        assert isinstance(result, str)
+
+    def test_decode_header_exception_caught(self):
+        """If decode_header itself raises, we should return str(raw)."""
+        with patch("gateway.platforms.email.decode_header", side_effect=Exception("boom")):
+            result = _decode_header_value("something")
+            assert result == "something"
+
+
+# ===================================================================
+# _extract_text_body
+# ===================================================================
+class TestExtractTextBody:
+    """Integration tests for body extraction with non-standard charsets."""
+
+    def _make_email(self, body: bytes, charset: str = "utf-8") -> email.message.Message:
+        """Build a minimal text/plain email with the given body charset."""
+        msg = email.message.Message()
+        msg["Content-Type"] = f"text/plain; charset={charset}"
+        msg.set_payload(body)
+        return msg
+
+    def test_utf8_body(self):
+        body = "Hello, world!".encode("utf-8")
+        msg = self._make_email(body, "utf-8")
+        assert _extract_text_body(msg) == "Hello, world!"
+
+    def test_unknown_8bit_body(self):
+        """Payload declared as ``unknown-8bit`` must not crash."""
+        body = "Hello from QQ Mail".encode("utf-8")
+        msg = self._make_email(body, "unknown-8bit")
+        # Should NOT raise LookupError
+        result = _extract_text_body(msg)
+        assert isinstance(result, str)
+        assert "Hello" in result
+
+    def test_gbk_body(self):
+        """Chinese encoding should still work normally."""
+        body = "你好世界".encode("gbk")
+        msg = self._make_email(body, "gbk")
+        assert "你好" in _extract_text_body(msg)
+
+    def test_multipart_with_unknown_charset(self):
+        """Multipart message with unknown-8bit text/plain part."""
+        outer = email.message.Message()
+        outer["Content-Type"] = "multipart/alternative; boundary=boundary"
+        inner = email.message.Message()
+        inner["Content-Type"] = "text/plain; charset=unknown-8bit"
+        inner.set_payload("Test body".encode("utf-8"))
+        # Manually attach as payload list
+        outer.set_payload([inner])
+        result = _extract_text_body(outer)
+        assert isinstance(result, str)


### PR DESCRIPTION
## What does this PR do?

Fixes `LookupError: unknown encoding: unknown-8bit` when the email gateway fetches messages from QQ Mail (and other servers that report non-standard charsets). The IMAP fetch loop now gracefully handles unrecognised charset names by falling back to UTF-8 with replacement characters.

## Related Issue

Fixes #35901

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/email.py`: Added `_resolve_charset()` helper that validates charset names against `codecs.lookup()` and falls back to `utf-8` for unrecognised values (e.g. `unknown-8bit`, `x-unknown`). Updated `_decode_header_value()` to handle `email.header.Header` objects and catch `decode_header()` exceptions. Updated `_extract_text_body()` to use `_resolve_charset()` for all charset resolution.
- `tests/gateway/test_email_encoding.py`: Added 21 regression tests covering `_resolve_charset()`, `_decode_header_value()`, and `_extract_text_body()` with non-standard charsets.

## How to Test

1. Run `pytest tests/gateway/test_email_encoding.py -v` — all 21 tests should pass
2. Verify the fix against a QQ Mail account: configure `EMAIL_IMAP_HOST=imap.qq.com` and send a test email to the account. The gateway should fetch it without `unknown encoding` errors.
3. Verify existing email providers (Gmail, Outlook) still work normally — the `_resolve_charset()` function passes through valid charsets unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/email.py` — `_resolve_charset()`, `_decode_header_value()`, `_extract_text_body()`
- Blast radius: LOW — changes are isolated to email platform adapter charset handling; no other modules import these private functions
- Related patterns: `_resolve_charset()` follows the same defensive-decode pattern used in `_extract_text_body()` with `errors="replace"` — extends it to also handle LookupError for unknown charset names
