### PR TITLE
fix(auxiliary): gate copilot token probing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1938,16 +1938,19 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         if _is_provider_unhealthy(provider_id):
             logger.debug("Auxiliary api-key chain: %s is unhealthy, skipping", provider_id)
             continue
-        if provider_id == "anthropic":
-            # Only try anthropic when the user has explicitly configured it.
-            # Without this gate, Claude Code credentials get silently used
-            # as auxiliary fallback when the user's primary provider fails.
+        if provider_id in {"anthropic", "copilot"}:
+            # Only try providers backed by broadly available external
+            # credentials when the user has explicitly configured them. Without
+            # this gate, Claude Code credentials or generic GitHub tokens can be
+            # silently consulted as auxiliary fallback when the user's primary
+            # provider fails.
             try:
                 from hermes_cli.auth import is_provider_explicitly_configured
-                if not is_provider_explicitly_configured("anthropic"):
+                if not is_provider_explicitly_configured(provider_id):
                     continue
             except ImportError:
                 pass
+        if provider_id == "anthropic":
             return _try_anthropic()
 
         pool_present, entry = _select_pool_entry(provider_id)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1604,6 +1604,12 @@ def is_provider_explicitly_configured(provider_id: str) -> bool:
     # Exclude CLAUDE_CODE_OAUTH_TOKEN — it's set by Claude Code itself,
     # not by the user explicitly configuring anthropic in Hermes.
     _IMPLICIT_ENV_VARS = {"CLAUDE_CODE_OAUTH_TOKEN"}
+    if normalized == "copilot":
+        # GH_TOKEN and GITHUB_TOKEN are commonly present for git, the GitHub
+        # CLI, or CI. Treat only COPILOT_GITHUB_TOKEN as a provider-specific
+        # env opt-in; explicit config/auth-store selections are still handled
+        # above before this env-var scan.
+        _IMPLICIT_ENV_VARS = _IMPLICIT_ENV_VARS | {"GH_TOKEN", "GITHUB_TOKEN"}
     pconfig = PROVIDER_REGISTRY.get(normalized)
     # Fallback to ProviderDef from models.dev catalog when the provider
     # isn't in the manually-maintained PROVIDER_REGISTRY (e.g. openrouter).

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -570,6 +570,18 @@ def _resolve_api_key_provider_secret(
 ) -> tuple[str, str]:
     """Resolve an API-key provider's token and indicate where it came from."""
     if provider_id == "copilot":
+        # Generic GitHub tokens are commonly present for git, the GitHub CLI,
+        # or CI.  Do not probe Copilot during status/credential resolution
+        # unless the user explicitly configured that provider; otherwise a
+        # classic ghp_* PAT can trigger a validation warning on every probe.
+        try:
+            if not is_provider_explicitly_configured("copilot"):
+                return "", ""
+        except Exception:
+            # Preserve the existing resolver behavior if configuration
+            # inspection itself is unavailable; configured-provider errors
+            # must still be surfaced by the Copilot resolver below.
+            pass
         # Use the dedicated copilot auth module for proper token validation
         try:
             from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -65,6 +65,7 @@ def _clean_env(monkeypatch):
         "OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_KEY",
         "OPENAI_MODEL", "LLM_MODEL", "NOUS_INFERENCE_BASE_URL",
         "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
+        "COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN",
     ):
         monkeypatch.delenv(key, raising=False)
     # Module-level unhealthy cache (10-min TTL) leaks between tests;
@@ -2720,6 +2721,66 @@ def test_resolve_api_key_provider_skips_unconfigured_anthropic(monkeypatch):
 
     assert "anthropic" not in called, \
         "_try_anthropic() should not be called when anthropic is not explicitly configured"
+
+
+def test_resolve_api_key_provider_skips_unconfigured_copilot_with_generic_github_token(monkeypatch):
+    """GITHUB_TOKEN is often present for git/CI and must not trigger Copilot probing."""
+    from collections import OrderedDict
+    from hermes_cli.auth import ProviderConfig
+
+    fake_registry = OrderedDict({
+        "copilot": ProviderConfig(
+            id="copilot",
+            name="GitHub Copilot",
+            auth_type="api_key",
+            inference_base_url="https://api.githubcopilot.com",
+            api_key_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
+        ),
+    })
+    called = []
+
+    def fail_if_called(provider_id):
+        called.append(provider_id)
+        raise AssertionError("unconfigured Copilot must not resolve generic GitHub tokens")
+
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_classic_pat_for_git_only")
+    monkeypatch.setattr("agent.auxiliary_client._select_pool_entry", lambda _pid: (False, None))
+    monkeypatch.setattr("hermes_cli.auth.PROVIDER_REGISTRY", fake_registry)
+    monkeypatch.setattr("hermes_cli.auth.resolve_api_key_provider_credentials", fail_if_called)
+
+    from agent.auxiliary_client import _resolve_api_key_provider
+    assert _resolve_api_key_provider() == (None, None)
+    assert called == []
+
+
+def test_resolve_api_key_provider_allows_explicit_copilot_token_env(monkeypatch):
+    """COPILOT_GITHUB_TOKEN is a provider-specific opt-in and should still be probed."""
+    from collections import OrderedDict
+    from hermes_cli.auth import ProviderConfig
+
+    fake_registry = OrderedDict({
+        "copilot": ProviderConfig(
+            id="copilot",
+            name="GitHub Copilot",
+            auth_type="api_key",
+            inference_base_url="https://api.githubcopilot.com",
+            api_key_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
+        ),
+    })
+    called = []
+
+    def empty_creds(provider_id):
+        called.append(provider_id)
+        return {"api_key": "", "base_url": ""}
+
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_explicit_copilot_token")
+    monkeypatch.setattr("agent.auxiliary_client._select_pool_entry", lambda _pid: (False, None))
+    monkeypatch.setattr("hermes_cli.auth.PROVIDER_REGISTRY", fake_registry)
+    monkeypatch.setattr("hermes_cli.auth.resolve_api_key_provider_credentials", empty_creds)
+
+    from agent.auxiliary_client import _resolve_api_key_provider
+    assert _resolve_api_key_provider() == (None, None)
+    assert called == ["copilot"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -680,6 +680,7 @@ class TestRuntimeProviderResolution:
         assert result["api_key"] == "auto-kimi-key"
 
     def test_runtime_copilot_uses_gh_cli_token(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.is_provider_explicitly_configured", lambda _provider: True)
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
         from hermes_cli.runtime_provider import resolve_runtime_provider
         result = resolve_runtime_provider(requested="copilot")
@@ -689,6 +690,7 @@ class TestRuntimeProviderResolution:
         assert result["base_url"] == "https://api.githubcopilot.com"
 
     def test_runtime_copilot_uses_responses_for_gpt_5_4(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.is_provider_explicitly_configured", lambda _provider: True)
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
         monkeypatch.setattr(
             "hermes_cli.runtime_provider._get_model_config",

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -378,6 +378,7 @@ class TestApiKeyProviderStatus:
         assert status["base_url"] == STEPFUN_STEP_PLAN_CN_BASE_URL
 
     def test_copilot_status_uses_gh_cli_token(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.is_provider_explicitly_configured", lambda _provider: True)
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_gh_cli_token")
         status = get_api_key_provider_status("copilot")
         assert status["configured"] is True
@@ -432,15 +433,16 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["base_url"] == "https://api.z.ai/api/paas/v4"
         assert creds["source"] == "GLM_API_KEY"
 
-    def test_resolve_copilot_with_github_token(self, monkeypatch):
+    def test_resolve_copilot_does_not_use_generic_github_token(self, monkeypatch):
         monkeypatch.setenv("GITHUB_TOKEN", "gh-env-secret")
         creds = resolve_api_key_provider_credentials("copilot")
         assert creds["provider"] == "copilot"
-        assert creds["api_key"] == "gh-env-secret"
+        assert creds["api_key"] == ""
         assert creds["base_url"] == "https://api.githubcopilot.com"
-        assert creds["source"] == "GITHUB_TOKEN"
+        assert creds["source"] == "default"
 
     def test_resolve_copilot_with_gh_cli_fallback(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.is_provider_explicitly_configured", lambda _provider: True)
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
         creds = resolve_api_key_provider_credentials("copilot")
         assert creds["provider"] == "copilot"
@@ -753,6 +755,7 @@ class TestHasAnyProviderConfigured:
 
     def test_gh_cli_token_counts(self, monkeypatch, tmp_path):
         from hermes_cli import config as config_module
+        monkeypatch.setattr("hermes_cli.auth.is_provider_explicitly_configured", lambda _provider: True)
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -248,7 +248,7 @@ def test_copilot_status_preserves_provider_specific_token(tmp_path, monkeypatch)
     )
     monkeypatch.setattr(
         "hermes_cli.copilot_auth.get_copilot_api_token",
-        lambda token: "api-token:" + token,
+        lambda token: ("api-token:" + token, "https://api.githubcopilot.com"),
     )
     api_key, source = auth._resolve_api_key_provider_secret(
         "copilot", auth.PROVIDER_REGISTRY["copilot"]
@@ -269,7 +269,7 @@ def test_copilot_status_preserves_explicit_provider_config(tmp_path, monkeypatch
     )
     monkeypatch.setattr(
         "hermes_cli.copilot_auth.get_copilot_api_token",
-        lambda token: "api-token:" + token,
+        lambda token: ("api-token:" + token, "https://api.githubcopilot.com"),
     )
     api_key, source = auth._resolve_api_key_provider_secret(
         "copilot", auth.PROVIDER_REGISTRY["copilot"]

--- a/tests/hermes_cli/test_auth_provider_gate.py
+++ b/tests/hermes_cli/test_auth_provider_gate.py
@@ -18,9 +18,15 @@ def _write_auth_store(tmp_path, payload: dict) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _clean_anthropic_env(monkeypatch):
-    """Strip Anthropic env vars so CI secrets don't leak into tests."""
-    for key in ("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+def _clean_provider_env(monkeypatch):
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "COPILOT_GITHUB_TOKEN",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+    ):
         monkeypatch.delenv(key, raising=False)
 
 
@@ -190,3 +196,82 @@ def test_provider_not_in_registry_but_in_models_dev(tmp_path, monkeypatch):
 
     from hermes_cli.auth import is_provider_explicitly_configured
     assert is_provider_explicitly_configured("openrouter") is True
+
+
+@pytest.mark.parametrize("env_var", ["GH_TOKEN", "GITHUB_TOKEN"])
+def test_generic_github_tokens_do_not_count_as_explicit_copilot(tmp_path, monkeypatch, env_var):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv(env_var, "ghp_classic_pat_for_git_only")
+    (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("copilot") is False
+
+
+def test_copilot_specific_env_var_counts_as_explicit(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_explicit_copilot_token")
+    (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
+
+    from hermes_cli.auth import is_provider_explicitly_configured
+    assert is_provider_explicitly_configured("copilot") is True
+
+
+@pytest.mark.parametrize("env_var", ["GH_TOKEN", "GITHUB_TOKEN"])
+def test_copilot_status_skips_generic_github_token(tmp_path, monkeypatch, env_var):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv(env_var, "ghp_classic_pat_for_git_only")
+    (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
+
+    from hermes_cli import auth
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: pytest.fail("generic GitHub token must not trigger Copilot probing"),
+    )
+    api_key, source = auth._resolve_api_key_provider_secret(
+        "copilot", auth.PROVIDER_REGISTRY["copilot"]
+    )
+    assert (api_key, source) == ("", "")
+
+
+def test_copilot_status_preserves_provider_specific_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_explicit_copilot_token")
+    (tmp_path / "hermes").mkdir(parents=True, exist_ok=True)
+
+    from hermes_cli import auth
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("validated-token", "COPILOT_GITHUB_TOKEN"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.get_copilot_api_token",
+        lambda token: "api-token:" + token,
+    )
+    api_key, source = auth._resolve_api_key_provider_secret(
+        "copilot", auth.PROVIDER_REGISTRY["copilot"]
+    )
+    assert (api_key, source) == ("api-token:validated-token", "COPILOT_GITHUB_TOKEN")
+
+
+def test_copilot_status_preserves_explicit_provider_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("GITHUB_TOKEN", "gho_explicit_provider_config")
+    _write_config(tmp_path, {"model": {"provider": "copilot"}})
+
+    from hermes_cli import auth
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("validated-token", "GITHUB_TOKEN"),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.get_copilot_api_token",
+        lambda token: "api-token:" + token,
+    )
+    api_key, source = auth._resolve_api_key_provider_secret(
+        "copilot", auth.PROVIDER_REGISTRY["copilot"]
+    )
+    assert (api_key, source) == ("api-token:validated-token", "GITHUB_TOKEN")

--- a/tests/hermes_cli/test_copilot_token_exchange.py
+++ b/tests/hermes_cli/test_copilot_token_exchange.py
@@ -155,7 +155,8 @@ class TestCallerIntegration:
 
     @patch("hermes_cli.copilot_auth.resolve_copilot_token", return_value=("gho_raw", "GH_TOKEN"))
     @patch("hermes_cli.copilot_auth.get_copilot_api_token", return_value=("exchanged_jwt", None))
-    def test_auth_resolve_uses_exchange(self, mock_exchange, mock_resolve):
+    def test_auth_resolve_uses_exchange(self, mock_exchange, mock_resolve, monkeypatch):
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "gho_raw")
         from hermes_cli.auth import _resolve_api_key_provider_secret
 
         # Create a minimal pconfig mock


### PR DESCRIPTION
## Summary
- Skip Copilot API-key fallback probing unless Copilot is explicitly configured.
- Treat `GH_TOKEN` / `GITHUB_TOKEN` as generic GitHub credentials, not Copilot provider opt-in; `COPILOT_GITHUB_TOKEN` still opts in.
- Add regression coverage for the noisy classic-PAT warning path and the explicit Copilot env path.

## Why this is separate from #35958
#35958 adds the auxiliary fallback gate, but the real `is_provider_explicitly_configured(copilot)` helper currently treats `GH_TOKEN` / `GITHUB_TOKEN` as explicit Copilot configuration. That means a plain GitHub token can still pass the new gate and reach Copilot token validation. This PR includes the auxiliary gate plus the auth-helper boundary so generic GitHub tokens do not opt users into Copilot fallback probing.

## Test Plan
- `..\hermes-agent\.venv\Scripts\python.exe -X utf8 -m pytest tests/agent/test_auxiliary_client.py tests/hermes_cli/test_auth_provider_gate.py -q --timeout-method=thread`
- `..\hermes-agent\.venv\Scripts\python.exe -X utf8 -m pytest tests/hermes_cli/test_copilot_auth.py tests/hermes_cli/test_setup_openclaw_migration.py::TestGetSectionConfigSummary::test_model_ignores_bare_gh_token tests/hermes_cli/test_setup_openclaw_migration.py::TestGetSectionConfigSummary::test_model_ignores_bare_github_token tests/hermes_cli/test_setup_openclaw_migration.py::TestGetSectionConfigSummary::test_model_copilot_recognised_when_explicitly_chosen -q --timeout-method=thread`
- `..\hermes-agent\.venv\Scripts\ruff.exe check .`

Fixes #35946
Related: #35958