### PR TITLE
fix: remove unused variable assignments

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -836,7 +836,6 @@ def _reconcile_classification(
     Every removed skill is placed in exactly one bucket.
     """
     heur_cons = {e["name"]: e for e in heuristic.get("consolidated", [])}
-    heur_pruned = {e["name"] for e in heuristic.get("pruned", [])}
 
     model_cons = {e["from"]: e for e in model_block.get("consolidations", [])}
     model_pruned = {e["name"]: e for e in model_block.get("prunings", [])}

--- a/agent/lsp/cli.py
+++ b/agent/lsp/cli.py
@@ -55,7 +55,7 @@ def register_subparser(subparsers: argparse._SubParsersAction) -> None:
         help="Even attempt servers marked manual-install (best effort)",
     )
 
-    sub_restart = sub.add_parser(
+    sub.add_parser(
         "restart",
         help="Tear down running LSP clients (next edit re-spawns)",
     )


### PR DESCRIPTION
## Summary

Remove two unused variable assignments identified by ruff lint:

- `agent/lsp/cli.py`: `sub_restart` was assigned the result of `sub.add_parser("restart", ...)` but the result was never used after parser setup — the variable name was simply dead code.
- `agent/curator.py`: `heur_pruned` was constructed from `heuristic.get("pruned", [])` but was never referenced in any downstream logic, unlike the related `model_pruned` which was actively used.

## Changes

```
agent/lsp/cli.py  | 2 +-
agent/curator.py  | 1 -
2 files changed, 1 insertion(+), 2 deletions(-)
```

## Verification

- `python3 -m py_compile agent/lsp/cli.py agent/curator.py` — no syntax errors
- `ruff check agent/lsp/cli.py agent/curator.py` — all checks passed
- No functional logic changed; only removed inert assignments