### PR TITLE
fix(gateway): allow source code/log extensions in MEDIA: delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1177,7 +1177,23 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     # Archives
     ".zip", ".tar", ".gz", ".tgz", ".bz2", ".xz", ".7z", ".rar", ".apk", ".ipa",
     # Web / rendered output
-    ".html", ".htm",
+    ".html", ".htm", ".css",
+    # Source code (delivered as file attachments — non-credential code review,
+    # snippet sharing, log triage). Sensitive config (.env, .conf, .ini) is
+    # intentionally excluded; the credential-path denylist in
+    # ``_media_delivery_denied_paths`` is a defence-in-depth backstop, but
+    # keeping these out of the extension allowlist also prevents accidental
+    # delivery from non-denied locations.
+    ".py", ".js", ".ts", ".tsx", ".jsx", ".mjs", ".cjs",
+    ".go", ".rs", ".sh", ".bash", ".zsh", ".fish",
+    ".sol", ".cpp", ".cc", ".cxx", ".c", ".h", ".hpp",
+    ".java", ".kt", ".scala",
+    ".rb", ".php", ".swift",
+    ".lua", ".pl", ".r",
+    # Build / project metadata (non-credential)
+    ".toml",
+    # Logs
+    ".log",
 )
 
 # Regex alternation fragment of bare extensions (no leading dot), e.g.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17485,11 +17485,10 @@ class GatewayRunner:
                 if _hm.get("role") in {"tool", "function"}:
                     _hc = _hm.get("content", "")
                     if "MEDIA:" in _hc:
+                        from gateway.platforms.base import _MEDIA_EXT_ALTERNATION
                         _TOOL_MEDIA_RE = re.compile(
-                            r'MEDIA:((?:[A-Za-z]:[/\\]|/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
-                            r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
-                            r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|apk|ipa))',
+                            r'MEDIA:((?:[A-Za-z]:[/\\]|/|~\/)\S+\.(?:'
+                            + _MEDIA_EXT_ALTERNATION + r'))',
                             re.IGNORECASE
                         )
                         for _match in _TOOL_MEDIA_RE.finditer(_hc):
@@ -17811,11 +17810,10 @@ class GatewayRunner:
                     if msg.get("role") in {"tool", "function"}:
                         content = msg.get("content", "")
                         if "MEDIA:" in content:
+                            from gateway.platforms.base import _MEDIA_EXT_ALTERNATION
                             _TOOL_MEDIA_RE = re.compile(
-                                r'MEDIA:((?:[A-Za-z]:[/\\]|/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
-                                r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
-                                r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                                r'txt|csv|apk|ipa))',
+                                r'MEDIA:((?:[A-Za-z]:[/\\]|/|~\/)\S+\.(?:'
+                                + _MEDIA_EXT_ALTERNATION + r'))',
                                 re.IGNORECASE
                             )
                             for match in _TOOL_MEDIA_RE.finditer(content):

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -449,6 +449,54 @@ class TestMediaExtensionAllowlistParity:
         assert "Here is your report:" in stripped
 
 
+class TestSourceCodeMediaDelivery:
+    """Source code, build manifests, and log files are deliverable as MEDIA:.
+
+    Code review, snippet sharing, and log triage are common chat-driven
+    workflows; without ``.py``/``.js``/``.ts``/``.log`` etc. in the allowlist
+    the agent silently dropped the attachment and the user only saw the prose
+    around it. Sensitive single-purpose config formats (``.env``, ``.conf``,
+    ``.ini``) are intentionally excluded — the credential-path denylist is a
+    backstop, but keeping these out of the extension allowlist is the cheaper
+    layer of defence.
+    """
+
+    SOURCE_CODE_EXTS = [
+        # Python / shell / Web
+        "py", "js", "ts", "tsx", "jsx", "mjs", "cjs",
+        "sh", "bash", "zsh", "fish",
+        # Systems / native
+        "go", "rs", "sol", "cpp", "cc", "cxx", "c", "h", "hpp",
+        # JVM / mobile
+        "java", "kt", "scala", "swift",
+        # Scripting
+        "rb", "php", "lua", "pl", "r",
+        # Build / metadata / web
+        "toml", "css",
+        # Logs
+        "log",
+    ]
+
+    def test_source_code_extensions_extract_via_media_tag(self):
+        for ext in self.SOURCE_CODE_EXTS:
+            path = f"/home/u/snippet.{ext}"
+            media, _ = BasePlatformAdapter.extract_media(f"See MEDIA:{path}")
+            assert media == [(path, False)], (
+                f".{ext} should extract via MEDIA: tag"
+            )
+
+    def test_sensitive_config_extensions_are_NOT_in_allowlist(self):
+        """``.env``/``.conf``/``.ini`` are deliberately omitted — adding them
+        would let a prompt-injected agent run exfiltrate credentials by
+        emitting ``MEDIA:~/.env`` even on hosts where the path-denylist
+        somehow doesn't cover the location."""
+        from gateway.platforms.base import MEDIA_DELIVERY_EXTS
+        for ext in (".env", ".conf", ".ini"):
+            assert ext not in MEDIA_DELIVERY_EXTS, (
+                f"{ext} must stay out of the MEDIA allowlist"
+            )
+
+
 class TestMediaDeliveryPathValidation:
     def _patch_roots(self, monkeypatch, *roots):
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

The `MEDIA:` extension allowlist (`MEDIA_DELIVERY_EXTS`, introduced by #34844 / #34517) covered docs, spreadsheets, archives, and rendered web output but not source code, build manifests, or logs. A response of `MEDIA:/path/to/script.py` was silently dropped — `extract_media()` didn't match it, `MEDIA_TAG_CLEANUP_RE` left the tag in the body, and the file never reached the user. Same story for `.ts/.tsx`, `.go`, `.rs`, `.sh`, `.sol`, `.toml`, `.log`, etc. — exactly the file types most likely to be shared in a chat workflow (code review, snippet sharing, log triage).

This is a follow-up to #34844 that closes the remaining gap.

## Changes

- **Extend `MEDIA_DELIVERY_EXTS`** with source code (Python / JS / TS / shell / systems / JVM / scripting / Solidity / web), build metadata (`.toml`, `.css`), and `.log`.

  Sensitive single-purpose configs (`.env`, `.conf`, `.ini`) are deliberately **excluded**. The credential-path denylist in `_media_delivery_denied_paths` is the runtime backstop, but keeping these out of the extension allowlist is the cheaper, earlier layer of defence — a malicious prompt-injection that emits `MEDIA:~/some/.env` from a non-denied location is now ignored at the extractor instead of relying solely on the path check.

- **Replace two duplicated extension regexes in `gateway/run.py`** (history scan + post-run scan) with imports of `_MEDIA_EXT_ALTERNATION` from `gateway/platforms/base.py`. They had been drifting from the source of truth that #34844 introduced; pulling them through the shared constant closes the gap and means future extension additions only need to land in one place.

## Test plan

Two new regression tests in `tests/gateway/test_platform_base.py::TestSourceCodeMediaDelivery`:

- Every newly-added extension extracts via `MEDIA:` tag.
- `.env` / `.conf` / `.ini` stay **out** of the allowlist (anti-regression for the credential-leak guardrail).

```
$ scripts/run_tests.sh tests/gateway/test_platform_base.py
129 tests passed, 0 failed
```

Adjacent gateway tests (`test_send_image_file.py`, `test_dingtalk.py`) also still pass — no behaviour change on the existing allowed types.

## Manual verification

Tested live on a private Discord-connected gateway: a reply containing `MEDIA:/home/user/snippet.py` now delivers as a native file attachment. Before the patch, the same reply showed only the surrounding prose with the path silently stripped.
