### PR TITLE
fix(docker): avoid s6 overlay archive chmod on QNAP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,9 @@ ARG S6_OVERLAY_AARCH64_SHA256=0952056ff913482163cc30e35b2e944b507ba1025d78f5becb
 ARG S6_OVERLAY_SYMLINKS_SHA256=a60dc5235de3ecbcf874b9c1f18d73263ab99b289b9329aa950e8729c4789f0e
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp/
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-noarch.tar.xz /tmp/
+# QNAP Container Station can fail chmod while tar restores archive metadata
+# for s6-overlay symlinks. Extract with the build umask, then restore the
+# one required setuid helper mode with a targeted chmod on a regular file.
 RUN set -eu; \
     case "${TARGETARCH:-amd64}" in \
         amd64) s6_arch="x86_64"; s6_arch_sha="${S6_OVERLAY_X86_64_SHA256}" ;; \
@@ -70,9 +73,12 @@ RUN set -eu; \
         printf '%s  %s\n' "${S6_OVERLAY_SYMLINKS_SHA256}" /tmp/s6-overlay-symlinks-noarch.tar.xz; \
     } > /tmp/s6-overlay.sha256; \
     sha256sum -c /tmp/s6-overlay.sha256; \
-    tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz; \
-    tar -C / -Jxpf /tmp/s6-overlay-arch.tar.xz; \
-    tar -C / -Jxpf /tmp/s6-overlay-symlinks-noarch.tar.xz; \
+    tar -C / --no-same-owner --no-same-permissions -Jxf /tmp/s6-overlay-noarch.tar.xz; \
+    tar -C / --no-same-owner --no-same-permissions -Jxf /tmp/s6-overlay-arch.tar.xz; \
+    tar -C / --no-same-owner --no-same-permissions -Jxf /tmp/s6-overlay-symlinks-noarch.tar.xz; \
+    s6_suexec="$(find /package/admin -path '*/command/s6-overlay-suexec' -type f -print -quit)"; \
+    if [ -z "${s6_suexec}" ]; then echo "s6-overlay-suexec not found" >&2; exit 1; fi; \
+    chmod 4755 "${s6_suexec}"; \
     rm /tmp/s6-overlay-*.tar.xz /tmp/s6-overlay.sha256; \
     # #34192: backward-compat shim for orchestration templates that still\
     # reference the legacy /usr/bin/tini entrypoint (e.g. Hostinger's\

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -140,6 +140,30 @@ def test_dockerfile_entrypoint_routes_through_the_init(dockerfile_text):
     )
 
 
+def test_s6_overlay_extract_avoids_preserving_archive_modes(dockerfile_text):
+    """s6-overlay extraction must not force chmod-heavy metadata restore.
+
+    QNAP Container Station can report EFAULT ("Bad address") when GNU tar,
+    running as root, restores modes from the s6-overlay archives. The image
+    only needs the files extracted with the normal build umask, which keeps
+    scripts executable without preserving symlink mode metadata.
+    """
+    s6_extract_steps = [
+        step
+        for step in _run_steps(dockerfile_text)
+        if "s6-overlay" in step and "tar -C /" in step
+    ]
+
+    assert s6_extract_steps, "Dockerfile must extract the s6-overlay archives"
+    for step in s6_extract_steps:
+        assert "--no-same-permissions" in step
+        assert "--no-same-owner" in step
+        assert "s6-overlay-suexec" in step
+        assert "chmod 4755" in step
+        assert "-Jxpf" not in step
+        assert "--same-permissions" not in step
+
+
 def test_dockerfile_installs_tui_dependencies(dockerfile_text):
     # The TUI workspace manifests must be present so ``npm install`` can
     # resolve dependencies. The bundled ``hermes-ink`` workspace package is


### PR DESCRIPTION
## What does this PR do?

Fixes Docker builds on QNAP Container Station by avoiding GNU tar's archive metadata restore for the s6-overlay tarballs. QNAP can fail those chmod operations with `Bad address`, especially on the s6-overlay symlink entries.

The extraction now uses the build umask with `--no-same-owner --no-same-permissions`, then restores the one required setuid helper mode for `s6-overlay-suexec` with a targeted chmod on that regular file. This keeps s6-overlay installed without adding a tini fallback or redesigning the Docker image.

Duplicate PR search before implementation found no active equivalent PR for `35084`, `QNAP s6-overlay`, `Cannot change mode`, or `Bad address`.

## Related Issue

Fixes #35084

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `Dockerfile`: extract s6-overlay archives without preserving archive owner/mode metadata, then restore `s6-overlay-suexec` to `4755`.
- `tests/tools/test_dockerfile_pid1_reaping.py`: add a Dockerfile contract test for the QNAP-safe extraction flags and required setuid restoration.

## How to Test

1. `rm -rf .tmp-s6-extract && mkdir .tmp-s6-extract && curl -fsSL -o .tmp-s6-noarch.tar.xz https://github.com/just-containers/s6-overlay/releases/download/v3.2.3.0/s6-overlay-noarch.tar.xz && curl -fsSL -o .tmp-s6-arch.tar.xz https://github.com/just-containers/s6-overlay/releases/download/v3.2.3.0/s6-overlay-x86_64.tar.xz && curl -fsSL -o .tmp-s6-symlinks.tar.xz https://github.com/just-containers/s6-overlay/releases/download/v3.2.3.0/s6-overlay-symlinks-noarch.tar.xz && tar -C .tmp-s6-extract --no-same-owner --no-same-permissions -Jxf .tmp-s6-noarch.tar.xz && tar -C .tmp-s6-extract --no-same-owner --no-same-permissions -Jxf .tmp-s6-arch.tar.xz && tar -C .tmp-s6-extract --no-same-owner --no-same-permissions -Jxf .tmp-s6-symlinks.tar.xz && s6_suexec="$(find .tmp-s6-extract/package/admin -path '*/command/s6-overlay-suexec' -type f -print -quit)" && test -n "$s6_suexec" && chmod 4755 "$s6_suexec" && test -x .tmp-s6-extract/init && test -x .tmp-s6-extract/package/admin/s6-overlay/command/with-contenv && test -L .tmp-s6-extract/command/with-contenv && test -L .tmp-s6-extract/usr/bin/with-contenv && stat -c '%a %n' "$s6_suexec" .tmp-s6-extract/init .tmp-s6-extract/package/admin/s6-overlay/command/with-contenv && rm -rf .tmp-s6-extract .tmp-s6-noarch.tar.xz .tmp-s6-arch.tar.xz .tmp-s6-symlinks.tar.xz`
2. `.venv/bin/python -m pytest tests/tools/test_dockerfile_pid1_reaping.py -q`
3. `git diff --check`

Docker build was not run locally because this environment does not have `docker`, `podman`, or `buildah` installed. I do not have QNAP hardware, so the fix is validated through the Dockerfile extraction path and static regression coverage.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux checkout with Python 3.11 venv; no Docker daemon available

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused test output:

```text
........                                                                 [100%]
8 passed in 0.10s
```