### PR TITLE
docs(himalaya): route CLI calls through terminal

### DIFF
--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -101,7 +101,12 @@ folder.aliases.trash = "Trash"
 
 ## Hermes Integration Notes
 
-- **Reading, listing, searching, moving, deleting** all work directly through the terminal tool
+Himalaya is **not** a Hermes Python/API tool. Do not call `himalaya(...)`,
+`default_api.himalaya(...)`, `send_email(...)`, or any other fabricated
+function. Invoke the external `himalaya` executable through the `terminal`
+tool, e.g. `terminal(command="himalaya envelope list --output json")`.
+
+- **Reading, listing, searching, moving, deleting** all work through `terminal(command="himalaya ...")`
 - **Composing/replying/forwarding** — piped input (`cat << EOF | himalaya template send`) is recommended for reliability. Interactive `$EDITOR` mode works with `pty=true` + background + process tool, but requires knowing the editor and its commands
 - Use `--output json` for structured output that's easier to parse programmatically
 - The `himalaya account configure` wizard requires interactive input — use PTY mode: `terminal(command="himalaya account configure", pty=true)`

--- a/tests/skills/test_himalaya_skill.py
+++ b/tests/skills/test_himalaya_skill.py
@@ -1,0 +1,18 @@
+"""Regression coverage for the bundled Himalaya email skill."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SKILL_MD = Path(__file__).resolve().parents[2] / "skills/email/himalaya/SKILL.md"
+
+
+def test_himalaya_skill_frames_cli_as_terminal_invocation() -> None:
+    content = SKILL_MD.read_text(encoding="utf-8")
+
+    assert "not** a Hermes Python/API tool" in content
+    assert "default_api.himalaya" in content
+    assert "send_email(...)" in content
+    assert 'terminal(command="himalaya envelope list --output json")' in content
+    assert 'terminal(command="himalaya ...")' in content

--- a/website/docs/user-guide/skills/bundled/email/email-himalaya.md
+++ b/website/docs/user-guide/skills/bundled/email/email-himalaya.md
@@ -32,6 +32,11 @@ The following is the complete skill definition that Hermes loads when this skill
 
 Himalaya is a CLI email client that lets you manage emails from the terminal using IMAP, SMTP, Notmuch, or Sendmail backends.
 
+This skill is separate from the Hermes Email gateway adapter. The gateway
+adapter lets people email the agent and uses Hermes' built-in IMAP/SMTP
+adapter; this skill lets the agent operate a mailbox from terminal tools and
+requires the external `himalaya` CLI.
+
 ## References
 
 - `references/configuration.md` (config file setup + IMAP/SMTP authentication)
@@ -111,7 +116,12 @@ folder.aliases.trash = "Trash"
 
 ## Hermes Integration Notes
 
-- **Reading, listing, searching, moving, deleting** all work directly through the terminal tool
+Himalaya is **not** a Hermes Python/API tool. Do not call `himalaya(...)`,
+`default_api.himalaya(...)`, `send_email(...)`, or any other fabricated
+function. Invoke the external `himalaya` executable through the `terminal`
+tool, e.g. `terminal(command="himalaya envelope list --output json")`.
+
+- **Reading, listing, searching, moving, deleting** all work through `terminal(command="himalaya ...")`
 - **Composing/replying/forwarding** — piped input (`cat << EOF | himalaya template send`) is recommended for reliability. Interactive `$EDITOR` mode works with `pty=true` + background + process tool, but requires knowing the editor and its commands
 - Use `--output json` for structured output that's easier to parse programmatically
 - The `himalaya account configure` wizard requires interactive input — use PTY mode: `terminal(command="himalaya account configure", pty=true)`


### PR DESCRIPTION
## Summary
- Clarifies that the bundled Himalaya skill must invoke the external `himalaya` CLI through the `terminal` tool, not as a fabricated Hermes API function.
- Closes #36012.

## Why
- Users reported Hermes attempting calls like `default_api.himalaya(...)` / `send_email(...)` and then incorrectly reporting Himalaya as unavailable even though the CLI works from the shell.
- The skill already documented raw CLI commands, but the Hermes integration notes did not explicitly guard against treating the skill name as a callable tool.

## Changes
- `skills/email/himalaya/SKILL.md`: adds explicit terminal-tool invocation framing and anti-pattern examples.
- `website/docs/user-guide/skills/bundled/email/email-himalaya.md`: regenerates the bundled skill docs page from the source skill.
- `tests/skills/test_himalaya_skill.py`: adds regression coverage for the terminal invocation guidance.

## Validation
- `python -m pytest tests/skills/test_himalaya_skill.py -q -o 'addopts='`
- `python -m ruff check tests/skills/test_himalaya_skill.py`
- `git diff --check`

## Scope
- In scope: skill/docs prompt framing for the Himalaya CLI invocation path.
- Out of scope: adding a first-class email/Himalaya Python tool or changing the email gateway adapter.
