### PR TITLE
feat(tools): support client provided tools in API

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -61,6 +61,143 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
+# Toolset name used for client-provided tools registered in the global registry.
+_CLIENT_TOOLS_TOOLSET = "_client_tools"
+
+
+def _validate_client_tool(tool: dict) -> Optional[str]:
+    """Validate a client-provided tool definition.
+
+    Returns an error message string on failure, or None if valid.
+    """
+    if not isinstance(tool, dict):
+        return "Tool must be a JSON object"
+    if tool.get("type") != "function":
+        return "Tool type must be 'function'"
+    func = tool.get("function", {})
+    if not isinstance(func, dict):
+        return "Tool 'function' must be a JSON object"
+    name = func.get("name", "")
+    if not name or not isinstance(name, str):
+        return "Tool function must have a non-empty 'name'"
+    if not func.get("description"):
+        return f"Tool '{name}' must have a 'description'"
+    if not func.get("parameters"):
+        return f"Tool '{name}' must have 'parameters' (JSON Schema)"
+    return None
+
+
+def _make_client_tool_handler(url: str, tool_name: str):
+    """Return a synchronous handler for a client-registered tool.
+
+    * If *url* is non-empty: makes a POST request to *url* with the tool
+      arguments as JSON body (``x-hermes-url`` forwarding).
+    * If *url* is empty: returns a success acknowledgment — the tool is
+      client-managed (standard OpenAI function-calling round-trip).
+    """
+    import requests as _requests
+
+    def handler(args: dict, **kwargs) -> str:
+        if not url:
+            # No x-hermes-url → client-managed tool.  The model gets an
+            # acknowledgment instead of a hard error.  The actual execution
+            # happens client-side (standard OpenAI function-calling round
+            # trip) and results are fed back via conversation history.
+            return json.dumps({
+                "result": "acknowledged",
+                "note": (
+                    "Tool call forwarded to client for execution "
+                    "(no x-hermes-url configured on this tool)."
+                ),
+                "tool_args": args,
+            })
+        try:
+            resp = _requests.post(url, json=args, timeout=60)
+            resp.raise_for_status()
+            # Return raw response text — the model expects a tool result
+            # string.  If the response is JSON it will be parsed naturally
+            # by the model.
+            return resp.text
+        except _requests.Timeout:
+            return json.dumps({"error": f"Client tool '{tool_name}' timed out after 60s"})
+        except _requests.ConnectionError:
+            return json.dumps({"error": f"Client tool '{tool_name}' connection refused to {url}"})
+        except Exception as e:
+            return json.dumps({"error": f"Client tool '{tool_name}' error: {e}"})
+
+    return handler
+
+
+def _register_client_tools(client_tools: List[dict]) -> set:
+    """Register client-provided tools in the global tool registry.
+
+    Every tool is registered — those with ``x-hermes-url`` get a handler that
+    forwards calls via HTTP POST; those without get a no-op handler that
+    acknowledges the call (the client handles execution in the standard
+    OpenAI function-calling round-trip).
+
+    Tools whose names conflict with built-in Hermes tools are skipped
+    (``override=False``).
+
+    Returns the set of successfully registered tool names so callers can
+    deregister them later.
+
+    Each tool is registered under ``_CLIENT_TOOLS_TOOLSET`` so the toolset
+    resolution machinery picks them up automatically when the toolset is
+    included in ``enabled_toolsets``.
+    """
+    from tools.registry import registry
+
+    names: set[str] = set()
+    skipped: list[str] = []
+
+    for tool in client_tools:
+        func = tool.get("function", {})
+        name = func.get("name", "")
+        if not name:
+            continue
+
+        existing = registry.get_entry(name)
+        if existing is not None:
+            skipped.append(name)
+            continue
+
+        url = func.get("x-hermes-url", "")
+        schema = {
+            "name": name,
+            "description": func.get("description", ""),
+            "parameters": func.get("parameters", {}),
+        }
+        registry.register(
+            name=name,
+            toolset=_CLIENT_TOOLS_TOOLSET,
+            schema=schema,
+            handler=_make_client_tool_handler(url, name),
+            check_fn=lambda: True,
+            override=False,
+        )
+        names.add(name)
+
+    if skipped:
+        logger.warning(
+            "Client tools skipped (names conflict with built-in tools): %s",
+            skipped,
+        )
+
+    return names
+
+
+def _deregister_client_tools(names: set):
+    """Remove client-provided tools from the global tool registry."""
+    from tools.registry import registry
+
+    for name in names:
+        try:
+            registry.deregister(name)
+        except Exception:
+            logger.debug("Error deregistering client tool '%s' (already removed)", name)
+
+
 # Default settings
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
@@ -962,6 +1099,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_start_callback=None,
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
+        extra_toolsets: Optional[List[str]] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -977,6 +1115,11 @@ class APIServerAdapter(BasePlatformAdapter):
         key is meant to persist across transcripts so long-term memory
         providers (e.g. Honcho) can scope their per-chat state correctly
         — matching the semantics of the native gateway's ``session_key``.
+
+        ``extra_toolsets`` is an optional list of additional toolset names
+        to enable for this agent instance, on top of the configured platform
+        toolsets.  Used by the client-tools feature to inject dynamically-
+        registered tools into the agent's tool list.
         """
         from run_agent import AIAgent
         from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config, GatewayRunner
@@ -988,6 +1131,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        if extra_toolsets:
+            for ts in extra_toolsets:
+                if ts not in enabled_toolsets:
+                    enabled_toolsets.append(ts)
 
         max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
 
@@ -1106,6 +1253,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_stop": True,
                 "run_approval_response": True,
                 "tool_progress_events": True,
+                "client_tools": True,
+                "client_tools_forwarding": "x-hermes-url",
                 "approval_events": True,
                 "session_resources": True,
                 "session_chat": True,
@@ -1505,12 +1654,14 @@ class APIServerAdapter(BasePlatformAdapter):
         if system_prompt is not None and not isinstance(system_prompt, str):
             return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
         history = self._conversation_history_for_session(session_id)
+        client_tools: List[dict] = body.get("tools") or []
         result, usage = await self._run_agent(
             user_message=user_message,
             conversation_history=history,
             ephemeral_system_prompt=system_prompt,
             session_id=session_id,
             gateway_session_key=gateway_session_key,
+            client_tools=client_tools or None,
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
         final_response = result.get("final_response", "") if isinstance(result, dict) else ""
@@ -1688,6 +1839,29 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
+
+        # Extract client-provided tools (OpenAI standard ``tools`` parameter).
+        # Each tool should have the standard OpenAI ``{type: "function",
+        # function: {name, description, parameters}}`` shape.  An optional
+        # ``function.x-hermes-url`` field tells the server where to forward
+        # execution.  Tools whose names conflict with built-in Hermes tools
+        # are silently dropped with a warning.
+        client_tools: List[dict] = []
+        raw_tools = body.get("tools")
+        if raw_tools is not None:
+            if not isinstance(raw_tools, list):
+                return web.json_response(
+                    _openai_error("'tools' must be an array"),
+                    status=400,
+                )
+            for i, tool in enumerate(raw_tools):
+                err = _validate_client_tool(tool)
+                if err:
+                    return web.json_response(
+                        _openai_error(f"tools[{i}]: {err}"),
+                        status=400,
+                    )
+                client_tools.append(tool)
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
@@ -1868,6 +2042,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                client_tools=client_tools or None,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -1887,6 +2062,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                client_tools=client_tools or None,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -2766,6 +2942,24 @@ class APIServerAdapter(BasePlatformAdapter):
         conversation = body.get("conversation")
         store = _coerce_request_bool(body.get("store"), default=True)
 
+        # Extract client-provided tools (same format as chat completions).
+        client_tools: List[dict] = []
+        raw_tools = body.get("tools")
+        if raw_tools is not None:
+            if not isinstance(raw_tools, list):
+                return web.json_response(
+                    _openai_error("'tools' must be an array"),
+                    status=400,
+                )
+            for i, tool in enumerate(raw_tools):
+                err = _validate_client_tool(tool)
+                if err:
+                    return web.json_response(
+                        _openai_error(f"tools[{i}]: {err}"),
+                        status=400,
+                    )
+                client_tools.append(tool)
+
         # conversation and previous_response_id are mutually exclusive
         if conversation and previous_response_id:
             return web.json_response(_openai_error("Cannot use both 'conversation' and 'previous_response_id'"), status=400)
@@ -2900,6 +3094,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                client_tools=client_tools or None,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -2933,6 +3128,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                client_tools=client_tools or None,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -3435,6 +3631,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
+        client_tools: Optional[List[dict]] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -3446,10 +3643,21 @@ class APIServerAdapter(BasePlatformAdapter):
         at ``agent_ref[0]`` before ``run_conversation`` begins.  This allows
         callers (e.g. the SSE writer) to call ``agent.interrupt()`` from
         another thread to stop in-progress LLM calls.
+
+        If *client_tools* is provided, each tool definition is temporarily
+        registered in the global tool registry before the agent is created
+        and deregistered after the conversation completes.  Client tool
+        names that conflict with built-in tools are silently skipped.
         """
+        # ── Temporarily register client-provided tools ────────────────
+        registered_client_tool_names: set = set()
+        if client_tools:
+            registered_client_tool_names = _register_client_tools(client_tools)
+
         loop = asyncio.get_running_loop()
 
         def _run():
+            extra = [_CLIENT_TOOLS_TOOLSET] if registered_client_tool_names else None
             agent = self._create_agent(
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
@@ -3458,6 +3666,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_start_callback=tool_start_callback,
                 tool_complete_callback=tool_complete_callback,
                 gateway_session_key=gateway_session_key,
+                extra_toolsets=extra,
             )
             if agent_ref is not None:
                 agent_ref[0] = agent
@@ -3480,7 +3689,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 result["session_id"] = _eff_sid
             return result, usage
 
-        return await loop.run_in_executor(None, _run)
+        try:
+            return await loop.run_in_executor(None, _run)
+        finally:
+            # ── Clean up temporarily registered tools ────────────────
+            if registered_client_tool_names:
+                _deregister_client_tools(registered_client_tool_names)
 
     # ------------------------------------------------------------------
     # /v1/runs — structured event streaming

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -30,10 +30,37 @@ from gateway.platforms.api_server import (
     ResponseStore,
     _IdempotencyCache,
     _derive_chat_session_id,
+    _register_client_tools,
+    _deregister_client_tools,
+    _validate_client_tool,
+    _make_client_tool_handler,
+    _CLIENT_TOOLS_TOOLSET,
     check_api_server_requirements,
     cors_middleware,
     security_headers_middleware,
 )
+
+# Register a stub built-in tool so client-tool conflict detection works in tests.
+_STUB_TOOL_NAME = "_test_stub_builtin"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _seed_registry_with_stub_tool():
+    """Pre-seed a lightweight built-in tool for conflict-detection tests."""
+    from tools.registry import registry
+    registry.register(
+        name=_STUB_TOOL_NAME,
+        toolset="_test_fixtures",
+        schema={
+            "name": _STUB_TOOL_NAME,
+            "description": "Stub built-in for testing conflict detection",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=lambda args, **kw: json.dumps({"ok": True}),
+        check_fn=lambda: True,
+    )
+    yield
+    registry.deregister(_STUB_TOOL_NAME)
 
 
 # ---------------------------------------------------------------------------
@@ -1503,6 +1530,330 @@ class TestDeriveChatSessionId:
         """None system prompt doesn't crash."""
         sid = _derive_chat_session_id(None, "test")
         assert isinstance(sid, str) and len(sid) > 4
+
+
+# ---------------------------------------------------------------------------
+# Client-provided tools — unit tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestClientToolValidation:
+    """Tests for _validate_client_tool and _make_client_tool_handler."""
+
+    def test_valid_tool_passes(self):
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+                "x-hermes-url": "http://localhost:8080/weather",
+            },
+        }
+        assert _validate_client_tool(tool) is None
+
+    def test_valid_tool_without_url_passes(self):
+        """x-hermes-url is optional — validation only checks shape."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "do_something",
+                "description": "A test tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"x": {"type": "string"}},
+                },
+            },
+        }
+        assert _validate_client_tool(tool) is None
+
+    def test_not_a_dict_fails(self):
+        err = _validate_client_tool("not a dict")
+        assert err is not None
+
+    def test_wrong_type_fails(self):
+        err = _validate_client_tool({"type": "code_interpreter"})
+        assert err is not None
+
+    def test_missing_name_fails(self):
+        err = _validate_client_tool({
+            "type": "function",
+            "function": {"description": "no name here", "parameters": {"type": "object", "properties": {}}},
+        })
+        assert err is not None
+
+    def test_missing_description_fails(self):
+        err = _validate_client_tool({
+            "type": "function",
+            "function": {"name": "foo", "parameters": {"type": "object", "properties": {}}},
+        })
+        assert err is not None
+
+    def test_missing_parameters_fails(self):
+        err = _validate_client_tool({
+            "type": "function",
+            "function": {"name": "foo", "description": "desc"},
+        })
+        assert err is not None
+
+    def test_handler_without_url_acks(self):
+        """No-URL handler returns an acknowledgment, not an error."""
+        handler = _make_client_tool_handler("", "test_tool")
+        result = json.loads(handler({"x": 1}))
+        assert result["result"] == "acknowledged"
+        assert "tool_args" in result
+        assert result["tool_args"] == {"x": 1}
+
+    def test_handler_with_unreachable_url_returns_error(self):
+        handler = _make_client_tool_handler("http://localhost:1/nope", "fail_tool")
+        result = json.loads(handler({"x": 1}))
+        assert "error" in result
+
+
+class TestClientToolRegistry:
+    """Tests for _register_client_tools / _deregister_client_tools."""
+
+    def test_register_and_deregister(self):
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "my_test_tool",
+                "description": "Test tool",
+                "parameters": {"type": "object", "properties": {"x": {"type": "string"}}},
+                "x-hermes-url": "http://localhost:9999/test",
+            },
+        }]
+        names = _register_client_tools(tools)
+        assert "my_test_tool" in names
+
+        from tools.registry import registry
+        assert registry.get_entry("my_test_tool") is not None
+
+        registered_names = registry.get_tool_names_for_toolset(_CLIENT_TOOLS_TOOLSET)
+        assert "my_test_tool" in registered_names
+
+        _deregister_client_tools(names)
+        assert registry.get_entry("my_test_tool") is None
+
+    def test_conflict_with_builtin_is_skipped(self):
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": _STUB_TOOL_NAME,
+                "description": "Should be skipped",
+                "parameters": {"type": "object", "properties": {}},
+                "x-hermes-url": "http://localhost:1/conflict",
+            },
+        }]
+        names = _register_client_tools(tools)
+        assert _STUB_TOOL_NAME not in names
+        # Built-in must still be intact
+        from tools.registry import registry
+        assert registry.get_entry(_STUB_TOOL_NAME) is not None
+        assert registry.get_entry(_STUB_TOOL_NAME).toolset == "_test_fixtures"
+
+    def test_register_without_url_registers(self):
+        """Tools without x-hermes-url should still be registered."""
+        from tools.registry import registry
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "no_url_tool",
+                "description": "No URL provided",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }]
+        names = _register_client_tools(tools)
+        assert "no_url_tool" in names
+        entry = registry.get_entry("no_url_tool")
+        assert entry is not None
+        # Handler must return an acknowledgment, not an error
+        result = json.loads(entry.handler({}))
+        assert result["result"] == "acknowledged"
+
+    def test_register_empty_list_returns_empty_set(self):
+        names = _register_client_tools([])
+        assert names == set()
+
+    def test_register_double_deregister_does_not_crash(self):
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "double_test",
+                "description": "Test double deregister",
+                "parameters": {"type": "object", "properties": {}},
+                "x-hermes-url": "http://localhost:1/x",
+            },
+        }]
+        names = _register_client_tools(tools)
+        _deregister_client_tools(names)
+        _deregister_client_tools(names)  # second call must not raise
+
+
+class TestClientToolsChatCompletions:
+    """End-to-end tests for client tools via the chat completions endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_tools_parameter_forwards_to_run_agent(self, adapter):
+        """tools from the request body should be passed to _run_agent."""
+        mock_result = {"final_response": "ok", "messages": []}
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "tools": [
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "description": "Get weather",
+                                    "parameters": {
+                                        "type": "object",
+                                        "properties": {"city": {"type": "string"}},
+                                        "required": ["city"],
+                                    },
+                                    "x-hermes-url": "http://localhost:8080/weather",
+                                },
+                            },
+                        ],
+                    },
+                )
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_tools_must_be_array(self, adapter):
+        """Non-array tools should return 400."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "tools": "not-an-array",
+                },
+            )
+            assert resp.status == 400
+            data = await resp.json()
+            assert "tools" in data["error"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_invalid_tool_returns_400(self, adapter):
+        """A tool missing required fields should return 400."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "tools": [{"type": "function", "function": {"name": "incomplete"}}],
+                },
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_tools_passed_in_streaming_mode(self, adapter):
+        """tools should be forwarded even when stream=True."""
+        mock_result = {"final_response": "ok", "messages": []}
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                        "stream": True,
+                        "tools": [
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": "stream_tool",
+                                    "description": "Test tool in stream",
+                                    "parameters": {"type": "object", "properties": {}},
+                                    "x-hermes-url": "http://localhost:8080/tool",
+                                },
+                            },
+                        ],
+                    },
+                )
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_no_tools_is_ok(self, adapter):
+        """Omitting the tools parameter entirely should still work."""
+        mock_result = {"final_response": "ok", "messages": []}
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                    },
+                )
+            assert resp.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            # client_tools should be None when no tools are provided
+            assert call_kwargs.get("client_tools") is None
+
+
+class TestClientToolsResponses:
+    """End-to-end tests for client tools via the responses endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_tools_parameter_forwards_to_run_agent(self, adapter):
+        mock_result = {"final_response": "ok", "messages": []}
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "test",
+                        "input": "Hello",
+                        "tools": [
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": "resp_tool",
+                                    "description": "A tool in responses API",
+                                    "parameters": {"type": "object", "properties": {"x": {"type": "string"}}},
+                                    "x-hermes-url": "http://localhost:8080/tool",
+                                },
+                            },
+                        ],
+                    },
+                )
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_invalid_tools_in_responses_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/responses",
+                json={
+                    "model": "test",
+                    "input": "Hello",
+                    "tools": "bad-value",
+                },
+            )
+            assert resp.status == 400
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -229,6 +229,119 @@ Health check. Returns `{"status": "ok"}`. Also available at **GET /v1/health** f
 
 Extended health check that also reports active sessions, running agents, and resource usage. Useful for monitoring/observability tooling.
 
+## Client-Provided Tools
+
+The API server accepts the standard OpenAI `tools` parameter on both `/v1/chat/completions` and `/v1/responses`. Client-provided tools fall into two categories:
+
+### Tools with `x-hermes-url` (server-executed)
+
+Include an `x-hermes-url` field in the tool's function definition to have the agent execute it by forwarding the call to your HTTP endpoint.
+
+This is ideal for tools that run on the client machine — screen capture, local file picker, IoT control, phone flashlight — where a lightweight HTTP server can handle the request and return the result in the same agent turn.
+
+```json
+{
+  "model": "hermes-agent",
+  "messages": [{"role": "user", "content": "Turn on the flashlight."}],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "flashlight",
+        "description": "Control the device flashlight",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "on": {"type": "boolean", "description": "True to turn on, false to turn off"}
+          },
+          "required": ["on"]
+        },
+        "x-hermes-url": "http://localhost:8080/flashlight"
+      }
+    }
+  ]
+}
+```
+
+On the client, run a small HTTP server that handles the tool:
+
+```python
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+@app.post("/flashlight")
+def handle_flashlight():
+    on = request.json.get("on", False)
+    # ... control your device's flashlight
+    return jsonify({"result": f"flashlight {'on' if on else 'off'}"})
+
+@app.post("/screen")
+def handle_screen():
+    # ... capture screen contents
+    return jsonify({"result": "..."})
+```
+
+The agent POSTs the tool arguments as JSON to your `x-hermes-url`, waits for the response, and continues. One agent turn, no extra round-trips.
+
+### Tools without `x-hermes-url` (client-managed)
+
+Tools without `x-hermes-url` follow the standard OpenAI function-calling round-trip. The agent registers them and returns `tool_calls` in its response; your client executes them and sends `tool` role results back in the next request.
+
+This is the right pattern when running a local HTTP server is impractical (mobile constraints, platform sandboxing) or when the tool requires user interaction (file picker, confirmation dialog).
+
+```python
+# First request: agent returns tool_calls
+response = client.chat.completions.create(
+    model="hermes-agent",
+    messages=[{"role": "user", "content": "Turn on the flashlight."}],
+    tools=[{
+        "type": "function",
+        "function": {
+            "name": "flashlight",
+            "description": "Control the device flashlight",
+            "parameters": {"type": "object", "properties": {
+                "on": {"type": "boolean"}
+            }, "required": ["on"]},
+        },
+    }],
+)
+
+# Client extracts tool_calls, executes flashlight locally, sends result back
+tool_call = response.choices[0].message.tool_calls[0]
+result = json.dumps({"on": True})  # client's actual execution
+
+# Second request: feed result back
+client.chat.completions.create(
+    model="hermes-agent",
+    messages=[
+        {"role": "user", "content": "Turn on the flashlight."},
+        {"role": "assistant", "content": None, "tool_calls": [tool_call]},
+        {"role": "tool", "tool_call_id": tool_call.id, "content": result},
+    ],
+)
+```
+
+The handler for URL-less tools returns a success acknowledgment so the model never sees an error message. No warnings are logged.
+
+### Conflict with built-in tools
+
+If a client-provided tool has the same name as a built-in Hermes tool, it is silently skipped. Built-in tools cannot be overridden.
+
+### Capability advertisement
+
+```json
+{
+  "object": "hermes.api_server.capabilities",
+  "features": {
+    "client_tools": true,
+    "client_tools_forwarding": "x-hermes-url"
+  }
+}
+```
+
+Check `/v1/capabilities` to detect whether the running API server supports client tools.
+
 ## Runs API (streaming-friendly alternative)
 
 In addition to `/v1/chat/completions` and `/v1/responses`, the server exposes a **runs** API for long-form sessions where the client wants to subscribe to progress events instead of managing streaming themselves.


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
Adds client-provided tool support to the OpenAI-compatible API server. Clients can now include tool definitions in the standard `tools` parameter on `/v1/chat/completions` and `/v1/responses`. Tools with an `x-hermes-url` field are executed by the agent via HTTP forwarding to the client's endpoint. Tools without a URL follow the standard OpenAI function-calling round-trip (model returns `tool_calls`, client executes and sends results back in the next request).


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #20950

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- **`gateway/platforms/api_server.py`** — Added `_validate_client_tool()`, `_make_client_tool_handler()`, `_register_client_tools()`, `_deregister_client_tools()` helper functions. Modified `_create_agent()` to accept `extra_toolsets`. Modified `_run_agent()` to accept `client_tools`, register them before agent creation, and deregister in a `finally` block. Modified `_handle_chat_completions()` and `_handle_responses()` to parse `tools` from request bodies. Updated `/v1/capabilities` to advertise `client_tools` and `client_tools_forwarding`.
- **`tests/gateway/test_api_server.py`** — Added 21 tests across 4 test classes covering validation, registry integration, and end-to-end flow for both chat completions and responses endpoints.
- **`website/docs/user-guide/features/api-server.md`** — Added **Client-Provided Tools** documentation section covering both `x-hermes-url` (server-executed) and URL-less (client-managed) modes with examples.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Start the gateway with `API_SERVER_ENABLED=true` and `API_SERVER_KEY=test-key`
2. Send a chat completion request with a tool that has `x-hermes-url: http://localhost:8080/mytool` and verify the agent POSTs arguments to that URL
3. Send a request with a tool that has no `x-hermes-url` and verify the agent acknowledges the call without errors
4. Send a request with a tool name that conflicts with a built-in Hermes tool and verify it's silently skipped
5. Repeat steps 2-4 with the `/v1/responses` endpoint

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


