### PR TITLE
fix(agent): route 'thinking blocks cannot be modified' 400 to recovery

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -546,14 +546,32 @@ def classify_api_error(
             should_fallback=True,
         )
 
-    # Anthropic thinking block signature invalid (400).
+    # Anthropic thinking block recovery (400).  Two distinct failure modes,
+    # same recovery (strip all reasoning_details and retry without thinking
+    # blocks — see the thinking_signature handler in conversation_loop.py):
+    #   1. Signature mismatch: a thinking block is signed against the full
+    #      turn content; any upstream mutation (context compression, session
+    #      truncation, message merging) invalidates the signature.
+    #      Pattern: "signature" + "thinking".
+    #   2. Frozen-block mutation: Anthropic rejects any change to the
+    #      thinking/redacted_thinking blocks in the *latest* assistant
+    #      message — "`thinking` or `redacted_thinking` blocks in the latest
+    #      assistant message cannot be modified. These blocks must remain as
+    #      they were in the original response."  This carries no "signature"
+    #      token, so the original pattern missed it and the turn hard-aborted
+    #      as a non-retryable client error instead of self-healing.
+    #      Pattern: "thinking" + ("cannot be modified" | "must remain as they were").
     # Don't gate on provider — OpenRouter proxies Anthropic errors, so the
     # provider may be "openrouter" even though the error is Anthropic-specific.
-    # The message pattern ("signature" + "thinking") is unique enough.
+    # The combined patterns are unique enough.
     if (
         status_code == 400
-        and "signature" in error_msg
         and "thinking" in error_msg
+        and (
+            "signature" in error_msg
+            or "cannot be modified" in error_msg
+            or "must remain as they were" in error_msg
+        )
     ):
         return _result(
             FailoverReason.thinking_signature,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -661,6 +661,42 @@ class TestClassifyApiError:
         # Without "thinking" in the message, it shouldn't be thinking_signature
         assert result.reason != FailoverReason.thinking_signature
 
+    def test_anthropic_thinking_blocks_cannot_be_modified(self):
+        """Frozen-block mutation 400 (no 'signature' token) must route to
+        thinking_signature recovery, not hard-abort. Regression for the
+        real-world error: latest-assistant thinking blocks 'cannot be
+        modified' after upstream message mutation."""
+        e = MockAPIError(
+            "messages.73.content.10: `thinking` or `redacted_thinking` blocks "
+            "in the latest assistant message cannot be modified. These blocks "
+            "must remain as they were in the original response.",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="anthropic")
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_anthropic_thinking_cannot_be_modified_via_openrouter(self):
+        """Same frozen-block error proxied through OpenRouter must also be
+        caught (provider is not gated)."""
+        e = MockAPIError(
+            "`thinking` or `redacted_thinking` blocks in the latest assistant "
+            "message cannot be modified.",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="openrouter")
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_400_cannot_be_modified_without_thinking_not_classified(self):
+        """A 400 'cannot be modified' that has nothing to do with thinking
+        blocks must NOT be swept into thinking_signature recovery."""
+        e = MockAPIError(
+            "this field cannot be modified after creation", status_code=400,
+        )
+        result = classify_api_error(e, provider="anthropic", approx_tokens=0)
+        assert result.reason != FailoverReason.thinking_signature
+
     def test_invalid_encrypted_content_classified_as_retryable_replay_failure(self):
         body = {
             "error": {


### PR DESCRIPTION
## What does this PR do?

Routes a specific Anthropic 400 — *"`thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified. These blocks must remain as they were in the original response."* — to the existing thinking-block recovery path instead of hard-aborting the turn.

The classifier's `thinking_signature` branch only matched on the substring `"signature"`. This frozen-block variant carries no `"signature"` token, so it fell through to a non-retryable client error and aborted the turn with a bare "Non-retryable error" — even though the existing `strip reasoning_details and retry` recovery (the same one used for signature mismatches) would have healed it.

This broadens the 400 match to also catch `"cannot be modified"` / `"must remain as they were"`, still gated on `"thinking"` being present, so the turn self-heals. A negative-case test ensures an unrelated "cannot be modified" 400 (without `"thinking"`) is **not** swept into the recovery.

This is **defense-in-depth**, orthogonal to the root-cause work in #35975 / #17861 (which prevent the block mutation in the first place). It does not change correct behavior — it only converts a terminal failure into a one-shot recovery attempt. Happy to fold or close this if a root-cause fix supersedes it.

## Related Issue

- Relates to #35975 (extended-thinking + interleaved tool turn → non-retryable HTTP 400 crash-loop) and #17861 (multi-turn history loses thinking blocks). Complementary, not a replacement.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`: broaden the `thinking_signature` 400 classification from `"signature" + "thinking"` to `"thinking"` + (`"signature"` | `"cannot be modified"` | `"must remain as they were"`).
- `tests/agent/test_error_classifier.py`: 3 tests — the frozen-block error classifies as `thinking_signature`/retryable both natively and proxied via OpenRouter; an unrelated "cannot be modified" 400 (no `"thinking"`) does not.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_error_classifier.py` (158/158 pass)
2. New tests cover both the positive (native + OpenRouter) and negative cases.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(agent): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate — there are several open PRs on thinking-block handling (#35265, #24407, #35976, #36071, #35855), but they all key on the `"signature"` path / preserving block order. None handle the `"cannot be modified"` string, which is the specific gap this addresses.
- [x] My PR contains **only** changes related to this fix (classifier match + its tests)
- [x] I've run the relevant suites and they pass (`tests/agent/test_error_classifier.py` 158/158, plus the full blast radius of modules importing `error_classifier` — 2,152 passing)
- [x] I've added tests
- [x] I've tested on my platform: macOS 26.5, Python 3.11

### Documentation & Housekeeping

- [x] N/A — no public API, config key, or architecture change

## Notes for reviewers

- The recovery this routes to (`thinking_signature` → strip `reasoning_details`, retry once) already exists; this PR only widens what reaches it.
- Pre-existing unrelated note: on my machine `tests/test_tui_gateway_server.py::test_browser_manage_connect_default_local_reports_launch_hint` also fails on a clean checkout of `main` (browser launch-hint test, unrelated) — not introduced by this PR.
