### PR TITLE
fix(mcp): suppress oauth stdin prompts during background discovery

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from contextlib import nullcontext
 from typing import Optional
 
 _mcp_discovery_lock = threading.Lock()
@@ -36,9 +37,7 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
 
         def _discover() -> None:
             try:
-                from tools.mcp_tool import discover_mcp_tools
-
-                discover_mcp_tools()
+                _discover_mcp_tools_without_interactive_oauth()
             except Exception:
                 logger.debug("Background MCP tool discovery failed", exc_info=True)
 
@@ -49,6 +48,19 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
         )
         _mcp_discovery_thread = thread
         thread.start()
+
+
+def _discover_mcp_tools_without_interactive_oauth() -> None:
+    """Run MCP discovery without letting OAuth read from the user's stdin."""
+    try:
+        from tools.mcp_oauth import suppress_interactive_oauth
+    except Exception:
+        suppress_interactive_oauth = nullcontext
+
+    with suppress_interactive_oauth():
+        from tools.mcp_tool import discover_mcp_tools
+
+        discover_mcp_tools()
 
 
 def wait_for_mcp_discovery(timeout: float = 0.75) -> None:

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -81,11 +81,58 @@ def test_prepare_agent_startup_backgrounds_blocking_mcp_for_chat(monkeypatch):
         main_mod._prepare_agent_startup(_agent_args())
         elapsed = time.monotonic() - start
         assert elapsed < 0.2
+        deadline = time.monotonic() + 1.0
+        while calls["mcp"] == 0 and time.monotonic() < deadline:
+            time.sleep(0.01)
         assert calls["mcp"] == 1
         assert mcp_startup._mcp_discovery_thread is not None
         assert mcp_startup._mcp_discovery_thread.is_alive()
     finally:
         stop.set()
+
+
+def test_background_mcp_discovery_suppresses_interactive_oauth(monkeypatch):
+    state = {"active": False, "during_discover": None}
+
+    class SuppressInteractiveOAuth:
+        def __enter__(self):
+            state["active"] = True
+
+        def __exit__(self, *_exc):
+            state["active"] = False
+
+    def _discover():
+        state["during_discover"] = state["active"]
+
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        types.SimpleNamespace(
+            read_raw_config=lambda: {"mcp_servers": {"demo": {"url": "https://mcp.example.test/mcp"}}},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_oauth",
+        types.SimpleNamespace(
+            suppress_interactive_oauth=lambda: SuppressInteractiveOAuth(),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "tools.mcp_tool",
+        types.SimpleNamespace(discover_mcp_tools=_discover),
+    )
+
+    mcp_startup.start_background_mcp_discovery(
+        logger=types.SimpleNamespace(debug=lambda *_a, **_k: None),
+        thread_name="test-mcp-discovery",
+    )
+    assert mcp_startup._mcp_discovery_thread is not None
+    mcp_startup._mcp_discovery_thread.join(timeout=1.0)
+
+    assert state["during_discover"] is True
+    assert state["active"] is False
 
 
 def test_prepare_agent_startup_skips_mcp_bootstrap_for_tui_chat(monkeypatch):

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -456,6 +456,18 @@ class TestIsInteractive:
         monkeypatch.setattr("tools.mcp_oauth.sys.stdin", mock_stdin)
         assert _is_interactive() is False
 
+    def test_suppress_interactive_oauth_disables_stdin_prompts(self, monkeypatch):
+        import tools.mcp_oauth as mod
+
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        monkeypatch.setattr("tools.mcp_oauth.sys.stdin", mock_stdin)
+
+        assert _is_interactive() is True
+        with mod.suppress_interactive_oauth():
+            assert _is_interactive() is False
+        assert _is_interactive() is True
+
 
 class TestWaitForCallbackNoBlocking:
     """_wait_for_callback() must never call input() — it raises instead."""
@@ -753,6 +765,26 @@ class TestWaitForCallbackPasteIntegration:
                     asyncio.run(_wait_for_callback())
         err = capsys.readouterr().err
         assert "paste the redirect URL" not in err
+
+    def test_paste_prompt_NOT_shown_when_interactivity_suppressed(self, monkeypatch, capsys):
+        """Background MCP discovery must not race the CLI/TUI stdin reader."""
+        import tools.mcp_oauth as mod
+
+        mod._oauth_port = _find_free_port()
+        mock_stdin = MagicMock()
+        mock_stdin.isatty.return_value = True
+        monkeypatch.setattr(mod.sys, "stdin", mock_stdin)
+
+        async def instant_sleep(_):
+            pass
+
+        with patch.object(mod.asyncio, "sleep", instant_sleep):
+            with mod.suppress_interactive_oauth():
+                with pytest.raises(OAuthNonInteractiveError):
+                    asyncio.run(_wait_for_callback())
+        err = capsys.readouterr().err
+        assert "paste the redirect URL" not in err
+        mock_stdin.readline.assert_not_called()
 
 
 class TestPasteCallbackSkipToken:

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -44,6 +44,7 @@ import sys
 import threading
 import time
 import webbrowser
+from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
@@ -92,6 +93,7 @@ class OAuthNonInteractiveError(RuntimeError):
 # Port used by the most recent build_oauth_auth() call.  Exposed so that
 # tests can verify the callback server and the redirect_uri share a port.
 _oauth_port: int | None = None
+_oauth_interactivity = threading.local()
 
 
 # Skip tokens accepted at the paste prompt — exit OAuth without auth.
@@ -137,10 +139,23 @@ def _find_free_port() -> int:
 
 def _is_interactive() -> bool:
     """Return True if we can reasonably expect to interact with a user."""
+    if not getattr(_oauth_interactivity, "enabled", True):
+        return False
     try:
         return sys.stdin.isatty()
     except (AttributeError, ValueError):
         return False
+
+
+@contextmanager
+def suppress_interactive_oauth():
+    """Temporarily disable stdin-based OAuth prompts on the current thread."""
+    previous = getattr(_oauth_interactivity, "enabled", True)
+    _oauth_interactivity.enabled = False
+    try:
+        yield
+    finally:
+        _oauth_interactivity.enabled = previous
 
 
 def _can_open_browser() -> bool:

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -244,8 +244,11 @@ def main():
     if _has_mcp_servers:
         def _discover_mcp_background() -> None:
             try:
-                from tools.mcp_tool import discover_mcp_tools
-                discover_mcp_tools()
+                from hermes_cli.mcp_startup import (
+                    _discover_mcp_tools_without_interactive_oauth,
+                )
+
+                _discover_mcp_tools_without_interactive_oauth()
             except Exception:
                 logger.warning(
                     "Background MCP tool discovery failed", exc_info=True


### PR DESCRIPTION
## Summary
- prevent background MCP discovery from enabling MCP OAuth's stdin paste fallback
- share the non-interactive discovery wrapper with the TUI gateway startup path
- add regressions for suppressed OAuth interactivity and background discovery

Closes #35927.

## Validation
- `uv run --extra dev python -X utf8 -m pytest tests/hermes_cli/test_mcp_startup.py tests/tui_gateway/test_wait_for_mcp_discovery.py tests/tools/test_mcp_oauth.py::TestIsInteractive tests/tools/test_mcp_oauth.py::TestWaitForCallbackNoBlocking tests/tools/test_mcp_oauth.py::TestWaitForCallbackPasteIntegration tests/tools/test_mcp_oauth.py::TestWaitForCallbackSkipIntegration -q --timeout-method=thread`
- `uv run --extra dev ruff check .`

Note: `bash scripts/run_tests.sh ...` could not start on this Windows host because Bash/Service/CreateInstance returned `E_FAIL`; the focused pytest command above was used for local verification.