### PR TITLE
docs(skills): add bundled troubleshooting notes

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -140,6 +140,18 @@ hermes mcp test NAME        Test connection
 hermes mcp configure NAME   Toggle tool selection
 ```
 
+When a stdio MCP server argument starts with `-`, pass it through the
+equals form so argparse keeps it attached to `--args`:
+
+```bash
+hermes mcp add example-server \
+  --command /path/to/server \
+  --args=--transport=stdio
+```
+
+The space form (`--args "--transport=stdio"`) can be misread as a top-level
+Hermes option because `--args` accepts zero or more values.
+
 ### Gateway (Messaging Platforms)
 
 ```
@@ -289,6 +301,11 @@ The registry of record is `hermes_cli/commands.py` — every consumer
 /kanban [sub]        Multi-profile collaboration board (tasks, links, comments)
 /plugins             List plugins (CLI)
 ```
+
+Installed skills also expose dynamic slash commands named after the skill
+(for example `/github-auth`). Use `/skill <name>` or preload with
+`hermes --skills <name>` / `hermes -s <name>` when that is clearer for the
+session.
 
 ### Gateway
 ```
@@ -825,7 +842,8 @@ and logs — avoids shell-escaping backslashes in bash.
 ### Skills not showing
 1. `hermes skills list` — verify installed
 2. `hermes skills config` — check platform enablement
-3. Load explicitly: `/skill name` or `hermes -s name`
+3. Load explicitly: use `/skill name`, the skill's own slash command
+   such as `/github-auth`, or `hermes -s name`
 
 ### Gateway issues
 Check logs first:
@@ -837,6 +855,8 @@ Common gateway problems:
 - **Gateway dies on SSH logout**: Enable linger: `sudo loginctl enable-linger $USER`
 - **Gateway dies on WSL2 close**: WSL2 requires `systemd=true` in `/etc/wsl.conf` for systemd services to work. Without it, gateway falls back to `nohup` (dies when session closes).
 - **Gateway crash loop**: Reset the failed state: `systemctl --user reset-failed hermes-gateway`
+- **Gateway sends "Still working..." pings**: These are emitted by the gateway, not by the agent response. They are controlled by `agent.gateway_notify_interval` (default `180` seconds, bridged to `HERMES_AGENT_NOTIFY_INTERVAL`). To disable them for a profile, run `hermes -p <profile> config set agent.gateway_notify_interval 0` and restart that profile's gateway. Prompt or memory instructions alone do not suppress the notifier.
+- **`sudo hermes ...` says `sudo: hermes: command not found`**: `sudo` may use a secure PATH that excludes user-local installs such as `~/.local/bin/hermes`. Check the path with `command -v hermes`, then use the absolute path, for example `sudo /home/<user>/.local/bin/hermes gateway restart --system`, or operate the unit directly with `sudo systemctl restart hermes-gateway.service`.
 
 ### Platform-specific issues
 - **Discord bot silent**: Must enable **Message Content Intent** in Bot → Privileged Gateway Intents.

--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -37,6 +37,22 @@ git config --global credential.helper 2>/dev/null || echo "no git credential hel
 2. If `gh` is installed but not authenticated → use "gh auth" method below
 3. If `gh` is not installed → use "git-only" method below (no sudo needed)
 
+### Repository context before auth diagnosis
+
+A GitHub command failing in the current directory does not prove GitHub is
+unauthenticated. Establish repository context first:
+
+```bash
+pwd
+git rev-parse --show-toplevel 2>/dev/null || echo "not in a git repository"
+gh auth status 2>/dev/null || true
+```
+
+- If `gh auth status` succeeds but `git rev-parse` reports "not in a git repository", fix the working directory or repository selection instead of re-authenticating.
+- Run repo-scoped commands from the owning checkout, either by setting the tool working directory or by using `cd /abs/path && ...`.
+- For `gh` commands that support it, use `-R OWNER/REPO` when no local checkout is needed.
+- Only diagnose an auth failure after both the repo-context check and the auth/token check fail.
+
 ---
 
 ## Method 1: Git-Only Authentication (No gh, No sudo)


### PR DESCRIPTION
## What does this PR do?

Adds small recurring troubleshooting and usage notes to bundled skills so users do not need local skill edits for common Hermes setup issues.

This keeps the change docs-only and tied to current source behavior:
- gateway \"Still working...\" pings are configured by `agent.gateway_notify_interval`, bridged to `HERMES_AGENT_NOTIFY_INTERVAL`, and disabled with `0`
- `sudo hermes ...` may fail when sudo's secure PATH excludes a user-local Hermes install
- `hermes mcp add --args` needs the equals form for arguments that start with `-`
- installed skills can be invoked by dynamic slash commands or preloaded with `--skills` / `-s`
- GitHub auth diagnosis should first establish repository context

Duplicate PR search completed before editing: no open PR matched `35405`; key-term searches for gateway notify interval, sudo secure PATH, MCP `--args`, and repo-context/auth diagnosis found related gateway/MCP/auth PRs but no active equivalent bundled-skill docs PR.

## Related Issue

Fixes #35405

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `skills/autonomous-ai-agents/hermes-agent/SKILL.md` with MCP `--args` quoting guidance, dynamic skill slash-command usage, gateway notify-interval troubleshooting, and sudo secure PATH troubleshooting.
- Updated `skills/github/github-auth/SKILL.md` to check repository context before diagnosing auth failures.

## How to Test

1. `git diff --check`
2. `python3` markdown/frontmatter/code-fence sanity check for the two touched `SKILL.md` files
3. `rg` source/doc anchor check for `gateway_notify_interval`, `HERMES_AGENT_NOTIFY_INTERVAL`, `--args=--transport=stdio`, repository-context wording, dynamic slash-command wording, and sudo secure PATH wording

Docs-only change; I did not run the full pytest suite.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, docs-only checks listed above

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A - this updates existing bundled skill documentation only.

## Screenshots / Logs

N/A.