### PR TITLE
fix(video-gen): omit duration for range-based FAL families when unspecified

### DIFF
--- a/plugins/video_gen/fal/__init__.py
+++ b/plugins/video_gen/fal/__init__.py
@@ -180,7 +180,11 @@ def _clamp_duration(family: Dict[str, Any], duration: Optional[int]) -> Optional
     if not durations:
         return duration
     if duration is None:
-        return durations[0]
+        # Range families (e.g. pixverse-v6 (1,15)) should omit the field so
+        # the FAL endpoint applies its own default rather than receiving the
+        # minimum value.  Enum families (e.g. veo3.1 (4,6,8)) keep sending
+        # their first entry as the default.
+        return None if _is_duration_range(durations) else durations[0]
     if _is_duration_range(durations):
         lo, hi = durations
         return max(lo, min(hi, duration))

--- a/tests/plugins/video_gen/test_fal_plugin.py
+++ b/tests/plugins/video_gen/test_fal_plugin.py
@@ -322,6 +322,29 @@ class TestPayloadBuilder:
         assert p["generate_audio"] is True
         assert p["negative_prompt"] == "ugly"
 
+    def test_range_families_omit_duration_when_unspecified(self):
+        """Range-based families must omit `duration` when the caller doesn't
+        specify one so FAL applies its endpoint default, not the minimum."""
+        from plugins.video_gen.fal import FAL_FAMILIES, _build_payload
+
+        for family_id in ("pixverse-v6", "seedance-2.0", "kling-v3-4k"):
+            meta = FAL_FAMILIES[family_id]
+            p = _build_payload(
+                meta,
+                prompt="x",
+                image_url=None,
+                duration=None,
+                aspect_ratio="16:9",
+                resolution="720p",
+                negative_prompt=None,
+                audio=None,
+                seed=None,
+            )
+            assert "duration" not in p, (
+                f"{family_id}: duration=None should omit the field, "
+                f"got {p.get('duration')!r}"
+            )
+
     def test_happy_horse_minimal_payload(self):
         """Happy Horse has sparse docs — payload should be minimal."""
         from plugins.video_gen.fal import FAL_FAMILIES, _build_payload


### PR DESCRIPTION
## Problem

`_clamp_duration` returns `durations[0]` for **all** families when `duration=None`, bypassing the `_is_duration_range` heuristic that was added to distinguish range families `(min, max)` from enum families `(4, 6, 8)`.

This causes three range-based families to always send their **minimum** value to FAL instead of omitting the field and letting the endpoint apply its own default:

| Family | Sent (before) | Correct behaviour |
|--------|--------------|-------------------|
| `pixverse-v6` (default) | `"1"` | field omitted |
| `seedance-2.0` | `"4"` | field omitted |
| `kling-v3-4k` | `"3"` | field omitted |

`pixverse-v6` is `DEFAULT_MODEL`, so every call to `video_generate(prompt="…")` without an explicit duration produced a 1-second video.

Families with `durations=None` (`ltx-2.3`, `happy-horse`) already omitted the field correctly; enum families like `veo3.1` continue to send their first entry as the default.

## Root cause

```python
# plugins/video_gen/fal/__init__.py
def _clamp_duration(family, duration):
    durations = family.get("durations")
    if not durations:
        return duration          # ltx-2.3 / happy-horse → None → omitted ✓
    if duration is None:
        return durations[0]      # BUG: fires before _is_duration_range check ✗
    if _is_duration_range(durations):   # never reached when duration is None
        ...
```

## Fix

```python
    if duration is None:
        return None if _is_duration_range(durations) else durations[0]
```

One-line change. Symmetric with the `not durations` branch above it. No behaviour change for explicit duration values or enum families.

## Testing

Added `TestPayloadBuilder::test_range_families_omit_duration_when_unspecified` covering all three affected families (`pixverse-v6`, `seedance-2.0`, `kling-v3-4k`). All existing `TestPayloadBuilder` tests continue to pass.