### PR TITLE
fix(cron): lower grace period from 120s to 30s for sub-minute jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -344,11 +344,11 @@ def _recoverable_oneshot_run_at(
 def _compute_grace_seconds(schedule: dict) -> int:
     """Compute how late a job can be and still catch up instead of fast-forwarding.
 
-    Uses half the schedule period, clamped between 120 seconds and 2 hours.
+    Uses half the schedule period, clamped between 30 seconds and 2 hours.
     This ensures daily jobs can catch up if missed by up to 2 hours,
-    while frequent jobs (every 5-10 min) still fast-forward quickly.
+    while sub-minute to 5-minute jobs (every 30s-5m) still run instead of being silently skipped.
     """
-    MIN_GRACE = 120
+    MIN_GRACE = 30
     MAX_GRACE = 7200  # 2 hours
 
     kind = schedule.get("kind")


### PR DESCRIPTION
## Summary

Sub-minute cron jobs (every 30s–5m) were being silently skipped because the 120-second minimum grace period (`MIN_GRACE`) caused the scheduler to fast-forward past scheduled runs.

## Change

Reduces `MIN_GRACE` from **120 → 30 seconds**, so frequent cron jobs actually execute instead of being fast-forwarded. The grace period is computed as `max(MIN_GRACE, min(period_seconds / 2, MAX_GRACE))`, so:

| Schedule   | Old grace | New grace |
|------------|-----------|-----------|
| every 30s  | 120s      | 30s       |
| every 5min | 150s      | 150s      |
| daily      | 2h        | 2h        |

## Testing

- [ ] Verify a 30s-interval cron job fires correct number of times over a 5-minute window
- [ ] Confirm daily cron jobs still catch up normally (MAX_GRACE unchanged at 7200s)
