### PR TITLE
feat(gateway): telegram ACK reactions + safe Hermes update to v0.15.1

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1026,6 +1026,10 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["TELEGRAM_IGNORED_THREADS"] = str(ignored_threads)
                 if "reactions" in telegram_cfg and not os.getenv("TELEGRAM_REACTIONS"):
                     os.environ["TELEGRAM_REACTIONS"] = str(telegram_cfg["reactions"]).lower()
+                if "ack_reactions" in telegram_cfg and not os.getenv("TELEGRAM_ACK_REACTIONS"):
+                    os.environ["TELEGRAM_ACK_REACTIONS"] = str(telegram_cfg["ack_reactions"]).lower()
+                if "ack_reaction_emoji" in telegram_cfg and not os.getenv("TELEGRAM_ACK_REACTION_EMOJI"):
+                    os.environ["TELEGRAM_ACK_REACTION_EMOJI"] = str(telegram_cfg["ack_reaction_emoji"]).strip()
                 if "proxy_url" in telegram_cfg and not os.getenv("TELEGRAM_PROXY"):
                     os.environ["TELEGRAM_PROXY"] = str(telegram_cfg["proxy_url"]).strip()
                 # reply_to_mode: top-level preferred, falls back to extra.reply_to_mode

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2119,11 +2119,26 @@ class SlackAdapter(BasePlatformAdapter):
                     if ext not in SUPPORTED_DOCUMENT_TYPES:
                         continue  # Skip unsupported file types silently
 
-                    # Check file size (Slack limit: 20 MB for bots)
+                    # Slack limit: was 20 MB for bots originally; raised to 100 MB
+                    # (2026-05-24) and now redirects > 100MB to Drive Inbox.
                     file_size = f.get("size", 0)
-                    MAX_DOC_BYTES = 20 * 1024 * 1024
+                    MAX_DOC_BYTES = 100 * 1024 * 1024
                     if not file_size or file_size > MAX_DOC_BYTES:
-                        logger.warning("[Slack] Document too large or unknown size: %s", file_size)
+                        size_mb = (file_size or 0) / (1024 * 1024)
+                        fname = f.get("name", "arquivo")
+                        drive_url = os.environ.get(
+                            "CHICO_DRIVE_INBOX_URL",
+                            "https://drive.google.com/drive/my-drive",
+                        )
+                        notice = (
+                            f"\U0001F4CE Arquivo muito grande: {fname} ({size_mb:.1f} MB, limite 100 MB). "
+                            f"Sobe aqui no Drive: {drive_url} e me fala processa drive."
+                        )
+                        attachment_notices.append(notice)
+                        logger.info(
+                            "[Slack] Document too large, redirected to Drive: %s (%s bytes)",
+                            fname, file_size,
+                        )
                         continue
 
                     # Download and cache

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5432,7 +5432,6 @@ class TelegramAdapter(BasePlatformAdapter):
                         "The document is too large or its size could not be verified. "
                         f"Maximum: {limit_mb} MB."
                     )
-                    logger.info("[Telegram] Document too large: %s bytes", doc.file_size)
                     await self.handle_message(event)
                     return
 
@@ -5899,8 +5898,16 @@ class TelegramAdapter(BasePlatformAdapter):
     # ── Message reactions (processing lifecycle) ──────────────────────────
 
     def _reactions_enabled(self) -> bool:
-        """Check if message reactions are enabled via config/env."""
+        """Check if processing lifecycle reactions are enabled via config/env."""
         return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in {"false", "0", "no"}
+
+    def _ack_reactions_enabled(self) -> bool:
+        """Check if deterministic ACK reaction is enabled via config/env."""
+        return os.getenv("TELEGRAM_ACK_REACTIONS", "false").lower() not in {"false", "0", "no"}
+
+    def _ack_reaction_emoji(self) -> str:
+        """Return emoji used for immediate receipt ACK."""
+        return (os.getenv("TELEGRAM_ACK_REACTION_EMOJI", "🫡") or "🫡").strip() or "🫡"
 
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
         """Set a single emoji reaction on a Telegram message."""
@@ -5938,6 +5945,15 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.debug("[%s] clear reactions failed: %s", self.name, e)
             return False
 
+    async def handle_message(self, event: MessageEvent) -> None:
+        """Process message and optionally ACK receipt before LLM processing."""
+        if self._ack_reactions_enabled():
+            chat_id = getattr(event.source, "chat_id", None)
+            message_id = getattr(event, "message_id", None)
+            if chat_id and message_id:
+                await self._set_reaction(chat_id, message_id, self._ack_reaction_emoji())
+        await super().handle_message(event)
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction when message processing begins."""
         if not self._reactions_enabled():
@@ -5945,6 +5961,10 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if chat_id and message_id:
+            # When ACK reactions are enabled, keep ACK visible briefly before
+            # replacing it with the in-progress marker.
+            if self._ack_reactions_enabled():
+                await asyncio.sleep(1.0)
             await self._set_reaction(chat_id, message_id, "\U0001f440")
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, ProcessingOutcome
 from gateway.session import SessionSource
 
 
@@ -79,6 +79,34 @@ def test_reactions_disabled_with_no(monkeypatch):
     monkeypatch.setenv("TELEGRAM_REACTIONS", "no")
     adapter = _make_adapter()
     assert adapter._reactions_enabled() is False
+
+
+def test_ack_reactions_disabled_by_default(monkeypatch):
+    """ACK reactions should be disabled by default."""
+    monkeypatch.delenv("TELEGRAM_ACK_REACTIONS", raising=False)
+    adapter = _make_adapter()
+    assert adapter._ack_reactions_enabled() is False
+
+
+def test_ack_reactions_enabled_when_set_true(monkeypatch):
+    """Setting TELEGRAM_ACK_REACTIONS=true enables ACK reactions."""
+    monkeypatch.setenv("TELEGRAM_ACK_REACTIONS", "true")
+    adapter = _make_adapter()
+    assert adapter._ack_reactions_enabled() is True
+
+
+def test_ack_reaction_emoji_defaults_to_salute(monkeypatch):
+    """ACK emoji defaults to salute when not configured."""
+    monkeypatch.delenv("TELEGRAM_ACK_REACTION_EMOJI", raising=False)
+    adapter = _make_adapter()
+    assert adapter._ack_reaction_emoji() == "🫡"
+
+
+def test_ack_reaction_emoji_reads_from_env(monkeypatch):
+    """ACK emoji should use TELEGRAM_ACK_REACTION_EMOJI when provided."""
+    monkeypatch.setenv("TELEGRAM_ACK_REACTION_EMOJI", "✅")
+    adapter = _make_adapter()
+    assert adapter._ack_reaction_emoji() == "✅"
 
 
 # ── _set_reaction ────────────────────────────────────────────────────
@@ -273,6 +301,50 @@ async def test_clear_reactions_returns_false_without_bot(monkeypatch):
     result = await adapter._clear_reactions("123", "456")
     assert result is False
 
+@pytest.mark.asyncio
+async def test_handle_message_sets_ack_reaction_before_super(monkeypatch):
+    """ACK reaction should be applied immediately before normal message processing."""
+    monkeypatch.setenv("TELEGRAM_ACK_REACTIONS", "true")
+    monkeypatch.setenv("TELEGRAM_ACK_REACTION_EMOJI", "✅")
+    adapter = _make_adapter()
+    event = _make_event()
+
+    called = {"super": False}
+
+    async def _fake_super(self, _event):
+        called["super"] = True
+
+    monkeypatch.setattr(BasePlatformAdapter, "handle_message", _fake_super)
+
+    await adapter.handle_message(event)
+
+    adapter._bot.set_message_reaction.assert_awaited_once_with(
+        chat_id=123,
+        message_id=456,
+        reaction="✅",
+    )
+    assert called["super"] is True
+
+
+@pytest.mark.asyncio
+async def test_handle_message_skips_ack_when_disabled(monkeypatch):
+    """When ACK reactions are disabled, adapter should delegate directly to super."""
+    monkeypatch.delenv("TELEGRAM_ACK_REACTIONS", raising=False)
+    adapter = _make_adapter()
+    event = _make_event()
+
+    called = {"super": False}
+
+    async def _fake_super(self, _event):
+        called["super"] = True
+
+    monkeypatch.setattr(BasePlatformAdapter, "handle_message", _fake_super)
+
+    await adapter.handle_message(event)
+
+    adapter._bot.set_message_reaction.assert_not_awaited()
+    assert called["super"] is True
+
 
 # ── config.py bridging ───────────────────────────────────────────────
 
@@ -284,34 +356,46 @@ def test_config_bridges_telegram_reactions(monkeypatch, tmp_path):
     config_file.write_text(yaml.dump({
         "telegram": {
             "reactions": True,
+            "ack_reactions": True,
+            "ack_reaction_emoji": "🫡",
         },
     }))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     # Use setenv (not delenv) so monkeypatch registers cleanup even when
     # the var doesn't exist yet — load_gateway_config will overwrite it.
     monkeypatch.setenv("TELEGRAM_REACTIONS", "")
+    monkeypatch.setenv("TELEGRAM_ACK_REACTIONS", "")
+    monkeypatch.setenv("TELEGRAM_ACK_REACTION_EMOJI", "")
 
     from gateway.config import load_gateway_config
     load_gateway_config()
 
     import os
     assert os.getenv("TELEGRAM_REACTIONS") == "true"
+    assert os.getenv("TELEGRAM_ACK_REACTIONS") == "true"
+    assert os.getenv("TELEGRAM_ACK_REACTION_EMOJI") == "🫡"
 
 
 def test_config_reactions_env_takes_precedence(monkeypatch, tmp_path):
-    """Env var should take precedence over config.yaml for reactions."""
+    """Env vars should take precedence over config.yaml for reactions."""
     import yaml
     config_file = tmp_path / "config.yaml"
     config_file.write_text(yaml.dump({
         "telegram": {
             "reactions": True,
+            "ack_reactions": True,
+            "ack_reaction_emoji": "🫡",
         },
     }))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setenv("TELEGRAM_REACTIONS", "false")
+    monkeypatch.setenv("TELEGRAM_ACK_REACTIONS", "false")
+    monkeypatch.setenv("TELEGRAM_ACK_REACTION_EMOJI", "✅")
 
     from gateway.config import load_gateway_config
     load_gateway_config()
 
     import os
     assert os.getenv("TELEGRAM_REACTIONS") == "false"
+    assert os.getenv("TELEGRAM_ACK_REACTIONS") == "false"
+    assert os.getenv("TELEGRAM_ACK_REACTION_EMOJI") == "✅"


### PR DESCRIPTION
## Context
Updated local Hermes checkout from v0.13.0 to v0.15.1 with local gateway customizations preserved.

## What changed
- Telegram: deterministic ACK reaction before processing (, )
- Telegram: preserve lifecycle reactions and cancelled clear behavior
- Gateway config bridge for ACK reaction env vars
- Slack: keep oversized attachment flow (100MB cap + Drive redirect notice)
- Tests: expanded telegram reaction coverage

## Validation
- ...........................                                              [100%]
=============================== warnings summary ===============================
venv/lib/python3.11/site-packages/_pytest/config/__init__.py:1303
  /root/.hermes/hermes-agent/venv/lib/python3.11/site-packages/_pytest/config/__init__.py:1303: PytestAssertRewriteWarning: Module already imported so cannot be rewritten; anyio
    self._mark_plugins_for_rewrite(hook, disable_autoload)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
27 passed, 1 warning in 0.63s
- Result: 27 passed

## Risk / rollout
- Sensitive area: messaging adapters (telegram/slack)
- Recommend merge after CI green + quick gateway smoke test
