### PR TITLE
gateway: fall back to psutil for process start time on non-Linux (fixes restart flap on macOS)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -115,6 +115,19 @@ def _get_process_start_time(pid: int) -> Optional[int]:
         # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
         return int(stat_path.read_text(encoding="utf-8").split()[21])
     except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
+        pass
+    # No /proc (macOS / Windows / non-Linux): fall back to psutil's create_time
+    # (epoch seconds, stable per pid). Without this the value is None on those
+    # platforms, so the gateway takeover / planned-stop markers — which require a
+    # non-None start time on both sides to match — never match. That misclassifies
+    # every `--replace` / `gateway stop` SIGTERM as an unexpected crash, which under
+    # a KeepAlive supervisor (launchd/systemd) causes a restart flap and can get the
+    # service booted out entirely.
+    try:
+        import psutil  # type: ignore
+
+        return int(psutil.Process(pid).create_time())
+    except Exception:
         return None
 
 


### PR DESCRIPTION
## Problem

`_get_process_start_time` in `gateway/status.py` reads `/proc/<pid>/stat` (field 22). That path doesn't exist on **macOS or Windows**, so the function returns `None` there.

The gateway's takeover and planned-stop markers (`_consume_pid_marker_for_self`) require a **non-None start time on both sides** to match. On non-Linux they therefore never match, so every `hermes gateway run --replace` takeover and every `hermes gateway stop` SIGTERM is misclassified as an **unexpected crash** rather than a planned shutdown.

Under a KeepAlive supervisor (launchd on macOS, systemd on Linux) that misclassification causes a **restart flap**; with no `ThrottleInterval` the supervisor can boot the service out of the domain entirely. We hit this on a macOS host: a `--replace` during an active turn flapped and launchd removed the gateway service.

## Fix

Fall back to `psutil.Process(pid).create_time()` (epoch seconds, stable per pid) when `/proc` is unavailable. This gives the markers a stable, matchable start-time key on any platform.

- Linux behavior is unchanged (the `/proc` path is tried first).
- The psutil import is guarded; if psutil is absent it returns `None` (prior behavior). psutil is already used elsewhere in the gateway (e.g. process scanning).

## Test

On macOS, `_get_process_start_time(os.getpid())` now returns a stable integer across repeated calls (previously `None`), so takeover/planned-stop markers match and the restart flap is resolved.