### PR TITLE
feat(anthropic_adapter): make third-party User-Agent configurable via model.third_party_user_agent

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -641,6 +641,23 @@ def _build_anthropic_client_with_bearer_hook(
     return _anthropic_sdk.Anthropic(**kwargs)
 
 
+def _get_third_party_user_agent() -> str:
+    """Return the User-Agent for third-party Anthropic endpoints.
+
+    Reads ``model.third_party_user_agent`` from the Hermes config.
+    Defaults to ``"curl/8.4.0"`` — a neutral UA accepted by one-api /
+    new-api gateways that block the official
+    ``Anthropic/Python x.y`` SDK User-Agent with HTTP 403.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        config = load_config_readonly()
+        model_config = config.get("model", {}) if isinstance(config, dict) else {}
+        return str(model_config.get("third_party_user_agent") or "curl/8.4.0")
+    except Exception:
+        return "curl/8.4.0"
+
+
 def build_anthropic_client(
     api_key,
     base_url: str = None,
@@ -739,8 +756,16 @@ def build_anthropic_client(
         # don't follow Anthropic's sk-ant-* prefix convention and would be
         # misclassified as OAuth tokens.
         kwargs["api_key"] = api_key
-        if common_betas:
-            kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+        # one-api/new-api gateways block the official
+        # "Anthropic/Python x.y" SDK User-Agent with 403.
+        # Override with a neutral UA so x-api-key requests are accepted,
+        # same technique as the Kimi branch above.
+        # Default is "curl/8.4.0"; set model.third_party_user_agent in
+        # config.yaml to use a different value.
+        kwargs["default_headers"] = {
+            "User-Agent": _get_third_party_user_agent(),
+            **( {"anthropic-beta": ",".join(common_betas)} if common_betas else {} )
+        }
     elif _is_oauth_token(api_key):
         # OAuth access token / setup-token → Bearer auth + Claude Code identity.
         # Anthropic routes OAuth requests based on user-agent and headers;

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -109,9 +109,11 @@ class TestBuildAnthropicClient:
             build_anthropic_client("sk-ant-api03-x", base_url="https://custom.api.com")
             kwargs = mock_sdk.Anthropic.call_args[1]
             assert kwargs["base_url"] == "https://custom.api.com"
-            assert kwargs["default_headers"] == {
-                "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
-            }
+            # custom.api.com is a third-party (non-anthropic.com) endpoint;
+            # it gets the User-Agent override in addition to common betas.
+            assert kwargs["default_headers"]["User-Agent"] == "curl/8.4.0"
+            assert "interleaved-thinking-2025-05-14" in kwargs["default_headers"]["anthropic-beta"]
+            assert "fine-grained-tool-streaming-2025-05-14" in kwargs["default_headers"]["anthropic-beta"]
 
     def test_azure_anthropic_endpoint_keeps_context_1m_beta(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
@@ -191,6 +193,42 @@ class TestBuildAnthropicClient:
             # Azure keeps the 1M-context beta (it's not MiniMax).
             betas = kwargs["default_headers"]["anthropic-beta"]
             assert "context-1m-2025-08-07" in betas
+
+    def test_third_party_endpoint_uses_default_user_agent(self):
+        """Third-party endpoints get curl/8.4.0 UA by default."""
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "sk-abc123", base_url="https://api.proxy.example.com"
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["default_headers"]["User-Agent"] == "curl/8.4.0"
+            # Verify betas are also present when common_betas exist
+            assert "anthropic-beta" in kwargs["default_headers"]
+
+    def test_third_party_endpoint_uses_configured_user_agent(self):
+        """model.third_party_user_agent in config overrides the default UA."""
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk, \
+             patch("agent.anthropic_adapter._get_third_party_user_agent",
+                   return_value="MyCustomAgent/2.0"):
+            build_anthropic_client(
+                "sk-abc123", base_url="https://api.proxy.example.com"
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["default_headers"]["User-Agent"] == "MyCustomAgent/2.0"
+
+    def test_third_party_endpoint_user_agent_with_common_betas(self):
+        """UA and anthropic-beta coexist in default_headers for third-party."""
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk, \
+             patch("agent.anthropic_adapter._get_third_party_user_agent",
+                   return_value="TestUA/1.0"):
+            build_anthropic_client(
+                "sk-abc123", base_url="https://api.proxy.example.com"
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            headers = kwargs["default_headers"]
+            assert headers["User-Agent"] == "TestUA/1.0"
+            assert "anthropic-beta" in headers
+            assert "interleaved-thinking-2025-05-14" in headers["anthropic-beta"]
 
 
 class TestReadClaudeCodeCredentials:


### PR DESCRIPTION
## Problem

one-api / new-api API gateways behind Cloudflare WAFs block the official `Anthropic/Python x.y` SDK User-Agent with HTTP 403. The local workaround was hardcoding `"curl/8.4.0"` in `agent/anthropic_adapter.py` — but it gets overwritten on every `hermes update`.

Related: #12785, #24293

## Changes

- **agent/anthropic_adapter.py**: Added `_get_third_party_user_agent()` helper that reads `model.third_party_user_agent` from Hermes config. Defaults to `"curl/8.4.0"`.
- **tests/agent/test_anthropic_adapter.py**: 3 new tests: default UA, config override, UA + betas coexistence. Updated `test_custom_base_url` to account for the new header.

## Config

```yaml
model:
  # Optional — defaults to "curl/8.4.0"
  third_party_user_agent: "MyApp/1.0"
```

## Testing

```
pytest tests/agent/test_anthropic_adapter.py -k "not TestRunOauthSetupToken"
# 153 passed
```