### PR TITLE
docs(termux): prefer nodejs-lts package

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -661,7 +661,7 @@ check_node() {
     fi
 
     if [ "$DISTRO" = "termux" ]; then
-        log_info "Node.js not found — installing Node.js via pkg..."
+        log_info "Node.js not found — installing Node.js LTS via pkg..."
     else
         log_info "Node.js not found — installing Node.js $NODE_VERSION LTS..."
     fi
@@ -670,14 +670,14 @@ check_node() {
 
 install_node() {
     if [ "$DISTRO" = "termux" ]; then
-        log_info "Installing Node.js via pkg..."
-        if pkg install -y nodejs >/dev/null; then
+        log_info "Installing Node.js LTS via pkg..."
+        if pkg install -y nodejs-lts >/dev/null; then
             local installed_ver
             installed_ver=$(node --version 2>/dev/null)
             log_success "Node.js $installed_ver installed via pkg"
             HAS_NODE=true
         else
-            log_warn "Failed to install Node.js via pkg"
+            log_warn "Failed to install Node.js LTS via pkg"
             HAS_NODE=false
         fi
         return 0
@@ -1991,7 +1991,7 @@ print_success() {
         echo "Note: Node.js could not be installed automatically."
         echo "Browser tools need Node.js. Install manually:"
         if [ "$DISTRO" = "termux" ]; then
-            echo "  pkg install nodejs"
+            echo "  pkg install nodejs-lts"
         else
             echo "  https://nodejs.org/en/download/"
         fi

--- a/scripts/lib/node-bootstrap.sh
+++ b/scripts/lib/node-bootstrap.sh
@@ -98,8 +98,8 @@ _nb_try_nvm() {
 
 _nb_try_termux_pkg() {
     _nb_is_termux || return 1
-    _nb_log "Installing Node.js via pkg..."
-    pkg install -y nodejs >/dev/null 2>&1 || return 1
+    _nb_log "Installing Node.js LTS via pkg..."
+    pkg install -y nodejs-lts >/dev/null 2>&1 || return 1
     _nb_have_modern_node || return 1
     _nb_ok "Node $(node --version) installed via pkg"
     return 0

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -53,7 +53,7 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 ```
 
 The installer detects Termux automatically and switches to a tested Android flow:
-- uses Termux `pkg` for system dependencies (`git`, `python`, `nodejs`, `ripgrep`, `ffmpeg`, build tools)
+- uses Termux `pkg` for system dependencies (`git`, `python`, `nodejs-lts`, `ripgrep`, `ffmpeg`, build tools)
 - creates the virtualenv with `python -m venv`
 - exports `ANDROID_API_LEVEL` automatically for Android wheel builds
 - prefers the broad `.[termux-all]` extra and falls back to the smaller `.[termux]` extra (and finally a base install) if the first attempt fails to compile

--- a/website/docs/getting-started/termux.md
+++ b/website/docs/getting-started/termux.md
@@ -66,14 +66,14 @@ If you want the explicit commands or need to debug a failed install, use the man
 
 ```bash
 pkg update
-pkg install -y git python clang rust make pkg-config libffi openssl nodejs ripgrep ffmpeg
+pkg install -y git python clang rust make pkg-config libffi openssl nodejs-lts ripgrep ffmpeg
 ```
 
 Why these packages?
 - `python` — runtime + venv support
 - `git` — clone/update the repo
 - `clang`, `rust`, `make`, `pkg-config`, `libffi`, `openssl` — needed to build a few Python dependencies on Android
-- `nodejs` — optional Node runtime for experiments beyond the tested core path
+- `nodejs-lts` — optional Node.js LTS runtime for experiments beyond the tested core path
 - `ripgrep` — fast file search
 - `ffmpeg` — media / TTS conversions
 
@@ -208,7 +208,7 @@ python -m pip install -e '.[termux]' -c constraints-termux.txt
 Install them with Termux packages:
 
 ```bash
-pkg install ripgrep nodejs
+pkg install ripgrep nodejs-lts
 ```
 
 ### Build failures while installing Python packages

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -53,7 +53,7 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 ```
 
 安装程序会自动检测 Termux 并切换到经过测试的 Android 流程：
-- 使用 Termux `pkg` 安装系统依赖（`git`、`python`、`nodejs`、`ripgrep`、`ffmpeg`、构建工具）
+- 使用 Termux `pkg` 安装系统依赖（`git`、`python`、`nodejs-lts`、`ripgrep`、`ffmpeg`、构建工具）
 - 使用 `python -m venv` 创建虚拟环境
 - 自动导出 `ANDROID_API_LEVEL` 以用于 Android wheel 构建
 - 优先使用较宽泛的 `.[termux-all]` extra，若首次编译失败则回退到较小的 `.[termux]` extra（最终回退到基础安装）

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/termux.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/termux.md
@@ -66,14 +66,14 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 
 ```bash
 pkg update
-pkg install -y git python clang rust make pkg-config libffi openssl nodejs ripgrep ffmpeg
+pkg install -y git python clang rust make pkg-config libffi openssl nodejs-lts ripgrep ffmpeg
 ```
 
 各包用途说明：
 - `python` — 运行时 + 虚拟环境支持
 - `git` — 克隆/更新仓库
 - `clang`、`rust`、`make`、`pkg-config`、`libffi`、`openssl` — 在 Android 上构建部分 Python 依赖所需
-- `nodejs` — 可选的 Node 运行时，用于已验证核心路径之外的实验
+- `nodejs-lts` — 可选的 Node.js LTS 运行时，用于已验证核心路径之外的实验
 - `ripgrep` — 快速文件搜索
 - `ffmpeg` — 媒体 / TTS 转换
 
@@ -208,7 +208,7 @@ python -m pip install -e '.[termux]' -c constraints-termux.txt
 使用 Termux 包安装：
 
 ```bash
-pkg install ripgrep nodejs
+pkg install ripgrep nodejs-lts
 ```
 
 ### 安装 Python 包时构建失败


### PR DESCRIPTION
## Summary
- update Termux installer paths to install `nodejs-lts` instead of `nodejs`
- align the English and Simplified Chinese Termux docs with the LTS package name
- update the Termux fallback/manual install guidance for missing Node.js

Fixes #35816

## Testing
- `bash -n scripts/install.sh`
- `bash -n scripts/lib/node-bootstrap.sh`
- `git diff --check`