### PR TITLE
fix(auxiliary): route custom:<name> through named-provider arm + Palantir Bearer auth

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -487,6 +487,7 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
     return (
         normalized.startswith(("https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic"))
         or "azure.com" in normalized
+        or "palantirfoundry" in normalized
     )
 
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3047,10 +3047,26 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
         resolved_provider = main_provider
         explicit_base_url = None
         explicit_api_key = None
-        if runtime_base_url and (main_provider == "custom" or main_provider.startswith("custom:")):
+        if runtime_base_url and main_provider == "custom":
+            # Anonymous custom endpoint (OPENAI_BASE_URL / config.model.base_url)
+            # — pass through with explicit base_url + api_key.
             resolved_provider = "custom"
             explicit_base_url = runtime_base_url
             explicit_api_key = runtime_api_key or None
+        elif main_provider.startswith("custom:"):
+            # Named custom provider (custom_providers / providers dict entry).
+            # KEEP the full ``custom:<name>`` so resolve_provider_client lands in
+            # the named-custom-provider arm — that arm honours the entry's
+            # api_mode (e.g. anthropic_messages → AnthropicAuxiliaryClient,
+            # avoiding the /anthropic→/v1 rewrite that 404s against proxies
+            # like Palantir Foundry's Anthropic surface).  Do NOT collapse to
+            # plain "custom"; that path strips /anthropic and routes through
+            # OpenAI chat.completions.
+            resolved_provider = main_provider
+            # base_url / api_key come from the named entry itself — leave the
+            # explicit_* overrides unset so the named arm reads them from config.
+            if runtime_api_key:
+                explicit_api_key = runtime_api_key
         elif runtime_api_key:
             # Pin auxiliary to the same api_key as the active main chat session
             # so that a working key is reused instead of re-selecting from the pool


### PR DESCRIPTION
## Problem

When the user's main chat provider is a named custom_providers entry exposing an Anthropic Messages surface (e.g. Palantir Foundry's `/api/v2/llm/proxy/anthropic`, custom LiteLLM/Bedrock-Anthropic proxies, internal corp gateways), **every auxiliary task returns HTTP 404 NOT_FOUND**:

- `generate_title` (chat titles)
- session compression / summarisation
- web extract
- session search rerank
- any tool that calls `_resolve_auto()` to pick an aux client

The main chat works fine. Only the auxiliary path was broken, which made the bug confusing — users got working assistant replies but always saw "Untitled" sessions and fallback summaries.

## Root cause

In `agent/auxiliary_client.py::_resolve_auto`, both the literal `custom` provider and any `custom:<name>` provider were collapsed to plain `"custom"` with the runtime base_url passed through as `explicit_base_url`:

```python
if runtime_base_url and (main_provider == "custom" or main_provider.startswith("custom:")):
    resolved_provider = "custom"            # collapses custom:palantir-* → "custom"
    explicit_base_url = runtime_base_url    # /api/v2/llm/proxy/anthropic
    explicit_api_key = runtime_api_key or None
```

That string then lands in `resolve_provider_client`'s anonymous-custom arm (`if provider == "custom":`), which unconditionally calls `_to_openai_base_url(...)` on the URL. That helper strips a trailing `/anthropic` and substitutes `/v1` — designed for providers like MiniMax/ZAI that expose both surfaces under one origin.

For Palantir the rewrite produces `/api/v2/llm/proxy/v1`, which does not exist:

```
404 NOT_FOUND
Path /api/v2/llm/proxy/v1/chat/completions not found
```

Worse, the named entry's `api_mode: anthropic_messages` flag (which would have selected `AnthropicAuxiliaryClient`) is dropped on the floor because the anonymous arm never reads it.

Secondary issue: Palantir's Anthropic proxy authenticates via `Authorization: Bearer <token>`, not the SDK default `x-api-key` header — `_requires_bearer_auth` in `anthropic_adapter.py` didn't recognise palantirfoundry hosts, so even if we'd taken the right code path the request would 401.

## Fix

Two minimal changes:

**`agent/auxiliary_client.py`** — split the conditional. Only the literal `"custom"` provider continues to take the anonymous-custom path; `custom:<name>` keeps its full `custom:<name>` string when passed to `resolve_provider_client`, so the named-custom-provider arm (added in earlier work) handles it. That arm honours the entry's `api_mode` and uses the original `/anthropic` URL untouched.

**`agent/anthropic_adapter.py`** — extend `_requires_bearer_auth` to match `palantirfoundry` hosts alongside the existing MiniMax / Azure matches.

Diff stat: `+18 -1`.

## Verification

End-to-end tested against a live Palantir Foundry deployment with both `claude-4-6-opus` and `claude-4-7-opus`:

```
Smoke: client=AnthropicAuxiliaryClient, model=ri.language-model-service..language-model.anthropic-claude-4-7-opus
E2E title: 'Casual Polish greeting exchange'    # real title, no 404, no fallback
```

Regression tests on adjacent providers — `_resolve_auto` paths intact:

| Main provider config            | Resolved client            | base_url                                       |
|---------------------------------|----------------------------|------------------------------------------------|
| anonymous `custom` + base_url   | OpenAI                     | `https://api.openai.com/v1/` (unchanged)       |
| built-in NVIDIA                 | OpenAI                     | `https://integrate.api.nvidia.com/v1/`         |
| custom (no base_url)            | GeminiNativeClient (Step-2 chain) | n/a — falls through, unchanged          |
| **custom:palantir-claude47 (new)** | **AnthropicAuxiliaryClient** | **`…/proxy/anthropic` preserved**     |

## Who this helps

Anyone using `custom_providers` with `api_mode: anthropic_messages` to point Hermes at an internal Anthropic-compatible proxy: Palantir Foundry, LiteLLM, Bedrock-Anthropic proxies, AWS Bedrock gateway with anthropic shape, vendor-specific corporate AIP gateways. Before this PR, those setups silently 404'd every auxiliary call. After, auxiliary tasks reuse the main session's working credentials and api_mode.

## Notes

- No new dependencies.
- No new config knobs — uses the existing `custom_providers.<name>.api_mode: anthropic_messages` flag.
- Built-in `_requires_bearer_auth` matchers are still a denylist of known proxies (MiniMax, Azure, now Palantir). Could be made config-driven in a follow-up but kept conservative here.
