### PR TITLE
feat(windows): add Windows self-termination guard patterns to approval.py

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1361,6 +1361,238 @@ class TestGatewayProtection:
         assert dangerous is False
 
 
+class TestWindowsSelfTerminationGuards:
+    """Windows equivalents of the pkill/killall self-termination guards.
+
+    The Unix guards above protect ``pkill hermes`` / ``killall gateway``;
+    these tests cover the Windows process-control spellings (taskkill,
+    Stop-Process, tskill, wmic, Get-Process pipelines, sc/sc.exe) that can
+    kill the gateway's own hermes.exe process just as easily.  Every
+    accepted spelling gets a positive case; every matcher gets an
+    unrelated-process negative case.
+    """
+
+    # ── taskkill ──────────────────────────────────────────────────
+
+    def test_taskkill_force_hermes_detected(self):
+        cmd = "taskkill /F /IM hermes.exe"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_taskkill_quoted_image_name_detected(self):
+        """/IM "hermes.exe" with a quoted image name must be caught."""
+        cmd = 'taskkill /f /im "hermes.exe"'
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_taskkill_graceful_hermes_detected(self):
+        """taskkill without /F still terminates the gateway."""
+        cmd = "taskkill /IM hermes.exe"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_taskkill_python_with_hermes_filter_detected(self):
+        cmd = 'taskkill /f /im python.exe /fi "WINDOWTITLE eq hermes*"'
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_taskkill_unrelated_not_flagged(self):
+        cmd = "taskkill /f /im nginx.exe"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    # ── PowerShell Stop-Process ───────────────────────────────────
+
+    def test_stop_process_name_hermes_detected(self):
+        cmd = "Stop-Process -Name hermes"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_stop_process_quoted_name_detected(self):
+        cmd = 'Stop-Process -Name "hermes" -Force'
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_stop_process_pid_from_hermes_pidfile_detected(self):
+        cmd = (
+            "Stop-Process -Id"
+            " (Get-Content $env:LOCALAPPDATA\\hermes\\gateway.pid)"
+        )
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_stop_process_unrelated_not_flagged(self):
+        cmd = "Stop-Process -Name notepad"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    # ── tskill (legacy Windows) ───────────────────────────────────
+
+    def test_tskill_hermes_detected(self):
+        cmd = "tskill hermes"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_tskill_unrelated_not_flagged(self):
+        cmd = "tskill chrome"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    # ── wmic ──────────────────────────────────────────────────────
+
+    def test_wmic_delete_hermes_detected(self):
+        cmd = 'wmic process where name="hermes.exe" delete'
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_wmic_call_terminate_quoted_detected(self):
+        cmd = """wmic process where "name='hermes.exe'" call terminate"""
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_wmic_unrelated_not_flagged(self):
+        cmd = 'wmic process where name="nginx.exe" delete'
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    # ── Get-Process pipeline ──────────────────────────────────────
+
+    def test_get_process_piped_to_stop_process_detected(self):
+        cmd = "Get-Process hermes | Stop-Process -Force"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    # ── sc / sc.exe service control ───────────────────────────────
+
+    def test_sc_stop_hermes_detected(self):
+        cmd = "sc stop hermes"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_sc_exe_stop_hermes_detected(self):
+        """Explicit sc.exe invocation must be caught (review regression)."""
+        cmd = "sc.exe stop hermes"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_sc_stop_unrelated_not_flagged(self):
+        cmd = "sc stop nginx"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_sc_exe_stop_unrelated_not_flagged(self):
+        cmd = "sc.exe stop nginx"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_sc_remote_stop_hermes_detected(self):
+        """sc \\machine stop hermes (remote target syntax) must be caught."""
+        cmd = r"sc \\localhost stop hermes"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_sc_remote_stop_unrelated_not_flagged(self):
+        cmd = r"sc \\server01 stop nginx"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    # ── net stop ──────────────────────────────────────────────────
+
+    def test_net_stop_hermes_detected(self):
+        cmd = "net stop hermes"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_net_stop_quoted_hermes_detected(self):
+        cmd = 'net stop "hermes gateway"'
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_net_stop_unrelated_not_flagged(self):
+        cmd = "net stop nginx"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_net_start_hermes_not_flagged(self):
+        """Starting (not stopping) the service is safe."""
+        cmd = "net start hermes"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    # ── PowerShell service cmdlets ────────────────────────────────
+
+    def test_stop_service_name_hermes_detected(self):
+        cmd = "Stop-Service -Name hermes -Force"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_restart_service_quoted_hermes_detected(self):
+        """Restart-Service stops the gateway too."""
+        cmd = 'Restart-Service -Name "hermes"'
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_get_service_piped_to_stop_service_detected(self):
+        cmd = "Get-Service hermes | Stop-Service -Force"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_get_service_piped_to_restart_service_detected(self):
+        cmd = "Get-Service hermes | Restart-Service"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_stop_service_unrelated_not_flagged(self):
+        cmd = "Stop-Service -Name nginx"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    def test_get_service_hermes_read_only_not_flagged(self):
+        """Querying the service without stopping it is safe."""
+        cmd = "Get-Service hermes | Select-Object Name, Status"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+    # ── CIM (modern WMIC replacement) ─────────────────────────────
+
+    def test_cim_delete_hermes_detected(self):
+        cmd = (
+            'Get-CimInstance Win32_Process -Filter "Name=\'hermes.exe\'" |'
+            " Invoke-CimMethod -MethodName Delete"
+        )
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_cim_delete_unrelated_not_flagged(self):
+        cmd = (
+            'Get-CimInstance Win32_Process -Filter "Name=\'nginx.exe\'" |'
+            " Invoke-CimMethod -MethodName Delete"
+        )
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
+
 class TestNormalizationBypass:
     """Obfuscation techniques must not bypass dangerous command detection."""
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -710,6 +710,26 @@ DANGEROUS_PATTERNS = [
     # directly against the service label (commonly `ai.hermes.gateway`).
     # Catch the operations that stop, restart, or unload it.
     (r'\blaunchctl\s+(stop|kickstart|bootout|unload|kill|disable|remove)\b.*\b(hermes|ai\.hermes)\b', "stop/restart hermes launchd service (kills running agents)"),
+    # Windows self-termination protection: taskkill, Stop-Process,
+    # Stop/Restart-Service, tskill, wmic, CIM, net stop, sc/sc.exe.
+    # These are the Windows equivalents of pkill/killall and can kill the
+    # gateway's own process (hermes.exe) just as easily.
+    # The image-name match tolerates optional quotes (`/IM "hermes.exe"`)
+    # and does not require /F — a graceful taskkill still terminates the
+    # gateway.  The sc match tolerates an optional `\\machine` remote
+    # target (`sc \\host stop hermes`).
+    (r'\btaskkill\b.*\/im\s+["\x27]?hermes', "Windows taskkill targeting hermes.exe (self-termination)"),
+    (r'\btaskkill\b.*\/im\s+["\x27]?python.*hermes', "Windows taskkill targeting hermes python process (self-termination)"),
+    (r'\bStop-Process\b.*-?Name\s+["\x27]?\s*hermes', "PowerShell Stop-Process targeting hermes (self-termination)"),
+    (r'\bStop-Process\b.*-?Id\s+.*hermes', "PowerShell Stop-Process via hermes PID (self-termination)"),
+    (r'\btskill\b\s+hermes', "Windows tskill targeting hermes (self-termination)"),
+    (r'\bwmic\s+process\b.*where\s+.*name\s*=\s*["\x27]?hermes', "WMIC delete hermes process (self-termination)"),
+    (r'\bGet-Process\b.*hermes.*\|\s*Stop-Process\b', "PowerShell Get-Process hermes piped to Stop-Process (self-termination)"),
+    (r'\bsc(?:\.exe)?\s+(?:\\?\S+\s+)?stop\b\s+hermes', "Windows sc/sc.exe stop hermes service (self-termination)"),
+    (r'\bnet\s+stop\b\s+["\x27]?hermes', "Windows net stop hermes service (self-termination)"),
+    (r'\b(?:Stop-Service|Restart-Service)\b.*-?Name\s+["\x27]?\s*hermes', "PowerShell Stop/Restart-Service targeting hermes (self-termination)"),
+    (r'\bGet-Service\b.*hermes.*\|\s*(?:Stop-Service|Restart-Service)\b', "PowerShell Get-Service hermes piped to Stop/Restart-Service (self-termination)"),
+    (r'\b(?:Get-CimInstance|Invoke-CimMethod)\b.*hermes.*\bDelete\b', "CIM delete hermes process/service (self-termination)"),
     # File copy/move/edit into sensitive system paths (/etc/ and macOS
     # /private/etc/ mirror).
     (rf'\b(cp|mv|install)\b.*\s{_SYSTEM_CONFIG_PATH}', "copy/move file into system config path"),


### PR DESCRIPTION
## Summary

Windows-specific dangerous command guard patterns (`tools/approval.py`).

The existing DANGEROUS_PATTERNS catch UNIX process-kill commands (`pkill hermes`, `killall gateway`, `systemctl restart`) but miss their Windows equivalents. This adds Windows patterns covering process kills **and** service stops:

- `taskkill` (by image name — quoted `/IM "hermes.exe"` and graceful no-`/F` variants included — and python image filtered to hermes processes)
- `Stop-Process` (by `-Name` incl. quoted variants, and by `-Id` resolved from a hermes pidfile)
- `Get-Process hermes | Stop-Process` pipeline
- `tskill hermes` (legacy Windows)
- `wmic process ... delete` and its modern CIM replacement (`Get-CimInstance` / `Invoke-CimMethod ... Delete`)
- `sc stop hermes` / `sc.exe stop hermes`, including remote target syntax `sc \\host stop hermes`
- `net stop hermes`
- `Stop-Service` / `Restart-Service` (both `-Name` form and `Get-Service` pipelines)

These prevent the agent from killing its own gateway process on Windows, complementing the existing UNIX guards.

### Tests

New `tests/tools/test_approval.py::TestWindowsSelfTerminationGuards` — positive cases for every accepted spelling plus unrelated-process negative cases, mirroring the existing `TestGatewayProtection` contract. Full `test_approval.py` suite passes (343 passed; the 2 `TestDetectDangerousRm` failures are pre-existing Windows-environment issues also present on pristine `main`).

### Review feedback addressed

- Added the missing tests for every accepted Windows spelling (positive + unrelated-process negatives).
- The service-control matcher accepts the explicit `sc.exe` spelling, with a regression test.
- Adversarial review of the guards surfaced further spelling gaps in the same family — `net stop`, `Stop-Service`/`Restart-Service`, the CIM successor to WMIC, and `sc \\host` remote syntax — all now covered with tests.
- Dropped the `scripts/windows/` deployment helpers from the first revision: they duplicated the maintained Windows service backend (`hermes_cli/gateway_windows.py`, `hermes gateway install/start/restart`) and the `hermes dashboard` web lifecycle, and hard-coded contributor-specific paths. Windows users are better served by the native install + service commands.

### Known limitations

- Absolute-path invocations (`C:\Windows\System32\taskkill.exe /f /im hermes.exe`) bypass all `\b`-anchored patterns — a pre-existing normalization-layer behavior that also affects upstream's own Windows patterns. Filed as #71890.
- Two-step pidfile indirection (`$p = Get-Content ...\hermes\gateway.pid; taskkill /f /pid $p`) cannot be caught at regex detection time — the same limitation class as Unix `kill $(pgrep)` without the substitution visible on the command line.

## Related

The Windows self-termination issue is a sibling of #31179 (model kills its own host process). While #31179 adds model-level awareness, these approval.py patterns add a hard tool-level guard that requires human confirmation before executing Windows process-kill / service-stop commands targeting hermes.

<!-- hermes-sweeper:review=35971 -->
