### PR TITLE
fix(google-meet): stabilize join flow, captions, and TTS audio

### DIFF
--- a/plugins/google_meet/README.md
+++ b/plugins/google_meet/README.md
@@ -73,6 +73,13 @@ hermes meet auth                                         # optional
 hermes meet join https://meet.google.com/abc-defg-hij    # transcribe
 ```
 
+When the bot runs locally, it will try to attach to the live Hermes Chrome
+profile first via CDP instead of launching a fresh browser. The preferred
+endpoint is `http://127.0.0.1:18800`, or whatever you set in
+`browser.cdp_url` / `HERMES_BROWSER_CDP_URL` / `HERMES_MEET_CDP_URL`.
+If that endpoint is unavailable, it falls back to a separate Playwright
+Chromium instance.
+
 ## Realtime mode
 
 Linux (preferred, most automated):

--- a/plugins/google_meet/SKILL.md
+++ b/plugins/google_meet/SKILL.md
@@ -66,6 +66,12 @@ pip install playwright websockets && python -m playwright install chromium
 #   Then set OPENAI_API_KEY or HERMES_MEET_REALTIME_KEY in ~/.hermes/.env
 ```
 
+When running locally, the Meet bot prefers the live Hermes Chrome CDP
+endpoint first — usually `http://127.0.0.1:18800`. You can override that
+with `browser.cdp_url` in `~/.hermes/config.yaml`, or with the env vars
+`HERMES_BROWSER_CDP_URL` / `HERMES_MEET_CDP_URL`. If the CDP endpoint is
+unavailable, the bot falls back to a fresh Playwright Chromium instance.
+
 For a remote node:
 ```bash
 # on the user's Mac (where Chrome is signed in):

--- a/plugins/google_meet/cli.py
+++ b/plugins/google_meet/cli.py
@@ -2,8 +2,11 @@
 
 Wires ``hermes meet <subcommand>``:
   setup       — preflight playwright, chromium, auth file, print fixes
-  auth        — open a browser to sign into Google, save storage state
-  join <url>  — join a Meet URL synchronously (also callable from the agent)
+  auth        — sign into Google; local runs prefer the live Hermes Chrome
+                CDP session first (usually ``http://127.0.0.1:18800``)
+  join <url>  — join a Meet URL synchronously; local runs prefer the live
+                Hermes Chrome CDP session first (usually
+                ``http://127.0.0.1:18800``)
   status      — print current bot state
   transcript  — print the transcript
   stop        — leave the current meeting
@@ -27,6 +30,10 @@ def _auth_state_path() -> Path:
     return Path(get_hermes_home()) / "workspace" / "meetings" / "auth.json"
 
 
+def _auth_profile_dir() -> Path:
+    return Path(get_hermes_home()) / "workspace" / "meetings" / "auth-profile"
+
+
 # ---------------------------------------------------------------------------
 # argparse wiring
 # ---------------------------------------------------------------------------
@@ -38,11 +45,20 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
     """
     subs = subparser.add_subparsers(dest="meet_command")
 
-    subs.add_parser("setup", help="Preflight: playwright, chromium, auth")
+    subs.add_parser(
+        "setup",
+        help=(
+            "Preflight: playwright, chromium, auth; local runs prefer the live "
+            "Hermes Chrome CDP session first"
+        ),
+    )
 
     inst_p = subs.add_parser(
         "install",
-        help="Install prerequisites (pip deps, Chromium, platform audio tools)",
+        help=(
+            "Install prerequisites (pip deps, Chromium, platform audio tools); "
+            "local runs prefer the live Hermes Chrome CDP session first"
+        ),
     )
     inst_p.add_argument(
         "--realtime", action="store_true",
@@ -53,9 +69,21 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
         help="Answer yes to all prompts (use with care; will run sudo apt-get or brew without asking).",
     )
 
-    subs.add_parser("auth", help="Sign in to Google and save session state")
+    subs.add_parser(
+        "auth",
+        help=(
+            "Sign in to Google and save session state; local runs prefer the "
+            "live Hermes Chrome CDP session first"
+        ),
+    )
 
-    join_p = subs.add_parser("join", help="Join a Meet URL")
+    join_p = subs.add_parser(
+        "join",
+        help=(
+            "Join a Meet URL; local runs prefer the live Hermes Chrome CDP "
+            "session first"
+        ),
+    )
     join_p.add_argument("url", help="https://meet.google.com/...")
     join_p.add_argument("--guest-name", default="Hermes Agent")
     join_p.add_argument("--duration", default=None, help="e.g. 30m, 2h, 90s")
@@ -334,7 +362,13 @@ def _cmd_install(*, realtime: bool, assume_yes: bool) -> int:
 
 
 def _cmd_auth() -> int:
-    """Open a headed Chromium, let the user sign in, save storage_state."""
+    """Open Chrome, let the user sign in, save storage_state.
+
+    We first try to attach to the existing browser instance used for browser
+    control (CDP on 127.0.0.1:18800). That path avoids launching a fresh
+    automation browser and is the most Google-friendly option. If that fails,
+    we fall back to a persistent Chrome profile.
+    """
     try:
         from playwright.sync_api import sync_playwright
     except ImportError:
@@ -345,22 +379,54 @@ def _cmd_auth() -> int:
         return 1
 
     path = _auth_state_path()
+    profile_dir = _auth_profile_dir()
     path.parent.mkdir(parents=True, exist_ok=True)
+    profile_dir.mkdir(parents=True, exist_ok=True)
 
-    print(f"opening Chromium — sign in to Google, then return here and press Enter.")
+    print("opening Chrome — sign in to Google, then return here and press Enter.")
     print(f"saving storage state to: {path}")
+    print(f"fallback persistent profile dir: {profile_dir}")
     try:
         with sync_playwright() as pw:
-            browser = pw.chromium.launch(headless=False)
-            context = browser.new_context()
-            page = context.new_page()
+            context = None
+            browser = None
+            try:
+                browser = pw.chromium.connect_over_cdp("http://127.0.0.1:18800")
+                context = browser.contexts[0] if browser.contexts else None
+                print("attached to existing Chrome via CDP on 127.0.0.1:18800")
+            except Exception as cdp_err:
+                print(f"CDP attach failed, falling back to persistent Chrome: {cdp_err}")
+                browser = None
+                context = None
+
+            if context is None:
+                context = pw.chromium.launch_persistent_context(
+                    user_data_dir=str(profile_dir),
+                    headless=False,
+                    channel="chrome",
+                    viewport={"width": 1280, "height": 800},
+                    user_agent=(
+                        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+                    ),
+                    permissions=["microphone", "camera"],
+                    args=["--disable-blink-features=AutomationControlled"],
+                )
+                print("launched persistent Chrome profile")
+
+            page = context.pages[0] if context.pages else context.new_page()
             page.goto("https://accounts.google.com/", wait_until="domcontentloaded")
             try:
                 input("press Enter after you've signed in ... ")
             except EOFError:
                 pass
             context.storage_state(path=str(path))
-            browser.close()
+            context.close()
+            if browser is not None:
+                try:
+                    browser.close()
+                except Exception:
+                    pass
     except Exception as e:
         print(f"auth failed: {e}")
         return 1

--- a/plugins/google_meet/meet_bot.py
+++ b/plugins/google_meet/meet_bot.py
@@ -35,8 +35,11 @@ import signal
 import sys
 import threading
 import time
+import urllib.request
 from pathlib import Path
 from typing import Optional
+
+from hermes_constants import get_hermes_home
 
 # Match ``https://meet.google.com/abc-defg-hij`` or ``.../lookup/...`` — the
 # short three-segment code or a lookup URL. Anything else is rejected.
@@ -52,6 +55,50 @@ MEET_URL_RE = re.compile(
 # Filenames the bot reads/writes in ``HERMES_MEET_OUT_DIR``.
 SAY_QUEUE_FILENAME = "say_queue.jsonl"
 SAY_PCM_FILENAME = "speaker.pcm"
+
+
+def _probe_cdp_url(cdp_url: str) -> bool:
+    """Return True when *cdp_url* looks like a live Chrome DevTools endpoint."""
+    if not cdp_url:
+        return False
+    try:
+        with urllib.request.urlopen(f"{cdp_url.rstrip('/')}/json/version", timeout=2) as resp:
+            json.load(resp)
+        return True
+    except Exception:
+        return False
+
+
+def _resolve_browser_cdp_url() -> Optional[str]:
+    """Return the browser CDP endpoint to attach to, if one is available.
+
+    Preference order:
+      1. explicit environment overrides
+      2. ``browser.cdp_url`` in the active Hermes config
+      3. the live Hermes Chrome profile at ``http://127.0.0.1:18800`` if it is reachable
+    """
+    for key in ("HERMES_MEET_CDP_URL", "HERMES_BROWSER_CDP_URL"):
+        raw = os.environ.get(key, "").strip()
+        if raw:
+            return raw
+
+    cfg_path = Path(get_hermes_home()) / "config.yaml"
+    if cfg_path.is_file():
+        try:
+            import yaml  # type: ignore
+
+            data = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+            browser_cfg = data.get("browser") or {}
+            raw = str(browser_cfg.get("cdp_url", "")).strip()
+            if raw:
+                return raw
+        except Exception:
+            pass
+
+    live_url = "http://127.0.0.1:18800"
+    if _probe_cdp_url(live_url):
+        return live_url
+    return None
 
 
 def _is_safe_meet_url(url: str) -> bool:
@@ -117,10 +164,41 @@ class _BotState:
 
     # -------- transcript ------------------------------------------------
 
+    @staticmethod
+    def _normalize_caption_parts(speaker: str, text: str) -> tuple[str, str]:
+        """Normalize speaker/text pairs before dedupe + persistence.
+
+        Meet's live caption DOM sometimes delivers the speaker in a separate
+        node, and sometimes only as the first line of the raw caption block.
+        This helper preserves the dedicated speaker when present, but also
+        recovers a leading speaker line from raw block text so transcripts keep
+        the attribution even when the DOM shifts.
+        """
+        speaker = (speaker or "").strip()
+        text = (text or "").strip()
+        if not text:
+            return speaker, text
+
+        if not speaker:
+            lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+            if len(lines) >= 2:
+                maybe_speaker = lines[0]
+                maybe_text = " ".join(lines[1:]).strip()
+                if maybe_text:
+                    return maybe_speaker, maybe_text
+            if ":" in text:
+                maybe_speaker, maybe_text = text.split(":", 1)
+                maybe_speaker = maybe_speaker.strip()
+                maybe_text = maybe_text.strip()
+                if maybe_speaker and maybe_text and len(maybe_speaker) <= 80:
+                    return maybe_speaker, maybe_text
+
+        return speaker, text
+
     def record_caption(self, speaker: str, text: str) -> None:
         """Append a caption line if we haven't seen this exact (speaker, text)."""
-        speaker = (speaker or "").strip() or "Unknown"
-        text = (text or "").strip()
+        speaker, text = self._normalize_caption_parts(speaker, text)
+        speaker = speaker or "Unknown"
         if not text:
             return
         key = f"{speaker}|{text}"
@@ -215,9 +293,9 @@ _CAPTION_OBSERVER_JS = r"""
       });
       return;
     }
-    // Fallback: treat the whole region's innerText as one anonymous line.
-    const text = (root.innerText || '').split('\n').filter(Boolean).pop();
-    pushEntry('', text);
+    // Fallback: keep the full caption block so Python can recover the
+    // speaker name from the first line when Meet's DOM shape changes.
+    pushEntry('', root.innerText || '');
   }
 
   function attach() {
@@ -245,21 +323,137 @@ _CAPTION_OBSERVER_JS = r"""
 
 
 def _enable_captions_js() -> str:
-    """Return a small JS snippet that tries to click the 'Turn on captions' button.
+    """Return a JS snippet that clicks Meet's captions toggle if present.
 
-    Best-effort — Meet's caption toggle is keyboard-accessible via ``c``. We
-    dispatch that keystroke as a cheap fallback. Real click targeting is too
-    brittle to rely on.
+    This is click-first on purpose: the DOM text/ARIA labels are more stable
+    than the keyboard shortcut, and we only use the shortcut as a fallback in
+    Python if the click doesn't take.
     """
     return r"""
     (() => {
-      const ev = new KeyboardEvent('keydown', {
-        key: 'c', code: 'KeyC', keyCode: 67, which: 67, bubbles: true,
-      });
-      document.body.dispatchEvent(ev);
-      return true;
+      const selectors = [
+        'button[aria-label*="Turn on captions" i]',
+        'button[aria-label*="Show captions" i]',
+        'button[aria-label*="Captions" i]',
+        '[role="button"][aria-label*="Turn on captions" i]',
+        '[role="button"][aria-label*="Show captions" i]',
+        '[role="button"][aria-label*="Captions" i]',
+        'button:has-text("Turn on captions")',
+        '[role="button"]:has-text("Turn on captions")',
+      ];
+      for (const sel of selectors) {
+        const el = document.querySelector(sel);
+        if (el) {
+          try {
+            el.click();
+            return true;
+          } catch (e) {}
+        }
+      }
+      return false;
     })();
     """
+
+
+def _turn_on_captions(page, timeout_s: float = 10.0) -> bool:
+    """Best-effort: enable Meet captions immediately after join.
+
+    Returns True if we observe the toggle flip to "Turn off captions" or the
+    caption region appear. False means we fell back to best-effort dispatches
+    but didn't get a positive confirmation.
+    """
+    deadline = time.time() + max(1.0, timeout_s)
+    last_error = None
+    while time.time() < deadline:
+        try:
+            if _detect_captioning_enabled(page) is True:
+                return True
+        except Exception as e:
+            last_error = e
+        try:
+            page.evaluate(_enable_captions_js())
+        except Exception as e:
+            last_error = e
+        try:
+            if _detect_captioning_enabled(page) is True:
+                return True
+        except Exception as e:
+            last_error = e
+        try:
+            page.keyboard.press("c")
+        except Exception as e:
+            last_error = e
+        try:
+            if _detect_captioning_enabled(page) is True:
+                return True
+        except Exception as e:
+            last_error = e
+        time.sleep(0.8)
+    if last_error:
+        return False
+    return False
+
+
+def _detect_captioning_enabled(page) -> Optional[bool]:
+    """Probe Meet's live UI to see whether captions are actually enabled.
+
+    Returns:
+      * True  — the UI indicates captions are on (toggle says "Turn off")
+      * False — the UI indicates captions are off (toggle says "Turn on")
+      * None  — the page is mid-transition or we couldn't tell confidently
+    """
+    probe = r"""
+    (() => {
+      const on = document.querySelector(
+        'button[aria-label*="Turn off captions" i], ' +
+        '[role="button"][aria-label*="Turn off captions" i], ' +
+        'button[aria-label*="Hide captions" i], ' +
+        '[role="button"][aria-label*="Hide captions" i], ' +
+        'button[aria-label*="Live captions" i], ' +
+        '[role="button"][aria-label*="Live captions" i]'
+      );
+      if (on) return true;
+
+      const region = document.querySelector(
+        '[role="region"][aria-label*="aption" i], ' +
+        'div[jsname="YSxPC"], ' +
+        'div[jsname="tgaKEf"]'
+      );
+      if (region) return true;
+
+      const off = document.querySelector(
+        'button[aria-label*="Turn on captions" i], ' +
+        '[role="button"][aria-label*="Turn on captions" i], ' +
+        'button[aria-label*="Show captions" i], ' +
+        '[role="button"][aria-label*="Show captions" i]'
+      );
+      if (off) return false;
+
+      return null;
+    })();
+    """
+    try:
+        val = page.evaluate(probe)
+    except Exception:
+        return None
+    if val is True:
+        return True
+    if val is False:
+        return False
+    return None
+
+
+def _sync_captioning_state(page, state: _BotState) -> None:
+    """Fold the live Meet UI caption state into ``status.json``.
+
+    This keeps the file-backed status aligned with what the browser is actually
+    showing, without flipping the flag off during transient DOM gaps.
+    """
+    detected = _detect_captioning_enabled(page)
+    if detected is None:
+        return
+    if detected != state.captioning:
+        state.set(captioning=detected)
 
 
 def _start_realtime_speaker(
@@ -295,6 +489,7 @@ def _start_realtime_speaker(
     pcm_path = out_dir / SAY_PCM_FILENAME
     queue_path = out_dir / SAY_QUEUE_FILENAME
     processed_path = out_dir / "say_processed.jsonl"
+    audio_log_path = out_dir / "realtime-audio.log"
     # Reset the sink file so we start clean each session.
     pcm_path.write_bytes(b"")
     # Make sure the queue exists so the speaker poller doesn't error on
@@ -309,6 +504,9 @@ def _start_realtime_speaker(
             instructions=instructions,
             audio_sink_path=pcm_path,
             sample_rate=24000,
+        )
+        sys.stderr.write(
+            f"[google_meet realtime] init session model={model} voice={voice} pcm={pcm_path} queue={queue_path} audio_log={audio_log_path}\n"
         )
         session.connect()
     except Exception as e:
@@ -339,70 +537,137 @@ def _start_realtime_speaker(
     rt["speaker_thread"] = t_speaker
 
     # PCM pump: feeds speaker.pcm (24kHz s16le mono) into the OS audio
-    # device that Chrome's fake mic reads from. Different tools per
-    # platform, but the contract is the same — block-read the growing
-    # PCM file and stream it to the device in near-real-time.
+    # device that Chrome's fake mic reads from. The sink needs a *live*
+    # stream, so we tail the growing PCM file and pipe only the newly
+    # appended bytes into the playback process.
     platform_tag = (bridge_info or {}).get("platform")
     if platform_tag == "linux":
+        import shutil as _shutil
         import subprocess as _sp
+        import threading as _threading
 
         sink = (bridge_info or {}).get("write_target") or "hermes_meet_sink"
         try:
+            player = "pacat" if _shutil.which("pacat") else "paplay"
+            cmd = [
+                player,
+                "--playback" if player == "pacat" else "--raw",
+                f"--device={sink}",
+                "--rate=24000",
+                "--format=s16le",
+                "--channels=1",
+            ]
+            if player != "pacat":
+                cmd.append("-")
+            sys.stderr.write(f"[google_meet audio] starting player={player} sink={sink} cmd={' '.join(cmd)}\n")
+            log_fp = open(audio_log_path, "a", buffering=1, encoding="utf-8")
             proc = _sp.Popen(
-                [
-                    "paplay",
-                    "--raw",
-                    "--rate=24000",
-                    "--format=s16le",
-                    "--channels=1",
-                    f"--device={sink}",
-                    str(pcm_path),
-                ],
-                stdin=_sp.DEVNULL,
+                cmd,
+                stdin=_sp.PIPE,
                 stdout=_sp.DEVNULL,
-                stderr=_sp.DEVNULL,
+                stderr=log_fp,
+                bufsize=0,
             )
+
+            def _pump_pcm_tail() -> None:
+                pos = 0
+                try:
+                    with open(pcm_path, "rb") as fp:
+                        while not stop_flag.get("stop", False):
+                            fp.seek(pos)
+                            chunk = fp.read(4096)
+                            if chunk:
+                                pos = fp.tell()
+                                if proc.stdin:
+                                    try:
+                                        proc.stdin.write(chunk)
+                                        proc.stdin.flush()
+                                    except Exception as exc:
+                                        sys.stderr.write(f"[google_meet audio] write failed: {exc}\n")
+                                        break
+                            else:
+                                time.sleep(0.05)
+                finally:
+                    try:
+                        if proc.stdin:
+                            proc.stdin.close()
+                    except Exception:
+                        pass
+
+            def _monitor_player() -> None:
+                while not stop_flag.get("stop", False):
+                    rc = proc.poll()
+                    if rc is not None:
+                        sys.stderr.write(f"[google_meet audio] player exited rc={rc}\n")
+                        state.set(error=f"audio player exited rc={rc}")
+                        break
+                    time.sleep(1.0)
+
+            pump_thread = _threading.Thread(target=_pump_pcm_tail, name="meet-pcm-pump", daemon=True)
+            pump_thread.start()
+            monitor_thread = _threading.Thread(target=_monitor_player, name="meet-pcm-monitor", daemon=True)
+            monitor_thread.start()
             rt["pcm_pump"] = proc
+            rt["pcm_pump_thread"] = pump_thread
+            rt["pcm_pump_monitor_thread"] = monitor_thread
+            rt["pcm_pump_log_fp"] = log_fp
         except FileNotFoundError:
-            state.set(error="paplay not found — install pulseaudio-utils for realtime on Linux")
+            state.set(error="pacat/paplay not found — install pulseaudio-utils for realtime on Linux")
     elif platform_tag == "darwin":
-        # macOS: use ffmpeg to tail-read speaker.pcm and write it to the
-        # BlackHole output device. The user must have BlackHole selected
-        # as the default input in System Settings → Sound for Chrome to
-        # pick it up. We prefer ffmpeg because it's scriptable and can
-        # target AVFoundation devices by name; fall back to afplay-ing
-        # the file in a tight loop if ffmpeg is absent.
+        # macOS: use ffmpeg to read speaker.pcm as it grows and write it to
+        # BlackHole. The user must have BlackHole selected as the default
+        # input in System Settings → Sound for Chrome to pick it up.
         import shutil as _shutil
         import subprocess as _sp
+        import threading as _threading
 
         device_name = (bridge_info or {}).get("write_target") or "BlackHole 2ch"
         if _shutil.which("ffmpeg"):
             try:
-                # -re: read input at native frame rate.
-                # -f avfoundation -i: speaker path as raw PCM.
-                # -f s16le -ar 24000 -ac 1 -i <pcm>: interpret the file.
-                # -f audiotoolbox -audio_device_index: write to BlackHole.
-                # Simpler: output as raw via coreaudio using "-f audiotoolbox".
-                # ffmpeg's audiotoolbox output picks the current default
-                # output device, which isn't what we want. Instead we use
-                # -f avfoundation with the named device as OUTPUT via
-                # -vn and the device name.
                 proc = _sp.Popen(
                     [
                         "ffmpeg",
                         "-nostdin", "-hide_banner", "-loglevel", "error",
-                        "-re",
                         "-f", "s16le", "-ar", "24000", "-ac", "1",
-                        "-i", str(pcm_path),
+                        "-i", "pipe:0",
                         "-f", "audiotoolbox",
                         "-audio_device_index", _mac_audio_device_index(device_name),
                         "-",
                     ],
-                    stdin=_sp.DEVNULL,
+                    stdin=_sp.PIPE,
                     stdout=_sp.DEVNULL,
                     stderr=_sp.DEVNULL,
+                    bufsize=0,
                 )
+
+                def _pump_pcm_tail() -> None:
+                    pos = 0
+                    try:
+                        with open(pcm_path, "rb") as fp:
+                            while not stop_flag.get("stop", False):
+                                fp.seek(pos)
+                                chunk = fp.read(4096)
+                                if chunk:
+                                    pos = fp.tell()
+                                    if proc.stdin:
+                                        try:
+                                            proc.stdin.write(chunk)
+                                            proc.stdin.flush()
+                                        except Exception:
+                                            break
+                                else:
+                                    time.sleep(0.05)
+                    finally:
+                        try:
+                            if proc.stdin:
+                                proc.stdin.close()
+                        except Exception:
+                            pass
+
+                pump_thread = _threading.Thread(target=_pump_pcm_tail, name="meet-pcm-pump", daemon=True)
+                pump_thread.start()
                 rt["pcm_pump"] = proc
+                rt["pcm_pump_thread"] = pump_thread
             except FileNotFoundError:
                 state.set(error="ffmpeg not found — install via `brew install ffmpeg` for realtime on macOS")
             except Exception as e:
@@ -442,6 +707,56 @@ def _mac_audio_device_index(device_name: str) -> str:
         if m.group(2).strip().lower() == needle:
             return m.group(1)
     return "0"
+
+
+def _open_browser_session(
+    pw,
+    *,
+    headed: bool,
+    auth_state: str,
+    chrome_env: dict,
+    chrome_args: list[str],
+):
+    """Open Meet in the live Hermes CDP browser if available, else locally.
+
+    Returns ``(browser, context, page, using_cdp)``.
+    """
+    for key, value in chrome_env.items():
+        os.environ[key] = value
+
+    cdp_url = _resolve_browser_cdp_url()
+    if cdp_url:
+        try:
+            browser = pw.chromium.connect_over_cdp(cdp_url)
+            if not browser.contexts:
+                raise RuntimeError(f"connected to {cdp_url} but no browser contexts were available")
+            context = browser.contexts[0]
+            try:
+                context.grant_permissions(["microphone", "camera"], origin="https://meet.google.com")
+            except Exception:
+                pass
+            page = context.new_page()
+            return browser, context, page, True
+        except Exception:
+            pass
+
+    browser = pw.chromium.launch(
+        headless=not headed,
+        args=chrome_args,
+    )
+    context_args = {
+        "viewport": {"width": 1280, "height": 800},
+        "user_agent": (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+        ),
+        "permissions": ["microphone", "camera"],
+    }
+    if auth_state and Path(auth_state).is_file():
+        context_args["storage_state"] = auth_state
+    context = browser.new_context(**context_args)
+    page = context.new_page()
+    return browser, context, page, False
 
 
 def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
@@ -494,6 +809,10 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
         "session": None,           # RealtimeSession | None
         "speaker_thread": None,    # threading.Thread | None
         "speaker_stop": None,      # callable | None
+        "pcm_pump": None,          # subprocess.Popen | None
+        "pcm_pump_thread": None,   # threading.Thread | None
+        "pcm_pump_monitor_thread": None,   # threading.Thread | None
+        "pcm_pump_log_fp": None,   # file handle for playback stderr
     }
     if rt["enabled"]:
         if not realtime_api_key:
@@ -538,26 +857,13 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
 
     try:
         with sync_playwright() as pw:
-            # Playwright's launch() doesn't take env; we set PULSE_SOURCE
-            # via the process env before launch so the child Chrome inherits it.
-            for k, v in chrome_env.items():
-                os.environ[k] = v
-            browser = pw.chromium.launch(
-                headless=not headed,
-                args=chrome_args,
+            browser, context, page, using_cdp = _open_browser_session(
+                pw,
+                headed=headed,
+                auth_state=auth_state,
+                chrome_env=chrome_env,
+                chrome_args=chrome_args,
             )
-            context_args = {
-                "viewport": {"width": 1280, "height": 800},
-                "user_agent": (
-                    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-                    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-                ),
-                "permissions": ["microphone", "camera"],
-            }
-            if auth_state and Path(auth_state).is_file():
-                context_args["storage_state"] = auth_state
-            context = browser.new_context(**context_args)
-            page = context.new_page()
 
             try:
                 page.goto(url, wait_until="domcontentloaded", timeout=30_000)
@@ -570,12 +876,13 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
             _try_guest_name(page, guest_name)
             _click_join(page, state)
 
-            # Install caption observer and attempt to enable captions.
+            # Install caption observer and enable captions immediately after join.
+            captions_enabled = False
             try:
-                page.evaluate(_enable_captions_js())
-                state.set(captions_enabled_attempted=True)
+                captions_enabled = _turn_on_captions(page)
             except Exception:
                 pass
+            state.set(captions_enabled_attempted=True)
             try:
                 page.evaluate(_CAPTION_OBSERVER_JS)
             except Exception as e:
@@ -584,7 +891,10 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
             # Note: in_call=False until admission is confirmed (we detect
             # either the Leave button or the caption region, signalling we
             # made it past the lobby).
-            state.set(captioning=True, join_attempted_at=time.time())
+            captioning = _detect_captioning_enabled(page)
+            if captioning is None:
+                captioning = bool(captions_enabled)
+            state.set(captioning=bool(captioning), join_attempted_at=time.time())
 
             # v2 realtime: start the speaker thread reading from the
             # plugin-side say queue. The thread reads JSONL lines written by
@@ -619,6 +929,7 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
                 os.environ.get("HERMES_MEET_LOBBY_TIMEOUT", "300")
             )
             last_admission_check = 0.0
+            last_caption_attempt = 0.0
             while not stop_flag["stop"]:
                 now = time.time()
                 if deadline and now > deadline:
@@ -678,6 +989,18 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
                         state.set(leave_reason="page_closed")
                         break
 
+                # Keep captioning status in sync with the live Meet UI so the
+                # file-backed status doesn't lag or get stuck when the DOM
+                # changes or Meet silently toggles the control.
+                _sync_captioning_state(page, state)
+                if state.in_call and not state.captioning and (now - last_caption_attempt) > 5.0:
+                    last_caption_attempt = now
+                    try:
+                        if _turn_on_captions(page, timeout_s=3.0):
+                            state.set(captioning=True, captions_enabled_attempted=True)
+                    except Exception:
+                        pass
+
                 # Fold the realtime session's byte/timestamp counters into
                 # the status file so meet_status can surface them.
                 if rt["session"] is not None:
@@ -697,8 +1020,14 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
             except Exception:
                 pass
 
-            context.close()
-            browser.close()
+            if using_cdp:
+                try:
+                    page.close()
+                except Exception:
+                    pass
+            else:
+                context.close()
+                browser.close()
             # v2: teardown realtime speaker + audio bridge.
             if rt["speaker_stop"]:
                 try:
@@ -708,6 +1037,30 @@ def run_bot() -> int:  # noqa: C901 — orchestration, explicit branches
             if rt["speaker_thread"] is not None:
                 try:
                     rt["speaker_thread"].join(timeout=5.0)
+                except Exception:
+                    pass
+            if rt.get("pcm_pump_thread") is not None:
+                try:
+                    rt["pcm_pump_thread"].join(timeout=5.0)
+                except Exception:
+                    pass
+            if rt.get("pcm_pump_monitor_thread") is not None:
+                try:
+                    rt["pcm_pump_monitor_thread"].join(timeout=5.0)
+                except Exception:
+                    pass
+            if rt.get("pcm_pump") is not None:
+                try:
+                    rt["pcm_pump"].terminate()
+                    rt["pcm_pump"].wait(timeout=5.0)
+                except Exception:
+                    try:
+                        rt["pcm_pump"].kill()
+                    except Exception:
+                        pass
+            if rt.get("pcm_pump_log_fp") is not None:
+                try:
+                    rt["pcm_pump_log_fp"].close()
                 except Exception:
                     pass
             if rt["session"]:
@@ -754,7 +1107,7 @@ def _detect_admission(page) -> bool:
     """
     probe = r"""
     (() => {
-      const leave = document.querySelector('button[aria-label*="eave call" i]');
+      const leave = document.querySelector('button[aria-label*="eave call" i], [role="button"][aria-label*="eave call" i], button[aria-label*="end call" i], [role="button"][aria-label*="end call" i], button[aria-label*="leave meeting" i], [role="button"][aria-label*="leave meeting" i]');
       if (leave) return true;
       if (window.__hermesMeetInstalled) {
         const caps = document.querySelector(
@@ -763,7 +1116,7 @@ def _detect_admission(page) -> bool:
         );
         if (caps) return true;
       }
-      const parts = document.querySelector('[aria-label*="articipants" i]');
+      const parts = document.querySelector('[aria-label*="articipants" i], [role="button"][aria-label*="articipants" i]');
       if (parts) return true;
       return false;
     })();
@@ -813,22 +1166,105 @@ def _looks_like_human_speaker(speaker: str, bot_guest_name: str) -> bool:
     return True
 
 
-def _click_join(page, state: _BotState) -> None:
+def _click_mic_prompt(page) -> bool:
+    """Dismiss Meet's pre-join audio prompt when it appears.
+
+    Meet sometimes inserts a modal asking whether people should hear you.
+    For this bot we want the no-mic path so the join flow can continue
+    without waiting for device permissions or a stale overlay.
+    """
+    for label in ("Continue without microphone", "Use microphone"):
+        try:
+            btn = page.get_by_role("button", name=label, exact=False).first
+            if btn.count() and btn.is_visible():
+                try:
+                    btn.scroll_into_view_if_needed(timeout=1_000)
+                except Exception:
+                    pass
+                try:
+                    btn.click(timeout=2_000)
+                except Exception:
+                    btn.click(timeout=2_000, force=True)
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _click_join(page, state: _BotState, retries: int = 3) -> None:
     """Click 'Join now' or 'Ask to join' if either button is visible.
+
+    The Meet lobby is a little slippery: a click may be intercepted by the
+    microphone prompt, the target may re-render, or the button may appear one
+    beat later than the first DOM probe. We therefore:
+
+    1. dismiss the mic prompt if present,
+    2. try both join labels,
+    3. verify admission, and
+    4. retry a couple of times if the page still looks like the lobby.
 
     Flags ``lobby_waiting`` when we hit the "waiting for host to admit you"
     state so the agent can surface that in status.
     """
-    for label in ("Join now", "Ask to join"):
-        try:
-            btn = page.get_by_role("button", name=label, exact=False).first
-            if btn.count() and btn.is_visible():
-                btn.click(timeout=3_000)
+    join_labels = ("Join now", "Ask to join")
+    for _ in range(max(1, retries)):
+        _click_mic_prompt(page)
+
+        clicked_label = None
+        for label in join_labels:
+            try:
+                btn = page.get_by_role("button", name=label, exact=False).first
+                if not (btn.count() and btn.is_visible()):
+                    continue
+                try:
+                    btn.scroll_into_view_if_needed(timeout=1_000)
+                except Exception:
+                    pass
+                try:
+                    btn.click(timeout=3_000)
+                except Exception:
+                    btn.click(timeout=3_000, force=True)
+                clicked_label = label
                 if label == "Ask to join":
                     state.set(lobby_waiting=True)
                 break
+            except Exception:
+                continue
+
+        if _detect_admission(page):
+            return
+
+        if clicked_label == "Ask to join":
+            # If Meet actually accepted the request, the lobby button should
+            # disappear and admission will be detected on the next poll. If the
+            # button is still there, keep retrying a couple of times in case the
+            # first click was swallowed by a rerender or overlay.
+            try:
+                still_visible = bool(
+                    page.get_by_role("button", name="Ask to join", exact=False).first.count()
+                    and page.get_by_role("button", name="Ask to join", exact=False).first.is_visible()
+                )
+            except Exception:
+                still_visible = False
+            if not still_visible:
+                return
+        elif clicked_label == "Join now":
+            try:
+                still_visible = bool(
+                    page.get_by_role("button", name="Join now", exact=False).first.count()
+                    and page.get_by_role("button", name="Join now", exact=False).first.is_visible()
+                )
+            except Exception:
+                still_visible = False
+            if not still_visible:
+                # We clicked the button but Meet is still re-rendering or
+                # switching states; give it another beat before the next loop.
+                pass
+
+        try:
+            page.wait_for_timeout(800)
         except Exception:
-            continue
+            time.sleep(0.8)
 
 
 def _parse_duration(raw: str) -> Optional[float]:

--- a/plugins/google_meet/plugin.yaml
+++ b/plugins/google_meet/plugin.yaml
@@ -1,6 +1,6 @@
 name: google_meet
 version: 0.2.0
-description: "Join a Google Meet call, transcribe live captions, speak in realtime, and follow up afterwards. v1 transcribe-only is the default; v2 realtime duplex audio via OpenAI Realtime + BlackHole/PulseAudio ships with mode='realtime'; v3 remote node host lets the bot run on a different machine than the gateway (gateway on Linux, Chrome+signed-in profile on the user's Mac). Explicit-by-design: only joins meet.google.com URLs passed in \u2014 no calendar scanning, no auto-dial."
+description: "Join a Google Meet call, transcribe live captions, speak in realtime, and follow up afterwards. v1 transcribe-only is the default; v2 realtime duplex audio via OpenAI Realtime + BlackHole/PulseAudio ships with mode='realtime'; v3 remote node host lets the bot run on a different machine than the gateway (gateway on Linux, Chrome+signed-in profile on the user's Mac). When running locally, the bot prefers the live Hermes browser CDP endpoint (usually http://127.0.0.1:18800) instead of launching a separate unauthenticated browser. Explicit-by-design: only joins meet.google.com URLs passed in — no calendar scanning, no auto-dial."
 author: NousResearch
 kind: standalone
 platforms:

--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import base64
 import json
+import os
+import sys
 import time
 import uuid
 from pathlib import Path
@@ -22,6 +24,7 @@ from typing import Any, Callable, Optional
 
 
 REALTIME_URL = "wss://api.openai.com/v1/realtime"
+REALTIME_MODEL = os.getenv("OPENAI_REALTIME_MODEL", "gpt-realtime")
 
 
 def _require_websockets():
@@ -49,10 +52,18 @@ class RealtimeSession:
     different threads; a lock serializes WebSocket writes.
     """
 
+    DEFAULT_INSTRUCTIONS = (
+        "You are a text-to-speech engine for a Google Meet bot. "
+        "When given text to speak, read it verbatim and only verbatim. "
+        "Do not paraphrase, summarize, expand, continue from prior context, "
+        "or add any extra words. Output should be a clean spoken reading of "
+        "the provided text and nothing else."
+    )
+
     def __init__(
         self,
         api_key: str,
-        model: str = "gpt-realtime",
+        model: str = REALTIME_MODEL,
         voice: str = "alloy",
         instructions: str = "",
         audio_sink_path: Optional[Path] = None,
@@ -62,9 +73,11 @@ class RealtimeSession:
         self.api_key = api_key
         self.model = model
         self.voice = voice
-        self.instructions = instructions
+        self.instructions = instructions.strip() if instructions and instructions.strip() else self.DEFAULT_INSTRUCTIONS
         self.audio_sink_path = Path(audio_sink_path) if audio_sink_path else None
         self.sample_rate = sample_rate
+        self.tts_model = os.getenv("OPENAI_TTS_MODEL", "gpt-4o-mini-tts")
+        self._tts_client: Any = None
         self._ws: Any = None
         self._send_lock = _threading.Lock()
         self._last_response_id: Optional[str] = None
@@ -78,30 +91,51 @@ class RealtimeSession:
         """Open WS and send session.update with voice+instructions."""
         connect = _require_websockets()
         url = f"{REALTIME_URL}?model={self.model}"
+        sys.stderr.write(
+            f"[google_meet realtime] connect model={self.model} voice={self.voice} "
+            f"sample_rate={self.sample_rate} sink={self.audio_sink_path}\n"
+        )
         headers = [
             ("Authorization", f"Bearer {self.api_key}"),
-            ("OpenAI-Beta", "realtime=v1"),
         ]
+        # The realtime session is mostly idle between speaks; client-side
+        # keepalive pings have proven flaky here and can kill an otherwise
+        # healthy socket mid-session. Disable them and let reconnect logic
+        # handle real disconnects.
+        kwargs = {
+            "ping_interval": None,
+            "ping_timeout": None,
+        }
         # websockets.sync.client.connect accepts either additional_headers=
         # (newer) or extra_headers= depending on version; try the newer
         # name first and fall back.
         try:
-            self._ws = connect(url, additional_headers=headers)
+            self._ws = connect(url, additional_headers=headers, **kwargs)
         except TypeError:
-            self._ws = connect(url, extra_headers=headers)
+            self._ws = connect(url, extra_headers=headers, **kwargs)
 
         self._send_json(
             {
                 "type": "session.update",
                 "session": {
-                    "voice": self.voice,
+                    "type": "realtime",
+                    "model": self.model,
                     "instructions": self.instructions,
-                    "modalities": ["audio", "text"],
-                    "output_audio_format": "pcm16",
-                    "input_audio_format": "pcm16",
+                    "output_modalities": ["audio"],
+                    "audio": {
+                        "input": {
+                            "format": {"type": "audio/pcm", "rate": self.sample_rate},
+                            "turn_detection": {"type": "semantic_vad"},
+                        },
+                        "output": {
+                            "format": {"type": "audio/pcm", "rate": self.sample_rate},
+                            "voice": self.voice,
+                        },
+                    },
                 },
             }
         )
+        sys.stderr.write("[google_meet realtime] session.update sent\n")
 
     def close(self) -> None:
         if self._ws is not None:
@@ -113,6 +147,65 @@ class RealtimeSession:
 
     # ── speaking ──────────────────────────────────────────────────────────
 
+    def _speak_via_tts(self, text: str, timeout: float) -> dict:
+        """Generate PCM with the dedicated TTS endpoint and append it to the sink."""
+        try:
+            from openai import OpenAI
+        except ImportError as exc:  # pragma: no cover - dependency is expected to exist
+            raise RuntimeError("openai package is required for TTS playback") from exc
+
+        if self._tts_client is None:
+            self._tts_client = OpenAI(api_key=self.api_key)
+
+        start = time.monotonic()
+        preview = text.replace("\n", " ").strip()
+        if len(preview) > 120:
+            preview = preview[:120] + "…"
+        sys.stderr.write(
+            f"[google_meet tts] speak start model={self.tts_model} voice={self.voice} text={preview!r} timeout={timeout}\n"
+        )
+
+        response = self._tts_client.audio.speech.create(
+            model=self.tts_model,
+            voice=self.voice,
+            input=text,
+            instructions=self.instructions,
+            response_format="pcm",
+            timeout=timeout,
+        )
+
+        bytes_written = 0
+        sink_fp = None
+        if self.audio_sink_path is not None:
+            self.audio_sink_path.parent.mkdir(parents=True, exist_ok=True)
+            sink_fp = open(self.audio_sink_path, "ab")
+        try:
+            for chunk in response.iter_bytes():
+                if not chunk:
+                    continue
+                if sink_fp is not None:
+                    sink_fp.write(chunk)
+                    sink_fp.flush()
+                bytes_written += len(chunk)
+                self.audio_bytes_out += len(chunk)
+                self.last_audio_out_at = time.time()
+        finally:
+            if sink_fp is not None:
+                sink_fp.close()
+            try:
+                response.close()
+            except Exception:
+                pass
+
+        if bytes_written <= 0:
+            raise RuntimeError("TTS produced zero audio bytes")
+
+        duration_ms = (time.monotonic() - start) * 1000.0
+        sys.stderr.write(
+            f"[google_meet tts] response finished bytes={bytes_written} duration_ms={duration_ms:.1f}\n"
+        )
+        return {"ok": True, "bytes_written": bytes_written, "duration_ms": duration_ms}
+
     def speak(self, text: str, timeout: float = 30.0) -> dict:
         """Send ``text`` and accumulate the audio response.
 
@@ -123,7 +216,24 @@ class RealtimeSession:
         if self._ws is None:
             raise RuntimeError("RealtimeSession.connect() must be called first")
 
+        try:
+            return self._speak_via_tts(text, timeout)
+        except Exception as exc:
+            sys.stderr.write(f"[google_meet tts] failed, falling back to realtime: {exc}\n")
+
         start = time.monotonic()
+        preview = text.replace("\n", " ").strip()
+        if len(preview) > 120:
+            preview = preview[:120] + "…"
+        sys.stderr.write(f"[google_meet realtime] speak start text={preview!r} timeout={timeout}\n")
+
+        # Force a literal reading path: the model sees the text wrapped in an
+        # explicit verbatim instruction so it is less likely to continue or
+        # paraphrase prior context.
+        speak_text = (
+            "Read the following text verbatim, with no additions or omissions:\n"
+            f"```{text}```"
+        )
 
         self._send_json(
             {
@@ -131,14 +241,13 @@ class RealtimeSession:
                 "item": {
                     "type": "message",
                     "role": "user",
-                    "content": [{"type": "input_text", "text": text}],
+                    "content": [{"type": "input_text", "text": speak_text}],
                 },
             }
         )
         self._send_json(
             {
                 "type": "response.create",
-                "response": {"modalities": ["audio"]},
             }
         )
 
@@ -158,6 +267,7 @@ class RealtimeSession:
                 raw = self._recv(timeout=remaining)
                 if raw is None:
                     # Connection closed by peer.
+                    sys.stderr.write("[google_meet realtime] socket closed by peer while speaking\n")
                     break
                 try:
                     frame = json.loads(raw) if isinstance(raw, (str, bytes, bytearray)) else raw
@@ -166,7 +276,7 @@ class RealtimeSession:
                 if not isinstance(frame, dict):
                     continue
                 ftype = frame.get("type")
-                if ftype == "response.audio.delta":
+                if ftype in {"response.audio.delta", "response.output_audio.delta"}:
                     b64 = frame.get("delta") or frame.get("audio") or ""
                     if b64 and sink_fp is not None:
                         try:
@@ -179,23 +289,37 @@ class RealtimeSession:
                             bytes_written += len(chunk)
                             self.audio_bytes_out += len(chunk)
                             self.last_audio_out_at = time.time()
-                elif ftype == "response.created":
+                elif ftype in {"response.created", "response.output_item.created"}:
                     rid = (frame.get("response") or {}).get("id")
                     if rid:
                         self._last_response_id = rid
-                elif ftype in {"response.done", "response.completed", "response.cancelled"}:
+                        sys.stderr.write(f"[google_meet realtime] response created id={rid}\n")
+                elif ftype in {
+                    "response.done",
+                    "response.completed",
+                    "response.cancelled",
+                    "response.output_audio.done",
+                }:
+                    sys.stderr.write(
+                        f"[google_meet realtime] response finished type={ftype} bytes={bytes_written} "
+                        f"duration_ms={(time.monotonic() - start) * 1000.0:.1f}\n"
+                    )
                     break
                 elif ftype == "error":
                     err = frame.get("error") or frame
+                    sys.stderr.write(f"[google_meet realtime] error frame: {err}\n")
                     raise RuntimeError(f"realtime error: {err}")
-                # All other frames (response.created, response.output_item.*,
-                # response.audio_transcript.delta, rate_limits.updated, ...)
+                # All other frames (response.output_item.*,
+                # response.output_audio_transcript.delta, rate_limits.updated, ...)
                 # are ignored for v2.
         finally:
             if sink_fp is not None:
                 sink_fp.close()
 
         duration_ms = (time.monotonic() - start) * 1000.0
+        sys.stderr.write(
+            f"[google_meet realtime] speak done bytes={bytes_written} duration_ms={duration_ms:.1f}\n"
+        )
         return {
             "ok": True,
             "bytes_written": bytes_written,
@@ -311,13 +435,20 @@ class RealtimeSpeaker:
             # speak() call because new entries may have arrived.
             head = entries[0]
             text = (head.get("text") or "").strip()
+            sys.stderr.write(
+                f"[google_meet realtime] queue head id={head.get('id')} len={len(text)} remaining={len(entries)}\n"
+            )
             if text:
                 try:
                     result = self.session.speak(text)
                 except Exception as exc:
                     result = {"ok": False, "error": str(exc)}
+                    sys.stderr.write(f"[google_meet realtime] speak failed: {exc}\n")
             else:
                 result = {"ok": True, "bytes_written": 0, "duration_ms": 0.0}
+            sys.stderr.write(
+                f"[google_meet realtime] queue result id={head.get('id')} ok={result.get('ok')} bytes={result.get('bytes_written')}\n"
+            )
             self._append_processed(head, result)
 
             # Re-read the queue from disk in case it was appended to

--- a/tests/plugins/google_meet/test_join_flow.py
+++ b/tests/plugins/google_meet/test_join_flow.py
@@ -1,0 +1,149 @@
+import pytest
+
+from plugins.google_meet import meet_bot
+from plugins.google_meet.realtime.openai_client import RealtimeSession
+
+
+class FakeLocator:
+    def __init__(self, page, label, visible=True, click_hides=False):
+        self.page = page
+        self.label = label
+        self.visible = visible
+        self.click_hides = click_hides
+        self.click_count = 0
+
+    @property
+    def first(self):
+        return self
+
+    def count(self):
+        return 1 if self.visible else 0
+
+    def is_visible(self):
+        return self.visible
+
+    def scroll_into_view_if_needed(self, timeout=None):
+        return None
+
+    def click(self, timeout=None, force=False):
+        self.click_count += 1
+        self.page.actions.append(self.label)
+        if self.click_hides:
+            self.visible = False
+
+
+class FakePage:
+    def __init__(self, locators):
+        self.locators = locators
+        self.actions = []
+        self.wait_calls = []
+
+    def get_by_role(self, role, name=None, exact=False):
+        key = str(name)
+        if key not in self.locators:
+            return FakeLocator(self, key, visible=False)
+        return self.locators[key]
+
+    def wait_for_timeout(self, ms):
+        self.wait_calls.append(ms)
+
+
+class DummyState:
+    def __init__(self):
+        self.lobby_waiting = False
+        self.calls = []
+
+    def set(self, **kwargs):
+        self.calls.append(kwargs)
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def test_click_join_handles_ask_to_join_and_sets_lobby_waiting(monkeypatch):
+    page = FakePage(
+        {
+            "Ask to join": FakeLocator(None, "Ask to join", visible=True, click_hides=True),
+            "Join now": FakeLocator(None, "Join now", visible=False),
+            "Continue without microphone": FakeLocator(None, "Continue without microphone", visible=False),
+            "Use microphone": FakeLocator(None, "Use microphone", visible=False),
+        }
+    )
+    for locator in page.locators.values():
+        locator.page = page
+    state = DummyState()
+    monkeypatch.setattr(meet_bot, "_detect_admission", lambda _page: False)
+
+    meet_bot._click_join(page, state, retries=2)
+
+    assert page.actions == ["Ask to join"]
+    assert state.lobby_waiting is True
+    assert page.wait_calls == []
+
+
+def test_click_join_retries_join_now_when_first_click_does_not_admit(monkeypatch):
+    page = FakePage(
+        {
+            "Join now": FakeLocator(None, "Join now", visible=True),
+            "Ask to join": FakeLocator(None, "Ask to join", visible=False),
+            "Continue without microphone": FakeLocator(None, "Continue without microphone", visible=False),
+            "Use microphone": FakeLocator(None, "Use microphone", visible=False),
+        }
+    )
+    for locator in page.locators.values():
+        locator.page = page
+    state = DummyState()
+    detect_calls = {"n": 0}
+
+    def fake_detect(_page):
+        detect_calls["n"] += 1
+        return detect_calls["n"] >= 2
+
+    monkeypatch.setattr(meet_bot, "_detect_admission", fake_detect)
+
+    meet_bot._click_join(page, state, retries=3)
+
+    assert page.actions == ["Join now", "Join now"]
+    assert detect_calls["n"] == 2
+    assert state.lobby_waiting is False
+
+
+def test_speak_uses_tts_first(monkeypatch, tmp_path):
+    session = RealtimeSession(api_key="sk-test", audio_sink_path=tmp_path / "speaker.pcm")
+    session._ws = object()
+
+    called = {"tts": 0}
+
+    def fake_tts(text, timeout):
+        called["tts"] += 1
+        return {"ok": True, "bytes_written": 1234, "duration_ms": 12.3}
+
+    def fail_realtime(*args, **kwargs):
+        raise AssertionError("realtime fallback should not be used when TTS succeeds")
+
+    monkeypatch.setattr(session, "_speak_via_tts", fake_tts)
+    monkeypatch.setattr(session, "_send_json", fail_realtime)
+
+    result = session.speak("Testing 1,2,3!!", timeout=5.0)
+
+    assert called["tts"] == 1
+    assert result["bytes_written"] == 1234
+
+
+def test_click_join_dismisses_mic_prompt_before_join(monkeypatch):
+    page = FakePage(
+        {
+            "Continue without microphone": FakeLocator(None, "Continue without microphone", visible=True, click_hides=True),
+            "Use microphone": FakeLocator(None, "Use microphone", visible=False),
+            "Join now": FakeLocator(None, "Join now", visible=True),
+            "Ask to join": FakeLocator(None, "Ask to join", visible=False),
+        }
+    )
+    for locator in page.locators.values():
+        locator.page = page
+    state = DummyState()
+    monkeypatch.setattr(meet_bot, "_detect_admission", lambda _page: True)
+
+    meet_bot._click_join(page, state, retries=1)
+
+    assert page.actions == ["Continue without microphone", "Join now"]
+    assert state.lobby_waiting is False

--- a/tests/plugins/test_google_meet_plugin.py
+++ b/tests/plugins/test_google_meet_plugin.py
@@ -62,6 +62,177 @@ def test_is_safe_meet_url_rejects_non_meet_urls():
     assert not _is_safe_meet_url(123)  # type: ignore[arg-type]
 
 
+def test_open_browser_session_prefers_live_cdp(monkeypatch):
+    from plugins.google_meet import meet_bot
+
+    calls = []
+
+    class _FakePage:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _FakeContext:
+        def __init__(self):
+            self.pages = []
+
+        def grant_permissions(self, *args, **kwargs):
+            calls.append(("grant_permissions", args, kwargs))
+
+        def new_page(self):
+            page = _FakePage()
+            self.pages.append(page)
+            calls.append(("new_page",))
+            return page
+
+    class _FakeBrowser:
+        def __init__(self):
+            self.contexts = [_FakeContext()]
+
+    class _FakeChromium:
+        def connect_over_cdp(self, url):
+            calls.append(("connect_over_cdp", url))
+            return _FakeBrowser()
+
+        def launch(self, **kwargs):
+            calls.append(("launch", kwargs))
+            raise AssertionError("local launch should not be used when CDP is available")
+
+    class _FakePW:
+        chromium = _FakeChromium()
+
+    monkeypatch.setattr(meet_bot, "_resolve_browser_cdp_url", lambda: "http://127.0.0.1:18800")
+
+    browser, context, page, using_cdp = meet_bot._open_browser_session(
+        _FakePW(),
+        headed=False,
+        auth_state="",
+        chrome_env={},
+        chrome_args=["--test-flag"],
+    )
+
+    assert using_cdp is True
+    assert calls[0] == ("connect_over_cdp", "http://127.0.0.1:18800")
+    assert any(name == "new_page" for (name, *_) in calls)
+    assert browser.contexts[0] is context
+    assert page in context.pages
+
+
+def test_turn_on_captions_clicks_then_falls_back_to_keyboard(monkeypatch):
+    from plugins.google_meet import meet_bot
+
+    class _FakeLocator:
+        def __init__(self, page, query):
+            self.page = page
+            self.query = query
+            self.first = self
+
+        def count(self):
+            return self.page._count(self.query)
+
+    class _FakeKeyboard:
+        def __init__(self, page):
+            self.page = page
+            self.presses = []
+
+        def press(self, key):
+            self.presses.append(key)
+            if self.page.enable_via_keyboard:
+                self.page.captions_enabled = True
+                self.page.caption_region_visible = True
+
+    class _FakePage:
+        def __init__(self, *, enable_via_click, enable_via_keyboard):
+            self.enable_via_click = enable_via_click
+            self.enable_via_keyboard = enable_via_keyboard
+            self.captions_enabled = False
+            self.caption_region_visible = False
+            self.evaluate_calls = 0
+            self.keyboard = _FakeKeyboard(self)
+
+        def _count(self, query):
+            if "Turn off captions" in query:
+                return 1 if self.captions_enabled else 0
+            if "YSxPC" in query or "tgaKEf" in query or "aption" in query:
+                return 1 if self.caption_region_visible else 0
+            return 0
+
+        def locator(self, query):
+            return _FakeLocator(self, query)
+
+        def evaluate(self, js):
+            self.evaluate_calls += 1
+            if "selectors" in js:
+                if self.enable_via_click:
+                    self.captions_enabled = True
+                    self.caption_region_visible = True
+                return True
+            if "Turn off captions" in js:
+                if self.captions_enabled:
+                    return True
+                if self.caption_region_visible:
+                    return True
+                return False
+            return True
+
+    clicked = _FakePage(enable_via_click=True, enable_via_keyboard=False)
+    assert meet_bot._turn_on_captions(clicked, timeout_s=0.2) is True
+    assert clicked.evaluate_calls >= 1
+    assert clicked.keyboard.presses == []
+
+    fallback = _FakePage(enable_via_click=False, enable_via_keyboard=True)
+    assert meet_bot._turn_on_captions(fallback, timeout_s=0.2) is True
+    assert fallback.evaluate_calls >= 1
+    assert fallback.keyboard.presses == ["c"]
+
+
+def test_sync_captioning_state_tracks_live_ui(tmp_path):
+    from plugins.google_meet import meet_bot
+    from plugins.google_meet.meet_bot import _BotState
+
+    class _FakePage:
+        def __init__(self):
+            self.captions_on = False
+            self.caption_region_visible = False
+            self.captions_off_visible = True
+
+        def evaluate(self, js):
+            if "Turn off captions" not in js:
+                return None
+            if self.captions_on:
+                return True
+            if self.caption_region_visible:
+                return True
+            if self.captions_off_visible:
+                return False
+            return None
+
+    state = _BotState(out_dir=tmp_path / "unused", meeting_id="x-y-z",
+                      url="https://meet.google.com/x-y-z")
+    page = _FakePage()
+
+    # Unknown state should not disturb the current flag.
+    state.captioning = False
+    page.captions_off_visible = False
+    meet_bot._sync_captioning_state(page, state)
+    assert state.captioning is False
+
+    # Live UI says captions are on.
+    page.captions_on = True
+    meet_bot._sync_captioning_state(page, state)
+    assert state.captioning is True
+
+    # Live UI says captions are off.
+    page.captions_on = False
+    page.caption_region_visible = False
+    page.captions_off_visible = True
+    state.captioning = True
+    meet_bot._sync_captioning_state(page, state)
+    assert state.captioning is False
+
+
 def test_meeting_id_extraction():
     from plugins.google_meet.meet_bot import _meeting_id_from_url
 
@@ -112,6 +283,19 @@ def test_bot_state_ignores_blank_text(tmp_path):
     assert status["transcriptLines"] == 1
     # blank-speaker falls back to "Unknown"
     assert "Unknown: text but no speaker" in (tmp_path / "s" / "transcript.txt").read_text()
+
+
+def test_bot_state_recovers_speaker_from_raw_caption_block(tmp_path):
+    from plugins.google_meet.meet_bot import _BotState
+
+    state = _BotState(out_dir=tmp_path / "s2", meeting_id="x-y-z",
+                      url="https://meet.google.com/x-y-z")
+    state.record_caption("", "Matthew Jaeh\nThank you my mind. Yeah.")
+
+    transcript = (tmp_path / "s2" / "transcript.txt").read_text()
+    assert "Matthew Jaeh: Thank you my mind. Yeah." in transcript
+    status = json.loads((tmp_path / "s2" / "status.json").read_text())
+    assert status["transcriptLines"] == 1
 
 
 def test_parse_duration():
@@ -713,12 +897,35 @@ def test_realtime_session_cancel_response_sends_cancel_frame():
     assert envelope == {"type": "response.cancel"}
 
 
-def test_realtime_session_counters_initialized():
-    from plugins.google_meet.realtime.openai_client import RealtimeSession
+def test_realtime_session_connect_disables_keepalive_pings(monkeypatch):
+    from plugins.google_meet.realtime import openai_client
 
-    sess = RealtimeSession(api_key="sk-test", audio_sink_path=None)
-    assert sess.audio_bytes_out == 0
-    assert sess.last_audio_out_at is None
+    calls = []
+
+    class _FakeWs:
+        def send(self, msg):
+            calls.append(("send", msg))
+
+        def close(self):
+            calls.append(("close",))
+
+    def _fake_connect(url, **kwargs):
+        calls.append(("connect", url, kwargs))
+        return _FakeWs()
+
+    monkeypatch.setattr(openai_client, "_require_websockets", lambda: _fake_connect)
+
+    sess = openai_client.RealtimeSession(api_key="sk-test", audio_sink_path=None)
+    sess.connect()
+
+    connect_calls = [c for c in calls if c[0] == "connect"]
+    assert connect_calls, calls
+    _, url, kwargs = connect_calls[0]
+    assert url.startswith("wss://api.openai.com/v1/realtime?model=")
+    assert kwargs["ping_interval"] is None
+    assert kwargs["ping_timeout"] is None
+    assert kwargs.get("additional_headers") == [("Authorization", "Bearer sk-test")]
+    assert any(c[0] == "send" for c in calls)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR stabilizes the Google Meet plugin end-to-end:

- Uses the logged-in CDP browser profile for Meet auth
- Enables captions by default and retries caption activation when needed
- Handles both `Join now` and `Ask to join` flows reliably
- Improves speaker identification in live captions
- Restores TTS audio delivery into the meeting via the audio bridge

## Verification
- `python -m pytest tests/plugins/test_google_meet_plugin.py tests/plugins/google_meet/test_join_flow.py -q`
- Result: `59 passed`
