### PR TITLE
fix(whatsapp): allow same-account group messages

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2612,6 +2612,8 @@ DEFAULT_CONFIG = {
         # Default (None) uses the built-in "⚕ *Hermes Agent*" header.
         # Set to "" (empty string) to disable the header entirely.
         # Supports \n for newlines, e.g. "🤖 *My Bot*\n──────\n"
+        # Allow same-account group messages; group/mention gates still apply.
+        "process_from_me_groups": False,
     },
 
     # Telegram platform settings (gateway mode)

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -334,6 +334,33 @@ def _file_content_hash(path: Path) -> str:
         return ""
 
 
+_BRIDGE_RUNTIME_ENV_KEYS = (
+    "WHATSAPP_DEBUG",
+    "WHATSAPP_FORWARD_OWNER_MESSAGES",
+    "WHATSAPP_PROCESS_FROM_ME_GROUPS",
+    "WHATSAPP_DM_POLICY",
+    "WHATSAPP_ALLOWED_USERS",
+    "WHATSAPP_REPLY_PREFIX",
+    "WHATSAPP_MAX_MESSAGE_LENGTH",
+    "WHATSAPP_CHUNK_DELAY_MS",
+    "WHATSAPP_SEND_TIMEOUT_MS",
+    "HERMES_IMAGE_CACHE_DIR",
+    "HERMES_AUDIO_CACHE_DIR",
+    "HERMES_DOCUMENT_CACHE_DIR",
+)
+
+
+def _bridge_runtime_config_hash(
+    *, mode: str, port: int, session_path: Path, env: dict
+) -> str:
+    """Fingerprint process-start settings that affect bridge behavior."""
+    import hashlib
+
+    parts = [f"mode={mode}", f"port={port}", f"session={session_path}"]
+    parts.extend(f"{key}={env.get(key, '<unset>')}" for key in _BRIDGE_RUNTIME_ENV_KEYS)
+    return hashlib.sha256("\0".join(parts).encode()).hexdigest()[:16]
+
+
 def check_whatsapp_requirements() -> bool:
     """
     Check if WhatsApp dependencies are available.
@@ -568,6 +595,28 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
             # Ensure session directory exists
             self._session_path.mkdir(parents=True, exist_ok=True)
+            # Build the exact subprocess environment before the reuse check.
+            # The runtime hash makes every process-start setting part of the
+            # stale-bridge handshake without exposing those values in /health.
+            whatsapp_mode = os.getenv("WHATSAPP_MODE", "self-chat")
+            bridge_env = with_hermes_node_path()
+            if self._reply_prefix is not None:
+                bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
+            from gateway.platforms.base import (
+                get_audio_cache_dir as _get_audio_dir,
+                get_document_cache_dir as _get_doc_dir,
+                get_image_cache_dir as _get_img_dir,
+            )
+            bridge_env["HERMES_IMAGE_CACHE_DIR"] = str(_get_img_dir())
+            bridge_env["HERMES_AUDIO_CACHE_DIR"] = str(_get_audio_dir())
+            bridge_env["HERMES_DOCUMENT_CACHE_DIR"] = str(_get_doc_dir())
+            expected_runtime_hash = _bridge_runtime_config_hash(
+                mode=whatsapp_mode,
+                port=self._bridge_port,
+                session_path=self._session_path,
+                env=bridge_env,
+            )
+            bridge_env["HERMES_BRIDGE_RUNTIME_HASH"] = expected_runtime_hash
             
             # Check if bridge is already running and connected
             import aiohttp
@@ -592,7 +641,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 # treated as stale by definition.
                                 running_hash = data.get("scriptHash", "")
                                 disk_hash = _file_content_hash(bridge_path)
-                                if running_hash and disk_hash and running_hash == disk_hash:
+                                running_runtime_hash = data.get(
+                                    "runtimeConfigHash", ""
+                                )
+                                if (
+                                    running_hash
+                                    and disk_hash
+                                    and running_hash == disk_hash
+                                    and running_runtime_hash
+                                    == expected_runtime_hash
+                                ):
                                     print(f"[{self.name}] Using existing bridge (status: {bridge_status})")
                                     self._mark_connected()
                                     self._bridge_process = None  # Not managed by us
@@ -601,7 +659,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                     return True
                                 print(
                                     f"[{self.name}] Running bridge is stale "
-                                    f"(running={running_hash or 'unversioned'}, disk={disk_hash}), restarting"
+                                    f"(running_hash={running_hash or 'unversioned'}, "
+                                    f"disk_hash={disk_hash}, "
+                                    f"running_runtime={running_runtime_hash or 'unversioned'}, "
+                                    f"expected_runtime={expected_runtime_hash}), restarting"
                                 )
                             else:
                                 print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")
@@ -616,30 +677,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # Start the bridge process in its own process group.
             # Route output to a log file so QR codes, errors, and reconnection
             # messages are preserved for troubleshooting.
-            whatsapp_mode = os.getenv("WHATSAPP_MODE", "self-chat")
             self._bridge_log = self._session_path.parent / "bridge.log"
             bridge_log_fh = open(self._bridge_log, "a", encoding="utf-8")
             self._bridge_log_fh = bridge_log_fh
-
-            # Build bridge subprocess environment.
-            # Pass WHATSAPP_REPLY_PREFIX from config.yaml so the Node bridge
-            # can use it without the user needing to set a separate env var.
-            # with_hermes_node_path() copies os.environ when called with no arg.
-            bridge_env = with_hermes_node_path()
-            if self._reply_prefix is not None:
-                bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
-            # Pass the profile-aware cache directories so the bridge writes
-            # media where the Python side reads it.  Without these the bridge
-            # hardcodes ~/.hermes/{image,audio,document}_cache, which diverges
-            # under HERMES_HOME overrides, profiles, and the new cache/ layout.
-            from gateway.platforms.base import (
-                get_audio_cache_dir as _get_audio_dir,
-                get_document_cache_dir as _get_doc_dir,
-                get_image_cache_dir as _get_img_dir,
-            )
-            bridge_env["HERMES_IMAGE_CACHE_DIR"] = str(_get_img_dir())
-            bridge_env["HERMES_AUDIO_CACHE_DIR"] = str(_get_audio_dir())
-            bridge_env["HERMES_DOCUMENT_CACHE_DIR"] = str(_get_doc_dir())
 
             self._bridge_process = subprocess.Popen(
                 [

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -379,6 +379,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     - allow_from: List of sender IDs allowed in DMs (when dm_policy="allowlist")
     - group_policy: "open" | "allowlist" | "disabled" | "pairing" — which groups are processed (default: "pairing")
     - group_allow_from: List of group JIDs allowed (when group_policy="allowlist")
+    - process_from_me_groups: Allow same-account group messages to reach the
+      normal group-policy and mention gates (default: false)
 
     Behavior (gating, mention parsing, markdown conversion, chunking) is
     provided by ``WhatsAppBehaviorMixin`` so the Cloud API adapter can
@@ -1736,6 +1738,13 @@ def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
         os.environ["WHATSAPP_ALLOWED_USERS"] = str(af)
     if "group_policy" in whatsapp_cfg and not os.getenv("WHATSAPP_GROUP_POLICY"):
         os.environ["WHATSAPP_GROUP_POLICY"] = str(whatsapp_cfg["group_policy"]).lower()
+    if (
+        "process_from_me_groups" in whatsapp_cfg
+        and not os.getenv("WHATSAPP_PROCESS_FROM_ME_GROUPS")
+    ):
+        os.environ["WHATSAPP_PROCESS_FROM_ME_GROUPS"] = str(
+            whatsapp_cfg["process_from_me_groups"]
+        ).lower()
     gaf = whatsapp_cfg.get("group_allow_from")
     if gaf is not None and not os.getenv("WHATSAPP_GROUP_ALLOWED_USERS"):
         if isinstance(gaf, list):

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -32,7 +32,10 @@ import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
-import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import {
+  classifyFromMeGroupGate,
+  classifyOwnerMessageGate,
+} from './owner_message_gate.js';
 import {
   buildPollPayload,
   buildLocationPayload,
@@ -74,6 +77,12 @@ const FORWARD_OWNER_MESSAGES =
   process.env &&
   typeof process.env.WHATSAPP_FORWARD_OWNER_MESSAGES === 'string' &&
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_FORWARD_OWNER_MESSAGES.toLowerCase());
+
+// Internal bridge flag populated from whatsapp.process_from_me_groups in
+// config.yaml. Same-account group messages remain disabled by default.
+const PROCESS_FROM_ME_GROUPS = ['1', 'true', 'yes', 'on'].includes(
+  String(process.env.WHATSAPP_PROCESS_FROM_ME_GROUPS || '').trim().toLowerCase(),
+);
 
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
@@ -546,16 +555,34 @@ async function startSocket() {
       // Handle fromMe messages based on mode
       let fromOwner = false;
       if (msg.key.fromMe) {
-        if (isGroup || chatId.includes('status')) {
+        if (chatId.includes('status')) {
           emitDebugEvent({
             stage: 'ignored',
-            reason: isGroup ? 'from_me_group' : 'from_me_status',
+            reason: 'from_me_status',
             chatId: redactWhatsAppId(chatId),
           });
           continue;
         }
 
-        if (WHATSAPP_MODE === 'bot') {
+        if (isGroup) {
+          const decision = classifyFromMeGroupGate({
+            mode: WHATSAPP_MODE,
+            enabled: PROCESS_FROM_ME_GROUPS,
+            recentlySent: recentlySentIds,
+            messageId: msg.key.id,
+          });
+          if (decision.action !== 'forward_group') {
+            emitDebugEvent({
+              stage: 'ignored',
+              reason: decision.action === 'drop_echo' ? 'agent_echo' : 'from_me_group',
+              chatId: redactWhatsAppId(chatId),
+              messageId: msg.key.id,
+            });
+            continue;
+          }
+          // The Python adapter remains authoritative for group_policy,
+          // group_allow_from, and mention requirements.
+        } else if (WHATSAPP_MODE === 'bot') {
           // Bot mode: separate bot number. fromMe inbound is either
           //   (a) an echo of our own /send (recentlySentIds will catch it), or
           //   (b) a message the owner typed from their own phone using the

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -1101,6 +1101,7 @@ app.get('/health', (req, res) => {
     queueLength: messageQueue.length,
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
+    runtimeConfigHash: process.env.HERMES_BRIDGE_RUNTIME_HASH || '',
   });
 });
 

--- a/scripts/whatsapp-bridge/owner_message_gate.js
+++ b/scripts/whatsapp-bridge/owner_message_gate.js
@@ -54,3 +54,29 @@ export function classifyOwnerMessageGate({
   }
   return { action: 'forward_owner' };
 }
+
+/**
+ * Classify a fromMe group message before it can enter the inbound queue.
+ *
+ * Same-account group processing is intentionally separate from the owner-DM
+ * path above: group authorization and mention handling belong to the Python
+ * adapter, while this bridge-level gate only enforces the explicit opt-in and
+ * suppresses echoes of messages sent through the bridge itself.
+ */
+export function classifyFromMeGroupGate({
+  mode,
+  enabled,
+  recentlySent,
+  messageId,
+}) {
+  if (mode !== 'bot') {
+    return { action: 'drop_mode' };
+  }
+  if (recentlySent && recentlySent.has(messageId)) {
+    return { action: 'drop_echo' };
+  }
+  if (!enabled) {
+    return { action: 'drop_disabled' };
+  }
+  return { action: 'forward_group' };
+}

--- a/scripts/whatsapp-bridge/owner_message_gate.test.mjs
+++ b/scripts/whatsapp-bridge/owner_message_gate.test.mjs
@@ -1,7 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import {
+  classifyFromMeGroupGate,
+  classifyOwnerMessageGate,
+} from './owner_message_gate.js';
 
 function makeRecentlySent(ids = []) {
   const set = new Set(ids);
@@ -123,4 +126,44 @@ test('disabled flag fires before allowlist check', () => {
     chatId: '111600547700784@lid',
   });
   assert.deepEqual(decision, { action: 'drop_disabled' });
+});
+
+test('enabled same-account group message is forwarded', () => {
+  const decision = classifyFromMeGroupGate({
+    mode: 'bot',
+    enabled: true,
+    recentlySent: makeRecentlySent(),
+    messageId: 'M-GROUP-1',
+  });
+  assert.deepEqual(decision, { action: 'forward_group' });
+});
+
+test('same-account group message is dropped when disabled', () => {
+  const decision = classifyFromMeGroupGate({
+    mode: 'bot',
+    enabled: false,
+    recentlySent: makeRecentlySent(),
+    messageId: 'M-GROUP-2',
+  });
+  assert.deepEqual(decision, { action: 'drop_disabled' });
+});
+
+test('same-account group outbound echo is dropped even when enabled', () => {
+  const decision = classifyFromMeGroupGate({
+    mode: 'bot',
+    enabled: true,
+    recentlySent: makeRecentlySent(['M-GROUP-ECHO']),
+    messageId: 'M-GROUP-ECHO',
+  });
+  assert.deepEqual(decision, { action: 'drop_echo' });
+});
+
+test('same-account group processing remains unavailable in self-chat mode', () => {
+  const decision = classifyFromMeGroupGate({
+    mode: 'self-chat',
+    enabled: true,
+    recentlySent: makeRecentlySent(),
+    messageId: 'M-GROUP-3',
+  });
+  assert.deepEqual(decision, { action: 'drop_mode' });
 });

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -272,6 +272,31 @@ def test_group_policy_allowlist_allows_listed_group():
     assert adapter._should_process_message(_group_message("agus test")) is True
 
 
+def test_same_account_group_payload_still_obeys_allowlist_and_mention_gate():
+    """Once the Node bridge admits a same-account group message, the normal
+    Python group-policy and mention gates must remain authoritative."""
+    adapter = _make_adapter(
+        group_policy="allowlist",
+        group_allow_from=["120363001234567890@g.us"],
+        require_mention=True,
+        mention_patterns=[r"^\s*@?hermes\b"],
+    )
+
+    assert adapter._should_process_message(
+        _group_message("hello everyone", fromOwner=False)
+    ) is False
+    assert adapter._should_process_message(
+        _group_message("@hermes status", fromOwner=False)
+    ) is True
+    assert adapter._should_process_message(
+        _group_message(
+            "@hermes status",
+            chatId="999999999999@g.us",
+            fromOwner=False,
+        )
+    ) is False
+
+
 def test_group_policy_open_allows_all_groups():
     adapter = _make_adapter(group_policy="open", require_mention=True)
 
@@ -297,6 +322,7 @@ def test_config_bridges_whatsapp_dm_and_group_policy(monkeypatch, tmp_path):
         "whatsapp:\n"
         "  dm_policy: disabled\n"
         "  group_policy: allowlist\n"
+        "  process_from_me_groups: true\n"
         "  group_allow_from:\n"
         "    - \"120363001234567890@g.us\"\n",
         encoding="utf-8",
@@ -306,6 +332,7 @@ def test_config_bridges_whatsapp_dm_and_group_policy(monkeypatch, tmp_path):
     monkeypatch.delenv("WHATSAPP_DM_POLICY", raising=False)
     monkeypatch.delenv("WHATSAPP_GROUP_POLICY", raising=False)
     monkeypatch.delenv("WHATSAPP_GROUP_ALLOWED_USERS", raising=False)
+    monkeypatch.delenv("WHATSAPP_PROCESS_FROM_ME_GROUPS", raising=False)
 
     config = load_gateway_config()
 
@@ -316,6 +343,22 @@ def test_config_bridges_whatsapp_dm_and_group_policy(monkeypatch, tmp_path):
     assert __import__("os").environ["WHATSAPP_DM_POLICY"] == "disabled"
     assert __import__("os").environ["WHATSAPP_GROUP_POLICY"] == "allowlist"
     assert __import__("os").environ["WHATSAPP_GROUP_ALLOWED_USERS"] == "120363001234567890@g.us"
+    assert __import__("os").environ["WHATSAPP_PROCESS_FROM_ME_GROUPS"] == "true"
+
+
+def test_process_from_me_groups_env_takes_precedence(monkeypatch, tmp_path):
+    config_dir = tmp_path / ".hermes"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text(
+        "whatsapp:\n  process_from_me_groups: false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(config_dir))
+    monkeypatch.setenv("WHATSAPP_PROCESS_FROM_ME_GROUPS", "true")
+
+    load_gateway_config()
+
+    assert __import__("os").environ["WHATSAPP_PROCESS_FROM_ME_GROUPS"] == "true"
 
 
 def test_config_bridges_whatsapp_allow_from(monkeypatch, tmp_path):

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -7,10 +7,11 @@ long-lived bridge process therefore survived gateway restarts AND
 ``hermes update``, serving pre-update bridge.js behavior forever (e.g.
 no inbound media download → images/voice notes arrive as placeholders).
 
-The fix: bridge.js reports a hash of its own source in ``/health``
-(``scriptHash``); the adapter compares it against the bridge.js on disk
-and restarts the bridge on mismatch.  Bridges that predate the handshake
-report no hash and are treated as stale by definition.
+The fix: bridge.js reports hashes for its own source and process-start
+configuration in ``/health`` (``scriptHash`` and ``runtimeConfigHash``); the
+adapter compares them against the current bridge.js and gateway configuration.
+A mismatch restarts the bridge. Bridges that predate either handshake report
+no hash and are treated as stale by definition.
 
 Also covers the npm dependency-refresh stamp: deps are reinstalled when
 package.json changes, not only when node_modules is missing.
@@ -139,9 +140,52 @@ class TestFileContentHash:
         assert _file_content_hash(f) == expected
 
 
+class TestBridgeRuntimeConfigHash:
+    def test_covers_every_process_start_setting(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import (
+            _BRIDGE_RUNTIME_ENV_KEYS,
+            _bridge_runtime_config_hash,
+        )
+
+        assert _BRIDGE_RUNTIME_ENV_KEYS == (
+            "WHATSAPP_DEBUG",
+            "WHATSAPP_FORWARD_OWNER_MESSAGES",
+            "WHATSAPP_PROCESS_FROM_ME_GROUPS",
+            "WHATSAPP_DM_POLICY",
+            "WHATSAPP_ALLOWED_USERS",
+            "WHATSAPP_REPLY_PREFIX",
+            "WHATSAPP_MAX_MESSAGE_LENGTH",
+            "WHATSAPP_CHUNK_DELAY_MS",
+            "WHATSAPP_SEND_TIMEOUT_MS",
+            "HERMES_IMAGE_CACHE_DIR",
+            "HERMES_AUDIO_CACHE_DIR",
+            "HERMES_DOCUMENT_CACHE_DIR",
+        )
+        baseline = _bridge_runtime_config_hash(
+            mode="bot", port=3001, session_path=tmp_path / "session", env={}
+        )
+        assert len(baseline) == 16
+        for key in _BRIDGE_RUNTIME_ENV_KEYS:
+            assert _bridge_runtime_config_hash(
+                mode="bot",
+                port=3001,
+                session_path=tmp_path / "session",
+                env={key: "changed"},
+            ) != baseline
+        assert _bridge_runtime_config_hash(
+            mode="self-chat", port=3001, session_path=tmp_path / "session", env={}
+        ) != baseline
+        assert _bridge_runtime_config_hash(
+            mode="bot", port=3002, session_path=tmp_path / "session", env={}
+        ) != baseline
+        assert _bridge_runtime_config_hash(
+            mode="bot", port=3001, session_path=tmp_path / "other", env={}
+        ) != baseline
+
+
 class TestStaleBridgeHandshake:
     @pytest.mark.asyncio
-    async def test_reuses_bridge_when_hash_matches(self, tmp_path):
+    async def test_reuses_bridge_when_hash_matches(self, tmp_path, monkeypatch):
         from plugins.platforms.whatsapp.adapter import _file_content_hash
 
         bridge_dir = _setup_bridge_dir(tmp_path)
@@ -151,9 +195,18 @@ class TestStaleBridgeHandshake:
             session_path=tmp_path / "session",
         )
         disk_hash = _file_content_hash(bridge_dir / "bridge.js")
-        mock_client = _mock_health({"status": "connected", "scriptHash": disk_hash})
+        monkeypatch.setenv("WHATSAPP_MODE", "self-chat")
+        monkeypatch.delenv("WHATSAPP_PROCESS_FROM_ME_GROUPS", raising=False)
+        mock_client = _mock_health(
+            {
+                "status": "connected",
+                "scriptHash": disk_hash,
+                "runtimeConfigHash": "runtime-ok",
+            }
+        )
 
         with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("plugins.platforms.whatsapp.adapter._bridge_runtime_config_hash", return_value="runtime-ok"), \
              patch("aiohttp.ClientSession", mock_client), \
              patch("plugins.platforms.whatsapp.adapter.asyncio.create_task") as mock_task, \
              patch("subprocess.Popen") as mock_popen, \
@@ -164,6 +217,42 @@ class TestStaleBridgeHandshake:
         assert result is True
         mock_popen.assert_not_called()  # reused, never spawned
         mock_task.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_restarts_bridge_on_runtime_config_mismatch(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        mock_client = _mock_health(
+            {
+                "status": "connected",
+                "scriptHash": disk_hash,
+                "runtimeConfigHash": "stale-runtime",
+            }
+        )
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("plugins.platforms.whatsapp.adapter._bridge_runtime_config_hash", return_value="expected-runtime"), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process") as mock_kill_port, \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            result = await adapter.connect()
+
+        assert result is False
+        mock_popen.assert_called_once()
+        mock_kill_port.assert_called_once_with(adapter._bridge_port)
 
     @pytest.mark.asyncio
     async def test_restarts_bridge_on_hash_mismatch(self, tmp_path):

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -38,6 +38,23 @@ bot stops working after a WhatsApp update, pull the latest Hermes version and re
 | **Separate bot number** (recommended) | Dedicate a phone number to the bot. People message that number directly. | Clean UX, multiple users, lower ban risk |
 | **Personal self-chat** | Use your own WhatsApp. You message yourself to talk to the agent. | Quick setup, single user, testing |
 
+### Advanced: Same-Account Groups
+
+If Hermes shares your WhatsApp account and should respond in a dedicated group, enable same-account group intake in `~/.hermes/config.yaml`:
+
+```yaml
+whatsapp:
+  process_from_me_groups: true
+  group_policy: allowlist
+  group_allow_from:
+    - "120363001234567890@g.us"
+  require_mention: true
+  mention_patterns:
+    - '^\s*@?hermes\b'
+```
+
+Run the bridge in `bot` mode for this setup. Messages sent by the linked account are admitted only when `process_from_me_groups` is enabled; Hermes's own outbound replies are suppressed as echoes. Admitted messages still must pass the configured group allowlist and mention gates. Keep the default `false` unless you intentionally use this same-account group pattern.
+
 ---
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- add `whatsapp.process_from_me_groups` as an opt-in for same-account WhatsApp group setups
- preserve outbound message-ID echo suppression before forwarding any `fromMe` group event
- keep Python `group_policy`, `group_allow_from`, and mention gates authoritative
- restart a reused bridge when its process-start configuration no longer matches the gateway configuration

## Why
When Hermes uses the same WhatsApp account as the operator, group messages authored by that account arrive from Baileys with `msg.key.fromMe === true`. The bridge previously discarded every such group message before Hermes's configured group allowlist and mention filters could evaluate it.

The new setting is disabled by default and is surfaced through `config.yaml`. It deliberately does not mark group messages as owner-DM handover events and does not apply the DM allowlist to groups.

## Configuration

```yaml
whatsapp:
  process_from_me_groups: true
  group_policy: allowlist
  group_allow_from:
    - "120363001234567890@g.us"
  require_mention: true
```

## Validation
- `node --check scripts/whatsapp-bridge/bridge.js`
- all WhatsApp bridge Node tests: **25 passed**
- all targeted WhatsApp Python tests: **330 passed**
- Ruff on changed Python paths: passed
- `git diff --check`: passed
- independent security/correctness review: passed after addressing stale reused-bridge configuration

## Safety properties
- default behavior remains disabled
- outbound IDs recorded by bridge sends are rejected before event/media extraction
- the downstream echo guard remains as defense in depth
- same-account group messages remain subject to group allowlists and mention requirements
- changes to mode, allowlists, DM policy, owner forwarding, same-account groups, reply prefix, send limits, or cache paths invalidate and restart a reused bridge
