### PR TITLE
fix(install): build desktop in 'desktop' stage on macOS/Linux instead of silently skipping

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2332,9 +2332,19 @@ postinstall_mode() {
 install_desktop() {
     local desktop_dir="$INSTALL_DIR/apps/desktop"
 
+    # The desktop stage only runs when a build is explicitly requested
+    # (--include-desktop / 'desktop' stage), so a missing toolchain is a hard
+    # failure, not a silent skip — a silent skip yields a "complete" install
+    # with no app and a confusing "couldn't find a built desktop" at launch.
+    # Try the Hermes-managed Node first (check_node adds $HERMES_HOME/node/bin
+    # to PATH or installs it) before giving up.
     if ! command -v npm >/dev/null 2>&1; then
-        log_warn "Skipping desktop build (Node.js / npm not on PATH)"
-        return 0
+        check_node
+    fi
+    if ! command -v npm >/dev/null 2>&1; then
+        log_error "Cannot build desktop app: Node.js / npm unavailable"
+        log_info "Install Node.js and retry: cd $desktop_dir && npm run pack"
+        return 1
     fi
     if [ ! -f "$desktop_dir/package.json" ]; then
         log_warn "Skipping desktop build (apps/desktop not present in checkout)"
@@ -2472,6 +2482,11 @@ run_stage_body() {
             detect_os
             resolve_install_layout
             require_install_dir
+            # Each stage runs in its own process, so the Hermes-managed Node
+            # provisioned during prerequisites/node-deps (at $HERMES_HOME/node/bin)
+            # isn't on PATH here. check_node re-adds it (or installs if missing)
+            # so install_desktop can find npm instead of silently skipping.
+            check_node
             install_desktop
             ;;
         complete)


### PR DESCRIPTION
## Summary
Makes the macOS (and Linux) **thin installer** path work end-to-end. The Tauri "Hermes Setup" installer (`apps/bootstrap-installer`) drives `scripts/install.sh` stage-by-stage, each stage in its own process. The `desktop` stage never called `check_node`, so the Hermes-managed Node provisioned during earlier stages (`$HERMES_HOME/node/bin`) wasn't on `PATH`. `install_desktop`'s `command -v npm` check then failed and the build was **silently skipped** — while still reporting `{"ok":true,"skipped":false}`.

Result for the user: the installer showed "Installation Complete", then "Launch Hermes" failed with *"Couldn't find a built Hermes desktop … the desktop build step may have been skipped or failed."*

## Changes
- `desktop` stage now calls `check_node` (mirrors every other Node-dependent stage) so the managed Node is on `PATH` (or gets installed).
- `install_desktop` self-provisions via `check_node` and **hard-fails** (`return 1`) if npm is still unavailable, instead of a silent `return 0`. The desktop stage only runs when a build is explicitly requested (`--include-desktop` / `desktop` stage), so a missing toolchain is a genuine failure, not graceful degradation — failing loudly prevents the confusing "complete but no app" state.

## Test plan
- [x] Built the Tauri "Hermes Setup" installer on macOS arm64; install flow runs through every stage.
- [x] Repro'd the bug: pre-fix run logged `⚠ Skipping desktop build (Node.js / npm not on PATH)` and "Launch Hermes" failed.
- [x] Post-fix: ran the `desktop` stage with the managed Node only (no system Node) → builds `apps/desktop/release/mac-arm64/Hermes.app`, which matches `resolve_hermes_desktop_exe`, so "Launch Hermes" succeeds.
- [x] `bash -n scripts/install.sh` passes.

## Notes
- Signing/notarization of the thin wrapper is intentionally **deferred** (separate follow-up). Tauri picks up `APPLE_*` signing env vars automatically at build time when we're ready, so no config change is needed here.