### PR TITLE
fix(doctor): warn on broad env file permissions

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -5,14 +5,15 @@ Diagnoses issues with Hermes Agent setup.
 """
 
 import os
+import stat
 import sys
 import subprocess
 import shutil
 from pathlib import Path
 
-from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
+from hermes_cli.config import get_project_root, get_hermes_home, get_env_path, is_managed
 from hermes_cli.env_loader import load_hermes_dotenv
-from hermes_constants import display_hermes_home
+from hermes_constants import display_hermes_home, is_container
 
 PROJECT_ROOT = get_project_root()
 HERMES_HOME = get_hermes_home()
@@ -100,6 +101,83 @@ def _termux_install_all_fallback_notes() -> list[str]:
 def _has_provider_env_config(content: str) -> bool:
     """Return True when ~/.hermes/.env contains provider auth/base URL settings."""
     return any(key in content for key in _PROVIDER_ENV_HINTS)
+
+
+def _env_file_has_broad_permissions(mode: int) -> bool:
+    """Return True when group/other users have any access to a secret .env."""
+    return bool(stat.S_IMODE(mode) & 0o077)
+
+
+def _display_path(path: Path) -> str:
+    """Render user paths compactly when they live below the home directory."""
+    try:
+        home_relative = path.expanduser().resolve().relative_to(Path.home().resolve())
+        return f"~/{home_relative.as_posix()}"
+    except (OSError, ValueError):
+        return str(path)
+
+
+def _iter_env_files_for_permission_check() -> list[Path]:
+    """Return the main and profile .env files that may contain API keys."""
+    paths = [HERMES_HOME / ".env"]
+    if HERMES_HOME.parent.name == "profiles":
+        profiles_root = HERMES_HOME.parent
+    else:
+        profiles_root = HERMES_HOME / "profiles"
+    if profiles_root.is_dir():
+        paths.extend(sorted(profiles_root.glob("*/.env")))
+
+    unique_paths: list[Path] = []
+    seen: set[Path] = set()
+    for path in paths:
+        try:
+            key = path.resolve()
+        except OSError:
+            key = path.absolute()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_paths.append(path)
+    return unique_paths
+
+
+def _collect_env_permission_warnings(paths: list[Path]) -> list[tuple[Path, int]]:
+    warnings: list[tuple[Path, int]] = []
+    for path in paths:
+        try:
+            if not path.is_file():
+                continue
+            mode = stat.S_IMODE(path.stat().st_mode)
+        except OSError:
+            continue
+        if _env_file_has_broad_permissions(mode):
+            warnings.append((path, mode))
+    return warnings
+
+
+def _env_file_permission_check_supported() -> bool:
+    """Match the chmod environments where Hermes expects owner-only .env files."""
+    if os.name == "nt":
+        return False
+    if os.environ.get("HERMES_CONTAINER") or os.environ.get("HERMES_SKIP_CHMOD"):
+        return False
+    if is_managed() or is_container():
+        return False
+    return True
+
+
+def _check_env_file_permissions(issues: list[str]) -> None:
+    if not _env_file_permission_check_supported():
+        return
+
+    warnings = _collect_env_permission_warnings(_iter_env_files_for_permission_check())
+    for path, mode in warnings:
+        display_path = _display_path(path)
+        check_warn(
+            "Insecure .env permissions",
+            f"({display_path} is {mode:03o}; expected 600)",
+        )
+        issues.append(f"Restrict {display_path}: chmod 600 {path}")
 
 
 def _honcho_is_configured_for_doctor() -> bool:
@@ -636,6 +714,8 @@ def run_doctor(args):
             else:
                 check_info("Run 'hermes setup' to create one")
                 issues.append("Run 'hermes setup' to create .env")
+
+    _check_env_file_permissions(issues)
     
     # Check ~/.hermes/config.yaml (primary) or project cli-config.yaml (fallback)
     config_path = HERMES_HOME / 'config.yaml'

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -51,6 +51,43 @@ class TestProviderEnvDetection:
         assert not _has_provider_env_config(content)
 
 
+class TestDoctorEnvFilePermissions:
+    def test_flags_group_or_other_access_bits(self):
+        assert not doctor._env_file_has_broad_permissions(0o600)
+        assert not doctor._env_file_has_broad_permissions(0o400)
+        assert doctor._env_file_has_broad_permissions(0o640)
+        assert doctor._env_file_has_broad_permissions(0o644)
+        assert doctor._env_file_has_broad_permissions(0o777)
+
+    def test_warns_for_broad_env_permissions(self, monkeypatch, tmp_path, capsys):
+        hermes_home = tmp_path / ".hermes"
+        root_env = hermes_home / ".env"
+        profile_env = hermes_home / "profiles" / "coder" / ".env"
+        monkeypatch.setattr(doctor, "_env_file_permission_check_supported", lambda: True)
+        monkeypatch.setattr(
+            doctor,
+            "_iter_env_files_for_permission_check",
+            lambda: [root_env, profile_env],
+        )
+        monkeypatch.setattr(
+            doctor,
+            "_collect_env_permission_warnings",
+            lambda paths: [(root_env, 0o644), (profile_env, 0o640)],
+        )
+
+        issues = []
+        doctor._check_env_file_permissions(issues)
+
+        out = capsys.readouterr().out
+        assert out.count("Insecure .env permissions") == 2
+        assert "644" in out
+        assert "640" in out
+        assert issues == [
+            f"Restrict {doctor._display_path(root_env)}: chmod 600 {root_env}",
+            f"Restrict {doctor._display_path(profile_env)}: chmod 600 {profile_env}",
+        ]
+
+
 class TestDoctorEnvFileEncoding:
     """Regression for #18637 (bug 3): `hermes doctor` crashed on Windows
     Chinese locale (GBK) because `.env` was read with Path.read_text() which


### PR DESCRIPTION
Adds a read-only doctor check for legacy `.env` files that are still group/other-accessible.

- scans the active Hermes `.env` and profile `.env` files
- warns with the current mode and a `chmod 600` hint
- skips Windows, managed installs, and container/skip-chmod environments where Hermes does not enforce POSIX file modes

Closes #35891

Checked with:
- `python -m pytest --timeout-method=thread tests/hermes_cli/test_doctor.py -q`
- `ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`
- `git diff --check`