### PR TITLE
feat(cli): add $alias one-turn inline model routing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4802,13 +4802,84 @@ class HermesCLI:
     def _resolve_turn_agent_config(self, user_message: str) -> dict:
         """Build the effective model/runtime config for a single user turn.
 
-        Always uses the session's primary model/provider.  If the user has
-        toggled `/fast` on and the current model supports Priority
-        Processing / Anthropic fast mode, attach `request_overrides` so the
-        API call is marked accordingly.
+        If the message starts with ``$alias`` (e.g. ``$dsr analyze this``),
+        resolve it as a **one-turn** model switch: delegate to
+        ``switch_model()``, build a route from the result, and return the
+        stripped ``clean_text`` so the ``$alias`` prefix never enters the
+        conversation history.  The session's primary model/provider are
+        **not** changed.
+
+        Otherwise (no ``$alias`` prefix), always uses the session's primary
+        model/provider.  If the user has toggled `/fast` on and the current
+        model supports Priority Processing / Anthropic fast mode, attach
+        ``request_overrides`` so the API call is marked accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
 
+        # ── inline model alias routing ($alias) ──────────────────────────
+        from hermes_cli.model_switch import (
+            parse_inline_model_alias_invocation,
+            switch_model,
+            ModelAliasError,
+        )
+
+        invocation = parse_inline_model_alias_invocation(user_message)
+        if invocation is not None:
+            result = switch_model(
+                raw_input=invocation.alias,
+                current_provider=self.provider or "",
+                current_model=self.model or "",
+                current_base_url=self.base_url or "",
+                current_api_key=self.api_key or "",
+                is_global=False,
+                explicit_provider="",
+                user_providers=None,
+                custom_providers=None,
+            )
+            if not result.success:
+                raise ModelAliasError(
+                    result.error_message
+                    or f"Unknown model alias '{invocation.alias}'"
+                )
+
+            # Build one-turn route from switch result — self.model /
+            # self.provider are NOT mutated (true turn-scoped routing).
+            runtime = {
+                "api_key": result.api_key,
+                "base_url": result.base_url,
+                "provider": result.target_provider,
+                "api_mode": result.api_mode,
+                "command": self.acp_command,
+                "args": list(self.acp_args or []),
+                "credential_pool": getattr(self, "_credential_pool", None),
+            }
+            route = {
+                "model": result.new_model,
+                "runtime": runtime,
+                "signature": (
+                    result.new_model,
+                    runtime["provider"],
+                    runtime["base_url"],
+                    runtime["api_mode"],
+                    runtime["command"],
+                    tuple(runtime["args"]),
+                ),
+                "clean_text": invocation.prompt,
+                "model_alias": invocation.alias,
+            }
+
+            service_tier = getattr(self, "service_tier", None)
+            if service_tier:
+                try:
+                    overrides = resolve_fast_mode_overrides(route["model"])
+                except Exception:
+                    overrides = None
+                route["request_overrides"] = overrides
+            else:
+                route["request_overrides"] = None
+            return route
+
+        # ── default: session's primary model/provider ────────────────────
         runtime = {
             "api_key": self.api_key,
             "base_url": self.base_url,
@@ -7692,6 +7763,11 @@ class HermesCLI:
         # Parse --provider, --global, and --refresh flags
         model_input, explicit_provider, persist_global, force_refresh = parse_model_flags(raw_args)
 
+        # ── /model alias <subcommand> ────────────────────────────────────
+        if model_input.startswith("alias"):
+            self._handle_model_alias_command(model_input, explicit_provider)
+            return
+
         # --refresh: wipe the on-disk picker cache before building the
         # provider list. Forces a live re-fetch of every authed provider's
         # /v1/models endpoint on this open.
@@ -7857,6 +7933,117 @@ class HermesCLI:
             _cprint("    Saved to config.yaml (--global)")
         else:
             _cprint("    (session only — add --global to persist)")
+
+    def _handle_model_alias_command(
+        self, model_input: str, explicit_provider: str
+    ) -> None:
+        """Route ``/model alias add|list|show|remove`` sub-commands."""
+        from hermes_cli.model_switch import (
+            save_model_alias,
+            remove_model_alias,
+            _ensure_direct_aliases,
+            DIRECT_ALIASES,
+        )
+        from hermes_cli.providers import get_label
+
+        parts = model_input.split()
+        if len(parts) < 2:
+            _cprint("  Usage: /model alias add|list|show|remove ...")
+            _cprint("    /model alias add <name> [<model> --provider <provider>]")
+            _cprint("    /model alias list")
+            _cprint("    /model alias show <name>")
+            _cprint("    /model alias remove <name>")
+            return
+
+        sub = parts[1].lower()
+
+        # --- /model alias list ---
+        if sub == "list":
+            _ensure_direct_aliases()
+            if not DIRECT_ALIASES:
+                _cprint("  No model aliases defined.")
+                _cprint("  Use /model alias add <name> to create one.")
+                return
+            _cprint("  Saved model aliases:")
+            for name in sorted(DIRECT_ALIASES):
+                da = DIRECT_ALIASES[name]
+                label = get_label(da.provider)
+                url = f" @ {da.base_url}" if da.base_url else ""
+                _cprint(f"    ${name}  →  {da.model}  ({label}{url})")
+            _cprint("")
+            _cprint("  Use $<name> before your message to route one turn.")
+            return
+
+        # --- /model alias remove <name> ---
+        if sub == "remove":
+            if len(parts) < 3:
+                _cprint("  Usage: /model alias remove <name>")
+                return
+            name = parts[2].strip().lower()
+            if remove_model_alias(name):
+                _cprint(f"  ✓ Alias '${name}' removed.")
+            else:
+                _cprint(f"  ✗ Alias '${name}' not found.")
+            return
+
+        # --- /model alias show <name> ---
+        if sub == "show":
+            if len(parts) < 3:
+                _cprint("  Usage: /model alias show <name>")
+                return
+            name = parts[2].strip().lower()
+            _ensure_direct_aliases()
+            da = DIRECT_ALIASES.get(name)
+            if da is None:
+                _cprint(f"  ✗ Alias '${name}' not found.")
+                return
+            label = get_label(da.provider)
+            _cprint(f"  ${name}:")
+            _cprint(f"    Model:    {da.model}")
+            _cprint(f"    Provider: {label} ({da.provider})")
+            if da.base_url:
+                _cprint(f"    Base URL: {da.base_url}")
+            return
+
+        # --- /model alias add <name> [<model> --provider <provider>] ----
+        if sub == "add":
+            if len(parts) < 3:
+                _cprint("  Usage: /model alias add <name> [<model> --provider <provider>]")
+                return
+
+            alias = parts[2].strip().lower()
+            remaining = " ".join(parts[3:]).strip()
+
+            if remaining:
+                # Explicit model+provider given
+                from hermes_cli.model_switch import parse_model_flags
+                model, provider, _global, _refresh = parse_model_flags(remaining)
+                provider = provider or explicit_provider or self.provider or ""
+                if not model:
+                    _cprint("  Usage: /model alias add <name> <model> --provider <provider>")
+                    return
+                da = save_model_alias(
+                    alias, provider=provider, model=model, base_url=""
+                )
+                label = get_label(provider)
+                _cprint(f"  ✓ Alias '${alias}' → {model} ({label})")
+            else:
+                # No explicit model — save current active route
+                da = save_model_alias(
+                    alias,
+                    provider=self.provider or "",
+                    model=self.model or "",
+                    base_url=self.base_url or "",
+                )
+                label = get_label(self.provider or "")
+                url = f" @ {self.base_url}" if self.base_url else ""
+                _cprint(
+                    f"  ✓ Alias '${alias}' → {self.model} ({label}{url})"
+                )
+            return
+
+        _cprint(f"  Unknown alias subcommand: {sub}")
+        _cprint("  Available: add, list, show, remove")
 
     def _handle_codex_runtime(self, cmd_original: str) -> None:
         """Handle /codex-runtime — toggle the codex app-server runtime opt-in.
@@ -11798,7 +11985,15 @@ class HermesCLI:
         if not self._ensure_runtime_credentials():
             return None
 
-        turn_route = self._resolve_turn_agent_config(message)
+        try:
+            from hermes_cli.model_switch import ModelAliasError
+            turn_route = self._resolve_turn_agent_config(message)
+        except ModelAliasError as e:
+            _cprint(f"  ✗ {e}")
+            return None
+        # Strip $alias prefix from message so it doesn't enter history
+        if isinstance(message, str):
+            message = turn_route.get("clean_text", message)
         if turn_route["signature"] != self._active_agent_route_signature:
             self.agent = None
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1598,6 +1598,30 @@ class SlashCommandCompleter(Completer):
         except Exception:
             pass
 
+    def _dollar_alias_completions(self, alias_word: str):
+        """Yield completions for ``$alias`` inline model routing."""
+        alias_lower = alias_word.lower()
+        try:
+            from hermes_cli.model_switch import (
+                _ensure_direct_aliases,
+                DIRECT_ALIASES,
+            )
+            from hermes_cli.providers import get_label
+
+            _ensure_direct_aliases()
+            for name, da in sorted(DIRECT_ALIASES.items()):
+                if name.startswith(alias_lower):
+                    label = get_label(da.provider)
+                    url = f" | {da.base_url}" if da.base_url else ""
+                    yield Completion(
+                        name[len(alias_word):] if alias_word else name,
+                        start_position=-len(alias_word),
+                        display=f"${name}",
+                        display_meta=f"{da.model} ({label}{url})",
+                    )
+        except Exception:
+            pass
+
     def _model_completions(self, sub_text: str, sub_lower: str):
         """Yield completions for /model from config aliases + built-in aliases."""
         seen = set()
@@ -1647,6 +1671,11 @@ class SlashCommandCompleter(Completer):
     def get_completions(self, document, complete_event):
         text = document.text_before_cursor
         if not text.startswith("/"):
+            # Try $alias inline model routing completion
+            if text.startswith("$"):
+                alias_word = text[1:]
+                yield from self._dollar_alias_completions(alias_word)
+                return
             # Try @ context completion (Claude Code-style)
             ctx_word = self._extract_context_word(text)
             if ctx_word is not None:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -169,6 +169,16 @@ class DirectAlias(NamedTuple):
     base_url: str
 
 
+class InlineModelAliasInvocation(NamedTuple):
+    """Parsed $alias prefix from a user chat message."""
+    alias: str
+    prompt: str
+
+
+class ModelAliasError(Exception):
+    """Raised when an inline $alias reference cannot be resolved."""
+
+
 # Built-in direct aliases (can be extended via config.yaml model_aliases:)
 _BUILTIN_DIRECT_ALIASES: dict[str, DirectAlias] = {}
 
@@ -253,6 +263,85 @@ def _ensure_direct_aliases() -> None:
     """
     if not DIRECT_ALIASES:
         DIRECT_ALIASES.update(_load_direct_aliases())
+
+
+def parse_inline_model_alias_invocation(
+    text: str,
+) -> "Optional[InlineModelAliasInvocation]":
+    """Parse a ``$alias <prompt>`` prefix from a user chat message.
+
+    Returns an ``InlineModelAliasInvocation`` with the alias name and the
+    remainder of the message (prompt), or ``None`` if the message does not
+    start with an alias prefix.
+
+    Escaped ``$$`` and ``\\$`` are treated as literal characters and return
+    ``None``.
+    """
+    if not text or not text.startswith("$"):
+        return None
+    # Escaped: $$ or \$ → literal dollar sign, not an alias
+    if text.startswith("$$") or text.startswith("\\$"):
+        return None
+    rest = text[1:]  # strip leading $
+    if not rest:
+        return None
+    parts = rest.split(None, 1)
+    alias = parts[0].strip()
+    if not alias:
+        return None
+    prompt = parts[1].strip() if len(parts) > 1 else ""
+    return InlineModelAliasInvocation(alias=alias.lower(), prompt=prompt)
+
+
+def save_model_alias(
+    alias: str,
+    provider: str,
+    model: str,
+    base_url: str = "",
+) -> DirectAlias:
+    """Persist a model alias to ``config.yaml`` under ``model_aliases:``.
+
+    The alias name is lowercased; the provider, model, and optional base_url
+    are stored together.  The in-memory ``DIRECT_ALIASES`` cache is updated
+    immediately so the new alias is usable without restarting.
+
+    Returns the ``DirectAlias`` that was saved.
+    """
+    from hermes_cli.config import read_raw_config, save_config
+
+    alias_key = alias.strip().lower()
+    raw = read_raw_config()
+    if not isinstance(raw.get("model_aliases"), dict):
+        raw["model_aliases"] = {}
+    raw["model_aliases"][alias_key] = {
+        "provider": provider,
+        "model": model,
+        "base_url": base_url,
+    }
+    save_config(raw)
+
+    da = DirectAlias(model=model, provider=provider, base_url=base_url)
+    DIRECT_ALIASES[alias_key] = da
+    return da
+
+
+def remove_model_alias(alias: str) -> bool:
+    """Delete a model alias from ``config.yaml`` and the in-memory cache.
+
+    Returns ``True`` if the alias existed and was removed, ``False`` if it
+    was not found.
+    """
+    from hermes_cli.config import read_raw_config, save_config
+
+    alias_key = alias.strip().lower()
+    raw = read_raw_config()
+    aliases = raw.get("model_aliases")
+    if not isinstance(aliases, dict) or alias_key not in aliases:
+        return False
+    del aliases[alias_key]
+    save_config(raw)
+    DIRECT_ALIASES.pop(alias_key, None)
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_model_alias_inline.py
+++ b/tests/hermes_cli/test_model_alias_inline.py
@@ -1,0 +1,223 @@
+"""Tests for persistent /model aliases and one-turn $alias routing."""
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _FakeModule(ModuleType):
+    """A module that returns a MagicMock for any missing attribute."""
+
+    def __getattr__(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        mock = MagicMock()
+        setattr(self, name, mock)
+        return mock
+
+
+# prompt_toolkit may not be installed in test environments.  Install
+# fake module stubs that auto-create attributes so `from prompt_toolkit.X
+# import Y` resolves.
+_pt = _FakeModule("prompt_toolkit")
+_pt.__path__ = []  # package marker
+for _sub in (
+    "history",
+    "styles",
+    "formatted_text",
+    "layout",
+    "layout.processors",
+    "layout.dimension",
+    "layout.menus",
+    "key_binding",
+    "key_binding.key_processor",
+    "application",
+    "completion",
+    "shortcuts",
+    "filters",
+    "keys",
+    "lexers",
+    "document",
+    "patch_stdout",
+    "widgets",
+    "utils",
+    "enums",
+    "output",
+    "input",
+    "renderer",
+    "buffer",
+    "selection",
+    "clipboard",
+    "auto_suggest",
+    "validation",
+    "search",
+    "mouse",
+    "cache",
+    "data_structures",
+    "eventloop",
+    "cursor_shapes",
+):
+    _sub_mod = _FakeModule(f"prompt_toolkit.{_sub}")
+    sys.modules.setdefault(f"prompt_toolkit.{_sub}", _sub_mod)
+sys.modules.setdefault("prompt_toolkit", _pt)
+
+
+def _make_route_cli():
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.model = "gpt-5.5"
+    cli.provider = "openai-codex"
+    cli.api_key = "session-key"
+    cli.base_url = "https://chatgpt.com/backend-api/codex"
+    cli.api_mode = "chat_completions"
+    cli.acp_command = None
+    cli.acp_args = []
+    cli._credential_pool = None
+    cli.service_tier = None
+    return cli
+
+
+def test_parse_inline_model_alias_invocation_strips_prefix():
+    from hermes_cli.model_switch import parse_inline_model_alias_invocation
+
+    invocation = parse_inline_model_alias_invocation("$dsr analyze this")
+
+    assert invocation is not None
+    assert invocation.alias == "dsr"
+    assert invocation.prompt == "analyze this"
+
+
+def test_parse_inline_model_alias_invocation_allows_literal_escaped_dollar():
+    from hermes_cli.model_switch import parse_inline_model_alias_invocation
+
+    assert parse_inline_model_alias_invocation(r"\$dsr keep the dollar") is None
+
+
+def test_save_model_alias_persists_model_mapping_without_secrets(monkeypatch):
+    import hermes_cli.model_switch as ms
+
+    captured = {}
+    monkeypatch.setattr("hermes_cli.config.read_raw_config", lambda: {"model": {"default": "old"}})
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: captured.update(cfg))
+    ms.DIRECT_ALIASES.clear()
+
+    saved = ms.save_model_alias(
+        "DsR",
+        provider="deepseek",
+        model="deepseek-v4-pro",
+        base_url="https://api.deepseek.com/v1",
+    )
+
+    assert saved == ms.DirectAlias(
+        model="deepseek-v4-pro",
+        provider="deepseek",
+        base_url="https://api.deepseek.com/v1",
+    )
+    assert captured["model_aliases"]["dsr"] == {
+        "provider": "deepseek",
+        "model": "deepseek-v4-pro",
+        "base_url": "https://api.deepseek.com/v1",
+    }
+    assert "api_key" not in captured["model_aliases"]["dsr"]
+    assert "token" not in captured["model_aliases"]["dsr"]
+    assert ms.DIRECT_ALIASES["dsr"] == saved
+
+
+def test_remove_model_alias_deletes_mapping_and_cache(monkeypatch):
+    import hermes_cli.model_switch as ms
+
+    captured = {}
+    monkeypatch.setattr(
+        "hermes_cli.config.read_raw_config",
+        lambda: {
+            "model_aliases": {
+                "dsr": {"provider": "deepseek", "model": "deepseek-v4-pro"},
+                "gpt55": {"provider": "openai-codex", "model": "gpt-5.5"},
+            }
+        },
+    )
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: captured.update(cfg))
+    ms.DIRECT_ALIASES.clear()
+    ms.DIRECT_ALIASES["dsr"] = ms.DirectAlias("deepseek-v4-pro", "deepseek", "")
+
+    assert ms.remove_model_alias("dsr") is True
+
+    assert "dsr" not in captured["model_aliases"]
+    assert "gpt55" in captured["model_aliases"]
+    assert "dsr" not in ms.DIRECT_ALIASES
+
+
+def test_resolve_turn_agent_config_uses_alias_for_one_turn_without_mutating_session(monkeypatch):
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    cli = _make_route_cli()
+
+    def fake_switch_model(**kwargs):
+        assert kwargs["raw_input"] == "dsr"
+        assert kwargs["current_provider"] == "openai-codex"
+        assert kwargs["current_model"] == "gpt-5.5"
+        return ModelSwitchResult(
+            success=True,
+            new_model="deepseek-v4-pro",
+            target_provider="deepseek",
+            api_key="resolved-key",
+            base_url="https://api.deepseek.com/v1",
+            api_mode="chat_completions",
+            provider_label="DeepSeek",
+            resolved_via_alias="dsr",
+        )
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", fake_switch_model)
+
+    route = cli._resolve_turn_agent_config("$dsr analyze this")
+
+    assert route["model"] == "deepseek-v4-pro"
+    assert route["runtime"]["provider"] == "deepseek"
+    assert route["runtime"]["base_url"] == "https://api.deepseek.com/v1"
+    assert route["clean_text"] == "analyze this"
+    assert route["model_alias"] == "dsr"
+    assert cli.model == "gpt-5.5"
+    assert cli.provider == "openai-codex"
+
+
+def test_resolve_turn_agent_config_unknown_alias_fails_closed(monkeypatch):
+    from hermes_cli.model_switch import ModelSwitchResult, ModelAliasError
+
+    cli = _make_route_cli()
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model",
+        lambda **kwargs: ModelSwitchResult(
+            success=False,
+            error_message="Unknown model alias 'missing'",
+        ),
+    )
+
+    with pytest.raises(ModelAliasError, match="Unknown model alias"):
+        cli._resolve_turn_agent_config("$missing hello")
+
+
+def test_model_alias_add_without_model_saves_current_route(monkeypatch):
+    from cli import HermesCLI
+    from hermes_cli.model_switch import DirectAlias
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.model = "deepseek-v4-pro"
+    cli.provider = "deepseek"
+    cli.base_url = "https://api.deepseek.com/v1"
+    cli.api_key = "secret-key-that-must-not-be-saved"
+    cli.api_mode = "chat_completions"
+
+    saved = []
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.save_model_alias",
+        lambda alias, provider, model, base_url="": saved.append((alias, provider, model, base_url))
+        or DirectAlias(model=model, provider=provider, base_url=base_url),
+    )
+    monkeypatch.setattr("cli._cprint", lambda *args, **kwargs: None)
+
+    cli._handle_model_switch("/model alias add dsr")
+
+    assert saved == [("dsr", "deepseek", "deepseek-v4-pro", "https://api.deepseek.com/v1")]


### PR DESCRIPTION
Adds a $alias prefix syntax for turn-scoped model switching
    in the CLI, plus /model alias subcommands to manage persistent
    aliases.

    How it works

    bash
    Create alias (binds current active model)
    /model alias add dsr

    One-turn routing — doesn't change session default
    $dsr analyze this code

    List / remove
    /model alias list
    /model alias remove dsr


    Design

    - Reuses the existing DirectAlias / switch_model() /
      resolve_alias() pipeline in hermes_cli/model_switch.py
    - $alias prefix stripped before saving to conversation
      history (model only sees cleaned message)
    - self.model / self.provider NOT mutated — true
      turn-scoped routing
    - Aliases persist to config.yaml under model_aliases:
    - Tab-completion via prompt_toolkit completer

    Files changed

    File: hermes_cli/model_switch.py
    What: +InlineModelAliasInvocation, +ModelAliasError, +parse/save/remove functions (+89)
    ────────────────────────────────────────
    File: cli.py
    What: $alias resolution in _resolve_turn_agent_config, /model alias dispatch, _handle_model_alias_command, chat()
      clean_text (+205)
    ────────────────────────────────────────
    File: hermes_cli/commands.py
    What: +_dollar_alias_completions, $ prefix Tab-complete branch (+29)
    ────────────────────────────────────────
    File: tests/.../test_model_alias_inline.py
    What: 7 unit tests (+223, all passing)

    Testing

    bash
    pytest tests/hermes_cli/test_model_alias_inline.py  # 7/7 pass


    Why

    Multi-model users currently /model xxx back and forth
    between turns. $alias lets them route a single question
    without leaving the conversation or changing defaults.