### PR TITLE
fix(acp): reset session counters on slash reset

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1790,7 +1790,18 @@ class HermesACPAgent(acp.Agent):
 
     def _cmd_reset(self, args: str, state: SessionState) -> str:
         state.history.clear()
-        self.session_manager.save_session(state.session_id)
+        reset_failed = False
+        try:
+            reset_session_state = getattr(state.agent, "reset_session_state", None)
+            if callable(reset_session_state):
+                reset_session_state()
+        except Exception:
+            reset_failed = True
+            logger.warning("ACP session state reset failed for %s", state.session_id, exc_info=True)
+        finally:
+            self.session_manager.save_session(state.session_id)
+        if reset_failed:
+            return "Conversation history cleared. Agent session state reset failed; see logs."
         return "Conversation history cleared."
 
     def _cmd_compact(self, args: str, state: SessionState) -> str:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1465,6 +1465,37 @@ class TestSlashCommands:
         assert "cleared" in result.lower()
         assert len(state.history) == 0
 
+    def test_reset_resets_agent_session_state(self, agent, mock_manager):
+        state = self._make_state(mock_manager)
+        state.history = [{"role": "user", "content": "hello"}]
+        state.agent.reset_session_state = MagicMock()
+
+        with patch.object(agent.session_manager, "save_session") as mock_save:
+            result = agent._handle_slash_command("/reset", state)
+
+        assert "cleared" in result.lower()
+        assert state.history == []
+        state.agent.reset_session_state.assert_called_once_with()
+        mock_save.assert_called_once_with(state.session_id)
+
+    def test_reset_saves_session_when_agent_state_reset_fails(self, agent, mock_manager):
+        state = self._make_state(mock_manager)
+        state.history = [{"role": "user", "content": "hello"}]
+        state.agent.reset_session_state = MagicMock(side_effect=RuntimeError("boom"))
+
+        with (
+            patch.object(agent.session_manager, "save_session") as mock_save,
+            patch("acp_adapter.server.logger") as mock_logger,
+        ):
+            result = agent._handle_slash_command("/reset", state)
+
+        assert "cleared" in result.lower()
+        assert "state reset failed" in result.lower()
+        assert state.history == []
+        state.agent.reset_session_state.assert_called_once_with()
+        mock_save.assert_called_once_with(state.session_id)
+        mock_logger.warning.assert_called_once()
+
     def test_version(self, agent, mock_manager):
         state = self._make_state(mock_manager)
         result = agent._handle_slash_command("/version", state)


### PR DESCRIPTION
## What does this PR do?

Fixes #35823.

ACP `/reset` already cleared the saved message history, but it did not reset the live `AIAgent` session state. Token counters and context compressor state could carry over into the next ACP conversation.

This PR calls the existing `reset_session_state()` helper during ACP reset. It also keeps session persistence reliable by saving the ACP session even if that optional reset hook raises.

## Related Issue

Fixes #35823

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `acp_adapter/server.py`: reset the live agent session state when `/reset` runs, then persist the ACP session in a `finally` block.
- `tests/acp/test_server.py`: add regression coverage for normal reset behavior and for the reset hook failure path.

## How to Test

1. `source /Users/blackishgreen03/workspace/hermes-agent/venv/bin/activate`
2. `python -m pytest tests/acp/test_server.py -q`
3. `git diff --check origin/main...HEAD`

GitHub Actions also ran `tests/acp/test_server.py` successfully. Current red test jobs are outside this PR's files: model catalog sync, GUI command mocks, and a web server websocket broadcast timeout.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and found the overlapping #35827; this PR keeps the additional failure-path handling requested during review.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted test result:

```text
80 passed, 1 warning in 2.43s
```