### PR TITLE
feat(desktop): opt-in demo/fixture mode for the renderer

### DIFF
--- a/apps/desktop/src/demo/bridge.ts
+++ b/apps/desktop/src/demo/bridge.ts
@@ -1,0 +1,258 @@
+// Fake window.hermesDesktop bridge for demo mode. Answers the renderer's REST
+// calls (window.hermesDesktop.api) from fixtures and stubs the rest of the
+// preload surface so the app boots with no Electron host / backend.
+import type { HermesApiRequest } from '../global'
+
+import {
+  CONFIG,
+  FS_TREE,
+  MESSAGES,
+  MODEL_INFO,
+  MODEL_OPTIONS,
+  PROFILES,
+  SESSIONS,
+  SKILLS,
+  STATUS,
+  TOOLSETS
+} from './fixtures'
+import { control } from './gateway'
+
+const noop = () => {}
+const off = () => noop
+
+function route(req: HermesApiRequest): unknown {
+  const path = (req.path || '').split('?')[0]
+  const method = (req.method || 'GET').toUpperCase()
+
+  if (path === '/api/config' || path === '/api/config/defaults') {
+    return CONFIG
+  }
+
+  if (path === '/api/config/schema') {
+    return { fields: {}, category_order: [] }
+  }
+
+  if (path === '/api/status') {
+    return STATUS
+  }
+
+  if (path === '/api/logs') {
+    return { file: 'gateway.log', lines: [] }
+  }
+
+  if (path === '/api/sessions') {
+    return { sessions: SESSIONS, total: SESSIONS.length, offset: 0, limit: 40 }
+  }
+
+  if (path === '/api/sessions/search') {
+    return { results: [] }
+  }
+
+  const messages = path.match(/^\/api\/sessions\/([^/]+)\/messages$/)
+
+  if (messages) {
+    const id = decodeURIComponent(messages[1])
+
+    return { session_id: id, messages: MESSAGES[id] || [] }
+  }
+
+  if (path === '/api/model/info') {
+    return MODEL_INFO
+  }
+
+  if (path === '/api/model/options') {
+    return MODEL_OPTIONS
+  }
+
+  if (path === '/api/model/auxiliary') {
+    return { main: { provider: MODEL_OPTIONS.provider, model: MODEL_OPTIONS.model }, tasks: [] }
+  }
+
+  if (path === '/api/skills') {
+    return SKILLS
+  }
+
+  if (path === '/api/tools/toolsets') {
+    return TOOLSETS
+  }
+
+  if (path === '/api/cron/jobs') {
+    return []
+  }
+
+  if (path === '/api/profiles') {
+    return { profiles: PROFILES }
+  }
+
+  const soul = path.match(/^\/api\/profiles\/([^/]+)\/soul$/)
+
+  if (soul) {
+    return {
+      content: `# ${decodeURIComponent(soul[1])} persona\n\nYou are Hermes — concise, capable, and autonomous.`,
+      exists: true
+    }
+  }
+
+  const setupCommand = path.match(/^\/api\/profiles\/([^/]+)\/setup-command$/)
+
+  if (setupCommand) {
+    return { command: `hermes --profile ${decodeURIComponent(setupCommand[1])}` }
+  }
+
+  if (path === '/api/messaging/platforms') {
+    return { platforms: [] }
+  }
+
+  if (path === '/api/providers/oauth') {
+    return { providers: [] }
+  }
+
+  if (path === '/api/env') {
+    return {}
+  }
+
+  if (path === '/api/analytics/usage') {
+    return { by_model: [], daily: [], period_days: 30, skills: { summary: {}, top_skills: [] }, totals: {} }
+  }
+
+  if (method !== 'GET') {
+    return { ok: true }
+  }
+
+  return {}
+}
+
+export const bridge = {
+  getConnection: () =>
+    Promise.resolve({
+      baseUrl: 'http://127.0.0.1:5174',
+      isFullscreen: false,
+      mode: 'local' as const,
+      nativeOverlayWidth: 0,
+      source: 'local' as const,
+      token: 'demo',
+      wsUrl: 'ws://127.0.0.1:5174/__demo_gateway',
+      logs: [],
+      windowButtonPosition: null
+    }),
+  getBootProgress: () =>
+    Promise.resolve({
+      error: null,
+      fakeMode: true,
+      message: 'Ready',
+      phase: 'ready',
+      progress: 100,
+      running: false,
+      timestamp: Date.now()
+    }),
+  getConnectionConfig: () =>
+    Promise.resolve({
+      envOverride: false,
+      mode: 'local' as const,
+      remoteTokenPreview: null,
+      remoteTokenSet: false,
+      remoteUrl: ''
+    }),
+  saveConnectionConfig: () =>
+    Promise.resolve({
+      envOverride: false,
+      mode: 'local' as const,
+      remoteTokenPreview: null,
+      remoteTokenSet: false,
+      remoteUrl: ''
+    }),
+  applyConnectionConfig: () =>
+    Promise.resolve({
+      envOverride: false,
+      mode: 'local' as const,
+      remoteTokenPreview: null,
+      remoteTokenSet: false,
+      remoteUrl: ''
+    }),
+  testConnectionConfig: () => Promise.resolve({ baseUrl: 'http://127.0.0.1:5174', ok: true, version: '0.0.0-demo' }),
+  api<T>(request: HermesApiRequest): Promise<T> {
+    return Promise.resolve(route(request) as T)
+  },
+  notify: () => Promise.resolve(true),
+  requestMicrophoneAccess: () => Promise.resolve(false),
+  readFileDataUrl: () => Promise.resolve(''),
+  readFileText: () => Promise.resolve({ path: '', text: '' }),
+  selectPaths: () => Promise.resolve([] as string[]),
+  writeClipboard: () => Promise.resolve(true),
+  saveImageFromUrl: () => Promise.resolve(true),
+  saveImageBuffer: () => Promise.resolve(''),
+  saveClipboardImage: () => Promise.resolve(''),
+  getPathForFile: () => '',
+  normalizePreviewTarget: () => Promise.resolve(null),
+  watchPreviewFile: () => Promise.resolve({ id: 'w1', path: '' }),
+  stopPreviewFileWatch: () => Promise.resolve(true),
+  setTitleBarTheme: noop,
+  setPreviewShortcutActive: noop,
+  openExternal: () => Promise.resolve(),
+  fetchLinkTitle: () => Promise.resolve(''),
+  revealLogs: () => Promise.resolve({ ok: true, path: '~/.hermes/logs' }),
+  getRecentLogs: () => Promise.resolve({ path: 'gateway.log', lines: [] }),
+  readDir: (path: string) => {
+    const key = (path || '').replace(/\/+$/, '')
+
+    const entries = (FS_TREE[key] || FS_TREE[path] || []).map(e => ({
+      name: e.name,
+      isDirectory: e.isDirectory,
+      path: `${key}/${e.name}`
+    }))
+
+    return Promise.resolve({ entries })
+  },
+  gitRoot: () => Promise.resolve(null),
+  terminal: {
+    dispose: () => Promise.resolve(true),
+    onData: (_id: string, callback: (payload: string) => void) => {
+      control.termCb = callback
+
+      return noop
+    },
+    onExit: off,
+    resize: () => Promise.resolve(true),
+    start: () => Promise.resolve({ id: 't1', cwd: '~/code/hermes-agent', shell: 'zsh' }),
+    write: () => Promise.resolve(true)
+  },
+  onClosePreviewRequested: off,
+  onOpenUpdatesRequested: off,
+  onWindowStateChanged: off,
+  onPreviewFileChanged: off,
+  onBackendExit: off,
+  onBootProgress: off,
+  getBootstrapState: () =>
+    Promise.resolve({
+      active: false,
+      manifest: null,
+      stages: {},
+      error: null,
+      log: [],
+      startedAt: null,
+      completedAt: null,
+      unsupportedPlatform: null
+    }),
+  resetBootstrap: () => Promise.resolve({ ok: true }),
+  repairBootstrap: () => Promise.resolve({ ok: true }),
+  onBootstrapEvent: off,
+  getVersion: () =>
+    Promise.resolve({
+      appVersion: '0.0.0-demo',
+      electronVersion: '',
+      nodeVersion: '',
+      platform: 'web',
+      hermesRoot: '~/.hermes'
+    }),
+  updates: {
+    check: () => Promise.resolve({ supported: false, reason: 'demo' }),
+    apply: () => Promise.resolve({ ok: true }),
+    getBranch: () => Promise.resolve({ branch: 'demo' }),
+    setBranch: (name: string) => Promise.resolve({ branch: name }),
+    onProgress: off
+  }
+} satisfies Window['hermesDesktop']
+
+export function installBridge(): void {
+  window.hermesDesktop = bridge
+}

--- a/apps/desktop/src/demo/demo.test.ts
+++ b/apps/desktop/src/demo/demo.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { isDemoMode } from '../lib/demo-flag'
+
+import { bridge } from './bridge'
+import { control, DemoSocket } from './gateway'
+
+afterEach(() => {
+  window.localStorage.clear()
+  window.location.hash = ''
+  control.socket = null
+})
+
+describe('isDemoMode', () => {
+  it('is off by default', () => {
+    expect(isDemoMode()).toBe(false)
+  })
+
+  it('enables via the ?demo=1 hash query', () => {
+    window.location.hash = '#/?demo=1'
+    expect(isDemoMode()).toBe(true)
+  })
+
+  it('enables via localStorage', () => {
+    window.localStorage.setItem('hermes.demo', '1')
+    expect(isDemoMode()).toBe(true)
+  })
+})
+
+describe('bridge.api (REST router)', () => {
+  it('serves the session list from fixtures', async () => {
+    const res = await bridge.api<{ sessions: Array<{ id: string }>; total: number }>({ path: '/api/sessions' })
+    expect(res.total).toBeGreaterThan(0)
+    expect(res.sessions.some(s => s.id === 's-release')).toBe(true)
+  })
+
+  it('serves messages for a known session', async () => {
+    const res = await bridge.api<{ session_id: string; messages: unknown[] }>({
+      path: '/api/sessions/s-release/messages'
+    })
+
+    expect(res.session_id).toBe('s-release')
+    expect(res.messages.length).toBeGreaterThan(0)
+  })
+
+  it('serves config and an empty default for unknown GETs', async () => {
+    expect(await bridge.api<{ display: unknown }>({ path: '/api/config' })).toHaveProperty('display')
+    expect(await bridge.api({ path: '/api/unknown' })).toEqual({})
+  })
+})
+
+describe('fake gateway', () => {
+  it('answers a JSON-RPC request from the handler map', async () => {
+    const socket = new DemoSocket('ws://demo')
+
+    const result = new Promise<unknown>(resolve => {
+      socket.onmessage = ev => {
+        const frame = JSON.parse(ev.data) as { id?: number; result?: unknown }
+
+        if (frame.id === 7) {
+          resolve(frame.result)
+        }
+      }
+    })
+
+    socket.send(JSON.stringify({ id: 7, method: 'setup.runtime_check' }))
+    expect(await result).toEqual({ ok: true })
+  })
+
+  it('playTurn emits a well-formed streaming sequence', async () => {
+    vi.useFakeTimers()
+
+    const events: Array<{ type: string }> = []
+    control.socket = {
+      deliver: (data: string) => {
+        events.push((JSON.parse(data) as { params: { type: string } }).params)
+      }
+    } as unknown as DemoSocket
+
+    const done = control.playTurn({ reasoning: 'r', tool: { name: 't', tool_id: '1' }, reply: ['ab'] }, 'sid')
+
+    await vi.runAllTimersAsync()
+    await done
+
+    const types = events.map(e => e.type)
+    expect(types[0]).toBe('message.start')
+    expect(types).toContain('reasoning.delta')
+    expect(types).toContain('tool.start')
+    expect(types).toContain('tool.complete')
+    expect(types).toContain('message.delta')
+    expect(types.at(-1)).toBe('message.complete')
+
+    vi.useRealTimers()
+  })
+})

--- a/apps/desktop/src/demo/fixtures.ts
+++ b/apps/desktop/src/demo/fixtures.ts
@@ -1,0 +1,249 @@
+// Canned data for demo mode. Plain objects — the REST shim returns them as the
+// generic api<T> result and consumers cast, so we don't need to import every
+// runtime type here. Keep this small and representative.
+
+const now = Date.now()
+const min = 60_000
+const hr = 60 * min
+
+const DEFAULT_PROVIDER = 'anthropic'
+const DEFAULT_MODEL = 'claude-sonnet-4.5'
+
+function session(
+  id: string,
+  title: string,
+  preview: string,
+  message_count: number,
+  ago: number,
+  model: string,
+  tool_call_count: number,
+  cwd = '~/code/hermes-agent'
+) {
+  return {
+    id,
+    title,
+    preview,
+    message_count,
+    started_at: now - ago - 20 * min,
+    last_active: now - ago,
+    ended_at: now - ago,
+    is_active: false,
+    model,
+    input_tokens: 1800 + message_count * 420,
+    output_tokens: 900 + message_count * 260,
+    tool_call_count,
+    cwd,
+    source: 'desktop'
+  }
+}
+
+export const SESSIONS = [
+  session(
+    's-release',
+    'Cut the desktop release notes',
+    'Drafted the changelog and opened the PR.',
+    18,
+    2 * min,
+    DEFAULT_MODEL,
+    8
+  ),
+  session(
+    's-ci',
+    'Debug failing CI on arm64',
+    'The wheel build needed a platform tag bump.',
+    24,
+    38 * min,
+    'gpt-5',
+    12
+  ),
+  session(
+    's-auth',
+    'Refactor auth middleware',
+    'Extracted the token guard into its own module.',
+    31,
+    3 * hr,
+    DEFAULT_MODEL,
+    15,
+    '~/work/api'
+  ),
+  session(
+    's-rfc',
+    'Summarize the 42-page sync RFC',
+    'Three options; I recommend the event-log design.',
+    9,
+    6 * hr,
+    'gpt-5',
+    2,
+    '~/work/specs'
+  )
+]
+
+const message = (role: string, content: string, ago: number) => ({ role, content, timestamp: now - ago })
+
+export const MESSAGES: Record<string, Array<Record<string, unknown>>> = {
+  's-release': [
+    message(
+      'user',
+      'We just merged the desktop GUI. Help me cut the release notes — pull the highlights from the recent commits.',
+      40 * min
+    ),
+    message('assistant', 'On it. Let me look at what landed since the last release.', 39 * min),
+    {
+      role: 'assistant',
+      timestamp: now - 39 * min,
+      content: '',
+      tool_calls: [
+        {
+          id: 'h1',
+          type: 'function',
+          function: { name: 'run_command', arguments: JSON.stringify({ command: 'git log --oneline --since=2.weeks' }) }
+        }
+      ]
+    },
+    {
+      role: 'tool',
+      tool_call_id: 'h1',
+      tool_name: 'run_command',
+      timestamp: now - 38 * min,
+      content:
+        '4cfc8b7 feat(desktop): native Electron shell\n9a21f0e feat(desktop): live gateway streaming\n1d7e220 feat(themes): theme engine\n…and 137 more'
+    },
+    message(
+      'assistant',
+      "Here's the shape of it — a native desktop app with live streaming chat, inline tool cards, a theme engine, a command palette, and one-click updates. Want me to draft the full changelog and open a PR?",
+      38 * min
+    )
+  ]
+}
+
+// A streamable turn for window.__demo.playTurn(). The gateway replays these as
+// server→client events (reasoning → tool → reply), the same shapes the live
+// backend emits.
+export const DEMO_TURN = {
+  prompt: 'Write a punchy launch tweet for the desktop app.',
+  reasoning:
+    'They want a launch tweet for the new desktop GUI. Keep it hook-first, concrete, end with a call to action.',
+  tool: {
+    name: 'read_file',
+    tool_id: 'demo-1',
+    args: { path: 'RELEASE_NOTES.md' },
+    result: {
+      output:
+        '# Hermes Desktop\n\n## Highlights\n- Native desktop app\n- Streaming chat + inline tool cards\n- Theme engine\n…',
+      exit_code: 0
+    }
+  },
+  reply: [
+    'Your agent has a desktop now. ',
+    'Native app, **streaming chat**, inline tool calls, a theme engine, ',
+    'and one-click updates.\n\nSame Hermes. Now with a window. → Download today.'
+  ]
+}
+
+export const CONFIG = {
+  agent: { reasoning_effort: 'medium', service_tier: 'default', personalities: { hermes: {} } },
+  display: { personality: 'hermes', skin: 'nous' },
+  terminal: { cwd: '~/code/hermes-agent' },
+  stt: { enabled: true },
+  voice: { max_recording_seconds: 120 }
+}
+
+export const MODEL_OPTIONS = {
+  provider: DEFAULT_PROVIDER,
+  model: DEFAULT_MODEL,
+  providers: [
+    {
+      name: 'Anthropic',
+      slug: 'anthropic',
+      is_current: true,
+      total_models: 2,
+      models: ['claude-sonnet-4.5', 'claude-opus-4.1']
+    },
+    { name: 'OpenAI', slug: 'openai', total_models: 2, models: ['gpt-5', 'gpt-5-mini'] }
+  ]
+}
+
+export const MODEL_INFO = { provider: DEFAULT_PROVIDER, model: DEFAULT_MODEL, effective_context_length: 200000 }
+
+export const STATUS = {
+  active_sessions: 1,
+  config_path: '~/.hermes/config.yaml',
+  config_version: 14,
+  gateway_pid: 4242,
+  gateway_running: true,
+  gateway_state: 'running',
+  gateway_updated_at: new Date().toISOString(),
+  hermes_home: '~/.hermes',
+  latest_config_version: 14,
+  version: ''
+}
+
+const skill = (name: string, category: string, description: string, enabled = true) => ({
+  name,
+  category,
+  description,
+  enabled
+})
+
+export const SKILLS = [
+  skill('frontend-design', 'engineering', 'Production-grade UI with high design quality.'),
+  skill('mcp-builder', 'engineering', 'Build Model Context Protocol servers for any API.'),
+  skill('pdf', 'documents', 'Extract, fill, merge and generate PDF documents.'),
+  skill('canvas-design', 'creative', 'Design posters and visual art as PNG / PDF.'),
+  skill('web-research', 'research', 'Deep web research with citations and synthesis.'),
+  skill('internal-comms', 'writing', 'Status reports, FAQs and incident write-ups.', false)
+]
+
+const toolset = (name: string, label: string, description: string, tools: string[], enabled = true) => ({
+  name,
+  label,
+  description,
+  tools,
+  enabled,
+  configured: true
+})
+
+export const TOOLSETS = [
+  toolset('files', 'Files', 'Read, write and search the workspace.', [
+    'read_file',
+    'write_file',
+    'edit',
+    'glob',
+    'grep'
+  ]),
+  toolset('shell', 'Shell', 'Run commands in a sandboxed terminal.', ['run_command', 'kill', 'background']),
+  toolset('web', 'Web', 'Search the web and fetch URLs.', ['web_search', 'fetch']),
+  toolset('image', 'Image', 'Generate and edit images.', ['generate_image', 'edit_image'], false)
+]
+
+const profile = (name: string, provider: string, model: string, skill_count: number, is_default = false) => ({
+  name,
+  provider,
+  model,
+  skill_count,
+  is_default,
+  has_env: true,
+  path: `~/.hermes/profiles/${name}`
+})
+
+export const PROFILES = [
+  profile('default', DEFAULT_PROVIDER, DEFAULT_MODEL, 18, true),
+  profile('research', 'openai', 'gpt-5', 9),
+  profile('ops', 'anthropic', 'claude-opus-4.1', 24)
+]
+
+const dir = (name: string) => ({ name, isDirectory: true })
+const file = (name: string) => ({ name, isDirectory: false })
+export const FS_TREE: Record<string, Array<{ name: string; isDirectory: boolean }>> = {
+  '~/code/hermes-agent': [
+    dir('agent'),
+    dir('apps'),
+    dir('gateway'),
+    dir('tools'),
+    file('AGENTS.md'),
+    file('README.md'),
+    file('pyproject.toml')
+  ],
+  '~/code/hermes-agent/agent': [file('loop.py'), file('tools.py'), file('memory.py')],
+  '~/code/hermes-agent/apps': [dir('desktop'), dir('shared')]
+}

--- a/apps/desktop/src/demo/gateway.ts
+++ b/apps/desktop/src/demo/gateway.ts
@@ -1,0 +1,183 @@
+// Fake JSON-RPC gateway for demo mode. Replaces window.WebSocket with a socket
+// that answers the renderer's RPC requests from fixtures and can push
+// server→client events (the same shapes the live backend emits). Exposes a
+// control surface used by window.__demo to drive a scripted turn.
+import { CONFIG, MODEL_OPTIONS } from './fixtures'
+
+type Json = Record<string, unknown>
+type GatewayEvent = { type: string; session_id?: string; payload?: Json }
+
+const OPEN = 1
+
+function sessionInfo(session_id: string, cwd = '~/code/hermes-agent'): Json {
+  return {
+    session_id,
+    stored_session_id: session_id,
+    resumed: session_id,
+    message_count: 0,
+    messages: [],
+    info: {
+      model: MODEL_OPTIONS.model,
+      provider: MODEL_OPTIONS.provider,
+      cwd,
+      branch: 'main',
+      running: false,
+      tools: {},
+      skills: []
+    }
+  }
+}
+
+// method -> (params) => result
+const rpc: Record<string, (params?: Json) => Json> = {
+  'setup.status': () => ({ provider_configured: true }),
+  'setup.runtime_check': () => ({ ok: true }),
+  'config.get': () => CONFIG,
+  'model.options': () => MODEL_OPTIONS,
+  'model.get': () => ({ provider: MODEL_OPTIONS.provider, model: MODEL_OPTIONS.model }),
+  'model.current': () => ({ provider: MODEL_OPTIONS.provider, model: MODEL_OPTIONS.model }),
+  'reload.env': () => ({ ok: true }),
+  'context.suggestions': () => ({ suggestions: [] }),
+  'complete.path': () => ({ completions: [] }),
+  'prompt.submit': () => ({ ok: true }),
+  'prompt.cancel': () => ({ ok: true }),
+  'session.resume': p => sessionInfo((p?.session_id as string) || 'demo-session'),
+  'session.create': p => sessionInfo('demo-session', (p?.cwd as string) || '~/code/hermes-agent')
+}
+
+export interface DemoTurn {
+  reasoning?: string
+  tool?: { name: string; tool_id: string; args?: Json; result?: Json }
+  reply: string[]
+}
+
+export interface DemoControl {
+  socket: DemoSocket | null
+  termCb: ((data: string) => void) | null
+  emit(event: GatewayEvent): boolean
+  term(data: string): void
+  playTurn(turn: DemoTurn, sessionId?: string): Promise<void>
+}
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
+
+export const control: DemoControl = {
+  socket: null,
+  termCb: null,
+  emit(event) {
+    if (!this.socket) {
+      return false
+    }
+
+    this.socket.deliver(JSON.stringify({ method: 'event', params: event }))
+
+    return true
+  },
+  term(data) {
+    this.termCb?.(data)
+  },
+  async playTurn(turn, sessionId = 'demo-session') {
+    this.emit({ type: 'message.start', session_id: sessionId })
+    await sleep(400)
+
+    if (turn.reasoning) {
+      this.emit({ type: 'reasoning.delta', session_id: sessionId, payload: { text: turn.reasoning } })
+      await sleep(900)
+    }
+
+    if (turn.tool) {
+      this.emit({
+        type: 'tool.start',
+        session_id: sessionId,
+        payload: { name: turn.tool.name, tool_id: turn.tool.tool_id, args: turn.tool.args }
+      })
+      await sleep(900)
+      this.emit({
+        type: 'tool.complete',
+        session_id: sessionId,
+        payload: { name: turn.tool.name, tool_id: turn.tool.tool_id, result: turn.tool.result }
+      })
+      await sleep(700)
+    }
+
+    const full = turn.reply.join('')
+
+    for (let i = 0; i < full.length; i += 3) {
+      this.emit({ type: 'message.delta', session_id: sessionId, payload: { text: full.slice(i, i + 3) } })
+      await sleep(24)
+    }
+
+    this.emit({ type: 'message.complete', session_id: sessionId, payload: { text: full } })
+  }
+}
+
+export class DemoSocket extends EventTarget {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  static readonly CLOSING = 2
+  static readonly CLOSED = 3
+
+  url: string
+  readyState = 0
+  onopen: ((ev: Event) => void) | null = null
+  onmessage: ((ev: MessageEvent) => void) | null = null
+  onclose: ((ev: Event) => void) | null = null
+  onerror: ((ev: Event) => void) | null = null
+
+  constructor(url: string) {
+    super()
+    this.url = url
+    control.socket = this
+    // open on the next tick so the connect()'s 'open' listener is attached first
+    setTimeout(() => {
+      this.readyState = OPEN
+      const ev = new Event('open')
+      this.dispatchEvent(ev)
+      this.onopen?.(ev)
+    }, 0)
+  }
+
+  deliver(data: string) {
+    const ev = new MessageEvent('message', { data })
+    this.dispatchEvent(ev)
+    this.onmessage?.(ev)
+  }
+
+  send(raw: string) {
+    let frame: { id?: number | string; method?: string; params?: Json }
+
+    try {
+      frame = JSON.parse(raw)
+    } catch {
+      return
+    }
+
+    if (frame.id != null) {
+      const handler = frame.method ? rpc[frame.method] : undefined
+      let result: Json = {}
+
+      try {
+        if (handler) {
+          result = handler(frame.params) || {}
+        }
+      } catch {
+        // ignore handler errors in demo mode
+      }
+
+      setTimeout(() => this.deliver(JSON.stringify({ jsonrpc: '2.0', id: frame.id, result })), 0)
+    }
+  }
+
+  close() {
+    this.readyState = 3
+    const ev = new Event('close')
+    this.dispatchEvent(ev)
+    this.onclose?.(ev)
+  }
+}
+
+export function installGateway(): DemoControl {
+  window.WebSocket = DemoSocket as unknown as typeof WebSocket
+
+  return control
+}

--- a/apps/desktop/src/demo/index.ts
+++ b/apps/desktop/src/demo/index.ts
@@ -1,0 +1,44 @@
+// Demo / fixture mode entry point. Lazy-loaded from main.tsx only when
+// isDemoMode() is true (so production builds tree-shake it out). Installs a fake
+// preload bridge + gateway — the app then runs with canned data and no backend —
+// plus a window.__demo scripting API for e2e tests and demo tooling.
+import { installBridge } from './bridge'
+import { DEMO_TURN } from './fixtures'
+import { control, type DemoTurn, installGateway } from './gateway'
+
+declare global {
+  interface Window {
+    __demo?: {
+      emit: (event: { type: string; session_id?: string; payload?: Record<string, unknown> }) => boolean
+      playTurn: (turn?: DemoTurn, sessionId?: string) => Promise<void>
+      term: (data: string) => void
+    }
+  }
+}
+
+let installed = false
+
+export function installDemo(): void {
+  if (installed) {
+    return
+  }
+
+  installed = true
+
+  // Returning users skip onboarding; setup.runtime_check (gateway) also reports
+  // ready, so the onboarding overlay never reappears once the gateway connects.
+  try {
+    window.localStorage.setItem('hermes-desktop-onboarded-v1', '1')
+  } catch {
+    // localStorage unavailable — degrade silently
+  }
+
+  installGateway()
+  installBridge()
+
+  window.__demo = {
+    emit: event => control.emit(event),
+    playTurn: (turn = DEMO_TURN, sessionId) => control.playTurn(turn, sessionId),
+    term: data => control.term(data)
+  }
+}

--- a/apps/desktop/src/lib/demo-flag.ts
+++ b/apps/desktop/src/lib/demo-flag.ts
@@ -1,0 +1,27 @@
+// Opt-in demo / fixture mode. When on, the renderer runs against canned data and
+// a fake gateway (no backend) — for screenshots, e2e tests, and demo videos.
+// Off by default; the demo module is dynamically imported only when this returns
+// true (see main.tsx), so production builds tree-shake it out entirely.
+//
+// Enable via any of:
+//   - build flag:   VITE_HERMES_DEMO=1
+//   - URL param:    #/...?demo=1   (HashRouter, so the query lives on the hash)
+//   - localStorage: hermes.demo = "1"
+export function isDemoMode(): boolean {
+  try {
+    if (import.meta.env.VITE_HERMES_DEMO === '1') {
+      return true
+    }
+
+    const hash = window.location.hash
+    const query = hash.includes('?') ? hash.slice(hash.indexOf('?') + 1) : ''
+
+    if (new URLSearchParams(query).get('demo') === '1') {
+      return true
+    }
+
+    return window.localStorage.getItem('hermes.demo') === '1'
+  } catch {
+    return false
+  }
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -8,6 +8,7 @@ import { HashRouter } from 'react-router-dom'
 import App from './app'
 import { HapticsProvider } from './components/haptics-provider'
 import { installClipboardShim } from './lib/clipboard'
+import { isDemoMode } from './lib/demo-flag'
 import { ThemeProvider } from './themes/context'
 
 installClipboardShim()
@@ -30,16 +31,27 @@ const queryClient = new QueryClient({
   }
 })
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <HapticsProvider>
-          <HashRouter>
-            <App />
-          </HashRouter>
-        </HapticsProvider>
-      </ThemeProvider>
-    </QueryClientProvider>
-  </StrictMode>
-)
+async function bootstrap() {
+  // Opt-in demo / fixture mode: run against canned data + a fake gateway (no
+  // backend). Dynamically imported so production builds tree-shake it out.
+  if (isDemoMode()) {
+    const { installDemo } = await import('./demo')
+    installDemo()
+  }
+
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <HapticsProvider>
+            <HashRouter>
+              <App />
+            </HashRouter>
+          </HapticsProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </StrictMode>
+  )
+}
+
+void bootstrap()


### PR DESCRIPTION
An opt-in mode that runs the **renderer** against canned data + a fake gateway, with **no backend** — for screenshots, e2e tests, and demo videos. Off by default; the whole module is dynamically imported only when enabled, so production builds tree-shake it out (zero cost when off).

## Enable
Any of: `VITE_HERMES_DEMO=1` (build), `#/...?demo=1` (URL), or `localStorage hermes.demo = "1"`.

## What
- `lib/demo-flag.ts` — `isDemoMode()`.
- `src/demo/fixtures.ts` — canned sessions, messages, model/config/status/skills/toolsets/profiles.
- `src/demo/bridge.ts` — a fake `window.hermesDesktop` preload bridge; a REST router serves `/api/*` from fixtures, the rest stubbed (`satisfies Window['hermesDesktop']`).
- `src/demo/gateway.ts` — a fake JSON-RPC `WebSocket` that answers the renderer's RPCs from fixtures, plus a small control surface.
- `src/demo/index.ts` — installs the above + a `window.__demo` scripting API (`emit`, `playTurn`) to drive a scripted streamed turn.
- `main.tsx` — one guarded `if (isDemoMode()) await import('./demo')…`.

## Why
Lets tests and demo/video tooling drive the real UI deterministically with no server. Today that's done by injecting a fake bridge externally, which drifts from the real protocol — this keeps it in-tree and honest. Pairs with the thread idle signal in #35960: wait on `[data-thread-state="idle"]` after `window.__demo.playTurn()`.

## Notes
- **Complements** `HERMES_DESKTOP_BOOT_FAKE` (which fakes the Electron boot/install overlay); this fakes the running app's data/gateway.
- **No change to the default (non-demo) path.** `tsc -b` clean; `test:ui` adds 8 passing tests. Verified it boots the app with fixtures (session list + history render, gateway reports ready, zero console errors).
- Targeting `bb/gui`; independent of #35960.
