### PR TITLE
fix(docker): ignore empty forwarded env values

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -302,6 +302,20 @@ def test_init_env_args_prefers_shell_env_over_hermes_dotenv(monkeypatch):
     assert "value_from_dotenv" not in args_str
 
 
+def test_init_env_args_falls_back_to_dotenv_for_empty_shell_env(monkeypatch):
+    """Empty forwarded env vars should not mask durable .env values."""
+    env = _make_execute_only_env(["DATABASE_URL"])
+
+    monkeypatch.setenv("DATABASE_URL", "")
+    monkeypatch.setattr(docker_env, "_load_hermes_env_vars", lambda: {"DATABASE_URL": "value_from_dotenv"})
+
+    args = env._build_init_env_args()
+    args_str = " ".join(args)
+
+    assert "DATABASE_URL=value_from_dotenv" in args_str
+    assert "DATABASE_URL= " not in args_str
+
+
 # ── docker_env tests ──────────────────────────────────────────────
 
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -814,9 +814,9 @@ class DockerEnvironment(BaseEnvironment):
         hermes_env = _load_hermes_env_vars() if forward_keys else {}
         for key in sorted(forward_keys):
             value = os.getenv(key)
-            if value is None:
+            if value in (None, ""):
                 value = hermes_env.get(key)
-            if value is not None:
+            if value not in (None, ""):
                 exec_env[key] = value
 
         args = []


### PR DESCRIPTION
﻿## Summary
- Treat empty-string values in `docker_forward_env` the same as unset values, so the durable Hermes `.env` fallback can supply the real secret.
- Do not inject `-e KEY=` into Docker init env args when both live env and `.env` are empty.
- Add regression coverage for the transient empty-env case reported in #35580.

## Root Cause
`DockerEnvironment._build_init_env_args()` only fell back to `~/.hermes/.env` when `os.getenv(key)` returned `None`. A present-but-empty variable skipped the fallback and was still forwarded as `-e KEY=`, masking valid secrets on disk inside sandboxed Docker commands.

## Test Plan
- RED: `..\hermes-agent\.venv\Scripts\python.exe -X utf8 -m pytest tests/tools/test_docker_environment.py::test_init_env_args_falls_back_to_dotenv_for_empty_shell_env -q --timeout-method=thread` failed with `AssertionError: assert 'DATABASE_URL=value_from_dotenv' in '-e DATABASE_URL='`.
- GREEN: `..\hermes-agent\.venv\Scripts\python.exe -X utf8 -m pytest tests/tools/test_docker_environment.py::test_init_env_args_falls_back_to_dotenv_for_empty_shell_env -q --timeout-method=thread` passed: 1 passed.
- `..\hermes-agent\.venv\Scripts\python.exe -X utf8 -m pytest tests/tools/test_docker_environment.py -q --timeout-method=thread` passed: 55 passed.
- `..\hermes-agent\.venv\Scripts\python.exe -X utf8 -m pytest tests/tools/test_docker_environment.py tests/tools/test_parse_env_var.py tests/tools/test_file_tools_container_config.py -q --timeout-method=thread` passed: 71 passed.
- `..\hermes-agent\.venv\Scripts\ruff.exe check tools\environments\docker.py tests\tools\test_docker_environment.py` passed.
- `..\hermes-agent\.venv\Scripts\ruff.exe check .` passed.
- `git diff --check` passed.

## Wrapper Note
- `C:\Program Files\Git\bin\bash.exe scripts/run_tests.sh tests/tools/test_docker_environment.py tests/tools/test_parse_env_var.py tests/tools/test_file_tools_container_config.py -- -q` could not run in this Windows worktree because the script only accepts POSIX `bin/activate` virtualenv layouts and this checkout has no `.venv`/`venv`.

Fixes #35580
