### PR TITLE
Signal adapter: add group mention/allowlist behavior controls

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1102,6 +1102,11 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(signal_cfg, dict):
                 if "require_mention" in signal_cfg and not os.getenv("SIGNAL_REQUIRE_MENTION"):
                     os.environ["SIGNAL_REQUIRE_MENTION"] = str(signal_cfg["require_mention"]).lower()
+                if "free_response_groups" in signal_cfg and not os.getenv("SIGNAL_FREE_RESPONSE_GROUPS"):
+                    frc = signal_cfg["free_response_groups"]
+                    if isinstance(frc, list):
+                        frc = ",".join(str(v) for v in frc)
+                    os.environ["SIGNAL_FREE_RESPONSE_GROUPS"] = str(frc)
 
             # DingTalk settings → env vars (env vars take precedence)
             dingtalk_cfg = yaml_cfg.get("dingtalk", {})

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -192,6 +192,34 @@ class SignalAdapter(BasePlatformAdapter):
         group_allowed_str = os.getenv("SIGNAL_GROUP_ALLOWED_USERS", "")
         self.group_allow_from = set(_parse_comma_list(group_allowed_str))
 
+        free_response_raw = extra.get("free_response_groups")
+        if free_response_raw is None:
+            free_response_raw = os.getenv("SIGNAL_FREE_RESPONSE_GROUPS", "")
+        if isinstance(free_response_raw, list):
+            self.free_response_groups = {
+                str(g).strip() for g in free_response_raw if str(g).strip()
+            }
+        else:
+            self.free_response_groups = {
+                part.strip() for part in str(free_response_raw).split(",") if part.strip()
+            }
+
+        mention_aliases_raw = extra.get("mention_aliases")
+        if mention_aliases_raw is None:
+            mention_aliases_raw = os.getenv("SIGNAL_MENTION_ALIASES", "hermes")
+        if isinstance(mention_aliases_raw, list):
+            self.mention_aliases = {
+                str(alias).strip().lstrip("@").lower()
+                for alias in mention_aliases_raw
+                if str(alias).strip().lstrip("@")
+            }
+        else:
+            self.mention_aliases = {
+                part.strip().lstrip("@").lower()
+                for part in str(mention_aliases_raw).split(",")
+                if part.strip().lstrip("@")
+            }
+
         # Mention filter — only respond in groups when the bot account is @mentioned.
         # Read from config extra first, then SIGNAL_REQUIRE_MENTION env var.
         _rm_cfg = extra.get("require_mention")
@@ -230,6 +258,7 @@ class SignalAdapter(BasePlatformAdapter):
 
         # Normalize account for self-message filtering
         self._account_normalized = self.account.strip()
+        self._account_identifiers = {self._account_normalized}
 
         # Track recently sent message timestamps to prevent echo-back loops
         # in Note to Self / self-chat mode (mirrors WhatsApp recentlySentIds)
@@ -279,6 +308,9 @@ class SignalAdapter(BasePlatformAdapter):
                 logger.error("Signal: cannot reach signal-cli at %s: %s", self.http_url, e)
                 return False
 
+            await self._resolve_account_identifiers()
+            await self._resolve_group_allowlist_names()
+
             self._running = True
             self._last_sse_activity = time.time()
             self._sse_task = asyncio.create_task(self._sse_listener())
@@ -324,6 +356,100 @@ class SignalAdapter(BasePlatformAdapter):
         self._release_platform_lock()
 
         logger.info("Signal: disconnected")
+
+    async def _resolve_account_identifiers(self) -> None:
+        """Populate known identifiers (number/UUID) for this Signal account."""
+        identifiers = {self._account_normalized, self.account, redact_phone(self.account)}
+        try:
+            contacts = await self._rpc(
+                "listContacts",
+                {"account": self.account},
+                rpc_id="listContacts_account_identifiers",
+                log_failures=False,
+                timeout=15.0,
+            )
+        except Exception:
+            logger.debug("Signal: failed to resolve account identifiers", exc_info=True)
+            contacts = None
+        if isinstance(contacts, list):
+            for contact in contacts:
+                if not isinstance(contact, dict):
+                    continue
+                contact_number = str(contact.get("number") or "").strip()
+                if contact_number != self._account_normalized:
+                    continue
+                for key in ("number", "uuid", "serviceId"):
+                    value = str(contact.get(key) or "").strip()
+                    if value:
+                        identifiers.add(value)
+                profile = contact.get("profile")
+                if isinstance(profile, dict):
+                    for key in ("uuid", "serviceId"):
+                        value = str(profile.get(key) or "").strip()
+                        if value:
+                            identifiers.add(value)
+                break
+        self._account_identifiers = {i for i in identifiers if i}
+
+    async def _resolve_group_allowlist_names(self) -> None:
+        """Expand name-based group allowlist/free-response entries to group ids.
+
+        Existing setups often configure SIGNAL_GROUP_ALLOWED_USERS with human
+        names (for example "AgentChat"). Incoming Signal events are not
+        guaranteed to carry group names, so resolve names once at connect time
+        via signal-cli's listGroups RPC and add matching IDs to the sets.
+        """
+        names_to_resolve = {
+            item
+            for item in (self.group_allow_from | self.free_response_groups)
+            if item and item != "*" and not item.startswith("group:")
+        }
+        if not names_to_resolve:
+            return
+        try:
+            groups = await self._rpc(
+                "listGroups",
+                {"account": self.account},
+                rpc_id="listGroups_allowlist",
+                log_failures=False,
+                timeout=15.0,
+            )
+        except Exception:
+            logger.debug("Signal: failed to resolve group allowlist names", exc_info=True)
+            return
+        if not isinstance(groups, list):
+            return
+
+        group_name_to_ids: Dict[str, set[str]] = {}
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            group_id = str(group.get("id") or "").strip()
+            group_name = str(group.get("name") or "").strip()
+            if not group_id or not group_name:
+                continue
+            group_name_to_ids.setdefault(group_name, set()).update({
+                group_id,
+                f"group:{group_id}",
+            })
+
+        resolved_group_ids: set[str] = set()
+        resolved_free_response_ids: set[str] = set()
+        for configured_name, ids in group_name_to_ids.items():
+            if configured_name in self.group_allow_from:
+                resolved_group_ids.update(ids)
+            if configured_name in self.free_response_groups:
+                resolved_free_response_ids.update(ids)
+        if resolved_group_ids:
+            self.group_allow_from.update(resolved_group_ids)
+        if resolved_free_response_ids:
+            self.free_response_groups.update(resolved_free_response_ids)
+        if resolved_group_ids or resolved_free_response_ids:
+            logger.info(
+                "Signal: resolved %d group allow/free-response name entr%s to group ids",
+                len(resolved_group_ids | resolved_free_response_ids),
+                "y" if len(resolved_group_ids | resolved_free_response_ids) == 1 else "ies",
+            )
 
     # ------------------------------------------------------------------
     # SSE Streaming (inbound messages)
@@ -455,7 +581,11 @@ class SignalAdapter(BasePlatformAdapter):
                     dest = sent_msg.get("destinationNumber") or sent_msg.get("destination")
                     sent_ts = sent_msg.get("timestamp")
                     sent_msg_group_info = sent_msg.get("groupInfo") or {}
-                    sent_msg_group_id = sent_msg_group_info.get("groupId") if sent_msg_group_info else None
+                    sent_msg_group_v2 = sent_msg.get("groupV2") or {}
+                    sent_msg_group_id = (
+                        (sent_msg_group_v2.get("id") if isinstance(sent_msg_group_v2, dict) else None)
+                        or (sent_msg_group_info.get("groupId") if isinstance(sent_msg_group_info, dict) else None)
+                    )
                     if dest == self._account_normalized or sent_msg_group_id:
                         # Check if this is an echo of our own outbound reply
                         if sent_ts and sent_ts in self._recent_sent_timestamps:
@@ -500,29 +630,31 @@ class SignalAdapter(BasePlatformAdapter):
 
         # Check for group message.
         # Modern Signal groups surface on dataMessage.groupV2.id; legacy V1
-        # groups still arrive under dataMessage.groupInfo.groupId. signal-cli
-        # versions differ in which field they expose for V2 groups — some
-        # forward the underlying libsignal envelope verbatim (groupV2), others
-        # normalize everything into groupInfo. Read groupV2 first and fall
-        # back to groupInfo so V2-only groups aren't misrouted as DMs.
+        # groups still arrive under dataMessage.groupInfo.groupId.
         group_info = data_message.get("groupInfo")
         group_v2 = data_message.get("groupV2")
         group_id = (
             (group_v2.get("id") if isinstance(group_v2, dict) else None)
             or (group_info.get("groupId") if isinstance(group_info, dict) else None)
         )
+        group_name = (
+            (group_v2.get("name") if isinstance(group_v2, dict) else None)
+            or (group_info.get("groupName") if isinstance(group_info, dict) else None)
+        )
         is_group = bool(group_id)
 
         # Group message filtering — derived from SIGNAL_GROUP_ALLOWED_USERS:
         # - No env var set → groups disabled (default safe behavior)
-        # - Env var set with group IDs → only those groups allowed
+        # - Env var set with group IDs or names → only those groups allowed
         # - Env var set with "*" → all groups allowed
         # DM auth is fully handled by run.py (_is_user_authorized)
         if is_group:
-            if not self.group_allow_from:
-                logger.debug("Signal: ignoring group message (no SIGNAL_GROUP_ALLOWED_USERS)")
-                return
-            if "*" not in self.group_allow_from and group_id not in self.group_allow_from:
+            group_allow_keys = {group_id, f"group:{group_id}"}
+            if group_name:
+                group_allow_keys.add(str(group_name))
+            if "*" not in self.group_allow_from and not (
+                group_allow_keys & self.group_allow_from
+            ):
                 logger.debug("Signal: group %s not in allowlist", group_id[:8] if group_id else "?")
                 return
 
@@ -536,22 +668,47 @@ class SignalAdapter(BasePlatformAdapter):
         if text and mentions:
             text = _render_mentions(text, mentions)
 
+        # Command bypass: if user sent a slash command, process even when
+        # mention-only mode is enabled.
+        is_command = bool(text and text.lstrip().startswith("/"))
+
         # Mention filter: in groups, only process messages that @mention the bot account
-        if is_group and self.require_mention:
+        if is_group and self.require_mention and not is_command:
             account_norm = self._account_normalized
-            # Check rendered mention tags OR raw mention metadata
-            mentioned_in_text = account_norm and (
-                f"@{account_norm}" in (text or "")
-            )
+            account_raw = self.account
+            account_redacted = redact_phone(account_raw)
+            account_candidates = {
+                candidate for candidate in (
+                    self._account_identifiers | {account_norm, account_raw, account_redacted}
+                ) if candidate
+            }
+            text_lower = (text or "").lower()
+            alias_candidates = {
+                alias for alias in self.mention_aliases if alias
+            }
+            # Check rendered mention tags OR raw mention metadata. Signal's
+            # rendered text can include either the account number or a local
+            # contact/display alias (for example "@hermes"), depending on how
+            # the sender has named the linked device in their contacts.
+            mentioned_in_text = bool((text or "") and (
+                any(a and f"@{a}" in text for a in account_candidates)
+                or any(f"@{alias}" in text_lower for alias in alias_candidates)
+            ))
             mentioned_in_metadata = any(
-                m.get("number") == account_norm or m.get("uuid") == account_norm
+                (m.get("number") in account_candidates) or (m.get("uuid") in account_candidates)
                 for m in (data_message.get("mentions") or [])
             )
             if not mentioned_in_text and not mentioned_in_metadata:
-                logger.debug(
-                    "Signal: ignoring group message (require_mention=true, bot not mentioned)"
+                is_free_response_group = "*" in self.free_response_groups or bool(
+                    {group_id, f"group:{group_id}", str(group_name or "")}
+                    & self.free_response_groups
                 )
-                return
+                if not is_free_response_group:
+                    logger.debug(
+                        "Signal: ignoring group message (require_mention=true, bot not mentioned)"
+                    )
+                    return
+
 
         # Extract quote (reply-to) context from Signal dataMessage
         quote_data = data_message.get("quote") or {}

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1,12 +1,13 @@
 """Tests for Signal messenger platform adapter."""
 import asyncio
 import base64
+import os
 import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch, AsyncMock
 from urllib.parse import quote
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 
 @pytest.fixture(autouse=True)
@@ -41,7 +42,7 @@ def _stub_rpc(return_value):
     """Return an async mock for SignalAdapter._rpc that captures call params."""
     captured = []
 
-    async def mock_rpc(method, params, rpc_id=None):
+    async def mock_rpc(method, params, rpc_id=None, **kwargs):
         captured.append({"method": method, "params": dict(params)})
         return return_value
 
@@ -55,7 +56,7 @@ def _stub_rpc(return_value):
 class TestSignalConfigLoading:
     def test_apply_env_overrides_signal(self, monkeypatch):
         monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
-        monkeypatch.setenv("SIGNAL_ACCOUNT", "+15551234567")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+155****4567")
 
         from gateway.config import GatewayConfig, _apply_env_overrides
         config = GatewayConfig()
@@ -65,7 +66,7 @@ class TestSignalConfigLoading:
         sc = config.platforms[Platform.SIGNAL]
         assert sc.enabled is True
         assert sc.extra["http_url"] == "http://localhost:9090"
-        assert sc.extra["account"] == "+15551234567"
+        assert sc.extra["account"] == "+155****4567"
 
     def test_signal_not_loaded_without_both_vars(self, monkeypatch):
         monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
@@ -76,6 +77,46 @@ class TestSignalConfigLoading:
         _apply_env_overrides(config)
 
         assert Platform.SIGNAL not in config.platforms
+
+    def test_yaml_bridges_signal_require_mention_and_free_response_groups(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "signal:\n"
+            "  require_mention: true\n"
+            "  free_response_groups:\n"
+            "    - group-a\n"
+            "    - group-b\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("SIGNAL_REQUIRE_MENTION", raising=False)
+        monkeypatch.delenv("SIGNAL_FREE_RESPONSE_GROUPS", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("SIGNAL_REQUIRE_MENTION") == "true"
+        assert os.environ.get("SIGNAL_FREE_RESPONSE_GROUPS") == "group-a,group-b"
+
+    def test_yaml_does_not_override_signal_require_mention_env(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "signal:\n"
+            "  require_mention: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("SIGNAL_REQUIRE_MENTION", "false")
+
+        load_gateway_config()
+
+        assert os.environ.get("SIGNAL_REQUIRE_MENTION") == "false"
+
 
 # ---------------------------------------------------------------------------
 # Adapter Init & Helpers
@@ -1824,7 +1865,7 @@ class TestSignalGroupV2Routing:
 
     @pytest.mark.asyncio
     async def test_group_v2_id_routes_as_group(self, monkeypatch):
-        adapter = _make_signal_adapter(monkeypatch, group_allowed="*")
+        adapter = _make_signal_adapter(monkeypatch, group_allowed="*", require_mention=False)
         captured = []
 
         async def _capture(event):
@@ -1845,8 +1886,39 @@ class TestSignalGroupV2Routing:
         assert captured[0].text == "hello v2"
 
     @pytest.mark.asyncio
+    async def test_sync_sent_group_v2_routes_as_group(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, group_allowed="*", require_mention=False)
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "+155****4567",
+                "sourceName": "Alice",
+                "sourceUuid": "sender-uuid",
+                "timestamp": 1700000000000,
+                "syncMessage": {
+                    "sentMessage": {
+                        "timestamp": 1700000000000,
+                        "message": "hello sync v2",
+                        "groupV2": {"id": "sync-v2=="},
+                    }
+                },
+            }
+        })
+
+        assert len(captured) == 1
+        assert captured[0].source.chat_id == "group:sync-v2=="
+        assert captured[0].source.chat_type == "group"
+        assert captured[0].text == "hello sync v2"
+
+    @pytest.mark.asyncio
     async def test_legacy_group_info_still_works(self, monkeypatch):
-        adapter = _make_signal_adapter(monkeypatch, group_allowed="*")
+        adapter = _make_signal_adapter(monkeypatch, group_allowed="*", require_mention=False)
         captured = []
 
         async def _capture(event):
@@ -1866,9 +1938,138 @@ class TestSignalGroupV2Routing:
         assert captured[0].source.chat_type == "group"
 
     @pytest.mark.asyncio
+    async def test_mention_required_for_groups_by_default(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            group_allowed="g-mentions==",
+            require_mention=True,
+        )
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+
+        # Missing mention must be ignored.
+        await adapter._handle_envelope(self._base_envelope({
+            "message": "hello everyone",
+            "groupV2": {"id": "g-mentions=="},
+        }))
+        assert len(captured) == 0
+
+        # Mentioned-by-metadata message should be delivered.
+        await adapter._handle_envelope(self._base_envelope({
+            "message": "hi \uFFFC",
+            "groupV2": {"id": "g-mentions=="},
+            "mentions": [
+                {
+                    "start": 3,
+                    "length": 1,
+                    "number": "+155****4567",
+                    "uuid": "05668cf3-8ffa-467e-9b24-f5eefa5cf475",
+                },
+            ],
+        }))
+
+        assert len(captured) == 1
+        assert captured[0].text == "hi @+155****4567"
+
+    @pytest.mark.asyncio
+    async def test_mention_required_accepts_account_uuid_metadata(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            group_allowed="g-mentions==",
+            require_mention=True,
+        )
+        adapter._account_identifiers.add("bot-account-uuid")
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+
+        await adapter._handle_envelope(self._base_envelope({
+            "message": "hi \uFFFC",
+            "groupV2": {"id": "g-mentions=="},
+            "mentions": [{"start": 3, "length": 1, "uuid": "bot-account-uuid"}],
+        }))
+
+        assert len(captured) == 1
+        assert captured[0].text == "hi @bot-account-uuid"
+
+    @pytest.mark.asyncio
+    async def test_plain_hermes_alias_satisfies_group_require_mention(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            group_allowed="g-mentions==",
+            require_mention=True,
+        )
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+
+        await adapter._handle_envelope(self._base_envelope({
+            "message": "@hermes are you there?",
+            "groupV2": {"id": "g-mentions=="},
+        }))
+
+        assert len(captured) == 1
+        assert captured[0].text == "@hermes are you there?"
+
+    @pytest.mark.asyncio
+    async def test_command_bypasses_group_require_mention(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            group_allowed="g-commands==",
+            require_mention=True,
+        )
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+
+        await adapter._handle_envelope(self._base_envelope({
+            "message": "/help",
+            "groupV2": {"id": "g-commands=="},
+        }))
+
+        assert len(captured) == 1
+        assert captured[0].text == "/help"
+
+    @pytest.mark.asyncio
+    async def test_free_response_group_bypasses_mention_filter(self, monkeypatch):
+        adapter = _make_signal_adapter(
+            monkeypatch,
+            group_allowed="g-free==",
+            free_response_groups="g-free==",
+            require_mention=True,
+        )
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+
+        await adapter._handle_envelope(self._base_envelope({
+            "message": "status update",
+            "groupV2": {"id": "g-free=="},
+        }))
+
+        assert len(captured) == 1
+        assert captured[0].text == "status update"
+
+    @pytest.mark.asyncio
     async def test_group_v2_preferred_over_group_info(self, monkeypatch):
         """When both fields are present, groupV2 wins — it's the authoritative V2 id."""
-        adapter = _make_signal_adapter(monkeypatch, group_allowed="*")
+        adapter = _make_signal_adapter(monkeypatch, group_allowed="*", require_mention=False)
         captured = []
 
         async def _capture(event):
@@ -1903,12 +2104,14 @@ class TestSignalGroupV2Routing:
 
         assert len(captured) == 1
         assert captured[0].source.chat_type == "dm"
-        assert captured[0].source.chat_id == "+15559998888"
+        assert captured[0].source.chat_id == captured[0].source.user_id
+        assert captured[0].source.user_id.endswith("8888")
+
 
     @pytest.mark.asyncio
     async def test_group_v2_respects_allowlist(self, monkeypatch):
         """V2 group ids flow through the same SIGNAL_GROUP_ALLOWED_USERS filter."""
-        adapter = _make_signal_adapter(monkeypatch, group_allowed="allowed-v2==")
+        adapter = _make_signal_adapter(monkeypatch, group_allowed="allowed-v2==", require_mention=False)
         captured = []
 
         async def _capture(event):
@@ -1930,6 +2133,49 @@ class TestSignalGroupV2Routing:
         }))
         assert len(captured) == 1
         assert captured[0].source.chat_id == "group:allowed-v2=="
+
+    @pytest.mark.asyncio
+    async def test_group_allowlist_accepts_group_names(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, group_allowed="AgentChat", require_mention=False)
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+
+        await adapter._handle_envelope(self._base_envelope({
+            "message": "allowed by name",
+            "groupV2": {"id": "agent-chat-v2==", "name": "AgentChat"},
+        }))
+
+        assert len(captured) == 1
+        assert captured[0].source.chat_id == "group:agent-chat-v2=="
+
+    @pytest.mark.asyncio
+    async def test_group_allowlist_names_resolve_to_ids_on_connect(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, group_allowed="AgentChat", require_mention=False)
+        adapter._rpc = AsyncMock(return_value=[
+            {"id": "resolved-agent-chat==", "name": "AgentChat"},
+        ])
+
+        await adapter._resolve_group_allowlist_names()
+
+        assert "resolved-agent-chat==" in adapter.group_allow_from
+        assert "group:resolved-agent-chat==" in adapter.group_allow_from
+
+    @pytest.mark.asyncio
+    async def test_account_identifier_resolution_adds_account_uuid(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, account="+155****4567")
+        adapter._rpc = AsyncMock(return_value=[
+            {"number": "+155****4567", "uuid": "account-uuid"},
+            {"number": "+155****9999", "uuid": "other-uuid"},
+        ])
+
+        await adapter._resolve_account_identifiers()
+
+        assert "account-uuid" in adapter._account_identifiers
+        assert "other-uuid" not in adapter._account_identifiers
 
     @pytest.mark.asyncio
     async def test_malformed_group_fields_fall_through_to_dm(self, monkeypatch):


### PR DESCRIPTION
## Summary
- Add config bridge for `signal.free_response_groups` from YAML to `SIGNAL_FREE_RESPONSE_GROUPS` in `load_gateway_config()`.
- Respect `free_response_groups` in `SignalAdapter` group mention filtering.
- Preserve command handling in group require-mention mode (slash commands bypass the mention gate).
- Keep group routing robust across `groupV2`/`groupInfo`, including sent-message sync envelopes from linked devices.
- Accept Signal group allowlist entries by group ID, `group:<id>`, or group name, and resolve configured names to group ids at connect time for configs like `SIGNAL_GROUP_ALLOWED_USERS=AgentChat`.
- Resolve the local Signal account UUID and accept UUID-based mention metadata, in addition to rendered number mentions/metadata.
- Accept plain Signal display aliases such as `@hermes` for group mention gating.
- Expand Signal tests for new behavior and confirm existing behavior with group routing paths.

## Validation
- `uv run python -m pytest tests/gateway/test_signal.py tests/gateway/test_config.py`
- Result: 172 passed
- Live local gateway reloaded and verified against Signal `AgentChat`; inbound `@hermes hello` messages were processed and answered in the group.

Closes #13478
