### PR TITLE
fix(tools): scope google chat toolset to platform

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -153,6 +153,7 @@ def _xai_credentials_present() -> bool:
 _TOOLSET_PLATFORM_RESTRICTIONS: Dict[str, Set[str]] = {
     "discord": {"discord"},
     "discord_admin": {"discord"},
+    "google_chat": {"google_chat"},
 }
 
 
@@ -1800,6 +1801,8 @@ def _get_platform_tools(
         known_map = config.get("known_plugin_toolsets", {})
         known_for_platform = set(known_map.get(platform, []))
         for pts in plugin_ts_keys:
+            if not _toolset_allowed_for_platform(pts, platform):
+                continue
             if pts in toolset_names:
                 # Explicitly listed in config — enabled
                 enabled_toolsets.add(pts)

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1316,7 +1316,6 @@ def test_discord_toolsets_not_available_on_other_platforms():
     assert _toolset_allowed_for_platform("discord_admin", "discord")
 
 
-
 def test_google_chat_toolset_not_available_on_other_platforms():
     from hermes_cli.tools_config import _toolset_allowed_for_platform
 
@@ -1345,7 +1344,6 @@ def test_save_platform_tools_strips_restricted_toolsets():
     assert "discord_admin" not in saved
     assert "web" in saved
     assert "terminal" in saved
-
 
 
 def test_save_platform_tools_strips_google_chat_toolset_from_non_google_chat():

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1316,6 +1316,16 @@ def test_discord_toolsets_not_available_on_other_platforms():
     assert _toolset_allowed_for_platform("discord_admin", "discord")
 
 
+
+def test_google_chat_toolset_not_available_on_other_platforms():
+    from hermes_cli.tools_config import _toolset_allowed_for_platform
+
+    for plat in ["cli", "telegram", "discord", "slack", "whatsapp", "signal"]:
+        assert not _toolset_allowed_for_platform("google_chat", plat), (
+            f"`google_chat` toolset leaked onto {plat}"
+        )
+    assert _toolset_allowed_for_platform("google_chat", "google_chat")
+
 def test_discord_toolsets_user_enabled_are_honored():
     """When the user opts in via `hermes tools`, the toolset appears."""
     config = {"platform_toolsets": {"discord": ["web", "terminal", "discord"]}}
@@ -1336,6 +1346,14 @@ def test_save_platform_tools_strips_restricted_toolsets():
     assert "web" in saved
     assert "terminal" in saved
 
+
+
+def test_save_platform_tools_strips_google_chat_toolset_from_non_google_chat():
+    config = {}
+    _save_platform_tools(config, "telegram", {"web", "google_chat"})
+    saved = config["platform_toolsets"]["telegram"]
+    assert "google_chat" not in saved
+    assert "web" in saved
 
 def test_get_platform_tools_feishu_includes_doc_and_drive():
     enabled = _get_platform_tools({}, "feishu")


### PR DESCRIPTION
## What does this PR do?

Scopes the bundled `google_chat` plugin toolset to the Google Chat platform so it does not appear as an opt-in toolset for unrelated platforms.

## Related Issue

N/A — small platform-toolset hygiene fix found while preparing Google Chat plugin work.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/tools_config.py`: add `google_chat` to platform-scoped toolset restrictions.
- `hermes_cli/tools_config.py`: skip restricted plugin toolsets while resolving default platform tools.
- `tests/hermes_cli/test_tools_config.py`: cover Google Chat toolset visibility and save-time stripping on non-Google-Chat platforms.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_tools_config.py`
2. `python /root/.codex/skills/hermes-upstream-pr/scripts/pr_preflight.py --base upstream/main`

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've added tests for my changes.
- [x] I've tested on Linux.

### Documentation & Housekeeping

- [x] Documentation update N/A.
- [x] `cli-config.yaml.example` update N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A.
- [x] Cross-platform impact considered: pure config-resolution logic and tests.
- [x] Tool descriptions/schemas update N/A.

## Related PRs

- #36035 continues the Google Chat setup path by allowing HTTP inbound mode without Pub/Sub.
- #36061 is a draft follow-up for platform HTTP event callbacks and Google Chat message dispatch.
- #36068 adds Google Chat clarify card rendering.
- #36069 depends on the callback and card-rendering drafts for card-click handling.

## Screenshots / Logs

Validation passed locally:

```text
scripts/run_tests.sh tests/hermes_cli/test_tools_config.py
90 tests passed, 0 failed
```
