### PR TITLE
fix(scripts): prevent Open WebUI first-admin LAN race (#36121)

### DIFF
--- a/scripts/setup_open_webui.sh
+++ b/scripts/setup_open_webui.sh
@@ -16,8 +16,12 @@ set -euo pipefail
 #   OPEN_WEBUI_PORT=8080
 #   OPEN_WEBUI_HOST=127.0.0.1
 #   OPEN_WEBUI_NAME='Johnny Hermes'
-#   OPEN_WEBUI_ENABLE_SIGNUP=true
+#   OPEN_WEBUI_ENABLE_SIGNUP=false   # default false — enable only for local first-run
+#   OPEN_WEBUI_I_UNDERSTAND_LAN_SIGNUP_RACE=true  # required with signup on LAN bind
 #   OPEN_WEBUI_ENABLE_SERVICE=auto   # auto|true|false
+#
+# Flags:
+#   --i-understand-lan-signup-race   # allow signup while bound to 0.0.0.0 / non-loopback
 #   OPEN_WEBUI_VENV=~/.local/open-webui-venv
 #   OPEN_WEBUI_DATA_DIR=~/.local/share/open-webui/data
 #   HERMES_API_PORT=8642
@@ -27,7 +31,8 @@ set -euo pipefail
 OPEN_WEBUI_PORT="${OPEN_WEBUI_PORT:-8080}"
 OPEN_WEBUI_HOST="${OPEN_WEBUI_HOST:-127.0.0.1}"
 OPEN_WEBUI_NAME="${OPEN_WEBUI_NAME:-Hermes Agent WebUI}"
-OPEN_WEBUI_ENABLE_SIGNUP="${OPEN_WEBUI_ENABLE_SIGNUP:-true}"
+OPEN_WEBUI_ENABLE_SIGNUP="${OPEN_WEBUI_ENABLE_SIGNUP:-false}"
+OPEN_WEBUI_I_UNDERSTAND_LAN_SIGNUP_RACE="${OPEN_WEBUI_I_UNDERSTAND_LAN_SIGNUP_RACE:-false}"
 OPEN_WEBUI_ENABLE_SERVICE="${OPEN_WEBUI_ENABLE_SERVICE:-auto}"
 OPEN_WEBUI_VENV="${OPEN_WEBUI_VENV:-$HOME/.local/open-webui-venv}"
 OPEN_WEBUI_DATA_DIR="${OPEN_WEBUI_DATA_DIR:-$HOME/.local/share/open-webui/data}"
@@ -42,6 +47,63 @@ LOG_DIR="$HOME/.hermes/logs"
 
 log() {
   printf '[open-webui-bootstrap] %s\n' "$*"
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --i-understand-lan-signup-race)
+        OPEN_WEBUI_I_UNDERSTAND_LAN_SIGNUP_RACE=true
+        ;;
+      -h|--help)
+        cat <<'EOF'
+Usage: bash scripts/setup_open_webui.sh [--i-understand-lan-signup-race]
+
+Bootstrap Open WebUI for Hermes. Signup defaults to disabled so the operator
+creates the admin account deliberately. Binding to 0.0.0.0 with signup enabled
+lets the first LAN client claim admin — use loopback first or pass the flag above.
+EOF
+        exit 0
+        ;;
+      *)
+        echo "Unknown argument: $1 (try --help)" >&2
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+_is_truthy() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    true|yes|1|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+_is_loopback_bind() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    127.0.0.1|localhost|::1) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+assert_signup_safe_for_bind() {
+  if _is_loopback_bind "$OPEN_WEBUI_HOST"; then
+    return 0
+  fi
+  if ! _is_truthy "$OPEN_WEBUI_ENABLE_SIGNUP"; then
+    return 0
+  fi
+  if _is_truthy "$OPEN_WEBUI_I_UNDERSTAND_LAN_SIGNUP_RACE"; then
+    log "WARNING: binding to ${OPEN_WEBUI_HOST}:${OPEN_WEBUI_PORT} with signup ENABLED."
+    log "WARNING: the first client on your network to open the UI can claim admin."
+    return 0
+  fi
+  echo "Refusing to continue: OPEN_WEBUI_HOST=${OPEN_WEBUI_HOST} is not loopback and OPEN_WEBUI_ENABLE_SIGNUP=true." >&2
+  echo "Any device on your LAN can become admin during setup (#36121)." >&2
+  echo "Fix: OPEN_WEBUI_ENABLE_SIGNUP=false (default), bind to 127.0.0.1 first, or pass --i-understand-lan-signup-race." >&2
+  exit 1
 }
 
 require_cmd() {
@@ -291,6 +353,8 @@ main() {
   require_cmd curl
   require_cmd python3
 
+  assert_signup_safe_for_bind
+
   install_macos_dependencies
 
   local api_key
@@ -346,4 +410,7 @@ main() {
   log 'Important: Open WebUI persists connection settings after first launch. If you later save a wrong API key in the Admin UI, update/delete that connection there or reset its database.'
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  parse_args "$@"
+  main
+fi

--- a/tests/scripts/test_setup_open_webui_signup_guard.py
+++ b/tests/scripts/test_setup_open_webui_signup_guard.py
@@ -1,0 +1,59 @@
+"""Tests for LAN/signup safety guard in scripts/setup_open_webui.sh (#36121)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "setup_open_webui.sh"
+
+_GUARD = f"""
+set -euo pipefail
+source {SCRIPT.as_posix()}
+assert_signup_safe_for_bind
+"""
+
+
+def _run_guard(*, host: str, signup: str, ack: str = "false") -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOME": env.get("HOME", "/tmp"),
+            "OPEN_WEBUI_HOST": host,
+            "OPEN_WEBUI_ENABLE_SIGNUP": signup,
+            "OPEN_WEBUI_I_UNDERSTAND_LAN_SIGNUP_RACE": ack,
+            "OPEN_WEBUI_PORT": "8080",
+        }
+    )
+    return subprocess.run(
+        ["bash", "-c", _GUARD],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_loopback_allows_signup_enabled():
+    result = _run_guard(host="127.0.0.1", signup="true")
+    assert result.returncode == 0
+
+
+def test_lan_bind_blocks_signup_enabled_without_ack():
+    result = _run_guard(host="0.0.0.0", signup="true")
+    assert result.returncode == 1
+    assert "Refusing to continue" in result.stderr
+    assert "36121" in result.stderr
+
+
+def test_lan_bind_allows_signup_disabled():
+    result = _run_guard(host="0.0.0.0", signup="false")
+    assert result.returncode == 0
+
+
+def test_lan_bind_allows_signup_with_explicit_ack():
+    result = _run_guard(host="0.0.0.0", signup="true", ack="true")
+    assert result.returncode == 0
+    assert "WARNING" in result.stdout

--- a/website/docs/user-guide/messaging/open-webui.md
+++ b/website/docs/user-guide/messaging/open-webui.md
@@ -62,6 +62,8 @@ HERMES_API_MODEL_NAME='My Hermes Agent' \
 bash scripts/setup_open_webui.sh
 ```
 
+Signup defaults to **disabled** so you control when the first admin account is created. If you bind to `0.0.0.0` for LAN access, keep signup off until your account exists, or pass `--i-understand-lan-signup-race` — otherwise the first device on your network to open the UI can claim admin.
+
 On Linux, automatic background service setup requires a working `systemd --user` session. If you are on a headless SSH box and want to skip service installation, run:
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

Closes a security footgun in `scripts/setup_open_webui.sh`: with `OPEN_WEBUI_ENABLE_SIGNUP=true` (previous default) and `OPEN_WEBUI_HOST=0.0.0.0`, the first device on the LAN to open the UI could claim the admin account during setup ([#36121](https://github.com/NousResearch/hermes-agent/issues/36121)).

- Default `OPEN_WEBUI_ENABLE_SIGNUP` to **false** so the operator enables signup only when ready to create the admin account locally.
- Refuse non-loopback binds (`0.0.0.0`, etc.) while signup is enabled unless `--i-understand-lan-signup-race` or `OPEN_WEBUI_I_UNDERSTAND_LAN_SIGNUP_RACE=true`.
- Emit loud warnings when the explicit ack path is used.
- Document the behavior in the Open WebUI integration guide.

## Related Issue

Fixes #36121

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/setup_open_webui.sh` — signup default `false`, `assert_signup_safe_for_bind`, `--i-understand-lan-signup-race`, `--help`; script only runs `main` when executed directly (sourcable for tests).
- `tests/scripts/test_setup_open_webui_signup_guard.py` — 4 guard cases.
- `website/docs/user-guide/messaging/open-webui.md` — LAN/signup note.

## How to Test

1. `scripts/run_tests.sh tests/scripts/test_setup_open_webui_signup_guard.py -v` — expect 4 passed.
2. Manual:
   - `OPEN_WEBUI_HOST=0.0.0.0 OPEN_WEBUI_ENABLE_SIGNUP=true bash scripts/setup_open_webui.sh` → should exit 1 with guidance.
   - Same with `--i-understand-lan-signup-race` → passes guard (then continues into normal setup).
   - Default `bash scripts/setup_open_webui.sh` on loopback → signup off in launcher.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] Conventional Commits (`test(scripts):`, `fix(scripts):`, `docs(open-webui):`)
- [x] Searched for duplicate PRs
- [x] PR contains only changes for this fix
- [x] Tests pass locally (macOS, Python 3.12)

### Documentation & Housekeeping

- [x] Updated `website/docs/user-guide/messaging/open-webui.md`
- [x] Cross-platform: bash guard uses POSIX `tr`/`case` (macOS/Linux)

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/scripts/test_setup_open_webui_signup_guard.py -v
4 workers [4 items]
============================== 4 passed in 1.73s ===============================
```