### PR TITLE
fix: normalize provider slug case in Telegram model picker keyboard

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2867,7 +2867,7 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception:
             group_providers = None
 
-        by_slug = {p.get("slug"): p for p in providers}
+        by_slug = {p.get("slug", "").lower(): p for p in providers}
 
         def _provider_button(p):
             count = p.get("total_models", len(p.get("models", [])))


### PR DESCRIPTION
## Summary

Fixes #35932 — Telegram `/model` inline keyboard silently drops user-defined providers with mixed-case slugs.

## Root Cause

`_build_provider_keyboard()` built a lookup dict `by_slug` with raw provider slugs, but `group_providers()` (from `hermes_cli/models.py`) lowercases all slugs in its output. The case mismatch caused all user-defined providers with mixed-case names (BitFun, Ark.cn-beijing.volces.com, etc.) to be silently dropped from the keyboard.

Built-in providers (openrouter, anthropic, etc.) were unaffected because their slugs are already lowercase.

## Fix

One-line change in `gateway/platforms/telegram.py`:

```diff
- by_slug = {p.get("slug"): p for p in providers}
+ by_slug = {p.get("slug", "").lower(): p for p in providers}
```

## Testing

- Verified manually: `/model` now shows all 5 user-defined providers including BitFun
- Built-in providers continue to work correctly
- Discord adapter does not use `group_providers()` in the same way — not affected

Closes #35932