### PR TITLE
fix(matrix): pop _pending_reactions on CANCELLED to prevent dict leak

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -2183,6 +2183,7 @@ class MatrixAdapter(BasePlatformAdapter):
         if not msg_id or not room_id:
             return
         if outcome == ProcessingOutcome.CANCELLED:
+            self._pending_reactions.pop((room_id, msg_id), None)
             return
         reaction_key = (room_id, msg_id)
         if reaction_key in self._pending_reactions:

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1885,6 +1885,28 @@ class TestMatrixReactions:
         self.adapter._send_reaction.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_on_processing_complete_cancelled_clears_pending_reactions(self):
+        """CANCELLED must pop the dict entry to prevent unbounded growth."""
+        from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome
+
+        self.adapter._reactions_enabled = True
+        self.adapter._send_reaction = AsyncMock(return_value=True)
+        self.adapter._pending_reactions = {("!room:ex", "$msg1"): "$eyes_123"}
+
+        source = MagicMock()
+        source.chat_id = "!room:ex"
+        event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={},
+            message_id="$msg1",
+        )
+        await self.adapter.on_processing_complete(event, ProcessingOutcome.CANCELLED)
+        assert self.adapter._pending_reactions == {}
+        self.adapter._send_reaction.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_on_processing_complete_no_pending_reaction(self):
         """on_processing_complete should skip redaction if no eyes reaction was tracked."""
         from gateway.platforms.base import MessageEvent, MessageType, ProcessingOutcome


### PR DESCRIPTION
## Problem

`on_processing_complete` returns early when `outcome == CANCELLED` before it
reaches the `self._pending_reactions.pop(reaction_key)` call. The
`(room_id, msg_id) → eyes_event_id` entry added by `on_processing_start` is
never removed, so every cancelled interaction permanently grows the dict.

```python
# gateway/platforms/matrix.py (before)
if outcome == ProcessingOutcome.CANCELLED:
    return                               # exits here ← pop() at line +4 never runs
reaction_key = (room_id, msg_id)
if reaction_key in self._pending_reactions:
    eyes_event_id = self._pending_reactions.pop(reaction_key)  # never reached
```

`_pending_reactions` is initialised as a plain `dict` with no eviction,
so leaked entries accumulate for the lifetime of the adapter process.

## Fix

Pop the entry before returning on the CANCELLED path. The 👀 reaction is
intentionally left in place (no redaction scheduled) — only the in-memory
tracking entry is freed.

```python
if outcome == ProcessingOutcome.CANCELLED:
    self._pending_reactions.pop((room_id, msg_id), None)
    return
```

One-line change. No behaviour change for SUCCESS or FAILURE paths.

## Testing

Added `test_on_processing_complete_cancelled_clears_pending_reactions`:
seeds `_pending_reactions` with one entry, fires CANCELLED, asserts the
dict is empty and `_send_reaction` was never called.