### PR TITLE
fix(agent): preserve interleaved thinking order on Anthropic replay

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1631,6 +1631,63 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
     Handles thinking blocks, regular content, tool calls, and
     reasoning_content injection for Kimi/DeepSeek endpoints.
     """
+    # Fast path — native Anthropic turn captured with its full ordered block
+    # list (set by transports/anthropic.py only when SIGNED thinking blocks are
+    # present). Replay the blocks in their ORIGINAL order so interleaved
+    # thinking/tool_use sequences round-trip verbatim. Rebuilding from the flat
+    # reasoning_details + tool_calls lists below reorders the turn to
+    # [all-thinking]+text+[all-tool_use], which modifies the signed thinking
+    # blocks and triggers HTTP 400 "thinking blocks in the latest assistant
+    # message cannot be modified".
+    ordered = m.get("anthropic_ordered_content")
+    _ordered_has_signed_thinking = isinstance(ordered, list) and any(
+        isinstance(b, dict)
+        and b.get("type") in {"thinking", "redacted_thinking"}
+        and (b.get("signature") or b.get("data"))
+        for b in ordered
+    )
+    if _ordered_has_signed_thinking:
+        # Replay tool inputs from the stored (already credential-redacted, see
+        # build_assistant_message #19798) tool_calls so the verbatim replay
+        # never resurrects the pre-redaction input captured at response time.
+        # Order still comes from the ordered block list.
+        redacted_by_id: Dict[str, Any] = {}
+        for tc in m.get("tool_calls", []) or []:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function", {}) or {}
+            raw_args = fn.get("arguments", "{}")
+            try:
+                parsed_args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+            except (json.JSONDecodeError, ValueError):
+                parsed_args = {}
+            redacted_by_id[_sanitize_tool_id(tc.get("id", ""))] = parsed_args
+        ordered_out: List[Dict[str, Any]] = []
+        for b in ordered:
+            if not isinstance(b, dict):
+                continue
+            btype = b.get("type")
+            if btype == "tool_use":
+                tid = _sanitize_tool_id(b.get("id", ""))
+                tinput = redacted_by_id.get(tid)
+                if tinput is None:
+                    tinput = b.get("input") if isinstance(b.get("input"), (dict, list)) else {}
+                ordered_out.append({
+                    "type": "tool_use",
+                    "id": tid,
+                    "name": b.get("name", ""),
+                    "input": tinput,
+                })
+            elif btype in {"thinking", "redacted_thinking"}:
+                ordered_out.append(copy.deepcopy(b))
+            elif btype == "text":
+                txt = b.get("text")
+                if isinstance(txt, str) and txt:
+                    ordered_out.append({"type": "text", "text": txt})
+            # Unknown block types are dropped — Anthropic would reject them.
+        if ordered_out:
+            return {"role": "assistant", "content": ordered_out}
+
     content = m.get("content", "")
     blocks = _extract_preserved_thinking_blocks(m)
     if content:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -924,6 +924,19 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
         if preserved:
             msg["reasoning_details"] = preserved
 
+    # Anthropic interleaved-thinking order preservation. The transport sets
+    # this (native Anthropic, signed-thinking turns only) to the exact ordered
+    # block list so the adapter can replay the turn verbatim instead of
+    # reordering thinking ahead of tool_use — a reorder Anthropic rejects with
+    # HTTP 400 ("thinking blocks in the latest assistant message cannot be
+    # modified"). Absent for every other provider/turn. Plain JSON-serializable
+    # dicts, so it survives session persistence.
+    ordered_blocks = getattr(assistant_message, "anthropic_ordered_content", None)
+    if ordered_blocks:
+        preserved_ordered = [b for b in ordered_blocks if isinstance(b, dict)]
+        if preserved_ordered:
+            msg["anthropic_ordered_content"] = preserved_ordered
+
     # Codex Responses API: preserve encrypted reasoning items for
     # multi-turn continuity. These get replayed as input on the next turn.
     codex_items = getattr(assistant_message, "codex_reasoning_items", None)

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -546,14 +546,26 @@ def classify_api_error(
             should_fallback=True,
         )
 
-    # Anthropic thinking block signature invalid (400).
+    # Anthropic thinking block replay rejected (400).
     # Don't gate on provider — OpenRouter proxies Anthropic errors, so the
     # provider may be "openrouter" even though the error is Anthropic-specific.
-    # The message pattern ("signature" + "thinking") is unique enough.
+    # Two distinct upstream messages both mean "the thinking block we replayed
+    # no longer matches what Anthropic originally returned", and both are
+    # recoverable by stripping reasoning_details and retrying:
+    #   1. "Invalid signature in thinking block ..."  (signature mismatch)
+    #   2. "thinking ... blocks in the latest assistant message cannot be
+    #      modified. These blocks must remain as they were in the original
+    #      response."  (content/order mismatch — e.g. interleaved-thinking
+    #      blocks reordered relative to tool_use on rebuild)
+    # The "thinking" token plus any one of these signals is unique enough.
     if (
         status_code == 400
-        and "signature" in error_msg
         and "thinking" in error_msg
+        and (
+            "signature" in error_msg
+            or "cannot be modified" in error_msg
+            or "must remain as they were" in error_msg
+        )
     ):
         return _result(
             FailoverReason.thinking_signature,

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -94,15 +94,35 @@ class AnthropicTransport(ProviderTransport):
         reasoning_parts = []
         reasoning_details = []
         tool_calls = []
+        # Full block list in ORIGINAL response order. When extended/interleaved
+        # thinking is active the turn comes back as e.g.
+        # [thinking, tool_use, thinking, tool_use, ...]; the flat
+        # reasoning_details + tool_calls lists below discard that interleave.
+        # Replaying them reordered as [all-thinking]+text+[all-tool_use]
+        # mutates the signed thinking blocks → HTTP 400 "thinking blocks in the
+        # latest assistant message cannot be modified". Capturing the ordered
+        # list lets the adapter replay the turn verbatim. See _convert_assistant_message.
+        ordered_blocks = []
 
         for block in response.content:
             if block.type == "text":
                 text_parts.append(block.text)
+                ordered_blocks.append({"type": "text", "text": block.text})
             elif block.type == "thinking":
                 reasoning_parts.append(block.thinking)
                 block_dict = _to_plain_data(block)
                 if isinstance(block_dict, dict):
                     reasoning_details.append(block_dict)
+                    ordered_blocks.append(block_dict)
+            elif block.type == "redacted_thinking":
+                # Redacted thinking carries an opaque 'data' payload (no
+                # plaintext). It must also round-trip verbatim on the latest
+                # turn, so capture it in both the details list and the ordered
+                # list (the legacy path silently dropped it).
+                block_dict = _to_plain_data(block)
+                if isinstance(block_dict, dict):
+                    reasoning_details.append(block_dict)
+                    ordered_blocks.append(block_dict)
             elif block.type == "tool_use":
                 name = block.name
                 if strip_tool_prefix and name.startswith(_MCP_PREFIX):
@@ -124,12 +144,30 @@ class AnthropicTransport(ProviderTransport):
                         arguments=json.dumps(block.input),
                     )
                 )
+                ordered_blocks.append({
+                    "type": "tool_use",
+                    "id": block.id,
+                    "name": name,
+                    "input": _to_plain_data(block.input),
+                })
 
         finish_reason = self._STOP_REASON_MAP.get(response.stop_reason, "stop")
 
         provider_data = {}
         if reasoning_details:
             provider_data["reasoning_details"] = reasoning_details
+            # Only preserve the ordered block list for native Anthropic turns
+            # carrying SIGNED thinking (signature, or redacted 'data'). Those
+            # are the turns where reorder triggers the 400. Kimi/DeepSeek
+            # /anthropic blocks are unsigned and keep their existing
+            # reasoning_content round-trip path untouched.
+            if any(
+                isinstance(b, dict)
+                and b.get("type") in ("thinking", "redacted_thinking")
+                and (b.get("signature") or b.get("data"))
+                for b in ordered_blocks
+            ):
+                provider_data["anthropic_ordered_content"] = ordered_blocks
 
         return NormalizedResponse(
             content="\n".join(text_parts) if text_parts else None,

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -122,6 +122,15 @@ class NormalizedResponse:
         return pd.get("reasoning_details")
 
     @property
+    def anthropic_ordered_content(self):
+        # Full ordered Anthropic content-block list (thinking/text/tool_use
+        # in original response order). Only set for native Anthropic turns
+        # that carry signed thinking blocks, where the interleave order must
+        # round-trip verbatim. None for every other provider/turn.
+        pd = self.provider_data or {}
+        return pd.get("anthropic_ordered_content")
+
+    @property
     def codex_reasoning_items(self):
         pd = self.provider_data or {}
         return pd.get("codex_reasoning_items")

--- a/tests/agent/test_interleaved_thinking_replay.py
+++ b/tests/agent/test_interleaved_thinking_replay.py
@@ -1,0 +1,178 @@
+"""Regression tests for the interleaved-thinking + tool_use HTTP 400 crash.
+
+Covers two bugs fixed together:
+
+  1. anthropic_adapter.convert_messages_to_anthropic reordered interleaved
+     thinking/tool_use blocks to [all-thinking]+text+[all-tool_use], which
+     modifies the signed thinking blocks and makes Anthropic reject the turn
+     with HTTP 400 "thinking blocks in the latest assistant message cannot be
+     modified." The fix replays the captured ordered block list verbatim.
+
+  2. error_classifier did not recognise that 400 string (it only matched
+     "signature"+"thinking"), so the existing strip-and-retry recovery never
+     fired and the agent hard-aborted. The fix broadens the pattern.
+"""
+
+import json
+
+from agent.anthropic_adapter import convert_messages_to_anthropic
+from agent.error_classifier import classify_api_error, FailoverReason
+
+
+class _FakeAPIError(Exception):
+    """Mimics an Anthropic SDK 400 with a structured body + status_code."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.status_code = 400
+        self.body = {
+            "type": "error",
+            "error": {"type": "invalid_request_error", "message": message},
+        }
+
+
+def _interleaved_assistant_message():
+    """An assistant turn exactly like the one that crashed: interleaved
+    signed thinking + tool_use blocks captured in anthropic_ordered_content."""
+    ordered = [
+        {"type": "thinking", "thinking": "First, list processes.", "signature": "SIG_A"},
+        {"type": "tool_use", "id": "toolu_01aaa", "name": "mcp_terminal", "input": {"cmd": "ps"}},
+        {"type": "thinking", "thinking": "Now check the ports.", "signature": "SIG_B"},
+        {"type": "tool_use", "id": "toolu_01bbb", "name": "mcp_terminal", "input": {"cmd": "netstat"}},
+        {"type": "thinking", "thinking": "And the config dir.", "signature": "SIG_C"},
+        {"type": "tool_use", "id": "toolu_01ccc", "name": "mcp_terminal", "input": {"cmd": "ls ~/.hermes"}},
+    ]
+    return {
+        "role": "assistant",
+        "content": "",
+        # Flat lists (the lossy representation that caused the reorder).
+        "reasoning_details": [b for b in ordered if b["type"] == "thinking"],
+        "tool_calls": [
+            {
+                "id": b["id"],
+                "type": "function",
+                "function": {"name": b["name"], "arguments": json.dumps(b["input"])},
+            }
+            for b in ordered
+            if b["type"] == "tool_use"
+        ],
+        # The ordered capture added by the fix.
+        "anthropic_ordered_content": ordered,
+    }
+
+
+def test_interleaved_order_preserved_verbatim():
+    messages = [
+        {"role": "user", "content": "why is hermes broken"},
+        _interleaved_assistant_message(),
+        {"role": "tool", "tool_call_id": "toolu_01aaa", "content": "proc list"},
+        {"role": "tool", "tool_call_id": "toolu_01bbb", "content": "port list"},
+        {"role": "tool", "tool_call_id": "toolu_01ccc", "content": "dir list"},
+    ]
+    _system, result = convert_messages_to_anthropic(
+        messages, base_url=None, model="claude-opus-4-8"
+    )
+    assistant = next(m for m in result if m["role"] == "assistant")
+    types_in_order = [b["type"] for b in assistant["content"]]
+
+    # The interleave MUST be preserved exactly — not collapsed to
+    # [thinking, thinking, thinking, tool_use, tool_use, tool_use].
+    assert types_in_order == [
+        "thinking", "tool_use", "thinking", "tool_use", "thinking", "tool_use"
+    ], types_in_order
+
+    # Signatures + thinking text round-trip byte-for-byte.
+    thinking_blocks = [b for b in assistant["content"] if b["type"] == "thinking"]
+    assert [b["signature"] for b in thinking_blocks] == ["SIG_A", "SIG_B", "SIG_C"]
+    assert [b["thinking"] for b in thinking_blocks] == [
+        "First, list processes.", "Now check the ports.", "And the config dir."
+    ]
+    # Tool ids round-trip so tool_result blocks still match.
+    tool_ids = [b["id"] for b in assistant["content"] if b["type"] == "tool_use"]
+    assert tool_ids == ["toolu_01aaa", "toolu_01bbb", "toolu_01ccc"]
+
+
+def test_classifier_catches_cannot_be_modified_400():
+    msg = (
+        "messages.1.content.4: `thinking` or `redacted_thinking` blocks in the "
+        "latest assistant message cannot be modified. These blocks must remain "
+        "as they were in the original response."
+    )
+    classified = classify_api_error(
+        _FakeAPIError(msg), provider="anthropic", model="claude-opus-4-8"
+    )
+    assert classified.reason == FailoverReason.thinking_signature, classified.reason
+    assert classified.retryable is True
+
+
+def test_classifier_still_catches_signature_400():
+    msg = "Invalid signature in thinking block."
+    classified = classify_api_error(
+        _FakeAPIError(msg), provider="anthropic", model="claude-opus-4-8"
+    )
+    assert classified.reason == FailoverReason.thinking_signature, classified.reason
+
+
+class _Block:
+    """Minimal stand-in for an Anthropic SDK content block.
+
+    Exposes attribute access (block.type, block.thinking, ...) AND model_dump()
+    so _to_plain_data() round-trips it to a plain dict like the real SDK.
+    """
+
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+    def model_dump(self):
+        return dict(self.__dict__)
+
+
+class _Resp:
+    def __init__(self, content, stop_reason="tool_use"):
+        self.content = content
+        self.stop_reason = stop_reason
+
+
+def test_normalize_response_captures_ordered_blocks_when_signed():
+    from agent.transports.anthropic import AnthropicTransport
+
+    resp = _Resp([
+        _Block(type="thinking", thinking="t1", signature="SIG_A"),
+        _Block(type="tool_use", id="toolu_01aaa", name="mcp_terminal", input={"cmd": "ps"}),
+        _Block(type="thinking", thinking="t2", signature="SIG_B"),
+        _Block(type="tool_use", id="toolu_01bbb", name="mcp_terminal", input={"cmd": "netstat"}),
+    ])
+    normalized = AnthropicTransport().normalize_response(resp)
+    ordered = (normalized.provider_data or {}).get("anthropic_ordered_content")
+    assert ordered is not None, "ordered content not captured for signed turn"
+    assert [b["type"] for b in ordered] == [
+        "thinking", "tool_use", "thinking", "tool_use"
+    ], [b["type"] for b in ordered]
+    assert [b.get("signature") for b in ordered if b["type"] == "thinking"] == ["SIG_A", "SIG_B"]
+    # The NormalizedResponse accessor exposes it too.
+    assert normalized.anthropic_ordered_content == ordered
+
+
+def test_normalize_response_skips_ordered_when_unsigned():
+    """Kimi/DeepSeek-style unsigned thinking must NOT trigger the ordered path
+    (they keep their reasoning_content round-trip)."""
+    from agent.transports.anthropic import AnthropicTransport
+
+    resp = _Resp([
+        _Block(type="thinking", thinking="t1"),  # no signature
+        _Block(type="tool_use", id="toolu_01aaa", name="mcp_terminal", input={"cmd": "ps"}),
+    ])
+    normalized = AnthropicTransport().normalize_response(resp)
+    pd = normalized.provider_data or {}
+    assert "anthropic_ordered_content" not in pd, "unsigned turn must not capture ordered blocks"
+    # reasoning_details is still captured (existing behaviour).
+    assert pd.get("reasoning_details")
+
+
+if __name__ == "__main__":
+    test_interleaved_order_preserved_verbatim()
+    test_classifier_catches_cannot_be_modified_400()
+    test_classifier_still_catches_signature_400()
+    test_normalize_response_captures_ordered_blocks_when_signed()
+    test_normalize_response_skips_ordered_when_unsigned()
+    print("ALL TESTS PASSED")


### PR DESCRIPTION
## What & why

Extended/interleaved thinking turns on Claude 4.x (the `interleaved-thinking` beta) return assistant content as an **ordered** sequence of thinking/tool_use blocks, e.g. `[thinking, tool_use, thinking, tool_use, ...]`.

`AnthropicTransport.normalize_response()` split these into flat `text` / `reasoning_details` / `tool_calls` collections, discarding the relative order, and `_convert_assistant_message()` rebuilt the turn as `[all-thinking] + text + [all-tool_use]`. Reordering the **signed** thinking blocks makes Anthropic reject the *next* request with a non-retryable:

> HTTP 400 — `thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response.

Result: on direct Anthropic (e.g. `claude-opus-4-x`), every multi-tool turn with thinking enabled hard-crashes the agent on the continuation call.

The existing thinking-signature recovery in `error_classifier` only matched messages containing both `"signature"` **and** `"thinking"`, so this 400 (which says *"cannot be modified"* / *"must remain as they were"*) fell through to a non-retryable abort — the strip-and-retry recovery never fired.

## Changes

- **`transports/anthropic.py`** — capture the full ordered block list (`anthropic_ordered_content`) when the turn carries **signed** thinking blocks; also capture `redacted_thinking` (previously dropped). Unsigned Kimi/DeepSeek `/anthropic` turns are intentionally excluded (no signature/`data`), so their `reasoning_content` round-trip is unaffected.
- **`transports/types.py`** — `anthropic_ordered_content` accessor on `NormalizedResponse`.
- **`chat_completion_helpers.py`** — persist the ordered list on the stored assistant message (plain JSON; survives session persistence).
- **`anthropic_adapter.py`** — `_convert_assistant_message` replays the ordered blocks verbatim (interleave order + signatures preserved). Tool inputs are re-sourced from the already-redacted `tool_calls`, so the #19798 credential redaction is preserved.
- **`error_classifier.py`** — broaden the thinking-recovery pattern to also catch `"cannot be modified"` / `"must remain as they were"`.

The whole path is gated on the presence of signed thinking blocks → **no behavior change** for non-thinking turns or unsigned (Kimi/DeepSeek) providers.

## How to test

```bash
python -m pytest -o "addopts=" tests/agent/test_interleaved_thinking_replay.py
```

New test covers: ordered capture, verbatim replay (order + signatures + tool-id match), both classifier message variants, and the unsigned-skip case.

Regression — all pass (681+ tests):
`tests/agent/test_anthropic_adapter.py`, `test_error_classifier.py`, `test_deepseek_anthropic_thinking.py`, `test_kimi_coding_anthropic_thinking.py`, `tests/agent/transports/`. `scripts/check-windows-footguns.py` clean on the diff.

Verified end-to-end: a live multi-tool Opus run that reproducibly crashed with the 400 now completes through multiple tool rounds.

## Platforms tested

- Windows 11 (Python 3.11, project venv)
