### PR TITLE
fix(gateway): stabilize Telegram DM-topic restarts

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -595,7 +595,11 @@ class TelegramAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]],
     ) -> bool:
         if cls._metadata_direct_messages_topic_id(metadata) is not None:
-            return False
+            return bool(
+                metadata
+                and metadata.get("telegram_dm_topic_reply_fallback")
+                and cls._metadata_reply_to_message_id(metadata) is not None
+            )
         if metadata and metadata.get("telegram_dm_topic_created_for_send"):
             return False
         return bool(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10347,6 +10347,8 @@ class GatewayRunner:
             }
             if event.source.thread_id:
                 notify_data["thread_id"] = event.source.thread_id
+            if event.message_id:
+                notify_data["message_id"] = event.message_id
             atomic_json_write(
                 _hermes_home / ".restart_notify.json",
                 notify_data,
@@ -14476,6 +14478,8 @@ class GatewayRunner:
         }
         if event.source.thread_id:
             pending["thread_id"] = event.source.thread_id
+        if event.message_id:
+            pending["message_id"] = event.message_id
         _tmp_pending = pending_path.with_suffix(".tmp")
         _tmp_pending.write_text(json.dumps(pending))
         _tmp_pending.replace(pending_path)
@@ -14623,6 +14627,7 @@ class GatewayRunner:
                     chat_type = pending.get("chat_type")
                     session_key = pending.get("session_key")
                     thread_id = pending.get("thread_id")
+                    message_id = pending.get("message_id")
                     if platform_str and chat_id:
                         platform = Platform(platform_str)
                         adapter = self.adapters.get(platform)
@@ -14631,6 +14636,7 @@ class GatewayRunner:
                             chat_id,
                             thread_id,
                             chat_type=chat_type,
+                            reply_to_message_id=message_id,
                             adapter=adapter,
                         )
                         # Fallback session key if not stored (old pending files)
@@ -14838,6 +14844,7 @@ class GatewayRunner:
             chat_id = pending.get("chat_id")
             chat_type = pending.get("chat_type")
             thread_id = pending.get("thread_id")
+            message_id = pending.get("message_id")
 
             if not exit_code_path.exists():
                 logger.info("Update notification deferred: update still running")
@@ -14864,6 +14871,7 @@ class GatewayRunner:
                     chat_id,
                     thread_id,
                     chat_type=chat_type,
+                    reply_to_message_id=message_id,
                     adapter=adapter,
                 )
                 # Strip ANSI escape codes for clean display
@@ -14909,6 +14917,7 @@ class GatewayRunner:
             chat_id = data.get("chat_id")
             chat_type = data.get("chat_type")
             thread_id = data.get("thread_id")
+            message_id = data.get("message_id")
 
             if not platform_str or not chat_id:
                 return None
@@ -14935,6 +14944,7 @@ class GatewayRunner:
                 chat_id,
                 thread_id,
                 chat_type=chat_type,
+                reply_to_message_id=message_id,
                 adapter=adapter,
             )
             result = await adapter.send(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3548,6 +3548,7 @@ class GatewayRunner:
                     chat_id,
                     thread_id,
                     chat_type=getattr(source, "chat_type", None) if source is not None else None,
+                    reply_to_message_id=getattr(source, "message_id", None) if source is not None else None,
                     adapter=adapter,
                 )
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2381,8 +2381,6 @@ Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
-RestartMaxDelaySec=300
-RestartSteps=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
@@ -2416,8 +2414,6 @@ Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
 Restart=always
 RestartSec=5
-RestartMaxDelaySec=300
-RestartSteps=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -646,3 +646,28 @@ async def test_shutdown_notifications_use_cached_live_thread_source_when_origin_
         "⚠️ Gateway shutting down — Your current task will be interrupted.",
         metadata={"thread_id": "topic-7"},
     )
+
+
+@pytest.mark.asyncio
+async def test_restart_shutdown_notification_anchors_telegram_dm_topic():
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    source = make_restart_source(chat_id="123456", thread_id="20197")
+    source.message_id = "462"
+    session_key = build_session_key(source)
+
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="shutdown"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    call = adapter.send.await_args
+    assert call.args[0] == "123456"
+    assert "Gateway restarting" in call.args[1]
+    assert call.kwargs["metadata"] == {
+        "thread_id": "20197",
+        "telegram_dm_topic_reply_fallback": True,
+        "direct_messages_topic_id": "20197",
+        "telegram_reply_to_message_id": "462",
+    }

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -60,6 +60,7 @@ async def test_restart_command_writes_notify_file(tmp_path, monkeypatch):
     assert data["platform"] == "telegram"
     assert data["chat_id"] == "42"
     assert data["chat_type"] == "dm"
+    assert data["message_id"] == "m1"
     assert "thread_id" not in data  # no thread → omitted
 
 
@@ -127,6 +128,7 @@ async def test_restart_command_preserves_thread_id(tmp_path, monkeypatch):
     data = json.loads((tmp_path / ".restart_notify.json").read_text())
     assert data["chat_type"] == "dm"
     assert data["thread_id"] == "777"
+    assert data["message_id"] == "m2"
 
 
 @pytest.mark.asyncio
@@ -390,6 +392,7 @@ async def test_send_restart_notification_with_thread(tmp_path, monkeypatch):
         "chat_id": "99",
         "chat_type": "dm",
         "thread_id": "777",
+        "message_id": "m2",
     }))
 
     runner, adapter = make_restart_runner()
@@ -403,6 +406,7 @@ async def test_send_restart_notification_with_thread(tmp_path, monkeypatch):
         "thread_id": "777",
         "telegram_dm_topic_reply_fallback": True,
         "direct_messages_topic_id": "777",
+        "telegram_reply_to_message_id": "m2",
     }
     assert not notify_path.exists()
 

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -598,6 +598,35 @@ async def test_send_uses_reply_fallback_for_hermes_dm_topics():
 
 
 @pytest.mark.asyncio
+async def test_send_uses_reply_anchor_when_direct_topic_fallback_metadata_exists():
+    """Restart/update replay metadata keeps the anchor authoritative when present."""
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(kwargs)
+        return SimpleNamespace(message_id=777)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="123",
+        content="test message",
+        metadata={
+            "thread_id": "20197",
+            "telegram_dm_topic_reply_fallback": True,
+            "direct_messages_topic_id": "20197",
+            "telegram_reply_to_message_id": "462",
+        },
+    )
+
+    assert result.success is True
+    assert call_log[0]["reply_to_message_id"] == 462
+    assert call_log[0]["message_thread_id"] == 20197
+    assert "direct_messages_topic_id" not in call_log[0]
+
+
+@pytest.mark.asyncio
 async def test_send_created_private_topic_uses_message_thread_without_anchor():
     """Topics created via createForumTopic are addressable by message_thread_id directly."""
     adapter = _make_adapter()

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -189,6 +189,7 @@ class TestHandleUpdateCommand:
         """Writes .update_pending.json with correct platform and chat info."""
         runner = _make_runner()
         event = _make_event(platform=Platform.TELEGRAM, chat_id="99999")
+        event.message_id = "m-update"
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
@@ -211,6 +212,7 @@ class TestHandleUpdateCommand:
         assert data["platform"] == "telegram"
         assert data["chat_id"] == "99999"
         assert data["chat_type"] == "dm"
+        assert data["message_id"] == "m-update"
         assert "timestamp" in data
         assert not (hermes_home / ".update_exit_code").exists()
 
@@ -223,6 +225,7 @@ class TestHandleUpdateCommand:
             chat_id="99999",
             thread_id="777",
         )
+        event.message_id = "m-update-thread"
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
@@ -241,6 +244,7 @@ class TestHandleUpdateCommand:
 
         data = json.loads((hermes_home / ".update_pending.json").read_text())
         assert data["thread_id"] == "777"
+        assert data["message_id"] == "m-update-thread"
 
     @pytest.mark.asyncio
     async def test_spawns_setsid(self, tmp_path):
@@ -472,6 +476,7 @@ class TestSendUpdateNotification:
             "chat_id": "67890",
             "chat_type": "dm",
             "thread_id": "777",
+            "message_id": "m-update-thread",
             "user_id": "12345",
         }
         (hermes_home / ".update_pending.json").write_text(json.dumps(pending))
@@ -488,6 +493,7 @@ class TestSendUpdateNotification:
             "thread_id": "777",
             "telegram_dm_topic_reply_fallback": True,
             "direct_messages_topic_id": "777",
+            "telegram_reply_to_message_id": "m-update-thread",
         }
 
     @pytest.mark.asyncio

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -326,6 +326,8 @@ class TestGeneratedSystemdUnits:
         assert "ExecStart=" in unit
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
+        assert "RestartMaxDelaySec=" not in unit
+        assert "RestartSteps=" not in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
         # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
@@ -387,6 +389,8 @@ class TestGeneratedSystemdUnits:
         assert "ExecStart=" in unit
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
+        assert "RestartMaxDelaySec=" not in unit
+        assert "RestartSteps=" not in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
         # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup


### PR DESCRIPTION
## What does this PR do?

Fixes two restart/update issues found while testing Telegram DM topic lanes:

- Carries the triggering Telegram message id through gateway restart/update replay files and active-session shutdown warnings so DM-topic notifications can be sent as anchored replies instead of relying on the anchorless `direct_messages_topic_id` fallback.
- Removes stepped systemd restart backoff from generated gateway service units so repeated in-chat `/restart` requests do not leave the service down for up to 300 seconds before respawn.

The previous synthetic notification fix preserved `chat_type` and `thread_id`, which stopped the hard "reply anchor required" failure, but field testing showed Telegram can accept `direct_messages_topic_id` while still routing the message to All / General. For Hermes-created Telegram DM topic lanes, the original `/restart` or `/update` message id is the reliable route anchor, so this PR persists it and passes it into the existing metadata builder.

The same testing also exposed a service-mode delay: `/restart` exits the gateway with status 75 and lets systemd respawn it. The generated unit had `RestartSteps=5` and `RestartMaxDelaySec=300`, so repeated planned restarts could ramp to a five-minute wait. Terminal `hermes gateway restart` already shortcuts this with `reset-failed`/`restart`, but in-chat `/restart` cannot do that after the process exits. Keeping the unit at a fixed `RestartSec=5` makes planned service restarts come back promptly.

## Related Issue

Follow-up to #36028.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: persist `message_id` in `.restart_notify.json` and `.update_pending.json`.
- `gateway/run.py`: feed the persisted message id back into `_thread_metadata_for_target()` for update streaming, final update notifications, restart notifications, and the pre-shutdown active-session restart warning.
- `gateway/platforms/telegram.py`: keep `direct_messages_topic_id` as an anchorless fallback, but treat DM-topic fallback metadata with `telegram_reply_to_message_id` as an anchored reply path.
- `hermes_cli/gateway.py`: remove `RestartSteps=5` and `RestartMaxDelaySec=300` from generated systemd units so planned gateway restarts use fixed `RestartSec=5` instead of stepped backoff.
- `tests/gateway/test_restart_notification.py`: assert restart replay persists and rebuilds the reply anchor, and that the active-session restart warning uses the Telegram DM-topic anchor.
- `tests/gateway/test_update_command.py`: assert update replay persists and rebuilds the reply anchor.
- `tests/gateway/test_telegram_thread_fallback.py`: cover the mixed metadata case where both `direct_messages_topic_id` and `telegram_reply_to_message_id` are present.
- `tests/hermes_cli/test_gateway_service.py`: assert generated systemd units do not include stepped restart backoff directives.

## How to Test

1. Update/reinstall the gateway service from this branch so the generated systemd unit no longer contains `RestartSteps=` or `RestartMaxDelaySec=`.
2. From a Telegram DM topic lane with an active task/session, run `/restart`.
3. Confirm the immediate `Gateway restarting — Your current task will be interrupted...` warning lands in the same DM topic, not All / General.
4. Confirm the post-restart `Gateway restarted successfully. Your session continues.` notification lands in the same DM topic, not All / General.
5. Confirm the gap between old gateway stop and new gateway startup is close to the fixed `RestartSec=5` service delay rather than ramping toward 300 seconds.
6. From a Telegram DM topic lane, run `/update` on a checkout where update can proceed, and confirm progress/final update notifications stay in that same DM topic.
7. Focused local checks run:
   - `python -m py_compile gateway/run.py gateway/platforms/telegram.py tests/gateway/test_restart_notification.py tests/gateway/test_update_command.py tests/gateway/test_telegram_thread_fallback.py`
   - `git diff --check -- gateway/run.py gateway/platforms/telegram.py tests/gateway/test_restart_notification.py tests/gateway/test_update_command.py tests/gateway/test_telegram_thread_fallback.py`
   - `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
   - `git diff --check -- hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Ubuntu shell, syntax checks, metadata helper checks, and local systemd unit reload

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

Local metadata probe after the change:

```text
private True
reply 462
kwargs {'message_thread_id': 20197}
private_no_anchor False
kwargs_no_anchor {'message_thread_id': None, 'direct_messages_topic_id': 20197}
```

Active-session shutdown warning probe after the follow-up:

```text
123456
⚠️ Gateway restarting — Your current task will be interrupted. Send any message after restart and I'll try to resume where you left off.
{'thread_id': '20197', 'telegram_dm_topic_reply_fallback': True, 'direct_messages_topic_id': '20197', 'telegram_reply_to_message_id': '462'}
```

Local service unit evidence after removing stepped restart backoff and reloading systemd:

```text
Restart=always
RestartUSec=5s
RestartSteps=0
RestartMaxDelayUSec=infinity
Result=success
```
