### PR TITLE
fix(gemini): strip self provider prefix before native generateContent

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -41,6 +41,16 @@ DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 GEMINI_DEFAULT_MAX_OUTPUT_TOKENS = 65535
 
 
+def bare_gemini_model_id(model: str) -> str:
+    """Strip Gemini's own provider prefix from an aggregator-style model id."""
+    name = (model or "").strip()
+    lowered = name.lower()
+    for prefix in ("google/", "gemini/"):
+        if lowered.startswith(prefix):
+            return name[len(prefix):].strip() or name
+    return name
+
+
 def is_native_gemini_base_url(base_url: str) -> bool:
     """Return True when the endpoint speaks Gemini's native REST API."""
     normalized = str(base_url or "").strip().rstrip("/").lower()
@@ -914,6 +924,7 @@ class GeminiNativeClient:
             thinking_config=thinking_config,
         )
 
+        model = bare_gemini_model_id(model)
         if stream:
             return self._stream_completion(model=model, request=request, timeout=timeout)
 

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -84,7 +84,6 @@ _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
 
 # Providers whose native naming is authoritative -- pass through unchanged.
 _AUTHORITATIVE_NATIVE_PROVIDERS: frozenset[str] = frozenset({
-    "gemini",
     "huggingface",
 })
 
@@ -103,6 +102,8 @@ _MATCHING_PREFIX_STRIP_PROVIDERS: frozenset[str] = frozenset({
     "arcee",
     "ollama-cloud",
     "custom",
+    "gemini",
+    "xai",
 })
 
 # Providers whose APIs require lowercase model IDs.  Xiaomi's

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -198,6 +198,45 @@ def test_native_client_uses_x_goog_api_key_and_native_models_endpoint(monkeypatc
     assert response.choices[0].message.content == "hello"
 
 
+@pytest.mark.parametrize("model, expected", [
+    ("google/gemini-2.0-flash", "gemini-2.0-flash"),
+    ("gemini/gemini-3-pro-preview", "gemini-3-pro-preview"),
+    ("Google/Gemini-2.5-Pro", "Gemini-2.5-Pro"),
+    ("models/gemini-x", "models/gemini-x"),
+    ("tunedModels/my-tune", "tunedModels/my-tune"),
+])
+def test_bare_gemini_model_id_strips_only_self_prefix(model, expected):
+    from agent.gemini_native_adapter import bare_gemini_model_id
+
+    assert bare_gemini_model_id(model) == expected
+
+
+def test_native_client_strips_self_prefix_from_model_url(monkeypatch):
+    from agent.gemini_native_adapter import GeminiNativeClient
+
+    recorded = {}
+
+    class DummyHTTP:
+        def post(self, url, json=None, headers=None, timeout=None):
+            recorded["url"] = url
+            return DummyResponse(payload={
+                "candidates": [{"content": {"parts": [{"text": "ok"}]}, "finishReason": "STOP"}],
+                "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2},
+            })
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr("agent.gemini_native_adapter.httpx.Client", lambda *a, **k: DummyHTTP())
+    client = GeminiNativeClient(api_key="AIza-test", base_url="https://generativelanguage.googleapis.com/v1beta")
+    client.chat.completions.create(
+        model="google/gemini-2.0-flash",
+        messages=[{"role": "user", "content": "Hello"}],
+    )
+
+    assert recorded["url"] == "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
+
+
 def test_native_http_error_keeps_status_and_retry_after():
     from agent.gemini_native_adapter import gemini_http_error
 

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -143,7 +143,8 @@ class TestGeminiModelNormalization:
         assert normalize_model_for_provider("gemini-2.5-flash", "gemini") == "gemini-2.5-flash"
 
     def test_strip_vendor_prefix(self):
-        assert normalize_model_for_provider("google/gemini-2.5-flash", "gemini") == "google/gemini-2.5-flash"
+        assert normalize_model_for_provider("google/gemini-2.5-flash", "gemini") == "gemini-2.5-flash"
+        assert normalize_model_for_provider("gemini/gemini-2.5-flash", "gemini") == "gemini-2.5-flash"
 
     def test_gemma_vendor_detection(self):
         assert detect_vendor("gemma-4-31b-it") == "google"

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -167,10 +167,13 @@ class TestAggregatorProviders:
 class TestIssue6211NativeProviderPrefixNormalization:
     @pytest.mark.parametrize("model,target_provider,expected", [
         ("zai/glm-5.1", "zai", "glm-5.1"),
-        ("google/gemini-2.5-pro", "gemini", "google/gemini-2.5-pro"),
+        ("google/gemini-2.5-pro", "gemini", "gemini-2.5-pro"),
+        ("gemini/gemini-2.5-pro", "gemini", "gemini-2.5-pro"),
         ("moonshot/kimi-k2.5", "kimi-coding", "kimi-k2.5"),
         ("anthropic/claude-sonnet-4.6", "openrouter", "anthropic/claude-sonnet-4.6"),
+        ("x-ai/grok-4-fast-reasoning", "xai", "grok-4-fast-reasoning"),
         ("Qwen/Qwen3.5-397B-A17B", "huggingface", "Qwen/Qwen3.5-397B-A17B"),
+        ("openai/gpt-5.4", "xai", "openai/gpt-5.4"),
         ("modal/zai-org/GLM-5-FP8", "custom", "modal/zai-org/GLM-5-FP8"),
     ])
     def test_native_provider_prefixes_are_only_stripped_on_matching_provider(


### PR DESCRIPTION
## Summary
Self-prefixed model ids now resolve to bare native ids before the Gemini/xAI native call, so `google/gemini-2.0-flash` no longer 404s. Ported from [openclaw/openclaw#88781](https://github.com/openclaw/openclaw/pull/88781) ("strip remaining provider self prefixes").

**Root cause:** the native Gemini adapter built `f"{base}/models/{model}:generateContent"` directly from the model id. A self-prefixed value (easily pasted from an aggregator slug into `config.yaml`, or left attached by an upstream resolver) produced the malformed resource path `models/google/gemini-2.0-flash:generateContent`, which Google rejects as an invalid model resource name.

## Changes
- `agent/gemini_native_adapter.py`: add `bare_gemini_model_id()` and strip a matching `google/` or `gemini/` self-prefix at URL construction. Applied once before the stream branch so it covers the sync `generateContent`, streaming `streamGenerateContent`, and (via delegation) the async paths. Legitimate namespaced ids (`tunedModels/...`, `models/...`) and cross-vendor refs pass through untouched.
- `hermes_cli/model_normalize.py`: route the `gemini` and `xai` providers through the existing matching-prefix stripper (defense-in-depth for the config path). HuggingFace stays an authoritative passthrough because its ids are legitimately `org/model`.
- Tests: adapter helper coverage + a transport-level assertion that a `google/`-prefixed model hits the bare native URL; updated the stale issue #6211 case that asserted gemini passthrough.

## How it was adapted
OpenClaw's fix split prefix handling between a runtime `stripSelfProviderModelPrefix` and prefix-preserving catalog normalization. Hermes already had matching-prefix stripping (`_strip_matching_provider_prefix`) and provider aliasing (`google` → `gemini`, `x-ai` → `xai`), so the adaptation was: (1) add the load-bearing strip at the native adapter's transport boundary, and (2) move `gemini`/`xai` out of pure passthrough into the matching-prefix set — without touching aggregator behavior (OpenRouter/Nous still get `vendor/model` slugs).

## Validation
| | Before | After |
|---|---|---|
| URL for `google/gemini-2.0-flash` (native) | `models/google/gemini-2.0-flash:generateContent` (404) | `models/gemini-2.0-flash:generateContent` |
| `normalize_model_for_provider("xai/grok-4", "xai")` | `xai/grok-4` | `grok-4` |
| `normalize_model_for_provider("Qwen/Qwen3.5", "huggingface")` | `Qwen/Qwen3.5` | `Qwen/Qwen3.5` (unchanged) |

Targeted suites: `tests/agent/test_gemini_native_adapter.py` (19) + `tests/hermes_cli/test_model_normalize.py` (80) + 3 model-switch files (32) — all pass. E2E: a loopback HTTP server confirmed a `google/gemini-2.0-flash` request reaches `/v1beta/models/gemini-2.0-flash:generateContent` and round-trips.

---
*Opened by the weekly OpenClaw PR scout (autonomous port).*
