### PR TITLE
feat(copilot): show Copilot quota in TUI status bar + /copilot-quota slash command

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -40,6 +40,12 @@ class AccountUsageSnapshot:
     windows: tuple[AccountUsageWindow, ...] = ()
     details: tuple[str, ...] = ()
     unavailable_reason: Optional[str] = None
+    # Optional compact status-bar labels (currently populated for Copilot).
+    # Width-adaptive: full label ≥120 cols, short ≥90, tiny below.
+    compact_label: Optional[str] = None
+    compact_short_label: Optional[str] = None
+    compact_tiny_label: Optional[str] = None
+    compact_level: Optional[str] = None  # ok / warn / error
 
     @property
     def available(self) -> bool:
@@ -885,6 +891,146 @@ def fetch_account_usage(
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+        if normalized == "copilot":
+            return _fetch_copilot_account_usage()
     except Exception:
         return None
     return None
+
+
+# --- Copilot ---------------------------------------------------------------
+
+_COPILOT_USAGE_CACHE: dict[str, Any] = {"snap": None, "fetched_at": 0.0}
+_COPILOT_USAGE_TTL_SECONDS = 300.0
+
+
+def _fetch_copilot_account_usage() -> Optional[AccountUsageSnapshot]:
+    """Fetch GitHub Copilot quota from ``api.github.com/copilot_internal/user``.
+
+    Result is cached in-process for 5 minutes to avoid hammering the endpoint
+    on every status-bar render. Only called when the active provider is
+    ``copilot`` (see ``fetch_account_usage``).
+    """
+    import time as _time
+
+    now = _time.time()
+    cached = _COPILOT_USAGE_CACHE.get("snap")
+    cached_at = float(_COPILOT_USAGE_CACHE.get("fetched_at") or 0.0)
+    if cached is not None and (now - cached_at) < _COPILOT_USAGE_TTL_SECONDS:
+        return cached
+
+    try:
+        from hermes_cli.copilot_auth import resolve_copilot_token
+    except Exception:
+        return None
+    try:
+        raw_token, _src = resolve_copilot_token()
+    except Exception:
+        return None
+    if not raw_token:
+        return None
+
+    headers = {
+        "Authorization": f"token {raw_token}",
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "hermes-agent",
+    }
+    try:
+        with httpx.Client(timeout=8.0) as client:
+            resp = client.get("https://api.github.com/copilot_internal/user", headers=headers)
+        if resp.status_code != 200:
+            return None
+        data = resp.json() or {}
+    except Exception:
+        return None
+
+    snapshot = _build_copilot_snapshot(data)
+    _COPILOT_USAGE_CACHE["snap"] = snapshot
+    _COPILOT_USAGE_CACHE["fetched_at"] = now
+    return snapshot
+
+
+def _extract_copilot_quota(data: dict) -> tuple[Optional[int], Optional[int]]:
+    """Pull (remaining, quota) premium-interaction counts from the API payload.
+
+    Handles the three flat field-name pairs GitHub has used across plans plus
+    the nested ``quota_snapshots.premium_interactions`` shape. Returns
+    ``(None, None)`` when no recognizable quota fields are present.
+    """
+    candidates = [
+        ("chat_enabled_quota_remaining", "chat_enabled_quota"),
+        ("premium_interactions_remaining", "premium_interactions_quota"),
+        ("monthly_quota_remaining", "monthly_quota"),
+    ]
+    for r_key, q_key in candidates:
+        if r_key in data and q_key in data:
+            try:
+                return int(data[r_key]), int(data[q_key])
+            except (TypeError, ValueError):
+                continue
+
+    snaps = data.get("quota_snapshots") or {}
+    pi = snaps.get("premium_interactions") if isinstance(snaps, dict) else None
+    if isinstance(pi, dict):
+        r_val = pi.get("remaining")
+        q_val = pi.get("entitlement")
+        if r_val is not None and q_val is not None:
+            try:
+                return int(r_val), int(q_val)
+            except (TypeError, ValueError):
+                pass
+    return None, None
+
+
+def _build_copilot_snapshot(data: dict) -> AccountUsageSnapshot:
+    """Build an ``AccountUsageSnapshot`` from a copilot_internal/user payload.
+
+    Split out from the HTTP fetcher so it can be unit-tested against fixture
+    JSON without network access.
+    """
+    plan = data.get("access_type_sku") or data.get("chat_enabled_plan") or None
+    windows: list[AccountUsageWindow] = []
+    compact_label: Optional[str] = None
+    compact_short: Optional[str] = None
+    compact_tiny: Optional[str] = None
+    level = "ok"
+
+    reset_at = _parse_dt(data.get("quota_reset_date"))
+    remaining, quota = _extract_copilot_quota(data)
+
+    if remaining is not None and quota and quota > 0:
+        used_pct = max(0.0, min(100.0, (1.0 - remaining / quota) * 100.0))
+        windows.append(
+            AccountUsageWindow(
+                label="Premium interactions",
+                used_percent=used_pct,
+                reset_at=reset_at,
+                detail=f"{remaining}/{quota} remaining",
+            )
+        )
+        reset_short = reset_at.astimezone().strftime("%b %-d") if reset_at else None
+        full = f"quota {remaining}/{quota} left"
+        short = f"q {remaining}/{quota}"
+        if reset_short:
+            full += f" · resets {reset_short}"
+            short += f" · {reset_short}"
+        compact_label = full
+        compact_short = short
+        compact_tiny = f"q {remaining}"
+        remaining_pct = (remaining / quota) * 100.0
+        if remaining_pct < 10:
+            level = "error"
+        elif remaining_pct < 25:
+            level = "warn"
+
+    return AccountUsageSnapshot(
+        provider="copilot",
+        source="copilot_internal_user",
+        fetched_at=_utc_now(),
+        plan=_title_case_slug(plan),
+        windows=tuple(windows),
+        compact_label=compact_label,
+        compact_short_label=compact_short,
+        compact_tiny_label=compact_tiny,
+        compact_level=level if compact_label else None,
+    )

--- a/cli.py
+++ b/cli.py
@@ -4650,6 +4650,33 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if context_length:
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
 
+        # Provider account quota (e.g. Copilot premium-interactions). Gated on
+        # an active Copilot provider: fetch_account_usage() performs a live
+        # HTTP request for Codex/Anthropic/OpenRouter too, and this snapshot is
+        # rebuilt on every status-bar render — so we only pay the network cost
+        # for the one provider that produces a compact status-bar label. The
+        # fetch is cached (5-min TTL) and any failure is swallowed silently.
+        if str(getattr(agent, "provider", "") or "").strip().lower() == "copilot":
+            try:
+                from agent.account_usage import fetch_account_usage
+
+                account_snapshot = fetch_account_usage(
+                    getattr(agent, "provider", None),
+                    base_url=getattr(agent, "base_url", None),
+                    api_key=getattr(agent, "api_key", None),
+                )
+                if account_snapshot:
+                    if account_snapshot.compact_label:
+                        snapshot["account_label"] = account_snapshot.compact_label
+                    if account_snapshot.compact_short_label:
+                        snapshot["account_label_short"] = account_snapshot.compact_short_label
+                    if account_snapshot.compact_tiny_label:
+                        snapshot["account_label_tiny"] = account_snapshot.compact_tiny_label
+                    if account_snapshot.compact_level:
+                        snapshot["account_level"] = account_snapshot.compact_level
+            except Exception:
+                pass
+
         return snapshot
 
     @staticmethod
@@ -5122,6 +5149,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             idle_since = snapshot.get("idle_since")
             if idle_since:
                 parts.append(idle_since)
+            account_label = (
+                snapshot.get("account_label_short")
+                if width < 96
+                else snapshot.get("account_label")
+            ) or snapshot.get("account_label_tiny") or snapshot.get("account_label")
+            if account_label:
+                parts.append(account_label)
             if yolo_active:
                 parts.append("⚠ YOLO")
             return self._trim_status_bar_text(" │ ".join(parts), width)
@@ -5236,6 +5270,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     if idle_since:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-dim", idle_since))
+                    # Position 9: provider account quota (e.g. Copilot premium
+                    # interactions). Colored by remaining-quota level.
+                    account_label = (
+                        snapshot.get("account_label_short")
+                        if width < 96
+                        else snapshot.get("account_label")
+                    ) or snapshot.get("account_label_tiny") or snapshot.get("account_label")
+                    if account_label:
+                        level = snapshot.get("account_level")
+                        quota_style = (
+                            "class:status-bar-error" if level == "error"
+                            else "class:status-bar-warn" if level == "warn"
+                            else "class:status-bar-dim"
+                        )
+                        frags.append(("class:status-bar-dim", " │ "))
+                        frags.append((quota_style, account_label))
                     if yolo_active:
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-yolo", "⚠ YOLO"))
@@ -8723,6 +8773,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             self._manual_compress(cmd_original)
         elif canonical == "usage":
             self._handle_usage_command(cmd_original)
+        elif canonical == "copilot-quota":
+            self._handle_copilot_quota_command(cmd_original)
         elif canonical == "credits":
             self._show_credits()
         elif canonical == "billing":
@@ -9622,6 +9674,45 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 print(f"  ❌ Compression failed: {e}")
 
 
+
+    def _handle_copilot_quota_command(self, cmd_original: str):
+        """Dispatch `/copilot-quota` (alias `/cquota`).
+
+        Verifies the active provider is Copilot, then fetches and renders the
+        Copilot account-limits snapshot directly. Does NOT reuse `/usage`
+        output filtering — that would surface another provider's limits when
+        Copilot isn't active.
+        """
+        provider = (
+            (getattr(self.agent, "provider", None) if self.agent else None)
+            or getattr(self, "provider", None)
+        )
+        normalized = str(provider or "").strip().lower()
+        if normalized != "copilot":
+            print("  /copilot-quota is only available on the copilot provider.")
+            print("  Switch with `/model` or `hermes auth` first.")
+            return
+
+        from agent.account_usage import fetch_account_usage, render_account_usage_lines
+
+        print("  ⏳ Fetching Copilot quota...")
+        account_snapshot = None
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
+            try:
+                account_snapshot = _pool.submit(
+                    fetch_account_usage, provider,
+                    base_url=(getattr(self.agent, "base_url", None) if self.agent else None) or getattr(self, "base_url", None),
+                    api_key=(getattr(self.agent, "api_key", None) if self.agent else None) or getattr(self, "api_key", None),
+                ).result(timeout=10.0)
+            except (concurrent.futures.TimeoutError, Exception):
+                account_snapshot = None
+
+        lines = render_account_usage_lines(account_snapshot)
+        if not lines:
+            print("  No Copilot quota data available.")
+            return
+        for line in lines:
+            print(f"  {line}")
 
     def _handle_usage_command(self, cmd_original: str):
         """Dispatch `/usage [reset [--force]]`.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9982,6 +9982,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "usage":
             return await self._handle_usage_command(event)
 
+        if canonical == "copilot-quota":
+            return await self._handle_copilot_quota_command(event)
+
         if canonical == "credits":
             return await self._handle_credits_command(event)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4114,6 +4114,58 @@ class GatewaySlashCommandsMixin:
             return "\n".join(parts)
         return t("gateway.usage.no_data")
 
+    async def _handle_copilot_quota_command(self, event: MessageEvent) -> str:
+        """Handle /copilot-quota (alias /cquota) -- Copilot account quota.
+
+        Resolves the active provider first and only renders when it is
+        ``copilot``. Does NOT string-filter generic ``/usage`` output — that
+        would surface another provider's account limits (Codex/Anthropic/
+        OpenRouter) when Copilot isn't the active provider.
+        """
+        from gateway.run import _AGENT_PENDING_SENTINEL
+        source = event.source
+        session_key = self._session_key_for_source(source)
+
+        agent = self._running_agents.get(session_key)
+        if not agent or agent is _AGENT_PENDING_SENTINEL:
+            _cache_lock = getattr(self, "_agent_cache_lock", None)
+            _cache = getattr(self, "_agent_cache", None)
+            if _cache_lock and _cache is not None:
+                with _cache_lock:
+                    cached = _cache.get(session_key)
+                    if cached:
+                        agent = cached[0]
+
+        provider = getattr(agent, "provider", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
+        base_url = getattr(agent, "base_url", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
+        api_key = getattr(agent, "api_key", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
+        if not provider and getattr(self, "_session_db", None) is not None:
+            try:
+                _entry = await self.async_session_store.get_or_create_session(source)
+                persisted = await self._session_db.get_session(_entry.session_id) or {}
+            except Exception:
+                persisted = {}
+            provider = provider or persisted.get("billing_provider")
+            base_url = base_url or persisted.get("billing_base_url")
+
+        if str(provider or "").strip().lower() != "copilot":
+            return t("gateway.copilot_quota.wrong_provider")
+
+        try:
+            account_snapshot = await asyncio.to_thread(
+                fetch_account_usage,
+                provider,
+                base_url=base_url,
+                api_key=api_key,
+            )
+        except Exception:
+            account_snapshot = None
+
+        account_lines = render_account_usage_lines(account_snapshot, markdown=True)
+        if not account_lines:
+            return t("gateway.copilot_quota.no_data")
+        return "\n".join(account_lines)
+
     async def _handle_insights_command(self, event: MessageEvent) -> str:
         """Handle /insights command -- show usage insights and analytics."""
         args = event.get_command_args().strip()

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -230,6 +230,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True),
     CommandDef("usage", "Show token usage and rate limits; `reset` redeems a banked Codex limit reset", "Info",
                args_hint="[reset [--force]]"),
+    CommandDef("copilot-quota", "Show GitHub Copilot premium-interactions quota", "Info",
+               aliases=("cquota",)),
     CommandDef("credits", "Show Nous credit balance and top up", "Info"),
     CommandDef("billing", "Manage Nous terminal billing — buy credits, auto-reload, limits", "Info",
                cli_only=True),

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -379,6 +379,10 @@ gateway:
     unknown_subcommand:       "Unknown /usage subcommand: `{args}`. Try `/usage` or `/usage reset [--force]`."
     reset_wrong_provider:     "Banked usage resets are only available on the openai-codex provider. Switch with `/model` first."
 
+  copilot_quota:
+    wrong_provider:           "`/copilot-quota` is only available on the copilot provider. Switch with `/model` first."
+    no_data:                  "No Copilot quota data available."
+
   credits:
     not_logged_in:            "Not logged into Nous Portal. Log in to see your credit balance and top up."
 

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -201,3 +201,150 @@ def test_fetch_account_usage_openrouter_omits_quota_window_when_key_has_no_limit
     assert snapshot.windows == ()
     assert "Credits balance: $74.50" in snapshot.details
     assert "API key usage: $25.50 total • $1.25 today • $4.50 this week • $18.00 this month" in snapshot.details
+
+
+# --- Copilot ---------------------------------------------------------------
+
+import agent.account_usage as _au
+from agent.account_usage import _build_copilot_snapshot, _extract_copilot_quota
+
+
+def _reset_copilot_cache():
+    _au._COPILOT_USAGE_CACHE["snap"] = None
+    _au._COPILOT_USAGE_CACHE["fetched_at"] = 0.0
+
+
+def test_extract_copilot_quota_flat_field_pairs():
+    assert _extract_copilot_quota(
+        {"chat_enabled_quota_remaining": 120, "chat_enabled_quota": 300}
+    ) == (120, 300)
+    assert _extract_copilot_quota(
+        {"premium_interactions_remaining": 5, "premium_interactions_quota": 50}
+    ) == (5, 50)
+    assert _extract_copilot_quota(
+        {"monthly_quota_remaining": 900, "monthly_quota": 1000}
+    ) == (900, 1000)
+
+
+def test_extract_copilot_quota_nested_snapshot_shape():
+    data = {"quota_snapshots": {"premium_interactions": {"remaining": 42, "entitlement": 300}}}
+    assert _extract_copilot_quota(data) == (42, 300)
+
+
+def test_extract_copilot_quota_returns_none_when_absent():
+    assert _extract_copilot_quota({"unrelated": 1}) == (None, None)
+
+
+def test_build_copilot_snapshot_labels_and_ok_level():
+    snap = _build_copilot_snapshot(
+        {
+            "access_type_sku": "copilot_pro",
+            "chat_enabled_quota_remaining": 250,
+            "chat_enabled_quota": 300,
+            "quota_reset_date": "2026-08-01",
+        }
+    )
+    assert snap.provider == "copilot"
+    assert snap.compact_label == "quota 250/300 left · resets Aug 1"
+    assert snap.compact_short_label == "q 250/300 · Aug 1"
+    assert snap.compact_tiny_label == "q 250"
+    assert snap.compact_level == "ok"  # 83% remaining
+    assert snap.windows and snap.windows[0].label == "Premium interactions"
+
+
+def test_build_copilot_snapshot_warn_and_error_levels():
+    warn = _build_copilot_snapshot(
+        {"premium_interactions_remaining": 60, "premium_interactions_quota": 300}
+    )  # 20% remaining
+    assert warn.compact_level == "warn"
+
+    err = _build_copilot_snapshot(
+        {"premium_interactions_remaining": 15, "premium_interactions_quota": 300}
+    )  # 5% remaining
+    assert err.compact_level == "error"
+
+
+def test_build_copilot_snapshot_no_quota_yields_no_compact_label():
+    snap = _build_copilot_snapshot({"access_type_sku": "copilot_pro"})
+    assert snap.compact_label is None
+    assert snap.compact_level is None
+
+
+def test_fetch_account_usage_copilot(monkeypatch):
+    _reset_copilot_cache()
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("tok-abc", "test"),
+    )
+    payload = {
+        "access_type_sku": "copilot_pro",
+        "chat_enabled_quota_remaining": 100,
+        "chat_enabled_quota": 300,
+    }
+    monkeypatch.setattr(_au.httpx, "Client", lambda *a, **k: _Client(payload))
+
+    snap = fetch_account_usage("copilot")
+    assert snap is not None
+    assert snap.provider == "copilot"
+    assert snap.compact_label == "quota 100/300 left"
+
+
+def test_fetch_account_usage_copilot_http_failure_returns_none(monkeypatch):
+    _reset_copilot_cache()
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("tok-abc", "test"),
+    )
+
+    class _FailClient(_Client):
+        def get(self, url, headers=None):
+            return _Response({}, status_code=500)
+
+    monkeypatch.setattr(_au.httpx, "Client", lambda *a, **k: _FailClient({}))
+    assert fetch_account_usage("copilot") is None
+
+
+def test_fetch_account_usage_copilot_no_token_returns_none(monkeypatch):
+    _reset_copilot_cache()
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: (None, None),
+    )
+    assert fetch_account_usage("copilot") is None
+
+
+def test_fetch_account_usage_copilot_caches_within_ttl(monkeypatch):
+    _reset_copilot_cache()
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("tok-abc", "test"),
+    )
+    calls = {"n": 0}
+    payload = {"chat_enabled_quota_remaining": 100, "chat_enabled_quota": 300}
+
+    class _CountingClient(_Client):
+        def get(self, url, headers=None):
+            calls["n"] += 1
+            return _Response(payload)
+
+    monkeypatch.setattr(_au.httpx, "Client", lambda *a, **k: _CountingClient(payload))
+
+    first = fetch_account_usage("copilot")
+    second = fetch_account_usage("copilot")
+    assert first is second
+    assert calls["n"] == 1  # second call served from cache
+
+
+def test_fetch_account_usage_does_not_hit_copilot_for_other_providers(monkeypatch):
+    """Provider gating: a non-copilot provider must never resolve a Copilot
+    token or hit the Copilot endpoint."""
+    _reset_copilot_cache()
+
+    def _boom():
+        raise AssertionError("resolve_copilot_token must not be called for non-copilot providers")
+
+    monkeypatch.setattr("hermes_cli.copilot_auth.resolve_copilot_token", _boom)
+    # Unknown/blank providers short-circuit before any copilot path.
+    assert fetch_account_usage("") is None
+    assert fetch_account_usage("auto") is None
+

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3279,6 +3279,32 @@ def _get_usage(agent) -> dict:
                 usage["dev_credits_spent_micros"] = int(spent)
         except Exception:
             pass
+    # Provider account quota (e.g. Copilot premium-interactions) as compact
+    # status-bar labels. Gated on an active Copilot provider: _get_usage() is
+    # emitted on every completed TUI turn, and fetch_account_usage() performs a
+    # live HTTP request for Codex/Anthropic/OpenRouter too — only Copilot
+    # produces a compact label, so we skip the fetch for every other provider.
+    # The fetch is cached (5-min TTL) and any failure is swallowed silently.
+    if str(getattr(agent, "provider", "") or "").strip().lower() == "copilot":
+        try:
+            from agent.account_usage import fetch_account_usage
+
+            account_snapshot = fetch_account_usage(
+                getattr(agent, "provider", None),
+                base_url=getattr(agent, "base_url", None),
+                api_key=getattr(agent, "api_key", None),
+            )
+            if account_snapshot:
+                if account_snapshot.compact_label:
+                    usage["account_label"] = account_snapshot.compact_label
+                if account_snapshot.compact_short_label:
+                    usage["account_label_short"] = account_snapshot.compact_short_label
+                if account_snapshot.compact_tiny_label:
+                    usage["account_label_tiny"] = account_snapshot.compact_tiny_label
+                if account_snapshot.compact_level:
+                    usage["account_level"] = account_snapshot.compact_level
+        except Exception:
+            pass
     return usage
 
 

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -565,6 +565,42 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    aliases: ['cquota'],
+    help: 'show GitHub Copilot premium-interactions quota',
+    name: 'copilot-quota',
+    run: (_arg, ctx) => {
+      ctx.gateway.rpc<SessionUsageResponse>('session.usage', { session_id: ctx.sid }).then(r => {
+        if (ctx.stale()) {
+          return
+        }
+
+        if (r) {
+          patchUiState({
+            usage: {
+              account_label: r.account_label,
+              account_label_short: r.account_label_short,
+              account_label_tiny: r.account_label_tiny,
+              account_level: r.account_level,
+              calls: r.calls ?? 0,
+              input: r.input ?? 0,
+              output: r.output ?? 0,
+              total: r.total ?? 0
+            }
+          })
+        }
+
+        if (!r?.account_label) {
+          ctx.transcript.sys('no Copilot quota data available (is the copilot provider active?)')
+
+          return
+        }
+
+        ctx.transcript.sys(r.account_label)
+      })
+    }
+  },
+
+  {
     help: 'session usage + Nous credits',
     name: 'usage',
     run: (_arg, ctx) => {
@@ -575,7 +611,16 @@ export const sessionCommands: SlashCommand[] = [
 
         if (r) {
           patchUiState({
-            usage: { calls: r.calls ?? 0, input: r.input ?? 0, output: r.output ?? 0, total: r.total ?? 0 }
+            usage: {
+              account_label: r.account_label,
+              account_label_short: r.account_label_short,
+              account_label_tiny: r.account_label_tiny,
+              account_level: r.account_level,
+              calls: r.calls ?? 0,
+              input: r.input ?? 0,
+              output: r.output ?? 0,
+              total: r.total ?? 0
+            }
           })
         }
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -502,6 +502,19 @@ export function StatusRule({
       ? `Δ ${(usage.dev_credits_spent_micros / 10000).toFixed(1)}¢`
       : ''
 
+  // Provider account quota (e.g. Copilot premium-interactions). Width-budgeted
+  // like every tail segment; picks progressively shorter labels as the
+  // terminal narrows, and colors by remaining-quota level.
+  const accountLabelText =
+    cols < 90
+      ? usage.account_label_tiny ?? usage.account_label_short ?? usage.account_label
+      : cols < 120
+        ? usage.account_label_short ?? usage.account_label
+        : usage.account_label
+  const accountLevelColor =
+    usage.account_level === 'error' ? t.color.error : usage.account_level === 'warn' ? t.color.warn : t.color.muted
+  const showAccountLabel = !!accountLabelText && fits(SEP + stringWidth(accountLabelText))
+
   const showBar = !!bar && fits(SEP + stringWidth(`[${bar}] ${pct != null ? `${pct}%` : ''}`))
   const showDuration = segs.duration && !!sessionStartedAt && fits(SEP + MAX_DURATION_WIDTH)
 
@@ -649,6 +662,12 @@ export function StatusRule({
           <Text color={t.color.accent} wrap="truncate-end">
             {' │ '}
             {devCreditsText}
+          </Text>
+        ) : null}
+        {showAccountLabel ? (
+          <Text color={accountLevelColor} wrap="truncate-end">
+            {' │ '}
+            {accountLabelText}
           </Text>
         ) : null}
         {/* SpawnHud isn't part of the tail budget (its width is dynamic), so it

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -315,6 +315,10 @@ export interface SessionUndoResponse {
 }
 
 export interface SessionUsageResponse {
+  account_label?: string
+  account_label_short?: string
+  account_label_tiny?: string
+  account_level?: 'error' | 'ok' | 'warn'
   active_subagents?: number
   cache_read?: number
   cache_write?: number

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -170,6 +170,10 @@ export interface SessionInfo {
 }
 
 export interface Usage {
+  account_label?: string
+  account_label_short?: string
+  account_label_tiny?: string
+  account_level?: 'error' | 'ok' | 'warn'
   active_subagents?: number
   calls: number
   compressions?: number


### PR DESCRIPTION
## Summary

Adds GitHub Copilot account-usage data to the Hermes status bar and a dedicated `/copilot-quota` slash command, mirroring what is already wired up for OpenAI Codex, Anthropic, and OpenRouter.

When the active provider is `copilot`, the status bar now shows:

- **full** (≥120 cols):  `q 290/300 left · resets Jun 1`
- **short** (≥90 cols):  `q 290/300 · Jun 1`
- **tiny**:              `q 290`

Color follows the existing `ok / warn / error` levels (warn <25 % remaining, error <10 %).

## Why

Personal-context: I run Hermes against a Copilot Business seat (300 premium interactions/month) and want continuous visibility of how much I have left without leaving the TUI or hitting GitHub's web dashboard. Hermes already has a clean account-usage pipeline for other providers — this just plugs Copilot into it.

## Changes

| File | What |
|------|------|
| `agent/account_usage.py` | New `_fetch_copilot_account_usage()` hitting `api.github.com/copilot_internal/user` with a 5-min TTL cache, plus 4 new optional `compact_*` fields on `AccountUsageSnapshot` for adaptive labels |
| `cli.py`, `tui_gateway/server.py` | Pipe `compact_label / compact_short_label / compact_tiny_label / compact_level` through the status-bar snapshot and JSON-RPC `usage` response |
| `gateway/run.py`, `hermes_cli/commands.py` | Register `/copilot-quota` (alias `/cquota`) that returns only the account-limits section of `/usage` |
| `ui-tui/src/{types,gatewayTypes}.ts` | Extend `Usage` / `SessionUsageResponse` with the new fields |
| `ui-tui/src/components/appChrome.tsx` | Render the label with width-adaptive truncation |
| `ui-tui/src/app/slash/commands/session.ts` | Wire `/copilot-quota` and populate quota fields on `/usage` |
| `tests/...` | Tests for command registration, gateway handler, and TUI command catalog |

## How it gets the data

```
GET https://api.github.com/copilot_internal/user
Authorization: token <COPILOT_GITHUB_TOKEN>
```

This is the same endpoint Copilot CLI uses internally. The token comes from the existing `hermes_cli.copilot_auth.resolve_copilot_token()` helper, so there's no new auth path or env var.

## Testing

```bash
pytest tests/test_account_usage.py tests/cli/test_gquota_command.py        tests/gateway/test_usage_command.py tests/test_tui_gateway_server.py
# 289 passed
npm --prefix ui-tui run build  # clean
```

Verified live against my own Copilot Business seat — returns `q 286/300 left · resets Jun 1` in the status bar.

## Failure modes (all silent — never breaks the status bar)

- No Copilot token configured → fetcher returns `None`, status bar unchanged
- API returns non-200 / quota fields absent → returns a snapshot with `compact_label=None`, status bar unchanged
- httpx timeout (8 s) → fetcher returns `None`

## Notes

I've been carrying this patch locally for a few weeks. Posting upstream so other Copilot users can benefit and so I don't have to re-resolve a merge conflict every time `hermes update` runs.