### PR TITLE
fix: allow empty Honcho lazy init kwargs

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -449,7 +449,7 @@ class HonchoMemoryProvider(MemoryProvider):
             return True
         if self._cron_skipped:
             return False
-        if not self._config or not self._lazy_init_kwargs:
+        if not self._config or self._lazy_init_kwargs is None:
             return False
 
         try:

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -53,7 +53,7 @@ PROFILE_SCHEMA = {
             "card": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "New peer card as a list of fact strings. Omit to read the current card.",
+                "description": "Fact strings to merge into the current peer card. Existing facts are preserved. Omit to read the current card.",
             },
         },
         "required": [],
@@ -1118,6 +1118,16 @@ class HonchoMemoryProvider(MemoryProvider):
             ),
         }
 
+    def _tool_error_with_manager_reason(self, base: str) -> str:
+        reason = None
+        if self._manager is not None:
+            candidate = getattr(self._manager, "last_error", None)
+            if isinstance(candidate, str) and candidate.strip():
+                reason = candidate.strip()
+        if reason:
+            return tool_error(f"{base.rstrip('.')}: {reason}")
+        return tool_error(base)
+
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Record the conversation turn in Honcho (non-blocking).
 
@@ -1223,10 +1233,12 @@ class HonchoMemoryProvider(MemoryProvider):
             if tool_name == "honcho_profile":
                 peer = args.get("peer", "user")
                 card_update = args.get("card")
-                if card_update:
+                if "card" in args:
+                    if not isinstance(card_update, list):
+                        return tool_error("Parameter card must be a list of fact strings.")
                     result = self._manager.set_peer_card(self._session_key, card_update, peer=peer)
                     if result is None:
-                        return tool_error("Failed to update peer card.")
+                        return self._tool_error_with_manager_reason("Failed to update peer card.")
                     return json.dumps({"result": f"Peer card updated ({len(result)} facts).", "card": result})
                 card = self._manager.get_peer_card(self._session_key, peer=peer)
                 if not card:
@@ -1300,7 +1312,7 @@ class HonchoMemoryProvider(MemoryProvider):
                 ok = self._manager.create_conclusion(self._session_key, conclusion, peer=peer)
                 if ok:
                     return json.dumps({"result": f"Conclusion saved for {peer}: {conclusion}"})
-                return tool_error("Failed to save conclusion.")
+                return self._tool_error_with_manager_reason("Failed to save conclusion.")
 
             return tool_error(f"Unknown tool: {tool_name}")
 

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -18,6 +18,27 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_SECRET_PATTERNS = (
+    (re.compile(r"(Bearer\s+)[A-Za-z0-9._~+/=:-]+", re.IGNORECASE), r"\1[REDACTED]"),
+    (re.compile(r"(HONCHO_API_KEY=)[^\s]+", re.IGNORECASE), r"\1[REDACTED]"),
+    (re.compile(r"(api[_-]?key[=:])[^\s]+", re.IGNORECASE), r"\1[REDACTED]"),
+)
+
+
+def _safe_error_message(error: BaseException | str) -> str:
+    """Format an actionable Honcho error without leaking auth material."""
+    text = str(error) if not isinstance(error, str) else error
+    if not text:
+        text = type(error).__name__ if not isinstance(error, str) else "Unknown Honcho error"
+    for pattern, replacement in _SECRET_PATTERNS:
+        text = pattern.sub(replacement, text)
+    if not isinstance(error, str):
+        exc_name = type(error).__name__
+        if exc_name and exc_name not in text:
+            text = f"{exc_name}: {text}"
+    return text[:500]
+
+
 # Sentinel to signal the async writer thread to shut down
 _ASYNC_SHUTDOWN = object()
 _PEER_ID_HASH_LEN = 8
@@ -104,6 +125,7 @@ class HonchoSessionManager:
         self._cache_lock = threading.RLock()
         self._peers_cache: dict[str, Any] = {}
         self._sessions_cache: dict[str, Any] = {}
+        self._last_error: str | None = None
 
         # Write frequency state
         write_frequency = (config.write_frequency if config else "async")
@@ -158,6 +180,32 @@ class HonchoSessionManager:
         if self._honcho is None:
             self._honcho = get_honcho_client()
         return self._honcho
+
+    @property
+    def last_error(self) -> str | None:
+        return getattr(self, "_last_error", None)
+
+    def _clear_last_error(self) -> None:
+        self._last_error = None
+
+    def _record_last_error(self, message: BaseException | str) -> str:
+        self._last_error = _safe_error_message(message)
+        return self._last_error
+
+    @staticmethod
+    def _merge_card(existing: list[str], updates: list[str]) -> list[str]:
+        merged: list[str] = []
+        seen: set[str] = set()
+        for item in [*existing, *updates]:
+            fact = str(item).strip()
+            if not fact:
+                continue
+            key = fact.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(fact)
+        return merged
 
     def _get_or_create_peer(self, peer_id: str) -> Any:
         """
@@ -1160,18 +1208,22 @@ class HonchoSessionManager:
         Returns:
             True on success, False on failure.
         """
+        self._clear_last_error()
         if not content or not content.strip():
+            self._record_last_error("Conclusion content is empty.")
             return False
 
         session = self._cache.get(session_key)
         if not session:
             logger.warning("No session cached for '%s', skipping conclusion", session_key)
+            self._record_last_error(f"No Honcho session cached for '{session_key}'.")
             return False
 
         try:
             target_peer_id = self._resolve_peer_id(session, peer)
             if target_peer_id is None:
                 logger.warning("Could not resolve conclusion peer '%s' for session '%s'", peer, session_key)
+                self._record_last_error(f"Could not resolve conclusion peer '{peer}'.")
                 return False
 
             if target_peer_id == session.assistant_peer_id:
@@ -1191,7 +1243,8 @@ class HonchoSessionManager:
             logger.info("Created conclusion about %s for %s: %s", target_peer_id, session_key, content[:80])
             return True
         except Exception as e:
-            logger.error("Failed to create conclusion: %s", e)
+            reason = self._record_last_error(e)
+            logger.error("Failed to create conclusion: %s", reason)
             return False
 
     def delete_conclusion(self, session_key: str, conclusion_id: str, peer: str = "user") -> bool:
@@ -1237,29 +1290,41 @@ class HonchoSessionManager:
         Returns:
             Updated card on success, None on failure.
         """
+        self._clear_last_error()
         session = self._cache.get(session_key)
         if not session:
+            self._record_last_error(f"No Honcho session cached for '{session_key}'.")
+            return None
+        clean_card = [str(item).strip() for item in card if str(item).strip()]
+        if not clean_card:
+            self._record_last_error("Peer card update must include at least one fact.")
             return None
         try:
             observer_peer_id, target_peer_id = self._resolve_observer_target(session, peer)
             if observer_peer_id is None:
                 logger.warning("Could not resolve peer '%s' for set_peer_card in session '%s'", peer, session_key)
+                self._record_last_error(f"Could not resolve peer '{peer}'.")
                 return None
+            existing_card = self._fetch_peer_card(observer_peer_id, target=target_peer_id)
+            if not existing_card and target_peer_id is not None:
+                existing_card = self._fetch_peer_card(target_peer_id)
+            merged_card = self._merge_card(existing_card, clean_card)
             peer_obj = self._get_or_create_peer(observer_peer_id)
             result = (
-                peer_obj.set_card(card, target=target_peer_id)
+                peer_obj.set_card(merged_card, target=target_peer_id)
                 if target_peer_id is not None
-                else peer_obj.set_card(card)
+                else peer_obj.set_card(merged_card)
             )
             logger.info(
                 "Updated peer card observer=%s target=%s (%d facts)",
                 observer_peer_id,
                 target_peer_id or observer_peer_id,
-                len(card),
+                len(merged_card),
             )
             return result
         except Exception as e:
-            logger.error("Failed to set peer card: %s", e)
+            reason = self._record_last_error(e)
+            logger.error("Failed to set peer card: %s", reason)
             return None
 
     def seed_ai_identity(self, session_key: str, content: str, source: str = "manual") -> bool:

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -673,6 +673,40 @@ class TestToolsModeInitBehavior:
         )
         assert provider.prefetch("test query") == ""
 
+    def test_tools_lazy_handle_tool_call_accepts_empty_init_kwargs(self):
+        """tools lazy init treats empty kwargs as present and initializes on first tool call."""
+        import json
+        from unittest.mock import MagicMock, patch
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        cfg = HonchoClientConfig(
+            api_key="test-key",
+            enabled=True,
+            recall_mode="tools",
+            init_on_session_start=False,
+        )
+        provider = HonchoMemoryProvider()
+
+        mock_manager = MagicMock()
+        mock_session = MagicMock()
+        mock_session.messages = []
+        mock_manager.get_or_create.return_value = mock_session
+        mock_manager.get_peer_card.return_value = ["Steve prefers concise plans."]
+
+        with patch("plugins.memory.honcho.client.HonchoClientConfig.from_global_config", return_value=cfg), \
+             patch("plugins.memory.honcho.client.get_honcho_client", return_value=MagicMock()), \
+             patch("plugins.memory.honcho.session.HonchoSessionManager", return_value=mock_manager), \
+             patch("hermes_constants.get_hermes_home", return_value=MagicMock()):
+            provider.initialize(session_id="test-session-001")
+            assert provider._lazy_init_kwargs == {}
+
+            payload = json.loads(provider.handle_tool_call("honcho_profile", {}))
+
+        assert payload == {"result": ["Steve prefers concise plans."]}
+        mock_manager.get_or_create.assert_called_once_with(provider._session_key)
+        mock_manager.get_peer_card.assert_called_once_with(provider._session_key, peer="user")
+        assert provider._lazy_init_kwargs is None
+
     def test_explicit_peer_name_not_overridden_by_user_id(self):
         """Explicit peerName in config must not be replaced by gateway user_id."""
         _, cfg, _ = self._make_provider_with_config(

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -237,6 +237,7 @@ class TestPeerLookupHelpers:
         # so that a subsequent honcho_profile read returns what was written.
         mgr, session = self._make_cached_manager()
         assistant_peer = MagicMock()
+        assistant_peer.get_card.return_value = []
         assistant_peer.set_card.return_value = ["Role: user"]
         mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
 
@@ -397,6 +398,63 @@ class TestPeerLookupHelpers:
             "session_id": session.honcho_session_id,
         }])
 
+    def test_create_conclusion_records_sanitized_failure_reason(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        scope = MagicMock()
+        scope.create.side_effect = RuntimeError(
+            "Request timed out after 30.0s Bearer abc123 HONCHO_API_KEY=secret"
+        )
+        assistant_peer.conclusions_of.return_value = scope
+        mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
+
+        ok = mgr.create_conclusion(session.key, "Robert prefers vinyl")
+
+        assert ok is False
+        assert "Request timed out after 30.0s" in mgr.last_error
+        assert "Bearer [REDACTED]" in mgr.last_error
+        assert "HONCHO_API_KEY=[REDACTED]" in mgr.last_error
+        assert "abc123" not in mgr.last_error
+        assert "secret" not in mgr.last_error
+
+    def test_set_peer_card_merges_into_same_observer_target_card_used_for_reads(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        assistant_peer.set_card.return_value = ["Existing fact", "New fact"]
+        mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
+        mgr._fetch_peer_card = MagicMock(return_value=["Existing fact"])
+
+        result = mgr.set_peer_card(session.key, ["Existing fact", "New fact"], peer="user")
+
+        assert result == ["Existing fact", "New fact"]
+        mgr._fetch_peer_card.assert_called_once_with(
+            session.assistant_peer_id,
+            target=session.user_peer_id,
+        )
+        mgr._get_or_create_peer.assert_called_once_with(session.assistant_peer_id)
+        assistant_peer.set_card.assert_called_once_with(
+            ["Existing fact", "New fact"],
+            target=session.user_peer_id,
+        )
+
+    def test_set_peer_card_preserves_direct_target_card_fallback(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        assistant_peer.set_card.return_value = ["Direct target fact", "New fact"]
+        mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
+        mgr._fetch_peer_card = MagicMock(side_effect=[[], ["Direct target fact"]])
+
+        result = mgr.set_peer_card(session.key, ["New fact"], peer="user")
+
+        assert result == ["Direct target fact", "New fact"]
+        assert mgr._fetch_peer_card.call_args_list[0].args == (session.assistant_peer_id,)
+        assert mgr._fetch_peer_card.call_args_list[0].kwargs == {"target": session.user_peer_id}
+        assert mgr._fetch_peer_card.call_args_list[1].args == (session.user_peer_id,)
+        assistant_peer.set_card.assert_called_once_with(
+            ["Direct target fact", "New fact"],
+            target=session.user_peer_id,
+        )
+
 
 class TestConcludeToolDispatch:
     def test_conclude_schema_has_no_anyof(self):
@@ -447,6 +505,53 @@ class TestConcludeToolDispatch:
             "Assistant likes terse replies",
             peer="ai",
         )
+
+    def test_honcho_conclude_failure_includes_manager_reason(self):
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._manager.create_conclusion.return_value = False
+        provider._manager.last_error = "Request timed out after 30.0s"
+
+        result = provider.handle_tool_call(
+            "honcho_conclude",
+            {"conclusion": "User prefers dark mode"},
+        )
+
+        assert "Failed to save conclusion: Request timed out after 30.0s" in result
+
+    def test_honcho_profile_update_failure_includes_manager_reason(self):
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._manager.set_peer_card.return_value = None
+        provider._manager.last_error = "Honcho API unavailable"
+
+        result = provider.handle_tool_call(
+            "honcho_profile",
+            {"peer": "user", "card": ["User prefers dark mode"]},
+        )
+
+        assert "Failed to update peer card: Honcho API unavailable" in result
+
+    def test_honcho_read_tools_still_dispatch_to_manager(self):
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._manager.get_peer_card.return_value = ["Name: Robert"]
+        provider._manager.search_context.return_value = "Robert prefers dark mode"
+        provider._manager.get_session_context.return_value = {"card": "Name: Robert"}
+
+        profile = provider.handle_tool_call("honcho_profile", {"peer": "user"})
+        search = provider.handle_tool_call("honcho_search", {"peer": "user", "query": "dark"})
+        context = provider.handle_tool_call("honcho_context", {"peer": "user"})
+
+        assert "Name: Robert" in profile
+        assert "Robert prefers dark mode" in search
+        assert "Name: Robert" in context
 
     def test_honcho_profile_can_target_explicit_peer_id(self):
         provider = HonchoMemoryProvider()


### PR DESCRIPTION
## Summary
- Fix Honcho tools-only lazy session init so empty `kwargs` is treated as present, not missing.
- Add a focused regression test covering first tool call after tools-only init with `_lazy_init_kwargs == {}`.

## Test Plan
- `PYTHONPATH=$(pwd) python -m pytest -o addopts='' tests/honcho_plugin/test_session.py::TestToolsModeInitBehavior -q`