### PR TITLE
fix(aux): resolve key_env/api_key_env in auxiliary task config

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5958,6 +5958,16 @@ def _resolve_task_provider_model(
         cfg_model = str(task_config.get("model", "")).strip() or None
         cfg_base_url = str(task_config.get("base_url", "")).strip() or None
         cfg_api_key = str(task_config.get("api_key", "")).strip() or None
+        # Resolve key_env / api_key_env indirection when no explicit api_key is set,
+        # mirroring the provider-level resolution in resolve_provider_client() (lines
+        # 3501-3503). Without this, auxiliary.<task>.key_env references are silently
+        # ignored and the API key resolves to None → auth errors downstream.
+        if not cfg_api_key:
+            _task_key_env = (
+                task_config.get("key_env") or task_config.get("api_key_env") or ""
+            ).strip()
+            if _task_key_env:
+                cfg_api_key = os.getenv(_task_key_env, "").strip() or None
         cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
 
     # 'auto' is a sentinel meaning "inherit from main runtime / auto-detect", not

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -5653,3 +5653,84 @@ class TestCustomEndpointApiKeyInheritance:
             )
 
         assert captured.get("api_key") == "no-key-required"
+
+class TestResolveTaskProviderModelKeyEnv:
+    """_resolve_task_provider_model must resolve auxiliary.<task>.key_env → env var."""
+
+    def test_key_env_resolved_to_api_key(self, monkeypatch):
+        """When config has key_env but no explicit api_key, the env var should be read."""
+        from agent.auxiliary_client import _resolve_task_provider_model
+
+        monkeypatch.setenv("MY_TEST_AUX_KEY", "env-resolved-key-123")
+        config = {
+            "auxiliary": {
+                "vision": {
+                    "provider": "gemini",
+                    "model": "gemini-2.5-flash",
+                    "key_env": "MY_TEST_AUX_KEY",
+                }
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+
+        assert provider == "gemini"
+        assert api_key == "env-resolved-key-123"
+
+    def test_api_key_env_alias_also_resolved(self, monkeypatch):
+        """api_key_env (snake_case alias) should also work."""
+        from agent.auxiliary_client import _resolve_task_provider_model
+
+        monkeypatch.setenv("MY_ALIAS_KEY", "alias-resolved-key")
+        config = {
+            "auxiliary": {
+                "vision": {
+                    "provider": "gemini",
+                    "model": "gemini-2.5-flash",
+                    "api_key_env": "MY_ALIAS_KEY",
+                }
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+
+        assert api_key == "alias-resolved-key"
+
+    def test_explicit_api_key_wins_over_key_env(self, monkeypatch):
+        """An explicit api_key in config takes precedence over key_env."""
+        from agent.auxiliary_client import _resolve_task_provider_model
+
+        monkeypatch.setenv("MY_TEST_AUX_KEY", "env-key")
+        config = {
+            "auxiliary": {
+                "vision": {
+                    "provider": "gemini",
+                    "model": "gemini-2.5-flash",
+                    "api_key": "explicit-key",
+                    "key_env": "MY_TEST_AUX_KEY",
+                }
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+
+        assert api_key == "explicit-key"
+
+    def test_missing_env_var_returns_none(self, monkeypatch):
+        """If the env var referenced by key_env doesn't exist, api_key stays None."""
+        from agent.auxiliary_client import _resolve_task_provider_model
+
+        monkeypatch.delenv("NONEXISTENT_AUX_KEY", raising=False)
+        config = {
+            "auxiliary": {
+                "vision": {
+                    "provider": "gemini",
+                    "model": "gemini-2.5-flash",
+                    "key_env": "NONEXISTENT_AUX_KEY",
+                }
+            }
+        }
+        with patch("hermes_cli.config.load_config", return_value=config):
+            provider, model, base_url, api_key, api_mode = _resolve_task_provider_model("vision")
+
+        assert api_key is None


### PR DESCRIPTION
## Summary

`_resolve_task_provider_model()` reads per-task config from `auxiliary.<task>.api_key` but ignores the `key_env` and `api_key_env` fields — the documented way to reference an environment variable by name instead of hardcoding the key value.

Every other code path that resolves provider credentials already handles these fields:
- `resolve_provider_client()` — `providers.<name>.key_env` / `api_key_env`
- `agent_init.py` — fallback entries `key_env` / `api_key_env`
- `chat_completion_helpers.py` — fallback `key_env` / `api_key_env`
- `hermes_cli/providers.py` — provider registry `key_env`

This PR adds the same resolution to `_resolve_task_provider_model()`, so that:

```yaml
auxiliary:
  title_generation:
    provider: openrouter
    base_url: https://openrouter.ai/api/v1
    key_env: OPENROUTER_API_KEY
```

actually resolves the key from the environment, instead of silently ignoring it and sending requests with no auth (HTTP 401).

## What changed

- **`agent/auxiliary_client.py`** — After reading `cfg_api_key` from task config, resolve `key_env` / `api_key_env` when no explicit `api_key` is set. 10 lines added.
- **`tests/agent/test_auxiliary_client.py`** — 4 new tests in `TestResolveTaskProviderModelKeyEnv`.

## Testing

Four test cases:
1. `key_env` resolves to the env var value ✓
2. `api_key_env` alias resolves identically ✓
3. Explicit `api_key` takes precedence over `key_env` ✓
4. Missing env var → `api_key` is `None` (graceful, not the literal var name) ✓

## Notes

Previous iterations of this fix were in #28766 (closed as duplicate of #24088) and #24088 (stale branch, never merged). This PR is a clean rebase onto current `main` — just the 10-line fix + tests, no unrelated changes.

Closes #20139