### PR TITLE
docs: add tenant workspace pattern for profiles

### DIFF
--- a/website/docs/reference/profile-commands.md
+++ b/website/docs/reference/profile-commands.md
@@ -89,6 +89,8 @@ Creates a new profile.
 
 Creating a profile does **not** make that profile directory the default project/workspace directory for terminal commands. If you want a profile to start in a specific project, set `terminal.cwd` in that profile's `config.yaml`.
 
+For friend, colleague, team, or client agents, the [Tenant Workspaces for Profiles](../user-guide/tenant-workspaces.md) guide describes a docs-only operator convention for keeping tenant-created artifacts under one workspace and reviewing reusable candidates before promoting them to shared assets. This convention can be used with today's `profile create`; it is not a sandbox and does not add a new CLI flag yet.
+
 **Examples:**
 
 ```bash

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -148,6 +148,8 @@ Also note:
 - Changes to `SOUL.md` take effect cleanly on a new session. Existing sessions may still be using the old prompt state.
 - Asking the model "what directory are you in?" is not a reliable isolation test. If you need a predictable starting directory for tools, set `terminal.cwd` explicitly.
 
+For friend, colleague, team, or client agents, see [Tenant Workspaces for Profiles](./tenant-workspaces.md) for an operator convention that keeps tenant-created projects, scripts, cron manifests, support packets, and shared-skill candidates organized without claiming to be a sandbox.
+
 ## Running gateways
 
 Each profile runs its own gateway as a separate process with its own bot token:

--- a/website/docs/user-guide/tenant-workspaces.md
+++ b/website/docs/user-guide/tenant-workspaces.md
@@ -1,0 +1,199 @@
+---
+sidebar_position: 3
+---
+
+# Tenant Workspaces for Profiles
+
+Tenant workspaces are an operator pattern for running profile-scoped agents for friends, colleagues, teams, or clients without mixing their work artifacts together.
+
+:::info
+This page describes a convention built on top of Hermes profiles. It is **not** a security sandbox. Profiles isolate Hermes runtime state; a workspace organizes tenant-created artifacts; OS users, containers, or VMs provide hard filesystem isolation.
+:::
+
+## Mental model
+
+```text
+Profile     = the agent runtime and identity
+Workspace   = the tenant-owned workbench and artifact store
+Sandbox     = the operating-system or container boundary
+```
+
+A profile owns Hermes state:
+
+```text
+~/.hermes/profiles/<tenant>/
+  config.yaml
+  .env
+  SOUL.md
+  memories/
+  sessions/
+  skills/
+  cron/
+  logs/
+  workspace/
+```
+
+A tenant workspace owns work artifacts created for that tenant:
+
+```text
+~/.hermes/profiles/<tenant>/workspace/
+  projects/
+  scripts/
+  skills/
+  cron/
+  docs/
+  data/
+  runtime/
+  candidates/
+  support/
+  incidents/
+  TENANT_MANIFEST.md
+  CRON_MANIFEST.md
+```
+
+Using the profile-local `workspace/` directory is the simplest convention because it is created with every profile. Operators may choose an external root such as `~/agent-workspaces/<tenant>/`, but should then set that profile's `terminal.cwd` explicitly.
+
+## Why use this pattern?
+
+Tenant agents often create more than chat history:
+
+- private skills and prompt workflows
+- cron job scripts and manifests
+- customer or project drafts
+- support packets for operator review
+- incident summaries
+- reusable workflow candidates
+
+Keeping those artifacts inside one tenant workspace makes it easier to review, back up, export, archive, or promote work without reading unrelated profiles.
+
+## Recommended setup
+
+Create a profile normally:
+
+```bash
+hermes profile create client-a --description "Client A assistant for CRM drafts and reporting."
+```
+
+Then initialize the workspace convention:
+
+```bash
+mkdir -p ~/.hermes/profiles/client-a/workspace/{projects,scripts,skills,cron,docs,data,runtime,candidates,support,incidents}
+cp website/static/templates/tenant/TENANT_MANIFEST.md \
+  ~/.hermes/profiles/client-a/workspace/TENANT_MANIFEST.md
+cp website/static/templates/tenant/CRON_MANIFEST.md \
+  ~/.hermes/profiles/client-a/workspace/CRON_MANIFEST.md
+```
+
+Set the profile's default terminal working directory:
+
+```bash
+client-a config set terminal.cwd ~/.hermes/profiles/client-a/workspace
+```
+
+Use an absolute path if you manage profiles from scripts or services:
+
+```bash
+client-a config set terminal.cwd /home/user/.hermes/profiles/client-a/workspace
+```
+
+## Tenant governance block
+
+For tenant-style profiles, add a short governance block to that profile's `SOUL.md`:
+
+```markdown
+## Tenant Governance
+
+You are an isolated tenant profile.
+
+Runtime state belongs to this profile. Work artifacts belong in this tenant workspace.
+
+You may operate within this tenant's sandbox when the tenant user authorizes it.
+
+You must not represent the default/admin agent, other tenants, or shared/core systems.
+
+You must not read or modify other profiles, other tenant workspaces, default profile state, shared credentials, global cron jobs, or shared skill libraries unless explicitly authorized by the operator/admin.
+
+Private skills, cron jobs, workflows, and prompts are private by default.
+
+Reusable artifacts may be nominated as candidates, but candidate output must be sanitized and must not include private memory, session content, API keys, customer data, chat IDs, or secrets.
+
+Shared promotion requires review.
+```
+
+This block is guidance for the model. It does not enforce filesystem access. Use a stronger terminal backend, OS user, container, or VM when tenants are untrusted.
+
+## Private by default, shared by review
+
+Tenant-created skills and workflows should start private:
+
+```text
+private skill
+→ sanitized candidate bundle
+→ operator review
+→ shared skill or shared template
+```
+
+Do not automatically copy tenant skills into a global or shared skill library. Ask the tenant agent to produce a candidate card instead. A starter template is available at `website/static/templates/tenant/SKILL_CANDIDATE_CARD.md` in the repository and at `/templates/tenant/SKILL_CANDIDATE_CARD.md` on the built site.
+
+A safe candidate card should summarize:
+
+- skill name
+- one-sentence purpose
+- intended users
+- dependencies
+- risk level
+- whether private data was removed
+- what should and should not be shared
+
+It should not include raw memory, session transcripts, customer data, credentials, private file paths, or chat IDs.
+
+## Support without opening the whole profile
+
+When a tenant needs help, prefer a scoped support packet over full profile access. A starter template is available at `website/static/templates/tenant/SUPPORT_PACKET.md` in the repository and at `/templates/tenant/SUPPORT_PACKET.md` on the built site.
+
+A support packet should include:
+
+- issue summary
+- affected profile
+- affected job, skill, or script
+- sanitized error messages
+- expected behavior
+- explicit review scope
+- explicit exclusions
+
+This lets an operator help with a failing cron job or tool without reading the tenant's memory, sessions, or private skills by default.
+
+## Cron jobs
+
+Tenant cron jobs should be documented in a `CRON_MANIFEST.md` before they become important automation. A starter template is available at `website/static/templates/tenant/CRON_MANIFEST.md` in the repository and at `/templates/tenant/CRON_MANIFEST.md` on the built site.
+
+At minimum, record:
+
+- job name and purpose
+- schedule
+- data sources
+- delivery target
+- risk level
+- whether it writes data or sends external messages
+- restore or rollback steps
+- verification command
+
+Cron jobs should be quiet when nothing changed and should avoid sending noisy messages to shared channels.
+
+## Incident packets
+
+If a tenant bot sends the wrong message, writes bad data, leaks private context, or starts a noisy cron loop, stop the impact first and then create an incident packet. A starter template is available at `website/static/templates/tenant/INCIDENT_PACKET.md` in the repository and at `/templates/tenant/INCIDENT_PACKET.md` on the built site.
+
+The incident packet should preserve enough detail to debug while excluding secrets and raw private data unless the tenant explicitly authorizes a narrower review.
+
+## Relationship to profile isolation
+
+Profiles already give each agent its own Hermes home, but profiles are not sandboxes. On the local terminal backend, the process still has the host user's filesystem permissions.
+
+Tenant workspaces therefore provide organization and operator hygiene, not a hard security boundary.
+
+Use this pattern when tenants are trusted but should not accidentally mix artifacts. Use OS users, containers, VMs, SSH backends, or other sandboxing mechanisms when tenants are untrusted or data isolation must be enforced outside model instructions.
+
+## Related proposal
+
+This pattern is being discussed in [#35947: Add tenant workspace template and governance scaffolding for profiles](https://github.com/NousResearch/hermes-agent/issues/35947).

--- a/website/docs/user-guide/tenant-workspaces.md
+++ b/website/docs/user-guide/tenant-workspaces.md
@@ -74,26 +74,42 @@ Create a profile normally:
 hermes profile create client-a --description "Client A assistant for CRM drafts and reporting."
 ```
 
-Then initialize the workspace convention:
+Then, from an admin/default shell, initialize the workspace convention. If
+`HERMES_HOME` is set, it must identify the custom Hermes root. Do not run this
+path calculation from a profile-local shell where `HERMES_HOME` already points
+at that profile, or it would duplicate `profiles/client-a`.
+
+On Linux or macOS with Bash:
 
 ```bash
-mkdir -p ~/.hermes/profiles/client-a/workspace/{projects,scripts,skills,cron,docs,data,runtime,candidates,support,incidents}
-cp website/static/templates/tenant/TENANT_MANIFEST.md \
-  ~/.hermes/profiles/client-a/workspace/TENANT_MANIFEST.md
-cp website/static/templates/tenant/CRON_MANIFEST.md \
-  ~/.hermes/profiles/client-a/workspace/CRON_MANIFEST.md
+HERMES_ROOT="${HERMES_HOME:-$HOME/.hermes}"
+WORKSPACE="$HERMES_ROOT/profiles/client-a/workspace"
+mkdir -p "$WORKSPACE"/{projects,scripts,skills,cron,docs,data,runtime,candidates,support,incidents}
+curl -fL "https://hermes-agent.nousresearch.com/docs/templates/tenant/TENANT_MANIFEST.md" \
+  -o "$WORKSPACE/TENANT_MANIFEST.md"
+curl -fL "https://hermes-agent.nousresearch.com/docs/templates/tenant/CRON_MANIFEST.md" \
+  -o "$WORKSPACE/CRON_MANIFEST.md"
 ```
 
-Set the profile's default terminal working directory:
+Set the profile's default terminal working directory using the computed path:
 
 ```bash
-client-a config set terminal.cwd ~/.hermes/profiles/client-a/workspace
+client-a config set terminal.cwd "$WORKSPACE"
 ```
 
-Use an absolute path if you manage profiles from scripts or services:
+On native Windows with PowerShell:
 
-```bash
-client-a config set terminal.cwd /home/user/.hermes/profiles/client-a/workspace
+```powershell
+$HermesRoot = if ($env:HERMES_HOME) { $env:HERMES_HOME } else { Join-Path $env:LOCALAPPDATA 'hermes' }
+$Workspace = Join-Path $HermesRoot 'profiles\client-a\workspace'
+$Directories = 'projects', 'scripts', 'skills', 'cron', 'docs', 'data', 'runtime', 'candidates', 'support', 'incidents'
+New-Item -ItemType Directory -Force -Path $Workspace | Out-Null
+$Directories | ForEach-Object { New-Item -ItemType Directory -Force -Path (Join-Path $Workspace $_) | Out-Null }
+Invoke-WebRequest 'https://hermes-agent.nousresearch.com/docs/templates/tenant/TENANT_MANIFEST.md' `
+  -OutFile (Join-Path $Workspace 'TENANT_MANIFEST.md')
+Invoke-WebRequest 'https://hermes-agent.nousresearch.com/docs/templates/tenant/CRON_MANIFEST.md' `
+  -OutFile (Join-Path $Workspace 'CRON_MANIFEST.md')
+client-a config set terminal.cwd "$Workspace"
 ```
 
 ## Tenant governance block
@@ -133,7 +149,7 @@ private skill
 → shared skill or shared template
 ```
 
-Do not automatically copy tenant skills into a global or shared skill library. Ask the tenant agent to produce a candidate card instead. A starter template is available at `website/static/templates/tenant/SKILL_CANDIDATE_CARD.md` in the repository and at `/templates/tenant/SKILL_CANDIDATE_CARD.md` on the built site.
+Do not automatically copy tenant skills into a global or shared skill library. Ask the tenant agent to produce a candidate card instead. Use the published [skill candidate card template](https://hermes-agent.nousresearch.com/docs/templates/tenant/SKILL_CANDIDATE_CARD.md).
 
 A safe candidate card should summarize:
 
@@ -149,7 +165,7 @@ It should not include raw memory, session transcripts, customer data, credential
 
 ## Support without opening the whole profile
 
-When a tenant needs help, prefer a scoped support packet over full profile access. A starter template is available at `website/static/templates/tenant/SUPPORT_PACKET.md` in the repository and at `/templates/tenant/SUPPORT_PACKET.md` on the built site.
+When a tenant needs help, prefer a scoped support packet over full profile access. Use the published [support packet template](https://hermes-agent.nousresearch.com/docs/templates/tenant/SUPPORT_PACKET.md).
 
 A support packet should include:
 
@@ -165,7 +181,7 @@ This lets an operator help with a failing cron job or tool without reading the t
 
 ## Cron jobs
 
-Tenant cron jobs should be documented in a `CRON_MANIFEST.md` before they become important automation. A starter template is available at `website/static/templates/tenant/CRON_MANIFEST.md` in the repository and at `/templates/tenant/CRON_MANIFEST.md` on the built site.
+Tenant cron jobs should be documented in a `CRON_MANIFEST.md` before they become important automation. Use the published [cron manifest template](https://hermes-agent.nousresearch.com/docs/templates/tenant/CRON_MANIFEST.md).
 
 At minimum, record:
 
@@ -182,7 +198,7 @@ Cron jobs should be quiet when nothing changed and should avoid sending noisy me
 
 ## Incident packets
 
-If a tenant bot sends the wrong message, writes bad data, leaks private context, or starts a noisy cron loop, stop the impact first and then create an incident packet. A starter template is available at `website/static/templates/tenant/INCIDENT_PACKET.md` in the repository and at `/templates/tenant/INCIDENT_PACKET.md` on the built site.
+If a tenant bot sends the wrong message, writes bad data, leaks private context, or starts a noisy cron loop, stop the impact first and then create an incident packet. Use the published [incident packet template](https://hermes-agent.nousresearch.com/docs/templates/tenant/INCIDENT_PACKET.md).
 
 The incident packet should preserve enough detail to debug while excluding secrets and raw private data unless the tenant explicitly authorizes a narrower review.
 

--- a/website/static/templates/tenant/CRON_MANIFEST.md
+++ b/website/static/templates/tenant/CRON_MANIFEST.md
@@ -1,0 +1,52 @@
+# Cron Manifest
+
+Document tenant-owned cron jobs here. Keep one section per job.
+
+## `<job-name>`
+
+- Status: `draft | active | paused | retired`
+- Owner: `<tenant-name>`
+- Schedule: `<cron expression or natural schedule>`
+- Profile: `~/.hermes/profiles/<tenant-name>/`
+- Workspace path: `cron/<job-name>/`
+- Script/entrypoint: `<path>`
+- Delivery target: `<platform/channel/user/file>`
+- Data sources: `<files/APIs/services>`
+- Writes data: `yes/no`
+- Sends external messages: `yes/no`
+- Risk level: `low | medium | high`
+- Agent reasoning required: `yes/no`
+
+### Purpose
+
+What this job does and why it exists.
+
+### Expected output
+
+Describe the normal output shape. If nothing changed, say whether the job should stay silent.
+
+### Authorization
+
+Who approved this job and what resources it is allowed to access.
+
+### Verification
+
+```bash
+# command to run a one-shot smoke test
+```
+
+Expected result:
+
+```text
+<expected safe output>
+```
+
+### Rollback / pause
+
+```bash
+# command or operator steps to pause/remove/restore this job
+```
+
+### Notes
+
+Record known failure modes, rate limits, and privacy constraints.

--- a/website/static/templates/tenant/INCIDENT_PACKET.md
+++ b/website/static/templates/tenant/INCIDENT_PACKET.md
@@ -1,0 +1,78 @@
+# Incident Packet
+
+Use this after a tenant automation caused or may have caused harm, noise, data exposure, bad writes, or unexpected external actions.
+
+## Incident summary
+
+What happened?
+
+## Impact
+
+- Tenant: `<tenant-name>`
+- Started at: `<timestamp>`
+- Ended at: `<timestamp or ongoing>`
+- Affected users/systems: `<summary>`
+- Data exposure suspected: `yes/no/unknown`
+- External messages sent: `yes/no/unknown`
+- Data written or deleted: `yes/no/unknown`
+
+## Immediate containment
+
+What was stopped, paused, revoked, or rolled back?
+
+- [ ] Cron paused
+- [ ] Gateway stopped
+- [ ] Tool disabled
+- [ ] Credentials rotated/revoked
+- [ ] External messages corrected
+- [ ] Other: `<describe>`
+
+## Relevant component
+
+- Type: `cron | skill | script | gateway | tool | config | other`
+- Name: `<component-name>`
+- Path: `<relative path, if safe and authorized>`
+
+## Sanitized timeline
+
+```text
+<timestamp> <event>
+<timestamp> <event>
+```
+
+Do not include secrets, raw private messages, customer records, or full session transcripts unless explicitly authorized for a narrow review.
+
+## Suspected cause
+
+What likely caused the incident?
+
+## Authorized review scope
+
+- Allowed: `<specific files, commands, or logs>`
+- Excluded: `memory/, sessions/, unrelated skills/, credentials, raw customer data`
+
+## Recovery plan
+
+1. `<step>`
+2. `<step>`
+3. `<step>`
+
+## Verification before resume
+
+```bash
+# smoke test or validation command
+```
+
+Expected result:
+
+```text
+<safe expected output>
+```
+
+## Follow-up actions
+
+- [ ] Add regression test or guardrail
+- [ ] Update cron manifest
+- [ ] Update support docs
+- [ ] Rotate credentials if needed
+- [ ] Notify affected parties if needed

--- a/website/static/templates/tenant/SKILL_CANDIDATE_CARD.md
+++ b/website/static/templates/tenant/SKILL_CANDIDATE_CARD.md
@@ -1,0 +1,66 @@
+# Skill Candidate Card
+
+Use this when a tenant wants to nominate a private skill or workflow for shared review. This card is a summary, not the raw private skill.
+
+## Candidate
+
+- Name: `<skill-or-workflow-name>`
+- Type: `skill | workflow | cron-template | tool-pattern`
+- Source tenant: `<tenant-name>`
+- Proposed shared name: `<optional>`
+- Status: `draft | submitted | reviewed | promoted | rejected`
+
+## Purpose
+
+One sentence describing what the candidate does.
+
+## Intended users
+
+Who could reuse this if it became shared?
+
+## What should be shared
+
+Describe the reusable method, template, checklist, or code pattern.
+
+## What must remain private
+
+List anything removed or excluded from the candidate bundle.
+
+- Personal preferences
+- Customer data
+- Internal project names
+- Raw conversation excerpts
+- Memory/session content
+- Credentials, tokens, Sheet IDs, chat IDs, or private paths
+
+## Dependencies
+
+List tools, APIs, skills, or environment assumptions.
+
+## Risk level
+
+`low | medium | high`
+
+Explain why.
+
+## Sanitization checklist
+
+- [ ] No secrets or credentials
+- [ ] No raw memory or session transcript
+- [ ] No customer/private data
+- [ ] No private file paths or chat IDs
+- [ ] Examples are generic or synthetic
+- [ ] External side effects are documented
+
+## Evidence of usefulness
+
+Summarize usage count, success examples, or why this pattern is broadly reusable. Do not include private source data.
+
+## Review request
+
+What decision is requested from the operator/admin?
+
+- [ ] Review only
+- [ ] Convert to shared skill
+- [ ] Convert to shared template
+- [ ] Reject / keep private

--- a/website/static/templates/tenant/SUPPORT_PACKET.md
+++ b/website/static/templates/tenant/SUPPORT_PACKET.md
@@ -1,0 +1,60 @@
+# Support Packet
+
+Use this when a tenant asks an operator/admin agent for help without opening the whole profile.
+
+## Summary
+
+One or two sentences describing the issue.
+
+## Affected tenant
+
+- Tenant: `<tenant-name>`
+- Profile: `~/.hermes/profiles/<tenant-name>/`
+- Workspace: `~/.hermes/profiles/<tenant-name>/workspace/`
+
+## Affected component
+
+- Type: `cron | skill | script | gateway | tool | config | other`
+- Name: `<component-name>`
+- Path: `<relative path inside workspace/profile, if authorized>`
+
+## Expected behavior
+
+What should have happened?
+
+## Actual behavior
+
+What happened instead?
+
+## Sanitized errors
+
+```text
+<paste sanitized errors here>
+```
+
+Do not include secrets, raw customer data, private memory, or full session transcripts.
+
+## Already checked
+
+- [ ] Profile exists
+- [ ] Workspace exists
+- [ ] Relevant file exists
+- [ ] Credentials were not pasted into this packet
+- [ ] Cron/gateway status checked if relevant
+
+## Authorized review scope
+
+List exactly what the operator/admin may inspect.
+
+- Allowed: `<specific files, commands, or logs>`
+- Excluded: `memory/, sessions/, unrelated skills/, credentials, raw customer data`
+
+## Desired outcome
+
+What help is requested?
+
+- [ ] Diagnose only
+- [ ] Propose fix
+- [ ] Apply fix in tenant workspace
+- [ ] Create PR/patch
+- [ ] Other: `<describe>`

--- a/website/static/templates/tenant/TENANT_MANIFEST.md
+++ b/website/static/templates/tenant/TENANT_MANIFEST.md
@@ -1,0 +1,66 @@
+# Tenant Manifest
+
+## Tenant
+
+- Name: `<tenant-name>`
+- Owner: `<person/team/client>`
+- Profile: `~/.hermes/profiles/<tenant-name>/`
+- Workspace: `~/.hermes/profiles/<tenant-name>/workspace/`
+- Status: `active | paused | archived`
+
+## Purpose
+
+Describe what this tenant agent is responsible for.
+
+## Allowed scope
+
+List the resources this tenant user may authorize the agent to use.
+
+- This tenant profile
+- This tenant workspace
+- This tenant's approved files, APIs, or services
+
+## Forbidden scope
+
+List resources this profile must not read or modify without operator/admin authorization.
+
+- Default/admin profile state
+- Other tenant profiles or workspaces
+- Shared credentials
+- Global cron jobs
+- Shared skill libraries
+- Other private data stores
+
+## Credentials
+
+- Credential owner: `<tenant/operator>`
+- Stored in: `<profile .env / external secret manager>`
+- Notes: Do not paste secrets into this manifest.
+
+## Active projects
+
+| Project | Path | Status | Notes |
+|---|---|---|---|
+| `<name>` | `projects/<name>/` | `active` | `<notes>` |
+
+## Active cron jobs
+
+See `CRON_MANIFEST.md` for full details.
+
+| Job | Schedule | Risk | Output |
+|---|---|---|---|
+| `<job>` | `<schedule>` | `low/medium/high` | `<destination>` |
+
+## Shared candidates
+
+| Candidate | Type | Status | Notes |
+|---|---|---|---|
+| `<name>` | `skill/workflow/cron-template` | `draft/reviewed/promoted/rejected` | `<notes>` |
+
+## Support policy
+
+Support requests should use scoped support packets in `support/`. Do not attach raw memory, session transcripts, customer data, or secrets unless explicitly authorized for a narrow review.
+
+## Offboarding notes
+
+Document how to pause cron jobs, stop gateways, revoke credentials, export tenant-owned data, and archive this workspace.


### PR DESCRIPTION
## Summary

- Document the tenant workspace pattern for profile-scoped agents
- Clarify that tenant workspaces organize artifacts but are not security sandboxes
- Add starter templates for tenant manifests, cron manifests, skill candidate cards, support packets, and incident packets
- Link the new guide from profile docs and profile command reference

Refs #35947

## Verification

- `git diff --cached --check`
- `npm --prefix website run build`

Notes:

- The Docusaurus build completed successfully.
- The build still reports existing zh-Hans broken link/anchor warnings unrelated to this PR.
- This PR is docs/templates only; it does not add CLI flags, sandboxing, or write-scope enforcement.
