### PR TITLE
fix: surface model fallback changes in chat

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -903,6 +903,8 @@ def restore_primary_runtime(agent) -> bool:
         return False  # primary still in rate-limit cooldown, stay on fallback
 
     rt = agent._primary_runtime
+    old_model = getattr(agent, "model", "")
+    old_provider = getattr(agent, "provider", "")
     try:
         # ── Core runtime state ──
         agent.model = rt["model"]
@@ -958,6 +960,23 @@ def restore_primary_runtime(agent) -> bool:
             "Primary runtime restored for new turn: %s (%s)",
             agent.model, agent.provider,
         )
+        try:
+            from agent.model_change_notice import (
+                build_primary_runtime_restored_notice,
+                emit_model_change_notice,
+            )
+
+            emit_model_change_notice(
+                agent,
+                build_primary_runtime_restored_notice(
+                    old_provider,
+                    old_model,
+                    agent.provider,
+                    agent.model,
+                ),
+            )
+        except Exception:
+            logger.debug("Failed to emit primary runtime restored notice", exc_info=True)
         return True
     except Exception as e:
         logger.warning("Failed to restore primary runtime: %s", e)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1033,6 +1033,19 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     if not fb_provider or not fb_model:
         return agent._try_activate_fallback()  # skip invalid, try next
 
+    from agent.model_change_notice import (
+        build_anthropic_auto_fallback_blocked_notice,
+        build_fallback_model_change_notice,
+        emit_model_change_notice,
+        should_block_anthropic_auto_fallback,
+    )
+
+    if should_block_anthropic_auto_fallback(fb):
+        notice = build_anthropic_auto_fallback_blocked_notice(fb)
+        logger.warning(notice)
+        emit_model_change_notice(agent, notice)
+        return agent._try_activate_fallback(reason=reason)
+
     # Skip entries that resolve to the current (provider, model) — falling
     # back to the same backend that just failed loops the failure. Compare
     # base_url too so two distinct custom_providers entries pointing at the
@@ -1128,6 +1141,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_api_mode = "bedrock_converse"
 
         old_model = agent.model
+        old_provider = getattr(agent, "provider", "")
 
         # Clear the per-config context_length override so the fallback
         # model's actual context window is resolved instead of inheriting
@@ -1251,6 +1265,15 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             f"🔄 Primary model failed — switching to fallback: "
             f"{fb_model} via {fb_provider}"
         )
+        notice = build_fallback_model_change_notice(
+            old_provider,
+            old_model,
+            fb_provider,
+            fb_model,
+            reason=reason,
+            base_url=fb_base_url,
+        )
+        emit_model_change_notice(agent, notice)
         logger.info(
             "Fallback activated: %s → %s (%s)",
             old_model, fb_model, fb_provider,

--- a/agent/model_change_notice.py
+++ b/agent/model_change_notice.py
@@ -1,0 +1,171 @@
+"""User-visible notices for implicit model/provider changes.
+
+These helpers intentionally stay small and dependency-light so they can be used
+from gateway startup fallback, agent runtime fallback, and primary restoration
+without creating import cycles.
+"""
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+
+_TRUE_VALUES = {"1", "true", "yes", "y", "on", "allow", "allowed"}
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _boolish(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in _TRUE_VALUES
+    return False
+
+
+def _hostname(value: Any) -> str:
+    text = _clean(value)
+    if not text:
+        return ""
+    try:
+        parsed = urlparse(text if "://" in text else f"https://{text}")
+        return (parsed.hostname or "").lower()
+    except Exception:
+        return ""
+
+
+def runtime_label(provider: Any, model: Any) -> str:
+    """Human-readable provider/model label for notices."""
+    provider_text = _clean(provider) or "unknown"
+    model_text = _clean(model) or "unknown"
+    if provider_text == "unknown" and model_text != "unknown":
+        return model_text
+    if model_text == "unknown":
+        return provider_text
+    return f"{provider_text}/{model_text}"
+
+
+def reason_label(reason: Any) -> str:
+    if reason is None:
+        return ""
+    value = getattr(reason, "value", reason)
+    text = _clean(value).replace("_", " ")
+    return text
+
+
+def fallback_entry_targets_native_anthropic(entry: dict[str, Any] | None) -> bool:
+    """Return True for native Anthropic API fallback entries.
+
+    OpenRouter models like ``anthropic/claude-*`` are intentionally not blocked
+    here; this guard is for direct Anthropic API usage and Anthropic-compatible
+    routes that would spend Anthropic credentials without an explicit opt-in.
+    """
+    if not isinstance(entry, dict):
+        return False
+    provider = _clean(entry.get("provider")).lower()
+    if provider == "anthropic":
+        return True
+    base_host = _hostname(entry.get("base_url"))
+    if base_host == "api.anthropic.com" or base_host.endswith(".anthropic.com"):
+        return True
+    api_mode = _clean(entry.get("api_mode")).lower()
+    return api_mode == "anthropic_messages" and provider not in {"openrouter", ""}
+
+
+def anthropic_auto_fallback_allowed(entry: dict[str, Any] | None) -> bool:
+    """Whether a native Anthropic fallback entry has an explicit auto-use opt-in."""
+    if not isinstance(entry, dict):
+        return False
+    return any(
+        _boolish(entry.get(key))
+        for key in (
+            "allow_auto_fallback",
+            "allow_anthropic_fallback",
+            "allow_paid_fallback",
+        )
+    )
+
+
+def should_block_anthropic_auto_fallback(entry: dict[str, Any] | None) -> bool:
+    return fallback_entry_targets_native_anthropic(entry) and not anthropic_auto_fallback_allowed(entry)
+
+
+def build_anthropic_auto_fallback_blocked_notice(entry: dict[str, Any] | None) -> str:
+    provider = entry.get("provider") if isinstance(entry, dict) else "anthropic"
+    model = entry.get("model") if isinstance(entry, dict) else "unknown"
+    target = runtime_label(provider, model)
+    return (
+        f"⚠️ Automatic fallback to Anthropic API blocked: {target}. "
+        "Anthropic can incur direct API costs; set allow_auto_fallback: true "
+        "on that fallback entry only if you intentionally want this."
+    )
+
+
+def build_fallback_model_change_notice(
+    old_provider: Any,
+    old_model: Any,
+    new_provider: Any,
+    new_model: Any,
+    *,
+    reason: Any = None,
+    base_url: Any = None,
+) -> str:
+    old_label = runtime_label(old_provider, old_model)
+    new_label = runtime_label(new_provider, new_model)
+    message = f"⚠️ Model changed without your direction: {old_label} → {new_label}."
+    reason_text = reason_label(reason)
+    if reason_text:
+        message += f" Reason: {reason_text}."
+
+    new_provider_text = _clean(new_provider).lower()
+    base_host = _hostname(base_url)
+    if new_provider_text in {"custom", "ollama", "lmstudio", "llama-cpp"} or base_host in {
+        "localhost",
+        "127.0.0.1",
+        "0.0.0.0",
+    }:
+        message += " This may behave differently from the primary model."
+    return message
+
+
+def build_primary_runtime_restored_notice(
+    old_provider: Any,
+    old_model: Any,
+    new_provider: Any,
+    new_model: Any,
+) -> str:
+    return (
+        "✅ Primary model restored: "
+        f"{runtime_label(old_provider, old_model)} → {runtime_label(new_provider, new_model)}."
+    )
+
+
+def emit_model_change_notice(agent: Any, message: str) -> None:
+    """Emit a model-change notice to CLI and gateway without raising."""
+    text = _clean(message)
+    if not text:
+        return
+    try:
+        vprint = getattr(agent, "_vprint", None)
+        if callable(vprint):
+            vprint(f"{getattr(agent, 'log_prefix', '')}{text}", force=True)
+    except Exception:
+        pass
+    callback = getattr(agent, "status_callback", None)
+    if callback:
+        try:
+            callback("model_change", text)
+        except Exception:
+            try:
+                import logging
+
+                logging.getLogger(__name__).debug(
+                    "status_callback error in emit_model_change_notice",
+                    exc_info=True,
+                )
+            except Exception:
+                pass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1100,6 +1100,9 @@ def _resolve_runtime_agent_kwargs() -> dict:
             logger.warning("Primary provider auth failed: %s — trying fallback", auth_exc)
         fb_config = _try_resolve_fallback_provider()
         if fb_config is not None:
+            fb_config = dict(fb_config)
+            fb_config["_hermes_runtime_fallback"] = True
+            fb_config["_hermes_fallback_reason"] = "rate limit" if is_rate_limited_auth_error(auth_exc) else "auth"
             return fb_config
         raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
     except Exception as exc:
@@ -1129,7 +1132,15 @@ def _try_resolve_fallback_provider() -> dict | None:
         fb_list = get_fallback_chain(cfg)
         if not fb_list:
             return None
+        from agent.model_change_notice import (
+            build_anthropic_auto_fallback_blocked_notice,
+            should_block_anthropic_auto_fallback,
+        )
+
         for entry in fb_list:
+            if should_block_anthropic_auto_fallback(entry):
+                logger.warning(build_anthropic_auto_fallback_blocked_notice(entry))
+                continue
             try:
                 explicit_api_key = entry.get("api_key")
                 if not explicit_api_key:
@@ -2437,6 +2448,15 @@ class GatewayRunner:
                 resolved_session_key = None
 
         model = _resolve_gateway_model(user_config)
+        configured_model = model
+        configured_provider = ""
+        try:
+            cfg_for_provider = user_config if user_config is not None else _load_gateway_config()
+            model_cfg_for_provider = (cfg_for_provider or {}).get("model", {})
+            if isinstance(model_cfg_for_provider, dict):
+                configured_provider = str(model_cfg_for_provider.get("provider") or "").strip()
+        except Exception:
+            configured_provider = ""
         override = self._session_model_overrides.get(resolved_session_key) if resolved_session_key else None
         if override:
             override_model = override.get("model", model)
@@ -2467,6 +2487,9 @@ class GatewayRunner:
             )
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
+        if runtime_kwargs.get("_hermes_runtime_fallback"):
+            runtime_kwargs["_hermes_primary_model"] = configured_model
+            runtime_kwargs["_hermes_primary_provider"] = configured_provider
         runtime_model = runtime_kwargs.pop("model", None)
         if runtime_model:
             logger.info(
@@ -17043,6 +17066,18 @@ class GatewayRunner:
                     _redact_gateway_user_facing_secrets(str(message or ""))[:160],
                 )
                 return
+            if event_type == "model_change":
+                safe_schedule_threadsafe(
+                    _status_adapter.send(
+                        _status_chat_id,
+                        prepared_message,
+                        metadata=_status_thread_metadata,
+                    ),
+                    _loop_for_step,
+                    logger=logger,
+                    log_message="model_change status_callback scheduling error",
+                )
+                return
             _fut = safe_schedule_threadsafe(
                 _send_or_update_status_coro(_status_adapter, _status_chat_id, event_type, prepared_message, _status_thread_metadata),
                 _loop_for_step,
@@ -17106,6 +17141,23 @@ class GatewayRunner:
                     "run_agent resolved: model=%s provider=%s session=%s",
                     model, runtime_kwargs.get("provider"), session_key or "",
                 )
+                if runtime_kwargs.get("_hermes_runtime_fallback"):
+                    try:
+                        from agent.model_change_notice import build_fallback_model_change_notice
+
+                        _status_callback_sync(
+                            "model_change",
+                            build_fallback_model_change_notice(
+                                runtime_kwargs.get("_hermes_primary_provider"),
+                                runtime_kwargs.get("_hermes_primary_model"),
+                                runtime_kwargs.get("provider"),
+                                model,
+                                reason=runtime_kwargs.get("_hermes_fallback_reason"),
+                                base_url=runtime_kwargs.get("base_url"),
+                            ),
+                        )
+                    except Exception:
+                        logger.debug("Failed to emit runtime fallback notice", exc_info=True)
             except Exception as exc:
                 return {
                     "final_response": f"⚠️ Provider authentication failed: {exc}",

--- a/tests/gateway/test_auth_fallback.py
+++ b/tests/gateway/test_auth_fallback.py
@@ -113,3 +113,42 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
         assert calls == ["openrouter", "nous"]
         assert result["provider"] == "nous"
         assert result["model"] == "Hermes-4"
+
+    def test_anthropic_auth_fallback_requires_explicit_allow(self, tmp_path, monkeypatch):
+        """Native Anthropic API must not be used as an automatic auth fallback by default."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "fallback_providers:\n"
+            "  - provider: anthropic\n"
+            "    model: claude-sonnet-4-20250514\n"
+            "  - provider: openrouter\n"
+            "    model: meta-llama/llama-4-maverick\n"
+        )
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        calls = []
+
+        def _mock_resolve(**kwargs):
+            calls.append(kwargs.get("requested"))
+            return {
+                "api_key": "fallback-key",
+                "base_url": "https://openrouter.ai/api/v1",
+                "provider": kwargs.get("requested"),
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            }
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=_mock_resolve,
+        ):
+            from gateway.run import _try_resolve_fallback_provider
+
+            result = _try_resolve_fallback_provider()
+
+        assert calls == ["openrouter"]
+        assert result is not None
+        assert result["provider"] == "openrouter"
+        assert result["model"] == "meta-llama/llama-4-maverick"

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -92,6 +92,27 @@ class NoDeleteAdapter(CleanupCaptureAdapter):
 NoDeleteAdapter.delete_message = BasePlatformAdapter.delete_message
 
 
+class StatusUpdateCaptureAdapter(CleanupCaptureAdapter):
+    """Adapter that distinguishes permanent sends from editable status updates."""
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform)
+        self.status_updates = []
+
+    async def send_or_update_status(self, chat_id, status_key, content, metadata=None):
+        mid = self._mint_id()
+        self.status_updates.append(
+            {
+                "chat_id": chat_id,
+                "status_key": status_key,
+                "content": content,
+                "message_id": mid,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=mid)
+
+
 class ProgressAgent:
     """Emits two tool-progress events and returns a normal final response."""
 
@@ -129,6 +150,32 @@ class FailingAgent:
             "failed": True,
             "error": "simulated provider failure",
         }
+
+
+class ModelChangeStatusAgent:
+    def __init__(self, **kwargs):
+        self.status_callback = kwargs.get("status_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.status_callback
+        if cb is not None:
+            cb("lifecycle", "ordinary editable status")
+            cb(
+                "model_change",
+                "⚠️ Model changed without your direction: "
+                "openai-codex/gpt-5.5 → custom/qwen3.5:9b",
+            )
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+class RuntimeFallbackAgent:
+    def __init__(self, **kwargs):
+        self.status_callback = kwargs.get("status_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        return {"final_response": "done", "messages": [], "api_calls": 1}
 
 
 def _make_runner(adapter):
@@ -365,3 +412,103 @@ async def test_cleanup_chains_with_existing_callback(monkeypatch, tmp_path):
     # deletes at least one progress bubble.
     assert pre_existing_fired == [True]
     assert len(adapter.deleted) >= 1
+
+
+@pytest.mark.asyncio
+async def test_model_change_status_uses_permanent_send_not_editable_status(monkeypatch, tmp_path):
+    """Fallback/model-change warnings must remain visible in chat history.
+
+    Normal lifecycle status can go through send_or_update_status() and be edited
+    away. A model_change event is safety-significant, so it must be delivered as
+    a standalone send() even when the platform supports editable status bubbles.
+    """
+    adapter = StatusUpdateCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(monkeypatch, ModelChangeStatusAgent, cleanup_on=True)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    session_key = "agent:main:telegram:group:-1001"
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "done"
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if adapter.sent and adapter.status_updates:
+            break
+
+    assert any(update["status_key"] == "lifecycle" for update in adapter.status_updates)
+    assert not any(update["status_key"] == "model_change" for update in adapter.status_updates)
+    assert any(
+        "Model changed without your direction" in sent["content"]
+        for sent in adapter.sent
+    ), f"sent={adapter.sent} status_updates={adapter.status_updates}"
+
+
+@pytest.mark.asyncio
+async def test_runtime_auth_fallback_emits_permanent_model_change_notice(monkeypatch, tmp_path):
+    """Gateway-start auth fallback happens before the agent can emit status.
+
+    The gateway must still tell the chat when runtime resolution silently
+    switches from configured primary to fallback before AIAgent is constructed.
+    """
+    adapter = StatusUpdateCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(monkeypatch, RuntimeFallbackAgent, cleanup_on=True)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {
+            "model": {"provider": "openai-codex", "default": "gpt-5.5"},
+            "display": {"platforms": {"telegram": {"cleanup_progress": True}}},
+        },
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "api_key": "fake",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "model": "qwen3.5:9b",
+            "_hermes_runtime_fallback": True,
+            "_hermes_fallback_reason": "auth",
+        },
+    )
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    session_key = "agent:main:telegram:group:-1001"
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "done"
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if adapter.sent:
+            break
+
+    assert not any(update["status_key"] == "model_change" for update in adapter.status_updates)
+    assert any(
+        "Model changed without your direction" in sent["content"]
+        and "openai-codex/gpt-5.5" in sent["content"]
+        and "custom/qwen3.5:9b" in sent["content"]
+        and "auth" in sent["content"].lower()
+        for sent in adapter.sent
+    ), f"sent={adapter.sent} status_updates={adapter.status_updates}"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4875,9 +4875,100 @@ class TestAnthropicImageFallback:
 class TestFallbackAnthropicProvider:
     """Bug fix: _try_activate_fallback had no case for anthropic provider."""
 
-    def test_fallback_to_anthropic_sets_api_mode(self, agent):
+    def test_fallback_activation_emits_model_change_notice(self, agent):
+        agent.provider = "openai-codex"
+        agent.model = "gpt-5.5"
+        agent._primary_runtime["provider"] = "openai-codex"
+        agent._primary_runtime["model"] = "gpt-5.5"
+        agent._fallback_activated = False
+        agent._fallback_model = {"provider": "custom", "model": "qwen3.5:9b"}
+        agent._fallback_chain = [agent._fallback_model]
+        agent._fallback_index = 0
+
+        events = []
+        agent.status_callback = lambda event_type, message: events.append((event_type, message))
+
+        mock_client = MagicMock()
+        mock_client.base_url = "http://127.0.0.1:11434/v1"
+        mock_client.api_key = "ollama"
+
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            result = agent._try_activate_fallback(reason=FailoverReason.auth)
+
+        assert result is True
+        assert any(
+            event_type == "model_change"
+            and "without your direction" in message
+            and "openai-codex/gpt-5.5" in message
+            and "custom/qwen3.5:9b" in message
+            and "auth" in message.lower()
+            for event_type, message in events
+        ), events
+
+    def test_restore_primary_runtime_emits_model_recovery_notice(self, agent):
+        agent.provider = "custom"
+        agent.model = "qwen3.5:9b"
+        agent._fallback_activated = True
+        agent._fallback_index = 1
+        agent._rate_limited_until = 0
+        agent._primary_runtime.update(
+            {
+                "provider": "openai-codex",
+                "model": "gpt-5.5",
+                "base_url": "https://api.openai.com/v1",
+                "api_mode": "codex_responses",
+                "api_key": "test-key-1234567890",
+                "client_kwargs": {
+                    "api_key": "test-key-1234567890",
+                    "base_url": "https://api.openai.com/v1",
+                },
+            }
+        )
+
+        events = []
+        agent.status_callback = lambda event_type, message: events.append((event_type, message))
+
+        with patch.object(agent, "_create_openai_client", return_value=MagicMock()):
+            restored = agent._restore_primary_runtime()
+
+        assert restored is True
+        assert any(
+            event_type == "model_change"
+            and "restored" in message.lower()
+            and "custom/qwen3.5:9b" in message
+            and "openai-codex/gpt-5.5" in message
+            for event_type, message in events
+        ), events
+
+    def test_native_anthropic_fallback_blocked_without_explicit_allow(self, agent):
         agent._fallback_activated = False
         agent._fallback_model = {"provider": "anthropic", "model": "claude-sonnet-4-20250514"}
+        agent._fallback_chain = [agent._fallback_model]
+        agent._fallback_index = 0
+
+        events = []
+        agent.status_callback = lambda event_type, message: events.append((event_type, message))
+
+        with patch("agent.auxiliary_client.resolve_provider_client") as mock_resolve:
+            result = agent._try_activate_fallback()
+
+        assert result is False
+        mock_resolve.assert_not_called()
+        assert agent._fallback_activated is False
+        assert any(
+            event_type == "model_change"
+            and "Anthropic" in message
+            and "blocked" in message.lower()
+            for event_type, message in events
+        ), events
+
+    def test_fallback_to_anthropic_sets_api_mode(self, agent):
+        agent._fallback_activated = False
+        agent._fallback_model = {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-20250514",
+            "allow_auto_fallback": True,
+        }
         agent._fallback_chain = [agent._fallback_model]
         agent._fallback_index = 0
 
@@ -4900,7 +4991,11 @@ class TestFallbackAnthropicProvider:
 
     def test_fallback_to_anthropic_enables_prompt_caching(self, agent):
         agent._fallback_activated = False
-        agent._fallback_model = {"provider": "anthropic", "model": "claude-sonnet-4-20250514"}
+        agent._fallback_model = {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-20250514",
+            "allow_auto_fallback": True,
+        }
         agent._fallback_chain = [agent._fallback_model]
         agent._fallback_index = 0
 
@@ -5781,7 +5876,11 @@ class TestFallbackSetsOAuthFlag:
 
     def test_fallback_to_anthropic_oauth_sets_flag(self, agent):
         agent._fallback_activated = False
-        agent._fallback_model = {"provider": "anthropic", "model": "claude-sonnet-4-6"}
+        agent._fallback_model = {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "allow_auto_fallback": True,
+        }
         agent._fallback_chain = [agent._fallback_model]
         agent._fallback_index = 0
 
@@ -5804,7 +5903,11 @@ class TestFallbackSetsOAuthFlag:
 
     def test_fallback_to_anthropic_api_key_clears_flag(self, agent):
         agent._fallback_activated = False
-        agent._fallback_model = {"provider": "anthropic", "model": "claude-sonnet-4-6"}
+        agent._fallback_model = {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-6",
+            "allow_auto_fallback": True,
+        }
         agent._fallback_chain = [agent._fallback_model]
         agent._fallback_index = 0
 


### PR DESCRIPTION
## Summary
- Emit permanent gateway chat messages when Hermes changes provider/model without explicit user direction.
- Cover agent fallback activation, gateway auth/rate-limit fallback before agent construction, and recovery back to the primary runtime.
- Block automatic native Anthropic fallback unless the fallback entry explicitly sets `allow_auto_fallback: true`.
- Add regression coverage for gateway status routing, runtime fallback notices, recovery notices, and Anthropic fallback gating.

## Test plan
- `venv/bin/python -m pytest tests/run_agent/test_run_agent.py tests/gateway/test_auth_fallback.py tests/gateway/test_run_cleanup_progress.py -q` → `370 passed in 56.08s`
- `git diff --check`
- `venv/bin/python -m py_compile agent/model_change_notice.py agent/chat_completion_helpers.py agent/agent_runtime_helpers.py gateway/run.py`
- `hermes chat -q 'Reply exactly: HERMES_CODEX_PR_OK' --provider openai-codex -m gpt-5.5 -Q` → `HERMES_CODEX_PR_OK` (`20260531_190154_04e05b`)
