### PR TITLE
[codex] fix TUI fallback providers for dflash empty responses

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4929,6 +4929,28 @@ def test_make_agent_handles_null_agent_config(monkeypatch):
     assert mock_agent.call_args.kwargs["max_iterations"] == 80
 
 
+def test_make_agent_passes_fallback_chain_from_config(monkeypatch):
+    fallback_chain = [
+        {"provider": "opencode-zen", "model": "deepseek-v4-flash-free"},
+        {"provider": "taro", "model": "qwen3.6-27b-256k"},
+    ]
+    _setup_make_agent_mocks(
+        monkeypatch,
+        {
+            "fallback_providers": fallback_chain,
+            "fallback_model": {
+                "provider": "opencode-zen",
+                "model": "deepseek-v4-flash-free",
+            },
+        },
+    )
+
+    with patch("run_agent.AIAgent") as mock_agent:
+        server._make_agent("sid1", "key1")
+
+    assert mock_agent.call_args.kwargs["fallback_model"] == fallback_chain
+
+
 class _FakeAgentForBackground:
     base_url = None
     api_key = None
@@ -4981,6 +5003,20 @@ def test_background_agent_kwargs_handles_null_agent_config(monkeypatch):
     kwargs = server._background_agent_kwargs(_FakeAgentForBackground(), "task_1")
 
     assert kwargs["max_iterations"] == 40
+
+
+def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    agent = _FakeAgentForBackground()
+    agent._fallback_chain = [
+        {"provider": "opencode-zen", "model": "deepseek-v4-flash-free"},
+        {"provider": "taro", "model": "qwen3.6-27b-256k"},
+    ]
+    agent._fallback_model = {"provider": "opencode-zen", "model": "legacy-only"}
+
+    kwargs = server._background_agent_kwargs(agent, "task_1")
+
+    assert kwargs["fallback_model"] == agent._fallback_chain
 
 
 def test_config_show_displays_nested_max_turns(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_cli.fallback_config import get_fallback_chain
 from utils import is_truthy_value
 from tui_gateway.transport import (
     StdioTransport,
@@ -1972,7 +1973,10 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
         "platform": "tui",
         "session_db": _get_db(),
-        "fallback_model": getattr(agent, "_fallback_model", None),
+        "fallback_model": (
+            list(getattr(agent, "_fallback_chain", None) or [])
+            or getattr(agent, "_fallback_model", None)
+        ),
     }
 
 
@@ -2019,6 +2023,7 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
         pass
 
     cfg = _load_cfg()
+    fallback_chain = get_fallback_chain(cfg)
     agent_cfg = cfg.get("agent") or {}
     system_prompt = (agent_cfg.get("system_prompt", "") or "").strip()
     startup_skills = _parse_tui_skills_env()
@@ -2050,6 +2055,7 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
         acp_command=runtime.get("command"),
         acp_args=runtime.get("args"),
         credential_pool=runtime.get("credential_pool"),
+        fallback_model=fallback_chain or None,
         quiet_mode=True,
         # verbose_logging controls DEBUG-level agent logging; it is intentionally
         # independent of tool_progress_mode (which only controls per-tool


### PR DESCRIPTION
## What changed
- Load `fallback_providers` / legacy `fallback_model` config in TUI gateway session creation.
- Pass the resolved fallback chain into `AIAgent`, matching oneshot CLI behavior.
- Preserve the full fallback chain for TUI background turns instead of only carrying `_fallback_model`.
- Add regression coverage for TUI session construction and background agent kwargs.

## Root cause
TUI sessions ignored the configured fallback chain when constructing `AIAgent`. In local `taro/dflash` sessions, dflash can occasionally return an empty post-tool response. Hermes then retried the same context but had no fallback available in TUI, despite fallbacks being present in config, so the user saw a terminal `No reply` result.

## Impact
TUI behavior now matches oneshot CLI: if the primary model repeatedly returns empty output, the configured fallback chain can activate instead of ending the turn with no recovery path.

## Validation
- `python3 -m pytest tests/test_tui_gateway_server.py -q -k "make_agent or background_agent_kwargs"`
- `python3 -m pytest tests/run_agent/test_run_agent.py -q -k empty_response`
- `python3 -m pytest tests/run_agent/test_provider_fallback.py tests/cli/test_cli_init.py -q`
- Live taro import canary confirmed `_make_agent()` passes the configured fallback chain.
- Live `hermes-phone` tmux session was restarted after deploying the patched gateway file to the installed taro checkout.

## Notes
The full local `tests/test_tui_gateway_server.py -q` run had one unrelated environment-dependent browser-launch expectation failure on this Mac; the fallback-focused tests passed.

Fork mirror: https://github.com/OmarB97/hermes-agent/pull/47
