### PR TITLE
fix: complete macOS-native support for gateway service, tirith, and shutdown diagnostics

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10311,11 +10311,19 @@ class GatewayRunner:
         # Docker/Podman container, use the service restart path: exit with
         # code 75 so the service manager / container restart policy restarts
         # us.  The detached subprocess approach (setsid + bash) doesn't work
-        # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
-        # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
-        _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
-        if _under_service or _in_container:
+        # under systemd (KillMode=mixed kills the cgroup), launchd (the new
+        # detached child isn't the job launchd tracks, so KeepAlive races it),
+        # or Docker (tini exits when the gateway dies, taking the detached
+        # helper with it).
+        #
+        # detect_service_manager() recognizes launchd on macOS too (the old
+        # INVOCATION_ID-only check missed it, so a launchd-managed gateway
+        # wrongly took the detached path). A manual foreground `hermes gateway`
+        # returns None here → detached self-respawn, which is correct since no
+        # supervisor would honor exit-75.
+        from gateway.shutdown_forensics import detect_service_manager
+        _service_mgr = detect_service_manager()
+        if _service_mgr is not None:
             self.request_restart(detached=False, via_service=True)
         else:
             self.request_restart(detached=True, via_service=False)

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -32,6 +33,41 @@ for _name in ("SIGTERM", "SIGINT", "SIGHUP", "SIGQUIT", "SIGUSR1", "SIGUSR2"):
     _val = getattr(signal, _name, None)
     if _val is not None:
         _SIGNAL_NAME_BY_NUM[int(_val)] = _name
+
+
+def detect_service_manager() -> Optional[str]:
+    """Best-effort detection of an auto-restarting supervisor.
+
+    Returns ``"systemd"``, ``"launchd"``, ``"container"``, or ``None``.
+
+    Used to decide whether a *planned* restart should exit with code 75 (let
+    the supervisor respawn us via systemd ``RestartForceExitStatus=75`` or
+    launchd ``KeepAlive``) versus self-respawning a detached subprocess.
+    Getting this wrong on macOS is what made a launchd-managed gateway take
+    the detached path — and made a *manually* foreground-launched gateway
+    look (via ``ppid==1``) like it was supervised when nothing would restart
+    it.
+
+    Detection, in priority order:
+    * systemd sets ``INVOCATION_ID`` in the unit's environment.
+    * launchd (macOS): a managed LaunchAgent/Daemon is a direct child of
+      launchd (``ppid==1``); ``XPC_SERVICE_NAME`` carries the job label for
+      managed jobs ("0" or unset for interactive shells). A manual
+      ``hermes gateway`` in a Terminal has the shell as its parent, so it is
+      correctly reported as *unmanaged* (``None``).
+    * Docker/Podman expose ``/.dockerenv`` / ``/run/.containerenv``.
+    """
+    if os.environ.get("INVOCATION_ID"):
+        return "systemd"
+    if sys.platform == "darwin":
+        if os.getppid() == 1:
+            return "launchd"
+        xpc = os.environ.get("XPC_SERVICE_NAME", "")
+        if xpc and xpc != "0" and "." in xpc:
+            return "launchd"
+    if os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv"):
+        return "container"
+    return None
 
 
 def _signal_name(sig: Any) -> str:
@@ -140,7 +176,13 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
     journal_stream = os.environ.get("JOURNAL_STREAM")
     if journal_stream:
         ctx["systemd_journal_stream"] = journal_stream
-    ctx["under_systemd"] = bool(invocation_id) or ppid == 1
+    # Which supervisor (if any) will restart us — systemd / launchd / container.
+    # Note: ``ppid==1`` alone is NOT enough (a manual macOS foreground run that
+    # gets reparented could look supervised); detect_service_manager() scopes
+    # the ppid==1 signal to darwin/launchd.
+    ctx["service_manager"] = detect_service_manager()
+    # Back-compat: keep ``under_systemd`` but make it mean specifically systemd.
+    ctx["under_systemd"] = ctx["service_manager"] == "systemd"
 
     # Load average — high load points the finger at "something else
     # crushing the box" rather than "external killer".
@@ -194,6 +236,79 @@ def snapshot_shutdown_context(received_signal: Any = None) -> Dict[str, Any]:
     return ctx
 
 
+def _diagnostic_script(signal_name: str) -> str:
+    """Build the shutdown-diagnostic shell snippet for the current platform.
+
+    Linux exposes ``/proc``, GNU ``ps``/``pstree`` and ``dmesg``/``journalctl``.
+    macOS has none of those — BSD ``ps`` rejects ``--sort``/``f``, there is no
+    ``/proc``, and ``dmesg`` needs root — so a Linux-only snippet writes empty
+    sections. Each branch uses its platform's native equivalents so a correctly
+    installed gateway produces a useful snapshot on either OS.
+    """
+    pid = os.getpid()
+    header = (
+        f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
+        "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
+    )
+
+    if sys.platform == "darwin":
+        return (
+            header
+            + "echo '--- ps (top 60 by cpu) ---'; "
+            "ps -Ao pid,ppid,pcpu,pmem,rss,stat,lstart,command -r 2>/dev/null | head -60; "
+            "echo '--- our process chain ---'; "
+            f"ps -Ao pid,ppid,command 2>/dev/null | awk 'NR==1 || $1=={pid} || $2=={pid}'; "
+            "echo '--- load average ---'; "
+            "sysctl -n vm.loadavg 2>/dev/null || uptime || true; "
+            "echo '--- memory pressure (vm_stat) ---'; "
+            "vm_stat 2>/dev/null | head -8 || true; "
+            "echo '--- recent kills/low-memory (log show, best-effort) ---'; "
+            "log show --last 2m --predicate 'eventMessage CONTAINS \"low swap\" "
+            'OR senderImagePath CONTAINS "Kernel"\' 2>/dev/null '
+            "| grep -iE 'kill|memory|swap' | tail -20 || true; "
+            "echo '=== end ==='"
+        )
+
+    # Linux / other POSIX targets.
+    return (
+        header
+        + "echo '--- ps auxf (top 60 by cpu) ---'; "
+        "ps auxf --sort=-pcpu 2>/dev/null | head -60; "
+        "echo '--- pstree of self ---'; "
+        f"pstree -plau {pid} 2>/dev/null | head -40 || true; "
+        "echo '--- /proc/loadavg ---'; "
+        "cat /proc/loadavg 2>/dev/null || true; "
+        "echo '--- recent dmesg (oom/killed) ---'; "
+        "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
+        "echo '=== end ==='"
+    )
+
+
+def _bounded_diagnostic_argv(script: str, timeout_seconds: float) -> list:
+    """Wrap ``script`` so it self-terminates within ``timeout_seconds``.
+
+    Prefers GNU coreutils ``timeout`` (standard on Linux). On a stock macOS
+    that binary is absent (it's ``gtimeout`` from Homebrew coreutils, if
+    installed at all) — the old hard-coded ``["timeout", ...]`` made
+    ``Popen`` raise ``FileNotFoundError`` there, so the snapshot silently
+    never ran. When no external timeout helper exists, fall back to a shell
+    watchdog that kills our own process group after the deadline
+    (``start_new_session=True`` at the call site makes the spawned shell the
+    group leader, so ``kill -- -$$`` reaps any straggling children).
+    """
+    for name in ("timeout", "gtimeout"):
+        helper = shutil.which(name)
+        if helper:
+            return [helper, f"{timeout_seconds:.0f}", "bash", "-c", script]
+
+    guarded = (
+        f"( sleep {timeout_seconds:.0f}; kill -TERM -$$ 2>/dev/null ) & __wd=$!; "
+        f"{script}; "
+        "kill $__wd 2>/dev/null || true"
+    )
+    return ["bash", "-c", guarded]
+
+
 def spawn_async_diagnostic(
     log_path: Path,
     signal_name: str,
@@ -226,19 +341,7 @@ def spawn_async_diagnostic(
     if sys.platform == "win32":
         return None
 
-    script = (
-        f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
-        "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
-        "echo '--- ps auxf (top 60 by cpu) ---'; "
-        "ps auxf --sort=-pcpu 2>/dev/null | head -60; "
-        "echo '--- pstree of self ---'; "
-        f"pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
-        "echo '--- /proc/loadavg ---'; "
-        "cat /proc/loadavg 2>/dev/null || true; "
-        "echo '--- recent dmesg (oom/killed) ---'; "
-        "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
-        "echo '=== end ==='"
-    )
+    script = _diagnostic_script(signal_name)
 
     try:
         # Open the log file in append mode and let the subprocess inherit.
@@ -255,7 +358,7 @@ def spawn_async_diagnostic(
         # start_new_session, a SIGKILL on our cgroup takes the diag down
         # before it can flush.
         proc = subprocess.Popen(
-            ["timeout", f"{timeout_seconds:.0f}", "bash", "-c", script],
+            _bounded_diagnostic_argv(script, timeout_seconds),
             stdout=fd,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,
@@ -285,7 +388,7 @@ def format_context_for_log(ctx: Dict[str, Any]) -> str:
     parent_cmd = parent.get("cmdline", "(unknown)")
     parent_name = parent.get("name") or "?"
     parent_pid = parent.get("pid") or "?"
-    under_systemd = "yes" if ctx.get("under_systemd") else "no"
+    service_mgr = ctx.get("service_manager") or "none"
     load = ctx.get("loadavg_1m")
     load_str = f"{load:.2f}" if isinstance(load, (int, float)) else "?"
     extras: List[str] = []
@@ -302,7 +405,7 @@ def format_context_for_log(ctx: Dict[str, Any]) -> str:
     # Parent cmdline is the most useful single signal — log it prominently.
     return (
         f"signal={sig} "
-        f"under_systemd={under_systemd} "
+        f"service_mgr={service_mgr} "
         f"parent_pid={parent_pid} "
         f"parent_name={parent_name} "
         f"loadavg_1m={load_str}"

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -20,6 +20,7 @@ chain provenance proof.  Installation runs in a background thread so startup
 never blocks.
 """
 
+import errno
 import hashlib
 import json
 import logging
@@ -211,6 +212,55 @@ def _hermes_bin_dir() -> str:
     d = os.path.join(_get_hermes_home(), "bin")
     os.makedirs(d, exist_ok=True)
     return d
+
+
+def _quarantine_wrong_arch_binary(path: str, exc: OSError) -> bool:
+    """Self-heal a wrong-architecture auto-installed tirith binary.
+
+    A binary copied from another platform (e.g. a Linux ELF carried over
+    during a container→macOS migration) is a regular, executable file, so
+    the resolver happily returns it — but ``subprocess`` then fails with
+    ``ENOEXEC`` ("Exec format error") on every command and fail-open leaves
+    the bad binary in place forever.
+
+    When the failing binary is the one *we* auto-installed under
+    ``$HERMES_HOME/bin`` and the error is an exec-format mismatch, delete it
+    and reset the resolver so the next call re-downloads the correct build
+    for this platform.  Explicit user-configured paths are never touched.
+
+    Returns True if a quarantine happened (caller should re-resolve).
+    """
+    global _resolved_path, _install_failure_reason
+
+    if getattr(exc, "errno", None) != errno.ENOEXEC:
+        return False
+    try:
+        hermes_bin = os.path.join(_hermes_bin_dir(), "tirith")
+    except OSError:
+        return False
+    if os.path.realpath(path) != os.path.realpath(hermes_bin):
+        # Not our managed binary (explicit path / on PATH) — don't touch it.
+        return False
+
+    try:
+        os.replace(hermes_bin, hermes_bin + ".wrongarch.bak")
+    except OSError:
+        try:
+            os.unlink(hermes_bin)
+        except OSError:
+            return False
+
+    # Reset resolver state + clear failure markers so the next command
+    # re-downloads the correct-arch build instead of fail-opening forever.
+    _resolved_path = None
+    _install_failure_reason = ""
+    _clear_install_failed()
+    logger.warning(
+        "tirith binary at %s is the wrong architecture (%s); quarantined "
+        "and will re-download the correct build for this platform.",
+        hermes_bin, exc,
+    )
+    return True
 
 
 def _detect_target() -> str | None:
@@ -737,6 +787,28 @@ def check_command_security(command: str) -> dict:
         )
     except OSError as exc:
         # Covers FileNotFoundError, PermissionError, exec format error.
+        # Wrong-architecture binary (ENOEXEC) — typically a Linux ELF carried
+        # over during a container→macOS migration. Quarantine it and retry
+        # once so a freshly downloaded, correct-arch build can run instead of
+        # fail-opening on every command for the next 24h.
+        if _quarantine_wrong_arch_binary(tirith_path, exc):
+            # Re-resolve: the quarantined binary lives at the same path, so a
+            # successful re-download reuses that path — match on "exists and
+            # is executable", not on a changed path string. A still-broken
+            # binary just raises again and falls through to fail-open (no loop).
+            new_path = _resolve_tirith_path(cfg["tirith_path"])
+            if new_path and os.path.isfile(new_path) and os.access(new_path, os.X_OK):
+                try:
+                    result = subprocess.run(
+                        [new_path, "check", "--json", "--non-interactive",
+                         "--shell", "posix", "--", command],
+                        capture_output=True,
+                        text=True,
+                        timeout=timeout,
+                    )
+                    return _verdict_from_result(result, fail_open)
+                except (OSError, subprocess.TimeoutExpired):
+                    pass  # fall through to fail-open handling below
         # Dedupe by ``(errno, exc class)`` so a transient failure mode
         # surfaces once but doesn't drown the log on every command —
         # commonly seen on Windows when the configured path "tirith"
@@ -757,6 +829,16 @@ def check_command_security(command: str) -> dict:
             return {"action": "allow", "findings": [], "summary": f"tirith timed out ({timeout}s)"}
         return {"action": "block", "findings": [], "summary": "tirith timed out (fail-closed)"}
 
+    return _verdict_from_result(result, fail_open)
+
+
+def _verdict_from_result(result: subprocess.CompletedProcess, fail_open: bool) -> dict:
+    """Map a completed tirith run to a verdict dict.
+
+    Exit code is the source of truth (0=allow, 1=block, 2=warn); JSON stdout
+    only enriches findings/summary. Shared by the normal path and the
+    wrong-arch self-heal retry.
+    """
     # Map exit code to action
     exit_code = result.returncode
     if exit_code == 0:


### PR DESCRIPTION
## Summary

Three gaps surface when the gateway runs **natively on macOS** rather than in the Linux container it was originally built for. None are caught by the systemd/Docker-only code paths, so a container→macOS migration leaves the gateway unsupervised and its self-healing/diagnostics silently broken.

### 1. tirith self-heal for wrong-architecture binaries (`tools/tirith_security.py`)
A tirith binary carried over from another platform (e.g. a Linux ELF after a container→macOS move) is a regular executable file, so the resolver returns it — then **every command fails with `ENOEXEC` ("Exec format error")** and fail-open leaves the bad binary in place forever.

- Detect `ENOEXEC` on the auto-installed binary, quarantine it, re-download the correct build for the platform, and retry within the same call.
- Verdict-mapping extracted into `_verdict_from_result()` so the normal and retry paths share it.

### 2. launchd-aware service detection (`gateway/run.py`, `gateway/shutdown_forensics.py`)
Planned restarts (`/update`, `/restart`, stale-code) used `INVOCATION_ID` alone to decide the exit-75 "let the supervisor respawn us" path — a **systemd-only** signal. On macOS launchd this is never set, so a launchd-managed gateway wrongly took the detached-subprocess respawn (which races launchd `KeepAlive`).

- Add `detect_service_manager()` returning `systemd` / `launchd` / `container` / `None` and route restarts through it.
- A manual foreground run correctly returns `None` (detached self-respawn).
- The shutdown-forensics log now reports an accurate `service_mgr=` instead of a misleading `under_systemd=yes` on macOS.

### 3. macOS branch for the shutdown diagnostic (`gateway/shutdown_forensics.py`)
`spawn_async_diagnostic()` hard-coded GNU coreutils `timeout` (absent on stock macOS, where it's `gtimeout`), so `Popen` raised `FileNotFoundError` and the snapshot **never ran**. Its script also used Linux-only tools (`ps auxf --sort`, `pstree`, `/proc/loadavg`, `dmesg`/`journalctl`) that write empty sections on macOS.

- Add a platform-specific diagnostic script (BSD `ps`, `sysctl`, `vm_stat`, `log show`).
- Resolve `timeout`/`gtimeout` with a shell-watchdog fallback when neither exists.

## Testing
- `tests/tools/test_command_guards.py` — 18 passed
- `tests/tools/test_tirith_security.py` + `tests/gateway/test_shutdown_forensics.py` — all passed
- `test_spawns_subprocess_and_writes_output`, which previously **failed on macOS**, now passes.
- Manually verified: wrong-arch binary self-heals (quarantine → re-download → retry), `detect_service_manager()` returns the right value for manual/systemd/launchd, and the macOS diagnostic produces a full snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
