### PR TITLE
feat: add eikon install tool

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1145,9 +1145,10 @@ def _get_platform_tools(
     from toolsets import resolve_toolset, TOOLSETS
 
     platform_toolsets = config.get("platform_toolsets") or {}
-    toolset_names = platform_toolsets.get(platform)
+    raw_toolset_names = platform_toolsets.get(platform)
+    using_platform_default = raw_toolset_names is None or not isinstance(raw_toolset_names, list)
 
-    if toolset_names is None or not isinstance(toolset_names, list):
+    if using_platform_default:
         plat_info = PLATFORMS.get(platform)
         if plat_info:
             default_ts = plat_info["default_toolset"]
@@ -1155,6 +1156,8 @@ def _get_platform_tools(
             # Plugin platform — derive toolset name from platform key
             default_ts = f"hermes-{platform}"
         toolset_names = [default_ts]
+    else:
+        toolset_names = raw_toolset_names
 
     # YAML may parse bare numeric names (e.g. ``12306:``) as int.
     # Normalise to str so downstream sorted() never mixes types.
@@ -1296,16 +1299,23 @@ def _get_platform_tools(
             enabled_toolsets.add(ts_key)
             claimed.update(ts_tools)
 
-    # Plugin toolsets: enabled by default unless explicitly disabled, or
-    # unless the toolset is in _DEFAULT_OFF_TOOLSETS (e.g. spotify —
-    # shipped as a bundled plugin but user must opt in via `hermes tools`
-    # so we don't ship 7 Spotify tool schemas to users who don't use it).
-    # A plugin toolset is "known" for a platform once `hermes tools`
-    # has been saved for that platform (tracked via known_plugin_toolsets).
-    # Unknown plugins default to enabled; known-but-absent = disabled.
+    # Plugin toolsets: enabled by default only on the platform default
+    # composite surface, unless explicitly disabled/recorded via
+    # known_plugin_toolsets or listed in _DEFAULT_OFF_TOOLSETS (e.g.
+    # spotify). Once a platform has an explicit configurable selection,
+    # that saved list is authoritative: newly bundled plugin toolsets should
+    # not sneak into a user-selected `web,terminal` surface.
     if plugin_ts_keys:
         known_map = config.get("known_plugin_toolsets", {})
         known_for_platform = set(known_map.get(platform, []))
+        has_default_composite = any(
+            ts in platform_default_keys or ts == f"hermes-{platform}"
+            for ts in toolset_names
+        )
+        enable_unknown_plugin_defaults = (
+            using_platform_default
+            or (not has_explicit_config and has_default_composite)
+        )
         for pts in plugin_ts_keys:
             if pts in toolset_names:
                 # Explicitly listed in config — enabled
@@ -1313,10 +1323,11 @@ def _get_platform_tools(
             elif pts in _DEFAULT_OFF_TOOLSETS:
                 # Opt-in plugin toolset — stay off until user picks it
                 continue
-            elif pts not in known_for_platform:
-                # New plugin not yet seen by hermes tools — default enabled
+            elif enable_unknown_plugin_defaults and pts not in known_for_platform:
+                # Default/composite platform surface — expose newly available
+                # plugin toolsets until `hermes tools` has recorded a choice.
                 enabled_toolsets.add(pts)
-            # else: known but not in config = user disabled it
+            # else: explicit user selection or known-but-absent = disabled
 
     # Context-engine tools are runtime-provided by the active engine, so they
     # are not part of any static platform composite. When a non-default engine

--- a/plugins/eikon/__init__.py
+++ b/plugins/eikon/__init__.py
@@ -1,0 +1,17 @@
+"""Eikon install plugin."""
+
+from __future__ import annotations
+
+from plugins.eikon.schemas import EIKON_INSTALL_SCHEMA
+from plugins.eikon.tools import _handle_eikon_install, check_herm_available
+
+
+def register(ctx) -> None:
+    ctx.register_tool(
+        name="eikon_install",
+        toolset="eikon",
+        schema=EIKON_INSTALL_SCHEMA,
+        handler=_handle_eikon_install,
+        check_fn=check_herm_available,
+        emoji="⬡",
+    )

--- a/plugins/eikon/plugin.yaml
+++ b/plugins/eikon/plugin.yaml
@@ -1,0 +1,7 @@
+name: eikon
+version: 1.0.0
+description: "Herm eikon installer tool. Lets Hermes chat install terminal avatars through the existing `herm eikon install` CLI path."
+author: NousResearch
+kind: backend
+provides_tools:
+  - eikon_install

--- a/plugins/eikon/schemas.py
+++ b/plugins/eikon/schemas.py
@@ -1,0 +1,41 @@
+"""Tool schemas for the eikon plugin."""
+
+from __future__ import annotations
+
+EIKON_INSTALL_SCHEMA = {
+    "name": "eikon_install",
+    "description": (
+        "Install a Herm eikon/avatar from the public catalog, a manifest URL, "
+        "a git repository, or a local directory. Uses the existing `herm eikon install` "
+        "path; no separate eikon executable is required."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "source": {
+                "type": "string",
+                "description": "Catalog name, HTTPS manifest/base URL, git URL, or local directory.",
+            },
+            "name": {
+                "type": "string",
+                "description": "Optional installed name override.",
+            },
+            "media": {
+                "type": "boolean",
+                "description": "Whether to fetch source media into the profile. Default true.",
+                "default": True,
+            },
+            "no_source": {
+                "type": "boolean",
+                "description": "Alias for media=false.",
+                "default": False,
+            },
+            "set_active": {
+                "type": "boolean",
+                "description": "Set the installed eikon as the active Herm avatar. Default true.",
+                "default": True,
+            },
+        },
+        "required": ["source"],
+    },
+}

--- a/plugins/eikon/tools.py
+++ b/plugins/eikon/tools.py
@@ -1,0 +1,69 @@
+"""Handlers for the eikon plugin."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+def _json(data: dict[str, Any]) -> str:
+    return json.dumps(data)
+
+
+def _herm_bin() -> str | None:
+    override = os.getenv("HERM_EIKON_HERM_BIN", "").strip()
+    if override:
+        return override
+    return shutil.which("herm")
+
+
+def check_herm_available() -> bool:
+    binary = _herm_bin()
+    if not binary:
+        return False
+    if os.path.sep in binary:
+        return Path(binary).is_file() and os.access(binary, os.X_OK)
+    return shutil.which(binary) is not None
+
+
+def _handle_eikon_install(args: dict[str, Any], **_: Any) -> str:
+    source = str(args.get("source") or "").strip()
+    if not source:
+        return _json({"ok": False, "error": "source is required"})
+
+    binary = _herm_bin()
+    if not binary:
+        return _json({"ok": False, "error": "herm executable not found on PATH"})
+
+    cmd = [binary, "eikon", "install", source, "--json"]
+    name = str(args.get("name") or "").strip()
+    if name:
+        cmd.extend(["--name", name])
+    if args.get("media") is False or args.get("no_source") is True:
+        cmd.append("--no-source")
+    if args.get("set_active") is False:
+        cmd.append("--no-use")
+
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=120, check=False)
+    except FileNotFoundError:
+        return _json({"ok": False, "error": f"herm executable not found: {binary}"})
+    except subprocess.TimeoutExpired:
+        return _json({"ok": False, "error": "herm eikon install timed out"})
+
+    stdout = (proc.stdout or "").strip()
+    stderr = (proc.stderr or "").strip()
+    if proc.returncode != 0:
+        detail = stderr or stdout or f"exit {proc.returncode}"
+        return _json({"ok": False, "error": f"herm eikon install failed: {detail}"})
+
+    line = next((ln for ln in reversed(stdout.splitlines()) if ln.strip()), "")
+    try:
+        payload = json.loads(line)
+    except json.JSONDecodeError:
+        return _json({"ok": False, "error": "herm eikon install returned non-JSON output", "output": stdout})
+    return _json(payload)

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -270,6 +270,30 @@ def test_get_platform_tools_configurable_only_no_expansion():
     assert "web" not in enabled
 
 
+def test_get_platform_tools_plugin_defaults_respect_explicit_config():
+    """Bundled plugin toolsets belong on the default surface, but must not
+    bypass an explicit per-platform selection.
+    """
+    default_enabled = _get_platform_tools(
+        {}, "api_server", include_default_mcp_servers=False
+    )
+    explicit_enabled = _get_platform_tools(
+        {"platform_toolsets": {"api_server": ["web", "terminal"]}},
+        "api_server",
+        include_default_mcp_servers=False,
+    )
+    empty_enabled = _get_platform_tools(
+        {"platform_toolsets": {"api_server": []}},
+        "api_server",
+        include_default_mcp_servers=False,
+    )
+
+    assert "eikon" in default_enabled
+    assert "eikon" not in explicit_enabled
+    assert "eikon" not in empty_enabled
+    assert {"web", "terminal"}.issubset(explicit_enabled)
+
+
 def test_get_platform_tools_mixed_does_not_resurrect_default_off():
     """Expansion must subtract _DEFAULT_OFF_TOOLSETS from the implicit
     pull-in. Without this, ``hermes-cli`` expansion would re-enable

--- a/tests/plugins/test_eikon_plugin.py
+++ b/tests/plugins/test_eikon_plugin.py
@@ -1,0 +1,87 @@
+"""Tests for the bundled eikon install plugin."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+from tools.registry import registry
+from toolsets import resolve_toolset
+
+
+def _ctx() -> PluginContext:
+    mgr = PluginManager()
+    manifest = PluginManifest(name="eikon", key="eikon", kind="backend")
+    return PluginContext(manifest, mgr)
+
+
+def test_register_adds_default_eikon_install_tool() -> None:
+    from plugins.eikon import register
+
+    registry.deregister("eikon_install")
+    register(_ctx())
+
+    entry = registry.get_entry("eikon_install")
+    assert entry is not None
+    assert entry.toolset == "eikon"
+    assert entry.schema["name"] == "eikon_install"
+    assert "eikon_install" in resolve_toolset("hermes-cli")
+
+    registry.deregister("eikon_install")
+
+
+def test_handler_invokes_herm_eikon_install_json(monkeypatch, tmp_path: Path) -> None:
+    from plugins.eikon.tools import _handle_eikon_install, check_herm_available
+
+    args_file = tmp_path / "args.json"
+    herm = tmp_path / "herm"
+    herm.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, os, pathlib, sys\n"
+        "pathlib.Path(os.environ['ARGS_FILE']).write_text(json.dumps(sys.argv[1:]))\n"
+        "print(json.dumps({'ok': True, 'name': 'war', 'n': 0, 'bytes': 0, 'sources': {}, 'active': None}))\n",
+        encoding="utf-8",
+    )
+    herm.chmod(0o755)
+    monkeypatch.setenv("HERM_EIKON_HERM_BIN", str(herm))
+    monkeypatch.setenv("ARGS_FILE", str(args_file))
+
+    assert check_herm_available() is True
+    result = json.loads(_handle_eikon_install({
+        "source": "https://eikon.liftaris.dev/eikons/ares/",
+        "name": "war",
+        "media": False,
+        "set_active": False,
+    }))
+
+    assert result == {"ok": True, "name": "war", "n": 0, "bytes": 0, "sources": {}, "active": None}
+    assert json.loads(args_file.read_text(encoding="utf-8")) == [
+        "eikon", "install", "https://eikon.liftaris.dev/eikons/ares/",
+        "--json", "--name", "war", "--no-source", "--no-use",
+    ]
+
+
+def test_handler_returns_json_error_on_failure(monkeypatch, tmp_path: Path) -> None:
+    from plugins.eikon.tools import _handle_eikon_install
+
+    herm = tmp_path / "herm"
+    herm.write_text("#!/usr/bin/env sh\necho nope >&2\nexit 7\n", encoding="utf-8")
+    herm.chmod(0o755)
+    monkeypatch.setenv("HERM_EIKON_HERM_BIN", str(herm))
+
+    result = json.loads(_handle_eikon_install({"source": "ares"}))
+
+    assert result["ok"] is False
+    assert "herm eikon install failed" in result["error"]
+    assert "nope" in result["error"]
+
+
+def test_handler_rejects_missing_source() -> None:
+    from plugins.eikon.tools import _handle_eikon_install
+
+    assert json.loads(_handle_eikon_install({"source": ""})) == {
+        "ok": False,
+        "error": "source is required",
+    }

--- a/toolsets.py
+++ b/toolsets.py
@@ -68,6 +68,7 @@ _HERMES_CORE_TOOLS = [
     "kanban_complete", "kanban_block", "kanban_heartbeat",
     "kanban_comment", "kanban_create", "kanban_link",
     "kanban_unblock",
+    "eikon_install",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
 ]


### PR DESCRIPTION
## Summary

- Hermes now exposes an `eikon_install` tool when the Herm companion CLI is available.
- The tool delegates to `herm eikon install --json`, preserves install options for name overrides, source-media skipping, and activation, then returns structured JSON to the model.
- The bundled plugin is registered on the default tool surface while still respecting explicit per-platform toolset selections.

## Verification

- `python -m pytest tests/plugins/test_eikon_plugin.py tests/gateway/test_api_server_toolset.py tests/hermes_cli/test_tools_config.py -q`
- `python -m ruff check hermes_cli/tools_config.py tests/hermes_cli/test_tools_config.py plugins/eikon tests/plugins/test_eikon_plugin.py`
