### PR TITLE
feat(desktop): stable data-testid selectors + thread run-state signal

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -102,12 +102,14 @@ export const VirtualizedThread: FC<VirtualizedThreadProps> = ({
       <div
         className="size-full overflow-x-hidden overflow-y-auto overscroll-contain"
         data-slot="aui_thread-viewport"
+        data-testid="thread-viewport"
         ref={scrollerRef}
       >
         {renderEmpty ? (
           <div
             className="mx-auto grid h-full w-full max-w-(--composer-width) grid-rows-[minmax(0,1fr)_auto] min-w-0 gap-(--conversation-turn-gap) px-6 py-8"
             data-slot="aui_thread-content"
+            data-testid="thread-content"
           >
             {emptyPlaceholder}
           </div>
@@ -117,6 +119,7 @@ export const VirtualizedThread: FC<VirtualizedThreadProps> = ({
               'mx-auto flex w-full max-w-(--composer-width) min-w-0 flex-col px-6 pt-[calc(var(--titlebar-height)+1.5rem)]'
             )}
             data-slot="aui_thread-content"
+            data-testid="thread-content"
           >
             {/* Natural-flow virtualization: mounted items render as normal
                 flex siblings so `position: sticky` on the human bubble

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -140,6 +140,10 @@ export const Thread: FC<{
   sessionId = null,
   sessionKey
 }) => {
+  // Stable run-state signal for test automation / demo tooling: flips to "idle"
+  // once the agent has finished streaming (see data-thread-state on the root).
+  const threadRunning = useAuiState(s => s.thread.isRunning)
+
   const messageComponents = useMemo(
     () => ({
       AssistantMessage: () => <AssistantMessage onBranchInNewChat={onBranchInNewChat} />,
@@ -161,7 +165,11 @@ export const Thread: FC<{
 
   return (
     <GeneratedImageProvider>
-      <div className="relative grid h-full min-h-0 max-w-full grid-rows-[minmax(0,1fr)] overflow-hidden bg-transparent contain-[layout_paint]">
+      <div
+        className="relative grid h-full min-h-0 max-w-full grid-rows-[minmax(0,1fr)] overflow-hidden bg-transparent contain-[layout_paint]"
+        data-testid="chat-thread"
+        data-thread-state={threadRunning ? 'streaming' : 'idle'}
+      >
         <VirtualizedThread
           clampToComposer={clampToComposer}
           components={messageComponents}
@@ -236,6 +244,8 @@ const AssistantMessage: FC<{ onBranchInNewChat?: (messageId: string) => void }> 
           interruptedOnly && 'text-[0.8rem] leading-5 text-muted-foreground/82'
         )}
         data-slot="aui_assistant-message-content"
+        data-status={messageStatus}
+        data-testid="assistant-message-content"
       >
         {hoistedTodos.length > 0 && <HoistedTodoPanel todos={hoistedTodos} />}
         <MessagePrimitive.Parts components={MESSAGE_PARTS_COMPONENTS} />
@@ -376,6 +386,7 @@ const ThinkingDisclosure: FC<{
     <div
       className="text-[length:var(--conversation-tool-font-size)] text-(--ui-text-tertiary)"
       data-slot="aui_thinking-disclosure"
+      data-testid="thinking-disclosure"
       ref={enterRef}
     >
       <DisclosureRow onToggle={() => setUserOpen(!open)} open={open}>
@@ -639,6 +650,7 @@ function StickyHumanMessageContainer({ children }: { children: ReactNode }) {
       className="group/user-message sticky top-0 z-40 -mx-4 flex w-[calc(100%+2rem)] min-w-0 max-w-none flex-col items-stretch gap-0 self-end overflow-visible bg-(--ui-chat-surface-background) px-4 pb-(--conversation-turn-gap) pt-2"
       data-role="user"
       data-slot="aui_user-message-root"
+      data-testid="user-message"
     >
       {children}
     </div>

--- a/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
@@ -281,6 +281,7 @@ function ToolEntry({ part }: ToolEntryProps) {
         open && 'rounded-[0.625rem] border border-(--ui-stroke-tertiary)'
       )}
       data-slot="tool-block"
+      data-testid="tool-block"
       ref={enterRef}
     >
       <div className={cn(open && 'border-b border-(--ui-stroke-tertiary) px-2 py-1.5')}>
@@ -449,7 +450,7 @@ export const ToolGroupSlot: FC<PropsWithChildren<{ endIndex: number; startIndex:
 
   return (
     <ToolEmbedContext.Provider value={isGroup}>
-      <div className="min-w-0 max-w-full overflow-hidden" data-slot="tool-block" ref={enterRef}>
+      <div className="min-w-0 max-w-full overflow-hidden" data-slot="tool-block" data-testid="tool-block" ref={enterRef}>
         {isGroup && (
           <DisclosureRow
             key="header"


### PR DESCRIPTION
Adds low-cost, additive hooks the desktop chat needs for reliable e2e/automation and demo-video tooling — so tests/tools stop matching on Tailwind class names and waiting on arbitrary timeouts.

## What
- `data-testid` on the key chat nodes: `chat-thread` (root), `thread-viewport`, `thread-content`, `user-message`, `assistant-message-content`, `thinking-disclosure`, `tool-block`.
- `data-thread-state="streaming|idle"` on the thread root, driven by `thread.isRunning` — one attribute to wait on for "the agent finished streaming."
- `data-status={messageStatus}` on assistant message content (running / complete / …).

## Why
- `data-testid` is already the convention in the desktop tests; this just extends it to the chat surface.
- Automation currently has to grab the scroller via `.overflow-y-auto.overscroll-contain` and *guess* when streaming settles. `data-thread-state` makes "is the agent idle?" deterministic.

## Notes
- Purely additive — no behavior, layout, or styling change.
- `tsc -b` clean; `test:ui` assistant-ui suite (26 tests) passes.
- Targeting `bb/gui` since the desktop GUI lives here.

Follow-up (separate PR): an opt-in demo/fixture mode that drives this UI without a backend, using `data-thread-state` as the render-settled hook.
