### PR TITLE
feat(gateway): route platform HTTP event callbacks

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -900,6 +900,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # Number of in-flight runs on the non-streaming chat/responses paths
         # (the /v1/runs path tracks its own in-flight set via _run_streams).
         self._inflight_agent_runs: int = 0
+        self.gateway_runner: Optional[Any] = None
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -1071,6 +1072,118 @@ class APIServerAdapter(BasePlatformAdapter):
             {"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}},
             status=401,
         )
+
+    @staticmethod
+    def _normalize_callback_platform(value: str) -> str:
+        normalized = (value or "").strip().lower().replace("-", "_")
+        if not re.fullmatch(r"[a-z0-9_]+", normalized):
+            return ""
+        return normalized
+
+    def _get_platform_callback_adapter(
+        self,
+        request: "web.Request",
+        platform_name: str,
+    ) -> Optional[Any]:
+        injected = request.app.get("platform_event_adapters")
+        if isinstance(injected, dict):
+            adapter = injected.get(platform_name)
+            if adapter is not None:
+                return adapter
+
+        adapter = request.app.get(f"{platform_name}_adapter")
+        if adapter is not None:
+            return adapter
+
+        runner = self.gateway_runner or request.app.get("gateway_runner")
+        adapters = getattr(runner, "adapters", None)
+        if not adapters:
+            return None
+
+        try:
+            from gateway.config import Platform as _Platform
+            return adapters.get(_Platform(platform_name))
+        except Exception:
+            for platform, candidate in adapters.items():
+                if getattr(platform, "value", platform) == platform_name:
+                    return candidate
+        return None
+
+    async def _handle_platform_event_callback(self, request: "web.Request") -> "web.Response":
+        platform_name = self._normalize_callback_platform(
+            request.match_info.get("platform", "")
+        )
+        if not platform_name:
+            return web.json_response(
+                _openai_error(
+                    "Invalid platform name",
+                    code="invalid_platform",
+                ),
+                status=400,
+            )
+
+        adapter = self._get_platform_callback_adapter(request, platform_name)
+        if adapter is None:
+            return web.json_response(
+                _openai_error(
+                    "Platform adapter is not connected",
+                    code="platform_unavailable",
+                ),
+                status=503,
+            )
+
+        verifier = getattr(adapter, "verify_http_event_request", None)
+        dispatcher = getattr(adapter, "dispatch_http_event", None)
+        if verifier is None or dispatcher is None:
+            return web.json_response(
+                _openai_error(
+                    "Platform adapter does not support HTTP events",
+                    code="platform_http_events_unsupported",
+                ),
+                status=503,
+            )
+
+        ok, code = verifier(request.headers.get("Authorization", ""))
+        if not ok:
+            return web.json_response(
+                _openai_error(
+                    "Invalid platform event authorization",
+                    code=code or "invalid_platform_event_authorization",
+                ),
+                status=401,
+            )
+
+        try:
+            payload = await request.json()
+        except Exception:
+            return web.json_response(
+                _openai_error("Invalid JSON in platform event", code="invalid_json"),
+                status=400,
+            )
+
+        if not isinstance(payload, dict):
+            return web.json_response(
+                _openai_error(
+                    "Platform event must be a JSON object",
+                    code="invalid_request",
+                ),
+                status=400,
+            )
+
+        try:
+            result = await dispatcher(payload)
+        except Exception:
+            logger.exception("Platform HTTP event dispatch failed for %s", platform_name)
+            return web.json_response(
+                _openai_error(
+                    "Platform event dispatch failed",
+                    err_type="server_error",
+                    code="platform_event_dispatch_failed",
+                ),
+                status=500,
+            )
+
+        return web.json_response(result if isinstance(result, dict) else {})
 
     # ------------------------------------------------------------------
     # Session header helpers
@@ -4787,6 +4900,10 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
             self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
+            self._app.router.add_post(
+                "/api/platforms/{platform}/events",
+                self._handle_platform_event_callback,
+            )
             # Cron jobs management API
             self._app.router.add_get("/api/jobs", self._handle_list_jobs)
             self._app.router.add_post("/api/jobs", self._handle_create_job)
@@ -4812,6 +4929,8 @@ class APIServerAdapter(BasePlatformAdapter):
             # native routes first lets those shims no-op instead of shadowing the
             # upstream session-control handlers.
             self._app["api_server_adapter"] = self
+            if self.gateway_runner is not None:
+                self._app["gateway_runner"] = self.gateway_runner
 
             # Start background sweep to clean up orphaned (unconsumed) run streams
             sweep_task = asyncio.create_task(self._sweep_orphaned_runs())

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8512,7 +8512,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not check_api_server_requirements():
                 logger.warning("API Server: aiohttp not installed")
                 return None
-            return APIServerAdapter(config)
+            adapter = APIServerAdapter(config)
+            adapter.gateway_runner = self
+            return adapter
 
         elif platform == Platform.WEBHOOK:
             from gateway.platforms.webhook import WebhookAdapter, check_webhook_requirements

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -1,9 +1,9 @@
 """
 Google Chat platform adapter.
 
-Uses Google Cloud Pub/Sub (pull subscription) for inbound events and the
-Google Chat REST API for outbound messages. Pattern parallels Slack Socket
-Mode and Telegram long-polling: no public endpoint required.
+Uses authenticated HTTP callbacks or Google Cloud Pub/Sub for inbound
+events and the Google Chat REST API for outbound messages. Pub/Sub remains
+available for no-public-URL deployments.
 
 Concurrency model
 -----------------
@@ -625,33 +625,42 @@ class GoogleChatAdapter(BasePlatformAdapter):
         )
         return credentials
 
-    def _validate_config(self) -> Tuple[str, str]:
+    def _validate_config(self) -> Tuple[str, Optional[str]]:
         """Return (project_id, subscription_path) after validation.
 
-        Raises ValueError with a sanitized message on any config problem.
+        ``subscription_path`` is ``None`` for HTTP-inbound deployments. Raises
+        ValueError with a sanitized message on any config problem.
         """
-        project_id = self.config.extra.get("project_id")
-        subscription = self.config.extra.get("subscription_name")
+        project_id = (self.config.extra.get("project_id") or "").strip()
+        subscription = (self.config.extra.get("subscription_name") or "").strip()
+        http_events_url = (self.config.extra.get("http_events_url") or "").strip()
+
+        if subscription:
+            match = _SUBSCRIPTION_PATH_RE.match(subscription)
+            if not match:
+                raise ValueError(
+                    "GOOGLE_CHAT_SUBSCRIPTION_NAME must match "
+                    "'projects/<project>/subscriptions/<sub>'."
+                )
+            subscription_project = match.group("project")
+            if project_id and subscription_project != project_id:
+                raise ValueError(
+                    "project_id in GOOGLE_CHAT_PROJECT_ID does not match the "
+                    "project embedded in GOOGLE_CHAT_SUBSCRIPTION_NAME."
+                )
+            return project_id or subscription_project, subscription
+
+        if http_events_url:
+            return project_id, None
+
         if not project_id:
             raise ValueError(
                 "GOOGLE_CHAT_PROJECT_ID (or GOOGLE_CLOUD_PROJECT) is not set."
             )
-        if not subscription:
-            raise ValueError(
-                "GOOGLE_CHAT_SUBSCRIPTION_NAME (or GOOGLE_CHAT_SUBSCRIPTION) is not set."
-            )
-        match = _SUBSCRIPTION_PATH_RE.match(subscription)
-        if not match:
-            raise ValueError(
-                "GOOGLE_CHAT_SUBSCRIPTION_NAME must match "
-                "'projects/<project>/subscriptions/<sub>'."
-            )
-        if match.group("project") != project_id:
-            raise ValueError(
-                "project_id in GOOGLE_CHAT_PROJECT_ID does not match the "
-                "project embedded in GOOGLE_CHAT_SUBSCRIPTION_NAME."
-            )
-        return project_id, subscription
+        raise ValueError(
+            "GOOGLE_CHAT_SUBSCRIPTION_NAME (or GOOGLE_CHAT_SUBSCRIPTION) is not set. "
+            "Set GOOGLE_CHAT_HTTP_EVENTS_URL for HTTP callback mode."
+        )
 
     # ------------------------------------------------------------------
     # Loop bridge helpers (thread -> asyncio loop)
@@ -862,36 +871,37 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 "all threads as fresh)", exc_info=True,
             )
 
-        # Sanity check: subscription exists / SA has access.
-        self._subscriber = pubsub_v1.SubscriberClient(credentials=credentials)
-        try:
-            await asyncio.to_thread(
-                lambda: self._subscriber.get_subscription(
-                    request={"subscription": subscription_path}
+        if subscription_path is not None:
+            # Sanity check: subscription exists / SA has access.
+            self._subscriber = pubsub_v1.SubscriberClient(credentials=credentials)
+            try:
+                await asyncio.to_thread(
+                    lambda: self._subscriber.get_subscription(
+                        request={"subscription": subscription_path}
+                    )
                 )
-            )
-        except gax_exceptions.NotFound:
-            self._set_fatal_error(
-                code="subscription_not_found",
-                message="Pub/Sub subscription not found at configured path",
-                retryable=False,
-            )
-            return False
-        except gax_exceptions.PermissionDenied:
-            self._set_fatal_error(
-                code="subscription_permission",
-                message=(
-                    "Service Account lacks roles/pubsub.subscriber on the "
-                    "subscription"
-                ),
-                retryable=False,
-            )
-            return False
-        except Exception as exc:
-            msg = _redact_sensitive(str(exc))
-            logger.error("[GoogleChat] subscription.get failed: %s", msg)
-            self._set_fatal_error(code="subscription_check", message=msg, retryable=True)
-            return False
+            except gax_exceptions.NotFound:
+                self._set_fatal_error(
+                    code="subscription_not_found",
+                    message="Pub/Sub subscription not found at configured path",
+                    retryable=False,
+                )
+                return False
+            except gax_exceptions.PermissionDenied:
+                self._set_fatal_error(
+                    code="subscription_permission",
+                    message=(
+                        "Service Account lacks roles/pubsub.subscriber on the "
+                        "subscription"
+                    ),
+                    retryable=False,
+                )
+                return False
+            except Exception as exc:
+                msg = _redact_sensitive(str(exc))
+                logger.error("[GoogleChat] subscription.get failed: %s", msg)
+                self._set_fatal_error(code="subscription_check", message=msg, retryable=True)
+                return False
 
         # Resolve bot user_id (eager): cache first, then members.list.
         self._bot_user_id = self._load_cached_bot_id()
@@ -905,14 +915,22 @@ class GoogleChatAdapter(BasePlatformAdapter):
                     "will resolve on first addedToSpace or member lookup"
                 )
 
-        # Start the supervisor task that runs the Pub/Sub pull with exponential
-        # backoff + jitter on transient errors, bails out after N retries.
-        self._supervisor_task = asyncio.create_task(self._run_supervisor())
+        if subscription_path is not None:
+            # Start the supervisor task that runs the Pub/Sub pull with exponential
+            # backoff + jitter on transient errors, bails out after N retries.
+            self._supervisor_task = asyncio.create_task(self._run_supervisor())
+            inbound = "pubsub"
+        else:
+            self._supervisor_task = None
+            inbound = "http"
+
         self._mark_connected()
         logger.info(
-            "[GoogleChat] Connected; project=%s, subscription=<redacted>, "
+            "[GoogleChat] Connected; project=%s, inbound=%s, subscription=%s, "
             "bot_user_id=%s, flow_control(msgs=%s, bytes=%s)",
-            project_id,
+            project_id or "<unset>",
+            inbound,
+            "<redacted>" if subscription_path else "<none>",
             self._bot_user_id or "<unresolved>",
             self._max_messages,
             self._max_bytes,
@@ -2944,15 +2962,11 @@ class GoogleChatAdapter(BasePlatformAdapter):
 
 
 def _validate_config(config: PlatformConfig) -> bool:
-    """Plugin-side config gate: require both Pub/Sub project and subscription.
-
-    Mirrors the legacy dispatch entry in ``gateway/config.py`` so the
-    registry can decide whether the platform is configured without
-    importing the legacy table.
-    """
+    """Plugin-side config gate for HTTP callback or Pub/Sub inbound modes."""
     extra = getattr(config, "extra", {}) or {}
     return bool(
-        extra.get("project_id") and extra.get("subscription_name")
+        extra.get("http_events_url")
+        or (extra.get("project_id") and extra.get("subscription_name"))
     )
 
 
@@ -2977,7 +2991,8 @@ def _check_for_registry() -> bool:
         os.getenv("GOOGLE_CHAT_SUBSCRIPTION_NAME")
         or os.getenv("GOOGLE_CHAT_SUBSCRIPTION")
     )
-    return bool(project and subscription)
+    http_events_url = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_URL")
+    return bool(http_events_url or (project and subscription))
 
 
 def _is_connected(config: PlatformConfig) -> bool:
@@ -3007,12 +3022,16 @@ def _env_enablement() -> Optional[Dict[str, Any]]:
         os.getenv("GOOGLE_CHAT_SUBSCRIPTION_NAME")
         or os.getenv("GOOGLE_CHAT_SUBSCRIPTION")
     )
-    if not (project and subscription):
+    http_events_url = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_URL")
+    if not (http_events_url or (project and subscription)):
         return None
-    seed: Dict[str, Any] = {
-        "project_id": project,
-        "subscription_name": subscription,
-    }
+    seed: Dict[str, Any] = {}
+    if project:
+        seed["project_id"] = project
+    if subscription:
+        seed["subscription_name"] = subscription
+    if http_events_url:
+        seed["http_events_url"] = http_events_url
     sa_json = (
         os.getenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
         or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
@@ -3295,8 +3314,6 @@ def register(ctx) -> None:
         validate_config=_validate_config,
         is_connected=_is_connected,
         required_env=[
-            "GOOGLE_CHAT_PROJECT_ID",
-            "GOOGLE_CHAT_SUBSCRIPTION_NAME",
             "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON",
         ],
         install_hint="pip install 'hermes-agent[google_chat]'",

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -43,6 +43,8 @@ import logging
 import os
 import random
 import re
+import threading
+import time
 from pathlib import Path as _Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -71,18 +73,57 @@ HttpError: Any = Exception  # type: ignore
 MediaFileUpload: Any = None  # type: ignore
 
 _google_modules_loaded: bool = False
+_GOOGLE_ID_TOKEN_CERTS_TTL_SECONDS = 300
+_google_id_token_request: Any = None
+_google_id_token_request_lock = threading.Lock()
+
+
+class _CachedGoogleAuthRequest:
+    def __init__(self, request: Any, ttl_seconds: int = _GOOGLE_ID_TOKEN_CERTS_TTL_SECONDS) -> None:
+        self._request = request
+        self._ttl_seconds = ttl_seconds
+        self._lock = threading.Lock()
+        self._cache: Dict[Tuple[str, str], Tuple[float, Any]] = {}
+
+    def __call__(self, url: str, method: str = "GET", **kwargs: Any) -> Any:
+        cache_key = (method.upper(), url)
+        if cache_key[0] != "GET":
+            return self._request(url=url, method=method, **kwargs)
+
+        now = time.monotonic()
+        with self._lock:
+            cached = self._cache.get(cache_key)
+            if cached and cached[0] > now:
+                return cached[1]
+
+        response = self._request(url=url, method=method, **kwargs)
+        if getattr(response, "status", None) == 200:
+            with self._lock:
+                self._cache[cache_key] = (now + self._ttl_seconds, response)
+        return response
+
+
+def _get_google_id_token_request() -> Any:
+    global _google_id_token_request
+    with _google_id_token_request_lock:
+        if _google_id_token_request is None:
+            try:
+                from google.auth.transport import requests as google_requests
+            except ImportError as exc:
+                raise RuntimeError("google-auth is required for Google Chat HTTP callbacks") from exc
+            _google_id_token_request = _CachedGoogleAuthRequest(google_requests.Request())
+        return _google_id_token_request
 
 
 def _verify_google_id_token(token: str, audience: str) -> Dict[str, Any]:
     try:
-        from google.auth.transport import requests as google_requests
         from google.oauth2 import id_token
     except ImportError as exc:
         raise RuntimeError("google-auth is required for Google Chat HTTP callbacks") from exc
 
     return id_token.verify_oauth2_token(
         token,
-        google_requests.Request(),
+        _get_google_id_token_request(),
         audience,
     )
 

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -73,6 +73,20 @@ MediaFileUpload: Any = None  # type: ignore
 _google_modules_loaded: bool = False
 
 
+def _verify_google_id_token(token: str, audience: str) -> Dict[str, Any]:
+    try:
+        from google.auth.transport import requests as google_requests
+        from google.oauth2 import id_token
+    except ImportError as exc:
+        raise RuntimeError("google-auth is required for Google Chat HTTP callbacks") from exc
+
+    return id_token.verify_oauth2_token(
+        token,
+        google_requests.Request(),
+        audience,
+    )
+
+
 def _load_google_modules() -> bool:
     """Lazily import the heavy google-cloud + googleapiclient stack.
 
@@ -548,6 +562,21 @@ class GoogleChatAdapter(BasePlatformAdapter):
             self._max_bytes = int(os.getenv("GOOGLE_CHAT_MAX_BYTES", str(16 * 1024 * 1024)))
         except (ValueError, TypeError):
             self._max_bytes = 16 * 1024 * 1024
+        self._http_events_url = (
+            self.config.extra.get("http_events_url")
+            or os.getenv("GOOGLE_CHAT_HTTP_EVENTS_URL", "")
+            or ""
+        ).strip()
+        self._http_events_audience = (
+            self.config.extra.get("http_events_audience")
+            or os.getenv("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE", "")
+            or self._http_events_url
+        ).strip()
+        self._http_events_service_account_email = (
+            self.config.extra.get("http_events_service_account_email")
+            or os.getenv("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL", "")
+            or ""
+        ).strip().lower()
 
     # ------------------------------------------------------------------
     # Configuration loading and validation
@@ -1279,6 +1308,62 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 message.ack()
             except Exception:
                 pass
+
+    async def dispatch_http_event(self, envelope: Dict[str, Any]) -> Dict[str, Any]:
+        extracted = self._extract_message_payload(envelope)
+        if extracted is None:
+            return {}
+
+        msg, space, _fmt = extracted
+        sender = msg.get("sender") or {}
+        if sender.get("type") == "BOT":
+            return {}
+
+        msg_name = msg.get("name") or ""
+        if msg_name and self._dedup.is_duplicate(msg_name):
+            return {}
+
+        msg_with_space = dict(msg)
+        if "space" not in msg_with_space and space:
+            msg_with_space["space"] = space
+
+        enriched_env = dict(envelope)
+        if "space" not in enriched_env and space:
+            enriched_env["space"] = space
+
+        await self._dispatch_message(msg_with_space, enriched_env)
+        return {}
+
+    def verify_http_event_request(self, auth_header: str) -> Tuple[bool, str]:
+        if not self._http_events_audience or not self._http_events_service_account_email:
+            return False, "google_chat_http_events_not_configured"
+
+        if not auth_header.startswith("Bearer "):
+            return False, "missing_google_bearer"
+
+        token = auth_header[7:].strip()
+        if not token:
+            return False, "missing_google_bearer"
+
+        try:
+            claims = _verify_google_id_token(token, self._http_events_audience)
+        except Exception as exc:
+            logger.warning(
+                "[GoogleChat] HTTP event bearer verification failed: %s",
+                _redact_sensitive(str(exc)),
+            )
+            return False, "invalid_google_bearer"
+
+        expected = {
+            item.strip().lower()
+            for item in self._http_events_service_account_email.split(",")
+            if item.strip()
+        }
+        claim_email = str(claims.get("email") or "").strip().lower()
+        if not claim_email or claim_email not in expected:
+            return False, "unexpected_google_bearer_identity"
+
+        return True, ""
 
     async def _dispatch_message(self, msg: Dict[str, Any], envelope: Dict[str, Any]) -> None:
         """Translate a Chat message payload to a MessageEvent and hand off.
@@ -3032,6 +3117,12 @@ def _env_enablement() -> Optional[Dict[str, Any]]:
         seed["subscription_name"] = subscription
     if http_events_url:
         seed["http_events_url"] = http_events_url
+    http_events_audience = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE")
+    if http_events_audience:
+        seed["http_events_audience"] = http_events_audience
+    http_events_sa_email = os.getenv("GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL")
+    if http_events_sa_email:
+        seed["http_events_service_account_email"] = http_events_sa_email
     sa_json = (
         os.getenv("GOOGLE_CHAT_SERVICE_ACCOUNT_JSON")
         or os.getenv("GOOGLE_APPLICATION_CREDENTIALS")

--- a/plugins/platforms/google_chat/plugin.yaml
+++ b/plugins/platforms/google_chat/plugin.yaml
@@ -4,31 +4,34 @@ kind: platform
 version: 1.0.0
 description: >
   Google Chat gateway adapter for Hermes Agent.
-  Connects via Cloud Pub/Sub pull subscription for inbound events and the
-  Google Chat REST API for outbound messages — same ergonomics as Slack
-  Socket Mode or Telegram long-polling, no public URL required. Native
-  file attachments are delivered via per-user OAuth (each user runs
-  /setup-files once in their own DM).
+  Connects through authenticated HTTP callbacks or an optional Cloud Pub/Sub
+  pull subscription for inbound events, and uses the Google Chat REST API for
+  outbound messages. Native file attachments are delivered via per-user OAuth
+  (each user runs /setup-files once in their own DM).
 author: Ramón Fernández
 # ``requires_env`` entries are surfaced in ``hermes config`` UI via the
 # platform-plugin env var injector in ``hermes_cli/config.py``.  Using the
 # rich-dict form lets us contribute description/url/prompt metadata so users
 # see helpful guidance instead of the auto-generated fallback text.
 requires_env:
-  - name: GOOGLE_CHAT_PROJECT_ID
-    description: "GCP project ID hosting the Pub/Sub topic for Chat events. Falls back to GOOGLE_CLOUD_PROJECT."
-    prompt: "GCP project ID"
-    url: "https://console.cloud.google.com/"
-    password: false
-  - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
-    description: "Full Pub/Sub subscription path: projects/<proj>/subscriptions/<sub>. Legacy alias: GOOGLE_CHAT_SUBSCRIPTION."
-    prompt: "Pub/Sub subscription name"
-    password: false
   - name: GOOGLE_CHAT_SERVICE_ACCOUNT_JSON
     description: "Path to Service Account JSON key (or inline JSON). Leave empty to use Application Default Credentials on Cloud Run / GCE. Falls back to GOOGLE_APPLICATION_CREDENTIALS."
     prompt: "Path to SA JSON (or empty for ADC)"
     password: true
 optional_env:
+  - name: GOOGLE_CHAT_HTTP_EVENTS_URL
+    description: "Authenticated HTTP endpoint for Chat message events."
+    prompt: "HTTP events callback URL"
+    password: false
+  - name: GOOGLE_CHAT_PROJECT_ID
+    description: "GCP project ID for optional Pub/Sub inbound mode. Falls back to GOOGLE_CLOUD_PROJECT."
+    prompt: "GCP project ID"
+    url: "https://console.cloud.google.com/"
+    password: false
+  - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
+    description: "Optional Pub/Sub subscription path for pull-mode inbound events."
+    prompt: "Pub/Sub subscription name"
+    password: false
   - name: GOOGLE_CHAT_ALLOWED_USERS
     description: "Comma-separated user emails allowed to interact with the bot."
     prompt: "Allowed user emails (comma-separated)"

--- a/plugins/platforms/google_chat/plugin.yaml
+++ b/plugins/platforms/google_chat/plugin.yaml
@@ -23,6 +23,14 @@ optional_env:
     description: "Authenticated HTTP endpoint for Chat message events."
     prompt: "HTTP events callback URL"
     password: false
+  - name: GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE
+    description: "Expected audience for Google-signed HTTP event bearer tokens. Defaults to GOOGLE_CHAT_HTTP_EVENTS_URL."
+    prompt: "HTTP events token audience"
+    password: false
+  - name: GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL
+    description: "Expected Google service account email for HTTP event bearer tokens."
+    prompt: "HTTP events service account email"
+    password: false
   - name: GOOGLE_CHAT_PROJECT_ID
     description: "GCP project ID for optional Pub/Sub inbound mode. Falls back to GOOGLE_CLOUD_PROJECT."
     prompt: "GCP project ID"

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -616,7 +616,26 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
+    app.router.add_post(
+        "/api/platforms/{platform}/events",
+        adapter._handle_platform_event_callback,
+    )
     return app
+
+
+class _FakeGoogleChatAdapter:
+    def __init__(self, *, verify_ok: bool = True, verify_code: str = ""):
+        self.verify_ok = verify_ok
+        self.verify_code = verify_code
+        self.dispatched = []
+
+    def verify_http_event_request(self, auth_header: str):
+        self.auth_header = auth_header
+        return self.verify_ok, self.verify_code
+
+    async def dispatch_http_event(self, payload):
+        self.dispatched.append(payload)
+        return {"ok": True}
 
 
 @pytest.fixture
@@ -2766,6 +2785,81 @@ class TestSendMethod:
         result = await adapter.send("chat1", "hello")
         assert result.success is False
         assert "HTTP request/response" in result.error
+
+
+class TestPlatformEventCallbackEndpoint:
+    @pytest.mark.asyncio
+    async def test_dispatches_authorized_google_chat_event(self, adapter):
+        app = _create_app(adapter)
+        google_adapter = _FakeGoogleChatAdapter()
+        app["platform_event_adapters"] = {"google_chat": google_adapter}
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/platforms/google_chat/events",
+                headers={"Authorization": "Bearer google-token"},
+                json={"type": "MESSAGE", "message": {"text": "hi"}},
+            )
+            body = await resp.json()
+
+        assert resp.status == 200
+        assert body == {"ok": True}
+        assert google_adapter.auth_header == "Bearer google-token"
+        assert google_adapter.dispatched == [
+            {"type": "MESSAGE", "message": {"text": "hi"}}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_google_chat_auth(self, adapter):
+        app = _create_app(adapter)
+        app["platform_event_adapters"] = {
+            "google_chat": _FakeGoogleChatAdapter(
+                verify_ok=False,
+                verify_code="invalid_google_bearer",
+            )
+        }
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/platforms/google_chat/events",
+                headers={"Authorization": "Bearer bad"},
+                json={"type": "MESSAGE"},
+            )
+            body = await resp.json()
+
+        assert resp.status == 401
+        assert body["error"]["code"] == "invalid_google_bearer"
+
+    @pytest.mark.asyncio
+    async def test_requires_connected_google_chat_adapter(self, adapter):
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/platforms/google_chat/events",
+                headers={"Authorization": "Bearer google-token"},
+                json={"type": "MESSAGE"},
+            )
+            body = await resp.json()
+
+        assert resp.status == 503
+        assert body["error"]["code"] == "platform_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_rejects_malformed_platform_event_json(self, adapter):
+        app = _create_app(adapter)
+        app["platform_event_adapters"] = {"google_chat": _FakeGoogleChatAdapter()}
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/api/platforms/google_chat/events",
+                headers={"Authorization": "Bearer google-token"},
+                data="{",
+            )
+            body = await resp.json()
+
+        assert resp.status == 400
+        assert body["error"]["code"] == "invalid_json"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -252,6 +252,7 @@ class TestEnvConfigLoading:
         "GOOGLE_CLOUD_PROJECT",
         "GOOGLE_CHAT_SUBSCRIPTION_NAME",
         "GOOGLE_CHAT_SUBSCRIPTION",
+        "GOOGLE_CHAT_HTTP_EVENTS_URL",
         "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON",
         "GOOGLE_APPLICATION_CREDENTIALS",
         "GOOGLE_CHAT_HOME_CHANNEL",
@@ -280,7 +281,12 @@ class TestEnvConfigLoading:
         cfg = load_gateway_config()
         assert _GC not in cfg.platforms
 
-
+    def test_http_events_enable_without_pubsub(self, monkeypatch):
+        self._clean_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_CHAT_HTTP_EVENTS_URL", "https://example.test/google-chat/events")
+        cfg = load_gateway_config()
+        assert _GC in cfg.platforms
+        assert cfg.platforms[_GC].extra["http_events_url"] == "https://example.test/google-chat/events"
 
 
 # ===========================================================================
@@ -389,6 +395,47 @@ class TestValidateConfig:
         project, sub = a._validate_config()
         assert project == "test-project"
         assert sub == "projects/test-project/subscriptions/test-sub"
+
+    def test_http_events_mode_does_not_require_pubsub(self):
+        cfg = PlatformConfig(enabled=True)
+        cfg.extra["http_events_url"] = "https://example.test/google-chat/events"
+        a = GoogleChatAdapter(cfg)
+        project, sub = a._validate_config()
+        assert project == ""
+        assert sub is None
+
+    def test_full_subscription_can_infer_project(self):
+        cfg = PlatformConfig(enabled=True)
+        cfg.extra["subscription_name"] = "projects/inferred/subscriptions/sub"
+        a = GoogleChatAdapter(cfg)
+        project, sub = a._validate_config()
+        assert project == "inferred"
+        assert sub == "projects/inferred/subscriptions/sub"
+
+
+class TestConnectModes:
+    @pytest.mark.asyncio
+    async def test_connect_http_mode_skips_pubsub_subscriber(self, tmp_path, monkeypatch):
+        cfg = PlatformConfig(enabled=True)
+        cfg.extra.update({
+            "http_events_url": "https://example.test/google-chat/events",
+            "service_account_json": "{}",
+        })
+        a = GoogleChatAdapter(cfg)
+        a._thread_count_store._path = tmp_path / "google_chat_thread_counts.json"
+        monkeypatch.setattr(_gc_mod, "_load_google_modules", lambda: True)
+        monkeypatch.setattr(a, "_load_sa_credentials", MagicMock(return_value=MagicMock()))
+        monkeypatch.setattr(_gc_mod, "build_service", MagicMock(return_value=MagicMock()))
+        subscriber_client = MagicMock()
+        monkeypatch.setattr(_gc_mod, "pubsub_v1", MagicMock(SubscriberClient=subscriber_client))
+        a._resolve_bot_user_id = AsyncMock(return_value=None)
+
+        assert await a.connect() is True
+        subscriber_client.assert_not_called()
+        assert a._subscription_path is None
+        assert a._supervisor_task is None
+        assert a.is_connected is True
+        await a.disconnect()
 
 
 # ===========================================================================

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -253,6 +253,8 @@ class TestEnvConfigLoading:
         "GOOGLE_CHAT_SUBSCRIPTION_NAME",
         "GOOGLE_CHAT_SUBSCRIPTION",
         "GOOGLE_CHAT_HTTP_EVENTS_URL",
+        "GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE",
+        "GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL",
         "GOOGLE_CHAT_SERVICE_ACCOUNT_JSON",
         "GOOGLE_APPLICATION_CREDENTIALS",
         "GOOGLE_CHAT_HOME_CHANNEL",
@@ -283,10 +285,32 @@ class TestEnvConfigLoading:
 
     def test_http_events_enable_without_pubsub(self, monkeypatch):
         self._clean_env(monkeypatch)
-        monkeypatch.setenv("GOOGLE_CHAT_HTTP_EVENTS_URL", "https://example.test/google-chat/events")
+        monkeypatch.setenv(
+            "GOOGLE_CHAT_HTTP_EVENTS_URL",
+            "https://example.test/google-chat/events",
+        )
+        monkeypatch.setenv(
+            "GOOGLE_CHAT_HTTP_EVENTS_AUDIENCE",
+            "https://callback.example.test/events",
+        )
+        monkeypatch.setenv(
+            "GOOGLE_CHAT_HTTP_EVENTS_SERVICE_ACCOUNT_EMAIL",
+            "chat-callback@example.iam.gserviceaccount.com",
+        )
         cfg = load_gateway_config()
         assert _GC in cfg.platforms
-        assert cfg.platforms[_GC].extra["http_events_url"] == "https://example.test/google-chat/events"
+        assert (
+            cfg.platforms[_GC].extra["http_events_url"]
+            == "https://example.test/google-chat/events"
+        )
+        assert (
+            cfg.platforms[_GC].extra["http_events_audience"]
+            == "https://callback.example.test/events"
+        )
+        assert (
+            cfg.platforms[_GC].extra["http_events_service_account_email"]
+            == "chat-callback@example.iam.gserviceaccount.com"
+        )
 
 
 # ===========================================================================
@@ -411,6 +435,82 @@ class TestValidateConfig:
         project, sub = a._validate_config()
         assert project == "inferred"
         assert sub == "projects/inferred/subscriptions/sub"
+
+
+class TestHttpEventIngress:
+    def test_verify_http_event_request_accepts_expected_google_identity(self, monkeypatch):
+        cfg = PlatformConfig(enabled=True)
+        cfg.extra.update(
+            {
+                "http_events_url": "https://example.test/google-chat/events",
+                "http_events_service_account_email": (
+                    "chat-callback@example.iam.gserviceaccount.com"
+                ),
+            }
+        )
+        a = GoogleChatAdapter(cfg)
+
+        def fake_verify(token, audience):
+            assert token == "signed-token"
+            assert audience == "https://example.test/google-chat/events"
+            return {"email": "chat-callback@example.iam.gserviceaccount.com"}
+
+        monkeypatch.setattr(_gc_mod, "_verify_google_id_token", fake_verify)
+
+        assert a.verify_http_event_request("Bearer signed-token") == (True, "")
+
+    def test_verify_http_event_request_rejects_unexpected_identity(self, monkeypatch):
+        cfg = PlatformConfig(enabled=True)
+        cfg.extra.update(
+            {
+                "http_events_url": "https://example.test/google-chat/events",
+                "http_events_service_account_email": (
+                    "expected@example.iam.gserviceaccount.com"
+                ),
+            }
+        )
+        a = GoogleChatAdapter(cfg)
+        monkeypatch.setattr(
+            _gc_mod,
+            "_verify_google_id_token",
+            lambda _token, _audience: {
+                "email": "other@example.iam.gserviceaccount.com"
+            },
+        )
+
+        ok, code = a.verify_http_event_request("Bearer signed-token")
+
+        assert ok is False
+        assert code == "unexpected_google_bearer_identity"
+
+    def test_verify_http_event_request_requires_callback_identity_config(self):
+        cfg = PlatformConfig(enabled=True)
+        cfg.extra["http_events_url"] = "https://example.test/google-chat/events"
+        a = GoogleChatAdapter(cfg)
+
+        assert a.verify_http_event_request("Bearer signed-token") == (
+            False,
+            "google_chat_http_events_not_configured",
+        )
+
+    @pytest.mark.asyncio
+    async def test_dispatch_http_event_routes_message_payload(self, adapter):
+        envelope = _make_chat_envelope(text="hello from http")
+
+        result = await adapter.dispatch_http_event(envelope)
+
+        assert result == {}
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "hello from http"
+        assert event.source.chat_id == "spaces/S"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_http_event_ignores_bot_messages(self, adapter):
+        envelope = _make_chat_envelope(text="bot echo", sender_type="BOT")
+
+        assert await adapter.dispatch_http_event(envelope) == {}
+        adapter.handle_message.assert_not_awaited()
 
 
 class TestConnectModes:

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -438,6 +438,68 @@ class TestValidateConfig:
 
 
 class TestHttpEventIngress:
+    def test_cached_google_auth_request_reuses_successful_get_response(self, monkeypatch):
+        now = [100.0]
+        calls = []
+
+        class Response:
+            status = 200
+
+        response = Response()
+
+        def raw_request(**kwargs):
+            calls.append(kwargs)
+            return response
+
+        monkeypatch.setattr(_gc_mod.time, "monotonic", lambda: now[0])
+        request = _gc_mod._CachedGoogleAuthRequest(raw_request, ttl_seconds=300)
+
+        assert request("https://www.googleapis.com/oauth2/v1/certs") is response
+        assert request("https://www.googleapis.com/oauth2/v1/certs") is response
+        assert len(calls) == 1
+
+        now[0] += 301
+        assert request("https://www.googleapis.com/oauth2/v1/certs") is response
+        assert len(calls) == 2
+
+    def test_cached_google_auth_request_does_not_cache_post_response(self):
+        calls = []
+
+        def raw_request(**kwargs):
+            calls.append(kwargs)
+            return object()
+
+        request = _gc_mod._CachedGoogleAuthRequest(raw_request, ttl_seconds=300)
+
+        request("https://example.test/token", method="POST")
+        request("https://example.test/token", method="POST")
+
+        assert len(calls) == 2
+
+    def test_verify_google_id_token_uses_cached_request_and_configured_audience(self, monkeypatch):
+        request = object()
+        captured = {}
+
+        monkeypatch.setattr(_gc_mod, "_get_google_id_token_request", lambda: request)
+
+        class FakeIdToken:
+            @staticmethod
+            def verify_oauth2_token(token, req, audience):
+                captured.update(token=token, request=req, audience=audience)
+                return {"email": "bot@example.test"}
+
+        monkeypatch.setitem(sys.modules, "google.oauth2.id_token", FakeIdToken)
+        monkeypatch.setattr(sys.modules["google.oauth2"], "id_token", FakeIdToken, raising=False)
+
+        assert _gc_mod._verify_google_id_token("signed-token", "https://callback.example/events") == {
+            "email": "bot@example.test"
+        }
+        assert captured == {
+            "token": "signed-token",
+            "request": request,
+            "audience": "https://callback.example/events",
+        }
+
     def test_verify_http_event_request_accepts_expected_google_identity(self, monkeypatch):
         cfg = PlatformConfig(enabled=True)
         cfg.extra.update(


### PR DESCRIPTION
## What does this PR do?

Adds a generic API-server callback route for platform plugins and wires the Google Chat plugin to accept authenticated HTTP `MESSAGE` events through that route.

This gives platform plugins a provider-authenticated HTTP callback path, so Google Chat can receive message events without requiring every deployment to run a Pub/Sub pull worker.

Depends on #36035. This draft is intentionally stacked while #36035 is still open; after #36035 lands, this branch should be rebased so the final diff contains only the callback route and message dispatch work.

Related Google Chat PRs: #36027, #36035.

## Related Issue

N/A — follow-up to the pluginized Google Chat HTTP inbound transport work in #36035.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/api_server.py`: add `/api/platforms/{platform}/events` for platform-owned HTTP event callbacks.
- `gateway/run.py`: pass the gateway runner reference to the API server adapter so callbacks can resolve connected platform adapters.
- `plugins/platforms/google_chat/adapter.py`: verify Google-signed callback bearer tokens and dispatch valid HTTP `MESSAGE` events through the existing message path.
- `plugins/platforms/google_chat/plugin.yaml`: surface callback audience and expected service-account email env metadata.
- `tests/gateway/test_api_server.py`: cover callback dispatch, authorization failure, unavailable adapter, and malformed JSON.
- `tests/gateway/test_google_chat.py`: cover Google Chat HTTP event verification and message dispatch.

## How to Test

1. `python -m py_compile gateway/platforms/api_server.py gateway/run.py plugins/platforms/google_chat/adapter.py tests/gateway/test_api_server.py tests/gateway/test_google_chat.py`
2. `git diff --check`
3. `scripts/run_tests.sh tests/gateway/test_api_server.py tests/gateway/test_google_chat.py`
4. `python /root/.codex/skills/hermes-upstream-pr/scripts/pr_preflight.py --base fix/google-chat-http-inbound-mode`

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this feature slice, but is currently stacked on #36035 while draft.
- [x] I've added tests for my changes.
- [x] I've tested on Linux.

### Documentation & Housekeeping

- [x] Documentation update N/A; plugin manifest env metadata updated.
- [x] `cli-config.yaml.example` update N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A.
- [x] Cross-platform impact considered: aiohttp route/config logic and tests only.
- [x] Tool descriptions/schemas update N/A.

## Related PRs

- #36027 is the smaller Google Chat toolset scoping cleanup.
- #36035 is the required setup/connectivity dependency for this draft follow-up.
- #36068 adds Google Chat clarify card rendering.
- #36069 depends on this PR and #36068 for card-click handling.

## Screenshots / Logs

Validation passed locally:

```text
scripts/run_tests.sh tests/gateway/test_api_server.py tests/gateway/test_google_chat.py
329 tests passed, 0 failed
```
