### PR TITLE
fix(docker): full container_config parity for file_tools and code_execution_tool

### DIFF
--- a/tests/tools/test_code_execution_container_config.py
+++ b/tests/tools/test_code_execution_container_config.py
@@ -1,0 +1,104 @@
+"""Tests for docker container_config key propagation in code_execution_tool.
+
+Mirrors test_file_tools_container_config.py: _get_or_create_env() builds its
+own container_config dict independently of terminal_tool._create_environment's
+caller, so it must be pinned separately to catch the same class of drift
+(container comes up missing docker_env/docker_extra_args/etc. depending on
+which tool wins the race to create the shared per-task container).
+"""
+
+from unittest.mock import patch, MagicMock
+import tools.code_execution_tool as code_execution_tool
+
+
+def _make_env_config(**overrides):
+    base = {
+        "env_type": "docker",
+        "docker_image": "test-image:latest",
+        "singularity_image": "docker://test",
+        "modal_image": "test",
+        "daytona_image": "test",
+        "cwd": "/workspace",
+        "host_cwd": None,
+        "timeout": 180,
+        "container_cpu": 2,
+        "container_memory": 4096,
+        "container_disk": 20480,
+        "container_persistent": False,
+        "docker_volumes": [],
+        "docker_run_as_host_user": False,
+        "docker_network": True,
+        "docker_mount_cwd_to_workspace": True,
+        "docker_forward_env": ["MY_SECRET", "API_KEY"],
+        "docker_env": {},
+        "docker_extra_args": [],
+        "modal_mode": "auto",
+        "docker_persist_across_processes": True,
+        "docker_orphan_reaper": True,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCodeExecutionContainerConfig:
+    def _run(self, env_config, task_id):
+        captured = {}
+        mock_env = MagicMock()
+
+        def fake_create_env(**kwargs):
+            captured.update(kwargs)
+            return mock_env
+
+        with patch("tools.terminal_tool._get_env_config", return_value=env_config), \
+             patch("tools.terminal_tool._task_env_overrides", {}), \
+             patch("tools.terminal_tool._active_environments", {}), \
+             patch("tools.terminal_tool._creation_locks", {}), \
+             patch("tools.terminal_tool._creation_locks_lock", __import__("threading").Lock()), \
+             patch("tools.terminal_tool._create_environment", side_effect=fake_create_env), \
+             patch("tools.terminal_tool._start_cleanup_thread"), \
+             patch("tools.terminal_tool._last_activity", {}), \
+             patch("tools.terminal_tool._env_lock", __import__("threading").Lock()), \
+             patch("tools.terminal_tool._resolve_container_task_id", side_effect=lambda tid: tid):
+            code_execution_tool._get_or_create_env(task_id)
+
+        return captured
+
+    def test_docker_env_passed(self):
+        cc = self._run(_make_env_config(docker_env={"HTTP_PROXY": "http://proxy:8080"}), "t1").get("container_config", {})
+        assert cc.get("docker_env") == {"HTTP_PROXY": "http://proxy:8080"}
+
+    def test_docker_env_defaults_to_empty_dict(self):
+        cfg = _make_env_config()
+        del cfg["docker_env"]
+        cc = self._run(cfg, "t2").get("container_config", {})
+        assert cc.get("docker_env") == {}
+
+    def test_docker_extra_args_passed(self):
+        cc = self._run(_make_env_config(docker_extra_args=["--network=fetcher-net"]), "t3").get("container_config", {})
+        assert cc.get("docker_extra_args") == ["--network=fetcher-net"]
+
+    def test_docker_extra_args_defaults_to_empty_list(self):
+        cfg = _make_env_config()
+        del cfg["docker_extra_args"]
+        cc = self._run(cfg, "t4").get("container_config", {})
+        assert cc.get("docker_extra_args") == []
+
+    def test_docker_mount_cwd_to_workspace_passed(self):
+        cc = self._run(_make_env_config(docker_mount_cwd_to_workspace=True), "t5").get("container_config", {})
+        assert cc.get("docker_mount_cwd_to_workspace") is True
+
+    def test_docker_forward_env_passed(self):
+        cc = self._run(_make_env_config(docker_forward_env=["MY_SECRET"]), "t6").get("container_config", {})
+        assert cc.get("docker_forward_env") == ["MY_SECRET"]
+
+    def test_docker_persist_across_processes_passed(self):
+        cc = self._run(_make_env_config(docker_persist_across_processes=False), "t7").get("container_config", {})
+        assert cc.get("docker_persist_across_processes") is False
+
+    def test_docker_orphan_reaper_passed(self):
+        cc = self._run(_make_env_config(docker_orphan_reaper=False), "t8").get("container_config", {})
+        assert cc.get("docker_orphan_reaper") is False
+
+    def test_modal_mode_passed(self):
+        cc = self._run(_make_env_config(modal_mode="sandbox"), "t9").get("container_config", {})
+        assert cc.get("modal_mode") == "sandbox"

--- a/tests/tools/test_file_tools_container_config.py
+++ b/tests/tools/test_file_tools_container_config.py
@@ -21,6 +21,11 @@ def _make_env_config(**overrides):
         "docker_volumes": [],
         "docker_mount_cwd_to_workspace": True,
         "docker_forward_env": ["MY_SECRET", "API_KEY"],
+        "docker_env": {},
+        "docker_extra_args": [],
+        "modal_mode": "auto",
+        "docker_persist_across_processes": True,
+        "docker_orphan_reaper": True,
     }
     base.update(overrides)
     return base
@@ -72,6 +77,30 @@ class TestFileToolsContainerConfig:
         del cfg["docker_forward_env"]
         cc = self._run(cfg, "t4").get("container_config", {})
         assert cc.get("docker_forward_env") == []
+
+    def test_docker_env_passed(self):
+        """docker_env is forwarded to container_config (order-dependent-container regression)."""
+        cc = self._run(_make_env_config(docker_env={"HTTP_PROXY": "http://proxy:8080"}), "t5").get("container_config", {})
+        assert cc.get("docker_env") == {"HTTP_PROXY": "http://proxy:8080"}
+
+    def test_docker_env_defaults_to_empty_dict(self):
+        """docker_env defaults to {} when absent from config."""
+        cfg = _make_env_config()
+        del cfg["docker_env"]
+        cc = self._run(cfg, "t6").get("container_config", {})
+        assert cc.get("docker_env") == {}
+
+    def test_docker_extra_args_passed(self):
+        """docker_extra_args is forwarded to container_config (order-dependent-container regression)."""
+        cc = self._run(_make_env_config(docker_extra_args=["--network=fetcher-net"]), "t7").get("container_config", {})
+        assert cc.get("docker_extra_args") == ["--network=fetcher-net"]
+
+    def test_docker_extra_args_defaults_to_empty_list(self):
+        """docker_extra_args defaults to [] when absent from config."""
+        cfg = _make_env_config()
+        del cfg["docker_extra_args"]
+        cc = self._run(cfg, "t8").get("container_config", {})
+        assert cc.get("docker_extra_args") == []
 
     def test_cwd_only_raw_task_override_reaches_file_environment(self):
         """CWD-only task overrides collapse to default but must keep their cwd."""

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -682,9 +682,16 @@ def _get_or_create_env(task_id: str):
                 "container_memory": config.get("container_memory", 5120),
                 "container_disk": config.get("container_disk", 51200),
                 "container_persistent": config.get("container_persistent", True),
+                "modal_mode": config.get("modal_mode", "auto"),
                 "docker_volumes": config.get("docker_volumes", []),
+                "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                "docker_forward_env": config.get("docker_forward_env", []),
+                "docker_env": config.get("docker_env", {}),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+                "docker_extra_args": config.get("docker_extra_args", []),
                 "docker_network": config.get("docker_network", True),
+                "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+                "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
             }
 
         ssh_config = None

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1143,11 +1143,16 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "container_memory": config.get("container_memory", 5120),
                     "container_disk": config.get("container_disk", 51200),
                     "container_persistent": config.get("container_persistent", True),
+                    "modal_mode": config.get("modal_mode", "auto"),
                     "docker_volumes": config.get("docker_volumes", []),
                     "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
                     "docker_forward_env": config.get("docker_forward_env", []),
+                    "docker_env": config.get("docker_env", {}),
                     "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+                    "docker_extra_args": config.get("docker_extra_args", []),
                     "docker_network": config.get("docker_network", True),
+                    "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+                    "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
                 }
 
             ssh_config = None


### PR DESCRIPTION
## Docker: full container_config parity for file_tools and code_execution_tool

`terminal_tool._create_environment()` is the source of truth for the docker `container_config` dict: `modal_mode`, `docker_volumes`, `docker_mount_cwd_to_workspace`, `docker_forward_env`, `docker_env`, `docker_run_as_host_user`, `docker_extra_args`, `docker_network`, `docker_persist_across_processes`, `docker_orphan_reaper`.

The shared per-task container is created lazily by whichever tool wins the race to touch it first (`_resolve_container_task_id`). `file_tools._get_file_ops()` and `code_execution_tool._get_or_create_env()` each build their own `container_config` dict, and both omitted several of the above keys — so a file or code-execution op winning the race silently dropped the user's configured proxy env, extra `docker run` flags, orphan reaping, and (for `code_execution_tool` specifically) cwd mounting and forwarded env too. Order-dependent and non-deterministic from the user's perspective.

### Fix

Bring both `file_tools.py` and `code_execution_tool.py` to full parity with `terminal_tool.py`'s `container_config` dict, not just `docker_env`/`docker_extra_args`.

### Tests

- Extended `tests/tools/test_file_tools_container_config.py` with `docker_env`/`docker_extra_args` coverage.
- New `tests/tools/test_code_execution_container_config.py` pinning all container-config keys for `code_execution_tool._get_or_create_env`, mirroring the file_tools test.

---

**Changes from the original PR, per review:**
- Dropped the `cli.py` / `gateway/run.py` `TERMINAL_DOCKER_EXTRA_ARGS` bridge hunks — already merged via #50631 (`de6b3ae3`).
- Widened the docker fix from 2 keys (`docker_env`, `docker_extra_args`) to full parity (7 more keys were still missing in `code_execution_tool.py`, 5 in `file_tools.py`) after @teknium1 pointed out `terminal_tool.py:2202-2216` forwards a wider set than either tool carried — matches the parity work referenced in #35660.
- Dropped the agent circuit-breaker entirely rather than reworking it. `main` already ships `agent/tool_guardrails.py`'s `ToolCallGuardrailController`, which is fully wired into both `execute_tool_calls_sequential` and `execute_tool_calls_concurrent` (`tool_executor.py`) and already halts `run_conversation` (`conversation_loop.py:4690`) via `_tool_guardrail_halt_decision`. It covers the same repeated-identical-failure case (`exact_failure_warn_after`/`exact_failure_block_after`) without the streak-key bug the original addition had (A,B,A double-counted A) and without the concurrent-path gap. The 44k-token memory-replace retry loop that motivated the original addition would be caught by this existing controller today if `tool_loop_guardrails.hard_stop_enabled` is turned on (it's opt-in, off by default) — a config change, not a code change, and outside this PR's scope.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
