### PR TITLE
fix(anthropic): demote reordered thinking signatures on interleaved multi-thinking turns

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1948,6 +1948,29 @@ def _manage_thinking_signatures(
             # Demote ALL thinking blocks on this turn to text so the turn replays
             # cleanly and the model can re-plan from the surviving tool results.
             signature_dead = bool(m.get("_thinking_signature_invalidated"))
+            # A second source of dead signatures: interleaved extended thinking.
+            # With thinking + tool use, Anthropic emits blocks interleaved
+            # (thinking, tool_use, thinking, tool_use, ...) and signs each thinking
+            # block against its ORIGINAL position in that sequence.  Hermes stores
+            # thinking (reasoning_details) and tool_calls separately and rebuilds
+            # the turn as [all thinking][text][all tool_use] in
+            # _convert_assistant_message, so any turn with 2+ thinking blocks
+            # alongside tool_use has been reordered and its signatures no longer
+            # match (the reported content.N lands in the tool_use region).
+            # reasoning_details carries no positional anchor to re-interleave from,
+            # so demote to text.  A single leading thinking block is unaffected —
+            # its position is unchanged.
+            if not signature_dead:
+                _n_thinking = sum(
+                    1 for b in m["content"]
+                    if isinstance(b, dict) and b.get("type") in _THINKING_TYPES
+                )
+                _has_tool_use = any(
+                    isinstance(b, dict) and b.get("type") == "tool_use"
+                    for b in m["content"]
+                )
+                if _n_thinking >= 2 and _has_tool_use:
+                    signature_dead = True
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1647,6 +1647,72 @@ class TestThinkingBlockSignatureManagement:
         assert len(thinking) == 1
         assert thinking[0]["signature"] == "sig_valid"
 
+    def test_interleaved_multi_thinking_demoted_on_last_turn(self):
+        """Multiple signed thinking blocks + tool_use on the last turn are demoted.
+
+        Extended thinking interleaves thinking and tool_use blocks; Anthropic
+        signs each thinking block against its original interleaved position.
+        Hermes rebuilds the turn as [all thinking][text][all tool_use], so any
+        turn with 2+ thinking blocks alongside tool_use is reordered and the
+        signatures are dead. They must be demoted to text (reasoning preserved),
+        not replayed verbatim, or Anthropic 400s with "thinking ... cannot be
+        modified".
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Working on it.",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "First step.", "signature": "sig1"},
+                    {"type": "thinking", "thinking": "Second step.", "signature": "sig2"},
+                ],
+                "tool_calls": [
+                    {"id": "tc_a", "function": {"name": "a", "arguments": "{}"}},
+                    {"id": "tc_b", "function": {"name": "b", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_a", "content": "result A"},
+            {"role": "tool", "tool_call_id": "tc_b", "content": "result B"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        blocks = result[0]["content"]
+        # No thinking blocks survive — all demoted.
+        assert not any(b.get("type") in ("thinking", "redacted_thinking") for b in blocks)
+        # Reasoning preserved as text.
+        text_contents = [b.get("text", "") for b in blocks if b.get("type") == "text"]
+        assert "First step." in text_contents
+        assert "Second step." in text_contents
+        # Both tool_use blocks survive.
+        tool_use = [b for b in blocks if b.get("type") == "tool_use"]
+        assert len(tool_use) == 2
+
+    def test_single_thinking_with_tool_use_kept_signed(self):
+        """A single signed thinking block + tool_use is NOT demoted (no over-fire).
+
+        With only one thinking block its position (leading the turn) is
+        unchanged by Hermes' reconstruction, so the signature is still valid and
+        must be replayed verbatim.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Working.",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Only step.", "signature": "sig_solo"},
+                ],
+                "tool_calls": [
+                    {"id": "tc_one", "function": {"name": "a", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_one", "content": "result"},
+        ]
+        _, result = convert_messages_to_anthropic(messages)
+        blocks = result[0]["content"]
+        thinking = [b for b in blocks if b.get("type") == "thinking"]
+        assert len(thinking) == 1
+        assert thinking[0]["signature"] == "sig_solo"
+
+
     def test_unsigned_thinking_downgraded_to_text_on_last_turn(self):
         """Unsigned thinking blocks on the last turn become text blocks."""
         messages = [


### PR DESCRIPTION
## What does this PR do?

Extended-thinking Claude models interleave `thinking` and `tool_use` blocks (`thinking, tool_use, thinking, tool_use, …`) and sign **each** `thinking` block against its **original position** in that sequence. `_convert_assistant_message` rebuilds the assistant turn as `[all thinking][text][all tool_use]`, so any latest turn carrying **2+ thinking blocks alongside tool_use** is reordered and its signatures no longer match. Replaying them returns a non-retryable HTTP 400:

```
messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest
assistant message cannot be modified. These blocks must remain as they were
in the original response.
```

Since the turn is rebuilt from the store every iteration, the gateway loops on it with no recovery. The reported `content.M` lands in the tool_use region (Anthropic is validating the original interleaved layout), which is the tell that this is a reorder rather than the orphan-strip case fixed in #35859.

`reasoning_details` carries no positional anchor to re-interleave the blocks from, so faithful reconstruction is impossible. This extends the existing dead-signature handling in `_manage_thinking_signatures`: when the latest turn has 2+ thinking blocks and any tool_use, demote those thinking blocks to text (reasoning preserved) instead of replaying dead signatures. A single leading thinking block is unaffected — its position is unchanged, so its signature is still valid.

This is distinct from #35847/#35859 (orphan-stripped tool_use): there are no orphans here — every tool_use is answered — so that fix does not cover it.

## Related Issue

Fixes #35975

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py` — `_manage_thinking_signatures`: mark the latest turn's signature dead (→ demote thinking to text) when it has 2+ thinking blocks alongside tool_use.
- `tests/agent/test_anthropic_adapter.py` — two tests: interleaved multi-thinking demotion, and a single-thinking + tool_use no-over-fire guard.

## How to Test

```
pytest tests/agent/test_anthropic_adapter.py -k "thinking or signature or orphan or interleav" -q
```

(21 passed locally — the 2 new tests plus the existing thinking/signature/orphan suite, confirming no over-fire regression on `test_signed_thinking_preserved_on_last_turn`.)

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] Tests pass
- [x] I've added tests for my changes
- [x] Tested on macOS 26.4, Python 3.11.15

### Documentation & Housekeeping

- [x] N/A — behavior fix, no config/doc/schema changes.
