### PR TITLE
fix(security): sanitize tracebacks + anchor path regex to FS roots

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -578,22 +578,9 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
 
 
 def _sanitize_error_msg(exc: Exception, max_len: int = 200) -> str:
-    """Return a sanitized error string safe for HTTP responses.
-
-    Truncates long messages and strips absolute paths to avoid leaking
-    internal filesystem layout or stack details to external clients.
-    """
-    import re
-    msg = str(exc)
-    # Strip absolute filesystem paths (Unix and Windows).
-    # Only match paths rooted at known system directories to avoid
-    # clobbering API endpoints like /api/v1/chat/completions.
-    _FS_ROOTS = r'(?:home|Users|opt|var|tmp|etc|usr|root|srv|proc|sys|dev|mnt|media|run|boot|lib|bin|sbin|snap|nix|private)'
-    msg = re.sub(r'(?:/' + _FS_ROOTS + r')(?:/[\w.-]+)+', '<path>', msg)
-    msg = re.sub(r'[A-Za-z]:\\(?:[\w.-]+\\)+[\w.-]+', '<path>', msg)
-    if len(msg) > max_len:
-        msg = msg[:max_len] + "..."
-    return msg
+    """Return a sanitized error string safe for HTTP responses."""
+    from hermes_cli.sanitize import sanitize_error_msg
+    return sanitize_error_msg(exc, max_len=max_len)
 
 
 if AIOHTTP_AVAILABLE:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -585,8 +585,11 @@ def _sanitize_error_msg(exc: Exception, max_len: int = 200) -> str:
     """
     import re
     msg = str(exc)
-    # Strip absolute paths (Unix and Windows)
-    msg = re.sub(r'/(?:[\w.-]+/)+[\w.-]+', '<path>', msg)
+    # Strip absolute filesystem paths (Unix and Windows).
+    # Only match paths rooted at known system directories to avoid
+    # clobbering API endpoints like /api/v1/chat/completions.
+    _FS_ROOTS = r'(?:home|Users|opt|var|tmp|etc|usr|root|srv|proc|sys|dev|mnt|media|run|boot|lib|bin|sbin|snap|nix|private)'
+    msg = re.sub(r'(?:/' + _FS_ROOTS + r')(?:/[\w.-]+)+', '<path>', msg)
     msg = re.sub(r'[A-Za-z]:\\(?:[\w.-]+\\)+[\w.-]+', '<path>', msg)
     if len(msg) > max_len:
         msg = msg[:max_len] + "..."

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -577,6 +577,22 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
     }
 
 
+def _sanitize_error_msg(exc: Exception, max_len: int = 200) -> str:
+    """Return a sanitized error string safe for HTTP responses.
+
+    Truncates long messages and strips absolute paths to avoid leaking
+    internal filesystem layout or stack details to external clients.
+    """
+    import re
+    msg = str(exc)
+    # Strip absolute paths (Unix and Windows)
+    msg = re.sub(r'/(?:[\w.-]+/)+[\w.-]+', '<path>', msg)
+    msg = re.sub(r'[A-Za-z]:\\(?:[\w.-]+\\)+[\w.-]+', '<path>', msg)
+    if len(msg) > max_len:
+        msg = msg[:max_len] + "..."
+    return msg
+
+
 if AIOHTTP_AVAILABLE:
     @web.middleware
     async def body_limit_middleware(request, handler):
@@ -2614,7 +2630,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     agent_error = result["error"]
             except Exception as e:  # noqa: BLE001
                 logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
-                agent_error = str(e)
+                agent_error = _sanitize_error_msg(e)
 
             # Close the message item if it was opened
             final_response_text = "".join(final_text_parts) or final_response_text
@@ -3149,7 +3165,7 @@ class APIServerAdapter(BasePlatformAdapter):
             jobs = _cron_list(include_disabled=include_disabled)
             return web.json_response({"jobs": jobs})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            return web.json_response({"error": _sanitize_error_msg(e)}, status=500)
 
     async def _handle_create_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs — create a new cron job."""
@@ -3202,7 +3218,7 @@ class APIServerAdapter(BasePlatformAdapter):
             job = _cron_create(**kwargs)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            return web.json_response({"error": _sanitize_error_msg(e)}, status=500)
 
     async def _handle_get_job(self, request: "web.Request") -> "web.Response":
         """GET /api/jobs/{job_id} — get a single cron job."""
@@ -3221,7 +3237,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            return web.json_response({"error": _sanitize_error_msg(e)}, status=500)
 
     async def _handle_update_job(self, request: "web.Request") -> "web.Response":
         """PATCH /api/jobs/{job_id} — update a cron job."""
@@ -3258,7 +3274,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            return web.json_response({"error": _sanitize_error_msg(e)}, status=500)
 
     async def _handle_delete_job(self, request: "web.Request") -> "web.Response":
         """DELETE /api/jobs/{job_id} — delete a cron job."""
@@ -3277,7 +3293,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"ok": True})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            return web.json_response({"error": _sanitize_error_msg(e)}, status=500)
 
     async def _handle_pause_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs/{job_id}/pause — pause a cron job."""
@@ -3296,7 +3312,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            return web.json_response({"error": _sanitize_error_msg(e)}, status=500)
 
     async def _handle_resume_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs/{job_id}/resume — resume a paused cron job."""
@@ -3315,7 +3331,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            return web.json_response({"error": _sanitize_error_msg(e)}, status=500)
 
     async def _handle_run_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs/{job_id}/run — trigger immediate execution."""
@@ -3334,7 +3350,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            return web.json_response({"error": _sanitize_error_msg(e)}, status=500)
 
     # ------------------------------------------------------------------
     # Output extraction helper
@@ -3856,7 +3872,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._set_run_status(
                     run_id,
                     "failed",
-                    error=str(exc),
+                    error=_sanitize_error_msg(exc),
                     last_event="run.failed",
                 )
                 try:
@@ -3864,7 +3880,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         "event": "run.failed",
                         "run_id": run_id,
                         "timestamp": time.time(),
-                        "error": str(exc),
+                        "error": _sanitize_error_msg(exc),
                     })
                 except Exception:
                     pass
@@ -4028,7 +4044,7 @@ class APIServerAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.exception("[api_server] approval resolution failed for run %s", run_id)
-            return web.json_response(_openai_error(str(exc)), status=500)
+            return web.json_response(_openai_error(_sanitize_error_msg(exc)), status=500)
 
         if resolved <= 0:
             return web.json_response(

--- a/hermes_cli/sanitize.py
+++ b/hermes_cli/sanitize.py
@@ -1,0 +1,58 @@
+"""Shared sanitization helpers for error messages and tracebacks.
+
+Used by both the HTTP API server (gateway/platforms/api_server.py) and the
+terminal tool (tools/terminal_tool.py) to strip filesystem paths from error
+messages before they reach external clients or LLM context.
+"""
+import re
+
+# Known filesystem root directory names.
+_FS_ROOTS = (
+    r'(?:home|Users|opt|var|tmp|etc|usr|root|srv|proc|sys|dev|mnt|'
+    r'media|run|boot|lib|bin|sbin|snap|nix|private)'
+)
+
+# Match an absolute Unix path rooted at a known FS directory.
+# - `(?<![\w/])` prevents matching inside longer paths or identifiers
+#   (e.g. /api/v1/home/user stays unmatched because of the leading /api).
+# - Requires at least 2 segments after the root so short fragments like
+#   /home/user are not clobbered — only full paths like /home/user/file.
+# - Negative lookahead `(?!/v\d/)` right after the root name prevents
+#   matching API-style continuations like /var/lib/v1/chat.
+_UNIX_PATH = re.compile(
+    r'(?<![\w/])'                    # not preceded by word char or /
+    r'/' + _FS_ROOTS +               # /<root>
+    r'(?!/v\d/)'                     # not /root/v1/... (API path)
+    r'(?:/[\w.-]+){2,}',             # at least 2 more segments
+)
+
+# Match an absolute Windows path (C:\Users\..., D:\..., etc.).
+_WIN_PATH = re.compile(
+    r'[A-Za-z]:\\(?:[\w.-]+\\)+[\w.-]+'
+)
+
+
+def sanitize_error_msg(exc: Exception, max_len: int = 200) -> str:
+    """Return a sanitized error string safe for HTTP responses and LLM context.
+
+    Truncates long messages and strips absolute paths to avoid leaking
+    internal filesystem layout or stack details.
+    """
+    msg = str(exc)
+    msg = _UNIX_PATH.sub('<path>', msg)
+    msg = _WIN_PATH.sub('<path>', msg)
+    if len(msg) > max_len:
+        msg = msg[:max_len] + "..."
+    return msg
+
+
+def sanitize_traceback(tb_str: str, max_len: int = 2000) -> str:
+    """Return a sanitized traceback string safe for LLM context.
+
+    Strips absolute paths and truncates long tracebacks.
+    """
+    tb_str = _UNIX_PATH.sub('<path>', tb_str)
+    tb_str = _WIN_PATH.sub('<path>', tb_str)
+    if len(tb_str) > max_len:
+        tb_str = tb_str[:max_len] + "\n... (truncated)"
+    return tb_str

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2414,7 +2414,7 @@ def terminal_tool(
         logger.error("terminal_tool exception:\n%s", tb_str)
         # Sanitize traceback: strip absolute paths and truncate to avoid
         # leaking sensitive local variables or long stack traces to LLM context.
-        tb_str = re.sub(r'/(?:[\w.-]+/)+[\w.-]+', '<path>', tb_str)
+        tb_str = re.sub(r'(?:/(?:home|Users|opt|var|tmp|etc|usr|root|srv|proc|sys|dev|mnt|media|run|boot|lib|bin|sbin|snap|nix|private))(?:/[\w.-]+)+', '<path>', tb_str)
         tb_str = re.sub(r'[A-Za-z]:\\(?:[\w.-]+\\)+[\w.-]+', '<path>', tb_str)
         if len(tb_str) > 2000:
             tb_str = tb_str[:2000] + "\n... (truncated)"

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2409,15 +2409,11 @@ def terminal_tool(
             return json.dumps(result_dict, ensure_ascii=False)
 
     except Exception as e:
-        import traceback, re
+        import traceback
+        from hermes_cli.sanitize import sanitize_traceback
         tb_str = traceback.format_exc()
         logger.error("terminal_tool exception:\n%s", tb_str)
-        # Sanitize traceback: strip absolute paths and truncate to avoid
-        # leaking sensitive local variables or long stack traces to LLM context.
-        tb_str = re.sub(r'(?:/(?:home|Users|opt|var|tmp|etc|usr|root|srv|proc|sys|dev|mnt|media|run|boot|lib|bin|sbin|snap|nix|private))(?:/[\w.-]+)+', '<path>', tb_str)
-        tb_str = re.sub(r'[A-Za-z]:\\(?:[\w.-]+\\)+[\w.-]+', '<path>', tb_str)
-        if len(tb_str) > 2000:
-            tb_str = tb_str[:2000] + "\n... (truncated)"
+        tb_str = sanitize_traceback(tb_str)
         return json.dumps({
             "output": "",
             "exit_code": -1,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2409,9 +2409,15 @@ def terminal_tool(
             return json.dumps(result_dict, ensure_ascii=False)
 
     except Exception as e:
-        import traceback
+        import traceback, re
         tb_str = traceback.format_exc()
         logger.error("terminal_tool exception:\n%s", tb_str)
+        # Sanitize traceback: strip absolute paths and truncate to avoid
+        # leaking sensitive local variables or long stack traces to LLM context.
+        tb_str = re.sub(r'/(?:[\w.-]+/)+[\w.-]+', '<path>', tb_str)
+        tb_str = re.sub(r'[A-Za-z]:\\(?:[\w.-]+\\)+[\w.-]+', '<path>', tb_str)
+        if len(tb_str) > 2000:
+            tb_str = tb_str[:2000] + "\n... (truncated)"
         return json.dumps({
             "output": "",
             "exit_code": -1,


### PR DESCRIPTION
## What

Sanitize tracebacks and HTTP error messages before sending to clients/LLMs. Anchored path regex to known filesystem roots to avoid clobbering API endpoints.

Supersedes #36114 (closed).

### Changes

**gateway/platforms/api_server.py** — `_sanitize_error_msg()`:
- Strip absolute filesystem paths from HTTP 500 error responses
- Regex anchored to known FS roots (`/home`, `/usr`, `/opt`, `/var`, etc.) so API endpoints like `/api/v1/chat/completions` are preserved
- Truncate long messages to 200 chars

**tools/terminal_tool.py** — traceback sanitization:
- Same anchored regex to strip absolute paths from tracebacks before sending to LLM context
- Truncate to 2000 chars

### Issue from #36114 review (liuhao1024)

> Path-stripping regex is too aggressive — matches API endpoints like `/api/v1/chat/completions`

Fixed: regex now anchored to known filesystem root prefixes.