### PR TITLE
fix: silence unused Slack events

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -622,6 +622,26 @@ class SlackAdapter(BasePlatformAdapter):
             async def handle_file_change(event, say):
                 pass
 
+            # These workspace activity events are intentionally subscribed for
+            # future/diagnostic use in some Slack apps but are not actionable for
+            # Hermes responses. Ack them explicitly so Slack Bolt does not emit
+            # high-volume "unhandled request" warnings that bury real errors.
+            @self._app.event("reaction_added")
+            async def handle_reaction_added(event, say):
+                pass
+
+            @self._app.event("reaction_removed")
+            async def handle_reaction_removed(event, say):
+                pass
+
+            @self._app.event("member_joined_channel")
+            async def handle_member_joined_channel(event, say):
+                pass
+
+            @self._app.event("member_left_channel")
+            async def handle_member_left_channel(event, say):
+                pass
+
             @self._app.event("assistant_thread_started")
             async def handle_assistant_thread_started(event, say):
                 await self._handle_assistant_thread_lifecycle_event(event)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -189,6 +189,10 @@ class TestAppMentionHandler:
         assert "app_mention" in registered_events
         assert "assistant_thread_started" in registered_events
         assert "assistant_thread_context_changed" in registered_events
+        assert "reaction_added" in registered_events
+        assert "reaction_removed" in registered_events
+        assert "member_joined_channel" in registered_events
+        assert "member_left_channel" in registered_events
         # Slack slash commands are registered via a single regex matcher
         # covering every COMMAND_REGISTRY entry (e.g. /hermes, /btw, /stop,
         # /model, ...) so users get native-slash parity with Discord and


### PR DESCRIPTION
## Summary
- Register no-op Slack event handlers for unused channel/reaction events.
- Prevent Bolt from logging noisy "Unhandled request" warnings for expected events.
- Add regression coverage that the handlers are registered.

## Test Plan
- `python -m pytest tests/gateway/test_slack.py -q`
