### PR TITLE
fix: respect memory_enabled flag for MEMORY_GUIDANCE injection

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -112,7 +112,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
 
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []
-    if "memory" in agent.valid_tool_names:
+    if "memory" in agent.valid_tool_names and getattr(agent, "_memory_enabled", True):
         tool_guidance.append(MEMORY_GUIDANCE)
     if "session_search" in agent.valid_tool_names:
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1072,8 +1072,16 @@ class TestBuildSystemPrompt:
     def test_memory_guidance_when_memory_tool_loaded(self, agent_with_memory_tool):
         from agent.prompt_builder import MEMORY_GUIDANCE
 
+        agent_with_memory_tool._memory_enabled = True
         prompt = agent_with_memory_tool._build_system_prompt()
         assert MEMORY_GUIDANCE in prompt
+
+    def test_no_memory_guidance_when_memory_disabled(self, agent_with_memory_tool):
+        from agent.prompt_builder import MEMORY_GUIDANCE
+
+        agent_with_memory_tool._memory_enabled = False
+        prompt = agent_with_memory_tool._build_system_prompt()
+        assert MEMORY_GUIDANCE not in prompt
 
     def test_no_memory_guidance_without_tool(self, agent):
         from agent.prompt_builder import MEMORY_GUIDANCE


### PR DESCRIPTION
## Problem

The stable tier injected `MEMORY_GUIDANCE` whenever the `memory` tool was registered in `valid_tool_names`, ignoring the `memory_enabled` config flag. This caused contradictory instructions when users set `memory_enabled: false` — the system prompt told the agent to "Save durable facts using the memory tool" even though memory was explicitly disabled.

This is inconsistent with the volatile tier, which already checks `agent._memory_enabled` before injecting memory content (MEMORY.md, USER.md blocks).

## Use Case

Users running third-party memory providers (MemPalace, Mem0, etc.) via the plugin system set `memory_enabled: false` to disable the built-in memory. The built-in MEMORY_GUIDANCE instructions contradict the plugin's own instructions, confusing the agent.

## Fix

Added `and getattr(agent, "_memory_enabled", True)` check to the MEMORY_GUIDANCE injection in `build_system_prompt_parts()`, matching the existing pattern in the volatile tier.

`getattr` with default `True` preserves backward compatibility for code paths that don't initialize `_memory_enabled`.

## Tests

- Updated `test_memory_guidance_when_memory_tool_loaded` to explicitly set `_memory_enabled = True`
- Added `test_no_memory_guidance_when_memory_disabled` to verify the fix
- All 3 memory_guidance tests pass
