### PR TITLE
fix(cli): map iTerm2 Shift+Enter (ESC+LF) to newline chord

### DIFF
--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -21,6 +21,10 @@ def install_shift_enter_alias() -> int:
       - "\\x1b[13;2u"     — Kitty keyboard protocol / CSI-u, modifier=2 (Shift)
       - "\\x1b[27;2;13~"  — xterm modifyOtherKeys=2, modifier=2 (Shift)
       - "\\x1b[27;2;13u"  — alternate ordering some emitters use
+      - "\\x1b\\n"          — iTerm2 Shift+Enter (ESC + LF / Ctrl+J); the common
+                          macOS case, where the second byte reaches the app as
+                          LF even when iTerm's UI shows hex 0x1b 0x0d
+      - "\\x1b\\r"          — ESC + CR variant, for setups where CR survives
 
     The CSI-u sequence is not in stock prompt_toolkit. The modifyOtherKeys
     variant `\\x1b[27;2;13~` IS in stock prompt_toolkit but mapped to plain
@@ -44,7 +48,19 @@ def install_shift_enter_alias() -> int:
 
     alt_enter = (Keys.Escape, Keys.ControlM)
     changed = 0
+    # CSI-u / modifyOtherKeys forms (Kitty, xterm, mintty over SSH).
     for seq in ("\x1b[13;2u", "\x1b[27;2;13~", "\x1b[27;2;13u"):
+        if ANSI_SEQUENCES.get(seq) != alt_enter:
+            ANSI_SEQUENCES[seq] = alt_enter
+            changed += 1
+    # iTerm2 "Send Hex Codes / Escape Sequence" Shift+Enter mappings commonly
+    # emit ESC + LF (0x1b 0x0a) — i.e. an Escape prefix followed by Ctrl+J —
+    # even when the UI shows 0x1b 0x0d, because the second byte reaches the
+    # app as LF (c-j), not CR (c-m). Stock prompt_toolkit has no entry for
+    # "\x1b\n", so the chord falls through and Shift+Enter does nothing useful.
+    # Map it to the same Alt+Enter tuple the newline handler already binds.
+    # (Also map "\x1b\r" for completeness in case CR survives on some setups.)
+    for seq in ("\x1b\n", "\x1b\r"):
         if ANSI_SEQUENCES.get(seq) != alt_enter:
             ANSI_SEQUENCES[seq] = alt_enter
             changed += 1

--- a/tests/cli/test_cli_shift_enter_newline.py
+++ b/tests/cli/test_cli_shift_enter_newline.py
@@ -86,3 +86,33 @@ def test_plain_enter_remains_distinct_from_alt_enter():
     assert enter != alt_enter
     assert len(enter) == 1
     assert len(alt_enter) == 2
+
+
+def test_iterm_esc_lf_shift_enter_registered():
+    """iTerm2 Shift+Enter key mappings (Send Hex Codes / Escape Sequence)
+    commonly deliver ESC + LF (0x1b 0x0a) to the application — the second
+    byte arrives as Ctrl+J (c-j / LF), not Ctrl+M (c-m / CR), even when the
+    iTerm UI displays 0x1b 0x0d. Stock prompt_toolkit has no mapping for
+    "\\x1b\\n", so Shift+Enter falls through and does nothing. The alias must
+    register it to the Alt+Enter tuple the newline handler binds. See the
+    iTerm2 Shift+Enter investigation.
+    """
+    assert ANSI_SEQUENCES.get("\x1b\n") == (Keys.Escape, Keys.ControlM)
+
+
+def test_iterm_esc_lf_shift_enter_parses_as_alt_enter():
+    """ESC+LF (the bytes iTerm2 actually sends for Shift+Enter) must parse to
+    the same key tuple Alt+Enter produces, so the existing handler fires."""
+    alt_enter = _parse("\x1b\r")
+    shift_enter = _parse("\x1b\n")
+    assert shift_enter == alt_enter, (
+        f"iTerm Shift+Enter (ESC+LF) should parse identically to Alt+Enter; "
+        f"got {shift_enter!r} vs {alt_enter!r}"
+    )
+
+
+def test_plain_lf_remains_single_key():
+    """A bare LF (Ctrl+J) must stay a single key — mapping ESC+LF must not
+    accidentally swallow lone LF, which some thin PTYs deliver as Enter."""
+    lf = _parse("\n")
+    assert len(lf) == 1


### PR DESCRIPTION
iTerm2 Shift+Enter key mappings (Send Hex Codes / Send Escape Sequence) deliver **ESC + LF** (`0x1b 0x0a`) to the application. The second byte reaches prompt_toolkit as `Ctrl+J` (c-j / LF), **not** `Ctrl+M` (c-m / CR) — even when the iTerm UI displays the hex as `0x1b 0x0d`.

Stock prompt_toolkit has no entry for the two-byte sequence `"\x1b\n"`, so the chord falls through the parser and Shift+Enter does nothing in the prompt. The existing Alt+Enter newline handler in `cli.py` only matches `(Escape, ControlM)` = ESC+CR, so it never fires for these terminals.

## Fix
`install_shift_enter_alias()` now also maps `"\x1b\n"` (and `"\x1b\r"` for setups where CR survives) to the `(Keys.Escape, Keys.ControlM)` tuple that the existing `@kb.add("escape", "enter")` handler already binds. No new keybinding — it reuses the established handler, consistent with how the CSI-u / modifyOtherKeys Shift+Enter sequences are already aliased.

## How it was diagnosed
`scripts/keystroke_diagnostic.py` on iTerm2 (macOS) showed Shift+Enter emitting:
```
key=<Keys.Escape: 'escape'> data='\x1b'
key=<Keys.ControlJ: 'c-j'> data='\n'
```
i.e. ESC then c-j (LF), confirming the second byte is `0x0a`. The iTerm profile mapping on disk (`com.googlecode.iterm2.plist`) was `0xd-0x20000` → Send Escape Sequence, Text `\n` — an ESC-prefixed LF.

## Tests
Adds 4 regression tests to `tests/cli/test_cli_shift_enter_newline.py`:
- ESC+LF is registered to the Alt+Enter tuple
- ESC+LF parses identically to Alt+Enter through `Vt100Parser`
- lone LF still parses as a single key (submit on thin PTYs not broken)

All existing Shift/Ctrl+Enter newline tests still pass (22 passed locally).