### PR TITLE
fix(gateway): avoid repeated compression loops

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -715,7 +715,11 @@ class ContextCompressor(ContextEngine):
 
         baseline = self.last_rough_tokens_when_real_prompt_fit or self.last_compression_rough_tokens
         if baseline <= 0:
-            return False
+            tolerated_over_threshold = max(8192, int(self.threshold_tokens * 0.10))
+            if rough_tokens > self.threshold_tokens + tolerated_over_threshold:
+                return False
+            self.last_rough_tokens_when_real_prompt_fit = max(self.threshold_tokens, rough_tokens)
+            return True
 
         growth = max(0, rough_tokens - baseline)
         tolerated_growth = max(4096, int(self.threshold_tokens * 0.05))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -751,6 +751,69 @@ def _collect_auto_append_media_tags(
 
     return media_tags, has_voice_directive
 
+_COMPRESSION_CALIBRATION_FIELDS = (
+    "last_prompt_tokens",
+    "last_real_prompt_tokens",
+    "last_compression_rough_tokens",
+    "last_rough_tokens_when_real_prompt_fit",
+)
+
+
+def _nonnegative_int(value: Any) -> int:
+    try:
+        ivalue = int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, ivalue)
+
+
+def _calibration_source_value(source: Any, field: str) -> Any:
+    if isinstance(source, dict):
+        return source.get(field, 0)
+    return getattr(source, field, 0)
+
+
+def _compression_calibration_from_session_entry(session_entry: Any) -> Dict[str, int]:
+    if session_entry is None:
+        return {}
+    return {
+        field: _nonnegative_int(_calibration_source_value(session_entry, field))
+        for field in _COMPRESSION_CALIBRATION_FIELDS
+    }
+
+
+def _hydrate_gateway_compression_calibration(agent: Any, calibration_source: Any) -> None:
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is None or calibration_source is None:
+        return
+
+    for field in _COMPRESSION_CALIBRATION_FIELDS:
+        value = _nonnegative_int(_calibration_source_value(calibration_source, field))
+        if value > 0:
+            setattr(compressor, field, value)
+
+    # Backward compatibility for sessions created before the explicit
+    # calibration fields existed: below-threshold last_prompt_tokens came from
+    # a successful provider call often enough to be useful as a conservative
+    # "real prompt fit" signal. Above-threshold values still won't defer.
+    if _nonnegative_int(getattr(compressor, "last_real_prompt_tokens", 0)) <= 0:
+        last_prompt = _nonnegative_int(
+            _calibration_source_value(calibration_source, "last_prompt_tokens")
+        )
+        if last_prompt > 0:
+            compressor.last_real_prompt_tokens = last_prompt
+
+
+def _compression_calibration_from_agent(agent: Any) -> Dict[str, int]:
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is None:
+        return {}
+    return {
+        field: _nonnegative_int(getattr(compressor, field, 0))
+        for field in _COMPRESSION_CALIBRATION_FIELDS
+    }
+
+
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
 # Must run BEFORE any HTTP library (discord, aiohttp, etc.) is imported.
@@ -9115,6 +9178,10 @@ class GatewayRunner:
                                     )
                                     # Reset stored token count — transcript was rewritten
                                     session_entry.last_prompt_tokens = 0
+                                    session_entry.last_real_prompt_tokens = 0
+                                    session_entry.last_compression_rough_tokens = 0
+                                    session_entry.last_rough_tokens_when_real_prompt_fit = 0
+                                    self.session_store._save()
                                     history = _compressed
                                     _new_count = len(_compressed)
                                     _new_tokens = estimate_messages_tokens_rough(
@@ -9295,6 +9362,9 @@ class GatewayRunner:
                 run_generation=run_generation,
                 event_message_id=self._reply_anchor_for_event(event),
                 channel_prompt=event.channel_prompt,
+                compression_calibration=_compression_calibration_from_session_entry(
+                    session_entry
+                ),
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -9631,6 +9701,11 @@ class GatewayRunner:
             self.session_store.update_session(
                 session_entry.session_key,
                 last_prompt_tokens=agent_result.get("last_prompt_tokens", 0),
+                last_real_prompt_tokens=agent_result.get("last_real_prompt_tokens", 0),
+                last_compression_rough_tokens=agent_result.get("last_compression_rough_tokens", 0),
+                last_rough_tokens_when_real_prompt_fit=agent_result.get(
+                    "last_rough_tokens_when_real_prompt_fit", 0
+                ),
             )
 
             # Auto voice reply: send TTS audio before the text response
@@ -11335,6 +11410,10 @@ class GatewayRunner:
         self.session_store.rewrite_transcript(session_entry.session_id, truncated)
         # Reset stored token count — transcript was truncated
         session_entry.last_prompt_tokens = 0
+        session_entry.last_real_prompt_tokens = 0
+        session_entry.last_compression_rough_tokens = 0
+        session_entry.last_rough_tokens_when_real_prompt_fit = 0
+        self.session_store._save()
         
         # Re-send by creating a fake text event with the old message
         retry_event = MessageEvent(
@@ -11685,6 +11764,10 @@ class GatewayRunner:
 
         # Reset stored token count — transcript was truncated.
         session_entry.last_prompt_tokens = 0
+        session_entry.last_real_prompt_tokens = 0
+        session_entry.last_compression_rough_tokens = 0
+        session_entry.last_rough_tokens_when_real_prompt_fit = 0
+        self.session_store._save()
         # Evict the cached agent so the next turn rebuilds from the active-only
         # transcript and memory providers refresh their per-session caches.
         try:
@@ -12983,7 +13066,11 @@ class GatewayRunner:
                 self.session_store.rewrite_transcript(new_session_id, compressed)
                 # Reset stored token count — transcript changed, old value is stale
                 self.session_store.update_session(
-                    session_entry.session_key, last_prompt_tokens=0
+                    session_entry.session_key,
+                    last_prompt_tokens=0,
+                    last_real_prompt_tokens=0,
+                    last_compression_rough_tokens=0,
+                    last_rough_tokens_when_real_prompt_fit=0,
                 )
                 new_tokens = estimate_request_tokens_rough(
                     compressed, system_prompt=_sys_prompt, tools=_tools
@@ -16679,6 +16766,7 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        compression_calibration: Optional[Dict[str, int]] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -17593,6 +17681,8 @@ class GatewayRunner:
                         self._enforce_agent_cache_cap()
                 logger.debug("Created new agent for session %s (sig=%s)", session_key, _sig)
 
+            _hydrate_gateway_compression_calibration(agent, compression_calibration)
+
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
@@ -18023,11 +18113,13 @@ class GatewayRunner:
             _output_toks = 0
             _context_length = 0
             _agent = agent_holder[0]
+            _compression_calibration = {}
             if _agent and hasattr(_agent, "context_compressor"):
                 _last_prompt_toks = getattr(_agent.context_compressor, "last_prompt_tokens", 0)
                 _input_toks = getattr(_agent, "session_prompt_tokens", 0)
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
                 _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
+                _compression_calibration = _compression_calibration_from_agent(_agent)
             _resolved_model = getattr(_agent, "model", None) if _agent else None
 
             if not final_response:
@@ -18046,6 +18138,7 @@ class GatewayRunner:
                     "tools": tools_holder[0] or [],
                     "history_offset": len(agent_history),
                     "last_prompt_tokens": _last_prompt_toks,
+                    **_compression_calibration,
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
@@ -18202,6 +18295,7 @@ class GatewayRunner:
                 "tools": tools_holder[0] or [],
                 "history_offset": _effective_history_offset,
                 "last_prompt_tokens": _last_prompt_toks,
+                **_compression_calibration,
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -452,6 +452,9 @@ class SessionEntry:
     
     # Last API-reported prompt tokens (for accurate compression pre-check)
     last_prompt_tokens: int = 0
+    last_real_prompt_tokens: int = 0
+    last_compression_rough_tokens: int = 0
+    last_rough_tokens_when_real_prompt_fit: int = 0
     
     # Set when a session was created because the previous one expired;
     # consumed once by the message handler to inject a notice into context
@@ -506,6 +509,9 @@ class SessionEntry:
             "cache_write_tokens": self.cache_write_tokens,
             "total_tokens": self.total_tokens,
             "last_prompt_tokens": self.last_prompt_tokens,
+            "last_real_prompt_tokens": self.last_real_prompt_tokens,
+            "last_compression_rough_tokens": self.last_compression_rough_tokens,
+            "last_rough_tokens_when_real_prompt_fit": self.last_rough_tokens_when_real_prompt_fit,
             "estimated_cost_usd": self.estimated_cost_usd,
             "cost_status": self.cost_status,
             "expiry_finalized": self.expiry_finalized,
@@ -562,6 +568,9 @@ class SessionEntry:
             cache_write_tokens=data.get("cache_write_tokens", 0),
             total_tokens=data.get("total_tokens", 0),
             last_prompt_tokens=data.get("last_prompt_tokens", 0),
+            last_real_prompt_tokens=data.get("last_real_prompt_tokens", 0),
+            last_compression_rough_tokens=data.get("last_compression_rough_tokens", 0),
+            last_rough_tokens_when_real_prompt_fit=data.get("last_rough_tokens_when_real_prompt_fit", 0),
             estimated_cost_usd=data.get("estimated_cost_usd", 0.0),
             cost_status=data.get("cost_status", "unknown"),
             expiry_finalized=data.get("expiry_finalized", data.get("memory_flushed", False)),
@@ -958,6 +967,9 @@ class SessionStore:
         self,
         session_key: str,
         last_prompt_tokens: int = None,
+        last_real_prompt_tokens: int = None,
+        last_compression_rough_tokens: int = None,
+        last_rough_tokens_when_real_prompt_fit: int = None,
     ) -> None:
         """Update lightweight session metadata after an interaction."""
         with self._lock:
@@ -968,6 +980,12 @@ class SessionStore:
                 entry.updated_at = _now()
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
+                if last_real_prompt_tokens is not None:
+                    entry.last_real_prompt_tokens = last_real_prompt_tokens
+                if last_compression_rough_tokens is not None:
+                    entry.last_compression_rough_tokens = last_compression_rough_tokens
+                if last_rough_tokens_when_real_prompt_fit is not None:
+                    entry.last_rough_tokens_when_real_prompt_fit = last_rough_tokens_when_real_prompt_fit
                 self._save()
 
     def suspend_session(self, session_key: str) -> bool:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -82,6 +82,23 @@ class TestPreflightDeferral:
 
         assert compressor.should_defer_preflight_to_real_usage(93_000) is False
 
+    def test_defers_near_threshold_without_rough_baseline_after_real_fit(self, compressor):
+        compressor.threshold_tokens = 85_000
+        compressor.last_real_prompt_tokens = 70_000
+        compressor.last_rough_tokens_when_real_prompt_fit = 0
+        compressor.last_compression_rough_tokens = 0
+
+        assert compressor.should_defer_preflight_to_real_usage(92_000) is True
+        assert compressor.last_rough_tokens_when_real_prompt_fit == 92_000
+
+    def test_does_not_defer_far_above_threshold_without_rough_baseline(self, compressor):
+        compressor.threshold_tokens = 85_000
+        compressor.last_real_prompt_tokens = 70_000
+        compressor.last_rough_tokens_when_real_prompt_fit = 0
+        compressor.last_compression_rough_tokens = 0
+
+        assert compressor.should_defer_preflight_to_real_usage(100_000) is False
+
 
 
 class TestCompress:

--- a/tests/gateway/test_compression_calibration.py
+++ b/tests/gateway/test_compression_calibration.py
@@ -1,0 +1,102 @@
+from types import SimpleNamespace
+
+from gateway.run import (
+    _compression_calibration_from_agent,
+    _compression_calibration_from_session_entry,
+    _hydrate_gateway_compression_calibration,
+)
+
+
+def test_hydrates_gateway_compression_calibration_fields():
+    compressor = SimpleNamespace(
+        last_prompt_tokens=0,
+        last_real_prompt_tokens=0,
+        last_compression_rough_tokens=0,
+        last_rough_tokens_when_real_prompt_fit=0,
+    )
+    agent = SimpleNamespace(context_compressor=compressor)
+    entry = SimpleNamespace(
+        last_prompt_tokens=91_000,
+        last_real_prompt_tokens=90_000,
+        last_compression_rough_tokens=139_000,
+        last_rough_tokens_when_real_prompt_fit=139_000,
+    )
+
+    _hydrate_gateway_compression_calibration(agent, entry)
+
+    assert compressor.last_prompt_tokens == 91_000
+    assert compressor.last_real_prompt_tokens == 90_000
+    assert compressor.last_compression_rough_tokens == 139_000
+    assert compressor.last_rough_tokens_when_real_prompt_fit == 139_000
+
+
+def test_hydrates_gateway_compression_calibration_from_snapshot():
+    compressor = SimpleNamespace(
+        last_prompt_tokens=0,
+        last_real_prompt_tokens=0,
+        last_compression_rough_tokens=0,
+        last_rough_tokens_when_real_prompt_fit=0,
+    )
+    agent = SimpleNamespace(context_compressor=compressor)
+    snapshot = {
+        "last_prompt_tokens": 91_000,
+        "last_real_prompt_tokens": 90_000,
+        "last_compression_rough_tokens": 139_000,
+        "last_rough_tokens_when_real_prompt_fit": 139_000,
+    }
+
+    _hydrate_gateway_compression_calibration(agent, snapshot)
+
+    assert compressor.last_prompt_tokens == 91_000
+    assert compressor.last_real_prompt_tokens == 90_000
+    assert compressor.last_compression_rough_tokens == 139_000
+    assert compressor.last_rough_tokens_when_real_prompt_fit == 139_000
+
+
+def test_hydrates_legacy_last_prompt_as_real_fit_signal():
+    compressor = SimpleNamespace(
+        last_prompt_tokens=0,
+        last_real_prompt_tokens=0,
+        last_compression_rough_tokens=0,
+        last_rough_tokens_when_real_prompt_fit=0,
+    )
+    agent = SimpleNamespace(context_compressor=compressor)
+    entry = SimpleNamespace(last_prompt_tokens=220_000)
+
+    _hydrate_gateway_compression_calibration(agent, entry)
+
+    assert compressor.last_prompt_tokens == 220_000
+    assert compressor.last_real_prompt_tokens == 220_000
+
+
+def test_extracts_gateway_compression_calibration_from_session_entry():
+    entry = SimpleNamespace(
+        last_prompt_tokens=98_000,
+        last_real_prompt_tokens=97_000,
+        last_compression_rough_tokens=140_000,
+        last_rough_tokens_when_real_prompt_fit=141_000,
+    )
+
+    assert _compression_calibration_from_session_entry(entry) == {
+        "last_prompt_tokens": 98_000,
+        "last_real_prompt_tokens": 97_000,
+        "last_compression_rough_tokens": 140_000,
+        "last_rough_tokens_when_real_prompt_fit": 141_000,
+    }
+
+
+def test_extracts_gateway_compression_calibration_fields():
+    compressor = SimpleNamespace(
+        last_prompt_tokens=98_000,
+        last_real_prompt_tokens=98_000,
+        last_compression_rough_tokens=140_000,
+        last_rough_tokens_when_real_prompt_fit=140_000,
+    )
+    agent = SimpleNamespace(context_compressor=compressor)
+
+    assert _compression_calibration_from_agent(agent) == {
+        "last_prompt_tokens": 98_000,
+        "last_real_prompt_tokens": 98_000,
+        "last_compression_rough_tokens": 140_000,
+        "last_rough_tokens_when_real_prompt_fit": 140_000,
+    }

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1051,6 +1051,9 @@ class TestLastPromptTokens:
             updated_at=datetime.now(),
         )
         assert entry.last_prompt_tokens == 0
+        assert entry.last_real_prompt_tokens == 0
+        assert entry.last_compression_rough_tokens == 0
+        assert entry.last_rough_tokens_when_real_prompt_fit == 0
 
     def test_session_entry_roundtrip(self):
         """last_prompt_tokens should survive serialization/deserialization."""
@@ -1062,11 +1065,20 @@ class TestLastPromptTokens:
             created_at=datetime.now(),
             updated_at=datetime.now(),
             last_prompt_tokens=42000,
+            last_real_prompt_tokens=41000,
+            last_compression_rough_tokens=90000,
+            last_rough_tokens_when_real_prompt_fit=88000,
         )
         d = entry.to_dict()
         assert d["last_prompt_tokens"] == 42000
+        assert d["last_real_prompt_tokens"] == 41000
+        assert d["last_compression_rough_tokens"] == 90000
+        assert d["last_rough_tokens_when_real_prompt_fit"] == 88000
         restored = SessionEntry.from_dict(d)
         assert restored.last_prompt_tokens == 42000
+        assert restored.last_real_prompt_tokens == 41000
+        assert restored.last_compression_rough_tokens == 90000
+        assert restored.last_rough_tokens_when_real_prompt_fit == 88000
 
     def test_session_entry_from_old_data(self):
         """Old session data without last_prompt_tokens should default to 0."""
@@ -1083,6 +1095,9 @@ class TestLastPromptTokens:
         }
         entry = SessionEntry.from_dict(data)
         assert entry.last_prompt_tokens == 0
+        assert entry.last_real_prompt_tokens == 0
+        assert entry.last_compression_rough_tokens == 0
+        assert entry.last_rough_tokens_when_real_prompt_fit == 0
 
     def test_update_session_sets_last_prompt_tokens(self, tmp_path):
         """update_session should store the actual prompt token count."""
@@ -1103,8 +1118,17 @@ class TestLastPromptTokens:
         )
         store._entries = {"k1": entry}
 
-        store.update_session("k1", last_prompt_tokens=85000)
+        store.update_session(
+            "k1",
+            last_prompt_tokens=85000,
+            last_real_prompt_tokens=72000,
+            last_compression_rough_tokens=120000,
+            last_rough_tokens_when_real_prompt_fit=118000,
+        )
         assert entry.last_prompt_tokens == 85000
+        assert entry.last_real_prompt_tokens == 72000
+        assert entry.last_compression_rough_tokens == 120000
+        assert entry.last_rough_tokens_when_real_prompt_fit == 118000
 
     def test_update_session_none_does_not_change(self, tmp_path):
         """update_session with default (None) should not change last_prompt_tokens."""
@@ -1123,11 +1147,17 @@ class TestLastPromptTokens:
             created_at=datetime.now(),
             updated_at=datetime.now(),
             last_prompt_tokens=50000,
+            last_real_prompt_tokens=49000,
+            last_compression_rough_tokens=90000,
+            last_rough_tokens_when_real_prompt_fit=88000,
         )
         store._entries = {"k1": entry}
 
         store.update_session("k1")  # No last_prompt_tokens arg
         assert entry.last_prompt_tokens == 50000  # unchanged
+        assert entry.last_real_prompt_tokens == 49000
+        assert entry.last_compression_rough_tokens == 90000
+        assert entry.last_rough_tokens_when_real_prompt_fit == 88000
 
     def test_update_session_zero_resets(self, tmp_path):
         """update_session with last_prompt_tokens=0 should reset the field."""
@@ -1146,11 +1176,23 @@ class TestLastPromptTokens:
             created_at=datetime.now(),
             updated_at=datetime.now(),
             last_prompt_tokens=85000,
+            last_real_prompt_tokens=72000,
+            last_compression_rough_tokens=120000,
+            last_rough_tokens_when_real_prompt_fit=118000,
         )
         store._entries = {"k1": entry}
 
-        store.update_session("k1", last_prompt_tokens=0)
+        store.update_session(
+            "k1",
+            last_prompt_tokens=0,
+            last_real_prompt_tokens=0,
+            last_compression_rough_tokens=0,
+            last_rough_tokens_when_real_prompt_fit=0,
+        )
         assert entry.last_prompt_tokens == 0
+        assert entry.last_real_prompt_tokens == 0
+        assert entry.last_compression_rough_tokens == 0
+        assert entry.last_rough_tokens_when_real_prompt_fit == 0
 
 class TestRewriteTranscriptPreservesReasoning:
     """rewrite_transcript must not drop reasoning fields from SQLite."""


### PR DESCRIPTION
## What does this PR do?

Prevents gateway sessions from repeatedly burning preflight compression calls after a real provider prompt recently fit within the model window.

Gateway agents can be cached, evicted, or rebuilt across turns. Before this change, the compressor's calibration state lived only on the in-memory agent instance, so the next gateway turn could see a noisy rough token estimate near the threshold and compact again even though the previous real provider request fit. This PR persists that calibration on `SessionEntry`, snapshots it before entering the executor thread, hydrates the agent compressor from the snapshot, and writes updated calibration back after the run.

It also resets calibration when transcripts are rewritten or truncated so stale fit signals do not survive `/retry`, `/undo`, hygiene compression, or manual `/compress`.

## Related Issue

None.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py`: defer near-threshold preflight compression when recent real prompt usage fit but no rough baseline is available yet.
- `gateway/session.py`: persist compression calibration fields in session metadata.
- `gateway/run.py`: hydrate compressor calibration from a session snapshot and write updated calibration back after agent runs.
- `tests/gateway/test_compression_calibration.py`: cover session/agent calibration hydration and extraction.
- `tests/agent/test_context_compressor.py` and `tests/gateway/test_session.py`: extend regression coverage for the new behavior and metadata round-trips.

## How to Test

1. `HOME=/private/tmp/hermes-pr-home scripts/run_tests.sh tests/gateway/test_compression_calibration.py tests/gateway/test_session.py tests/agent/test_context_compressor.py tests/run_agent/test_413_compression.py -- -o addopts=''`
2. `/Users/dracoglasser/.hermes/hermes-agent/venv/bin/python -m py_compile agent/context_compressor.py gateway/run.py gateway/session.py`
3. `git diff --check HEAD~1..HEAD`

Local note: the shared local venv used for this run does not have `pytest-timeout`, so the focused wrapper run passed `-o addopts=''` to bypass the local-only missing plugin while still using `scripts/run_tests.sh`.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local gateway worktree

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

Focused wrapper run:

```text
=== Summary: 4 files, 192 tests passed, 0 failed (100% complete) in 1.7s (36 workers) ===
```

Manual live validation: after applying the same fix in the local gateway worktree and restarting the gateway, Telegram replies no longer hit the repeated preflight compression / `NameError` loop observed during testing.