### PR TITLE
fix(gateway): timeout slash confirmation handlers

### DIFF
--- a/tests/tools/test_slash_confirm.py
+++ b/tests/tools/test_slash_confirm.py
@@ -126,6 +126,28 @@ class TestResolve:
         assert slash_confirm.get_pending("sess1") is None
 
     @pytest.mark.asyncio
+    async def test_resolve_handler_timeout_returns_error_string(self):
+        async def handler(choice):
+            await asyncio.Event().wait()
+
+        slash_confirm.register("sess1", "cid1", "new", handler)
+
+        result = await asyncio.wait_for(
+            slash_confirm.resolve(
+                "sess1",
+                "cid1",
+                "once",
+                handler_timeout=0.01,
+            ),
+            timeout=0.5,
+        )
+
+        assert result is not None
+        assert "timed out" in result.lower()
+        # Entry should still be popped even when handler times out.
+        assert slash_confirm.get_pending("sess1") is None
+
+    @pytest.mark.asyncio
     async def test_resolve_non_string_return_becomes_none(self):
         async def handler(choice):
             return {"not": "a string"}

--- a/tools/slash_confirm.py
+++ b/tools/slash_confirm.py
@@ -46,6 +46,7 @@ _lock = threading.RLock()
 # the adapter drops the callback_data (Telegram: ~48h; Discord: ephemeral;
 # Slack: 3s ack + long-lived actions).
 DEFAULT_TIMEOUT_SECONDS = 300
+DEFAULT_HANDLER_TIMEOUT_SECONDS = 30.0
 
 
 def register(
@@ -101,6 +102,7 @@ async def resolve(
     confirm_id: str,
     choice: str,
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    handler_timeout: float | None = DEFAULT_HANDLER_TIMEOUT_SECONDS,
 ) -> Optional[str]:
     """Resolve a pending confirm.
 
@@ -130,7 +132,21 @@ async def resolve(
     if not handler:
         return None
     try:
-        result = await handler(choice)
+        if handler_timeout is None:
+            result = await handler(choice)
+        else:
+            result = await asyncio.wait_for(handler(choice), timeout=handler_timeout)
+    except asyncio.TimeoutError:
+        logger.error(
+            "Slash-confirm handler for /%s timed out after %.1fs",
+            command,
+            handler_timeout or 0.0,
+            exc_info=True,
+        )
+        return (
+            f"❌ Confirmation for /{command} timed out. "
+            "Try again, or use /stop first if the session is busy."
+        )
     except Exception as exc:
         logger.error(
             "Slash-confirm handler for /%s raised: %s",


### PR DESCRIPTION
﻿## Summary
- Add a bounded timeout around slash-confirm handlers so Telegram/Slack/Discord button callbacks cannot wait forever when the confirmed command stalls.
- Return a user-visible timeout message for the confirmation follow-up instead of leaving the callback path silent.
- Add regression coverage for a hanging `/new` confirmation handler.

## Root Cause
`tools.slash_confirm.resolve()` popped the pending confirmation and then awaited the registered handler with no execution bound. Telegram button callbacks call this path directly, so a stalled `_handle_reset_command()` could keep the callback task waiting indefinitely after the button was acknowledged.

## Test Plan
- RED: `..\hermes-agent\.venv\Scripts\python.exe -X utf8 -m pytest tests/tools/test_slash_confirm.py::TestResolve::test_resolve_handler_timeout_returns_error_string -q --timeout-method=thread` failed with `TypeError: resolve() got an unexpected keyword argument 'handler_timeout'`.
- GREEN: `..\hermes-agent\.venv\Scripts\python.exe -X utf8 -m pytest tests/tools/test_slash_confirm.py::TestResolve::test_resolve_handler_timeout_returns_error_string -q --timeout-method=thread` passed: 1 passed.
- `..\hermes-agent\.venv\Scripts\python.exe -X utf8 -m pytest tests/tools/test_slash_confirm.py tests/gateway/test_destructive_slash_confirm.py tests/gateway/test_telegram_slash_confirm.py -q --timeout-method=thread` passed: 26 passed.
- `..\hermes-agent\.venv\Scripts\python.exe -X utf8 -m pytest tests/tools/test_slash_confirm.py tests/gateway/test_destructive_slash_confirm.py tests/gateway/test_telegram_slash_confirm.py tests/cli/test_slash_confirm_windows.py tests/cli/test_destructive_slash_confirm.py -q --timeout-method=thread` passed: 51 passed.
- `..\hermes-agent\.venv\Scripts\ruff.exe check tools\slash_confirm.py tests\tools\test_slash_confirm.py` passed.
- `..\hermes-agent\.venv\Scripts\ruff.exe check .` passed with the pre-existing `run_agent.py:68` invalid `# noqa` warning.
- `git diff --check` passed.

## Wrapper Note
- `C:\Program Files\Git\bin\bash.exe scripts/run_tests.sh tests/tools/test_slash_confirm.py tests/gateway/test_destructive_slash_confirm.py tests/gateway/test_telegram_slash_confirm.py -- -q` could not run in this Windows worktree because the script only accepts POSIX `bin/activate` virtualenv layouts and this checkout has no `.venv`/`venv`.

Fixes #35994
