### PR TITLE
fix(mcp): fail fast on HTML content-type instead of waiting full connect_timeout

### DIFF
--- a/tests/tools/test_mcp_preflight_content_type.py
+++ b/tests/tools/test_mcp_preflight_content_type.py
@@ -1,0 +1,137 @@
+"""Tests for _MCPServer._preflight_content_type early-fail behaviour."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools.mcp_tool import MCPServerTask
+
+
+@pytest.fixture()
+def server():
+    """Return a minimal MCPServerTask instance (bypasses __init__ complexity)."""
+    s = MCPServerTask.__new__(MCPServerTask)
+    s.name = "test-server"
+    return s
+
+
+# ---------------------------------------------------------------------------
+# HTML response → ConnectionError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preflight_rejects_html(server):
+    """A text/html response must raise ConnectionError immediately."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "text/html; charset=utf-8"}
+
+    mock_client = AsyncMock()
+    mock_client.head = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(ConnectionError, match="text/html"):
+            await server._preflight_content_type("https://example.com")
+
+
+@pytest.mark.asyncio
+async def test_preflight_rejects_html_on_get_fallback(server):
+    """When HEAD returns 405, fall back to GET — still reject HTML."""
+    head_response = MagicMock()
+    head_response.status_code = 405
+
+    get_response = MagicMock()
+    get_response.status_code = 200
+    get_response.headers = {"content-type": "text/html"}
+
+    mock_client = AsyncMock()
+    mock_client.head = AsyncMock(return_value=head_response)
+    mock_client.get = AsyncMock(return_value=get_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(ConnectionError, match="text/html"):
+            await server._preflight_content_type("https://example.com")
+
+
+# ---------------------------------------------------------------------------
+# Non-HTML responses → silent pass-through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preflight_accepts_json(server):
+    """application/json must NOT raise."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+
+    mock_client = AsyncMock()
+    mock_client.head = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        # Should not raise
+        await server._preflight_content_type("https://mcp-server.example.com/mcp")
+
+
+@pytest.mark.asyncio
+async def test_preflight_accepts_no_content_type(server):
+    """Missing Content-Type header must NOT raise."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {}
+
+    mock_client = AsyncMock()
+    mock_client.head = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        await server._preflight_content_type("https://mcp-server.example.com/mcp")
+
+
+@pytest.mark.asyncio
+async def test_preflight_swallows_network_errors(server):
+    """Network errors / timeouts must silently pass through."""
+
+    mock_client = AsyncMock()
+    mock_client.head = AsyncMock(side_effect=TimeoutError("connect timed out"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        # Should not raise — let the real MCP handshake deal with it
+        await server._preflight_content_type("https://unreachable.example.com")
+
+
+@pytest.mark.asyncio
+async def test_preflight_passes_headers_and_verify(server):
+    """Custom headers and ssl_verify are forwarded to the probe client."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+
+    mock_client = AsyncMock()
+    mock_client.head = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("httpx.AsyncClient", return_value=mock_client) as client_cls:
+        await server._preflight_content_type(
+            "https://mcp.example.com/mcp",
+            headers={"Authorization": "Bearer tok"},
+            ssl_verify=False,
+        )
+        # Verify the client was created with ssl_verify=False
+        client_cls.assert_called_once()
+        call_kwargs = client_cls.call_args
+        assert call_kwargs.kwargs.get("verify") is False

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1457,6 +1457,54 @@ class MCPServerTask:
                             # PID-reuse can't surface stale pgroup state later.
                             _stdio_pgids.pop(pid, None)
 
+    @staticmethod
+    async def _preflight_content_type(
+        url: str,
+        *,
+        headers: Optional[dict] = None,
+        ssl_verify: bool = True,
+        timeout: float = 5.0,
+    ) -> None:
+        """Quick content-type probe before handing *url* to the MCP SDK.
+
+        A misconfigured ``mcp_servers.<name>.url`` that points at a plain web
+        app (returning ``text/html``) causes the MCP SDK to sit on the
+        connection for the full ``connect_timeout`` (default 60 s) before
+        surfacing ``CancelledError``.  A cheap HEAD request lets us detect
+        this in ≤ 5 s and raise immediately with an actionable message.
+
+        Non-HTML responses (``application/json``, missing header, network
+        errors) silently pass through so the normal MCP handshake proceeds.
+        """
+        try:
+            import httpx as _httpx
+
+            probe_headers = dict(headers) if headers else {}
+            # HEAD is idempotent and lightweight; fall back to GET if the
+            # server rejects HEAD (405 Method Not Allowed).
+            async with _httpx.AsyncClient(
+                verify=ssl_verify,
+                follow_redirects=True,
+                timeout=_httpx.Timeout(timeout),
+            ) as client:
+                resp = await client.head(url, headers=probe_headers)
+                if resp.status_code == 405:
+                    resp = await client.get(url, headers=probe_headers)
+            ct = resp.headers.get("content-type", "")
+            if "text/html" in ct.lower():
+                raise ConnectionError(
+                    f"MCP server '{url}' returned Content-Type: {ct}. "
+                    "This looks like a regular web page, not an MCP endpoint. "
+                    "Verify the URL points to an MCP Streamable HTTP or SSE "
+                    "endpoint (e.g. https://host/mcp, not https://host/)."
+                )
+        except ConnectionError:
+            raise
+        except Exception:
+            # Network errors, timeouts, etc. — let the real MCP handshake
+            # deal with them; this is just a best-effort early check.
+            pass
+
     async def _run_http(self, config: dict):
         """Run the server using HTTP/StreamableHTTP transport."""
         if not _MCP_HTTP_AVAILABLE:
@@ -1467,6 +1515,14 @@ class MCPServerTask:
             )
 
         url = config["url"]
+        # Pre-flight: reject obvious non-MCP endpoints (e.g. a web app
+        # returning HTML) in seconds instead of waiting the full
+        # connect_timeout (default 60 s).
+        await self._preflight_content_type(
+            url,
+            headers=dict(config.get("headers") or {}),
+            ssl_verify=config.get("ssl_verify", True),
+        )
         headers = dict(config.get("headers") or {})
         # Some MCP servers require MCP-Protocol-Version on the initial
         # initialize request and reject session-less POSTs otherwise.


### PR DESCRIPTION
## What does this PR do?

Adds a lightweight HTTP pre-flight check to `MCPServerTask._run_http()` that detects misconfigured MCP server URLs returning `text/html` (e.g. pointing at a web app root) and fails fast with an actionable error message, instead of waiting the full `connect_timeout` (default 60 s) before surfacing `CancelledError`.

## Related Issue

Fixes #36052

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: Added `_preflight_content_type()` static method on `MCPServerTask` that sends a HEAD request (with GET fallback on 405) and raises `ConnectionError` if the response `Content-Type` is `text/html`. Called from `_run_http()` before the MCP SDK handshake.
- `tests/tools/test_mcp_preflight_content_type.py`: 6 tests covering HTML rejection (HEAD + GET fallback), JSON acceptance, missing Content-Type, network error passthrough, and header/verify forwarding.

## How to Test

1. Configure a misconfigured MCP server in `config.yaml`:
   ```yaml
   mcp_servers:
     bad_endpoint:
       url: "https://example.com"  # returns text/html
   ```
2. Start Hermes — the server should fail within ~5 s with: `MCP server 'https://example.com' returned Content-Type: text/html; ...`
3. Configure a valid MCP server URL — connection proceeds normally.
4. Run: `pytest tests/tools/test_mcp_preflight_content_type.py -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `MCPServerTask._run_http` (callers: 2 — `_run` dispatcher, SSE skip path)
- Blast radius: LOW — pre-flight check is additive; all exceptions (except `ConnectionError`) are swallowed to preserve existing behavior
- Related patterns: PR #29764 (soft-fail slow MCP discovery at startup) addresses a complementary concern (slow servers, not wrong content type)
