### PR TITLE
fix(agent): persist empty-response transcript rewinds to the SQLite session store

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1398,13 +1398,23 @@ class AIAgent:
 
         Ensures conversations are never lost, even on errors or early returns.
         """
-        self._drop_trailing_empty_response_scaffolding(messages)
+        rewound_transcript = self._drop_trailing_empty_response_scaffolding(messages)
         self._apply_persist_user_message_override(messages)
         self._session_messages = messages
         self._save_session_log(messages)
+        if rewound_transcript and self._session_db:
+            try:
+                self._session_db.replace_messages(self.session_id, messages)
+                self._last_flushed_db_idx = len(messages)
+                return
+            except Exception as e:
+                logger.warning(
+                    "Failed to rewrite session DB after empty-response cleanup: %s",
+                    e,
+                )
         self._flush_messages_to_session_db(messages, conversation_history)
 
-    def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
+    def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> bool:
         """Remove private empty-response retry/failure scaffolding from transcript tails.
 
         Also rewinds past any trailing tool-result / assistant(tool_calls) pair
@@ -1412,7 +1422,8 @@ class AIAgent:
         a raw ``tool`` message and the next user turn lands as
         ``...tool, user, user`` — a protocol-invalid sequence that most
         providers silently reject (returns empty content), causing the
-        empty-retry loop to fire forever. See #<TBD>.
+        empty-retry loop to fire forever. Returns True when the transcript was
+        mutated so callers can rewrite already-flushed persistent stores.
         """
         # Pass 1: strip the flagged scaffolding messages themselves.
         dropped_scaffolding = False
@@ -1434,7 +1445,7 @@ class AIAgent:
         # result. Only runs when scaffolding was actually present — normal
         # conversation tails (real tool loops mid-progress) are untouched.
         if not dropped_scaffolding:
-            return
+            return False
 
         # Drop any trailing tool-result messages
         while (
@@ -1456,6 +1467,7 @@ class AIAgent:
             and messages[-1].get("tool_calls")
         ):
             messages.pop()
+        return True
 
     def _repair_message_sequence(self, messages: List[Dict]) -> int:
         """Forwarder — see ``agent.agent_runtime_helpers.repair_message_sequence``."""

--- a/tests/run_agent/test_empty_response_recovery_persistence.py
+++ b/tests/run_agent/test_empty_response_recovery_persistence.py
@@ -3,12 +3,22 @@
 from run_agent import AIAgent
 
 
+class _RewriteTrackingDB:
+    def __init__(self):
+        self.replaced = []
+
+    def replace_messages(self, session_id, messages):
+        self.replaced.append((session_id, [m.copy() for m in messages]))
+
+
 def _agent_with_stubbed_persistence():
     agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "test-session"
     agent._persist_user_message_idx = None
     agent._persist_user_message_override = None
     agent._session_db = None
     agent._session_messages = []
+    agent._last_flushed_db_idx = 0
     agent.flushed_session_db_messages = []
     agent._flush_messages_to_session_db = lambda messages, conversation_history=None: (
         agent.flushed_session_db_messages.append([m.copy() for m in messages])
@@ -92,3 +102,33 @@ def test_persist_session_strips_marked_terminal_empty_sentinel():
     assert messages == [{"role": "user", "content": "continue"}]
     assert agent.flushed_session_db_messages[-1] == messages
     assert all(not msg.get("_empty_terminal_sentinel") for msg in messages)
+
+
+def test_persist_session_rewrites_db_when_empty_cleanup_rewinds_flushed_tail():
+    agent = _agent_with_stubbed_persistence()
+    agent._session_db = _RewriteTrackingDB()
+    agent._last_flushed_db_idx = 3
+    messages = [
+        {"role": "user", "content": "run the task"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "call_1", "type": "function",
+                            "function": {"name": "search_files", "arguments": "{}"}}],
+        },
+        {"role": "tool", "content": "{}", "tool_call_id": "call_1"},
+        {
+            "role": "assistant",
+            "content": "(empty)",
+            "_empty_terminal_sentinel": True,
+        },
+    ]
+
+    AIAgent._persist_session(agent, messages, conversation_history=[])
+
+    assert messages == [{"role": "user", "content": "run the task"}]
+    assert agent._session_db.replaced == [
+        ("test-session", [{"role": "user", "content": "run the task"}])
+    ]
+    assert agent._last_flushed_db_idx == 1
+    assert agent.flushed_session_db_messages == []


### PR DESCRIPTION
## Summary

Hermes already dropped synthetic empty-response scaffolding and orphan tool tails in memory after repeated empty model responses, but the SQLite session store was append-only. If a tool result had already been flushed, the TUI could reload the poisoned tail on resume and keep replaying the same invalid boundary.

This changes `_persist_session` so that when the empty-response cleanup rewinds the transcript, the SQLite session messages are replaced with the cleaned transcript and the flush index is reset to the cleaned length.

## Validation

- `./scripts/run_tests.sh tests/run_agent/test_empty_response_recovery_persistence.py tests/run_agent/test_message_sequence_repair.py`