### PR TITLE
fix(matrix,whatsapp): cancel text batch tasks on disconnect

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -982,6 +982,12 @@ class MatrixAdapter(BasePlatformAdapter):
             await asyncio.gather(*redaction_tasks, return_exceptions=True)
         self._reaction_redaction_tasks.clear()
 
+        for task in self._pending_text_batch_tasks.values():
+            if task and not task.done():
+                task.cancel()
+        self._pending_text_batch_tasks.clear()
+        self._pending_text_batches.clear()
+
         # Close the SQLite crypto store database.
         if hasattr(self, "_crypto_db") and self._crypto_db:
             try:

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -833,6 +833,12 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 pass
         self._poll_task = None
 
+        for task in self._pending_text_batch_tasks.values():
+            if task and not task.done():
+                task.cancel()
+        self._pending_text_batch_tasks.clear()
+        self._pending_text_batches.clear()
+
         # Close the persistent HTTP session
         if self._http_session and not self._http_session.closed:
             await self._http_session.close()

--- a/tests/gateway/test_matrix_whatsapp_text_batch_disconnect.py
+++ b/tests/gateway/test_matrix_whatsapp_text_batch_disconnect.py
@@ -1,0 +1,158 @@
+"""Tests for text batch task cleanup on Matrix and WhatsApp disconnect.
+
+Both adapters use _pending_text_batch_tasks / _pending_text_batches to
+debounce rapid message bursts.  disconnect() must cancel and clear those
+tasks so sleeping flush coroutines do not wake up and call handle_message()
+on a dead adapter.  Parity with Telegram/Discord (PR #8109).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Minimal adapter factories (avoid full __init__ which needs live credentials)
+# ---------------------------------------------------------------------------
+
+
+def _make_matrix_adapter():
+    from gateway.platforms.matrix import MatrixAdapter
+
+    config = PlatformConfig(enabled=True, token="test-token")
+    adapter = object.__new__(MatrixAdapter)
+    adapter._platform = Platform.MATRIX
+    adapter.config = config
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = 0.05
+    adapter._text_batch_split_delay_seconds = 0.1
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter.handle_message = AsyncMock()
+    # Stubs for disconnect()
+    adapter._closing = False
+    adapter._sync_task = None
+    adapter._reaction_redaction_tasks = set()
+    adapter._pending_reactions = {}
+    adapter._crypto_db = None
+    adapter._client = None
+    adapter._mark_disconnected = MagicMock()
+    return adapter
+
+
+def _make_whatsapp_adapter():
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    config = PlatformConfig(enabled=True, extra={"session_name": "test"})
+    adapter = object.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = config
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = 0.05
+    adapter._text_batch_split_delay_seconds = 0.1
+    adapter.handle_message = AsyncMock()
+    # Stubs for disconnect()
+    adapter._shutting_down = False
+    adapter._bridge_process = None
+    adapter._poll_task = None
+    adapter._http_session = None
+    adapter._release_platform_lock = MagicMock()
+    adapter._mark_disconnected = MagicMock()
+    adapter._close_bridge_log = MagicMock()
+    adapter._fatal_error_message = None
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sleeping_task(delay: float = 10.0) -> asyncio.Task:
+    """Return a running task that sleeps for `delay` seconds."""
+    return asyncio.ensure_future(asyncio.sleep(delay))
+
+
+# ---------------------------------------------------------------------------
+# Matrix tests
+# ---------------------------------------------------------------------------
+
+
+class TestMatrixTextBatchDisconnect:
+    @pytest.mark.asyncio
+    async def test_disconnect_cancels_pending_batch_tasks(self):
+        """disconnect() must cancel sleeping flush tasks."""
+        adapter = _make_matrix_adapter()
+
+        task = _make_sleeping_task()
+        adapter._pending_text_batch_tasks["key1"] = task
+
+        await adapter.disconnect()
+        await asyncio.sleep(0)  # let the event loop process the cancellation
+
+        assert task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_clears_batch_dicts(self):
+        """disconnect() must empty both batch dicts."""
+        adapter = _make_matrix_adapter()
+
+        task = _make_sleeping_task()
+        adapter._pending_text_batch_tasks["key1"] = task
+        adapter._pending_text_batches["key1"] = MagicMock()
+
+        await adapter.disconnect()
+
+        assert adapter._pending_text_batch_tasks == {}
+        assert adapter._pending_text_batches == {}
+
+    @pytest.mark.asyncio
+    async def test_disconnect_with_no_pending_tasks_is_safe(self):
+        """disconnect() with empty dicts must not raise."""
+        adapter = _make_matrix_adapter()
+        await adapter.disconnect()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# WhatsApp tests
+# ---------------------------------------------------------------------------
+
+
+class TestWhatsAppTextBatchDisconnect:
+    @pytest.mark.asyncio
+    async def test_disconnect_cancels_pending_batch_tasks(self):
+        """disconnect() must cancel sleeping flush tasks."""
+        adapter = _make_whatsapp_adapter()
+
+        task = _make_sleeping_task()
+        adapter._pending_text_batch_tasks["key1"] = task
+
+        await adapter.disconnect()
+        await asyncio.sleep(0)  # let the event loop process the cancellation
+
+        assert task.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_clears_batch_dicts(self):
+        """disconnect() must empty both batch dicts."""
+        adapter = _make_whatsapp_adapter()
+
+        task = _make_sleeping_task()
+        adapter._pending_text_batch_tasks["key1"] = task
+        adapter._pending_text_batches["key1"] = MagicMock()
+
+        await adapter.disconnect()
+
+        assert adapter._pending_text_batch_tasks == {}
+        assert adapter._pending_text_batches == {}
+
+    @pytest.mark.asyncio
+    async def test_disconnect_with_no_pending_tasks_is_safe(self):
+        """disconnect() with empty dicts must not raise."""
+        adapter = _make_whatsapp_adapter()
+        await adapter.disconnect()  # should not raise


### PR DESCRIPTION
## Problem

Both `MatrixAdapter` and `WhatsAppAdapter` debounce rapid message bursts by
spawning `asyncio` tasks stored in `_pending_text_batch_tasks`. Their
`disconnect()` implementations cancel the main loop task (`_sync_task` /
`_poll_task`) but never touch the batch flush tasks.

After disconnect, sleeping flush tasks wake up after their delay and call
`handle_message()` on a dead adapter — the Matrix `_client` is `None`, the
WhatsApp `_http_session` is closed, and `_shutting_down` / `_closing` flags
are set. The call either silently drops the message or surfaces a confusing
error on the terminated adapter.

## Fix

Add the same cancel-and-clear block that PR #8109 applied to Telegram and
Discord, completing parity across all four adapters:

```python
for task in self._pending_text_batch_tasks.values():
    if task and not task.done():
        task.cancel()
self._pending_text_batch_tasks.clear()
self._pending_text_batches.clear()
```

Inserted in Matrix `disconnect()` after `_reaction_redaction_tasks.clear()`
and in WhatsApp `disconnect()` after the `_poll_task` teardown, before the
HTTP session is closed.

## Testing

Added `tests/gateway/test_matrix_whatsapp_text_batch_disconnect.py` with six
tests (3 per adapter): cancel-on-disconnect, dict-cleared-on-disconnect, and
safe-with-empty-dicts. Mirrors the test style from PR #8109.