### PR TITLE
fix(feishu): handle admins config as JSON string in addition to YAML list

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1496,6 +1496,13 @@ class FeishuAdapter(BasePlatformAdapter):
 
         # Bot-level admins
         raw_admins = extra.get("admins", [])
+        if isinstance(raw_admins, str):
+            import json
+            try:
+                parsed = json.loads(raw_admins)
+                raw_admins = parsed if isinstance(parsed, list) else [raw_admins]
+            except (json.JSONDecodeError, TypeError):
+                raw_admins = [raw_admins]
         admins = frozenset(str(u).strip() for u in raw_admins if str(u).strip())
 
         # Default group policy (for groups not in group_rules)


### PR DESCRIPTION
## Problem

When `config.yaml` contains `feishu.admins` as a JSON string (e.g. `'[\ou_xxx\]'`), the adapter iterates over individual characters instead of open_ids, causing authorization checks to always fail. This makes Gateway approval card buttons unresponsive.

## Fix

Detect when `raw_admins` is a string, attempt JSON parsing, and fall back to treating non-JSON strings as single values. YAML list format continues to work as before.

## Changes

- `gateway/platforms/feishu.py`: Add JSON string handling for admins config (7 lines)