### PR TITLE
fix(desktop): report desktop_contract in lazy session.create info

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3572,6 +3572,33 @@ def test_session_create_continues_when_state_db_is_unavailable(monkeypatch):
     server._sessions.pop(sid, None)
 
 
+def test_session_create_lazy_info_reports_desktop_contract(monkeypatch):
+    """The lazy session.create info payload must carry desktop_contract, else
+    the desktop GUI reads it as undefined and falsely warns "Backend out of
+    date" on every launch even against a current backend."""
+
+    class _FakeWorker:
+        def __init__(self, key, model):
+            self.key = key
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **kw: None)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.create", "params": {"cols": 80}}
+    )
+    info = resp["result"]["info"]
+
+    assert info["desktop_contract"] == server.DESKTOP_BACKEND_CONTRACT
+
+    server._sessions.pop(resp["result"]["session_id"], None)
+
+
 def test_session_list_returns_clean_error_when_state_db_is_unavailable(monkeypatch):
     monkeypatch.setattr(server, "_get_db", lambda: None)
     monkeypatch.setattr(server, "_db_error", "locking protocol")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2789,6 +2789,7 @@ def _(rid, params: dict) -> dict:
                 "cwd": _sessions[sid]["cwd"],
                 "branch": _git_branch_for_cwd(_sessions[sid]["cwd"]),
                 "lazy": True,
+                "desktop_contract": DESKTOP_BACKEND_CONTRACT,
                 "profile_name": _current_profile_name(),
             },
         },


### PR DESCRIPTION
## Summary
- The desktop GUI's "Backend out of date" toast fires from `reportBackendContract(info.desktop_contract)`, which treats a **missing** contract as a pre-GUI/old backend.
- The full `_session_info()` always reports `desktop_contract: 1`, but the **lazy `session.create`** path hand-builds a partial `info` dict that omitted it.
- Since the desktop creates a session on every launch, `desktop_contract` came through as `undefined` → false "Backend out of date" warning **every time**, regardless of how current the backend actually was (updating never silenced it).
- Fix: include `DESKTOP_BACKEND_CONTRACT` in the lazy payload, matching what resume/branch already do via `_session_info`.

## Test plan
- [x] Added `test_session_create_lazy_info_reports_desktop_contract` — asserts the lazy `session.create` info carries `desktop_contract == DESKTOP_BACKEND_CONTRACT` (regression guard for the false toast).
- [x] `scripts/run_tests.sh tests/test_tui_gateway_server.py` → 191 passed.