### PR TITLE
fix(agent): sync Anthropic claude_code tokens before proactive refresh

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1238,8 +1238,24 @@ class CredentialPool:
             # For anthropic claude_code entries, sync from the credentials file
             # before any status/refresh checks. This picks up tokens refreshed
             # by other processes (Claude Code CLI, other Hermes profiles).
+            #
+            # Sync fires in two cases:
+            #   1. The entry is already EXHAUSTED/DEAD — recover stale state
+            #      when fresh tokens are sitting on disk.
+            #   2. The entry is OK but about to be proactively refreshed
+            #      (access token within the expiry skew).  Anthropic refresh
+            #      tokens are single-use: if another process (a `claude
+            #      /login` in a second terminal, or another Hermes profile)
+            #      already consumed our refresh token and wrote a fresh pair
+            #      to ~/.claude/.credentials.json, refreshing with OUR stale
+            #      copy fails and marks the entry exhausted (last_error_code
+            #      null).  Adopting the file's fresh tokens BEFORE the refresh
+            #      attempt closes that race — we either no longer need to
+            #      refresh, or refresh with the live token.  See the
+            #      OAuth-refresh-race incident notes.
             if (self.provider == "anthropic" and entry.source == "claude_code"
-                    and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}):
+                    and (entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}
+                         or (refresh and self._entry_needs_refresh(entry)))):
                 synced = self._sync_anthropic_entry_from_credentials_file(entry)
                 if synced is not entry:
                     entry = synced

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1444,6 +1444,88 @@ def test_load_pool_removes_nous_device_code_when_singleton_quarantined(tmp_path,
     assert [entry["id"] for entry in auth_payload["credential_pool"]["nous"]] == ["manual-key"]
 
 
+def test_anthropic_ok_entry_adopts_fresh_file_tokens_before_proactive_refresh(
+    tmp_path, monkeypatch
+):
+    """Regression: single-use OAuth refresh-token race.
+
+    The gateway holds a CredentialPool in memory across turns.  If another
+    process (a `claude /login` in a second terminal, or another Hermes
+    profile) consumes the entry's single-use refresh token and writes a
+    fresh pair to ~/.claude/.credentials.json, the in-memory entry is now
+    stale and seeding (which only runs at load_pool time) won't re-run.
+
+    When that in-memory entry's access token next enters the refresh skew,
+    _available_entries(refresh=True) must adopt the file's fresh tokens
+    BEFORE attempting the doomed network refresh with the stale token —
+    otherwise the refresh fails and the entry is marked exhausted with
+    last_error_code=null.
+
+    Tested at the method level (CredentialPool built directly) to isolate
+    the _available_entries sync path from load_pool's seeding/upsert.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    from agent.credential_pool import (
+        CredentialPool,
+        PooledCredential,
+        AUTH_TYPE_OAUTH,
+        STATUS_OK,
+    )
+
+    # OK entry whose access token is within the 120s refresh skew, holding
+    # the STALE refresh token already consumed by another process.
+    near_expiry_ms = int(time.time() * 1000) + 30_000
+    stale_entry = PooledCredential.from_dict(
+        "anthropic",
+        {
+            "id": "racey",
+            "label": "claude-code",
+            "auth_type": AUTH_TYPE_OAUTH,
+            "priority": 0,
+            "source": "claude_code",
+            "access_token": "stale-access-token",
+            "refresh_token": "stale-consumed-refresh-token",
+            "expires_at_ms": near_expiry_ms,
+            "last_status": STATUS_OK,
+        },
+    )
+
+    # The credentials file holds the FRESH pair written by the other process,
+    # with an access token far outside the skew (so no refresh is needed once
+    # adopted).
+    fresh_expiry_ms = int(time.time() * 1000) + 8 * 3600 * 1000
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials",
+        lambda: {
+            "accessToken": "fresh-access-token",
+            "refreshToken": "fresh-rotated-refresh-token",
+            "expiresAt": fresh_expiry_ms,
+        },
+    )
+
+    # Guard: the doomed network refresh must never be called.  If the fix
+    # regresses, selection falls through to this and fails loudly instead of
+    # silently attempting a network refresh with the stale token.
+    def _boom(*_a, **_kw):
+        raise AssertionError(
+            "refresh_anthropic_oauth_pure was called — the stale refresh "
+            "token should have been replaced by the file sync first"
+        )
+
+    monkeypatch.setattr("agent.anthropic_adapter.refresh_anthropic_oauth_pure", _boom)
+
+    pool = CredentialPool("anthropic", [stale_entry])
+    entry = pool.select()
+
+    assert entry is not None
+    # Adopted the fresh file tokens, status healthy, no exhaustion.
+    assert entry.refresh_token == "fresh-rotated-refresh-token"
+    assert entry.access_token == "fresh-access-token"
+    assert entry.last_status in (None, "ok")
+    assert entry.last_error_code is None
+
+
 def test_load_pool_removes_stale_file_backed_singleton_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)


### PR DESCRIPTION
## What does this PR do?

Closes an in-memory OAuth refresh-token race for Anthropic `claude_code` credential-pool entries.

A long-lived process (the gateway) holds the `CredentialPool` in memory across turns. If another process consumes the entry's **single-use** OAuth refresh token and writes a fresh pair to `~/.claude/.credentials.json` — a `claude /login` in a second terminal, or another Hermes profile — the in-memory entry keeps the stale token. When that entry's access token next enters the 2-minute refresh skew, `_available_entries(refresh=True)` attempts a refresh with the stale token, Anthropic rejects it, and the entry is marked `exhausted` with `last_error_code=null`. The user sees a spurious "exhausted / no Anthropic credentials" even though a valid token is sitting on disk and they are nowhere near any usage cap.

The existing credentials-file sync (`_sync_anthropic_entry_from_credentials_file`) only fired when the entry was **already** `EXHAUSTED`/`DEAD` — too late to prevent the failing refresh. This broadens the gate so it also fires when an OK entry is **about to be proactively refreshed**, adopting the file's fresh tokens first. The sync is already a no-op when tokens match, so the OK-path call is safe and cheap.

## Related Issue

- Relates to #21107 (Anthropic auth fails when Keychain and `~/.claude/.credentials.json` hold different OAuth tokens).
- Mirrors the approach of #26469 (`fix(codex): refresh pool entries from auth store`) for the Anthropic provider — the Codex side already syncs the auth store before refreshing; Anthropic only synced *after* exhaustion.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/credential_pool.py`: in `_available_entries`, broaden the anthropic `claude_code` credentials-file sync gate from `last_status in {EXHAUSTED, DEAD}` to also include `(refresh and self._entry_needs_refresh(entry))`, so an OK entry that is about to be proactively refreshed adopts fresh on-disk tokens before attempting a refresh with a possibly-consumed single-use token.
- `tests/agent/test_credential_pool.py`: regression test reproducing the race at the `CredentialPool` method level. It asserts the fresh file tokens are adopted and the network refresh (`refresh_anthropic_oauth_pure`) is **never** called (guarded with a raising stub).

## How to Test

1. `scripts/run_tests.sh tests/agent/test_credential_pool.py`
2. The new test `test_anthropic_ok_entry_adopts_fresh_file_tokens_before_proactive_refresh` fails on `main` (refresh with the stale token marks the entry exhausted → `select()` returns `None`) and passes with this change.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (closest is #26469, which fixes the same class of race for the Codex provider — this is the Anthropic-side counterpart)
- [x] My PR contains **only** changes related to this fix (credential-pool sync + its test)
- [x] I've run the relevant suites and they pass (`tests/agent/test_credential_pool.py` 79/79, plus the full blast radius of modules importing `credential_pool` — 2,152 passing)
- [x] I've added a regression test
- [x] I've tested on my platform: macOS 26.5, Python 3.11

### Documentation & Housekeeping

- [x] N/A — no public API, config key, or architecture change

## Notes for reviewers

- The OK-path sync is gated on `refresh and self._entry_needs_refresh(entry)`, so it only runs for entries actually about to refresh (no extra file reads on every selection).
- Pre-existing unrelated note: on my machine `tests/test_tui_gateway_server.py::test_browser_manage_connect_default_local_reports_launch_hint` fails on a clean checkout of `main` as well (browser launch-hint test, unrelated to this change) — not introduced by this PR.
