### PR TITLE
fix: harden cron output retention and kanban list limit

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2,7 +2,7 @@
 Cron job storage and management.
 
 Jobs are stored in ~/.hermes/cron/jobs.json
-Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
+Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}_{uuid}.md
 """
 
 import copy
@@ -42,8 +42,11 @@ JOBS_FILE = CRON_DIR / "jobs.json"
 # Required when tick() runs jobs in parallel threads — without this,
 # concurrent mark_job_run / advance_next_run calls can clobber each other.
 _jobs_file_lock = threading.Lock()
+_output_prune_lock = threading.Lock()
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
+DEFAULT_MAX_OUTPUT_FILES_PER_JOB = 100
+MAX_OUTPUT_FILES_PER_JOB_ENV = "HERMES_CRON_MAX_OUTPUT_FILES_PER_JOB"
 
 # Fields on a cron job that must never change after creation. ``id`` is used
 # as a filesystem path component under ``OUTPUT_DIR``; allowing it to be
@@ -66,6 +69,65 @@ def _job_output_dir(job_id: str) -> Path:
     if Path(text).is_absolute() or Path(text).drive:
         raise ValueError(f"Invalid cron job id for output path: {job_id!r}")
     return OUTPUT_DIR / text
+
+
+def _max_output_files_per_job() -> int:
+    """Return the per-job cron output retention cap."""
+    raw = os.getenv(MAX_OUTPUT_FILES_PER_JOB_ENV, "").strip()
+    if not raw:
+        return DEFAULT_MAX_OUTPUT_FILES_PER_JOB
+
+    try:
+        limit = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; using default %d",
+            MAX_OUTPUT_FILES_PER_JOB_ENV,
+            raw,
+            DEFAULT_MAX_OUTPUT_FILES_PER_JOB,
+        )
+        return DEFAULT_MAX_OUTPUT_FILES_PER_JOB
+
+    if limit < 1:
+        logger.warning(
+            "%s must be >= 1; using default %d",
+            MAX_OUTPUT_FILES_PER_JOB_ENV,
+            DEFAULT_MAX_OUTPUT_FILES_PER_JOB,
+        )
+        return DEFAULT_MAX_OUTPUT_FILES_PER_JOB
+
+    return limit
+
+
+def _output_file_sort_key(path: Path):
+    """Sort output files from oldest to newest for retention pruning."""
+    try:
+        stat = path.stat()
+        return (stat.st_mtime_ns, path.name)
+    except OSError:
+        return (0, path.name)
+
+
+def _prune_job_outputs(job_output_dir: Path, max_files: int, keep: Optional[Path] = None) -> None:
+    """Prune oldest markdown outputs in one job directory down to ``max_files``."""
+    if max_files < 1:
+        return
+
+    files = [path for path in job_output_dir.glob("*.md") if path.is_file()]
+    excess = len(files) - max_files
+    if excess <= 0:
+        return
+
+    candidates = [path for path in files if keep is None or path != keep]
+    candidates.sort(key=_output_file_sort_key)
+
+    for path in candidates[:excess]:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning("Failed to prune cron output %s: %s", path, exc)
 
 
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
@@ -1093,14 +1155,14 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
 
 
 def save_job_output(job_id: str, output: str):
-    """Save job output to file."""
+    """Save job output to a collision-safe file and prune old outputs."""
     ensure_dirs()
     job_output_dir = _job_output_dir(job_id)
     job_output_dir.mkdir(parents=True, exist_ok=True)
     _secure_dir(job_output_dir)
     
-    timestamp = _hermes_now().strftime("%Y-%m-%d_%H-%M-%S")
-    output_file = job_output_dir / f"{timestamp}.md"
+    timestamp = _hermes_now().strftime("%Y-%m-%d_%H-%M-%S_%f")
+    output_file = job_output_dir / f"{timestamp}_{uuid.uuid4().hex}.md"
     
     fd, tmp_path = tempfile.mkstemp(dir=str(job_output_dir), suffix='.tmp', prefix='.output_')
     try:
@@ -1108,8 +1170,14 @@ def save_job_output(job_id: str, output: str):
             f.write(output)
             f.flush()
             os.fsync(f.fileno())
-        atomic_replace(tmp_path, output_file)
-        _secure_file(output_file)
+        with _output_prune_lock:
+            atomic_replace(tmp_path, output_file)
+            _secure_file(output_file)
+            _prune_job_outputs(
+                job_output_dir,
+                _max_output_files_per_job(),
+                keep=output_file,
+            )
     except BaseException:
         try:
             os.unlink(tmp_path)

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -130,6 +130,17 @@ def _parse_branch_flag(value: Optional[str]) -> Optional[str]:
     return branch
 
 
+def _positive_int_arg(value: str) -> int:
+    """Argparse type for positive integer count flags like ``--limit``."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError("must be a positive integer") from None
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
 def _check_dispatcher_presence() -> tuple[bool, str]:
     """Return ``(running, message)``.
 
@@ -396,6 +407,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                              "(set on tasks created from inside an ACP loop)")
     p_list.add_argument("--archived", action="store_true",
                         help="Include archived tasks")
+    p_list.add_argument("--limit", type=_positive_int_arg, default=None,
+                        help="Maximum number of tasks to list")
     p_list.add_argument("--json", action="store_true")
     p_list.add_argument(
         "--sort",
@@ -1426,6 +1439,7 @@ def _cmd_list(args: argparse.Namespace) -> int:
             tenant=args.tenant,
             session_id=args.session,
             include_archived=args.archived,
+            limit=getattr(args, "limit", None),
             order_by=getattr(args, "sort", None),
             workflow_template_id=args.workflow_template_id,
             current_step_key=args.current_step_key,

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -4,6 +4,7 @@ import threading
 import pytest
 from datetime import datetime, timedelta, timezone
 
+import cron.jobs as cron_jobs
 from cron.jobs import (
     parse_duration,
     parse_schedule,
@@ -179,7 +180,9 @@ class TestComputeNextRun:
 
 @pytest.fixture()
 def tmp_cron_dir(tmp_path, monkeypatch):
-    """Redirect cron storage to a temp directory."""
+    """Redirect cron storage to a temp HERMES_HOME."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("cron.jobs.HERMES_DIR", tmp_path)
     monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
     monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
     monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
@@ -978,6 +981,103 @@ class TestSaveJobOutput:
         assert output_file.exists()
         assert output_file.read_text() == "# Results\nEverything ok."
         assert "test123" in str(output_file)
+
+    def test_concurrent_same_second_outputs_use_unique_readable_filenames(self, tmp_cron_dir, monkeypatch):
+        fixed_now = datetime(2026, 5, 29, 22, 0, 1, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: fixed_now)
+        paths = []
+        errors = []
+
+        def write_output(index):
+            try:
+                paths.append(save_job_output("test123", f"output {index}"))
+            except Exception as exc:  # pragma: no cover - assertion below reports details
+                errors.append(exc)
+
+        threads = [threading.Thread(target=write_output, args=(i,)) for i in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert not errors
+        assert len(paths) == 8
+        assert len({path.name for path in paths}) == 8
+        for path in paths:
+            assert path.exists()
+            assert path.name.startswith("2026-05-29_22-00-01")
+        assert {path.read_text() for path in paths} == {f"output {i}" for i in range(8)}
+
+    def test_prunes_old_outputs_to_env_override_per_job(self, tmp_cron_dir, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_MAX_OUTPUT_FILES_PER_JOB", "2")
+        output_times = iter(
+            datetime(2026, 5, 29, 22, minute, tzinfo=timezone.utc)
+            for minute in range(4)
+        )
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: next(output_times))
+
+        paths = [save_job_output("retention-job", f"output {i}") for i in range(4)]
+
+        job_output_dir = tmp_cron_dir / "cron" / "output" / "retention-job"
+        remaining = sorted(job_output_dir.glob("*.md"))
+        assert len(remaining) == 2
+        assert {path.read_text() for path in remaining} == {"output 2", "output 3"}
+        assert not paths[0].exists()
+        assert not paths[1].exists()
+
+    def test_concurrent_retention_pruning_keeps_current_save_output(self, tmp_cron_dir, monkeypatch):
+        """A save must not return after another pruner deleted its own output."""
+        monkeypatch.setenv("HERMES_CRON_MAX_OUTPUT_FILES_PER_JOB", "1")
+        monkeypatch.setattr(
+            "cron.jobs._hermes_now",
+            lambda: datetime(2026, 5, 29, 22, 0, 1, tzinfo=timezone.utc),
+        )
+        first_prune_started = threading.Event()
+        second_publish_seen = threading.Event()
+        real_atomic_replace = cron_jobs.atomic_replace
+        real_prune = cron_jobs._prune_job_outputs
+        publish_count = 0
+        observe_lock = threading.Lock()
+        errors = []
+        returned = []
+
+        def observed_atomic_replace(tmp_path, output_file):
+            nonlocal publish_count
+            real_atomic_replace(tmp_path, output_file)
+            with observe_lock:
+                publish_count += 1
+                if publish_count == 2:
+                    second_publish_seen.set()
+
+        def observed_prune(*args, **kwargs):
+            if not first_prune_started.is_set():
+                first_prune_started.set()
+                second_publish_seen.wait(timeout=0.2)
+            return real_prune(*args, **kwargs)
+
+        monkeypatch.setattr("cron.jobs.atomic_replace", observed_atomic_replace)
+        monkeypatch.setattr("cron.jobs._prune_job_outputs", observed_prune)
+
+        def write_output(index):
+            try:
+                path = save_job_output("race-job", f"output {index}")
+                returned.append((index, path, path.exists()))
+            except Exception as exc:  # pragma: no cover - assertion below reports details
+                errors.append(exc)
+
+        first = threading.Thread(target=write_output, args=(0,))
+        first.start()
+        assert first_prune_started.wait(timeout=5)
+        second = threading.Thread(target=write_output, args=(1,))
+        second.start()
+        first.join()
+        second.join()
+
+        assert not errors
+        assert len(returned) == 2
+        assert all(exists_at_return for _, _, exists_at_return in returned)
+        remaining = list((tmp_cron_dir / "cron" / "output" / "race-job").glob("*.md"))
+        assert len(remaining) == 1
 
     @pytest.mark.parametrize("bad_job_id", ["../escape", "nested/escape", ".", "..", ""])
     def test_rejects_unsafe_job_id(self, tmp_cron_dir, bad_job_id):

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -23,6 +23,12 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+def _list_json_titles(rest: str = "") -> list[str]:
+    suffix = f" {rest}" if rest else ""
+    payload = json.loads(kc.run_slash(f"list --json{suffix}"))
+    return [row["title"] for row in payload]
+
+
 # ---------------------------------------------------------------------------
 # Workspace flag parsing
 # ---------------------------------------------------------------------------
@@ -233,6 +239,48 @@ def test_kanban_list_json_includes_session_id(kanban_home):
         and row.get("session_id") == "acp-x"
         for row in payload
     )
+
+
+def test_run_slash_list_sort_priority_desc_and_limit(kanban_home):
+    """CLI list wires --sort/--limit into the canonical DB ordering."""
+    with kb.connect() as conn:
+        kb.create_task(conn, title="high-priority", assignee="ops", priority=30)
+        kb.create_task(conn, title="low-priority", assignee="ops", priority=1)
+        kb.create_task(conn, title="mid-priority", assignee="ops", priority=10)
+
+    # Canonical priority-desc is the reverse of the default high-priority-first
+    # order: lower priority values first, then created_at as the tiebreaker.
+    assert _list_json_titles("--sort priority-desc --limit 2") == [
+        "low-priority",
+        "mid-priority",
+    ]
+
+
+def test_run_slash_list_archived_default_and_explicit_status(kanban_home):
+    with kb.connect() as conn:
+        live = kb.create_task(conn, title="live task", assignee="ops", priority=10)
+        archived = kb.create_task(conn, title="archived task", assignee="ops", priority=20)
+        assert kb.archive_task(conn, archived)
+
+    default_titles = _list_json_titles()
+    assert "live task" in default_titles
+    assert "archived task" not in default_titles
+
+    archived_titles = _list_json_titles("--status archived")
+    assert archived_titles == ["archived task"]
+
+    include_archived_titles = _list_json_titles("--archived")
+    assert "live task" in include_archived_titles
+    assert "archived task" in include_archived_titles
+    assert live != archived
+
+
+def test_run_slash_list_invalid_sort_reports_allowed_choices(kanban_home):
+    out = kc.run_slash("list --sort newest")
+    assert "usage error" in out
+    assert "invalid choice" in out
+    assert "created-desc" in out
+    assert "priority-desc" in out
 
 
 def test_run_slash_usage_error_returns_message(kanban_home):


### PR DESCRIPTION
## Summary
- use collision-resistant cron output filenames and serialize publish/prune for concurrent saves
- add regression coverage for retention pruning keeping the current save output
- wire hermes kanban list --limit through to the DB query with CLI coverage

## Verification
- git diff --check
- added-line secret scan: 0 hits
- /home/securevps/.hermes/hermes-agent/venv/bin/python -m pytest tests/cron/test_jobs.py tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_db.py -q -o addopts=  # 425 passed, 1 warning (discord audioop deprecation)