### PR TITLE
fix(gemini): add role field to systemInstruction for Gemma compatibility (#27121)

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -323,7 +323,7 @@ def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[st
     system_instruction = None
     joined_system = "\n".join(part for part in system_text_parts if part).strip()
     if joined_system:
-        system_instruction = {"parts": [{"text": joined_system}]}
+        system_instruction = {"role": "system", "parts": [{"text": joined_system}]}
     return contents, system_instruction
 
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -326,3 +326,28 @@ def test_stream_event_translation_keeps_identical_calls_in_distinct_parts():
     assert tool_chunks[0].choices[0].delta.tool_calls[0].index == 0
     assert tool_chunks[1].choices[0].delta.tool_calls[0].index == 1
     assert tool_chunks[0].choices[0].delta.tool_calls[0].id != tool_chunks[1].choices[0].delta.tool_calls[0].id
+
+
+def test_system_instruction_includes_role_field():
+    # Gemma models (and strict Gemini API validation) require systemInstruction
+    # to carry a "role": "system" key — without it the API returns HTTP 500.
+    # Regression guard for #27121.
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+        ],
+        tools=[],
+        tool_choice=None,
+    )
+
+    assert "systemInstruction" in request
+    si = request["systemInstruction"]
+    assert si.get("role") == "system", (
+        "systemInstruction must have role='system' — Gemma returns HTTP 500 without it"
+    )
+    assert si["parts"][0]["text"] == "You are a helpful assistant."
+    # System message must not appear in contents
+    assert all(c.get("role") != "system" for c in request["contents"])


### PR DESCRIPTION
## Problem

Gemma models (e.g. gemma-4-31b-it) return HTTP 500 on any request with a system prompt. Root cause: the native adapter builds systemInstruction as:

```python
{"parts": [{"text": joined_system}]}
```

The Gemini API requires a role field:

```python
{"role": "system", "parts": [{"text": joined_system}]}
```

Gemini 2.x models tolerate the missing field, which masked the bug until Gemma usage surfaced it.

## Fix

One-line change in `agent/gemini_native_adapter.py` line 326. Added a regression test asserting the role field is present and the system message does not appear in contents.

## Test plan

- [x] 12/12 `tests/agent/test_gemini_native_adapter.py` tests pass
- [x] New test `test_system_instruction_includes_role_field` explicitly guards against regression

Closes #27121

Generated with [Claude Code](https://claude.com/claude-code)