### PR TITLE
fix(kanban): send finalize nudge when judge says done on last budgeted turn

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -873,7 +873,10 @@ def run_kanban_goal_loop(
             prompt = KANBAN_GOAL_CONTINUATION_TEMPLATE.format(reason=_truncate(reason, 400))
 
         # Budget check BEFORE spending another turn.
-        if turns_used >= max_turns:
+        # Exception: when the judge just said "done" for the first time this
+        # iteration, allow one grace turn to send the finalize nudge so the
+        # worker has a chance to call kanban_complete.
+        if turns_used >= max_turns and verdict != "done":
             _log(f"kanban goal loop: task {task_id} exhausted {turns_used}/{max_turns} turns; blocking")
             try:
                 block_fn(

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -298,3 +298,32 @@ def test_loop_stops_if_task_reclaimed(monkeypatch):
         first_response="x",
     )
     assert res["outcome"] == "stopped"
+
+
+def test_loop_finalize_nudge_runs_on_last_turn(monkeypatch):
+    """When the judge says 'done' on the final budgeted turn, the loop must
+    send the finalize nudge instead of blocking with 'turn budget exhausted'.
+
+    Before the fix, the budget check fired AFTER preparing the finalize
+    prompt, so run_turn() was never called and the card was incorrectly
+    blocked even though the judge said the work was complete.
+    """
+    _patch_judge(monkeypatch, ["done", "done"])
+    # Worker completes after receiving the finalize nudge.
+    statuses = iter(["running", "done"])
+    turns = []
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t7",
+        goal_text="task",
+        run_turn=lambda p: turns.append(p) or "done",
+        task_status_fn=lambda: next(statuses),
+        block_fn=lambda r: pytest.fail(f"should not block: {r}"),
+        # max_turns=1 means budget is already at ceiling on the first
+        # judge call (turns_used starts at 1).
+        max_turns=1,
+        first_response="looks complete",
+    )
+    assert res["outcome"] == "completed_by_worker"
+    assert len(turns) == 1, "finalize nudge must have been sent"
+    assert "still open" in turns[0]


### PR DESCRIPTION
## Problem

`run_kanban_goal_loop` incorrectly blocks a card with **"turn budget
exhausted"** when the judge says `"done"` exactly on the last budgeted
turn.

Execution trace for `max_turns=N`, `turns_used=N`:

```
verdict, reason = judge_goal(...)         # returns "done"
prompt = KANBAN_GOAL_FINALIZE_TEMPLATE    # finalize nudge prepared ✓
nudged_to_finalize = True

# Budget check fires here — too early
if turns_used >= max_turns:               # True
    block_fn("turn budget exhausted")     # ← wrong: judge said "done"
    return {"outcome": "blocked_budget"}

run_turn(prompt)                          # ← never reached
```

The worker's last turn was judged complete. It just needs one more turn to
call `kanban_complete`. Instead the card is stuck in `blocked` with a
misleading reason, requiring manual intervention for a task that was
actually done.

## Root cause

The budget check at the end of the loop body does not distinguish between:
- **Continuation path** (`verdict="continue"`) — budget check should fire ✓
- **First finalize nudge** (`verdict="done"`, `nudged_to_finalize` just set) — budget check should be skipped ✗

## Fix

```python
# Before
if turns_used >= max_turns:

# After
if turns_used >= max_turns and verdict != "done":
```

At this point in the code, `verdict == "done"` can only mean we just
prepared the first finalize nudge (the second `"done"` verdict takes the
early-return path at the `nudged_to_finalize` check above and never reaches
the budget check). The one-word addition grants exactly one grace turn for
the finalize nudge; all other budget semantics are unchanged.

## Testing

Added `test_loop_finalize_nudge_runs_on_last_turn`: uses `max_turns=1` so
the budget ceiling is hit immediately on the first judge call (`turns_used`
starts at 1), judges returns `"done"`, and asserts that `block_fn` is never
called, the finalize nudge is sent, and the outcome is
`"completed_by_worker"` after the worker responds.

All seven existing loop-layer tests continue to pass.