### PR TITLE
fix(achievements): stop card hover click loop

### DIFF
--- a/plugins/hermes-achievements/dashboard/dist/style.css
+++ b/plugins/hermes-achievements/dashboard/dist/style.css
@@ -21,7 +21,7 @@
 .ha-pills button.active, .ha-pills button:hover { color: var(--color-foreground); border-color: var(--ha-tier, var(--color-ring)); background: color-mix(in srgb, var(--color-primary) 16%, var(--color-card)); }
 .ha-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: .9rem; }
 .ha-card { --ha-tier: var(--color-border); position: relative; overflow: hidden; min-height: 214px; border: 1px solid color-mix(in srgb, var(--ha-tier) 46%, var(--color-border)); background: radial-gradient(circle at 2.6rem 2.2rem, color-mix(in srgb, var(--ha-tier) 16%, transparent), transparent 34%), linear-gradient(180deg, rgba(255,255,255,.04), transparent), color-mix(in srgb, var(--color-card) 92%, #000); transition: transform .16s ease, border-color .16s ease, opacity .16s ease, box-shadow .16s ease; }
-.ha-card:hover { transform: translateY(-2px); border-color: var(--ha-tier); box-shadow: 0 0 0 1px color-mix(in srgb, var(--ha-tier) 16%, transparent); }
+.ha-card:hover { border-color: var(--ha-tier); box-shadow: 0 0 0 1px color-mix(in srgb, var(--ha-tier) 16%, transparent); }
 .ha-card-content { position: relative; z-index: 1; padding: 1rem !important; display: flex; flex-direction: column; gap: .75rem; height: 100%; }
 .ha-card-head { display: grid; grid-template-columns: 3.1rem minmax(0, 1fr) auto; gap: .85rem; align-items: start; }
 .ha-icon { display: grid; place-items: center; width: 2.9rem; height: 2.9rem; color: var(--ha-tier); }

--- a/plugins/hermes-achievements/tests/test_achievement_engine.py
+++ b/plugins/hermes-achievements/tests/test_achievement_engine.py
@@ -151,6 +151,21 @@ class AchievementEngineTests(unittest.TestCase):
         stats = plugin_api.analyze_messages("s2", "Real config", [{"content": "edited config.yaml, manifest.json, and .env.local"}])
         self.assertGreaterEqual(stats["config_events"], 3)
 
+    def test_dashboard_card_hover_does_not_move_click_target(self):
+        style_css = (
+            Path(__file__).resolve().parents[1]
+            / "dashboard"
+            / "dist"
+            / "style.css"
+        ).read_text(encoding="utf-8")
+
+        hover_rule = next(
+            line for line in style_css.splitlines() if line.startswith(".ha-card:hover")
+        )
+        self.assertNotIn("transform:", hover_rule)
+        self.assertIn("border-color: var(--ha-tier)", hover_rule)
+        self.assertIn("box-shadow:", hover_rule)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What does this PR do?

Fixes the Achievements dashboard badge/card hover feedback loop reported in #35116. Achievement cards previously moved upward with `transform: translateY(-2px)` on hover. When a user clicked a card near the pointer boundary, the card could move out from under the pointer, lose hover, move back, and repeat, which looked like continuous auto-clicking/re-rendering. This keeps hover border/shadow feedback but removes the physical movement of the click target.

I checked for duplicate work before opening this PR: no open PR directly references `#35116`, `Achievement badges auto-click`, `achievement re-render`, or `auto-click` in title/body. Open PR #29780 is related to #29380 and stabilizes the share-dialog-specific hover transform case; this PR covers the general achievement card hover movement reported in #35116.

## Related Issue

Fixes #35116

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/hermes-achievements/dashboard/dist/style.css`: remove the `translateY(-2px)` movement from achievement card hover while keeping visual hover feedback.
- `plugins/hermes-achievements/tests/test_achievement_engine.py`: add a regression assertion that the bundled dashboard hover rule does not move the card click target.

## How to Test

1. `scripts/run_tests.sh plugins/hermes-achievements/tests/test_achievement_engine.py`
2. `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest plugins/hermes-achievements/tests/test_achievement_engine.py -q -o 'addopts='`
3. `node --check plugins/hermes-achievements/dashboard/dist/index.js`
4. `python3 -m py_compile plugins/hermes-achievements/tests/test_achievement_engine.py plugins/hermes-achievements/dashboard/plugin_api.py`
5. `git diff --check`

Note: `python3 -m pytest ...` with the system Python failed because pytest is not installed in that interpreter, so I reran through the repo venv and the repo test wrapper.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux local worktree

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused test output:

```text
Discovered 1 test files (11 tests) under ['plugins/hermes-achievements/tests/test_achievement_engine.py']; running with -j 32
[100.0% |    11/11 | ✓11 | ✗ 0] ✓ plugins/hermes-achievements/tests/test_achievement_engine.py (11✓, 0.3s)
```
