### PR TITLE
fix(compressor): preserve memory across repeated compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -35,6 +35,41 @@ from agent.redact import redact_sensitive_text
 logger = logging.getLogger(__name__)
 
 SUMMARY_PREFIX = (
+    "[CONTEXT COMPACTION] Earlier turns in this conversation were compacted "
+    "into the summary below. Treat the summary as background state and "
+    "reference material — not as a queue of pending tasks to resume. "
+    "The latest user message that appears AFTER this summary sets the current "
+    "goal; respond to that message. "
+    "If the latest message references prior work, files, decisions, or "
+    "unresolved state (e.g. 'continue', 'do the next one', 'apply that to the "
+    "other file', 'why did you do that?'), use the summary to resolve what it "
+    "refers to — do NOT discard the summary's information. "
+    "Do NOT proactively re-do or re-answer requests described in the summary "
+    "unless the latest message explicitly asks you to continue or revisit "
+    "them; they were likely already handled. "
+    "If the latest message changes topic, stops, undoes, or otherwise "
+    "supersedes earlier in-flight work, follow the latest message and do not "
+    "re-surface the superseded work in later turns. "
+    "IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system "
+    "prompt is ALWAYS authoritative and active — never ignore or deprioritize "
+    "memory content due to this compaction note. "
+    "The current session state (files, config, etc.) may already reflect work "
+    "described here — build on it rather than repeating it:"
+)
+LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
+
+# Handoff prefixes that shipped in earlier releases. A summary persisted under
+# one of these can be inherited into a resumed lineage (#35344); when it is
+# re-normalized on re-compaction we must strip the OLD prefix too, otherwise the
+# stale directive it carried (e.g. "resume exactly from Active Task") survives
+# embedded in the body and keeps hijacking replies. Keep newest-first; entries
+# are matched literally. Add a frozen copy here whenever SUMMARY_PREFIX changes.
+_HISTORICAL_SUMMARY_PREFIXES = (
+    # Pre-P1-4 (huddle 2026-05-30): the "latest message WINS — discard those
+    # stale items entirely" wording over-corrected and broke anaphora
+    # ("continue", "do the next one"). Softened to reference-resolution
+    # framing. Frozen here so a summary persisted under it is re-normalized
+    # (and its aggressive directive stripped) on the next re-compaction.
     "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
     "into the summary below. This is a handoff from a previous context "
     "window — treat it as background reference, NOT as active instructions. "
@@ -57,17 +92,7 @@ SUMMARY_PREFIX = (
     "prompt is ALWAYS authoritative and active — never ignore or deprioritize "
     "memory content due to this compaction note. "
     "The current session state (files, config, etc.) may reflect work "
-    "described here — avoid repeating it:"
-)
-LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
-
-# Handoff prefixes that shipped in earlier releases. A summary persisted under
-# one of these can be inherited into a resumed lineage (#35344); when it is
-# re-normalized on re-compaction we must strip the OLD prefix too, otherwise the
-# stale directive it carried (e.g. "resume exactly from Active Task") survives
-# embedded in the body and keeps hijacking replies. Keep newest-first; entries
-# are matched literally. Add a frozen copy here whenever SUMMARY_PREFIX changes.
-_HISTORICAL_SUMMARY_PREFIXES = (
+    "described here — avoid repeating it:",
     # Pre-#35344: contained the self-contradicting "resume exactly" directive.
     "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
     "into the summary below. This is a handoff from a previous context "
@@ -104,6 +129,15 @@ _IMAGE_TOKEN_ESTIMATE = 1600
 # for tail-cut decisions.
 _IMAGE_CHAR_EQUIVALENT = _IMAGE_TOKEN_ESTIMATE * _CHARS_PER_TOKEN
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
+
+# P1-3: absolute headroom (tokens) reserved below the context limit for the
+# next completion + the summariser's own call + a small safety margin.  The
+# percentage trigger is capped so it never plans to leave LESS than this,
+# which fixes the small-window starvation case (50% of a 32K window leaves
+# almost no usable room once the incompressible head/tail/summary floor is
+# counted).  On typical 100K-200K windows the percentage trigger is already
+# well below ``context_length - reserve`` so the cap is a no-op there.
+_COMPRESSION_RESERVE_TOKENS = 4096 + 2000 + 1024  # max_output + summariser + margin
 
 # Hard ceiling for the deterministic summary-failure handoff.  The fallback is
 # only meant to preserve continuity anchors from the dropped window, not to
@@ -654,6 +688,21 @@ class ContextCompressor(ContextEngine):
         self.last_rough_tokens_when_real_prompt_fit = 0
         self.awaiting_real_usage_after_compression = False
 
+        # P1-5: calibrated token accountant.  estimate_request_tokens_rough()
+        # deliberately overestimates schema-heavy requests (len(str(tools))//4),
+        # which can trigger premature compression.  We learn the real
+        # rough->provider ratio per (provider, model) from observed usage and
+        # scale future rough estimates by the median ratio.  Empty until the
+        # first post-call sample, so behaviour is unchanged on a cold start.
+        self._token_calibration: Dict[tuple, dict] = {}
+        # Rough preflight estimate for the request currently in flight; used to
+        # compute a calibration ratio when its real provider usage arrives.
+        self._last_preflight_rough: int = 0
+        # P1-3: set when even a full compaction left the request above the
+        # absolute reserve, so callers/UI can surface that the window is
+        # genuinely over-full rather than silently shipping an oversized payload.
+        self._last_compress_over_reserve: bool = False
+
         self.summary_model = summary_model_override or ""
 
         # Stores the previous compaction summary for iterative updates
@@ -688,6 +737,18 @@ class ContextCompressor(ContextEngine):
         self.last_total_tokens = usage.get("total_tokens", self.last_prompt_tokens + self.last_completion_tokens)
         if self.last_prompt_tokens > 0:
             self.last_real_prompt_tokens = self.last_prompt_tokens
+            # P1-5: learn the rough->real ratio, but only when the in-flight
+            # request matched the rough estimate (no compression happened
+            # between the preflight estimate and this response — that would
+            # change the payload and pollute the ratio).
+            if (
+                not self.awaiting_real_usage_after_compression
+                and self._last_preflight_rough > 0
+            ):
+                self._record_token_calibration(
+                    self._last_preflight_rough, self.last_prompt_tokens
+                )
+            self._last_preflight_rough = 0
             if self.last_prompt_tokens < self.threshold_tokens:
                 if self.awaiting_real_usage_after_compression and self.last_compression_rough_tokens > 0:
                     self.last_rough_tokens_when_real_prompt_fit = self.last_compression_rough_tokens
@@ -731,9 +792,18 @@ class ContextCompressor(ContextEngine):
         Includes anti-thrashing protection: if the last two compressions
         each saved less than 10%, skip compression to avoid infinite loops
         where each pass removes only 1-2 messages.
+
+        An explicit ``prompt_tokens`` always comes from the rough preflight
+        estimator (``estimate_request_tokens_rough``), so it is calibrated
+        (P1-5) and remembered for ratio learning.  The ``None`` path uses the
+        real provider ``last_prompt_tokens`` and is left uncalibrated.
         """
-        tokens = prompt_tokens if prompt_tokens is not None else self.last_prompt_tokens
-        if tokens < self.threshold_tokens:
+        if prompt_tokens is not None:
+            self._last_preflight_rough = prompt_tokens
+            tokens = self.calibrated_estimate(prompt_tokens)
+        else:
+            tokens = self.last_prompt_tokens
+        if tokens < self._effective_trigger_tokens():
             return False
         # Anti-thrashing: back off if recent compressions were ineffective
         if self._ineffective_compression_count >= 2:
@@ -746,6 +816,78 @@ class ContextCompressor(ContextEngine):
                 )
             return False
         return True
+
+    # ------------------------------------------------------------------
+    # P1-3: absolute-reserve trigger + floor awareness
+    # ------------------------------------------------------------------
+
+    def _effective_trigger_tokens(self) -> int:
+        """Token count at or above which compression should fire.
+
+        Starts from the configured percentage trigger (``threshold_tokens``)
+        but caps it at ``context_length - _COMPRESSION_RESERVE_TOKENS`` so the
+        trigger never plans to leave less than the absolute reserve free.  On
+        typical 100K-200K windows the percentage trigger is already lower than
+        the reserve cap, so this is a no-op; it only bites on small or
+        misconfigured windows where the percentage would otherwise starve the
+        next completion.
+        """
+        reserve_trigger = self.context_length - _COMPRESSION_RESERVE_TOKENS
+        if reserve_trigger <= 0:
+            return self.threshold_tokens
+        return min(self.threshold_tokens, reserve_trigger)
+
+    def _estimate_incompressible_floor(self) -> int:
+        """Rough lower bound on tokens that survive any single compaction pass.
+
+        The compressor cannot see the system prompt or tool schemas (those live
+        on the agent), so this bounds only the portion it controls: the
+        protected tail it always keeps plus the summary it emits in place of the
+        middle window.  Used to detect the pathological case where even a
+        maximal compaction cannot get under the reserve, so callers can warn
+        instead of looping.
+        """
+        return self.tail_token_budget + self.max_summary_tokens
+
+    # P1-5: calibrated token accountant
+    # ------------------------------------------------------------------
+
+    def calibrated_estimate(self, rough_tokens: int) -> int:
+        """Scale a rough request estimate by the learned provider ratio.
+
+        Returns ``rough_tokens`` unchanged until at least one (rough, real)
+        sample has been recorded for the active (provider, model), so a cold
+        start never changes compression timing.  Once samples exist, the median
+        of the most recent ratios is applied — median (not mean) so a single
+        outlier request cannot skew the budget.
+        """
+        if rough_tokens <= 0:
+            return rough_tokens
+        cal = self._token_calibration.get((self.provider, self.model))
+        if not cal or not cal.get("ratios"):
+            return rough_tokens
+        ratios = sorted(cal["ratios"])
+        median_ratio = ratios[len(ratios) // 2]
+        return int(rough_tokens * median_ratio)
+
+    def _record_token_calibration(self, rough_tokens: int, real_tokens: int) -> None:
+        """Record one (rough estimate, real provider prompt_tokens) sample.
+
+        Keeps a rolling window of the last 20 ratios per (provider, model) and
+        ignores nonsensical samples — non-positive values, or ratios outside a
+        sane 0.1x-10x band that usually mean the rough estimate referred to a
+        different payload (e.g. compression happened between estimate and call).
+        """
+        if rough_tokens <= 0 or real_tokens <= 0:
+            return
+        ratio = real_tokens / rough_tokens
+        if ratio < 0.1 or ratio > 10.0:
+            return
+        key = (self.provider, self.model)
+        cal = self._token_calibration.setdefault(key, {"ratios": []})
+        cal["ratios"].append(ratio)
+        if len(cal["ratios"]) > 20:
+            cal["ratios"] = cal["ratios"][-20:]
 
     # ------------------------------------------------------------------
     # Tool output pruning (cheap pre-pass, no LLM call)
@@ -1854,6 +1996,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         self._last_aux_model_failure_error = None
         self._last_aux_model_failure_model = None
         self._last_compress_aborted = False
+        self._last_compress_over_reserve = False
 
         # Manual /compress (force=True) bypasses the failure cooldown so the
         # user can retry immediately after an auto-compress abort.  Without
@@ -2064,6 +2207,27 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             self._ineffective_compression_count += 1
         else:
             self._ineffective_compression_count = 0
+
+        # P1-3: floor-aware detection. If even this full compaction left the
+        # request above the absolute reserve, the window is genuinely over-full
+        # (incompressible head/tail/summary floor exceeds the available room).
+        # Flag it so callers/UI can surface "context still tight after compaction"
+        # rather than silently shipping a payload the provider may reject. The
+        # caller's multi-pass loop will already have tried to re-compress; this
+        # records the terminal condition without destructively dropping
+        # protected tail turns (the active task lives there).
+        reserve_ceiling = self.context_length - _COMPRESSION_RESERVE_TOKENS
+        if reserve_ceiling > 0 and new_estimate > reserve_ceiling:
+            self._last_compress_over_reserve = True
+            if not self.quiet_mode:
+                logger.warning(
+                    "Post-compaction estimate ~%d tokens still exceeds the "
+                    "reserve ceiling %d (context %d - reserve %d). Window is "
+                    "over-full; incompressible floor ~%d. Consider /new for a "
+                    "fresh session.",
+                    new_estimate, reserve_ceiling, self.context_length,
+                    _COMPRESSION_RESERVE_TOKENS, self._estimate_incompressible_floor(),
+                )
 
         if not self.quiet_mode:
             logger.info(

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -130,6 +130,11 @@ _IMAGE_TOKEN_ESTIMATE = 1600
 _IMAGE_CHAR_EQUIVALENT = _IMAGE_TOKEN_ESTIMATE * _CHARS_PER_TOKEN
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
 
+# P0-2: max live summary segments before the two oldest are merged into one.
+# At 5 segments the merged-render is already ~4-5 paragraphs; merging keeps
+# the "previous context" injection token-bounded for very long sessions.
+_SEGMENT_MERGE_THRESHOLD: int = 5
+
 # P1-3: absolute headroom (tokens) reserved below the context limit for the
 # next completion + the summariser's own call + a small safety margin.  The
 # percentage trigger is capped so it never plans to leave LESS than this,
@@ -574,6 +579,8 @@ class ContextCompressor(ContextEngine):
         self._context_probed = False
         self._context_probe_persistable = False
         self._previous_summary = None
+        self._summary_segments = []
+        self._turns_seen = 0
         self._last_summary_error = None
         self._last_summary_dropped_count = 0
         self._last_summary_fallback_used = False
@@ -705,8 +712,25 @@ class ContextCompressor(ContextEngine):
 
         self.summary_model = summary_model_override or ""
 
-        # Stores the previous compaction summary for iterative updates
+        # Stores the previous compaction summary for iterative updates.
+        # Legacy field — kept for backward compat (resumed sessions that
+        # have an older persisted summary message but no _summary_segments yet).
+        # New code writes to _summary_segments instead.
         self._previous_summary: Optional[str] = None
+
+        # P0-2: append-only segment list.  Each entry is a dict:
+        #   {"start": int, "end": int, "text": str}
+        # where start/end are global turn-sequence numbers (monotone, never
+        # reset within a session) bounding the turns whose information lives
+        # in this segment.  Each turn is summarized EXACTLY ONCE — segments
+        # are never re-fed into the LLM.  The rendered view (injected into
+        # the assistant context at compress time) is assembled from ALL
+        # segments, with older ones condensed more aggressively.
+        self._summary_segments: List[Dict[str, Any]] = []
+        # Global turn counter — number of message-list positions that have
+        # passed through the compressor since session start.  Advanced once
+        # per compress() call by (compress_end - compress_start) new turns.
+        self._turns_seen: int = 0
         # Anti-thrashing: track whether last compression was effective
         self._last_compression_savings_pct: float = 100.0
         self._ineffective_compression_count: int = 0
@@ -1329,6 +1353,78 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             summary = summary[: _FALLBACK_SUMMARY_MAX_CHARS - 42].rstrip() + "\n...[fallback summary truncated]"
         return summary
 
+    # ------------------------------------------------------------------
+    # P0-2: append-only segment helpers
+    # ------------------------------------------------------------------
+
+    def _render_summary_from_segments(self) -> str:
+        """Assemble a human-readable summary body from all live segments.
+
+        Older segments are rendered condensed (just their stored text, which
+        was already compact at the time it was written); newer segments are
+        rendered verbatim.  The assembler never re-summarizes — it only
+        concatenates.
+
+        Returns an empty string when there are no segments.
+        """
+        if not self._summary_segments:
+            return ""
+        parts = []
+        n = len(self._summary_segments)
+        for i, seg in enumerate(self._summary_segments):
+            text = (seg.get("text") or "").strip()
+            if not text:
+                continue
+            if i < n - 1:
+                # Older segment: label it so the model knows it's historical.
+                label = f"--- Earlier context (turns {seg['start']+1}-{seg['end']}) ---"
+                parts.append(f"{label}\n{text}")
+            else:
+                # Newest segment: no label, render verbatim.
+                parts.append(text)
+        return "\n\n".join(parts)
+
+    def _compact_old_segments(self) -> None:
+        """Merge the two oldest segments into one when the list is too long.
+
+        Merging is purely text concatenation — NO LLM call.  The merged
+        segment covers the union of the two input turn ranges and contains
+        both bodies separated by a blank line.  This keeps token growth
+        bounded without any re-summarization degradation.
+        """
+        if not hasattr(self, "_summary_segments") or len(self._summary_segments) <= _SEGMENT_MERGE_THRESHOLD:
+            return
+        a = self._summary_segments[0]
+        b = self._summary_segments[1]
+        merged_text = (a.get("text") or "").strip() + "\n\n" + (b.get("text") or "").strip()
+        merged = {"start": a["start"], "end": b["end"], "text": merged_text}
+        self._summary_segments = [merged] + self._summary_segments[2:]
+        if not self.quiet_mode:
+            logger.debug(
+                "Compacted oldest two summary segments into one "
+                "(turns %d-%d + %d-%d → %d-%d)",
+                a["start"], a["end"], b["start"], b["end"],
+                merged["start"], merged["end"],
+            )
+
+    def _context_for_new_turns(self) -> str:
+        """Build the 'previous context' injection for a delta-summarization call.
+
+        Returns a compact rendition of all prior segments: enough for the LLM
+        to understand what has already been recorded (so it can avoid
+        duplication and can handle forward-references), but NOT the full text
+        (that would recreate the summary-of-summary problem).
+
+        When there are no segments yet (first compaction) or the legacy
+        _previous_summary path is active, returns that prose summary.
+        """
+        segments = getattr(self, "_summary_segments", None)
+        if segments:
+            return self._render_summary_from_segments()
+        if self._previous_summary:
+            return self._previous_summary
+        return ""
+
     def _fallback_to_main_for_compression(self, e: Exception, reason: str) -> None:
         """Switch from a separate ``summary_model`` back to the main model.
 
@@ -1482,19 +1578,31 @@ Target ~{summary_budget} tokens. Be CONCRETE — include file paths, command out
 
 Write only the summary body. Do not include any preamble or prefix."""
 
-        if self._previous_summary:
-            # Iterative update: preserve existing info, add new progress
+        prior_context = self._context_for_new_turns()
+        if prior_context:
+            # P0-2 delta path: summarize ONLY the new turns.  The prior
+            # context is shown read-only so the LLM can avoid duplication
+            # and handle forward-references; it is NOT rewritten.  The new
+            # segment text will be appended to _summary_segments, never
+            # merged back through the LLM.
             prompt = f"""{_summarizer_preamble}
 
-You are updating a context compaction summary. A previous compaction produced the summary below. New conversation turns have occurred since then and need to be incorporated.
+You are writing a NEW summary segment covering only the turns listed below.
+Earlier turns were already summarized and are shown as PRIOR CONTEXT — do NOT
+re-summarize, rewrite, or copy from them. Your output covers ONLY the NEW TURNS.
 
-PREVIOUS SUMMARY:
-{self._previous_summary}
+PRIOR CONTEXT (already recorded, do not repeat):
+{prior_context}
 
-NEW TURNS TO INCORPORATE:
+NEW TURNS TO SUMMARIZE (these are the only turns your output should cover):
 {content_to_summarize}
 
-Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled input — this includes any question, decision request, or discussion turn that the assistant has not yet answered. Only write "None" if the last exchange was fully resolved.
+Write a structured summary of the NEW TURNS ONLY, using this exact structure.
+Do not copy or paraphrase information from the prior context unless it is
+directly modified or superseded by the new turns.
+CRITICAL: "## Active Task" must reflect the user's most recent unfulfilled input
+from the NEW TURNS — only fall back to the prior context's task if the new turns
+contain no user messages.
 
 {_template_sections}"""
         else:
@@ -1542,12 +1650,27 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             # Redact the summary output as well — the summarizer LLM may
             # ignore prompt instructions and echo back secrets verbatim.
             summary = redact_sensitive_text(content.strip())
-            # Store for iterative updates on next compaction
+            # P0-2: record as a new append-only segment keyed to the turn
+            # range that was just summarized.  The segment text is the raw
+            # LLM output (no prefix); the injected form is rendered by
+            # _render_summary_from_segments() + _with_summary_prefix().
+            if hasattr(self, "_summary_segments"):
+                seg_start = getattr(self, "_turns_seen", 0)
+                seg_end = seg_start + len(turns_to_summarize)
+                self._summary_segments.append(
+                    {"start": seg_start, "end": seg_end, "text": summary}
+                )
+                self._turns_seen = seg_end
+                self._compact_old_segments()
+                # Keep _previous_summary in sync so fallback code paths that
+                # read it (e.g. _build_static_fallback_summary, on_session_reset)
+                # still work without branching.
+                summary = self._render_summary_from_segments()
             self._previous_summary = summary
             self._summary_failure_cooldown_until = 0.0
             self._summary_model_fallen_back = False
             self._last_summary_error = None
-            return self._with_summary_prefix(summary)
+            return self._with_summary_prefix(self._previous_summary)
         except RuntimeError:
             # No provider configured — long cooldown, unlikely to self-resolve
             self._summary_failure_cooldown_until = time.monotonic() + _SUMMARY_FAILURE_COOLDOWN_SECONDS
@@ -2051,6 +2174,17 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         if summary_idx is not None:
             if summary_body and not self._previous_summary:
                 self._previous_summary = summary_body
+                # P0-2: bootstrap segments from a legacy persisted summary so
+                # the delta path works on the very first re-compaction of a
+                # resumed session.  Assign turn range [0, 0) as a sentinel —
+                # the real range is unknown from a persisted message, but the
+                # key invariant (never re-feed this text as LLM input) is still
+                # honoured: _context_for_new_turns() includes it, and the next
+                # LLM call will only be asked to summarize the NEW turns.
+                if not self._summary_segments:
+                    self._summary_segments.append(
+                        {"start": 0, "end": 0, "text": summary_body}
+                    )
             turns_to_summarize = messages[max(compress_start, summary_idx + 1):compress_end]
 
         if not self.quiet_mode:

--- a/tests/agent/test_context_compressor_huddle_fixes.py
+++ b/tests/agent/test_context_compressor_huddle_fixes.py
@@ -3,6 +3,7 @@
 Covers the four items implemented from
 ``Vaults/handoffs/compression-fix-handover.md`` against the live compressor:
 
+  P0-2  append-only segment summarization (no summary-of-summary degradation)
   P1-5  calibrated token accountant (rough -> provider ratio learning)
   P1-3  absolute-reserve trigger cap + floor-awareness
   P1-4  softened SUMMARY_PREFIX (anaphora-preserving, no "discard" over-correction)
@@ -20,6 +21,7 @@ from agent.context_compressor import (
     SUMMARY_PREFIX,
     _COMPRESSION_RESERVE_TOKENS,
     _HISTORICAL_SUMMARY_PREFIXES,
+    _SEGMENT_MERGE_THRESHOLD,
 )
 
 
@@ -269,3 +271,144 @@ class TestToolPairingBoundaries:
         sanitized = c._sanitize_tool_pairs(msgs)
         tool_ids = {m.get("tool_call_id") for m in sanitized if m.get("role") == "tool"}
         assert "lonely" in tool_ids  # a stub result was inserted
+
+
+# ---------------------------------------------------------------------------
+# P0-2: append-only segment summarization (no summary-of-summary)
+# ---------------------------------------------------------------------------
+
+class TestSegmentSummarization:
+    def _msgs(self, n=10):
+        return [
+            {"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"}
+            for i in range(n)
+        ]
+
+    def test_first_compaction_creates_one_segment(self):
+        c = _make()
+        assert c._summary_segments == []
+        with patch("agent.context_compressor.call_llm", return_value=_summary_response("seg0")):
+            c.compress(self._msgs(), current_tokens=90_000)
+        assert len(c._summary_segments) == 1
+        assert c._summary_segments[0]["text"] == "seg0"
+
+    def test_second_compaction_adds_segment_not_replaces(self):
+        """Each compress() call appends a new segment — old segments survive."""
+        c = _make()
+        with patch("agent.context_compressor.call_llm", return_value=_summary_response("first")):
+            c.compress(self._msgs(), current_tokens=90_000)
+        assert len(c._summary_segments) == 1
+
+        # Simulate more content arriving and a second compaction.
+        c._turns_seen = 0  # reset so second compress has something to do
+        c._previous_summary = "first"
+        with patch("agent.context_compressor.call_llm", return_value=_summary_response("second")):
+            c.compress(self._msgs(), current_tokens=90_000)
+        # Both segments survive — no replacement.
+        assert len(c._summary_segments) == 2
+        texts = [s["text"] for s in c._summary_segments]
+        assert "first" in texts
+        assert "second" in texts
+
+    def test_second_compaction_prompt_uses_prior_context_not_full_rewrite(self):
+        """The delta path must show PRIOR CONTEXT (old segment) and ask for
+        NEW TURNS only — never 'PREVIOUS SUMMARY:' (old iterative-rewrite path)."""
+        c = _make()
+        c._summary_segments = [{"start": 0, "end": 5, "text": "FACTUAL-PRIOR-SEGMENT"}]
+        c._previous_summary = "FACTUAL-PRIOR-SEGMENT"
+
+        with patch("agent.context_compressor.call_llm", return_value=_summary_response("new")) as mock:
+            c.compress(self._msgs(), current_tokens=90_000)
+
+        prompt = mock.call_args.kwargs["messages"][0]["content"]
+        assert "PRIOR CONTEXT" in prompt
+        assert "NEW TURNS TO SUMMARIZE" in prompt
+        # Must not use the old iterative-rewrite label.
+        assert "PREVIOUS SUMMARY:" not in prompt
+        # The old segment content appears once (as context, not as input turns).
+        assert prompt.count("FACTUAL-PRIOR-SEGMENT") == 1
+
+    def test_render_segments_labels_older_entries(self):
+        c = _make()
+        c._summary_segments = [
+            {"start": 0, "end": 10, "text": "old-facts"},
+            {"start": 10, "end": 20, "text": "new-facts"},
+        ]
+        rendered = c._render_summary_from_segments()
+        assert "old-facts" in rendered
+        assert "new-facts" in rendered
+        # Only the older segment gets a label; newest is verbatim.
+        assert "Earlier context" in rendered
+        # The newest segment has no label prefix.
+        lines = rendered.splitlines()
+        last_nonempty = next(l for l in reversed(lines) if l.strip())
+        assert last_nonempty == "new-facts"
+
+    def test_render_empty_segments_returns_empty(self):
+        c = _make()
+        assert c._render_summary_from_segments() == ""
+
+    def test_compact_merges_oldest_when_threshold_exceeded(self):
+        c = _make()
+        # Add _SEGMENT_MERGE_THRESHOLD + 1 segments to trigger compaction.
+        for i in range(_SEGMENT_MERGE_THRESHOLD + 1):
+            c._summary_segments.append({"start": i * 10, "end": (i + 1) * 10, "text": f"seg{i}"})
+        c._compact_old_segments()
+        assert len(c._summary_segments) == _SEGMENT_MERGE_THRESHOLD
+        # The first entry is the merged pair covering seg0+seg1.
+        merged = c._summary_segments[0]
+        assert "seg0" in merged["text"]
+        assert "seg1" in merged["text"]
+        assert merged["start"] == 0
+        assert merged["end"] == 20
+
+    def test_compact_noop_at_threshold(self):
+        c = _make()
+        for i in range(_SEGMENT_MERGE_THRESHOLD):
+            c._summary_segments.append({"start": i, "end": i + 1, "text": f"seg{i}"})
+        c._compact_old_segments()
+        assert len(c._summary_segments) == _SEGMENT_MERGE_THRESHOLD
+
+    def test_legacy_previous_summary_bootstraps_segment(self):
+        """On first re-compaction after resume, legacy _previous_summary must
+        be bootstrapped into _summary_segments so the delta path fires."""
+        from agent.context_compressor import SUMMARY_PREFIX
+        old_body = "LEGACY-BODY unique facts"
+        msgs = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": f"{SUMMARY_PREFIX}\n{old_body}"},
+            {"role": "assistant", "content": "ack"},
+            {"role": "user", "content": "new1"},
+            {"role": "assistant", "content": "ans1"},
+            {"role": "user", "content": "new2"},
+            {"role": "assistant", "content": "ans2"},
+            {"role": "user", "content": "active"},
+        ]
+        c = _make(protect_first_n=1, protect_last_n=1)
+        assert c._summary_segments == []
+        with patch("agent.context_compressor.call_llm", return_value=_summary_response("new-seg")):
+            c.compress(msgs, current_tokens=90_000)
+        # Segments: the bootstrapped legacy one + the new one.
+        assert len(c._summary_segments) >= 1
+        texts = [s["text"] for s in c._summary_segments]
+        assert "new-seg" in texts
+
+    def test_previous_summary_kept_in_sync(self):
+        """_previous_summary is always the rendered view of all segments
+        (for fallback code paths that read it directly)."""
+        c = _make()
+        with patch("agent.context_compressor.call_llm", return_value=_summary_response("alpha")):
+            c.compress(self._msgs(), current_tokens=90_000)
+        # _previous_summary = rendered form of segments.
+        assert "alpha" in c._previous_summary
+        rendered = c._render_summary_from_segments()
+        assert c._previous_summary == rendered
+
+    def test_on_session_reset_clears_segments(self):
+        c = _make()
+        c._summary_segments = [{"start": 0, "end": 10, "text": "stuff"}]
+        c._turns_seen = 10
+        c.on_session_reset()
+        assert c._summary_segments == []
+        assert c._turns_seen == 0
+        assert c._previous_summary is None

--- a/tests/agent/test_context_compressor_huddle_fixes.py
+++ b/tests/agent/test_context_compressor_huddle_fixes.py
@@ -1,0 +1,271 @@
+"""Regression tests for the 2026-05-30 compression-huddle fixes.
+
+Covers the four items implemented from
+``Vaults/handoffs/compression-fix-handover.md`` against the live compressor:
+
+  P1-5  calibrated token accountant (rough -> provider ratio learning)
+  P1-3  absolute-reserve trigger cap + floor-awareness
+  P1-4  softened SUMMARY_PREFIX (anaphora-preserving, no "discard" over-correction)
+  P0-1  tool_use / tool_result pairing held across compaction boundaries
+
+P0-1 was already implemented in the live code (``_align_boundary_*``,
+``_sanitize_tool_pairs``); these add boundary stress cases the handoff asked for.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from agent.context_compressor import (
+    ContextCompressor,
+    SUMMARY_PREFIX,
+    _COMPRESSION_RESERVE_TOKENS,
+    _HISTORICAL_SUMMARY_PREFIXES,
+)
+
+
+def _make(**kwargs):
+    ctx = kwargs.pop("_ctx", 100_000)
+    defaults = dict(model="test/model", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+    defaults.update(kwargs)
+    with patch("agent.context_compressor.get_model_context_length", return_value=ctx):
+        return ContextCompressor(**defaults)
+
+
+def _summary_response(text="summary text"):
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message.content = text
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# P1-5: calibrated token accountant
+# ---------------------------------------------------------------------------
+
+class TestTokenCalibration:
+    def test_cold_start_returns_rough_unchanged(self):
+        c = _make()
+        assert c.calibrated_estimate(90_000) == 90_000
+
+    def test_zero_or_negative_returns_input(self):
+        c = _make()
+        c._record_token_calibration(100, 50)
+        assert c.calibrated_estimate(0) == 0
+        assert c.calibrated_estimate(-5) == -5
+
+    def test_median_ratio_applied(self):
+        c = _make()
+        # Real consistently ~half of rough → median ratio 0.5.
+        for _ in range(3):
+            c._record_token_calibration(rough_tokens=100_000, real_tokens=50_000)
+        assert c.calibrated_estimate(90_000) == 45_000
+
+    def test_insane_ratios_ignored(self):
+        c = _make()
+        c._record_token_calibration(100_000, 5)        # ratio 0.00005 → ignored
+        c._record_token_calibration(100, 100_000)      # ratio 1000   → ignored
+        assert c._token_calibration.get((c.provider, c.model)) is None
+        assert c.calibrated_estimate(90_000) == 90_000
+
+    def test_window_capped_at_20(self):
+        c = _make()
+        for _ in range(30):
+            c._record_token_calibration(100_000, 80_000)
+        assert len(c._token_calibration[(c.provider, c.model)]["ratios"]) == 20
+
+    def test_update_from_response_records_when_not_post_compression(self):
+        c = _make()
+        c.awaiting_real_usage_after_compression = False
+        c._last_preflight_rough = 100_000
+        c.update_from_response({"prompt_tokens": 70_000})
+        ratios = c._token_calibration[(c.provider, c.model)]["ratios"]
+        assert ratios == [0.7]
+        assert c._last_preflight_rough == 0  # consumed
+
+    def test_update_from_response_skips_after_compression(self):
+        c = _make()
+        c.awaiting_real_usage_after_compression = True  # compaction just ran
+        c._last_preflight_rough = 100_000
+        c.update_from_response({"prompt_tokens": 70_000})
+        assert c._token_calibration.get((c.provider, c.model)) is None
+
+    def test_should_compress_uses_calibrated_estimate(self):
+        # threshold_percent 0.85 on 100K → threshold 85K; effective trigger 85K.
+        c = _make(threshold_percent=0.85)
+        # Uncalibrated: 90K rough trips the trigger.
+        assert c.should_compress(prompt_tokens=90_000) is True
+        # Learn that this provider runs ~0.5x the rough estimate.
+        for _ in range(3):
+            c._record_token_calibration(100_000, 50_000)
+        # Now the same 90K rough calibrates to 45K and should NOT trip.
+        assert c.should_compress(prompt_tokens=90_000) is False
+        # And should_compress remembered the raw rough for ratio learning.
+        assert c._last_preflight_rough == 90_000
+
+
+# ---------------------------------------------------------------------------
+# P1-3: absolute-reserve trigger cap + floor awareness
+# ---------------------------------------------------------------------------
+
+class TestReserveAndFloor:
+    def test_trigger_is_percentage_on_normal_window(self):
+        # 100K / 85% → 85K threshold; reserve cap is 100K-7120=92880, so no-op.
+        c = _make(threshold_percent=0.85)
+        assert c._effective_trigger_tokens() == 85_000
+
+    def test_trigger_capped_on_small_window(self):
+        # 70K context, 50% → threshold floored to MIN 64K, but reserve cap
+        # 70000-7120=62880 is lower, so the trigger is pulled down to leave room.
+        c = _make(_ctx=70_000, threshold_percent=0.50)
+        assert c.threshold_tokens == 64_000
+        assert c._effective_trigger_tokens() == 70_000 - _COMPRESSION_RESERVE_TOKENS
+
+    def test_trigger_falls_back_when_reserve_exceeds_context(self):
+        c = _make(_ctx=5_000)  # smaller than the reserve itself
+        assert c._effective_trigger_tokens() == c.threshold_tokens
+
+    def test_incompressible_floor(self):
+        c = _make()
+        assert c._estimate_incompressible_floor() == c.tail_token_budget + c.max_summary_tokens
+
+    def test_over_reserve_flag_false_on_normal_compaction(self):
+        c = _make()
+        msgs = [{"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"} for i in range(8)]
+        with patch("agent.context_compressor.call_llm", return_value=_summary_response()):
+            c.compress(msgs, current_tokens=90_000)
+        assert c._last_compress_over_reserve is False
+
+    def test_over_reserve_flag_set_when_result_exceeds_ceiling(self):
+        c = _make()  # ceiling = 100000 - 7120 = 92880
+        msgs = [{"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"} for i in range(8)]
+        with patch("agent.context_compressor.call_llm", return_value=_summary_response()), \
+             patch("agent.context_compressor.estimate_messages_tokens_rough", return_value=95_000):
+            c.compress(msgs, current_tokens=99_000)
+        assert c._last_compress_over_reserve is True
+
+    def test_over_reserve_flag_reset_each_call(self):
+        c = _make()
+        c._last_compress_over_reserve = True
+        msgs = [{"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"} for i in range(8)]
+        with patch("agent.context_compressor.call_llm", return_value=_summary_response()):
+            c.compress(msgs, current_tokens=90_000)
+        assert c._last_compress_over_reserve is False
+
+
+# ---------------------------------------------------------------------------
+# P1-4: softened SUMMARY_PREFIX
+# ---------------------------------------------------------------------------
+
+class TestSoftenedPrefix:
+    def test_no_aggressive_discard_directives(self):
+        # The handoff explicitly asks that these over-corrections be gone.
+        for banned in ("resume exactly", "## Active Task", "WINS", "discard those"):
+            assert banned not in SUMMARY_PREFIX, f"{banned!r} should not be in SUMMARY_PREFIX"
+
+    def test_preserves_anaphora_resolution(self):
+        # The whole point of P1-4: keep info so "continue"/"do the next one" resolve.
+        assert "continue" in SUMMARY_PREFIX
+        assert "do NOT discard" in SUMMARY_PREFIX
+
+    def test_preserves_memory_authority_line(self):
+        # Dropping this would be a regression independent of the huddle.
+        assert "MEMORY.md" in SUMMARY_PREFIX and "authoritative" in SUMMARY_PREFIX
+
+    def test_still_discourages_blind_resumption(self):
+        # Anti-hijack intent (#35344) must survive the softening.
+        assert "unless the latest message explicitly asks" in SUMMARY_PREFIX
+
+    def test_previous_hardened_prefix_is_stripped_on_renormalization(self):
+        old_hardened = _HISTORICAL_SUMMARY_PREFIXES[0]
+        renormalized = ContextCompressor._with_summary_prefix(f"{old_hardened}\nbody text")
+        assert renormalized == f"{SUMMARY_PREFIX}\nbody text"
+        # The aggressive directive must not survive embedded in the body.
+        assert "WINS" not in renormalized
+
+    def test_pre_35344_prefix_still_stripped(self):
+        pre_35344 = _HISTORICAL_SUMMARY_PREFIXES[-1]
+        renormalized = ContextCompressor._with_summary_prefix(f"{pre_35344}\nbody text")
+        assert renormalized == f"{SUMMARY_PREFIX}\nbody text"
+        assert "resume exactly" not in renormalized
+
+    def test_old_prefixed_summary_is_detected_as_summary(self):
+        old_hardened = _HISTORICAL_SUMMARY_PREFIXES[0]
+        assert ContextCompressor._is_context_summary_content(f"{old_hardened}\nbody")
+
+
+# ---------------------------------------------------------------------------
+# P0-1: tool pairing across compaction boundaries (boundary stress)
+# ---------------------------------------------------------------------------
+
+class TestToolPairingBoundaries:
+    @staticmethod
+    def _assert_well_formed(result):
+        call_ids = set()
+        for m in result:
+            if m.get("role") == "assistant":
+                for tc in m.get("tool_calls") or []:
+                    cid = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+                    if cid:
+                        call_ids.add(cid)
+        result_ids = {m.get("tool_call_id") for m in result if m.get("role") == "tool"}
+        result_ids.discard(None)
+        # Every surviving tool result has a matching assistant tool_call.
+        assert result_ids <= call_ids, f"orphan tool results: {result_ids - call_ids}"
+        # Every surviving assistant tool_call has a matching result.
+        assert call_ids <= result_ids, f"unanswered tool_calls: {call_ids - result_ids}"
+
+    def test_tool_group_straddling_tail_boundary(self):
+        """A multi-call assistant turn whose results sit right at the tail cut
+        must not leave dangling ids after compaction."""
+        c = _make(protect_first_n=2, protect_last_n=2)
+        msgs = [
+            {"role": "user", "content": "start"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "middle work"},
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "read", "arguments": "{}"}},
+                {"id": "c2", "type": "function", "function": {"name": "read", "arguments": "{}"}},
+            ]},
+            {"role": "tool", "tool_call_id": "c1", "content": "r1" * 200},
+            {"role": "tool", "tool_call_id": "c2", "content": "r2" * 200},
+            {"role": "assistant", "content": "done with middle"},
+            {"role": "user", "content": "tail q"},
+            {"role": "assistant", "content": "tail a"},
+            {"role": "user", "content": "latest"},
+        ]
+        with patch("agent.context_compressor.call_llm", return_value=_summary_response()):
+            result = c.compress(msgs, current_tokens=90_000)
+        self._assert_well_formed(result)
+
+    def test_orphan_tool_result_whose_call_is_summarized(self):
+        """If only the tool result (not its assistant call) would survive a cut,
+        the sanitizer must drop the orphan result."""
+        c = _make(protect_first_n=2, protect_last_n=2)
+        msgs = [
+            {"role": "user", "content": "start"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "mid", "type": "function", "function": {"name": "x", "arguments": "{}"}},
+            ]},
+            {"role": "tool", "tool_call_id": "mid", "content": "y" * 400},
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+            {"role": "user", "content": "latest"},
+        ]
+        with patch("agent.context_compressor.call_llm", return_value=_summary_response()):
+            result = c.compress(msgs, current_tokens=90_000)
+        self._assert_well_formed(result)
+
+    def test_sanitizer_stubs_unanswered_calls_directly(self):
+        c = _make()
+        msgs = [
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "lonely", "type": "function", "function": {"name": "x", "arguments": "{}"}},
+            ]},
+            {"role": "user", "content": "next"},
+        ]
+        sanitized = c._sanitize_tool_pairs(msgs)
+        tool_ids = {m.get("tool_call_id") for m in sanitized if m.get("role") == "tool"}
+        assert "lonely" in tool_ids  # a stub result was inserted

--- a/tests/agent/test_context_compressor_summary_continuity.py
+++ b/tests/agent/test_context_compressor_summary_continuity.py
@@ -37,23 +37,38 @@ def _messages_with_handoff(summary_body: str):
 
 
 def test_existing_previous_summary_is_not_serialized_again_as_new_turn():
-    """Same-process iterative compression should not feed the old handoff twice."""
+    """Same-process iterative compression should not feed the old handoff twice.
+
+    P0-2: the new delta path sends old context as PRIOR CONTEXT (read-only),
+    asks the LLM to summarize only the NEW TURNS, and must not include the
+    summary text as a serialized [USER] turn in the content.
+    """
     compressor = _compressor()
     old_summary = "OLD-SUMMARY-BODY unique continuity facts"
     compressor._previous_summary = old_summary
+    # Bootstrap segments so the delta path is active.
+    compressor._summary_segments = [{"start": 0, "end": 5, "text": old_summary}]
 
     with patch("agent.context_compressor.call_llm", return_value=_response("updated summary")) as mock_call:
         compressor.compress(_messages_with_handoff(old_summary))
 
     prompt = mock_call.call_args.kwargs["messages"][0]["content"]
-    assert "PREVIOUS SUMMARY:" in prompt
-    assert "NEW TURNS TO INCORPORATE:" in prompt
+    # New delta-path labels
+    assert "PRIOR CONTEXT" in prompt
+    assert "NEW TURNS TO SUMMARIZE" in prompt
+    # Old summary text appears exactly once (in the PRIOR CONTEXT block, not as a user turn).
     assert prompt.count(old_summary) == 1
+    # The handoff message must never be serialized as [USER]: <prefix> in the prompt.
     assert f"[USER]: {SUMMARY_PREFIX}" not in prompt
 
 
 def test_resume_rehydrates_previous_summary_from_handoff_message():
-    """After restart/resume, the persisted handoff should regain summary identity."""
+    """After restart/resume, the persisted handoff should regain summary identity.
+
+    P0-2: on first re-compaction after resume (no live segments yet), the
+    legacy summary is bootstrapped into _summary_segments and the delta path
+    uses it as PRIOR CONTEXT so the LLM only summarizes the new turns.
+    """
     compressor = _compressor()
     old_summary = "RESUMED-SUMMARY-BODY durable continuity facts"
     assert compressor._previous_summary is None
@@ -62,9 +77,13 @@ def test_resume_rehydrates_previous_summary_from_handoff_message():
         compressor.compress(_messages_with_handoff(old_summary))
 
     prompt = mock_call.call_args.kwargs["messages"][0]["content"]
-    assert "PREVIOUS SUMMARY:" in prompt
-    assert "NEW TURNS TO INCORPORATE:" in prompt
+    # After rehydration the delta path fires — legacy "TURNS TO SUMMARIZE:"
+    # (cold-start path) must not appear.
     assert "TURNS TO SUMMARIZE:" not in prompt
+    # New delta-path labels
+    assert "PRIOR CONTEXT" in prompt
+    assert "NEW TURNS TO SUMMARIZE" in prompt
+    # Summary body appears exactly once in the PRIOR CONTEXT block.
     assert prompt.count(old_summary) == 1
     assert f"[USER]: {SUMMARY_PREFIX}" not in prompt
 


### PR DESCRIPTION
## Summary

This PR implements the compression fixes from the May 30 context-compressor huddle:

- add calibrated rough-token accounting so compression decisions can learn from real token usage
- reserve a fixed output/summarizer buffer by capping the effective compression trigger at `context_length - 7120`
- soften the summary prefix so prior context remains usable for anaphora without reviving stale active-task hijacks
- add boundary tests for tool-call/tool-result tail splitting behavior
- replace repeated summary-of-summary rewriting with append-only summary segments, so each compressed turn range is summarized once and older facts are rendered forward rather than rewritten by the LLM

## Why

Repeated prose re-summarization can degrade operational memory over long sessions. The append-only segment design keeps prior compressed ranges stable while still giving the summarizer read-only prior context for continuity.

## Validation

- `venv/bin/python -m pytest tests/agent/test_context_compressor.py tests/agent/test_context_compressor_huddle_fixes.py tests/agent/test_context_compressor_summary_continuity.py`
  - 129 passed, 1 warning
- Deterministic session-compression eval against a real 22 MB Codex JSONL transcript:
  - typed ledger retention after 5 passes: 100.0%
  - typed ledger retention after 10 passes: 100.0%
  - typed ledger retention after 25 passes: 100.0%
  - typed ledger retention after 50 passes: 100.0%
  - recursive summary baseline after 5 passes: 53.4%

## Notes

The fork branch is currently behind upstream `main`; this is opened as a draft so maintainers can review the compression design before merge-readiness cleanup.