### PR TITLE
fix: apply BlueBubbles mobile routing safeguards

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -30,6 +30,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
     cache_audio_from_bytes,
     cache_document_from_bytes,
+    resolve_channel_prompt,
 )
 from gateway.platforms.helpers import strip_markdown
 
@@ -229,8 +230,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     def _webhook_url(self) -> str:
         """Compute the external webhook URL for BlueBubbles registration."""
         host = self.webhook_host
-        if host in {"0.0.0.0", "127.0.0.1", "localhost", "::"}:
-            host = "localhost"
+        if host in {"0.0.0.0", "::"}:
+            host = "127.0.0.1"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 
     @property
@@ -945,6 +946,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             ),
             media_urls=media_urls,
             media_types=media_types,
+            channel_prompt=resolve_channel_prompt(
+                self.config.extra,
+                str(session_chat_id),
+                str(chat_identifier) if chat_identifier else None,
+            ),
         )
         task = asyncio.create_task(self.handle_message(event))
         self._background_tasks.add(task)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -12,6 +12,7 @@ import hashlib
 import logging
 import os
 import json
+import re
 import threading
 import uuid
 from pathlib import Path
@@ -665,6 +666,13 @@ def build_session_key(
     return ":".join(key_parts)
 
 
+def _slugify_shared_session_key(value: Any) -> str:
+    """Normalize a configured shared-session key into a safe key fragment."""
+    raw = str(value or "").strip().lower()
+    slug = re.sub(r"[^a-z0-9_.-]+", "-", raw).strip("-._")
+    return slug[:96]
+
+
 class SessionStore:
     """
     Manages session storage and retrieval.
@@ -741,8 +749,41 @@ class SessionStore:
                 logger.debug("Could not remove temp file %s: %s", tmp_path, e)
             raise
     
+    def _shared_session_extra(self, source: SessionSource) -> Dict[str, Any]:
+        """Return platform ``extra`` settings that request a shared session."""
+        try:
+            platform_cfg = self.config.platforms.get(source.platform)
+        except Exception:
+            platform_cfg = None
+        extra = getattr(platform_cfg, "extra", {}) if platform_cfg else {}
+        return extra if isinstance(extra, dict) else {}
+
+    def _shared_session_key(self, source: SessionSource) -> Optional[str]:
+        """Return a configured shared session key for this source, if any.
+
+        This intentionally affects only Hermes's transcript/session lookup. The
+        original ``SessionSource.chat_id`` is preserved on the event so replies,
+        auth, notices, and delivery still target the real platform chat.
+        """
+        extra = self._shared_session_extra(source)
+        raw_key = extra.get("shared_session_key")
+        slug = _slugify_shared_session_key(raw_key)
+        if not slug:
+            return None
+        platform = source.platform.value
+        return f"agent:main:{platform}:shared:{slug}"
+
+    def _shared_session_title(self, source: SessionSource) -> Optional[str]:
+        """Return the optional display title for a configured shared session."""
+        extra = self._shared_session_extra(source)
+        title = str(extra.get("shared_session_title") or "").strip()
+        return title or None
+
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
+        shared_key = self._shared_session_key(source)
+        if shared_key:
+            return shared_key
         return build_session_key(
             source,
             group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
@@ -865,6 +906,7 @@ class SessionStore:
         Creates a session record in SQLite when a new session starts.
         """
         session_key = self._generate_session_key(source)
+        shared_title = self._shared_session_title(source)
         now = _now()
 
         # SQLite calls are made outside the lock to avoid holding it during I/O.
@@ -900,6 +942,8 @@ class SessionStore:
                     reset_reason = self._should_reset(entry, source)
                 if not reset_reason:
                     entry.updated_at = now
+                    if shared_title and entry.display_name != shared_title:
+                        entry.display_name = shared_title
                     self._save()
                     return entry
                 else:
@@ -923,7 +967,7 @@ class SessionStore:
                 created_at=now,
                 updated_at=now,
                 origin=source,
-                display_name=source.chat_name,
+                display_name=shared_title or source.chat_name,
                 platform=source.platform,
                 chat_type=source.chat_type,
                 was_auto_reset=was_auto_reset,
@@ -949,6 +993,11 @@ class SessionStore:
         if self._db and db_create_kwargs:
             try:
                 self._db.create_session(**db_create_kwargs)
+                if shared_title:
+                    try:
+                        self._db.set_session_title(session_id, shared_title)
+                    except ValueError as e:
+                        logger.debug("Could not title shared gateway session %s: %s", session_id, e)
             except Exception as e:
                 print(f"[gateway] Warning: Failed to create SQLite session: {e}")
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -890,13 +890,14 @@ class SessionDB:
         system_prompt: str = None,
         user_id: str = None,
         parent_session_id: str = None,
+        title: Optional[str] = None,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                   system_prompt, parent_session_id, title, started_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
@@ -905,6 +906,7 @@ class SessionDB:
                     json.dumps(model_config) if model_config else None,
                     system_prompt,
                     parent_session_id,
+                    title,
                     time.time(),
                 ),
             )

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -132,6 +132,35 @@ class TestBlueBubblesHelpers:
 
 
 class TestBlueBubblesWebhookParsing:
+    @pytest.mark.asyncio
+    async def test_webhook_applies_channel_prompt_from_chat_guid(self, monkeypatch):
+        adapter = _make_adapter(
+            monkeypatch,
+            channel_prompts={"any;-;+15551234567": "Use Google Calendar task rules."},
+        )
+        events = []
+
+        async def fake_handle_message(event):
+            events.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        class Request:
+            query = {"password": "secret"}
+            headers = {}
+
+            async def read(self):
+                return b'{"type":"new-message","data":{"guid":"MESSAGE-GUID","text":"Todo send invoice tomorrow at noon","handle":{"address":"+15551234567"},"isFromMe":false,"chats":[{"guid":"any;-;+15551234567","chatIdentifier":"+15551234567"}]}}'
+
+        response = await adapter._handle_webhook(Request())
+        assert response.status == 200
+
+        import asyncio
+
+        await asyncio.sleep(0)
+        assert len(events) == 1
+        assert events[0].channel_prompt == "Use Google Calendar task rules."
+
     def test_webhook_prefers_chat_guid_over_message_guid(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         payload = {
@@ -422,19 +451,24 @@ class TestBlueBubblesAttachmentDownload:
 
 
 class TestBlueBubblesWebhookUrl:
-    """_webhook_url property normalises local hosts to 'localhost'."""
+    """_webhook_url preserves explicit loopback host choices."""
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
-        assert "localhost" in adapter._webhook_url
+        # Default webhook_host is 0.0.0.0 → normalized to explicit IPv4 loopback.
+        assert "127.0.0.1" in adapter._webhook_url
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url
 
-    @pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1", "localhost", "::"])
-    def test_local_hosts_normalized(self, monkeypatch, host):
+    @pytest.mark.parametrize("host", ["0.0.0.0", "::"])
+    def test_wildcard_hosts_normalized_to_ipv4_loopback(self, monkeypatch, host):
         adapter = _make_adapter(monkeypatch, webhook_host=host)
-        assert adapter._webhook_url.startswith("http://localhost:")
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
+
+    @pytest.mark.parametrize("host", ["127.0.0.1", "localhost"])
+    def test_explicit_loopback_hosts_preserved(self, monkeypatch, host):
+        adapter = _make_adapter(monkeypatch, webhook_host=host)
+        assert adapter._webhook_url.startswith(f"http://{host}:")
 
     def test_custom_host_preserved(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")

--- a/tests/gateway/test_shared_platform_sessions.py
+++ b/tests/gateway/test_shared_platform_sessions.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource, SessionStore
+
+
+def _store(tmp_path: Path) -> SessionStore:
+    cfg = GatewayConfig(
+        platforms={
+            Platform.BLUEBUBBLES: PlatformConfig(
+                enabled=True,
+                extra={
+                    "shared_session_key": "Rogher Mobile HQ",
+                    "shared_session_title": "Rogher Mobile HQ",
+                },
+            )
+        }
+    )
+    store = SessionStore(tmp_path / "sessions", cfg)
+    # These tests only care about the gateway session index. Avoid coupling to
+    # SQLite state.db setup in the unit test.
+    store._db = None
+    return store
+
+
+def test_configured_platform_shared_session_key_reuses_session_across_chats(tmp_path):
+    store = _store(tmp_path)
+    first = SessionSource(
+        platform=Platform.BLUEBUBBLES,
+        chat_id="iMessage;+;chat-one",
+        chat_type="dm",
+        user_id="nick",
+        chat_name="Thread One",
+    )
+    second = SessionSource(
+        platform=Platform.BLUEBUBBLES,
+        chat_id="iMessage;+;chat-two",
+        chat_type="dm",
+        user_id="nick",
+        chat_name="Thread Two",
+    )
+
+    first_entry = store.get_or_create_session(first)
+    second_entry = store.get_or_create_session(second)
+
+    assert first_entry.session_key == "agent:main:bluebubbles:shared:rogher-mobile-hq"
+    assert second_entry.session_key == first_entry.session_key
+    assert second_entry.session_id == first_entry.session_id
+    assert second_entry.display_name == "Rogher Mobile HQ"
+    # Delivery metadata is not collapsed: replies can still target the real
+    # iMessage thread that originally created the shared session.
+    assert first_entry.origin is not None
+    assert first_entry.origin.chat_id == "iMessage;+;chat-one"
+
+
+def test_unconfigured_platform_keeps_default_dm_isolation(tmp_path):
+    store = SessionStore(tmp_path / "sessions", GatewayConfig())
+    store._db = None
+    first = SessionSource(platform=Platform.BLUEBUBBLES, chat_id="one", chat_type="dm")
+    second = SessionSource(platform=Platform.BLUEBUBBLES, chat_id="two", chat_type="dm")
+
+    assert store.get_or_create_session(first).session_key == "agent:main:bluebubbles:dm:one"
+    assert store.get_or_create_session(second).session_key == "agent:main:bluebubbles:dm:two"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1158,6 +1158,58 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     return {"resolved": resolved, "choice": choice}
 
 
+def _bluebubbles_apple_calendar_guard(command: str) -> tuple[bool, str | None]:
+    """Block Apple Calendar automation from BlueBubbles/mobile sessions.
+
+    Nick's mobile/iMessage capture flow must use Google Calendar by default.
+    Apple Calendar/Fantastical are synced views only unless Nick explicitly asks
+    for Apple Calendar.  The terminal approval layer only sees the command, not
+    the original user intent, so BlueBubbles sessions fail closed for direct
+    Apple Calendar osascript automation; explicitly requested Apple Calendar
+    edits should be performed from a non-BlueBubbles/manual context.
+    """
+    if _get_session_platform().lower() != "bluebubbles":
+        return (False, None)
+    normalized = _normalize_command_for_detection(command).lower()
+    if "osascript" not in normalized:
+        return (False, None)
+    if re.search(r'\btell\s+application\s+["\']?(calendar|ical)["\']?', normalized):
+        return (True, "Apple Calendar osascript is blocked from BlueBubbles/mobile sessions; use Google Calendar via google_api.py instead")
+    return (False, None)
+
+
+def _bluebubbles_apple_reminders_guard(command: str) -> tuple[bool, str | None]:
+    """Block Apple Reminders creation from BlueBubbles/mobile sessions.
+
+    The mobile path has repeatedly interpreted dated/timed event requests as
+    Apple Reminders. For BlueBubbles, fail closed on direct reminder creation so
+    dated/timed requests route to Google Calendar unless Nick explicitly asks in
+    a manual/non-mobile context for Apple Reminders.
+    """
+    if _get_session_platform().lower() != "bluebubbles":
+        return (False, None)
+    normalized = _normalize_command_for_detection(command).lower()
+    if not re.search(r"\bremindctl\b", normalized):
+        return (False, None)
+    if re.search(r"\b(add|edit)\b", normalized):
+        return (True, "Apple Reminders creation/editing is blocked from BlueBubbles/mobile sessions; dated or timed mobile requests must use Google Calendar via google_api.py")
+    return (False, None)
+
+
+def _bluebubbles_calendar_block_result(description: str) -> dict:
+    return {
+        "approved": False,
+        "message": (
+            f"BLOCKED: {description}. Mobile/iMessage dated or timed captures must "
+            "create and read events through Google Calendar by default. Do not retry "
+            "with Apple Calendar or Apple Reminders automation; use the "
+            "google-workspace skill or google_api.py."
+        ),
+        "outcome": "blocked",
+        "user_consent": False,
+    }
+
+
 def check_all_command_guards(command: str, env_type: str,
                              approval_callback=None) -> dict:
     """Run all pre-exec security checks and return a single approval decision.
@@ -1170,6 +1222,26 @@ def check_all_command_guards(command: str, env_type: str,
     # Skip containers for both checks
     if env_type in {"docker", "singularity", "modal", "daytona"}:
         return {"approved": True, "message": None}
+
+    is_bluebubbles_calendar, bluebubbles_calendar_desc = _bluebubbles_apple_calendar_guard(command)
+    if is_bluebubbles_calendar:
+        desc = bluebubbles_calendar_desc or "Apple Calendar osascript is blocked from BlueBubbles/mobile sessions"
+        logger.warning(
+            "BlueBubbles Apple Calendar guard block: %s (command: %s)",
+            desc,
+            command[:200],
+        )
+        return _bluebubbles_calendar_block_result(desc)
+
+    is_bluebubbles_reminders, bluebubbles_reminders_desc = _bluebubbles_apple_reminders_guard(command)
+    if is_bluebubbles_reminders:
+        desc = bluebubbles_reminders_desc or "Apple Reminders are blocked from BlueBubbles/mobile sessions for dated or timed captures"
+        logger.warning(
+            "BlueBubbles Apple Reminders guard block: %s (command: %s)",
+            desc,
+            command[:200],
+        )
+        return _bluebubbles_calendar_block_result(desc)
 
     # Hardline floor: unconditional block for catastrophic commands
     # (rm -rf /, mkfs, dd to raw device, shutdown/reboot, fork bomb,
@@ -1481,6 +1553,26 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
     # in check_all_command_guards / check_dangerous_command.
     if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
         return {"approved": True, "message": None}
+
+    is_bluebubbles_calendar, bluebubbles_calendar_desc = _bluebubbles_apple_calendar_guard(code)
+    if is_bluebubbles_calendar:
+        desc = bluebubbles_calendar_desc or "Apple Calendar osascript is blocked from BlueBubbles/mobile sessions"
+        logger.warning(
+            "BlueBubbles Apple Calendar guard block in execute_code (session %s): %s",
+            get_current_session_key(""),
+            desc,
+        )
+        return _bluebubbles_calendar_block_result(desc)
+
+    is_bluebubbles_reminders, bluebubbles_reminders_desc = _bluebubbles_apple_reminders_guard(code)
+    if is_bluebubbles_reminders:
+        desc = bluebubbles_reminders_desc or "Apple Reminders are blocked from BlueBubbles/mobile sessions for dated or timed captures"
+        logger.warning(
+            "BlueBubbles Apple Reminders guard block in execute_code (session %s): %s",
+            get_current_session_key(""),
+            desc,
+        )
+        return _bluebubbles_calendar_block_result(desc)
 
     # --yolo or approvals.mode=off: bypass (session- or process-scoped).
     approval_mode = _get_approval_mode()


### PR DESCRIPTION
## Summary
- attach configured channel_prompts to BlueBubbles webhook MessageEvents so mobile-specific routing rules actually reach the agent
- add shared-session support for configured platform sessions without collapsing delivery metadata
- block Apple Calendar/Reminders automation from BlueBubbles sessions so mobile dated/timed captures fail closed to Google Calendar

## Tests
- python -m pytest tests/gateway/test_bluebubbles.py tests/tools/test_approval.py tests/gateway/test_shared_platform_sessions.py -q