### PR TITLE
fix(notifications): event-driven TUI adapter, interrupt wait, queue drain

### DIFF
--- a/gateway/platforms/tui_adapter.py
+++ b/gateway/platforms/tui_adapter.py
@@ -1,0 +1,106 @@
+"""HTTP-based platform adapter for TUI/CLI notification delivery.
+
+This adapter registers with the gateway's adapter system so that
+_kanban_notifier_watcher (and any other gateway-side event source) can
+deliver events to connected TUI/CLI sessions via ``adapter.send()``.
+
+Unlike the previous file-based adapter that polled a JSON-lines file,
+this adapter POSTs events directly to the TUI server's HTTP endpoint.
+Event-driven — no polling, no files, no queues.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+logger = logging.getLogger(__name__)
+
+_HERMES_HOME = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+_PORT_FILE = _HERMES_HOME / "tui_notify_port"
+
+
+def _read_tui_port() -> int:
+    """Read the TUI notification HTTP port from the port file."""
+    try:
+        return int(_PORT_FILE.read_text().strip())
+    except (OSError, ValueError):
+        return 0
+
+
+def _post_event(chat_id: str, content: str, metadata: dict | None = None) -> None:
+    """POST a notification event to the TUI server's HTTP endpoint."""
+    port = _read_tui_port()
+    if not port:
+        logger.debug("tui_adapter: TUI notification port not found")
+        return
+    payload = json.dumps({
+        "chat_id": chat_id,
+        "content": content,
+        "metadata": metadata or {},
+    }, ensure_ascii=False).encode("utf-8")
+    try:
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/notify",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            resp.read()
+    except Exception as exc:
+        logger.debug("tui_adapter: POST failed: %s", exc)
+
+
+class TUIAdapter(BasePlatformAdapter):
+    """Platform adapter that delivers messages via HTTP POST to the TUI.
+
+    The gateway's kanban notifier calls ``adapter.send(chat_id, msg)``
+    which POSTs the event to the TUI server's local HTTP endpoint.
+    The TUI server dispatches events directly to active sessions.
+    """
+
+    def __init__(self, config: PlatformConfig, platform: Platform):
+        super().__init__(config, platform)
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """POST the event to the TUI server."""
+        try:
+            _post_event(chat_id, content, metadata)
+            return SendResult(success=True)
+        except Exception as exc:
+            logger.warning("tui_adapter: POST failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    async def connect(self) -> bool:
+        """No external connection needed — HTTP POST only."""
+        self._running = True
+        return True
+
+    async def disconnect(self) -> None:
+        """No external connection to tear down."""
+        self._running = False
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Return minimal chat info for the TUI platform."""
+        return {"chat_id": chat_id, "platform": "tui", "type": "direct"}
+
+    async def start(self) -> None:
+        """No external connection needed — HTTP POST only."""
+        self._running = True
+
+    async def stop(self) -> None:
+        self._running = False

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -111,7 +111,9 @@ async def test_runner_allows_cron_only_mode_when_no_platforms_are_enabled(monkey
 
     assert ok is True
     assert runner.should_exit_cleanly is False
-    assert runner.adapters == {}
+    # TUI/CLI adapters are always registered for kanban delivery;
+    # only external platform adapters should be absent.
+    assert {k for k in runner.adapters} <= {Platform("tui"), Platform("cli")}
     state = read_runtime_status()
     assert state["gateway_state"] == "running"
 
@@ -447,7 +449,9 @@ async def test_runner_degrades_gracefully_when_all_adapters_missing(monkeypatch,
     # Must NOT return False — gateway should keep running for cron.
     assert ok is True
     assert runner.should_exit_cleanly is False
-    assert runner.adapters == {}
+    # TUI/CLI adapters are always registered for kanban delivery;
+    # only external platform adapters should be absent.
+    assert {k for k in runner.adapters} <= {Platform("tui"), Platform("cli")}
     # Runtime state must remain "running", not "startup_failed".
     state = read_runtime_status()
     assert state["gateway_state"] == "running"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2,7 +2,6 @@ import atexit
 import concurrent.futures
 import contextvars
 import copy
-import inspect
 import json
 import logging
 import os
@@ -14,15 +13,10 @@ import time
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
-from hermes_constants import (
-    get_hermes_home,
-    get_hermes_home_override,
-    reset_hermes_home_override,
-    set_hermes_home_override,
-)
 from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_constants import get_hermes_home
 from utils import is_truthy_value
 from tui_gateway.transport import (
     StdioTransport,
@@ -135,32 +129,162 @@ _prompt_lock = threading.Lock()
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _cfg_path = None
-_session_resume_lock = threading.Lock()
 try:
     _slash_timeout = float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S") or "45")
 except (ValueError, TypeError):
     _slash_timeout = 45.0
 _SLASH_WORKER_TIMEOUT_S = max(5.0, _slash_timeout)
-
-# When a WebSocket client (the dashboard's embedded-chat tab / desktop app)
-# disconnects, ``tui_gateway.ws`` detaches the transport but intentionally
-# leaves the session parked so a quick reconnect can reattach it (see ws.py).
-# That park is unbounded, though: a browser refresh spins up a brand-new
-# ``session.create`` (new sid + a fresh _SlashWorker via _deferred_build) and
-# never reattaches the OLD sid, so the old session's slash-worker subprocess
-# lingers forever — one leaked python process per refresh (#38591 fallout).
-# After this grace window, an orphaned (transport-detached, not-running) WS
-# session is reaped: its _SlashWorker is closed and the session finalized.
-# Set to 0 to disable (park forever, pre-fix behaviour).
-try:
-    _ws_orphan_reap_grace = float(
-        os.environ.get("HERMES_TUI_WS_ORPHAN_REAP_GRACE_S") or "20"
-    )
-except (ValueError, TypeError):
-    _ws_orphan_reap_grace = 20.0
-_WS_ORPHAN_REAP_GRACE_S = max(0.0, _ws_orphan_reap_grace)
 _DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
 _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
+# ── Kanban→TUI notification bridge ──────────────────────────────
+# The gateway's _kanban_notifier_watcher delivers terminal kanban events
+# via the TUI platform adapter, which POSTs them to a local HTTP
+# endpoint on the TUI server.  The endpoint dispatches events directly
+# to active sessions — event-driven, no polling, no queues, no files.
+
+
+def _format_kanban_event(ev, task_id: str) -> "str | None":
+    """Format a kanban event into an ``[IMPORTANT: ...]`` message.
+
+    Uses upstream's Event object attributes (``ev.kind``, ``ev.payload``).
+    """
+    kind = ev.kind if hasattr(ev, "kind") else ev.get("kind", "")
+    payload = ev.payload if hasattr(ev, "payload") else (ev.get("payload") or {})
+    if payload is None:
+        payload = {}
+
+    if kind == "completed":
+        handoff = ""
+        if payload.get("summary"):
+            h = str(payload["summary"]).strip().splitlines()[0][:200]
+            handoff = f"\n{h}"
+        return f"[IMPORTANT: Kanban task {task_id} done{handoff}]"
+    elif kind == "blocked":
+        reason = ""
+        if payload.get("reason"):
+            reason = f": {str(payload['reason'])[:160]}"
+        return f"[IMPORTANT: Kanban task {task_id} blocked{reason}]"
+    elif kind == "crashed":
+        return (
+            f"[IMPORTANT: Kanban task {task_id} worker crashed;"
+            " dispatcher will retry]"
+        )
+    elif kind == "timed_out":
+        limit = int(payload.get("limit_seconds", 0)) if payload else 0
+        return (
+            f"[IMPORTANT: Kanban task {task_id} timed out"
+            f" (max_runtime={limit}s); will retry]"
+        )
+    elif kind == "gave_up":
+        err = ""
+        if payload.get("error"):
+            err = f"\n{str(payload['error'])[:200]}"
+        return (
+            f"[IMPORTANT: Kanban task {task_id} gave up after"
+            f" repeated spawn failures{err}]"
+        )
+    return None
+
+
+def _format_kanban_event_from_payload(
+    kind: str, task_id: str, payload: dict,
+) -> "str | None":
+    """Format a kanban event from raw kind/payload into ``[IMPORTANT: ...]``.
+
+    Same logic as _format_kanban_event but takes raw values instead of
+    an Event object.  Used for events pushed through the completion_queue
+    by _notify_kanban_event in kanban_db.py.
+    """
+    if kind == "completed":
+        handoff = ""
+        if payload.get("summary"):
+            h = str(payload["summary"]).strip().splitlines()[0][:200]
+            handoff = f"\n{h}"
+        return f"[IMPORTANT: Kanban task {task_id} done{handoff}]"
+    elif kind == "blocked":
+        reason = ""
+        if payload.get("reason"):
+            reason = f": {str(payload['reason'])[:160]}"
+        return f"[IMPORTANT: Kanban task {task_id} blocked{reason}]"
+    elif kind == "crashed":
+        return (
+            f"[IMPORTANT: Kanban task {task_id} worker crashed;"
+            " dispatcher will retry]"
+        )
+    elif kind == "timed_out":
+        limit = int(payload.get("limit_seconds", 0)) if payload else 0
+        return (
+            f"[IMPORTANT: Kanban task {task_id} timed out"
+            f" (max_runtime={limit}s); will retry]"
+        )
+    elif kind == "gave_up":
+        err = ""
+        if payload.get("error"):
+            err = f"\n{str(payload['error'])[:200]}"
+        return (
+            f"[IMPORTANT: Kanban task {task_id} gave up after"
+            f" repeated spawn failures{err}]"
+        )
+    return None
+
+
+# Kanban→TUI delivery bridge: events from the gateway's TUI adapter
+# are dispatched directly to active sessions via push_kanban_event.
+
+
+def push_kanban_event(task_id: str, kind: str, payload: dict) -> None:
+    """Receive a kanban event from the gateway's TUI adapter.
+
+    Called by TUIAdapter delivery callback when the gateway's
+    _kanban_notifier_watcher delivers a terminal kanban event.
+    Dispatches directly to all active TUI sessions (event-driven,
+    no polling, no queues).
+    """
+    for _sid, _session in list(_sessions.items()):
+        try:
+            _dispatch_kanban_to_session(_sid, _session, task_id, kind, payload)
+        except Exception:
+            pass
+
+
+def _on_process_event(evt: dict) -> None:
+    """Event-driven handler for process_registry completion events.
+
+    Registered as process_registry._completion_callback at session init.
+    Dispatches completion/watch events directly to active sessions.
+    """
+    evt_type = evt.get("type", "")
+    if evt_type == "kanban_event":
+        push_kanban_event(
+            evt.get("task_id", ""),
+            evt.get("kind", ""),
+            evt.get("payload") or {},
+        )
+        return
+    # For non-kanban events (completion, watch_match, etc.), dispatch
+    # to all active sessions as status updates.
+    from tools.process_registry import format_process_notification
+    text = format_process_notification(evt)
+    if not text:
+        return
+    for _sid, _session in list(_sessions.items()):
+        try:
+            with _session["history_lock"]:
+                if _session.get("running"):
+                    _session.setdefault("_pending_kanban", []).append(text)
+                    _emit("status.update", _sid, {"kind": "process", "text": text})
+                    continue
+                _session["running"] = True
+            _rid = f"__notif__{int(time.time() * 1000)}"
+            try:
+                _emit("message.start", _sid)
+                _run_prompt_submit(_rid, _sid, _session, text)
+            except Exception:
+                with _session["history_lock"]:
+                    _session["running"] = False
+        except Exception:
+            pass
+
 
 # ── Async RPC dispatch (#12546) ──────────────────────────────────────
 # A handful of handlers block the dispatcher loop in entry.py for seconds
@@ -177,6 +301,7 @@ _LONG_HANDLERS = frozenset(
         "cli.exec",
         "session.branch",
         "session.compress",
+        "session.interrupt",
         "session.resume",
         "shell.exec",
         "skills.manage",
@@ -228,10 +353,11 @@ class _SlashWorker:
     """Persistent HermesCLI subprocess for slash commands."""
 
     def __init__(self, session_key: str, model: str):
-        self._lock = threading.Lock()
+        self._write_lock = threading.Lock()   # serialises stdin writes
+        self._resp_lock = threading.Lock()    # protects _responses dict
         self._seq = 0
         self.stderr_tail: list[str] = []
-        self.stdout_queue: queue.Queue[dict | None] = queue.Queue()
+        self._responses: dict[int, queue.Queue] = {}
 
         argv = [
             sys.executable,
@@ -260,10 +386,19 @@ class _SlashWorker:
     def _drain_stdout(self):
         for line in self.proc.stdout or []:
             try:
-                self.stdout_queue.put(json.loads(line))
+                msg = json.loads(line)
             except json.JSONDecodeError:
                 continue
-        self.stdout_queue.put(None)
+            rid = msg.get("id")
+            if rid is not None:
+                with self._resp_lock:
+                    q = self._responses.get(rid)
+                if q is not None:
+                    q.put(msg)
+        # Pipe closed — wake every waiter so they see the EOF.
+        with self._resp_lock:
+            for q in self._responses.values():
+                q.put(None)
 
     def _drain_stderr(self):
         for line in self.proc.stderr or []:
@@ -274,21 +409,24 @@ class _SlashWorker:
         if self.proc.poll() is not None:
             raise RuntimeError("slash worker exited")
 
-        with self._lock:
+        # Per-request queue: drain_stdout routes by id into this queue.
+        rq: queue.Queue = queue.Queue()
+        with self._write_lock:
             self._seq += 1
             rid = self._seq
+            with self._resp_lock:
+                self._responses[rid] = rq
             self.proc.stdin.write(json.dumps({"id": rid, "command": command}) + "\n")
             self.proc.stdin.flush()
 
+        try:
             while True:
                 try:
-                    msg = self.stdout_queue.get(timeout=_SLASH_WORKER_TIMEOUT_S)
+                    msg = rq.get(timeout=_SLASH_WORKER_TIMEOUT_S)
                 except queue.Empty:
                     raise RuntimeError("slash worker timed out")
                 if msg is None:
                     break
-                if msg.get("id") != rid:
-                    continue
                 if not msg.get("ok"):
                     raise RuntimeError(msg.get("error", "slash worker failed"))
                 return str(msg.get("output", "")).rstrip()
@@ -296,6 +434,9 @@ class _SlashWorker:
             raise RuntimeError(
                 f"slash worker closed pipe{': ' + chr(10).join(self.stderr_tail[-8:]) if self.stderr_tail else ''}"
             )
+        finally:
+            with self._resp_lock:
+                self._responses.pop(rid, None)
 
     def close(self):
         if getattr(self, "_closed", False):
@@ -345,44 +486,11 @@ def _notify_session_boundary(event_type: str, session_id: str | None) -> None:
         pass
 
 
-def _claim_active_session_slot(
-    session_key: str,
-    *,
-    live_session_id: str,
-    surface: str = "tui",
-) -> tuple[Any, str | None]:
-    try:
-        from hermes_cli.active_sessions import try_acquire_active_session
-
-        return try_acquire_active_session(
-            session_id=session_key,
-            surface=surface,
-            config=_load_cfg(),
-            metadata={"live_session_id": live_session_id},
-        )
-    except Exception as exc:
-        logger.warning("Failed to claim active session slot: %s", exc)
-        return None, None
-
-
-def _release_active_session_slot(session: dict | None) -> None:
-    if not session:
-        return
-    lease = session.pop("active_session_lease", None)
-    if lease is None:
-        return
-    try:
-        lease.release()
-    except Exception:
-        logger.debug("Failed to release active session slot", exc_info=True)
-
-
 def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> None:
     """Best-effort finalize hook + memory commit for a session."""
     if not session or session.get("_finalized"):
         return
     session["_finalized"] = True
-    _release_active_session_slot(session)
     stop_event = session.get("_notif_stop")
     if stop_event is not None:
         stop_event.set()
@@ -662,31 +770,6 @@ def _db_unavailable_error(rid, *, code: int):
     return _err(rid, code, f"state.db unavailable: {detail}")
 
 
-# ── per-session profile scoping (global remote mode) ───────────────────────────
-# One dashboard normally serves its launch profile. But the desktop's app-global
-# remote mode points every profile at this single backend, so resume/prompt must
-# be able to act on ANOTHER local profile's state.db + home. The desktop passes
-# ``profile`` on those calls; we open that profile's db and bind its HERMES_HOME
-# (a ContextVar override) for the duration of the call so config/skills/model and
-# message persistence all resolve to the right profile. Omitted/own profile → the
-# launch profile (unchanged for single-profile and per-profile-remote setups).
-def _profile_home(profile: str | None) -> Path | None:
-    """Resolve a named profile's home on THIS host, or None for the launch profile."""
-    name = (profile or "").strip()
-    if not name:
-        return None
-    try:
-        from hermes_cli import profiles as profiles_mod
-
-        home = Path(profiles_mod.get_profile_dir(name))
-    except Exception:
-        return None
-    # Already the launch profile? No override needed.
-    if home.resolve() == Path(_hermes_home).resolve():
-        return None
-    return home if (home / "state.db").exists() or home.exists() else None
-
-
 def write_json(obj: dict) -> bool:
     """Emit one JSON frame. Routes via the most-specific transport available.
 
@@ -869,32 +952,17 @@ def _start_agent_build(sid: str, session: dict) -> None:
     key = session["session_key"]
 
     def _build() -> None:
-        with _sessions_lock:
-            current = _sessions.get(sid)
+        current = _sessions.get(sid)
         if current is None:
             ready.set()
             return
 
         worker = None
         notify_registered = False
-        home_token = None
-        profile_home = current.get("profile_home")
         try:
             tokens = _set_session_context(key)
-            # Build against the session's profile (global-remote): bind its
-            # HERMES_HOME so config/skills/model resolve to it, and hand the
-            # agent that profile's db so turns persist to the right state.db.
-            session_db = None
-            if profile_home:
-                home_token = set_hermes_home_override(profile_home)
-                try:
-                    from hermes_state import SessionDB
-
-                    session_db = SessionDB(db_path=Path(profile_home) / "state.db")
-                except Exception:
-                    session_db = None
             try:
-                agent = _make_agent(sid, key, session_db=session_db)
+                agent = _make_agent(sid, key)
             finally:
                 _clear_session_context(tokens)
 
@@ -919,30 +987,38 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 )
                 notify_registered = True
                 load_permanent_allowlist()
-            except Exception:
+            except ImportError:
                 pass
 
             _wire_callbacks(sid)
-            # Hydrate credits notices at session OPEN (not just on the first
-            # message), so depletion / usage-band warnings show at "ready". Runs
-            # off the build thread, after the notice_callback is wired. Fail-open.
-            try:
-                from agent.credits_tracker import seed_credits_at_session_start
-
-                seed_credits_at_session_start(agent)
-            except Exception:
-                pass
-            with _sessions_lock:
-                if sid in _sessions:
-                    _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
+            _sessions[sid]["_notif_stop"] = threading.Event()
+            # Register event-driven callback for process completions
+            from tools.process_registry import process_registry
+            process_registry._completion_callback = _on_process_event
             _notify_session_boundary("on_session_reset", key)
 
-            info = _session_info(agent, current)
+            info = _session_info(agent)
+            warn = _probe_credentials(agent)
+            if warn:
+                info["credential_warning"] = warn
             cfg_warn = _probe_config_health(_load_cfg())
             if cfg_warn:
                 info["config_warning"] = cfg_warn
                 logger.warning(cfg_warn)
             _emit("session.info", sid, info)
+            # Ensure loop manager for this session (idempotent).
+            # The slash_worker persisted state to SessionDB; this
+            # LoopManager with TUI dispatch picks up the ticking.
+            if "_loop_manager" not in current:
+                try:
+                    from hermes_cli.loop import LoopManager
+                    lk = current.get("session_key") or sid
+                    current["_loop_manager"] = LoopManager(
+                        session_id=lk,
+                        dispatch=_make_tui_dispatch(current, sid),
+                    )
+                except ImportError:
+                    pass
         except Exception as e:
             current["agent_error"] = str(e)
             _emit("error", sid, {"message": f"agent init failed: {e}"})
@@ -964,6 +1040,28 @@ def _start_agent_build(sid: str, session: dict) -> None:
             ready.set()
 
     threading.Thread(target=_build, daemon=True).start()
+
+
+def _make_tui_dispatch(session: dict, sid: str) -> Callable[[str], bool]:
+    """Return a dispatch callback that injects loop prompts via _run_prompt_submit.
+
+    The callback returns True if the prompt was submitted, False if the
+    session is busy and the ticker should retry next tick.
+    """
+    def _dispatch(prompt: str) -> bool:
+        with session["history_lock"]:
+            if session.get("running"):
+                return False
+            session["running"] = True
+        try:
+            _emit("message.start", sid)
+            _run_prompt_submit(None, sid, session, prompt)
+            return True
+        except Exception:
+            with session["history_lock"]:
+                session["running"] = False
+            return False
+    return _dispatch
 
 
 def _sess_nowait(params, rid):
@@ -993,167 +1091,6 @@ def _normalize_completion_path(path_part: str) -> str:
     return expanded
 
 
-def _completion_cwd(params: dict | None = None) -> str:
-    raw = (
-        (params or {}).get("cwd")
-        or _sessions.get((params or {}).get("session_id") or "", {}).get("cwd")
-        or os.environ.get("TERMINAL_CWD")
-        or os.getcwd()
-    )
-    try:
-        resolved = os.path.abspath(os.path.expanduser(str(raw)))
-        if os.path.isdir(resolved):
-            return resolved
-    except Exception:
-        pass
-    return os.getcwd()
-
-
-def _terminal_task_cwd(session: dict | None) -> str:
-    """Return the cwd that terminal_tool should use for this TUI session.
-
-    ``_completion_cwd`` validates paths on the host so file completion does not
-    point at nonsense.  Non-local terminal backends are different: their cwd is
-    inside the target environment, so an SSH path like /home/user/workspace may
-    not exist on the local macOS host but is still the correct execution cwd.
-    """
-    backend = (os.environ.get("TERMINAL_ENV") or "").strip().lower()
-    if backend and backend != "local":
-        raw = os.environ.get("TERMINAL_CWD", "").strip()
-        if not raw:
-            try:
-                terminal_cfg = _load_cfg().get("terminal", {})
-                if isinstance(terminal_cfg, dict):
-                    raw = str(terminal_cfg.get("cwd") or "").strip()
-            except Exception:
-                raw = ""
-        if raw and raw not in {".", "auto", "cwd"}:
-            return raw
-
-    return _session_cwd(session)
-
-
-def _git_branch_for_cwd(cwd: str) -> str:
-    try:
-        result = subprocess.run(
-            ["git", "-C", cwd, "branch", "--show-current"],
-            capture_output=True,
-            text=True,
-            timeout=1.5,
-            check=False,
-        )
-        if result.returncode == 0:
-            branch = result.stdout.strip()
-            if branch:
-                return branch
-        head = subprocess.run(
-            ["git", "-C", cwd, "rev-parse", "--short", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=1.5,
-            check=False,
-        )
-        return head.stdout.strip() if head.returncode == 0 else ""
-    except Exception:
-        return ""
-
-
-def _session_cwd(session: dict | None) -> str:
-    if session and session.get("cwd"):
-        return str(session["cwd"])
-    return _completion_cwd()
-
-
-def _register_session_cwd(session: dict | None) -> None:
-    if not session:
-        return
-    try:
-        from tools.terminal_tool import register_task_env_overrides
-
-        register_task_env_overrides(
-            session["session_key"], {"cwd": _terminal_task_cwd(session)}
-        )
-    except Exception:
-        pass
-
-
-def _ensure_session_db_row(session: dict) -> None:
-    """Idempotently persist the session's DB row on first real activity.
-
-    Called from prompt.submit so a row only exists once the user actually sends
-    a message — abandoned drafts never leave an empty "Untitled" session behind.
-    Uses INSERT OR IGNORE under the hood, so re-calls (and the AIAgent's own
-    lazy create) are no-ops.
-
-    Only an *explicitly chosen* workspace is persisted as the session's cwd.
-    The agent still runs in the auto-detected directory (session["cwd"]), but
-    we don't stamp that onto the row — otherwise every session the user never
-    picked a folder for gets grouped under whatever directory the desktop
-    happened to launch in (e.g. "desktop"). Leaving it null groups them under
-    "No workspace", which is the desired default.
-    """
-    key = session.get("session_key")
-    if not key:
-        return
-    # Persist into the session's own profile db (global remote mode), not the
-    # launch profile's — otherwise the row lands in the wrong state.db, the
-    # unified list mis-tags it, and resume 404s ("session not found").
-    profile_home = session.get("profile_home")
-    if profile_home:
-        from hermes_state import SessionDB
-
-        try:
-            db = SessionDB(db_path=Path(profile_home) / "state.db")
-        except Exception:
-            logger.debug("failed to open profile db for session row", exc_info=True)
-            return
-        close_db = True
-    else:
-        db = _get_db()
-        close_db = False
-    if db is None:
-        return
-    try:
-        db.create_session(
-            key,
-            source="tui",
-            model=_resolve_model(),
-            cwd=_session_cwd(session) if session.get("explicit_cwd") else None,
-        )
-    except Exception:
-        logger.debug("failed to persist desktop session row", exc_info=True)
-    finally:
-        if close_db:
-            try:
-                db.close()
-            except Exception:
-                pass
-
-
-def _set_session_cwd(session: dict, cwd: str) -> str:
-    resolved = os.path.abspath(os.path.expanduser(str(cwd)))
-    if not os.path.isdir(resolved):
-        raise ValueError(f"working directory does not exist: {cwd}")
-    session["cwd"] = resolved
-    # An explicit user choice — persist it as the workspace (and let a later
-    # lazy row creation persist it too, not the launch-dir fallback).
-    session["explicit_cwd"] = True
-    _register_session_cwd(session)
-    db = _get_db()
-    if db is not None:
-        try:
-            db.update_session_cwd(session.get("session_key", ""), resolved)
-        except Exception:
-            logger.debug("failed to persist session cwd", exc_info=True)
-    try:
-        from tools.terminal_tool import cleanup_vm
-
-        cleanup_vm(session["session_key"])
-    except Exception:
-        pass
-    return resolved
-
-
 # ── Config I/O ────────────────────────────────────────────────────────
 
 
@@ -1169,13 +1106,7 @@ def _load_cfg() -> dict:
     try:
         import yaml
 
-        # Honor a per-session profile override (see session.resume) so a resumed
-        # remote profile loads ITS config (model, skills, prompt); otherwise the
-        # launch profile's _hermes_home. Cache is keyed on the resolved path, so
-        # profiles don't clobber each other.
-        override = get_hermes_home_override()
-        home = override if isinstance(override, str) and override else _hermes_home
-        p = Path(home) / "config.yaml"
+        p = _hermes_home / "config.yaml"
         mtime = p.stat().st_mtime if p.exists() else None
         with _cfg_lock:
             if _cfg_cache is not None and _cfg_mtime == mtime and _cfg_path == p:
@@ -1190,7 +1121,7 @@ def _load_cfg() -> dict:
             _cfg_mtime = mtime
             _cfg_path = p
         return data
-    except Exception:
+    except (FileNotFoundError, yaml.YAMLError, TypeError):
         pass
     return {}
 
@@ -1207,37 +1138,16 @@ def _save_cfg(cfg: dict):
         _cfg_path = path
         try:
             _cfg_mtime = path.stat().st_mtime
-        except Exception:
+        except OSError:
             _cfg_mtime = None
 
 
-def _cwd_for_session_key(session_key: str) -> str:
-    """Reverse-map session_key to the session's logical cwd.
-
-    Snapshots ``_sessions`` first: concurrent RPC handlers mutate it from the
-    thread pool, so iterating the live view risks ``RuntimeError: dictionary
-    changed size during iteration``.
-    """
-    if not session_key:
-        return ""
-    with _sessions_lock:
-        for sess in list(_sessions.values()):
-            if sess.get("session_key") == session_key:
-                return str(sess.get("cwd") or "")
-    return ""
-
-
-def _set_session_context(session_key: str, cwd: str | None = None) -> list:
+def _set_session_context(session_key: str) -> list:
     try:
         from gateway.session_context import set_session_vars
 
-        # Ephemeral task IDs (background, preview) aren't in `_sessions`, so the
-        # reverse-map returns "" and would clear the cwd override. Callers that
-        # know the parent workspace pass it explicitly so spawned agents inherit
-        # it instead of falling back to the gateway launch dir.
-        resolved = cwd if cwd is not None else _cwd_for_session_key(session_key)
-        return set_session_vars(session_key=session_key, cwd=resolved)
-    except Exception:
+        return set_session_vars(session_key=session_key)
+    except ImportError:
         return []
 
 
@@ -1248,7 +1158,7 @@ def _clear_session_context(tokens: list) -> None:
         from gateway.session_context import clear_session_vars
 
         clear_session_vars(tokens)
-    except Exception:
+    except ImportError:
         pass
 
 
@@ -1265,19 +1175,16 @@ def _enable_gateway_prompts() -> None:
 def _block(event: str, sid: str, payload: dict, timeout: int = 300) -> str:
     rid = uuid.uuid4().hex[:8]
     ev = threading.Event()
-    with _prompt_lock:
-        _pending[rid] = (sid, ev)
-        payload["request_id"] = rid
-        _pending_prompt_payloads[rid] = (event, dict(payload))
+    _pending[rid] = (sid, ev)
+    payload["request_id"] = rid
+    _pending_prompt_payloads[rid] = (event, dict(payload))
     try:
         _emit(event, sid, payload)
         ev.wait(timeout=timeout)
     finally:
-        with _prompt_lock:
-            _pending.pop(rid, None)
-            _pending_prompt_payloads.pop(rid, None)
-    with _prompt_lock:
-        return _answers.pop(rid, "")
+        _pending.pop(rid, None)
+        _pending_prompt_payloads.pop(rid, None)
+    return _answers.pop(rid, "")
 
 
 def _clear_pending(sid: str | None = None) -> None:
@@ -1289,11 +1196,10 @@ def _clear_pending(sid: str | None = None) -> None:
     sessions sharing the same tui_gateway process.  When *sid* is
     None, every pending prompt is released (used during shutdown).
     """
-    with _prompt_lock:
-        for rid, (owner_sid, ev) in list(_pending.items()):
-            if sid is None or owner_sid == sid:
-                _answers[rid] = ""
-                ev.set()
+    for rid, (owner_sid, ev) in list(_pending.items()):
+        if sid is None or owner_sid == sid:
+            _answers[rid] = ""
+            ev.set()
 
 
 # ── Agent factory ────────────────────────────────────────────────────
@@ -1314,7 +1220,7 @@ def resolve_skin() -> dict:
             "tool_prefix": skin.tool_prefix,
             "help_header": (skin.branding or {}).get("help_header", ""),
         }
-    except Exception:
+    except (ImportError, AttributeError):
         return {}
 
 
@@ -1363,7 +1269,7 @@ def _resolve_startup_runtime() -> tuple[str, str | None]:
         if detected:
             provider, detected_model = detected
             return detected_model, provider
-    except Exception:
+    except (ImportError, ValueError):
         pass
     return model, None
 
@@ -1487,7 +1393,7 @@ def _load_enabled_toolsets() -> list[str] | None:
 
     try:
         from toolsets import validate_toolset
-    except Exception:
+    except ImportError:
         validate_toolset = None
 
     if explicit and validate_toolset is not None:
@@ -1500,7 +1406,7 @@ def _load_enabled_toolsets() -> list[str] | None:
 
                 discover_plugins()
                 plugin_valid = [name for name in unresolved if validate_toolset(name)]
-            except Exception:
+            except ImportError:
                 plugin_valid = []
 
             if plugin_valid:
@@ -1540,7 +1446,7 @@ def _load_enabled_toolsets() -> list[str] | None:
                     mcp_names.add(str(name))
                 else:
                     mcp_disabled.add(str(name))
-        except Exception:
+        except (FileNotFoundError, json.JSONDecodeError):
             mcp_names = set()
             mcp_disabled = set()
 
@@ -1593,7 +1499,7 @@ def _load_enabled_toolsets() -> list[str] | None:
         if fallback_notice is not None:
             print(fallback_notice, file=sys.stderr, flush=True)
         return enabled or None
-    except Exception:
+    except (ImportError, FileNotFoundError, RuntimeError):
         if fallback_notice is not None:
             print(
                 "[tui] no valid HERMES_TUI_TOOLSETS entries and configured CLI toolsets could not be loaded; enabling all toolsets",
@@ -1628,6 +1534,7 @@ def _restart_slash_worker(sid: str, session: dict):
             getattr(session.get("agent"), "model", _resolve_model()),
         )
     except Exception:
+        logger.warning("Failed to create slash worker", exc_info=True)
         session["slash_worker"] = None
         return
     # Route through the same store-iff-still-mapped guard as the spawn sites:
@@ -1695,7 +1602,7 @@ def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:
         cfg = load_config()
         user_provs = cfg.get("providers")
         custom_provs = get_compatible_custom_providers(cfg)
-    except Exception:
+    except (ImportError, FileNotFoundError):
         pass
 
     result = switch_model(
@@ -1723,27 +1630,21 @@ def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:
         _restart_slash_worker(sid, session)
         _emit("session.info", sid, _session_info(agent, session))
 
-    # Record the switch as a PER-SESSION override so a later rebuild of THIS
-    # session (e.g. /new via _reset_session_agent, or resume) re-derives the
-    # user's chosen model/provider instead of falling back to global config.
+    os.environ["HERMES_MODEL"] = result.new_model
+    os.environ["HERMES_INFERENCE_MODEL"] = result.new_model
+    # Keep the process-level provider env vars in sync with the user's
+    # explicit choice so any ambient re-resolution (credential pool refresh,
+    # compressor rebuild, aux clients) and startup re-resolution on /new
+    # both pick up the new provider instead of the original one persisted
+    # in config or env.
     #
-    # We deliberately do NOT write process-global env vars (HERMES_MODEL /
-    # HERMES_INFERENCE_MODEL / HERMES_TUI_PROVIDER / HERMES_INFERENCE_PROVIDER)
-    # here. The desktop backend hosts every same-profile session in ONE process,
-    # so mutating os.environ on a /model switch leaked the new model/provider
-    # into every OTHER live session's next agent rebuild — switching the model
-    # in one session silently changed it in the others (the cross-session
-    # contamination bug). agent.switch_model() above already mutated the right
-    # agent in place; the override dict makes that choice survive a rebuild
-    # without touching shared process state.
-    if isinstance(session, dict):
-        session["model_override"] = {
-            "model": result.new_model,
-            "provider": result.target_provider,
-            "base_url": result.base_url,
-            "api_key": result.api_key,
-            "api_mode": result.api_mode,
-        }
+    # HERMES_TUI_PROVIDER is the canonical "explicit-this-process" carrier
+    # consumed by _resolve_startup_runtime() — set it unconditionally on
+    # /model so /new can't fall through to static-catalog detection and
+    # pick a coincidentally-matching native provider (fixes #16857).
+    if result.target_provider:
+        os.environ["HERMES_INFERENCE_PROVIDER"] = result.target_provider
+        os.environ["HERMES_TUI_PROVIDER"] = result.target_provider
     if persist_global:
         _persist_model_switch(result)
     return {"value": result.new_model, "warning": result.warning_message or ""}
@@ -1843,12 +1744,12 @@ def _sync_session_key_after_compress(
 
         try:
             unregister_gateway_notify(old_key)
-        except Exception:
+        except KeyError:
             pass
         session["session_key"] = new_session_id
         try:
             yolo_was_on = is_session_yolo_enabled(old_key)
-        except Exception:
+        except (ImportError, KeyError):
             yolo_was_on = False
         if yolo_was_on:
             try:
@@ -1861,7 +1762,7 @@ def _sync_session_key_after_compress(
                 new_session_id,
                 lambda data: _emit("approval.request", sid, data),
             )
-        except Exception:
+        except ImportError:
             pass
     except Exception:
         # Even if the approval module fails to import, still anchor the
@@ -1918,17 +1819,8 @@ def _get_usage(agent) -> dict:
         usage["cost_status"] = cost.status
         if cost.amount_usd is not None:
             usage["cost_usd"] = float(cost.amount_usd)
-    except Exception:
+    except (AttributeError, ImportError):
         pass
-    # Dev-only live credits-spent readout (L0 usage-aware-credits). Gated on
-    # HERMES_DEV_CREDITS so the payload stays clean when the flag is off.
-    if is_truthy_value(os.environ.get("HERMES_DEV_CREDITS")):
-        try:
-            spent = agent.get_credits_spent_micros()
-            if spent is not None:
-                usage["dev_credits_spent_micros"] = int(spent)
-        except Exception:
-            pass
     return usage
 
 
@@ -1939,7 +1831,7 @@ def _probe_credentials(agent) -> str:
         provider = getattr(agent, "provider", "") or ""
         if not key or key == "no-key-required":
             return f"No API key configured for provider '{provider}'. First message will fail."
-    except Exception:
+    except AttributeError:
         pass
     return ""
 
@@ -1982,26 +1874,11 @@ def _current_profile_name() -> str:
         from hermes_cli.profiles import get_active_profile_name
 
         return get_active_profile_name() or "default"
-    except Exception:
+    except ImportError:
         return "default"
 
 
-# Monotonic GUI<->backend contract version. The desktop app refuses to drive a
-# backend reporting less than its required value (or none at all — a pre-GUI
-# checkout), surfacing a one-click "update to align" prompt instead of failing
-# cryptically downstream. Bump whenever the desktop's backend contract changes.
-DESKTOP_BACKEND_CONTRACT = 1
-
-
-def _session_info(agent, session: dict | None = None) -> dict:
-    if session is None:
-        for candidate in _sessions.values():
-            if candidate.get("agent") is agent:
-                session = candidate
-                break
-    cwd = _session_cwd(session)
-    cfg_personality = ((_load_cfg().get("display") or {}).get("personality") or "")
-    personality = (session or {}).get("personality", cfg_personality)
+def _session_info(agent) -> dict:
     reasoning_config = getattr(agent, "reasoning_config", None)
     reasoning_effort = ""
     if (
@@ -2010,38 +1887,14 @@ def _session_info(agent, session: dict | None = None) -> dict:
     ):
         reasoning_effort = str(reasoning_config.get("effort", "") or "")
     service_tier = getattr(agent, "service_tier", None) or ""
-    # Effective approval-bypass state — the same three sources that
-    # check_all_command_guards() ORs together: persistent config
-    # (approvals.mode=off), the process-scoped --yolo env, and the
-    # per-session flag. Reporting only the per-session flag here would lie to
-    # the desktop status bar (it would show YOLO "off" while approvals.mode=off
-    # silently auto-approves every dangerous command).
-    yolo = False
-    try:
-        from tools.approval import (
-            _YOLO_MODE_FROZEN,
-            _get_approval_mode,
-            is_session_yolo_enabled,
-        )
-
-        session_key = (session or {}).get("session_key")
-        session_yolo = bool(is_session_yolo_enabled(session_key)) if session_key else False
-        yolo = bool(_YOLO_MODE_FROZEN) or session_yolo or _get_approval_mode() == "off"
-    except Exception:
-        yolo = False
     info: dict = {
         "model": getattr(agent, "model", ""),
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",
-        "yolo": yolo,
         "tools": {},
         "skills": {},
-        "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
-        "personality": str(personality or ""),
-        "running": bool((session or {}).get("running")),
-        "desktop_contract": DESKTOP_BACKEND_CONTRACT,
+        "cwd": os.getenv("TERMINAL_CWD", os.getcwd()),
         "version": "",
         "release_date": "",
         "update_behind": None,
@@ -2054,7 +1907,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
 
         info["version"] = __version__
         info["release_date"] = __release_date__
-    except Exception:
+    except (ImportError, AttributeError):
         pass
     try:
         from model_tools import get_toolset_for_tool
@@ -2064,23 +1917,26 @@ def _session_info(agent, session: dict | None = None) -> dict:
             info["tools"].setdefault(get_toolset_for_tool(name) or "other", []).append(
                 name
             )
-    except Exception:
+    except (ImportError, AttributeError):
         pass
     try:
         from hermes_cli.banner import get_available_skills
 
         info["skills"] = get_available_skills()
     except Exception:
+        logger.debug("Failed to load available skills", exc_info=True)
         pass
     try:
         from tools.mcp_tool import get_mcp_status
 
         info["mcp_servers"] = get_mcp_status()
     except Exception:
+        logger.debug("Failed to get MCP status", exc_info=True)
         info["mcp_servers"] = []
     try:
         info["system_prompt"] = getattr(agent, "_cached_system_prompt", "") or ""
     except Exception:
+        logger.debug("Failed to get system prompt", exc_info=True)
         pass
     try:
         from hermes_cli.banner import get_update_result
@@ -2089,10 +1945,8 @@ def _session_info(agent, session: dict | None = None) -> dict:
         info["update_behind"] = get_update_result(timeout=0.5)
         info["update_command"] = recommended_update_command()
     except Exception:
+        logger.debug("Failed to get update info", exc_info=True)
         pass
-    warn = _probe_credentials(agent)
-    if warn:
-        info["credential_warning"] = warn
     return info
 
 
@@ -2101,19 +1955,12 @@ def _tool_ctx(name: str, args: dict) -> str:
         from agent.display import build_tool_preview
 
         return build_tool_preview(name, args, max_len=80) or ""
-    except Exception:
+    except (ImportError, AttributeError):
         return ""
 
 
-# Tool Args/Result text shipped to the TUI for the verbose trail line. The TUI
-# renders only a small persisted preview (ui-tui VERBOSE_TRAIL_MAX_CHARS), kept
-# all session and expanded by default — so shipping more than that is pure pipe
-# waste AND feeds the Ink render-tree blowup that silently OOM-killed the TUI
-# parent (#34095). Cap here to match the render budget (a hair more, so the
-# "[omitted …]" label is still informative when output is genuinely large).
-# Full output stays in the agent context and the SQLite session, untouched.
-_TUI_VERBOSE_TEXT_MAX_CHARS = 1_000
-_TUI_VERBOSE_TEXT_MAX_LINES = 16
+_TUI_VERBOSE_TEXT_MAX_CHARS = 16_000
+_TUI_VERBOSE_TEXT_MAX_LINES = 240
 
 
 def _cap_tui_verbose_text(text: str) -> str:
@@ -2158,6 +2005,7 @@ def _redact_tui_verbose_text(text: str) -> str:
 
         redacted = redact_sensitive_text(str(text), force=True)
     except Exception:
+        logger.warning("Redaction failed — sensitive data may leak", exc_info=True)
         return ""
     return _cap_tui_verbose_text(redacted)
 
@@ -2166,6 +2014,7 @@ def _tool_args_text(args: dict) -> str:
     try:
         raw = json.dumps(args or {}, indent=2, ensure_ascii=False, default=str)
     except Exception:
+        logger.debug("JSON serialization failed for tool args", exc_info=True)
         raw = str(args or {})
     return _redact_tui_verbose_text(raw)
 
@@ -2176,6 +2025,7 @@ def _tool_result_text(result: object) -> str:
 
         raw = _multimodal_text_summary(result)
     except Exception:
+        logger.debug("Multimodal text summary failed", exc_info=True)
         raw = str(result)
     return _redact_tui_verbose_text(raw)
 
@@ -2204,6 +2054,7 @@ def _tool_summary(name: str, result: str, duration_s: float | None) -> str | Non
     try:
         data = json.loads(result)
     except Exception:
+        logger.debug("JSON parse failed for tool summary", exc_info=True)
         data = None
 
     dur = _fmt_tool_duration(duration_s)
@@ -2238,6 +2089,7 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
             if snapshot is not None:
                 session.setdefault("edit_snapshots", {})[tool_call_id] = snapshot
         except Exception:
+            logger.debug("capture_local_edit_snapshot failed", exc_info=True)
             pass
         session.setdefault("tool_started_at", {})[tool_call_id] = time.time()
     if _tool_progress_enabled(sid):
@@ -2256,7 +2108,7 @@ def _on_tool_start(sid: str, tool_call_id: str, name: str, args: dict):
 
 
 def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result: str):
-    payload = {"tool_id": tool_call_id, "name": name, "args": args}
+    payload = {"tool_id": tool_call_id, "name": name}
     session = _sessions.get(sid)
     snapshot = None
     started_at = None
@@ -2266,10 +2118,6 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
     duration_s = time.time() - started_at if started_at else None
     if duration_s is not None:
         payload["duration_s"] = duration_s
-    try:
-        payload["result"] = json.loads(result)
-    except Exception:
-        payload["result"] = result
     summary = _tool_summary(name, result, duration_s)
     if summary:
         payload["summary"] = summary
@@ -2283,6 +2131,7 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
             if isinstance(data, dict) and isinstance(data.get("todos"), list):
                 payload["todos"] = data.get("todos")
         except Exception:
+            logger.debug("todo result parse failed", exc_info=True)
             pass
     try:
         from agent.display import render_edit_diff_with_delta
@@ -2297,6 +2146,7 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
         ):
             payload["inline_diff"] = "\n".join(rendered)
     except Exception:
+        logger.debug("render_edit_diff_with_delta failed", exc_info=True)
         pass
     if _tool_progress_enabled(sid) or payload.get("inline_diff"):
         _emit("tool.complete", sid, payload)
@@ -2313,9 +2163,7 @@ def _on_tool_progress(
     if not _tool_progress_enabled(sid):
         return
     if event_type == "tool.started" and name:
-        # `_on_tool_start` already emits the authoritative `tool.start` with
-        # the stable tool id and args. Emitting another id-less progress row
-        # here makes the desktop live view diverge from hydrated history.
+        _emit("tool.progress", sid, {"name": name, "preview": preview or ""})
         return
     if event_type == "reasoning.available" and preview:
         payload: dict[str, object] = {"text": str(preview)}
@@ -2405,24 +2253,6 @@ def _agent_cbs(sid: str) -> dict:
         "status_callback": lambda kind, text=None: _status_update(
             sid, str(kind), None if text is None else str(text)
         ),
-        # Credits/notice spine (L1): an AgentNotice fired by the agent becomes a
-        # notification.show WS event; a recovery clear becomes notification.clear.
-        # Snake_case payload to match the existing gateway-event convention.
-        "notice_callback": lambda n: _emit(
-            "notification.show",
-            sid,
-            {
-                "text": n.text,
-                "level": n.level,
-                "kind": n.kind,
-                "ttl_ms": n.ttl_ms,
-                "key": n.key,
-                "id": n.id,
-            },
-        ),
-        "notice_clear_callback": lambda key: _emit(
-            "notification.clear", sid, {"key": key}
-        ),
         "clarify_callback": lambda q, c: _block(
             "clarify.request", sid, {"question": q, "choices": c}
         ),
@@ -2476,11 +2306,13 @@ def _available_personalities(cfg: dict | None = None) -> dict:
 
         return (load_cli_config().get("agent") or {}).get("personalities", {}) or {}
     except Exception:
+        logger.debug("load_cli_config failed for personalities", exc_info=True)
         try:
             from hermes_cli.config import load_config as _load_full_cfg
 
             return (_load_full_cfg().get("agent") or {}).get("personalities", {}) or {}
         except Exception:
+            logger.debug("load_config failed for personalities", exc_info=True)
             cfg = cfg or _load_cfg()
             return (cfg.get("agent") or {}).get("personalities", {}) or {}
 
@@ -2505,19 +2337,8 @@ def _validate_personality(value: str, cfg: dict | None = None) -> tuple[str, str
     return name, _render_personality_prompt(personalities[name])
 
 
-def _prompt_text(value) -> str:
-    """Normalize config prompt values from YAML before handing them to AIAgent."""
-    if value is None:
-        return ""
-    if isinstance(value, str):
-        return value.strip()
-    if isinstance(value, list):
-        return "\n".join(str(item).strip() for item in value if str(item).strip())
-    return str(value).strip()
-
-
 def _apply_personality_to_session(
-    sid: str, session: dict, new_prompt: str, personality: str = ""
+    sid: str, session: dict, new_prompt: str
 ) -> tuple[bool, dict | None]:
     """Apply a personality change to an existing session without resetting history.
 
@@ -2535,7 +2356,6 @@ def _apply_personality_to_session(
     """
     if not session:
         return False, None
-    session["personality"] = personality
 
     agent = session.get("agent")
     if agent:
@@ -2623,145 +2443,11 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
     }
 
 
-def _ephemeral_preview_agent_kwargs(agent, task_id: str) -> dict:
-    kwargs = _background_agent_kwargs(agent, task_id)
-    kwargs.update(
-        {
-            "enabled_toolsets": ["terminal", "file"],
-            "session_db": None,
-            "skip_memory": True,
-        }
-    )
-    return kwargs
-
-
-def _preview_restart_history(session: dict, max_messages: int = 24, max_tool_chars: int = 1200) -> list[dict]:
-    """Distill the parent session's recent history into a context the
-    ephemeral preview-restart agent can actually use.
-
-    The restart agent has no idea what app the user was building, what
-    server they ran, what cwd was active, or which port belongs to which
-    project. Without this, it would take the bare URL + console logs and
-    guess — usually starting the wrong thing.
-
-    We keep the last ``max_messages`` messages from the parent session so
-    the restart agent sees recent user prompts, assistant replies, and
-    most importantly any terminal/tool calls. Tool result payloads are
-    truncated so we don't blow the context window with file dumps.
-    """
-    try:
-        with session["history_lock"]:
-            history = list(session.get("history", []) or [])
-    except Exception:
-        history = list(session.get("history", []) or [])
-
-    if not history:
-        return []
-
-    # Anchor on the last user turn so we always include at least the most
-    # recent request and the assistant/tool work that followed it. Then
-    # extend backwards up to max_messages so we capture the prior context.
-    last_user_idx = None
-    for idx in range(len(history) - 1, -1, -1):
-        if history[idx].get("role") == "user":
-            last_user_idx = idx
-            break
-
-    start = max(0, len(history) - max_messages)
-    if last_user_idx is not None:
-        start = min(start, last_user_idx)
-
-    trimmed: list[dict] = []
-    for msg in history[start:]:
-        if not isinstance(msg, dict):
-            continue
-        role = msg.get("role")
-        if role not in ("user", "assistant", "tool", "system"):
-            continue
-
-        copy = {k: v for k, v in msg.items() if k != "reasoning"}
-        # Truncate heavy tool outputs so a single 50KB file read doesn't
-        # crowd out the rest of the context.
-        if role == "tool":
-            content = copy.get("content")
-            if isinstance(content, str) and len(content) > max_tool_chars:
-                copy["content"] = (
-                    content[:max_tool_chars]
-                    + f"\n... (truncated, original {len(content)} chars)"
-                )
-        trimmed.append(copy)
-
-    return trimmed
-
-
-def _preview_tool_result_preview(name: str, result: str) -> str:
-    try:
-        data = json.loads(result)
-    except Exception:
-        return ""
-
-    if not isinstance(data, dict):
-        return ""
-
-    if name == "terminal":
-        output = str(data.get("output") or "").strip()
-        exit_code = data.get("exit_code")
-        if output:
-            return output[-1200:]
-        if data.get("session_id"):
-            return f"Background process started: {data.get('session_id')}"
-        if exit_code is not None:
-            return f"terminal exited with code {exit_code}"
-
-    return str(data.get("error") or "").strip()[:1200]
-
-
-def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
-    started_at: dict[str, float] = {}
-
-    def progress(message: str, level: str = "info") -> None:
-        text = str(message or "").strip()
-        if text:
-            _emit("preview.restart.progress", parent, {"task_id": task_id, "level": level, "text": text})
-
-    def tool_start(tool_call_id: str, name: str, args: dict) -> None:
-        started_at[tool_call_id] = time.time()
-        ctx = _tool_ctx(name, args)
-        progress(f"Running {name}{f': {ctx}' if ctx else ''}")
-
-    def tool_complete(tool_call_id: str, name: str, _args: dict, result: str) -> None:
-        duration_s = time.time() - started_at.get(tool_call_id, time.time())
-        summary = _tool_summary(name, result, duration_s) or f"Finished {name}{f' in {_fmt_tool_duration(duration_s)}' if duration_s else ''}"
-        output = _preview_tool_result_preview(name, result)
-        progress(summary + (f"\n{output}" if output else ""))
-
-    def tool_progress(event_type: str, name: str | None = None, preview: str | None = None, **_kwargs) -> None:
-        if preview:
-            progress(str(preview))
-        elif name:
-            progress(f"{event_type.replace('.', ' ')}: {name}")
-
-    return {
-        "tool_start_callback": tool_start,
-        "tool_complete_callback": tool_complete,
-        "tool_progress_callback": tool_progress,
-        "tool_gen_callback": lambda name: progress(f"Preparing {name}"),
-        "status_callback": lambda kind, text=None: progress(text if text is not None else kind),
-    }
-
-
 def _reset_session_agent(sid: str, session: dict) -> dict:
     tokens = _set_session_context(session["session_key"])
     try:
         new_agent = _make_agent(
-            sid,
-            session["session_key"],
-            session_id=session["session_key"],
-            # Preserve this session's chosen model across /new so a reset
-            # doesn't silently revert to global config (or to a model another
-            # session set). See the cross-session-contamination note in
-            # _apply_model_switch.
-            model_override=session.get("model_override"),
+            sid, session["session_key"], session_id=session["session_key"]
         )
     finally:
         _clear_session_context(tokens)
@@ -2773,22 +2459,17 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
     session["show_reasoning"] = _load_show_reasoning()
     session["tool_progress_mode"] = _load_tool_progress_mode()
     session["tool_started_at"] = {}
+    session["_pending_kanban"] = []
     with session["history_lock"]:
         session["history"] = []
         session["history_version"] = int(session.get("history_version", 0)) + 1
-    info = _session_info(new_agent, session)
+    info = _session_info(new_agent)
     _emit("session.info", sid, info)
     _restart_slash_worker(sid, session)
     return info
 
 
-def _make_agent(
-    sid: str,
-    key: str,
-    session_id: str | None = None,
-    session_db=None,
-    model_override: dict | None = None,
-):
+def _make_agent(sid: str, key: str, session_id: str | None = None):
     from run_agent import AIAgent
     from hermes_cli.runtime_provider import resolve_runtime_provider
 
@@ -2807,7 +2488,7 @@ def _make_agent(
 
     cfg = _load_cfg()
     agent_cfg = cfg.get("agent") or {}
-    system_prompt = _prompt_text(agent_cfg.get("system_prompt", ""))
+    system_prompt = (agent_cfg.get("system_prompt", "") or "").strip()
     startup_skills = _parse_tui_skills_env()
     if startup_skills:
         from agent.skill_commands import build_preloaded_skills_prompt
@@ -2822,35 +2503,11 @@ def _make_agent(
             system_prompt = "\n\n".join(
                 part for part in (system_prompt, skills_prompt) if part
             ).strip()
-    # Prefer a per-session model override (set by a prior in-session /model
-    # switch) over global config/env resolution. This keeps a rebuilt session
-    # (/new, resume) on the model the user picked FOR THIS SESSION, without
-    # reading process-global env vars that another session may have changed.
-    if model_override and model_override.get("model"):
-        model = str(model_override.get("model") or "")
-        requested_provider = model_override.get("provider") or None
-        override_base_url = model_override.get("base_url")
-        override_api_key = model_override.get("api_key")
-        override_api_mode = model_override.get("api_mode")
-        runtime = resolve_runtime_provider(
-            requested=requested_provider,
-            target_model=model or None,
-        )
-        # The switch already resolved concrete credentials/endpoint; honor them
-        # so a custom/named endpoint survives the rebuild even if global
-        # resolution would pick a different one.
-        if override_base_url:
-            runtime["base_url"] = override_base_url
-        if override_api_key:
-            runtime["api_key"] = override_api_key
-        if override_api_mode:
-            runtime["api_mode"] = override_api_mode
-    else:
-        model, requested_provider = _resolve_startup_runtime()
-        runtime = resolve_runtime_provider(
-            requested=requested_provider,
-            target_model=model or None,
-        )
+    model, requested_provider = _resolve_startup_runtime()
+    runtime = resolve_runtime_provider(
+        requested=requested_provider,
+        target_model=model or None,
+    )
     return AIAgent(
         model=model,
         max_iterations=_cfg_max_turns(cfg, 90),
@@ -2872,7 +2529,7 @@ def _make_agent(
         enabled_toolsets=_load_enabled_toolsets(),
         platform="tui",
         session_id=session_id or key,
-        session_db=session_db if session_db is not None else _get_db(),
+        session_db=_get_db(),
         ephemeral_system_prompt=system_prompt or None,
         checkpoints_enabled=is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS")),
         pass_session_id=is_truthy_value(os.environ.get("HERMES_TUI_PASS_SESSION_ID")),
@@ -2884,47 +2541,29 @@ def _make_agent(
 
 def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
     now = time.time()
-    with _sessions_lock:
-        _sessions[sid] = {
-            "agent": agent,
-            "session_key": key,
-            "history": history,
-            "history_lock": threading.Lock(),
-            "history_version": 0,
-            "inflight_turn": None,
-            "created_at": now,
-            "last_active": now,
-            "running": False,
-            "attached_images": [],
-            "image_counter": 0,
-            "cwd": _completion_cwd(),
-            "cols": cols,
-            "slash_worker": None,
-            "show_reasoning": _load_show_reasoning(),
-            "tool_progress_mode": _load_tool_progress_mode(),
-            "edit_snapshots": {},
-            "tool_started_at": {},
-            # Per-session model override set by an in-session /model switch.
-            # Honored on rebuild (/new, resume) so a switch in THIS session
-            # never leaks into siblings via process-global env vars.
-            "model_override": None,
-            # Pin async event emissions to whichever transport created the
-            # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
-            "transport": current_transport() or _stdio_transport,
-        }
-    db = _get_db()
-    if db is not None:
-        row = db.get_session(key)
-        if row and row.get("cwd"):
-            with _sessions_lock:
-                if sid in _sessions:
-                    _sessions[sid]["cwd"] = row["cwd"]
-        else:
-            try:
-                db.update_session_cwd(key, _sessions[sid]["cwd"])
-            except Exception:
-                logger.debug("failed to persist resumed session cwd", exc_info=True)
-    _register_session_cwd(_sessions[sid])
+    _sessions[sid] = {
+        "agent": agent,
+        "session_key": key,
+        "history": history,
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "inflight_turn": None,
+        "created_at": now,
+        "last_active": now,
+        "running": False,
+        "attached_images": [],
+        "image_counter": 0,
+        "cols": cols,
+        "slash_worker": None,
+        "show_reasoning": _load_show_reasoning(),
+        "tool_progress_mode": _load_tool_progress_mode(),
+        "edit_snapshots": {},
+        "tool_started_at": {},
+        "_pending_kanban": [],
+        # Pin async event emissions to whichever transport created the
+        # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
+        "transport": current_transport() or _stdio_transport,
+    }
     try:
         _attach_worker(
             sid,
@@ -2932,6 +2571,7 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
             _SlashWorker(key, getattr(agent, "model", _resolve_model())),
         )
     except Exception:
+        logger.warning("Failed to create slash worker on session start", exc_info=True)
         # Defer hard-failure to slash.exec; chat still works without slash worker.
         _sessions[sid]["slash_worker"] = None
     try:
@@ -2940,6 +2580,7 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         register_gateway_notify(key, lambda data: _emit("approval.request", sid, data))
         load_permanent_allowlist()
     except Exception:
+        logger.debug("Approval registration failed on session start", exc_info=True)
         pass
     # Surface the self-improvement background review's "💾 …" summary as a
     # review.summary event so Ink can render it as a persistent system line
@@ -2951,15 +2592,17 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
             "review.summary", _sid, {"text": str(message)}
         )
     except Exception:
+        logger.debug("background_review_callback not available on agent", exc_info=True)
         # Bare AIAgents that don't expose the attribute (unlikely, but keep
         # session startup resilient).
         pass
     _wire_callbacks(sid)
-    with _sessions_lock:
-        if sid in _sessions:
-            _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
+    _sessions[sid]["_notif_stop"] = threading.Event()
+    # Register event-driven callback for process completions
+    from tools.process_registry import process_registry
+    process_registry._completion_callback = _on_process_event
     _notify_session_boundary("on_session_reset", key)
-    _emit("session.info", sid, _session_info(agent, _sessions.get(sid, {})))
+    _emit("session.info", sid, _session_info(agent))
 
 
 def _new_session_key() -> str:
@@ -2967,7 +2610,7 @@ def _new_session_key() -> str:
 
 
 def _with_checkpoints(session, fn):
-    return fn(session["agent"]._checkpoint_mgr, _session_cwd(session))
+    return fn(session["agent"]._checkpoint_mgr, os.getenv("TERMINAL_CWD", os.getcwd()))
 
 
 def _resolve_checkpoint_hash(mgr, cwd: str, ref: str) -> str:
@@ -2983,7 +2626,8 @@ def _resolve_checkpoint_hash(mgr, cwd: str, ref: str) -> str:
 
 def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
     """Pre-analyze attached images via vision and prepend descriptions to user text."""
-    import asyncio, json as _json
+    import asyncio
+    import json as _json
     from tools.vision_tools import vision_analyze_tool
 
     prompt = (
@@ -3009,6 +2653,7 @@ def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
                 else f"[The user attached an image but analysis failed.]\n{hint}"
             )
         except Exception:
+            logger.warning("Image analysis failed", exc_info=True)
             parts.append(f"[The user attached an image but analysis failed.]\n{hint}")
 
     text = user_text or ""
@@ -3048,93 +2693,6 @@ def _content_display_text(content: Any) -> str:
     return str(content)
 
 
-def _coerce_message_text(content: Any) -> str:
-    """Render ``message['content']`` as a plain string for transport.
-
-    Provider-side, ``content`` may be a string (most common), a list of
-    multimodal parts (e.g. ``[{"type": "text", "text": "..."},
-    {"type": "image_url", "image_url": {...}}]``), or a single structured
-    dict. Calling ``.strip()`` on a list raises ``'list' object has no
-    attribute 'strip'`` and breaks session resume entirely.
-
-    Image parts (``image_url``) are preserved by appending the underlying
-    URL (data: or http:) into the text. The desktop renderer pulls these
-    back out via ``extractEmbeddedImages`` so the user sees the image
-    instead of the URL — and it stops the resume payload from disagreeing
-    with the cached message (which would otherwise cause the inline image
-    to flash, then disappear when the resume payload overwrites the cache).
-
-    Other structured dict shapes (audio, unknown types) fall back to a
-    bracketed placeholder so resume doesn't drop the message entirely.
-    """
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, (int, float)):
-        return str(content)
-    if isinstance(content, list):
-        chunks: list[str] = []
-        for part in content:
-            if isinstance(part, str):
-                chunks.append(part)
-                continue
-            if not isinstance(part, dict):
-                continue
-            text = part.get("text")
-            if isinstance(text, str):
-                chunks.append(text)
-                continue
-            kind = part.get("type")
-            if kind in {"text", "input_text", "output_text"}:
-                t = part.get("text") or part.get("content") or ""
-                if t:
-                    chunks.append(str(t))
-                continue
-            if kind in {"image_url", "input_image", "image"}:
-                image_url = part.get("image_url")
-                url = ""
-                if isinstance(image_url, dict):
-                    candidate = image_url.get("url")
-                    if isinstance(candidate, str):
-                        url = candidate
-                elif isinstance(image_url, str):
-                    url = image_url
-                if url:
-                    chunks.append(f"\n{url}")
-                else:
-                    chunks.append("\n[image]")
-                continue
-            if kind in {"input_audio", "audio"}:
-                chunks.append("\n[audio]")
-                continue
-            if kind:
-                chunks.append(f"\n[{kind}]")
-        return "".join(chunks)
-    if isinstance(content, dict):
-        kind = content.get("type")
-        if kind in {"text", "input_text", "output_text"}:
-            return str(content.get("text") or content.get("content") or "")
-        if kind in {"image_url", "input_image", "image"}:
-            image_url = content.get("image_url")
-            url = ""
-            if isinstance(image_url, dict):
-                candidate = image_url.get("url")
-                if isinstance(candidate, str):
-                    url = candidate
-            elif isinstance(image_url, str):
-                url = image_url
-            return url or "[image]"
-        if kind in {"input_audio", "audio"}:
-            return "[audio]"
-        if kind:
-            return f"[{kind}]"
-        if "text" in content:
-            return str(content.get("text") or "")
-        return "[structured content]"
-    return str(content)
-
-
 def _history_to_messages(history: list[dict]) -> list[dict]:
     messages = []
     tool_call_args = {}
@@ -3145,7 +2703,7 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
         role = m.get("role")
         if role not in {"user", "assistant", "tool", "system"}:
             continue
-        content_text = _coerce_message_text(m.get("content"))
+        content_text = _content_display_text(m.get("content"))
         if role == "assistant" and m.get("tool_calls"):
             for tc in m["tool_calls"]:
                 fn = tc.get("function", {})
@@ -3169,73 +2727,9 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
             continue
         if not content_text.strip():
             continue
-        msg = {"role": role, "text": content_text}
-        if role == "assistant":
-            for key in (
-                "reasoning",
-                "reasoning_content",
-                "reasoning_details",
-                "codex_reasoning_items",
-            ):
-                if key in m and m.get(key) is not None:
-                    msg[key] = m.get(key)
-        messages.append(msg)
+        messages.append({"role": role, "text": content_text})
 
     return messages
-
-
-def _coerce_seed_history(value: Any) -> list[dict]:
-    if not isinstance(value, list):
-        return []
-
-    history = []
-    for item in value:
-        if not isinstance(item, dict):
-            continue
-
-        role = item.get("role")
-        if role not in ("user", "assistant", "system"):
-            continue
-
-        content = item.get("content")
-        if content is None:
-            content = item.get("text")
-        if not isinstance(content, str) or not content.strip():
-            continue
-
-        history.append({"role": role, "content": content})
-
-    return history
-
-
-def _content_display_text(content: Any) -> str:
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, (int, float)):
-        return str(content)
-    if isinstance(content, list):
-        parts = []
-        for part in content:
-            text = _content_display_text(part).strip()
-            if text:
-                parts.append(text)
-        return "\n".join(parts)
-    if isinstance(content, dict):
-        kind = content.get("type")
-        if kind in {"text", "input_text", "output_text"}:
-            return str(content.get("text") or content.get("content") or "")
-        if kind in {"image_url", "input_image", "image"}:
-            return "[image]"
-        if kind in {"input_audio", "audio"}:
-            return "[audio]"
-        if kind:
-            return f"[{kind}]"
-        if "text" in content:
-            return str(content.get("text") or "")
-        return "[structured content]"
-    return str(content)
 
 
 def _inflight_text(value: Any) -> str:
@@ -3294,32 +2788,10 @@ def _(rid, params: dict) -> dict:
     sid = uuid.uuid4().hex[:8]
     key = _new_session_key()
     cols = int(params.get("cols", 80))
-    history = _coerce_seed_history(params.get("messages"))
-    title = str(params.get("title") or "").strip()
-    # Did the client pick a workspace, or are we falling back to the gateway's
-    # launch directory? Only an explicit choice is persisted as the session's
-    # workspace (see _ensure_session_db_row); otherwise it lands in "No
-    # workspace" instead of whatever folder the desktop launched in.
-    raw_cwd = str(params.get("cwd") or "").strip()
-    try:
-        explicit_cwd = bool(raw_cwd) and os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd)))
-    except Exception:
-        explicit_cwd = False
-    resolved_cwd = _completion_cwd(params)
     _enable_gateway_prompts()
-
-    # ``profile`` (app-global remote mode): a new chat started under a non-launch
-    # profile must build its agent + persist against THAT profile's home/state.db,
-    # not the dashboard's launch profile. Stored on the session so _start_agent_build
-    # and each turn re-bind HERMES_HOME. None/own profile → launch (unchanged).
-    profile = (params.get("profile") or "").strip() or None
-    profile_home = _profile_home(profile)
 
     ready = threading.Event()
     now = time.time()
-    lease, limit_message = _claim_active_session_slot(key, live_session_id=sid)
-    if limit_message is not None:
-        return _err(rid, 4090, limit_message)
 
     with _sessions_lock:
         _sessions[sid] = {
@@ -3328,7 +2800,6 @@ def _(rid, params: dict) -> dict:
             "agent_ready": ready,
             "attached_images": [],
             "close_on_disconnect": is_truthy_value(params.get("close_on_disconnect", False)),
-            "active_session_lease": lease,
             "cols": cols,
             "created_at": now,
             "edit_snapshots": {},
@@ -3375,17 +2846,12 @@ def _(rid, params: dict) -> dict:
         rid,
         {
             "session_id": sid,
-            "stored_session_id": key,
-            "message_count": len(history),
-            "messages": _history_to_messages(history),
             "info": {
                 "model": _resolve_model(),
                 "tools": {},
                 "skills": {},
-                "cwd": _sessions[sid]["cwd"],
-                "branch": _git_branch_for_cwd(_sessions[sid]["cwd"]),
+                "cwd": os.getenv("TERMINAL_CWD", os.getcwd()),
                 "lazy": True,
-                "desktop_contract": DESKTOP_BACKEND_CONTRACT,
                 "profile_name": _current_profile_name(),
             },
         },
@@ -3487,26 +2953,9 @@ def _(rid, params: dict) -> dict:
     target = params.get("session_id", "")
     if not target:
         return _err(rid, 4006, "session_id required")
-    try:
-        cols = int(params.get("cols", 80))
-    except (TypeError, ValueError):
-        cols = 80
-    # ``profile`` (app-global remote mode): resume a session that lives in another
-    # local profile's state.db. None/own profile → the launch profile (unchanged).
-    profile = (params.get("profile") or "").strip() or None
-    profile_home = _profile_home(profile)
-
-    # In a profile scope, the agent OWNS a long-lived db handle bound to that
-    # profile (do NOT auto-close it here). Otherwise reuse the shared launch db.
-    if profile_home is not None:
-        from hermes_state import SessionDB
-
-        db = SessionDB(db_path=profile_home / "state.db")
-    else:
-        db = _get_db()
+    db = _get_db()
     if db is None:
         return _db_unavailable_error(rid, code=5000)
-
     found = db.get_session(target)
     if not found:
         found = db.get_session_by_title(target)
@@ -3514,97 +2963,23 @@ def _(rid, params: dict) -> dict:
             target = found["id"]
         else:
             return _err(rid, 4007, "session not found")
-    # Fast path: if the session is already live, reuse it under the lock.
-    with _session_resume_lock:
-        live = _find_live_session_by_key(target)
-        if live is not None:
-            sid, session = live
-            payload = _live_session_payload(
-                sid,
-                session,
-                cols=cols,
-                touch=True,
-                transport=current_transport() or _stdio_transport,
-            )
-            payload["resumed"] = target
-            return _ok(rid, payload)
-
-    # Build the agent OUTSIDE the lock — _make_agent can block for seconds
-    # (MCP discovery, prompt/skill build, AIAgent construction). Holding
-    # _session_resume_lock across it would stall session.close on the main
-    # dispatch thread (it's not a _LONG_HANDLER), blocking fast-path RPCs.
     sid = uuid.uuid4().hex[:8]
-    lease, limit_message = _claim_active_session_slot(target, live_session_id=sid)
-    if limit_message is not None:
-        return _err(rid, 4090, limit_message)
     _enable_gateway_prompts()
-    home_token = (
-        set_hermes_home_override(str(profile_home)) if profile_home is not None else None
-    )
     try:
         db.reopen_session(target)
         history = db.get_messages_as_conversation(target)
         display_history = db.get_messages_as_conversation(
             target, include_ancestors=True
         )
-        display_history_prefix = display_history[
-            : max(0, len(display_history) - len(history))
-        ]
         messages = _history_to_messages(display_history)
         tokens = _set_session_context(target)
         try:
-            # Pass the profile's db so the agent persists turns to the right
-            # state.db; home override is active here so config/skills/model
-            # resolve to the profile too.
-            agent = _make_agent(sid, target, session_id=target, session_db=db)
+            agent = _make_agent(sid, target, session_id=target)
         finally:
             _clear_session_context(tokens)
+        _init_session(sid, target, agent, history, cols=int(params.get("cols", 80)))
     except Exception as e:
-        if lease is not None:
-            lease.release()
         return _err(rid, 5000, f"resume failed: {e}")
-    finally:
-        if home_token is not None:
-            reset_hermes_home_override(home_token)
-
-    # Double-checked locking: another concurrent resume may have created the
-    # live session while we were building. Re-check under the lock; if it won,
-    # discard our just-built agent and reuse theirs (no worker/poller wired yet).
-    with _session_resume_lock:
-        live = _find_live_session_by_key(target)
-        if live is not None:
-            try:
-                if hasattr(agent, "close"):
-                    agent.close()
-            except Exception:
-                pass
-            if lease is not None:
-                lease.release()
-            other_sid, other_session = live
-            payload = _live_session_payload(
-                other_sid,
-                other_session,
-                cols=cols,
-                touch=True,
-                transport=current_transport() or _stdio_transport,
-            )
-            payload["resumed"] = target
-            return _ok(rid, payload)
-        try:
-            _init_session(sid, target, agent, history, cols=cols)
-            if sid in _sessions:
-                _sessions[sid]["display_history_prefix"] = display_history_prefix
-                # Remember the profile home so each turn re-binds HERMES_HOME (the
-                # agent persists to its own db, but mid-turn home reads — memory,
-                # skills — must resolve to the resumed profile too).
-                if profile_home is not None:
-                    _sessions[sid]["profile_home"] = str(profile_home)
-                _sessions[sid]["active_session_lease"] = lease
-        except Exception as e:
-            if lease is not None:
-                lease.release()
-            return _err(rid, 5000, f"resume failed: {e}")
-        session = _sessions.get(sid) or {}
     return _ok(
         rid,
         {
@@ -3612,38 +2987,9 @@ def _(rid, params: dict) -> dict:
             "resumed": target,
             "message_count": len(messages),
             "messages": messages,
-            "info": _session_info(agent, session),
-            "inflight": None,
-            "running": False,
-            "session_key": target,
-            "started_at": float(session.get("created_at") or time.time()),
-            "status": "idle",
+            "info": _session_info(agent),
         },
     )
-
-
-@method("session.cwd.set")
-def _(rid, params: dict) -> dict:
-    session, err = _sess_nowait(params, rid)
-    if err:
-        return err
-    if session.get("running"):
-        return _err(rid, 4009, "session busy")
-    raw = str(params.get("cwd", "") or "").strip()
-    if not raw:
-        return _err(rid, 4016, "cwd required")
-    try:
-        cwd = _set_session_cwd(session, raw)
-    except ValueError as e:
-        return _err(rid, 4017, str(e))
-    agent = session.get("agent")
-    info = _session_info(agent, session) if agent is not None else {
-        "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
-        "lazy": True,
-    }
-    _emit("session.info", params.get("session_id", ""), info)
-    return _ok(rid, info)
 
 
 def _session_pending_kind(sid: str) -> str:
@@ -3710,15 +3056,6 @@ def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
     }
 
 
-def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
-    for sid, session in list(_sessions.items()):
-        if session.get("_finalized"):
-            continue
-        if str(session.get("session_key") or "") == session_key:
-            return sid, session
-    return None
-
-
 def _fallback_session_info(session: dict) -> dict:
     agent = session.get("agent")
     if agent is not None:
@@ -3732,41 +3069,6 @@ def _fallback_session_info(session: dict) -> dict:
     }
 
 
-def _live_session_payload(
-    sid: str,
-    session: dict,
-    *,
-    cols: int | None = None,
-    touch: bool = False,
-    transport: Transport | None = None,
-) -> dict:
-    with session["history_lock"]:
-        if cols is not None:
-            session["cols"] = cols
-        if transport is not None:
-            session["transport"] = transport
-        if touch:
-            session["last_active"] = time.time()
-        history = list(session.get("display_history_prefix") or []) + list(
-            session.get("history") or []
-        )
-        inflight = _inflight_snapshot(session)
-        running = bool(session.get("running"))
-    payload = {
-        "info": _fallback_session_info(session),
-        "message_count": len(history),
-        "messages": _history_to_messages(history),
-        "running": running,
-        "session_id": sid,
-        "session_key": session.get("session_key") or sid,
-        "started_at": float(session.get("created_at") or time.time()),
-        "status": _session_live_status(sid, session),
-    }
-    if inflight:
-        payload["inflight"] = inflight
-    return payload
-
-
 @method("session.active_list")
 def _(rid, params: dict) -> dict:
     """Return live TUI sessions in this gateway process.
@@ -3777,8 +3079,7 @@ def _(rid, params: dict) -> dict:
     """
     current = str(params.get("current_session_id") or "")
     try:
-        with _sessions_lock:
-            snapshot = list(_sessions.items())
+        snapshot = list(_sessions.items())
     except Exception as e:
         return _err(rid, 5036, f"could not enumerate active sessions: {e}")
 
@@ -3817,9 +3118,27 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
 
+    with session["history_lock"]:
+        session["last_active"] = time.time()
+        history = list(session.get("display_history") or session.get("history") or [])
+        inflight = _inflight_snapshot(session)
+        running = bool(session.get("running"))
+    status = _session_live_status(sid, session)
+    payload = {
+        "info": _fallback_session_info(session),
+        "message_count": len(history),
+        "messages": _history_to_messages(history),
+        "running": running,
+        "session_id": sid,
+        "session_key": session.get("session_key") or sid,
+        "started_at": float(session.get("created_at") or time.time()),
+        "status": status,
+    }
+    if inflight:
+        payload["inflight"] = inflight
     return _ok(
         rid,
-        _live_session_payload(sid, session, touch=True),
+        payload,
     )
 
 
@@ -3848,8 +3167,7 @@ def _(rid, params: dict) -> dict:
     # dictionary changed size during iteration``.  If even the snapshot
     # raises, fail closed (refuse the delete) rather than fail open.
     try:
-        with _sessions_lock:
-            snapshot = list(_sessions.values())
+        snapshot = list(_sessions.values())
     except Exception as e:
         return _err(rid, 5036, f"could not enumerate active sessions: {e}")
     active = {s.get("session_key") for s in snapshot if s.get("session_key")}
@@ -3893,6 +3211,7 @@ def _(rid, params: dict) -> dict:
             elif resolved_title:
                 session["pending_title"] = None
         except Exception:
+            logger.debug("Title resolution failed", exc_info=True)
             resolved_title = fallback
         return _ok(
             rid,
@@ -3934,24 +3253,14 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
     agent = session.get("agent")
-    usage: dict = (
-        _get_usage(agent)
-        if agent is not None
-        else {"calls": 0, "input": 0, "output": 0, "total": 0}
+    return _ok(
+        rid,
+        (
+            _get_usage(agent)
+            if agent is not None
+            else {"calls": 0, "input": 0, "output": 0, "total": 0}
+        ),
     )
-    # Nous credits block — agent-independent (a portal fetch), so it shows even
-    # with zero API calls or on a resumed session. The TUI /usage panel renders
-    # these lines regardless of `calls`. Fail-open: [] when not logged into Nous
-    # or on any portal hiccup.
-    try:
-        from agent.account_usage import nous_credits_lines
-
-        credits = nous_credits_lines()
-        if credits:
-            usage["credits_lines"] = credits
-    except Exception:
-        pass
-    return _ok(rid, usage)
 
 
 @method("session.status")
@@ -3970,6 +3279,7 @@ def _(rid, params: dict) -> dict:
         try:
             meta = db.get_session(key) or {}
         except Exception:
+            logger.debug("session.info DB read failed", exc_info=True)
             meta = {}
 
     def _dt(value, fallback: datetime | None = None) -> datetime:
@@ -3977,6 +3287,7 @@ def _(rid, params: dict) -> dict:
             try:
                 return datetime.fromtimestamp(float(value))
             except Exception:
+                logger.debug("Timestamp parse failed", exc_info=True)
                 pass
         return fallback or datetime.now()
 
@@ -4024,6 +3335,7 @@ def _(rid, params: dict) -> dict:
                 session["session_key"], include_ancestors=True
             )
         except Exception:
+            logger.warning("session.history DB read failed", exc_info=True)
             pass
     return _ok(
         rid,
@@ -4132,7 +3444,7 @@ def _(rid, params: dict) -> dict:
             summary = summarize_manual_compression(
                 before_messages, messages, before_tokens, after_tokens
             )
-            info = _session_info(agent, session)
+            info = _session_info(agent)
             _emit("session.info", sid, info)
             return _ok(
                 rid,
@@ -4163,52 +3475,23 @@ def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
         return err
+    import time as _time
 
-    agent = session["agent"]
-    # Mirror the classic CLI /save: snapshot under the Hermes profile home
-    # (~/.hermes/sessions/saved/) rather than the project/workspace CWD, and
-    # include the system prompt so the export matches the dashboard save.
-    saved_dir = get_hermes_home() / "sessions" / "saved"
+    filename = os.path.abspath(
+        f"hermes_conversation_{_time.strftime('%Y%m%d_%H%M%S')}.json"
+    )
     try:
-        saved_dir.mkdir(parents=True, exist_ok=True)
-    except Exception as e:
-        return _err(rid, 5011, f"failed to create save directory {saved_dir}: {e}")
-
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    path = saved_dir / f"hermes_conversation_{timestamp}.json"
-
-    with session["history_lock"]:
-        messages = list(session.get("history", []))
-
-    session_id = getattr(agent, "session_id", None) or session.get("session_key") or ""
-    # Prefer the agent's session_start datetime (matches the classic CLI export);
-    # fall back to the gateway session's created_at timestamp.
-    agent_start = getattr(agent, "session_start", None)
-    if isinstance(agent_start, datetime):
-        session_start = agent_start.isoformat()
-    else:
-        created_at = session.get("created_at")
-        session_start = (
-            datetime.fromtimestamp(created_at).isoformat()
-            if isinstance(created_at, (int, float))
-            else ""
-        )
-
-    try:
-        with open(path, "w", encoding="utf-8") as f:
+        with open(filename, "w", encoding="utf-8") as f:
             json.dump(
                 {
-                    "model": getattr(agent, "model", ""),
-                    "session_id": session_id,
-                    "session_start": session_start,
-                    "system_prompt": getattr(agent, "_cached_system_prompt", "") or "",
-                    "messages": messages,
+                    "model": getattr(session["agent"], "model", ""),
+                    "messages": session.get("history", []),
                 },
                 f,
                 indent=2,
                 ensure_ascii=False,
             )
-        return _ok(rid, {"file": str(path)})
+        return _ok(rid, {"file": filename})
     except Exception as e:
         return _err(rid, 5011, str(e))
 
@@ -4239,10 +3522,6 @@ def _(rid, params: dict) -> dict:
     if not history:
         return _err(rid, 4008, "nothing to branch — send a message first")
     new_key = _new_session_key()
-    new_sid = uuid.uuid4().hex[:8]
-    lease, limit_message = _claim_active_session_slot(new_key, live_session_id=new_sid)
-    if limit_message is not None:
-        return _err(rid, 4090, limit_message)
     branch_name = params.get("name", "")
     try:
         if branch_name:
@@ -4255,17 +3534,7 @@ def _(rid, params: dict) -> dict:
                 else f"{current} (branch)"
             )
         db.create_session(
-            new_key,
-            source="tui",
-            model=_resolve_model(),
-            # Stable _branched_from marker so list_sessions_rich() keeps the
-            # branch visible in /resume and /sessions. The TUI branch leaves
-            # the parent live (no end_reason='branched'), so the legacy
-            # end_reason heuristic never matches it — the marker is the only
-            # thing that surfaces TUI branches. See issue #20856.
-            model_config={"_branched_from": old_key},
-            parent_session_id=old_key,
-            cwd=_session_cwd(session),
+            new_key, source="tui", model=_resolve_model(), parent_session_id=old_key
         )
         for msg in history:
             db.append_message(
@@ -4275,9 +3544,8 @@ def _(rid, params: dict) -> dict:
             )
         db.set_session_title(new_key, title)
     except Exception as e:
-        if lease is not None:
-            lease.release()
         return _err(rid, 5008, f"branch failed: {e}")
+    new_sid = uuid.uuid4().hex[:8]
     try:
         tokens = _set_session_context(new_key)
         try:
@@ -4287,11 +3555,7 @@ def _(rid, params: dict) -> dict:
         _init_session(
             new_sid, new_key, agent, list(history), cols=session.get("cols", 80)
         )
-        if new_sid in _sessions:
-            _sessions[new_sid]["active_session_lease"] = lease
     except Exception as e:
-        if lease is not None:
-            lease.release()
         return _err(rid, 5000, f"agent init failed on branch: {e}")
     return _ok(rid, {"session_id": new_sid, "title": title, "parent": old_key})
 
@@ -4314,6 +3578,15 @@ def _(rid, params: dict) -> dict:
         resolve_gateway_approval(session["session_key"], "deny", resolve_all=True)
     except Exception:
         pass
+    # Wait for the agent loop to actually finish before returning.
+    # Without this, prompt.submit fires immediately after interrupt and
+    # hits "session busy" because session["running"] is still True — the
+    # agent hasn't had time to check _interrupt_requested and exit.
+    for _ in range(100):  # up to 5s
+        with session["history_lock"]:
+            if not session.get("running"):
+                break
+        time.sleep(0.05)
     return _ok(rid, {"status": "interrupted"})
 
 
@@ -4499,6 +3772,7 @@ def _(rid, params: dict) -> dict:
                 try:
                     raw = json.loads(p.read_text(encoding="utf-8"))
                 except Exception:
+                    logger.warning("Subagent state JSON read failed", exc_info=True)
                     raw = {}
                 subagents = raw.get("subagents") or []
                 entries.append(
@@ -4582,41 +3856,16 @@ def _(rid, params: dict) -> dict:
 @method("prompt.submit")
 def _(rid, params: dict) -> dict:
     sid, text = params.get("session_id", ""), params.get("text", "")
-    truncate_user_ordinal = params.get("truncate_before_user_ordinal")
     session, err = _sess_nowait(params, rid)
     if err:
         return err
-    # Re-bind to the current client transport for this request. This keeps
-    # streaming events on the active websocket even if an earlier disconnect
-    # or fallback moved the session transport to stdio.
-    if (t := current_transport()) is not None:
-        session["transport"] = t
     with session["history_lock"]:
         if session.get("running"):
             return _err(rid, 4009, "session busy")
-        if truncate_user_ordinal is not None:
-            try:
-                ordinal = int(truncate_user_ordinal)
-            except (TypeError, ValueError):
-                return _err(rid, 4004, "truncate_before_user_ordinal must be an integer")
-            history = session.get("history", [])
-            user_indices = [i for i, m in enumerate(history) if m.get("role") == "user"]
-            if ordinal >= len(user_indices):
-                return _err(rid, 4018, "target user message is no longer in session history")
-            truncated = history[: user_indices[ordinal]]
-            session["history"] = truncated
-            session["history_version"] = int(session.get("history_version", 0)) + 1
-            if (db := _get_db()) is not None:
-                try:
-                    db.replace_messages(session["session_key"], truncated)
-                except Exception as exc:
-                    print(f"[tui_gateway] prompt.submit: replace_messages failed: {exc}", file=sys.stderr)
         session["running"] = True
         session["last_active"] = time.time()
         _start_inflight_turn(session, text)
 
-    # Persist the DB row lazily, now that the user has actually sent a message.
-    _ensure_session_db_row(session)
     _start_agent_build(sid, session)
 
     def run_after_agent_ready() -> None:
@@ -4641,195 +3890,119 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"status": "streaming"})
 
 
-def _notification_event_belongs_elsewhere(session: dict, evt: dict) -> bool:
-    """True if ``evt`` is owned by a *different* live session.
-
-    Background-process events carry the ``session_key`` of the session that
-    started the process. Since all desktop sessions share one process-wide
-    completion queue, each poller must skip events it doesn't own so a
-    background job's completion surfaces in the session that launched it — not
-    whichever poller happened to dequeue first. Orphaned events (owner gone)
-    and global/system events (empty ``session_key``) return False so the
-    current poller still handles them rather than losing them.
-    """
-    evt_key = str(evt.get("session_key") or "")
-    if not evt_key:
-        return False
-    if evt_key == str(session.get("session_key") or ""):
-        return False
+def _dispatch_kanban_to_session(sid: str, session: dict, task_id: str, kind: str, payload: dict) -> None:
+    """Dispatch a kanban event to a TUI session (event-driven, no polling)."""
+    _msg = _format_kanban_event_from_payload(kind, task_id, payload or {})
+    if not _msg:
+        return
+    with session["history_lock"]:
+        if session.get("running"):
+            session.setdefault("_pending_kanban", []).append(_msg)
+            _emit("status.update", sid, {"kind": "process", "text": _msg})
+            return
+        session["running"] = True
+    _rid = f"__kanban__{int(time.time() * 1000)}"
     try:
-        with _sessions_lock:
-            snapshot = list(_sessions.values())
+        _emit("message.start", sid)
+        _run_prompt_submit(_rid, sid, session, _msg)
     except Exception:
-        # If we can't safely enumerate live sessions, fail open so we don't
-        # crash the poller thread or drop the event.
-        return False
-
-    return any(
-        s is not session and str(s.get("session_key") or "") == evt_key
-        for s in snapshot
-    )
-
-
-def _notification_event_dedup_key(evt: dict) -> tuple:
-    """Return the UI-emission identity for a process notification event.
-
-    Completion events are terminal notifications for a background process, so
-    they remain one-shot per process session. Watch-match events are not
-    terminal: a single background process can legitimately match the same or
-    different patterns many times, so include event-specific content to avoid
-    suppressing later distinct matches from the same process.
-    """
-    evt_type = evt.get("type", "completion")
-    evt_sid = evt.get("session_id", "")
-    if evt_type == "watch_match":
-        return (
-            evt_sid,
-            evt_type,
-            evt.get("command", ""),
-            evt.get("pattern", ""),
-            evt.get("output", ""),
-            evt.get("suppressed", 0),
-            evt.get("message_id", ""),
-        )
-    if evt_type.startswith("watch_overflow_") or evt_type == "watch_disabled":
-        return (
-            evt_sid,
-            evt_type,
-            evt.get("command", ""),
-            evt.get("message", ""),
-            evt.get("suppressed", 0),
-        )
-    return (evt_sid, evt_type)
-
-
-def _notification_poller_loop(
-    stop_event: threading.Event, sid: str, session: dict
-) -> None:
-    """Poll completion_queue and dispatch notifications autonomously.
-
-    Runs in a daemon thread started by _init_session(). Emits a
-    status.update (kind=process) for user visibility, then chains an
-    agent turn via _run_prompt_submit if the session is idle.
-
-    NOTE: The completion_queue is global (one per process). If multiple
-    TUI sessions coexist, whichever poller wakes first grabs the event,
-    even if the process was started by a different session. This matches
-    CLI/gateway behavior (single session per process).
-    """
-    from tools.process_registry import process_registry, format_process_notification
-
-    _emitted = set()  # dedup re-queued events so same completion isn't emitted 50 times while session is busy
-    while not stop_event.is_set() and not session.get("_finalized"):
-        try:
-            evt = process_registry.completion_queue.get(timeout=0.5)
-        except Exception:
-            continue
-
-        # Multiple desktop sessions share this one process-wide queue. Only
-        # consume events that belong to *this* session — otherwise a background
-        # process started in session A would surface its completion in whichever
-        # session's poller happened to wake first (Ben's "reported in a
-        # different session" bug). Leave foreign events for their owner.
-        if _notification_event_belongs_elsewhere(session, evt):
-            process_registry.completion_queue.put(evt)
-            time.sleep(0.1)
-            continue
-
-        _evt_sid = evt.get("session_id", "")
-        if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
-            continue
-
-        text = format_process_notification(evt)
-        if not text:
-            continue
-
-        # Only emit the same notification identity to TUI once — re-queued
-        # completions get re-emitted every 0.5s otherwise when session is busy,
-        # while distinct watch_match events from the same process must remain
-        # visible independently.
-        _dedup_key = _notification_event_dedup_key(evt)
-        if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
-            _emitted.add(_dedup_key)
-
         with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                continue
-            session["running"] = True
-
-        rid = f"__notif__{int(time.time() * 1000)}"
-        try:
-            _emit("message.start", sid)
-            _run_prompt_submit(rid, sid, session, text)
-        except Exception as exc:
-            print(
-                f"[tui_gateway] notification poller dispatch failed: "
-                f"{type(exc).__name__}: {exc}",
-                file=sys.stderr,
-            )
-            with session["history_lock"]:
-                session["running"] = False
-
-    # Drain any remaining events after stop signal (process all pending
-    # before exiting so nothing is lost on shutdown). Events owned by other
-    # live sessions are set aside and re-queued so their poller still sees them.
-    deferred: list = []
-    while not process_registry.completion_queue.empty():
-        try:
-            evt = process_registry.completion_queue.get_nowait()
-        except Exception:
-            break
-        if _notification_event_belongs_elsewhere(session, evt):
-            deferred.append(evt)
-            continue
-        _evt_sid = evt.get("session_id", "")
-        if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
-            continue
-        text = format_process_notification(evt)
-        if not text:
-            continue
-
-        _dedup_key = _notification_event_dedup_key(evt)
-        if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
-            _emitted.add(_dedup_key)
-
-        with session["history_lock"]:
-            if session.get("running"):
-                process_registry.completion_queue.put(evt)
-                break
-            session["running"] = True
-
-        rid = f"__notif__{int(time.time() * 1000)}"
-        try:
-            _emit("message.start", sid)
-            _run_prompt_submit(rid, sid, session, text)
-        except Exception as exc:
-            print(
-                f"[tui_gateway] notification poller dispatch failed: "
-                f"{type(exc).__name__}: {exc}",
-                file=sys.stderr,
-            )
-            with session["history_lock"]:
-                session["running"] = False
-
-    # Hand any other sessions' events back to the shared queue.
-    for evt in deferred:
-        process_registry.completion_queue.put(evt)
+            session["running"] = False
 
 
-def _start_notification_poller(sid: str, session: dict) -> threading.Event:
-    """Start the background notification poller for a TUI session."""
-    stop = threading.Event()
-    t = threading.Thread(
-        target=_notification_poller_loop,
-        args=(stop, sid, session),
-        daemon=True,
-    )
+# ── HTTP notification endpoint ───────────────────────────────────
+# The gateway's TUIAdapter POSTs kanban events to this endpoint.
+# Events are dispatched directly to active sessions — no polling.
+
+_NOTIF_HTTP_PORT: int = 0
+_NOTIF_HTTP_STARTED = False
+
+
+def _handle_notification_post(body: dict) -> None:
+    """Dispatch a notification event received via HTTP POST."""
+    content = body.get("content", "")
+    metadata = body.get("metadata", {})
+    task_id = metadata.get("task_id", "")
+    kind = metadata.get("kind", "completed")
+    payload = metadata.get("payload", {})
+
+    if not content:
+        return
+
+    if task_id:
+        for _sid, _session in list(_sessions.items()):
+            try:
+                _dispatch_kanban_to_session(
+                    _sid, _session, task_id, kind, payload,
+                )
+            except Exception:
+                pass
+    else:
+        for _sid, _session in list(_sessions.items()):
+            try:
+                with _session["history_lock"]:
+                    if _session.get("running"):
+                        _session.setdefault("_pending_kanban", []).append(content)
+                        _emit("status.update", _sid,
+                              {"kind": "process", "text": content})
+                        continue
+                    _session["running"] = True
+                _rid = f"__notif__{int(time.time() * 1000)}"
+                try:
+                    _emit("message.start", _sid)
+                    _run_prompt_submit(_rid, _sid, _session, content)
+                except Exception:
+                    with _session["history_lock"]:
+                        _session["running"] = False
+            except Exception:
+                pass
+
+
+def _start_notification_http() -> None:
+    """Start a minimal HTTP server for gateway→TUI notification delivery."""
+    global _NOTIF_HTTP_PORT, _NOTIF_HTTP_STARTED
+    if _NOTIF_HTTP_STARTED:
+        return
+    _NOTIF_HTTP_STARTED = True
+
+    import socket
+    from http.server import HTTPServer, BaseHTTPRequestHandler
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(length) if length else b""
+            try:
+                import json as _json
+                data = _json.loads(body)
+                _handle_notification_post(data)
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"ok")
+            except Exception as exc:
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(str(exc).encode())
+
+        def log_message(self, *args):
+            pass  # suppress stderr logging
+
+    server = HTTPServer(("127.0.0.1", 0), _Handler)
+    _NOTIF_HTTP_PORT = server.server_address[1]
+
+    # Write port to file so the gateway's TUIAdapter can find it.
+    _port_file = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes") / "tui_notify_port"
+    try:
+        _port_file.write_text(str(_NOTIF_HTTP_PORT))
+    except OSError:
+        pass
+
+    t = threading.Thread(target=server.serve_forever, name="notif-http", daemon=True)
     t.start()
-    return stop
+
+
+# Auto-start on module import.
+_start_notification_http()
 
 
 def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
@@ -4846,7 +4019,6 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
     def run():
         approval_token = None
         session_tokens = []
-        home_token = None  # per-turn HERMES_HOME override for a resumed remote profile
         goal_followup = None  # set by the post-turn goal hook below
         try:
             from tools.approval import (
@@ -4856,18 +4028,6 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
 
             approval_token = set_current_session_key(session["session_key"])
             session_tokens = _set_session_context(session["session_key"])
-            _profile_home_str = session.get("profile_home")
-            if _profile_home_str:
-                home_token = set_hermes_home_override(_profile_home_str)
-            # The sudo password callback is thread-local (tools.terminal_tool
-            # _callback_tls), so wiring it on the build thread doesn't reach this
-            # turn thread — terminal sudo prompts would fall through to /dev/tty
-            # and hang the headless gateway. Re-wire here so the prompt routes to
-            # the sudo.request overlay. (secret capture is a module global, so
-            # re-running is a harmless no-op.)
-            _wire_callbacks(sid)
-            cwd = _session_cwd(session)
-            _register_session_cwd(session)
             cols = session.get("cols", 80)
             streamer = make_stream_renderer(cols)
             prompt = text
@@ -4887,8 +4047,8 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 )
                 ctx = preprocess_context_references(
                     prompt,
-                    cwd=cwd,
-                    allowed_root=cwd,
+                    cwd=os.environ.get("TERMINAL_CWD", os.getcwd()),
+                    allowed_root=os.environ.get("TERMINAL_CWD", os.getcwd()),
                     context_length=ctx_len,
                 )
                 if ctx.blocked:
@@ -4968,16 +4128,11 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     payload["rendered"] = r
                 _emit("message.delta", sid, payload)
 
-            run_kwargs = {
-                "conversation_history": list(history),
-                "stream_callback": _stream,
-            }
-            try:
-                if "task_id" in inspect.signature(agent.run_conversation).parameters:
-                    run_kwargs["task_id"] = session["session_key"]
-            except (TypeError, ValueError):
-                pass
-            result = agent.run_conversation(run_message, **run_kwargs)
+            result = agent.run_conversation(
+                run_message,
+                conversation_history=list(history),
+                stream_callback=_stream,
+            )
 
             last_reasoning = None
             status_note = None
@@ -5073,6 +4228,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                             goals_cfg = _load_cfg().get("goals") or {}
                             goal_max_turns = int(goals_cfg.get("max_turns", 20) or 20)
                         except Exception:
+                            logger.debug("Goals config load failed", exc_info=True)
                             goal_max_turns = 20
                         goal_mgr = GoalManager(
                             session_id=sid_key,
@@ -5119,6 +4275,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                             _session_key, exc,
                         )
                     except Exception:
+                        logger.debug("Pending title DB save failed", exc_info=True)
                         # Transient DB failure — keep pending_title for retry.
                         pass
 
@@ -5140,6 +4297,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         session.get("history", []),
                     )
                 except Exception:
+                    logger.debug("Auto-title generation failed", exc_info=True)
                     pass
 
             # CLI parity: when voice-mode TTS is on, speak the agent reply
@@ -5186,15 +4344,13 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 if approval_token is not None:
                     reset_current_session_key(approval_token)
             except Exception:
+                logger.debug("Approval token reset failed", exc_info=True)
                 pass
-            if home_token is not None:
-                reset_hermes_home_override(home_token)
             _clear_session_context(session_tokens)
             with session["history_lock"]:
                 session["running"] = False
                 session["last_active"] = time.time()
                 _clear_inflight_turn(session)
-            _emit("session.info", sid, _session_info(agent, session))
 
         # Chain a goal-continuation turn if the judge said so. We do
         # this AFTER the finally releases session["running"], so the
@@ -5221,17 +4377,43 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 with session["history_lock"]:
                     session["running"] = False
 
+        # Drain pending kanban notifications that were queued while the
+        # session was busy.  Batch ALL pending into a single combined
+        # message so one user-message mid-drain doesn't orphan the rest.
+        with session["history_lock"]:
+            _pending = session.get("_pending_kanban", [])
+            if _pending and not session.get("running"):
+                _batch = "\n\n".join(_pending)
+                _pending.clear()
+                session["running"] = True
+            else:
+                _batch = None
+        if _batch:
+            try:
+                _emit("message.start", sid)
+                _run_prompt_submit(rid, sid, session, _batch)
+            except Exception as _pk_exc:
+                print(
+                    f"[tui_gateway] pending kanban dispatch failed: "
+                    f"{type(_pk_exc).__name__}: {_pk_exc}",
+                    file=sys.stderr,
+                )
+                with session["history_lock"]:
+                    session["running"] = False
+
         # Drain completion notifications that arrived during this turn.
-        # The background poller handles between-turn delivery; this is
-        # the safety net for events that arrived mid-turn.
+        # Events are delivered via process_registry._completion_callback;
+        # if the session is busy, queue for later dispatch.
         try:
             from tools.process_registry import process_registry
 
             for _evt, synth in process_registry.drain_notifications():
                 with session["history_lock"]:
                     if session.get("running"):
-                        process_registry.completion_queue.put(_evt)
-                        break
+                        session.setdefault("_pending_kanban", []).append(synth)
+                        _emit("status.update", sid,
+                              {"kind": "process", "text": synth})
+                        continue
                     session["running"] = True
                 try:
                     _emit("message.start", sid)
@@ -5337,294 +4519,6 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5027, str(e))
 
 
-# Byte-upload attach caps. 25 MB matches Anthropic's per-image limit; 50 MB / 25
-# pages bounds a single PDF drop so it can't blow the context budget.
-_ATTACH_BYTES_MAX_BYTES = 25 * 1024 * 1024
-_PDF_ATTACH_MAX_BYTES = 50 * 1024 * 1024
-_PDF_ATTACH_MAX_PAGES = 25
-
-# Leading magic bytes → file extension, for filename-less uploads.
-_IMAGE_MAGIC: tuple[tuple[bytes, str], ...] = (
-    (b"\x89PNG\r\n\x1a\n", ".png"),
-    (b"\xff\xd8\xff", ".jpg"),
-    (b"GIF87a", ".gif"),
-    (b"GIF89a", ".gif"),
-    (b"BM", ".bmp"),
-)
-
-
-def _decode_attach_base64(raw: str, *, mime_prefix: str) -> bytes | None:
-    """Decode a base64 (optionally data-URL-wrapped) payload.
-
-    Accepts ``data:<mime_prefix>...;base64,<b64>`` plus embedded whitespace.
-    Returns the decoded bytes, or ``None`` when the input isn't valid base64.
-    """
-    import base64 as _base64
-    import re as _re
-
-    cleaned = raw.strip()
-    m = _re.match(
-        rf"^data:{_re.escape(mime_prefix)}[a-zA-Z0-9.+-]*;base64,(.*)$",
-        cleaned,
-        _re.DOTALL,
-    )
-    if m:
-        cleaned = m.group(1)
-    cleaned = _re.sub(r"\s+", "", cleaned)
-    try:
-        return _base64.b64decode(cleaned, validate=True)
-    except Exception:
-        return None
-
-
-def _sniff_image_ext(img_bytes: bytes, filename: str = "") -> str:
-    """Resolve an image extension from a filename hint, else magic bytes.
-
-    Falls back to ``.png``. WebP needs the RIFF/WEBP container check, handled
-    before the generic table.
-    """
-    if filename:
-        suffix = Path(filename).suffix.lower()
-        if suffix:
-            return suffix
-    head = img_bytes[:16]
-    if head.startswith(b"RIFF") and head[8:12] == b"WEBP":
-        return ".webp"
-    for sig, ext in _IMAGE_MAGIC:
-        if head.startswith(sig):
-            return ext
-    return ".png"
-
-
-def _allowed_image_extensions() -> frozenset[str]:
-    try:
-        from cli import _IMAGE_EXTENSIONS
-
-        return frozenset(_IMAGE_EXTENSIONS)
-    except Exception:
-        return frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"})
-
-
-def _queue_attached_image(session: dict, img_bytes: bytes, ext: str, *, prefix: str) -> Path:
-    """Write image bytes into the gateway's images dir and queue them.
-
-    Mirrors what ``image.attach`` does for a local path: appends to
-    ``session["attached_images"]`` so the next ``prompt.submit`` picks it up via
-    the existing native-image-attach pipeline. Returns the written path.
-    """
-    session["image_counter"] = session.get("image_counter", 0) + 1
-    img_dir = _hermes_home / "images"
-    img_dir.mkdir(parents=True, exist_ok=True)
-    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    img_path = img_dir / f"{prefix}_{ts}_{session['image_counter']}{ext}"
-    try:
-        img_path.write_bytes(img_bytes)
-    except Exception:
-        session["image_counter"] = max(0, session["image_counter"] - 1)
-        raise
-    session.setdefault("attached_images", []).append(str(img_path))
-    return img_path
-
-
-@method("image.attach_bytes")
-def _(rid, params: dict) -> dict:
-    """Attach an image to the session from base64 bytes (remote-client path).
-
-    A desktop app or web dashboard running on a DIFFERENT machine than the
-    gateway can't hand us a local path — that file only exists on the client's
-    disk. So it uploads the raw image bytes (base64) and we write them into the
-    gateway's own images dir. The response shape mirrors ``image.attach`` so the
-    client treats both identically.
-
-    Params:
-      content_base64 / data (str, required): base64 image bytes. Accepts a
-        ``data:image/...;base64,`` prefix and embedded whitespace. ``data`` is
-        an accepted alias for older desktop builds.
-      filename / ext (str, optional): extension hint. Without it, magic bytes
-        identify PNG/JPEG/GIF/WebP/BMP, falling back to ``.png``.
-    """
-    session, err = _sess(params, rid)
-    if err:
-        return err
-
-    raw_b64 = str(params.get("content_base64") or params.get("data") or "").strip()
-    if not raw_b64:
-        return _err(rid, 4015, "content_base64 required")
-
-    img_bytes = _decode_attach_base64(raw_b64, mime_prefix="image/")
-    if img_bytes is None:
-        return _err(rid, 4017, "data is not valid base64")
-    if not img_bytes:
-        return _err(rid, 4017, "image is empty")
-    if len(img_bytes) > _ATTACH_BYTES_MAX_BYTES:
-        mb = _ATTACH_BYTES_MAX_BYTES // (1024 * 1024)
-        return _err(rid, 4018, f"image too large ({len(img_bytes)} bytes; cap is {mb} MB)")
-
-    filename = str(params.get("filename", "") or "")
-    ext_hint = str(params.get("ext", "") or "").strip().lower()
-    if ext_hint and not ext_hint.startswith("."):
-        ext_hint = "." + ext_hint
-    ext = _sniff_image_ext(img_bytes, filename or (f"x{ext_hint}" if ext_hint else ""))
-    if ext not in _allowed_image_extensions():
-        return _err(rid, 4016, f"unsupported image extension: {ext}")
-
-    try:
-        img_path = _queue_attached_image(session, img_bytes, ext, prefix="upload")
-    except Exception as e:
-        return _err(rid, 5027, f"write failed: {e}")
-
-    return _ok(
-        rid,
-        {
-            "attached": True,
-            "path": str(img_path),
-            "count": len(session["attached_images"]),
-            "remainder": "",
-            "text": f"[User attached image: {img_path.name}]",
-            "bytes": len(img_bytes),
-            **_image_meta(img_path),
-        },
-    )
-
-
-@method("pdf.attach")
-def _(rid, params: dict) -> dict:
-    """Attach a PDF by rendering each page to PNG and queuing the pages.
-
-    Anthropic's vision pipeline accepts images, not PDFs, so this runs
-    ``pdftoppm`` (poppler-utils) at 150 DPI per page and queues each rendered
-    page as an attached image. Accepts either a host ``path`` (local mode) or
-    base64 ``content_base64`` (remote upload). Caps at 50 MB / 25 pages per call.
-
-    Requires ``pdftoppm`` on $PATH (``apt install poppler-utils``); returns 5028
-    if missing.
-    """
-    import shutil
-    import subprocess
-    import tempfile
-
-    session, err = _sess(params, rid)
-    if err:
-        return err
-
-    if shutil.which("pdftoppm") is None:
-        return _err(rid, 5028, "pdftoppm not installed (poppler-utils package required)")
-
-    raw_path = str(params.get("path", "") or "").strip()
-    raw_b64 = str(params.get("content_base64") or params.get("data") or "").strip()
-    if not raw_path and not raw_b64:
-        return _err(rid, 4015, "path or content_base64 required")
-
-    with tempfile.TemporaryDirectory(prefix="pdf_attach_") as td:
-        td_path = Path(td)
-        if raw_b64:
-            pdf_bytes = _decode_attach_base64(raw_b64, mime_prefix="application/pdf")
-            if pdf_bytes is None:
-                return _err(rid, 4017, "data is not valid base64")
-            if not pdf_bytes:
-                return _err(rid, 4017, "decoded PDF is empty")
-            if len(pdf_bytes) > _PDF_ATTACH_MAX_BYTES:
-                mb = _PDF_ATTACH_MAX_BYTES // (1024 * 1024)
-                return _err(rid, 4018, f"PDF too large ({len(pdf_bytes)} bytes; cap is {mb} MB)")
-            if pdf_bytes[:5] != b"%PDF-":
-                return _err(rid, 4017, "payload is not a PDF (missing %PDF- magic bytes)")
-            pdf_path = td_path / "input.pdf"
-            pdf_path.write_bytes(pdf_bytes)
-            display_name = str(params.get("filename", "") or "uploaded.pdf")
-        else:
-            try:
-                from cli import _resolve_attachment_path
-
-                resolved = _resolve_attachment_path(raw_path)
-            except Exception:
-                resolved = None
-            if resolved is None or not Path(resolved).is_file():
-                return _err(rid, 4016, f"PDF not found: {raw_path}")
-            if Path(resolved).suffix.lower() != ".pdf":
-                return _err(rid, 4016, f"not a PDF: {Path(resolved).name}")
-            if Path(resolved).stat().st_size > _PDF_ATTACH_MAX_BYTES:
-                mb = _PDF_ATTACH_MAX_BYTES // (1024 * 1024)
-                return _err(rid, 4018, f"PDF too large; cap is {mb} MB")
-            pdf_path = Path(resolved)
-            display_name = pdf_path.name
-
-        try:
-            first_page = int(params.get("first_page") or 1)
-            last_page_param = params.get("last_page")
-            last_page = int(last_page_param) if last_page_param is not None else None
-        except (TypeError, ValueError):
-            return _err(rid, 4015, "first_page/last_page must be integers")
-
-        if first_page < 1:
-            return _err(rid, 4015, "first_page must be >= 1")
-        if last_page is None:
-            last_page = first_page + _PDF_ATTACH_MAX_PAGES - 1
-        if last_page < first_page:
-            return _err(rid, 4015, "last_page must be >= first_page")
-        if last_page - first_page + 1 > _PDF_ATTACH_MAX_PAGES:
-            return _err(rid, 4019, f"page range exceeds cap of {_PDF_ATTACH_MAX_PAGES} pages per attach call")
-
-        out_prefix = td_path / "page"
-        argv = [
-            "pdftoppm", "-png", "-r", "150",
-            "-f", str(first_page), "-l", str(last_page),
-            str(pdf_path), str(out_prefix),
-        ]
-        try:
-            res = subprocess.run(argv, capture_output=True, text=True, timeout=120)
-        except subprocess.TimeoutExpired:
-            return _err(rid, 5028, "pdftoppm timed out (>120s)")
-        if res.returncode != 0:
-            tail = (res.stderr or res.stdout or "").strip().splitlines()[-3:]
-            return _err(rid, 5028, "pdftoppm failed: " + " | ".join(tail))
-
-        rendered = sorted(td_path.glob("page-*.png"))
-        if not rendered:
-            return _err(rid, 5028, "pdftoppm produced no pages (corrupt PDF?)")
-
-        attached_pages = []
-        for src in rendered:
-            page_num = src.stem.split("-", 1)[-1]
-            try:
-                page_int = int(page_num)
-            except ValueError:
-                page_int = first_page + len(attached_pages)
-            dst = _queue_attached_image(session, src.read_bytes(), ".png", prefix=f"pdf_p{page_num}")
-            attached_pages.append({"path": str(dst), "page": page_int, **_image_meta(dst)})
-
-        return _ok(
-            rid,
-            {
-                "attached": True,
-                "filename": display_name,
-                "pages_attached": len(attached_pages),
-                "pages": attached_pages,
-                "count": len(session["attached_images"]),
-                "text": f"[User attached PDF: {display_name} ({len(attached_pages)} page(s))]",
-            },
-        )
-
-
-@method("image.detach")
-def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
-    if err:
-        return err
-    raw = str(params.get("path", "") or "").strip()
-    if not raw:
-        return _err(rid, 4015, "path required")
-    images = session.setdefault("attached_images", [])
-    before = len(images)
-    session["attached_images"] = [path for path in images if path != raw]
-    return _ok(
-        rid,
-        {
-            "detached": len(session["attached_images"]) != before,
-            "count": len(session["attached_images"]),
-        },
-    )
-
-
 @method("input.detect_drop")
 def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
@@ -5683,7 +4577,7 @@ def _(rid, params: dict) -> dict:
     task_id = f"bg_{uuid.uuid4().hex[:6]}"
 
     def run():
-        session_tokens = _set_session_context(task_id, cwd=_session_cwd(session))
+        session_tokens = _set_session_context(task_id)
         try:
             from run_agent import AIAgent
 
@@ -5718,131 +4612,17 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"task_id": task_id})
 
 
-@method("preview.restart")
-def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
-    if err:
-        return err
-
-    url = str(params.get("url") or "").strip()
-    cwd = str(params.get("cwd") or "").strip()
-    context = str(params.get("context") or "").strip()
-
-    if not url:
-        return _err(rid, 4012, "url required")
-
-    task_id = f"preview_{uuid.uuid4().hex[:6]}"
-    parent = params.get("session_id", "")
-    parent_history = _preview_restart_history(session)
-    has_history = bool(parent_history)
-    prompt = "\n".join(
-        line
-        for line in [
-            "The desktop preview pane cannot load a local server URL.",
-            "",
-            f"Preview URL: {url}",
-            f"Current working directory: {cwd or '(unknown)'}",
-            "",
-            f"Preview console:\n{context}" if context else "",
-            "" if context else "",
-            (
-                "The conversation history above is from the user's main session — including the commands you (the assistant) previously ran to start servers, edit files, or check ports. Use it to figure out exactly which server should be running at this Preview URL. The user did not start a brand new task; recover what they had working."
-                if has_history
-                else None
-            ),
-            "Restart exactly the app intended for the Preview URL, not Hermes Desktop itself.",
-            "The Preview URL and port are the target. Preserve that target unless you conclude it is impossible.",
-            "If the prior conversation shows a specific command that bound this URL/port, prefer re-running THAT exact command (in the same cwd) over guessing a new one.",
-            "First inspect what process, if any, owns the Preview URL port. If a stale server exists, inspect its cwd and prefer that cwd over the Hermes/Desktop process cwd.",
-            "The Current working directory is only a hint. Do not assume it is the preview app root when the port owner or files indicate another root.",
-            "If the console shows a module-script MIME error for src/main.tsx or similar, a static server is serving source files. Do not restart python -m http.server or any dumb static server for that app.",
-            "For module-script MIME failures, inspect package.json/vite config in the candidate app root and start the real dev server/bundler (for example npm/pnpm/yarn dev) so module transforms happen.",
-            "Before declaring success, verify the Preview URL responds with the intended app, not Hermes Desktop. If it serves Hermes/Desktop UI or another unrelated app, stop that process and report failure.",
-            "Do not modify files. Do not ask the user unless blocked.",
-            "Prefer existing project scripts or commands when they are clear.",
-            "If a stale process owns the needed port, handle it safely.",
-            "Start long-running servers detached/in the background, then return immediately.",
-            "Do not run a foreground dev server command that blocks this background task.",
-            "Keep the final response short: what command/server was started, or why it could not be restarted.",
-        ]
-        if line
-    )
-
-    # Normalize defensively: a malformed client path (embedded NUL, etc.) must
-    # not blow up the whole restart — treat it as "no validated cwd".
-    try:
-        preview_cwd = os.path.abspath(os.path.expanduser(cwd)) if cwd else ""
-        if preview_cwd and not os.path.isdir(preview_cwd):
-            preview_cwd = ""
-    except Exception:
-        preview_cwd = ""
-
-    def run():
-        # Pin the validated preview cwd, else the parent workspace — never an
-        # invalid client path, which would silently fall back to the launch dir.
-        session_tokens = _set_session_context(task_id, cwd=(preview_cwd or _session_cwd(session)))
-        try:
-            from run_agent import AIAgent
-            from tools.terminal_tool import register_task_env_overrides
-
-            if preview_cwd:
-                register_task_env_overrides(task_id, {"cwd": preview_cwd})
-
-            history_note = (
-                f" (with {len(parent_history)} parent-session messages of context)"
-                if parent_history
-                else ""
-            )
-            _emit(
-                "preview.restart.progress",
-                parent,
-                {"task_id": task_id, "text": f"Starting hidden restart agent{history_note}"},
-            )
-            result = AIAgent(
-                **_ephemeral_preview_agent_kwargs(session["agent"], task_id),
-                **_preview_restart_callbacks(parent, task_id),
-            ).run_conversation(
-                user_message=prompt,
-                task_id=task_id,
-                conversation_history=parent_history or None,
-            )
-            text = (
-                result.get("final_response", str(result))
-                if isinstance(result, dict)
-                else str(result)
-            )
-            _emit("preview.restart.complete", parent, {"task_id": task_id, "text": text})
-        except Exception as e:
-            _emit(
-                "preview.restart.complete",
-                parent,
-                {"task_id": task_id, "text": f"error: {e}"},
-            )
-        finally:
-            try:
-                from tools.terminal_tool import clear_task_env_overrides
-
-                clear_task_env_overrides(task_id)
-            except Exception:
-                pass
-            _clear_session_context(session_tokens)
-
-    threading.Thread(target=run, daemon=True).start()
-    return _ok(rid, {"task_id": task_id})
-
-
 # ── Methods: respond ─────────────────────────────────────────────────
 
 
 def _respond(rid, params, key):
     r = params.get("request_id", "")
-    with _prompt_lock:
-        entry = _pending.get(r)
-        if not entry:
-            return _err(rid, 4009, f"no pending {key} request")
-        _, ev = entry
-        _answers[r] = params.get(key, "")
-        ev.set()
+    entry = _pending.get(r)
+    if not entry:
+        return _err(rid, 4009, f"no pending {key} request")
+    _, ev = entry
+    _answers[r] = params.get(key, "")
+    ev.set()
     return _ok(rid, {"status": "ok"})
 
 
@@ -5986,7 +4766,7 @@ def _(rid, params: dict) -> dict:
             _emit(
                 "session.info",
                 params.get("session_id", ""),
-                _session_info(agent, session),
+                _session_info(agent),
             )
         return _ok(rid, {"key": key, "value": nv})
 
@@ -6283,20 +5063,6 @@ def _(rid, params: dict) -> dict:
         _write_config_key("display.tui_status_indicator", raw)
         return _ok(rid, {"key": key, "value": raw})
 
-    if key in {"cwd", "terminal.cwd", "workdir"}:
-        raw = str(value or "").strip()
-        if not raw:
-            return _err(rid, 4002, "cwd required")
-        cwd = os.path.abspath(os.path.expanduser(raw))
-        if not os.path.isdir(cwd):
-            return _err(rid, 4002, f"working directory does not exist: {raw}")
-        _write_config_key("terminal.cwd", cwd)
-        os.environ["TERMINAL_CWD"] = cwd
-        return _ok(
-            rid,
-            {"key": "terminal.cwd", "value": cwd, "cwd": cwd, "branch": _git_branch_for_cwd(cwd)},
-        )
-
     if key in {"prompt", "personality", "skin"}:
         try:
             cfg = _load_cfg()
@@ -6313,9 +5079,9 @@ def _(rid, params: dict) -> dict:
                 pname, new_prompt = _validate_personality(str(value or ""), cfg)
                 _write_config_key("display.personality", pname)
                 _write_config_key("agent.system_prompt", new_prompt)
-                nv = str(value or "none")
+                nv = str(value or "default")
                 history_reset, info = _apply_personality_to_session(
-                    sid_key, session, new_prompt, pname
+                    sid_key, session, new_prompt
                 )
             else:
                 _write_config_key(f"display.{key}", value)
@@ -6359,11 +5125,6 @@ def _(rid, params: dict) -> dict:
         from hermes_constants import display_hermes_home
 
         return _ok(rid, {"home": str(_hermes_home), "display": display_hermes_home()})
-    if key == "project":
-        cfg_terminal = _load_cfg().get("terminal") or {}
-        raw = str(params.get("cwd", "") or cfg_terminal.get("cwd", "") or "").strip()
-        cwd = _completion_cwd({"cwd": raw} if raw else {})
-        return _ok(rid, {"cwd": cwd, "branch": _git_branch_for_cwd(cwd)})
     if key == "full":
         return _ok(rid, {"config": _load_cfg()})
     if key == "prompt":
@@ -6387,7 +5148,7 @@ def _(rid, params: dict) -> dict:
     if key == "personality":
         return _ok(
             rid,
-            {"value": (_load_cfg().get("display") or {}).get("personality") or "none"},
+            {"value": (_load_cfg().get("display") or {}).get("personality", "default")},
         )
     if key == "reasoning":
         cfg = _load_cfg()
@@ -6467,6 +5228,7 @@ def _(rid, params: dict) -> dict:
                 rid, {"mtime": cfg_path.stat().st_mtime if cfg_path.exists() else 0}
             )
         except Exception:
+            logger.debug("config.mtime stat failed", exc_info=True)
             return _ok(rid, {"mtime": 0})
     return _err(rid, 4002, f"unknown config key: {key}")
 
@@ -6479,75 +5241,6 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"provider_configured": bool(_has_any_provider_configured())})
     except Exception as e:
         return _err(rid, 5016, str(e))
-
-
-@method("setup.runtime_check")
-def _(rid, params: dict) -> dict:
-    """Strict provider check: does the configured/default model actually resolve to a usable runtime?
-
-    Unlike setup.status (which returns True if ANY provider auth state is
-    discoverable, including indirect fallbacks like ``gh auth token`` for
-    Copilot), this runs the same resolve_runtime_provider() call the agent
-    uses on session creation. It returns ok=False with the auth error message
-    when the user's configured model cannot actually be served, so UIs can
-    surface onboarding before the user submits a doomed prompt.
-    """
-    try:
-        from hermes_cli.runtime_provider import resolve_runtime_provider
-        from hermes_cli.auth import has_usable_secret
-        from hermes_cli.main import _has_any_provider_configured
-
-        runtime = resolve_runtime_provider(requested=None)
-        provider_configured = bool(_has_any_provider_configured())
-        provider = runtime.get("provider") or "provider"
-        source = str(runtime.get("source") or "")
-        if not provider_configured and provider == "bedrock" and source in {
-            "iam-role",
-            "aws-sdk-default-chain",
-        }:
-            return _ok(
-                rid,
-                {
-                    "ok": False,
-                    "provider": provider,
-                    "model": runtime.get("model"),
-                    "source": source,
-                    "error": "No Hermes provider is configured.",
-                },
-            )
-
-        api_key = runtime.get("api_key")
-        api_key_text = "" if callable(api_key) else str(api_key or "").strip()
-        credential_ok = (
-            callable(api_key)
-            or api_key_text in {"aws-sdk", "no-key-required"}
-            or has_usable_secret(api_key_text)
-            or bool(runtime.get("command"))
-        )
-
-        if not credential_ok:
-            return _ok(
-                rid,
-                {
-                    "ok": False,
-                    "provider": provider,
-                    "model": runtime.get("model"),
-                    "source": runtime.get("source"),
-                    "error": f"No usable credentials found for {provider}.",
-                },
-            )
-
-        return _ok(
-            rid,
-            {
-                "ok": True,
-                "provider": runtime.get("provider"),
-                "model": runtime.get("model"),
-                "source": runtime.get("source"),
-            },
-        )
-    except Exception as e:
-        return _ok(rid, {"ok": False, "error": str(e)})
 
 
 # ── Methods: tools & system ──────────────────────────────────────────
@@ -6585,6 +5278,7 @@ def _(rid, params: dict) -> dict:
                 if isinstance(_approvals, dict):
                     _confirm_required = bool(_approvals.get("mcp_reload_confirm", True))
             except Exception:
+                logger.debug("MCP reload confirm config load failed", exc_info=True)
                 _confirm_required = True
             if _confirm_required:
                 # Return a structured response the Ink client can surface
@@ -6633,11 +5327,7 @@ def _(rid, params: dict) -> dict:
                     "Failed to refresh cached agent tools after /reload-mcp: %s",
                     _exc,
                 )
-            _emit(
-                "session.info",
-                params.get("session_id", ""),
-                _session_info(agent, session),
-            )
+            _emit("session.info", params.get("session_id", ""), _session_info(agent))
 
         # Honor `always=true` by persisting the opt-out to config.
         if bool(params.get("always", False)):
@@ -6706,7 +5396,7 @@ _PENDING_INPUT_COMMANDS: frozenset[str] = frozenset(
         "steer",
         "plan",
         "goal",
-        "undo",
+        "loop",
     }
 )
 
@@ -6884,6 +5574,7 @@ def _resolve_name(name: str) -> str:
         r = resolve_command(name)
         return r.name if r else name
     except Exception:
+        logger.debug("command.resolve failed", exc_info=True)
         return name
 
 
@@ -6932,6 +5623,7 @@ def _(rid, params: dict) -> dict:
             result = resolve_plugin_command_result(handler(arg))
             return _ok(rid, {"type": "plugin", "output": str(result or "")})
     except Exception:
+        logger.warning("Plugin command handler failed", exc_info=True)
         pass
 
     try:
@@ -6956,6 +5648,7 @@ def _(rid, params: dict) -> dict:
                     },
                 )
     except Exception:
+        logger.warning("Skill command handler failed", exc_info=True)
         pass
 
     # ── Commands that queue messages onto _pending_input in the CLI ───
@@ -7017,6 +5710,7 @@ def _(rid, params: dict) -> dict:
                         },
                     )
             except Exception:
+                logger.debug("Steer command queue failed", exc_info=True)
                 pass
         # Fallback: no active run, treat as next-turn message
         return _ok(rid, {"type": "send", "message": arg})
@@ -7037,6 +5731,7 @@ def _(rid, params: dict) -> dict:
             goals_cfg = _load_cfg().get("goals") or {}
             max_turns = int(goals_cfg.get("max_turns", 20) or 20)
         except Exception:
+            logger.debug("Goal command config load failed", exc_info=True)
             max_turns = 20
         mgr = GoalManager(session_id=sid_key, default_max_turns=max_turns)
 
@@ -7092,106 +5787,93 @@ def _(rid, params: dict) -> dict:
             {"type": "send", "notice": notice, "message": state.goal},
         )
 
-    if name == "undo":
-        # /undo [N]: back up N user turns (default 1), soft-delete the
-        # truncated rows on disk, and prefill the composer with the text
-        # of the user message we backed up to so it can be edited and
-        # resubmitted. N=1 is the Claude-Code-style single-step undo;
-        # /undo 3 backs up three user turns at once. See issue #21910.
+    if name == "loop":
         if not session:
-            return _err(rid, 4001, "no active session to undo")
-        if session.get("running"):
-            return _err(
-                rid, 4009, "session busy — /interrupt the current turn before /undo"
+            return _err(rid, 4001, "no active session")
+        try:
+            from hermes_cli.loop import LoopManager, _parse_loop_command, format_interval
+        except Exception as exc:
+            return _err(rid, 5030, f"loop unavailable: {exc}")
+
+        sid_key = session.get("session_key") or ""
+        if not sid_key:
+            return _err(rid, 4001, "no session key")
+
+        # Use the session's existing loop manager (with TUI dispatch)
+        # or create one if it doesn't exist yet.
+        mgr = session.get("_loop_manager")
+        if mgr is None or getattr(mgr, "session_id", None) != sid_key:
+            mgr = LoopManager(
+                session_id=sid_key,
+                dispatch=_make_tui_dispatch(session, params.get("session_id", "")),
             )
-        db = _get_db()
-        if db is None:
-            return _db_unavailable_error(rid, code=5008)
-        session_key = session.get("session_key", "")
-        if not session_key:
-            return _err(rid, 4001, "no session key for undo")
-        # Parse the optional count argument (e.g. "/undo 3" → 3).
-        n = 1
-        arg_str = (arg or "").strip()
-        if arg_str:
+            session["_loop_manager"] = mgr
+
+        parsed = _parse_loop_command(arg)
+        action = parsed["action"]
+
+        if action == "status":
+            return _ok(rid, {"type": "exec", "output": mgr.status_line()})
+
+        if action == "pause_all":
+            paused = mgr.pause()
+            if not paused:
+                return _ok(rid, {"type": "exec", "output": "No active loops."})
+            ids = ", ".join(f"#{s.id}" for s in paused)
+            return _ok(rid, {"type": "exec", "output": f"⏸ Paused: {ids}"})
+
+        if action == "pause":
+            paused = mgr.pause(uid=parsed["uid"])
+            if not paused:
+                return _ok(rid, {"type": "exec", "output": f"No loop #{parsed['uid']}."})
+            return _ok(rid, {"type": "exec", "output": f"⏸ Loop #{parsed['uid']} paused: {paused[0].prompt}"})
+
+        if action == "resume_all":
+            resumed = mgr.resume()
+            if not resumed:
+                return _ok(rid, {"type": "exec", "output": "No paused loops."})
+            ids = ", ".join(f"#{s.id}" for s in resumed)
+            return _ok(rid, {"type": "exec", "output": f"▶ Resumed: {ids}"})
+
+        if action == "resume":
+            resumed = mgr.resume(uid=parsed["uid"])
+            if not resumed:
+                return _ok(rid, {"type": "exec", "output": f"No loop #{parsed['uid']}."})
+            return _ok(rid, {"type": "exec", "output": f"▶ Loop #{parsed['uid']} resumed: {resumed[0].prompt}"})
+
+        if action == "clear_all":
+            count = mgr.clear()
+            if count:
+                return _ok(rid, {"type": "exec", "output": f"✓ {count} loop(s) cleared."})
+            return _ok(rid, {"type": "exec", "output": "No active loops."})
+
+        if action == "clear":
+            count = mgr.clear(uid=parsed["uid"])
+            if count:
+                return _ok(rid, {"type": "exec", "output": f"✓ Loop #{parsed['uid']} cleared."})
+            return _ok(rid, {"type": "exec", "output": f"No loop #{parsed['uid']}."})
+
+        if action == "set":
             try:
-                n = int(arg_str.split()[0])
-            except (ValueError, IndexError):
-                return _err(rid, 4004, f"undo: invalid count {arg_str!r} — use /undo or /undo N")
-        if n < 1:
-            n = 1
-        try:
-            recents = db.list_recent_user_messages(session_key, limit=max(n, 10))
-        except Exception as e:
-            return _err(rid, 5008, f"undo: failed to load history: {e}")
-        if not recents:
-            return _err(rid, 4018, "no user messages to undo")
-        # recents[0] is the most-recent user turn; pick the Nth-from-last.
-        # If N exceeds the number of user turns, back up to the oldest.
-        target_idx = min(n - 1, len(recents) - 1)
-        target_id = recents[target_idx]["id"]
-        try:
-            result = db.rewind_to_message(session_key, target_id)
-        except ValueError as e:
-            return _err(rid, 4004, f"undo: {e}")
-        except Exception as e:
-            return _err(rid, 5008, f"undo: {e}")
-        # Reload the active-only transcript into the in-memory session
-        # history so subsequent turns see the truncated view.
-        try:
-            active = db.get_messages_as_conversation(session_key)
-        except Exception:
-            active = []
-        with session["history_lock"]:
-            session["history"] = list(active)
-            session["history_version"] = int(session.get("history_version", 0)) + 1
-        # Notify memory providers — same hook /branch fires, plus the
-        # rewound flag so providers caching per-turn document state
-        # know to invalidate. See #6672 + #21910.
-        agent = session.get("agent")
-        if agent is not None:
-            mm = getattr(agent, "_memory_manager", None)
-            if mm is not None:
-                try:
-                    mm.on_session_switch(
-                        session_key,
-                        parent_session_id="",
-                        reset=False,
-                        rewound=True,
-                    )
-                except Exception:
-                    pass
-            if hasattr(agent, "_invalidate_system_prompt"):
-                try:
-                    agent._invalidate_system_prompt()
-                except Exception:
-                    pass
-            if hasattr(agent, "_last_flushed_db_idx"):
-                try:
-                    agent._last_flushed_db_idx = len(active)
-                except Exception:
-                    pass
-        target_msg = result.get("target_message") or {}
-        target_text = target_msg.get("content") or ""
-        if isinstance(target_text, list):
-            parts = [
-                p.get("text", "") for p in target_text
-                if isinstance(p, dict) and p.get("type") == "text"
-            ]
-            target_text = "\n".join(t for t in parts if t)
-        if not isinstance(target_text, str):
-            target_text = ""
-        rewound_count = result.get("rewound_count", 0)
-        turns_undone = target_idx + 1
-        turn_word = "turn" if turns_undone == 1 else "turns"
-        notice = (
-            f"↶ Undid {turns_undone} {turn_word} ({rewound_count} message(s)). "
-            "Edit and resubmit, or send a new message."
-        )
-        return _ok(
-            rid,
-            {"type": "prefill", "message": target_text, "notice": notice},
-        )
+                state = mgr.add(
+                    parsed["prompt"],
+                    interval_seconds=parsed["interval"],
+                )
+            except ValueError as exc:
+                return _err(rid, 4004, f"invalid loop: {exc}")
+
+            interval_str = format_interval(state.interval_seconds)
+            notice = (
+                f"⊙ Loop #{state.id} set: every {interval_str} → {state.prompt}\n"
+                "Controls: /loop list · /loop pause · /loop resume · /loop clear"
+            )
+            return _ok(
+                rid,
+                {"type": "exec", "output": notice},
+            )
+
+        if action == "error":
+            return _err(rid, 4004, parsed.get("message", "invalid /loop command"))
 
     if name in {"snapshot", "snap"}:
         subcommand = arg.split(maxsplit=1)[0].lower() if arg else ""
@@ -7421,7 +6103,6 @@ def _(rid, params: dict) -> dict:
 
     items: list[dict] = []
     try:
-        root = _completion_cwd(params)
         is_context = word.startswith("@")
         query = word[1:] if is_context else word
 
@@ -7454,13 +6135,8 @@ def _(rid, params: dict) -> dict:
         # editors like Cursor / VS Code do for Cmd-P. Path-ish queries (with
         # `/`, `./`, `~/`, `/abs`) fall through to the directory-listing
         # path so explicit navigation intent is preserved.
-        if (
-            is_context
-            and path_part
-            and len(path_part.strip()) >= 2
-            and "/" not in path_part
-            and prefix_tag != "folder"
-        ):
+        if is_context and path_part and "/" not in path_part and prefix_tag != "folder":
+            root = os.getcwd()
             ranked: list[tuple[tuple[int, int], str, str]] = []
             for rel in _list_repo_files(root):
                 basename = os.path.basename(rel)
@@ -7493,9 +6169,6 @@ def _(rid, params: dict) -> dict:
             search_dir = os.path.dirname(expanded) or "."
             match = os.path.basename(expanded)
 
-        search_dir = (
-            search_dir if os.path.isabs(search_dir) else os.path.join(root, search_dir)
-        )
         if not os.path.isdir(search_dir):
             return _ok(rid, {"items": []})
 
@@ -7503,8 +6176,6 @@ def _(rid, params: dict) -> dict:
         match_lower = match.lower()
         for entry in sorted(os.listdir(search_dir)):
             if match and not entry.lower().startswith(match_lower):
-                continue
-            if is_context and entry in _FUZZY_FALLBACK_EXCLUDES:
                 continue
             if is_context and not prefix_tag and entry.startswith("."):
                 continue
@@ -7515,7 +6186,7 @@ def _(rid, params: dict) -> dict:
             # which used to defeat the prefix and let `@folder:` list files.
             if prefix_tag and want_dir != is_dir:
                 continue
-            rel = os.path.relpath(full, root).replace(os.sep, "/")
+            rel = os.path.relpath(full)
             suffix = "/" if is_dir else ""
 
             if is_context and prefix_tag:
@@ -7746,8 +6417,6 @@ def _(rid, params: dict) -> dict:
             include_unconfigured=True,
             picker_hints=True,
             canonical_order=True,
-            pricing=True,
-            capabilities=True,
             max_models=50,
         )
         return _ok(rid, payload)
@@ -7911,24 +6580,24 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             result = _apply_model_switch(sid, session, arg)
             return result.get("warning", "")
         elif name == "personality" and arg and agent:
-            pname, new_prompt = _validate_personality(arg, _load_cfg())
-            _apply_personality_to_session(sid, session, new_prompt, pname)
+            _, new_prompt = _validate_personality(arg, _load_cfg())
+            _apply_personality_to_session(sid, session, new_prompt)
         elif name == "prompt" and agent:
             cfg = _load_cfg()
-            new_prompt = _prompt_text((cfg.get("agent") or {}).get("system_prompt", ""))
+            new_prompt = (cfg.get("agent") or {}).get("system_prompt", "") or ""
             agent.ephemeral_system_prompt = new_prompt or None
             agent._cached_system_prompt = None
         elif name == "compress" and agent:
             _compress_session_history(session, arg)
             _sync_session_key_after_compress(sid, session)
-            _emit("session.info", sid, _session_info(agent, session))
+            _emit("session.info", sid, _session_info(agent))
         elif name == "fast" and agent:
             mode = arg.lower()
             if mode in {"fast", "on"}:
                 agent.service_tier = "priority"
             elif mode in {"normal", "off"}:
                 agent.service_tier = None
-            _emit("session.info", sid, _session_info(agent, session))
+            _emit("session.info", sid, _session_info(agent))
         elif name == "reload-mcp" and agent and hasattr(agent, "reload_mcp_tools"):
             agent.reload_mcp_tools()
         elif name == "stop":
@@ -7982,6 +6651,7 @@ def _(rid, params: dict) -> dict:
                 rid, 4018, f"skill command: use command.dispatch for {_cmd_key}"
             )
     except Exception:
+        logger.debug("Skill command check failed", exc_info=True)
         pass
 
     plugin_handler = None
@@ -7995,6 +6665,7 @@ def _(rid, params: dict) -> dict:
 
             plugin_handler = get_plugin_command_handler(_cmd_base)
         except Exception:
+            logger.debug("Plugin handler lookup failed", exc_info=True)
             plugin_handler = None
             resolve_plugin_command_result = None
 
@@ -8444,6 +7115,7 @@ def _resolve_browser_cdp_url() -> str:
         if isinstance(browser_cfg, dict):
             return str(browser_cfg.get("cdp_url", "") or "").strip()
     except Exception:
+        logger.debug("Browser CDP URL config read failed", exc_info=True)
         pass
     return ""
 
@@ -8476,6 +7148,7 @@ def _http_ok(url: str, timeout: float) -> bool:
         with urllib.request.urlopen(url, timeout=timeout) as resp:
             return 200 <= getattr(resp, "status", 200) < 300
     except Exception:
+        logger.debug("CDP URL probe failed", exc_info=True)
         return False
 
 
@@ -8646,6 +7319,7 @@ def _browser_disconnect(rid) -> dict:
 
             cleanup_all_browsers()
         except Exception:
+            logger.debug("Browser cleanup failed", exc_info=True)
             pass
 
     reap()
@@ -9029,20 +7703,15 @@ def _(rid, params: dict) -> dict:
     if not cmd:
         return _err(rid, 4004, "empty command")
     try:
-        from tools.approval import detect_dangerous_command, detect_hardline_command
+        from tools.approval import detect_dangerous_command
 
-        is_hardline, hardline_desc = detect_hardline_command(cmd)
-        if is_hardline:
-            return _err(
-                rid, 4005, f"blocked (hardline): {hardline_desc}. Use the agent for dangerous commands."
-            )
         is_dangerous, _, desc = detect_dangerous_command(cmd)
         if is_dangerous:
             return _err(
                 rid, 4005, f"blocked: {desc}. Use the agent for dangerous commands."
             )
     except ImportError:
-        return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
+        pass
     try:
         r = subprocess.run(
             cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd()

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -19,7 +19,6 @@ import {
 } from '../lib/text.js'
 import type { ActiveTool, ActivityItem, Msg, SubagentProgress, TodoItem } from '../types.js'
 
-import type { Notice } from './interfaces.js'
 import { resetFlowOverlays } from './overlayStore.js'
 import { pushSnapshot } from './spawnHistoryStore.js'
 import { archiveDoneTodos, getTurnState, patchTurnState, resetTurnState } from './turnStore.js'
@@ -133,17 +132,6 @@ class TurnController {
   private streamDelay = STREAM_IDLE_BATCH_MS
   private toolProgressTimer: Timer = null
 
-  // ── Credits notice machinery (Strategy B) ───────────────────────────
-  //
-  // A notice arriving mid-turn must NOT show (FaceTicker wins while busy);
-  // it is held here, latest-wins, and applied at turn end via onTurnEnd().
-  // The TTL clock starts only when the notice becomes VISIBLE (on apply),
-  // never on arrival, so an 8s "restored" notice shows for its full life.
-  // `noticeTimer` is DEDICATED — it is never the shared `statusTimer`.
-  private pendingNotice: Notice | null = null
-  private noticeTimer: Timer = null
-  private noticeIdSeq = 0
-
   boostStreamingForTyping() {
     this.streamDelay = STREAM_TYPING_BATCH_MS
   }
@@ -167,100 +155,6 @@ class TurnController {
 
   clearStatusTimer() {
     this.statusTimer = clear(this.statusTimer)
-  }
-
-  // ── Notice: arrival ──────────────────────────────────────────────────
-  //
-  // A `notification.show` arrived. If a turn is in flight (`busy`), the
-  // FaceTicker owns the verb slot, so we hold the notice (latest-wins) and
-  // let onTurnEnd() apply it when the turn finishes. If idle, apply it now.
-  // The Python side emits STABLE ids per notice kind (e.g. `credits.warn90`,
-  // `credits.restored`), NOT unique-per-emission ids.  The id-guard in
-  // applyNotice() is a defensive backup; the primary latest-wins mechanism is
-  // that applyNotice/clearNotice always cancel the prior timer first.
-  showNotice(notice: Notice) {
-    const stamped: Notice = { ...notice, id: notice.id || `n${++this.noticeIdSeq}` }
-
-    if (getUiState().busy) {
-      this.pendingNotice = stamped
-
-      return
-    }
-
-    this.applyNotice(stamped)
-  }
-
-  // ── Notice: clear by key (R3-H3 / HIGH-3) ────────────────────────────
-  //
-  // `notification.clear` only clears the visible notice when its key
-  // matches — a stale/late clear must not wipe a NEWER notice. Always drop
-  // a matching pending notice so it can't resurface at the next turn end.
-  clearNotice(key?: string) {
-    if (this.pendingNotice && this.pendingNotice.key === key) {
-      this.pendingNotice = null
-    }
-
-    if (getUiState().notice?.key === key) {
-      this.clearNoticeTimer()
-      patchUiState({ notice: null })
-    }
-  }
-
-  // Apply a notice to the visible UI state and (re)arm its TTL clock.
-  // Latest-wins: clear any prior TTL timer FIRST so an older notice's
-  // expiry can't wipe this one. A 'ttl' notice with `ttl_ms` self-expires;
-  // 'sticky' (default) persists until an explicit clear.
-  private applyNotice(notice: Notice) {
-    this.clearNoticeTimer()
-    patchUiState({ notice })
-
-    if (notice.kind === 'ttl' && typeof notice.ttl_ms === 'number' && notice.ttl_ms > 0) {
-      const id = notice.id
-
-      this.noticeTimer = setTimeout(() => {
-        this.noticeTimer = null
-
-        // Defensive backup: the prior timer was already cancelled by
-        // clearNoticeTimer() when a newer notice was applied, so in
-        // practice this guard only fires for the notice that armed it.
-        if (getUiState().notice?.id === id) {
-          patchUiState({ notice: null })
-        }
-      }, notice.ttl_ms)
-    }
-  }
-
-  private clearNoticeTimer() {
-    this.noticeTimer = clear(this.noticeTimer)
-  }
-
-  // ── Notice: turn-end flush (R3-C1 / R3-H4) ───────────────────────────
-  //
-  // Invoked ONLY by the three real turn-end sites (recordMessageComplete,
-  // interruptTurn, recordError) — NEVER by idle()/reset(), which would leak
-  // session A's notice into session B. Applies a pending NEW notice so it
-  // appears now that FaceTicker has yielded; the TTL clock starts here, when
-  // the notice first becomes visible. With no pending notice this is a
-  // no-op, so a standing sticky notice REappears untouched after the turn.
-  private flushPendingNotice() {
-    if (!this.pendingNotice) {
-      return
-    }
-
-    const notice = this.pendingNotice
-    this.pendingNotice = null
-    this.applyNotice(notice)
-  }
-
-  // Drop all notice state — pending + timer + visible (R3-H5). Called by
-  // reset()/fullReset() so a session A notice can't bleed into session B.
-  private clearNoticeState() {
-    this.pendingNotice = null
-    this.clearNoticeTimer()
-
-    if (getUiState().notice) {
-      patchUiState({ notice: null })
-    }
   }
 
   endReasoningPhase() {
@@ -288,14 +182,9 @@ class TurnController {
     resetFlowOverlays()
   }
 
-  // `keepBusy` holds the session busy after interrupting so a queued message
-  // drains on the gateway's real settle edge (message.complete, suppressed
-  // while `interrupted`) instead of racing the still-unwinding turn — the race
-  // duplicated the user bubble, leaked a "queued: …" note, and surfaced the
-  // cancelled turn's "[interrupted]" reply.
-  interruptTurn({ appendMessage, gw, sid, sys }: InterruptDeps, opts: { keepBusy?: boolean } = {}) {
+  interruptTurn({ appendMessage, gw, sid, sys }: InterruptDeps) {
     this.interrupted = true
-    gw.request<SessionInterruptResponse>('session.interrupt', { session_id: sid }).catch(() => {})
+    const interruptPromise = gw.request<SessionInterruptResponse>('session.interrupt', { session_id: sid }).catch(() => {})
 
     this.closeReasoningSegment()
 
@@ -329,24 +218,15 @@ class TurnController {
       sys('interrupted')
     }
 
-    this.clearStatusTimer()
-
-    if (opts.keepBusy) {
-      // `idle()` already cleared busy; re-assert it so the drain waits for settle.
-      patchUiState({ busy: true, status: 'interrupting…' })
-
-      return
-    }
-
     patchUiState({ status: 'interrupted' })
+    this.clearStatusTimer()
 
     this.statusTimer = setTimeout(() => {
       this.statusTimer = null
       patchUiState({ status: 'ready' })
     }, INTERRUPT_COOLDOWN_MS)
 
-    // Real turn end: surface any notice held back while busy.
-    this.flushPendingNotice()
+    return interruptPromise
   }
 
   pruneTransient() {
@@ -549,9 +429,6 @@ class TurnController {
     this.segmentMessages = []
     this.turnTools = []
     this.persistedToolLabels.clear()
-
-    // Real turn end: surface any notice held back while busy.
-    this.flushPendingNotice()
   }
 
   recordMessageComplete(payload: { rendered?: string; reasoning?: string; text?: string }) {
@@ -644,10 +521,6 @@ class TurnController {
     this.bufRef = ''
     this.interrupted = false
     patchTurnState({ activity: [], outcome: '' })
-
-    // Real turn end: surface any notice held back while busy. Done after
-    // idle() flips busy=false so applyNotice() reaches the visible slot.
-    this.flushPendingNotice()
 
     return { finalMessages, finalText, wasInterrupted }
   }
@@ -851,9 +724,6 @@ class TurnController {
     this.turnTools = []
     this.toolTokenAcc = 0
     this.persistedToolLabels.clear()
-    // Session boundary: drop notice state so session A's sticky can't bleed
-    // into session B (R3-H5). reset()/fullReset() CLEAR — they never flush.
-    this.clearNoticeState()
     patchTurnState({ activity: [], outcome: '' })
   }
 
@@ -907,17 +777,6 @@ class TurnController {
     this.toolTokenAcc = 0
     this.interrupted = false
     this.persistedToolLabels.clear()
-    // "Flash and yield" notices clear when a new turn starts: a usage-band heads-up
-    // (credits.usage, 50/75/90%) and the one-time "grant spent" transition
-    // (credits.grant_spent) should show once, then get out of the way — not camp the
-    // bar (e.g. "Grant spent · $990 top-up left" sitting there with plenty of top-up
-    // left). Depletion (credits.depleted) and other notices stay — they're explicitly
-    // sticky until the policy clears them. The Python `active` latch retains the key,
-    // so a yielded notice won't re-fire on the next turn.
-    const yieldingNoticeKey = getUiState().notice?.key
-    if (yieldingNoticeKey === 'credits.usage' || yieldingNoticeKey === 'credits.grant_spent') {
-      this.clearNotice(yieldingNoticeKey)
-    }
     patchUiState({ busy: true })
     patchTurnState({ activity: [], outcome: '', subagents: [], toolTokens: 0, tools: [], turnTrail: [] })
   }

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -687,7 +687,7 @@ export function useMainApp(gw: GatewayClient) {
       patchUiState({ busy: true, status: 'running…' })
       sendQueued(next)
     }
-  }, [ui.sid, ui.busy, composerActions, composerRefs, sendQueued])
+  }, [ui.sid, ui.busy, composerActions, composerRefs, sendQueued, composerState.queuedDisplay.length])
 
   const { pagerPageSize } = useInputHandlers({
     actions: {

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -105,7 +105,11 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
         patchUiState({ busy: true, status: 'running…' })
         turnController.bufRef = ''
-        turnController.interrupted = false
+        // NOTE: do NOT reset turnController.interrupted here.
+        // startMessage() (fired by gateway's message.start event) resets it.
+        // If we clear it now, a stale message.complete from the interrupted
+        // turn arrives with wasInterrupted=false and re-appends its partial
+        // response — doubling.  See #doubling-race.
 
         gw.request<PromptSubmitResponse>('prompt.submit', { session_id: sid, text: submitText }).catch((e: Error) => {
           if (isSessionBusyError(e)) {
@@ -207,10 +211,10 @@ export function useSubmission(opts: UseSubmissionOptions) {
       if (hasInterpolation(text)) {
         patchUiState({ busy: true })
 
-        return interpolate(text, send)
+        return interpolate(text, (t: string) => send(t, false))
       }
 
-      send(text)
+      send(text, false)
     },
     [interpolate, send, shellExec]
   )
@@ -220,28 +224,25 @@ export function useSubmission(opts: UseSubmissionOptions) {
   //   - 'steer'     : inject into the current turn via session.steer; falls
   //                   back to queue when steer is rejected (no agent / no
   //                   tool window).
-  //   - 'interrupt' (default): queue the text + interrupt with `keepBusy`; the
-  //                   busy→false settle edge drains it once (desktop parity).
-  //                   No optimistic send → no duplicate bubble / race note.
+  //   - 'interrupt' (default): cancel the in-flight turn, then send the
+  //                   new text as a fresh prompt so it actually moves.
   //
-  // `opts.fallbackToFront` re-inserts at the queue head (queue-edit picks keep
-  // their position); the mainline submit path appends.
+  // `opts.fallbackToFront` controls whether a steer fallback re-inserts
+  // at the front of the queue (used by the queue-edit path to preserve
+  // a picked item's position); the mainline submit path always appends.
   const handleBusyInput = useCallback(
     (full: string, opts: { fallbackToFront?: boolean } = {}) => {
       const live = getUiState()
       const mode = live.busyInputMode
 
-      const enqueueText = () => {
+      const fallback = (note: string) => {
         if (opts.fallbackToFront) {
           composerRefs.queueRef.current.unshift(full)
           composerActions.syncQueue()
         } else {
           composerActions.enqueue(full)
         }
-      }
 
-      const fallback = (note: string) => {
-        enqueueText()
         sys(note)
       }
 
@@ -263,14 +264,42 @@ export function useSubmission(opts: UseSubmissionOptions) {
         return
       }
 
-      // 'interrupt': queue + interrupt(keepBusy); the settle edge drains it once.
-      enqueueText()
-
+      // 'interrupt' (default): tear down the current turn, then send.
+      // Await `session.interrupt` so the gateway has processed the cancel
+      // before we fire `prompt.submit` — otherwise the submit hits
+      // "session busy" and the message gets queued instead of going through.
       if (live.sid) {
-        turnController.interruptTurn({ appendMessage, gw, sid: live.sid, sys }, { keepBusy: true })
+        const interruptDone = turnController.interruptTurn({ appendMessage, gw, sid: live.sid, sys })
+
+        patchUiState({ busy: true, status: 'interrupting…' })
+
+        interruptDone
+          .then(() => {
+            if (hasInterpolation(full)) {
+              return interpolate(full, send)
+            }
+
+            send(full)
+          })
+          .catch(() => {
+            // Gateway unreachable or timed out — fall back to queue
+            composerActions.enqueue(full)
+            patchUiState({ busy: true, status: 'queued for next turn' })
+            sys(`queued: "${full.slice(0, 50)}${full.length > 50 ? '…' : ''}"`)
+          })
+
+        return
       }
+
+      if (hasInterpolation(full)) {
+        patchUiState({ busy: true })
+
+        return interpolate(full, send)
+      }
+
+      send(full)
     },
-    [appendMessage, composerActions, composerRefs, gw, sys]
+    [appendMessage, composerActions, composerRefs, gw, interpolate, send, sys]
   )
 
   const dispatchSubmission = useCallback(
@@ -372,11 +401,7 @@ export function useSubmission(opts: UseSubmissionOptions) {
         lastEmptyAt.current = now
 
         if (doubleTap && live.busy && live.sid) {
-          // Force-send: keep busy when a message is queued so the settle edge
-          // drains it once (no race). Empty queue = plain Stop → 'ready'.
-          const hasQueued = composerRefs.queueRef.current.length > 0
-
-          return turnController.interruptTurn({ appendMessage, gw, sid: live.sid, sys }, { keepBusy: hasQueued })
+          return turnController.interruptTurn({ appendMessage, gw, sid: live.sid, sys })
         }
 
         if (doubleTap && live.sid && composerRefs.queueRef.current.length) {


### PR DESCRIPTION
Three fixes for notification delivery and TUI input handling:

## Changes

### 1. Gateway: await interrupt (tui_gateway/server.py)
`session.interrupt` now waits up to 5s for `session['running']` to become `False` before returning. Previously it returned immediately while the agent was still running, causing `prompt.submit` to hit 'session busy'. Also added to `_LONG_HANDLERS` so the wait runs on the thread pool.

### 2. TUI: await interrupt before send (ui-tui/src/app/useSubmission.ts)
`handleBusyInput` now awaits the `session.interrupt` promise before calling `send()`. Previously it fired interrupt and send simultaneously, creating a race where the submit arrived before the gateway processed the cancel.

### 3. TUI: drain queue on enqueue (ui-tui/src/app/useMainApp.ts)
The drain `useEffect` now watches `queuedDisplay.length` so it re-fires when a message is enqueued after the drain already ran with an empty queue.

### 4. TUI: interruptTurn returns promise (ui-tui/src/app/turnController.ts)
`interruptTurn()` now returns the interrupt promise instead of fire-and-forget.

## Also includes
- Event-driven TUI platform adapter (HTTP POST, no polling)
- Kanban→TUI notification bridge
- Deduplication of file watcher events and adapter subscriptions
- Test fix for always-on TUI adapter in startup failure tests

## Testing
- Spam test: rapid user messages no longer get 'queued:' — interrupt waits for agent to stop before accepting new input
- Kanban notification: task completion → worker → notification delivers to TUI session
- CI: fork CI green