### PR TITLE
fix: preserve mixed-case providers in Telegram model picker

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2908,7 +2908,11 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception:
             group_providers = None
 
-        by_slug = {p.get("slug"): p for p in providers}
+        by_slug = {
+            str(p.get("slug") or "").strip().lower(): p
+            for p in providers
+            if str(p.get("slug") or "").strip()
+        }
 
         def _provider_button(p):
             count = p.get("total_models", len(p.get("models", [])))

--- a/tests/gateway/test_telegram_model_picker.py
+++ b/tests/gateway/test_telegram_model_picker.py
@@ -146,6 +146,40 @@ class TestTelegramModelPicker:
         # State is cleaned up after a successful switch.
         assert "12345" not in adapter._model_picker_state
 
+    def test_provider_keyboard_preserves_mixed_case_custom_provider_slug(self, monkeypatch):
+        """Custom providers with mixed-case slugs still render in /model.
+
+        group_providers() lowercases ungrouped slug rows for canonical matching;
+        the Telegram keyboard must still resolve that row back to the original
+        provider entry so the picker shows the provider and preserves the
+        configured slug in callback_data.
+        """
+        import gateway.platforms.telegram as tg
+
+        built: list = []
+
+        class _RecordingButton:
+            def __init__(self, text, callback_data=None, **kw):
+                self.text = text
+                self.callback_data = callback_data
+                built.append(callback_data)
+
+        class _RecordingMarkup:
+            def __init__(self, rows):
+                self.inline_keyboard = rows
+
+        monkeypatch.setattr(tg, "InlineKeyboardButton", _RecordingButton)
+        monkeypatch.setattr(tg, "InlineKeyboardMarkup", _RecordingMarkup)
+
+        adapter = _make_adapter()
+
+        adapter._build_provider_keyboard([
+            {"slug": "BitFun", "name": "BitFun", "total_models": 2},
+        ])
+
+        assert "mp:BitFun" in built
+        assert "mx" in built
+
     @pytest.mark.asyncio
     async def test_provider_group_folds_and_drills_down(self, monkeypatch):
         """A provider family (e.g. MiniMax) collapses to one mpg: button at


### PR DESCRIPTION
## Summary
- Normalize Telegram /model provider lookup keys before matching grouped picker rows
- Preserve the original configured provider slug in callback_data
- Add a regression test for mixed-case custom provider slugs

## Test Plan
- [x] RED: python -m pytest tests/gateway/test_telegram_model_picker.py::TestTelegramModelPicker::test_provider_keyboard_preserves_mixed_case_custom_provider_slug -q -o 'addopts=' (failed before fix)
- [x] GREEN: python -m pytest tests/gateway/test_telegram_model_picker.py::TestTelegramModelPicker::test_provider_keyboard_preserves_mixed_case_custom_provider_slug -q -o 'addopts='
- [x] python -m pytest tests/gateway/test_telegram_model_picker.py -q -o 'addopts='
- [x] git diff --check

Closes #35932