### PR TITLE
cli-shim: hermes model picker + runtime-resolver fix (builds on #26634)

### DIFF
--- a/agent/CLI_SHIM_PROPOSAL.md
+++ b/agent/CLI_SHIM_PROPOSAL.md
@@ -1,0 +1,286 @@
+# cli-shim Provider — RFC / Proposal
+
+Status: DRAFT. Looking for upstream guidance before promoting to a non-draft PR.
+
+This document accompanies the `feat/cli-shim-provider` branch. It proposes a new
+hermes model-provider, `cli-shim`, that satisfies inference requests by shelling
+out to locally-installed CLI tools (`claude`, `codex`, `gemini`) that the user
+has already authenticated with their OAuth subscription, instead of via REST
+APIs with an API key.
+
+Source under review:
+- `agent/cli_shim_client.py` (~530 LOC) — the OpenAI-shaped facade
+- `plugins/model-providers/cli-shim/` — provider profile + manifest
+- Hooks in `run_agent.py`, `agent/auxiliary_client.py`, `hermes_cli/auth.py`
+
+---
+
+## 1. Motivation
+
+- **Subscription users have no API keys.** Customers on Claude Max ($100–$200/mo),
+  ChatGPT Pro ($200/mo), and Gemini Advanced already pay for capacity, but the
+  vendor-issued credential is bound to the desktop/CLI app via OAuth, not to a
+  programmatic `sk-...` key. Today they cannot use hermes without paying a
+  second time for API access.
+- **Fleet scenarios hit 429s on API plans.** A 27-agent hermes fleet (kanban
+  workers, gateway sub-agents, cron jobs) overruns Anthropic / OpenAI per-minute
+  rate limits within seconds. The OAuth-backed CLIs route through a different
+  quota bucket (interactive Pro plan), so spilling fleet traffic there is a real
+  release valve.
+- **Every existing hermes provider requires an API key.** The `providers/`
+  registry, the setup wizard, and `resolve_provider_client()` all assume an
+  `env_vars=("ANTHROPIC_API_KEY", ...)` style credential. There is no first-class
+  affordance for a provider whose auth lives in `~/.codex/auth.json` or
+  `~/.claude/.credentials.json`.
+- **Local-first is on-trend.** Developers running claude/codex/gemini CLIs
+  already trust them; reusing those sessions is the path of least surprise and
+  zero extra secret management.
+- **Graceful degradation for the budget chain.** Wiring `cli-shim` at the bottom
+  of `fallback_model` chains lets paid-API hermes fleets fail over to the
+  user's interactive subscription rather than crashing on quota exhaustion.
+
+## 2. Architecture
+
+### 2.1 Dispatch table
+
+The single function `_dispatch_for_model(model)` in `cli_shim_client.py` maps a
+hermes-side model alias to a concrete CLI invocation plus a "mode" flag that
+selects the run path:
+
+    claude-sonnet-cli / claude-sonnet / sonnet-cli  -> claude --print --model sonnet  (mode=print)
+    claude-opus-cli   / claude-opus   / opus-cli    -> claude --print --model opus    (mode=print)
+    codex-gpt5-cli    / codex-gpt5.5-cli / codex    -> codex exec --skip-git-repo-check
+                                                              --model gpt-5.5         (mode=codex_exec)
+    gemini-cli        / gemini-acp    / gemini      -> gemini --acp                   (mode=acp)
+    <anything else>                                 -> claude --print --model <model> (mode=print, fallback)
+
+### 2.2 Subprocess invocation per CLI
+
+- **`mode=print`** — `_run_print()`. Pure single-shot `subprocess.Popen(..., stdin=PIPE,
+  stdout=PIPE, stderr=PIPE)`, prompt written on stdin, stdout consumed
+  whole on completion, timeout enforced via `proc.communicate(timeout=...)`.
+- **`mode=codex_exec`** — `_run_codex_exec()`. Same as above, but appends
+  `--output-last-message <tmpfile>`; the codex `exec` subcommand writes only
+  the final assistant turn there, sidestepping the noisy `user\n...\ncodex\n...`
+  scaffold that pollutes stdout. If the tempfile is empty (no assistant turn),
+  falls back to `_scrub_codex_stdout()` which regex-strips the scaffold.
+- **`mode=acp`** — Delegates to the existing `CopilotACPClient._run_prompt()`
+  with `command="gemini" args=["--acp"]`. Gemini's ACP mode supports streamed
+  tool-use, so the full ACP loop is reused verbatim.
+
+### 2.3 Concurrency caps
+
+A 27-agent fleet that all decide to invoke `cli-shim` on the same turn would
+spawn 27 simultaneous `claude` subprocesses (~500 MB resident each) and OOM the
+host. To prevent that, every dispatch path passes through `_ConcurrencyGate`,
+which acquires two `threading.BoundedSemaphore` slots in order:
+
+1. A **global** semaphore — `HERMES_CLI_SHIM_GLOBAL_MAX` (default `6`).
+2. A **per-CLI** semaphore — `HERMES_CLI_SHIM_CLAUDE_MAX` (3),
+   `HERMES_CLI_SHIM_CODEX_MAX` (4), `HERMES_CLI_SHIM_GEMINI_MAX` (3).
+
+If either acquire times out (`HERMES_CLI_SHIM_QUEUE_TIMEOUT`, default 120 s)
+the gate raises `RuntimeError`, the call fails fast, and the agent's fallback
+chain can try the next provider.
+
+### 2.4 Streaming-chunk synthesis
+
+Hermes' agent loop calls `client.chat.completions.create(..., stream=True)` and
+iterates the result with `for chunk in stream:`. None of the underlying CLIs
+emit per-token streams over their CLI surface, so `_CliShimChatCompletions.create()`:
+
+1. Pops `stream` out of `kwargs`,
+2. Runs the full single-shot subprocess and builds an OpenAI-shaped response,
+3. If `stream=True`, hands the response to `_wrap_response_as_stream()` which
+   yields three (or more) `SimpleNamespace` chunks:
+   - chunk 1: `delta.role="assistant"`, full content as a single delta,
+   - chunks 2..n: one chunk per extracted tool_call, each carrying full args,
+   - chunk N+1: `delta` empty, `finish_reason="stop"|"tool_calls"`, `usage` attached.
+
+Each chunk shape matches `openai.types.chat.ChatCompletionChunk` closely enough
+for hermes' stream consumer.
+
+### 2.5 Output extraction
+
+After the subprocess returns, response text is fed to
+`_extract_tool_calls_from_text()` (re-exported from `agent.copilot_acp_client`).
+That helper parses fenced tool_call JSON blocks the CLI emitted and returns
+`(tool_calls, cleaned_text)`. The cleaned text becomes
+`assistant_message.content`; `finish_reason` flips to `"tool_calls"` when any
+were found.
+
+### 2.6 Diagram
+
+```
+  hermes run_agent.AIAgent
+        │  (chat.completions.create stream=True)
+        ▼
+  CliShimClient ──── _dispatch_for_model(model) ──┐
+        │                                         │
+        │                            ┌────────────┼────────────┐
+        │                            │            │            │
+        │                       claude-*       codex-*       gemini-*
+        │                            │            │            │
+        ▼                            ▼            ▼            ▼
+  _ConcurrencyGate(global=6)   _run_print  _run_codex_exec  CopilotACPClient
+        +per-CLI(3/4/3)            │            │             (ACP loop)
+        │                          │            │             │
+        ▼                          ▼            ▼             ▼
+        ──────── subprocess.Popen(claude|codex|gemini --acp) ──
+                                   │
+                                   ▼
+                       stdout / --output-last-message
+                                   │
+                                   ▼
+                  _extract_tool_calls_from_text()
+                                   │
+                                   ▼
+        ──── OpenAI-shaped response (SimpleNamespace) ─────
+                                   │
+                                   ▼  (when stream=True)
+                _wrap_response_as_stream() → chunk1 / tcN / final
+```
+
+## 3. Configuration
+
+End-user wiring in `~/.hermes/config.yaml`:
+
+```yaml
+provider: cli-shim
+model: codex-gpt5.5-cli       # or claude-sonnet-cli / claude-opus-cli / gemini-cli
+```
+
+No `~/.hermes/.env` entries are required — the underlying CLIs read their own
+OAuth caches (`~/.claude/`, `~/.codex/auth.json`, `~/.gemini/`).
+
+For fallback chaining, put it last in the budget chain:
+
+```yaml
+provider: anthropic
+model: claude-sonnet-4
+fallback_model:
+  - provider: openai
+    model: gpt-5
+  - provider: cli-shim
+    model: codex-gpt5.5-cli
+```
+
+Concurrency tuning (optional):
+
+```bash
+export HERMES_CLI_SHIM_GLOBAL_MAX=6        # total simultaneous subprocesses
+export HERMES_CLI_SHIM_CLAUDE_MAX=3
+export HERMES_CLI_SHIM_CODEX_MAX=4
+export HERMES_CLI_SHIM_GEMINI_MAX=3
+export HERMES_CLI_SHIM_QUEUE_TIMEOUT=120   # seconds before bail-out
+```
+
+## 4. Interface (Provider protocol surface)
+
+`CliShimClient` mimics the subset of the `openai.OpenAI` client that
+`AIAgent.run_conversation()` actually touches:
+
+- `client.chat.completions.create(model=..., messages=..., tools=..., tool_choice=..., stream=..., timeout=...)`
+  Returns either:
+    - `SimpleNamespace(choices=[SimpleNamespace(message=..., finish_reason=...)], usage=..., model=...)` (when `stream=False`)
+    - a generator yielding chunk `SimpleNamespace`s (when `stream=True`)
+- `client.close()` — terminates any active subprocess and flips `is_closed`.
+- Attributes: `api_key`, `base_url`, `is_closed`.
+
+`message` shape on the non-stream return:
+```
+SimpleNamespace(
+    content=<cleaned_text>,
+    tool_calls=[...],          # OpenAI shape: id/type=function/function.name+arguments
+    reasoning=<text or None>,
+    reasoning_content=<text or None>,
+    reasoning_details=None,
+)
+```
+`usage` has `prompt_tokens=0, completion_tokens=0, total_tokens=0,
+prompt_tokens_details.cached_tokens=0` (the CLIs don't expose token accounting).
+
+Provider profile (`plugins/model-providers/cli-shim/__init__.py`):
+`ProviderProfile(name="cli-shim", aliases=("local-cli-shim","cli"),
+api_mode="chat_completions", env_vars=(), base_url="cli://shim",
+auth_type="external_process")`. `fetch_models()` returns the four canonical
+aliases.
+
+Routing hooks: `agent/auxiliary_client.py::resolve_provider_client()` and
+`run_agent.py::AIAgent._build_openai_client()` both detect `provider=="cli-shim"`
+or `base_url=="cli://shim"` and instantiate `CliShimClient`.
+
+## 5. Failure modes
+
+| Condition | Surface |
+|---|---|
+| CLI binary not on `PATH` | `_run_print` / `_run_codex_exec` catch `FileNotFoundError` and raise `RuntimeError("Could not start CLI '<name>'. Install it or check PATH.")` |
+| Subprocess timeout | `subprocess.TimeoutExpired` → `proc.kill()` → re-raised as `TimeoutError("CLI '<name>' timed out after <s>s")` |
+| Non-zero exit | `RuntimeError("CLI '<name>' exited <rc>: <stderr tail (last 800 chars)>")` |
+| OAuth expired | The CLI itself prints its login URL on stderr; we surface it via the same non-zero-exit `RuntimeError` so the agent log captures the URL |
+| Upstream rate-limit (CLI prints 429-style banner and exits non-zero) | Re-raised as `RuntimeError`; hermes' fallback chain sees a normal exception and tries the next provider |
+| Global semaphore exhausted | `RuntimeError("cli-shim global concurrency cap reached (...) queue timeout 120s exceeded")` after `HERMES_CLI_SHIM_QUEUE_TIMEOUT` |
+| Per-CLI semaphore exhausted | Same pattern, "per-CLI cap reached for '<cli>'" |
+| Codex writes no tempfile (no assistant turn produced) | `_scrub_codex_stdout()` fallback extracts whatever it can from the noisy stdout |
+| Client `close()` while subprocess in flight | `terminate()` then `wait(2s)` then `kill()`; guarded by `_active_process_lock` |
+
+## 6. Operational notes
+
+- **Per-CLI concurrency caps** track empirical RSS: claude ~500 MB, codex ~400 MB,
+  gemini ~350 MB. Defaults (3/4/3 with global 6) leave headroom on a 16 GB box.
+- **`codex --output-last-message`** is essential. Without it, codex `exec`
+  stdout is a multi-line scaffold (`user\n<prompt>\ncodex\n<resp>\ntokens used\n<n>`),
+  and `_extract_tool_calls_from_text` mis-fires on the scaffold text. Writing
+  the final message to a tempfile and reading it back yields clean output.
+- **gpt-5.5 pinning.** Commit `63f2814fe` pins `codex exec` to `--model gpt-5.5`.
+  The ChatGPT $200 Pro plan grants unrestricted gpt-5.5 access; without the
+  explicit `--model` flag, codex inherits whatever the OAuth account's interactive
+  default happens to be (often a smaller model), so hermes traffic silently
+  downgrades. Pinning makes the inference predictable.
+- **Gemini ACP mode.** Unlike claude/codex, gemini's CLI supports the Agent
+  Communication Protocol over stdio. We piggy-back on the existing
+  `CopilotACPClient._run_prompt` rather than reimplementing the JSON-RPC loop —
+  tool-use, streaming, and cancellation all come for free.
+- **Streaming is synthesized, not native.** A single delta chunk carries the
+  whole assistant turn. This is acceptable for hermes' iterate-and-then-handle
+  loop but would not satisfy a real UI that expects per-token deltas.
+
+## 7. Open questions for upstream
+
+1. **OAuth detection — hermes-core feature?** Today each CLI's OAuth cache is
+   discovered implicitly (we just exec the binary and let it find its own
+   credentials). Should hermes-core have a first-class affordance to detect
+   "is the user logged into claude/codex/gemini" so the setup wizard can show
+   it as an auth option alongside API keys? That would also let the gateway UI
+   surface "Login expired — re-run `claude login`" diagnostics rather than
+   buried-in-stderr `RuntimeError`s.
+2. **Streaming synthesis acceptable?** This PR synthesizes streaming chunks
+   from a single-shot CLI invocation. Is that acceptable as a permanent design
+   choice, or do you want a manifest flag like `supports_streaming: false` so
+   callers can branch and avoid the fake-stream code path entirely?
+3. **No-API-key manifest convention.** `plugins/model-providers/cli-shim/__init__.py`
+   sets `env_vars=()` and `auth_type="external_process"`. The setup wizard's
+   API-key prompt is suppressed for these, but the convention isn't
+   documented anywhere. Worth a `requires_api_key: false` (or
+   `auth: oauth_external`) manifest field that the wizard, doctor, and config
+   validator can all read?
+4. **Provider-level fallback semantics.** When `cli-shim` raises (semaphore
+   exhausted, CLI not installed), should hermes-core auto-skip to the next
+   `fallback_model` entry, or is that already the contract? The current code
+   relies on the existing exception propagation path — confirmation appreciated.
+5. **Per-CLI concurrency policy.** The caps are env-var-tuned today. Would
+   upstream prefer a config-yaml schema (e.g. `cli_shim.concurrency.claude: 3`)
+   so the values can be checkpointed alongside the rest of the profile?
+6. **Token-accounting reporting.** `usage` is zeroed because the CLIs don't
+   expose counts. Should we estimate via the local tokenizer for budget
+   bookkeeping, or is `0` acceptable since the cost is borne by the
+   subscription, not the API budget?
+
+---
+
+## Appendix: commits on this branch
+
+    11df32884  feat(cli-shim): local CLI provider for OAuth-backed claude/codex/gemini fallback
+    3e5d0ec90  fix(cli-shim): concurrency caps + codex --output-last-message + ChatGPT-account model fix
+    04e7d1cd5  fix(cli-shim): synthesize streaming chunks when stream=True
+    63f2814fe  feat(cli-shim): pin codex to gpt-5.5 (ChatGPT Pro plan unrestricted)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3141,6 +3141,21 @@ def resolve_provider_client(
             logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
+        elif provider == "cli-shim":
+            # Local CLI shim — uses OAuth subscriptions on the host
+            # (claude/codex/gemini). No API key needed.
+            if not final_model:
+                final_model = "claude-sonnet-cli"
+            from agent.cli_shim_client import CliShimClient, CLI_SHIM_BASE_URL
+
+            client = CliShimClient(
+                api_key="cli-shim",
+                base_url=CLI_SHIM_BASE_URL,
+                model=final_model,
+            )
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                    else (client, final_model))
         logger.warning("resolve_provider_client: external-process provider %s not "
                        "directly supported", provider)
         return None, None

--- a/agent/cli_shim_client.py
+++ b/agent/cli_shim_client.py
@@ -167,7 +167,80 @@ class _CliShimChatCompletions:
         self._client = client
 
     def create(self, **kwargs: Any) -> Any:
-        return self._client._create_chat_completion(**kwargs)
+        # When hermes asks for streaming, return a synthetic single-chunk
+        # iterator that wraps the whole response. The CLIs we shell out to
+        # don't support per-token streaming, so we collect the full response
+        # and emit it as one delta chunk + a final chunk with finish_reason.
+        stream_requested = bool(kwargs.pop("stream", False))
+        response = self._client._create_chat_completion(**kwargs)
+        if not stream_requested:
+            return response
+        return _wrap_response_as_stream(response)
+
+
+def _wrap_response_as_stream(response: Any):
+    """Yield OpenAI-shaped streaming chunks from a fully-formed response.
+
+    Hermes' stream consumer iterates chunks, each with .choices[].delta.
+    We emit:
+      1) one chunk with the full content as a delta
+      2) one chunk per tool_call (if any) with the full tool args
+      3) one final chunk with finish_reason set and usage attached
+    """
+    choice = response.choices[0]
+    msg = choice.message
+    finish_reason = choice.finish_reason or "stop"
+    model = response.model
+
+    # Chunk 1: content delta
+    content = getattr(msg, "content", "") or ""
+    delta1 = SimpleNamespace(
+        role="assistant",
+        content=content,
+        tool_calls=None,
+        reasoning=getattr(msg, "reasoning", None),
+        reasoning_content=getattr(msg, "reasoning_content", None),
+    )
+    yield SimpleNamespace(
+        id="cli-shim-stream-1",
+        model=model,
+        choices=[SimpleNamespace(index=0, delta=delta1, finish_reason=None)],
+        usage=None,
+    )
+
+    # Chunk 2+: tool_calls (each as its own delta following OpenAI shape)
+    tool_calls = getattr(msg, "tool_calls", None) or []
+    for i, tc in enumerate(tool_calls):
+        delta_tc = SimpleNamespace(
+            role=None,
+            content=None,
+            tool_calls=[
+                SimpleNamespace(
+                    index=i,
+                    id=getattr(tc, "id", f"call_{i}"),
+                    type="function",
+                    function=SimpleNamespace(
+                        name=getattr(tc.function, "name", ""),
+                        arguments=getattr(tc.function, "arguments", "{}"),
+                    ),
+                )
+            ],
+        )
+        yield SimpleNamespace(
+            id=f"cli-shim-stream-tc-{i}",
+            model=model,
+            choices=[SimpleNamespace(index=0, delta=delta_tc, finish_reason=None)],
+            usage=None,
+        )
+
+    # Final chunk: finish_reason + usage
+    delta_final = SimpleNamespace(role=None, content=None, tool_calls=None)
+    yield SimpleNamespace(
+        id="cli-shim-stream-final",
+        model=model,
+        choices=[SimpleNamespace(index=0, delta=delta_final, finish_reason=finish_reason)],
+        usage=response.usage,
+    )
 
 
 class _CliShimChatNamespace:

--- a/agent/cli_shim_client.py
+++ b/agent/cli_shim_client.py
@@ -73,16 +73,17 @@ def _dispatch_for_model(model: str) -> dict[str, Any]:
             "args": ["--print", "--model", "opus"],
             "label": "claude-opus-cli",
         }
-    if m in ("codex-gpt5-cli", "codex-cli", "codex"):
-        # ChatGPT subscription accounts don't accept `--model gpt-5` —
-        # codex picks the right model from the OAuth'd account itself.
+    if m in ("codex-gpt5-cli", "codex-cli", "codex", "codex-gpt55-cli", "codex-gpt5.5-cli"):
+        # ChatGPT $200 Pro subscription — unrestricted gpt-5.5 access.
+        # Pinning the model explicitly ensures we get the latest codex model
+        # regardless of the OAuth account's interactive default.
         # We use --output-last-message to get clean output instead of the
         # interactive scaffold; the temp-file path is filled in at call time.
         return {
             "mode": "codex_exec",
             "command": "codex",
-            "args": ["exec", "--skip-git-repo-check"],
-            "label": "codex-gpt5-cli",
+            "args": ["exec", "--skip-git-repo-check", "--model", "gpt-5.5"],
+            "label": "codex-gpt5.5-cli",
         }
     if m in ("gemini-cli", "gemini-acp", "gemini"):
         return {

--- a/agent/cli_shim_client.py
+++ b/agent/cli_shim_client.py
@@ -37,6 +37,23 @@ from agent.copilot_acp_client import (
 CLI_SHIM_BASE_URL = "cli://shim"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
 
+# Concurrency caps — prevent the 27-agent fleet from OOM-killing the host
+# by spawning 27 simultaneous claude/codex subprocesses (~500MB each).
+# Override via env vars for tuning without code change.
+_GLOBAL_MAX = int(os.environ.get("HERMES_CLI_SHIM_GLOBAL_MAX", "6"))
+_PER_CLI_MAX = {
+    "claude": int(os.environ.get("HERMES_CLI_SHIM_CLAUDE_MAX", "3")),
+    "codex":  int(os.environ.get("HERMES_CLI_SHIM_CODEX_MAX",  "4")),
+    "gemini": int(os.environ.get("HERMES_CLI_SHIM_GEMINI_MAX", "3")),
+}
+_GLOBAL_SEMAPHORE = threading.BoundedSemaphore(_GLOBAL_MAX)
+_PER_CLI_SEMAPHORES: dict[str, threading.BoundedSemaphore] = {
+    cli: threading.BoundedSemaphore(cap) for cli, cap in _PER_CLI_MAX.items()
+}
+_SEMAPHORE_ACQUIRE_TIMEOUT = float(
+    os.environ.get("HERMES_CLI_SHIM_QUEUE_TIMEOUT", "120")
+)
+
 
 # Per-model dispatch table.
 # Each entry: (command_resolver, args_template, supports_acp)
@@ -57,10 +74,14 @@ def _dispatch_for_model(model: str) -> dict[str, Any]:
             "label": "claude-opus-cli",
         }
     if m in ("codex-gpt5-cli", "codex-cli", "codex"):
+        # ChatGPT subscription accounts don't accept `--model gpt-5` —
+        # codex picks the right model from the OAuth'd account itself.
+        # We use --output-last-message to get clean output instead of the
+        # interactive scaffold; the temp-file path is filled in at call time.
         return {
-            "mode": "print",
+            "mode": "codex_exec",
             "command": "codex",
-            "args": ["exec", "--model", "gpt-5"],
+            "args": ["exec", "--skip-git-repo-check"],
             "label": "codex-gpt5-cli",
         }
     if m in ("gemini-cli", "gemini-acp", "gemini"):
@@ -90,6 +111,55 @@ def _resolve_timeout(timeout: Any) -> float:
     ]
     numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
     return max(numeric) if numeric else _DEFAULT_TIMEOUT_SECONDS
+
+
+class _ConcurrencyGate:
+    """Acquire both global + per-CLI semaphores or raise quickly.
+
+    Prevents the 27-agent fleet from spawning 27 simultaneous CLI subprocesses
+    and OOM-killing the host. If we can't acquire within the queue timeout,
+    we raise so the agent fails fast and tries the next provider in the chain.
+    """
+
+    def __init__(self, cli_name: str) -> None:
+        self._cli_name = cli_name
+        self._per_cli = _PER_CLI_SEMAPHORES.get(cli_name)
+        self._holding_global = False
+        self._holding_per_cli = False
+
+    def __enter__(self) -> "_ConcurrencyGate":
+        if not _GLOBAL_SEMAPHORE.acquire(timeout=_SEMAPHORE_ACQUIRE_TIMEOUT):
+            raise RuntimeError(
+                f"cli-shim global concurrency cap reached "
+                f"({_GLOBAL_MAX}); queue timeout {_SEMAPHORE_ACQUIRE_TIMEOUT}s "
+                f"exceeded waiting for slot."
+            )
+        self._holding_global = True
+        if self._per_cli is not None:
+            if not self._per_cli.acquire(timeout=_SEMAPHORE_ACQUIRE_TIMEOUT):
+                _GLOBAL_SEMAPHORE.release()
+                self._holding_global = False
+                raise RuntimeError(
+                    f"cli-shim per-CLI cap reached for '{self._cli_name}' "
+                    f"({_PER_CLI_MAX.get(self._cli_name)}); queue timeout "
+                    f"{_SEMAPHORE_ACQUIRE_TIMEOUT}s exceeded."
+                )
+            self._holding_per_cli = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._holding_per_cli and self._per_cli is not None:
+            try:
+                self._per_cli.release()
+            except ValueError:
+                pass
+            self._holding_per_cli = False
+        if self._holding_global:
+            try:
+                _GLOBAL_SEMAPHORE.release()
+            except ValueError:
+                pass
+            self._holding_global = False
 
 
 class _CliShimChatCompletions:
@@ -177,26 +247,36 @@ class CliShimClient:
         if dispatch["mode"] == "acp":
             # Delegate to the ACP subprocess loop — reuse the copilot ACP
             # client's protocol, just pointed at the gemini binary.
-            acp_client = CopilotACPClient(
-                api_key="cli-shim-gemini",
-                base_url="acp://gemini",
-                command=self._command_override or dispatch["command"],
-                args=self._args_override or dispatch["args"],
-                acp_cwd=self._cwd,
-            )
-            try:
-                response_text, reasoning_text = acp_client._run_prompt(
-                    prompt_text, timeout_seconds=timeout_seconds
+            with _ConcurrencyGate(dispatch["command"]):
+                acp_client = CopilotACPClient(
+                    api_key="cli-shim-gemini",
+                    base_url="acp://gemini",
+                    command=self._command_override or dispatch["command"],
+                    args=self._args_override or dispatch["args"],
+                    acp_cwd=self._cwd,
                 )
-            finally:
-                acp_client.close()
+                try:
+                    response_text, reasoning_text = acp_client._run_prompt(
+                        prompt_text, timeout_seconds=timeout_seconds
+                    )
+                finally:
+                    acp_client.close()
+        elif dispatch["mode"] == "codex_exec":
+            with _ConcurrencyGate(dispatch["command"]):
+                response_text, reasoning_text = self._run_codex_exec(
+                    prompt_text,
+                    command=self._command_override or dispatch["command"],
+                    args=self._args_override or dispatch["args"],
+                    timeout_seconds=timeout_seconds,
+                )
         else:
-            response_text, reasoning_text = self._run_print(
-                prompt_text,
-                command=self._command_override or dispatch["command"],
-                args=self._args_override or dispatch["args"],
-                timeout_seconds=timeout_seconds,
-            )
+            with _ConcurrencyGate(dispatch["command"]):
+                response_text, reasoning_text = self._run_print(
+                    prompt_text,
+                    command=self._command_override or dispatch["command"],
+                    args=self._args_override or dispatch["args"],
+                    timeout_seconds=timeout_seconds,
+                )
 
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
 
@@ -274,3 +354,103 @@ class CliShimClient:
             )
 
         return (stdout or "").strip(), ""
+
+    def _run_codex_exec(
+        self,
+        prompt_text: str,
+        *,
+        command: str,
+        args: list[str],
+        timeout_seconds: float,
+    ) -> tuple[str, str]:
+        """codex exec with --output-last-message <tmpfile> for clean output.
+
+        Codex CLI's stdout in `exec` mode is a noisy scaffold ('user\\n...\\ncodex\\n...').
+        Using --output-last-message writes ONLY the final assistant message to
+        a tempfile, which we then read back.
+        """
+        import tempfile
+
+        resolved = shutil.which(command) or command
+        with tempfile.NamedTemporaryFile(
+            mode="r", suffix=".txt", delete=False, prefix="codex-cli-shim-"
+        ) as tmp:
+            tmp_path = tmp.name
+
+        full_args = list(args) + ["--output-last-message", tmp_path]
+
+        try:
+            proc = subprocess.Popen(
+                [resolved] + full_args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                cwd=self._cwd,
+                env=_build_subprocess_env(),
+            )
+        except FileNotFoundError as exc:
+            try:
+                os.unlink(tmp_path)
+            except Exception:
+                pass
+            raise RuntimeError(
+                f"Could not start CLI '{command}'. Install it or check PATH."
+            ) from exc
+
+        with self._active_process_lock:
+            self._active_process = proc
+        self.is_closed = False
+
+        try:
+            try:
+                stdout, stderr = proc.communicate(
+                    input=prompt_text, timeout=timeout_seconds
+                )
+            except subprocess.TimeoutExpired as exc:
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+                raise TimeoutError(
+                    f"CLI '{command}' timed out after {timeout_seconds}s"
+                ) from exc
+            finally:
+                with self._active_process_lock:
+                    self._active_process = None
+
+            if proc.returncode != 0:
+                tail = (stderr or "").strip()[-800:]
+                raise RuntimeError(
+                    f"CLI '{command}' exited {proc.returncode}: {tail}"
+                )
+
+            # Read the clean last-message output
+            try:
+                with open(tmp_path, "r", encoding="utf-8") as f:
+                    response_text = f.read().strip()
+            except FileNotFoundError:
+                # Codex didn't write the file (no assistant turn happened);
+                # fall back to scrubbing stdout.
+                response_text = self._scrub_codex_stdout(stdout or "")
+
+            return response_text, ""
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except Exception:
+                pass
+
+    @staticmethod
+    def _scrub_codex_stdout(raw: str) -> str:
+        """Last-resort fallback: extract the assistant turn from noisy codex stdout."""
+        lines = raw.splitlines()
+        # codex output format: "...\ncodex\n<message>\ntokens used\n<n>"
+        try:
+            idx = lines.index("codex")
+            tail = lines[idx + 1 :]
+            if "tokens used" in tail:
+                tail = tail[: tail.index("tokens used")]
+            return "\n".join(tail).strip()
+        except ValueError:
+            return raw.strip()

--- a/agent/cli_shim_client.py
+++ b/agent/cli_shim_client.py
@@ -422,9 +422,14 @@ class CliShimClient:
                 self._active_process = None
 
         if proc.returncode != 0:
-            tail = (stderr or "").strip()[-800:]
+            # Claude Code (and some other CLIs) print fatal errors to stdout,
+            # not stderr — so a stderr-only message leaves "exited N:" blank and
+            # the real cause invisible. Surface stdout too, preferring stderr.
+            err_tail = (stderr or "").strip()[-800:]
+            out_tail = (stdout or "").strip()[-800:]
+            detail = err_tail or out_tail or "(no output on stderr or stdout)"
             raise RuntimeError(
-                f"CLI '{command}' exited {proc.returncode}: {tail}"
+                f"CLI '{command}' exited {proc.returncode}: {detail}"
             )
 
         return (stdout or "").strip(), ""
@@ -494,9 +499,11 @@ class CliShimClient:
                     self._active_process = None
 
             if proc.returncode != 0:
-                tail = (stderr or "").strip()[-800:]
+                err_tail = (stderr or "").strip()[-800:]
+                out_tail = (stdout or "").strip()[-800:]
+                detail = err_tail or out_tail or "(no output on stderr or stdout)"
                 raise RuntimeError(
-                    f"CLI '{command}' exited {proc.returncode}: {tail}"
+                    f"CLI '{command}' exited {proc.returncode}: {detail}"
                 )
 
             # Read the clean last-message output

--- a/agent/cli_shim_client.py
+++ b/agent/cli_shim_client.py
@@ -1,0 +1,276 @@
+"""OpenAI-compatible shim that forwards Hermes requests to local CLIs.
+
+Supports four sub-modes selected by the `model` field on each request:
+
+  claude-sonnet-cli   -> `claude --print --model sonnet`
+  claude-opus-cli     -> `claude --print --model opus`
+  codex-gpt5-cli      -> `codex exec --model gpt-5`
+  gemini-cli          -> delegates to CopilotACPClient-style ACP loop
+                        against `gemini --acp` (full tool-use ACP path)
+
+All paths share the OpenAI-shaped facade. claude/codex use a single-shot
+subprocess.run(... input=prompt ...) and regex-extract tool calls from
+the response text. gemini uses the full ACP protocol via the copilot
+ACP loop logic so streaming tool-use works.
+
+The class deliberately reuses _format_messages_as_prompt and
+_extract_tool_calls_from_text from agent.copilot_acp_client.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import subprocess
+import threading
+from types import SimpleNamespace
+from typing import Any
+
+from agent.copilot_acp_client import (
+    CopilotACPClient,
+    _format_messages_as_prompt,
+    _extract_tool_calls_from_text,
+    _build_subprocess_env,
+)
+
+CLI_SHIM_BASE_URL = "cli://shim"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+
+
+# Per-model dispatch table.
+# Each entry: (command_resolver, args_template, supports_acp)
+def _dispatch_for_model(model: str) -> dict[str, Any]:
+    m = (model or "").strip().lower()
+    if m in ("claude-sonnet-cli", "claude-sonnet", "sonnet-cli"):
+        return {
+            "mode": "print",
+            "command": "claude",
+            "args": ["--print", "--model", "sonnet"],
+            "label": "claude-sonnet-cli",
+        }
+    if m in ("claude-opus-cli", "claude-opus", "opus-cli"):
+        return {
+            "mode": "print",
+            "command": "claude",
+            "args": ["--print", "--model", "opus"],
+            "label": "claude-opus-cli",
+        }
+    if m in ("codex-gpt5-cli", "codex-cli", "codex"):
+        return {
+            "mode": "print",
+            "command": "codex",
+            "args": ["exec", "--model", "gpt-5"],
+            "label": "codex-gpt5-cli",
+        }
+    if m in ("gemini-cli", "gemini-acp", "gemini"):
+        return {
+            "mode": "acp",
+            "command": "gemini",
+            "args": ["--acp"],
+            "label": "gemini-cli",
+        }
+    # Default: treat as a hint for `claude --model <model>`.
+    return {
+        "mode": "print",
+        "command": "claude",
+        "args": ["--print", "--model", model],
+        "label": f"claude-{model}-cli",
+    }
+
+
+def _resolve_timeout(timeout: Any) -> float:
+    if timeout is None:
+        return _DEFAULT_TIMEOUT_SECONDS
+    if isinstance(timeout, (int, float)):
+        return float(timeout)
+    candidates = [
+        getattr(timeout, attr, None)
+        for attr in ("read", "write", "connect", "pool", "timeout")
+    ]
+    numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
+    return max(numeric) if numeric else _DEFAULT_TIMEOUT_SECONDS
+
+
+class _CliShimChatCompletions:
+    def __init__(self, client: "CliShimClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _CliShimChatNamespace:
+    def __init__(self, client: "CliShimClient"):
+        self.completions = _CliShimChatCompletions(client)
+
+
+class CliShimClient:
+    """Minimal OpenAI-client-compatible facade for local CLIs.
+
+    The `model` field on each request selects the underlying CLI; the
+    constructor's `model` is a default fallback.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        model: str | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        cwd: str | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "cli-shim"
+        self.base_url = base_url or CLI_SHIM_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._default_model = model or "claude-sonnet-cli"
+        self._command_override = command
+        self._args_override = list(args) if args else None
+        self._cwd = cwd or os.getcwd()
+        self.chat = _CliShimChatNamespace(self)
+        self.is_closed = False
+        self._active_process: subprocess.Popen[str] | None = None
+        self._active_process_lock = threading.Lock()
+
+    def close(self) -> None:
+        self.is_closed = True
+        proc: subprocess.Popen[str] | None
+        with self._active_process_lock:
+            proc = self._active_process
+            self._active_process = None
+        if proc is None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=2)
+        except Exception:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        **_: Any,
+    ) -> Any:
+        effective_model = model or self._default_model
+        dispatch = _dispatch_for_model(effective_model)
+
+        prompt_text = _format_messages_as_prompt(
+            messages or [],
+            model=effective_model,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        timeout_seconds = _resolve_timeout(timeout)
+
+        if dispatch["mode"] == "acp":
+            # Delegate to the ACP subprocess loop — reuse the copilot ACP
+            # client's protocol, just pointed at the gemini binary.
+            acp_client = CopilotACPClient(
+                api_key="cli-shim-gemini",
+                base_url="acp://gemini",
+                command=self._command_override or dispatch["command"],
+                args=self._args_override or dispatch["args"],
+                acp_cwd=self._cwd,
+            )
+            try:
+                response_text, reasoning_text = acp_client._run_prompt(
+                    prompt_text, timeout_seconds=timeout_seconds
+                )
+            finally:
+                acp_client.close()
+        else:
+            response_text, reasoning_text = self._run_print(
+                prompt_text,
+                command=self._command_override or dispatch["command"],
+                args=self._args_override or dispatch["args"],
+                timeout_seconds=timeout_seconds,
+            )
+
+        tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
+
+        usage = SimpleNamespace(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+        assistant_message = SimpleNamespace(
+            content=cleaned_text,
+            tool_calls=tool_calls,
+            reasoning=reasoning_text or None,
+            reasoning_content=reasoning_text or None,
+            reasoning_details=None,
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        return SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=dispatch["label"],
+        )
+
+    def _run_print(
+        self,
+        prompt_text: str,
+        *,
+        command: str,
+        args: list[str],
+        timeout_seconds: float,
+    ) -> tuple[str, str]:
+        """Single-shot subprocess.run for --print/--exec style CLIs."""
+        resolved = shutil.which(command) or command
+        try:
+            proc = subprocess.Popen(
+                [resolved] + list(args),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                cwd=self._cwd,
+                env=_build_subprocess_env(),
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start CLI '{command}'. "
+                f"Install it or check PATH."
+            ) from exc
+
+        with self._active_process_lock:
+            self._active_process = proc
+        self.is_closed = False
+
+        try:
+            stdout, stderr = proc.communicate(
+                input=prompt_text, timeout=timeout_seconds
+            )
+        except subprocess.TimeoutExpired as exc:
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            raise TimeoutError(
+                f"CLI '{command}' timed out after {timeout_seconds}s"
+            ) from exc
+        finally:
+            with self._active_process_lock:
+                self._active_process = None
+
+        if proc.returncode != 0:
+            tail = (stderr or "").strip()[-800:]
+            raise RuntimeError(
+                f"CLI '{command}' exited {proc.returncode}: {tail}"
+            )
+
+        return (stdout or "").strip(), ""

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -197,6 +197,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "cli-shim": ProviderConfig(
+        id="cli-shim",
+        name="Local CLI Shim",
+        auth_type="external_process",
+        inference_base_url="cli://shim",
+        base_url_env_var="CLI_SHIM_BASE_URL",
+    ),
     "gemini": ProviderConfig(
         id="gemini",
         name="Google AI Studio",
@@ -4122,6 +4129,19 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
+
+    # cli-shim doesn't need a specific command resolved up front — the
+    # client dispatches to claude/codex/gemini per-request based on the
+    # model field. Just return the marker base_url + a sentinel command.
+    if provider_id == "cli-shim":
+        return {
+            "provider": provider_id,
+            "api_key": "cli-shim",
+            "base_url": base_url.rstrip("/"),
+            "command": "cli-shim",
+            "args": [],
+            "source": "process",
+        }
 
     command = (
         os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2523,6 +2523,8 @@ def select_provider_and_model(args=None):
         _model_flow_copilot_acp(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
+    elif selected_provider == "cli-shim":
+        _model_flow_cli_shim(config, current_model)
     elif selected_provider == "custom":
         _model_flow_custom(config)
     elif (
@@ -5064,6 +5066,74 @@ def _model_flow_copilot_acp(config, current_model=""):
     )
     _save_model_choice(selected)
 
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
+def _model_flow_cli_shim(config, current_model=""):
+    """Local CLI shim flow — routes Hermes turns through the locally-installed
+    claude/codex/gemini CLIs using each CLI's own OAuth login. No API key.
+
+    Mirrors `_model_flow_copilot_acp` but skips credential entry entirely: the
+    CLIs read their own credential caches (~/.claude, ~/.codex, ~/.gemini), so
+    the only choice the user makes here is which model alias to route to.
+    """
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "cli-shim"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+    effective_base = pconfig.inference_base_url  # "cli://shim"
+
+    print("  cli-shim routes Hermes turns through your locally-installed CLIs")
+    print("  (claude / codex / gemini) using their own OAuth login — no API key.")
+    print("  Ensure the CLI backing your chosen model is installed and logged in:")
+    print("    claude-*-cli → `claude`,  codex-* → `codex`,  gemini-cli → `gemini`")
+    print()
+
+    # No credential to resolve up front — each CLI uses its own OAuth cache.
+    # Surface a soft diagnostic if the resolver objects, but never block here.
+    try:
+        resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+
+    # Single source of truth for the selectable aliases: the provider profile.
+    model_list = ["claude-sonnet-cli", "claude-opus-cli", "codex-gpt5-cli", "gemini-cli"]
+    try:
+        from providers import get_provider_profile
+
+        prof = get_provider_profile(provider_id)
+        fetched = prof.fetch_models() if prof is not None else None
+        if fetched:
+            model_list = fetched
+    except Exception:
+        pass
+
+    selected = _prompt_model_selection(model_list, current_model=current_model)
+    if not selected:
+        print("No change.")
+        return
+
+    _save_model_choice(selected)
     cfg = load_config()
     model = cfg.get("model")
     if not isinstance(model, dict):

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -940,7 +940,10 @@ try:
     for _pp in _list_providers_for_canonical():
         if _pp.name in _canonical_slugs:
             continue
-        if _pp.auth_type in {"oauth_device_code", "oauth_external", "external_process", "aws_sdk", "copilot"}:
+        # cli-shim is exempt from the skip below: it ships a dedicated no-API-key
+        # picker flow (_model_flow_cli_shim in hermes_cli/main.py), so it is safe
+        # to surface in the model picker even though its auth_type is external_process.
+        if _pp.name != "cli-shim" and _pp.auth_type in {"oauth_device_code", "oauth_external", "external_process", "aws_sdk", "copilot"}:
             continue  # non-api-key flows need bespoke picker UX; skip auto-inject
         _label = _pp.display_name or _pp.name
         _desc = _pp.description or f"{_label} (direct API)"

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1465,6 +1465,25 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    if provider == "cli-shim":
+        # Local CLI shim — claude/codex/gemini via their own OAuth subscription,
+        # no API key. The marker base_url "cli://shim" routes client creation to
+        # CliShimClient; the per-request model field selects which CLI runs.
+        # resolve_provider_client() builds the client, but the main/gateway
+        # runtime path resolves credentials here first — without this branch it
+        # falls through to auto→openrouter and demands an API key (#cli-shim).
+        creds = resolve_external_process_provider_credentials(provider)
+        return {
+            "provider": "cli-shim",
+            "api_mode": "chat_completions",
+            "base_url": creds.get("base_url", "").rstrip("/"),
+            "api_key": creds.get("api_key", ""),
+            "command": creds.get("command", ""),
+            "args": list(creds.get("args") or []),
+            "source": creds.get("source", "process"),
+            "requested_provider": requested_provider,
+        }
+
     # Anthropic (native Messages API)
     if provider == "anthropic":
         # Allow base URL override from config.yaml model.base_url, but only

--- a/plugins/model-providers/cli-shim/__init__.py
+++ b/plugins/model-providers/cli-shim/__init__.py
@@ -1,0 +1,47 @@
+"""cli-shim provider profile.
+
+cli-shim shells out to locally-installed CLIs that the user already
+authenticated with OAuth (claude, codex, gemini). NO API keys required —
+the CLIs use their own credentials cache.
+
+The `model` field on each request selects which CLI to invoke:
+  - claude-sonnet-cli   -> `claude --print --model sonnet`
+  - claude-opus-cli     -> `claude --print --model opus`
+  - codex-gpt5-cli      -> `codex exec --model gpt-5`
+  - gemini-cli          -> `gemini --acp ...` (ACP path, tool-use capable)
+
+api_mode="chat_completions" routes through standard run_agent.py paths;
+the cli-shim base_url `cli://shim` triggers the CliShimClient branch.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class CliShimProfile(ProviderProfile):
+    """Local CLI shim — external process, no REST models endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        return [
+            "claude-sonnet-cli",
+            "claude-opus-cli",
+            "codex-gpt5-cli",
+            "gemini-cli",
+        ]
+
+
+cli_shim = CliShimProfile(
+    name="cli-shim",
+    aliases=("local-cli-shim", "cli"),
+    api_mode="chat_completions",
+    env_vars=(),  # OAuth-only — managed by the CLIs themselves
+    base_url="cli://shim",
+    auth_type="external_process",
+)
+
+register_provider(cli_shim)

--- a/plugins/model-providers/cli-shim/__init__.py
+++ b/plugins/model-providers/cli-shim/__init__.py
@@ -38,6 +38,8 @@ class CliShimProfile(ProviderProfile):
 cli_shim = CliShimProfile(
     name="cli-shim",
     aliases=("local-cli-shim", "cli"),
+    display_name="CLI shim (claude/codex/gemini)",
+    description="Local claude/codex/gemini CLIs via their own OAuth login — no API key",
     api_mode="chat_completions",
     env_vars=(),  # OAuth-only — managed by the CLIs themselves
     base_url="cli://shim",

--- a/plugins/model-providers/cli-shim/plugin.yaml
+++ b/plugins/model-providers/cli-shim/plugin.yaml
@@ -1,0 +1,5 @@
+name: cli-shim-provider
+kind: model-provider
+version: 1.0.0
+description: Local CLI shim — shells out to claude/codex/gemini CLIs (OAuth)
+author: Hermes local

--- a/run_agent.py
+++ b/run_agent.py
@@ -6523,6 +6523,21 @@ class AIAgent:
                 self._client_log_context(),
             )
             return client
+        if self.provider == "cli-shim" or str(client_kwargs.get("base_url", "")).startswith("cli://shim"):
+            from agent.cli_shim_client import CliShimClient
+
+            # CliShimClient ignores api_key/base_url for routing; pass model
+            # through so per-request dispatch lands on the right CLI.
+            shim_kwargs = dict(client_kwargs)
+            shim_kwargs.setdefault("model", getattr(self, "model", None) or "claude-sonnet-cli")
+            client = CliShimClient(**shim_kwargs)
+            logger.info(
+                "CLI shim client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                self._client_log_context(),
+            )
+            return client
         if self.provider == "google-gemini-cli" or str(client_kwargs.get("base_url", "")).startswith("cloudcode-pa://"):
             from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
 

--- a/tests/hermes_cli/test_cli_shim_provider.py
+++ b/tests/hermes_cli/test_cli_shim_provider.py
@@ -1,0 +1,91 @@
+"""Tests for the cli-shim provider's picker + runtime-resolution wiring.
+
+cli-shim (local claude/codex/gemini CLIs via OAuth, no API key) shipped with
+client construction wired up but not the picker UX or the runtime credential
+path. These tests pin the two fixes:
+
+* ``resolve_runtime_provider`` resolves cli-shim instead of falling through to
+  the API-key fallback (which defaulted to openrouter and bailed with an empty
+  API key).
+* cli-shim is surfaced in the ``hermes model`` picker (CANONICAL_PROVIDERS)
+  despite its ``external_process`` auth_type.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+# Match the other hermes_cli provider tests: stub python-dotenv if absent so
+# importing hermes_cli modules never blows up on a missing optional dep.
+if "dotenv" not in sys.modules:
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = fake_dotenv
+
+from hermes_cli.runtime_provider import resolve_runtime_provider
+from hermes_cli.models import CANONICAL_PROVIDERS
+from providers import get_provider_profile
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider_env(monkeypatch):
+    # Clear env so the runtime resolver can't accidentally satisfy itself with
+    # an unrelated provider key — the cli-shim branch must stand on its own.
+    for key in (
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "HERMES_INFERENCE_PROVIDER",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestCliShimRuntimeResolution:
+    def test_resolve_runtime_provider_returns_cli_shim(self):
+        runtime = resolve_runtime_provider(requested="cli-shim")
+        assert runtime["provider"] == "cli-shim"
+        assert runtime["base_url"] == "cli://shim"
+        # Placeholder key — CliShimClient ignores it for routing, but it must be
+        # non-empty so the downstream empty-key guard doesn't abort.
+        assert runtime["api_key"] == "cli-shim"
+        assert runtime["api_mode"] == "chat_completions"
+
+    def test_does_not_fall_back_to_openrouter(self):
+        # Regression: before the fix, cli-shim fell through every named branch to
+        # the API-key fallback, defaulted resolved_provider to "openrouter", and
+        # returned an empty api_key — surfacing "Set OPENROUTER_API_KEY".
+        runtime = resolve_runtime_provider(requested="cli-shim")
+        assert runtime["provider"] != "openrouter"
+        assert runtime["api_key"], "cli-shim must resolve a non-empty (placeholder) api_key"
+        assert runtime["base_url"], "cli-shim must resolve a non-empty base_url"
+
+
+class TestCliShimPickerIntegration:
+    def test_cli_shim_in_canonical_providers(self):
+        slugs = {p.slug for p in CANONICAL_PROVIDERS}
+        assert "cli-shim" in slugs, (
+            "cli-shim should be auto-injected into the model picker despite its "
+            "external_process auth_type"
+        )
+
+    def test_cli_shim_picker_row_has_label_and_description(self):
+        row = next(p for p in CANONICAL_PROVIDERS if p.slug == "cli-shim")
+        assert row.label, "picker label should not be empty"
+        # Description should make clear it is the no-API-key local-CLI path.
+        assert "no api key" in row.tui_desc.lower()
+
+
+class TestCliShimProfile:
+    def test_profile_is_external_process(self):
+        profile = get_provider_profile("cli-shim")
+        assert profile is not None
+        assert profile.auth_type == "external_process"
+
+    def test_profile_exposes_cli_model_aliases(self):
+        profile = get_provider_profile("cli-shim")
+        models = profile.fetch_models()
+        assert "claude-sonnet-cli" in models
+        assert "claude-opus-cli" in models


### PR DESCRIPTION
## What does this PR do?

Builds on #26634 (the `cli-shim` local-CLI model provider) and makes it work
end-to-end. Two gaps in the original draft prevented `cli-shim` from being
usable: it couldn't be selected from the UI, and selecting it in config made
the agent crash at startup. This PR fixes both. Full credit for the cli-shim
feature itself goes to the author of #26634 — those commits are carried
unchanged; this PR only adds the two fixes on top.

## Related Issue

Builds on / depends on #26634 (no separate issue filed).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/runtime_provider.py` — add a `cli-shim` branch in
  `resolve_runtime_provider` (mirrors `copilot-acp`). #26634 wired
  `resolve_provider_client` but not this path, so the TUI/gateway fell through
  to the API-key fallback, defaulted the provider to `openrouter`, and aborted
  with "Provider resolver returned an empty API key". Now returns
  `base_url=cli://shim`, `api_key=cli-shim` (placeholder), `api_mode=chat_completions`.
- `hermes_cli/models.py` — exempt cli-shim from the `external_process`
  auto-inject skip so it appears in the `hermes model` picker.
- `hermes_cli/main.py` — add `_model_flow_cli_shim`, a no-API-key selection
  flow that lists the profile's CLI model aliases and persists `provider: cli-shim`.
- `plugins/model-providers/cli-shim/__init__.py` — add `display_name` /
  `description` so the picker row reads sensibly.

## How to Test

1. Have a logged-in `claude` CLI on the host (`echo hi | claude --print --model sonnet`).
2. `hermes model` → select **"CLI shim (claude/codex/gemini)"** → pick
   `claude-sonnet-cli`. Confirm it writes `model.provider: cli-shim` to config.yaml.
3. Start hermes and send a prompt — it should route through `claude --print`
   with no API key, instead of erroring at provider resolution.
4. Sanity check the resolver directly:
   `python -c "from hermes_cli.runtime_provider import resolve_runtime_provider as r; print(r(requested='cli-shim'))"`
   → `provider/base_url/api_key = cli-shim / cli://shim / cli-shim`.

## Checklist

### Code

- [ ] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(cli-shim):`, `fix(cli-shim):`)
- [x] I searched for existing PRs (this explicitly builds on #26634)
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Linux (Fedora-based server, root install)

### Documentation & Housekeeping

- [x] Docstrings added for the new flow; RFC doc (`CLI_SHIM_PROPOSAL.md`, from #26634) unchanged
- [x] N/A — no new config keys (uses existing `model.provider` / `model.default`)
- [x] N/A — no architecture/workflow change
- [x] Cross-platform: the added code is platform-neutral Python; subprocess dispatch is from #26634
- [x] N/A — no tool behavior changed

## Screenshots / Logs

Before (provider: cli-shim, on #26634 alone):
> ⚠️ Provider resolver returned an empty API key. Set OPENROUTER_API_KEY

After: agent initializes on `cli-shim` and answers via `claude --print` with no API key.
