### PR TITLE
fix(agent): extract param field from error body for Xiaomi MiMo recovery

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -509,12 +509,30 @@ def classify_api_error(
                         pass
         if not _body_msg:
             _body_msg = str(body.get("message") or "").lower()
-    # Combine all message sources for pattern matching
+    # Combine all message sources for pattern matching.
+    # Also extract ``param`` — some providers (Xiaomi MiMo, some Alibaba
+    # endpoints) put the actionable detail in a top-level ``param`` field
+    # rather than in ``message``.  E.g. Xiaomi returns:
+    #   {"code":"400","message":"Param Incorrect","param":"`text` is not set"}
+    # Without this, patterns like "text is not set" never reach the matcher
+    # and the error misclassifies as non-retryable format_error.
+    _param_msg = ""
+    if isinstance(body, dict):
+        _param_raw = body.get("param") or ""
+        if not _param_raw:
+            _err_obj_for_param = body.get("error", {})
+            if isinstance(_err_obj_for_param, dict):
+                _param_raw = _err_obj_for_param.get("param") or ""
+        if isinstance(_param_raw, str) and _param_raw.strip():
+            # Strip backticks — Xiaomi wraps field names: `` `text` is not set``
+            _param_msg = _param_raw.strip().lower().replace("`", "")
     parts = [_raw_msg]
     if _body_msg and _body_msg not in _raw_msg:
         parts.append(_body_msg)
     if _metadata_msg and _metadata_msg not in _raw_msg and _metadata_msg not in _body_msg:
         parts.append(_metadata_msg)
+    if _param_msg and _param_msg not in _raw_msg and _param_msg not in _body_msg:
+        parts.append(_param_msg)
     error_msg = " ".join(parts)
     provider_lower = (provider or "").strip().lower()
     model_lower = (model or "").strip().lower()

--- a/run_agent.py
+++ b/run_agent.py
@@ -3970,11 +3970,13 @@ class AIAgent:
                         text_parts.append(text)
 
             if not had_image:
-                # List-type content but no image parts — leave alone (some
-                # providers reject ANY list content, but stripping a
-                # text-only list doesn't reduce ambiguity; let the caller
-                # surface the original error if this turns out to be the
-                # case).
+                # List-type content but no image parts.  Some providers
+                # (Xiaomi MiMo, some Alibaba endpoints) reject ANY list
+                # content in tool messages — not just images.  Flatten
+                # text-only lists to a plain string so the retry succeeds.
+                if text_parts:
+                    msg["content"] = "\n\n".join(text_parts)
+                    changed = True
                 continue
 
             if text_parts:

--- a/tests/run_agent/test_multimodal_tool_content_recovery.py
+++ b/tests/run_agent/test_multimodal_tool_content_recovery.py
@@ -73,16 +73,17 @@ class TestStripImagePartsHelper:
         assert agent._try_strip_image_parts_from_tool_messages(msgs) is False
         assert msgs[0]["content"] == "plain string result"
 
-    def test_tool_message_list_without_image_unchanged(self):
-        """List content with only text parts is left alone — caller surfaces
-        the original error if this turns out to also be rejected."""
+    def test_tool_message_list_without_image_flattened(self):
+        """List content with only text parts is flattened to a plain string —
+        providers like Xiaomi MiMo reject ANY list-type tool content."""
         agent = _make_agent()
         msgs = [
             {"role": "tool", "tool_call_id": "x", "content": [
                 {"type": "text", "text": "hello"},
             ]},
         ]
-        assert agent._try_strip_image_parts_from_tool_messages(msgs) is False
+        assert agent._try_strip_image_parts_from_tool_messages(msgs) is True
+        assert msgs[0]["content"] == "hello"
 
     def test_tool_message_list_with_image_downgrades(self):
         agent = _make_agent()


### PR DESCRIPTION
## What changed and why

The Xiaomi MiMo API returns HTTP 400 errors with the actionable detail in a `param` field, not `message`:

```json
{"code":"400","message":"Param Incorrect","param":"`text` is not set"}
```

The error classifier only extracted `message` for pattern matching, so the existing `"text is not set"` pattern in `_MULTIMODAL_TOOL_CONTENT_PATTERNS` never matched. This caused sessions to abort with **"Non-retryable error (HTTP 400). Aborting."** when automatic recovery was available.

Additionally, the recovery handler only stripped image parts from list-type tool messages. Xiaomi rejects **ANY** list-type tool content (including text-only lists like `[{"type":"text","text":"result"}]`), so text-only lists are now flattened to plain strings.

### Changes

- **`agent/error_classifier.py`** — Extract `param` field from error body (both top-level and nested under `error`) and include it in the pattern-matching string. Strips backticks that Xiaomi wraps around field names.
- **`run_agent.py`** — `_try_strip_image_parts_from_tool_messages` now also flattens text-only list content to a plain string (not just image-bearing lists).
- **`tests/run_agent/test_multimodal_tool_content_recovery.py`** — Updated test to reflect new behavior (text-only lists are now flattened).

## How to test

```python
from agent.error_classifier import classify_api_error, FailoverReason

class XiaomiError(Exception):
    def __init__(self):
        super().__init__("HTTP 400: Param Incorrect")
        self.status_code = 400
        self.body = {"code":"400","message":"Param Incorrect","param":"`text` is not set","type":""}

r = classify_api_error(XiaomiError(), provider="xiaomi", model="mimo-v2.5-pro")
assert r.reason == FailoverReason.multimodal_tool_content_unsupported
assert r.retryable == True
```

## Platforms tested

- macOS (Apple Silicon)

## Related

- Issue #27344 (multimodal tool content rejection)
