### PR TITLE
fix(cli): route oneshot Copilot GPT-5 via responses

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -242,6 +242,61 @@ def _create_session_db_for_oneshot():
         return None
 
 
+def _normalize_runtime_for_oneshot(
+    effective_model: str,
+    runtime: dict,
+) -> tuple[str, dict]:
+    """Apply the same provider-specific model/API routing used by chat.
+
+    ``hermes -z`` bypasses ``HermesCLI._ensure_runtime_credentials()``, which
+    is where Copilot/OpenCode model IDs are normalized and GPT-5/Codex models
+    are routed to the Responses API. Keep this helper intentionally small so
+    oneshot stays quiet while still sharing the critical routing semantics.
+    """
+    normalized_runtime = dict(runtime)
+    resolved_provider = str(normalized_runtime.get("provider") or "").strip()
+    resolved_mode = str(normalized_runtime.get("api_mode") or "chat_completions").strip()
+    current_model = (effective_model or "").strip()
+
+    try:
+        from hermes_cli.model_normalize import (
+            _AGGREGATOR_PROVIDERS,
+            normalize_model_for_provider,
+        )
+
+        if resolved_provider not in _AGGREGATOR_PROVIDERS:
+            normalized_model = normalize_model_for_provider(current_model, resolved_provider)
+            if normalized_model:
+                current_model = normalized_model
+    except Exception:
+        pass
+
+    if resolved_provider == "copilot":
+        try:
+            from hermes_cli.models import copilot_model_api_mode, normalize_copilot_model_id
+
+            api_key = normalized_runtime.get("api_key")
+            canonical = normalize_copilot_model_id(current_model, api_key=api_key)
+            if canonical:
+                current_model = canonical
+            resolved_mode = copilot_model_api_mode(current_model, api_key=api_key)
+        except Exception:
+            pass
+    elif resolved_provider in {"opencode-zen", "opencode-go"}:
+        try:
+            from hermes_cli.models import normalize_opencode_model_id, opencode_model_api_mode
+
+            canonical = normalize_opencode_model_id(resolved_provider, current_model)
+            if canonical:
+                current_model = canonical
+            resolved_mode = opencode_model_api_mode(resolved_provider, current_model)
+        except Exception:
+            pass
+
+    normalized_runtime["api_mode"] = resolved_mode or "chat_completions"
+    return current_model, normalized_runtime
+
+
 def _run_agent(
     prompt: str,
     model: Optional[str] = None,
@@ -319,6 +374,7 @@ def _run_agent(
         target_model=effective_model or None,
         explicit_base_url=explicit_base_url_from_alias,
     )
+    effective_model, runtime = _normalize_runtime_for_oneshot(effective_model, runtime)
 
     # Pull in explicit toolsets when provided; otherwise use whatever the user
     # has enabled for "cli". sorted() gives stable ordering for config-derived

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -858,6 +858,62 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     assert captured["prompt"] == "recall this"
 
 
+def test_oneshot_normalizes_copilot_gpt5_to_responses(monkeypatch):
+    """hermes -z should keep the same Copilot GPT-5 API routing as chat."""
+    from hermes_cli.oneshot import _run_agent
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+
+        def chat(self, prompt):
+            captured["prompt"] = prompt
+            return "ok"
+
+    def mod(name, **attrs):
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=FakeAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "gpt-5.5"}}),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {
+                "api_key": None,
+                "base_url": "https://api.githubcopilot.com",
+                "provider": "copilot",
+                "api_mode": "chat_completions",
+                "credential_pool": None,
+            },
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: set()),
+    )
+
+    assert _run_agent("hello", model="gpt-5.5", provider="copilot", toolsets=[]) == "ok"
+    assert captured["model"] == "gpt-5.5"
+    assert captured["provider"] == "copilot"
+    assert captured["api_mode"] == "codex_responses"
+    assert captured["prompt"] == "hello"
+
+
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
     captured = {}
     active_path_during_call = None


### PR DESCRIPTION
## Summary
- apply provider-specific model/API-mode normalization in `hermes -z` before constructing `AIAgent`
- route Copilot GPT-5/Codex models through `codex_responses`, matching `hermes chat -q -Q`
- add regression coverage for the Copilot GPT-5 oneshot route

Fixes #35980.

## Validation
- `uv run python -m py_compile hermes_cli/oneshot.py`
- `uv run --extra dev pytest tests/hermes_cli/test_tui_resume_flow.py -q`
- isolated smoke: `uv run hermes --provider copilot -m gpt-5.5 -z "Reply with exactly: HERMES_Z_OK"` -> `HERMES_Z_OK`
- BMA foreground validator passed on smoke stdout
