### PR TITLE
fix(discord): add opt-in bot mention fallback

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -786,7 +786,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
+                        if not self._message_mentions_self(message):
                             return
                     # "all" falls through; bot is permitted — skip the
                     # human-user allowlist below (bots aren't in it).
@@ -2223,6 +2223,38 @@ class DiscordAdapter(BasePlatformAdapter):
                 os.unlink(wav_path)
             except OSError:
                 pass
+
+    def _message_mentions_self(self, message) -> bool:
+        """Return True when a Discord message mentions this bot.
+
+        discord.py can miss ``message.mentions`` for bot-authored messages in
+        some gateway/message-content configurations, while ``raw_mentions`` and
+        the literal ``<@id>`` token are still present. Bot admission for
+        DISCORD_ALLOW_BOTS=mentions must therefore check all three sources.
+        """
+        client_user = getattr(self._client, "user", None)
+        self_id = str(getattr(client_user, "id", "")) if client_user else ""
+        if not self_id:
+            return False
+
+        mentioned_ids = {
+            str(getattr(member, "id", ""))
+            for member in getattr(message, "mentions", [])
+            if getattr(member, "id", None) is not None
+        }
+        if self_id in mentioned_ids:
+            return True
+
+        raw_mentions = {
+            str(user_id)
+            for user_id in getattr(message, "raw_mentions", [])
+            if user_id is not None
+        }
+        if self_id in raw_mentions:
+            return True
+
+        content = getattr(message, "content", "") or ""
+        return f"<@{self_id}>" in content or f"<@!{self_id}>" in content
 
     def _is_allowed_user(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -782,11 +782,17 @@ class DiscordAdapter(BasePlatformAdapter):
                 # permitted by DISCORD_ALLOW_BOTS are not rejected for
                 # not being in DISCORD_ALLOWED_USERS (fixes #4466).
                 if getattr(message.author, "bot", False):
-                    allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
+                    allow_bots = self.config.extra.get("allow_bots", "")
+                    if not allow_bots:
+                        allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none")
+                    allow_bots = str(allow_bots).lower().strip()
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
-                        if not self._message_mentions_self(message):
+                        if not self._message_mentions_self(
+                            message,
+                            allow_fallback=self._discord_bot_mention_fallback(),
+                        ):
                             return
                     # "all" falls through; bot is permitted — skip the
                     # human-user allowlist below (bots aren't in it).
@@ -2224,13 +2230,13 @@ class DiscordAdapter(BasePlatformAdapter):
             except OSError:
                 pass
 
-    def _message_mentions_self(self, message) -> bool:
+    def _message_mentions_self(self, message, *, allow_fallback: bool = False) -> bool:
         """Return True when a Discord message mentions this bot.
 
-        discord.py can miss ``message.mentions`` for bot-authored messages in
-        some gateway/message-content configurations, while ``raw_mentions`` and
-        the literal ``<@id>`` token are still present. Bot admission for
-        DISCORD_ALLOW_BOTS=mentions must therefore check all three sources.
+        The primary check uses discord.py's resolved ``message.mentions``.
+        ``allow_fallback`` enables the Discord-platform compatibility fallback
+        for bot-authored messages where Discord preserves ``raw_mentions`` or
+        literal ``<@id>`` text but omits resolved mentions.
         """
         client_user = getattr(self._client, "user", None)
         self_id = str(getattr(client_user, "id", "")) if client_user else ""
@@ -2244,6 +2250,8 @@ class DiscordAdapter(BasePlatformAdapter):
         }
         if self_id in mentioned_ids:
             return True
+        if not allow_fallback:
+            return False
 
         raw_mentions = {
             str(user_id)
@@ -3641,6 +3649,15 @@ class DiscordAdapter(BasePlatformAdapter):
         """Resolve a Discord per-channel prompt, preferring the exact channel over its parent."""
         from gateway.platforms.base import resolve_channel_prompt
         return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
+
+    def _discord_bot_mention_fallback(self) -> bool:
+        """Return whether bot-authored mention checks may use raw/text fallbacks."""
+        configured = self.config.extra.get("bot_mention_fallback")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return os.getenv("DISCORD_BOT_MENTION_FALLBACK", "false").lower() in {"true", "1", "yes", "on"}
 
     def _discord_require_mention(self) -> bool:
         """Return whether Discord channel messages require a bot mention."""

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -5,6 +5,10 @@ import unittest
 from unittest.mock import MagicMock
 
 
+def setUpModule():
+    os.environ.pop("DISCORD_ALLOW_BOTS", None)
+
+
 def _make_author(*, bot: bool = False, is_self: bool = False):
     """Create a mock Discord author."""
     author = MagicMock()
@@ -15,13 +19,14 @@ def _make_author(*, bot: bool = False, is_self: bool = False):
     return author
 
 
-def _make_message(*, author=None, content="hello", mentions=None, is_dm=False):
+def _make_message(*, author=None, content="hello", mentions=None, raw_mentions=None, is_dm=False):
     """Create a mock Discord message."""
     msg = MagicMock()
     msg.author = author or _make_author()
     msg.content = content
     msg.attachments = []
     msg.mentions = mentions or []
+    msg.raw_mentions = raw_mentions or []
     if is_dm:
         import discord
         msg.channel = MagicMock(spec=discord.DMChannel)
@@ -51,7 +56,12 @@ class TestDiscordBotFilter(unittest.TestCase):
             if allow == "none":
                 return False
             elif allow == "mentions":
-                if not client_user or client_user not in message.mentions:
+                from gateway.config import PlatformConfig
+                from plugins.platforms.discord.adapter import DiscordAdapter
+
+                adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+                adapter._client = MagicMock(user=client_user)
+                if not adapter._message_mentions_self(message):
                     return False
             # "all" falls through
         
@@ -96,6 +106,34 @@ class TestDiscordBotFilter(unittest.TestCase):
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, mentions=[our_user])
         self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    def test_allow_bots_mentions_accepts_raw_mentions_without_resolved_mentions(self):
+        """Bot-authored messages can lack resolved mentions but still include raw IDs."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, mentions=[], raw_mentions=[our_user.id])
+        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    def test_allow_bots_mentions_accepts_literal_mention_without_resolved_mentions(self):
+        """Bot-authored messages can preserve literal <@id> text even if mentions is empty."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content=f"ping <@{our_user.id}>", mentions=[], raw_mentions=[])
+        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    def test_allow_bots_mentions_accepts_nickname_literal_mention(self):
+        """Discord nickname mention syntax (<@!id>) should also count."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content=f"ping <@!{our_user.id}>", mentions=[], raw_mentions=[])
+        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    def test_allow_bots_mentions_rejects_literal_mention_for_another_bot(self):
+        """Literal mention fallback must still require this bot's ID."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content="ping <@111111>", mentions=[], raw_mentions=[111111])
+        self.assertFalse(self._run_filter(msg, "mentions", our_user))
 
     def test_default_is_none(self):
         """Default behavior (no env var) should be 'none'."""

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 def setUpModule():
     os.environ.pop("DISCORD_ALLOW_BOTS", None)
+    os.environ.pop("DISCORD_BOT_MENTION_FALLBACK", None)
 
 
 def _make_author(*, bot: bool = False, is_self: bool = False):
@@ -45,7 +46,7 @@ def _make_message(*, author=None, content="hello", mentions=None, raw_mentions=N
 class TestDiscordBotFilter(unittest.TestCase):
     """Test the DISCORD_ALLOW_BOTS filtering logic."""
 
-    def _run_filter(self, message, allow_bots="none", client_user=None):
+    def _run_filter(self, message, allow_bots="none", client_user=None, *, bot_mention_fallback=False):
         """Simulate the on_message filter logic and return whether message was accepted."""
         # Replicate the exact filter logic from discord.py on_message
         if message.author == client_user:
@@ -61,7 +62,7 @@ class TestDiscordBotFilter(unittest.TestCase):
 
                 adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
                 adapter._client = MagicMock(user=client_user)
-                if not adapter._message_mentions_self(message):
+                if not adapter._message_mentions_self(message, allow_fallback=bot_mention_fallback):
                     return False
             # "all" falls through
         
@@ -112,28 +113,66 @@ class TestDiscordBotFilter(unittest.TestCase):
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, mentions=[], raw_mentions=[our_user.id])
-        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+        self.assertFalse(self._run_filter(msg, "mentions", our_user))
+        self.assertTrue(self._run_filter(msg, "mentions", our_user, bot_mention_fallback=True))
 
     def test_allow_bots_mentions_accepts_literal_mention_without_resolved_mentions(self):
         """Bot-authored messages can preserve literal <@id> text even if mentions is empty."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, content=f"ping <@{our_user.id}>", mentions=[], raw_mentions=[])
-        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+        self.assertFalse(self._run_filter(msg, "mentions", our_user))
+        self.assertTrue(self._run_filter(msg, "mentions", our_user, bot_mention_fallback=True))
 
     def test_allow_bots_mentions_accepts_nickname_literal_mention(self):
         """Discord nickname mention syntax (<@!id>) should also count."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, content=f"ping <@!{our_user.id}>", mentions=[], raw_mentions=[])
-        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+        self.assertFalse(self._run_filter(msg, "mentions", our_user))
+        self.assertTrue(self._run_filter(msg, "mentions", our_user, bot_mention_fallback=True))
 
     def test_allow_bots_mentions_rejects_literal_mention_for_another_bot(self):
         """Literal mention fallback must still require this bot's ID."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, content="ping <@111111>", mentions=[], raw_mentions=[111111])
-        self.assertFalse(self._run_filter(msg, "mentions", our_user))
+        self.assertFalse(self._run_filter(msg, "mentions", our_user, bot_mention_fallback=True))
+
+    def test_discord_bot_mention_fallback_defaults_false(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.discord.adapter import DiscordAdapter
+
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+        self.assertFalse(adapter._discord_bot_mention_fallback())
+
+    def test_discord_bot_mention_fallback_reads_platform_config(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.discord.adapter import DiscordAdapter
+
+        adapter = DiscordAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="test-token",
+                extra={"bot_mention_fallback": True},
+            )
+        )
+        self.assertTrue(adapter._discord_bot_mention_fallback())
+
+    def test_discord_bot_mention_fallback_reads_env_when_config_unset(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.discord.adapter import DiscordAdapter
+
+        old = os.environ.get("DISCORD_BOT_MENTION_FALLBACK")
+        os.environ["DISCORD_BOT_MENTION_FALLBACK"] = "true"
+        try:
+            adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+            self.assertTrue(adapter._discord_bot_mention_fallback())
+        finally:
+            if old is None:
+                os.environ.pop("DISCORD_BOT_MENTION_FALLBACK", None)
+            else:
+                os.environ["DISCORD_BOT_MENTION_FALLBACK"] = old
 
     def test_default_is_none(self):
         """Default behavior (no env var) should be 'none'."""

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -282,6 +282,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
+| `DISCORD_BOT_MENTION_FALLBACK` | No | `false` | Compatibility fallback for `DISCORD_ALLOW_BOTS="mentions"`. When `true`, bot-authored messages may match Hermes by `raw_mentions` or literal `<@id>` / `<@!id>` text if Discord does not populate resolved `message.mentions`. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
 | `DISCORD_ALLOWED_CHANNELS` | No | — | Comma-separated channel IDs. When set, the bot **only** responds in these channels (plus DMs if allowed). Overrides `config.yaml` `discord.allowed_channels`. Combine with `DISCORD_IGNORED_CHANNELS` to express allow/deny rules. |
@@ -310,6 +311,8 @@ discord:
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
+  allow_bots: "none"              # "none", "mentions", or "all" for peer bot messages
+  bot_mention_fallback: false     # If true, match peer-bot @mentions from raw IDs/text too
   reactions: true                 # Add emoji reactions during processing
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading


### PR DESCRIPTION
## Summary
- accept peer-bot Discord messages with `allow_bots: "mentions"` using normal resolved mentions by default
- add opt-in `discord.bot_mention_fallback` / `DISCORD_BOT_MENTION_FALLBACK` for raw mention IDs and literal `<@id>` / `<@!id>` text when Discord does not populate `message.mentions`
- document `allow_bots` and the new fallback in the Discord messaging docs

## Test Plan
- `python -m pytest tests/gateway/test_discord_bot_filter.py -q -o 'addopts='` → 15 passed
- `python -m pytest tests/gateway/test_discord_bot_auth_bypass.py tests/gateway/test_discord_free_response.py tests/gateway/test_discord_allowed_mentions.py -q -o 'addopts='` → 64 passed

## Risk
- Low. The raw/text fallback is opt-in and only affects peer-bot messages when Discord bot admission is set to `mentions`; default behavior remains resolved `message.mentions` only.
