### PR TITLE
fix(file): normalize Windows read_file paths

### DIFF
--- a/tests/tools/test_file_operations_windows_paths.py
+++ b/tests/tools/test_file_operations_windows_paths.py
@@ -1,0 +1,171 @@
+"""Regression tests for Windows paths passed through Git Bash file ops."""
+
+import pytest
+
+from tools.file_operations import ShellFileOperations
+
+
+class _FakeGitBashEnv:
+    cwd = r"C:\Users\alice\project"
+
+    def __init__(self):
+        self.commands: list[str] = []
+        self.uses_msys_paths = True
+
+    def execute(self, command: str, cwd: str = None, **kwargs) -> dict:
+        self.commands.append(command)
+        if r"C:\Users\alice\project\notes.txt" in command:
+            return {"output": "", "returncode": 1}
+        if "/c/Users/alice/project/notes.txt" not in command:
+            return {"output": "", "returncode": 1}
+        if command.startswith("wc -c"):
+            return {"output": "12\n", "returncode": 0}
+        if command.startswith("head -c"):
+            return {"output": "hello\nworld\n", "returncode": 0}
+        if command.startswith("sed -n"):
+            return {"output": "hello\nworld\n", "returncode": 0}
+        if command.startswith("wc -l"):
+            return {"output": "2\n", "returncode": 0}
+        return {"output": "", "returncode": 1}
+
+
+def test_read_file_converts_windows_drive_path_for_git_bash(monkeypatch):
+    """Native C:\\ paths must be translated before shelling through Git Bash."""
+    from tools import file_operations
+
+    monkeypatch.setattr(file_operations.os, "name", "nt", raising=False)
+    env = _FakeGitBashEnv()
+    ops = ShellFileOperations(env)
+
+    result = ops.read_file(r"C:\Users\alice\project\notes.txt")
+
+    assert result.error is None
+    assert "1|hello" in result.content
+    assert all(r"C:\Users\alice\project\notes.txt" not in cmd for cmd in env.commands)
+    assert any("/c/Users/alice/project/notes.txt" in cmd for cmd in env.commands)
+
+
+class _FakeWslBashEnv:
+    cwd = r"C:\Users\alice\project"
+
+    def __init__(self):
+        self.commands: list[str] = []
+        self.uses_msys_paths = True
+        self.windows_bash_path_style = "wsl"
+
+    def execute(self, command: str, cwd: str = None, **kwargs) -> dict:
+        self.commands.append(command)
+        if r"C:\Users\alice\project\notes.txt" in command:
+            return {"output": "", "returncode": 1}
+        if "/mnt/c/Users/alice/project/notes.txt" not in command:
+            return {"output": "", "returncode": 1}
+        if command.startswith("wc -c"):
+            return {"output": "12\n", "returncode": 0}
+        if command.startswith("head -c"):
+            return {"output": "hello\nworld\n", "returncode": 0}
+        if command.startswith("sed -n"):
+            return {"output": "hello\nworld\n", "returncode": 0}
+        if command.startswith("wc -l"):
+            return {"output": "2\n", "returncode": 0}
+        return {"output": "", "returncode": 1}
+
+
+def test_read_file_converts_windows_drive_path_for_wsl_bash(monkeypatch):
+    """WSL bash expects mounted drive paths instead of Git Bash /c paths."""
+    from tools import file_operations
+    from tools.environments import local
+
+    monkeypatch.setattr(file_operations.os, "name", "nt", raising=False)
+    monkeypatch.setattr(local, "_find_bash", lambda: r"C:\Windows\System32\bash.exe")
+    env = _FakeWslBashEnv()
+    ops = ShellFileOperations(env)
+
+    result = ops.read_file(r"C:\Users\alice\project\notes.txt")
+
+    assert result.error is None
+    assert "1|hello" in result.content
+    assert all(r"C:\Users\alice\project\notes.txt" not in cmd for cmd in env.commands)
+    assert any("/mnt/c/Users/alice/project/notes.txt" in cmd for cmd in env.commands)
+
+
+def test_windows_drive_path_for_bash_supports_other_drives(monkeypatch):
+    """Drive-letter conversion must preserve non-C drives too."""
+    from tools import file_operations
+    from tools.file_operations import _windows_drive_path_for_bash
+
+    monkeypatch.setattr(file_operations.os, "name", "nt", raising=False)
+
+    result = _windows_drive_path_for_bash(r"D:\hermes jiyi\2026-04-29.md")
+
+    assert result == "/d/hermes jiyi/2026-04-29.md"
+
+
+@pytest.fixture
+def windows_denylist(monkeypatch):
+    """Make the denylist block only the native Windows credential path."""
+    from tools import file_operations
+
+    blocked = r"C:\Users\alice\.ssh\id_rsa"
+    calls: list[str] = []
+
+    def fake_is_write_denied(path: str) -> bool:
+        calls.append(path)
+        return path == blocked
+
+    monkeypatch.setattr(file_operations.os, "name", "nt", raising=False)
+    monkeypatch.setattr(file_operations, "_shared_is_write_denied", fake_is_write_denied)
+    return blocked, calls
+
+
+def test_msys_write_denied_paths_are_checked_as_native_windows(windows_denylist):
+    """MSYS path conversion must not bypass credential write-deny checks."""
+    from tools.file_operations import _is_write_denied
+
+    _blocked, calls = windows_denylist
+
+    assert _is_write_denied("/c/Users/alice/.ssh/id_rsa") is True
+    assert r"C:\Users\alice\.ssh\id_rsa" in calls
+
+
+def test_write_file_denies_converted_windows_credential_path(windows_denylist):
+    blocked, _calls = windows_denylist
+    env = _FakeGitBashEnv()
+    ops = ShellFileOperations(env)
+
+    result = ops.write_file(blocked, "secret")
+
+    assert result.error and "Write denied" in result.error
+    assert env.commands == []
+
+
+def test_delete_file_denies_converted_windows_credential_path(windows_denylist):
+    blocked, _calls = windows_denylist
+    env = _FakeGitBashEnv()
+    ops = ShellFileOperations(env)
+
+    result = ops.delete_file(blocked)
+
+    assert result.error and "Delete denied" in result.error
+    assert env.commands == []
+
+
+def test_move_file_denies_converted_windows_credential_destination(windows_denylist):
+    blocked, _calls = windows_denylist
+    env = _FakeGitBashEnv()
+    ops = ShellFileOperations(env)
+
+    result = ops.move_file(r"C:\Users\alice\safe.txt", blocked)
+
+    assert result.error and "Move denied" in result.error
+    assert env.commands == []
+
+
+def test_patch_replace_denies_converted_windows_credential_path(windows_denylist):
+    blocked, _calls = windows_denylist
+    env = _FakeGitBashEnv()
+    ops = ShellFileOperations(env)
+
+    result = ops.patch_replace(blocked, "old", "new")
+
+    assert result.error and "Write denied" in result.error
+    assert env.commands == []

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -46,6 +46,10 @@ class TestMsysToWindowsPath:
         assert _msys_to_windows_path("/c/Users/NVIDIA") == r"C:\Users\NVIDIA"
         assert _msys_to_windows_path("/d/Projects/foo bar") == r"D:\Projects\foo bar"
 
+    def test_translates_wsl_mount_drive_path(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert _msys_to_windows_path("/mnt/c/Users/NVIDIA") == r"C:\Users\NVIDIA"
+
     def test_translates_bare_drive_root(self, monkeypatch):
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
         # Bare "/c" alone should resolve to the drive root.
@@ -68,6 +72,52 @@ class TestMsysToWindowsPath:
     def test_empty_string(self, monkeypatch):
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
         assert _msys_to_windows_path("") == ""
+
+
+class TestQuoteCwdForWindowsBash:
+    def test_windows_cwd_is_quoted_as_git_bash_path(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+
+        with patch.object(
+            LocalEnvironment, "init_session", autospec=True, return_value=None
+        ):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+
+        env.windows_bash_path_style = "msys"
+
+        assert env._quote_cwd_for_cd(r"C:\Users\NVIDIA") == "/c/Users/NVIDIA"
+
+    def test_windows_cwd_is_quoted_as_wsl_bash_path(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+
+        with patch.object(
+            LocalEnvironment, "init_session", autospec=True, return_value=None
+        ):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+
+        env.windows_bash_path_style = "wsl"
+
+        assert env._quote_cwd_for_cd(r"C:\Users\NVIDIA") == "/mnt/c/Users/NVIDIA"
+
+    def test_windows_session_files_are_quoted_as_wsl_bash_paths(
+        self, monkeypatch, tmp_path,
+    ):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+
+        with patch.object(
+            LocalEnvironment, "init_session", autospec=True, return_value=None
+        ):
+            env = LocalEnvironment(cwd=str(tmp_path), timeout=10)
+
+        env.windows_bash_path_style = "wsl"
+        env._snapshot_path = r"C:/Users/NVIDIA/.hermes/cache/terminal/snap.sh"
+        env._cwd_file = r"C:/Users/NVIDIA/.hermes/cache/terminal/cwd.txt"
+        env._snapshot_ready = True
+
+        script = env._wrap_command("pwd", r"C:\Users\NVIDIA")
+
+        assert "source /mnt/c/Users/NVIDIA/.hermes/cache/terminal/snap.sh" in script
+        assert "pwd -P > /mnt/c/Users/NVIDIA/.hermes/cache/terminal/cwd.txt" in script
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_resolve_path.py
+++ b/tests/tools/test_resolve_path.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from types import SimpleNamespace
 
 
-
 class TestResolvePath:
     """Verify _resolve_path respects TERMINAL_CWD for worktree isolation."""
 
@@ -25,6 +24,33 @@ class TestResolvePath:
         absolute = (tmp_path / "already-absolute.txt").resolve()
         result = _resolve_path(str(absolute))
         assert result == absolute
+
+    def test_windows_msys_absolute_path_normalizes_to_drive_path(self, monkeypatch):
+        """Git Bash /c/... absolute paths must normalize to Windows drive paths."""
+        monkeypatch.setattr(os, "name", "nt", raising=False)
+        from tools.file_tools import _msys_path_to_windows
+
+        result = _msys_path_to_windows("/c/Users/alice/project/file.txt")
+
+        assert result == r"C:\Users\alice\project\file.txt"
+
+    def test_windows_msys_absolute_path_supports_other_drives(self, monkeypatch):
+        """MSYS drive prefixes are not limited to C:."""
+        monkeypatch.setattr(os, "name", "nt", raising=False)
+        from tools.file_tools import _msys_path_to_windows
+
+        result = _msys_path_to_windows("/d/hermes jiyi/2026-04-29.md")
+
+        assert result == r"D:\hermes jiyi\2026-04-29.md"
+
+    def test_windows_wsl_absolute_path_normalizes_to_drive_path(self, monkeypatch):
+        """WSL /mnt/c/... absolute paths must normalize to Windows drive paths."""
+        monkeypatch.setattr(os, "name", "nt", raising=False)
+        from tools.file_tools import _msys_path_to_windows
+
+        result = _msys_path_to_windows("/mnt/c/Users/alice/project/file.txt")
+
+        assert result == r"C:\Users\alice\project\file.txt"
 
     def test_falls_back_to_cwd_without_terminal_cwd(self, monkeypatch):
         """Without TERMINAL_CWD, falls back to os.getcwd()."""

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -359,7 +359,7 @@ class BaseEnvironment(ABC):
         # Restore configured cwd after login shell profile scripts, which may
         # change the working directory (e.g. bashrc `cd ~`).  Without this,
         # pwd -P captures the profile's directory, not terminal.cwd.
-        _quoted_cwd = shlex.quote(self.cwd)
+        _quoted_cwd = self._quote_cwd_for_cd(self.cwd)
         # Quote the snapshot / cwd-file paths so Git Bash on Windows handles
         # ``C:/Users/...``-shaped paths without glob-splitting the colon or
         # tripping on drive letters.  On POSIX this is a no-op (no colons /
@@ -367,8 +367,8 @@ class BaseEnvironment(ABC):
         # caused ``C:/Users/.../hermes-snap-*.sh: No such file or directory``
         # errors on Windows, leaking via stderr (merged into stdout on Linux
         # backends) into every terminal-tool response.
-        _quoted_snap = shlex.quote(self._snapshot_path)
-        _quoted_cwd_file = shlex.quote(self._cwd_file)
+        _quoted_snap = self._quote_path_for_shell(self._snapshot_path)
+        _quoted_cwd_file = self._quote_path_for_shell(self._cwd_file)
         bootstrap = (
             f"export -p > {_quoted_snap}\n"
             f"declare -f | grep -vE '^_[^_]' >> {_quoted_snap}\n"
@@ -414,6 +414,9 @@ class BaseEnvironment(ABC):
             return f"$HOME/{shlex.quote(cwd[2:])}"
         return shlex.quote(cwd)
 
+    def _quote_path_for_shell(self, path: str) -> str:
+        return shlex.quote(path)
+
     def _wrap_command(self, command: str, cwd: str) -> str:
         """Build the full bash script that sources snapshot, cd's, runs command,
         re-dumps env vars, and emits CWD markers."""
@@ -423,8 +426,8 @@ class BaseEnvironment(ABC):
         # ``C:/Users/...``-shaped paths without glob-splitting the colon or
         # tripping on drive letters.  POSIX paths are unaffected.  See
         # :meth:`init_session` for the same fix on the bootstrap block.
-        _quoted_snap = shlex.quote(self._snapshot_path)
-        _quoted_cwd_file = shlex.quote(self._cwd_file)
+        _quoted_snap = self._quote_path_for_shell(self._snapshot_path)
+        _quoted_cwd_file = self._quote_path_for_shell(self._cwd_file)
 
         parts = []
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -30,6 +30,11 @@ def _msys_to_windows_path(cwd: str) -> str:
     """
     if not _IS_WINDOWS or not cwd:
         return cwd
+    m = re.match(r'^/mnt/([a-zA-Z])(/.*)?$', cwd)
+    if m:
+        drive = m.group(1).upper()
+        tail = (m.group(2) or "").replace('/', '\\')
+        return f"{drive}:{tail or chr(92)}"  # chr(92) = backslash, avoid raw-string escape
     # Match leading "/<single letter>/" or exactly "/<letter>" (bare drive root).
     m = re.match(r'^/([a-zA-Z])(/.*)?$', cwd)
     if not m:
@@ -37,6 +42,21 @@ def _msys_to_windows_path(cwd: str) -> str:
     drive = m.group(1).upper()
     tail = (m.group(2) or "").replace('/', '\\')
     return f"{drive}:{tail or chr(92)}"  # chr(92) = backslash, avoid raw-string escape
+
+
+def _windows_to_bash_path(path: str, path_style: str = "msys") -> str:
+    """Translate a native Windows drive path to the active bash path syntax."""
+    if not _IS_WINDOWS or not path:
+        return path
+    m = re.match(r"^([a-zA-Z]):[\\/](.*)$", path)
+    if not m:
+        return path
+    drive = m.group(1).lower()
+    tail = m.group(2).replace("\\", "/")
+    prefix = f"/mnt/{drive}" if path_style == "wsl" else f"/{drive}"
+    if tail:
+        return f"{prefix}/{tail}"
+    return f"{prefix}/"
 
 
 def _resolve_safe_cwd(cwd: str) -> str:
@@ -288,7 +308,30 @@ def _find_bash() -> str:
     )
 
 
-# Backward compat — process_registry.py imports this name
+def _windows_bash_path_style_from_path(bash_path: str) -> str:
+    """Return the Windows drive-prefix style expected by a bash executable."""
+    if not _IS_WINDOWS or not bash_path:
+        return "msys"
+    normalized = os.path.normcase(os.path.normpath(bash_path))
+    if (
+        normalized.endswith(r"\windows\system32\bash.exe")
+        or normalized.endswith(r"\microsoft\windowsapps\bash.exe")
+    ):
+        return "wsl"
+    return "msys"
+
+
+def _detect_windows_bash_path_style() -> str:
+    """Detect whether Windows bash expects Git Bash or WSL drive prefixes."""
+    if not _IS_WINDOWS:
+        return "msys"
+    try:
+        return _windows_bash_path_style_from_path(_find_bash())
+    except Exception:
+        return "msys"
+
+
+# Backward compat: process_registry.py imports this name.
 _find_shell = _find_bash
 
 
@@ -445,6 +488,8 @@ class LocalEnvironment(BaseEnvironment):
         if cwd:
             cwd = os.path.expanduser(cwd)
         super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
+        self.uses_msys_paths = _IS_WINDOWS
+        self.windows_bash_path_style = _detect_windows_bash_path_style()
         self.init_session()
 
     def get_temp_dir(self) -> str:
@@ -494,6 +539,16 @@ class LocalEnvironment(BaseEnvironment):
             return candidate.rstrip("/") or "/"
 
         return "/tmp"
+
+    def _quote_cwd_for_cd(self, cwd: str) -> str:
+        if _IS_WINDOWS:
+            cwd = _windows_to_bash_path(cwd, self.windows_bash_path_style)
+        return super()._quote_cwd_for_cd(cwd)
+
+    def _quote_path_for_shell(self, path: str) -> str:
+        if _IS_WINDOWS:
+            path = _windows_to_bash_path(path, self.windows_bash_path_style)
+        return super()._quote_path_for_shell(path)
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -143,9 +143,33 @@ def _has_bom(text: Optional[str]) -> bool:
     return bool(text) and text.startswith(_UTF8_BOM)
 
 
+def _windows_bash_path_to_drive(path: str) -> str:
+    """Convert Git Bash/MSYS drive paths back to native Windows syntax."""
+    if os.name != "nt" or not path:
+        return path
+    match = re.match(r"^/mnt/([a-zA-Z])(?:/(.*))?$", path)
+    if match:
+        drive = match.group(1).upper()
+        tail = (match.group(2) or "").replace("/", "\\")
+        if tail:
+            return f"{drive}:\\{tail}"
+        return f"{drive}:\\"
+    match = re.match(r"^/([a-zA-Z])(?:/(.*))?$", path)
+    if not match:
+        return path
+    drive = match.group(1).upper()
+    tail = (match.group(2) or "").replace("/", "\\")
+    if tail:
+        return f"{drive}:\\{tail}"
+    return f"{drive}:\\"
+
+
 def _is_write_denied(path: str) -> bool:
     """Return True if path is on the write deny list."""
-    return _shared_is_write_denied(path)
+    if _shared_is_write_denied(path):
+        return True
+    native_path = _windows_bash_path_to_drive(path)
+    return native_path != path and _shared_is_write_denied(native_path)
 
 
 # =============================================================================
@@ -472,6 +496,32 @@ def _looks_like_linter_unusable(base_cmd: str, output: str) -> bool:
     return any(p in lower for p in patterns)
 
 
+def _is_windows_wsl_bash(bash_path: str) -> bool:
+    """Return True for Windows WSL bash launchers."""
+    if os.name != "nt" or not bash_path:
+        return False
+    normalized = os.path.normcase(os.path.normpath(bash_path))
+    return (
+        normalized.endswith(r"\windows\system32\bash.exe")
+        or normalized.endswith(r"\microsoft\windowsapps\bash.exe")
+    )
+
+
+def _windows_drive_path_for_bash(path: str, path_style: str = "msys") -> str:
+    """Convert native Windows drive paths to bash drive path syntax."""
+    if os.name != "nt" or not path:
+        return path
+    match = re.match(r"^([a-zA-Z]):[\\/](.*)$", path)
+    if not match:
+        return path
+    drive = match.group(1).lower()
+    tail = match.group(2).replace("\\", "/")
+    prefix = f"/mnt/{drive}" if path_style == "wsl" else f"/{drive}"
+    if tail:
+        return f"{prefix}/{tail}"
+    return f"{prefix}/"
+
+
 def _lint_json_inproc(content: str) -> tuple[bool, str]:
     """In-process JSON syntax check.  Returns (ok, error_message)."""
     import json as _json
@@ -638,6 +688,24 @@ class ShellFileOperations(FileOperations):
 
         # Cache for command availability checks
         self._command_cache: Dict[str, bool] = {}
+
+    def _uses_msys_paths(self) -> bool:
+        """Return True when this backend expects MSYS-style drive paths."""
+        return bool(getattr(self.env, "uses_msys_paths", False))
+
+    def _windows_bash_path_style(self) -> str:
+        """Return the POSIX drive-prefix style expected by this Windows shell."""
+        explicit = getattr(self.env, "windows_bash_path_style", None)
+        if explicit in {"msys", "wsl"}:
+            return explicit
+        try:
+            from tools.environments.local import _find_bash
+        except Exception:
+            return "msys"
+        try:
+            return "wsl" if _is_windows_wsl_bash(_find_bash()) else "msys"
+        except Exception:
+            return "msys"
     
     def _exec(self, command: str, cwd: str = None, timeout: int = None,
               stdin_data: str = None) -> ExecuteResult:
@@ -762,6 +830,8 @@ class ShellFileOperations(FileOperations):
                         suffix = path[1 + len(username):]  # e.g. "/rest/of/path"
                         return user_home + suffix
         
+        if self._uses_msys_paths():
+            return _windows_drive_path_for_bash(path, self._windows_bash_path_style())
         return path
     
     def _escape_shell_arg(self, arg: str) -> str:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import re
 import threading
 from pathlib import Path
 
@@ -85,6 +86,27 @@ def _resolve_path(filepath: str, task_id: str = "default") -> Path:
     return _resolve_path_for_task(filepath, task_id)
 
 
+def _msys_path_to_windows(filepath: str) -> str:
+    """Convert Git Bash/MSYS absolute paths like /c/Users/x on Windows."""
+    if os.name != "nt" or not filepath:
+        return filepath
+    match = re.match(r"^/mnt/([a-zA-Z])(?:/(.*))?$", filepath)
+    if match:
+        drive = match.group(1).upper()
+        tail = (match.group(2) or "").replace("/", "\\")
+        if tail:
+            return f"{drive}:\\{tail}"
+        return f"{drive}:\\"
+    match = re.match(r"^/([a-zA-Z])(?:/(.*))?$", filepath)
+    if not match:
+        return filepath
+    drive = match.group(1).upper()
+    tail = (match.group(2) or "").replace("/", "\\")
+    if tail:
+        return f"{drive}:\\{tail}"
+    return f"{drive}:\\"
+
+
 def _get_live_tracking_cwd(task_id: str = "default") -> str | None:
     """Return the task's live terminal cwd for bookkeeping when available."""
     try:
@@ -153,7 +175,7 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path:
     See :func:`_resolve_base_dir` for how the base is chosen. Absolute input
     paths are returned resolved-but-unanchored.
     """
-    p = Path(filepath).expanduser()
+    p = Path(_msys_path_to_windows(filepath)).expanduser()
     if p.is_absolute():
         return p.resolve()
     return (_resolve_base_dir(task_id) / p).resolve()


### PR DESCRIPTION
## Summary
- Normalize Git Bash (`/c/...`) and WSL (`/mnt/c/...`) drive paths before resolving file-tool paths on Windows.
- Convert native Windows drive-letter paths before shelling out through Git Bash or WSL bash, including LocalEnvironment cwd/session artifact paths.
- Preserve write-deny checks after bash-path conversion so protected native Windows paths cannot be bypassed through `/c/...` or `/mnt/c/...` aliases.

Fixes #35819.

## Validation
- `uv run --extra dev python -X utf8 -m pytest tests/tools/test_resolve_path.py tests/tools/test_file_operations_windows_paths.py tests/tools/test_file_read_guards.py tests/tools/test_local_env_windows_msys.py -q --timeout-method=thread` → 67 passed, 3 skipped
- Windows LocalEnvironment smoke: `ShellFileOperations(LocalEnvironment(...)).read_file("C:\\...\\notes.txt")` → read succeeded with `error: None`
- `uv run --extra dev ruff check .` → All checks passed

## Note
- `bash scripts/run_tests.sh ...` is not runnable in this Windows checkout because the shell wrapper is checked out with CRLF line endings (`set: pipefail\r: invalid option name`), so the focused pytest suite was run directly with `uv run`.