### PR TITLE
  fix(weixin): detect stale context_token when iLink returns "rate limited" (#35949)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -96,15 +96,21 @@ RATE_LIMIT_ERRCODE = -2  # iLink frequency limit — backoff and retry
 MESSAGE_DEDUP_TTL_SECONDS = 300
 
 
+_STALE_SESSION_ERRMSGS = frozenset({"unknown error", "rate limited"})
+
+
 def _is_stale_session_ret(
     ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]",
 ) -> bool:
-    """True when iLink returns ret=-2 / errcode=-2 with 'unknown error',
-    which is a stale-session signal (same as errcode=-14) rather than
-    a genuine rate limit."""
+    """True when iLink returns ret=-2 / errcode=-2 with an errmsg that iLink
+    reuses for stale ``context_token`` (same condition as errcode=-14) rather
+    than a genuine rate limit. iLink has been observed returning both
+    ``"unknown error"`` and ``"rate limited"`` for expired tokens; the caller's
+    one-shot tokenless retry guard keeps a real rate-limit from being retried
+    more than once before falling through to the rate-limit backoff branch."""
     if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
         return False
-    return (errmsg or "").lower() == "unknown error"
+    return (errmsg or "").strip().lower() in _STALE_SESSION_ERRMSGS
 
 
 MEDIA_IMAGE = 1

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -82,9 +82,21 @@ _TABLE_RULE_RE = re.compile(r"^\s*\|?(?:\s*:?-{3,}:?\s*\|)+\s*:?-{3,}:?\s*\|?\s*
 _FENCE_RE = re.compile(r"^```([^\n`]*)\s*$")
 
 
-def _is_stale_session_ret(ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]") -> bool:
-    """ret/errcode=-2 with 'unknown error' is a stale-session signal (like -14), not a real rate limit."""
-    return (ret == RATE_LIMIT_ERRCODE or errcode == RATE_LIMIT_ERRCODE) and (errmsg or "").lower() == "unknown error"
+_STALE_SESSION_ERRMSGS = frozenset({"unknown error", "rate limited"})
+
+
+def _is_stale_session_ret(
+    ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]",
+) -> bool:
+    """True when iLink returns ret=-2 / errcode=-2 with an errmsg that iLink
+    reuses for stale ``context_token`` (same condition as errcode=-14) rather
+    than a genuine rate limit. iLink has been observed returning both
+    ``"unknown error"`` and ``"rate limited"`` for expired tokens; the caller's
+    one-shot tokenless retry guard keeps a real rate-limit from being retried
+    more than once before falling through to the rate-limit backoff branch."""
+    if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
+        return False
+    return (errmsg or "").strip().lower() in _STALE_SESSION_ERRMSGS
 
 
 def _is_session_expired(resp: Dict[str, Any], ret: Any, errcode: Any) -> bool:

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -827,8 +827,17 @@ class TestIsStaleSessionRet:
     def test_unknown_error_case_insensitive(self):
         assert weixin._is_stale_session_ret(-2, None, "Unknown Error") is True
 
+    def test_ret_minus_2_with_rate_limited_is_stale(self):
+        # Regression for #35949: iLink also returns "rate limited" for an
+        # expired context_token, not just genuine throttling. The send loop's
+        # `retried_without_token` guard caps the false-positive cost at one
+        # tokenless retry before the rate-limit backoff branch takes over.
+        assert weixin._is_stale_session_ret(-2, None, "rate limited") is True
+        assert weixin._is_stale_session_ret(None, -2, "Rate Limited") is True
+        assert weixin._is_stale_session_ret(-2, None, "  rate limited  ") is True
+
     def test_ret_minus_2_with_freq_limit_is_not_stale(self):
-        # Genuine rate limit — must NOT be treated as stale session.
+        # Other rate-limit phrasings must NOT be treated as stale session.
         assert weixin._is_stale_session_ret(-2, None, "freq limit") is False
 
     def test_ret_minus_2_with_no_errmsg_is_not_stale(self):

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -552,8 +552,17 @@ class TestIsStaleSessionRet:
     """Regression test for #17228: distinguish stale-session ret=-2 from rate-limit ret=-2."""
 
 
+    def test_ret_minus_2_with_rate_limited_is_stale(self):
+        # Regression for #35949: iLink also returns "rate limited" for an
+        # expired context_token, not just genuine throttling. The send loop's
+        # `retried_without_token` guard caps the false-positive cost at one
+        # tokenless retry before the rate-limit backoff branch takes over.
+        assert weixin._is_stale_session_ret(-2, None, "rate limited") is True
+        assert weixin._is_stale_session_ret(None, -2, "Rate Limited") is True
+        assert weixin._is_stale_session_ret(-2, None, "  rate limited  ") is True
+
     def test_ret_minus_2_with_freq_limit_is_not_stale(self):
-        # Genuine rate limit — must NOT be treated as stale session.
+        # Other rate-limit phrasings must NOT be treated as stale session.
         assert weixin._is_stale_session_ret(-2, None, "freq limit") is False
 
 


### PR DESCRIPTION
## Summary

  Fixes #35949 — Weixin iLink stale `context_token` was misidentified as a rate limit, causing permanent outbound send failure.

  iLink's `sendmessage` endpoint returns `ret=-2, errmsg="rate limited"` for an **expired `context_token`**, not just `"unknown error"`. The stale-session matcher 
  `_is_stale_session_ret` only recognised `"unknown error"`, so every outbound message exhausted all 4 retries against the dead token. Only inbound replies survived because they 
  refresh the token from the incoming webhook.

  ## Fix

  case-insensitive comparison preserved).
  
  The send loop at `_send_text_chunk` (`weixin.py:1640`) already guards itself with `retried_without_token`, so the false-positive cost on a *genuine* rate-limit is capped at one 
  tokenless retry before falling through to the rate-limit backoff branch. Inbound paths and the `-14` `SESSION_EXPIRED_ERRCODE` path are untouched.
  
  Chose Option B from the issue (expand the matcher) over Option A (treat all `ret=-2` as stale) to preserve the existing backoff behavior for genuine throttling.

  ## Test plan
  
  - [x] New regression test `TestIsStaleSessionRet::test_ret_minus_2_with_rate_limited_is_stale` covers `"rate limited"`, mixed case, and surrounding whitespace.
  - [x] Existing 7 tests in `TestIsStaleSessionRet` still pass (no regression on `"unknown error"`, `"freq limit"`, empty errmsg, `-14`, or success codes).
  - [x] `pytest tests/gateway/test_weixin.py::TestIsStaleSessionRet` — 8 passed.
  - [ ] Manual: confirm stale-token chat now recovers on next send instead of looping with `ret=-2`.

  ## Workaround (still valid for users on older builds)

  Delete the cached token file to force regeneration.
