### PR TITLE
fix(vision): correct kwarg names in _resolve_single_provider for fallback chain (#35876)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2974,8 +2974,8 @@ def _resolve_single_provider(
     client, resolved_model = resolve_provider_client(
         provider=provider,
         model=model,
-        base_url=base_url,
-        api_key=api_key,
+        explicit_base_url=base_url,
+        explicit_api_key=api_key,
     )
     return client
 


### PR DESCRIPTION
## What

Fixes #35876 — Vision fallback chain silently fails on Gemini quota errors because `_resolve_single_provider()` passes wrong kwarg names to `resolve_provider_client()`.

## Root Cause

In `agent/auxiliary_client.py`, `_resolve_single_provider()` called `resolve_provider_client(provider=..., model=..., base_url=base_url, api_key=api_key)`. But the target function's parameter names are `explicit_base_url` and `explicit_api_key` — not `base_url` and `api_key`. This causes a `TypeError` at call time, silently swallowed by the `except Exception` at the call site, breaking the entire fallback chain.

## Impact

- Gemini free tier users get HTTP 429 (quota exhausted)
- Fallback chain silently returns None for all providers
- User sees raw Gemini error instead of falling back to MiMo/Ollama

## Fix

Changed kwarg names to match: `explicit_base_url=base_url` and `explicit_api_key=api_key`.

## Changes

- **`agent/auxiliary_client.py`**: 2-line fix in `_resolve_single_provider()` (line ~2977)

## Verification

- **Tests**: `tests/agent/test_auxiliary_client.py` — 190 passed, 1 pre-existing timing flake (`test_enforces_total_timeout_while_stream_keeps_emitting_events`)
- **Files changed**: 1 (`agent/auxiliary_client.py`)
- **Scope**: Exactly one focused commit ahead of upstream/main