### PR TITLE
fix(dashboard): inline critical-CSS bootstrap for user themes to mitigate flash

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3827,6 +3827,64 @@ def _normalise_prefix(raw: Optional[str]) -> str:
     return normalise_prefix(raw)
 
 
+def _render_active_theme_bootstrap_css() -> str:
+    """Critical-CSS shim for the active user theme.
+
+    Returns a ``<style>`` block with the ``:root`` CSS variables that
+    ``ThemeProvider.applyTheme()`` installs once the
+    ``/api/dashboard/themes`` round-trip completes.  The goal is to
+    eliminate the green flash where the first paint shows the bundle's
+    default Hermes Teal canvas before the SPA flips the configured user
+    theme into place.
+
+    Built-in themes return an empty string — their full definitions live
+    in ``web/src/themes/presets.ts`` and are applied by the bundle
+    before paint, so no shim is needed for them.
+    """
+    try:
+        config = load_config()
+        active = cfg_get(config, "dashboard", "theme", default="default")
+        if not active or not isinstance(active, str):
+            return ""
+        # Built-in: the bundle already owns the definition, no flash.
+        if any(b["name"] == active for b in _BUILTIN_DASHBOARD_THEMES):
+            return ""
+        for theme in _discover_user_themes():
+            if theme.get("name") != active:
+                continue
+            palette = theme.get("palette") or {}
+            bg = palette.get("background") or {}
+            mg = palette.get("midground") or {}
+            bg_hex = bg.get("hex", "#0a0a0a") if isinstance(bg, dict) else "#0a0a0a"
+            mg_hex = mg.get("hex", "#e5e5e5") if isinstance(mg, dict) else "#e5e5e5"
+            typo = theme.get("typography") or {}
+            font_sans = typo.get("fontSans") or _THEME_DEFAULT_TYPOGRAPHY["fontSans"]
+            base_size = typo.get("baseSize") or _THEME_DEFAULT_TYPOGRAPHY["baseSize"]
+            # Defensive ``</style>`` escape — current values are well-known
+            # hex/font strings, but this keeps the helper safe if it is
+            # later extended to ship user-authored CSS literals.
+            def _esc(s: str) -> str:
+                return str(s).replace("</", "<\\/")
+            return (
+                '<style id="hermes-theme-bootstrap">'
+                ":root{"
+                f"--background-base:{_esc(bg_hex)};"
+                f"--color-background:{_esc(bg_hex)};"
+                f"--midground-base:{_esc(mg_hex)};"
+                f"--color-midground:{_esc(mg_hex)};"
+                f"--font-sans:{_esc(font_sans)};"
+                f"--font-base-size:{_esc(base_size)};"
+                "}"
+                f"html,body{{background-color:{_esc(bg_hex)};color:{_esc(mg_hex)};"
+                f"font-family:{_esc(font_sans)};font-size:{_esc(base_size)};}}"
+                "</style>"
+            )
+        return ""
+    except Exception:
+        _log.debug("theme bootstrap render failed", exc_info=True)
+        return ""
+
+
 def mount_spa(application: FastAPI):
     """Mount the built SPA. Falls back to index.html for client-side routing.
 
@@ -3893,6 +3951,16 @@ def mount_spa(application: FastAPI):
             html = html.replace('href="/fonts/', f'href="{prefix}/fonts/')
             html = html.replace('href="/ds-assets/', f'href="{prefix}/ds-assets/')
             html = html.replace('src="/ds-assets/', f'src="{prefix}/ds-assets/')
+        # Theme flash mitigation: when the active theme is a user theme
+        # (``HERMES_HOME/dashboard-themes/<name>.yaml``), inject a minimal
+        # critical-CSS block so the first paint uses the target palette.
+        # Without this the SPA paints the default Hermes Teal canvas, then
+        # ``ThemeProvider`` flips the CSS variables once
+        # ``/api/dashboard/themes`` resolves.  Built-in themes are already
+        # in the bundle's ``presets.ts`` so no shim is needed for them.
+        theme_bootstrap = _render_active_theme_bootstrap_css()
+        if theme_bootstrap:
+            html = html.replace("</head>", f"{theme_bootstrap}</head>", 1)
         html = html.replace("</head>", f"{bootstrap_script}</head>", 1)
         return HTMLResponse(
             html,


### PR DESCRIPTION
## Problem

User themes (\`~/.hermes/dashboard-themes/*.yaml\`) reach the SPA only after the \`/api/dashboard/themes\` round-trip completes at React mount.  The bundle paints the first frame with the default Hermes Teal canvas because:

- the bundled stylesheet (\`<link rel=\"stylesheet\">\`) declares \`:root { --background-base: #041c1c; ... }\` for the built-in default;
- the bundled \`web/src/themes/presets.ts\` exposes the same default-theme palette as the \`ThemeProvider\` initial state;
- \`ThemeProvider.applyTheme(<user theme>)\` only fires once the API response arrives and \`setUserThemeDefs\` populates the lookup.

The user sees a green canvas behind the loading SPA on every reload whenever the active theme is a user theme.  This makes the user-themes extension point — the documented way to ship a custom palette without rebuilding the bundle — feel second-class compared to built-ins.

Built-in themes do not have this problem.  Their full definitions are bundled inside \`presets.ts\`, so the SPA owns the palette before first paint.

## Solution (backend only)

\`_serve_index()\` injects a small critical-CSS \`<style>\` block inside \`<head>\` whenever the active theme is a user theme.  The block carries the six CSS variables that determine the canvas/text colour and base typography:

- \`--background-base\`, \`--color-background\`
- \`--midground-base\`, \`--color-midground\`
- \`--font-sans\`, \`--font-base-size\`

…and an \`html, body\` rule that paints the canvas using those variables.

Because the inline \`<style>\` follows the bundle's \`<link>\` in DOM order and matches the same \`:root\` specificity (0,0,1,0), the later declaration wins the CSS cascade.  The static canvas behind the SPA is already in the user theme's palette before any JavaScript runs.

When \`ThemeProvider\` later mounts and \`applyTheme()\` writes the same variables as inline styles on \`documentElement\`, the values are identical to what the bootstrap block set — there is no second-paint discrepancy on the critical variables.

\`_render_active_theme_bootstrap_css()\` looks up the active theme through the existing \`_discover_user_themes()\` helper.  No-op for built-in active themes (empty string returned, no \`<style>\` injected).  No new endpoints, no config flags, no frontend changes.

## Benefits

- **Eliminates the static green-canvas-behind-the-SPA on reload.**  The first paint is already in the user theme's palette.
- **No frontend rebuild required.**  Operators already running a user theme get the fix as soon as the backend image updates.
- **No regression for built-in themes.**  Active built-in returns an empty string from the helper; HTML output is byte-identical.
- **No new public surface.**  Reuses \`_discover_user_themes()\` / \`load_config()\` / \`cfg_get()\`; no API endpoints, no config keys, no breaking changes.
- **Trivial review surface.**  ~60 LOC backend change; the helper plus one \`html.replace()\` call.
- **Trust model unchanged.**  YAML themes are already trusted: \`_normalise_theme_definition\` accepts user-supplied \`customCSS\` up to 32 KiB.  The bootstrap helper only emits well-known hex/font strings sourced from the same normalised definition, and \`</\` is escaped defensively inside the block.

## Test plan

- [x] Manual: \`~/.hermes/dashboard-themes/mission-control.yaml\` (dark canvas) + \`config.yaml dashboard.theme: mission-control\`; reload — the canvas behind the SPA loads in the MC palette, no green flash.
- [x] Manual: switch to a built-in theme via the picker (\`config.yaml dashboard.theme: midnight\`), reload — \`<style id=\"hermes-theme-bootstrap\">\` is **not** injected (View Source confirmed); bundle behaviour unchanged.
- [x] Manual: no user themes configured + built-in active — empty string returned by the helper, HTML output unchanged.
- [x] HTML response contains \`<style id=\"hermes-theme-bootstrap\">\` immediately before the existing \`bootstrap_script\` block, in that order.
- [ ] CI: a snapshot test on \`_render_active_theme_bootstrap_css()\` for built-in / user / missing-active / no-user-themes cases would catch regressions — happy to add in a follow-up if maintainers prefer.

## Notes

The patch is intentionally conservative: it covers only the canvas / text / font variables.  A residual short flash is still possible if the bundle's \`ThemeProvider\` re-applies the default theme as inline styles on \`documentElement\` between mount and the API response — that race is best fixed on the frontend (e.g. having \`ThemeProvider\` read a backend-injected JS global with the active theme's full definition).  Filing that as a separate PR keeps each change focused and reviewable in isolation; this PR removes the static green-canvas case that every user-theme operator hits on every reload today.