### PR TITLE
fix(dashboard): require auth for plugin inventory

### DIFF
--- a/hermes_cli/dashboard_auth/public_paths.py
+++ b/hermes_cli/dashboard_auth/public_paths.py
@@ -43,7 +43,6 @@ PUBLIC_API_PATHS: frozenset[str] = frozenset({
     # Read-only model metadata (context windows, etc.) — same shape as
     # provider catalogs already exposed on the public internet.
     "/api/model/info",
-    # Read-only theme + plugin manifests for the dashboard skin engine.
+    # Read-only theme manifests for the dashboard skin engine.
     "/api/dashboard/themes",
-    "/api/dashboard/plugins",
 })

--- a/tests/hermes_cli/test_dashboard_auth_middleware.py
+++ b/tests/hermes_cli/test_dashboard_auth_middleware.py
@@ -88,7 +88,6 @@ def test_gated_status_is_public(gated_app):
     "/api/config/schema",
     "/api/model/info",
     "/api/dashboard/themes",
-    "/api/dashboard/plugins",
 ])
 def test_other_public_api_paths_are_public_under_gate(gated_app, path):
     """The remaining ``PUBLIC_API_PATHS`` entries must also bypass the
@@ -111,6 +110,29 @@ def test_other_public_api_paths_are_public_under_gate(gated_app, path):
             f"{path} redirected to {location} — should be public, "
             "not bounced to /login"
         )
+
+
+def test_dashboard_plugins_requires_gate_session(gated_app):
+    """Dashboard plugin inventory is sensitive enough to require login."""
+    r = gated_app.get("/api/dashboard/plugins", follow_redirects=False)
+    assert r.status_code == 401
+
+
+def test_dashboard_plugins_allows_cookie_authenticated_gate_session(gated_app):
+    """Cookie-authenticated dashboard users can still load plugin manifests."""
+    r1 = gated_app.get("/auth/login?provider=stub", follow_redirects=False)
+    assert r1.status_code == 302
+    state = r1.headers["location"].split("state=")[1]
+
+    r2 = gated_app.get(
+        f"/auth/callback?code=stub_code&state={state}",
+        follow_redirects=False,
+    )
+    assert r2.status_code == 302
+
+    r3 = gated_app.get("/api/dashboard/plugins")
+    assert r3.status_code == 200, r3.text
+    assert isinstance(r3.json(), list)
 
 
 def test_gated_html_redirects_to_login(gated_app):

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -324,6 +324,8 @@ class TestWebServerEndpoints:
         resp = unauth_client.get("/api/status")
         assert resp.status_code == 200
         resp = unauth_client.get("/api/dashboard/plugins")
+        assert resp.status_code == 401
+        resp = self.client.get("/api/dashboard/plugins")
         assert resp.status_code == 200
         resp = unauth_client.get("/api/dashboard/plugins/rescan")
         assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- Remove `/api/dashboard/plugins` from the shared public dashboard API allowlist.
- Keep theme/config/status/model metadata public, but require dashboard auth before exposing installed plugin manifests.
- Add regressions for unauthenticated gated requests, cookie-authenticated gated requests, and legacy session-token requests for the manifest inventory endpoint.

## Why
`/api/dashboard/plugins` returns discovered dashboard plugin inventory, including manifest fields such as names, labels, versions, entrypoints, slots, API presence, and source. That is useful after the dashboard is unlocked, but it should not be pre-auth public inventory for anyone who can reach the dashboard hostname.

The SPA manifest fetch already goes through `fetchJSON`, which sends the loopback session token header and includes gated-mode cookies, so authenticated access to this endpoint is preserved.

## Scope note
This PR intentionally does not change `/api/dashboard/plugins/hub` or other route-level `_require_token()` endpoints. The OAuth-cookie behavior for those endpoints is the separate #35492 bug and already has open fixes in #35500/#35589. This PR only gates the pre-auth public `/api/dashboard/plugins` manifest inventory endpoint.

## Related
- Related to #35828: same dashboard public allowlist hardening pattern, but for dashboard plugin manifests rather than model metadata.
- Related to #35842 and #27631: config gating can reduce what plugin discovery returns, but this endpoint should still not be pre-auth public.
- Related to #32267/#32277: plugin static/source asset exposure was handled separately; this covers the JSON manifest inventory endpoint.
- Not a duplicate of #35589/#35500/#35492, which cover `/api/dashboard/plugins/hub` accepting valid OAuth sessions.

## Tests
- `ruff check hermes_cli/dashboard_auth/public_paths.py tests/hermes_cli/test_dashboard_auth_middleware.py tests/hermes_cli/test_web_server.py`
- `python -X utf8 -m pytest -p no:cacheprovider tests/hermes_cli/test_dashboard_auth_middleware.py::test_dashboard_plugins_requires_gate_session tests/hermes_cli/test_dashboard_auth_middleware.py::test_dashboard_plugins_allows_cookie_authenticated_gate_session tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_unauthenticated_api_blocked -q --timeout-method=thread`
- `python -X utf8 -m pytest -p no:cacheprovider tests/hermes_cli/test_dashboard_auth_middleware.py -q --timeout-method=thread`
- `python -X utf8 -m pytest -p no:cacheprovider tests/hermes_cli/test_web_server.py::TestWebServerEndpoints -q --timeout-method=thread`
- `ruff check .`
- `python -X utf8 -m pytest -p no:cacheprovider tests/hermes_cli/test_dashboard_auth_middleware.py tests/hermes_cli/test_web_server.py::TestWebServerEndpoints -q --timeout-method=thread`

`bash scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_middleware.py tests/hermes_cli/test_web_server.py::TestWebServerEndpoints -q` was attempted on this Windows checkout but failed before pytest startup because the wrapper is parsed with CRLF (`$'\r': command not found`, invalid `pipefail`).