### PR TITLE
fix(auxiliary): skip unconfigured copilot fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1409,16 +1409,18 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         if _is_provider_unhealthy(provider_id):
             logger.debug("Auxiliary api-key chain: %s is unhealthy, skipping", provider_id)
             continue
-        if provider_id == "anthropic":
-            # Only try anthropic when the user has explicitly configured it.
-            # Without this gate, Claude Code credentials get silently used
-            # as auxiliary fallback when the user's primary provider fails.
+        if provider_id in {"anthropic", "copilot"}:
+            # Only try providers that can discover broad user credentials
+            # when the user has explicitly configured them. Without this gate,
+            # unrelated ambient credentials can be probed as auxiliary
+            # fallback and produce noisy warnings.
             try:
                 from hermes_cli.auth import is_provider_explicitly_configured
-                if not is_provider_explicitly_configured("anthropic"):
+                if not is_provider_explicitly_configured(provider_id):
                     continue
             except ImportError:
                 pass
+        if provider_id == "anthropic":
             return _try_anthropic()
 
         pool_present, entry = _select_pool_entry(provider_id)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1675,6 +1675,43 @@ def test_resolve_api_key_provider_skips_unconfigured_anthropic(monkeypatch):
         "_try_anthropic() should not be called when anthropic is not explicitly configured"
 
 
+def test_resolve_api_key_provider_skips_unconfigured_copilot(monkeypatch):
+    """_resolve_api_key_provider must not probe Copilot tokens unless configured."""
+    from collections import OrderedDict
+    from hermes_cli.auth import ProviderConfig
+
+    fake_registry = OrderedDict({
+        "copilot": ProviderConfig(
+            id="copilot",
+            name="GitHub Copilot",
+            auth_type="api_key",
+            inference_base_url="https://api.githubcopilot.com",
+            api_key_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
+        ),
+    })
+
+    def fail_if_probed(provider_id):
+        raise AssertionError(f"{provider_id} credentials should not be probed")
+
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_classic_pat")
+    monkeypatch.setattr("hermes_cli.auth.PROVIDER_REGISTRY", fake_registry)
+    monkeypatch.setattr(
+        "hermes_cli.auth.is_provider_explicitly_configured",
+        lambda pid: False,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        fail_if_probed,
+    )
+    monkeypatch.setattr(
+        "agent.auxiliary_client._select_pool_entry",
+        lambda provider_id: (False, None),
+    )
+
+    from agent.auxiliary_client import _resolve_api_key_provider
+    assert _resolve_api_key_provider() == (None, None)
+
+
 # ---------------------------------------------------------------------------
 # model="default" elimination (#7512)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Prevents Copilot credentials from being probed as part of the generic auxiliary API-key fallback unless Copilot is explicitly configured.

This matches the existing Anthropic gate and avoids noisy token-validation warnings when a user has a regular `GITHUB_TOKEN` in the environment but is using a different provider.

Closes #35946

Checked with:
- `python -m pytest --timeout-method=thread tests/agent/test_auxiliary_client.py -q`
- `ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
- `git diff --check`