### PR TITLE
fix(agent): use default max_tokens=16384 in iteration-limit summary call

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1374,6 +1374,11 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 summary_kwargs["temperature"] = _summary_temperature
             if agent.max_tokens is not None:
                 summary_kwargs.update(agent._max_tokens_param(agent.max_tokens))
+            else:
+                # Anthropic rejects calls without max_tokens; cloud providers
+                # default to ~4-8K (too small for 90-turn summaries); local
+                # llama.cpp runs unbounded until KV cache saturates.
+                summary_kwargs.update(agent._max_tokens_param(16384))
             if _lm_reasoning_effort is not None:
                 summary_kwargs["reasoning_effort"] = _lm_reasoning_effort
 
@@ -1465,6 +1470,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                     summary_kwargs["temperature"] = _summary_temperature
                 if agent.max_tokens is not None:
                     summary_kwargs.update(agent._max_tokens_param(agent.max_tokens))
+                else:
+                    summary_kwargs.update(agent._max_tokens_param(16384))
                 if _lm_reasoning_effort is not None:
                     summary_kwargs["reasoning_effort"] = _lm_reasoning_effort
                 if summary_extra_body:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3001,6 +3001,26 @@ class TestHandleMaxIterations:
             "call_123"
         ]
 
+    def test_summary_includes_max_tokens_when_unset(self, agent):
+        """Regression: when agent.max_tokens is None, the summary call must
+        still include an explicit output budget so Anthropic doesn't 400 and
+        cloud providers don't default to an inadequate 4-8K cap."""
+        agent.max_tokens = None
+        resp = _mock_response(content="Here is a summary.")
+        agent.client.chat.completions.create.return_value = resp
+        agent._cached_system_prompt = "You are helpful."
+
+        agent._handle_max_iterations([{"role": "user", "content": "do stuff"}], 90)
+
+        kwargs = agent.client.chat.completions.create.call_args.kwargs
+        # Must have either max_tokens or max_completion_tokens (provider-dependent)
+        has_output_cap = "max_tokens" in kwargs or "max_completion_tokens" in kwargs
+        assert has_output_cap, (
+            f"Summary call missing output budget when max_tokens=None: {list(kwargs.keys())}"
+        )
+        cap_value = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens")
+        assert cap_value == 16384
+
 
 class TestRunConversation:
     """Tests for the main run_conversation method.


### PR DESCRIPTION
## What does this PR do?

Adds a fallback `max_tokens=16384` to the iteration-exhaustion summary call in `handle_max_iterations()` when `agent.max_tokens` is unset. Without this, the summary API call omits the output budget entirely, causing provider-specific failures.

## Related Issue

Fixes #35979

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: Added `else` branches (primary + retry paths) that pass `max_tokens=16384` via `_max_tokens_param()` when `agent.max_tokens is None`. This matches the Anthropic transport's own default (`params.get("max_tokens", 16384)` in `agent/transports/anthropic.py:69`).
- `tests/run_agent/test_run_agent.py`: Added `test_summary_includes_max_tokens_when_unset` regression test that verifies the summary call includes an explicit output cap even when `agent.max_tokens` is `None`.

## How to Test

1. Run `pytest tests/run_agent/test_run_agent.py::TestHandleMaxIterations -xvs` — all 11 tests should pass
2. Verify the new test specifically: `pytest tests/run_agent/test_run_agent.py::TestHandleMaxIterations::test_summary_includes_max_tokens_when_unset -xvs`
3. Confirm the fix: set `agent.max_tokens = None` on an AIAgent instance, trigger `handle_max_iterations()`, and inspect `call_args.kwargs` — should contain `max_tokens=16384` (or `max_completion_tokens=16384` for OpenAI-direct endpoints)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/chat_completion_helpers.py::handle_max_iterations` (lines 1265-1491)
- Blast radius: LOW — summary call only, does not affect the main conversation loop
- Related patterns: `_max_tokens_param()` dispatches `max_tokens` vs `max_completion_tokens` based on provider (OpenAI/Azure/Copilot vs others); Anthropic transport defaults to 16384 in `build_kwargs()` at `agent/transports/anthropic.py:69`
