### PR TITLE
feat: add compression debounce controls

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1236,6 +1236,12 @@ def init_agent(
         pass
     compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in {"true", "1", "yes"}
     compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
+    try:
+        compression_min_interval_seconds = max(
+            0.0, float(_compression_cfg.get("min_interval_seconds", 0) or 0)
+        )
+    except (TypeError, ValueError):
+        compression_min_interval_seconds = 0.0
     compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
     # protect_first_n is the number of non-system messages to protect at
     # the head, in addition to the system prompt (which is always
@@ -1466,6 +1472,7 @@ def init_agent(
             provider=agent.provider,
             api_mode=agent.api_mode,
             abort_on_summary_failure=compression_abort_on_summary_failure,
+            min_interval_seconds=compression_min_interval_seconds,
         )
     agent.compression_enabled = compression_enabled
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -596,6 +596,7 @@ class ContextCompressor(ContextEngine):
         provider: str = "",
         api_mode: str = "",
         abort_on_summary_failure: bool = False,
+        min_interval_seconds: float = 0,
     ):
         self.model = model
         self.base_url = base_url
@@ -607,6 +608,14 @@ class ContextCompressor(ContextEngine):
         self.protect_last_n = protect_last_n
         self.summary_target_ratio = max(0.10, min(summary_target_ratio, 0.80))
         self.quiet_mode = quiet_mode
+        try:
+            self.min_interval_seconds = max(0.0, float(min_interval_seconds or 0))
+        except (TypeError, ValueError):
+            self.min_interval_seconds = 0.0
+        self._last_auto_compression_attempt_at: float = 0.0
+        self._last_compress_deferred_reason: Optional[str] = None
+        self._last_compress_status: str = "idle"
+        self._last_compress_reason: Optional[str] = None
         # When True, summary-generation failure aborts compression entirely
         # (returns messages unchanged, sets _last_compress_aborted=True).
         # When False (default = historical behavior), insert a
@@ -1854,12 +1863,17 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
         self._last_compress_aborted = False
+        self._last_compress_deferred_reason = None
+        self._last_compress_status = "started"
+        self._last_compress_reason = None
+        original_messages = messages
 
         # Manual /compress (force=True) bypasses the failure cooldown so the
         # user can retry immediately after an auto-compress abort.  Without
         # this, /compress would silently no-op for 30-60s after a failure.
         if force and self._summary_failure_cooldown_until > 0.0:
             self._summary_failure_cooldown_until = 0.0
+
         n_messages = len(messages)
         # Only need head + 3 tail messages minimum (token budget decides the real tail size)
         _min_for_compress = self._protect_head_size(messages) + 3 + 1
@@ -1869,9 +1883,38 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                     "Cannot compress: only %d messages (need > %d)",
                     n_messages, _min_for_compress,
                 )
+            self._last_compress_status = "skipped"
+            self._last_compress_reason = "too_few_messages"
             return messages
 
         display_tokens = current_tokens if current_tokens else self.last_prompt_tokens or estimate_messages_tokens_rough(messages)
+
+        # Determine whether there is an actual compression window before any
+        # cheap pre-pass mutates a copy of the messages. A min-interval defer
+        # must be a true no-op for all callers, including direct
+        # ContextCompressor.compress() users.
+        compress_start = self._protect_head_size(messages)
+        compress_start = self._align_boundary_forward(messages, compress_start)
+        compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
+
+        if compress_start >= compress_end:
+            self._last_compress_status = "skipped"
+            self._last_compress_reason = "no_compression_window"
+            return original_messages
+
+        min_interval_seconds = getattr(self, "min_interval_seconds", 0.0)
+        if not force and min_interval_seconds > 0:
+            now = time.monotonic()
+            last_attempt_at = getattr(self, "_last_auto_compression_attempt_at", 0.0)
+            if (
+                last_attempt_at > 0
+                and now - last_attempt_at < min_interval_seconds
+            ):
+                self._last_compress_status = "deferred"
+                self._last_compress_reason = "min_interval"
+                self._last_compress_deferred_reason = "min_interval"
+                return original_messages
+            self._last_auto_compression_attempt_at = now
 
         # Phase 1: Prune old tool results (cheap, no LLM call)
         messages, pruned_count = self._prune_old_tool_results(
@@ -1881,15 +1924,15 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         if pruned_count and not self.quiet_mode:
             logger.info("Pre-compression: pruned %d old tool result(s)", pruned_count)
 
-        # Phase 2: Determine boundaries
+        # Phase 2: Recompute boundaries after pruning/truncating copied messages.
         compress_start = self._protect_head_size(messages)
         compress_start = self._align_boundary_forward(messages, compress_start)
-
-        # Use token-budget tail protection instead of fixed message count
         compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
 
         if compress_start >= compress_end:
-            return messages
+            self._last_compress_status = "skipped"
+            self._last_compress_reason = "no_compression_window"
+            return original_messages
 
         turns_to_summarize = messages[compress_start:compress_end]
         # A persisted handoff summary can sit in the protected head after a
@@ -1951,6 +1994,8 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             self._last_summary_dropped_count = 0  # nothing actually dropped
             self._last_summary_fallback_used = False
             self._last_compress_aborted = True
+            self._last_compress_status = "aborted"
+            self._last_compress_reason = "summary_failure"
             if not self.quiet_mode:
                 logger.warning(
                     "Summary generation failed — aborting compression "
@@ -1959,7 +2004,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                     "frozen until the next /compress or /new.",
                     n_skipped,
                 )
-            return messages
+            return original_messages
 
         # Phase 4: Assemble compressed message list
         compressed = []
@@ -2075,4 +2120,6 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             )
             logger.info("Compression #%d complete", self.compression_count)
 
+        self._last_compress_status = "compressed"
+        self._last_compress_reason = None
         return compressed

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -50,6 +50,17 @@ class ContextEngine(ABC):
     context_length: int = 0
     compression_count: int = 0
 
+    # -- Last compression status (read by wrappers/persistence layers) --------
+    #
+    # Engines that can distinguish success/no-op should set these after each
+    # ``compress()`` call.  Supported status values are:
+    # ``compressed``, ``skipped``, ``deferred``, and ``aborted``.
+    # Legacy engines that do not set a status remain supported: wrappers infer
+    # success only when the returned messages differ from the input.
+    _last_compress_status: str | None = None
+    _last_compress_reason: str | None = None
+    _last_compress_aborted: bool = False
+
     # -- Compaction parameters (read by run_agent.py for preflight) --------
     #
     # These control the preflight compression check.  Subclasses may

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -425,13 +425,6 @@ def compress_context(
             except Exception as _rel_err:
                 logger.debug("compression lock release failed: %s", _rel_err)
 
-    # Notify external memory provider before compression discards context
-    if agent._memory_manager:
-        try:
-            agent._memory_manager.on_pre_compress(messages)
-        except Exception:
-            pass
-
     try:
         compressed = agent.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic, force=force)
     except TypeError:
@@ -444,11 +437,9 @@ def compress_context(
         _release_lock()
         raise
 
-    # If compression aborted (aux LLM failed to produce a usable summary)
-    # the compressor returns the input messages unchanged.  Surface the
-    # error to the user, skip the session-rotation work entirely (no
-    # session has logically ended), and let auto-compress callers detect
-    # the no-op via len(returned) == len(input).
+    # If compression aborted (aux LLM failed to produce a usable summary), the
+    # compressor returns the input messages unchanged. Surface the error to the
+    # user and skip session rotation entirely because no session logically ended.
     if getattr(agent.context_compressor, "_last_compress_aborted", False):
         _err = getattr(agent.context_compressor, "_last_summary_error", None) or "unknown error"
         if getattr(agent, "_last_compression_summary_warning", None) != _err:
@@ -463,6 +454,57 @@ def compress_context(
             _existing_sp = agent._build_system_prompt(system_message)
         _release_lock()  # compression aborted — no rotation will happen
         return messages, _existing_sp
+
+    if getattr(agent.context_compressor, "_last_compress_deferred_reason", None) == "min_interval":
+        logger.info(
+            "context compression deferred by compressor: session=%s reason=min_interval",
+            agent.session_id or "none",
+        )
+        _existing_sp = getattr(agent, "_cached_system_prompt", None)
+        if not _existing_sp:
+            _existing_sp = agent._build_system_prompt(system_message)
+        _release_lock()  # compression deferred — no rotation will happen
+        return messages, _existing_sp
+
+    _compress_status = getattr(agent.context_compressor, "_last_compress_status", None)
+    if not isinstance(_compress_status, str):
+        _compress_status = None
+
+    # Built-in ContextCompressor exposes an explicit status contract.  Legacy
+    # plugin engines may not yet set it, so infer success only when they return
+    # a changed message list.  Unchanged/no-status returns still fail closed and
+    # skip every post-success side effect below.
+    if _compress_status is None and compressed != messages:
+        _compress_status = "compressed"
+        try:
+            setattr(agent.context_compressor, "_last_compress_status", "compressed")
+            setattr(agent.context_compressor, "_last_compress_reason", None)
+        except Exception:
+            pass
+
+    if _compress_status != "compressed":
+        logger.info(
+            "context compression produced no confirmed mutation: "
+            "session=%s status=%s reason=%s",
+            agent.session_id or "none",
+            _compress_status,
+            getattr(agent.context_compressor, "_last_compress_reason", None),
+        )
+        _existing_sp = getattr(agent, "_cached_system_prompt", None)
+        if not _existing_sp:
+            _existing_sp = agent._build_system_prompt(system_message)
+        _release_lock()
+        return messages, _existing_sp
+
+    # Notify external memory provider before compression discards context.
+    # This runs only after the compressor actually proceeds; no-op paths
+    # (lock skip, summary abort, debounce defer) must not trigger memory or
+    # session-rotation side effects.
+    if agent._memory_manager:
+        try:
+            agent._memory_manager.on_pre_compress(messages)
+        except Exception:
+            pass
 
     summary_error = getattr(agent.context_compressor, "_last_summary_error", None)
     if summary_error:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -343,7 +343,7 @@ tool_loop_guardrails:
 # HOW IT WORKS:
 # 1. Tracks actual token usage from API responses (not estimates)
 # 2. When prompt_tokens >= threshold% of model's context_length, triggers compression
-# 3. Protects first 3 turns (system prompt, initial request, first response)
+# 3. Protects the system prompt plus the first N non-system head messages
 # 4. Protects last N turns (default 20 messages = ~10 full turns of recent context)
 # 5. Summarizes middle turns using a fast/cheap model
 # 6. Inserts summary as a user message, continues conversation seamlessly
@@ -366,6 +366,23 @@ compression:
   # Summary output is separately capped at 12K tokens (Gemini output limit).
   # Range: 0.10 - 0.80
   target_ratio: 0.20
+
+  # Minimum seconds between automatic compression attempts, including failed
+  # or aborted attempts (default: 0 = disabled).
+  # Applies to in-agent compression and gateway token-pressure hygiene. Gateway
+  # hard message-count safety compression and manual /compress bypass it.
+  min_interval_seconds: 0
+
+  # When true, preserve the original messages if the compression summarizer
+  # fails (for example provider 400 "bad format", timeout, or invalid
+  # auxiliary.compression configuration)
+  # instead of inserting a deterministic fallback marker and dropping the
+  # middle window. Recommended with flaky/strict auxiliary providers.
+  abort_on_summary_failure: false
+
+  # Gateway hard safety valve: force hygiene compression when a session reaches
+  # this many persisted messages. Bypasses min_interval_seconds.
+  hygiene_hard_message_limit: 400
 
   # Number of most-recent messages to always preserve (default: 20 ≈ 10 full turns)
   # Higher values keep more recent conversation intact at the cost of more aggressive

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -65,6 +65,7 @@ _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
+_HYGIENE_WARNING_COOLDOWN_SECS = 3600.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
@@ -8915,6 +8916,7 @@ class GatewayRunner:
             _hyg_threshold_pct = 0.85
             _hyg_compression_enabled = True
             _hyg_hard_msg_limit = 400
+            _hyg_min_interval_seconds = 0.0
             _hyg_config_context_length = None
             _hyg_provider = None
             _hyg_base_url = None
@@ -8941,9 +8943,9 @@ class GatewayRunner:
                         _hyg_provider = _model_cfg.get("provider") or None
                         _hyg_base_url = _model_cfg.get("base_url") or None
 
-                    # Read compression settings — only use enabled flag.
-                    # The threshold is intentionally separate from the agent's
-                    # compression.threshold (hygiene runs higher).
+                    # Read compression settings used by gateway hygiene.
+                    # The token threshold is intentionally separate from the
+                    # agent's compression.threshold (hygiene runs higher).
                     _comp_cfg = _hyg_data.get("compression", {})
                     if isinstance(_comp_cfg, dict):
                         _hyg_compression_enabled = str(
@@ -8957,6 +8959,13 @@ class GatewayRunner:
                                     _hyg_hard_msg_limit = _parsed
                             except (TypeError, ValueError):
                                 pass
+                        try:
+                            _hyg_min_interval_seconds = max(
+                                0.0,
+                                float(_comp_cfg.get("min_interval_seconds", 0) or 0),
+                            )
+                        except (TypeError, ValueError):
+                            _hyg_min_interval_seconds = 0.0
 
                 try:
                     _hyg_model, _hyg_runtime = self._resolve_session_agent_runtime(
@@ -9041,11 +9050,37 @@ class GatewayRunner:
                 # Threshold is configurable via
                 # compression.hygiene_hard_message_limit.
                 # (#2153)
-                _HARD_MSG_LIMIT = _hyg_hard_msg_limit
-                _needs_compress = (
-                    _approx_tokens >= _compress_token_threshold
-                    or _msg_count >= _HARD_MSG_LIMIT
-                )
+                _hard_msg_limit = _hyg_hard_msg_limit
+                _needs_compress_by_tokens = _approx_tokens >= _compress_token_threshold
+                _needs_compress_by_hard_limit = _msg_count >= _hard_msg_limit
+                _needs_compress = _needs_compress_by_tokens or _needs_compress_by_hard_limit
+
+                # Debounce routine token-pressure hygiene, but do not suppress the
+                # hard message-count safety valve. The hard limit exists to break
+                # oversized-session death spirals; if it is exceeded, we should keep
+                # trying even if a previous attempt was recent.
+                if (
+                    _needs_compress_by_tokens
+                    and not _needs_compress_by_hard_limit
+                    and _hyg_min_interval_seconds > 0
+                ):
+                    _now = time.time()
+                    _last_hyg_attempt = float(
+                        getattr(session_entry, "last_hygiene_compression_at", 0.0)
+                        or 0.0
+                    )
+                    _elapsed = _now - _last_hyg_attempt if _last_hyg_attempt > 0 else None
+                    if _elapsed is not None and _elapsed < 0:
+                        # Wall-clock moved backwards; do not over-defer.
+                        _elapsed = None
+                    if _elapsed is not None and _elapsed < _hyg_min_interval_seconds:
+                        _needs_compress = False
+                        _remaining = _hyg_min_interval_seconds - _elapsed
+                        logger.info(
+                            "Session hygiene: compression deferred by "
+                            "compression.min_interval_seconds (%.0fs remaining)",
+                            _remaining,
+                        )
 
                 if _needs_compress:
                     logger.info(
@@ -9088,6 +9123,13 @@ class GatewayRunner:
                                 try:
                                     _hyg_agent._print_fn = lambda *a, **kw: None
 
+                                    if _hyg_min_interval_seconds > 0:
+                                        session_entry.last_hygiene_compression_at = time.time()
+                                        try:
+                                            self.session_store._save()
+                                        except Exception:
+                                            pass
+
                                     loop = asyncio.get_running_loop()
                                     _compressed, _ = await loop.run_in_executor(
                                         None,
@@ -9097,97 +9139,197 @@ class GatewayRunner:
                                         ),
                                     )
 
-                                    # _compress_context ends the old session and creates
-                                    # a new session_id.  Write compressed messages into
-                                    # the NEW session so the old transcript stays intact
-                                    # and searchable via session_search.
-                                    _hyg_new_sid = _hyg_agent.session_id
-                                    if _hyg_new_sid != session_entry.session_id:
-                                        session_entry.session_id = _hyg_new_sid
-                                        self.session_store._save()
-                                        self._sync_telegram_topic_binding(
-                                            source, session_entry,
-                                            reason="hygiene-compression",
-                                        )
-
-                                    self.session_store.rewrite_transcript(
-                                        session_entry.session_id, _compressed
-                                    )
-                                    # Reset stored token count — transcript was rewritten
-                                    session_entry.last_prompt_tokens = 0
-                                    history = _compressed
-                                    _new_count = len(_compressed)
-                                    _new_tokens = estimate_messages_tokens_rough(
-                                        _compressed
-                                    )
-
-                                    logger.info(
-                                        "Session hygiene: compressed %s → %s msgs, "
-                                        "~%s → ~%s tokens",
-                                        _msg_count, _new_count,
-                                        f"{_approx_tokens:,}", f"{_new_tokens:,}",
-                                    )
-
-                                    if _new_tokens >= _warn_token_threshold:
-                                        logger.warning(
-                                            "Session hygiene: still ~%s tokens after "
-                                            "compression",
-                                            f"{_new_tokens:,}",
-                                        )
-
-                                    # If summary generation failed, the
-                                    # compressor aborts entirely and returns
-                                    # messages unchanged — nothing is dropped.
-                                    # Surface a visible warning to the gateway
-                                    # user — agent.log alone is invisible on
-                                    # TG/Discord/etc. — so they know the chat
-                                    # is "frozen" at the current size and can
-                                    # /compress to retry or /reset to start
-                                    # fresh.
                                     _comp = getattr(_hyg_agent, "context_compressor", None)
-                                    if _comp is not None and getattr(_comp, "_last_compress_aborted", False):
-                                        _err = getattr(_comp, "_last_summary_error", None) or "unknown error"
-                                        _warn_msg = (
-                                            "⚠️ Context compression aborted "
-                                            f"({_err}). No messages were dropped — "
-                                            "conversation is unchanged. Run /compress "
-                                            "to retry, /reset for a clean session, or "
-                                            "check your auxiliary.compression model "
-                                            "configuration."
+                                    if _comp is not None:
+                                        _comp_status = getattr(_comp, "_last_compress_status", None)
+                                        _comp_reason = getattr(_comp, "_last_compress_reason", None)
+                                        _comp_aborted = bool(
+                                            getattr(_comp, "_last_compress_aborted", False)
                                         )
-                                        try:
-                                            _adapter = self.adapters.get(source.platform)
-                                            if _adapter and source.chat_id:
-                                                await _adapter.send(source.chat_id, _warn_msg, metadata=_hyg_meta)
-                                        except Exception as _werr:
-                                            logger.warning(
-                                                "Failed to deliver compression-failure warning to user: %s",
-                                                _werr,
-                                            )
-                                    # Separately: if the user's CONFIGURED aux
-                                    # model failed and we recovered by falling
-                                    # back to the main model, tell them — a
-                                    # misconfigured auxiliary.compression.model
-                                    # is something only they can fix, and
-                                    # silent recovery would hide it.
-                                    elif _comp is not None and getattr(_comp, "_last_aux_model_failure_model", None):
-                                        _aux_model = getattr(_comp, "_last_aux_model_failure_model", "")
-                                        _aux_err = getattr(_comp, "_last_aux_model_failure_error", None) or "unknown error"
-                                        _aux_msg = (
-                                            f"ℹ️ Configured compression model `{_aux_model}` "
-                                            f"failed ({_aux_err}). Recovered using your main "
-                                            "model — context is intact — but you may want to "
-                                            "check `auxiliary.compression.model` in config.yaml."
+                                    else:
+                                        _comp_status = None
+                                        _comp_reason = None
+                                        _comp_aborted = False
+                                    if not isinstance(_comp_status, str):
+                                        _comp_status = None
+                                    _confirmed_compressed = (
+                                        _comp_status == "compressed" and not _comp_aborted
+                                    )
+                                    _hyg_new_sid = _hyg_agent.session_id
+
+                                    # Rewrite only on positive evidence of real compression.
+                                    # The hygiene input intentionally strips persisted messages down to
+                                    # role/content user+assistant pairs before compression. Rewriting the
+                                    # canonical transcript with that reduced list on any no-op/unknown path
+                                    # would drop tool messages, metadata, and other fields while claiming
+                                    # the conversation is unchanged.
+                                    if not _confirmed_compressed:
+                                        logger.info(
+                                            "Session hygiene: compression produced no mutation "
+                                            "for %s (status=%s reason=%s)",
+                                            session_entry.session_id,
+                                            _comp_status or ("aborted" if _comp_aborted else "unknown"),
+                                            _comp_reason,
                                         )
-                                        try:
-                                            _adapter = self.adapters.get(source.platform)
-                                            if _adapter and source.chat_id:
-                                                await _adapter.send(source.chat_id, _aux_msg, metadata=_hyg_meta)
-                                        except Exception as _werr:
-                                            logger.warning(
-                                                "Failed to deliver aux-model-fallback notice to user: %s",
-                                                _werr,
+                                        if _comp_aborted:
+                                            _err = _redact_gateway_user_facing_secrets(
+                                                getattr(_comp, "_last_summary_error", None)
+                                                or "unknown error"
                                             )
+                                            _warn_category = "compression-abort:"
+                                            _warn_key = f"{_warn_category}{_err}"
+                                            _warn_now = time.time()
+                                            _last_warn_key = getattr(
+                                                session_entry,
+                                                "last_hygiene_compression_warning_key",
+                                                "",
+                                            )
+                                            _last_warn_at = float(
+                                                getattr(
+                                                    session_entry,
+                                                    "last_hygiene_compression_warning_at",
+                                                    0.0,
+                                                ) or 0.0
+                                            )
+                                            _warn_recent = (
+                                                _last_warn_key.startswith(_warn_category)
+                                                and _last_warn_at > 0
+                                                and (
+                                                    _warn_now - _last_warn_at
+                                                    < _HYGIENE_WARNING_COOLDOWN_SECS
+                                                )
+                                            )
+                                            if _warn_recent:
+                                                logger.info(
+                                                    "Session hygiene: compression abort warning "
+                                                    "already sent recently for %s",
+                                                    session_entry.session_id,
+                                                )
+                                            else:
+                                                _warn_msg = (
+                                                    "⚠️ Context compression aborted "
+                                                    f"({_err}). No messages were dropped — "
+                                                    "conversation is unchanged. Run /compress "
+                                                    "to retry, or /reset (alias: /new) for "
+                                                    "a clean session. If this repeats, check "
+                                                    "auxiliary.compression.model."
+                                                )
+                                                try:
+                                                    _adapter = self.adapters.get(source.platform)
+                                                    if _adapter and source.chat_id:
+                                                        await _adapter.send(source.chat_id, _warn_msg, metadata=_hyg_meta)
+                                                        session_entry.last_hygiene_compression_warning_key = _warn_key
+                                                        session_entry.last_hygiene_compression_warning_at = _warn_now
+                                                        try:
+                                                            self.session_store._save()
+                                                        except Exception:
+                                                            pass
+                                                except Exception as _werr:
+                                                    logger.warning(
+                                                        "Failed to deliver compression-failure warning to user: %s",
+                                                        _werr,
+                                                    )
+                                    else:
+                                        # _compress_context ends the old session and creates
+                                        # a new session_id.  Write compressed messages into
+                                        # the NEW session so the old transcript stays intact
+                                        # and searchable via session_search.
+                                        if _hyg_new_sid != session_entry.session_id:
+                                            session_entry.session_id = _hyg_new_sid
+                                            self.session_store._save()
+                                            self._sync_telegram_topic_binding(
+                                                source, session_entry,
+                                                reason="hygiene-compression",
+                                            )
+
+                                        self.session_store.rewrite_transcript(
+                                            session_entry.session_id, _compressed
+                                        )
+                                        # Reset stored token count — transcript was rewritten
+                                        session_entry.last_prompt_tokens = 0
+                                        history = _compressed
+                                        _new_count = len(_compressed)
+                                        _new_tokens = estimate_messages_tokens_rough(
+                                            _compressed
+                                        )
+
+                                        logger.info(
+                                            "Session hygiene: compressed %s → %s msgs, "
+                                            "~%s → ~%s tokens",
+                                            _msg_count, _new_count,
+                                            f"{_approx_tokens:,}", f"{_new_tokens:,}",
+                                        )
+
+                                        if _new_tokens >= _warn_token_threshold:
+                                            logger.warning(
+                                                "Session hygiene: still ~%s tokens after "
+                                                "compression",
+                                                f"{_new_tokens:,}",
+                                            )
+
+                                        # If the user's CONFIGURED aux model failed and we recovered
+                                        # by falling back to the main model, tell them — a
+                                        # misconfigured auxiliary.compression.model is something only
+                                        # they can fix, and silent recovery would hide it.
+                                        if _comp is not None and getattr(_comp, "_last_aux_model_failure_model", None):
+                                            _aux_model = _redact_gateway_user_facing_secrets(
+                                                getattr(_comp, "_last_aux_model_failure_model", "")
+                                            )
+                                            _aux_err = _redact_gateway_user_facing_secrets(
+                                                getattr(_comp, "_last_aux_model_failure_error", None)
+                                                or "unknown error"
+                                            )
+                                            _warn_category = "compression-aux-fallback:"
+                                            _warn_key = f"{_warn_category}{_aux_model}:{_aux_err}"
+                                            _warn_now = time.time()
+                                            _last_warn_key = getattr(
+                                                session_entry,
+                                                "last_hygiene_compression_warning_key",
+                                                "",
+                                            )
+                                            _last_warn_at = float(
+                                                getattr(
+                                                    session_entry,
+                                                    "last_hygiene_compression_warning_at",
+                                                    0.0,
+                                                ) or 0.0
+                                            )
+                                            _warn_recent = (
+                                                _last_warn_key.startswith(_warn_category)
+                                                and _last_warn_at > 0
+                                                and (
+                                                    _warn_now - _last_warn_at
+                                                    < _HYGIENE_WARNING_COOLDOWN_SECS
+                                                )
+                                            )
+                                            if _warn_recent:
+                                                logger.info(
+                                                    "Session hygiene: aux-model fallback notice "
+                                                    "already sent recently for %s",
+                                                    session_entry.session_id,
+                                                )
+                                            else:
+                                                _aux_msg = (
+                                                    f"ℹ️ Configured compression model `{_aux_model}` "
+                                                    f"failed ({_aux_err}). Recovered using your main "
+                                                    "model — context is intact — but you may want to "
+                                                    "check `auxiliary.compression.model` in config.yaml."
+                                                )
+                                                try:
+                                                    _adapter = self.adapters.get(source.platform)
+                                                    if _adapter and source.chat_id:
+                                                        await _adapter.send(source.chat_id, _aux_msg, metadata=_hyg_meta)
+                                                        session_entry.last_hygiene_compression_warning_key = _warn_key
+                                                        session_entry.last_hygiene_compression_warning_at = _warn_now
+                                                        try:
+                                                            self.session_store._save()
+                                                        except Exception:
+                                                            pass
+                                                except Exception as _werr:
+                                                    logger.warning(
+                                                        "Failed to deliver aux-model-fallback notice to user: %s",
+                                                        _werr,
+                                                    )
                                 finally:
                                     # Evict the cached agent so the next turn
                                     # rebuilds its system prompt from current

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -452,6 +452,15 @@ class SessionEntry:
     
     # Last API-reported prompt tokens (for accurate compression pre-check)
     last_prompt_tokens: int = 0
+
+    # Wall-clock timestamp of the most recent gateway session-hygiene
+    # compression attempt. Persisted so debounce survives the fresh AIAgent
+    # instance created for each hygiene pass and gateway restarts.
+    last_hygiene_compression_at: float = 0.0
+    # Last visible hygiene compression abort warning; avoids chat spam when the
+    # same failing session is retried repeatedly.
+    last_hygiene_compression_warning_key: str = ""
+    last_hygiene_compression_warning_at: float = 0.0
     
     # Set when a session was created because the previous one expired;
     # consumed once by the message handler to inject a notice into context
@@ -506,6 +515,9 @@ class SessionEntry:
             "cache_write_tokens": self.cache_write_tokens,
             "total_tokens": self.total_tokens,
             "last_prompt_tokens": self.last_prompt_tokens,
+            "last_hygiene_compression_at": self.last_hygiene_compression_at,
+            "last_hygiene_compression_warning_key": self.last_hygiene_compression_warning_key,
+            "last_hygiene_compression_warning_at": self.last_hygiene_compression_warning_at,
             "estimated_cost_usd": self.estimated_cost_usd,
             "cost_status": self.cost_status,
             "expiry_finalized": self.expiry_finalized,
@@ -562,6 +574,9 @@ class SessionEntry:
             cache_write_tokens=data.get("cache_write_tokens", 0),
             total_tokens=data.get("total_tokens", 0),
             last_prompt_tokens=data.get("last_prompt_tokens", 0),
+            last_hygiene_compression_at=float(data.get("last_hygiene_compression_at", 0.0) or 0.0),
+            last_hygiene_compression_warning_key=data.get("last_hygiene_compression_warning_key", ""),
+            last_hygiene_compression_warning_at=float(data.get("last_hygiene_compression_warning_at", 0.0) or 0.0),
             estimated_cost_usd=data.get("estimated_cost_usd", 0.0),
             cost_status=data.get("cost_status", "unknown"),
             expiry_finalized=data.get("expiry_finalized", data.get("memory_flushed", False)),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1056,6 +1056,7 @@ DEFAULT_CONFIG = {
         "enabled": True,
         "threshold": 0.50,            # compress when context usage exceeds this ratio
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
+        "min_interval_seconds": 0,    # minimum seconds between automatic compression attempts
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 400,  # gateway session-hygiene force-compress threshold by message count
         "protect_first_n": 3,         # non-system head messages always preserved

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -74,6 +74,8 @@ def _build_agent_with_db(db: SessionDB, session_id: str):
     compressor.last_completion_tokens = 0
     compressor._last_summary_error = None
     compressor._last_compress_aborted = False
+    compressor._last_compress_status = "compressed"
+    compressor._last_compress_reason = None
     compressor._last_aux_model_failure_model = None
     compressor._last_aux_model_failure_error = None
     agent.context_compressor = compressor
@@ -171,6 +173,45 @@ def test_skipped_compression_returns_messages_unchanged(tmp_path: Path) -> None:
     assert agent.session_id == parent_sid
     # Compressor was never called (the skip happens before .compress())
     agent.context_compressor.compress.assert_not_called()
+
+
+def test_min_interval_defer_does_not_rotate_or_split_session(tmp_path: Path) -> None:
+    """Debounce defer is a no-op at the compress_context wrapper layer.
+
+    ContextCompressor.compress() returns the original messages when
+    min_interval_seconds is active.  compress_context() must treat that like
+    a skipped compression: no session split, no memory pre-compress hook, and
+    no compression-boundary callback.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "DEBOUNCE_DEFER_TEST"
+    db.create_session(parent_sid, source="discord")
+
+    agent = _build_agent_with_db(db, parent_sid)
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+    compressor = MagicMock()
+    compressor.compress.return_value = messages
+    compressor.compression_count = 0
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_compress_deferred_reason = "min_interval"
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+    agent.context_compressor = compressor
+    agent._memory_manager = MagicMock()
+    agent._cached_system_prompt = "cached system prompt"
+
+    returned, _sp = agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    assert returned is messages or returned == messages
+    assert agent.session_id == parent_sid
+    assert _count_children(db, parent_sid) == 0
+    assert db.get_compression_lock_holder(parent_sid) is None
+    agent._memory_manager.on_pre_compress.assert_not_called()
+    compressor.on_session_start.assert_not_called()
 
 
 class _NoLockSubsystemDB:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -175,6 +175,132 @@ class TestCompress:
         compressor.compress(msgs)
         assert compressor.compression_count == 2
 
+    def test_auto_compress_respects_min_interval_seconds(self):
+        """Automatic compression should debounce repeated summarizer calls."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "## Active Task\nfirst summary"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test/model",
+                protect_first_n=1,
+                protect_last_n=2,
+                min_interval_seconds=300,
+                quiet_mode=True,
+            )
+
+        msgs = [{"role": "system", "content": "System"}] + self._make_messages(12)
+        with (
+            patch("agent.context_compressor.time.monotonic", side_effect=[100.0, 100.0, 200.0]),
+            patch.object(c, "_find_tail_cut_by_tokens", return_value=10),
+            patch("agent.context_compressor.call_llm", return_value=mock_response) as call_llm,
+        ):
+            first = c.compress(msgs)
+            second = c.compress(msgs)
+
+        assert call_llm.call_count == 1
+        assert first != msgs
+        assert second is msgs
+        assert c._last_compress_status == "deferred"
+        assert c._last_compress_deferred_reason == "min_interval"
+
+    def test_min_interval_defer_is_true_noop_before_tool_pruning(self):
+        """Debounced auto compression should not prune or otherwise mutate context."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "## Active Task\nfirst summary"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test/model",
+                protect_first_n=1,
+                protect_last_n=2,
+                min_interval_seconds=300,
+                quiet_mode=True,
+            )
+        c.tail_token_budget = 1
+
+        long_tool_output = "x" * 500
+        msgs = [
+            {"role": "system", "content": "System"},
+            {"role": "user", "content": "please inspect"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": '{"command":"pytest"}'},
+                }],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": long_tool_output},
+        ] + self._make_messages(10)
+
+        with (
+            patch("agent.context_compressor.time.monotonic", side_effect=[100.0, 100.0, 200.0]),
+            patch.object(c, "_find_tail_cut_by_tokens", return_value=10),
+            patch("agent.context_compressor.call_llm", return_value=mock_response),
+        ):
+            c.compress(msgs)
+            second = c.compress(msgs)
+
+        assert c._last_compress_deferred_reason == "min_interval"
+        assert second is msgs
+        assert second[3]["content"] == long_tool_output
+
+    def test_force_compress_bypasses_min_interval_seconds(self):
+        """Manual /compress force=True should retry even during debounce."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "## Active Task\nforced summary"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test/model",
+                protect_first_n=1,
+                protect_last_n=2,
+                min_interval_seconds=300,
+                quiet_mode=True,
+            )
+
+        msgs = [{"role": "system", "content": "System"}] + self._make_messages(12)
+        with (
+            patch("agent.context_compressor.time.monotonic", side_effect=[100.0, 100.0, 200.0, 200.0]),
+            patch.object(c, "_find_tail_cut_by_tokens", return_value=10),
+            patch("agent.context_compressor.call_llm", return_value=mock_response) as call_llm,
+        ):
+            first = c.compress(msgs)
+            second = c.compress(msgs, force=True)
+
+        assert call_llm.call_count == 2
+        assert c._last_compress_status == "compressed"
+        assert c._last_compress_deferred_reason is None
+
+    def test_min_interval_default_zero_preserves_existing_behavior(self):
+        """Default debounce of zero should preserve back-to-back auto compression."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "## Active Task\ndefault summary"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test/model",
+                protect_first_n=1,
+                protect_last_n=2,
+                quiet_mode=True,
+            )
+
+        msgs = [{"role": "system", "content": "System"}] + self._make_messages(12)
+        with (
+            patch.object(c, "_find_tail_cut_by_tokens", return_value=10),
+            patch("agent.context_compressor.call_llm", return_value=mock_response) as call_llm,
+        ):
+            c.compress(msgs)
+            c.compress(msgs)
+
+        assert call_llm.call_count == 2
+
     def test_protects_first_and_last(self, compressor):
         msgs = self._make_messages(10)
         result = compressor.compress(msgs)
@@ -1056,6 +1182,77 @@ class TestAbortOnSummaryFailure:
         assert c._last_compress_aborted is False
         assert c._last_summary_fallback_used is False
         assert c._last_summary_dropped_count == 0
+
+    def test_summary_abort_records_attempt_for_min_interval_debounce(self):
+        """Strict provider 400s should preserve context when abort is enabled.
+
+        This mirrors provider/config-specific 400-format failures: abort + debounce
+        prevents fallback-marker context loss and immediate repeat attempts.
+        """
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=True,
+                min_interval_seconds=300,
+            )
+        msgs = self._make_msgs()
+        err = Exception("Error code: 400 - Chat completion bad format")
+
+        with (
+            patch("agent.context_compressor.time.monotonic", side_effect=[100.0, 101.0, 102.0, 200.0]),
+            patch("agent.context_compressor.call_llm", side_effect=err) as call_llm,
+        ):
+            first = c.compress(msgs)
+            assert first is msgs
+            assert c._last_compress_aborted is True
+            assert c._last_summary_fallback_used is False
+
+            second = c.compress(msgs)
+
+        assert call_llm.call_count == 1
+        assert second is msgs
+        assert c._last_compress_deferred_reason == "min_interval"
+        assert c._last_summary_fallback_used is False
+        assert not any(
+            isinstance(m.get("content"), str) and "Summary generation was unavailable" in m["content"]
+            for m in second
+        )
+
+    def test_abort_on_summary_failure_preserves_messages_before_tool_pruning(self):
+        """Abort must return the original context even when old tool output is prunable."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=1,
+                protect_last_n=1,
+                abort_on_summary_failure=True,
+            )
+        c.tail_token_budget = 1
+        long_tool_output = "TOOL_OUTPUT_" * 1000
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "head"},
+            {"role": "tool", "tool_call_id": "old-call", "content": long_tool_output},
+            {"role": "assistant", "content": "after tool"},
+            {"role": "user", "content": "msg 3"},
+            {"role": "assistant", "content": "msg 4"},
+            {"role": "user", "content": "msg 5"},
+            {"role": "assistant", "content": "tail"},
+        ]
+
+        with (
+            patch.object(c, "_find_tail_cut_by_tokens", return_value=6),
+            patch("agent.context_compressor.call_llm", side_effect=Exception("400 bad format")),
+        ):
+            result = c.compress(msgs)
+
+        assert c._last_compress_aborted is True
+        assert result == msgs
+        assert any(m.get("content") == long_tool_output for m in result)
 
     def test_force_true_bypasses_failure_cooldown(self):
         """Manual /compress passes force=True so it can retry immediately

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -336,7 +336,7 @@ async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, t
     runner._voice_mode = {}
     runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
     runner.session_store = MagicMock()
-    runner.session_store.get_or_create_session.return_value = SessionEntry(
+    session_entry = SessionEntry(
         session_key="agent:main:telegram:group:-1001:17585",
         session_id="sess-1",
         created_at=datetime.now(),
@@ -344,6 +344,7 @@ async def test_session_hygiene_messages_stay_in_originating_topic(monkeypatch, t
         platform=Platform.TELEGRAM,
         chat_type="group",
     )
+    runner.session_store.get_or_create_session.return_value = session_entry
     runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
     runner.session_store.has_any_sessions.return_value = True
     runner.session_store.rewrite_transcript = MagicMock()
@@ -408,20 +409,27 @@ async def test_session_hygiene_warns_user_when_compression_aborts(monkeypatch, t
 
     class FakeCompressAgentWithSummaryFailure:
         last_instance = None
+        attempts = 0
 
         def __init__(self, **kwargs):
+            type(self).attempts += 1
             self.model = kwargs.get("model")
             self.session_id = kwargs.get("session_id", "fake-session")
             self._print_fn = None
             self.shutdown_memory_provider = MagicMock()
             self.close = MagicMock()
             # Simulate a compressor that hit summary-generation failure
-            # and ABORTED — no fallback inserted, no messages dropped.
+            # and ABORTED — no fallback inserted, no messages dropped. The
+            # request id changes on every attempt so the test proves cooldown
+            # is category-based, not exact-error-text-based.
             self.context_compressor = SimpleNamespace(
                 _last_compress_aborted=True,
                 _last_summary_fallback_used=False,
                 _last_summary_dropped_count=0,
-                _last_summary_error="404 model not found: gemini-3-flash-preview",
+                _last_summary_error=(
+                    f"404 model not found: gemini-3-flash-preview "
+                    f"request-{type(self).attempts} sk-testSECRET123456789"
+                ),
             )
             type(self).last_instance = self
 
@@ -506,12 +514,109 @@ async def test_session_hygiene_warns_user_when_compression_aborts(monkeypatch, t
     # Warning must include the underlying error and tell the user nothing
     # was dropped.
     assert "404" in warn["content"]
+    assert "[REDACTED]" in warn["content"]
+    assert "sk-testSECRET" not in warn["content"]
     assert "No messages were dropped" in warn["content"]
+    assert "/reset (alias: /new)" in warn["content"]
+    assert "auxiliary.compression.model" in warn["content"]
     # Warning must land in the originating topic/thread, not the main channel.
     assert warn["chat_id"] == "-1001"
     assert warn["metadata"] == {"thread_id": "17585"}
+    # Abort/no-op must not rewrite the canonical transcript with the hygiene
+    # agent's reduced user/assistant-only message list.
+    runner.session_store.rewrite_transcript.assert_not_called()
+
+    # Repeating the same abort inside the warning cooldown should not spam the
+    # chat/thread with another visible warning.
+    second = await runner._handle_message(event)
+    assert second == "ok"
+    warning_messages = [s for s in adapter.sent if "Context compression aborted" in s["content"]]
+    assert len(warning_messages) == 1, adapter.sent
 
     FakeCompressAgentWithSummaryFailure.last_instance.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_session_hygiene_non_compressed_status_does_not_rewrite_transcript(monkeypatch, tmp_path):
+    """Gateway hygiene must fail closed when wrapper returns unchanged messages without confirmed compression."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FakeNoopCompressAgent:
+        last_instance = None
+
+        def __init__(self, **kwargs):
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self._print_fn = None
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+            self.context_compressor = SimpleNamespace(
+                _last_compress_aborted=False,
+                _last_compress_status="idle",
+                _last_compress_reason=None,
+            )
+            type(self).last_instance = self
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            # Wrapper/legacy no-op that nevertheless rotates internally; gateway
+            # must not treat session_id change alone as proof of compression.
+            self.session_id = f"{self.session_id}_rotated"
+            return (messages, None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeNoopCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    session_entry = SessionEntry(
+        session_key="agent:main:telegram:private:12345",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="private",
+    )
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = _make_history(6, content_size=400)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(return_value={"final_response": "ok", "messages": [], "tools": [], "history_offset": 0, "last_prompt_tokens": 0})
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", lambda *_args, **_kwargs: 100)
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="private", user_id="12345"),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert session_entry.session_id == "sess-1"
+    runner.session_store.rewrite_transcript.assert_not_called()
+    FakeNoopCompressAgent.last_instance.close.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -527,21 +632,31 @@ async def test_session_hygiene_informs_user_when_aux_model_fails_but_recovers(mo
 
     class FakeCompressAgentWithAuxRecovery:
         last_instance = None
+        attempts = 0
 
         def __init__(self, **kwargs):
+            type(self).attempts += 1
             self.model = kwargs.get("model")
             self.session_id = kwargs.get("session_id", "fake-session")
             self._print_fn = None
             self.shutdown_memory_provider = MagicMock()
             self.close = MagicMock()
             # Compression succeeded (no placeholder inserted) but the
-            # configured aux model errored and we fell back to main.
+            # configured aux model errored and we fell back to main. The
+            # request id changes on every attempt so the test proves cooldown
+            # is category-based, not exact-error-text-based.
             self.context_compressor = SimpleNamespace(
                 _last_summary_fallback_used=False,
                 _last_summary_dropped_count=0,
                 _last_summary_error=None,
                 _last_aux_model_failure_model="gemini-3-flash-preview",
-                _last_aux_model_failure_error="404 model not found",
+                _last_aux_model_failure_error=(
+                    f"404 model not found request-{type(self).attempts} "
+                    "sk-testSECRET123456789"
+                ),
+                _last_compress_status="compressed",
+                _last_compress_reason=None,
+                _last_compress_aborted=False,
             )
             type(self).last_instance = self
 
@@ -630,10 +745,22 @@ async def test_session_hygiene_informs_user_when_aux_model_fails_but_recovers(mo
     note = aux_notes[0]
     assert "gemini-3-flash-preview" in note["content"]
     assert "404" in note["content"]
+    assert "[REDACTED]" in note["content"]
+    assert "sk-testSECRET" not in note["content"]
     assert "auxiliary.compression.model" in note["content"]
     # Note must land in the originating topic/thread.
     assert note["chat_id"] == "-1001"
     assert note["metadata"] == {"thread_id": "17585"}
+
+    # Repeating the same fallback inside the warning cooldown should not spam
+    # the chat/thread with another visible note.
+    second = await runner._handle_message(event)
+    assert second == "ok"
+    aux_notes = [
+        s for s in adapter.sent
+        if "Configured compression model" in s["content"]
+    ]
+    assert len(aux_notes) == 1, adapter.sent
 
     FakeCompressAgentWithAuxRecovery.last_instance.close.assert_called_once()
 
@@ -662,6 +789,11 @@ async def test_session_hygiene_honors_configurable_hard_message_limit(
             self._print_fn = None
             self.shutdown_memory_provider = MagicMock()
             self.close = MagicMock()
+            self.context_compressor = SimpleNamespace(
+                _last_compress_status="compressed",
+                _last_compress_reason=None,
+                _last_compress_aborted=False,
+            )
             type(self).last_instance = self
 
         def _compress_context(self, messages, *_args, **_kwargs):
@@ -678,10 +810,12 @@ async def test_session_hygiene_honors_configurable_hard_message_limit(
         "compression:\n"
         "  enabled: true\n"
         "  hygiene_hard_message_limit: 10\n"
+        "  min_interval_seconds: 300\n"
     )
 
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
+    monkeypatch.setattr(gateway_run.time, "time", lambda: 1000.0)
 
     adapter = HygieneCaptureAdapter()
     runner = object.__new__(GatewayRunner)
@@ -699,6 +833,7 @@ async def test_session_hygiene_honors_configurable_hard_message_limit(
         updated_at=datetime.now(),
         platform=Platform.TELEGRAM,
         chat_type="private",
+        last_hygiene_compression_at=900.0,
     )
     # 12 messages: below 400 default → no compression without override,
     # but above the configured limit of 10 → should compress.
@@ -748,12 +883,105 @@ async def test_session_hygiene_honors_configurable_hard_message_limit(
     result = await runner._handle_message(event)
 
     assert result == "ok"
-    # The compression agent was instantiated → hard-limit fired on the
-    # configured value (10), not the hardcoded 400 default.
+    # The compression agent was instantiated and its output was committed →
+    # hard-limit fired on the configured value (10), not the hardcoded 400 default.
     assert FakeCompressAgent.last_instance is not None, (
         "Expected hygiene compression to fire when message count (12) "
         "exceeds configured hygiene_hard_message_limit (10)"
     )
+    runner.session_store.rewrite_transcript.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_session_hygiene_respects_min_interval_across_fresh_agents(
+    monkeypatch, tmp_path
+):
+    """Gateway hygiene should debounce token-pressure attempts across fresh AIAgents.
+
+    The timestamp lives on SessionEntry, not ContextCompressor, so repeated
+    gateway turns cannot hammer the compression summarizer while a session is
+    already above the token threshold but below the hard message-count safety valve.
+    """
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FakeCompressAgent:
+        last_instance = None
+
+        def __init__(self, **kwargs):
+            type(self).last_instance = self
+            self.session_id = kwargs.get("session_id", "fake-session")
+            self._print_fn = None
+            self.shutdown_memory_provider = MagicMock()
+            self.close = MagicMock()
+
+        def _compress_context(self, messages, *_args, **_kwargs):
+            self.session_id = f"{self.session_id}_compressed"
+            return ([{"role": "assistant", "content": "compressed"}], None)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeCompressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        "compression:\n"
+        "  enabled: true\n"
+        "  min_interval_seconds: 300\n"
+    )
+
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+    monkeypatch.setattr(gateway_run.time, "time", lambda: 1000.0)
+
+    adapter = HygieneCaptureAdapter()
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    session_entry = SessionEntry(
+        session_key="agent:main:telegram:private:12345",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="private",
+        last_hygiene_compression_at=900.0,
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = _make_history(12, content_size=5_000)
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._run_agent = AsyncMock(return_value={"final_response": "ok", "messages": [], "tools": [], "history_offset": 0, "last_prompt_tokens": 0})
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    monkeypatch.setattr("agent.model_metadata.get_model_context_length", lambda *_args, **_kwargs: 100)
+
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="private", user_id="12345"),
+        message_id="1",
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result == "ok"
+    assert FakeCompressAgent.last_instance is None
+    assert session_entry.last_hygiene_compression_at == 900.0
+    runner.session_store.rewrite_transcript.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -778,6 +778,12 @@ class TestUserMessagePreviewConfig:
         assert preview["last_lines"] == 2
 
 
+class TestCompressionConfig:
+    def test_default_config_includes_min_interval_seconds(self):
+        compression = DEFAULT_CONFIG["compression"]
+        assert compression["min_interval_seconds"] == 0
+
+
 class TestEnvWriteDenylist:
     """``save_env_value`` refuses to persist env-var names that
     influence how subprocesses execute — ``LD_PRELOAD``, ``PYTHONPATH``,

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -56,6 +56,8 @@ class TestCompressionBoundaryHook:
             # conversation_compression.py does not short-circuit before the
             # session-id rotation we are asserting on.
             compressor._last_compress_aborted = False
+            compressor._last_compress_status = "compressed"
+            compressor._last_compress_reason = None
             agent.context_compressor = compressor
 
             original_sid = agent.session_id
@@ -127,6 +129,75 @@ class TestCompressionBoundaryHook:
             f"got {comp_calls!r}"
         )
 
+    def test_no_status_unchanged_result_does_not_rotate_session(self):
+        """Legacy/no-status compressors returning unchanged messages must fail closed."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+
+            class LegacyNoStatusCompressor:
+                compression_count = 0
+                last_prompt_tokens = 0
+                last_completion_tokens = 0
+                _last_summary_error = None
+                _last_compress_aborted = False
+
+                def __init__(self):
+                    self.on_session_start = MagicMock()
+
+                def compress(self, messages, **_kwargs):
+                    return messages
+
+            compressor = LegacyNoStatusCompressor()
+            agent.context_compressor = compressor
+            original_sid = agent.session_id
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+
+            compressed, _prompt = agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+            assert compressed is messages
+            assert agent.session_id == original_sid
+            compressor.on_session_start.assert_not_called()
+
+    def test_no_status_changed_result_rotates_for_legacy_plugins(self):
+        """Legacy/no-status compressors that actually change messages still work."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            agent = self._make_agent(db)
+
+            class LegacyNoStatusCompressor:
+                compression_count = 1
+                last_prompt_tokens = 0
+                last_completion_tokens = 0
+                _last_summary_error = None
+                _last_compress_aborted = False
+
+                def __init__(self):
+                    self.on_session_start = MagicMock()
+
+                def compress(self, _messages, **_kwargs):
+                    return [{"role": "user", "content": "compressed legacy output"}]
+
+            compressor = LegacyNoStatusCompressor()
+            agent.context_compressor = compressor
+            original_sid = agent.session_id
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+
+            compressed, _prompt = agent._compress_context(messages, "sys", approx_tokens=10_000)
+
+            assert compressed != messages
+            assert agent.session_id != original_sid
+            assert getattr(compressor, "_last_compress_status") == "compressed"
+            comp_calls = [
+                c for c in compressor.on_session_start.call_args_list
+                if c.kwargs.get("boundary_reason") == "compression"
+            ]
+            assert comp_calls
+
     def test_hook_failure_does_not_break_compression(self):
         """If the context engine raises from on_session_start, compression still completes."""
         from hermes_state import SessionDB
@@ -142,6 +213,8 @@ class TestCompressionBoundaryHook:
             compressor.last_completion_tokens = 0
             compressor._last_summary_error = None
             compressor._last_compress_aborted = False
+            compressor._last_compress_status = "compressed"
+            compressor._last_compress_reason = None
 
             # Raise only on the compression-boundary call, not on earlier calls.
             def _raise_on_compression(*args, **kwargs):

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -67,6 +67,33 @@ def test_plugin_engine_gets_context_length_on_init():
     assert engine.threshold_tokens == int(204_800 * engine.threshold_percent)
 
 
+def test_builtin_compressor_receives_min_interval_config():
+    """compression.min_interval_seconds should propagate into ContextCompressor."""
+    cfg = {
+        "compression": {"min_interval_seconds": 300},
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.context_compressor.min_interval_seconds == 300.0
+
+
 def test_active_context_engine_tools_survive_explicit_platform_toolsets():
     """LCM-style recovery tools must survive saved `hermes tools` lists."""
     engine = _ToolEngine()

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -60,7 +60,14 @@ grow too large between turns (e.g., overnight accumulation in Telegram/Discord).
 - **Threshold**: Fixed at 85% of model context length
 - **Token source**: Prefers actual API-reported tokens from last turn; falls back
   to rough character-based estimate (`estimate_messages_tokens_rough`)
-- **Fires**: Only when `len(history) >= 4` and compression is enabled
+- **Eligible**: Only when `len(history) >= 4` and compression is enabled;
+  actual attempts depend on token pressure, hard message limit, and debounce
+- **Debounce**: Honors `compression.min_interval_seconds` for token-pressure
+  attempts using a persisted per-session timestamp, because hygiene creates a
+  fresh `AIAgent` for each compression attempt. The hard message-count safety
+  valve bypasses this debounce.
+- **Hard message limit**: Also runs when history reaches
+  `compression.hygiene_hard_message_limit` messages (default: 400)
 - **Purpose**: Catch sessions that escaped the agent's own compressor
 
 The gateway hygiene threshold is intentionally higher than the agent's compressor.
@@ -83,7 +90,12 @@ compression:
   enabled: true              # Enable/disable compression (default: true)
   threshold: 0.50            # Fraction of context window (default: 0.50 = 50%)
   target_ratio: 0.20         # How much of threshold to keep as tail (default: 0.20)
+  min_interval_seconds: 0    # Debounce in-agent and gateway token-pressure attempts
+  abort_on_summary_failure: false
+  # Preserve original context instead of fallback marker on summary failure
+  protect_first_n: 3         # Non-system head messages to preserve; system prompt is always preserved
   protect_last_n: 20         # Minimum protected tail messages (default: 20)
+  hygiene_hard_message_limit: 400  # Gateway hard safety valve; bypasses debounce
 
 # Summarization model/provider configured under auxiliary:
 auxiliary:
@@ -99,8 +111,11 @@ auxiliary:
 |-----------|---------|-------|-------------|
 | `threshold` | `0.50` | 0.0-1.0 | Compression triggers when prompt tokens ≥ `threshold × context_length` |
 | `target_ratio` | `0.20` | 0.10-0.80 | Controls tail protection token budget: `threshold_tokens × target_ratio` |
+| `min_interval_seconds` | `0` | ≥0 | Minimum seconds between in-agent and gateway token-pressure compression attempts; `0` disables debounce. Manual `/compress` and gateway hard message-count safety compression bypass it. |
+| `abort_on_summary_failure` | `false` | bool | When `true`, failed summary generation preserves original messages instead of inserting a deterministic fallback marker and dropping the middle window. Useful for strict/flaky providers that return 400 `bad format`, timeouts, or malformed responses. |
 | `protect_last_n` | `20` | ≥1 | Minimum number of recent messages always preserved |
-| `protect_first_n` | `3` | (hardcoded) | System prompt + first exchange always preserved |
+| `protect_first_n` | `3` | ≥0 | Number of non-system head messages to preserve; the system prompt is always preserved implicitly |
+| `hygiene_hard_message_limit` | `400` | ≥1 | Gateway safety valve: attempts hygiene compression once history reaches this many messages, bypassing `min_interval_seconds` |
 
 ### Computed Values (for a 200K context model at defaults)
 
@@ -143,7 +158,7 @@ outputs (file contents, terminal output, search results).
 ┌─────────────────────────────────────────────────────────────┐
 │  Message list                                               │
 │                                                             │
-│  [0..2]  ← protect_first_n (system + first exchange)        │
+│  [head] ← system + protect_first_n non-system messages        │
 │  [3..N]  ← middle turns → SUMMARIZED                        │
 │  [N..end] ← tail (by token budget OR protect_last_n)        │
 │                                                             │
@@ -161,7 +176,7 @@ to find the parent assistant message, keeping groups intact.
 ### Phase 3: Generate Structured Summary
 
 :::warning Summary model context length
-The summary model must have a context window **at least as large** as the main agent model's. The entire middle section is sent to the summary model in a single `call_llm(task="compression")` call. If the summary model's context is smaller, the API returns a context-length error — `_generate_summary()` catches it, logs a warning, and returns `None`. The compressor then drops the middle turns **without a summary**, silently losing conversation context. This is the most common cause of degraded compaction quality.
+The summary model should have enough context for the middle section sent in a single `call_llm(task="compression")` call. If the summary model's context is too small, the API may return a context-length error — `_generate_summary()` catches it, logs a warning, and returns `None`. With the default `abort_on_summary_failure: false`, Hermes inserts a deterministic “summary unavailable” fallback marker before dropping the middle window; with `abort_on_summary_failure: true`, Hermes preserves the original messages unchanged and aborts compression.
 :::
 
 The middle turns are summarized using the auxiliary LLM with a structured

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -629,6 +629,7 @@ All compression settings live in `config.yaml` (no environment variables).
 compression:
   enabled: true                                     # Toggle compression on/off
   threshold: 0.50                                   # Compress at this % of context limit
+  min_interval_seconds: 0                           # Minimum seconds between automatic attempts (0 = disabled)
   target_ratio: 0.20                                # Fraction of threshold to preserve as recent tail
   protect_last_n: 20                                # Min recent messages to keep uncompressed
   protect_first_n: 3                                # Non-system head messages pinned across compactions (0 = pin nothing)
@@ -646,7 +647,9 @@ auxiliary:
 Older configs with `compression.summary_model`, `compression.summary_provider`, and `compression.summary_base_url` are automatically migrated to `auxiliary.compression.*` on first load (config version 17). No manual action needed.
 :::
 
-`hygiene_hard_message_limit` is a gateway-only **pre-compression safety valve**. Runaway sessions with thousands of messages can hit model context limits before the normal percent-of-context threshold fires; when message count crosses this ceiling, Hermes forces compression regardless of token usage. Default `400` — raise it for platforms where very long sessions are normal, lower it to force more aggressive compression. Editing this value on a running gateway takes effect on the next message (see below).
+`min_interval_seconds` debounces automatic compression attempts. Default `0` preserves immediate retry behavior. When set above zero, failed/aborted attempts are also debounced so a bad summary model or transient provider outage cannot spam repeated compression calls. Manual `force=True` paths bypass the debounce.
+
+`hygiene_hard_message_limit` is a gateway-only **pre-compression safety valve**. Runaway sessions with thousands of messages can hit model context limits before the normal percent-of-context threshold fires; when message count crosses this ceiling, Hermes forces compression regardless of token usage and ignores `min_interval_seconds`. Default `400` — raise it for platforms where very long sessions are normal, lower it to force more aggressive compression. Editing this value on a running gateway takes effect on the next message (see below).
 
 `protect_first_n` controls how many **non-system** head messages are pinned across every compaction. Default `3` — the opening user/assistant exchange survives every summarizer pass so the original goal stays visible. On long-running rolling-compaction sessions where the opening turn is no longer relevant, set `protect_first_n: 0` to pin nothing but the system prompt + summary + tail. The system prompt itself is always preserved regardless of this setting.
 
@@ -691,7 +694,7 @@ Points at a custom OpenAI-compatible endpoint. Uses `OPENAI_API_KEY` for auth.
 | any | set | Use the custom endpoint directly (provider ignored) |
 
 :::warning Summary model context length requirement
-The summary model **must** have a context window at least as large as your main agent model's. The compressor sends the full middle section of the conversation to the summary model — if that model's context window is smaller than the main model's, the summarization call will fail with a context length error. When this happens, the middle turns are **dropped without a summary**, losing conversation context silently. If you override the model, verify its context length meets or exceeds your main model's.
+The summary model **must** have a context window at least as large as your main agent model's. The compressor sends the full middle section of the conversation to the summary model — if that model's context window is smaller than the main model's, the summarization call can fail with a context length error. By default Hermes falls back to a compact marker instead of silently dropping middle turns. If `compression.abort_on_summary_failure: true` is set, compression aborts and leaves the conversation unchanged so you can fix the summary model and retry. If you override the model, verify its context length meets or exceeds your main model's.
 :::
 
 ## Context Engine


### PR DESCRIPTION
## Summary

Adds safer Hermes context compression debounce/backoff controls and gateway session hygiene around compression outcomes.

- Add `compression.min_interval_seconds` config default and propagation into `ContextCompressor`.
- Debounce automatic compression while preserving `force=True` behavior.
- Keep deferred automatic compression as a no-op that returns original messages.
- Harden gateway/session handling so abort/defer/no-op compression outcomes do not rotate or rewrite session state incorrectly.
- Add warning dedupe/cooldown for gateway compression/rate-limit/fallback user notices, including dynamic provider error text.
- Document configuration behavior without changing localized docs.

## Why

Automatic context compression can be attempted repeatedly around token-limit boundaries. This change adds a configurable minimum interval for automatic attempts and makes gateway session persistence more conservative when compression is skipped, deferred, or aborted.

## How to test

Recommended contributor test wrapper, focused on the changed and adjacent paths:

```text
scripts/run_tests.sh tests/agent/test_context_compressor.py tests/gateway/test_session_hygiene.py tests/run_agent/test_plugin_context_engine_init.py tests/hermes_cli/test_config.py tests/run_agent/test_compression_boundary_hook.py tests/agent/test_compression_concurrent_fork.py
```

Latest local result:

```text
223 passed, 0 failed in 6.3s
```

Additional pre-publish validation run twice after the final amend:

```text
214 passed
ruff: All checks passed
compileall: passed
docs/config sanity: passed; no localized docs touched
git diff --check: passed
git diff --check origin/main...HEAD: passed
secret assignment scan: passed
shell injection marker scan: passed
eval/exec scan: passed
pickle scan: passed
```

Manual smoke:

```text
ContextCompressor min_interval construction and repeated compression call: passed
hermes --version: Hermes Agent v0.15.1
```

## Platforms tested

- WSL2 on Windows, Python 3.11.14

## Related issues

- No public issue linked.
