### PR TITLE
Make LazyHermes goal handoff executable

### DIFF
--- a/plugins/lazyhermes/NOTICE.md
+++ b/plugins/lazyhermes/NOTICE.md
@@ -1,0 +1,11 @@
+# Notice
+
+This plugin is a Hermes-native adaptation inspired by LazyCodex/OmO:
+
+- Repository: https://github.com/code-yeongyu/lazycodex
+- Reference commit inspected for this port:
+  `3fb8802e314dc0a1f23481dd3782cdca26b92dc2`
+
+The implementation here is not a vendored runtime. It re-implements the
+portable workflow concepts against Hermes' plugin, hook, skill, and LSP
+surfaces.

--- a/plugins/lazyhermes/README.md
+++ b/plugins/lazyhermes/README.md
@@ -1,0 +1,29 @@
+# lazyhermes
+
+Hermes-native retrofit of the LazyCodex/OmO workflow ideas. The plugin keeps
+the useful parts local to Hermes:
+
+- `/ulw-plan` and `/ultrawork-plan` create durable plans in `plans/`, then forward a
+  LazyCodex-style goal bootstrap to the Hermes agent instead of stopping at plan creation.
+- `/ulw-loop` and `/ultrawork-loop` create run state under
+  `.hermes/lazyhermes/runs/` and dispatch the task back to the Hermes agent.
+- `/start-work` opens or dry-runs a plan against a workspace.
+- The `pre_llm_call` hook injects an Ultrawork directive when the user says
+  `ulw` or `ultrawork`. Direct `ulw <task>` prompts also include goal-tool
+  instructions: call `get_goal` first, call `create_goal` only when needed, and
+  reserve `update_goal` for verified completion or a real blocker.
+- Explicit skills are available as `lazyhermes:ultrawork`, `lazyhermes:rules`,
+  and `lazyhermes:lsp`.
+
+Enable with:
+
+```yaml
+plugins:
+  enabled:
+    - lazyhermes
+```
+
+## Reference
+
+Inspired by `code-yeongyu/lazycodex` and its bundled OmO plugin layout. This
+port does not execute `bunx`, `omo`, or any external prompt-runtime installer.

--- a/plugins/lazyhermes/__init__.py
+++ b/plugins/lazyhermes/__init__.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import core
+
+
+def register(ctx) -> None:
+    base = Path(__file__).resolve().parent
+
+    ctx.register_hook("pre_llm_call", core.pre_llm_call)
+
+    ctx.register_command(
+        "ulw-plan",
+        core.command_ulw_plan,
+        description="Create a durable Ultrawork implementation plan",
+        args_hint='"what to build"',
+    )
+    ctx.register_command(
+        "ultrawork-plan",
+        core.command_ulw_plan,
+        description="Alias for /ulw-plan",
+        args_hint='"what to build"',
+    )
+    ctx.register_command(
+        "ulw",
+        core.command_ulw,
+        description="Start an Ultrawork run and execute the task immediately",
+        args_hint='"task" [--completion-promise TEXT] [--strategy reset|continue]',
+    )
+    ctx.register_command(
+        "ulw-loop",
+        core.command_ulw_loop,
+        description="Start an Ultrawork run and execute the task immediately",
+        args_hint='"task" [--completion-promise TEXT] [--strategy reset|continue]',
+    )
+    ctx.register_command(
+        "ultrawork-loop",
+        core.command_ulw_loop,
+        description="Alias for /ulw-loop",
+        args_hint='"task" [--completion-promise TEXT] [--strategy reset|continue]',
+    )
+    ctx.register_command(
+        "start-work",
+        core.command_start_work,
+        description="Open or dry-run a LazyHermes plan against a workspace",
+        args_hint="[plan-name] [--worktree PATH] [--dry-run]",
+    )
+
+    ctx.register_skill(
+        "ultrawork",
+        base / "skills" / "ultrawork" / "SKILL.md",
+        "Hermes-native Ultrawork execution discipline.",
+    )
+    ctx.register_skill(
+        "rules",
+        base / "skills" / "rules" / "SKILL.md",
+        "Read and apply repo-local Hermes guidance files.",
+    )
+    ctx.register_skill(
+        "lsp",
+        base / "skills" / "lsp" / "SKILL.md",
+        "Use Hermes' native LSP diagnostics and symbol tooling.",
+    )

--- a/plugins/lazyhermes/core.py
+++ b/plugins/lazyhermes/core.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+import json
+import re
+import shlex
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+try:
+    from hermes_constants import get_hermes_home
+except Exception:
+    import os
+
+    def get_hermes_home() -> Path:
+        val = (os.environ.get("HERMES_HOME") or "").strip()
+        return Path(val).expanduser() if val else Path.home() / ".hermes"
+
+
+ULTRAWORK_PATTERN = re.compile(r"\b(?:ultrawork|ulw)\b", re.IGNORECASE)
+DIRECT_ULW_PATTERN = re.compile(r"^\s*(?:ulw|ultrawork)\b\s+(?P<task>.+?)\s*$", re.IGNORECASE | re.DOTALL)
+_SLUG_PATTERN = re.compile(r"[^a-z0-9]+")
+
+ULTRAWORK_CONTEXT = "\n".join(
+    [
+        "<lazyhermes-ultrawork>",
+        "The user invoked Ultrawork/LazyHermes. Operate in a durable, evidence-first loop:",
+        "- restate the concrete completion promise before changing files;",
+        "- keep the implementation scoped to the current repository and existing Hermes patterns;",
+        "- use focused tests and manual verification evidence before claiming done;",
+        "- preserve unrelated user changes and avoid destructive git commands;",
+        "- keep local state, plans, and evidence under plans/ or .hermes/lazyhermes when useful.",
+        "",
+        "<lazyhermes-goal-bootstrap>",
+        "When this turn has a concrete objective, reflect LazyCodex goal semantics through model-facing tools:",
+        "- First call get_goal.",
+        "- If no active goal exists, call create_goal with objective and status only.",
+        '- The create_goal payload shape is exactly: {"objective": "<current concrete objective>", "status": "active"}.',
+        "- If get_goal reports the same objective as active, continue without creating a duplicate.",
+        "- Use update_goal only after verified completion or a real unrecoverable blocker.",
+        "</lazyhermes-goal-bootstrap>",
+        "</lazyhermes-ultrawork>",
+    ]
+)
+
+
+@dataclass(frozen=True)
+class CommandArgs:
+    positional: list[str]
+    options: dict[str, str | bool]
+
+
+def slugify(text: str, fallback: str = "lazyhermes-plan") -> str:
+    lowered = text.strip().lower()
+    slug = _SLUG_PATTERN.sub("-", lowered).strip("-")
+    return (slug[:60].strip("-") or fallback)
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def run_id(prefix: str = "run") -> str:
+    return f"{prefix}-{utc_now().strftime('%Y%m%dT%H%M%SZ')}-{uuid.uuid4().hex[:8]}"
+
+
+def parse_args(raw_args: str) -> CommandArgs:
+    try:
+        tokens = shlex.split(raw_args or "")
+    except ValueError as exc:
+        raise ValueError(f"could not parse arguments: {exc}") from exc
+
+    positional: list[str] = []
+    options: dict[str, str | bool] = {}
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if not token.startswith("--"):
+            positional.append(token)
+            i += 1
+            continue
+
+        key_value = token[2:]
+        if not key_value:
+            i += 1
+            continue
+        if "=" in key_value:
+            key, value = key_value.split("=", 1)
+            options[key] = value
+            i += 1
+            continue
+        key = key_value
+        if i + 1 < len(tokens) and not tokens[i + 1].startswith("--"):
+            options[key] = tokens[i + 1]
+            i += 2
+        else:
+            options[key] = True
+            i += 1
+
+    return CommandArgs(positional=positional, options=options)
+
+
+def workspace_from_option(value: str | bool | None) -> Path:
+    if isinstance(value, str) and value.strip():
+        return Path(value).expanduser().resolve()
+    return Path.cwd().resolve()
+
+
+def plan_dir(workspace: Path) -> Path:
+    return workspace / "plans"
+
+
+def lazyhermes_dir(workspace: Path) -> Path:
+    return workspace / ".hermes" / "lazyhermes"
+
+
+def event_log_path() -> Path:
+    return get_hermes_home() / "lazyhermes" / "events.jsonl"
+
+
+def append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def record_event(event: str, **fields: Any) -> None:
+    payload = {
+        "event": event,
+        "timestamp": utc_now().isoformat(),
+        **fields,
+    }
+    try:
+        append_jsonl(event_log_path(), payload)
+    except OSError:
+        pass
+
+
+def pre_llm_call(**kwargs: Any) -> dict[str, str] | None:
+    user_message = str(kwargs.get("user_message") or "")
+    if "<lazyhermes-run-context>" in user_message:
+        return None
+    if not ULTRAWORK_PATTERN.search(user_message):
+        return None
+    direct = DIRECT_ULW_PATTERN.match(user_message)
+    run_context = ""
+    if direct:
+        task = direct.group("task").strip()
+        if task:
+            workspace = Path.cwd().resolve()
+            run_dir = write_run_state(
+                workspace,
+                task=task,
+                command="ulw",
+            )
+            run_context = "\n\n" + build_run_agent_message(load_run_state(run_dir))
+    record_event(
+        "ultrawork_trigger",
+        session_id=str(kwargs.get("session_id") or ""),
+        platform=str(kwargs.get("platform") or ""),
+    )
+    return {"context": ULTRAWORK_CONTEXT + run_context}
+
+
+def build_goal_instruction(
+    objective: str,
+    *,
+    plan: Path | None = None,
+    workspace: Path | None = None,
+) -> str:
+    objective = objective.strip() or "Complete the requested LazyHermes task with evidence."
+    create_goal = {
+        "objective": objective,
+        "status": "active",
+    }
+    plan_line = f"Plan: {plan}" if plan else "Plan: none"
+    workspace_line = f"Workspace: {workspace}" if workspace else "Workspace: current"
+    return "\n".join(
+        [
+            "<lazyhermes-goal-instruction>",
+            "LazyCodex-style Codex goal handoff for Hermes.",
+            workspace_line,
+            plan_line,
+            "",
+            "Codex goal integration constraints:",
+            "- Do not type /goal and do not stop after creating a local LazyHermes plan.",
+            "- First call get_goal. If no active goal exists, call create_goal with the payload below.",
+            "- If get_goal reports the same objective as active, continue without creating a duplicate.",
+            "- If get_goal reports a different active goal, finish or checkpoint it before starting this plan.",
+            "- Keep goals unlimited; do not add numeric budgets or limits.",
+            "- Call update_goal({\"status\": \"complete\"}) only after the requested work is implemented, tested, and manually verified.",
+            "- If blocked, preserve evidence and call update_goal({\"status\": \"blocked\"}) only when no meaningful recovery path remains.",
+            "",
+            "create_goal payload:",
+            json.dumps(create_goal, indent=2, sort_keys=True),
+            "</lazyhermes-goal-instruction>",
+        ]
+    )
+
+
+def create_plan(brief: str, workspace: Path | None = None) -> Path:
+    brief = brief.strip()
+    if not brief:
+        raise ValueError('usage: /ulw-plan "what to build"')
+
+    root = (workspace or Path.cwd()).resolve()
+    out_dir = plan_dir(root)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / f"{slugify(brief)}.md"
+    if path.exists():
+        path = out_dir / f"{slugify(brief)}-{utc_now().strftime('%H%M%S')}.md"
+
+    now = utc_now().isoformat()
+    content = "\n".join(
+        [
+            f"# {brief}",
+            "",
+            f"Created: {now}",
+            "Source: lazyhermes",
+            "",
+            "## Completion Promise",
+            "",
+            "- [ ] Define the user-visible outcome in one sentence.",
+            "",
+            "## Constraints",
+            "",
+            "- [ ] Preserve unrelated user changes.",
+            "- [ ] Prefer existing Hermes patterns and local APIs.",
+            "- [ ] Keep LazyHermes state local to this workspace.",
+            "",
+            "## Implementation Steps",
+            "",
+            "- [ ] Inspect the relevant files and tests.",
+            "- [ ] Make the smallest coherent implementation.",
+            "- [ ] Add or update focused tests.",
+            "- [ ] Run targeted verification and capture evidence.",
+            "",
+            "## Verification Evidence",
+            "",
+            "- [ ] Record commands, outputs, screenshots, or manual checks needed to trust the result.",
+            "",
+        ]
+    )
+    path.write_text(content, encoding="utf-8")
+    record_event("plan_created", workspace=str(root), plan=str(path), brief=brief)
+    return path
+
+
+def unchecked_items(markdown: str) -> list[str]:
+    items: list[str] = []
+    for line in markdown.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("- [ ] "):
+            items.append(stripped[6:].strip())
+    return items
+
+
+def find_plan(name: str, workspace: Path) -> Path | None:
+    plans = plan_dir(workspace)
+    if not plans.exists():
+        return None
+
+    raw = name.strip()
+    if not raw:
+        candidates = sorted(plans.glob("*.md"), key=lambda p: p.stat().st_mtime, reverse=True)
+        return candidates[0] if candidates else None
+
+    direct = Path(raw).expanduser()
+    if direct.exists():
+        return direct.resolve()
+
+    slug = slugify(raw, fallback=raw)
+    candidates = [
+        plans / raw,
+        plans / f"{raw}.md",
+        plans / slug,
+        plans / f"{slug}.md",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate.resolve()
+    return None
+
+
+def write_run_state(
+    workspace: Path,
+    *,
+    task: str,
+    command: str,
+    plan: Path | None = None,
+    completion_promise: str = "",
+    strategy: str = "continue",
+) -> Path:
+    rid = run_id("lazyhermes")
+    run_dir = lazyhermes_dir(workspace) / "runs" / rid
+    evidence_dir = run_dir / "evidence"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    state = {
+        "run_id": rid,
+        "created_at": utc_now().isoformat(),
+        "workspace": str(workspace),
+        "command": command,
+        "task": task,
+        "completion_promise": completion_promise,
+        "strategy": strategy,
+        "plan": str(plan) if plan else "",
+        "evidence_dir": str(evidence_dir),
+    }
+    (run_dir / "state.json").write_text(
+        json.dumps(state, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    append_jsonl(run_dir / "ledger.jsonl", {"event": "run_started", **state})
+    record_event("run_started", workspace=str(workspace), command=command, run_id=rid)
+    return run_dir
+
+
+def load_run_state(run_dir: Path) -> dict[str, Any]:
+    return json.loads((run_dir / "state.json").read_text(encoding="utf-8"))
+
+
+def build_run_agent_message(state: dict[str, Any]) -> str:
+    plan_line = f"\nPlan: {state['plan']}" if state.get("plan") else ""
+    promise = state.get("completion_promise") or "Complete the requested task with evidence."
+    plan_path = Path(state["plan"]) if state.get("plan") else None
+    workspace = Path(state["workspace"]) if state.get("workspace") else None
+    return "\n".join(
+        [
+            state["task"],
+            "",
+            build_goal_instruction(state["task"], plan=plan_path, workspace=workspace),
+            "",
+            "<lazyhermes-run-context>",
+            f"run_id: {state['run_id']}",
+            f"workspace: {state['workspace']}",
+            f"evidence_dir: {state['evidence_dir']}",
+            f"ledger: {Path(state['evidence_dir']).parent / 'ledger.jsonl'}",
+            f"strategy: {state['strategy']}",
+            f"completion_promise: {promise}",
+            f"task: {state['task']}{plan_line}",
+            "",
+            "Execute this LazyHermes request now. Inspect the workspace as needed,",
+            "keep useful evidence under evidence_dir, append meaningful progress to the ledger,",
+            "and answer the user with the result instead of stopping after run creation.",
+            "</lazyhermes-run-context>",
+        ]
+    )
+
+
+def build_dispatch_result(run_dir: Path, *, display: str) -> dict[str, str]:
+    state = load_run_state(run_dir)
+    return {
+        "display": display,
+        "agent_message": build_run_agent_message(state),
+        "run_dir": str(run_dir),
+    }
+
+
+def _join_positional(positional: Iterable[str]) -> str:
+    return " ".join(part for part in positional if part).strip()
+
+
+def build_plan_agent_message(brief: str, plan: Path, workspace: Path) -> str:
+    return "\n".join(
+        [
+            brief,
+            "",
+            build_goal_instruction(brief, plan=plan, workspace=workspace),
+            "",
+            "<lazyhermes-plan-context>",
+            f"workspace: {workspace}",
+            f"plan: {plan}",
+            "",
+            "Execute this LazyHermes plan now. Use the plan as a durable artifact,",
+            "but drive the actual Codex goal loop through the model-facing goal tools",
+            "before implementation and after verification.",
+            "</lazyhermes-plan-context>",
+        ]
+    )
+
+
+def command_ulw_plan(raw_args: str) -> dict[str, str]:
+    args = parse_args(raw_args)
+    workspace = workspace_from_option(args.options.get("worktree"))
+    brief = _join_positional(args.positional)
+    path = create_plan(brief, workspace)
+    return {
+        "display": f"Created LazyHermes plan: {path}\nForwarding goal bootstrap to Hermes agent now.",
+        "agent_message": build_plan_agent_message(brief, path, workspace),
+        "plan": str(path),
+    }
+
+
+def _command_ulw_dispatch(raw_args: str, *, command: str) -> dict[str, str]:
+    args = parse_args(raw_args)
+    workspace = workspace_from_option(args.options.get("worktree"))
+    task = _join_positional(args.positional)
+    if not task:
+        raise ValueError('usage: /ulw-loop "task" [--completion-promise TEXT] [--strategy reset|continue]')
+    completion = str(args.options.get("completion-promise") or "")
+    strategy = str(args.options.get("strategy") or "continue")
+    if strategy not in {"continue", "reset"}:
+        raise ValueError("--strategy must be either 'continue' or 'reset'")
+    run_dir = write_run_state(
+        workspace,
+        task=task,
+        command=command,
+        completion_promise=completion,
+        strategy=strategy,
+    )
+    promise = f"\nCompletion promise: {completion}" if completion else ""
+    display = (
+        f"Started LazyHermes Ultrawork run: {run_dir}"
+        f"{promise}\nForwarding task to Hermes agent now."
+    )
+    return build_dispatch_result(run_dir, display=display)
+
+
+def command_ulw_loop(raw_args: str) -> dict[str, str]:
+    return _command_ulw_dispatch(raw_args, command="ulw-loop")
+
+
+def command_ulw(raw_args: str) -> dict[str, str]:
+    return _command_ulw_dispatch(raw_args, command="ulw")
+
+
+def command_start_work(raw_args: str) -> str:
+    args = parse_args(raw_args)
+    workspace = workspace_from_option(args.options.get("worktree"))
+    plan_name = _join_positional(args.positional)
+    plan = find_plan(plan_name, workspace)
+    if plan is None:
+        raise ValueError(f"no plan found for '{plan_name or 'latest'}' in {plan_dir(workspace)}")
+
+    text = plan.read_text(encoding="utf-8")
+    open_items = unchecked_items(text)
+    if args.options.get("dry-run"):
+        preview = "\n".join(f"- {item}" for item in open_items[:8]) or "- no unchecked items found"
+        return f"LazyHermes dry-run for {plan}:\n{preview}"
+
+    run_dir = write_run_state(
+        workspace,
+        task=f"Start work from {plan.name}",
+        command="start-work",
+        plan=plan,
+    )
+    first_items = "\n".join(f"- {item}" for item in open_items[:5]) or "- no unchecked items found"
+    return (
+        f"Started LazyHermes work run: {run_dir}\n"
+        f"Plan: {plan}\n"
+        f"Open items:\n{first_items}"
+    )

--- a/plugins/lazyhermes/plugin.yaml
+++ b/plugins/lazyhermes/plugin.yaml
@@ -1,0 +1,8 @@
+name: lazyhermes
+version: 0.1.0
+description: "Hermes-native LazyCodex/OmO workflow retrofit: ultrawork commands, skills, and prompt steering."
+author: "Hermes Agent"
+kind: standalone
+auto_load: true
+hooks:
+  - pre_llm_call

--- a/plugins/lazyhermes/skills/lsp/SKILL.md
+++ b/plugins/lazyhermes/skills/lsp/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: lsp
+description: Use Hermes' native LSP diagnostics and symbols instead of launching a separate Codex LSP service.
+---
+
+# LazyHermes LSP
+
+Use Hermes' existing LSP support for code intelligence. Prefer the repo's
+native diagnostics, symbol lookup, and file operation tools before adding
+new parsing scripts.
+
+For a LazyHermes retrofit, this skill means:
+
+1. Reuse `agent/lsp` and Hermes file operations.
+2. Run targeted diagnostics for files you change when the project supports it.
+3. Treat LSP findings as evidence to combine with tests, not as a replacement
+   for behavioral verification.

--- a/plugins/lazyhermes/skills/rules/SKILL.md
+++ b/plugins/lazyhermes/skills/rules/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: rules
+description: Read and apply repo-local Hermes guidance files before changing code.
+---
+
+# LazyHermes Rules
+
+Before editing, inspect the nearest relevant guidance files such as
+`AGENTS.md`, `CLAUDE.md`, `HERMES.md`, `README.md`, and repo-local handoff
+documents when they exist.
+
+Apply guidance in this order:
+
+1. Current user instruction.
+2. Repo-local guidance closest to the files being changed.
+3. Existing code style and test patterns.
+4. LazyHermes workflow defaults.
+
+Never revert unrelated user work. If guidance conflicts, follow the more
+specific current instruction and call out the conflict.

--- a/plugins/lazyhermes/skills/ultrawork/SKILL.md
+++ b/plugins/lazyhermes/skills/ultrawork/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: ultrawork
+description: Hermes-native Ultrawork execution discipline for durable, evidence-backed implementation.
+---
+
+# LazyHermes Ultrawork
+
+Use this skill when the user invokes `ulw`, `ultrawork`, `/ulw-loop`, or asks
+for an implementation to be carried through with strong verification.
+
+1. State the completion promise in concrete user-visible terms.
+2. Preserve unrelated user changes and work inside the active repository.
+3. Keep a short checklist for multi-step work.
+4. Prefer existing Hermes APIs, plugins, skills, and LSP support over new sidecars.
+5. Add focused tests for changed behavior.
+6. Verify with targeted commands and record the evidence before claiming done.
+7. Store durable plan/run artifacts under `plans/` or `.hermes/lazyhermes/` when useful.

--- a/tests/cli/test_lazyhermes_plugin_dispatch.py
+++ b/tests/cli/test_lazyhermes_plugin_dispatch.py
@@ -1,0 +1,89 @@
+import queue
+import sys
+from unittest.mock import MagicMock, patch
+
+
+def test_plugin_command_dispatch_payload_is_queued_for_agent():
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs):
+        from cli import HermesCLI
+
+        cli = HermesCLI.__new__(HermesCLI)
+        cli.config = {}
+        cli.console = MagicMock()
+        cli.agent = None
+        cli.conversation_history = []
+        cli.session_id = "test-session"
+        cli._pending_input = queue.Queue()
+
+        payload = {
+            "display": "Started LazyHermes Ultrawork run: /tmp/run",
+            "agent_message": "<lazyhermes-ultrawork-run>\nTask: QA\n</lazyhermes-ultrawork-run>",
+        }
+
+        with patch("cli._get_plugin_cmd_handler_names", return_value={"ulw"}), \
+             patch("hermes_cli.plugins.get_plugin_command_handler", return_value=lambda _args: payload), \
+             patch("cli._cprint") as printed:
+            assert cli.process_command("/ulw QA") is True
+
+        printed.assert_called_once_with(payload["display"])
+        assert cli._pending_input.get_nowait() == payload["agent_message"]
+
+
+def test_stringified_plugin_command_dispatch_payload_is_queued_for_agent():
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs):
+        from cli import HermesCLI
+
+        cli = HermesCLI.__new__(HermesCLI)
+        cli.config = {}
+        cli.console = MagicMock()
+        cli.agent = None
+        cli.conversation_history = []
+        cli.session_id = "test-session"
+        cli._pending_input = queue.Queue()
+
+        payload = {
+            "display": "Started LazyHermes Ultrawork run: /tmp/run",
+            "agent_message": "QA",
+        }
+
+        with patch("cli._get_plugin_cmd_handler_names", return_value={"ulw"}), \
+             patch("hermes_cli.plugins.get_plugin_command_handler", return_value=lambda _args: str(payload)), \
+             patch("cli._cprint") as printed:
+            assert cli.process_command("/ulw QA") is True
+
+        printed.assert_called_once_with(payload["display"])
+        assert cli._pending_input.get_nowait() == payload["agent_message"]

--- a/tests/gateway/test_lazyhermes_plugin_dispatch.py
+++ b/tests/gateway/test_lazyhermes_plugin_dispatch.py
@@ -1,0 +1,125 @@
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    source = _make_source()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(
+        emit=AsyncMock(),
+        emit_collect=AsyncMock(return_value=[]),
+        loaded_hooks=False,
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_run_generation = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner._is_telegram_topic_root_lobby = lambda _source: False
+    runner._should_send_telegram_lobby_reminder = lambda _source: False
+    return runner
+
+
+def test_telegram_ulw_plugin_payload_forwards_to_agent(monkeypatch):
+    payload = {
+        "display": "Started LazyHermes Ultrawork run: /tmp/lazyhermes-run",
+        "agent_message": "inspect this folder",
+        "run_dir": "/tmp/lazyhermes-run",
+    }
+    seen = {}
+
+    async def _capture(event, source, _quick_key, _run_generation):
+        seen["text"] = event.text
+        return "FORWARDED"
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        lambda name: (lambda _args: payload) if name == "ulw-loop" else None,
+    )
+
+    runner = _make_runner()
+    runner._handle_message_with_agent = _capture
+
+    result = asyncio.run(runner._handle_message(_make_event("/ulw_loop inspect this folder")))
+
+    assert result == "FORWARDED"
+    assert seen["text"] == "inspect this folder"
+
+
+def test_telegram_ulw_plan_plugin_forwards_goal_bootstrap(monkeypatch):
+    payload = {
+        "display": "Created LazyHermes plan: /tmp/plan.md\nForwarding goal bootstrap to Hermes agent now.",
+        "agent_message": "global rollout\n\n<lazyhermes-goal-instruction>\nFirst call get_goal.\n</lazyhermes-goal-instruction>",
+        "plan": "/tmp/plan.md",
+    }
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        lambda name: (lambda _args: payload) if name == "ulw-plan" else None,
+    )
+
+    seen = {}
+
+    async def _capture(event, source, _quick_key, _run_generation):
+        seen["text"] = event.text
+        return "FORWARDED"
+
+    runner = _make_runner()
+    runner._handle_message_with_agent = _capture
+
+    result = asyncio.run(runner._handle_message(_make_event("/ulw_plan global rollout")))
+
+    assert result == "FORWARDED"
+    assert "First call get_goal" in seen["text"]

--- a/tests/plugins/test_lazyhermes_plugin.py
+++ b/tests/plugins/test_lazyhermes_plugin.py
@@ -1,0 +1,236 @@
+import json
+from pathlib import Path
+
+
+def test_lazyhermes_registers_commands_hook_and_skills(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "plugins:\n  enabled:\n    - lazyhermes\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(Path(__file__).resolve().parents[2] / "plugins"))
+
+    import hermes_cli.plugins as plugins_mod
+    from hermes_cli.plugins import get_plugin_commands, invoke_hook
+    from tools.skills_tool import skill_view
+
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", None)
+
+    commands = get_plugin_commands()
+    assert {"ulw", "ulw-plan", "ultrawork-plan", "ulw-loop", "ultrawork-loop", "start-work"} <= set(commands)
+
+    hook_results = invoke_hook(
+        "pre_llm_call",
+        session_id="s1",
+        user_message="please use ulw for this",
+        conversation_history=[],
+        is_first_turn=True,
+        model="test",
+    )
+    assert hook_results
+    assert "lazyhermes-ultrawork" in hook_results[0]["context"]
+    assert "lazyhermes-goal-bootstrap" in hook_results[0]["context"]
+    assert "First call get_goal" in hook_results[0]["context"]
+    assert '"status": "active"' in hook_results[0]["context"]
+
+    result = json.loads(skill_view("lazyhermes:ultrawork"))
+    assert result["success"] is True
+    assert "LazyHermes Ultrawork" in result["content"]
+
+
+def test_lazyhermes_bundled_plugin_auto_loads_without_enabled_config(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("plugins:\n  enabled: []\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(Path(__file__).resolve().parents[2] / "plugins"))
+
+    import hermes_cli.plugins as plugins_mod
+    from hermes_cli.plugins import get_plugin_commands
+
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", None)
+
+    commands = get_plugin_commands()
+
+    assert "ulw" in commands
+    assert "ulw-loop" in commands
+    assert "ulw-plan" in commands
+
+
+def test_ulw_plan_command_creates_plan_and_goal_dispatch(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.chdir(tmp_path)
+
+    from plugins.lazyhermes import core
+
+    result = core.command_ulw_plan('"Retrofit Hermes with LazyCodex patterns"')
+
+    assert result["display"].startswith("Created LazyHermes plan")
+    assert "Forwarding goal bootstrap to Hermes agent now." in result["display"]
+    created = tmp_path / "plans" / "retrofit-hermes-with-lazycodex-patterns.md"
+    assert created.exists()
+    assert "Completion Promise" in created.read_text(encoding="utf-8")
+    assert result["plan"] == str(created)
+    assert result["agent_message"].startswith("Retrofit Hermes with LazyCodex patterns")
+    assert str(created) in result["agent_message"]
+    assert "<lazyhermes-goal-instruction>" in result["agent_message"]
+    assert "First call get_goal" in result["agent_message"]
+    assert "create_goal payload" in result["agent_message"]
+    assert '"status": "active"' in result["agent_message"]
+    assert "update_goal" in result["agent_message"]
+
+
+def test_ulw_plan_goal_dispatch_handles_existing_goal_before_create(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.chdir(tmp_path)
+
+    from plugins.lazyhermes import core
+
+    result = core.command_ulw_plan('"Respect active Codex goal"')
+
+    assert "If get_goal reports the same objective as active, continue without creating a duplicate" in result["agent_message"]
+    assert "If get_goal reports a different active goal, finish or checkpoint it before starting this plan" in result["agent_message"]
+
+
+def test_ulw_loop_command_creates_local_run_state_and_agent_dispatch(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.chdir(tmp_path)
+
+    from plugins.lazyhermes import core
+
+    result = core.command_ulw_loop(
+        '"Ship plugin" --completion-promise "commands and skills work" --strategy reset'
+    )
+
+    assert result["display"].startswith("Started LazyHermes Ultrawork run")
+    assert result["agent_message"].startswith("Ship plugin")
+    assert "<lazyhermes-run-context>" in result["agent_message"]
+    assert "Ship plugin" in result["agent_message"]
+    assert "commands and skills work" in result["display"]
+    run_dirs = list((tmp_path / ".hermes" / "lazyhermes" / "runs").glob("lazyhermes-*"))
+    assert len(run_dirs) == 1
+    state = json.loads((run_dirs[0] / "state.json").read_text(encoding="utf-8"))
+    assert state["command"] == "ulw-loop"
+    assert state["task"] == "Ship plugin"
+    assert state["completion_promise"] == "commands and skills work"
+    assert state["strategy"] == "reset"
+    assert (run_dirs[0] / "ledger.jsonl").exists()
+    assert result["run_dir"] == str(run_dirs[0])
+
+
+def test_ulw_alias_command_creates_dispatch_payload(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.chdir(tmp_path)
+
+    from plugins.lazyhermes import core
+
+    result = core.command_ulw('"Summarize this folder"')
+
+    assert result["display"].startswith("Started LazyHermes Ultrawork run")
+    assert result["agent_message"].startswith("Summarize this folder")
+    assert "<lazyhermes-run-context>" in result["agent_message"]
+    run_dirs = list((tmp_path / ".hermes" / "lazyhermes" / "runs").glob("lazyhermes-*"))
+    assert len(run_dirs) == 1
+    state = json.loads((run_dirs[0] / "state.json").read_text(encoding="utf-8"))
+    assert state["command"] == "ulw"
+
+
+def test_bare_ulw_pre_llm_call_creates_run_context(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.chdir(tmp_path)
+
+    from plugins.lazyhermes import core
+
+    result = core.pre_llm_call(
+        session_id="s1",
+        user_message="ulw analyze this folder",
+        conversation_history=[],
+        is_first_turn=True,
+        model="test",
+    )
+
+    assert result is not None
+    assert "lazyhermes-run-context" in result["context"]
+    assert "lazyhermes-goal-instruction" in result["context"]
+    assert "First call get_goal" in result["context"]
+    assert '"status": "active"' in result["context"]
+    assert "analyze this folder" in result["context"]
+    run_dirs = list((tmp_path / ".hermes" / "lazyhermes" / "runs").glob("lazyhermes-*"))
+    assert len(run_dirs) == 1
+
+
+def test_pre_llm_call_does_not_duplicate_internal_dispatch_context(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.chdir(tmp_path)
+
+    from plugins.lazyhermes import core
+
+    result = core.pre_llm_call(
+        session_id="s1",
+        user_message="Ship\n\n<lazyhermes-run-context>\ntask: Ship\n</lazyhermes-run-context>",
+        conversation_history=[],
+        is_first_turn=True,
+        model="test",
+    )
+
+    assert result is None
+    run_root = tmp_path / ".hermes" / "lazyhermes" / "runs"
+    assert not run_root.exists()
+
+
+def test_start_work_dry_run_reads_plan_items(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.chdir(tmp_path)
+    plans = tmp_path / "plans"
+    plans.mkdir()
+    plan = plans / "demo.md"
+    plan.write_text(
+        "# Demo\n\n- [ ] First task\n- [x] Done task\n- [ ] Second task\n",
+        encoding="utf-8",
+    )
+
+    from plugins.lazyhermes import core
+
+    message = core.command_start_work("demo --dry-run")
+
+    assert f"LazyHermes dry-run for {plan}" in message
+    assert "First task" in message
+    assert "Second task" in message
+    assert "Done task" not in message
+
+
+def test_start_work_creates_run_for_plan(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.chdir(tmp_path)
+    plans = tmp_path / "plans"
+    plans.mkdir()
+    plan = plans / "demo.md"
+    plan.write_text("# Demo\n\n- [ ] First task\n", encoding="utf-8")
+
+    from plugins.lazyhermes import core
+
+    message = core.command_start_work("demo")
+
+    assert "Started LazyHermes work run" in message
+    run_dirs = list((tmp_path / ".hermes" / "lazyhermes" / "runs").glob("lazyhermes-*"))
+    assert len(run_dirs) == 1
+    state = json.loads((run_dirs[0] / "state.json").read_text(encoding="utf-8"))
+    assert state["plan"] == str(plan.resolve())


### PR DESCRIPTION
## Summary
- Add the bundled LazyHermes plugin with /ulw, /ulw-loop, /ulw-plan, and /start-work commands.
- Change /ulw-plan from text-only plan creation into an agent dispatch payload with LazyCodex-style model-facing goal instructions.
- Cover CLI, gateway, and plugin hook behavior with focused tests.

## Test Plan
- pytest -q -o addopts='' tests/plugins/test_lazyhermes_plugin.py tests/gateway/test_lazyhermes_plugin_dispatch.py tests/cli/test_lazyhermes_plugin_dispatch.py tests/tui_gateway/test_protocol.py
- venv/bin/python -m py_compile plugins/lazyhermes/core.py plugins/lazyhermes/__init__.py
- venv/bin/python -m ruff check plugins/lazyhermes/core.py plugins/lazyhermes/__init__.py tests/plugins/test_lazyhermes_plugin.py tests/gateway/test_lazyhermes_plugin_dispatch.py tests/cli/test_lazyhermes_plugin_dispatch.py

## Notes
- Direct push to NousResearch/hermes-agent was denied for this GitHub account, so this is opened from the wjgoarxiv fork.
- npm publish was attempted but blocked because the root package is marked private.