### PR TITLE
feat(skills): show search result popularity

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -109,6 +109,71 @@ def _format_extra_metadata_lines(extra: Dict[str, Any]) -> list[str]:
     return lines
 
 
+def _format_count(value: Any) -> Optional[str]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return f"{value:,}"
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        normalized = stripped.replace(",", "")
+        if normalized.isdigit():
+            return f"{int(normalized):,}"
+        return stripped
+    return None
+
+
+def _popularity_payload(extra: Dict[str, Any]) -> Dict[str, Any]:
+    if not extra:
+        return {}
+
+    payload: Dict[str, Any] = {}
+    for key in (
+        "installs",
+        "install_count",
+        "downloads",
+        "download_count",
+        "stars",
+        "stargazers_count",
+    ):
+        value = extra.get(key)
+        formatted = _format_count(value)
+        if formatted is not None:
+            payload[key] = value.strip() if isinstance(value, str) else value
+
+    weekly_value = extra.get("weekly_installs")
+    weekly = _format_count(weekly_value)
+    if weekly is not None:
+        payload["weekly_installs"] = (
+            weekly_value.strip() if isinstance(weekly_value, str) else weekly_value
+        )
+
+    return payload
+
+
+def _format_popularity(extra: Dict[str, Any]) -> str:
+    payload = _popularity_payload(extra)
+    if not payload:
+        return "-"
+
+    labels = []
+    installs = payload["installs"] if "installs" in payload else payload.get("install_count")
+    if installs is not None:
+        labels.append(f"{_format_count(installs)} installs")
+    if "weekly_installs" in payload:
+        labels.append(f"{_format_count(payload['weekly_installs'])} weekly")
+    downloads = payload["downloads"] if "downloads" in payload else payload.get("download_count")
+    if downloads is not None:
+        labels.append(f"{_format_count(downloads)} downloads")
+    stars = payload["stars"] if "stars" in payload else payload.get("stargazers_count")
+    if stars is not None:
+        labels.append(f"{_format_count(stars)} stars")
+
+    return "\n".join(labels) if labels else "-"
+
+
 def _resolve_source_meta_and_bundle(identifier: str, sources):
     """Resolve metadata and bundle for a specific identifier."""
     meta = None
@@ -272,6 +337,7 @@ def do_search(query: str, source: str = "all", limit: int = 10,
                 "source": r.source,
                 "trust_level": r.trust_level,
                 "description": r.description,
+                "popularity": _popularity_payload(getattr(r, "extra", {}) or {}),
             }
             for r in results
         ]
@@ -289,6 +355,7 @@ def do_search(query: str, source: str = "all", limit: int = 10,
     table = Table(title=f"Skills Hub — {len(results)} result(s)")
     table.add_column("Name", style="bold cyan")
     table.add_column("Description", max_width=60)
+    table.add_column("Popularity", style="dim", no_wrap=True)
     table.add_column("Source", style="dim")
     table.add_column("Trust", style="dim")
     # overflow="fold" keeps the full slug visible (wraps instead of
@@ -303,6 +370,7 @@ def do_search(query: str, source: str = "all", limit: int = 10,
         table.add_row(
             r.name,
             r.description[:60] + ("..." if len(r.description) > 60 else ""),
+            _format_popularity(getattr(r, "extra", {}) or {}),
             r.source,
             f"[{trust_style}]{trust_label}[/]",
             r.identifier,

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -669,6 +669,24 @@ _LONG_RESULT = type("R", (), {
     "identifier": _LONG_SLUG,
 })()
 
+_POPULAR_RESULT = type("R", (), {
+    "name": "react-best-practices",
+    "description": "React guidance",
+    "source": "skills.sh",
+    "trust_level": "community",
+    "identifier": "skills-sh/vercel-labs/agent-skills/vercel-react-best-practices",
+    "extra": {"installs": 207679, "weekly_installs": "1.2K", "stars": 42},
+})()
+
+_BROWSE_SH_POPULAR_RESULT = type("R", (), {
+    "name": "search-listings",
+    "description": "Search site listings",
+    "source": "browse-sh",
+    "trust_level": "community",
+    "identifier": "browse-sh/airbnb.com/search-listings-ddgioa",
+    "extra": {"install_count": 3210},
+})()
+
 
 def test_do_search_identifier_column_does_not_truncate_long_slug():
     """The Identifier column must use overflow='fold', not the default ellipsis.
@@ -740,6 +758,60 @@ def test_do_search_json_flag_emits_full_identifiers(capsys):
     assert payload[0]["identifier"] == _LONG_SLUG
     assert payload[0]["name"] == "get-forecast"
     assert payload[0]["source"] == "browse-sh"
+    assert payload[0]["popularity"] == {}
     # Table render must be suppressed — sink should be empty (no "Searching for:" header).
     assert "Searching for:" not in sink.getvalue()
 
+
+def test_do_search_displays_existing_popularity_metadata():
+    """Search results should surface popularity already provided by source metadata."""
+    from hermes_cli.skills_hub import do_search
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=120)
+
+    with patch("tools.skills_hub.unified_search", return_value=[_POPULAR_RESULT]), \
+         patch("tools.skills_hub.create_source_router", return_value={}), \
+         patch("tools.skills_hub.GitHubAuth"):
+        do_search("react", console=console)
+
+    output = sink.getvalue()
+    assert "Popularity" in output
+    assert "207,679 installs" in output
+    assert "1.2K weekly" in output
+    assert "42 stars" in output
+
+
+def test_do_search_json_includes_existing_popularity_metadata(capsys):
+    from hermes_cli.skills_hub import do_search
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    with patch("tools.skills_hub.unified_search", return_value=[_POPULAR_RESULT]), \
+         patch("tools.skills_hub.create_source_router", return_value={}), \
+         patch("tools.skills_hub.GitHubAuth"):
+        do_search("react", console=console, as_json=True)
+
+    import json as _json
+    payload = _json.loads(capsys.readouterr().out)
+    assert payload[0]["popularity"] == {
+        "installs": 207679,
+        "stars": 42,
+        "weekly_installs": "1.2K",
+    }
+    assert sink.getvalue() == ""
+
+
+def test_do_search_displays_browse_sh_install_count_metadata():
+    from hermes_cli.skills_hub import do_search
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=120)
+
+    with patch("tools.skills_hub.unified_search", return_value=[_BROWSE_SH_POPULAR_RESULT]), \
+         patch("tools.skills_hub.create_source_router", return_value={}), \
+         patch("tools.skills_hub.GitHubAuth"):
+        do_search("airbnb", console=console)
+
+    assert "3,210 installs" in sink.getvalue()


### PR DESCRIPTION
## What does this PR do?

Adds a `Popularity` column to `hermes skills search` / `/skills search` results using popularity metadata that Skills Hub sources already provide. The JSON output now includes an additive `popularity` object with those existing fields for scripting.

This does not add any new network calls or synthesize popularity values. It only surfaces existing metadata such as skills.sh installs/weekly installs, browse.sh install counts, and any existing downloads/stars fields exposed by a source or the centralized index.

## Related Issue

Fixes #36003

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/skills_hub.py`: format and display existing popularity metadata in search tables and `--json` output.
- `tests/hermes_cli/test_skills_hub.py`: cover skills.sh popularity fields, browse.sh install counts, and no-metadata JSON behavior.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_skills_hub.py -- -q`
2. `scripts/run_tests.sh tests/tools/test_skills_hub.py -- -q`
3. `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused checks passed locally:

```text
scripts/run_tests.sh tests/hermes_cli/test_skills_hub.py -- -q  # 30 passed
scripts/run_tests.sh tests/tools/test_skills_hub.py -- -q       # 141 passed
git diff --check                                                # no output
```