### PR TITLE
fix(desktop): track main for self-update now that GUI merged

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -188,10 +188,10 @@ const BOOTSTRAP_MARKER_SCHEMA_VERSION = 1
 
 const DESKTOP_CONNECTION_CONFIG_PATH = path.join(app.getPath('userData'), 'connection.json')
 const DESKTOP_UPDATE_CONFIG_PATH = path.join(app.getPath('userData'), 'updates.json')
-// Branch we track for self-update. Flip to 'main' once the GUI work merges —
-// single field edit, no rebuild required. User can also override at runtime
-// via hermesDesktop.updates.setBranch().
-const DEFAULT_UPDATE_BRANCH = 'bb/gui'
+// Branch we track for self-update. The GUI work has merged to main, so this
+// tracks main. User can also override at runtime via
+// hermesDesktop.updates.setBranch().
+const DEFAULT_UPDATE_BRANCH = 'main'
 // desktop.log lives under HERMES_HOME/logs/ so it sits next to agent.log,
 // errors.log, gateway.log produced by hermes_logging.setup_logging — one log
 // directory per user, regardless of which UI surface produced the line.


### PR DESCRIPTION
## Summary
- The desktop self-update branch (`DEFAULT_UPDATE_BRANCH` in `apps/desktop/electron/main.cjs`) still pointed at `bb/gui`, the pre-merge feature branch.
- Now that the desktop app has merged to `main` (#20059), flip the default to `main` so freshly built apps detect and apply updates against the correct branch instead of leaning on the runtime self-heal fallback (which only kicks in once `bb/gui` is deleted from origin).

## Notes
- One-line functional change; remaining `bb/gui` mentions in the tree are comments/tests and are intentionally left as historical references.
- Users can still override at runtime via `hermesDesktop.updates.setBranch()`.

## Test plan
- [ ] Build the desktop app from this branch and confirm "check for updates" targets `origin/main`.