### PR TITLE
feat(image_gen): add reference-image (image-to-image) support

### DIFF
--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -17,6 +17,7 @@ Selection precedence (first hit wins):
 
 from __future__ import annotations
 
+import base64
 import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple
@@ -70,6 +71,69 @@ _XAI_ASPECT_RATIOS = {
 _XAI_RESOLUTIONS = {"1k", "2k"}
 
 DEFAULT_RESOLUTION = "1k"
+
+# Local-file extensions xAI's edits endpoint accepts, mapped to the MIME type
+# used when inlining the file as a base64 data URI.
+_IMAGE_MIME = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+}
+
+
+# ---------------------------------------------------------------------------
+# Reference-image helpers (image-to-image via /v1/images/edits)
+# ---------------------------------------------------------------------------
+
+
+def _to_edit_image_entry(ref: str) -> Dict[str, str]:
+    """Turn a user-supplied image reference into an xAI edits image entry.
+
+    Remote URLs (``http(s)://``) and ``data:`` URIs pass through untouched.
+    A local file path is read and inlined as a base64 ``data:`` URI — xAI's
+    edits endpoint accepts data URIs directly, which avoids having to host
+    the file on a public URL first (and sidesteps the NAS-returns-HTML
+    gotcha that the video path has to work around).
+    """
+    value = (ref or "").strip()
+    if not value:
+        raise ValueError("empty image reference")
+    if value.startswith(("http://", "https://", "data:")):
+        return {"url": value}
+    if not os.path.isfile(value):
+        raise ValueError(f"reference image not found: {value}")
+    ext = os.path.splitext(value)[1].lower()
+    mime = _IMAGE_MIME.get(ext)
+    if mime is None:
+        raise ValueError(
+            f"unsupported image type '{ext or '?'}' (use png, jpg, or webp)"
+        )
+    with open(value, "rb") as fh:
+        encoded = base64.b64encode(fh.read()).decode("ascii")
+    return {"url": f"data:{mime};base64,{encoded}"}
+
+
+def _collect_input_images(
+    image_url: Any,
+    reference_image_urls: Any,
+) -> List[str]:
+    """Merge ``image_url`` and ``reference_image_urls`` into one ordered list.
+
+    The primary ``image_url`` comes first, then any reference images. Empty
+    / non-string entries are dropped. Mirrors the video tool's surface,
+    which exposes both a primary drive image and a list of refs.
+    """
+    out: List[str] = []
+    if isinstance(image_url, str) and image_url.strip():
+        out.append(image_url.strip())
+    if isinstance(reference_image_urls, str):
+        reference_image_urls = [reference_image_urls]
+    if isinstance(reference_image_urls, (list, tuple)):
+        for item in reference_image_urls:
+            if isinstance(item, str) and item.strip():
+                out.append(item.strip())
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -162,9 +226,21 @@ class XAIImageGenProvider(ImageGenProvider):
         self,
         prompt: str,
         aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        *,
+        image_url: Optional[str] = None,
+        reference_image_urls: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        """Generate an image using xAI's grok-imagine-image."""
+        """Generate an image using xAI's grok-imagine-image.
+
+        Text-to-image by default. When ``image_url`` and/or
+        ``reference_image_urls`` are supplied, the call routes to xAI's
+        ``/images/edits`` endpoint instead — using the input image(s) as a
+        reference for image-to-image / character / style transfer. Inputs
+        may be public URLs, ``data:`` URIs, or local file paths (inlined as
+        base64). Single input uses the ``image`` field; multiple use the
+        ``images`` array.
+        """
         creds = resolve_xai_http_credentials()
         api_key = str(creds.get("api_key") or "").strip()
         provider_name = str(creds.get("provider") or "xai").strip() or "xai"
@@ -189,6 +265,28 @@ class XAIImageGenProvider(ImageGenProvider):
             "resolution": xai_res,
         }
 
+        # Reference-image (image-to-image) path: route to /images/edits and
+        # attach the input image(s). Text-to-image stays on /images/generations.
+        input_refs = _collect_input_images(image_url, reference_image_urls)
+        endpoint = "images/generations"
+        if input_refs:
+            try:
+                entries = [_to_edit_image_entry(ref) for ref in input_refs]
+            except Exception as exc:
+                return error_response(
+                    error=f"Invalid reference image: {exc}",
+                    error_type="invalid_input",
+                    provider=provider_name,
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+            endpoint = "images/edits"
+            if len(entries) == 1:
+                payload["image"] = entries[0]
+            else:
+                payload["images"] = entries
+
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
@@ -199,10 +297,10 @@ class XAIImageGenProvider(ImageGenProvider):
 
         try:
             response = requests.post(
-                f"{base_url}/images/generations",
+                f"{base_url}/{endpoint}",
                 headers=headers,
                 json=payload,
-                timeout=120,
+                timeout=180 if input_refs else 120,
             )
             response.raise_for_status()
         except requests.HTTPError as exc:
@@ -313,6 +411,9 @@ class XAIImageGenProvider(ImageGenProvider):
         extra: Dict[str, Any] = {
             "resolution": xai_res,
         }
+        if input_refs:
+            extra["edited"] = True
+            extra["input_images"] = len(input_refs)
 
         return success_response(
             image=image_ref,

--- a/tests/plugins/image_gen/test_xai_provider.py
+++ b/tests/plugins/image_gen/test_xai_provider.py
@@ -320,6 +320,94 @@ class TestGenerate:
 
 
 # ---------------------------------------------------------------------------
+# Reference-image (image-to-image) tests
+# ---------------------------------------------------------------------------
+
+
+class TestXAIImageEdits:
+    def _ok_resp(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"url": "https://xai.image/edited.png"}]}
+        return mock_resp
+
+    def test_text_to_image_uses_generations_endpoint(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._ok_resp()) as mock_post:
+            XAIImageGenProvider().generate(prompt="a fox")
+
+        url = mock_post.call_args.args[0] if mock_post.call_args.args else mock_post.call_args[0][0]
+        assert url.endswith("/images/generations")
+
+    def test_single_reference_routes_to_edits_with_image_field(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._ok_resp()) as mock_post:
+            result = XAIImageGenProvider().generate(
+                prompt="make it watercolor",
+                image_url="https://example.com/photo.png",
+            )
+
+        url = mock_post.call_args.args[0] if mock_post.call_args.args else mock_post.call_args[0][0]
+        payload = mock_post.call_args.kwargs.get("json")
+        assert url.endswith("/images/edits")
+        assert payload["image"] == {"url": "https://example.com/photo.png"}
+        assert "images" not in payload
+        assert result["success"] is True
+        assert result["edited"] is True
+        assert result["input_images"] == 1
+
+    def test_multiple_references_use_images_array(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._ok_resp()) as mock_post:
+            XAIImageGenProvider().generate(
+                prompt="blend these",
+                image_url="https://example.com/a.png",
+                reference_image_urls=["https://example.com/b.png"],
+            )
+
+        payload = mock_post.call_args.kwargs.get("json")
+        assert "image" not in payload
+        assert payload["images"] == [
+            {"url": "https://example.com/a.png"},
+            {"url": "https://example.com/b.png"},
+        ]
+
+    def test_local_file_inlined_as_base64_data_uri(self, tmp_path):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        img = tmp_path / "ref.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\nFAKEPNGDATA")
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=self._ok_resp()) as mock_post:
+            XAIImageGenProvider().generate(prompt="restyle", image_url=str(img))
+
+        payload = mock_post.call_args.kwargs.get("json")
+        assert payload["image"]["url"].startswith("data:image/png;base64,")
+
+    def test_missing_local_reference_returns_error(self):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        result = XAIImageGenProvider().generate(
+            prompt="restyle", image_url="/no/such/file.png",
+        )
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_input"
+
+    def test_unsupported_extension_rejected(self, tmp_path):
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        bad = tmp_path / "ref.tiff"
+        bad.write_bytes(b"II*\x00")
+        result = XAIImageGenProvider().generate(prompt="restyle", image_url=str(bad))
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_input"
+
+
+# ---------------------------------------------------------------------------
 # Registration test
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -363,11 +363,19 @@ class TestAspectRatioNormalization:
 
 class TestRegistryIntegration:
 
-    def test_schema_exposes_only_prompt_and_aspect_ratio_to_agent(self, image_tool):
-        """The agent-facing schema must stay tight — model selection is a
-        user-level config choice, not an agent-level arg."""
+    def test_schema_exposes_expected_agent_args(self, image_tool):
+        """The agent-facing schema stays tight — prompt, aspect_ratio, and
+        the optional reference-image inputs (image-to-image). Model/backend
+        selection remains a user-level config choice, never an agent arg."""
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
-        assert set(props.keys()) == {"prompt", "aspect_ratio"}
+        assert set(props.keys()) == {
+            "prompt", "aspect_ratio", "image_url", "reference_image_urls",
+        }
+        # Backend/model selection must NOT leak into the agent surface.
+        assert "model" not in props
+        assert "provider" not in props
+        # Only prompt is required; reference images are optional.
+        assert image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["required"] == ["prompt"]
 
     def test_aspect_ratio_enum_is_three_values(self, image_tool):
         enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["aspect_ratio"]["enum"]

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -30,6 +30,26 @@ class _FakeCodexProvider(ImageGenProvider):
         }
 
 
+class _EchoKwargsProvider(ImageGenProvider):
+    """Provider that echoes the kwargs it received, so we can assert the
+    image-to-image inputs are forwarded by the dispatcher."""
+
+    @property
+    def name(self) -> str:
+        return "codex"
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        return {
+            "success": True,
+            "image": "/tmp/echo.png",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "provider": "codex",
+            "received_image_url": kwargs.get("image_url"),
+            "received_reference_image_urls": kwargs.get("reference_image_urls"),
+        }
+
+
 class TestPluginDispatch:
     def test_dispatch_routes_to_codex_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool
@@ -51,6 +71,50 @@ class TestPluginDispatch:
         assert payload["provider"] == "codex"
         assert payload["image"] == "/tmp/codex-test.png"
         assert payload["aspect_ratio"] == "square"
+
+    def test_dispatch_forwards_reference_images(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from agent import image_gen_registry as registry_module
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: codex\n")
+
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "codex")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: _EchoKwargsProvider() if name == "codex" else None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider(
+            "restyle this", "square",
+            image_url="https://example.com/hero.png",
+            reference_image_urls=["https://example.com/ref1.png", "/local/ref2.jpg"],
+        )
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is True
+        assert payload["received_image_url"] == "https://example.com/hero.png"
+        assert payload["received_reference_image_urls"] == [
+            "https://example.com/ref1.png", "/local/ref2.jpg",
+        ]
+
+    def test_dispatch_omits_reference_kwargs_when_absent(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from agent import image_gen_registry as registry_module
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: codex\n")
+
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "codex")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: _EchoKwargsProvider() if name == "codex" else None)
+
+        # No image inputs → provider should see neither kwarg (None echoed).
+        dispatched = image_generation_tool._dispatch_to_plugin_provider("plain text-to-image", "landscape")
+        payload = json.loads(dispatched)
+
+        assert payload["received_image_url"] is None
+        assert payload["received_reference_image_urls"] is None
 
     def test_dispatch_reports_missing_registered_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -887,10 +887,15 @@ from tools.registry import registry, tool_error
 IMAGE_GENERATE_SCHEMA = {
     "name": "image_generate",
     "description": (
-        "Generate high-quality images from text prompts. The underlying "
-        "backend (FAL, OpenAI, etc.) and model are user-configured and not "
-        "selectable by the agent. Returns either a URL or an absolute file "
-        "path in the `image` field; display it with markdown "
+        "Generate high-quality images from text prompts. Optionally pass a "
+        "reference image (image_url / reference_image_urls) to do "
+        "image-to-image — character, style, or product reference — on "
+        "backends that support it (e.g. xAI Grok Imagine). The output "
+        "orientation is controlled solely by `aspect_ratio`, never by the "
+        "reference image. The underlying "
+        "backend (FAL, OpenAI, xAI, etc.) and model are user-configured and "
+        "not selectable by the agent. Returns either a URL or an absolute "
+        "file path in the `image` field; display it with markdown "
         "![description](url-or-path) and the gateway will deliver it."
     ),
     "parameters": {
@@ -903,8 +908,40 @@ IMAGE_GENERATE_SCHEMA = {
             "aspect_ratio": {
                 "type": "string",
                 "enum": list(VALID_ASPECT_RATIOS),
-                "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
+                "description": (
+                    "Output orientation, and ALWAYS honored — it is fully "
+                    "independent of any reference image. A reference image "
+                    "(image_url / reference_image_urls) does NOT constrain or "
+                    "force the output shape: request 'portrait' and you get a "
+                    "portrait result even from a landscape reference. Set this "
+                    "from what the user asked for; if the user gave a photo to "
+                    "restyle and did not state an orientation, ask which they "
+                    "want rather than assuming. 'landscape' is 16:9 wide, "
+                    "'portrait' is 16:9 tall, 'square' is 1:1."
+                ),
                 "default": DEFAULT_ASPECT_RATIO,
+            },
+            "image_url": {
+                "type": "string",
+                "description": (
+                    "Optional reference image for image-to-image generation. "
+                    "Pass a public URL, a data: URI, or a local file path "
+                    "from the conversation; the backend uses it as the "
+                    "primary reference (e.g. keep this character/product and "
+                    "restyle per the prompt). Only honored by backends that "
+                    "support image input (currently xAI Grok Imagine); "
+                    "text-only backends ignore it."
+                ),
+            },
+            "reference_image_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional list of additional reference images (style or "
+                    "character refs), each a URL, data: URI, or local path. "
+                    "Combined with image_url when both are given. Only "
+                    "honored by backends that support multi-image input."
+                ),
             },
         },
         "required": ["prompt"],
@@ -951,7 +988,12 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(
+    prompt: str,
+    aspect_ratio: str,
+    image_url: Optional[str] = None,
+    reference_image_urls: Optional[list] = None,
+):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -962,6 +1004,10 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
     ``plugins/image_gen/fal/`` plugin (the plugin re-enters this module's
     pipeline via ``_it`` indirection so behavior is identical to the
     direct call, just routed through the registry).
+
+    ``image_url`` / ``reference_image_urls`` enable image-to-image on
+    providers that support it; providers that don't simply ignore them
+    (every provider's ``generate`` absorbs ``**kwargs``).
     """
     configured = _read_configured_image_provider()
     if not configured:
@@ -1008,6 +1054,10 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
         if configured_model:
             kwargs["model"] = configured_model
+        if image_url:
+            kwargs["image_url"] = image_url
+        if reference_image_urls:
+            kwargs["reference_image_urls"] = reference_image_urls
         result = provider.generate(**kwargs)
     except Exception as exc:
         logger.warning(
@@ -1030,17 +1080,45 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
     return json.dumps(result)
 
 
+def _normalize_reference_images(value):
+    """Coerce the schema's reference_image_urls into a clean list of strings.
+
+    Accepts a single string or a list; drops empties. Returns None when
+    nothing usable is present so dispatch can omit the kwarg entirely.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, (list, tuple)):
+        return None
+    out = [item.strip() for item in value if isinstance(item, str) and item.strip()]
+    return out or None
+
+
 def _handle_image_generate(args, **kw):
     prompt = args.get("prompt", "")
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    image_url = (args.get("image_url") or "").strip() or None
+    reference_image_urls = _normalize_reference_images(args.get("reference_image_urls"))
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(
+        prompt, aspect_ratio, image_url, reference_image_urls,
+    )
     if dispatched is not None:
         return dispatched
+
+    if image_url or reference_image_urls:
+        logger.info(
+            "image_generate: reference image(s) supplied but the active "
+            "in-tree FAL path is text-to-image only — ignoring them. "
+            "Configure an image_gen provider that supports image input "
+            "(e.g. xAI) to use reference images."
+        )
 
     return image_generate_tool(
         prompt=prompt,


### PR DESCRIPTION
## What

Adds reference-image (image-to-image) support to `image_generate`, matching
the surface `video_generate` already exposes. Previously the image tool was
text-only.

## Why

`video_generate` accepts a drive image + reference images, but
`image_generate` had no way to pass an input image — so character/style/
product reference, the most common practical request, was impossible.

## Changes

- **Tool schema**: optional `image_url` and `reference_image_urls`, threaded
  `_handle_image_generate` → `_dispatch_to_plugin_provider` → provider.
  Providers that do not support image input ignore them (every `generate`
  absorbs `**kwargs`); the in-tree FAL path logs that it cannot use them.
- **xAI provider**: when an input image is present, route to
  `/v1/images/edits` instead of `/v1/images/generations` (single →
  `image`, multiple → `images`). Inputs may be public URLs, `data:` URIs,
  or local file paths; local files are inlined as base64 data URIs, so no
  public-hosting step is required. Response gains `edited` / `input_images`.

## Tests

Edits routing, single vs multiple inputs, base64 inlining of local files,
missing-file / unsupported-extension errors, dispatch forwarding, and the
widened agent-schema contract. Verified end-to-end against the live xAI API
(URL reference and local-file reference both returned an edited image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
