### PR TITLE
fix(tui): make phone status readable

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1084,6 +1084,14 @@ def run_conversation(
         approx_request_tokens = estimate_request_tokens_rough(
             api_messages, tools=agent.tools or None
         )
+        # Some local/OpenAI-compatible lanes do not return usage on streamed
+        # responses. Keep a rough request-pressure estimate available for the
+        # TUI status bar so context does not stay pinned at 0 until a provider
+        # supplies real token usage.
+        try:
+            agent._last_request_context_tokens = approx_request_tokens
+        except Exception:
+            pass
 
         _runtime_context_error = _ollama_context_limit_error(
             agent, approx_request_tokens

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -712,6 +712,40 @@ def test_get_usage_uses_rough_context_when_provider_usage_is_missing():
     assert usage["context_estimated"] is True
 
 
+def test_get_usage_estimates_initial_context_from_system_and_tools(monkeypatch):
+    from agent import model_metadata
+
+    captured = {}
+
+    def fake_estimate(messages, system_prompt="", tools=None):
+        captured["messages"] = messages
+        captured["system_prompt"] = system_prompt
+        captured["tools"] = tools
+        return 12000
+
+    monkeypatch.setattr(model_metadata, "estimate_request_tokens_rough", fake_estimate)
+
+    tools = [{"function": {"name": "read_file", "parameters": {}}}]
+    agent = types.SimpleNamespace(
+        _cached_system_prompt="system",
+        context_compressor=types.SimpleNamespace(
+            compression_count=0,
+            context_length=262000,
+            last_prompt_tokens=0,
+        ),
+        model="dflash",
+        tools=tools,
+    )
+
+    usage = server._get_usage(agent)
+
+    assert captured == {"messages": [], "system_prompt": "system", "tools": tools}
+    assert usage["context_used"] == 12000
+    assert usage["context_percent"] == 5
+    assert usage["context_estimated"] is True
+    assert agent._last_usage_context_estimate == 12000
+
+
 def test_resolve_model_uses_inference_model_env(monkeypatch):
     monkeypatch.delenv("HERMES_MODEL", raising=False)
     monkeypatch.setenv("HERMES_INFERENCE_MODEL", " anthropic/claude-sonnet-4.6\n")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -671,6 +671,47 @@ def test_status_callback_accepts_single_message_argument():
     )
 
 
+def test_status_callbacks_include_live_usage_when_session_is_active(monkeypatch):
+    usage = {"context_used": 20900, "context_max": 262000, "context_percent": 8}
+    monkeypatch.setitem(server._sessions, "sid", {"agent": object()})
+    monkeypatch.setattr(server, "_get_usage", lambda _agent: usage)
+
+    with patch("tui_gateway.server._emit") as emit:
+        callbacks = server._agent_cbs("sid")
+        callbacks["thinking_callback"]("thinking...")
+        callbacks["status_callback"]("process", "running tool")
+
+    assert emit.call_args_list[0].args == (
+        "thinking.delta",
+        "sid",
+        {"text": "thinking...", "usage": usage},
+    )
+    assert emit.call_args_list[1].args == (
+        "status.update",
+        "sid",
+        {"kind": "process", "text": "running tool", "usage": usage},
+    )
+
+
+def test_get_usage_uses_rough_context_when_provider_usage_is_missing():
+    agent = types.SimpleNamespace(
+        _last_request_context_tokens=20900,
+        context_compressor=types.SimpleNamespace(
+            compression_count=0,
+            context_length=262000,
+            last_prompt_tokens=0,
+        ),
+        model="dflash",
+    )
+
+    usage = server._get_usage(agent)
+
+    assert usage["context_used"] == 20900
+    assert usage["context_max"] == 262000
+    assert usage["context_percent"] == 8
+    assert usage["context_estimated"] is True
+
+
 def test_resolve_model_uses_inference_model_env(monkeypatch):
     monkeypatch.delenv("HERMES_MODEL", raising=False)
     monkeypatch.setenv("HERMES_INFERENCE_MODEL", " anthropic/claude-sonnet-4.6\n")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -400,6 +400,40 @@ def _usage_for_sid(sid: str) -> dict | None:
         return None
 
 
+def _rough_context_estimate(agent) -> int:
+    for attr in ("_last_request_context_tokens", "_last_request_tokens_estimate"):
+        try:
+            value = int(getattr(agent, attr, 0) or 0)
+        except Exception:
+            value = 0
+        if value > 0:
+            return value
+
+    try:
+        cached = int(getattr(agent, "_last_usage_context_estimate", 0) or 0)
+    except Exception:
+        cached = 0
+    if cached > 0:
+        return cached
+
+    try:
+        from agent.model_metadata import estimate_request_tokens_rough
+
+        estimate = estimate_request_tokens_rough(
+            [],
+            system_prompt=getattr(agent, "_cached_system_prompt", "") or "",
+            tools=getattr(agent, "tools", None) or None,
+        )
+    except Exception:
+        estimate = 0
+    if estimate > 0:
+        try:
+            agent._last_usage_context_estimate = estimate
+        except Exception:
+            pass
+    return estimate
+
+
 def _status_update(sid: str, kind: str, text: str | None = None):
     body = (text if text is not None else kind).strip()
     if not body:
@@ -1341,11 +1375,7 @@ def _sync_session_key_after_compress(
 
 def _get_usage(agent) -> dict:
     g = lambda k, fb=None: getattr(agent, k, 0) or (getattr(agent, fb, 0) if fb else 0)
-    rough_context = int(
-        getattr(agent, "_last_request_context_tokens", 0)
-        or getattr(agent, "_last_request_tokens_estimate", 0)
-        or 0
-    )
+    rough_context = _rough_context_estimate(agent)
     usage = {
         "model": getattr(agent, "model", "") or "",
         "input": g("session_input_tokens", "session_prompt_tokens"),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -390,14 +390,28 @@ def _emit(event: str, sid: str, payload: dict | None = None):
     write_json({"jsonrpc": "2.0", "method": "event", "params": params})
 
 
+def _usage_for_sid(sid: str) -> dict | None:
+    try:
+        agent = (_sessions.get(sid) or {}).get("agent")
+        if agent is None:
+            return None
+        return _get_usage(agent)
+    except Exception:
+        return None
+
+
 def _status_update(sid: str, kind: str, text: str | None = None):
     body = (text if text is not None else kind).strip()
     if not body:
         return
+    payload = {"kind": kind if text is not None else "status", "text": body}
+    usage = _usage_for_sid(sid)
+    if usage is not None:
+        payload["usage"] = usage
     _emit(
         "status.update",
         sid,
-        {"kind": kind if text is not None else "status", "text": body},
+        payload,
     )
 
 
@@ -1327,6 +1341,11 @@ def _sync_session_key_after_compress(
 
 def _get_usage(agent) -> dict:
     g = lambda k, fb=None: getattr(agent, k, 0) or (getattr(agent, fb, 0) if fb else 0)
+    rough_context = int(
+        getattr(agent, "_last_request_context_tokens", 0)
+        or getattr(agent, "_last_request_tokens_estimate", 0)
+        or 0
+    )
     usage = {
         "model": getattr(agent, "model", "") or "",
         "input": g("session_input_tokens", "session_prompt_tokens"),
@@ -1341,12 +1360,15 @@ def _get_usage(agent) -> dict:
     }
     comp = getattr(agent, "context_compressor", None)
     if comp:
-        ctx_used = getattr(comp, "last_prompt_tokens", 0) or usage["total"] or 0
+        ctx_real = getattr(comp, "last_prompt_tokens", 0) or 0
+        ctx_used = ctx_real if ctx_real > 0 else rough_context or usage["total"] or 0
+        ctx_estimated = ctx_real <= 0 and rough_context > 0
         ctx_max = getattr(comp, "context_length", 0) or 0
         if ctx_max:
             usage["context_used"] = ctx_used
             usage["context_max"] = ctx_max
             usage["context_percent"] = max(0, min(100, round(ctx_used / ctx_max * 100)))
+            usage["context_estimated"] = ctx_estimated
         usage["compressions"] = getattr(comp, "compression_count", 0) or 0
     try:
         from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
@@ -1767,6 +1789,13 @@ def _on_tool_progress(
 
 
 def _agent_cbs(sid: str) -> dict:
+    def _thinking_delta(text):
+        payload = {"text": text}
+        usage = _usage_for_sid(sid)
+        if usage is not None:
+            payload["usage"] = usage
+        _emit("thinking.delta", sid, payload)
+
     return {
         "tool_start_callback": lambda tc_id, name, args: _on_tool_start(
             sid, tc_id, name, args
@@ -1779,7 +1808,7 @@ def _agent_cbs(sid: str) -> dict:
         ),
         "tool_gen_callback": lambda name: _tool_progress_enabled(sid)
         and _emit("tool.generating", sid, {"name": name}),
-        "thinking_callback": lambda text: _emit("thinking.delta", sid, {"text": text}),
+        "thinking_callback": _thinking_delta,
         "reasoning_callback": lambda text: _emit(
             "reasoning.delta",
             sid,

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -110,9 +110,49 @@ describe('StatusRule compact phone layout', () => {
 
     const content = textContent(element)
 
-    expect(content).toContain('model dflash')
+    expect(content).toContain('dflash')
     expect(content).toContain('ctx 20.9k/262k 8%')
     expect(content).toContain('1 session')
     expect(content).toContain('~/Workspaces')
+  })
+
+  it('does not spill compact busy status words across phone lines', () => {
+    const now = new Date('2026-05-31T22:30:00Z').getTime()
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+
+    try {
+      const element = StatusRule({
+        bgCount: 0,
+        busy: true,
+        cols: 58,
+        cwdLabel: '~/Workspaces',
+        liveSessionCount: 1,
+        model: 'dflash',
+        sessionStartedAt: now - 90_000,
+        showCost: false,
+        status: 'deliberating...',
+        statusColor: DEFAULT_THEME.color.ok,
+        t: DEFAULT_THEME,
+        turnStartedAt: now - 45_000,
+        usage: {
+          context_estimated: true,
+          context_max: 262000,
+          context_percent: 8,
+          context_used: 20900,
+          total: 20900
+        },
+        voiceLabel: 'voice off'
+      })
+
+      const content = textContent(element)
+
+      expect(content).toContain('busy 45s | dflash | ctx ~20.9k/262k 8%')
+      expect(content).toContain('dur 1m 30s | voice off | 1 session | ~/Workspaces')
+      expect(content).not.toContain('deliberating')
+      expect(content).not.toContain('model dfla')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -57,6 +57,7 @@ const findClickableWithText = (node: ReactNodeLike, needle: string): React.React
 describe('StatusRule session count click target', () => {
   it('makes the live session count itself clickable', () => {
     const openSwitcher = vi.fn()
+
     const element = StatusRule({
       bgCount: 0,
       busy: false,
@@ -80,5 +81,38 @@ describe('StatusRule session count click target', () => {
     expect(clickableSessionCount).not.toBeNull()
     clickableSessionCount!.props.onClick({ stopImmediatePropagation: vi.fn() })
     expect(openSwitcher).toHaveBeenCalledOnce()
+  })
+})
+
+describe('StatusRule compact phone layout', () => {
+  it('keeps model and context usage readable in narrow terminals', () => {
+    const element = StatusRule({
+      bgCount: 0,
+      busy: false,
+      cols: 58,
+      cwdLabel: '~/Workspaces',
+      liveSessionCount: 1,
+      model: 'dflash',
+      sessionStartedAt: null,
+      showCost: false,
+      status: 'ready',
+      statusColor: DEFAULT_THEME.color.ok,
+      t: DEFAULT_THEME,
+      turnStartedAt: null,
+      usage: {
+        context_max: 262000,
+        context_percent: 8,
+        context_used: 20900,
+        total: 20900
+      },
+      voiceLabel: ''
+    })
+
+    const content = textContent(element)
+
+    expect(content).toContain('model dflash')
+    expect(content).toContain('ctx 20.9k/262k 8%')
+    expect(content).toContain('1 session')
+    expect(content).toContain('~/Workspaces')
   })
 })

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -54,6 +54,28 @@ const findClickableWithText = (node: ReactNodeLike, needle: string): React.React
   return findClickableWithText(node.props.children, needle)
 }
 
+const coloredTextSegments = (node: ReactNodeLike): { color?: string; text: string }[] => {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return []
+  }
+
+  if (Array.isArray(node)) {
+    return node.flatMap(coloredTextSegments)
+  }
+
+  if (!React.isValidElement(node)) {
+    return []
+  }
+
+  const own =
+    typeof node.props.color === 'string' ? [{ color: node.props.color, text: textContent(node.props.children) }] : []
+
+  return [...own, ...coloredTextSegments(node.props.children)]
+}
+
+const colorForText = (node: ReactNodeLike, needle: string) =>
+  coloredTextSegments(node).find(segment => segment.text.includes(needle))?.color
+
 describe('StatusRule session count click target', () => {
   it('makes the live session count itself clickable', () => {
     const openSwitcher = vi.fn()
@@ -114,6 +136,40 @@ describe('StatusRule compact phone layout', () => {
     expect(content).toContain('ctx 20.9k/262k 8%')
     expect(content).toContain('1 session')
     expect(content).toContain('~/Workspaces')
+    expect(colorForText(element, '- ready')).toBe(DEFAULT_THEME.color.statusGood)
+    expect(colorForText(element, 'dflash')).toBe(DEFAULT_THEME.color.primary)
+    expect(colorForText(element, 'ctx 20.9k/262k 8%')).toBe(DEFAULT_THEME.color.statusGood)
+    expect(colorForText(element, '1 session')).toBe(DEFAULT_THEME.color.accent)
+    expect(colorForText(element, '~/Workspaces')).toBe(DEFAULT_THEME.color.label)
+  })
+
+  it('colors compact context by low, moderate, and high usage', () => {
+    const renderWithContext = (contextPercent: number) =>
+      StatusRule({
+        bgCount: 0,
+        busy: false,
+        cols: 58,
+        cwdLabel: '~/Workspaces',
+        liveSessionCount: 1,
+        model: 'dflash',
+        sessionStartedAt: null,
+        showCost: false,
+        status: 'ready',
+        statusColor: DEFAULT_THEME.color.ok,
+        t: DEFAULT_THEME,
+        turnStartedAt: null,
+        usage: {
+          context_max: 100000,
+          context_percent: contextPercent,
+          context_used: contextPercent * 1000,
+          total: contextPercent * 1000
+        },
+        voiceLabel: ''
+      })
+
+    expect(colorForText(renderWithContext(8), 'ctx 8k/100k 8%')).toBe(DEFAULT_THEME.color.statusGood)
+    expect(colorForText(renderWithContext(60), 'ctx 60k/100k 60%')).toBe(DEFAULT_THEME.color.statusWarn)
+    expect(colorForText(renderWithContext(85), 'ctx 85k/100k 85%')).toBe(DEFAULT_THEME.color.statusCritical)
   })
 
   it('does not spill compact busy status words across phone lines', () => {

--- a/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
+++ b/ui-tui/src/__tests__/appChromeStatusRule.test.tsx
@@ -147,7 +147,7 @@ describe('StatusRule compact phone layout', () => {
 
       const content = textContent(element)
 
-      expect(content).toContain('busy 45s | dflash | ctx ~20.9k/262k 8%')
+      expect(content).toContain('- busy 45s | dflash | ctx ~20.9k/262k 8%')
       expect(content).toContain('dur 1m 30s | voice off | 1 session | ~/Workspaces')
       expect(content).not.toContain('deliberating')
       expect(content).not.toContain('model dfla')

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -319,6 +319,51 @@ describe('createGatewayEventHandler', () => {
     }
   })
 
+  it('updates status-bar usage from live thinking and status events', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({
+      payload: {
+        text: 'thinking...',
+        usage: {
+          calls: 1,
+          context_estimated: true,
+          context_max: 262000,
+          context_percent: 8,
+          context_used: 20900,
+          input: 0,
+          output: 0,
+          total: 0
+        }
+      },
+      type: 'thinking.delta'
+    } as any)
+
+    expect(getUiState().usage.context_used).toBe(20900)
+    expect(getUiState().usage.context_estimated).toBe(true)
+
+    onEvent({
+      payload: {
+        kind: 'process',
+        text: 'running tool',
+        usage: {
+          calls: 1,
+          context_max: 262000,
+          context_percent: 9,
+          context_used: 24000,
+          input: 0,
+          output: 0,
+          total: 0
+        }
+      },
+      type: 'status.update'
+    } as any)
+
+    expect(getUiState().usage.context_used).toBe(24000)
+    expect(getUiState().usage.context_percent).toBe(9)
+  })
+
   it('ignores late thinking.delta after the turn has already completed', () => {
     vi.useFakeTimers()
     const appended: Msg[] = []

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -406,6 +406,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           return
         }
 
+        if (ev.payload?.usage) {
+          patchUiState(state => ({ ...state, usage: { ...state.usage, ...ev.payload!.usage } }))
+        }
+
         const text = ev.payload?.text
 
         if (text !== undefined) {
@@ -430,6 +434,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         if (!p?.text) {
           return
+        }
+
+        if (p.usage) {
+          patchUiState(state => ({ ...state, usage: { ...state.usage, ...p.usage } }))
         }
 
         if (p.kind === 'goal') {

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -1,6 +1,6 @@
 import { Box, type ScrollBoxHandle, stringWidth, Text } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
-import { type ReactNode, type RefObject, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, type ReactNode, type RefObject, useEffect, useMemo, useRef, useState } from 'react'
 import unicodeSpinners from 'unicode-animations'
 
 import { $delegationState } from '../app/delegationStore.js'
@@ -273,15 +273,36 @@ const fitCompactText = (text: string, width: number) => {
     return ''
   }
 
-  if (text.length <= width) {
+  if (stringWidth(text) <= width) {
     return text
   }
 
   if (width <= 3) {
-    return text.slice(0, width)
+    let clipped = ''
+
+    for (const char of text) {
+      if (stringWidth(clipped + char) > width) {
+        break
+      }
+
+      clipped += char
+    }
+
+    return clipped
   }
 
-  return `${text.slice(0, width - 3).trimEnd()}...`
+  let clipped = ''
+  const targetWidth = width - 3
+
+  for (const char of text) {
+    if (stringWidth(clipped + char) > targetWidth) {
+      break
+    }
+
+    clipped += char
+  }
+
+  return `${clipped.trimEnd()}...`
 }
 
 const compactModelLabel = (model: string, effort?: string, fast?: boolean) => {
@@ -312,6 +333,147 @@ const contextStatusLabel = (usage: Usage) => {
   const prefix = usage.context_estimated ? 'ctx ~' : 'ctx '
 
   return usage.context_max && pct != null ? `${prefix}${ctxLabel} ${pct}%` : `${prefix}${ctxLabel}`
+}
+
+interface CompactStatusSegment {
+  color: string
+  dimColor?: boolean
+  minWidth?: number
+  shrinkPriority?: number
+  text: string
+}
+
+const COMPACT_SEPARATOR = ' | '
+
+const compactContextColor = (usage: Usage, t: Theme) => {
+  const pct = usage.context_percent
+
+  if (pct == null) {
+    return t.color.muted
+  }
+
+  if (pct >= 80) {
+    return t.color.statusCritical
+  }
+
+  if (pct >= 50) {
+    return t.color.statusWarn
+  }
+
+  return t.color.statusGood
+}
+
+const compactStatusColor = (status: string, busy: boolean, statusColor: string, t: Theme) => {
+  if (busy) {
+    return t.color.statusWarn
+  }
+
+  const normalized = status.trim().toLowerCase()
+
+  if (!normalized || normalized === 'ready' || normalized === 'idle') {
+    return t.color.statusGood
+  }
+
+  if (
+    normalized.includes('error') ||
+    normalized.includes('fail') ||
+    normalized.includes('invalid') ||
+    normalized.includes('auth')
+  ) {
+    return t.color.statusCritical
+  }
+
+  if (normalized.includes('retry') || normalized.includes('recover') || normalized.includes('warn')) {
+    return t.color.statusWarn
+  }
+
+  return statusColor
+}
+
+const compactVoiceColor = (voiceLabel: string, t: Theme) => {
+  const normalized = voiceLabel.trim().toLowerCase()
+
+  if (!normalized || normalized.includes('off')) {
+    return t.color.muted
+  }
+
+  if (voiceLabel.startsWith('●') || normalized.includes('record')) {
+    return t.color.error
+  }
+
+  if (voiceLabel.startsWith('◉') || normalized.includes('listen') || normalized.includes('on')) {
+    return t.color.warn
+  }
+
+  return t.color.label
+}
+
+const compactSegmentWidth = (segments: CompactStatusSegment[]) =>
+  segments.reduce(
+    (total, segment, index) => total + stringWidth(segment.text) + (index > 0 ? stringWidth(COMPACT_SEPARATOR) : 0),
+    0
+  )
+
+const fitCompactSegments = (segments: CompactStatusSegment[], width: number) => {
+  const fitted = segments.filter(segment => segment.text).map(segment => ({ ...segment }))
+
+  if (width <= 0 || fitted.length === 0) {
+    return []
+  }
+
+  let guard = 0
+
+  while (compactSegmentWidth(fitted) > width && guard < 20) {
+    guard += 1
+
+    const candidate = fitted
+      .filter(segment => stringWidth(segment.text) > (segment.minWidth ?? 4))
+      .sort((a, b) => (b.shrinkPriority ?? 0) - (a.shrinkPriority ?? 0))[0]
+
+    if (!candidate) {
+      break
+    }
+
+    const overBy = compactSegmentWidth(fitted) - width
+    const currentWidth = stringWidth(candidate.text)
+    const minWidth = candidate.minWidth ?? 4
+    const targetWidth = Math.max(minWidth, currentWidth - overBy)
+
+    candidate.text = fitCompactText(candidate.text, targetWidth)
+  }
+
+  while (compactSegmentWidth(fitted) > width && fitted.length > 1) {
+    fitted.pop()
+  }
+
+  if (compactSegmentWidth(fitted) > width && fitted[0]) {
+    fitted[0].text = fitCompactText(fitted[0].text, width)
+  }
+
+  return fitted
+}
+
+function compactStatusLine(segments: CompactStatusSegment[], t: Theme, width: number) {
+  const fitted = fitCompactSegments(segments, width)
+
+  return (
+    <Box height={1} overflow="hidden" width={width}>
+      <Text wrap="truncate-end">
+        {fitted.map((segment, index) => (
+          <Fragment key={`${index}-${segment.text}`}>
+            {index > 0 ? (
+              <Text color={t.color.border} dimColor>
+                {COMPACT_SEPARATOR}
+              </Text>
+            ) : null}
+            <Text color={segment.color} dimColor={segment.dimColor}>
+              {segment.text}
+            </Text>
+          </Fragment>
+        ))}
+      </Text>
+    </Box>
+  )
 }
 
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
@@ -396,31 +558,70 @@ export function StatusRule({
       ? `busy${turnStartedAt ? ` ${fmtDuration(now - turnStartedAt)}` : ''}`
       : status || 'ready'
 
-    const firstLine = fitCompactText(
-      [`- ${primaryStatus}`, compactModelLabel(model, modelReasoningEffort, modelFast), compactCtxLabel]
-        .filter(Boolean)
-        .join(' | '),
-      width
-    )
+    const firstLine: CompactStatusSegment[] = [
+      {
+        color: compactStatusColor(primaryStatus, busy, statusColor, t),
+        minWidth: 7,
+        shrinkPriority: 2,
+        text: `- ${primaryStatus}`
+      },
+      {
+        color: t.color.primary,
+        minWidth: 6,
+        shrinkPriority: 3,
+        text: compactModelLabel(model, modelReasoningEffort, modelFast)
+      },
+      {
+        color: compactContextColor(usage, t),
+        minWidth: 14,
+        shrinkPriority: 1,
+        text: compactCtxLabel
+      }
+    ]
 
-    const secondLine = fitCompactText(
-      [
-        sessionStartedAt ? `dur ${fmtDuration(now - sessionStartedAt)}` : '',
-        voiceLabel || '',
-        sessionCountText,
-        bgCount > 0 ? `${bgCount} bg` : '',
-        showCost && typeof usage.cost_usd === 'number' ? `$${usage.cost_usd.toFixed(4)}` : '',
-        cwdLabel || ''
-      ]
-        .filter(Boolean)
-        .join(' | '),
-      width
-    )
+    const secondLine: CompactStatusSegment[] = [
+      {
+        color: t.color.label,
+        minWidth: 7,
+        shrinkPriority: 2,
+        text: sessionStartedAt ? `dur ${fmtDuration(now - sessionStartedAt)}` : ''
+      },
+      {
+        color: compactVoiceColor(voiceLabel || '', t),
+        minWidth: 6,
+        shrinkPriority: 2,
+        text: voiceLabel || ''
+      },
+      {
+        color: t.color.accent,
+        minWidth: 8,
+        shrinkPriority: 1,
+        text: sessionCountText
+      },
+      {
+        color: t.color.statusWarn,
+        minWidth: 4,
+        shrinkPriority: 2,
+        text: bgCount > 0 ? `${bgCount} bg` : ''
+      },
+      {
+        color: t.color.statusWarn,
+        minWidth: 7,
+        shrinkPriority: 2,
+        text: showCost && typeof usage.cost_usd === 'number' ? `$${usage.cost_usd.toFixed(4)}` : ''
+      },
+      {
+        color: t.color.label,
+        minWidth: 8,
+        shrinkPriority: 3,
+        text: cwdLabel || ''
+      }
+    ]
 
     return (
       <Box flexDirection="column" height={2} width={width}>
-        <Text color={statusColor}>{firstLine}</Text>
-        <Text color={t.color.muted}>{secondLine}</Text>
+        {compactStatusLine(firstLine, t, width)}
+        {compactStatusLine(secondLine, t, width)}
       </Box>
     )
   }

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -266,6 +266,24 @@ const shortModelLabel = (model: string) =>
 const modelLabel = (model: string, effort?: string, fast?: boolean) =>
   [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
 
+const COMPACT_STATUS_COLS = 92
+
+const contextStatusLabel = (usage: Usage) => {
+  const ctxLabel = usage.context_max
+    ? `${fmtK(usage.context_used ?? 0)}/${fmtK(usage.context_max)}`
+    : usage.total > 0
+      ? `${fmtK(usage.total)} tok`
+      : ''
+
+  if (!ctxLabel) {
+    return ''
+  }
+
+  const pct = usage.context_percent
+
+  return usage.context_max && pct != null ? `ctx ${ctxLabel} ${pct}%` : `ctx ${ctxLabel}`
+}
+
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   const [active, setActive] = useState(false)
   const [color, setColor] = useState(t.color.accent)
@@ -282,7 +300,7 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
     const id = setTimeout(() => setActive(false), 650)
 
     return () => clearTimeout(id)
-  }, [t.color.accent, tick])
+  }, [t.color.accent, t.color.error, t.color.warn, tick])
 
   if (!active) {
     return null
@@ -320,8 +338,11 @@ export function StatusRule({
       : ''
 
   const bar = usage.context_max ? ctxBar(pct) : ''
+  const compact = cols > 0 && cols < COMPACT_STATUS_COLS
+  const compactBarWidth = cols < 70 ? 0 : cols < 82 ? 5 : 7
   const { leftWidth, rightWidth, separatorWidth } = statusRuleWidths(cols, cwdLabel)
   const sessionCountText = liveSessionCount > 0 ? statusSessionCountLabel(liveSessionCount) : ''
+
   const handleSessionCountClick = (event: { stopImmediatePropagation?: () => void }) => {
     event.stopImmediatePropagation?.()
     onSessionCountClick?.()
@@ -336,6 +357,98 @@ export function StatusRule({
       <Text color={t.color.muted}> │ {sessionCountText}</Text>
     )
   ) : null
+
+  if (compact) {
+    const width = Math.max(1, cols || 1)
+    const compactModelLabel = modelLabel(model, modelReasoningEffort, modelFast)
+    const compactCtxLabel = contextStatusLabel(usage)
+    const compactBar = usage.context_max && compactBarWidth > 0 ? ctxBar(pct, compactBarWidth) : ''
+
+    return (
+      <Box flexDirection="column" height={2} width={width}>
+        <Box flexDirection="row" overflow="hidden" width={width}>
+          <Text color={t.color.border} wrap="truncate-end">
+            {'─ '}
+          </Text>
+          {busy ? (
+            <FaceTicker color={statusColor} startedAt={turnStartedAt} />
+          ) : (
+            <Text color={statusColor} wrap="truncate-end">
+              {status}
+            </Text>
+          )}
+          {compactModelLabel ? (
+            <Text color={t.color.muted} wrap="truncate-end">
+              {' │ model '}
+              {compactModelLabel}
+            </Text>
+          ) : null}
+          {compactCtxLabel ? (
+            <Text color={t.color.muted} wrap="truncate-end">
+              {' │ '}
+              {compactCtxLabel}
+            </Text>
+          ) : null}
+          {compactBar ? (
+            <Text color={barColor} wrap="truncate-end">
+              {' '}
+              [{compactBar}]
+            </Text>
+          ) : null}
+        </Box>
+
+        <Box flexDirection="row" overflow="hidden" width={width}>
+          <Text color={t.color.border}>  </Text>
+          {sessionStartedAt ? (
+            <Text color={t.color.muted} wrap="truncate-end">
+              dur <SessionDuration startedAt={sessionStartedAt} />
+            </Text>
+          ) : (
+            <Text color={t.color.muted} wrap="truncate-end">
+              {cwdLabel ? 'cwd ' : ''}
+            </Text>
+          )}
+          {typeof usage.compressions === 'number' && usage.compressions > 0 ? (
+            <Text color={usage.compressions >= 10 ? t.color.error : usage.compressions >= 5 ? t.color.warn : t.color.muted}>
+              {' │ cmp '}
+              {usage.compressions}
+            </Text>
+          ) : null}
+          <SpawnHud t={t} />
+          {voiceLabel ? (
+            <Text
+              color={
+                voiceLabel.startsWith('●') ? t.color.error : voiceLabel.startsWith('◉') ? t.color.warn : t.color.muted
+              }
+              wrap="truncate-end"
+            >
+              {' │ '}
+              {voiceLabel}
+            </Text>
+          ) : null}
+          {sessionCountNode}
+          {bgCount > 0 ? (
+            <Text color={t.color.muted} wrap="truncate-end">
+              {' │ '}
+              {bgCount} bg
+            </Text>
+          ) : null}
+          {showCost && typeof usage.cost_usd === 'number' ? (
+            <Text color={t.color.muted} wrap="truncate-end">
+              {' │ $'}
+              {usage.cost_usd.toFixed(4)}
+            </Text>
+          ) : null}
+          {cwdLabel ? (
+            <Text color={t.color.label} wrap="truncate-end">
+              {' │ '}
+              {cwdLabel}
+            </Text>
+          ) : null}
+        </Box>
+      </Box>
+    )
+  }
 
   return (
     <Box height={1}>

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -268,9 +268,37 @@ const modelLabel = (model: string, effort?: string, fast?: boolean) =>
 
 const COMPACT_STATUS_COLS = 92
 
+const fitCompactText = (text: string, width: number) => {
+  if (width <= 0) {
+    return ''
+  }
+
+  if (text.length <= width) {
+    return text
+  }
+
+  if (width <= 3) {
+    return text.slice(0, width)
+  }
+
+  return `${text.slice(0, width - 3).trimEnd()}...`
+}
+
+const compactModelLabel = (model: string, effort?: string, fast?: boolean) => {
+  const label = modelLabel(model, effort, fast)
+
+  if (label.length <= 18) {
+    return label
+  }
+
+  return fitCompactText(label, 18)
+}
+
 const contextStatusLabel = (usage: Usage) => {
+  const ctxUsed = usage.context_used && usage.context_used > 0 ? usage.context_used : usage.total
+
   const ctxLabel = usage.context_max
-    ? `${fmtK(usage.context_used ?? 0)}/${fmtK(usage.context_max)}`
+    ? `${fmtK(ctxUsed ?? 0)}/${fmtK(usage.context_max)}`
     : usage.total > 0
       ? `${fmtK(usage.total)} tok`
       : ''
@@ -281,7 +309,9 @@ const contextStatusLabel = (usage: Usage) => {
 
   const pct = usage.context_percent
 
-  return usage.context_max && pct != null ? `ctx ${ctxLabel} ${pct}%` : `ctx ${ctxLabel}`
+  const prefix = usage.context_estimated ? 'ctx ~' : 'ctx '
+
+  return usage.context_max && pct != null ? `${prefix}${ctxLabel} ${pct}%` : `${prefix}${ctxLabel}`
 }
 
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
@@ -339,9 +369,9 @@ export function StatusRule({
 
   const bar = usage.context_max ? ctxBar(pct) : ''
   const compact = cols > 0 && cols < COMPACT_STATUS_COLS
-  const compactBarWidth = cols < 70 ? 0 : cols < 82 ? 5 : 7
   const { leftWidth, rightWidth, separatorWidth } = statusRuleWidths(cols, cwdLabel)
   const sessionCountText = liveSessionCount > 0 ? statusSessionCountLabel(liveSessionCount) : ''
+  const now = Date.now()
 
   const handleSessionCountClick = (event: { stopImmediatePropagation?: () => void }) => {
     event.stopImmediatePropagation?.()
@@ -360,92 +390,37 @@ export function StatusRule({
 
   if (compact) {
     const width = Math.max(1, cols || 1)
-    const compactModelLabel = modelLabel(model, modelReasoningEffort, modelFast)
     const compactCtxLabel = contextStatusLabel(usage)
-    const compactBar = usage.context_max && compactBarWidth > 0 ? ctxBar(pct, compactBarWidth) : ''
+
+    const primaryStatus = busy
+      ? `busy${turnStartedAt ? ` ${fmtDuration(now - turnStartedAt)}` : ''}`
+      : status || 'ready'
+
+    const firstLine = fitCompactText(
+      ['-', primaryStatus, compactModelLabel(model, modelReasoningEffort, modelFast), compactCtxLabel]
+        .filter(Boolean)
+        .join(' | '),
+      width
+    )
+
+    const secondLine = fitCompactText(
+      [
+        sessionStartedAt ? `dur ${fmtDuration(now - sessionStartedAt)}` : '',
+        voiceLabel || '',
+        sessionCountText,
+        bgCount > 0 ? `${bgCount} bg` : '',
+        showCost && typeof usage.cost_usd === 'number' ? `$${usage.cost_usd.toFixed(4)}` : '',
+        cwdLabel || ''
+      ]
+        .filter(Boolean)
+        .join(' | '),
+      width
+    )
 
     return (
       <Box flexDirection="column" height={2} width={width}>
-        <Box flexDirection="row" overflow="hidden" width={width}>
-          <Text color={t.color.border} wrap="truncate-end">
-            {'─ '}
-          </Text>
-          {busy ? (
-            <FaceTicker color={statusColor} startedAt={turnStartedAt} />
-          ) : (
-            <Text color={statusColor} wrap="truncate-end">
-              {status}
-            </Text>
-          )}
-          {compactModelLabel ? (
-            <Text color={t.color.muted} wrap="truncate-end">
-              {' │ model '}
-              {compactModelLabel}
-            </Text>
-          ) : null}
-          {compactCtxLabel ? (
-            <Text color={t.color.muted} wrap="truncate-end">
-              {' │ '}
-              {compactCtxLabel}
-            </Text>
-          ) : null}
-          {compactBar ? (
-            <Text color={barColor} wrap="truncate-end">
-              {' '}
-              [{compactBar}]
-            </Text>
-          ) : null}
-        </Box>
-
-        <Box flexDirection="row" overflow="hidden" width={width}>
-          <Text color={t.color.border}>  </Text>
-          {sessionStartedAt ? (
-            <Text color={t.color.muted} wrap="truncate-end">
-              dur <SessionDuration startedAt={sessionStartedAt} />
-            </Text>
-          ) : (
-            <Text color={t.color.muted} wrap="truncate-end">
-              {cwdLabel ? 'cwd ' : ''}
-            </Text>
-          )}
-          {typeof usage.compressions === 'number' && usage.compressions > 0 ? (
-            <Text color={usage.compressions >= 10 ? t.color.error : usage.compressions >= 5 ? t.color.warn : t.color.muted}>
-              {' │ cmp '}
-              {usage.compressions}
-            </Text>
-          ) : null}
-          <SpawnHud t={t} />
-          {voiceLabel ? (
-            <Text
-              color={
-                voiceLabel.startsWith('●') ? t.color.error : voiceLabel.startsWith('◉') ? t.color.warn : t.color.muted
-              }
-              wrap="truncate-end"
-            >
-              {' │ '}
-              {voiceLabel}
-            </Text>
-          ) : null}
-          {sessionCountNode}
-          {bgCount > 0 ? (
-            <Text color={t.color.muted} wrap="truncate-end">
-              {' │ '}
-              {bgCount} bg
-            </Text>
-          ) : null}
-          {showCost && typeof usage.cost_usd === 'number' ? (
-            <Text color={t.color.muted} wrap="truncate-end">
-              {' │ $'}
-              {usage.cost_usd.toFixed(4)}
-            </Text>
-          ) : null}
-          {cwdLabel ? (
-            <Text color={t.color.label} wrap="truncate-end">
-              {' │ '}
-              {cwdLabel}
-            </Text>
-          ) : null}
-        </Box>
+        <Text color={statusColor}>{firstLine}</Text>
+        <Text color={t.color.muted}>{secondLine}</Text>
       </Box>
     )
   }

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -397,7 +397,7 @@ export function StatusRule({
       : status || 'ready'
 
     const firstLine = fitCompactText(
-      ['-', primaryStatus, compactModelLabel(model, modelReasoningEffort, modelFast), compactCtxLabel]
+      [`- ${primaryStatus}`, compactModelLabel(model, modelReasoningEffort, modelFast), compactCtxLabel]
         .filter(Boolean)
         .join(' | '),
       width

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -504,9 +504,9 @@ export type GatewayEvent =
   | { payload?: { skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
   | { payload?: GatewaySkin; session_id?: string; type: 'skin.changed' }
   | { payload: SessionInfo; session_id?: string; type: 'session.info' }
-  | { payload?: { text?: string }; session_id?: string; type: 'thinking.delta' }
+  | { payload?: { text?: string; usage?: Usage }; session_id?: string; type: 'thinking.delta' }
   | { payload?: undefined; session_id?: string; type: 'message.start' }
-  | { payload?: { kind?: string; text?: string }; session_id?: string; type: 'status.update' }
+  | { payload?: { kind?: string; text?: string; usage?: Usage }; session_id?: string; type: 'status.update' }
   | { payload?: { state?: 'idle' | 'listening' | 'transcribing' }; session_id?: string; type: 'voice.status' }
   | { payload?: { no_speech_limit?: boolean; text?: string }; session_id?: string; type: 'voice.transcript' }
   | { payload: { line: string }; session_id?: string; type: 'gateway.stderr' }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -168,6 +168,7 @@ export interface Usage {
   context_max?: number
   context_percent?: number
   context_used?: number
+  context_estimated?: boolean
   cost_status?: string
   cost_usd?: number
   input: number


### PR DESCRIPTION
## Summary
- split the TUI status rule into a compact two-line layout on narrow phone terminals
- keep model, context used/window/percent, session count, voice state, duration, and cwd legible instead of compressing them into one row
- keep the existing wide terminal layout unchanged

## Verification
- `npm test -- appChromeStatusRule statusRule statusBarTicker`
- `npx eslint src/components/appChrome.tsx src/__tests__/appChromeStatusRule.test.tsx`
- `npm run build`