### PR TITLE
fix(web): dispatch plugin-registered backends instead of falling through to DDGS

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -685,3 +685,94 @@ def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 
     assert "EXA_API_KEY" in _web_requires_env()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #35970 — custom plugin backends should not silently
+# fall through to DDGS when configured via web.backend.
+# ---------------------------------------------------------------------------
+
+from agent.web_search_registry import WebSearchProvider
+
+class _StubWebProvider(WebSearchProvider):
+    def __init__(self, name, available=True):
+        self._name = name
+        self._available = available
+
+    @property
+    def name(self):
+        return self._name
+
+    def is_available(self):
+        return self._available
+
+    def supports_search(self):
+        return True
+
+    def supports_extract(self):
+        return True
+
+
+def _unregister(name):
+    import agent.web_search_registry as reg
+    try:
+        # registry stores by name internally; clear via reset helper if present
+        if hasattr(reg, "_PROVIDERS"):
+            reg._PROVIDERS.pop(name, None)
+        elif hasattr(reg, "_providers"):
+            reg._providers.pop(name, None)
+    except Exception:
+        pass
+
+
+def test_get_backend_returns_plugin_registered_name(monkeypatch):
+    """A backend name registered via web_search_registry should be returned
+    instead of falling through to env-var auto-detect (which would land on
+    DDGS / firecrawl)."""
+    from agent import web_search_registry as reg
+    from tools.web_tools import _get_backend
+
+    provider = _StubWebProvider("pkl-extract-test")
+    reg.register_provider(provider)
+    try:
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "pkl-extract-test"}):
+            assert _get_backend() == "pkl-extract-test"
+    finally:
+        _unregister("pkl-extract-test")
+
+
+def test_get_backend_unknown_and_unregistered_falls_through(monkeypatch):
+    """When the configured backend isn't in the hardcoded allowlist AND not
+    in the registry, fall back to the env-var auto-detect path (legacy)."""
+    from tools.web_tools import _get_backend
+
+    with patch("tools.web_tools._load_web_config", return_value={"backend": "nope-not-real"}):
+        with patch("tools.web_tools._has_env", return_value=False), \
+             patch("tools.web_tools._is_tool_gateway_ready", return_value=False), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=False):
+            # Final default is "firecrawl"
+            assert _get_backend() == "firecrawl"
+
+
+def test_is_backend_available_uses_registry_for_plugin_backends(monkeypatch):
+    from agent import web_search_registry as reg
+    from tools.web_tools import _is_backend_available
+
+    provider = _StubWebProvider("pkl-extract-avail", available=True)
+    reg.register_provider(provider)
+    try:
+        assert _is_backend_available("pkl-extract-avail") is True
+    finally:
+        _unregister("pkl-extract-avail")
+
+
+def test_is_backend_available_respects_plugin_is_available_false(monkeypatch):
+    from agent import web_search_registry as reg
+    from tools.web_tools import _is_backend_available
+
+    provider = _StubWebProvider("pkl-extract-unavail", available=False)
+    reg.register_provider(provider)
+    try:
+        assert _is_backend_available("pkl-extract-unavail") is False
+    finally:
+        _unregister("pkl-extract-unavail")

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -133,6 +133,18 @@ def _get_backend() -> str:
     if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
         return configured
 
+    # Plugin-registered backends: when the configured name resolves to a
+    # provider registered via agent.web_search_registry, use it directly
+    # instead of silently falling through to env-var auto-detect (which
+    # would land on DDGS and emit a misleading error). See #35970.
+    if configured:
+        try:
+            from agent.web_search_registry import get_provider as _registry_get_provider
+            if _registry_get_provider(configured) is not None:
+                return configured
+        except Exception:
+            pass
+
     # Fallback for manual / legacy config — pick the highest-priority
     # available backend. Firecrawl also counts as available when the managed
     # tool gateway is configured for Nous subscribers.
@@ -218,6 +230,22 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    # Plugin-registered backends - defer availability to the providers own
+    # is_available() so per-capability overrides (web.search_backend etc.)
+    # also work for custom plugins. See #35970.
+    try:
+        from agent.web_search_registry import get_provider as _registry_get_provider
+        provider = _registry_get_provider(backend)
+        if provider is not None:
+            is_avail = getattr(provider, "is_available", None)
+            if callable(is_avail):
+                try:
+                    return bool(is_avail())
+                except Exception:
+                    return True
+            return True
+    except Exception:
+        pass
     return False
 
 


### PR DESCRIPTION
## Summary

Fixes #35970 — custom `WebSearchProvider` plugins registered via the bundled-plugin system were silently bypassed: when a user set `web.backend: my-custom-name` in `~/.hermes/config.yaml`, `_get_backend()` ignored the value (because the name wasn't in a hardcoded allowlist) and fell through to env-var auto-detect, which usually lands on DDGS. The user then hit the misleading `"DuckDuckGo (ddgs) is a search-only backend"` error and assumed plugin loading was broken.

## Root cause

`tools/web_tools.py` has two hardcoded gates that don't know about the plugin registry:

1. `_get_backend()` — `if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}: return configured`. Anything outside this set drops to the env-var fallback.
2. `_is_backend_available()` — same `if/elif backend == "...":` chain. Returns `False` for unknown names, which also breaks the per-capability override (`web.search_backend`, `web.extract_backend`) in `_get_capability_backend()`.

The `agent.web_search_registry` already knows about plugin-registered providers (`get_provider(name)`), but `web_tools.py` never consulted it from these two functions.

## Fix

Implements Option B from the issue author: keep the hardcoded allowlist as a **fast-path** (no registry import for bundled backends, no behaviour change for existing setups) and add a registry fallback when the configured name is non-empty but not in the set.

- `_get_backend()`: if `configured` is set and `web_search_registry.get_provider(configured)` returns a provider, return that name instead of falling through to env-var auto-detect.
- `_is_backend_available()`: if the backend name isn't matched by the existing if/elif chain, look it up in the registry. Defer availability to the provider's own `is_available()` method (the `WebSearchProvider` ABC already declares it abstract).

Import of `agent.web_search_registry` is lazy/local inside both functions to keep the existing import order (avoid any circular import surprise on cold start).

## Tests

Added 4 regression tests in `tests/tools/test_web_tools_config.py` using a small `_StubWebProvider(WebSearchProvider)` helper:

- `test_get_backend_returns_plugin_registered_name` — registered name flows through `_get_backend()` unchanged.
- `test_get_backend_unknown_and_unregistered_falls_through` — names neither in the allowlist nor in the registry still hit the legacy env-var path (back-compat).
- `test_is_backend_available_uses_registry_for_plugin_backends` — registry providers report available.
- `test_is_backend_available_respects_plugin_is_available_false` — a registered provider whose `is_available()` returns False is reported unavailable.

```
pytest tests/tools/test_web_tools_config.py tests/plugins/web/test_web_search_provider_plugins.py -q
...
104 passed in 2.86s
```

## Scope / risk

- 2 files changed, +119 / -0.
- No behavioural change for the 8 bundled backends (allowlist fast-path preserved).
- Lazy import — no module-import-time impact.
- No new dependencies.
