### PR TITLE
fix(cli): wire /whoami to CLI dispatch so it stops printing 'Unknown command'

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6270,6 +6270,29 @@ class HermesCLI:
         print(f"  Home:    {display}")
         print()
 
+    def _handle_whoami_command(self):
+        """Show slash-command access for the current CLI user.
+
+        In the CLI there is no admin/user split — the local user owns the
+        session and has full access. Mirrors the gateway's /whoami output
+        format (gateway/run.py :: _handle_whoami_command) but simplified.
+        """
+        from hermes_cli.commands import COMMAND_REGISTRY
+        from collections import Counter
+
+        # Exclude gateway-only commands from the CLI tally.
+        visible = [c for c in COMMAND_REGISTRY if not getattr(c, "gateway_only", False)]
+        by_cat = Counter(getattr(c, "category", "Other") or "Other" for c in visible)
+
+        print()
+        print("  Access:  full (CLI owner)")
+        print(f"  Available slash commands: {len(visible)}")
+        for cat, count in sorted(by_cat.items()):
+            print(f"    - {cat}: {count}")
+        print()
+        print("  Use /help for the full list, /help <cmd> for details.")
+        print()
+
     def show_config(self):
         """Display current configuration with kawaii ASCII art."""
         # Get terminal config from environment (which was set from cli-config.yaml)
@@ -8441,6 +8464,8 @@ class HermesCLI:
             self.show_help()
         elif canonical == "profile":
             self._handle_profile_command()
+        elif canonical == "whoami":
+            self._handle_whoami_command()
         elif canonical == "tools":
             self._handle_tools_command(cmd_original)
         elif canonical == "toolsets":


### PR DESCRIPTION
## Summary

Fixes #35892.

`/whoami` is registered in `COMMAND_REGISTRY` (`hermes_cli/commands.py:112`) and so appears in tab-completion, but `cli.py` `process_command()` has no `elif` branch for it. The command falls through the elif chain into the generic prefix-matcher and prints `Unknown command: /whoami` — confusing for users because autocomplete advertises it as a real command.

The gateway already has a working handler (`gateway/run.py` `_handle_whoami_command` ~L9806); the CLI/TUI path was simply missing.

## Changes

- Add `elif canonical == "whoami":` branch in `cli.py` `process_command()` next to the other info commands (`/profile`, `/help`).
- Add a small `_handle_whoami_command()` method on `HermesCLI`. In the CLI there is no admin/user split (the local user owns the session), so it reports `Access: full (CLI owner)` plus a per-category count of visible (non-`gateway_only`) slash commands, and points the user at `/help` for the full listing. Output style matches the adjacent `_handle_profile_command()`.

## Test plan

- `python -c 'import cli'` — clean import, no syntax errors.
- `pytest tests/hermes_cli/test_commands.py` — 144 passed.
- Manual: typing `/whoami` in the CLI now prints the access summary instead of `Unknown command`.

## Scope

Single-file change (`cli.py`), +25 lines. No gateway behavior touched.